### PR TITLE
feat: add local action entrypoints

### DIFF
--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -67,6 +67,21 @@ sorting over the matching local dataset.
 The shared `@jobhunter/contracts` package exports the request schemas, response
 types, and `createJobHunterApiClient()` for the future React frontend.
 
+## Local Actions
+
+Python automation can also be invoked through a structured local action wrapper:
+
+```bash
+jobhunter action score --limit 5
+jobhunter action apply --url https://example.com/job --dry-run
+jobhunter action profile_import --pdf ~/resume.pdf
+```
+
+The action wrapper records start/finish events in `job_events` and returns a
+JSON result. The current implementation delegates to the existing Python stage
+runners; later API phases can call the same entrypoint instead of executing
+copyable CLI command strings.
+
 ## Verify
 
 ```bash

--- a/src/jobhunter/actions.py
+++ b/src/jobhunter/actions.py
@@ -161,7 +161,7 @@ def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
     if request.stage == "apply":
         from jobhunter.apply.launcher import main as apply_main
 
-        apply_main(
+        applied, failed = apply_main(
             limit=request.limit,
             target_url=request.job_url,
             min_score=request.min_score,
@@ -171,14 +171,14 @@ def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
             continuous=request.continuous,
             workers=request.workers,
         )
-        return {"status": "ok"}
+        return {"status": "ok" if failed == 0 else "failed", "applied": applied, "failed": failed}
     if request.stage == "profile_import":
         if not request.pdf_path:
             raise ValueError("profile_import requires pdf_path.")
         from jobhunter.profile_import import import_resume_pdf
         from jobhunter.scoring.pdf import load_resume_style
 
-        pdf_path = Path(request.pdf_path)
+        pdf_path = Path(request.pdf_path).expanduser()
         draft = import_resume_pdf(
             pdf_path.read_bytes(),
             filename=pdf_path.name,
@@ -195,6 +195,8 @@ def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
 
 def _action_succeeded(result: dict[str, Any]) -> bool:
     if result.get("errors"):
+        return False
+    if int(result.get("failed") or 0) > 0:
         return False
     status = str(result.get("status") or "ok").lower()
     return not status.startswith("error") and status not in {"failed", "failure"}
@@ -270,4 +272,3 @@ def _describe_action(request: LocalActionRequest) -> dict[str, Any]:
         "min_score": request.min_score,
         "validation_mode": request.validation_mode,
     }
-

--- a/src/jobhunter/actions.py
+++ b/src/jobhunter/actions.py
@@ -1,0 +1,273 @@
+"""Structured local action entrypoints for JobHunter automation.
+
+These wrappers give API/UI callers one local surface for invoking existing
+Python automation without pasting shell commands. They intentionally delegate to
+the current stage implementations; later phases can replace the internals with
+queue-backed workers without changing the caller contract.
+"""
+
+from __future__ import annotations
+
+import traceback
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+from uuid import uuid4
+
+from jobhunter import config
+from jobhunter.database import get_connection, init_db
+from jobhunter.pipeline import STAGE_ORDER, run_pipeline
+from jobhunter.state import record_job_event, utc_now
+
+ACTION_STAGES: tuple[str, ...] = (*STAGE_ORDER, "apply", "profile_import")
+
+
+@dataclass(frozen=True)
+class LocalActionRequest:
+    """Input for a local automation action."""
+
+    stage: str
+    job_url: str | None = None
+    limit: int = 0
+    workers: int = 1
+    min_score: int = 7
+    validation_mode: str = "normal"
+    dry_run: bool = False
+    rescore: bool = False
+    retailor: bool = False
+    model: str = "haiku"
+    headless: bool = False
+    continuous: bool = False
+    pdf_path: str | None = None
+    import_profile: bool = True
+    import_style: bool = True
+
+
+@dataclass(frozen=True)
+class LocalActionResult:
+    """Structured result returned by every local action wrapper."""
+
+    ok: bool
+    action_id: str
+    stage: str
+    status: str
+    started_at: str
+    finished_at: str
+    duration_ms: int
+    job_url: str | None = None
+    dry_run: bool = False
+    result: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+    traceback: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def run_local_action(request: LocalActionRequest) -> LocalActionResult:
+    """Run one structured local action and record start/finish events."""
+    if request.stage not in ACTION_STAGES:
+        raise ValueError(f"Unknown action stage: {request.stage}")
+
+    _bootstrap_runtime()
+    action_id = f"act-{uuid4().hex}"
+    started_at = utc_now()
+    start = perf_counter()
+    _record_action_event(
+        request,
+        "action_started",
+        "info",
+        f"{request.stage} action started",
+        {"action_id": action_id, "dry_run": request.dry_run},
+    )
+
+    if request.dry_run:
+        return _finish_action(
+            request,
+            action_id,
+            started_at,
+            start,
+            ok=True,
+            status="dry_run",
+            result={"planned": _describe_action(request)},
+        )
+
+    try:
+        result = _execute_action(request)
+        ok = _action_succeeded(result)
+        status = "succeeded" if ok else "failed"
+        return _finish_action(request, action_id, started_at, start, ok=ok, status=status, result=result)
+    except Exception as exc:  # noqa: BLE001 - action API must return structured failure
+        return _finish_action(
+            request,
+            action_id,
+            started_at,
+            start,
+            ok=False,
+            status="failed",
+            result={},
+            error=str(exc),
+            traceback_text=traceback.format_exc(),
+        )
+
+
+def run_stage_action(
+    stage: str,
+    *,
+    job_url: str | None = None,
+    limit: int = 0,
+    workers: int = 1,
+    min_score: int = 7,
+    validation_mode: str = "normal",
+    dry_run: bool = False,
+    rescore: bool = False,
+    retailor: bool = False,
+) -> LocalActionResult:
+    """Convenience entrypoint for a pipeline stage action."""
+    return run_local_action(
+        LocalActionRequest(
+            stage=stage,
+            job_url=job_url,
+            limit=limit,
+            workers=workers,
+            min_score=min_score,
+            validation_mode=validation_mode,
+            dry_run=dry_run,
+            rescore=rescore,
+            retailor=retailor,
+        )
+    )
+
+
+def _bootstrap_runtime() -> None:
+    config.load_env()
+    config.ensure_dirs()
+    init_db()
+
+
+def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
+    if request.stage in STAGE_ORDER:
+        return run_pipeline(
+            stages=[request.stage],
+            min_score=request.min_score,
+            dry_run=False,
+            workers=request.workers,
+            validation_mode=request.validation_mode,
+            limit=request.limit,
+            rescore=request.rescore,
+            retailor=request.retailor,
+        )
+    if request.stage == "apply":
+        from jobhunter.apply.launcher import main as apply_main
+
+        apply_main(
+            limit=request.limit,
+            target_url=request.job_url,
+            min_score=request.min_score,
+            headless=request.headless,
+            model=request.model,
+            dry_run=False,
+            continuous=request.continuous,
+            workers=request.workers,
+        )
+        return {"status": "ok"}
+    if request.stage == "profile_import":
+        if not request.pdf_path:
+            raise ValueError("profile_import requires pdf_path.")
+        from jobhunter.profile_import import import_resume_pdf
+        from jobhunter.scoring.pdf import load_resume_style
+
+        pdf_path = Path(request.pdf_path)
+        draft = import_resume_pdf(
+            pdf_path.read_bytes(),
+            filename=pdf_path.name,
+            base_profile=config.load_profile(),
+            base_style=load_resume_style(),
+        )
+        if not request.import_profile:
+            draft.pop("profile", None)
+        if not request.import_style:
+            draft.pop("style", None)
+        return {"status": "ok", "draft": draft}
+    raise ValueError(f"Unknown action stage: {request.stage}")
+
+
+def _action_succeeded(result: dict[str, Any]) -> bool:
+    if result.get("errors"):
+        return False
+    status = str(result.get("status") or "ok").lower()
+    return not status.startswith("error") and status not in {"failed", "failure"}
+
+
+def _finish_action(
+    request: LocalActionRequest,
+    action_id: str,
+    started_at: str,
+    start: float,
+    *,
+    ok: bool,
+    status: str,
+    result: dict[str, Any],
+    error: str | None = None,
+    traceback_text: str | None = None,
+) -> LocalActionResult:
+    finished_at = utc_now()
+    duration_ms = int((perf_counter() - start) * 1000)
+    _record_action_event(
+        request,
+        "action_succeeded" if ok else "action_failed",
+        "info" if ok else "error",
+        f"{request.stage} action {status}",
+        {
+            "action_id": action_id,
+            "duration_ms": duration_ms,
+            "error": error,
+        },
+    )
+    return LocalActionResult(
+        ok=ok,
+        action_id=action_id,
+        stage=request.stage,
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        job_url=request.job_url,
+        dry_run=request.dry_run,
+        result=result,
+        error=error,
+        traceback=traceback_text,
+    )
+
+
+def _record_action_event(
+    request: LocalActionRequest,
+    event_type: str,
+    level: str,
+    message: str,
+    payload: dict[str, Any],
+) -> None:
+    conn = get_connection()
+    record_job_event(
+        conn,
+        request.job_url,
+        request.stage,
+        event_type,
+        level=level,
+        message=message,
+        payload=payload,
+    )
+    conn.commit()
+
+
+def _describe_action(request: LocalActionRequest) -> dict[str, Any]:
+    return {
+        "stage": request.stage,
+        "job_url": request.job_url,
+        "limit": request.limit,
+        "workers": request.workers,
+        "min_score": request.min_score,
+        "validation_mode": request.validation_mode,
+    }
+

--- a/src/jobhunter/actions.py
+++ b/src/jobhunter/actions.py
@@ -67,33 +67,45 @@ class LocalActionResult:
 
 def run_local_action(request: LocalActionRequest) -> LocalActionResult:
     """Run one structured local action and record start/finish events."""
-    if request.stage not in ACTION_STAGES:
-        raise ValueError(f"Unknown action stage: {request.stage}")
-
-    _bootstrap_runtime()
     action_id = f"act-{uuid4().hex}"
     started_at = utc_now()
     start = perf_counter()
-    _record_action_event(
-        request,
-        "action_started",
-        "info",
-        f"{request.stage} action started",
-        {"action_id": action_id, "dry_run": request.dry_run},
-    )
 
-    if request.dry_run:
-        return _finish_action(
-            request,
-            action_id,
-            started_at,
-            start,
-            ok=True,
-            status="dry_run",
-            result={"planned": _describe_action(request)},
+    if request.stage not in ACTION_STAGES:
+        return LocalActionResult(
+            ok=False,
+            action_id=action_id,
+            stage=request.stage,
+            status="failed",
+            started_at=started_at,
+            finished_at=utc_now(),
+            duration_ms=int((perf_counter() - start) * 1000),
+            job_url=request.job_url,
+            dry_run=request.dry_run,
+            error=f"Unknown action stage: {request.stage}",
         )
 
     try:
+        _bootstrap_runtime()
+        _record_action_event(
+            request,
+            "action_started",
+            "info",
+            f"{request.stage} action started",
+            {"action_id": action_id, "dry_run": request.dry_run},
+        )
+
+        if request.dry_run:
+            return _finish_action(
+                request,
+                action_id,
+                started_at,
+                start,
+                ok=True,
+                status="dry_run",
+                result={"planned": _describe_action(request)},
+            )
+
         result = _execute_action(request)
         ok = _action_succeeded(result)
         status = "succeeded" if ok else "failed"
@@ -162,7 +174,7 @@ def _execute_action(request: LocalActionRequest) -> dict[str, Any]:
         from jobhunter.apply.launcher import main as apply_main
 
         applied, failed = apply_main(
-            limit=request.limit,
+            limit=_effective_apply_limit(request),
             target_url=request.job_url,
             min_score=request.min_score,
             headless=request.headless,
@@ -202,6 +214,10 @@ def _action_succeeded(result: dict[str, Any]) -> bool:
     return not status.startswith("error") and status not in {"failed", "failure"}
 
 
+def _effective_apply_limit(request: LocalActionRequest) -> int:
+    return 0 if request.continuous else max(1, request.limit)
+
+
 def _finish_action(
     request: LocalActionRequest,
     action_id: str,
@@ -216,17 +232,20 @@ def _finish_action(
 ) -> LocalActionResult:
     finished_at = utc_now()
     duration_ms = int((perf_counter() - start) * 1000)
-    _record_action_event(
-        request,
-        "action_succeeded" if ok else "action_failed",
-        "info" if ok else "error",
-        f"{request.stage} action {status}",
-        {
-            "action_id": action_id,
-            "duration_ms": duration_ms,
-            "error": error,
-        },
-    )
+    try:
+        _record_action_event(
+            request,
+            "action_succeeded" if ok else "action_failed",
+            "info" if ok else "error",
+            f"{request.stage} action {status}",
+            {
+                "action_id": action_id,
+                "duration_ms": duration_ms,
+                "error": error,
+            },
+        )
+    except Exception:  # noqa: BLE001 - action results must stay JSON-safe when event logging fails
+        pass
     return LocalActionResult(
         ok=ok,
         action_id=action_id,
@@ -264,11 +283,7 @@ def _record_action_event(
 
 
 def _describe_action(request: LocalActionRequest) -> dict[str, Any]:
-    return {
-        "stage": request.stage,
-        "job_url": request.job_url,
-        "limit": request.limit,
-        "workers": request.workers,
-        "min_score": request.min_score,
-        "validation_mode": request.validation_mode,
-    }
+    planned = asdict(request)
+    if request.stage == "apply":
+        planned["effective_limit"] = _effective_apply_limit(request)
+    return planned

--- a/src/jobhunter/apply/launcher.py
+++ b/src/jobhunter/apply/launcher.py
@@ -1153,7 +1153,7 @@ def worker_loop(worker_id: int = 0, limit: int = 1,
 def main(limit: int = 1, target_url: str | None = None,
          min_score: int = 7, headless: bool = False, model: str = "sonnet",
          dry_run: bool = False, continuous: bool = False,
-         poll_interval: int = 60, workers: int = 1) -> None:
+         poll_interval: int = 60, workers: int = 1) -> tuple[int, int]:
     """Launch the apply pipeline.
 
     Args:
@@ -1180,6 +1180,9 @@ def main(limit: int = 1, target_url: str | None = None,
     else:
         effective_limit = limit
         mode_label = f"{limit} jobs"
+
+    total_applied = 0
+    total_failed = 0
 
     # Initialize dashboard for all workers
     for i in range(workers):
@@ -1292,3 +1295,4 @@ def main(limit: int = 1, target_url: str | None = None,
     finally:
         _stop_event.set()
         kill_all_chrome()
+    return total_applied, total_failed

--- a/src/jobhunter/cli.py
+++ b/src/jobhunter/cli.py
@@ -463,6 +463,38 @@ def main(
 
 
 @app.command()
+def action(
+    stage: str = typer.Argument(..., help=f"Action stage. Valid: {', '.join((*VALID_STAGES, 'apply', 'profile_import'))}."),
+    url: Optional[str] = typer.Option(None, "--url", help="Target job URL for targeted actions."),
+    limit: int = typer.Option(0, "--limit", help="Maximum records to process. 0 means stage default."),
+    workers: int = typer.Option(1, "--workers", "-w", help="Worker count for supported actions."),
+    min_score: int = typer.Option(7, "--min-score", help="Minimum fit score for material/apply actions."),
+    validation: str = typer.Option("normal", "--validation", help="Validation mode for material generation."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Return the planned action without executing."),
+    pdf_path: Optional[str] = typer.Option(None, "--pdf", help="Resume PDF path for profile_import."),
+) -> None:
+    """Run a structured local action and print its JSON result."""
+    from jobhunter.actions import LocalActionRequest, run_local_action
+
+    validation = _validate_validation_mode(validation)
+    result = run_local_action(
+        LocalActionRequest(
+            stage=stage,
+            job_url=url,
+            limit=limit,
+            workers=workers,
+            min_score=min_score,
+            validation_mode=validation,
+            dry_run=dry_run,
+            pdf_path=pdf_path,
+        )
+    )
+    console.print_json(data=result.to_dict())
+    if not result.ok:
+        raise typer.Exit(code=1)
+
+
+@app.command()
 def init() -> None:
     """Run the first-time setup wizard (profile, resume, search config)."""
     from jobhunter.wizard.init import run_wizard

--- a/src/jobhunter/cli.py
+++ b/src/jobhunter/cli.py
@@ -477,18 +477,22 @@ def action(
     from jobhunter.actions import LocalActionRequest, run_local_action
 
     validation = _validate_validation_mode(validation)
-    result = run_local_action(
-        LocalActionRequest(
-            stage=stage,
-            job_url=url,
-            limit=limit,
-            workers=workers,
-            min_score=min_score,
-            validation_mode=validation,
-            dry_run=dry_run,
-            pdf_path=pdf_path,
+    try:
+        result = run_local_action(
+            LocalActionRequest(
+                stage=stage,
+                job_url=url,
+                limit=limit,
+                workers=workers,
+                min_score=min_score,
+                validation_mode=validation,
+                dry_run=dry_run,
+                pdf_path=pdf_path,
+            )
         )
-    )
+    except (OSError, ValueError) as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
     console.print_json(data=result.to_dict())
     if not result.ok:
         raise typer.Exit(code=1)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from jobhunter import actions
+from jobhunter.actions import LocalActionRequest, run_local_action
+from jobhunter.cli import app
+from jobhunter.database import close_connection, get_connection, init_db
+
+
+def test_local_stage_action_records_events(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    calls = []
+
+    def fake_pipeline(**kwargs):
+        calls.append(kwargs)
+        return {"stages": [{"stage": "score", "status": "ok", "elapsed": 0.01}], "errors": {}, "elapsed": 0.01}
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(actions, "run_pipeline", fake_pipeline)
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="score", limit=3, workers=2))
+        rows = conn.execute("SELECT event_type, stage, level FROM job_events ORDER BY event_id").fetchall()
+
+        assert result.ok is True
+        assert result.stage == "score"
+        assert calls[0]["stages"] == ["score"]
+        assert calls[0]["limit"] == 3
+        assert calls[0]["workers"] == 2
+        assert [(row["event_type"], row["stage"], row["level"]) for row in rows] == [
+            ("action_started", "score", "info"),
+            ("action_succeeded", "score", "info"),
+        ]
+    finally:
+        close_connection(db_path)
+
+
+def test_local_action_returns_structured_failure(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    def broken_pipeline(**_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(actions, "run_pipeline", broken_pipeline)
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="tailor"))
+        failure = conn.execute("SELECT event_type, level, message FROM job_events ORDER BY event_id DESC LIMIT 1").fetchone()
+
+        assert result.ok is False
+        assert result.status == "failed"
+        assert result.error == "boom"
+        assert "RuntimeError" in (result.traceback or "")
+        assert failure["event_type"] == "action_failed"
+        assert failure["level"] == "error"
+    finally:
+        close_connection(db_path)
+
+
+def test_local_action_dry_run_does_not_execute(monkeypatch, tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+
+    def should_not_run(**_kwargs):  # pragma: no cover - assertion guard
+        raise AssertionError("pipeline should not run")
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(actions, "run_pipeline", should_not_run)
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="enrich", dry_run=True))
+        assert result.ok is True
+        assert result.status == "dry_run"
+        assert result.result["planned"]["stage"] == "enrich"
+    finally:
+        close_connection(db_path)
+
+
+def test_action_cli_prints_json(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+
+    def fake_pipeline(**_kwargs):
+        return {"stages": [{"stage": "pdf", "status": "ok", "elapsed": 0.01}], "errors": {}, "elapsed": 0.01}
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(actions, "run_pipeline", fake_pipeline)
+
+    try:
+        result = CliRunner().invoke(app, ["action", "pdf", "--limit", "1"])
+        assert result.exit_code == 0
+        assert '"stage": "pdf"' in result.stdout
+        assert '"ok": true' in result.stdout
+    finally:
+        close_connection(db_path)
+

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -78,10 +78,22 @@ def test_local_action_dry_run_does_not_execute(monkeypatch, tmp_path):
     monkeypatch.setattr(actions, "run_pipeline", should_not_run)
 
     try:
-        result = run_local_action(LocalActionRequest(stage="enrich", dry_run=True))
+        result = run_local_action(
+            LocalActionRequest(
+                stage="enrich",
+                dry_run=True,
+                rescore=True,
+                retailor=True,
+                import_profile=False,
+                import_style=True,
+            )
+        )
         assert result.ok is True
         assert result.status == "dry_run"
         assert result.result["planned"]["stage"] == "enrich"
+        assert result.result["planned"]["rescore"] is True
+        assert result.result["planned"]["retailor"] is True
+        assert result.result["planned"]["import_profile"] is False
     finally:
         close_connection(db_path)
 
@@ -102,6 +114,40 @@ def test_apply_action_propagates_failed_count(tmp_path, monkeypatch):
         assert result.result["failed"] == 1
     finally:
         close_connection(db_path)
+
+
+def test_apply_action_uses_single_job_default_limit(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+    calls = []
+
+    def fake_apply(**kwargs):
+        calls.append(kwargs)
+        return (1, 0)
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(launcher, "main", fake_apply)
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="apply", job_url="https://example.com/job"))
+
+        assert result.ok is True
+        assert calls[0]["limit"] == 1
+        assert calls[0]["continuous"] is False
+    finally:
+        close_connection(db_path)
+
+
+def test_local_action_returns_structured_bootstrap_failure(monkeypatch):
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: (_ for _ in ()).throw(RuntimeError("db unavailable")))
+
+    result = run_local_action(LocalActionRequest(stage="score"))
+
+    assert result.ok is False
+    assert result.status == "failed"
+    assert result.error == "db unavailable"
+    assert "RuntimeError" in (result.traceback or "")
 
 
 def test_profile_import_action_expands_user_paths(tmp_path, monkeypatch):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -4,8 +4,11 @@ from typer.testing import CliRunner
 
 from jobhunter import actions
 from jobhunter.actions import LocalActionRequest, run_local_action
+from jobhunter.apply import launcher
 from jobhunter.cli import app
 from jobhunter.database import close_connection, get_connection, init_db
+from jobhunter import profile_import
+from jobhunter.scoring import pdf as scoring_pdf
 
 
 def test_local_stage_action_records_events(tmp_path, monkeypatch):
@@ -83,6 +86,53 @@ def test_local_action_dry_run_does_not_execute(monkeypatch, tmp_path):
         close_connection(db_path)
 
 
+def test_apply_action_propagates_failed_count(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(launcher, "main", lambda **_kwargs: (0, 1))
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="apply", job_url="https://example.com/job", limit=1))
+
+        assert result.ok is False
+        assert result.status == "failed"
+        assert result.result["failed"] == 1
+    finally:
+        close_connection(db_path)
+
+
+def test_profile_import_action_expands_user_paths(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+    pdf_path = tmp_path / "resume.pdf"
+    pdf_path.write_bytes(b"%PDF")
+
+    def fake_import(data, *, filename, base_profile, base_style):
+        return {
+            "profile": {"filename": filename, "bytes": len(data), "base": base_profile},
+            "style": base_style,
+        }
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+    monkeypatch.setattr(actions.config, "load_profile", lambda: {"name": "Base"})
+    monkeypatch.setattr(profile_import, "import_resume_pdf", fake_import)
+    monkeypatch.setattr(scoring_pdf, "load_resume_style", lambda: {"font": "moderncv"})
+
+    try:
+        result = run_local_action(LocalActionRequest(stage="profile_import", pdf_path="~/resume.pdf"))
+
+        assert result.ok is True
+        assert result.result["draft"]["profile"] == {"filename": "resume.pdf", "bytes": 4, "base": {"name": "Base"}}
+        assert result.result["draft"]["style"] == {"font": "moderncv"}
+    finally:
+        close_connection(db_path)
+
+
 def test_action_cli_prints_json(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     init_db(db_path)
@@ -102,3 +152,19 @@ def test_action_cli_prints_json(tmp_path, monkeypatch):
     finally:
         close_connection(db_path)
 
+
+def test_action_cli_reports_validation_errors_without_traceback(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    init_db(db_path)
+
+    monkeypatch.setattr(actions, "_bootstrap_runtime", lambda: None)
+    monkeypatch.setattr(actions, "get_connection", lambda: get_connection(db_path))
+
+    try:
+        result = CliRunner().invoke(app, ["action", "not-a-stage"])
+
+        assert result.exit_code == 1
+        assert "Unknown action stage: not-a-stage" in result.stdout
+        assert "Traceback" not in result.stdout
+    finally:
+        close_connection(db_path)


### PR DESCRIPTION
## Summary
- Add structured local action wrappers for pipeline stages, apply, and profile PDF import
- Record action start/finish events and return JSON-safe action results
- Add a jobhunter action CLI entrypoint as a bridge for future UI/API actions

## Verification
- npm test
- uv run pytest -q
- git diff --check