### PR TITLE
feat: add React frontend shell

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JobHunter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@jobhunter/web",
+  "version": "0.3.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@jobhunter/contracts": "file:../../packages/contracts"
+  }
+}
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@jobhunter/contracts": "file:../../packages/contracts"
+    "@jobhunter/contracts": "file:../../packages/contracts",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   }
 }
-

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,7 +13,7 @@ import {
   type StageState,
   STAGES,
 } from "@jobhunter/contracts";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type View = "dashboard" | "jobs" | "artifacts" | "profile";
 type Direction = "asc" | "desc";
@@ -86,7 +86,7 @@ export function App(): JSX.Element {
             </button>
           ))}
         </nav>
-        <select className="select" value={density} onChange={(event) => setDensity(event.target.value)}>
+        <select aria-label="Row density" className="select" value={density} onChange={(event) => setDensity(event.target.value)}>
           <option value="compact">compact</option>
           <option value="regular">regular</option>
           <option value="comfy">comfy</option>
@@ -188,12 +188,14 @@ function Dashboard({
                   ["done", stage.succeeded],
                   ["failed", stage.failed],
                   ["blocked", stage.blocked],
-                  ["pending", stage.pending + stage.running],
+                  ["running", stage.running],
+                  ["pending", stage.pending],
                 ]}
               />
               <span className="legend">
                 {stage.failed ? <span className="danger">{stage.failed} failed</span> : null}
                 {stage.blocked ? <span className="warn">{stage.blocked} blocked</span> : null}
+                {stage.running ? <span>{stage.running} running</span> : null}
                 <span>{stage.pending} pending</span>
               </span>
             </button>
@@ -250,27 +252,35 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
   const [error, setError] = useState("");
+  const requestSeq = useRef(0);
 
   const load = useCallback(async () => {
+    const requestId = requestSeq.current + 1;
+    requestSeq.current = requestId;
     setLoading(true);
     setError("");
     try {
-      setData(
-        await api.jobs({
-          page,
-          pageSize,
-          q: query,
-          sort,
-          dir,
-          stage: stage === "all" ? undefined : stage,
-          state: state === "all" ? undefined : state,
-        }),
-      );
+      const nextData = await api.jobs({
+        page,
+        pageSize,
+        q: query,
+        sort,
+        dir,
+        stage: stage === "all" ? undefined : stage,
+        state: state === "all" ? undefined : state,
+      });
+      if (requestId === requestSeq.current) {
+        setData(nextData);
+      }
     } catch (requestError) {
-      setData(null);
-      setError(requestError instanceof Error ? requestError.message : "Unable to load jobs.");
+      if (requestId === requestSeq.current) {
+        setData(null);
+        setError(requestError instanceof Error ? requestError.message : "Unable to load jobs.");
+      }
     } finally {
-      setLoading(false);
+      if (requestId === requestSeq.current) {
+        setLoading(false);
+      }
     }
   }, [dir, page, pageSize, query, sort, stage, state]);
 
@@ -305,8 +315,22 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
       <CardHeader title="Jobs" meta={data ? `${data.pagination.total} total` : "loading"} />
       {error ? <div className="banner inline">{error}</div> : null}
       <div className="toolbar">
-        <input aria-label="Search jobs" placeholder="Filter jobs, companies, errors..." value={query} onChange={(event) => setQuery(event.target.value)} />
-        <select value={stage} onChange={(event) => setStage(event.target.value as Stage | "all")}>
+        <input
+          aria-label="Search jobs"
+          placeholder="Filter jobs, companies, errors..."
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setPage(1);
+          }}
+        />
+        <select
+          value={stage}
+          onChange={(event) => {
+            setStage(event.target.value as Stage | "all");
+            setPage(1);
+          }}
+        >
           <option value="all">all stages</option>
           {STAGES.map((item) => (
             <option key={item} value={item}>
@@ -314,16 +338,41 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
             </option>
           ))}
         </select>
-        <select value={state} onChange={(event) => setState(event.target.value as StageState | "all")}>
+        <select
+          value={state}
+          onChange={(event) => {
+            setState(event.target.value as StageState | "all");
+            setPage(1);
+          }}
+        >
           {["all", "pending", "running", "succeeded", "failed", "blocked", "exhausted", "stale"].map((item) => (
             <option key={item} value={item}>
               {item} states
             </option>
           ))}
         </select>
-        <SelectPairs options={jobSortFields} value={sort} onChange={setSort} />
-        <DirectionSelect value={dir} onChange={setDir} />
-        <PageSize value={pageSize} onChange={setPageSize} />
+        <SelectPairs
+          options={jobSortFields}
+          value={sort}
+          onChange={(value) => {
+            setSort(value);
+            setPage(1);
+          }}
+        />
+        <DirectionSelect
+          value={dir}
+          onChange={(value) => {
+            setDir(value);
+            setPage(1);
+          }}
+        />
+        <PageSize
+          value={pageSize}
+          onChange={(value) => {
+            setPageSize(value);
+            setPage(1);
+          }}
+        />
         <button className="tab" onClick={() => void load()} type="button">
           refresh
         </button>
@@ -361,26 +410,34 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
   const [dir, setDir] = useState<Direction>("desc");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
+  const requestSeq = useRef(0);
 
   const load = useCallback(async () => {
+    const requestId = requestSeq.current + 1;
+    requestSeq.current = requestId;
     setLoading(true);
     setError("");
     try {
-      setData(
-        await api.artifacts({
-          page,
-          pageSize,
-          q: query,
-          sort,
-          dir,
-          status: status === "all" ? "" : status,
-        }),
-      );
+      const nextData = await api.artifacts({
+        page,
+        pageSize,
+        q: query,
+        sort,
+        dir,
+        status: status === "all" ? "" : status,
+      });
+      if (requestId === requestSeq.current) {
+        setData(nextData);
+      }
     } catch (requestError) {
-      setData(null);
-      setError(requestError instanceof Error ? requestError.message : "Unable to load artifacts.");
+      if (requestId === requestSeq.current) {
+        setData(null);
+        setError(requestError instanceof Error ? requestError.message : "Unable to load artifacts.");
+      }
     } finally {
-      setLoading(false);
+      if (requestId === requestSeq.current) {
+        setLoading(false);
+      }
     }
   }, [dir, page, pageSize, query, sort, status]);
 
@@ -393,17 +450,50 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
       <CardHeader title="Artifacts" meta={data ? `${data.pagination.total} total` : "loading"} />
       {error ? <div className="banner inline">{error}</div> : null}
       <div className="toolbar">
-        <input aria-label="Search artifacts" placeholder="Filter artifacts..." value={query} onChange={(event) => setQuery(event.target.value)} />
-        <select value={status} onChange={(event) => setStatus(event.target.value)}>
+        <input
+          aria-label="Search artifacts"
+          placeholder="Filter artifacts..."
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setPage(1);
+          }}
+        />
+        <select
+          value={status}
+          onChange={(event) => {
+            setStatus(event.target.value);
+            setPage(1);
+          }}
+        >
           {["all", "active", "approved", "candidate", "stale"].map((item) => (
             <option key={item} value={item}>
               {item}
             </option>
           ))}
         </select>
-        <SelectPairs options={artifactSortFields} value={sort} onChange={setSort} />
-        <DirectionSelect value={dir} onChange={setDir} />
-        <PageSize value={pageSize} onChange={setPageSize} />
+        <SelectPairs
+          options={artifactSortFields}
+          value={sort}
+          onChange={(value) => {
+            setSort(value);
+            setPage(1);
+          }}
+        />
+        <DirectionSelect
+          value={dir}
+          onChange={(value) => {
+            setDir(value);
+            setPage(1);
+          }}
+        />
+        <PageSize
+          value={pageSize}
+          onChange={(value) => {
+            setPageSize(value);
+            setPage(1);
+          }}
+        />
         <button className="tab" onClick={() => void load()} type="button">
           refresh
         </button>
@@ -437,16 +527,22 @@ function ProfileView(): JSX.Element {
   const [templateText, setTemplateText] = useState("");
   const [showImport, setShowImport] = useState(true);
   const [loadRevision, setLoadRevision] = useState(0);
+  const [loadError, setLoadError] = useState("");
 
   useEffect(() => {
     async function load() {
-      const [profileResponse, settingsResponse] = await Promise.all([api.profile(), api.settings()]);
-      setProfile(profileResponse);
-      setSettings(settingsResponse);
-      setProfileText(JSON.stringify(profileResponse.profile, null, 2));
-      setStyleText(JSON.stringify(profileResponse.style, null, 2));
-      setTemplateText(profileResponse.templateText);
-      setLoadRevision((value) => value + 1);
+      setLoadError("");
+      try {
+        const [profileResponse, settingsResponse] = await Promise.all([api.profile(), api.settings()]);
+        setProfile(profileResponse);
+        setSettings(settingsResponse);
+        setProfileText(JSON.stringify(profileResponse.profile, null, 2));
+        setStyleText(JSON.stringify(profileResponse.style, null, 2));
+        setTemplateText(profileResponse.templateText);
+        setLoadRevision((value) => value + 1);
+      } catch (requestError) {
+        setLoadError(requestError instanceof Error ? requestError.message : "Unable to load profile.");
+      }
     }
     void load();
   }, []);
@@ -457,6 +553,7 @@ function ProfileView(): JSX.Element {
     <div className="profile-layout">
       <section className="card">
         <CardHeader title="Profile" meta={settings ? `min fit ${settings.settings.minFitScore}` : "loading"} />
+        {loadError ? <div className="banner inline">{loadError}</div> : null}
         {showImport ? (
           <section className="import-panel">
             <label className="import-target">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,9 +1,11 @@
 import {
+  type ArtifactSortField,
   type ArtifactSummary,
   createJobHunterApiClient,
   type DashboardSummary,
   type JobDetail,
   type JobSummary,
+  type JobSortField,
   type PaginatedResponse,
   type ProfileConfigResponse,
   type SettingsResponse,
@@ -190,8 +192,8 @@ function Dashboard({
                 ]}
               />
               <span className="legend">
-                {stage.failed ? <span className="failed">{stage.failed} failed</span> : null}
-                {stage.blocked ? <span className="blocked">{stage.blocked} blocked</span> : null}
+                {stage.failed ? <span className="danger">{stage.failed} failed</span> : null}
+                {stage.blocked ? <span className="warn">{stage.blocked} blocked</span> : null}
                 <span>{stage.pending} pending</span>
               </span>
             </button>
@@ -243,25 +245,30 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
   const [query, setQuery] = useState("");
   const [stage, setStage] = useState<Stage | "all">("all");
   const [state, setState] = useState<StageState | "all">("all");
-  const [sort, setSort] = useState("discovered_at");
+  const [sort, setSort] = useState<JobSortField>("discovered_at");
   const [dir, setDir] = useState<Direction>("desc");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
+  const [error, setError] = useState("");
 
   const load = useCallback(async () => {
     setLoading(true);
+    setError("");
     try {
       setData(
         await api.jobs({
           page,
           pageSize,
           q: query,
-          sort: sort as never,
+          sort,
           dir,
           stage: stage === "all" ? undefined : stage,
           state: state === "all" ? undefined : state,
         }),
       );
+    } catch (requestError) {
+      setData(null);
+      setError(requestError instanceof Error ? requestError.message : "Unable to load jobs.");
     } finally {
       setLoading(false);
     }
@@ -296,6 +303,7 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
   return (
     <section className="card full">
       <CardHeader title="Jobs" meta={data ? `${data.pagination.total} total` : "loading"} />
+      {error ? <div className="banner inline">{error}</div> : null}
       <div className="toolbar">
         <input aria-label="Search jobs" placeholder="Filter jobs, companies, errors..." value={query} onChange={(event) => setQuery(event.target.value)} />
         <select value={stage} onChange={(event) => setStage(event.target.value as Stage | "all")}>
@@ -345,24 +353,35 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
 
 function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.Element {
   const [data, setData] = useState<PaginatedResponse<ArtifactSummary> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState("all");
-  const [sort, setSort] = useState("created_at");
+  const [sort, setSort] = useState<ArtifactSortField>("created_at");
   const [dir, setDir] = useState<Direction>("desc");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);
 
   const load = useCallback(async () => {
-    setData(
-      await api.artifacts({
-        page,
-        pageSize,
-        q: query,
-        sort: sort as never,
-        dir,
-        status: status === "all" ? "" : status,
-      }),
-    );
+    setLoading(true);
+    setError("");
+    try {
+      setData(
+        await api.artifacts({
+          page,
+          pageSize,
+          q: query,
+          sort,
+          dir,
+          status: status === "all" ? "" : status,
+        }),
+      );
+    } catch (requestError) {
+      setData(null);
+      setError(requestError instanceof Error ? requestError.message : "Unable to load artifacts.");
+    } finally {
+      setLoading(false);
+    }
   }, [dir, page, pageSize, query, sort, status]);
 
   useEffect(() => {
@@ -372,6 +391,7 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
   return (
     <section className="card full">
       <CardHeader title="Artifacts" meta={data ? `${data.pagination.total} total` : "loading"} />
+      {error ? <div className="banner inline">{error}</div> : null}
       <div className="toolbar">
         <input aria-label="Search artifacts" placeholder="Filter artifacts..." value={query} onChange={(event) => setQuery(event.target.value)} />
         <select value={status} onChange={(event) => setStatus(event.target.value)}>
@@ -389,6 +409,7 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
         </button>
       </div>
       <div className="table">
+        {loading && !data ? <Empty title="Loading artifacts." /> : null}
         {data?.items.map((artifact) => (
           <button className="data-row artifact" key={artifact.artifactId} onClick={() => onOpenJob(artifact.jobKey)} type="button">
             <span className={`tag ${artifact.status === "active" ? "ok" : "muted"}`}>{artifact.status}</span>
@@ -499,7 +520,7 @@ function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void })
   return (
     <div className="drawer-backdrop">
       <aside className="drawer">
-        <button className="drawer-close" onClick={onClose} type="button">
+        <button aria-label="Close job details" className="drawer-close" onClick={onClose} type="button">
           x
         </button>
         {error ? <Empty title={error} /> : null}
@@ -653,17 +674,17 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-function SelectPairs({
+function SelectPairs<T extends string>({
   options,
   value,
   onChange,
 }: {
-  options: readonly (readonly [string, string])[];
-  value: string;
-  onChange: (value: string) => void;
+  options: readonly (readonly [T, string])[];
+  value: T;
+  onChange: (value: T) => void;
 }): JSX.Element {
   return (
-    <select value={value} onChange={(event) => onChange(event.target.value)}>
+    <select value={value} onChange={(event) => onChange(event.target.value as T)}>
       {options.map(([item, label]) => (
         <option key={item} value={item}>
           {label}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,751 @@
+import {
+  type ArtifactSummary,
+  createJobHunterApiClient,
+  type DashboardSummary,
+  type JobDetail,
+  type JobSummary,
+  type PaginatedResponse,
+  type ProfileConfigResponse,
+  type SettingsResponse,
+  type Stage,
+  type StageState,
+  STAGES,
+} from "@jobhunter/contracts";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+type View = "dashboard" | "jobs" | "artifacts" | "profile";
+type Direction = "asc" | "desc";
+type LoadState = "idle" | "loading" | "ready" | "error";
+
+const api = createJobHunterApiClient(import.meta.env.VITE_JOBHUNTER_API_BASE_URL ?? "");
+
+const jobSortFields = [
+  ["discovered_at", "Discovered"],
+  ["title", "Title"],
+  ["company", "Company"],
+  ["fit_score", "Fit score"],
+  ["current_stage", "Stage"],
+  ["current_state", "State"],
+] as const;
+
+const artifactSortFields = [
+  ["created_at", "Created"],
+  ["title", "Title"],
+  ["company", "Company"],
+  ["type", "Type"],
+  ["status", "Status"],
+  ["size_bytes", "Size"],
+] as const;
+
+export function App(): JSX.Element {
+  const [view, setView] = useState<View>("dashboard");
+  const [density, setDensity] = useState("regular");
+  const [connected, setConnected] = useState(false);
+  const [status, setStatus] = useState<LoadState>("idle");
+  const [error, setError] = useState("");
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const [selectedJobKey, setSelectedJobKey] = useState("");
+
+  const refreshSummary = useCallback(async () => {
+    setStatus("loading");
+    setError("");
+    try {
+      await api.health();
+      setConnected(true);
+      setSummary(await api.dashboardSummary());
+      setStatus("ready");
+    } catch (requestError) {
+      setConnected(false);
+      setStatus("error");
+      setError(requestError instanceof Error ? requestError.message : "Unable to reach JobHunter API.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshSummary();
+  }, [refreshSummary]);
+
+  const selectKpi = (target: "all" | "failed" | "blocked" | "ready") => {
+    setView("jobs");
+    window.dispatchEvent(new CustomEvent("jobhunter:set-jobs-filter", { detail: target }));
+  };
+
+  return (
+    <div className="app" data-density={density}>
+      <header className="topbar">
+        <button className="brand" onClick={() => setView("dashboard")} type="button">
+          <span className="brand-mark">jh</span>
+          <span>jobhunter</span>
+        </button>
+        <nav className="nav" aria-label="Main navigation">
+          {(["dashboard", "jobs", "artifacts", "profile"] as const).map((item) => (
+            <button className={view === item ? "on" : ""} key={item} onClick={() => setView(item)} type="button">
+              {item}
+            </button>
+          ))}
+        </nav>
+        <select className="select" value={density} onChange={(event) => setDensity(event.target.value)}>
+          <option value="compact">compact</option>
+          <option value="regular">regular</option>
+          <option value="comfy">comfy</option>
+        </select>
+        <button className="tab" onClick={() => void refreshSummary()} type="button">
+          refresh
+        </button>
+        <span className={`pulse ${connected ? "" : "offline"}`}>{connected ? "live" : "offline"}</span>
+      </header>
+
+      {summary ? <Kpis summary={summary} onSelect={selectKpi} /> : <KpiSkeleton />}
+
+      {error ? <div className="banner">{error}</div> : null}
+
+      <main className="main">
+        {view === "dashboard" ? (
+          <Dashboard summary={summary} status={status} onOpenJobs={selectKpi} />
+        ) : view === "jobs" ? (
+          <JobsView onOpenJob={setSelectedJobKey} />
+        ) : view === "artifacts" ? (
+          <ArtifactsView onOpenJob={setSelectedJobKey} />
+        ) : (
+          <ProfileView />
+        )}
+      </main>
+
+      {selectedJobKey ? <JobDrawer jobKey={selectedJobKey} onClose={() => setSelectedJobKey("")} /> : null}
+    </div>
+  );
+}
+
+function Kpis({
+  summary,
+  onSelect,
+}: {
+  summary: DashboardSummary;
+  onSelect: (target: "all" | "failed" | "blocked" | "ready") => void;
+}): JSX.Element {
+  const items = [
+    ["Jobs", summary.totals.jobs, "+0 today", "all", ""],
+    ["Failures", summary.totals.failures, "needs retry", "failed", "alert"],
+    ["Blocked", summary.totals.blocked, "upstream missing", "blocked", "warn"],
+    ["Ready", summary.totals.ready, "ready queue", "ready", "ok"],
+    ["Applied", summary.totals.applied, "+0 today", "all", ""],
+    ["Dry runs", summary.totals.dryRuns, "today excluded", "all", ""],
+  ] as const;
+  return (
+    <section className="kpis">
+      {items.map(([label, value, caption, target, tone]) => (
+        <button className={`kpi ${tone ? `tone-${tone}` : ""}`} key={label} onClick={() => onSelect(target)} type="button">
+          <span className="kpi-lbl">{label}</span>
+          <span className="kpi-val">{value}</span>
+          <span className="kpi-delta">{caption}</span>
+        </button>
+      ))}
+    </section>
+  );
+}
+
+function KpiSkeleton(): JSX.Element {
+  return (
+    <section className="kpis">
+      {["Jobs", "Failures", "Blocked", "Ready", "Applied", "Dry runs"].map((label) => (
+        <div className="kpi" key={label}>
+          <span className="kpi-lbl">{label}</span>
+          <span className="kpi-val">-</span>
+          <span className="kpi-delta">waiting for API</span>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function Dashboard({
+  summary,
+  status,
+  onOpenJobs,
+}: {
+  summary: DashboardSummary | null;
+  status: LoadState;
+  onOpenJobs: (target: "all" | "failed" | "blocked" | "ready") => void;
+}): JSX.Element {
+  if (!summary) {
+    return <Empty title={status === "loading" ? "Loading dashboard." : "No dashboard data."} />;
+  }
+  return (
+    <div className="dashboard-grid">
+      <section className="card span-2">
+        <CardHeader title="Pipeline" meta={`${summary.totals.jobs} jobs`} />
+        <div className="funnel">
+          {summary.funnel.map((stage, index) => (
+            <button className="funnel-row" key={stage.stage} onClick={() => onOpenJobs("all")} type="button">
+              <span className="funnel-stage">
+                <span className="funnel-num">{String(index + 1).padStart(2, "0")}</span> {stage.stage}
+              </span>
+              <SegmentBar
+                total={stage.total}
+                values={[
+                  ["done", stage.succeeded],
+                  ["failed", stage.failed],
+                  ["blocked", stage.blocked],
+                  ["pending", stage.pending + stage.running],
+                ]}
+              />
+              <span className="legend">
+                {stage.failed ? <span className="failed">{stage.failed} failed</span> : null}
+                {stage.blocked ? <span className="blocked">{stage.blocked} blocked</span> : null}
+                <span>{stage.pending} pending</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+      <section className="card">
+        <CardHeader title="Apply runs" meta={`${summary.applyRuns.length} recent`} />
+        <div className="rows">
+          {summary.applyRuns.length ? (
+            summary.applyRuns.map((run) => (
+              <div className="mini-row" key={run.runId}>
+                <StatusDot state={run.status === "running" ? "running" : run.status === "failed" ? "failed" : "succeeded"} />
+                <span className="title-stack">
+                  <b>{run.title}</b>
+                  <span>{run.company}</span>
+                </span>
+                {run.dryRun ? <span className="tag info">dry-run</span> : null}
+              </div>
+            ))
+          ) : (
+            <Empty title="No apply runs." />
+          )}
+        </div>
+      </section>
+      <section className="card">
+        <CardHeader title="Recent activity" meta={`${summary.activity.length} events`} />
+        <div className="rows">
+          {summary.activity.length ? (
+            summary.activity.map((activity, index) => (
+              <div className="activity-row" key={`${activity.at}-${index}`}>
+                <span className={`tag ${activity.level === "error" ? "danger" : "muted"}`}>{activity.level}</span>
+                <span className="stage-pill">{activity.stage}</span>
+                <span>{activity.message}</span>
+              </div>
+            ))
+          ) : (
+            <Empty title="No activity yet." />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.Element {
+  const [data, setData] = useState<PaginatedResponse<JobSummary> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [stage, setStage] = useState<Stage | "all">("all");
+  const [state, setState] = useState<StageState | "all">("all");
+  const [sort, setSort] = useState("discovered_at");
+  const [dir, setDir] = useState<Direction>("desc");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(50);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setData(
+        await api.jobs({
+          page,
+          pageSize,
+          q: query,
+          sort: sort as never,
+          dir,
+          stage: stage === "all" ? undefined : stage,
+          state: state === "all" ? undefined : state,
+        }),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [dir, page, pageSize, query, sort, stage, state]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const listener = (event: Event) => {
+      const target = (event as CustomEvent<string>).detail;
+      setPage(1);
+      if (target === "failed") {
+        setState("failed");
+        setStage("all");
+      } else if (target === "blocked") {
+        setState("blocked");
+        setStage("all");
+      } else if (target === "ready") {
+        setStage("apply");
+        setState("pending");
+      } else {
+        setStage("all");
+        setState("all");
+      }
+    };
+    window.addEventListener("jobhunter:set-jobs-filter", listener);
+    return () => window.removeEventListener("jobhunter:set-jobs-filter", listener);
+  }, []);
+
+  return (
+    <section className="card full">
+      <CardHeader title="Jobs" meta={data ? `${data.pagination.total} total` : "loading"} />
+      <div className="toolbar">
+        <input aria-label="Search jobs" placeholder="Filter jobs, companies, errors..." value={query} onChange={(event) => setQuery(event.target.value)} />
+        <select value={stage} onChange={(event) => setStage(event.target.value as Stage | "all")}>
+          <option value="all">all stages</option>
+          {STAGES.map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+        <select value={state} onChange={(event) => setState(event.target.value as StageState | "all")}>
+          {["all", "pending", "running", "succeeded", "failed", "blocked", "exhausted", "stale"].map((item) => (
+            <option key={item} value={item}>
+              {item} states
+            </option>
+          ))}
+        </select>
+        <SelectPairs options={jobSortFields} value={sort} onChange={setSort} />
+        <DirectionSelect value={dir} onChange={setDir} />
+        <PageSize value={pageSize} onChange={setPageSize} />
+        <button className="tab" onClick={() => void load()} type="button">
+          refresh
+        </button>
+      </div>
+      <div className="table">
+        {loading && !data ? <Empty title="Loading jobs." /> : null}
+        {data?.items.map((job) => (
+          <button className="data-row job" key={job.jobKey} onClick={() => onOpenJob(job.jobKey)} type="button">
+            <span className={`fit ${scoreTier(job.fitScore)}`}>{job.fitScore ?? "-"}</span>
+            <span className="title-stack">
+              <b>{job.title}</b>
+              <span>{job.company}</span>
+            </span>
+            <span>{job.location || "-"}</span>
+            <span>
+              <span className="stage-pill">{job.currentStage}</span> <span className={`tag ${stateTone(job.currentState)}`}>{job.currentState}</span>
+            </span>
+            <span className="mono">{job.discoveredAt ? new Date(job.discoveredAt).toLocaleDateString() : "-"}</span>
+          </button>
+        ))}
+        {data && data.items.length === 0 ? <Empty title="No jobs match." /> : null}
+      </div>
+      <Pager pagination={data?.pagination} page={page} onPage={setPage} />
+    </section>
+  );
+}
+
+function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.Element {
+  const [data, setData] = useState<PaginatedResponse<ArtifactSummary> | null>(null);
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("all");
+  const [sort, setSort] = useState("created_at");
+  const [dir, setDir] = useState<Direction>("desc");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(50);
+
+  const load = useCallback(async () => {
+    setData(
+      await api.artifacts({
+        page,
+        pageSize,
+        q: query,
+        sort: sort as never,
+        dir,
+        status: status === "all" ? "" : status,
+      }),
+    );
+  }, [dir, page, pageSize, query, sort, status]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <section className="card full">
+      <CardHeader title="Artifacts" meta={data ? `${data.pagination.total} total` : "loading"} />
+      <div className="toolbar">
+        <input aria-label="Search artifacts" placeholder="Filter artifacts..." value={query} onChange={(event) => setQuery(event.target.value)} />
+        <select value={status} onChange={(event) => setStatus(event.target.value)}>
+          {["all", "active", "approved", "candidate", "stale"].map((item) => (
+            <option key={item} value={item}>
+              {item}
+            </option>
+          ))}
+        </select>
+        <SelectPairs options={artifactSortFields} value={sort} onChange={setSort} />
+        <DirectionSelect value={dir} onChange={setDir} />
+        <PageSize value={pageSize} onChange={setPageSize} />
+        <button className="tab" onClick={() => void load()} type="button">
+          refresh
+        </button>
+      </div>
+      <div className="table">
+        {data?.items.map((artifact) => (
+          <button className="data-row artifact" key={artifact.artifactId} onClick={() => onOpenJob(artifact.jobKey)} type="button">
+            <span className={`tag ${artifact.status === "active" ? "ok" : "muted"}`}>{artifact.status}</span>
+            <span className="title-stack">
+              <b>{artifact.title}</b>
+              <span>{artifact.company}</span>
+            </span>
+            <span>{artifact.type}</span>
+            <span className="path-cell">{artifact.localPath}</span>
+            <span className="mono">{artifact.size}</span>
+          </button>
+        ))}
+        {data && data.items.length === 0 ? <Empty title="No artifacts match." /> : null}
+      </div>
+      <Pager pagination={data?.pagination} page={page} onPage={setPage} />
+    </section>
+  );
+}
+
+function ProfileView(): JSX.Element {
+  const [profile, setProfile] = useState<ProfileConfigResponse | null>(null);
+  const [settings, setSettings] = useState<SettingsResponse | null>(null);
+  const [profileText, setProfileText] = useState("");
+  const [styleText, setStyleText] = useState("");
+  const [templateText, setTemplateText] = useState("");
+  const [showImport, setShowImport] = useState(true);
+  const [loadRevision, setLoadRevision] = useState(0);
+
+  useEffect(() => {
+    async function load() {
+      const [profileResponse, settingsResponse] = await Promise.all([api.profile(), api.settings()]);
+      setProfile(profileResponse);
+      setSettings(settingsResponse);
+      setProfileText(JSON.stringify(profileResponse.profile, null, 2));
+      setStyleText(JSON.stringify(profileResponse.style, null, 2));
+      setTemplateText(profileResponse.templateText);
+      setLoadRevision((value) => value + 1);
+    }
+    void load();
+  }, []);
+
+  const profileName = useMemo(() => extractName(profile?.profile), [profile]);
+
+  return (
+    <div className="profile-layout">
+      <section className="card">
+        <CardHeader title="Profile" meta={settings ? `min fit ${settings.settings.minFitScore}` : "loading"} />
+        {showImport ? (
+          <section className="import-panel">
+            <label className="import-target">
+              <span className="import-icon">PDF</span>
+              <span>
+                <b>Resume PDF</b>
+                <small>No file selected</small>
+              </span>
+              <input aria-label="Resume PDF" type="file" accept="application/pdf" />
+              <em>choose file</em>
+            </label>
+            <div className="import-options">
+              <label>
+                <input type="checkbox" defaultChecked /> profile data
+              </label>
+              <label>
+                <input type="checkbox" defaultChecked /> style data
+              </label>
+              <button className="tab" disabled type="button">
+                import
+              </button>
+              <button className="tab" onClick={() => setShowImport(false)} type="button">
+                hide
+              </button>
+            </div>
+          </section>
+        ) : (
+          <button className="tab" onClick={() => setShowImport(true)} type="button">
+            show import
+          </button>
+        )}
+        <Editor label="profile.json" revision={loadRevision} value={profileText} onChange={setProfileText} />
+        <Editor label="resume_style.json" revision={loadRevision} value={styleText} onChange={setStyleText} />
+        <Editor label="resume_template.tex" revision={loadRevision} value={templateText} onChange={setTemplateText} />
+      </section>
+      <aside className="preview">
+        <div className="preview-page">
+          <h1>{profileName || "Profile preview"}</h1>
+          <p className="muted">{extractContact(profile?.profile)}</p>
+          <h2>Executive profile</h2>
+          <p>{extractSummary(profile?.profile)}</p>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void }): JSX.Element {
+  const [detail, setDetail] = useState<JobDetail | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setDetail(null);
+    setError("");
+    api
+      .job(jobKey)
+      .then(setDetail)
+      .catch((requestError: unknown) => setError(requestError instanceof Error ? requestError.message : "Unable to load job."));
+  }, [jobKey]);
+
+  return (
+    <div className="drawer-backdrop">
+      <aside className="drawer">
+        <button className="drawer-close" onClick={onClose} type="button">
+          x
+        </button>
+        {error ? <Empty title={error} /> : null}
+        {!detail && !error ? <Empty title="Loading job." /> : null}
+        {detail ? (
+          <>
+            <div className="drawer-head">
+              <span className={`fit ${scoreTier(detail.job.fitScore)}`}>{detail.job.fitScore ?? "-"}</span>
+              <span>
+                <small>{detail.job.company}</small>
+                <h2>{detail.job.title}</h2>
+                <p>{detail.job.location || "-"} · {detail.job.salary || "-"}</p>
+              </span>
+            </div>
+            <div className="notice">
+              <b>{detail.job.nextAction || "Next action"}</b>
+              <code>{`jobhunter retry ${detail.job.currentStage} ${detail.job.jobKey}`}</code>
+            </div>
+            <div className="timeline">
+              {detail.stages.map((stage) => (
+                <div key={stage.stage}>
+                  <StatusDot state={stage.state} />
+                  <b>{stage.stage}</b>
+                  <span>{stage.state}</span>
+                </div>
+              ))}
+            </div>
+            <Section title="Artifacts">
+              {detail.artifacts.map((artifact) => (
+                <div className="mini-row" key={artifact.artifactId}>
+                  <span className={`tag ${artifact.status === "active" ? "ok" : "muted"}`}>{artifact.status}</span>
+                  <span>{artifact.type}</span>
+                  <code>{artifact.localPath}</code>
+                </div>
+              ))}
+            </Section>
+            <Section title="Score reasoning">
+              <p>{detail.job.scoreReasoning || "-"}</p>
+            </Section>
+            <Section title="Description preview">
+              <p>{detail.job.descriptionPreview || "-"}</p>
+            </Section>
+          </>
+        ) : null}
+      </aside>
+    </div>
+  );
+}
+
+function CardHeader({ title, meta }: { title: string; meta?: string }): JSX.Element {
+  return (
+    <header className="card-hd">
+      <h2>{title}</h2>
+      {meta ? <span className="meta">{meta}</span> : null}
+    </header>
+  );
+}
+
+function SegmentBar({ total, values }: { total: number; values: Array<[string, number]> }): JSX.Element {
+  return (
+    <span className="bar">
+      {values.map(([name, value]) => (
+        <span className={`seg-${name}`} key={name} style={{ width: `${total ? (value / total) * 100 : 0}%` }} />
+      ))}
+    </span>
+  );
+}
+
+function Pager({
+  pagination,
+  page,
+  onPage,
+}: {
+  pagination?: PaginatedResponse<unknown>["pagination"];
+  page: number;
+  onPage: (page: number) => void;
+}): JSX.Element {
+  return (
+    <div className="pager">
+      <button className="tab" disabled={page <= 1} onClick={() => onPage(page - 1)} type="button">
+        previous
+      </button>
+      <span className="meta">
+        page {pagination?.page ?? page} / {pagination?.pages ?? 1}
+      </span>
+      <button className="tab" disabled={page >= (pagination?.pages ?? 1)} onClick={() => onPage(page + 1)} type="button">
+        next
+      </button>
+    </div>
+  );
+}
+
+function Editor({
+  label,
+  revision,
+  value,
+  onChange,
+}: {
+  label: string;
+  revision: number;
+  value: string;
+  onChange: (value: string) => void;
+}): JSX.Element {
+  const [original, setOriginal] = useState(value);
+  const dirty = value !== original;
+
+  useEffect(() => {
+    setOriginal(value);
+  }, [revision]);
+
+  return (
+    <label className={`editor ${dirty ? "dirty" : ""}`}>
+      <span>
+        {label}
+        {dirty ? (
+          <span className="field-actions-inline">
+            <button
+              className="tab on"
+              onClick={(event) => {
+                event.preventDefault();
+                setOriginal(value);
+              }}
+              type="button"
+            >
+              save draft
+            </button>
+            <button
+              className="tab"
+              onClick={(event) => {
+                event.preventDefault();
+                onChange(original);
+              }}
+              type="button"
+            >
+              discard
+            </button>
+          </span>
+        ) : null}
+      </span>
+      <textarea value={value} onChange={(event) => onChange(event.target.value)} />
+    </label>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }): JSX.Element {
+  return (
+    <section className="section">
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function SelectPairs({
+  options,
+  value,
+  onChange,
+}: {
+  options: readonly (readonly [string, string])[];
+  value: string;
+  onChange: (value: string) => void;
+}): JSX.Element {
+  return (
+    <select value={value} onChange={(event) => onChange(event.target.value)}>
+      {options.map(([item, label]) => (
+        <option key={item} value={item}>
+          {label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function DirectionSelect({ value, onChange }: { value: Direction; onChange: (value: Direction) => void }): JSX.Element {
+  return (
+    <select value={value} onChange={(event) => onChange(event.target.value as Direction)}>
+      <option value="desc">desc</option>
+      <option value="asc">asc</option>
+    </select>
+  );
+}
+
+function PageSize({ value, onChange }: { value: number; onChange: (value: number) => void }): JSX.Element {
+  return (
+    <select value={value} onChange={(event) => onChange(Number(event.target.value))}>
+      {[25, 50, 100, 200].map((item) => (
+        <option key={item} value={item}>
+          {item}/page
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function StatusDot({ state }: { state: string }): JSX.Element {
+  return <span className={`status-dot ${state}`} />;
+}
+
+function Empty({ title }: { title: string }): JSX.Element {
+  return <div className="empty">{title}</div>;
+}
+
+function scoreTier(score: number | null): string {
+  if ((score ?? 0) >= 8) {
+    return "good";
+  }
+  if ((score ?? 0) >= 6) {
+    return "mid";
+  }
+  return "none";
+}
+
+function stateTone(state: string): string {
+  if (["failed", "exhausted"].includes(state)) {
+    return "danger";
+  }
+  if (state === "blocked") {
+    return "warn";
+  }
+  if (state === "succeeded") {
+    return "ok";
+  }
+  return "muted";
+}
+
+function extractName(profile: unknown): string {
+  return readString(profile, ["personal", "full_name"]);
+}
+
+function extractContact(profile: unknown): string {
+  return [readString(profile, ["personal", "email"]), readString(profile, ["personal", "phone"]), readString(profile, ["personal", "city"])]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function extractSummary(profile: unknown): string {
+  return readString(profile, ["resume", "executive_profile_baseline"]) || readString(profile, ["resume", "summary"]) || "-";
+}
+
+function readString(source: unknown, path: string[]): string {
+  let value = source;
+  for (const part of path) {
+    if (!value || typeof value !== "object" || !(part in value)) {
+      return "";
+    }
+    value = (value as Record<string, unknown>)[part];
+  }
+  return typeof value === "string" ? value : "";
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App.js";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,0 +1,699 @@
+:root {
+  --bg: #fafaf7;
+  --paper: #fff;
+  --paper-2: #f5f4ef;
+  --rule: rgba(20, 18, 12, 0.1);
+  --rule-2: rgba(20, 18, 12, 0.18);
+  --ink: #1d1c18;
+  --muted: #737067;
+  --soft: #a09c90;
+  --danger: #b5473a;
+  --warn: #a97721;
+  --ok: #397b57;
+  --info: #617892;
+  --font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --mono: "SFMono-Regular", ui-monospace, Menlo, monospace;
+  --row: 42px;
+}
+
+[data-density="compact"] {
+  --row: 34px;
+  font-size: 12px;
+}
+
+[data-density="comfy"] {
+  --row: 50px;
+  font-size: 14px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--font);
+  font-size: 13px;
+}
+
+button,
+input,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+code,
+.mono {
+  font-family: var(--mono);
+  font-size: 0.92em;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 14px 24px;
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  font-weight: 700;
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 5px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.nav {
+  display: flex;
+  gap: 4px;
+}
+
+.nav button,
+.tab {
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  padding: 6px 10px;
+  color: var(--muted);
+}
+
+.nav button:hover,
+.nav button.on,
+.tab:hover,
+.tab.on {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.tab:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.select,
+select,
+input,
+textarea {
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  background: var(--paper);
+  padding: 7px 9px;
+}
+
+.pulse {
+  margin-left: auto;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+.pulse::before {
+  content: "";
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 6px;
+  border-radius: 50%;
+  background: var(--ok);
+}
+
+.pulse.offline::before {
+  background: var(--danger);
+}
+
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  background: var(--paper);
+  border-bottom: 1px solid var(--rule);
+}
+
+.kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  border: 0;
+  border-right: 1px solid var(--rule);
+  background: transparent;
+  padding: 14px 20px;
+  text-align: left;
+}
+
+.kpi:hover {
+  background: var(--paper-2);
+}
+
+.kpi-lbl {
+  color: var(--soft);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.kpi-val {
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.kpi-delta,
+.meta,
+.muted {
+  color: var(--muted);
+}
+
+.tone-alert .kpi-val,
+.danger {
+  color: var(--danger);
+}
+
+.tone-warn .kpi-val,
+.warn {
+  color: var(--warn);
+}
+
+.tone-ok .kpi-val,
+.ok {
+  color: var(--ok);
+}
+
+.main {
+  padding: 18px 24px 80px;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(340px, 0.8fr);
+  gap: 18px;
+}
+
+.span-2 {
+  grid-row: span 2;
+}
+
+.card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--paper);
+}
+
+.card.full {
+  width: 100%;
+}
+
+.card-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.card-hd h2 {
+  margin: 0;
+  font-size: 14px;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.toolbar input {
+  min-width: min(420px, 100%);
+  flex: 1;
+}
+
+.funnel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 8px 12px;
+}
+
+.funnel-row {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr) 220px;
+  align-items: center;
+  gap: 14px;
+  min-height: var(--row);
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.funnel-row:hover,
+.data-row:hover {
+  background: var(--paper-2);
+}
+
+.funnel-num,
+.stage-pill,
+.tag,
+.meta {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.bar {
+  display: flex;
+  height: 10px;
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 3px;
+  background: var(--paper-2);
+}
+
+.seg-done {
+  background: var(--ink);
+}
+
+.seg-failed {
+  background: var(--danger);
+}
+
+.seg-blocked {
+  background: var(--warn);
+}
+
+.seg-pending {
+  background: var(--soft);
+}
+
+.legend {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.rows,
+.table {
+  display: flex;
+  flex-direction: column;
+}
+
+.data-row {
+  display: grid;
+  align-items: center;
+  width: 100%;
+  min-height: var(--row);
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  padding: 9px 16px;
+  text-align: left;
+}
+
+.data-row.job {
+  grid-template-columns: 54px minmax(220px, 1.2fr) minmax(160px, 0.8fr) 210px 120px;
+  gap: 14px;
+}
+
+.data-row.artifact {
+  grid-template-columns: 92px minmax(220px, 1fr) 160px minmax(240px, 1.3fr) 90px;
+  gap: 14px;
+}
+
+.mini-row,
+.activity-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  min-height: var(--row);
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.activity-row {
+  grid-template-columns: 70px 90px minmax(0, 1fr);
+}
+
+.title-stack {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.title-stack b,
+.title-stack span,
+.path-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.title-stack span,
+.path-cell {
+  color: var(--muted);
+}
+
+.fit {
+  display: inline-flex;
+  width: 38px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper-2);
+  font-family: var(--mono);
+}
+
+.fit.good {
+  border-color: rgba(57, 123, 87, 0.3);
+  background: rgba(57, 123, 87, 0.1);
+  color: var(--ok);
+}
+
+.fit.mid {
+  color: var(--warn);
+}
+
+.tag,
+.stage-pill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 4px;
+  background: var(--paper-2);
+  padding: 2px 6px;
+}
+
+.tag.ok {
+  background: rgba(57, 123, 87, 0.1);
+  color: var(--ok);
+}
+
+.tag.warn {
+  background: rgba(169, 119, 33, 0.12);
+  color: var(--warn);
+}
+
+.tag.danger {
+  background: rgba(181, 71, 58, 0.1);
+  color: var(--danger);
+}
+
+.tag.info {
+  background: rgba(97, 120, 146, 0.1);
+  color: var(--info);
+}
+
+.pager {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--rule);
+}
+
+.empty,
+.banner {
+  padding: 28px 16px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.banner {
+  border-bottom: 1px solid var(--rule);
+  background: rgba(181, 71, 58, 0.08);
+  color: var(--danger);
+}
+
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: flex;
+  justify-content: flex-end;
+  background: rgba(20, 18, 12, 0.35);
+}
+
+.drawer {
+  width: min(760px, 58vw);
+  overflow: auto;
+  background: var(--paper);
+  box-shadow: -18px 0 42px rgba(0, 0, 0, 0.18);
+}
+
+.drawer-close {
+  position: sticky;
+  top: 12px;
+  float: right;
+  margin: 12px;
+  border: 0;
+  background: transparent;
+}
+
+.drawer-head {
+  display: flex;
+  gap: 16px;
+  padding: 24px 28px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.drawer-head h2 {
+  margin: 4px 0;
+  font-size: 22px;
+}
+
+.notice {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 16px 28px;
+  border: 1px solid rgba(199, 103, 69, 0.24);
+  border-radius: 6px;
+  background: rgba(199, 103, 69, 0.1);
+  padding: 12px;
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 10px;
+  padding: 18px 28px;
+  border-bottom: 1px solid var(--rule);
+  text-align: center;
+}
+
+.timeline div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.status-dot {
+  width: 14px;
+  height: 14px;
+  border: 3px solid var(--ink);
+  border-radius: 50%;
+  background: var(--paper);
+}
+
+.status-dot.failed,
+.status-dot.exhausted {
+  border-color: var(--danger);
+}
+
+.status-dot.blocked {
+  border-color: var(--warn);
+}
+
+.status-dot.running,
+.status-dot.queued {
+  border-color: var(--info);
+}
+
+.section {
+  padding: 18px 28px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.section h3 {
+  margin: 0 0 10px;
+  font-size: 13px;
+}
+
+.profile-layout {
+  display: grid;
+  grid-template-columns: minmax(460px, 1.4fr) minmax(360px, 0.8fr);
+  gap: 18px;
+}
+
+.import-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(220px, 1fr);
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.import-target {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-height: 116px;
+  border: 1px dashed var(--rule-2);
+  border-radius: 6px;
+  background: var(--paper-2);
+  padding: 14px;
+}
+
+.import-target span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.import-target input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+}
+
+.import-target em {
+  margin-left: auto;
+  color: var(--muted);
+  font-style: normal;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.import-icon {
+  display: inline-flex;
+  width: 38px;
+  height: 38px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.import-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--rule);
+  color: var(--muted);
+}
+
+.editor textarea {
+  min-height: 180px;
+  resize: vertical;
+  font-family: var(--mono);
+}
+
+.editor.dirty textarea {
+  border-color: var(--warn);
+}
+
+.field-actions-inline {
+  float: right;
+  display: inline-flex;
+  gap: 6px;
+}
+
+.preview {
+  position: sticky;
+  top: 78px;
+  align-self: start;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--paper);
+}
+
+.preview-page {
+  padding: 24px;
+  line-height: 1.45;
+}
+
+.preview-page h1 {
+  margin: 0 0 6px;
+  font-size: 24px;
+}
+
+.preview-page h2 {
+  margin-top: 22px;
+  border-top: 1px solid var(--rule);
+  padding-top: 14px;
+  color: var(--muted);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1000px) {
+  .kpis,
+  .dashboard-grid,
+  .profile-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .drawer {
+    width: min(100vw, 760px);
+  }
+
+  .data-row.job,
+  .data-row.artifact,
+  .funnel-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -311,6 +311,10 @@ textarea {
   background: var(--warn);
 }
 
+.seg-running {
+  background: var(--info);
+}
+
 .seg-pending {
   background: var(--soft);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -460,6 +460,11 @@ textarea {
   color: var(--danger);
 }
 
+.banner.inline {
+  padding: 12px 16px;
+  text-align: left;
+}
+
 .drawer-backdrop {
   position: fixed;
   inset: 0;

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,10 @@
+import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [react()],
-  root: new URL(".", import.meta.url).pathname,
+  root: fileURLToPath(new URL(".", import.meta.url)),
   envPrefix: "VITE_",
   server: {
     port: 5173,
@@ -17,4 +18,3 @@ export default defineConfig({
     emptyOutDir: true,
   },
 });
-

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,20 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  root: new URL(".", import.meta.url).pathname,
+  envPrefix: "VITE_",
+  server: {
+    port: 5173,
+    strictPort: false,
+    proxy: {
+      "/v1": "http://127.0.0.1:8766",
+    },
+  },
+  build: {
+    outDir: "../../dist/web",
+    emptyOutDir: true,
+  },
+});
+

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -71,7 +71,6 @@ types, and `createJobHunterApiClient()` for the future React frontend.
 
 ```bash
 npm test
-npm run web:build
 uv run pytest tests/test_dashboard_server.py -q
 ```
 

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -27,6 +27,16 @@ The API defaults to:
 http://127.0.0.1:8766
 ```
 
+The React frontend shell is under `apps/web`:
+
+```bash
+npm run web:dev
+```
+
+The Vite dev server proxies `/v1/*` to the local API at
+`http://127.0.0.1:8766`. Set `VITE_JOBHUNTER_API_BASE_URL` if the API is bound
+elsewhere.
+
 Environment variables:
 
 - `JOBHUNTER_DIR`: local app directory, default `~/.jobhunter`
@@ -61,6 +71,7 @@ types, and `createJobHunterApiClient()` for the future React frontend.
 
 ```bash
 npm test
+npm run web:build
 uv run pytest tests/test_dashboard_server.py -q
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,9 @@
       "name": "@jobhunter/web",
       "version": "0.3.0",
       "dependencies": {
-        "@jobhunter/contracts": "file:../../packages/contracts"
+        "@jobhunter/contracts": "file:../../packages/contracts",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,43 +25,324 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.6.0",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.1",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3",
+        "vite": "^7.3.0",
         "vitest": "^4.1.5"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
+    "apps/web": {
+      "name": "@jobhunter/web",
+      "version": "0.3.0",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
+        "@jobhunter/contracts": "file:../../packages/contracts"
       }
     },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -641,6 +922,42 @@
       "resolved": "packages/contracts",
       "link": true
     },
+    "node_modules/@jobhunter/web": {
+      "resolved": "apps/web",
+      "link": true
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -648,33 +965,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -683,10 +982,31 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
-    "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
       "cpu": [
         "arm64"
       ],
@@ -695,15 +1015,12 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
       "cpu": [
         "arm64"
       ],
@@ -712,15 +1029,12 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
       "cpu": [
         "x64"
       ],
@@ -729,15 +1043,26 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
       "cpu": [
         "x64"
       ],
@@ -746,15 +1071,12 @@
       "optional": true,
       "os": [
         "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
       "cpu": [
         "arm"
       ],
@@ -763,15 +1085,26 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
       "cpu": [
         "arm64"
       ],
@@ -780,15 +1113,12 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
       ],
@@ -797,15 +1127,40 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
       "cpu": [
         "ppc64"
       ],
@@ -814,15 +1169,54 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
       "cpu": [
         "s390x"
       ],
@@ -831,15 +1225,12 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
       "cpu": [
         "x64"
       ],
@@ -848,15 +1239,12 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
       ],
@@ -865,15 +1253,26 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
       "cpu": [
         "arm64"
       ],
@@ -882,34 +1281,12 @@
       "optional": true,
       "os": [
         "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
       "cpu": [
         "arm64"
       ],
@@ -918,15 +1295,26 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
       "cpu": [
         "x64"
       ],
@@ -935,17 +1323,21 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      ]
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -954,15 +1346,49 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "tslib": "^2.4.0"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/better-sqlite3": {
@@ -1008,6 +1434,47 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1221,6 +1688,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "12.9.0",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
@@ -1255,6 +1735,40 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1278,6 +1792,27 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -1313,6 +1848,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -1356,6 +1916,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -1413,6 +1980,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -1622,6 +2199,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -1682,6 +2269,26 @@
         "node": ">= 10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
@@ -1706,6 +2313,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/light-my-request": {
       "version": "6.6.0",
@@ -1750,6 +2370,8 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -1787,6 +2409,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1808,6 +2431,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1829,6 +2453,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1850,6 +2475,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1871,6 +2497,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1892,6 +2519,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1913,6 +2541,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1934,6 +2563,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1955,6 +2585,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1976,6 +2607,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -1997,12 +2629,23 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
@@ -2042,6 +2685,13 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -2078,6 +2728,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -2275,6 +2932,39 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -2342,38 +3032,49 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
-    "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@types/estree": "1.0.8"
       },
       "bin": {
-        "rolldown": "bin/cli.mjs"
+        "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -2426,6 +3127,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -2666,14 +3374,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
@@ -2727,6 +3427,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2734,17 +3465,18 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2760,10 +3492,9 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -2776,16 +3507,13 @@
         "@types/node": {
           "optional": true
         },
-        "@vitejs/devtools": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
         "jiti": {
           "optional": true
         },
         "less": {
+          "optional": true
+        },
+        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2922,6 +3650,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "api:start": "tsx services/api/src/main.ts",
     "api:check": "tsc --noEmit",
     "api:test": "vitest run services/api/test",
-    "test": "npm run api:check && npm run api:test"
+    "web:dev": "vite --config apps/web/vite.config.ts --host 127.0.0.1",
+    "web:build": "vite build --config apps/web/vite.config.ts",
+    "web:preview": "vite preview --config apps/web/vite.config.ts --host 127.0.0.1",
+    "test": "npm run api:check && npm run api:test && npm run web:build"
   },
   "repository": {
     "type": "git",
@@ -46,8 +49,14 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.6.0",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
+    "vite": "^7.3.0",
     "vitest": "^4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   "scripts": {
     "api:dev": "tsx services/api/src/main.ts",
     "api:start": "tsx services/api/src/main.ts",
-    "api:check": "tsc --noEmit",
+    "api:check": "tsc --noEmit --project tsconfig.api.json",
     "api:test": "vitest run services/api/test",
+    "web:check": "tsc --noEmit --project tsconfig.web.json",
     "web:dev": "vite --config apps/web/vite.config.ts --host 127.0.0.1",
     "web:build": "vite build --config apps/web/vite.config.ts",
     "web:preview": "vite preview --config apps/web/vite.config.ts --host 127.0.0.1",
-    "test": "npm run api:check && npm run api:test && npm run web:build"
+    "test": "npm run api:check && npm run api:test && npm run web:check && npm run web:build"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.api.json
+++ b/tsconfig.api.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["services/**/*.ts", "packages/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,

--- a/tsconfig.web.json
+++ b/tsconfig.web.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["apps/**/*.ts", "packages/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Add a Vite React frontend shell under apps/web
- Use the shared TypeScript API client for dashboard, jobs, artifacts, job detail, and profile reads
- Add web build scripts and document local React frontend usage

## Verification
- npm test
- uv run pytest -q
- git diff --check
- Headless browser smoke against the Vite app and local TypeScript API