### PR TITLE
feat: make stage state canonical

### DIFF
--- a/src/jobhunter/state.py
+++ b/src/jobhunter/state.py
@@ -128,15 +128,46 @@ def initialize_missing_state_rows(conn=None, limit: int = 0, *, min_score: int =
     """
     if conn is None:
         conn = get_connection()
-    query = "SELECT * FROM jobs ORDER BY discovered_at DESC"
-    params: list[Any] = []
+    query = """
+        SELECT jobs.*
+        FROM jobs
+        LEFT JOIN job_stage_states states ON states.job_url = jobs.url
+        GROUP BY jobs.url
+        HAVING
+            COUNT(states.stage) < ?
+            OR SUM(
+                CASE
+                    WHEN states.stage IS NULL THEN 1
+                    WHEN states.state = 'pending'
+                        AND COALESCE(states.attempt_count, 0) = 0
+                        AND states.error_code IS NULL
+                        AND states.error_message IS NULL
+                        AND states.next_action IS NULL
+                        AND states.started_at IS NULL
+                        AND states.finished_at IS NULL
+                        AND states.duration_ms IS NULL
+                        AND states.blocked_by_json IS NULL
+                    THEN 1
+                    WHEN states.stage = 'discover'
+                        AND states.state = 'succeeded'
+                        AND COALESCE(states.attempt_count, 0) = 0
+                        AND states.started_at IS NULL
+                        AND states.finished_at IS NULL
+                    THEN 1
+                    ELSE 0
+                END
+            ) > 0
+        ORDER BY jobs.discovered_at DESC
+    """
+    params: list[Any] = [len(STAGE_ORDER)]
     if limit > 0:
         query += " LIMIT ?"
         params.append(limit)
     rows = conn.execute(query, params).fetchall()
+    explicit_by_job = _load_all_explicit_states(conn)
     for row in rows:
         job = _row_to_dict(row)
-        _materialize_legacy_stage_rows(conn, job, min_score=min_score)
+        _materialize_legacy_stage_rows(conn, job, min_score=min_score, explicit=explicit_by_job.get(job["url"], {}))
     conn.commit()
     return len(rows)
 
@@ -616,9 +647,27 @@ def _load_explicit_states(conn, job_url: str) -> dict[str, dict[str, Any]]:
     return explicit
 
 
-def _materialize_legacy_stage_rows(conn, job: dict[str, Any], *, min_score: int = 7) -> None:
+def _load_all_explicit_states(conn) -> dict[str, dict[str, dict[str, Any]]]:
+    rows = conn.execute("SELECT * FROM job_stage_states").fetchall()
+    by_job: dict[str, dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        data = _row_to_dict(row)
+        data["blocked_by"] = _json_loads(data.pop("blocked_by_json", None), [])
+        data["metadata"] = _json_loads(data.pop("metadata_json", None), {})
+        data["retryable"] = bool(data.get("retryable", 1))
+        by_job.setdefault(data["job_url"], {})[data["stage"]] = data
+    return by_job
+
+
+def _materialize_legacy_stage_rows(
+    conn,
+    job: dict[str, Any],
+    *,
+    min_score: int = 7,
+    explicit: dict[str, dict[str, Any]] | None = None,
+) -> None:
     """Create canonical rows from legacy job columns without clobbering real state."""
-    explicit = _load_explicit_states(conn, job["url"])
+    explicit = _load_explicit_states(conn, job["url"]) if explicit is None else explicit
     for legacy_state in derive_legacy_stage_states(job, min_score=min_score):
         existing = explicit.get(legacy_state["stage"])
         if existing and not _is_placeholder_state(existing, legacy_state):
@@ -644,17 +693,28 @@ def _materialize_legacy_stage_rows(conn, job: dict[str, Any], *, min_score: int 
 
 def _is_placeholder_state(existing: dict[str, Any], legacy_state: dict[str, Any]) -> bool:
     """Return true for rows created by the old default-row backfill."""
-    if legacy_state["state"] == existing.get("state"):
+    if _has_real_state_fields(existing):
         return False
+    if existing.get("state") == "pending":
+        return True
     return (
-        existing.get("state") == "pending"
-        and int(existing.get("attempt_count") or 0) == 0
-        and not existing.get("error_code")
-        and not existing.get("error_message")
-        and not existing.get("next_action")
-        and not existing.get("blocked_by")
-        and not existing.get("started_at")
-        and not existing.get("finished_at")
+        existing.get("stage") == "discover"
+        and existing.get("state") == "succeeded"
+        and legacy_state.get("state") == "succeeded"
+    )
+
+
+def _has_real_state_fields(existing: dict[str, Any]) -> bool:
+    return (
+        int(existing.get("attempt_count") or 0) != 0
+        or bool(existing.get("error_code"))
+        or bool(existing.get("error_message"))
+        or bool(existing.get("next_action"))
+        or bool(existing.get("blocked_by"))
+        or bool(existing.get("started_at"))
+        or bool(existing.get("finished_at"))
+        or bool(existing.get("duration_ms"))
+        or bool(existing.get("metadata"))
     )
 
 
@@ -668,7 +728,11 @@ def get_job_stage_states(conn, job: dict[str, Any], *, min_score: int = 7) -> li
 
     states: list[dict[str, Any]] = []
     for stage in STAGE_ORDER:
-        states.append(explicit.get(stage) or legacy[stage])
+        existing = explicit.get(stage)
+        if existing and not _is_placeholder_state(existing, legacy[stage]):
+            states.append(existing)
+        else:
+            states.append(legacy[stage])
     return states
 
 

--- a/src/jobhunter/state.py
+++ b/src/jobhunter/state.py
@@ -107,14 +107,16 @@ def ensure_job_stage_rows(conn, job_url: str, *, discovered_at: str | None = Non
     now = utc_now()
     for stage in STAGE_ORDER:
         state = "succeeded" if stage == "discover" else "pending"
+        attempt_count = 1 if stage == "discover" and discovered_at else 0
+        started_at = discovered_at if stage == "discover" else None
         finished_at = discovered_at if stage == "discover" else None
         conn.execute(
             """
             INSERT OR IGNORE INTO job_stage_states (
-                job_url, stage, state, attempt_count, max_attempts, updated_at, finished_at
-            ) VALUES (?, ?, ?, 0, ?, ?, ?)
+                job_url, stage, state, attempt_count, max_attempts, started_at, updated_at, finished_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (job_url, stage, state, MAX_ATTEMPTS.get(stage), now, finished_at),
+            (job_url, stage, state, attempt_count, MAX_ATTEMPTS.get(stage), started_at, now, finished_at),
         )
 
 
@@ -151,8 +153,6 @@ def initialize_missing_state_rows(conn=None, limit: int = 0, *, min_score: int =
                     WHEN states.stage = 'discover'
                         AND states.state = 'succeeded'
                         AND COALESCE(states.attempt_count, 0) = 0
-                        AND states.started_at IS NULL
-                        AND states.finished_at IS NULL
                     THEN 1
                     ELSE 0
                 END
@@ -164,9 +164,11 @@ def initialize_missing_state_rows(conn=None, limit: int = 0, *, min_score: int =
         query += " LIMIT ?"
         params.append(limit)
     rows = conn.execute(query, params).fetchall()
-    explicit_by_job = _load_all_explicit_states(conn)
-    for row in rows:
-        job = _row_to_dict(row)
+    if not rows:
+        return 0
+    jobs = [_row_to_dict(row) for row in rows]
+    explicit_by_job = _load_explicit_states_for_jobs(conn, [job["url"] for job in jobs])
+    for job in jobs:
         _materialize_legacy_stage_rows(conn, job, min_score=min_score, explicit=explicit_by_job.get(job["url"], {}))
     conn.commit()
     return len(rows)
@@ -649,6 +651,18 @@ def _load_explicit_states(conn, job_url: str) -> dict[str, dict[str, Any]]:
 
 def _load_all_explicit_states(conn) -> dict[str, dict[str, dict[str, Any]]]:
     rows = conn.execute("SELECT * FROM job_stage_states").fetchall()
+    return _group_explicit_states(rows)
+
+
+def _load_explicit_states_for_jobs(conn, job_urls: list[str]) -> dict[str, dict[str, dict[str, Any]]]:
+    if not job_urls:
+        return {}
+    placeholders = ",".join("?" for _ in job_urls)
+    rows = conn.execute(f"SELECT * FROM job_stage_states WHERE job_url IN ({placeholders})", job_urls).fetchall()
+    return _group_explicit_states(rows)
+
+
+def _group_explicit_states(rows) -> dict[str, dict[str, dict[str, Any]]]:
     by_job: dict[str, dict[str, dict[str, Any]]] = {}
     for row in rows:
         data = _row_to_dict(row)
@@ -693,6 +707,13 @@ def _materialize_legacy_stage_rows(
 
 def _is_placeholder_state(existing: dict[str, Any], legacy_state: dict[str, Any]) -> bool:
     """Return true for rows created by the old default-row backfill."""
+    if (
+        existing.get("stage") == "discover"
+        and existing.get("state") == "succeeded"
+        and legacy_state.get("state") == "succeeded"
+        and int(existing.get("attempt_count") or 0) == 0
+    ):
+        return True
     if _has_real_state_fields(existing):
         return False
     if existing.get("state") == "pending":

--- a/src/jobhunter/state.py
+++ b/src/jobhunter/state.py
@@ -118,22 +118,25 @@ def ensure_job_stage_rows(conn, job_url: str, *, discovered_at: str | None = Non
         )
 
 
-def initialize_missing_state_rows(conn=None, limit: int = 0) -> int:
+def initialize_missing_state_rows(conn=None, limit: int = 0, *, min_score: int = 7) -> int:
     """Backfill missing stage rows for existing jobs.
 
-    Existing explicit rows are not overwritten. This makes migration safe and
-    cheap enough to run from dashboard generation or startup paths.
+    Existing non-placeholder explicit rows are not overwritten. Missing rows and
+    old auto-created placeholder rows are materialized from the legacy ``jobs``
+    columns once, after which readers can treat ``job_stage_states`` as the
+    canonical source of pipeline truth.
     """
     if conn is None:
         conn = get_connection()
-    query = "SELECT url, discovered_at FROM jobs ORDER BY discovered_at DESC"
+    query = "SELECT * FROM jobs ORDER BY discovered_at DESC"
     params: list[Any] = []
     if limit > 0:
         query += " LIMIT ?"
         params.append(limit)
     rows = conn.execute(query, params).fetchall()
     for row in rows:
-        ensure_job_stage_rows(conn, row["url"], discovered_at=row["discovered_at"])
+        job = _row_to_dict(row)
+        _materialize_legacy_stage_rows(conn, job, min_score=min_score)
     conn.commit()
     return len(rows)
 
@@ -613,27 +616,60 @@ def _load_explicit_states(conn, job_url: str) -> dict[str, dict[str, Any]]:
     return explicit
 
 
+def _materialize_legacy_stage_rows(conn, job: dict[str, Any], *, min_score: int = 7) -> None:
+    """Create canonical rows from legacy job columns without clobbering real state."""
+    explicit = _load_explicit_states(conn, job["url"])
+    for legacy_state in derive_legacy_stage_states(job, min_score=min_score):
+        existing = explicit.get(legacy_state["stage"])
+        if existing and not _is_placeholder_state(existing, legacy_state):
+            continue
+        set_stage_state(
+            conn,
+            job["url"],
+            legacy_state["stage"],
+            legacy_state["state"],
+            attempt_count=legacy_state.get("attempt_count"),
+            max_attempts=legacy_state.get("max_attempts"),
+            started_at=legacy_state.get("started_at"),
+            finished_at=legacy_state.get("finished_at"),
+            duration_ms=legacy_state.get("duration_ms"),
+            error_code=legacy_state.get("error_code"),
+            error_message=legacy_state.get("error_message"),
+            retryable=bool(legacy_state.get("retryable", True)),
+            blocked_by=legacy_state.get("blocked_by") or [],
+            next_action=legacy_state.get("next_action"),
+            metadata=legacy_state.get("metadata") or {},
+        )
+
+
+def _is_placeholder_state(existing: dict[str, Any], legacy_state: dict[str, Any]) -> bool:
+    """Return true for rows created by the old default-row backfill."""
+    if legacy_state["state"] == existing.get("state"):
+        return False
+    return (
+        existing.get("state") == "pending"
+        and int(existing.get("attempt_count") or 0) == 0
+        and not existing.get("error_code")
+        and not existing.get("error_message")
+        and not existing.get("next_action")
+        and not existing.get("blocked_by")
+        and not existing.get("started_at")
+        and not existing.get("finished_at")
+    )
+
+
 def get_job_stage_states(conn, job: dict[str, Any], *, min_score: int = 7) -> list[dict[str, Any]]:
-    """Return merged explicit + legacy stage states for one job."""
+    """Return canonical stage states for one job."""
     legacy = {item["stage"]: item for item in derive_legacy_stage_states(job, min_score=min_score)}
     explicit = _load_explicit_states(conn, job["url"])
-    merged: list[dict[str, Any]] = []
 
+    if not explicit:
+        return [legacy[stage] for stage in STAGE_ORDER]
+
+    states: list[dict[str, Any]] = []
     for stage in STAGE_ORDER:
-        legacy_state = legacy[stage]
-        explicit_state = explicit.get(stage)
-        if not explicit_state:
-            merged.append(legacy_state)
-            continue
-
-        if legacy_state["state"] == "succeeded":
-            merged.append({**explicit_state, **legacy_state})
-        elif explicit_state.get("state") not in (None, "pending"):
-            merged.append({**legacy_state, **explicit_state})
-        else:
-            merged.append(legacy_state)
-
-    return merged
+        states.append(explicit.get(stage) or legacy[stage])
+    return states
 
 
 def _first_actionable_stage(states: list[dict[str, Any]]) -> dict[str, Any] | None:
@@ -791,7 +827,7 @@ def _all_job_summaries(
     *,
     min_score: int,
 ) -> list[tuple[dict[str, Any], dict[str, dict[str, Any]]]]:
-    initialize_missing_state_rows(conn)
+    initialize_missing_state_rows(conn, min_score=min_score)
     rows = conn.execute("SELECT * FROM jobs ORDER BY discovered_at DESC NULLS LAST, title").fetchall()
     summaries = []
     for row in rows:
@@ -1221,7 +1257,7 @@ def build_dashboard_data(
     if min_score is not None:
         settings = config.normalize_dashboard_settings({"min_fit_score": min_score}, base=settings)
     min_score_value = int(settings["min_fit_score"])
-    initialize_missing_state_rows(conn)
+    initialize_missing_state_rows(conn, min_score=min_score_value)
 
     rows = conn.execute("SELECT * FROM jobs ORDER BY discovered_at DESC NULLS LAST, title").fetchall()
     jobs = [_row_to_dict(row) for row in rows]
@@ -1353,7 +1389,8 @@ def build_dashboard_data(
         "apply_runs": apply_runs,
         "job_detail": job_detail,
         "legacy": {
-            "using_legacy_columns": True,
+            "using_legacy_columns": False,
+            "stage_truth": "job_stage_states",
             "state_rows_initialized": True,
         },
     }

--- a/tests/test_state_dashboard.py
+++ b/tests/test_state_dashboard.py
@@ -9,6 +9,7 @@ from jobhunter.state import (
     derive_legacy_stage_states,
     ensure_job_stage_rows,
     get_job_stage_states,
+    initialize_missing_state_rows,
     set_stage_state,
 )
 from jobhunter.view import generate_dashboard
@@ -177,7 +178,8 @@ def test_placeholder_stage_rows_are_upgraded_from_legacy_columns(tmp_path):
         conn.commit()
 
         before = get_job_stage_states(conn, job)
-        assert next(item for item in before if item["stage"] == "score")["state"] == "pending"
+        assert next(item for item in before if item["stage"] == "score")["state"] == "succeeded"
+        assert next(item for item in before if item["stage"] == "apply")["next_action"] == f"jobhunter apply --url {job['url']}"
 
         data = build_dashboard_data(conn)
         after = get_job_stage_states(conn, job)
@@ -185,6 +187,7 @@ def test_placeholder_stage_rows_are_upgraded_from_legacy_columns(tmp_path):
         assert next(item for item in after if item["stage"] == "score")["state"] == "succeeded"
         assert next(item for item in after if item["stage"] == "tailor")["state"] == "succeeded"
         assert any(item["job_url"] == job["url"] for item in data["ready"])
+        assert initialize_missing_state_rows(conn) == 0
     finally:
         close_connection(db_path)
 

--- a/tests/test_state_dashboard.py
+++ b/tests/test_state_dashboard.py
@@ -192,6 +192,36 @@ def test_placeholder_stage_rows_are_upgraded_from_legacy_columns(tmp_path):
         close_connection(db_path)
 
 
+def test_old_discover_placeholder_with_timestamp_is_upgraded(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(conn, job["url"], discovered_at=job["discovered_at"])
+        conn.execute(
+            """
+            UPDATE job_stage_states
+            SET attempt_count = 0, started_at = ?, finished_at = ?
+            WHERE job_url = ? AND stage = 'discover'
+            """,
+            (job["discovered_at"], job["discovered_at"], job["url"]),
+        )
+        conn.commit()
+
+        assert initialize_missing_state_rows(conn) == 1
+
+        discover = conn.execute(
+            "SELECT attempt_count, started_at, finished_at FROM job_stage_states WHERE job_url = ? AND stage = 'discover'",
+            (job["url"],),
+        ).fetchone()
+        assert discover["attempt_count"] == 1
+        assert discover["started_at"] == job["discovered_at"]
+        assert discover["finished_at"] == job["discovered_at"]
+    finally:
+        close_connection(db_path)
+
+
 def test_generate_dashboard_embeds_payload(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)

--- a/tests/test_state_dashboard.py
+++ b/tests/test_state_dashboard.py
@@ -4,7 +4,13 @@ from typer.testing import CliRunner
 
 from jobhunter.cli import app
 from jobhunter.database import close_connection, get_connection, init_db
-from jobhunter.state import build_dashboard_data, derive_legacy_stage_states
+from jobhunter.state import (
+    build_dashboard_data,
+    derive_legacy_stage_states,
+    ensure_job_stage_rows,
+    get_job_stage_states,
+    set_stage_state,
+)
 from jobhunter.view import generate_dashboard
 
 
@@ -104,6 +110,81 @@ def test_dashboard_data_builds_triage_and_ready_queues(tmp_path):
         assert any(item["job_url"] == "https://example.com/broken" for item in data["triage"])
         assert any(item["job_url"] == "https://example.com/ready" for item in data["ready"])
         assert {stage["stage"] for stage in data["funnel"]} >= {"discover", "enrich", "apply"}
+    finally:
+        close_connection(db_path)
+
+
+def test_explicit_stage_state_overrides_legacy_success(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    resume = Path(tmp_path) / "resume.txt"
+    cover = Path(tmp_path) / "cover.txt"
+    resume.with_suffix(".pdf").write_text("%PDF", encoding="utf-8")
+    cover.with_suffix(".pdf").write_text("%PDF", encoding="utf-8")
+    resume.write_text("tailored", encoding="utf-8")
+    cover.write_text("cover", encoding="utf-8")
+
+    try:
+        job = _insert_job(
+            conn,
+            full_description="Build distributed systems.",
+            application_url="https://example.com/apply",
+            fit_score=9,
+            tailored_resume_path=str(resume),
+            cover_letter_path=str(cover),
+        )
+        set_stage_state(
+            conn,
+            job["url"],
+            "score",
+            "failed",
+            error_code="LLM_ERROR",
+            error_message="score failed",
+            next_action=f"jobhunter retry score {job['url']}",
+        )
+
+        data = build_dashboard_data(conn)
+        summary = next(item for item in data["jobs"] if item["job_url"] == job["url"])
+        triage = next(item for item in data["triage"] if item["job_url"] == job["url"])
+
+        assert summary["current_stage"] == "score"
+        assert summary["current_state"] == "failed"
+        assert triage["error_code"] == "LLM_ERROR"
+    finally:
+        close_connection(db_path)
+
+
+def test_placeholder_stage_rows_are_upgraded_from_legacy_columns(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    resume = Path(tmp_path) / "resume.txt"
+    cover = Path(tmp_path) / "cover.txt"
+    resume.write_text("tailored", encoding="utf-8")
+    cover.write_text("cover", encoding="utf-8")
+    resume.with_suffix(".pdf").write_text("%PDF", encoding="utf-8")
+    cover.with_suffix(".pdf").write_text("%PDF", encoding="utf-8")
+
+    try:
+        job = _insert_job(
+            conn,
+            full_description="Build distributed systems.",
+            application_url="https://example.com/apply",
+            fit_score=9,
+            tailored_resume_path=str(resume),
+            cover_letter_path=str(cover),
+        )
+        ensure_job_stage_rows(conn, job["url"], discovered_at=job["discovered_at"])
+        conn.commit()
+
+        before = get_job_stage_states(conn, job)
+        assert next(item for item in before if item["stage"] == "score")["state"] == "pending"
+
+        data = build_dashboard_data(conn)
+        after = get_job_stage_states(conn, job)
+
+        assert next(item for item in after if item["stage"] == "score")["state"] == "succeeded"
+        assert next(item for item in after if item["stage"] == "tailor")["state"] == "succeeded"
+        assert any(item["job_url"] == job["url"] for item in data["ready"])
     finally:
         close_connection(db_path)
 


### PR DESCRIPTION
## Summary
- Materialize legacy-derived stage rows into job_stage_states during local migration
- Treat job_stage_states as the canonical source for current stage, current state, failures, blockers, and next action
- Upgrade old placeholder pending rows without overwriting real explicit stage state

## Verification
- npm test
- uv run pytest -q
- git diff --check