### PR TITLE
feat: route dashboard commands through actions

### DIFF
--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -78,9 +78,9 @@ jobhunter action profile_import --pdf ~/resume.pdf
 ```
 
 The action wrapper records start/finish events in `job_events` and returns a
-JSON result. The current implementation delegates to the existing Python stage
-runners; later API phases can call the same entrypoint instead of executing
-copyable CLI command strings.
+JSON result. The live Python dashboard now uses this path for retry, stage, and
+apply buttons instead of shelling out through copyable command strings. The
+commands remain visible for manual copying.
 
 ## Verify
 

--- a/src/jobhunter/dashboard_server.py
+++ b/src/jobhunter/dashboard_server.py
@@ -20,6 +20,7 @@ from urllib.parse import parse_qs, urlparse
 
 from rich.console import Console
 
+from jobhunter.actions import LocalActionRequest, run_local_action
 from jobhunter import config
 from jobhunter.database import close_connection, get_connection
 from jobhunter.pipeline import STAGE_ORDER
@@ -310,30 +311,53 @@ class DashboardHandler(BaseHTTPRequestHandler):
             )
             return
 
-        log_path = _command_log_path(action["label"])
-        log_file = log_path.open("w", encoding="utf-8")
-        try:
-            proc = subprocess.Popen(
-                args,
-                cwd=_project_root(),
-                env=_command_env(),
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-        finally:
-            log_file.close()
+        result = self._run_structured_command_action(command, action)
         self._send_json(
             {
-                "ok": True,
+                "ok": result.get("ok", False),
                 "cmd": command,
-                "mode": "background",
-                "pid": proc.pid,
-                "log_path": str(log_path),
-                "message": f"Started {command}",
+                "mode": "action",
+                "action": result,
+                "message": result.get("message") or result.get("status") or command,
+                "output": json.dumps(result, indent=2, sort_keys=True),
             },
-            status=HTTPStatus.ACCEPTED,
+            status=HTTPStatus.OK if result.get("ok", False) else HTTPStatus.ACCEPTED,
         )
+
+    def _run_structured_command_action(self, command: str, action: dict[str, Any]) -> dict[str, Any]:
+        if action["kind"] == "retry":
+            stage = action["stage"]
+            job_url = reset_job_stage(
+                self._fresh_connection(),
+                action["url"],
+                stage,
+                reset_attempts=bool(action.get("reset_attempts")),
+            )
+            if not action.get("run_after"):
+                return {
+                    "ok": True,
+                    "kind": "retry",
+                    "stage": stage,
+                    "job_url": job_url,
+                    "status": "reset",
+                    "message": f"Reset {stage} for retry.",
+                }
+            if stage == "apply":
+                request = LocalActionRequest(stage="apply", job_url=job_url, limit=1)
+            else:
+                request = LocalActionRequest(stage=stage, limit=1)
+            result = run_local_action(request).to_dict()
+            result["kind"] = "retry"
+            result["job_url"] = job_url
+            return result
+
+        if action["kind"] == "stage":
+            return run_local_action(action["request"]).to_dict()
+
+        if action["kind"] == "apply":
+            return run_local_action(action["request"]).to_dict()
+
+        raise ValueError(f"Unsupported structured command action for {command}.")
 
     def _handle_update_config(self) -> None:
         payload = self._read_json()
@@ -618,15 +642,36 @@ def _parse_dashboard_command(command: str, data: dict[str, Any]) -> dict[str, An
 
     if subcommand == "retry":
         _validate_retry_command(argv, known_urls)
-        return {"mode": "background" if "--run" in argv else "capture", "argv": argv, "label": "retry"}
+        return {
+            "mode": "action",
+            "kind": "retry",
+            "argv": argv,
+            "label": "retry",
+            "stage": argv[2],
+            "url": argv[3],
+            "reset_attempts": "--reset-attempts" in argv,
+            "run_after": "--run" in argv,
+        }
 
     if subcommand == "apply":
         _validate_apply_command(argv, known_urls)
-        return {"mode": "background", "argv": argv, "label": "apply"}
+        return {
+            "mode": "action",
+            "kind": "apply",
+            "argv": argv,
+            "label": "apply",
+            "request": _local_action_request_from_apply(argv),
+        }
 
     if subcommand in valid_stage_commands:
         _validate_stage_command(argv)
-        return {"mode": "background", "argv": argv, "label": subcommand}
+        return {
+            "mode": "action",
+            "kind": "stage",
+            "argv": argv,
+            "label": subcommand,
+            "request": _local_action_request_from_stage(argv),
+        }
 
     raise ValueError(f"Command is not allowed from the dashboard: {subcommand or command}")
 
@@ -650,6 +695,45 @@ def _validate_info_command(argv: list[str]) -> None:
             raise ValueError(f"Unsupported runs option: {flag}")
         return
     raise ValueError(f"Unsupported {subcommand} command options.")
+
+
+def _local_action_request_from_stage(argv: list[str]) -> LocalActionRequest:
+    stage = argv[1]
+    return LocalActionRequest(
+        stage=stage,
+        limit=_int_option(argv, "--limit", "-l", default=0),
+        workers=_int_option(argv, "--workers", "-w", default=1),
+        min_score=_int_option(argv, "--min-score", default=7),
+        validation_mode=_str_option(argv, "--validation", default="normal"),
+        dry_run="--dry-run" in argv,
+        rescore="--rescore" in argv,
+        retailor="--retailor" in argv,
+    )
+
+
+def _local_action_request_from_apply(argv: list[str]) -> LocalActionRequest:
+    return LocalActionRequest(
+        stage="apply",
+        job_url=_str_option(argv, "--url", default=None),
+        limit=_int_option(argv, "--limit", "-l", default=0),
+        workers=_int_option(argv, "--workers", "-w", default=1),
+        min_score=_int_option(argv, "--min-score", default=7),
+        model=_str_option(argv, "--model", "-m", default="haiku") or "haiku",
+        headless="--headless" in argv,
+        dry_run="--dry-run" in argv,
+    )
+
+
+def _str_option(argv: list[str], *flags: str, default: str | None = "") -> str | None:
+    for index, item in enumerate(argv):
+        if item in flags and index + 1 < len(argv):
+            return argv[index + 1]
+    return default
+
+
+def _int_option(argv: list[str], *flags: str, default: int = 0) -> int:
+    value = _str_option(argv, *flags, default=None)
+    return int(value) if value not in (None, "") else default
 
 
 def _validate_retry_command(argv: list[str], known_urls: set[str]) -> None:

--- a/src/jobhunter/dashboard_server.py
+++ b/src/jobhunter/dashboard_server.py
@@ -17,6 +17,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 from rich.console import Console
 
@@ -75,6 +76,8 @@ class DashboardHTTPServer(ThreadingHTTPServer):
     def __init__(self, server_address, handler_class, *, min_score: int | None = None):
         super().__init__(server_address, handler_class)
         self.dashboard_settings = config.load_dashboard_settings()
+        self.command_actions: dict[str, dict[str, Any]] = {}
+        self.command_actions_lock = threading.Lock()
         if min_score is not None:
             self.dashboard_settings = config.normalize_dashboard_settings(
                 {"min_fit_score": min_score},
@@ -140,6 +143,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 self._handle_list_artifacts(parsed.query)
             elif parsed.path == "/api/job":
                 self._handle_get_job(parsed.query)
+            elif parsed.path == "/api/action":
+                self._handle_get_action(parsed.query)
             elif parsed.path == "/api/profile-config":
                 self._handle_get_profile_config()
             else:
@@ -287,8 +292,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
             )
             return
 
-        args = _dashboard_command_args(action["argv"])
         if action["mode"] == "capture":
+            args = _dashboard_command_args(action["argv"])
             completed = subprocess.run(
                 args,
                 cwd=_project_root(),
@@ -311,18 +316,102 @@ class DashboardHandler(BaseHTTPRequestHandler):
             )
             return
 
-        result = self._run_structured_command_action(command, action)
+        if self._should_queue_structured_action(action):
+            result = self._queue_structured_command_action(command, action)
+            response_ok = True
+            response_status = HTTPStatus.ACCEPTED
+        else:
+            result = self._run_structured_command_action(command, action)
+            response_ok = result.get("ok", False)
+            response_status = HTTPStatus.OK if response_ok else HTTPStatus.ACCEPTED
+
         self._send_json(
             {
-                "ok": result.get("ok", False),
+                "ok": response_ok,
                 "cmd": command,
                 "mode": "action",
                 "action": result,
                 "message": result.get("message") or result.get("status") or command,
                 "output": json.dumps(result, indent=2, sort_keys=True),
             },
-            status=HTTPStatus.OK if result.get("ok", False) else HTTPStatus.ACCEPTED,
+            status=response_status,
         )
+
+    @staticmethod
+    def _should_queue_structured_action(action: dict[str, Any]) -> bool:
+        return not (action["kind"] == "retry" and not action.get("run_after"))
+
+    def _queue_structured_command_action(self, command: str, action: dict[str, Any]) -> dict[str, Any]:
+        action_id = f"cmd_{int(time.time() * 1000)}_{uuid4().hex[:10]}"
+        queued = {
+            "ok": True,
+            "action_id": action_id,
+            "cmd": command,
+            "kind": action["kind"],
+            "status": "queued",
+            "message": "Queued local action.",
+            "created_at": time.time(),
+        }
+        self._store_command_action(action_id, queued)
+        worker = threading.Thread(
+            target=self._run_queued_command_action,
+            args=(action_id, command, action),
+            daemon=True,
+        )
+        worker.start()
+        return queued
+
+    def _run_queued_command_action(self, action_id: str, command: str, action: dict[str, Any]) -> None:
+        self._store_command_action(
+            action_id,
+            {"status": "running", "message": "Running local action.", "started_at": time.time()},
+        )
+        try:
+            result = self._run_structured_command_action(command, action)
+            ok = bool(result.get("ok", False))
+            status = "succeeded" if ok else "failed"
+            self._store_command_action(
+                action_id,
+                {
+                    "ok": ok,
+                    "status": status,
+                    "message": result.get("message") or result.get("status") or status,
+                    "result": result,
+                    "output": json.dumps(result, indent=2, sort_keys=True),
+                    "finished_at": time.time(),
+                },
+            )
+        except Exception as exc:  # pragma: no cover - exercised through HTTP behavior.
+            failure = {"ok": False, "status": "failed", "error": str(exc)}
+            self._store_command_action(
+                action_id,
+                {
+                    **failure,
+                    "message": str(exc),
+                    "result": failure,
+                    "output": json.dumps(failure, indent=2, sort_keys=True),
+                    "finished_at": time.time(),
+                },
+            )
+
+    def _store_command_action(self, action_id: str, patch: dict[str, Any]) -> None:
+        with self.server.command_actions_lock:
+            current = self.server.command_actions.get(action_id, {"action_id": action_id})
+            self.server.command_actions[action_id] = {**current, **patch}
+
+    def _handle_get_action(self, query: str) -> None:
+        params = parse_qs(query)
+        action_id = (params.get("id") or [""])[0]
+        if not action_id:
+            self._send_error(HTTPStatus.BAD_REQUEST, "bad_request", "'id' is required.")
+            return
+        with self.server.command_actions_lock:
+            action = self.server.command_actions.get(action_id)
+            payload = dict(action) if action else None
+        if payload is None:
+            self._send_error(HTTPStatus.NOT_FOUND, "not_found", f"No action found for {action_id}.")
+            return
+        self._send_json({"ok": True, "action": payload})
 
     def _run_structured_command_action(self, command: str, action: dict[str, Any]) -> dict[str, Any]:
         if action["kind"] == "retry":
@@ -712,16 +801,22 @@ def _local_action_request_from_stage(argv: list[str]) -> LocalActionRequest:
 
 
 def _local_action_request_from_apply(argv: list[str]) -> LocalActionRequest:
+    job_url = _str_option(argv, "--url", default=None)
+    limit_default = 1 if job_url and not _has_option(argv, "--limit", "-l") else 0
     return LocalActionRequest(
         stage="apply",
-        job_url=_str_option(argv, "--url", default=None),
-        limit=_int_option(argv, "--limit", "-l", default=0),
+        job_url=job_url,
+        limit=_int_option(argv, "--limit", "-l", default=limit_default),
         workers=_int_option(argv, "--workers", "-w", default=1),
         min_score=_int_option(argv, "--min-score", default=7),
         model=_str_option(argv, "--model", "-m", default="haiku") or "haiku",
         headless="--headless" in argv,
         dry_run="--dry-run" in argv,
     )
+
+
+def _has_option(argv: list[str], *flags: str) -> bool:
+    return any(item in flags for item in argv)
 
 
 def _str_option(argv: list[str], *flags: str, default: str | None = "") -> str | None:

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -715,24 +715,32 @@ def test_dashboard_command_endpoint_captures_allowlisted_status(tmp_path, monkey
         close_connection(db_path)
 
 
-def test_dashboard_command_endpoint_starts_allowlisted_apply(tmp_path, monkeypatch):
+def test_dashboard_command_endpoint_runs_allowlisted_apply_action(tmp_path, monkeypatch):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
     _insert_job(conn)
     calls = []
 
-    class _Proc:
-        pid = 12345
+    class _Result:
+        def __init__(self, request):
+            self.request = request
 
-    def fake_popen(args, **kwargs):
-        calls.append((args, kwargs))
-        return _Proc()
+        def to_dict(self):
+            return {
+                "ok": True,
+                "stage": self.request.stage,
+                "job_url": self.request.job_url,
+                "status": "succeeded",
+            }
+
+    def fake_run_local_action(request):
+        calls.append(request)
+        return _Result(request)
 
     try:
         monkeypatch.setattr("jobhunter.database.DB_PATH", db_path)
         monkeypatch.setattr("jobhunter.config.DB_PATH", db_path)
-        monkeypatch.setattr("jobhunter.dashboard_server.config.APP_DIR", Path(tmp_path) / ".jobhunter")
-        monkeypatch.setattr("jobhunter.dashboard_server.subprocess.Popen", fake_popen)
+        monkeypatch.setattr("jobhunter.dashboard_server.run_local_action", fake_run_local_action)
 
         with _ServerContext() as server:
             result = server.post_json(
@@ -741,10 +749,44 @@ def test_dashboard_command_endpoint_starts_allowlisted_apply(tmp_path, monkeypat
             )
 
         assert result["ok"] is True
-        assert result["mode"] == "background"
-        assert result["pid"] == 12345
-        assert calls[0][0][-3:] == ["apply", "--url", "https://example.com/job"]
-        assert Path(result["log_path"]).parent.name == "dashboard_commands"
+        assert result["mode"] == "action"
+        assert result["action"]["stage"] == "apply"
+        assert result["action"]["job_url"] == "https://example.com/job"
+        assert calls[0].stage == "apply"
+        assert calls[0].job_url == "https://example.com/job"
+    finally:
+        close_connection(db_path)
+
+
+def test_dashboard_command_endpoint_resets_retry_without_shelling_out(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_job(conn, detail_error="timeout")
+
+    def fail_run(*_args, **_kwargs):  # pragma: no cover - assertion guard
+        raise AssertionError("retry command should not shell out")
+
+    try:
+        monkeypatch.setattr("jobhunter.database.DB_PATH", db_path)
+        monkeypatch.setattr("jobhunter.config.DB_PATH", db_path)
+        monkeypatch.setattr("jobhunter.dashboard_server.subprocess.run", fail_run)
+
+        with _ServerContext() as server:
+            result = server.post_json(
+                "/api/command",
+                {"cmd": "jobhunter retry enrich https://example.com/job --reset-attempts"},
+            )
+
+        state = conn.execute(
+            "SELECT state, attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert result["ok"] is True
+        assert result["mode"] == "action"
+        assert result["action"]["kind"] == "retry"
+        assert result["action"]["status"] == "reset"
+        assert state["state"] == "pending"
+        assert state["attempt_count"] == 0
     finally:
         close_connection(db_path)
 

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -1,5 +1,6 @@
 import json
 import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -737,23 +738,38 @@ def test_dashboard_command_endpoint_runs_allowlisted_apply_action(tmp_path, monk
         calls.append(request)
         return _Result(request)
 
+    def fail_shell(*_args, **_kwargs):  # pragma: no cover - assertion guard
+        raise AssertionError("apply command should not shell out")
+
     try:
         monkeypatch.setattr("jobhunter.database.DB_PATH", db_path)
         monkeypatch.setattr("jobhunter.config.DB_PATH", db_path)
         monkeypatch.setattr("jobhunter.dashboard_server.run_local_action", fake_run_local_action)
+        monkeypatch.setattr("jobhunter.dashboard_server.subprocess.run", fail_shell)
+        monkeypatch.setattr("jobhunter.dashboard_server.subprocess.Popen", fail_shell)
 
         with _ServerContext() as server:
             result = server.post_json(
                 "/api/command",
                 {"cmd": "jobhunter apply --url https://example.com/job"},
             )
+            action_id = result["action"]["action_id"]
+            action = result["action"]
+            for _ in range(20):
+                action = server.get_json(f"/api/action?id={urllib.parse.quote(action_id)}")["action"]
+                if action["status"] == "succeeded":
+                    break
+                time.sleep(0.05)
 
         assert result["ok"] is True
         assert result["mode"] == "action"
-        assert result["action"]["stage"] == "apply"
-        assert result["action"]["job_url"] == "https://example.com/job"
+        assert result["action"]["status"] == "queued"
+        assert action["status"] == "succeeded"
+        assert action["result"]["stage"] == "apply"
+        assert action["result"]["job_url"] == "https://example.com/job"
         assert calls[0].stage == "apply"
         assert calls[0].job_url == "https://example.com/job"
+        assert calls[0].limit == 1
     finally:
         close_connection(db_path)
 


### PR DESCRIPTION
## Summary
- Route dashboard retry, stage, and apply command buttons through structured local actions
- Keep copyable CLI commands while removing shell spawning for action commands
- Add regression coverage for action-backed apply and retry command paths

## Verification
- npm test
- uv run pytest -q
- git diff --check