### PR TITLE
feat: restore local UI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ discover -> enrich -> score -> tailor -> cover -> pdf -> apply
 ```
 
 The automation engine is Python. The newer product surface is a local
-TypeScript API plus a React web UI. SQLite and local files remain the source of
-truth while the project validates reliability before any hosted/SaaS hardening.
+TypeScript API plus a React/Vite web shell. The intended frontend direction is
+TanStack Router for client-side routing plus TanStack Query for API/cache state
+management. SQLite and local files remain the source of truth while the project
+validates reliability before any hosted/SaaS hardening.
 
 ## What It Does
 
@@ -34,7 +36,8 @@ JobHunter is split by responsibility:
 
 - `services/api`: local TypeScript/Fastify API for typed read models, local
   product actions, profile/settings, artifacts, and worker invocation.
-- `apps/web`: React/Vite local web UI.
+- `apps/web`: current React/Vite local web shell; planned direction is
+  TanStack Router plus TanStack Query as the UI grows beyond the shell.
 - `src/jobhunter`: Python automation engine, CLI, workers, profile import, PDF
   creation, and apply automation.
 
@@ -96,7 +99,7 @@ uv sync
 uv run jobhunter doctor
 ```
 
-For development of the local TypeScript API and React app:
+For development of the local TypeScript API and current React/Vite shell:
 
 ```bash
 npm install
@@ -236,7 +239,7 @@ Run the local TypeScript API:
 npm run api:dev
 ```
 
-Run the React web UI:
+Run the current React/Vite web shell:
 
 ```bash
 npm run web:dev
@@ -311,9 +314,19 @@ Useful focused checks:
 ```bash
 npm run api:check
 npm run api:test
+npm run qa:test
 npm run web:check
 npm run web:build
 uv run --extra dev pytest tests/test_state_dashboard.py -q
+```
+
+Seed a disposable local QA workspace when you need to exercise destructive UI
+flows without touching `~/.jobhunter`:
+
+```bash
+npm run qa:seed -- /tmp/jobhunter-qa
+JOBHUNTER_DIR=/tmp/jobhunter-qa npm run api:dev
+VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 npm run web:dev -- --port 5173
 ```
 
 Build the Python package:
@@ -330,7 +343,9 @@ The near-term priority is local reliability:
 - keep retries targeted and observable;
 - keep generated artifacts registered before the UI opens them;
 - keep dry-run apply behavior safe;
-- keep product-facing behavior in the TypeScript API and React app.
+- keep product-facing behavior in the TypeScript API and current React/Vite
+  shell while steering frontend architecture toward TanStack Router and
+  TanStack Query.
 
 Hosted accounts, billing, object storage, Postgres migration, hosted workers,
 and SaaS deployment are intentionally deferred until the local workflow is

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,8 +1,12 @@
 import {
   type ArtifactSortField,
   type ArtifactSummary,
+  type CredentialKey,
+  CredentialKeys,
+  type CredentialsResponse,
   createJobHunterApiClient,
   type DashboardSummary,
+  type DashboardSettings,
   type JobDetail,
   type JobSummary,
   type JobSortField,
@@ -13,22 +17,34 @@ import {
   type StageState,
   STAGES,
 } from "@jobhunter/contracts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-type View = "dashboard" | "jobs" | "artifacts" | "profile";
+type View = "dashboard" | "jobs" | "artifacts" | "config" | "profile";
 type Direction = "asc" | "desc";
 type LoadState = "idle" | "loading" | "ready" | "error";
+type Theme = "light" | "dark";
+type ActivityEvent = DashboardSummary["activity"][number];
+type ApplyRunSummary = DashboardSummary["applyRuns"][number];
+type JobSortColumn = Extract<JobSortField, "discovered_at" | "title" | "company" | "location" | "fit_score" | "current_stage" | "current_state">;
+type ArtifactGroup = {
+  groupKey: string;
+  jobKey: string;
+  title: string;
+  company: string;
+  artifacts: ArtifactSummary[];
+};
 
 const api = createJobHunterApiClient(import.meta.env.VITE_JOBHUNTER_API_BASE_URL ?? "");
 
-const jobSortFields = [
-  ["discovered_at", "Discovered"],
-  ["title", "Title"],
-  ["company", "Company"],
-  ["fit_score", "Fit score"],
-  ["current_stage", "Stage"],
-  ["current_state", "State"],
-] as const;
+const jobTableColumns: Array<{ field: JobSortColumn; label: string }> = [
+  { field: "fit_score", label: "Fit score" },
+  { field: "title", label: "Title" },
+  { field: "company", label: "Company" },
+  { field: "location", label: "Location" },
+  { field: "current_stage", label: "Stage" },
+  { field: "current_state", label: "State" },
+  { field: "discovered_at", label: "Discovered" },
+];
 
 const artifactSortFields = [
   ["created_at", "Created"],
@@ -42,11 +58,18 @@ const artifactSortFields = [
 export function App(): JSX.Element {
   const [view, setView] = useState<View>("dashboard");
   const [density, setDensity] = useState("regular");
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = window.localStorage.getItem("jobhunter-theme");
+    return saved === "dark" ? "dark" : "light";
+  });
   const [connected, setConnected] = useState(false);
   const [status, setStatus] = useState<LoadState>("idle");
   const [error, setError] = useState("");
   const [summary, setSummary] = useState<DashboardSummary | null>(null);
+  const [globalQuery, setGlobalQuery] = useState("");
   const [selectedJobKey, setSelectedJobKey] = useState("");
+  const [selectedActivity, setSelectedActivity] = useState<ActivityEvent | null>(null);
+  const [selectedApplyRun, setSelectedApplyRun] = useState<ApplyRunSummary | null>(null);
 
   const refreshSummary = useCallback(async () => {
     setStatus("loading");
@@ -67,9 +90,32 @@ export function App(): JSX.Element {
     void refreshSummary();
   }, [refreshSummary]);
 
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    window.localStorage.setItem("jobhunter-theme", theme);
+  }, [theme]);
+
   const selectKpi = (target: "all" | "failed" | "blocked" | "ready") => {
     setView("jobs");
     window.dispatchEvent(new CustomEvent("jobhunter:set-jobs-filter", { detail: target }));
+  };
+  const openJob = (jobKey: string) => {
+    setSelectedActivity(null);
+    setSelectedApplyRun(null);
+    setSelectedJobKey(jobKey);
+  };
+  const openActivity = (activity: ActivityEvent) => {
+    if (activity.jobKey) {
+      openJob(activity.jobKey);
+      return;
+    }
+    setSelectedApplyRun(null);
+    setSelectedActivity(activity);
+  };
+  const openApplyRun = (run: ApplyRunSummary) => {
+    setSelectedActivity(null);
+    setSelectedJobKey("");
+    setSelectedApplyRun(run);
   };
 
   return (
@@ -80,21 +126,46 @@ export function App(): JSX.Element {
           <span>jobhunter</span>
         </button>
         <nav className="nav" aria-label="Main navigation">
-          {(["dashboard", "jobs", "artifacts", "profile"] as const).map((item) => (
+          {(["dashboard", "jobs", "artifacts", "config", "profile"] as const).map((item) => (
             <button className={view === item ? "on" : ""} key={item} onClick={() => setView(item)} type="button">
               {item}
             </button>
           ))}
         </nav>
+        <input
+          aria-label="Global search"
+          className="global-search"
+          placeholder="Filter jobs, errors, companies..."
+          value={globalQuery}
+          onChange={(event) => setGlobalQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && globalQuery.trim()) {
+              setView("jobs");
+            }
+          }}
+        />
         <select aria-label="Row density" className="select" value={density} onChange={(event) => setDensity(event.target.value)}>
           <option value="compact">compact</option>
           <option value="regular">regular</option>
           <option value="comfy">comfy</option>
         </select>
-        <button className="tab" onClick={() => void refreshSummary()} type="button">
-          refresh
+        <button
+          aria-label="Reload dashboard data from the local API"
+          className="tab"
+          onClick={() => void refreshSummary()}
+          type="button"
+        >
+          {status === "loading" ? "syncing local data" : "sync local data"}
         </button>
-        <span className={`pulse ${connected ? "" : "offline"}`}>{connected ? "live" : "offline"}</span>
+        <button
+          aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
+          className="tab"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+          type="button"
+        >
+          theme
+        </button>
+        <span className={`pulse ${connected ? "" : "offline"}`}>{connected ? "local API live" : "local API offline"}</span>
       </header>
 
       {summary ? <Kpis summary={summary} onSelect={selectKpi} /> : <KpiSkeleton />}
@@ -103,17 +174,36 @@ export function App(): JSX.Element {
 
       <main className="main">
         {view === "dashboard" ? (
-          <Dashboard summary={summary} status={status} onOpenJobs={selectKpi} />
+          <Dashboard
+            summary={summary}
+            status={status}
+            onOpenActivity={openActivity}
+            onOpenApplyRun={openApplyRun}
+            onOpenJobs={selectKpi}
+          />
         ) : view === "jobs" ? (
-          <JobsView onOpenJob={setSelectedJobKey} />
+          <JobsView globalQuery={globalQuery} onJobsChanged={refreshSummary} onOpenJob={openJob} />
         ) : view === "artifacts" ? (
-          <ArtifactsView onOpenJob={setSelectedJobKey} />
+          <ArtifactsView globalQuery={globalQuery} onOpenJob={openJob} />
+        ) : view === "config" ? (
+          <ConfigView />
         ) : (
           <ProfileView />
         )}
       </main>
 
       {selectedJobKey ? <JobDrawer jobKey={selectedJobKey} onClose={() => setSelectedJobKey("")} /> : null}
+      {selectedApplyRun ? (
+        <ApplyRunDrawer
+          run={selectedApplyRun}
+          onClose={() => setSelectedApplyRun(null)}
+          onOpenJob={(jobKey) => {
+            setSelectedApplyRun(null);
+            openJob(jobKey);
+          }}
+        />
+      ) : null}
+      {selectedActivity ? <ActivityDetailDrawer activity={selectedActivity} onClose={() => setSelectedActivity(null)} /> : null}
     </div>
   );
 }
@@ -163,10 +253,14 @@ function KpiSkeleton(): JSX.Element {
 function Dashboard({
   summary,
   status,
+  onOpenActivity,
+  onOpenApplyRun,
   onOpenJobs,
 }: {
   summary: DashboardSummary | null;
   status: LoadState;
+  onOpenActivity: (activity: ActivityEvent) => void;
+  onOpenApplyRun: (run: ApplyRunSummary) => void;
   onOpenJobs: (target: "all" | "failed" | "blocked" | "ready") => void;
 }): JSX.Element {
   if (!summary) {
@@ -207,14 +301,14 @@ function Dashboard({
         <div className="rows">
           {summary.applyRuns.length ? (
             summary.applyRuns.map((run) => (
-              <div className="mini-row" key={run.runId}>
+              <button className="mini-row clickable-row" key={run.runId} onClick={() => onOpenApplyRun(run)} type="button">
                 <StatusDot state={run.status === "running" ? "running" : run.status === "failed" ? "failed" : "succeeded"} />
-                <span className="title-stack">
-                  <b>{run.title}</b>
-                  <span>{run.company}</span>
+              <span className="title-stack">
+                <b>{run.title}</b>
+                <span>{run.company} · {formatDateTime(run.startedAt)}</span>
                 </span>
                 {run.dryRun ? <span className="tag info">dry-run</span> : null}
-              </div>
+              </button>
             ))
           ) : (
             <Empty title="No apply runs." />
@@ -226,11 +320,22 @@ function Dashboard({
         <div className="rows">
           {summary.activity.length ? (
             summary.activity.map((activity, index) => (
-              <div className="activity-row" key={`${activity.at}-${index}`}>
+              <button
+                className="activity-row clickable-row"
+                key={`${activity.eventId}-${activity.at}-${index}`}
+                onClick={() => onOpenActivity(activity)}
+                type="button"
+              >
                 <span className={`tag ${activity.level === "error" ? "danger" : "muted"}`}>{activity.level}</span>
                 <span className="stage-pill">{activity.stage}</span>
-                <span>{activity.message}</span>
-              </div>
+                <span className="activity-main">
+                  <b>{activity.message}</b>
+                  <span>{activity.title ? `${activity.title} · ${activity.company ?? "Unknown"}` : activity.jobKey ?? `event ${activity.eventId}`}</span>
+                </span>
+                <span className="mono" title={`${formatDateTime(activity.at)} #${activity.eventId}`}>
+                  {formatDateTime(activity.at)} #{activity.eventId}
+                </span>
+              </button>
             ))
           ) : (
             <Empty title="No activity yet." />
@@ -241,12 +346,22 @@ function Dashboard({
   );
 }
 
-function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.Element {
+function JobsView({
+  globalQuery,
+  onJobsChanged,
+  onOpenJob,
+}: {
+  globalQuery: string;
+  onJobsChanged: () => Promise<void>;
+  onOpenJob: (jobKey: string) => void;
+}): JSX.Element {
   const [data, setData] = useState<PaginatedResponse<JobSummary> | null>(null);
   const [loading, setLoading] = useState(false);
-  const [query, setQuery] = useState("");
   const [stage, setStage] = useState<Stage | "all">("all");
   const [state, setState] = useState<StageState | "all">("all");
+  const [deleted, setDeleted] = useState<"active" | "deleted">("active");
+  const [selectedJobs, setSelectedJobs] = useState<Set<string>>(() => new Set());
+  const [allMatchingSelected, setAllMatchingSelected] = useState(false);
   const [sort, setSort] = useState<JobSortField>("discovered_at");
   const [dir, setDir] = useState<Direction>("desc");
   const [page, setPage] = useState(1);
@@ -263,9 +378,10 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
       const nextData = await api.jobs({
         page,
         pageSize,
-        q: query,
+        q: globalQuery,
         sort,
         dir,
+        deleted,
         stage: stage === "all" ? undefined : stage,
         state: state === "all" ? undefined : state,
       });
@@ -282,7 +398,7 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
         setLoading(false);
       }
     }
-  }, [dir, page, pageSize, query, sort, stage, state]);
+  }, [deleted, dir, globalQuery, page, pageSize, sort, stage, state]);
 
   useEffect(() => {
     void load();
@@ -305,25 +421,104 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
         setStage("all");
         setState("all");
       }
+      setDeleted("active");
     };
     window.addEventListener("jobhunter:set-jobs-filter", listener);
     return () => window.removeEventListener("jobhunter:set-jobs-filter", listener);
   }, []);
+
+  useEffect(() => {
+    setPage(1);
+  }, [globalQuery]);
+
+  useEffect(() => {
+    setSelectedJobs(new Set());
+    setAllMatchingSelected(false);
+  }, [deleted, dir, globalQuery, page, pageSize, sort, stage, state]);
+
+  const toggleSelection = (jobKey: string, selected: boolean) => {
+    setAllMatchingSelected(false);
+    setSelectedJobs((current) => {
+      const next = new Set(current);
+      if (selected) {
+        next.add(jobKey);
+      } else {
+        next.delete(jobKey);
+      }
+      return next;
+    });
+  };
+
+  const selectPage = () => {
+    setAllMatchingSelected(false);
+    setSelectedJobs(new Set(data?.items.map((job) => job.jobKey) ?? []));
+  };
+
+  const selectAllMatching = () => {
+    setSelectedJobs(new Set());
+    setAllMatchingSelected(Boolean(data?.pagination.total));
+  };
+
+  const clearSelection = () => {
+    setSelectedJobs(new Set());
+    setAllMatchingSelected(false);
+  };
+
+  const currentJobFilter = () => ({
+    q: globalQuery,
+    stage: stage === "all" ? undefined : stage,
+    state: state === "all" ? undefined : state,
+    deleted,
+  });
+
+  const changeSort = (field: JobSortColumn) => {
+    if (sort === field) {
+      setDir((current) => (current === "asc" ? "desc" : "asc"));
+    } else {
+      setSort(field);
+      setDir(field === "discovered_at" || field === "fit_score" ? "desc" : "asc");
+    }
+    setPage(1);
+  };
+
+  const mutateSelected = async () => {
+    const jobKeys = Array.from(selectedJobs);
+    const count = allMatchingSelected ? data?.pagination.total ?? 0 : jobKeys.length;
+    if (!count) {
+      return;
+    }
+    const restoring = deleted === "deleted";
+    const action = restoring ? "restore" : "delete";
+    if (!window.confirm(`${restoring ? "Restore" : "Soft delete"} ${count} selected job${count === 1 ? "" : "s"}?`)) {
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const payload = allMatchingSelected
+        ? { allMatching: true, filter: currentJobFilter(), jobKeys: [] }
+        : { allMatching: false, jobKeys };
+      if (restoring) {
+        await api.restoreJobs(payload);
+      } else {
+        await api.deleteJobs(payload);
+      }
+      clearSelection();
+      await Promise.all([load(), onJobsChanged()]);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : `Unable to ${action} selected jobs.`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selectedCount = allMatchingSelected ? data?.pagination.total ?? 0 : selectedJobs.size;
 
   return (
     <section className="card full">
       <CardHeader title="Jobs" meta={data ? `${data.pagination.total} total` : "loading"} />
       {error ? <div className="banner inline">{error}</div> : null}
       <div className="toolbar">
-        <input
-          aria-label="Search jobs"
-          placeholder="Filter jobs, companies, errors..."
-          value={query}
-          onChange={(event) => {
-            setQuery(event.target.value);
-            setPage(1);
-          }}
-        />
         <select
           value={stage}
           onChange={(event) => {
@@ -351,21 +546,6 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
             </option>
           ))}
         </select>
-        <SelectPairs
-          options={jobSortFields}
-          value={sort}
-          onChange={(value) => {
-            setSort(value);
-            setPage(1);
-          }}
-        />
-        <DirectionSelect
-          value={dir}
-          onChange={(value) => {
-            setDir(value);
-            setPage(1);
-          }}
-        />
         <PageSize
           value={pageSize}
           onChange={(value) => {
@@ -377,21 +557,84 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
           refresh
         </button>
       </div>
+      <div className="bulk-bar">
+        <div className="tabs">
+          <button className={`tab ${deleted === "active" ? "on" : ""}`} onClick={() => setDeleted("active")} type="button">
+            active jobs
+          </button>
+          <button className={`tab ${deleted === "deleted" ? "on" : ""}`} onClick={() => setDeleted("deleted")} type="button">
+            deleted jobs
+          </button>
+        </div>
+        <span className="meta">{selectedCount ? `${selectedCount} selected` : "select jobs to manage"}</span>
+        <button className="tab" disabled={!data?.items.length} onClick={selectPage} type="button">
+          select page
+        </button>
+        <button className="tab" disabled={!data?.pagination.total} onClick={selectAllMatching} type="button">
+          select all matching
+        </button>
+        <button className="tab" disabled={!selectedCount} onClick={clearSelection} type="button">
+          clear selected
+        </button>
+        <button
+          className={`tab ${deleted === "deleted" ? "on" : "danger-action"}`}
+          disabled={!selectedCount || loading}
+          onClick={() => void mutateSelected()}
+          type="button"
+        >
+          {deleted === "deleted" ? "restore selected" : "delete selected"}
+        </button>
+      </div>
       <div className="table">
+        <div className="data-row job job-header" role="row">
+          <span aria-hidden="true" />
+          {jobTableColumns.map((column) => (
+            <button
+              aria-sort={sort === column.field ? (dir === "asc" ? "ascending" : "descending") : "none"}
+              className={sort === column.field ? "sort-head active" : "sort-head"}
+              key={column.field}
+              onClick={() => changeSort(column.field)}
+              type="button"
+            >
+              {column.label}
+              {sort === column.field ? <span aria-hidden="true">{dir === "asc" ? " ↑" : " ↓"}</span> : null}
+            </button>
+          ))}
+        </div>
         {loading && !data ? <Empty title="Loading jobs." /> : null}
         {data?.items.map((job) => (
-          <button className="data-row job" key={job.jobKey} onClick={() => onOpenJob(job.jobKey)} type="button">
+          <div
+            className="data-row job"
+            key={job.jobKey}
+            role="button"
+            tabIndex={0}
+            onClick={() => onOpenJob(job.jobKey)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onOpenJob(job.jobKey);
+              }
+            }}
+          >
+            <span className="row-check">
+              <input
+                aria-label={`Select ${job.title}`}
+                checked={allMatchingSelected || selectedJobs.has(job.jobKey)}
+                type="checkbox"
+                onChange={(event) => toggleSelection(job.jobKey, event.target.checked)}
+                onClick={(event) => event.stopPropagation()}
+              />
+            </span>
             <span className={`fit ${scoreTier(job.fitScore)}`}>{job.fitScore ?? "-"}</span>
             <span className="title-stack">
               <b>{job.title}</b>
-              <span>{job.company}</span>
             </span>
+            <span className="muted-cell">{formatCompanySource(job.company, job.source)}</span>
             <span>{job.location || "-"}</span>
-            <span>
-              <span className="stage-pill">{job.currentStage}</span> <span className={`tag ${stateTone(job.currentState)}`}>{job.currentState}</span>
-            </span>
+            <span className="stage-pill">{job.currentStage}</span>
+            <span className={`tag ${stateTone(job.currentState)}`}>{job.currentState}</span>
             <span className="mono">{job.discoveredAt ? new Date(job.discoveredAt).toLocaleDateString() : "-"}</span>
-          </button>
+          </div>
         ))}
         {data && data.items.length === 0 ? <Empty title="No jobs match." /> : null}
       </div>
@@ -400,12 +643,17 @@ function JobsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.E
   );
 }
 
-function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): JSX.Element {
+function ArtifactsView({
+  globalQuery,
+  onOpenJob,
+}: {
+  globalQuery: string;
+  onOpenJob: (jobKey: string) => void;
+}): JSX.Element {
   const [data, setData] = useState<PaginatedResponse<ArtifactSummary> | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [openStatus, setOpenStatus] = useState("");
-  const [query, setQuery] = useState("");
   const [status, setStatus] = useState("all");
   const [sort, setSort] = useState<ArtifactSortField>("created_at");
   const [dir, setDir] = useState<Direction>("desc");
@@ -422,7 +670,7 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
       const nextData = await api.artifacts({
         page,
         pageSize,
-        q: query,
+        q: globalQuery,
         sort,
         dir,
         status: status === "all" ? "" : status,
@@ -440,11 +688,15 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
         setLoading(false);
       }
     }
-  }, [dir, page, pageSize, query, sort, status]);
+  }, [dir, globalQuery, page, pageSize, sort, status]);
 
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [globalQuery]);
 
   const openArtifact = async (artifact: ArtifactSummary) => {
     setError("");
@@ -457,21 +709,17 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
     }
   };
 
+  const artifactGroups = groupArtifacts(data?.items ?? []);
+
   return (
     <section className="card full">
-      <CardHeader title="Artifacts" meta={data ? `${data.pagination.total} total` : "loading"} />
+      <CardHeader
+        title="Artifacts"
+        meta={data ? `${artifactGroups.length} jobs · ${data.pagination.total} artifacts` : "loading"}
+      />
       {error ? <div className="banner inline">{error}</div> : null}
       {openStatus ? <div className="status-line">{openStatus}</div> : null}
       <div className="toolbar">
-        <input
-          aria-label="Search artifacts"
-          placeholder="Filter artifacts..."
-          value={query}
-          onChange={(event) => {
-            setQuery(event.target.value);
-            setPage(1);
-          }}
-        />
         <select
           value={status}
           onChange={(event) => {
@@ -479,7 +727,7 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
             setPage(1);
           }}
         >
-          {["all", "active", "approved", "candidate", "stale"].map((item) => (
+          {["all", "active", "approved", "candidate", "stale", "missing"].map((item) => (
             <option key={item} value={item}>
               {item}
             </option>
@@ -513,31 +761,278 @@ function ArtifactsView({ onOpenJob }: { onOpenJob: (jobKey: string) => void }): 
       </div>
       <div className="table">
         {loading && !data ? <Empty title="Loading artifacts." /> : null}
-        {data?.items.map((artifact) => (
-          <div className="data-row artifact" key={artifact.artifactId}>
-            <span className={`tag ${artifact.status === "active" ? "ok" : "muted"}`}>{artifact.status}</span>
+        {artifactGroups.map((group) => (
+          <div className="data-row artifact-group" key={group.groupKey}>
             <span className="title-stack">
-              <b>{artifact.title}</b>
-              <span>{artifact.company}</span>
+              <b>{group.title}</b>
+              <span>{group.company}</span>
             </span>
-            <span>{artifact.type}</span>
-            <span className="path-cell">{artifact.localPath}</span>
-            <span className="mono">{artifact.size}</span>
+            <span className="artifact-variants">
+              {group.artifacts.map((artifact) => (
+                <button
+                  className="artifact-variant"
+                  disabled={artifact.status === "missing"}
+                  key={artifact.artifactId}
+                  onClick={() => void openArtifact(artifact)}
+                  title={artifact.status === "missing" ? "Local file is missing; regenerate this artifact before opening it." : artifact.localPath}
+                  type="button"
+                >
+                  <span className={`tag ${artifactStatusTone(artifact.status)}`}>{artifactKind(artifact.type)}</span>
+                  <span>{artifactVersionLabel(artifact.type)}</span>
+                  <span className="mono">{artifact.size}</span>
+                </button>
+              ))}
+            </span>
             <span className="row-actions">
-              <button className="tab on" onClick={() => void openArtifact(artifact)} type="button">
-                open
-              </button>
-              <button className="tab" onClick={() => onOpenJob(artifact.jobKey)} type="button">
+              <button className="tab" onClick={() => onOpenJob(group.jobKey)} type="button">
                 job
               </button>
             </span>
           </div>
         ))}
-        {data && data.items.length === 0 ? <Empty title="No artifacts match." /> : null}
+        {data && artifactGroups.length === 0 ? <Empty title="No artifacts match." /> : null}
       </div>
       <Pager pagination={data?.pagination} page={page} onPage={setPage} />
     </section>
   );
+}
+
+function ConfigView(): JSX.Element {
+  const [settings, setSettings] = useState<DashboardSettings | null>(null);
+  const [originalSettings, setOriginalSettings] = useState<DashboardSettings | null>(null);
+  const [credentials, setCredentials] = useState<CredentialsResponse["credentials"]>([]);
+  const [credentialDrafts, setCredentialDrafts] = useState<Record<CredentialKey, string>>({
+    OPENAI_API_KEY: "",
+    GEMINI_API_KEY: "",
+    LLM_URL: "",
+  });
+  const [status, setStatus] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [credentialBusy, setCredentialBusy] = useState<CredentialKey | "">("");
+
+  const load = useCallback(async () => {
+    setError("");
+    setStatus("");
+    try {
+      const [settingsResponse, credentialsResponse] = await Promise.all([api.settings(), api.credentials()]);
+      setSettings(settingsResponse.settings);
+      setOriginalSettings(settingsResponse.settings);
+      setCredentials(credentialsResponse.credentials);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Unable to load settings.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const update = <K extends keyof DashboardSettings>(key: K, value: DashboardSettings[K]) => {
+    setSettings((current) => (current ? { ...current, [key]: value } : current));
+  };
+
+  const dirty = Boolean(settings && originalSettings && JSON.stringify(settings) !== JSON.stringify(originalSettings));
+
+  const save = async () => {
+    if (!settings) {
+      return;
+    }
+    setBusy(true);
+    setError("");
+    setStatus("");
+    try {
+      const response = await api.updateSettings(settings);
+      setSettings(response.settings);
+      setOriginalSettings(response.settings);
+      setStatus("settings saved");
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Unable to save settings.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const saveCredential = async (key: CredentialKey) => {
+    const value = credentialDrafts[key].trim();
+    if (!value) {
+      return;
+    }
+    setCredentialBusy(key);
+    setError("");
+    setStatus("");
+    try {
+      const response = await api.updateCredential({ key, value });
+      setCredentials(response.credentials);
+      setCredentialDrafts((current) => ({ ...current, [key]: "" }));
+      setStatus(`${credentialLabel(key)} saved in Keychain`);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : `Unable to save ${credentialLabel(key)}.`);
+    } finally {
+      setCredentialBusy("");
+    }
+  };
+
+  const removeCredential = async (key: CredentialKey) => {
+    setCredentialBusy(key);
+    setError("");
+    setStatus("");
+    try {
+      const response = await api.deleteCredential(key);
+      setCredentials(response.credentials);
+      setCredentialDrafts((current) => ({ ...current, [key]: "" }));
+      setStatus(`${credentialLabel(key)} removed from Keychain`);
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : `Unable to remove ${credentialLabel(key)}.`);
+    } finally {
+      setCredentialBusy("");
+    }
+  };
+
+  return (
+    <div className="config-layout">
+      <section className="card full">
+        <CardHeader title="Config" meta="scoring and targeting" />
+        {error ? <div className="banner inline">{error}</div> : null}
+        {status ? <div className="status-line">{status}</div> : null}
+        {settings ? (
+          <form
+            className="config-form"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void save();
+            }}
+          >
+            <label className="field">
+              <span>Minimum fit score</span>
+              <input
+                max={10}
+                min={0}
+                step={1}
+                type="number"
+                value={settings.minFitScore}
+                onChange={(event) => update("minFitScore", Number(event.target.value))}
+              />
+            </label>
+            <label className="field">
+              <span>Apply concurrency</span>
+              <input
+                max={16}
+                min={1}
+                step={1}
+                type="number"
+                value={settings.applyConcurrency}
+                onChange={(event) => update("applyConcurrency", Number(event.target.value))}
+              />
+            </label>
+            <label className="field">
+              <span>Target role</span>
+              <input value={settings.targetRole} onChange={(event) => update("targetRole", event.target.value)} />
+            </label>
+            <label className="field">
+              <span>Location filter</span>
+              <input value={settings.locationFilter} onChange={(event) => update("locationFilter", event.target.value)} />
+            </label>
+            <label className="field wide">
+              <span>Score criteria</span>
+              <textarea
+                placeholder="Criteria the scoring step should use when ranking jobs."
+                value={settings.scoreCriteria}
+                onChange={(event) => update("scoreCriteria", event.target.value)}
+              />
+            </label>
+            <label className="field wide">
+              <span>Targeting criteria</span>
+              <textarea
+                placeholder="Role, company, location, seniority, and exclusion criteria for the search pipeline."
+                value={settings.targetCriteria}
+                onChange={(event) => update("targetCriteria", event.target.value)}
+              />
+            </label>
+            <label className="field check">
+              <input
+                checked={settings.autoApply}
+                type="checkbox"
+                onChange={(event) => update("autoApply", event.target.checked)}
+              />
+              <span>Auto apply</span>
+            </label>
+            <div className="form-actions">
+              <button className="tab on" disabled={!dirty || busy} type="submit">
+                {busy ? "saving" : "save"}
+              </button>
+              <button
+                className="tab"
+                disabled={!dirty || busy || !originalSettings}
+                onClick={() => originalSettings && setSettings(originalSettings)}
+                type="button"
+              >
+                reset
+              </button>
+              <button className="tab" disabled={busy} onClick={() => void load()} type="button">
+                reload
+              </button>
+            </div>
+          </form>
+        ) : (
+          <Empty title="Loading config." />
+        )}
+      </section>
+      <section className="card full">
+        <CardHeader title="Credentials" meta="macOS Keychain" />
+        <div className="credential-list">
+          {CredentialKeys.map((key) => {
+            const credential = credentials.find((item) => item.key === key);
+            const configured = Boolean(credential?.configured);
+            return (
+              <div className="credential-row" key={key}>
+                <span className={`tag ${configured ? "ok" : "muted"}`}>{configured ? "configured" : "missing"}</span>
+                <span className="title-stack">
+                  <b>{credential?.label ?? credentialLabel(key)}</b>
+                  <span>{key}</span>
+                </span>
+                <input
+                  aria-label={credential?.label ?? credentialLabel(key)}
+                  placeholder={configured ? "Stored in Keychain" : "Paste value to store in Keychain"}
+                  type="password"
+                  value={credentialDrafts[key]}
+                  onChange={(event) => setCredentialDrafts((current) => ({ ...current, [key]: event.target.value }))}
+                />
+                <span className="row-actions">
+                  <button
+                    className="tab on"
+                    disabled={!credentialDrafts[key].trim() || credentialBusy === key}
+                    onClick={() => void saveCredential(key)}
+                    type="button"
+                  >
+                    save
+                  </button>
+                  <button
+                    className="tab"
+                    disabled={!configured || credentialBusy === key}
+                    onClick={() => void removeCredential(key)}
+                    type="button"
+                  >
+                    remove
+                  </button>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function credentialLabel(key: CredentialKey): string {
+  if (key === "OPENAI_API_KEY") {
+    return "OpenAI API key";
+  }
+  if (key === "GEMINI_API_KEY") {
+    return "Gemini API key";
+  }
+  return "LLM endpoint";
 }
 
 function ProfileView(): JSX.Element {
@@ -556,6 +1051,8 @@ function ProfileView(): JSX.Element {
   const [loadError, setLoadError] = useState("");
   const [saveStatus, setSaveStatus] = useState("");
   const [busy, setBusy] = useState("");
+  const [previewVersion, setPreviewVersion] = useState(0);
+  const [profileMode, setProfileMode] = useState<"fields" | "source">("fields");
 
   const applyProfileResponse = useCallback((profileResponse: ProfileConfigResponse) => {
     const nextProfileText = JSON.stringify(profileResponse.profile, null, 2);
@@ -567,6 +1064,7 @@ function ProfileView(): JSX.Element {
     setOriginalProfileText(nextProfileText);
     setOriginalStyleText(nextStyleText);
     setOriginalTemplateText(profileResponse.templateText);
+    setPreviewVersion((version) => version + 1);
   }, []);
 
   const load = useCallback(async () => {
@@ -585,7 +1083,6 @@ function ProfileView(): JSX.Element {
     void load();
   }, [load]);
 
-  const profileName = useMemo(() => extractName(profile?.profile), [profile]);
   const profileDirty = profileText !== originalProfileText;
   const styleDirty = styleText !== originalStyleText;
   const templateDirty = templateText !== originalTemplateText;
@@ -708,44 +1205,660 @@ function ProfileView(): JSX.Element {
             reload
           </button>
         </div>
-        <Editor
-          dirty={profileDirty}
-          label="profile.json"
-          saving={busy === "profile.json"}
-          value={profileText}
-          onChange={setProfileText}
-          onDiscard={() => setProfileText(originalProfileText)}
-          onSave={() => void savePatch("profile.json", { profileText })}
-        />
-        <Editor
-          dirty={styleDirty}
-          label="resume_style.json"
-          saving={busy === "resume_style.json"}
-          value={styleText}
-          onChange={setStyleText}
-          onDiscard={() => setStyleText(originalStyleText)}
-          onSave={() => void savePatch("resume_style.json", { styleText })}
-        />
-        <Editor
-          dirty={templateDirty}
-          label="resume_template.tex"
-          saving={busy === "resume_template.tex"}
-          value={templateText}
-          onChange={setTemplateText}
-          onDiscard={() => setTemplateText(originalTemplateText)}
-          onSave={() => void savePatch("resume_template.tex", { templateText })}
-        />
-      </section>
-      <aside className="preview">
-        <div className="preview-page">
-          <h1>{profileName || "Profile preview"}</h1>
-          <p className="muted">{extractContact(profile?.profile)}</p>
-          <h2>Executive profile</h2>
-          <p>{extractSummary(profile?.profile)}</p>
+        <div className="profile-mode-tabs">
+          <button className={`tab ${profileMode === "fields" ? "on" : ""}`} onClick={() => setProfileMode("fields")} type="button">
+            fields
+          </button>
+          <button className={`tab ${profileMode === "source" ? "on" : ""}`} onClick={() => setProfileMode("source")} type="button">
+            source
+          </button>
         </div>
+        {profileMode === "fields" ? (
+          <StructuredProfileEditor
+            profileText={profileText}
+            styleText={styleText}
+            onProfileTextChange={setProfileText}
+            onStyleTextChange={setStyleText}
+          />
+        ) : (
+          <>
+            <Editor
+              dirty={profileDirty}
+              label="profile.json"
+              saving={busy === "profile.json"}
+              value={profileText}
+              onChange={setProfileText}
+              onDiscard={() => setProfileText(originalProfileText)}
+              onSave={() => void savePatch("profile.json", { profileText })}
+            />
+            <Editor
+              dirty={styleDirty}
+              label="resume_style.json"
+              saving={busy === "resume_style.json"}
+              value={styleText}
+              onChange={setStyleText}
+              onDiscard={() => setStyleText(originalStyleText)}
+              onSave={() => void savePatch("resume_style.json", { styleText })}
+            />
+            <Editor
+              dirty={templateDirty}
+              label="resume_template.tex"
+              saving={busy === "resume_template.tex"}
+              value={templateText}
+              onChange={setTemplateText}
+              onDiscard={() => setTemplateText(originalTemplateText)}
+              onSave={() => void savePatch("resume_template.tex", { templateText })}
+            />
+          </>
+        )}
+      </section>
+      <aside className="preview pdf-preview">
+        <iframe
+          className="pdf-preview-frame"
+          key={previewVersion}
+          src={api.profilePreviewPdfUrl(previewVersion)}
+          title="Rendered resume PDF preview"
+        />
       </aside>
     </div>
   );
+}
+
+type JsonRecord = Record<string, unknown>;
+
+function StructuredProfileEditor({
+  profileText,
+  styleText,
+  onProfileTextChange,
+  onStyleTextChange,
+}: {
+  profileText: string;
+  styleText: string;
+  onProfileTextChange: (value: string) => void;
+  onStyleTextChange: (value: string) => void;
+}): JSX.Element {
+  const profile = parseJsonRecord(profileText);
+  const style = parseJsonRecord(styleText);
+
+  if (!profile || !style) {
+    return (
+      <div className="banner inline">
+        The structured editor needs valid JSON. Switch to source, fix the invalid file, then return to fields.
+      </div>
+    );
+  }
+
+  const updateProfileDraft = (updater: (draft: JsonRecord) => void) => {
+    const draft = cloneJsonRecord(profile);
+    updater(draft);
+    onProfileTextChange(JSON.stringify(draft, null, 2));
+  };
+
+  const updateProfilePath = (path: string, value: unknown) => {
+    updateProfileDraft((draft) => setPathValue(draft, path, value));
+  };
+
+  const updateStylePath = (path: string, value: unknown) => {
+    const draft = cloneJsonRecord(style);
+    setPathValue(draft, path, value);
+    onStyleTextChange(JSON.stringify(draft, null, 2));
+  };
+
+  const setRequiredId = (path: string, id: string, checked: boolean) => {
+    if (!id) {
+      return;
+    }
+    updateProfileDraft((draft) => {
+      const values = new Set(textArrayAt(draft, path));
+      if (checked) {
+        values.add(id);
+      } else {
+        values.delete(id);
+      }
+      setPathValue(draft, path, Array.from(values));
+    });
+  };
+
+  const setRequiredBullet = (entryId: string, bullet: string, checked: boolean) => {
+    if (!entryId || !bullet) {
+      return;
+    }
+    updateProfileDraft((draft) => {
+      const mapPath = "resume.tailoring_rules.required_bullets_by_experience_id";
+      const existing = recordAt(draft, mapPath);
+      const values = new Set(asTextArray(existing[entryId]));
+      if (checked) {
+        values.add(bullet);
+      } else {
+        values.delete(bullet);
+      }
+      setPathValue(draft, mapPath, { ...existing, [entryId]: Array.from(values) });
+    });
+  };
+
+  const addRepeatItem = (path: string) => {
+    updateProfileDraft((draft) => {
+      const items = recordArrayAt(draft, path);
+      setPathValue(draft, path, [...items, defaultRepeatItem(path)]);
+    });
+  };
+
+  const removeRepeatItem = (path: string, index: number) => {
+    updateProfileDraft((draft) => {
+      const items = recordArrayAt(draft, path);
+      setPathValue(
+        draft,
+        path,
+        items.filter((_, itemIndex) => itemIndex !== index),
+      );
+    });
+  };
+
+  const addBullet = (entryIndex: number) => {
+    updateProfileDraft((draft) => {
+      const path = `resume.experience_entries.${entryIndex}.bullets`;
+      setPathValue(draft, path, [...textArrayAt(draft, path), ""]);
+    });
+  };
+
+  const removeBullet = (entryIndex: number, bulletIndex: number) => {
+    updateProfileDraft((draft) => {
+      const path = `resume.experience_entries.${entryIndex}.bullets`;
+      setPathValue(
+        draft,
+        path,
+        textArrayAt(draft, path).filter((_, index) => index !== bulletIndex),
+      );
+    });
+  };
+
+  const textField = (path: string, label: string, type = "text", attrs: Record<string, unknown> = {}) => (
+    <label className="field">
+      <span>{label}</span>
+      <input
+        {...attrs}
+        type={type}
+        value={textAt(profile, path)}
+        onChange={(event) => updateProfilePath(path, type === "number" ? numberOrEmpty(event.target.value) : event.target.value)}
+      />
+    </label>
+  );
+
+  const selectField = (path: string, label: string, options: Array<[string, string]> | string[]) => (
+    <label className="field">
+      <span>{label}</span>
+      <select value={textAt(profile, path)} onChange={(event) => updateProfilePath(path, event.target.value)}>
+        {options.map((option) => {
+          const value = Array.isArray(option) ? option[0] : option;
+          const text = Array.isArray(option) ? option[1] : option;
+          return (
+            <option key={value} value={value}>
+              {text}
+            </option>
+          );
+        })}
+      </select>
+    </label>
+  );
+
+  const checkboxField = (path: string, label: string) => (
+    <label className="field check">
+      <input checked={Boolean(getPathValue(profile, path))} type="checkbox" onChange={(event) => updateProfilePath(path, event.target.checked)} />
+      <span>{label}</span>
+    </label>
+  );
+
+  const textareaField = (path: string, label: string, placeholder = "") => (
+    <label className="field wide">
+      <span>{label}</span>
+      <textarea placeholder={placeholder} value={textAt(profile, path)} onChange={(event) => updateProfilePath(path, event.target.value)} />
+    </label>
+  );
+
+  const listField = (path: string, label: string) => (
+    <label className="field wide">
+      <span>{label}</span>
+      <textarea value={textArrayAt(profile, path).join("\n")} onChange={(event) => updateProfilePath(path, lines(event.target.value))} />
+    </label>
+  );
+
+  const styleSelect = (path: string, label: string, options: Array<[string, string]>) => (
+    <label className="field">
+      <span>{label}</span>
+      <select value={textAt(style, path)} onChange={(event) => updateStylePath(path, event.target.value)}>
+        {options.map(([value, text]) => (
+          <option key={value} value={value}>
+            {text}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+
+  const styleNumber = (path: string, label: string, min: number, max: number, step: number) => (
+    <label className="field">
+      <span>{label}</span>
+      <input
+        max={max}
+        min={min}
+        step={step}
+        type="number"
+        value={textAt(style, path)}
+        onChange={(event) => updateStylePath(path, numberOrEmpty(event.target.value))}
+      />
+    </label>
+  );
+
+  const experienceEntries = recordArrayAt(profile, "resume.experience_entries");
+  const educationEntries = recordArrayAt(profile, "resume.education_entries");
+  const skillCategories = recordArrayAt(profile, "resume.skill_categories");
+  const requiredExperienceIds = new Set(textArrayAt(profile, "resume.tailoring_rules.required_experience_entry_ids"));
+  const requiredEducationIds = new Set(textArrayAt(profile, "resume.tailoring_rules.required_education_entry_ids"));
+  const requiredSkillIds = new Set(textArrayAt(profile, "resume.tailoring_rules.required_skill_category_ids"));
+
+  return (
+    <div className="profile-sections">
+      <section className="form-section">
+        <h3>Personal information</h3>
+        <div className="field-grid">
+          {textField("personal.full_name", "Full name", "text", { required: true })}
+          {textField("personal.preferred_name", "Preferred name")}
+          {textField("personal.email", "Email", "email", { required: true })}
+          {textField("personal.password", "Application password", "password", { autoComplete: "new-password" })}
+          {textField("personal.phone", "Phone", "tel")}
+          {textField("personal.address", "Address")}
+          {textField("personal.city", "City")}
+          {textField("personal.province_state", "State / province")}
+          {textField("personal.country", "Country")}
+          {textField("personal.postal_code", "Postal code")}
+          {textField("personal.linkedin_url", "LinkedIn URL", "url")}
+          {textField("personal.github_url", "GitHub URL", "url")}
+          {textField("personal.portfolio_url", "Portfolio URL", "url")}
+          {textField("personal.website_url", "Website URL", "url")}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Application defaults</h3>
+        <div className="field-grid">
+          {selectField("work_authorization.legally_authorized_to_work", "Legally authorized to work", ["Yes", "No"])}
+          {selectField("work_authorization.require_sponsorship", "Requires sponsorship", ["No", "Yes"])}
+          {textField("work_authorization.work_permit_type", "Work permit type")}
+          {textField("availability.earliest_start_date", "Earliest start date", "date")}
+          {selectField("availability.available_for_full_time", "Available full-time", ["Yes", "No"])}
+          {selectField("availability.available_for_contract", "Available for contract", ["No", "Yes"])}
+          {textField("compensation.salary_expectation", "Salary expectation", "number", { min: 0, step: 1000 })}
+          {textField("compensation.salary_currency", "Salary currency")}
+          {textField("compensation.salary_range_min", "Salary range min", "number", { min: 0, step: 1000 })}
+          {textField("compensation.salary_range_max", "Salary range max", "number", { min: 0, step: 1000 })}
+          {textField("compensation.currency_conversion_note", "Currency note")}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Resume baseline</h3>
+        <div className="field-grid">
+          {textField("experience.years_of_experience_total", "Total years of experience", "number", { min: 0, step: 1 })}
+          {textField("experience.education_level", "Education level")}
+          {textField("experience.current_job_title", "Current job title")}
+          {textField("experience.current_company", "Current company")}
+          {textField("experience.target_role", "Target role")}
+          {textField("resume.tailoring_rules.max_experience_bullets", "Max bullets per role", "number", { min: 1, max: 10, step: 1 })}
+        </div>
+        <div className="field-grid one">
+          {listField("resume_constraints.real_metrics", "Real metrics the AI may reuse")}
+          {textareaField("resume.executive_profile.baseline_text", "Executive profile baseline")}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Tailoring controls</h3>
+        <div className="field-grid">
+          {selectField("resume.tailoring_rules.tailoring_policy.mode", "Tailoring mode", [
+            ["strict", "Strict"],
+            ["balanced", "Balanced"],
+            ["aggressive", "Aggressive"],
+          ])}
+          {selectField("resume.tailoring_rules.writing_style.tone", "Writing tone", [
+            ["direct", "Direct"],
+            ["executive", "Executive"],
+            ["technical", "Technical"],
+            ["confident", "Confident"],
+            ["warm", "Warm"],
+          ])}
+          {selectField("resume.tailoring_rules.writing_style.bullet_style", "Bullet style", [
+            ["balanced", "Balanced"],
+            ["impact", "Impact"],
+            ["technical_depth", "Technical depth"],
+            ["leadership", "Leadership"],
+          ])}
+          {selectField("resume.tailoring_rules.writing_style.verbosity", "Verbosity", [
+            ["concise", "Concise"],
+            ["balanced", "Balanced"],
+            ["detailed", "Detailed"],
+          ])}
+          {selectField("resume.tailoring_rules.writing_style.keyword_density", "Keyword density", [
+            ["natural", "Natural"],
+            ["moderate", "Moderate"],
+            ["high", "High"],
+          ])}
+          {checkboxField("resume.tailoring_rules.writing_style.avoid_first_person", "Avoid first-person language")}
+          {checkboxField("resume.tailoring_rules.tailoring_policy.allow_summary_rewrite", "AI may rewrite the executive summary")}
+          {checkboxField("resume.tailoring_rules.tailoring_policy.allow_title_reframing", "AI may reframe experience titles")}
+          {checkboxField("resume.tailoring_rules.tailoring_policy.allow_achievement_rewriting", "AI may rewrite achievement bullets")}
+          {checkboxField("resume.tailoring_rules.tailoring_policy.allow_skill_reordering", "AI may reorder or trim skill items")}
+          {checkboxField("resume.tailoring_rules.tailoring_policy.allow_minor_inference", "AI may make minor inferred phrasing")}
+        </div>
+        <div className="field-grid one">
+          {textareaField("resume.tailoring_rules.custom_tailoring_prompt", "Additional tailoring prompt", "Optional guidance injected into every resume tailoring prompt.")}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Resume style</h3>
+        <div className="field-grid">
+          {styleSelect("document_font_size", "Text size", [
+            ["10pt", "Small"],
+            ["11pt", "Regular"],
+            ["12pt", "Large"],
+          ])}
+          {styleSelect("font_family", "Text font", [
+            ["sans", "Sans"],
+            ["roman", "Serif"],
+          ])}
+          {styleSelect("body_alignment", "Body alignment", [
+            ["justified", "Justified"],
+            ["left", "Left aligned"],
+          ])}
+          {styleSelect("moderncv_style", "Template style", [
+            ["banking", "Banking"],
+            ["classic", "Classic"],
+            ["casual", "Casual"],
+            ["oldstyle", "Oldstyle"],
+            ["fancy", "Fancy"],
+          ])}
+          {styleSelect("moderncv_color", "Accent color", [
+            ["black", "Black"],
+            ["blue", "Blue"],
+            ["burgundy", "Burgundy"],
+            ["green", "Green"],
+            ["grey", "Grey"],
+            ["orange", "Orange"],
+            ["purple", "Purple"],
+            ["red", "Red"],
+          ])}
+          {styleSelect("paper_size", "Paper", [
+            ["a4paper", "A4"],
+            ["letterpaper", "Letter"],
+          ])}
+          {styleNumber("page_scale", "Page scale", 0.7, 1, 0.01)}
+          {styleNumber("hints_column_width_cm", "Date column width (cm)", 1.5, 5, 0.1)}
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Experience entries</h3>
+        <div className="repeat-list">
+          {experienceEntries.map((entry, index) => {
+            const entryId = textFrom(entry.id);
+            const bullets = asTextArray(entry.bullets);
+            const requiredBullets = new Set(asTextArray(recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId]));
+            return (
+              <div className="repeat-card" key={`${entryId || "experience"}-${index}`}>
+                <div className="repeat-hd">
+                  <b>{textFrom(entry.title) || `Experience ${index + 1}`}</b>
+                  <div className="repeat-controls">
+                    <label className="choice">
+                      <input
+                        checked={requiredExperienceIds.has(entryId)}
+                        disabled={!entryId}
+                        type="checkbox"
+                        onChange={(event) =>
+                          setRequiredId("resume.tailoring_rules.required_experience_entry_ids", entryId, event.target.checked)
+                        }
+                      />
+                      <span>must appear in final resume</span>
+                    </label>
+                    <button className="tab" onClick={() => removeRepeatItem("resume.experience_entries", index)} type="button">
+                      remove experience
+                    </button>
+                  </div>
+                </div>
+                <div className="field-grid">
+                  {textField(`resume.experience_entries.${index}.id`, "Entry ID")}
+                  {textField(`resume.experience_entries.${index}.date_range`, "Date range")}
+                  {textField(`resume.experience_entries.${index}.title`, "Title")}
+                  {textField(`resume.experience_entries.${index}.company`, "Company")}
+                  {textField(`resume.experience_entries.${index}.location`, "Location")}
+                </div>
+                <div className="bullet-list">
+                  {bullets.map((bullet, bulletIndex) => (
+                    <div className="bullet-row" key={`${entryId}-${bulletIndex}`}>
+                      <label className="field">
+                        <span>Bullet</span>
+                        <textarea
+                          value={bullet}
+                          onChange={(event) =>
+                            updateProfilePath(`resume.experience_entries.${index}.bullets.${bulletIndex}`, event.target.value)
+                          }
+                        />
+                      </label>
+                      <label className="choice">
+                        <input
+                          checked={requiredBullets.has(bullet)}
+                          disabled={!entryId || !bullet}
+                          type="checkbox"
+                          onChange={(event) => setRequiredBullet(entryId, bullet, event.target.checked)}
+                        />
+                        <span>must appear</span>
+                      </label>
+                      <button className="tab" onClick={() => removeBullet(index, bulletIndex)} type="button">
+                        remove bullet
+                      </button>
+                    </div>
+                  ))}
+                  <button className="tab" onClick={() => addBullet(index)} type="button">
+                    add bullet
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+          <button className="tab" onClick={() => addRepeatItem("resume.experience_entries")} type="button">
+            add experience
+          </button>
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Education</h3>
+        <div className="repeat-list">
+          {educationEntries.map((entry, index) => {
+            const entryId = textFrom(entry.id);
+            return (
+              <div className="repeat-card" key={`${entryId || "education"}-${index}`}>
+                <div className="repeat-hd">
+                  <b>{textFrom(entry.degree) || `Education ${index + 1}`}</b>
+                  <div className="repeat-controls">
+                    <label className="choice">
+                      <input
+                        checked={requiredEducationIds.has(entryId)}
+                        disabled={!entryId}
+                        type="checkbox"
+                        onChange={(event) =>
+                          setRequiredId("resume.tailoring_rules.required_education_entry_ids", entryId, event.target.checked)
+                        }
+                      />
+                      <span>must appear in final resume</span>
+                    </label>
+                    <button className="tab" onClick={() => removeRepeatItem("resume.education_entries", index)} type="button">
+                      remove education
+                    </button>
+                  </div>
+                </div>
+                <div className="field-grid">
+                  {textField(`resume.education_entries.${index}.id`, "Entry ID")}
+                  {textField(`resume.education_entries.${index}.date`, "Completion month", "month")}
+                  {textField(`resume.education_entries.${index}.degree`, "Degree")}
+                  {textField(`resume.education_entries.${index}.institution`, "Institution")}
+                  {textField(`resume.education_entries.${index}.location`, "Location")}
+                </div>
+              </div>
+            );
+          })}
+          <button className="tab" onClick={() => addRepeatItem("resume.education_entries")} type="button">
+            add education
+          </button>
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Skill categories</h3>
+        <div className="repeat-list">
+          {skillCategories.map((entry, index) => {
+            const entryId = textFrom(entry.id);
+            return (
+              <div className="repeat-card" key={`${entryId || "skills"}-${index}`}>
+                <div className="repeat-hd">
+                  <b>{textFrom(entry.label) || `Skill category ${index + 1}`}</b>
+                  <div className="repeat-controls">
+                    <label className="choice">
+                      <input
+                        checked={requiredSkillIds.has(entryId)}
+                        disabled={!entryId}
+                        type="checkbox"
+                        onChange={(event) => setRequiredId("resume.tailoring_rules.required_skill_category_ids", entryId, event.target.checked)}
+                      />
+                      <span>must appear in final resume</span>
+                    </label>
+                    <button className="tab" onClick={() => removeRepeatItem("resume.skill_categories", index)} type="button">
+                      remove skill category
+                    </button>
+                  </div>
+                </div>
+                <div className="field-grid">
+                  {textField(`resume.skill_categories.${index}.id`, "Category ID")}
+                  {textField(`resume.skill_categories.${index}.label`, "Label")}
+                  {listField(`resume.skill_categories.${index}.items`, "Skills")}
+                </div>
+              </div>
+            );
+          })}
+          <button className="tab" onClick={() => addRepeatItem("resume.skill_categories")} type="button">
+            add skill category
+          </button>
+        </div>
+      </section>
+
+      <section className="form-section">
+        <h3>Voluntary EEO</h3>
+        <div className="field-grid">
+          {textField("eeo_voluntary.gender", "Gender")}
+          {textField("eeo_voluntary.race_ethnicity", "Race / ethnicity")}
+          {textField("eeo_voluntary.veteran_status", "Veteran status")}
+          {textField("eeo_voluntary.disability_status", "Disability status")}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function parseJsonRecord(text: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(text);
+    return isJsonRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function cloneJsonRecord(value: JsonRecord): JsonRecord {
+  return JSON.parse(JSON.stringify(value)) as JsonRecord;
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function getPathValue(source: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    const key = /^\d+$/.test(segment) ? Number(segment) : segment;
+    return (current as Record<string | number, unknown>)[key];
+  }, source);
+}
+
+function setPathValue(source: JsonRecord, path: string, value: unknown): void {
+  const segments = path.split(".");
+  let current: Record<string | number, unknown> = source;
+  segments.forEach((segment, index) => {
+    const key = /^\d+$/.test(segment) ? Number(segment) : segment;
+    if (index === segments.length - 1) {
+      current[key] = value;
+      return;
+    }
+    const nextSegment = segments[index + 1] ?? "";
+    const nextIsArray = /^\d+$/.test(nextSegment);
+    if (!current[key] || typeof current[key] !== "object") {
+      current[key] = nextIsArray ? [] : {};
+    }
+    current = current[key] as Record<string | number, unknown>;
+  });
+}
+
+function textAt(source: unknown, path: string): string {
+  return textFrom(getPathValue(source, path));
+}
+
+function textFrom(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value);
+}
+
+function textArrayAt(source: unknown, path: string): string[] {
+  return asTextArray(getPathValue(source, path));
+}
+
+function asTextArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map(textFrom).filter((item) => item.length > 0) : [];
+}
+
+function recordAt(source: unknown, path: string): JsonRecord {
+  const value = getPathValue(source, path);
+  return isJsonRecord(value) ? value : {};
+}
+
+function recordArrayAt(source: unknown, path: string): JsonRecord[] {
+  const value = getPathValue(source, path);
+  return Array.isArray(value) ? value.filter(isJsonRecord) : [];
+}
+
+function numberOrEmpty(value: string): number | string {
+  return value.trim() ? Number(value) : "";
+}
+
+function lines(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function defaultRepeatItem(path: string): JsonRecord {
+  if (path === "resume.experience_entries") {
+    return { id: "", date_range: "", title: "", company: "", location: "", bullets: [""] };
+  }
+  if (path === "resume.education_entries") {
+    return { id: "", date: "", degree: "", institution: "", location: "" };
+  }
+  if (path === "resume.skill_categories") {
+    return { id: "", label: "", items: [""] };
+  }
+  return {};
 }
 
 function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void }): JSX.Element {
@@ -753,6 +1866,8 @@ function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void })
   const [error, setError] = useState("");
   const [actionStatus, setActionStatus] = useState("");
   const [actionBusy, setActionBusy] = useState("");
+
+  useEscapeKey(true, onClose);
 
   const loadDetail = useCallback(async () => {
     setDetail(null);
@@ -803,9 +1918,15 @@ function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void })
             <div className="drawer-head">
               <span className={`fit ${scoreTier(detail.job.fitScore)}`}>{detail.job.fitScore ?? "-"}</span>
               <span>
-                <small>{detail.job.company}</small>
+                <small>
+                  {detail.job.company}
+                  {detail.job.source && detail.job.source !== detail.job.company ? ` · source: ${detail.job.source}` : ""}
+                </small>
                 <h2>{detail.job.title}</h2>
                 <p>{detail.job.location || "-"} · {detail.job.salary || "-"}</p>
+                <a className="external-link" href={detail.job.url} rel="noreferrer" target="_blank">
+                  open original posting
+                </a>
               </span>
             </div>
             <div className="action-panel">
@@ -870,23 +1991,132 @@ function JobDrawer({ jobKey, onClose }: { jobKey: string; onClose: () => void })
             <Section title="Artifacts">
               {detail.artifacts.map((artifact) => (
                 <div className="mini-row" key={artifact.artifactId}>
-                  <span className={`tag ${artifact.status === "active" ? "ok" : "muted"}`}>{artifact.status}</span>
+                  <span className={`tag ${artifactStatusTone(artifact.status)}`}>{artifact.status}</span>
                   <span>{artifact.type}</span>
                   <code>{artifact.localPath}</code>
-                  <button className="tab on" disabled={Boolean(actionBusy)} onClick={() => void openArtifact(artifact)} type="button">
+                  <button
+                    className="tab on"
+                    disabled={Boolean(actionBusy) || artifact.status === "missing"}
+                    title={artifact.status === "missing" ? "Local file is missing; regenerate this artifact before opening it." : undefined}
+                    onClick={() => void openArtifact(artifact)}
+                    type="button"
+                  >
                     open
                   </button>
                 </div>
               ))}
             </Section>
             <Section title="Score reasoning">
-              <p>{detail.job.scoreReasoning || "-"}</p>
+              <ScoreReasoning text={detail.job.scoreReasoning} fitScore={detail.job.fitScore} />
             </Section>
-            <Section title="Description preview">
-              <p>{detail.job.descriptionPreview || "-"}</p>
+            <Section title="Description">
+              <JobDescription text={detail.job.descriptionPreview} />
             </Section>
           </>
         ) : null}
+      </aside>
+    </div>
+  );
+}
+
+function ApplyRunDrawer({
+  run,
+  onClose,
+  onOpenJob,
+}: {
+  run: ApplyRunSummary;
+  onClose: () => void;
+  onOpenJob: (jobKey: string) => void;
+}): JSX.Element {
+  useEscapeKey(true, onClose);
+
+  return (
+    <div className="drawer-backdrop">
+      <aside className="drawer detail-drawer">
+        <button aria-label="Close apply run details" className="drawer-close" onClick={onClose} type="button">
+          x
+        </button>
+        <div className="drawer-head">
+          <StatusDot state={run.status === "running" ? "running" : run.status === "failed" ? "failed" : "succeeded"} />
+          <span>
+            <small>{run.company}</small>
+            <h2>{run.title || "Apply run"}</h2>
+            <p>{run.status} · {run.dryRun ? "dry-run" : "live run"}</p>
+          </span>
+        </div>
+        <Section title="Run details">
+          <dl className="detail-list">
+            <div>
+              <dt>Run id</dt>
+              <dd className="mono">{run.runId}</dd>
+            </div>
+            <div>
+              <dt>Job</dt>
+              <dd>{run.title || run.jobKey}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{run.status}</dd>
+            </div>
+            <div>
+              <dt>Dry-run</dt>
+              <dd>{run.dryRun ? "yes" : "no"}</dd>
+            </div>
+            <div>
+              <dt>Started</dt>
+              <dd>{formatDateTime(run.startedAt)}</dd>
+            </div>
+          </dl>
+          <button className="tab on" disabled={!run.jobKey} onClick={() => onOpenJob(run.jobKey)} type="button">
+            open related job
+          </button>
+        </Section>
+      </aside>
+    </div>
+  );
+}
+
+function ActivityDetailDrawer({ activity, onClose }: { activity: ActivityEvent; onClose: () => void }): JSX.Element {
+  useEscapeKey(true, onClose);
+
+  return (
+    <div className="drawer-backdrop">
+      <aside className="drawer detail-drawer">
+        <button aria-label="Close activity details" className="drawer-close" onClick={onClose} type="button">
+          x
+        </button>
+        <div className="drawer-head">
+          <span className={`tag ${activity.level === "error" ? "danger" : "muted"}`}>{activity.level}</span>
+          <span>
+            <small>{activity.stage}</small>
+            <h2>{activity.message}</h2>
+            <p>{formatDateTime(activity.at)}</p>
+          </span>
+        </div>
+        <Section title="Event details">
+          <dl className="detail-list">
+            <div>
+              <dt>Event id</dt>
+              <dd className="mono">{activity.eventId}</dd>
+            </div>
+            <div>
+              <dt>Stage</dt>
+              <dd>{activity.stage}</dd>
+            </div>
+            <div>
+              <dt>Level</dt>
+              <dd>{activity.level}</dd>
+            </div>
+            <div>
+              <dt>Timestamp</dt>
+              <dd>{formatDateTime(activity.at)}</dd>
+            </div>
+            <div>
+              <dt>Message</dt>
+              <dd>{activity.message}</dd>
+            </div>
+          </dl>
+        </Section>
       </aside>
     </div>
   );
@@ -997,6 +2227,56 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
+function ScoreReasoning({ text, fitScore }: { text: string; fitScore: number | null }): JSX.Element {
+  const parsed = parseScoreReasoning(text);
+  const keywordOnlyReason =
+    parsed.reason && parsed.keywords.length
+      ? parsed.reason.toLowerCase().replace(/\s+/g, " ") === parsed.keywords.join(", ").toLowerCase().replace(/\s+/g, " ")
+      : false;
+  return (
+    <div className="score-explainer">
+      <div className="score-line">
+        <span className={`fit ${scoreTier(fitScore)}`}>{fitScore ?? parsed.score ?? "-"}</span>
+        <span>
+          <b>{fitScore ?? parsed.score ?? "-"} / 10 fit score</b>
+          <small>Current scoring output. Feedback-based personalization is tracked as backlog work.</small>
+        </span>
+      </div>
+      {parsed.reason && !keywordOnlyReason ? (
+        <p>{parsed.reason}</p>
+      ) : (
+        <p className="muted">
+          This stored score only includes keyword evidence. It does not yet explain weighting, missing signals, or why this
+          landed at this exact value.
+        </p>
+      )}
+      {parsed.keywords.length ? (
+        <div className="keyword-list" aria-label="Tracked keywords">
+          {parsed.keywords.map((keyword) => (
+            <span className="tag info" key={keyword}>
+              {keyword}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function JobDescription({ text }: { text: string }): JSX.Element {
+  const blocks = descriptionBlocks(text);
+  if (!blocks.length) {
+    return <p className="muted">No description captured.</p>;
+  }
+  return (
+    <div className="description-text">
+      {blocks.map((block, index) => (
+        <p key={`${block.slice(0, 40)}-${index}`}>{block}</p>
+      ))}
+    </div>
+  );
+}
+
 function SelectPairs<T extends string>({
   options,
   value,
@@ -1069,18 +2349,157 @@ function stateTone(state: string): string {
   return "muted";
 }
 
-function extractName(profile: unknown): string {
-  return readString(profile, ["personal", "full_name"]);
+function artifactStatusTone(status: string): string {
+  if (status === "active" || status === "approved") {
+    return "ok";
+  }
+  if (status === "missing" || status === "stale") {
+    return "warn";
+  }
+  return "muted";
 }
 
-function extractContact(profile: unknown): string {
-  return [readString(profile, ["personal", "email"]), readString(profile, ["personal", "phone"]), readString(profile, ["personal", "city"])]
-    .filter(Boolean)
-    .join(" · ");
+function useEscapeKey(active: boolean, onEscape: () => void): void {
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+    const listener = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onEscape();
+      }
+    };
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  }, [active, onEscape]);
 }
 
-function extractSummary(profile: unknown): string {
-  return readString(profile, ["resume", "executive_profile_baseline"]) || readString(profile, ["resume", "summary"]) || "-";
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function parseScoreReasoning(text: string): { keywords: string[]; reason: string; score: number | null } {
+  const scoreMatch = text.match(/\bscore\s*:\s*([0-9]+(?:\.[0-9]+)?)/i);
+  const keywordMatch = text.match(/\bkeywords\s*:\s*(.*)$/i);
+  const score = scoreMatch ? Number.parseFloat(scoreMatch[1] ?? "") : null;
+  const keywords = keywordMatch
+    ? keywordMatch[1]
+        .split(",")
+        .map((keyword) => keyword.trim())
+        .filter(Boolean)
+    : [];
+  const cleanedText = text
+    .replace(/\bscore\s*:\s*[0-9]+(?:\.[0-9]+)?/gi, "")
+    .replace(/\bkeywords\s*:.*$/i, "")
+    .trim();
+  const lines = cleanedText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const reason = lines
+    .join("\n")
+    .trim();
+  return {
+    keywords,
+    reason,
+    score: Number.isFinite(score) ? score : null,
+  };
+}
+
+function descriptionBlocks(text: string): string[] {
+  const explicitBlocks = text
+    .replace(/\r\n/g, "\n")
+    .split(/\n{2,}/)
+    .map((block) => block.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  if (explicitBlocks.length > 1) {
+    return explicitBlocks;
+  }
+  const collapsed = explicitBlocks[0] ?? "";
+  if (!collapsed) {
+    return [];
+  }
+  const sentences = collapsed.split(/(?<=[.!?])\s+(?=[A-Z0-9*])/);
+  const blocks: string[] = [];
+  let current = "";
+  for (const sentence of sentences) {
+    const next = current ? `${current} ${sentence}` : sentence;
+    if (next.length > 520 && current) {
+      blocks.push(current);
+      current = sentence;
+    } else {
+      current = next;
+    }
+  }
+  if (current) {
+    blocks.push(current);
+  }
+  return blocks;
+}
+
+function formatCompanySource(company: string, source: string): string {
+  if (!source || source === "unknown" || source === company) {
+    return company;
+  }
+  return `${company} · ${source}`;
+}
+
+function groupArtifacts(artifacts: ArtifactSummary[]): ArtifactGroup[] {
+  const groups = new Map<string, ArtifactGroup>();
+  for (const artifact of artifacts) {
+    const groupKey = artifact.jobKey || `${artifact.title}:${artifact.company}`;
+    const group = groups.get(groupKey) ?? {
+      groupKey,
+      jobKey: artifact.jobKey,
+      title: artifact.title,
+      company: artifact.company,
+      artifacts: [],
+    };
+    group.artifacts.push(artifact);
+    groups.set(groupKey, group);
+  }
+  return Array.from(groups.values()).map((group) => ({
+    ...group,
+    artifacts: group.artifacts.slice().sort((left, right) => compareArtifactVersions(left, right)),
+  }));
+}
+
+function compareArtifactVersions(left: ArtifactSummary, right: ArtifactSummary): number {
+  return artifactVersionRank(left.type) - artifactVersionRank(right.type) || left.type.localeCompare(right.type);
+}
+
+function artifactVersionRank(type: string): number {
+  if (type.includes("resume") && type.endsWith("_txt")) {
+    return 10;
+  }
+  if (type.includes("resume") && type.endsWith("_pdf")) {
+    return 20;
+  }
+  if (type.includes("cover") && type.endsWith("_txt")) {
+    return 30;
+  }
+  if (type.includes("cover") && type.endsWith("_pdf")) {
+    return 40;
+  }
+  return 50;
+}
+
+function artifactKind(type: string): string {
+  return type.includes("cover") ? "cover" : type.includes("resume") ? "resume" : "artifact";
+}
+
+function artifactVersionLabel(type: string): string {
+  if (type.endsWith("_pdf")) {
+    return "PDF";
+  }
+  if (type.endsWith("_txt")) {
+    return "TXT";
+  }
+  return type.replaceAll("_", " ");
 }
 
 async function fileToBase64(file: File): Promise<string> {
@@ -1092,13 +2511,6 @@ async function fileToBase64(file: File): Promise<string> {
   return btoa(binary);
 }
 
-function readString(source: unknown, path: string[]): string {
-  let value = source;
-  for (const part of path) {
-    if (!value || typeof value !== "object" || !(part in value)) {
-      return "";
-    }
-    value = (value as Record<string, unknown>)[part];
-  }
-  return typeof value === "string" ? value : "";
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -26,6 +26,21 @@
   font-size: 14px;
 }
 
+[data-theme="dark"] {
+  --bg: #14130f;
+  --paper: #1a1814;
+  --paper-2: #221f1a;
+  --rule: rgba(255, 255, 255, 0.08);
+  --rule-2: rgba(255, 255, 255, 0.16);
+  --ink: #f1eee5;
+  --muted: #aaa69a;
+  --soft: #777368;
+  --danger: #d86c5d;
+  --warn: #d0a34a;
+  --ok: #69aa83;
+  --info: #88a1bc;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -93,6 +108,12 @@ code,
 .nav {
   display: flex;
   gap: 4px;
+}
+
+.global-search {
+  min-width: 280px;
+  max-width: 560px;
+  flex: 1;
 }
 
 .nav button,
@@ -257,6 +278,98 @@ textarea {
   flex: 1;
 }
 
+.config-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.config-form,
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 16px;
+  padding: 14px 16px;
+}
+
+.field-grid.one {
+  grid-template-columns: 1fr;
+}
+
+.field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+}
+
+.field textarea {
+  min-height: 84px;
+  resize: vertical;
+}
+
+.field.wide,
+.form-actions {
+  grid-column: 1 / -1;
+}
+
+.field.check {
+  flex-direction: row;
+  align-items: center;
+}
+
+.field.check input {
+  width: auto;
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.credential-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.credential-row {
+  display: grid;
+  grid-template-columns: 110px minmax(220px, 0.8fr) minmax(260px, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.credential-row input {
+  min-width: 0;
+}
+
+.bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--rule);
+  padding: 10px 16px;
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.danger-action {
+  color: var(--danger);
+}
+
 .funnel {
   display: flex;
   flex-direction: column;
@@ -347,12 +460,40 @@ textarea {
 }
 
 .data-row.job {
-  grid-template-columns: 54px minmax(220px, 1.2fr) minmax(160px, 0.8fr) 210px 120px;
+  grid-template-columns: 28px 70px minmax(180px, 1.25fr) minmax(160px, 0.85fr) minmax(150px, 0.85fr) 90px 105px 110px;
   gap: 14px;
 }
 
-.data-row.artifact {
-  grid-template-columns: 92px minmax(220px, 1fr) 150px minmax(240px, 1.3fr) 80px auto;
+.data-row.job-header {
+  min-height: 34px;
+  background: var(--paper-2);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.data-row.job-header:hover {
+  background: var(--paper-2);
+}
+
+.sort-head {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  text-align: left;
+}
+
+.sort-head.active,
+.sort-head:hover {
+  color: var(--ink);
+}
+
+.data-row.artifact-group {
+  grid-template-columns: minmax(240px, 0.8fr) minmax(320px, 1.4fr) auto;
   gap: 14px;
 }
 
@@ -368,7 +509,44 @@ textarea {
 }
 
 .activity-row {
-  grid-template-columns: 70px 90px minmax(0, 1fr);
+  grid-template-columns: 70px 90px minmax(0, 1fr) 130px;
+}
+
+.clickable-row {
+  width: 100%;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.clickable-row:hover {
+  background: var(--paper-2);
+}
+
+.activity-main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.activity-main b,
+.activity-main span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-main span {
+  color: var(--muted);
+}
+
+.activity-row > .mono {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .section .mini-row {
@@ -391,8 +569,16 @@ textarea {
 }
 
 .title-stack span,
-.path-cell {
+.path-cell,
+.muted-cell {
   color: var(--muted);
+}
+
+.muted-cell {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .fit {
@@ -461,6 +647,45 @@ textarea {
   gap: 6px;
 }
 
+.row-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.row-check input {
+  width: 16px;
+  height: 16px;
+}
+
+.artifact-variants {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.artifact-variant {
+  display: inline-grid;
+  grid-template-columns: auto auto auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper-2);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.artifact-variant:hover {
+  border-color: var(--rule-2);
+}
+
+.artifact-variant:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 .status-line {
   border-bottom: 1px solid var(--rule);
   padding: 9px 16px;
@@ -519,9 +744,53 @@ textarea {
   border-bottom: 1px solid var(--rule);
 }
 
+.drawer-head > span:last-child {
+  min-width: 0;
+}
+
 .drawer-head h2 {
   margin: 4px 0;
   font-size: 22px;
+}
+
+.external-link {
+  color: var(--info);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-decoration: none;
+}
+
+.external-link:hover {
+  text-decoration: underline;
+}
+
+.score-explainer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.score-line {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.score-line span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.score-line small {
+  color: var(--muted);
+}
+
+.keyword-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .notice {
@@ -606,6 +875,45 @@ textarea {
   font-size: 13px;
 }
 
+.detail-list {
+  display: grid;
+  gap: 10px;
+  margin: 0 0 14px;
+}
+
+.detail-list div {
+  display: grid;
+  grid-template-columns: 110px minmax(0, 1fr);
+  gap: 12px;
+}
+
+.detail-list dt {
+  color: var(--muted);
+}
+
+.detail-list dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.preformatted {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.description-text {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 72ch;
+}
+
+.description-text p {
+  margin: 0;
+  line-height: 1.45;
+}
+
 .profile-layout {
   display: grid;
   grid-template-columns: minmax(460px, 1.4fr) minmax(360px, 0.8fr);
@@ -683,6 +991,88 @@ textarea {
   border-bottom: 1px solid var(--rule);
 }
 
+.profile-mode-tabs {
+  display: flex;
+  gap: 6px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.profile-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 16px;
+}
+
+.form-section {
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  background: var(--paper);
+}
+
+.form-section h3 {
+  margin: 0;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-2);
+  padding: 10px 12px;
+  font-size: 13px;
+}
+
+.repeat-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.repeat-card {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper-2);
+  padding: 10px;
+}
+
+.repeat-hd,
+.repeat-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.repeat-hd {
+  justify-content: space-between;
+}
+
+.repeat-controls {
+  flex-wrap: wrap;
+}
+
+.choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.bullet-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bullet-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 120px auto;
+  align-items: start;
+  gap: 8px;
+}
+
 .editor {
   display: flex;
   flex-direction: column;
@@ -717,6 +1107,20 @@ textarea {
   background: var(--paper);
 }
 
+.pdf-preview {
+  height: calc(100vh - 112px);
+  min-height: 720px;
+  overflow: hidden;
+}
+
+.pdf-preview-frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: var(--paper);
+}
+
 .preview-page {
   padding: 24px;
   line-height: 1.45;
@@ -737,6 +1141,15 @@ textarea {
   text-transform: uppercase;
 }
 
+.preview-page ul {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.preview-page li + li {
+  margin-top: 6px;
+}
+
 @media (max-width: 1000px) {
   .kpis,
   .dashboard-grid,
@@ -750,8 +1163,11 @@ textarea {
 
   .data-row.job,
   .data-row.artifact,
+  .data-row.artifact-group,
+  .activity-row,
   .funnel-row,
   .action-panel,
+  .detail-list div,
   .section .mini-row {
     grid-template-columns: 1fr;
   }

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -23,13 +23,33 @@ This is the authoritative roadmap. Keep detailed historical proposals under
 - Separate original job URL from final application URL.
 - Reduce reliance on legacy nullable `jobs` columns in read paths.
 - Ensure artifact records are created before files are shown or opened in the UI.
+- Split employer/company from source board in the job model so Greenhouse,
+  LinkedIn, Talent.com, and direct employer records do not overload `site`.
+- Index normalized scoring keywords per job, expose keyword filters/search, and
+  add aggregate views or plots for keyword distribution across the pipeline.
+
+### Scoring Intelligence
+
+- Replace raw score reasoning strings with an explanatory score breakdown that
+  shows why a job received its exact fit score.
+- Let the user correct a job fit score, store the correction and rationale, and
+  use that feedback to personalize scoring for the remaining jobs based on
+  relevant signals to be defined.
 
 ### UI Quality
 
+- Spike the best long-term resume rendering path. Evaluate whether to keep
+  LaTeX as the PDF source of truth, switch to Tectonic, replace LaTeX with a
+  different document engine such as Typst, or move to an HTML/CSS paged-media
+  renderer. The spike should compare PDF fidelity, browser preview quality,
+  editable profile UX, local packaging, performance, generated artifact
+  compatibility, and migration cost.
 - Add React tests for persisted profile field save/discard behavior.
 - Add React tests for artifact open behavior.
 - Add browser smoke coverage for action buttons and action status polling.
 - Preserve user filters, sort, page, and selection during live updates.
+- Add side-by-side artifact comparison in the app, including AI-assisted
+  comparison for resume and cover-letter variants.
 
 ## SaaS And Commercialization
 

--- a/docs/plans/implemented/2026-05-03-local-reliability-qa.md
+++ b/docs/plans/implemented/2026-05-03-local-reliability-qa.md
@@ -10,6 +10,7 @@ Run these before merging the Phase 7 stack branch:
 
 ```bash
 npm test
+npm run qa:test
 uv run pytest -q
 git diff --check
 ```
@@ -26,6 +27,19 @@ npm run web:dev -- --port 5173
 Open the URL printed by Vite. It is usually `http://127.0.0.1:5173`, but Vite
 can choose a different port when 5173 is already in use because the web dev
 server does not run with `strictPort`.
+
+For destructive browser QA, seed a disposable workspace and point both servers
+at it:
+
+```bash
+npm run qa:seed -- /tmp/jobhunter-qa
+JOBHUNTER_DIR=/tmp/jobhunter-qa npm run api:dev
+VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 npm run web:dev -- --port 5173
+```
+
+The seed includes active and failed jobs, deleted-job workflows, artifacts,
+missing files, apply runs, dashboard events, profile files, settings, and a
+safe local artifact directory.
 
 ## Reliability Matrix
 
@@ -46,6 +60,7 @@ server does not run with `strictPort`.
 | Filters reset while editing | The React frontend has no automatic list polling; list refresh is explicit through the refresh button or filter changes. | Browser smoke |
 | Generated artifacts cannot be opened safely | The TypeScript API only opens known local artifact paths, and the React UI routes artifact buttons through that API. | `services/api/test/server.test.ts` and browser smoke |
 | Profile/style save and discard flows regress | The TypeScript API persists profile/style/template changes, and the React UI exposes save, discard, and resume-import draft controls. | `services/api/test/server.test.ts` and browser smoke |
+| Destructive UI workflows need safe data | A disposable seeded QA workspace exercises soft delete/restore, artifact open/missing handling, profile/settings saves, credentials, and dashboard filtering without touching the user's real local database. | `services/api/test/qa-workflow.test.ts` and browser smoke against `npm run qa:seed` |
 
 ## React Browser Smoke
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "web:dev": "vite --config apps/web/vite.config.ts --host 127.0.0.1",
     "web:build": "vite build --config apps/web/vite.config.ts",
     "web:preview": "vite preview --config apps/web/vite.config.ts --host 127.0.0.1",
+    "qa:seed": "tsx services/api/test/qa-seed.ts",
+    "qa:test": "vitest run services/api/test/qa-workflow.test.ts",
     "test": "npm run api:check && npm run api:test && npm run web:check && npm run web:build"
   },
   "repository": {

--- a/packages/contracts/src/client.ts
+++ b/packages/contracts/src/client.ts
@@ -5,11 +5,17 @@ import type {
   ArtifactListQuery,
   ArtifactOpenResponse,
   ArtifactSummary,
+  BulkJobMutationRequest,
   CancelJobActionRequest,
+  CredentialKey,
+  CredentialsResponse,
+  CredentialUpdateRequest,
   DashboardSummary,
+  DeleteJobRequest,
   GenerateMaterialsRequest,
   JobDetail,
   JobListQuery,
+  JobMutationResponse,
   JobSummary,
   MarkJobActionRequest,
   PaginatedResponse,
@@ -18,6 +24,7 @@ import type {
   ProfileImportResponse,
   ProfileUpdateRequest,
   RetryStageRequest,
+  SettingsUpdateRequest,
   SettingsResponse,
 } from "./schemas.js";
 
@@ -53,6 +60,22 @@ export class JobHunterApiClient {
     return this.get(`/v1/jobs/${encodeURIComponent(jobKey)}`);
   }
 
+  deleteJob(jobKey: string, body: DeleteJobRequest = {}): Promise<JobMutationResponse> {
+    return this.delete(`/v1/jobs/${encodeURIComponent(jobKey)}`, body);
+  }
+
+  deleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
+    return this.post("/v1/jobs/bulk-delete", body);
+  }
+
+  restoreJob(jobKey: string): Promise<JobMutationResponse> {
+    return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/restore`);
+  }
+
+  restoreJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
+    return this.post("/v1/jobs/bulk-restore", body);
+  }
+
   artifacts(query: Partial<ArtifactListQuery> = {}): Promise<PaginatedResponse<ArtifactSummary>> {
     return this.get("/v1/artifacts", query);
   }
@@ -69,6 +92,15 @@ export class JobHunterApiClient {
     return this.get("/v1/profile");
   }
 
+  profilePreviewPdfUrl(cacheKey?: QueryValue): string {
+    const path = "/v1/profile/preview.pdf";
+    const url = new URL(`${this.baseUrl}${path}`, this.baseUrl ? undefined : "http://jobhunter.local");
+    if (cacheKey !== undefined && cacheKey !== null && cacheKey !== "") {
+      url.searchParams.set("v", String(cacheKey));
+    }
+    return this.baseUrl ? url.href : `${url.pathname}${url.search}`;
+  }
+
   updateProfile(body: ProfileUpdateRequest): Promise<ProfileConfigResponse> {
     return this.patch("/v1/profile", body);
   }
@@ -79,6 +111,22 @@ export class JobHunterApiClient {
 
   settings(): Promise<SettingsResponse> {
     return this.get("/v1/settings");
+  }
+
+  updateSettings(body: SettingsUpdateRequest): Promise<SettingsResponse> {
+    return this.patch("/v1/settings", body);
+  }
+
+  credentials(): Promise<CredentialsResponse> {
+    return this.get("/v1/credentials");
+  }
+
+  updateCredential(body: CredentialUpdateRequest): Promise<CredentialsResponse> {
+    return this.patch("/v1/credentials", body);
+  }
+
+  deleteCredential(key: CredentialKey): Promise<CredentialsResponse> {
+    return this.delete(`/v1/credentials/${encodeURIComponent(key)}`);
   }
 
   retryStage(jobKey: string, body: RetryStageRequest): Promise<ActionRunResponse> {
@@ -117,8 +165,12 @@ export class JobHunterApiClient {
     return this.request("POST", path, { body });
   }
 
+  private async delete<T>(path: string, body?: unknown): Promise<T> {
+    return this.request("DELETE", path, { body });
+  }
+
   private async request<T>(
-    method: "GET" | "PATCH" | "POST",
+    method: "DELETE" | "GET" | "PATCH" | "POST",
     path: string,
     options: { body?: unknown; query?: Record<string, QueryValue> } = {},
   ): Promise<T> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -19,11 +19,14 @@ export const STAGE_STATES = [
   "stale",
 ] as const;
 export type StageState = (typeof STAGE_STATES)[number];
+export const JOB_DELETED_FILTERS = ["active", "deleted", "all"] as const;
+export type JobDeletedFilter = (typeof JOB_DELETED_FILTERS)[number];
 
 export const JOB_SORT_FIELDS = [
   "discovered_at",
   "title",
   "company",
+  "location",
   "fit_score",
   "current_stage",
   "current_state",
@@ -34,6 +37,15 @@ export const ARTIFACT_SORT_FIELDS = ["created_at", "title", "company", "type", "
 export type ArtifactSortField = (typeof ARTIFACT_SORT_FIELDS)[number];
 
 export const SortDirectionSchema = z.enum(["asc", "desc"]).default("desc").catch("desc");
+
+const optionalText = z
+  .string()
+  .trim()
+  .optional()
+  .catch("")
+  .transform((value) => value ?? "");
+
+const optionalNumber = z.coerce.number().int().optional().catch(undefined);
 
 export const RetryStageRequestSchema = z
   .object({
@@ -78,6 +90,40 @@ export const MarkJobActionRequestSchema = z
   .strict();
 export type MarkJobActionRequest = z.infer<typeof MarkJobActionRequestSchema>;
 
+export const DeleteJobRequestSchema = z
+  .object({
+    reason: z.string().trim().max(400).optional(),
+  })
+  .strict();
+export type DeleteJobRequest = z.infer<typeof DeleteJobRequestSchema>;
+
+export const BulkJobMutationFilterSchema = z
+  .object({
+    q: optionalText,
+    stage: z.enum(STAGES).optional().catch(undefined),
+    state: z.enum(STAGE_STATES).optional().catch(undefined),
+    deleted: z.enum(JOB_DELETED_FILTERS).default("active").catch("active"),
+    source: optionalText,
+    company: optionalText,
+    minFitScore: optionalNumber,
+    maxFitScore: optionalNumber,
+  })
+  .strict();
+export type BulkJobMutationFilter = z.infer<typeof BulkJobMutationFilterSchema>;
+
+export const BulkJobMutationRequestSchema = z
+  .object({
+    jobKeys: z.array(z.string().trim().min(1)).max(5000).default([]),
+    allMatching: z.boolean().default(false),
+    filter: BulkJobMutationFilterSchema.optional(),
+    reason: z.string().trim().max(400).optional(),
+  })
+  .strict()
+  .refine((value) => value.allMatching || value.jobKeys.length > 0, {
+    message: "Provide jobKeys or set allMatching.",
+  });
+export type BulkJobMutationRequest = z.infer<typeof BulkJobMutationRequestSchema>;
+
 export const ProfileUpdateRequestSchema = z
   .object({
     profile: z.unknown().optional(),
@@ -99,14 +145,29 @@ export const ProfileImportRequestSchema = z
   .strict();
 export type ProfileImportRequest = z.infer<typeof ProfileImportRequestSchema>;
 
-const optionalText = z
-  .string()
-  .trim()
-  .optional()
-  .catch("")
-  .transform((value) => value ?? "");
+export const SettingsUpdateRequestSchema = z
+  .object({
+    targetRole: z.string().trim().max(240).optional(),
+    locationFilter: z.string().trim().max(240).optional(),
+    minFitScore: z.coerce.number().int().min(0).max(10).optional(),
+    autoApply: z.boolean().optional(),
+    applyConcurrency: z.coerce.number().int().min(1).max(16).optional(),
+    scoreCriteria: z.string().max(8000).optional(),
+    targetCriteria: z.string().max(8000).optional(),
+  })
+  .strict();
+export type SettingsUpdateRequest = z.infer<typeof SettingsUpdateRequestSchema>;
 
-const optionalNumber = z.coerce.number().int().optional().catch(undefined);
+export const CredentialKeys = ["OPENAI_API_KEY", "GEMINI_API_KEY", "LLM_URL"] as const;
+export type CredentialKey = (typeof CredentialKeys)[number];
+
+export const CredentialUpdateRequestSchema = z
+  .object({
+    key: z.enum(CredentialKeys),
+    value: z.string().min(1).max(8000),
+  })
+  .strict();
+export type CredentialUpdateRequest = z.infer<typeof CredentialUpdateRequestSchema>;
 
 export const JobListQuerySchema = z
   .object({
@@ -118,6 +179,7 @@ export const JobListQuerySchema = z
     q: optionalText,
     stage: z.enum(STAGES).optional().catch(undefined),
     state: z.enum(STAGE_STATES).optional().catch(undefined),
+    deleted: z.enum(JOB_DELETED_FILTERS).default("active").catch("active"),
     source: optionalText,
     company: optionalText,
     minFitScore: optionalNumber,
@@ -184,6 +246,7 @@ export interface JobSummary {
   artifactCount: number;
   applyStatus: string | null;
   appliedAt: string | null;
+  deletedAt: string | null;
 }
 
 export interface ArtifactSummary {
@@ -236,7 +299,10 @@ export interface DashboardSummary {
     failed: number;
   }>;
   activity: Array<{
+    eventId: string;
     jobKey: string | null;
+    title: string | null;
+    company: string | null;
     stage: string;
     level: string;
     message: string;
@@ -327,12 +393,20 @@ export interface ActionRunResponse {
   message?: string;
 }
 
+export interface JobMutationResponse {
+  ok: true;
+  count: number;
+  jobKeys: string[];
+}
+
 export interface DashboardSettings {
   targetRole: string;
   locationFilter: string;
   minFitScore: number;
   autoApply: boolean;
   applyConcurrency: number;
+  scoreCriteria: string;
+  targetCriteria: string;
 }
 
 export interface SettingsResponse {
@@ -341,4 +415,14 @@ export interface SettingsResponse {
   paths: {
     settingsPath: string;
   };
+}
+
+export interface CredentialsResponse {
+  ok: true;
+  credentials: Array<{
+    key: CredentialKey;
+    label: string;
+    configured: boolean;
+    storage: "keychain";
+  }>;
 }

--- a/services/api/src/credentials.ts
+++ b/services/api/src/credentials.ts
@@ -1,0 +1,82 @@
+import { spawn } from "node:child_process";
+
+import type { CredentialKey, CredentialsResponse } from "./contracts.js";
+import { CredentialKeys } from "./contracts.js";
+
+const KEYCHAIN_SERVICE = "JobHunter";
+
+const LABELS: Record<CredentialKey, string> = {
+  OPENAI_API_KEY: "OpenAI API key",
+  GEMINI_API_KEY: "Gemini API key",
+  LLM_URL: "LLM endpoint",
+};
+
+export interface CredentialStore {
+  list(): Promise<CredentialsResponse>;
+  set(key: CredentialKey, value: string): Promise<CredentialsResponse>;
+  delete(key: CredentialKey): Promise<CredentialsResponse>;
+}
+
+export class KeychainCredentialStore implements CredentialStore {
+  async list(): Promise<CredentialsResponse> {
+    const credentials = await Promise.all(
+      CredentialKeys.map(async (key) => ({
+        key,
+        label: LABELS[key],
+        configured: await this.exists(key),
+        storage: "keychain" as const,
+      })),
+    );
+    return { ok: true, credentials };
+  }
+
+  async set(key: CredentialKey, value: string): Promise<CredentialsResponse> {
+    await runSecurity(["add-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key, "-w", value, "-U"]);
+    return this.list();
+  }
+
+  async delete(key: CredentialKey): Promise<CredentialsResponse> {
+    const result = await runSecurity(["delete-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key], {
+      allowFailure: true,
+    });
+    if (result.code !== 0 && !result.stderr.includes("could not be found")) {
+      throw new Error(result.stderr || `security exited with ${result.code}`);
+    }
+    return this.list();
+  }
+
+  private async exists(key: CredentialKey): Promise<boolean> {
+    const result = await runSecurity(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", key], {
+      allowFailure: true,
+    });
+    return result.code === 0;
+  }
+}
+
+async function runSecurity(
+  args: string[],
+  options: { allowFailure?: boolean } = {},
+): Promise<{ code: number; stderr: string; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("security", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const exitCode = code ?? 1;
+      if (exitCode === 0 || options.allowFailure) {
+        resolve({ code: exitCode, stderr: stderr.trim(), stdout: stdout.trim() });
+        return;
+      }
+      reject(new Error(stderr.trim() || `security exited with ${exitCode}`));
+    });
+  });
+}

--- a/services/api/src/local-actions.ts
+++ b/services/api/src/local-actions.ts
@@ -45,6 +45,17 @@ export type ProfileImporter = (
   context: ActionDispatchContext,
 ) => Promise<ProfileImportResult>;
 
+export interface ProfilePreviewInput {
+  profilePath: string;
+  resumeStylePath: string;
+  resumeTemplatePath: string;
+}
+
+export type ProfilePreviewRenderer = (
+  input: ProfilePreviewInput,
+  context: ActionDispatchContext,
+) => Promise<Buffer>;
+
 export const defaultActionDispatcher: ActionDispatcher = async (command, context) => {
   if (command.action === "retry_stage" && !command.runAfter) {
     return { status: "reset", message: "Stage reset for retry." };
@@ -107,6 +118,21 @@ export const defaultProfileImporter: ProfileImporter = async (input, context) =>
         result,
       },
     };
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+};
+
+export const defaultProfilePreviewRenderer: ProfilePreviewRenderer = async (input, context) => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-profile-preview-"));
+  const outputPath = path.join(tempDir, "resume-preview.pdf");
+  try {
+    await runCommand(
+      "uv",
+      ["run", "python", "-c", PROFILE_PREVIEW_SCRIPT, input.profilePath, input.resumeTemplatePath, outputPath],
+      context.appDir,
+    );
+    return fs.readFileSync(outputPath);
   } finally {
     fs.rmSync(tempDir, { force: true, recursive: true });
   }
@@ -215,6 +241,36 @@ async function runProfileImportCli(
   return runJsonCommand("uv", args, context.appDir);
 }
 
+function runCommand(command: string, args: string[], appDir: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: {
+        ...process.env,
+        JOBHUNTER_DIR: appDir,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      reject(new Error(stderr.trim() || stdout.trim() || `Command failed with exit code ${code ?? "unknown"}.`));
+    });
+  });
+}
+
 function runJsonCommand(command: string, args: string[], appDir: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
@@ -245,6 +301,47 @@ function runJsonCommand(command: string, args: string[], appDir: string): Promis
     });
   });
 }
+
+const PROFILE_PREVIEW_SCRIPT = `
+import json
+import sys
+from pathlib import Path
+
+from jobhunter.scoring.pdf import build_latex, render_pdf_latex
+
+profile_path = Path(sys.argv[1])
+template_path = Path(sys.argv[2])
+output_path = Path(sys.argv[3])
+
+profile = json.loads(profile_path.read_text(encoding="utf-8"))
+resume = profile.get("resume", {}) if isinstance(profile, dict) else {}
+executive_profile = resume.get("executive_profile", {}) if isinstance(resume.get("executive_profile", {}), dict) else {}
+
+data = {
+    "executive_profile": executive_profile.get("baseline_text", ""),
+    "experience_updates": [
+        {
+            "id": entry.get("id"),
+            "title": entry.get("title", ""),
+            "bullets": entry.get("bullets", []),
+        }
+        for entry in resume.get("experience_entries", [])
+        if isinstance(entry, dict) and entry.get("id")
+    ],
+    "skill_category_updates": [
+        {
+            "id": category.get("id"),
+            "items": category.get("items", []),
+        }
+        for category in resume.get("skill_categories", [])
+        if isinstance(category, dict) and category.get("id")
+    ],
+}
+
+template_text = template_path.read_text(encoding="utf-8") if template_path.exists() else None
+latex = build_latex(data, profile, template_text=template_text)
+render_pdf_latex(latex, str(output_path))
+`;
 
 function parseFirstJsonObject(output: string): unknown {
   const start = output.indexOf("{");

--- a/services/api/src/read-model.ts
+++ b/services/api/src/read-model.ts
@@ -4,8 +4,10 @@ import type {
   ArtifactDetail,
   ArtifactListQuery,
   ArtifactSummary,
+  BulkJobMutationFilter,
   DashboardSettings,
   DashboardSummary,
+  JobDeletedFilter,
   JobDetail,
   JobListQuery,
   JobSummary,
@@ -44,6 +46,7 @@ type JobRow = Record<string, unknown> & {
   apply_error?: string | null;
   apply_attempts?: number | null;
   applied_at?: string | null;
+  deleted_at?: string | null;
 };
 
 type StageRow = {
@@ -103,7 +106,10 @@ const DEFAULT_SETTINGS: DashboardSettings = {
   minFitScore: 7,
   autoApply: false,
   applyConcurrency: 1,
+  scoreCriteria: "",
+  targetCriteria: "",
 };
+const SOURCE_BOARD_NAMES = new Set(["greenhouse", "linkedin", "talent.com"]);
 
 const JOB_COLUMNS = [
   "url",
@@ -136,6 +142,7 @@ const SQL_JOB_SORT_COLUMNS: Partial<Record<string, string>> = {
   discovered_at: "discovered_at",
   title: "LOWER(COALESCE(title, ''))",
   company: "LOWER(COALESCE(site, ''))",
+  location: "LOWER(COALESCE(location, ''))",
   fit_score: "COALESCE(fit_score, -1)",
 };
 
@@ -174,7 +181,7 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
     return paginateWithTotal(summaries, page.total, page.page, query.pageSize, query.sort, query.dir, jobFilterPayload(query));
   }
 
-  const jobs = loadJobs(db, jobSqlFilter(query));
+  const jobs = loadJobs(db, jobSqlFilter(query), query.deleted);
   const explicitStates = loadStageStates(db);
   const artifactCounts = artifactCountByJob(db, jobs);
   const normalizedQuery = query.q.toLowerCase();
@@ -186,6 +193,18 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
   filtered.sort((left, right) => compareJobs(left, right, query.sort, query.dir));
 
   return paginate(filtered, query.page, query.pageSize, query.sort, query.dir, jobFilterPayload(query));
+}
+
+export function matchingJobKeys(db: SqliteDatabase, filter: Partial<BulkJobMutationFilter> = {}): string[] {
+  const query = normalizeMutationFilter(filter);
+  const jobs = loadJobs(db, jobSqlFilter(query), query.deleted);
+  const explicitStates = loadStageStates(db);
+  const artifactCounts = artifactCountByJob(db, jobs);
+  const normalizedQuery = query.q.toLowerCase();
+  return jobs
+    .map((job) => buildJobSummary(job, statesForJob(job, explicitStates), artifactCounts))
+    .filter((job) => filterJob(job, query, normalizedQuery))
+    .map((job) => job.jobKey);
 }
 
 export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | null {
@@ -200,11 +219,28 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
     ok: true,
     job: {
       ...buildJobSummary(job, stages, artifactCounts),
-      descriptionPreview: previewText(asString(job.full_description) || asString(job.description), 1800),
+      descriptionPreview: previewText(asString(job.full_description) || asString(job.description), 6000),
       scoreReasoning: asString(job.score_reasoning),
     },
     stages,
     artifacts: artifactsForJobs(db, [job]),
+  };
+}
+
+function normalizeMutationFilter(filter: Partial<BulkJobMutationFilter>): JobListQuery {
+  return {
+    page: 1,
+    pageSize: 50,
+    q: filter.q ?? "",
+    sort: "discovered_at",
+    dir: "desc",
+    stage: filter.stage,
+    state: filter.state,
+    deleted: filter.deleted ?? "active",
+    source: filter.source ?? "",
+    company: filter.company ?? "",
+    minFitScore: filter.minFitScore,
+    maxFitScore: filter.maxFitScore,
   };
 }
 
@@ -273,14 +309,26 @@ function normalizeSettings(raw: unknown): DashboardSettings {
       1,
       16,
     ),
+    scoreCriteria: normalizeText(source.scoreCriteria ?? source.score_criteria, DEFAULT_SETTINGS.scoreCriteria),
+    targetCriteria: normalizeText(source.targetCriteria ?? source.target_criteria, DEFAULT_SETTINGS.targetCriteria),
   };
 }
 
-function loadJobs(db: SqliteDatabase, sqlFilter = { where: "", params: [] as SqliteValue[] }): JobRow[] {
+function loadJobs(
+  db: SqliteDatabase,
+  sqlFilter = { where: "", params: [] as SqliteValue[] },
+  deleted: JobDeletedFilter = "active",
+): JobRow[] {
   if (!tableExists(db, "jobs")) {
     return [];
   }
-  return allRows<JobRow>(db, `SELECT ${JOB_COLUMNS.join(", ")} FROM jobs${sqlFilter.where}`, sqlFilter.params);
+  const deletion = deletedSqlFilter(db, deleted);
+  const filter = combineSqlFilters(sqlFilter, deletion);
+  return allRows<JobRow>(
+    db,
+    `SELECT ${JOB_COLUMNS.map((column) => `jobs.${column}`).join(", ")}${deletedSelect(db)} FROM jobs${deletedJoin(db)}${filter.where}`,
+    filter.params,
+  );
 }
 
 function loadJobPage(
@@ -291,8 +339,8 @@ function loadJobPage(
   if (!tableExists(db, "jobs")) {
     return { jobs: [], page: 1, total: 0 };
   }
-  const filter = jobSqlFilter(query);
-  const totalRow = getRow<{ count: number }>(db, `SELECT COUNT(*) AS count FROM jobs${filter.where}`, filter.params);
+  const filter = combineSqlFilters(jobSqlFilter(query), deletedSqlFilter(db, query.deleted));
+  const totalRow = getRow<{ count: number }>(db, `SELECT COUNT(*) AS count FROM jobs${deletedJoin(db)}${filter.where}`, filter.params);
   const total = Number(totalRow?.count ?? 0);
   const pages = Math.max(1, Math.ceil(total / query.pageSize));
   const page = Math.min(query.page, pages);
@@ -300,10 +348,44 @@ function loadJobPage(
   const direction = query.dir === "asc" ? "ASC" : "DESC";
   const jobs = allRows<JobRow>(
     db,
-    `SELECT ${JOB_COLUMNS.join(", ")} FROM jobs${filter.where} ORDER BY ${sqlSortColumn} ${direction}, url ASC LIMIT ? OFFSET ?`,
+    `SELECT ${JOB_COLUMNS.map((column) => `jobs.${column}`).join(", ")}${deletedSelect(db)} FROM jobs${deletedJoin(db)}${filter.where} ORDER BY ${sqlSortColumn} ${direction}, url ASC LIMIT ? OFFSET ?`,
     [...filter.params, query.pageSize, offset],
   );
   return { jobs, page, total };
+}
+
+function deletedJoin(db: SqliteDatabase): string {
+  return tableExists(db, "jobhunter_deleted_jobs")
+    ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = jobs.url AND d.restored_at IS NULL"
+    : "";
+}
+
+function deletedSelect(db: SqliteDatabase): string {
+  return tableExists(db, "jobhunter_deleted_jobs") ? ", d.deleted_at AS deleted_at" : ", NULL AS deleted_at";
+}
+
+function deletedSqlFilter(db: SqliteDatabase, mode: JobDeletedFilter): { where: string; params: SqliteValue[] } {
+  if (mode === "all") {
+    return { where: "", params: [] };
+  }
+  if (!tableExists(db, "jobhunter_deleted_jobs")) {
+    return mode === "deleted" ? { where: " WHERE 1 = 0", params: [] } : { where: "", params: [] };
+  }
+  return { where: mode === "deleted" ? " WHERE d.job_url IS NOT NULL" : " WHERE d.job_url IS NULL", params: [] };
+}
+
+function combineSqlFilters(
+  left: { where: string; params: SqliteValue[] },
+  right: { where: string; params: SqliteValue[] },
+): { where: string; params: SqliteValue[] } {
+  const clauses = [left.where, right.where].flatMap((where) => {
+    const trimmed = where.trim();
+    return trimmed ? [trimmed.replace(/^WHERE\s+/i, "")] : [];
+  });
+  return {
+    where: clauses.length ? ` WHERE ${clauses.join(" AND ")}` : "",
+    params: [...left.params, ...right.params],
+  };
 }
 
 function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue[] } {
@@ -340,6 +422,7 @@ function jobFilterPayload(query: JobListQuery): Record<string, unknown> {
     company: query.company,
     minFitScore: query.minFitScore ?? null,
     maxFitScore: query.maxFitScore ?? null,
+    deleted: query.deleted,
   };
 }
 
@@ -347,7 +430,11 @@ function findJob(db: SqliteDatabase, jobKey: string): JobRow | null {
   if (!tableExists(db, "jobs")) {
     return null;
   }
-  const row = getRow<JobRow>(db, "SELECT * FROM jobs WHERE url = ? OR application_url = ? LIMIT 1", [jobKey, jobKey]);
+  const row = getRow<JobRow>(
+    db,
+    `SELECT jobs.*${deletedSelect(db)} FROM jobs${deletedJoin(db)} WHERE jobs.url = ? OR jobs.application_url = ? LIMIT 1`,
+    [jobKey, jobKey],
+  );
   return row ?? null;
 }
 
@@ -388,7 +475,7 @@ function buildJobSummary(
     jobKey,
     url: jobKey,
     title: asString(job.title) || "Untitled",
-    company: asString(job.site) || "Unknown",
+    company: companyName(job),
     source: asString(job.site) || "unknown",
     strategy: asString(job.strategy),
     location: asString(job.location),
@@ -404,6 +491,7 @@ function buildJobSummary(
     artifactCount: artifactCounts.get(jobKey) ?? 0,
     applyStatus: asNullableString(job.apply_status),
     appliedAt: asNullableString(job.applied_at),
+    deletedAt: asNullableString(job.deleted_at),
   };
 }
 
@@ -567,14 +655,14 @@ function artifactsForJobs(db: SqliteDatabase, jobs: JobRow[]): ArtifactSummary[]
 
 function formatArtifact(row: ArtifactRow, job: JobRow): ArtifactSummary {
   const localPath = asString(row.path);
-  const sizeBytes = asNullableNumber(row.size_bytes);
+  const sizeBytes = asNullableNumber(row.size_bytes) ?? localFileSize(localPath);
   return {
     artifactId: asString(row.row_id ?? row.artifact_id) || `${asString(row.job_url)}:${asString(row.artifact_type)}:${localPath}`,
     jobKey: job.url ?? "",
     title: asString(job.title) || "Untitled",
-    company: asString(job.site) || "Unknown",
+    company: companyName(job),
     type: asString(row.artifact_type) || "artifact",
-    status: asString(row.status) || "active",
+    status: localPath && sizeBytes === null ? "missing" : asString(row.status) || "active",
     localPath,
     createdAt: asNullableString(row.created_at),
     sizeBytes,
@@ -612,18 +700,19 @@ function legacyArtifacts(job: JobRow, existing: ArtifactSummary[]): ArtifactSumm
     if (!localPath || seen.has(`${type}:${localPath}`)) {
       return [];
     }
+    const sizeBytes = localFileSize(localPath);
     return [
       {
         artifactId: `${job.url}:${type}:${localPath}`,
         jobKey: job.url ?? "",
         title: asString(job.title) || "Untitled",
-        company: asString(job.site) || "Unknown",
+        company: companyName(job),
         type,
-        status: "active",
+        status: sizeBytes === null ? "missing" : "active",
         localPath,
         createdAt: asNullableString(createdAt),
-        sizeBytes: null,
-        size: formatSize(null),
+        sizeBytes,
+        size: formatSize(sizeBytes),
       },
     ];
   });
@@ -662,6 +751,7 @@ function compareJobs(left: JobSummary, right: JobSummary, field: string, directi
     discovered_at: [left.discoveredAt, right.discoveredAt],
     title: [left.title, right.title],
     company: [left.company, right.company],
+    location: [left.location, right.location],
     fit_score: [left.fitScore ?? -1, right.fitScore ?? -1],
     current_stage: [left.currentStage, right.currentStage],
     current_state: [STATE_RANK[left.currentState], STATE_RANK[right.currentState]],
@@ -749,11 +839,43 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
   if (!tableExists(db, "job_events")) {
     return [];
   }
-  return allRows<Record<string, unknown>>(
-    db,
-    "SELECT job_url, stage, level, message, occurred_at FROM job_events ORDER BY occurred_at DESC, event_id DESC LIMIT 20",
-  ).map((row) => ({
+  const hideDeletedJoin = tableExists(db, "jobhunter_deleted_jobs")
+    ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = e.job_url AND d.restored_at IS NULL"
+    : "";
+  const hideDeletedWhere = tableExists(db, "jobhunter_deleted_jobs") ? "WHERE d.job_url IS NULL" : "";
+  const activitySql = tableExists(db, "jobs")
+    ? `SELECT
+      e.event_id,
+      e.job_url,
+      e.stage,
+      e.level,
+      e.message,
+      e.occurred_at,
+      j.title,
+      j.site
+    FROM job_events e
+    LEFT JOIN jobs j ON j.url = e.job_url
+    ${hideDeletedJoin}
+    ${hideDeletedWhere}
+    ORDER BY e.occurred_at DESC, e.event_id DESC
+    LIMIT 20`
+    : `SELECT
+      event_id,
+      job_url,
+      stage,
+      level,
+      message,
+      occurred_at,
+      NULL AS title,
+      NULL AS site
+    FROM job_events
+    ORDER BY occurred_at DESC, event_id DESC
+    LIMIT 20`;
+  return allRows<Record<string, unknown>>(db, activitySql).map((row) => ({
+    eventId: asString(row.event_id),
     jobKey: asNullableString(row.job_url),
+    title: asNullableString(row.title),
+    company: companyName({ ...row, url: row.job_url } as JobRow),
     stage: asString(row.stage) || "system",
     level: asString(row.level) || "info",
     message: asString(row.message) || "event",
@@ -765,14 +887,18 @@ function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {
   if (!tableExists(db, "apply_runs")) {
     return [];
   }
+  const deletedJoinSql = tableExists(db, "jobhunter_deleted_jobs")
+    ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = apply_runs.job_url AND d.restored_at IS NULL"
+    : "";
+  const deletedWhereSql = tableExists(db, "jobhunter_deleted_jobs") ? " WHERE d.job_url IS NULL" : "";
   return allRows<Record<string, unknown>>(
     db,
-    "SELECT run_id, job_url, title, site, status, result, dry_run, started_at FROM apply_runs ORDER BY started_at DESC LIMIT 12",
+    `SELECT run_id, apply_runs.job_url, title, site, status, result, dry_run, started_at FROM apply_runs${deletedJoinSql}${deletedWhereSql} ORDER BY started_at DESC LIMIT 12`,
   ).map((row) => ({
     runId: asString(row.run_id),
     jobKey: asString(row.job_url),
     title: asString(row.title) || "Untitled",
-    company: asString(row.site) || "Unknown",
+    company: companyName({ site: row.site, url: row.job_url } as JobRow),
     status: asString(row.status) || asString(row.result) || "unknown",
     dryRun: Boolean(row.dry_run),
     startedAt: asNullableString(row.started_at),
@@ -783,7 +909,11 @@ function dryRunCount(db: SqliteDatabase): number {
   if (!tableExists(db, "apply_runs")) {
     return 0;
   }
-  const row = getRow<{ count: number }>(db, "SELECT COUNT(*) AS count FROM apply_runs WHERE dry_run = 1");
+  const deletedJoinSql = tableExists(db, "jobhunter_deleted_jobs")
+    ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = apply_runs.job_url AND d.restored_at IS NULL"
+    : "";
+  const deletedWhereSql = tableExists(db, "jobhunter_deleted_jobs") ? " AND d.job_url IS NULL" : "";
+  const row = getRow<{ count: number }>(db, `SELECT COUNT(*) AS count FROM apply_runs${deletedJoinSql} WHERE dry_run = 1${deletedWhereSql}`);
   return Number(row?.count ?? 0);
 }
 
@@ -816,7 +946,7 @@ function pdfSibling(value: string | null | undefined): string {
 
 function formatSize(size: number | null): string {
   if (size === null) {
-    return "missing";
+    return "missing file";
   }
   if (size < 1024) {
     return `${size}b`;
@@ -825,6 +955,61 @@ function formatSize(size: number | null): string {
     return `${(size / 1024).toFixed(1)}kb`;
   }
   return `${(size / (1024 * 1024)).toFixed(1)}mb`;
+}
+
+function companyName(job: JobRow): string {
+  const source = asString(job.site);
+  const inferred = inferredCompanyFromUrl(asString(job.application_url) || asString(job.url));
+  if (inferred) {
+    return inferred;
+  }
+  if (!source || SOURCE_BOARD_NAMES.has(source.toLowerCase())) {
+    return "Unknown company";
+  }
+  return source;
+}
+
+function inferredCompanyFromUrl(rawUrl: string): string {
+  try {
+    const parsed = new URL(rawUrl);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (parsed.hostname.endsWith("greenhouse.io") && segments[0]) {
+      return titleFromSlug(segments[0]);
+    }
+    if (parsed.hostname === "jobs.lever.co" && segments[0]) {
+      return titleFromSlug(segments[0]);
+    }
+    if (parsed.hostname === "jobs.ashbyhq.com" && segments[0]) {
+      return titleFromSlug(segments[0]);
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
+function titleFromSlug(value: string): string {
+  const normalized = value.toLowerCase();
+  const knownNames: Record<string, string> = {
+    gitlab: "GitLab",
+  };
+  if (knownNames[normalized]) {
+    return knownNames[normalized];
+  }
+  return value
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function localFileSize(filePath: string): number | null {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile() ? stat.size : null;
+  } catch {
+    return null;
+  }
 }
 
 function compareValues(left: unknown, right: unknown): number {

--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -8,22 +8,30 @@ import {
   type ActionCommandPayload,
   ApplyJobRequestSchema,
   ArtifactListQuerySchema,
+  BulkJobMutationRequestSchema,
   CancelJobActionRequestSchema,
+  CredentialKeys,
+  CredentialUpdateRequestSchema,
+  DeleteJobRequestSchema,
   GenerateMaterialsRequestSchema,
   JobListQuerySchema,
   MarkJobActionRequestSchema,
   ProfileImportRequestSchema,
   ProfileUpdateRequestSchema,
   RetryStageRequestSchema,
+  SettingsUpdateRequestSchema,
 } from "./contracts.js";
 import { databaseExists, openDatabase, openReadOnlyDatabase } from "./db.js";
+import { KeychainCredentialStore, type CredentialStore } from "./credentials.js";
 import {
   buildActionResponse,
   defaultActionDispatcher,
   defaultArtifactOpener,
+  defaultProfilePreviewRenderer,
   defaultProfileImporter,
   type ActionDispatcher,
   type ArtifactOpener,
+  type ProfilePreviewRenderer,
   type ProfileImporter,
 } from "./local-actions.js";
 import {
@@ -41,8 +49,13 @@ import {
   markJobApplied,
   markJobSkipped,
   resetJobStage,
+  restoreJob,
+  restoreJobs,
   resolveJobUrl,
+  softDeleteJob,
+  softDeleteJobs,
   writeProfileConfig,
+  writeSettingsConfig,
 } from "./write-model.js";
 
 const LOCAL_ORIGIN_PATTERNS = [
@@ -50,7 +63,7 @@ const LOCAL_ORIGIN_PATTERNS = [
   /^https?:\/\/127\.0\.0\.1(?::\d+)?$/,
   /^https?:\/\/\[::1\](?::\d+)?$/,
 ];
-const LOCAL_CORS_METHODS = ["GET", "HEAD", "POST", "PATCH"];
+const LOCAL_CORS_METHODS = ["DELETE", "GET", "HEAD", "POST", "PATCH"];
 const UNSAFE_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
 
 export interface BuildAppOptions {
@@ -62,16 +75,20 @@ export interface BuildAppOptions {
   settingsPath: string;
   actionDispatcher?: ActionDispatcher;
   artifactOpener?: ArtifactOpener;
+  credentialStore?: CredentialStore;
   profileImporter?: ProfileImporter;
+  profilePreviewRenderer?: ProfilePreviewRenderer;
   logger?: boolean;
 }
 
 export function buildApp(options: BuildAppOptions): FastifyInstance {
-  const app = Fastify({ logger: options.logger ?? false });
+  const app = Fastify({ logger: options.logger ?? false, routerOptions: { maxParamLength: 4096 } });
   const appDir = options.appDir ?? path.dirname(options.dbPath);
   const actionDispatcher = options.actionDispatcher ?? defaultActionDispatcher;
   const artifactOpener = options.artifactOpener ?? defaultArtifactOpener;
+  const credentialStore = options.credentialStore ?? new KeychainCredentialStore();
   const profileImporter = options.profileImporter ?? defaultProfileImporter;
+  const profilePreviewRenderer = options.profilePreviewRenderer ?? defaultProfilePreviewRenderer;
   const actionContext = { appDir };
 
   void app.register(cors, {
@@ -107,6 +124,22 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     withDb(reply, options.dbPath, (db) => listJobs(db, JobListQuerySchema.parse(request.query))),
   );
 
+  app.post("/v1/jobs/bulk-delete", async (request, reply) => {
+    const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => softDeleteJobs(db, body));
+  });
+
+  app.post("/v1/jobs/bulk-restore", async (request, reply) => {
+    const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => restoreJobs(db, body));
+  });
+
   app.get<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) =>
     withDb(reply, options.dbPath, (db) => {
       const detail = getJobDetail(db, decodeRouteParam(request.params.jobKey));
@@ -116,6 +149,18 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       }
       return detail;
     }),
+  );
+
+  app.delete<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) => {
+    const body = parseBody(reply, DeleteJobRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => softDeleteJob(db, decodeRouteParam(request.params.jobKey), body));
+  });
+
+  app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/restore", async (request, reply) =>
+    withWritableDb(reply, options.dbPath, (db) => restoreJob(db, decodeRouteParam(request.params.jobKey))),
   );
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/actions/retry-stage", async (request, reply) => {
@@ -285,6 +330,30 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     }),
   );
 
+  app.get("/v1/profile/preview.pdf", async (_request, reply) => {
+    try {
+      const pdfBytes = await profilePreviewRenderer(
+        {
+          profilePath: options.profilePath,
+          resumeStylePath: options.resumeStylePath,
+          resumeTemplatePath: options.resumeTemplatePath,
+        },
+        actionContext,
+      );
+      return reply
+        .header("content-type", "application/pdf")
+        .header("cache-control", "no-store")
+        .send(pdfBytes);
+    } catch (error) {
+      void reply.code(500);
+      return {
+        ok: false,
+        error: "profile_preview_failed",
+        message: error instanceof Error ? error.message : "Unable to render profile preview.",
+      };
+    }
+  });
+
   app.patch("/v1/profile", async (request, reply) => {
     const body = parseBody(reply, ProfileUpdateRequestSchema, request.body ?? {});
     if (!body) {
@@ -335,6 +404,41 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   });
 
   app.get("/v1/settings", async () => readSettingsConfig({ settingsPath: options.settingsPath }));
+
+  app.patch("/v1/settings", async (request, reply) => {
+    const body = parseBody(reply, SettingsUpdateRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    try {
+      return writeSettingsConfig({ settingsPath: options.settingsPath }, body);
+    } catch (error) {
+      if (error instanceof InputError) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_settings", message: error.message };
+      }
+      throw error;
+    }
+  });
+
+  app.get("/v1/credentials", async () => credentialStore.list());
+
+  app.patch("/v1/credentials", async (request, reply) => {
+    const body = parseBody(reply, CredentialUpdateRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return credentialStore.set(body.key, body.value);
+  });
+
+  app.delete<{ Params: { key: string } }>("/v1/credentials/:key", async (request, reply) => {
+    const key = decodeRouteParam(request.params.key);
+    if (!CredentialKeys.includes(key as (typeof CredentialKeys)[number])) {
+      void reply.code(400);
+      return { ok: false, error: "invalid_credential_key" };
+    }
+    return credentialStore.delete(key as (typeof CredentialKeys)[number]);
+  });
 
   return app;
 }

--- a/services/api/src/write-model.ts
+++ b/services/api/src/write-model.ts
@@ -2,16 +2,21 @@ import fs from "node:fs";
 import path from "node:path";
 
 import type {
+  BulkJobMutationRequest,
+  DeleteJobRequest,
+  JobMutationResponse,
   MarkJobActionRequest,
   ProfileConfigResponse,
   ProfileUpdateRequest,
+  SettingsResponse,
+  SettingsUpdateRequest,
   Stage,
   StageState,
   StageSummary,
 } from "./contracts.js";
 import { STAGES } from "./contracts.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
-import { readProfileConfig } from "./read-model.js";
+import { matchingJobKeys, readProfileConfig, readSettingsConfig } from "./read-model.js";
 
 export class InputError extends Error {}
 
@@ -151,6 +156,65 @@ export function cancelJobAction(db: SqliteDatabase, jobKey: string, runId = ""):
   return { jobUrl, stage: getStageState(db, jobUrl, stage) };
 }
 
+export function softDeleteJob(db: SqliteDatabase, jobKey: string, request: DeleteJobRequest = {}): JobMutationResponse {
+  return softDeleteJobs(db, { allMatching: false, jobKeys: [jobKey], reason: request.reason });
+}
+
+export function softDeleteJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
+  ensureDeletedJobsTable(db);
+  const deletedAt = new Date().toISOString();
+  const jobKeys = mutableJobKeys(db, request);
+  const statement = db.prepare(`
+    INSERT INTO jobhunter_deleted_jobs (job_url, deleted_at, reason, restored_at)
+    VALUES (?, ?, ?, NULL)
+    ON CONFLICT(job_url) DO UPDATE SET
+      deleted_at = excluded.deleted_at,
+      reason = excluded.reason,
+      restored_at = NULL
+  `);
+  const transaction = db.transaction((keys: string[]) => {
+    for (const jobUrl of keys) {
+      statement.run(jobUrl, deletedAt, request.reason ?? null);
+      recordActionEvent(db, {
+        jobUrl,
+        stage: currentMutableStage(db, jobUrl),
+        eventType: "job_deleted",
+        level: "info",
+        message: "Job soft-deleted from the local API.",
+        payload: { reason: request.reason ?? "" },
+      });
+    }
+  });
+  transaction(jobKeys);
+  return { ok: true, count: jobKeys.length, jobKeys };
+}
+
+export function restoreJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
+  return restoreJobs(db, { allMatching: false, jobKeys: [jobKey] });
+}
+
+export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
+  ensureDeletedJobsTable(db);
+  const restoredAt = new Date().toISOString();
+  const jobKeys = mutableJobKeys(db, request);
+  const statement = db.prepare("UPDATE jobhunter_deleted_jobs SET restored_at = ? WHERE job_url = ? AND restored_at IS NULL");
+  const transaction = db.transaction((keys: string[]) => {
+    for (const jobUrl of keys) {
+      statement.run(restoredAt, jobUrl);
+      recordActionEvent(db, {
+        jobUrl,
+        stage: currentMutableStage(db, jobUrl),
+        eventType: "job_restored",
+        level: "info",
+        message: "Job restored from deleted jobs.",
+        payload: {},
+      });
+    }
+  });
+  transaction(jobKeys);
+  return { ok: true, count: jobKeys.length, jobKeys };
+}
+
 export function writeProfileConfig(paths: ProfilePaths, request: ProfileUpdateRequest): ProfileConfigResponse {
   let wrote = false;
   let profile: Record<string, unknown> | undefined;
@@ -185,6 +249,45 @@ export function writeProfileConfig(paths: ProfilePaths, request: ProfileUpdateRe
     writeText(paths.resumeTemplatePath, templateText);
   }
   return readProfileConfig(paths);
+}
+
+export function writeSettingsConfig(paths: { settingsPath: string }, request: SettingsUpdateRequest): SettingsResponse {
+  const next = readJsonObject(paths.settingsPath);
+  let wrote = false;
+
+  const assign = (key: string, value: unknown) => {
+    next[key] = value;
+    wrote = true;
+  };
+
+  if (request.targetRole !== undefined) {
+    assign("target_role", request.targetRole);
+  }
+  if (request.locationFilter !== undefined) {
+    assign("location_filter", request.locationFilter);
+  }
+  if (request.minFitScore !== undefined) {
+    assign("min_fit_score", request.minFitScore);
+  }
+  if (request.autoApply !== undefined) {
+    assign("auto_apply", request.autoApply);
+  }
+  if (request.applyConcurrency !== undefined) {
+    assign("apply_concurrency", request.applyConcurrency);
+  }
+  if (request.scoreCriteria !== undefined) {
+    assign("score_criteria", request.scoreCriteria);
+  }
+  if (request.targetCriteria !== undefined) {
+    assign("target_criteria", request.targetCriteria);
+  }
+
+  if (!wrote) {
+    throw new InputError("At least one settings field is required.");
+  }
+
+  writeJson(paths.settingsPath, next);
+  return readSettingsConfig(paths);
 }
 
 function updateLegacyJobColumnsForReset(
@@ -223,6 +326,31 @@ function updateLegacyJobColumnsForReset(
     }
   }
   updateExistingJobColumns(db, jobUrl, updates);
+}
+
+function ensureDeletedJobsTable(db: SqliteDatabase): void {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS jobhunter_deleted_jobs (
+      job_url TEXT PRIMARY KEY,
+      deleted_at TEXT NOT NULL,
+      reason TEXT,
+      restored_at TEXT,
+      FOREIGN KEY(job_url) REFERENCES jobs(url)
+    )`,
+  ).run();
+}
+
+function mutableJobKeys(db: SqliteDatabase, request: BulkJobMutationRequest): string[] {
+  if (request.allMatching) {
+    return uniqueJobKeys(matchingJobKeys(db, request.filter ?? {}));
+  }
+  return uniqueJobKeys(request.jobKeys)
+    .map((jobKey) => resolveJobUrl(db, jobKey))
+    .filter((jobUrl): jobUrl is string => Boolean(jobUrl));
+}
+
+function uniqueJobKeys(jobKeys: string[]): string[] {
+  return Array.from(new Set(jobKeys.map((jobKey) => jobKey.trim()).filter(Boolean)));
 }
 
 function updateExistingJobColumns(db: SqliteDatabase, jobUrl: string, updates: Record<string, SqliteValue>): void {
@@ -399,6 +527,17 @@ function parseJson(text: string, label: string): unknown {
 
 function writeJson(filePath: string, value: Record<string, unknown>): void {
   writeText(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readJsonObject(filePath: string): Record<string, unknown> {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+  const parsed = parseJson(fs.readFileSync(filePath, "utf8"), path.basename(filePath));
+  if (!isRecord(parsed)) {
+    throw new InputError(`${path.basename(filePath)} must be a JSON object.`);
+  }
+  return parsed;
 }
 
 function writeText(filePath: string, value: string): void {

--- a/services/api/test/qa-seed.ts
+++ b/services/api/test/qa-seed.ts
@@ -1,0 +1,407 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+
+export interface QaWorkspace {
+  appDir: string;
+  dbPath: string;
+  profilePath: string;
+  resumeStylePath: string;
+  resumeTemplatePath: string;
+  settingsPath: string;
+}
+
+interface QaJobSeed {
+  url: string;
+  title: string;
+  site: string;
+  strategy?: string;
+  location?: string;
+  fitScore?: number | null;
+  applicationUrl?: string;
+  description?: string;
+  fullDescription?: string;
+}
+
+const QA_NOW = "2026-05-04T12:00:00+00:00";
+const QA_RESUME_TEMPLATE = String.raw`\documentclass[11pt,a4paper,sans]{moderncv}
+
+\moderncvstyle{banking}
+\moderncvcolor{black}
+
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+\usepackage[scale=0.85]{geometry}
+\usepackage{enumitem}
+
+\setlength{\hintscolumnwidth}{3cm}
+
+{{ personal_data }}
+
+\begin{document}
+
+\makecvtitle
+\vspace*{-1.5em}
+
+{{ resume_body }}
+
+\end{document}
+`;
+
+export function createQaWorkspace(targetDir?: string): QaWorkspace {
+  const appDir = targetDir ? path.resolve(targetDir) : fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-qa-"));
+  fs.mkdirSync(appDir, { recursive: true });
+  const workspace = {
+    appDir,
+    dbPath: path.join(appDir, "jobhunter.db"),
+    profilePath: path.join(appDir, "profile.json"),
+    resumeStylePath: path.join(appDir, "resume_style.json"),
+    resumeTemplatePath: path.join(appDir, "resume_template.tex"),
+    settingsPath: path.join(appDir, "dashboard.json"),
+  };
+  seedQaWorkspace(workspace);
+  return workspace;
+}
+
+export function removeQaWorkspace(workspace: QaWorkspace): void {
+  fs.rmSync(workspace.appDir, { force: true, recursive: true });
+}
+
+export function seedQaWorkspace(workspace: QaWorkspace): void {
+  fs.mkdirSync(workspace.appDir, { recursive: true });
+  seedQaDatabase(workspace.dbPath);
+  fs.writeFileSync(
+    workspace.profilePath,
+    JSON.stringify(
+      {
+        schema_version: 2,
+        personal: {
+          full_name: "QA Candidate",
+          preferred_name: "QA",
+          email: "qa@example.local",
+          phone: "+1 555-0100",
+          city: "Remote City",
+          country: "Remote",
+        },
+        resume: {
+          executive_profile: {
+            baseline_text: "Platform and security engineering leader for QA validation.",
+          },
+          experience_entries: [
+            {
+              id: "qa_platform",
+              title: "Director of Platform Engineering",
+              company: "QA Systems",
+              date_range: "2024 -- Present",
+              bullets: ["Led platform reliability and security validation programs."],
+              must_include: true,
+            },
+          ],
+          skill_categories: [
+            {
+              id: "platform",
+              label: "Platform",
+              items: ["Kubernetes", "Security", "Developer Experience"],
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    workspace.resumeStylePath,
+    JSON.stringify(
+      {
+        document_font_size: "11pt",
+        font_family: "sans",
+        moderncv_style: "banking",
+        moderncv_color: "black",
+        paper_size: "a4paper",
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(workspace.resumeTemplatePath, QA_RESUME_TEMPLATE);
+  fs.writeFileSync(
+    workspace.settingsPath,
+    JSON.stringify(
+      {
+        target_role: "Director of Platform Engineering",
+        location_filter: "Remote",
+        min_fit_score: 7,
+        auto_apply: false,
+        apply_concurrency: 1,
+        score_criteria: "Prioritize platform reliability, security, and engineering leadership.",
+        target_criteria: "Remote-friendly senior engineering leadership roles.",
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+export function seedQaDatabase(dbPath: string): void {
+  fs.rmSync(dbPath, { force: true });
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+  const artifactDir = path.join(path.dirname(dbPath), "artifacts");
+  fs.mkdirSync(artifactDir, { recursive: true });
+
+  const resumeTxt = path.join(artifactDir, "gitlab-platform-resume.txt");
+  const resumePdf = path.join(artifactDir, "gitlab-platform-resume.pdf");
+  const coverTxt = path.join(artifactDir, "gitlab-platform-cover.txt");
+  const coverPdf = path.join(artifactDir, "gitlab-platform-cover.pdf");
+  fs.writeFileSync(resumeTxt, "QA tailored resume");
+  fs.writeFileSync(resumePdf, "%PDF-1.4\n% QA resume\n");
+  fs.writeFileSync(coverTxt, "QA cover letter");
+  fs.writeFileSync(coverPdf, "%PDF-1.4\n% QA cover\n");
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      title TEXT,
+      site TEXT,
+      strategy TEXT,
+      location TEXT,
+      salary TEXT,
+      discovered_at TEXT,
+      application_url TEXT,
+      description TEXT,
+      full_description TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER,
+      apply_status TEXT,
+      apply_error TEXT,
+      applied_at TEXT
+    );
+    CREATE TABLE job_stage_states (
+      job_url TEXT,
+      stage TEXT,
+      state TEXT,
+      attempt_count INTEGER,
+      max_attempts INTEGER,
+      started_at TEXT,
+      updated_at TEXT,
+      finished_at TEXT,
+      duration_ms INTEGER,
+      error_code TEXT,
+      error_message TEXT,
+      retryable INTEGER,
+      blocked_by_json TEXT,
+      next_action TEXT
+    );
+    CREATE TABLE job_artifacts (
+      job_url TEXT,
+      stage TEXT,
+      artifact_type TEXT,
+      status TEXT,
+      path TEXT,
+      created_at TEXT,
+      size_bytes INTEGER
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      level TEXT,
+      message TEXT,
+      occurred_at TEXT
+    );
+    CREATE TABLE apply_runs (
+      run_id TEXT,
+      job_url TEXT,
+      title TEXT,
+      site TEXT,
+      status TEXT,
+      result TEXT,
+      dry_run INTEGER,
+      started_at TEXT
+    );
+  `);
+
+  insertJob(db, {
+    url: "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    applicationUrl: "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    title: "Director of Platform Engineering",
+    site: "Greenhouse",
+    strategy: "qa",
+    location: "Remote, United States",
+    fitScore: 9,
+    description: "GitLab platform leadership role.",
+    fullDescription: "Lead platform security, reliability, and developer experience programs.",
+  });
+  insertJob(db, {
+    url: "https://talent.com/view?id=qa-marketing-director",
+    title: "Director of Marketing",
+    site: "Talent.com",
+    strategy: "qa",
+    location: "Remote, Louisiana",
+    fitScore: null,
+    description: "Marketing role intentionally below target.",
+  });
+  insertJob(db, {
+    url: "https://linkedin.com/jobs/view/qa-risk-manager",
+    title: "Senior Engineering Manager - Risk",
+    site: "linkedin",
+    strategy: "qa",
+    location: "USA, Remote",
+    fitScore: 8,
+    description: "Risk platform leadership role.",
+  });
+  insertJob(db, {
+    url: "https://motorolasolutions.com/careers/qa-command-center",
+    title: "Command Center Solutions Project Manager",
+    site: "Motorola Solutions",
+    strategy: "qa",
+    location: "Florida Remote Work",
+    fitScore: 5,
+    description: "Project management role.",
+  });
+
+  for (const stage of ["discover", "enrich", "score", "tailor", "cover", "pdf"]) {
+    insertStage(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", stage, "succeeded");
+  }
+  insertStage(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "apply", "pending");
+  insertStage(db, "https://talent.com/view?id=qa-marketing-director", "discover", "succeeded");
+  insertStage(db, "https://talent.com/view?id=qa-marketing-director", "enrich", "pending");
+  insertStage(db, "https://linkedin.com/jobs/view/qa-risk-manager", "discover", "succeeded");
+  insertStage(db, "https://linkedin.com/jobs/view/qa-risk-manager", "enrich", "succeeded");
+  insertStage(db, "https://linkedin.com/jobs/view/qa-risk-manager", "score", "failed", "LLM_ERROR");
+  insertStage(db, "https://motorolasolutions.com/careers/qa-command-center", "discover", "succeeded");
+  insertStage(db, "https://motorolasolutions.com/careers/qa-command-center", "enrich", "succeeded");
+  insertStage(db, "https://motorolasolutions.com/careers/qa-command-center", "score", "succeeded");
+  insertStage(db, "https://motorolasolutions.com/careers/qa-command-center", "tailor", "blocked", "MIN_SCORE");
+
+  insertArtifact(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "tailored_resume_txt", resumeTxt);
+  insertArtifact(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "tailored_resume_pdf", resumePdf);
+  insertArtifact(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "cover_letter_txt", coverTxt);
+  insertArtifact(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "cover_letter_pdf", coverPdf);
+  insertArtifact(db, "https://linkedin.com/jobs/view/qa-risk-manager", "tailored_resume_pdf", path.join(artifactDir, "missing.pdf"));
+
+  insertEvent(db, "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director", "apply", "info", "QA apply run queued");
+  insertEvent(db, "https://linkedin.com/jobs/view/qa-risk-manager", "score", "error", "QA score action failed");
+  insertEvent(db, "https://motorolasolutions.com/careers/qa-command-center", "tailor", "info", "QA tailor blocked by fit score");
+  db.prepare(
+    "INSERT INTO apply_runs (run_id, job_url, title, site, status, result, dry_run, started_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+  ).run(
+    "qa-run-1",
+    "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    "Director of Platform Engineering",
+    "Greenhouse",
+    "finished",
+    "succeeded",
+    1,
+    QA_NOW,
+  );
+  db.close();
+}
+
+function insertJob(db: Database.Database, job: QaJobSeed): void {
+  db.prepare(
+    `INSERT INTO jobs (
+      url, title, site, strategy, location, salary, discovered_at, application_url,
+      description, full_description, detail_scraped_at, fit_score, score_reasoning,
+      scored_at, tailored_resume_path, tailored_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    job.url,
+    job.title,
+    job.site,
+    job.strategy ?? "qa",
+    job.location ?? "Remote",
+    "",
+    QA_NOW,
+    job.applicationUrl ?? job.url,
+    job.description ?? "QA job description",
+    job.fullDescription ?? job.description ?? "QA job description",
+    QA_NOW,
+    job.fitScore ?? null,
+    "QA score reasoning with keywords: platform, security, reliability.",
+    job.fitScore === null ? null : QA_NOW,
+    null,
+    null,
+  );
+}
+
+function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string, errorCode: string | null = null): void {
+  db.prepare(
+    `INSERT INTO job_stage_states (
+      job_url, stage, state, attempt_count, max_attempts, updated_at,
+      error_code, error_message, retryable, blocked_by_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    jobUrl,
+    stage,
+    state,
+    state === "failed" ? 1 : 0,
+    3,
+    QA_NOW,
+    errorCode,
+    errorCode ? `${stage} failed` : null,
+    state === "blocked" ? 0 : 1,
+    "[]",
+  );
+}
+
+function insertArtifact(db: Database.Database, jobUrl: string, type: string, filePath: string): void {
+  db.prepare(
+    "INSERT INTO job_artifacts (job_url, stage, artifact_type, status, path, created_at, size_bytes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(jobUrl, artifactStage(type), type, "active", filePath, QA_NOW, localFileSize(filePath));
+}
+
+function insertEvent(db: Database.Database, jobUrl: string, stage: string, level: string, message: string): void {
+  db.prepare("INSERT INTO job_events (job_url, stage, level, message, occurred_at) VALUES (?, ?, ?, ?, ?)").run(
+    jobUrl,
+    stage,
+    level,
+    message,
+    QA_NOW,
+  );
+}
+
+function artifactStage(type: string): string {
+  if (type.startsWith("cover_letter")) {
+    return "cover";
+  }
+  return "tailor";
+}
+
+function localFileSize(filePath: string): number | null {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return null;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const workspace = createQaWorkspace(process.argv[2]);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        appDir: workspace.appDir,
+        dbPath: workspace.dbPath,
+        profilePath: workspace.profilePath,
+        resumeStylePath: workspace.resumeStylePath,
+        resumeTemplatePath: workspace.resumeTemplatePath,
+        settingsPath: workspace.settingsPath,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}

--- a/services/api/test/qa-workflow.test.ts
+++ b/services/api/test/qa-workflow.test.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { CredentialKey, CredentialsResponse } from "@jobhunter/contracts";
+import { CredentialKeys } from "@jobhunter/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CredentialStore } from "../src/credentials.js";
+import { buildApp, type BuildAppOptions } from "../src/server.js";
+import { createQaWorkspace, removeQaWorkspace, type QaWorkspace } from "./qa-seed.js";
+
+const LOOPBACK_HEADERS = { origin: "http://127.0.0.1:5173" };
+
+let workspace: QaWorkspace;
+let options: BuildAppOptions;
+
+beforeEach(() => {
+  workspace = createQaWorkspace();
+  options = {
+    dbPath: workspace.dbPath,
+    profilePath: workspace.profilePath,
+    resumeStylePath: workspace.resumeStylePath,
+    resumeTemplatePath: workspace.resumeTemplatePath,
+    settingsPath: workspace.settingsPath,
+    profilePreviewRenderer: async () => Buffer.from("%PDF-1.4\n% QA preview\n"),
+  };
+});
+
+afterEach(() => {
+  removeQaWorkspace(workspace);
+});
+
+describe("seeded local QA workflow", () => {
+  it("soft deletes and restores all matching jobs without touching nonmatching rows", async () => {
+    const app = buildApp(options);
+
+    const initial = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&pageSize=50&sort=title&dir=asc" });
+    expect(initial.statusCode, initial.body).toBe(200);
+    expect(initial.json().pagination.total).toBe(4);
+    expect(initial.json().items.map((job: { title: string }) => job.title)).toEqual([
+      "Command Center Solutions Project Manager",
+      "Director of Marketing",
+      "Director of Platform Engineering",
+      "Senior Engineering Manager - Risk",
+    ]);
+
+    const deleteFailed = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete",
+      headers: LOOPBACK_HEADERS,
+      payload: {
+        allMatching: true,
+        filter: { deleted: "active", state: "failed" },
+        jobKeys: [],
+        reason: "seeded QA delete",
+      },
+    });
+    expect(deleteFailed.statusCode, deleteFailed.body).toBe(200);
+    expect(deleteFailed.json()).toMatchObject({
+      count: 1,
+      jobKeys: ["https://linkedin.com/jobs/view/qa-risk-manager"],
+    });
+
+    const activeRisk = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&q=risk" });
+    expect(activeRisk.statusCode, activeRisk.body).toBe(200);
+    expect(activeRisk.json().pagination.total).toBe(0);
+
+    const deletedRisk = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted&q=risk" });
+    expect(deletedRisk.statusCode, deletedRisk.body).toBe(200);
+    expect(deletedRisk.json().pagination.total).toBe(1);
+    expect(deletedRisk.json().items[0]).toMatchObject({
+      title: "Senior Engineering Manager - Risk",
+      deletedAt: expect.any(String),
+    });
+
+    const dashboardAfterDelete = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+    expect(dashboardAfterDelete.statusCode, dashboardAfterDelete.body).toBe(200);
+    expect(dashboardAfterDelete.json().activity.map((event: { message: string }) => event.message)).not.toContain(
+      "QA score action failed",
+    );
+
+    const restoreDeleted = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-restore",
+      headers: LOOPBACK_HEADERS,
+      payload: { allMatching: true, filter: { deleted: "deleted" }, jobKeys: [] },
+    });
+    expect(restoreDeleted.statusCode, restoreDeleted.body).toBe(200);
+    expect(restoreDeleted.json()).toMatchObject({ count: 1 });
+
+    const restoredRisk = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&q=risk" });
+    expect(restoredRisk.statusCode, restoredRisk.body).toBe(200);
+    expect(restoredRisk.json().pagination.total).toBe(1);
+
+    await app.close();
+  });
+
+  it("hides deleted job artifacts and apply runs while preserving missing-file open safety", async () => {
+    const opener = vi.fn(async () => undefined);
+    const app = buildApp({ ...options, artifactOpener: opener });
+
+    const artifacts = await app.inject({ method: "GET", url: "/v1/artifacts?pageSize=20&sort=created_at&dir=desc" });
+    expect(artifacts.statusCode, artifacts.body).toBe(200);
+    expect(artifacts.json().pagination.total).toBe(5);
+    const gitlabArtifacts = artifacts
+      .json()
+      .items.filter((artifact: { jobKey: string }) => artifact.jobKey === "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director");
+    expect(gitlabArtifacts.map((artifact: { type: string }) => artifact.type).sort()).toEqual([
+      "cover_letter_pdf",
+      "cover_letter_txt",
+      "tailored_resume_pdf",
+      "tailored_resume_txt",
+    ]);
+    expect(new Set(gitlabArtifacts.map((artifact: { company: string }) => artifact.company))).toEqual(new Set(["GitLab"]));
+
+    const activeArtifact = gitlabArtifacts.find((artifact: { type: string }) => artifact.type === "tailored_resume_txt") as {
+      artifactId: string;
+      localPath: string;
+    };
+    const openActive = await app.inject({
+      method: "POST",
+      url: `/v1/artifacts/${encodeURIComponent(activeArtifact.artifactId)}/open`,
+      headers: LOOPBACK_HEADERS,
+    });
+    expect(openActive.statusCode, openActive.body).toBe(200);
+    expect(openActive.json()).toMatchObject({ opened: true, path: activeArtifact.localPath });
+    expect(opener).toHaveBeenCalledWith(activeArtifact.localPath);
+
+    const missingArtifact = artifacts.json().items.find((artifact: { status: string }) => artifact.status === "missing") as {
+      artifactId: string;
+    };
+    const openMissing = await app.inject({
+      method: "POST",
+      url: `/v1/artifacts/${encodeURIComponent(missingArtifact.artifactId)}/open`,
+      headers: LOOPBACK_HEADERS,
+    });
+    expect(openMissing.statusCode, openMissing.body).toBe(404);
+    expect(openMissing.json()).toMatchObject({ ok: false, error: "artifact_missing" });
+
+    const deleteGitlab = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete",
+      headers: LOOPBACK_HEADERS,
+      payload: { allMatching: true, filter: { q: "platform", deleted: "active" }, jobKeys: [] },
+    });
+    expect(deleteGitlab.statusCode, deleteGitlab.body).toBe(200);
+    expect(deleteGitlab.json()).toMatchObject({ count: 1 });
+
+    const artifactsAfterDelete = await app.inject({ method: "GET", url: "/v1/artifacts?pageSize=20" });
+    expect(artifactsAfterDelete.statusCode, artifactsAfterDelete.body).toBe(200);
+    expect(artifactsAfterDelete.json().items.map((artifact: { jobKey: string }) => artifact.jobKey)).not.toContain(
+      "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    );
+
+    const dashboardAfterDelete = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+    expect(dashboardAfterDelete.statusCode, dashboardAfterDelete.body).toBe(200);
+    expect(dashboardAfterDelete.json().applyRuns.map((run: { jobKey: string }) => run.jobKey)).not.toContain(
+      "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director",
+    );
+
+    await app.close();
+  });
+
+  it("persists profile, settings, credentials, and the rendered preview against seeded files", async () => {
+    const credentialStore = createMemoryCredentialStore();
+    const app = buildApp({ ...options, credentialStore });
+
+    const settings = await app.inject({ method: "GET", url: "/v1/settings" });
+    expect(settings.statusCode, settings.body).toBe(200);
+    expect(settings.json().settings).toMatchObject({
+      minFitScore: 7,
+      scoreCriteria: "Prioritize platform reliability, security, and engineering leadership.",
+      targetCriteria: "Remote-friendly senior engineering leadership roles.",
+    });
+
+    const updateSettings = await app.inject({
+      method: "PATCH",
+      url: "/v1/settings",
+      headers: LOOPBACK_HEADERS,
+      payload: {
+        minFitScore: 8,
+        scoreCriteria: "QA score criteria",
+        targetCriteria: "QA targeting criteria",
+      },
+    });
+    expect(updateSettings.statusCode, updateSettings.body).toBe(200);
+    expect(JSON.parse(fs.readFileSync(workspace.settingsPath, "utf8"))).toMatchObject({
+      min_fit_score: 8,
+      score_criteria: "QA score criteria",
+      target_criteria: "QA targeting criteria",
+    });
+
+    const profile = await app.inject({ method: "GET", url: "/v1/profile" });
+    expect(profile.statusCode, profile.body).toBe(200);
+    const profileDraft = profile.json().profile;
+    profileDraft.personal.full_name = "QA Candidate Edited";
+    const updateProfile = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      headers: LOOPBACK_HEADERS,
+      payload: { profileText: JSON.stringify(profileDraft, null, 2) },
+    });
+    expect(updateProfile.statusCode, updateProfile.body).toBe(200);
+    expect(JSON.parse(fs.readFileSync(workspace.profilePath, "utf8")).personal.full_name).toBe("QA Candidate Edited");
+
+    const preview = await app.inject({ method: "GET", url: "/v1/profile/preview.pdf" });
+    expect(preview.statusCode, preview.body).toBe(200);
+    expect(preview.headers["content-type"]).toContain("application/pdf");
+
+    const initialCredentials = await app.inject({ method: "GET", url: "/v1/credentials" });
+    expect(initialCredentials.statusCode, initialCredentials.body).toBe(200);
+    expect(initialCredentials.json().credentials.every((credential: { configured: boolean }) => !credential.configured)).toBe(true);
+
+    const saveCredential = await app.inject({
+      method: "PATCH",
+      url: "/v1/credentials",
+      headers: LOOPBACK_HEADERS,
+      payload: { key: "OPENAI_API_KEY", value: "sk-qa" },
+    });
+    expect(saveCredential.statusCode, saveCredential.body).toBe(200);
+    expect(saveCredential.json().credentials.find((credential: { key: string }) => credential.key === "OPENAI_API_KEY")).toMatchObject({
+      configured: true,
+      storage: "keychain",
+    });
+
+    const deleteCredential = await app.inject({
+      method: "DELETE",
+      url: "/v1/credentials/OPENAI_API_KEY",
+      headers: LOOPBACK_HEADERS,
+    });
+    expect(deleteCredential.statusCode, deleteCredential.body).toBe(200);
+    expect(deleteCredential.json().credentials.find((credential: { key: string }) => credential.key === "OPENAI_API_KEY")).toMatchObject({
+      configured: false,
+    });
+
+    await app.close();
+  });
+});
+
+function createMemoryCredentialStore(): CredentialStore {
+  const values = new Map<CredentialKey, string>();
+  const list = async (): Promise<CredentialsResponse> => ({
+    ok: true,
+    credentials: CredentialKeys.map((key) => ({
+      key,
+      label: key,
+      configured: values.has(key),
+      storage: "keychain" as const,
+    })),
+  });
+  return {
+    list,
+    set: async (key, value) => {
+      values.set(key, value);
+      return list();
+    },
+    delete: async (key) => {
+      values.delete(key);
+      return list();
+    },
+  };
+}

--- a/services/api/test/server.test.ts
+++ b/services/api/test/server.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
 
-import { createJobHunterApiClient } from "@jobhunter/contracts";
+import { CredentialKeys, createJobHunterApiClient, type CredentialKey } from "@jobhunter/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { resolveApiConfig } from "../src/config.js";
@@ -34,6 +34,8 @@ beforeEach(() => {
       min_fit_score: 8,
       auto_apply: true,
       apply_concurrency: 3,
+      score_criteria: "Security leadership and platform reliability.",
+      target_criteria: "Director-plus infrastructure and security roles.",
     }),
   );
 });
@@ -136,6 +138,11 @@ describe("local TypeScript API", () => {
         payload: { reason: "cross-site" },
       },
       {
+        method: "DELETE",
+        url: `/v1/jobs/${jobKey}`,
+        payload: { reason: "cross-site" },
+      },
+      {
         method: "POST",
         url: "/v1/artifacts/1/open",
       },
@@ -148,6 +155,15 @@ describe("local TypeScript API", () => {
         method: "POST",
         url: "/v1/profile/import-resume",
         payload: { filename: "resume.pdf", pdfBase64: Buffer.from("%PDF test").toString("base64") },
+      },
+      {
+        method: "PATCH",
+        url: "/v1/credentials",
+        payload: { key: "OPENAI_API_KEY", value: "cross-site" },
+      },
+      {
+        method: "DELETE",
+        url: "/v1/credentials/OPENAI_API_KEY",
       },
     ] as const;
 
@@ -227,7 +243,14 @@ describe("local TypeScript API", () => {
       succeeded: 2,
       blocked: 0,
     });
-    expect(body.activity[0]).toMatchObject({ stage: "score", level: "error" });
+    expect(body.activity[0]).toMatchObject({
+      eventId: "1",
+      jobKey: "https://example.com/jobs/failed-score",
+      title: "Backend Engineer",
+      company: "ExampleCo",
+      stage: "score",
+      level: "error",
+    });
     expect(body.applyRuns[0]).toMatchObject({ runId: "run-1", dryRun: true });
 
     await app.close();
@@ -265,6 +288,68 @@ describe("local TypeScript API", () => {
       currentState: "failed",
       fitScore: 8,
     });
+
+    await app.close();
+  });
+
+  it("soft-deletes jobs, hides them from active lists, and restores them", async () => {
+    const app = buildApp(options);
+    const readyKey = encodeURIComponent("https://example.com/jobs/ready");
+
+    const singleDelete = await app.inject({
+      method: "DELETE",
+      url: `/v1/jobs/${readyKey}`,
+      payload: { reason: "not relevant" },
+    });
+    const bulkDelete = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete",
+      payload: { allMatching: true, filter: { state: "failed", deleted: "active" }, jobKeys: [] },
+    });
+
+    expect(singleDelete.statusCode, singleDelete.body).toBe(200);
+    expect(singleDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: ["https://example.com/jobs/ready"] });
+    expect(bulkDelete.statusCode, bulkDelete.body).toBe(200);
+    expect(bulkDelete.json()).toMatchObject({ ok: true, count: 1, jobKeys: ["https://example.com/jobs/failed-score"] });
+
+    const active = await app.inject({ method: "GET", url: "/v1/jobs" });
+    expect(active.statusCode, active.body).toBe(200);
+    expect(active.json().pagination.total).toBe(1);
+    expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual(["https://example.com/jobs/blocked-tailor"]);
+
+    const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted&sort=title&dir=asc" });
+    expect(deleted.statusCode, deleted.body).toBe(200);
+    expect(deleted.json().pagination.total).toBe(2);
+    expect(deleted.json().items[0]).toMatchObject({ deletedAt: expect.any(String) });
+
+    const summary = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+    expect(summary.statusCode, summary.body).toBe(200);
+    expect(summary.json().totals).toMatchObject({
+      jobs: 1,
+      failures: 0,
+      blocked: 1,
+      ready: 0,
+      dryRuns: 0,
+    });
+    expect(summary.json().activity).toHaveLength(0);
+    expect(summary.json().applyRuns).toHaveLength(0);
+
+    const artifacts = await app.inject({ method: "GET", url: "/v1/artifacts" });
+    expect(artifacts.statusCode, artifacts.body).toBe(200);
+    expect(artifacts.json().pagination.total).toBe(0);
+
+    const restore = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-restore",
+      payload: { allMatching: true, filter: { deleted: "deleted" }, jobKeys: [] },
+    });
+    expect(restore.statusCode, restore.body).toBe(200);
+    expect(restore.json()).toMatchObject({ ok: true, count: 2 });
+
+    const restored = await app.inject({ method: "GET", url: "/v1/jobs" });
+    expect(restored.json().pagination.total).toBe(3);
+    const emptyDeleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted" });
+    expect(emptyDeleted.json().pagination.total).toBe(0);
 
     await app.close();
   });
@@ -391,6 +476,42 @@ describe("local TypeScript API", () => {
 
     expect(response.statusCode, response.body).toBe(200);
     expect(response.json()).toMatchObject({
+      ok: true,
+      opened: true,
+      path: artifact.localPath,
+    });
+    expect(opened).toEqual([artifact.localPath]);
+
+    await app.close();
+  });
+
+  it("resolves legacy artifact ids with slashes for detail and open routes", async () => {
+    const opened: string[] = [];
+    const app = buildApp({
+      ...options,
+      artifactOpener: async (artifactPath) => {
+        opened.push(artifactPath);
+      },
+    });
+    const listResponse = await app.inject({ method: "GET", url: "/v1/artifacts?type=tailored_resume_pdf" });
+    const artifact = listResponse.json().items[0];
+    fs.writeFileSync(artifact.localPath, "%PDF test");
+    const artifactId = encodeURIComponent(artifact.artifactId);
+
+    const detailResponse = await app.inject({ method: "GET", url: `/v1/artifacts/${artifactId}` });
+    const openResponse = await app.inject({ method: "POST", url: `/v1/artifacts/${artifactId}/open` });
+
+    expect(detailResponse.statusCode, detailResponse.body).toBe(200);
+    expect(detailResponse.json()).toMatchObject({
+      ok: true,
+      artifact: {
+        artifactId: artifact.artifactId,
+        jobKey: "https://example.com/jobs/ready",
+        type: "tailored_resume_pdf",
+      },
+    });
+    expect(openResponse.statusCode, openResponse.body).toBe(200);
+    expect(openResponse.json()).toMatchObject({
       ok: true,
       opened: true,
       path: artifact.localPath,
@@ -768,6 +889,27 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("serves a rendered profile PDF preview", async () => {
+    const renderer = vi.fn(async () => Buffer.from("%PDF-1.7\nmock preview"));
+    const app = buildApp({ ...options, profilePreviewRenderer: renderer });
+    const response = await app.inject({ method: "GET", url: "/v1/profile/preview.pdf" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.headers["content-type"]).toContain("application/pdf");
+    expect(response.headers["cache-control"]).toBe("no-store");
+    expect(response.rawPayload.subarray(0, 5).toString()).toBe("%PDF-");
+    expect(renderer).toHaveBeenCalledWith(
+      {
+        profilePath: options.profilePath,
+        resumeStylePath: options.resumeStylePath,
+        resumeTemplatePath: options.resumeTemplatePath,
+      },
+      expect.objectContaining({ appDir: tempDir }),
+    );
+
+    await app.close();
+  });
+
   it("returns normalized runtime settings", async () => {
     const app = buildApp(options);
     const response = await app.inject({ method: "GET", url: "/v1/settings" });
@@ -781,6 +923,8 @@ describe("local TypeScript API", () => {
         minFitScore: 8,
         autoApply: true,
         applyConcurrency: 3,
+        scoreCriteria: "Security leadership and platform reliability.",
+        targetCriteria: "Director-plus infrastructure and security roles.",
       },
       paths: {
         settingsPath: options.settingsPath,
@@ -803,7 +947,104 @@ describe("local TypeScript API", () => {
         minFitScore: 7,
         autoApply: false,
         applyConcurrency: 1,
+        scoreCriteria: "",
+        targetCriteria: "",
       },
+    });
+
+    await app.close();
+  });
+
+  it("persists editable runtime settings", async () => {
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/settings",
+      payload: {
+        targetRole: "CISO",
+        locationFilter: "Europe remote",
+        minFitScore: 9,
+        autoApply: false,
+        applyConcurrency: 2,
+        scoreCriteria: "Prioritize platform security, DevSecOps, and leadership scope.",
+        targetCriteria: "Target senior engineering leadership roles.",
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      settings: {
+        targetRole: "CISO",
+        locationFilter: "Europe remote",
+        minFitScore: 9,
+        autoApply: false,
+        applyConcurrency: 2,
+        scoreCriteria: "Prioritize platform security, DevSecOps, and leadership scope.",
+        targetCriteria: "Target senior engineering leadership roles.",
+      },
+    });
+    expect(JSON.parse(fs.readFileSync(options.settingsPath, "utf8"))).toMatchObject({
+      target_role: "CISO",
+      location_filter: "Europe remote",
+      min_fit_score: 9,
+      auto_apply: false,
+      apply_concurrency: 2,
+      score_criteria: "Prioritize platform security, DevSecOps, and leadership scope.",
+      target_criteria: "Target senior engineering leadership roles.",
+    });
+
+    await app.close();
+  });
+
+  it("stores credential configuration through the injected credential store", async () => {
+    const stored = new Map<CredentialKey, string>();
+    const credentialStore = {
+      list: vi.fn(async () => ({
+        ok: true as const,
+        credentials: CredentialKeys.map((key) => ({
+          key,
+          label: key,
+          configured: stored.has(key),
+          storage: "keychain" as const,
+        })),
+      })),
+      set: vi.fn(async (key: CredentialKey, value: string) => {
+        stored.set(key, value);
+        return credentialStore.list();
+      }),
+      delete: vi.fn(async (key: CredentialKey) => {
+        stored.delete(key);
+        return credentialStore.list();
+      }),
+    };
+    const app = buildApp({ ...options, credentialStore });
+
+    const initial = await app.inject({ method: "GET", url: "/v1/credentials" });
+    expect(initial.statusCode, initial.body).toBe(200);
+    expect(initial.json().credentials).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: "OPENAI_API_KEY", configured: false, storage: "keychain" }),
+        expect.objectContaining({ key: "GEMINI_API_KEY", configured: false, storage: "keychain" }),
+      ]),
+    );
+
+    const save = await app.inject({
+      method: "PATCH",
+      url: "/v1/credentials",
+      payload: { key: "OPENAI_API_KEY", value: "test-secret" },
+    });
+    expect(save.statusCode, save.body).toBe(200);
+    expect(credentialStore.set).toHaveBeenCalledWith("OPENAI_API_KEY", "test-secret");
+    expect(save.json().credentials.find((credential: { key: string }) => credential.key === "OPENAI_API_KEY")).toMatchObject({
+      configured: true,
+    });
+
+    const remove = await app.inject({ method: "DELETE", url: "/v1/credentials/OPENAI_API_KEY" });
+    expect(remove.statusCode, remove.body).toBe(200);
+    expect(credentialStore.delete).toHaveBeenCalledWith("OPENAI_API_KEY");
+    expect(remove.json().credentials.find((credential: { key: string }) => credential.key === "OPENAI_API_KEY")).toMatchObject({
+      configured: false,
     });
 
     await app.close();


### PR DESCRIPTION
## Summary
- Restores the local-first dashboard workflows for jobs, artifacts, profile editing, config, theme, and global search.
- Adds soft-delete/restore job flows, grouped artifact variants, PDF-backed profile preview, and keychain-backed credential configuration endpoints.
- Adds a seeded QA workspace and API regression tests for destructive and persistence workflows.

## Validation
- npm run qa:test
- npm test
- uv run --extra dev pytest -q
- uv run --extra dev ruff check .
- git diff --cached --check
- Browser QA with a seeded local workspace using the in-app browser on ports 15173/18766; preview restored to 127.0.0.1:5173 afterward.

## Notes
- QA seeding is available with npm run qa:seed -- /tmp/jobhunter-qa.
- Native browser confirm dialogs still require human approval during browser-use QA; the seeded API regression covers the delete/restore behavior without touching personal data.