### PR TITLE
test: add local reliability QA gate

### DIFF
--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -1,0 +1,61 @@
+# Local Reliability QA
+
+This checklist is the Phase 7 gate for the local-first architecture stack. It
+keeps the validation focused on local automation reliability before SaaS
+hardening.
+
+## Required Commands
+
+Run these before merging the Phase 7 stack branch:
+
+```bash
+npm test
+uv run pytest -q
+git diff --check
+```
+
+For browser smoke, run the local TypeScript API and React app, then verify the
+dashboard, jobs, artifacts, and profile views load against the local SQLite
+database:
+
+```bash
+npm run api:dev
+npm run web:dev -- --port 5173
+```
+
+## Reliability Matrix
+
+| Risk | Validation | Coverage |
+| --- | --- | --- |
+| Dry run marks a job applied | `mark_result(..., "dry_run")` leaves `applied_at` empty and records apply as skipped. | `tests/test_apply_regressions.py::test_dry_run_result_does_not_mark_job_applied` |
+| Apply agent hangs while stdout stays open | `run_job` times out while a child process is silent but still alive, then kills the process. | `tests/test_apply_regressions.py::test_run_job_timeout_stops_silent_stdout_hang` |
+| Targeted apply skips fresh jobs | Targeted apply can claim jobs where `apply_status` is `NULL`. | `tests/test_apply_regressions.py::test_targeted_apply_acquires_job_with_null_apply_status` |
+| Stages cannot be retried individually | Retry clears legacy fields and resets only the requested stage state. | `tests/test_state_dashboard.py::test_retry_command_resets_stage_state` |
+| Enrichment failures become terminal | Legacy enrichment failures are retryable and block downstream stages instead of being treated as done. | `tests/test_state_dashboard.py::test_legacy_state_marks_enrichment_failure_retryable` |
+| Legacy fields override explicit state | Explicit `job_stage_states` rows drive dashboard truth over legacy success columns. | `tests/test_state_dashboard.py::test_explicit_stage_state_overrides_legacy_success` |
+| Placeholder stage rows hide actual progress | Old placeholder state rows are upgraded from legacy columns. | `tests/test_state_dashboard.py::test_placeholder_stage_rows_are_upgraded_from_legacy_columns` |
+| PDF conversion publishes stray files | PDF conversion uses DB-backed cover-letter targets, not directory scans. | `tests/test_pdf_targets.py::test_pending_pdf_targets_only_include_db_cover_letters` |
+| Cover letters use the wrong resume | Cover generation requires a tailored resume instead of falling back silently. | `tests/test_cover_requirements.py::test_cover_generation_requires_tailored_resume` |
+| Profile PDF import corrupts defaults | Resume PDF import builds structured profile data while preserving application defaults and tailoring controls. | `tests/test_profile_import.py::test_profile_from_resume_text_builds_structured_profile_and_preserves_application_defaults` |
+| Style PDF import is opaque | Resume PDF import maps PDF metadata into editable style controls. | `tests/test_profile_import.py::test_style_from_pdf_metadata_infers_editable_style_controls` |
+| Jobs list overloads the UI | List APIs paginate after applying global filters and sorting. | `services/api/test/server.test.ts` |
+| Filters reset while editing | The React frontend has no automatic list polling; list refresh is explicit through the refresh button or filter changes. | Browser smoke |
+| Generated artifacts cannot be opened safely | The local dashboard only opens known artifact paths through the artifact-open endpoint. | `tests/test_dashboard_server.py` |
+| Profile/style save and discard flows regress | The local dashboard exposes profile patching, PDF import drafts, and field-level draft controls. | `tests/test_dashboard_server.py` and browser smoke |
+
+## Manual Browser Smoke
+
+Use the in-app browser or Playwright against `http://127.0.0.1:5173`:
+
+1. Confirm the API indicator shows live.
+2. Open dashboard, jobs, artifacts, and profile views.
+3. Filter jobs by text, stage, and state. Change pages, then use refresh and
+   confirm the selected filters remain in place.
+4. Sort jobs by fit score and title. Confirm results come from the API and are
+   not just sorting the visible page.
+5. Open a job drawer from jobs and artifacts.
+6. Open the profile view and edit a field. Confirm field-level draft controls
+   appear and discard restores the previous value.
+
+Do not move this stack into SaaS hardening until the automated commands pass
+and the manual browser smoke is clean.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -23,6 +23,10 @@ npm run api:dev
 npm run web:dev -- --port 5173
 ```
 
+Open the URL printed by Vite. It is usually `http://127.0.0.1:5173`, but Vite
+can choose a different port when 5173 is already in use because the web dev
+server does not run with `strictPort`.
+
 ## Reliability Matrix
 
 | Risk | Validation | Coverage |
@@ -40,12 +44,13 @@ npm run web:dev -- --port 5173
 | Style PDF import is opaque | Resume PDF import maps PDF metadata into editable style controls. | `tests/test_profile_import.py::test_style_from_pdf_metadata_infers_editable_style_controls` |
 | Jobs list overloads the UI | List APIs paginate after applying global filters and sorting. | `services/api/test/server.test.ts` |
 | Filters reset while editing | The React frontend has no automatic list polling; list refresh is explicit through the refresh button or filter changes. | Browser smoke |
-| Generated artifacts cannot be opened safely | The local dashboard only opens known artifact paths through the artifact-open endpoint. | `tests/test_dashboard_server.py` |
-| Profile/style save and discard flows regress | The local dashboard exposes profile patching, PDF import drafts, and field-level draft controls. | `tests/test_dashboard_server.py` and browser smoke |
+| Generated artifacts cannot be opened safely | The Python dashboard only opens known artifact paths through the artifact-open endpoint. The React shell currently validates artifact discovery only. | `tests/test_dashboard_server.py::test_dashboard_open_artifact_post_opens_known_file` and `tests/test_dashboard_server.py::test_dashboard_open_artifact_rejects_unknown_file` |
+| Profile/style save and discard flows regress | The Python dashboard persists profile patches and PDF import drafts safely. The React shell smoke only validates draft controls until React write endpoints land. | `tests/test_dashboard_server.py` and browser smoke |
 
-## Manual Browser Smoke
+## React Browser Smoke
 
-Use the in-app browser or Playwright against `http://127.0.0.1:5173`:
+Use the in-app browser or Playwright against the Vite URL printed by
+`npm run web:dev`:
 
 1. Confirm the API indicator shows live.
 2. Open dashboard, jobs, artifacts, and profile views.
@@ -55,7 +60,21 @@ Use the in-app browser or Playwright against `http://127.0.0.1:5173`:
    not just sorting the visible page.
 5. Open a job drawer from jobs and artifacts.
 6. Open the profile view and edit a field. Confirm field-level draft controls
-   appear and discard restores the previous value.
+   appear and discard restores the previous value. Do not count this as a
+   persistent profile/style save check until React write endpoints land.
+
+## Python Dashboard Smoke
+
+Run `uv run jobhunter dashboard` and use the printed local dashboard URL:
+
+1. Open a known generated artifact from a job drawer. Confirm unknown or missing
+   artifact paths are rejected by the UI/API.
+2. Edit a profile or style field, save it, reload the dashboard, and confirm the
+   saved value is still present.
+3. Edit another field and use discard or discard all. Confirm the previous value
+   is restored and no file changes are written.
+4. Import a resume PDF as a draft. Confirm the generated profile/style changes
+   remain unsaved until an explicit save action.
 
 Do not move this stack into SaaS hardening until the automated commands pass
 and the manual browser smoke is clean.

--- a/docs/ts-product-api-python-workers-architecture.md
+++ b/docs/ts-product-api-python-workers-architecture.md
@@ -839,6 +839,8 @@ Before moving toward SaaS hardening, verify:
 - generated artifacts open from the UI,
 - local profile/style save and discard flows work.
 
+The repeatable Phase 7 checklist lives in `docs/local-reliability-qa.md`.
+
 ## Test Strategy
 
 ### API Tests

--- a/tests/test_apply_regressions.py
+++ b/tests/test_apply_regressions.py
@@ -1,5 +1,8 @@
+import sys
+import time
 from pathlib import Path
 
+from jobhunter.apply import launcher
 from jobhunter.apply.launcher import acquire_job, mark_result
 from jobhunter.database import close_connection, get_connection, init_db
 
@@ -70,3 +73,64 @@ def test_dry_run_result_does_not_mark_job_applied(tmp_path, monkeypatch):
         assert state["error_code"] == "DRY_RUN"
     finally:
         close_connection(db_path)
+
+
+def test_run_job_timeout_stops_silent_stdout_hang(tmp_path, monkeypatch):
+    app_dir = tmp_path / "app"
+    log_dir = tmp_path / "logs"
+    worker_dir = tmp_path / "workers"
+    app_dir.mkdir()
+    log_dir.mkdir()
+    worker_dir.mkdir()
+    monkeypatch.setattr(launcher.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(launcher.config, "LOG_DIR", log_dir)
+    monkeypatch.setattr(launcher.config, "APPLY_WORKER_DIR", worker_dir)
+    monkeypatch.setitem(launcher.config.DEFAULTS, "apply_timeout", 1)
+    monkeypatch.setattr(launcher.prompt_mod, "build_prompt", lambda **_kwargs: "apply prompt")
+
+    original_popen = launcher.subprocess.Popen
+    spawned = []
+
+    def fake_popen(_cmd, *args, **kwargs):
+        script = (
+            "import sys, time\n"
+            "sys.stdout.write('{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"started\"}]}}\\n')\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(60)\n"
+        )
+        proc = original_popen([sys.executable, "-c", script], *args, **kwargs)
+        spawned.append(proc)
+        return proc
+
+    def safe_kill_process_tree(pid):
+        for proc in spawned:
+            if proc.pid == pid and proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+
+    monkeypatch.setattr(launcher.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(launcher, "_kill_process_tree", safe_kill_process_tree)
+
+    started = time.monotonic()
+    result, duration_ms = launcher.run_job(
+        {
+            "url": "https://example.com/job",
+            "application_url": "https://example.com/apply",
+            "title": "Platform Engineer",
+            "site": "ExampleCo",
+            "fit_score": 9,
+            "location": "Remote",
+            "full_description": "Build reliable systems.",
+            "cover_letter_path": None,
+            "tailored_resume_path": None,
+        },
+        port=9222,
+        worker_id=77,
+        run_ctx={"run_id": "timeout-test"},
+    )
+
+    assert result == "failed:timeout"
+    assert duration_ms >= 900
+    assert time.monotonic() - started < 5
+    assert spawned
+    assert all(proc.poll() is not None for proc in spawned)


### PR DESCRIPTION
## Summary
- add the Phase 7 local reliability QA checklist
- document automated and browser-smoke coverage for local reliability risks
- add a regression test for apply-agent silent stdout hangs timing out cleanly

## Verification
- npm test
- uv run pytest -q
- git diff --check
- browser smoke against http://127.0.0.1:5173