### PR TITLE
docs: add DDD + hexagonal target architecture and migration plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,21 @@ name: CI
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+      - ".env.example"
+      - "profile.example.json"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
+      - ".env.example"
+      - "profile.example.json"
   workflow_dispatch:
 
 jobs:

--- a/docs/ddd-target.md
+++ b/docs/ddd-target.md
@@ -70,12 +70,17 @@ This architecture follows **evolutionary architecture** as the meta-principle.
 The cloud target is non-negotiable, but the architecture lets us walk there one
 well-defined step at a time — it does not arrive on day one.
 
+> Evolutionary architecture means cloud adapters are named-not-built; it does
+> NOT mean preserving legacy code paths. Migrations within the codebase are
+> clean replacements: the new implementation lands in the same change that
+> deletes the old one.
+
 | Principle | How we apply it |
 |---|---|
 | **Name the evolution, do not pre-build it** | Every driven port names its cloud adapter and technology. No cloud adapter is implemented until the evolution trigger fires. Local adapters stay minimal. |
 | **Local-mode adapters stay simple** | Local adapters do not carry hosted concerns (auth context propagation, distributed tracing, tenant enforcement). They accept `TenantId` as a parameter but ignore it. Cloud machinery is absent from local code. |
 | **Fitness functions trigger evolution** | Every major design choice has a concrete, testable trigger (Section 9.4). "When concurrent users > 1" is a fitness function; "when we go to the cloud" is not. |
-| **Strangler-friendly migrations** | Each bounded context's adapters can be swapped independently. Discovery can migrate to Postgres while Scoring remains on SQLite. Section 9.5 describes context-by-context migration. |
+| **Independent context evolution** | Each bounded context's adapters can be swapped independently. Discovery can migrate to Postgres while Scoring remains on SQLite. Section 9.5 describes context-by-context cloud migration order. |
 | **Deliberate trade-offs** | Where we choose local simplicity over cloud-ready flexibility, we name it as a **Trade-off** with the upgrade path documented. We do not pretend the local choice IS the cloud choice. |
 
 ### Data-Orientation (Hickey / Wlaschin)
@@ -896,13 +901,6 @@ StageState =
   transition event, produces new state or rejects the transition. Pure function.
 - `PipelineScheduler` — given all job stage states and a pipeline run request,
   determines which jobs need processing at which stage. Pure function.
-- `LegacyStateDeriver` — (temporary, migration-period only) derives stage states
-  from legacy `jobs` table columns. **Removal criterion:** When a migration
-  query confirms zero jobs have legacy-only state (i.e.,
-  `SELECT COUNT(*) FROM jobs WHERE url NOT IN (SELECT DISTINCT job_url FROM job_stage_states)` returns 0),
-  AND the legacy enrichment/scoring/tailor/cover/apply columns have been dropped
-  from the `jobs` table, the `LegacyStateDeriver` can be deleted. Until then
-  it runs on read to fill gaps.
 
 **Orchestration guard against premature processing:** Processing contexts
 (Scoring, Materials, etc.) do not independently decide to process jobs. They
@@ -1482,10 +1480,9 @@ The current wide `jobs` table is narrowed in the target:
 | `cover_letter_path`, `cover_letter_at`, `cover_attempts` | Materials Generation | `job_materials` + `job_artifacts` |
 | `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, `agent_id`, etc. | Apply Automation | `apply_runs` (existing) |
 
-The migration creates new tables and backfills them from the wide `jobs` table.
-The legacy columns are retained (read-only) during the transition period. The
-`LegacyStateDeriver` in Pipeline Orchestration handles backward compatibility
-until all data is migrated.
+The migration creates new tables, backfills them from the wide `jobs` table in
+the same change, and drops the legacy columns. Each context's extraction PR
+migrates its data and removes the corresponding `jobs` columns in one step.
 
 ### 7.4 Current Tables to Aggregates Mapping
 
@@ -1842,12 +1839,13 @@ cloud" (circular), but measurable conditions.
 | No audit log | Postgres `audit_events` + CloudWatch | First compliance requirement (SOC2, GDPR data access log) | The `AuditSink` port is a no-op locally. |
 | `pdflatex` subprocess | Tectonic / Typst in container | Rendering spike conclusion **OR** cloud deployment (TeX Live is 4 GB, too large for containers) | `PdfRendererPort` absorbs any engine. |
 
-### 9.5 Strangler-Friendly Context Migration
+### 9.5 Cloud Migration Order
 
-Each bounded context's adapters can be swapped **independently** without
-freezing the rest of the system. This is critical because the current
-architecture shares one SQLite file across all contexts — the migration must
-break this shared-state coupling context by context.
+When the cloud trigger fires (per §9.4), bounded contexts migrate to their
+cloud adapters in a defined order. Migration is **incremental for
+reviewability**, not for parallel-path safety: JobHunter is a single-user
+product, so each context cutover is "stop the worker, migrate data, restart
+on the new adapter." There is no parallel old/new traffic.
 
 **Migration order (recommended):**
 
@@ -1855,36 +1853,29 @@ break this shared-state coupling context by context.
    well-structured and maps cleanly to a standalone repository. Migrate this
    context to Postgres first to establish the RDS infrastructure.
 
-2. **Scoring** — Second: extract scoring columns from the wide `jobs` table
-   into `job_scores` (new table). Scoring context reads from its own repository;
-   Operations projection reads from both old and new tables during transition.
+2. **Scoring** — Second: move `job_scores` data into Postgres. Scoring context
+   reads and writes Postgres exclusively after the cutover.
 
-3. **Materials Generation** — Third: similar extraction of tailor/cover/pdf
-   columns into `job_materials` + enriched `job_artifacts`. Artifact storage
-   swaps from local filesystem to S3.
+3. **Materials Generation** — Third: move `job_materials` and `job_artifacts`
+   into Postgres. Artifact storage swaps from local filesystem to S3 in the
+   same change.
 
-4. **Job Enrichment** — Fourth: extract enrichment columns into
-   `job_enrichments`. Detail fetcher port swaps to Browserbase.
+4. **Job Enrichment** — Fourth: move `job_enrichments` into Postgres. Detail
+   fetcher port swaps to Browserbase.
 
-5. **Job Discovery** — Fifth: narrow the `jobs` table to discovery-only columns.
-   At this point the wide table is fully decomposed.
+5. **Job Discovery** — Fifth: move the narrowed `jobs` table into Postgres.
 
-6. **Apply Automation** — Sixth: `apply_runs` + `apply_run_events` are already
-   separate tables. Browser port and agent port swap to cloud adapters.
+6. **Apply Automation** — Sixth: move `apply_runs` + `apply_run_events` into
+   Postgres. Browser port and agent port swap to cloud adapters.
 
 7. **Operations** — Last: switches from SQLite read model to Postgres read
    replica once all write-side contexts are on Postgres.
 
-**During partial migration:** Contexts that have migrated to Postgres publish
-events to both the in-process bus (for local-mode contexts still on SQLite)
-and the SQS outbox (for cloud-mode consumers). This dual-publish pattern is
-temporary and removed once all contexts are migrated. The `EventPublisher`
-port's adapter handles this transparently.
-
-**Rollback safety:** Each context migration is a separate deployment. If
-Scoring on Postgres shows issues, it can be rolled back to SQLite by
-switching the adapter config. The repository port interface is unchanged;
-only the adapter binding changes.
+**Per-context cutover:** Each context migration is a single deployment that
+stops the worker process, migrates data with a one-shot script, and restarts
+on the new adapter. The repository port interface is unchanged; only the
+adapter binding changes. There is no dual-publish or dual-write — this is a
+single-user system.
 
 ---
 
@@ -1906,10 +1897,11 @@ only the adapter binding changes.
    Monitor for `SQLITE_BUSY` errors.
 
 3. **Legacy data migration complexity.** The wide `jobs` table has ~800+ days of
-   production data. Backfilling new tables from legacy columns will require
-   careful handling of NULL semantics, inconsistent timestamps, and partial
-   state. **Mitigation:** The `LegacyStateDeriver` serves as the migration
-   bridge; it can run incrementally and idempotently.
+   data. Backfilling new tables from legacy columns will require careful
+   handling of NULL semantics, inconsistent timestamps, and partial state.
+   **Mitigation:** Each context's extraction PR ships a one-shot, idempotent
+   backfill script that runs against a staging database first; the same script
+   then runs in the cutover PR before the legacy columns are dropped.
 
 4. **In-process event bus reliability.** The synchronous in-process event bus
    means a crash between "command succeeded" and "projection updated" leaves

--- a/docs/ddd-target.md
+++ b/docs/ddd-target.md
@@ -548,6 +548,7 @@ Identity: (TenantId, JobId)
   — Consumed by: Pipeline Orchestration (to initialize stage states), Operations (to update job list).
 - `JobUpdated { tenantId, jobId, changedFields }` — Consumed by: Operations.
 - `JobDeleted { tenantId, jobId, reason, deletedAt }` — Consumed by: Operations.
+- `JobRestored { tenantId, jobId, restoredAt }` — Consumed by: Operations.
 
 **Domain Services:** None. Discovery logic (scraping, dedup) lives in adapters
 behind ports; the aggregate is purely data.
@@ -1335,42 +1336,6 @@ generating JSON Schema, TypeScript types, and Python dataclasses). TypeSpec is
 chosen over raw JSON Schema because it supports discriminated unions, which
 map directly to the domain event and StageState sum types.
 
-### 6.8 TS API Write Operations — Domain Logic Hosting
-
-The current TS API (`write-model.ts`) performs several write operations
-directly against SQLite. In the target, each operation maps to a driving port
-on the appropriate bounded context. The question is: which runtime *hosts*
-the domain logic?
-
-**Principle:** Simple state-transition commands that require no LLM, browser,
-or scraping infrastructure are hosted **in the TS API process** directly,
-using shared domain types from `packages/domain-types`. Complex processing
-commands are dispatched to the Python worker via JSON-RPC.
-
-| Current `write-model.ts` operation | Target driving port | Hosted in | Rationale |
-|---|---|---|---|
-| `resetJobStage` | `RetryStageUseCase` (Pipeline Orchestration) | **TS API** | Pure state machine transition — `StageStateMachine` is a shared domain type. No Python needed. |
-| `markJobApplied` | `MarkAppliedUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. No browser/LLM. |
-| `markJobSkipped` | `SkipJobUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. |
-| `softDeleteJob` | `DeleteJobUseCase` (Discovery) | **TS API** | Tombstone write. No Python needed. |
-| `restoreJob` | `RestoreJobUseCase` (Discovery) | **TS API** | Tombstone removal. |
-| `updateProfile` | `UpdateProfileUseCase` (Profile) | **TS API** | JSON validation and file write. |
-| pipeline run / discover / enrich / score / tailor / cover / apply | Stage commands via `StageCommandDispatcher` | **Python worker** (via JSON-RPC) | Requires LLM, browser, scraping infrastructure. |
-| profile import from PDF | `ImportProfileUseCase` (Profile) | **Python worker** (via JSON-RPC) | Requires `pypdf` + LLM extraction. |
-
-**Trade-off:** The TS API hosting simple commands means the `StageStateMachine`
-logic exists in both TypeScript (via `packages/domain-types`) and Python. This
-is acceptable because: (a) the state machine is a small, pure function with
-well-defined transitions; (b) it is generated from the shared TypeSpec IDL, so
-both implementations are derived from one source; (c) the alternative —
-routing every button click through a Python subprocess — adds unacceptable
-latency for simple UI operations.
-
-**Cloud evolution:** In cloud mode, both TS and Python import the same
-`StageStateMachine` from a shared package. The TS API continues to host simple
-commands directly (now against Postgres via the repository adapter). Complex
-commands go through Temporal instead of subprocess.
-
 ### 6.6 Operations Read-Model Projection Strategy
 
 The Operations context builds its projections by:
@@ -1410,6 +1375,42 @@ This eliminates the current coupling where `launcher.py` directly writes to
 the `jobs` table, `apply_runs` table, `apply_run_events` table, `job_events`
 table, and `job_stage_states` table while also updating the in-memory Rich
 dashboard — all in the same function.
+
+### 6.8 TS API Write Operations — Domain Logic Hosting
+
+The current TS API (`write-model.ts`) performs several write operations
+directly against SQLite. In the target, each operation maps to a driving port
+on the appropriate bounded context. The question is: which runtime *hosts*
+the domain logic?
+
+**Principle:** Simple state-transition commands that require no LLM, browser,
+or scraping infrastructure are hosted **in the TS API process** directly,
+using shared domain types from `packages/domain-types`. Complex processing
+commands are dispatched to the Python worker via JSON-RPC.
+
+| Current `write-model.ts` operation | Target driving port | Hosted in | Rationale |
+|---|---|---|---|
+| `resetJobStage` | `RetryStageUseCase` (Pipeline Orchestration) | **TS API** | Pure state machine transition — `StageStateMachine` is a shared domain type. No Python needed. |
+| `markJobApplied` | `MarkAppliedUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. No browser/LLM. |
+| `markJobSkipped` | `SkipJobUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. |
+| `softDeleteJob` | `DeleteJobUseCase` (Discovery) | **TS API** | Tombstone write. No Python needed. |
+| `restoreJob` | `RestoreJobUseCase` (Discovery) | **TS API** | Tombstone removal. |
+| `updateProfile` | `UpdateProfileUseCase` (Profile) | **TS API** | JSON validation and file write. |
+| pipeline run / discover / enrich / score / tailor / cover / apply | Stage commands via `StageCommandDispatcher` | **Python worker** (via JSON-RPC) | Requires LLM, browser, scraping infrastructure. |
+| profile import from PDF | `ImportProfileUseCase` (Profile) | **Python worker** (via JSON-RPC) | Requires `pypdf` + LLM extraction. |
+
+**Trade-off:** The TS API hosting simple commands means the `StageStateMachine`
+logic exists in both TypeScript (via `packages/domain-types`) and Python. This
+is acceptable because: (a) the state machine is a small, pure function with
+well-defined transitions; (b) it is generated from the shared TypeSpec IDL, so
+both implementations are derived from one source; (c) the alternative —
+routing every button click through a Python subprocess — adds unacceptable
+latency for simple UI operations.
+
+**Cloud evolution:** In cloud mode, both TS and Python import the same
+`StageStateMachine` from a shared package. The TS API continues to host simple
+commands directly (now against Postgres via the repository adapter). Complex
+commands go through Temporal instead of subprocess.
 
 ---
 
@@ -2057,7 +2058,7 @@ single-user system.
 | **SearchStrategy** | Discovery | The extraction method used to find jobs: `jobspy`, `workday_api`, `smart_extract`, `manual`. |
 | **Source** | Discovery | The origin board or career site where a job was found (e.g., LinkedIn, Greenhouse). |
 | **Stage** | Pipeline Orchestration | A named step in the pipeline: `discover`, `enrich`, `score`, `tailor`, `cover`, `pdf`, `apply`. |
-| **StageState** | Pipeline Orchestration | The current status of a job within a stage: `pending`, `queued`, `running`, `succeeded`, `failed`, `blocked`, `skipped`, `exhausted`, `stale`, `canceled`. |
+| **StageState** | Pipeline Orchestration | The current status of a job within a stage. The domain model represents each variant as a typed value (PascalCase: `Pending`, `Queued`, `Running`, `Succeeded`, `Failed`, `Blocked`, `Skipped`, `Exhausted`, `Stale`, `Canceled` — see §4.7). The lowercase forms (`pending`, `queued`, `running`, `succeeded`, `failed`, `blocked`, `skipped`, `exhausted`, `stale`, `canceled`) are the serialized representation written to `job_stage_states.state`, emitted in event payloads, and exposed through the API DTOs. |
 | **SubmissionResult** | Apply Automation | The outcome of an apply attempt: `applied`, `failed`, `captcha`, `login_issue`, `expired`, `manual`, `dry_run`. |
 | **TailoredResume** | Materials Generation | A resume customized for a specific job, derived from the master baseline via LLM. |
 | **TenantContext** | Platform (Identity) | A request-scoped value object containing `tenantId`, `userId`, and `roles`, injected by the API gateway / auth middleware into every use case call. |

--- a/docs/ddd-target.md
+++ b/docs/ddd-target.md
@@ -1,0 +1,2077 @@
+# DDD Target-State Architecture
+
+## 1. Purpose & Non-Goals
+
+### Purpose
+
+This document defines the **canonical target-state architecture** for JobHunter,
+modeled with Domain-Driven Design (DDD) and Hexagonal Architecture (Ports &
+Adapters). It is the authoritative reference for:
+
+- Bounded context boundaries and their relationships
+- Aggregate design with invariants and lifecycle rules
+- Domain events and cross-context integration contracts
+- Port interfaces and adapter seams for all I/O
+- The typed integration protocol between the TypeScript API and Python worker
+- Persistence boundary design that decouples domain types from storage schema
+
+Every modeling choice includes rationale so a senior engineer joining the team
+can re-derive the decision independently.
+
+**Cloud deployment is a hard requirement.** The local-first phase is a
+validation gate, not the end state. Every decision in this document is designed
+to ship to a hosted multi-tenant cloud deployment. Section 9 is not
+"compatibility" — it is the target deployment model.
+
+### Non-Goals
+
+- **Migration plan.** This document does not prescribe file moves, PR sequences,
+  or rollout phases. That is the migration-planning team's scope.
+- **Implementation code.** Pseudocode sketches appear where they aid clarity; no
+  production code is included.
+- **Deployment topology.** Kubernetes manifests, Terraform modules, CI/CD
+  pipelines, and region selection are infrastructure engineering, not domain
+  modeling. Section 9 names the concrete services and seams but does not design
+  the deployment.
+- **UI/frontend architecture.** React component structure, state management
+  libraries, and routing are not modeled. The Operations context covers
+  read-model projections that feed the UI.
+- **LLM prompt engineering.** Prompt content for scoring, tailoring, and cover
+  letter generation is domain knowledge but not architectural modeling.
+
+---
+
+## 2. Modeling Principles
+
+### DDD Principles Applied
+
+| Principle | How we apply it |
+|---|---|
+| **Ubiquitous Language** | Every bounded context defines its own glossary. The same term (e.g., "Job") means different things in Discovery vs. Scoring. Code, docs, and UI use identical terminology within each context. |
+| **Aggregates chosen by transactional consistency** | An aggregate boundary encloses exactly the data that must be consistent within a single transaction. Cross-aggregate consistency uses domain events and eventual consistency. |
+| **Entities have identity; Value Objects have equality-by-value** | `Job` is an entity (identity by `JobId`). `FitScore` is a value object (a score of 8 is the same regardless of where it was computed). |
+| **Domain Events are immutable facts** | Named in past tense (`JobDiscovered`, `ResumeApproved`). They record *what happened*, not *what to do*. They are the primary integration mechanism between bounded contexts. |
+| **Domain depends on nothing** | Domain types and logic have zero imports from infrastructure (no SQLite, no HTTP, no filesystem). All I/O crosses a port boundary. |
+| **Repositories abstract persistence** | Each aggregate root has a repository port. The domain sees an in-memory collection illusion; the adapter translates to SQLite/Postgres/filesystem. |
+| **Tenant identity is a first-class domain concept** | Every aggregate identity is scoped by `TenantId`. Every domain event carries `tenantId`. Every repository query, every event publication, every projection is tenant-scoped. In local-first mode, `TenantId` is a singleton constant (`local`); in hosted mode it is the authenticated user's tenant. The domain carries `TenantId`; adapters enforce isolation. |
+
+### Hexagonal Architecture Principles Applied
+
+| Principle | How we apply it |
+|---|---|
+| **Ports own protocol semantics** | A port defines *what* the application needs (e.g., `LlmPort.complete(prompt, schema) -> Result`) — not *how* it's implemented (Gemini, OpenAI, local). |
+| **Adapters are replaceable** | Every driven port has at least two plausible adapters: a local-first adapter (today) and a hosted adapter (SaaS future). The domain is untouched when swapping. |
+| **Driving ports are use cases** | Application services expose use cases (`ScoreJob`, `TailorResume`, `SubmitApplication`). External callers (CLI, API, test harness) drive through these ports. |
+| **Anti-Corruption Layers guard context boundaries** | When integrating with external systems (job boards, LLM APIs, ATS portals), an ACL translates external models into domain types at the boundary. |
+
+### Evolutionary Architecture
+
+This architecture follows **evolutionary architecture** as the meta-principle.
+The cloud target is non-negotiable, but the architecture lets us walk there one
+well-defined step at a time — it does not arrive on day one.
+
+| Principle | How we apply it |
+|---|---|
+| **Name the evolution, do not pre-build it** | Every driven port names its cloud adapter and technology. No cloud adapter is implemented until the evolution trigger fires. Local adapters stay minimal. |
+| **Local-mode adapters stay simple** | Local adapters do not carry hosted concerns (auth context propagation, distributed tracing, tenant enforcement). They accept `TenantId` as a parameter but ignore it. Cloud machinery is absent from local code. |
+| **Fitness functions trigger evolution** | Every major design choice has a concrete, testable trigger (Section 9.4). "When concurrent users > 1" is a fitness function; "when we go to the cloud" is not. |
+| **Strangler-friendly migrations** | Each bounded context's adapters can be swapped independently. Discovery can migrate to Postgres while Scoring remains on SQLite. Section 9.5 describes context-by-context migration. |
+| **Deliberate trade-offs** | Where we choose local simplicity over cloud-ready flexibility, we name it as a **Trade-off** with the upgrade path documented. We do not pretend the local choice IS the cloud choice. |
+
+### Data-Orientation (Hickey / Wlaschin)
+
+- **Immutable values over mutable objects.** Domain events, value objects, and
+  command results are immutable data. Aggregates are the only mutable concept,
+  and their mutations are expressed as event emissions.
+- **Make illegal states unrepresentable.** Stage state transitions are modeled as
+  a sum type / discriminated union — not nullable columns. A job cannot
+  simultaneously be `Running` and `Succeeded`.
+- **Functions transform data.** Scoring, tailoring, and cover letter generation
+  are pure functions `(Input, Profile, Config) -> Result` with I/O pushed to
+  the edges via ports.
+
+---
+
+## 3. Strategic Design — Bounded Contexts
+
+### Context Map
+
+```mermaid
+graph TB
+    subgraph "Core Domain"
+        JD["Job Discovery"]
+        JE["Job Enrichment"]
+        SC["Scoring"]
+        MG["Materials Generation"]
+        AA["Apply Automation"]
+    end
+
+    subgraph "Supporting Domain"
+        CP["Candidate Profile"]
+        PO["Pipeline Orchestration"]
+    end
+
+    subgraph "Generic Subdomain"
+        OPS["Operations / Read-Side"]
+    end
+
+    subgraph "Platform Contexts (cloud)"
+        IAM["Identity & Access"]
+        BILL["Billing & Entitlements"]
+        AUDIT["Audit Log"]
+        SECRETS["Secret Management"]
+    end
+
+    JD -->|"JobDiscovered (Published Language)"| PO
+    JE -->|"JobEnriched (Published Language)"| PO
+    SC -->|"JobScored (Published Language)"| PO
+    MG -->|"ResumeApproved / CoverLetterGenerated / PdfRendered (Published Language)"| PO
+    AA -->|"ApplicationSubmitted / ApplicationFailed (Published Language)"| PO
+
+    PO -->|"StageCompleted events"| OPS
+
+    CP -->|"Conformist (Profile read)"| SC
+    CP -->|"Conformist (Profile read)"| MG
+    CP -->|"Conformist (Profile read)"| AA
+
+    PO -->|"commands ▸"| JD
+    PO -->|"commands ▸"| JE
+    PO -->|"commands ▸"| SC
+    PO -->|"commands ▸"| MG
+    PO -->|"commands ▸"| AA
+
+    OPS -.->|"Projection queries"| JD
+    OPS -.->|"Projection queries"| SC
+    OPS -.->|"Projection queries"| MG
+    OPS -.->|"Projection queries"| AA
+
+    IAM -.->|"TenantContext (middleware)"| OPS
+    IAM -.->|"TenantContext (middleware)"| PO
+    BILL -.->|"Entitlement check"| PO
+    BILL -.->|"Usage metering"| AA
+    BILL -.->|"Usage metering"| SC
+    AUDIT -.->|"Event sink"| OPS
+    SECRETS -.->|"Credential fetch"| JD
+    SECRETS -.->|"Credential fetch"| JE
+    SECRETS -.->|"Credential fetch"| AA
+```
+
+### 3.1 Job Discovery
+
+**Purpose:** Find job postings from external sources and create canonical job
+records with stable identity.
+
+**Ubiquitous Language:**
+- **JobPosting** — a raw job listing as scraped from an external source.
+- **Source** — the origin board or career site (e.g., LinkedIn, Greenhouse, Workday).
+- **Employer** — the hiring company, distinct from the source board.
+- **SearchStrategy** — the extraction method used (jobspy, workday_api, smart_extract, manual).
+- **PostingUrl** — the original URL where the job was found.
+- **JobId** — a stable, system-generated identifier for a job (replaces URL-as-PK).
+
+**Upstream/Downstream:**
+- **Downstream supplier** to Pipeline Orchestration (Customer-Supplier): Orchestration
+  commands Discovery to run; Discovery publishes `JobDiscovered` events.
+- **Anti-Corruption Layer** against external job boards: raw scraped data is
+  translated into `JobPosting` value objects at the boundary. Board-specific
+  quirks (Workday CXS JSON, Indeed's anti-scraping, Glassdoor blocking) stay
+  in the ACL adapter, not the domain.
+
+**Responsibilities:**
+- Scrape job boards using configured search strategies
+- Deduplicate by URL and (future) by content similarity
+- Assign stable `JobId` and record `PostingUrl`
+- Extract employer name separately from source board
+- Emit `JobDiscovered` domain event
+
+**What it does NOT own:**
+- Job descriptions (that's Enrichment)
+- Scoring or fit evaluation
+- Application URLs (that's Enrichment)
+- Any notion of pipeline stage state
+
+**Boundary justification:** Discovery is the only context that touches external
+job board APIs and scraping infrastructure. Its domain types (`JobPosting`,
+`Source`, `SearchStrategy`) are meaningless outside this context. Separating
+it isolates scraping complexity and rate-limiting concerns from downstream
+processing. *Current pain point addressed:* `enrichment/detail.py` imports
+`discovery/smartextract.extract_json` and `discovery/jobspy.parse_proxy` —
+cross-context coupling that this boundary eliminates.
+
+---
+
+### 3.2 Job Enrichment
+
+**Purpose:** Enrich discovered jobs with full descriptions and direct
+application URLs by scraping job detail pages.
+
+**Ubiquitous Language:**
+- **DetailPage** — the canonical URL for a job's full posting.
+- **FullDescription** — the complete job description text extracted from the detail page.
+- **ApplicationUrl** — the direct URL to apply (may differ from the posting URL).
+- **ExtractionTier** — the method used: json_ld (Tier 1), css_selectors (Tier 2), llm_assisted (Tier 3).
+- **EnrichmentAttempt** — a single try at extracting detail from a job's page.
+
+**Upstream/Downstream:**
+- **Downstream supplier** to Pipeline Orchestration (Customer-Supplier).
+- Consumes `JobDiscovered` events to know which jobs need enrichment.
+- **Anti-Corruption Layer** against detail page HTML: the three-tier extraction
+  cascade (JSON-LD, CSS, LLM) is adapter logic, not domain logic.
+
+**Responsibilities:**
+- Navigate to job detail pages and extract full descriptions
+- Extract or infer application URLs
+- Record enrichment attempts and errors
+- Emit `JobEnriched` or `EnrichmentFailed` domain events
+
+**What it does NOT own:**
+- Job identity or deduplication (that's Discovery)
+- Scoring or candidate fit
+- Browser lifecycle management (that's an infrastructure adapter)
+- Deciding *which* jobs to enrich (that's Pipeline Orchestration)
+
+**Boundary justification:** Enrichment is I/O-heavy (HTTP requests, Playwright
+browser sessions, HTML parsing) with domain logic limited to URL resolution and
+extraction strategy selection. Separating it from Discovery allows independent
+retry policies and concurrency control. *Current pain point addressed:*
+`enrichment/detail.py` is 950 LOC mixing Playwright, BeautifulSoup, LLM calls,
+and state writes — the hexagonal boundary extracts all of this I/O into adapters.
+
+---
+
+### 3.3 Candidate Profile
+
+**Purpose:** Own the user's reusable career data, resume baseline, tailoring
+policies, and writing style preferences.
+
+**Ubiquitous Language:**
+- **Profile** — the complete candidate data document.
+- **ResumeBaseline** — the canonical master resume content (experience, education, skills).
+- **ExperienceEntry** — one role in the candidate's work history.
+- **EducationEntry** — one degree or certification.
+- **SkillCategory** — a named group of skills (e.g., "Programming Languages").
+- **TailoringPolicy** — rules governing what the LLM may modify during tailoring.
+- **WritingStyle** — tone, verbosity, bullet style, and other stylistic constraints.
+- **ResumeTemplate** — the LaTeX (or future alternative) template for PDF rendering.
+- **ApplicationDefaults** — default values for job application form fields.
+
+**Upstream/Downstream:**
+- **Conformist** relationship with Scoring, Materials Generation, and Apply
+  Automation: those contexts consume the Profile as-is. They do not influence
+  its shape.
+- No upstream dependency. Profile is independently managed by the user.
+
+**Responsibilities:**
+- Validate and store the candidate profile document
+- Provide a typed, immutable snapshot of profile data to consuming contexts
+- Import profile data from resume PDFs
+- Enforce structural invariants (required fields, valid entries)
+
+**What it does NOT own:**
+- Per-job tailored content (that's Materials Generation)
+- Scoring logic
+- Application submission
+
+**Boundary justification:** Profile is a single-user, single-document aggregate
+with its own lifecycle (user edits it independently of any job). Consuming
+contexts need a stable read-only view. *Current pain point addressed:*
+`profile.json` is loaded as a raw dict and threaded through tailor, cover,
+apply, wizard, and profile_import with no invariants enforced (briefing point 8).
+
+---
+
+### 3.4 Scoring
+
+**Purpose:** Evaluate candidate-job fit and produce structured, explainable
+scores.
+
+**Ubiquitous Language:**
+- **FitScore** — a 1-10 integer rating of candidate-job match quality.
+- **ScoreBreakdown** — structured explanation of why a job received its score (replaces raw reasoning strings).
+- **MatchedKeywords** — ATS keywords from the job description that match the candidate.
+- **ScoreCorrection** — a user-provided override with rationale.
+- **ScoringCriteria** — the rubric used to evaluate fit (technical skills weight, experience level, etc.).
+
+**Upstream/Downstream:**
+- **Downstream supplier** to Pipeline Orchestration.
+- Consumes `JobEnriched` events (needs full description to score).
+- Consumes Profile data (Conformist).
+- Publishes `JobScored` domain events.
+
+**Responsibilities:**
+- Score jobs against the candidate profile using LLM
+- Parse and validate LLM scoring responses
+- Record score breakdowns with matched keywords
+- Accept and store user score corrections
+- Emit `JobScored` domain events
+
+**What it does NOT own:**
+- Resume tailoring or cover letter generation (that's Materials Generation)
+- The profile itself (that's Candidate Profile)
+- Job descriptions (that's Enrichment)
+- Deciding which jobs to score (that's Pipeline Orchestration)
+
+**Boundary justification:** Scoring is a pure evaluation function:
+`(JobDescription, Profile, ScoringCriteria) -> FitScore + ScoreBreakdown`. It
+has no side effects on the job or profile. Separating it from Materials
+Generation prevents the current coupling where `scoring/tailor.py` directly
+imports `scoring/pdf.py` (briefing point 12). The backlog item for explanatory
+score breakdowns and user-corrected scores further justifies an independent
+context with its own persistence.
+
+---
+
+### 3.5 Materials Generation
+
+**Purpose:** Produce tailored application materials (resumes, cover letters,
+PDFs) for jobs that pass the scoring threshold.
+
+**Ubiquitous Language:**
+- **TailoredResume** — a resume customized for a specific job, derived from the master baseline.
+- **CoverLetter** — a job-specific cover letter.
+- **Artifact** — any generated file (resume, cover letter, PDF) with provenance metadata.
+- **ArtifactStatus** — lifecycle of a generated artifact: `candidate` | `approved` | `rejected` | `superseded`.
+- **ValidationResult** — output of structural and content validation (banned words, fabrication check).
+- **JudgeVerdict** — LLM-as-judge evaluation of a tailored resume's quality.
+- **RenderFormat** — the output format for a document: `latex_pdf` | `html_pdf` | `text`.
+
+**Upstream/Downstream:**
+- **Downstream supplier** to Pipeline Orchestration.
+- Consumes `JobScored` events (needs fit score to decide eligibility).
+- Consumes Profile data (Conformist).
+- Publishes `ResumeApproved`, `CoverLetterGenerated`, `PdfRendered` domain events.
+
+**Responsibilities:**
+- Generate tailored resumes from profile + job description via LLM
+- Validate tailored content (banned words, fabrication, structural integrity)
+- Optionally run LLM-as-judge for quality assessment
+- Generate cover letters
+- Render documents to PDF (resume via LaTeX, cover letter via HTML/Playwright)
+- Register generated artifacts with provenance metadata
+- Emit domain events for each material milestone
+
+**What it does NOT own:**
+- Scoring or fit evaluation (that's Scoring)
+- The candidate profile (that's Candidate Profile)
+- Application submission (that's Apply Automation)
+- Pipeline scheduling or retry logic (that's Pipeline Orchestration)
+
+**Boundary justification:** Materials Generation encompasses three current
+pipeline stages (tailor, cover, pdf) that share a tight invariant: cover
+letters require a tailored resume, PDFs require both. Grouping them in one
+context lets the aggregate enforce these dependencies directly rather than
+through cross-aggregate eventual consistency. *Current pain point addressed:*
+`scoring/tailor.py` (820 LOC) mixes LLM prompts, validation, judge logic, PDF
+generation, state writes, DB writes, and file writes — all of which get
+separated into domain logic (validation, assembly) and adapter concerns (LLM
+calls, file I/O, DB writes).
+
+---
+
+### 3.6 Apply Automation
+
+**Purpose:** Automate job application submission through browser-based
+interaction with ATS portals.
+
+**Ubiquitous Language:**
+- **ApplyRun** — a single attempt to submit an application for one job.
+- **BrowserWorker** — an isolated Chrome instance for one apply run.
+- **SubmissionResult** — the outcome: `applied` | `failed` | `captcha` | `login_issue` | `expired` | `manual` | `dry_run`.
+- **DryRun** — an apply attempt that navigates the ATS but does not submit.
+- **ApplyPrompt** — the instructions sent to Claude Code for autonomous browser operation.
+- **McpConfig** — Playwright MCP server configuration for a browser session.
+- **ApplyRunEvent** — a telemetry event within an apply run (structured observability).
+- **TokenUsage** — LLM token consumption and cost for an apply run.
+
+**Upstream/Downstream:**
+- **Downstream supplier** to Pipeline Orchestration.
+- Consumes Profile data (Conformist) for application defaults.
+- Requires materials from Materials Generation (tailored resume + cover letter PDFs).
+- Publishes `ApplicationSubmitted`, `ApplicationFailed` domain events.
+- **Anti-Corruption Layer** against ATS portals: ATS-specific behavior (Greenhouse
+  forms, Lever redirects, Workday multi-step wizards) is adapter logic.
+
+**Responsibilities:**
+- Acquire eligible jobs and launch browser-based apply sessions
+- Manage Chrome lifecycle (launch, CDP port allocation, cleanup)
+- Build and dispatch Claude Code + Playwright MCP prompts
+- Parse Claude Code output for submission results
+- Record apply run telemetry (events, tokens, cost, duration)
+- Handle dry-run mode (navigate but don't submit)
+- Emit domain events for submission outcomes
+
+**What it does NOT own:**
+- Job discovery, enrichment, scoring, or materials generation
+- Pipeline scheduling or job selection (that's Pipeline Orchestration)
+- Chrome installation or system browser management (infrastructure concern)
+- The candidate profile
+
+**Boundary justification:** Apply is the most complex and most isolated context.
+It manages subprocesses (Claude Code), browser processes (Chrome), MCP servers
+(Playwright), and durable telemetry — none of which any other context touches.
+Its `ApplyRun` aggregate has its own lifecycle and persistence (the `apply_runs`
++ `apply_run_events` tables). *Current pain point addressed:* `apply/launcher.py`
+(1300 LOC) tangles subprocess spawning, Chrome management, telemetry, DB writes,
+dashboard updates, and business rules — hexagonal ports separate each concern.
+
+---
+
+### 3.7 Pipeline Orchestration
+
+**Purpose:** Coordinate the flow of jobs through pipeline stages, manage stage
+state machines, enforce ordering and retry policies, and dispatch commands to
+the appropriate bounded contexts.
+
+**Ubiquitous Language:**
+- **Pipeline** — the canonical sequence of stages a job traverses.
+- **Stage** — a named step in the pipeline: `discover | enrich | score | tailor | cover | pdf | apply`.
+- **StageState** — the current status of a job within a stage (see state machine in Section 8).
+- **Attempt** — a numbered try at completing a stage.
+- **RetryPolicy** — max attempts and backoff rules per stage.
+- **BlockedReason** — why a stage cannot proceed (upstream dependency not met).
+- **NextAction** — the recommended CLI command or action to advance a blocked/failed stage.
+- **PipelineRun** — a batch execution of one or more stages across multiple jobs.
+
+**Upstream/Downstream:**
+- **Customer** in Customer-Supplier relationships with all processing contexts
+  (Discovery, Enrichment, Scoring, Materials, Apply): Orchestration decides
+  *when* and *which* jobs to process; processing contexts decide *how*.
+- Publishes `StageCompleted`, `StageFailed`, `StageExhausted` events to Operations.
+
+**Responsibilities:**
+- Maintain the stage state machine for every job
+- Enforce stage ordering and upstream dependencies
+- Track attempt counts and enforce retry limits
+- Derive the next action for failed or blocked stages
+- Dispatch commands to processing contexts
+- Coordinate streaming (concurrent) and sequential pipeline modes
+- Emit stage lifecycle events
+
+**What it does NOT own:**
+- The actual work of any stage (that belongs to the processing contexts)
+- Job identity or metadata (that's Discovery)
+- Read-model projections for the UI (that's Operations)
+- User-facing API contracts (that's Operations)
+
+**Boundary justification:** Orchestration is the "saga coordinator" — it knows
+the pipeline shape but not the processing details. This separation lets us
+replace the current `pipeline.py` procedural orchestrator with a
+state-machine-driven coordinator without touching Discovery, Scoring, or Apply
+logic. *Current pain point addressed:* `pipeline.py` (1100 LOC) is tightly
+coupled to specific stage modules and `dashboard.py` rendering (briefing point 3).
+The new boundary makes `pipeline.py` a thin adapter that reads the stage state
+machine and dispatches commands.
+
+---
+
+### 3.8 Operations / Read-Side
+
+**Purpose:** Provide the user-facing read model — dashboards, job lists, job
+detail views, artifact listings, and event logs — by projecting data from all
+bounded contexts into queryable views.
+
+**Ubiquitous Language:**
+- **DashboardSummary** — aggregate counts and distributions for the pipeline.
+- **JobListView** — a paginated, filterable list of jobs with current stage state.
+- **JobDetailView** — complete job information including all stage states, events, and artifacts.
+- **ArtifactListView** — generated materials with provenance and file metadata.
+- **EventLog** — chronological record of domain events for a job.
+- **ActionStatus** — the current state of a user-initiated action.
+
+**Upstream/Downstream:**
+- **Consumer** of domain events from all contexts.
+- **Open Host Service** to the React frontend via the TypeScript API.
+- Reads from projections built by domain events (not by querying processing
+  contexts' internal state directly).
+
+**Responsibilities:**
+- Build and maintain read-model projections from domain events
+- Serve dashboard summary, job list, job detail, artifact list queries
+- Provide event stream or change notification to the frontend
+- Translate domain types into API DTOs (via `packages/contracts`)
+
+**What it does NOT own:**
+- Pipeline state mutations (that's Pipeline Orchestration)
+- Job processing logic
+- Write operations on jobs or profiles (those go through the appropriate context's driving ports)
+
+**Boundary justification:** CQRS separation. The read side has fundamentally
+different optimization concerns (denormalized views, pagination, text search,
+aggregate counts) than the write side (transactional consistency, invariant
+enforcement). The existing `read-model.ts` already embodies this separation
+but re-derives legacy stage states at read time (briefing point 11) — the
+target eliminates this by having Orchestration write canonical stage states that
+the read model consumes directly.
+
+---
+
+## 4. Tactical Design
+
+### 4.1 Job Discovery Context
+
+#### Aggregate: Job
+
+```
+Aggregate Root: Job
+Identity: (TenantId, JobId)
+  - TenantId: tenant scope (constant "local" in local-first mode)
+  - JobId: system-generated UUID (replaces url-as-PK)
+```
+
+**Invariants:**
+- A Job must have exactly one `PostingUrl` and one `Source`.
+- A Job must have an `Employer` (may be "Unknown" if not extractable at discovery time).
+- `JobId` is immutable once assigned.
+- Duplicate `PostingUrl` **globally within a `TenantId`** is rejected (matches current behavior where `url` is PK). Same URL from different boards is the same job; different boards provide different *metadata* but not different job identity.
+
+**Lifecycle:**
+1. Created when a job posting is scraped from an external source.
+2. Updated if re-discovered with additional metadata (salary, location).
+3. Soft-deleted when the user deletes it.
+
+**Entities:** None (Job is the only entity; all other data is value objects).
+
+**Value Objects:**
+- `PostingUrl` — validated URL string.
+- `Source(board: string)` — the platform where the job was found (e.g., "linkedin", "greenhouse", "workday"). This is the board only; employer is a separate value object.
+- `Employer(name: string)` — the hiring company, separated from source board. Maps to current `jobs.company` (when extracted) vs `jobs.site` (which is `Source.board`).
+- `SearchStrategy` — enum: `jobspy | workday_api | smart_extract | manual`.
+- `JobMetadata(title, salary, description, location)` — discovery-time metadata.
+
+**Domain Events** (all events carry `tenantId`):
+- `JobDiscovered { tenantId, jobId, postingUrl, source, employer, metadata, discoveredAt }`
+  — Consumed by: Pipeline Orchestration (to initialize stage states), Operations (to update job list).
+- `JobUpdated { tenantId, jobId, changedFields }` — Consumed by: Operations.
+- `JobDeleted { tenantId, jobId, reason, deletedAt }` — Consumed by: Operations.
+
+**Domain Services:** None. Discovery logic (scraping, dedup) lives in adapters
+behind ports; the aggregate is purely data.
+
+---
+
+### 4.2 Job Enrichment Context
+
+#### Aggregate: JobEnrichment
+
+```
+Aggregate Root: JobEnrichment
+Identity: (TenantId, JobId)
+```
+
+One aggregate instance per job. `EnrichmentAttempt` is a child entity within
+the aggregate. This design ensures the invariant "at most one attempt Running
+per JobId" is enforced within a single aggregate boundary — not across
+multiple aggregate instances.
+
+**Invariants:**
+- At most one `EnrichmentAttempt` may be `Running` at a time (enforced within the aggregate).
+- `ExtractionTier` is recorded for every attempt (provenance).
+- Once any attempt succeeds, the aggregate is `Enriched` and further attempts are rejected unless explicitly reset.
+
+**Lifecycle:**
+1. Created when Orchestration commands enrichment for a job.
+2. Accumulates `EnrichmentAttempt` child entities (one per try).
+3. On success of any attempt, transitions to `Enriched`. Emits `JobEnriched`.
+4. On failure, remains open for retry (new attempt) until exhausted.
+
+**Entities (non-root):**
+- `EnrichmentAttempt { attemptNumber, extractionTier, status: Running|Succeeded|Failed, startedAt, finishedAt, error? }`
+
+**Value Objects:**
+- `FullDescription(text: string)` — the extracted job description.
+- `ApplicationUrl` — validated URL where the candidate can apply.
+- `ExtractionTier` — enum: `json_ld | css_selectors | llm_assisted`.
+- `EnrichmentError(code: string, message: string, retryable: bool)`.
+
+**Domain Events** (all events carry `tenantId`):
+- `JobEnriched { tenantId, jobId, fullDescription, applicationUrl, extractionTier, enrichedAt }`
+  — Consumed by: Pipeline Orchestration, Scoring (knows it can now score), Operations.
+- `EnrichmentFailed { tenantId, jobId, error, attemptNumber }`
+  — Consumed by: Pipeline Orchestration (to update stage state), Operations.
+
+**Domain Services:**
+- `ExtractionStrategySelector` — given a job's source and URL, determines which
+  extraction tier to attempt first. Pure function, no I/O.
+
+---
+
+### 4.3 Candidate Profile Context
+
+#### Aggregate: Profile
+
+```
+Aggregate Root: Profile
+Identity: (TenantId, ProfileId)
+  - TenantId: tenant scope
+  - ProfileId: user identity within a tenant (singleton "default" in local-first mode)
+```
+
+**Invariants:**
+- Profile must have at least one `ExperienceEntry`.
+- Every `ExperienceEntry` must have a non-empty `id`, `title`, and `company`.
+- Every `SkillCategory` must have a non-empty `id` and `label`.
+- `TailoringPolicy` fields are constrained to valid enum values.
+- `WritingStyle` fields are constrained to valid enum values.
+
+**Lifecycle:**
+1. Created during first-time setup (wizard) or resume import.
+2. Updated by user edits through the UI or CLI.
+3. Never deleted (but can be reset).
+
+**Entities (non-root):**
+- `ExperienceEntry { id, dateRange, title, company, location, bullets[] }`
+- `EducationEntry { id, date, degree, institution, location }`
+- `SkillCategory { id, label, items[] }`
+
+**Value Objects:**
+- `ExecutiveProfile(baselineText: string)`
+- `TailoringPolicy { mode, allowSummaryRewrite, allowTitleReframing, allowAchievementRewriting, allowSkillReordering, allowMinorInference }`
+- `WritingStyle { tone, bulletStyle, verbosity, keywordDensity, avoidFirstPerson }`
+- `ApplicationDefaults { ... }` — default form field values.
+- `ResumeConstraints { realMetrics[], maxExperienceBullets, ... }`
+
+**Domain Events** (all events carry `tenantId`):
+- `ProfileUpdated { tenantId, changedSections[], updatedAt }` — Consumed by: Operations.
+- `ProfileImported { tenantId, source, importedSections[], importedAt }` — Consumed by: Operations.
+
+**Domain Services:**
+- `ProfileSnapshot` — creates an immutable, validated snapshot of the Profile
+  for consumption by other contexts. This is the anti-corruption boundary: other
+  contexts receive a `ProfileSnapshot` value object, not a mutable reference.
+
+**Published Language:** `ProfileSnapshot` is a **published type** — part of the
+Profile context's Published Language. It lives in a shared types package
+(`packages/domain-types`) alongside domain event schemas. Consuming contexts
+(Scoring, Materials, Apply) import `ProfileSnapshot` as a read-only value
+object. They have a compile-time dependency on the type definition, not on the
+Profile context's internal modules.
+
+---
+
+### 4.4 Scoring Context
+
+#### Aggregate: JobScore
+
+```
+Aggregate Root: JobScore
+Identity: (TenantId, JobId, version: int)
+```
+
+**Invariants:**
+- `FitScore` must be in range [1, 10].
+- A `ScoreBreakdown` must accompany every score.
+- `MatchedKeywords` is a non-empty list (if the LLM returns no keywords, the score is invalid).
+- A `ScoreCorrection` supersedes the LLM score and must include a `reason`.
+
+**Lifecycle:**
+1. Created when Orchestration commands scoring for a job.
+2. May be rescored (creates a new version).
+3. May be corrected by the user (records correction alongside original).
+
+**Value Objects:**
+- `FitScore(value: int)` — constrained to [1, 10].
+- `ScoreBreakdown { technicalFit, experienceFit, reasoning }` — structured explanation.
+- `MatchedKeywords(keywords: string[])` — ATS-relevant keywords.
+- `ScoreCorrection { correctedScore: FitScore, reason: string, correctedAt: Timestamp, correctedBy: UserId? }`.
+- `ScoringCriteria { ... }` — the rubric configuration used.
+
+**Domain Events** (all events carry `tenantId`):
+- `JobScored { tenantId, jobId, fitScore, breakdown, keywords, version, scoredAt }`
+  — Consumed by: Pipeline Orchestration, Materials Generation (eligibility check), Operations.
+- `ScoreCorrected { tenantId, jobId, originalScore, correctedScore, reason, correctedAt }`
+  — Consumed by: Pipeline Orchestration (may re-trigger downstream), Operations.
+
+**Domain Services:**
+- `ScoreParser` — validates and parses LLM scoring responses into `FitScore` +
+  `ScoreBreakdown`. Pure function.
+- `EligibilityChecker` — given a `FitScore` and a `minScore` threshold, determines
+  if a job is eligible for materials generation. Pure function.
+
+---
+
+### 4.5 Materials Generation Context
+
+#### Aggregate: MaterialsSet
+
+```
+Aggregate Root: MaterialsSet
+Identity: (TenantId, JobId, generation: int)
+```
+
+The `MaterialsSet` groups the three related artifacts (tailored resume, cover
+letter, PDF renderings) that must be internally consistent for one job
+application.
+
+**Invariants:**
+- A `TailoredResume` must pass structural validation before being `approved`.
+- A `CoverLetter` can only be generated after a `TailoredResume` is `approved`.
+- PDFs can only be rendered after their source documents exist.
+- Banned words must not appear in any generated text.
+- Generated content must not fabricate experience entries, companies, or credentials.
+- Every artifact must be registered with provenance (source job, generation params, timestamp).
+
+**Lifecycle:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> ResumeInProgress: TailorResume command
+    ResumeInProgress --> ResumeValidating: LLM returns content
+    ResumeValidating --> ResumeApproved: validation passes
+    ResumeValidating --> ResumeFailed: validation fails
+    ResumeFailed --> ResumeInProgress: retry (within max attempts)
+    ResumeFailed --> Exhausted: max attempts reached
+    ResumeApproved --> CoverLetterInProgress: GenerateCoverLetter command
+    CoverLetterInProgress --> CoverLetterReady: generation succeeds
+    CoverLetterInProgress --> CoverLetterFailed: generation fails
+    CoverLetterReady --> PdfRendering: RenderPdfs command
+    PdfRendering --> Complete: all PDFs rendered
+    PdfRendering --> PdfFailed: rendering fails
+    Complete --> [*]
+```
+
+**Entities (non-root):**
+- `Artifact { artifactId, type, status, filePath, sizeBytes, metadata, createdAt }`
+
+**Value Objects:**
+- `TailoredResume { executiveProfile, experienceUpdates[], skillCategoryUpdates[] }`
+- `CoverLetter { text: string }`
+- `ValidationResult { valid: bool, errors: ValidationError[] }`
+- `JudgeVerdict { approved: bool, feedback: string, confidence: float }`
+- `ArtifactType` — enum: `tailored_resume | cover_letter | resume_pdf | cover_letter_pdf`
+- `ArtifactStatus` — enum: `candidate | approved | rejected | superseded`
+- `RenderFormat` — enum: `latex_pdf | html_pdf | text`
+
+**Domain Events** (all events carry `tenantId`):
+- `ResumeApproved { tenantId, jobId, artifactId, generation, approvedAt }`
+- `ResumeFailed { tenantId, jobId, validationErrors[], attemptNumber }`
+- `CoverLetterGenerated { tenantId, jobId, artifactId, generatedAt }`
+- `PdfRendered { tenantId, jobId, artifactType, artifactId, renderedAt }`
+- `MaterialsExhausted { tenantId, jobId, stage, attemptCount, maxAttempts }`
+
+> **Design note:** Domain events carry `artifactId`, not `filePath`. The
+> artifact's storage location (local path or S3 key) is an infrastructure
+> concern resolved at read time via `ArtifactStoragePort.resolve(artifactId)`.
+> This ensures events stored in `job_events` remain meaningful across
+> environments (local ↔ cloud) and can be replayed without path translation.
+  — Consumed by: Pipeline Orchestration, Operations.
+
+**Domain Services:**
+- `ResumeAssembler` — given LLM output + profile baseline, assembles the final
+  tailored resume text. Injects fixed structure (header, education) from the
+  master resume. Pure function.
+- `ContentValidator` — checks for banned words, fabrication, structural integrity.
+  Pure function.
+
+**Generation lifecycle:** When the user re-tailors a job, a **new
+`MaterialsSet`** is created with `generation` incremented. The previous
+`MaterialsSet` has its artifacts transitioned to `superseded` status and
+becomes read-only. The aggregate factory (`MaterialsSetFactory`) reads the
+current highest generation for the `(tenantId, jobId)` and creates
+`generation + 1`. This means the aggregate does not grow unboundedly —
+each generation is a fixed-size set of artifacts. Historical artifacts are
+queryable through the Operations read model (artifact list projection).
+
+---
+
+### 4.6 Apply Automation Context
+
+#### Aggregate: ApplyRun
+
+```
+Aggregate Root: ApplyRun
+Identity: (TenantId, RunId: UUID)
+```
+
+**Invariants:**
+- An `ApplyRun` must reference a valid `JobId`.
+- A job must have an `ApplicationUrl`, `TailoredResume`, and `CoverLetter` before
+  an `ApplyRun` can be created.
+- At most one `ApplyRun` may be `in_progress` for a given `JobId` at a time.
+- A `DryRun` must never mark the job as `applied`.
+- `TokenUsage` and `CostUsd` are recorded on completion.
+
+**Lifecycle:**
+
+```mermaid
+stateDiagram-v2
+    [*] --> Starting: CreateApplyRun
+    Starting --> InProgress: browser launched + Claude Code started
+    InProgress --> Succeeded: application submitted
+    InProgress --> Failed: error or timeout
+    InProgress --> Captcha: CAPTCHA detected
+    InProgress --> LoginIssue: login required
+    InProgress --> Expired: job no longer available
+    InProgress --> Manual: ATS requires manual steps
+    InProgress --> DryRunComplete: dry run finished
+    Failed --> [*]
+    Succeeded --> [*]
+    Captcha --> [*]
+    LoginIssue --> [*]
+    Expired --> [*]
+    Manual --> [*]
+    DryRunComplete --> [*]
+```
+
+**Entities (non-root):**
+- `ApplyRunEvent { eventId, eventType, level, message, payload, occurredAt }`
+
+**Value Objects:**
+- `SubmissionResult` — discriminated union:
+  `Applied { appliedAt, verificationConfidence }`
+  | `Failed { error, retryable }`
+  | `Captcha { details }`
+  | `LoginIssue { details }`
+  | `Expired {}`
+  | `Manual { reason }`
+  | `DryRunComplete { navigatedTo }`
+- `BrowserWorkerConfig { workerId, cdpPort, headless, userDataDir }`
+- `ApplyPrompt { text, mcpConfig }`
+- `TokenUsage { input, output, cacheRead, cacheCreate, costUsd }`
+
+**Domain Events** (all events carry `tenantId`):
+- `ApplicationSubmitted { tenantId, jobId, runId, appliedAt, verificationConfidence }`
+  — Consumed by: Pipeline Orchestration, Operations.
+- `ApplicationFailed { tenantId, jobId, runId, result: SubmissionResult, attemptNumber }`
+  — Consumed by: Pipeline Orchestration, Operations.
+- `ApplyRunStarted { tenantId, jobId, runId, workerId, model, dryRun, startedAt }`
+  — Consumed by: Operations (telemetry dashboard).
+- `ApplyRunEventRecorded { tenantId, runId, event: ApplyRunEvent }`
+  — Consumed by: Operations (live telemetry feed).
+
+**Domain Services:**
+- `ApplyEligibilityChecker` — validates that a job has all prerequisites for
+  apply (application URL, materials, not already applied, within attempt limits).
+  Pure function.
+
+---
+
+### 4.7 Pipeline Orchestration Context
+
+#### Aggregate: JobPipelineState
+
+```
+Aggregate Root: JobPipelineState
+Identity: (TenantId, JobId)
+```
+
+**Invariants:**
+- Every `JobId` has exactly one `StageState` per `Stage` (7 stages total).
+- Stage state transitions must follow the state machine (Section 8).
+- `attempt_count` monotonically increases (never decreases except on explicit reset).
+- A stage in `Running` state cannot transition to `Pending` (must go through `Failed` or `Succeeded`).
+- `blocked_by` is computed from upstream stage states; it cannot be set arbitrarily.
+
+**Value Objects:**
+- `Stage` — enum: `discover | enrich | score | tailor | cover | pdf | apply`
+- `StageState` — discriminated union (see Section 8 for full state machine):
+
+```
+StageState =
+  | Pending   { attemptCount, maxAttempts, nextAction? }
+  | Queued    { queuedAt }
+  | Running   { attemptCount, startedAt }
+  | Succeeded { attemptCount, finishedAt, durationMs }
+  | Failed    { attemptCount, maxAttempts, errorCode, errorMessage, retryable, nextAction? }
+  | Blocked   { blockedBy: Stage[], errorCode, errorMessage }
+  | Skipped   { reason: string }
+  | Exhausted { attemptCount, maxAttempts, errorCode, errorMessage, nextAction? }
+  | Stale     { reason: string }
+  | Canceled  { canceledAt, reason? }
+```
+
+- `RetryPolicy { maxAttempts: int, backoffMs?: int }`
+
+**Domain Events** (all events carry `tenantId`):
+- `StageStarted { tenantId, jobId, stage, attemptNumber, startedAt }`
+- `StageCompleted { tenantId, jobId, stage, state: Succeeded, finishedAt, durationMs }`
+- `StageFailed { tenantId, jobId, stage, errorCode, errorMessage, retryable, attemptNumber }`
+- `StageExhausted { tenantId, jobId, stage, attemptCount, maxAttempts }`
+- `StageReset { tenantId, jobId, stage, resetAttempts: bool, resetAt }`
+- `StageBlocked { tenantId, jobId, stage, blockedBy: Stage[] }`
+- `StageSkipped { tenantId, jobId, stage, reason }`
+  — All consumed by: Operations.
+
+**Domain Services:**
+- `StageStateMachine` — enforces valid transitions. Given current state +
+  transition event, produces new state or rejects the transition. Pure function.
+- `PipelineScheduler` — given all job stage states and a pipeline run request,
+  determines which jobs need processing at which stage. Pure function.
+- `LegacyStateDeriver` — (temporary, migration-period only) derives stage states
+  from legacy `jobs` table columns. **Removal criterion:** When a migration
+  query confirms zero jobs have legacy-only state (i.e.,
+  `SELECT COUNT(*) FROM jobs WHERE url NOT IN (SELECT DISTINCT job_url FROM job_stage_states)` returns 0),
+  AND the legacy enrichment/scoring/tailor/cover/apply columns have been dropped
+  from the `jobs` table, the `LegacyStateDeriver` can be deleted. Until then
+  it runs on read to fill gaps.
+
+**Orchestration guard against premature processing:** Processing contexts
+(Scoring, Materials, etc.) do not independently decide to process jobs. They
+only act in response to commands dispatched by Orchestration. Orchestration
+transitions the stage to `Running` *before* dispatching the command. If a
+processing context receives a raw `JobEnriched` event, it does NOT
+autonomously start scoring — it waits for Orchestration to evaluate the event,
+check upstream dependencies, and dispatch a `ScoreJob` command with the stage
+already in `Running` state. This single-dispatcher model eliminates the
+race condition where a processing context emits results for a stage that
+Orchestration hasn't acknowledged.
+
+---
+
+### 4.8 Operations / Read-Side Context
+
+This context has no aggregates of its own. It maintains **projections** (read
+models) built from domain events emitted by other contexts.
+
+**Projections:**
+- `DashboardProjection` — aggregate counts by stage, state, source, score distribution.
+- `JobListProjection` — denormalized job rows with current stage state, score, artifact status.
+- `JobDetailProjection` — full job view with all stage states, events, and artifacts.
+- `ArtifactListProjection` — all artifacts across jobs with provenance.
+- `ApplyRunProjection` — apply run telemetry with event timelines.
+
+**Domain Services:**
+- `ProjectionBuilder` — subscribes to domain events and updates projections.
+  In the local-first architecture, this is synchronous (direct DB writes after
+  domain operations). In the hosted future, this becomes an async event consumer.
+
+---
+
+## 5. Hexagonal Architecture — Ports & Adapters
+
+### Port Naming Convention
+
+- **Driving ports** (inbound): named as use cases — `ScoreJobUseCase`, `TailorResumeUseCase`.
+- **Driven ports** (outbound): named as capabilities — `JobRepository`, `LlmPort`, `BrowserPort`.
+
+### 5.1 Job Discovery Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `DiscoverJobsUseCase` | Trigger discovery for configured search strategies |
+| **Driving** | `ImportJobUseCase` | Manually add a single job by URL |
+| **Driving** | `DeleteJobUseCase` | Soft-delete a job (tombstone record). Emits `JobDeleted`. |
+| **Driving** | `RestoreJobUseCase` | Restore a soft-deleted job. Emits `JobRestored`. |
+| **Driven** | `JobBoardScraperPort` | Scrape job postings from external boards |
+| **Driven** | `JobRepository` | Persist and retrieve Job aggregates |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `JobBoardScraperPort` | `JobSpyAdapter`, `WorkdayApiAdapter`, `SmartExtractAdapter` (Playwright + LLM) | Same adapters, deployed as Kubernetes Jobs behind **AWS SQS** task queue with per-tenant rate limiting |
+| `JobRepository` | `SqliteJobRepository` | `PostgresJobRepository` (**AWS RDS Postgres 16** with pgbouncer connection pooling, tenant-scoped via `tenant_id` column + RLS) |
+| `EventPublisher` | `InProcessEventBus` (synchronous) | `SqsEventPublisher` (**AWS SQS FIFO** queues, one per bounded context, with message group = tenantId for ordered per-tenant delivery) |
+
+**Seam justification:** Job board scraping is the most brittle integration point
+(anti-scraping measures, API changes, rate limits). The port lets us swap
+scrapers without touching domain logic. The repository port lets us migrate
+from SQLite to Postgres without changing Discovery logic.
+
+### 5.2 Job Enrichment Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `EnrichJobUseCase` | Enrich a specific job's detail page |
+| **Driving** | `EnrichBatchUseCase` | Enrich a batch of jobs |
+| **Driven** | `DetailPageFetcherPort` | Navigate to and extract content from job detail pages |
+| **Driven** | `LlmPort` | LLM-assisted extraction (Tier 3) |
+| **Driven** | `EnrichmentRepository` | Persist enrichment results |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `DetailPageFetcherPort` | `PlaywrightBrowserAdapter` (local Playwright instance) | `BrowserbaseAdapter` (**Browserbase** managed browser fleet; sessions allocated per-tenant with concurrency cap; fallback: headless Chromium in **Kubernetes pods** with Playwright) |
+| `LlmPort` | `GeminiAdapter`, `OpenAiAdapter`, `LocalLlmAdapter` | `CloudLlmGatewayAdapter` (internal gateway service fronting Anthropic Claude / Google Gemini / OpenAI APIs with per-tenant token metering, rate limiting, and cost attribution via **Billing** context) |
+| `EnrichmentRepository` | `SqliteEnrichmentRepository` | `PostgresEnrichmentRepository` (RDS Postgres, tenant-scoped) |
+
+**Seam justification:** Enrichment's Playwright dependency is the primary
+obstacle to horizontal scaling. The `DetailPageFetcherPort` lets us swap local
+Playwright for a hosted browser fleet without changing extraction logic.
+
+### 5.3 Candidate Profile Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `GetProfileUseCase` | Retrieve the current profile snapshot |
+| **Driving** | `UpdateProfileUseCase` | Update profile sections |
+| **Driving** | `ImportProfileUseCase` | Import profile from a resume PDF |
+| **Driven** | `ProfileRepository` | Persist and retrieve the Profile aggregate |
+| **Driven** | `PdfParserPort` | Extract text and structure from resume PDFs |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `ProfileRepository` | `JsonFileProfileRepository` (reads/writes `profile.json`) | `PostgresProfileRepository` (RDS Postgres, keyed by `(tenant_id, profile_id)`) |
+| `PdfParserPort` | `PyPdfAdapter` | `PyPdfAdapter` (same library, runs in worker pod; no cloud service needed) |
+
+**Seam justification:** Profile storage is the simplest migration: `profile.json`
+becomes a Postgres row. The repository port makes this transparent.
+
+### 5.4 Scoring Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `ScoreJobUseCase` | Score one job against the candidate profile |
+| **Driving** | `ScoreBatchUseCase` | Score a batch of jobs |
+| **Driving** | `CorrectScoreUseCase` | User overrides a score |
+| **Driven** | `LlmPort` | LLM scoring (prompt + response parsing) |
+| **Driven** | `ScoreRepository` | Persist JobScore aggregates |
+| **Driven** | `ProfileSnapshotPort` | Read-only access to the current profile |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `LlmPort` | `GeminiAdapter`, `OpenAiAdapter`, `LocalLlmAdapter` | `CloudLlmGatewayAdapter` (see Enrichment; shared gateway service) |
+| `ScoreRepository` | `SqliteScoreRepository` | `PostgresScoreRepository` (RDS Postgres, tenant-scoped) |
+| `ProfileSnapshotPort` | `LocalProfileSnapshotAdapter` (reads profile.json) | `ProfileServiceGrpcClient` (internal **gRPC** call to Profile service; tenant context propagated via gRPC metadata) |
+
+### 5.5 Materials Generation Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `TailorResumeUseCase` | Generate a tailored resume for one job |
+| **Driving** | `GenerateCoverLetterUseCase` | Generate a cover letter for one job |
+| **Driving** | `RenderPdfUseCase` | Render documents to PDF |
+| **Driving** | `TailorBatchUseCase` | Batch tailor + cover + PDF for multiple jobs |
+| **Driven** | `LlmPort` | LLM for tailoring and cover letter generation |
+| **Driven** | `PdfRendererPort` | Render LaTeX or HTML to PDF |
+| **Driven** | `ArtifactStoragePort` | Write and register generated files |
+| **Driven** | `MaterialsRepository` | Persist MaterialsSet aggregates |
+| **Driven** | `ProfileSnapshotPort` | Read-only access to the current profile |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `LlmPort` | `GeminiAdapter`, `OpenAiAdapter` | `CloudLlmGatewayAdapter` (shared gateway; see Enrichment) |
+| `PdfRendererPort` | `LatexPdfAdapter` (pdflatex subprocess), `PlaywrightHtmlPdfAdapter` (cover letters) | `TectonicPdfAdapter` (**Tectonic** LaTeX engine in container; no TeX Live install required) or `TypstPdfAdapter` (if rendering spike favors Typst). Cover letters: `WeasyPrintAdapter` (pure-Python HTML→PDF, no browser needed in cloud) |
+| `ArtifactStoragePort` | `LocalFilesystemAdapter` (writes to `~/.jobhunter/tailored_resumes/`, etc.) | `S3ArtifactAdapter` (**AWS S3** with tenant-prefixed keys: `s3://jobhunter-artifacts/{tenantId}/{jobId}/`; presigned URLs for browser download; lifecycle policy for cost control) |
+| `MaterialsRepository` | `SqliteMaterialsRepository` | `PostgresMaterialsRepository` (RDS Postgres, tenant-scoped) |
+
+**Seam justification:** The `PdfRendererPort` is critical because the backlog
+explicitly calls for a resume rendering spike (LaTeX vs Tectonic vs Typst vs
+HTML/CSS). The port means the spike can evaluate multiple adapters without
+touching materials domain logic. The `ArtifactStoragePort` absorbs the
+local-to-cloud transition for generated files.
+
+### 5.6 Apply Automation Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `SubmitApplicationUseCase` | Launch an apply run for one job |
+| **Driving** | `SubmitBatchUseCase` | Batch apply for multiple jobs |
+| **Driven** | `BrowserPort` | Manage Chrome lifecycle (launch, CDP, cleanup) |
+| **Driven** | `AutonomousAgentPort` | Spawn and manage Claude Code subprocess with MCP |
+| **Driven** | `ApplyRunRepository` | Persist ApplyRun aggregates |
+| **Driven** | `ArtifactStoragePort` | Read materials (resume PDF, cover letter PDF) |
+| **Driven** | `ProfileSnapshotPort` | Read candidate application defaults |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `BrowserPort` | `LocalChromeAdapter` (launch Chrome on isolated CDP ports) | `BrowserbaseAdapter` (**Browserbase** managed sessions; per-tenant session pool with concurrency limits enforced by Billing entitlements; alternative: headless Chromium sidecars in **Kubernetes pods** with CDP exposed via localhost) |
+| `AutonomousAgentPort` | `ClaudeCodeCliAdapter` (subprocess + Playwright MCP) | `ClaudeApiAgentAdapter` (**Anthropic Claude API** with tool use / computer use; MCP replaced by direct Playwright API calls from a managed agent container; apply prompt unchanged, transport switches from CLI subprocess to API request) |
+| `ApplyRunRepository` | `SqliteApplyRunRepository` | `PostgresApplyRunRepository` (RDS Postgres, tenant-scoped) |
+
+**Seam justification:** Apply Automation is the most infrastructure-heavy context.
+The `BrowserPort` and `AutonomousAgentPort` isolate the two most complex
+infrastructure dependencies (Chrome lifecycle and Claude Code subprocess) behind
+clean interfaces. This is essential for the hosted future where browsers and
+agents are managed fleet resources.
+
+### 5.7 Pipeline Orchestration Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `RunPipelineUseCase` | Execute pipeline stages for a batch of jobs |
+| **Driving** | `RetryStageUseCase` | Reset and retry a specific stage for a job |
+| **Driving** | `CancelStageUseCase` | Cancel a running stage |
+| **Driving** | `MarkAppliedUseCase` | Manually mark a job as applied (no apply run). Transitions apply stage to `Succeeded`. |
+| **Driving** | `SkipJobUseCase` | Skip a job at relevant stages (e.g., below score threshold, not interested). Transitions specified stages to `Skipped`. |
+| **Driven** | `PipelineStateRepository` | Persist JobPipelineState aggregates |
+| **Driven** | `StageCommandDispatcher` | Dispatch commands to processing contexts |
+| **Driven** | `EventPublisher` | Publish domain events |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `PipelineStateRepository` | `SqlitePipelineStateRepository` | `PostgresPipelineStateRepository` (RDS Postgres, tenant-scoped) |
+| `StageCommandDispatcher` | `InProcessDispatcher` (direct function calls) | `TemporalWorkflowAdapter` (**Temporal** durable workflow engine; each pipeline run is a Temporal workflow, each stage dispatch is a Temporal activity; provides retry, timeout, visibility, and saga compensation out of the box; tenant context propagated via workflow metadata) |
+
+### 5.8 Operations / Read-Side Context
+
+| Port Type | Port | Description |
+|---|---|---|
+| **Driving** | `GetDashboardUseCase` | Dashboard summary query |
+| **Driving** | `ListJobsUseCase` | Paginated, filtered job list |
+| **Driving** | `GetJobDetailUseCase` | Full job detail with stages and artifacts |
+| **Driving** | `ListArtifactsUseCase` | Artifact listing with provenance |
+| **Driving** | `GetApplyRunsUseCase` | Apply run telemetry queries |
+| **Driven** | `ReadModelStore` | Query read-model projections |
+| **Driven** | `EventSubscriber` | Subscribe to domain events for projection updates |
+
+| Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
+|---|---|---|
+| `ReadModelStore` | `SqliteReadModelStore` (same DB, denormalized views) | `PostgresReadModelStore` (**AWS RDS Postgres read replica**; tenant-scoped queries via RLS; optional **ElastiCache Redis** for dashboard aggregation caching) |
+| `EventSubscriber` | `InProcessEventBus` | `SqsEventConsumer` (**AWS SQS FIFO** consumer; reads from per-context queues; processes events in tenant-ordered batches; dead-letter queue for failed projections) |
+
+---
+
+## 6. Cross-Context Integration
+
+### 6.1 Integration Backbone
+
+The integration backbone uses **domain events** as the primary mechanism for
+inter-context communication. Commands flow from Pipeline Orchestration to
+processing contexts; events flow from processing contexts back to Orchestration
+and Operations.
+
+```mermaid
+graph LR
+    subgraph "Command Flow"
+        PO["Pipeline Orchestration"] -->|"EnrichJob cmd"| JE["Job Enrichment"]
+        PO -->|"ScoreJob cmd"| SC["Scoring"]
+        PO -->|"TailorResume cmd"| MG["Materials Generation"]
+        PO -->|"SubmitApplication cmd"| AA["Apply Automation"]
+    end
+
+    subgraph "Event Flow"
+        JD["Job Discovery"] -->|"JobDiscovered"| EB["Event Bus"]
+        JE -->|"JobEnriched"| EB
+        SC -->|"JobScored"| EB
+        MG -->|"ResumeApproved"| EB
+        AA -->|"ApplicationSubmitted"| EB
+        EB -->|"events"| PO
+        EB -->|"events"| OPS["Operations"]
+    end
+```
+
+### 6.2 Event vs Command vs Request/Response
+
+| Mechanism | When to use | Examples |
+|---|---|---|
+| **Domain Event** (async, fire-and-forget) | Notify that something happened. Producer doesn't know or care who consumes it. | `JobDiscovered`, `JobScored`, `ResumeApproved`, `ApplicationSubmitted` |
+| **Command** (async, at-most-once) | Tell a specific context to do something. Orchestration dispatches to processing contexts. | `EnrichJob(jobId)`, `ScoreJob(jobId)`, `TailorResume(jobId)`, `SubmitApplication(jobId)` |
+| **Request/Response** (sync) | Query for data needed to proceed. Used for read-model queries and profile snapshot access. | `GetProfileSnapshot()`, `GetJobDetail(jobId)`, `GetDashboardSummary()` |
+
+### 6.3 Event Bus — Local and Cloud Implementations
+
+#### Local-First: In-Process Synchronous Bus
+
+In the local-first architecture, the event bus is **in-process and synchronous**.
+Domain events are published within the same transaction that produces them:
+
+```
+// Pseudocode for local-first event flow
+transaction {
+    aggregate.applyCommand(cmd)
+    events = aggregate.pendingEvents()
+    repository.save(aggregate)
+    eventStore.append(events)         // persisted to job_events table
+}
+// AFTER transaction commits — event dispatch is outside the transaction
+for event in events:
+    eventBus.publish(event)           // synchronous, same process
+    // each handler runs its own transaction for its own aggregate
+```
+
+> **Why dispatch is outside the transaction:** If event handlers ran inside
+> the producing transaction, a `ResumeApproved` handler that updates
+> `JobPipelineState` would modify two aggregates in one transaction —
+> violating the one-aggregate-per-transaction rule (Section 8.1). Dispatching
+> after commit means each handler opens its own transaction.
+
+**Trade-off:** This creates a small consistency gap: if the process crashes
+after the producing transaction commits but before all handlers execute, the
+event is persisted (in `job_events`) but downstream aggregates and projections
+are stale. In local-first mode, this risk is low (single process, no network).
+The startup reconciliation pass (below) is the safety net.
+
+**Crash recovery:** If the process crashes after `eventStore.append()` but
+before all projections update, the startup reconciliation pass replays
+events from `job_events` whose `event_id` exceeds the last processed
+watermark stored in each projection's metadata.
+
+#### Cloud: Transactional Outbox + SQS FIFO
+
+In the cloud deployment, events use the **transactional outbox pattern** to
+guarantee exactly-once delivery without distributed transactions:
+
+```
+// Pseudocode for cloud event flow
+postgres_transaction {
+    aggregate.applyCommand(cmd)
+    events = aggregate.pendingEvents()
+    repository.save(aggregate)
+    outbox.append(events)            // outbox table in same Postgres DB
+}
+// Async: outbox poller reads outbox, publishes to SQS FIFO, marks delivered
+outboxPoller.publishToSqs(events)
+// Async: SQS consumer reads events, updates projections
+sqsConsumer.process(events)
+```
+
+**Crash-consistency guarantees:**
+- **Aggregate + outbox** are in the same Postgres transaction — atomic.
+- **Outbox → SQS** uses a poller with at-least-once semantics. SQS FIFO
+  deduplication (by `eventId`) prevents duplicate delivery.
+- **SQS → projection** consumer is idempotent (checks `eventId` watermark).
+  Failed projections go to a dead-letter queue for manual inspection.
+- **No event is lost** because the outbox is the durable source of truth.
+  If SQS is temporarily unavailable, events queue in the outbox until the
+  poller catches up.
+
+**Same domain event shapes** are used in both local and cloud modes. The
+`EventPublisher` port accepts domain events; the local adapter writes to
+`job_events` + dispatches synchronously; the cloud adapter writes to the
+Postgres outbox table. The domain is unaware of which mode is active.
+
+### 6.4 `job_events` Table as Event Store
+
+The existing `job_events` table evolves from a passive log into the canonical
+event store:
+
+- **Write path:** Processing contexts append domain events to `job_events` with
+  structured `event_type`, `payload_json`, and `stage` fields.
+- **Read path:** Operations context queries `job_events` to build projections.
+  Pipeline Orchestration queries `job_events` to derive current state when
+  needed.
+- **Replay:** In the future, events can be replayed to rebuild projections or
+  backfill new read models.
+
+The `event_type` field becomes a discriminated union of all domain event types.
+The `payload_json` field contains the event-specific data (typed per event).
+
+### 6.5 TS API ↔ Python Worker Integration Protocol
+
+**Chosen application protocol: JSON-RPC 2.0 request/response.**
+**Transport: swappable — subprocess locally, HTTP/gRPC in cloud.**
+
+The application protocol (message shape) is **transport-independent**. The
+transport is an adapter concern behind the `StageCommandDispatcher` port.
+
+**Why JSON-RPC 2.0 as the application protocol:**
+
+1. **Structured, typed, language-neutral.** JSON-RPC defines request/response
+   envelopes with method names, typed params, and error codes. Both TypeScript
+   and Python have mature libraries.
+2. **Transport-agnostic by specification.** JSON-RPC is explicitly
+   transport-independent (RFC 8259 + JSON-RPC 2.0 spec). The same message
+   can travel over subprocess stdin/stdout, HTTP POST, WebSocket, or gRPC
+   with a JSON-RPC payload.
+3. **Cloud-ready without protocol change.** In hosted mode, the same JSON-RPC
+   messages flow over HTTP between the TS API service and the Python worker
+   service. Only the transport adapter changes — the application protocol,
+   message schemas, and handler logic are identical.
+
+**Transport adapters:**
+
+| Environment | Transport Adapter | How it works |
+|---|---|---|
+| **Local-first** | `SubprocessJsonRpcAdapter` | TS API spawns `uv run jobhunter rpc` subprocess. Request written to stdin as JSON-RPC. Response read from stdout. Existing `local-actions.ts` pattern, formalized. |
+| **Cloud** | `HttpJsonRpcAdapter` | TS API sends HTTP POST to Python worker service endpoint (`POST /rpc`). Same JSON-RPC body. Worker service is a FastAPI/Starlette app exposing the same handlers. |
+| **Cloud (async)** | `TemporalActivityAdapter` | For long-running stages (apply, discover), the TS API enqueues a Temporal activity. The activity worker deserializes the JSON-RPC params, runs the handler, and returns the JSON-RPC result. |
+
+**Protocol shape (unchanged across transports):**
+
+```
+// Request (same whether sent via stdin or HTTP POST body)
+{
+  "jsonrpc": "2.0",
+  "method": "executeStage",
+  "params": {
+    "tenantId": "tenant-xyz",
+    "stage": "score",
+    "jobId": "job-abc123",
+    "options": { "minScore": 7, "limit": 10 }
+  },
+  "id": "req-001"
+}
+
+// Response (same whether returned via stdout or HTTP response body)
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "ok": true,
+    "stage": "score",
+    "jobsProcessed": 10,
+    "events": [
+      { "type": "JobScored", "tenantId": "tenant-xyz", "jobId": "job-abc123", "fitScore": 8 }
+    ]
+  },
+  "id": "req-001"
+}
+```
+
+**Three dispatch modes** (matching current behavior, formalized):
+
+| Mode | When | JSON-RPC pattern | Examples |
+|---|---|---|---|
+| **Synchronous** | Result needed immediately, < 30s | Standard request → response | `profile_import`, `score` (single job) |
+| **Fire-and-forget with handle** | Long-running, > 30s | Request → `{ "runId": "..." }` immediately. Results arrive as domain events in `job_events`. | `apply`, `retry-stage`, `discover` |
+| **Streaming with progress** | Batch ops with incremental status | Request → newline-delimited JSON-RPC notifications on stdout, final response on completion | `run --stream` (pipeline), `score --batch` |
+
+For fire-and-forget mode, the `SubprocessJsonRpcAdapter` spawns the process
+detached (matching current `defaultActionDispatcher` behavior). The caller
+receives a `runId` and polls via the Operations read model or subscribes to
+domain events. In cloud mode, the `TemporalActivityAdapter` provides the same
+pattern natively — the Temporal workflow ID serves as the `runId`.
+
+**Key design constraint:** The `params` object always carries `tenantId`. In
+local mode, the subprocess adapter injects `tenantId: "local"`. In cloud mode,
+the HTTP adapter injects the authenticated tenant from the request context.
+The Python worker handler receives `tenantId` as a first-class parameter and
+passes it to all repository and event publisher calls.
+
+**Transport scope:** JSON-RPC over subprocess is the **local-mode transport**.
+In cloud mode, synchronous calls use `HttpJsonRpcAdapter` (same JSON-RPC body
+over HTTP POST). For long-running stages, the `StageCommandDispatcher` port
+switches to `TemporalWorkflowAdapter`, where each stage dispatch becomes a
+Temporal activity call over gRPC. The JSON-RPC envelope is not used in cloud
+async mode — the Temporal SDK provides typed request/response semantics
+natively. **Evolution trigger:** multi-process deployment requiring durable
+workflow orchestration (see Section 9.4).
+
+**Shared contract:** Both sides import the event type definitions from a shared
+schema. Today this is `packages/contracts` (Zod schemas) and mirrored Python
+dataclasses. The target adds a `packages/events` package that defines all
+domain event schemas in a language-neutral format (**TypeSpec** as the IDL,
+generating JSON Schema, TypeScript types, and Python dataclasses). TypeSpec is
+chosen over raw JSON Schema because it supports discriminated unions, which
+map directly to the domain event and StageState sum types.
+
+### 6.8 TS API Write Operations — Domain Logic Hosting
+
+The current TS API (`write-model.ts`) performs several write operations
+directly against SQLite. In the target, each operation maps to a driving port
+on the appropriate bounded context. The question is: which runtime *hosts*
+the domain logic?
+
+**Principle:** Simple state-transition commands that require no LLM, browser,
+or scraping infrastructure are hosted **in the TS API process** directly,
+using shared domain types from `packages/domain-types`. Complex processing
+commands are dispatched to the Python worker via JSON-RPC.
+
+| Current `write-model.ts` operation | Target driving port | Hosted in | Rationale |
+|---|---|---|---|
+| `resetJobStage` | `RetryStageUseCase` (Pipeline Orchestration) | **TS API** | Pure state machine transition — `StageStateMachine` is a shared domain type. No Python needed. |
+| `markJobApplied` | `MarkAppliedUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. No browser/LLM. |
+| `markJobSkipped` | `SkipJobUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. |
+| `softDeleteJob` | `DeleteJobUseCase` (Discovery) | **TS API** | Tombstone write. No Python needed. |
+| `restoreJob` | `RestoreJobUseCase` (Discovery) | **TS API** | Tombstone removal. |
+| `updateProfile` | `UpdateProfileUseCase` (Profile) | **TS API** | JSON validation and file write. |
+| pipeline run / discover / enrich / score / tailor / cover / apply | Stage commands via `StageCommandDispatcher` | **Python worker** (via JSON-RPC) | Requires LLM, browser, scraping infrastructure. |
+| profile import from PDF | `ImportProfileUseCase` (Profile) | **Python worker** (via JSON-RPC) | Requires `pypdf` + LLM extraction. |
+
+**Trade-off:** The TS API hosting simple commands means the `StageStateMachine`
+logic exists in both TypeScript (via `packages/domain-types`) and Python. This
+is acceptable because: (a) the state machine is a small, pure function with
+well-defined transitions; (b) it is generated from the shared TypeSpec IDL, so
+both implementations are derived from one source; (c) the alternative —
+routing every button click through a Python subprocess — adds unacceptable
+latency for simple UI operations.
+
+**Cloud evolution:** In cloud mode, both TS and Python import the same
+`StageStateMachine` from a shared package. The TS API continues to host simple
+commands directly (now against Postgres via the repository adapter). Complex
+commands go through Temporal instead of subprocess.
+
+### 6.6 Operations Read-Model Projection Strategy
+
+The Operations context builds its projections by:
+
+1. **Subscribing to domain events** from all processing contexts.
+2. **Updating denormalized views** in the read-model store.
+3. **Serving queries** through the TS API's Fastify routes.
+
+In the local-first architecture, "subscribing" means the projection builder
+runs in-process with the event bus. The TS API's `read-model.ts` queries
+the denormalized tables directly.
+
+**Key projection:** The `JobListProjection` replaces the current pattern of
+reading raw `jobs` rows + deriving stage states + re-computing from legacy
+columns. Instead, the projection is pre-computed from domain events:
+
+```
+JobListProjection = {
+    jobId, title, employer, source, location, salary,
+    currentStage, currentState,
+    fitScore, hasResume, hasCoverLetter, hasPdf, applyStatus,
+    discoveredAt, lastUpdatedAt
+}
+```
+
+### 6.7 Apply Automation Result Reporting
+
+Apply Automation reports results through domain events, not by directly
+mutating shared state:
+
+1. `ApplyRunStarted` — Operations updates the telemetry dashboard.
+2. `ApplyRunEventRecorded` — Operations appends to the live event feed.
+3. `ApplicationSubmitted` or `ApplicationFailed` — Pipeline Orchestration
+   transitions the `apply` stage state. Operations updates the job list.
+
+This eliminates the current coupling where `launcher.py` directly writes to
+the `jobs` table, `apply_runs` table, `apply_run_events` table, `job_events`
+table, and `job_stage_states` table while also updating the in-memory Rich
+dashboard — all in the same function.
+
+---
+
+## 7. Persistence Boundary
+
+### 7.1 Repositories Per Aggregate
+
+| Aggregate | Repository Port | Tables (current) | Tables (target) |
+|---|---|---|---|
+| `Job` (Discovery) | `JobRepository` | `jobs` (discovery columns only) | `jobs` (narrowed: jobId, postingUrl, employer, source, title, salary, description, location, discoveredAt) |
+| `JobEnrichment` | `EnrichmentRepository` | `jobs` (enrichment columns) | `job_enrichments` (new: jobId, fullDescription, applicationUrl, extractionTier, enrichedAt, error) |
+| `Profile` | `ProfileRepository` | `profile.json` file | `profile.json` (local) / `profiles` table (hosted) |
+| `JobScore` | `ScoreRepository` | `jobs` (scoring columns) | `job_scores` (new: jobId, version, fitScore, breakdown, keywords, scoredAt, correction) |
+| `MaterialsSet` | `MaterialsRepository` | `jobs` (tailor/cover columns) + `job_artifacts` | `job_materials` (new) + `job_artifacts` (existing, enriched) |
+| `ApplyRun` | `ApplyRunRepository` | `apply_runs` + `apply_run_events` | `apply_runs` + `apply_run_events` (existing, largely correct) |
+| `JobPipelineState` | `PipelineStateRepository` | `job_stage_states` | `job_stage_states` (existing, largely correct) |
+| Read-model projections | `ReadModelStore` | Computed at read time from `jobs` + `job_stage_states` | `job_list_view` (materialized/denormalized), `dashboard_stats` (materialized) |
+
+### 7.2 Decoupling Persistence Schema from Domain Types
+
+The key principle: **domain types are not database rows.** Each repository
+adapter translates between the two:
+
+```
+// Domain type (in the domain layer)
+type JobScore = {
+    jobId: JobId
+    version: int
+    fitScore: FitScore           // value object, constrained [1,10]
+    breakdown: ScoreBreakdown    // nested value object
+    keywords: MatchedKeywords    // list of strings
+    scoredAt: Timestamp
+    correction: ScoreCorrection? // optional nested value object
+}
+
+// Database row (in the adapter layer)
+CREATE TABLE job_scores (
+    job_id          TEXT NOT NULL,
+    version         INTEGER NOT NULL,
+    fit_score       INTEGER NOT NULL CHECK (fit_score BETWEEN 1 AND 10),
+    breakdown_json  TEXT NOT NULL,
+    keywords_json   TEXT NOT NULL,
+    scored_at       TEXT NOT NULL,
+    correction_json TEXT,
+    PRIMARY KEY (job_id, version)
+);
+```
+
+The `SqliteScoreRepository` adapter handles the translation:
+- `fitScore: FitScore(8)` ↔ `fit_score: 8`
+- `breakdown: ScoreBreakdown(...)` ↔ `breakdown_json: '{"technicalFit": ...}'`
+
+This decoupling means:
+- Domain types can evolve (add fields, change structure) without migration.
+- Persistence schema can be optimized independently (indexes, denormalization).
+- Switching from SQLite to Postgres changes only the adapter, not the domain.
+
+### 7.3 Migration Shape
+
+The current wide `jobs` table is narrowed in the target:
+
+| Current `jobs` columns | Target owner | Target table |
+|---|---|---|
+| `url`, `title`, `salary`, `description`, `location`, `site`, `strategy`, `discovered_at` | Job Discovery | `jobs` (narrowed) |
+| `full_description`, `application_url`, `detail_scraped_at`, `detail_error` | Job Enrichment | `job_enrichments` |
+| `fit_score`, `score_reasoning`, `scored_at` | Scoring | `job_scores` |
+| `tailored_resume_path`, `tailored_at`, `tailor_attempts` | Materials Generation | `job_materials` + `job_artifacts` |
+| `cover_letter_path`, `cover_letter_at`, `cover_attempts` | Materials Generation | `job_materials` + `job_artifacts` |
+| `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, `agent_id`, etc. | Apply Automation | `apply_runs` (existing) |
+
+The migration creates new tables and backfills them from the wide `jobs` table.
+The legacy columns are retained (read-only) during the transition period. The
+`LegacyStateDeriver` in Pipeline Orchestration handles backward compatibility
+until all data is migrated.
+
+### 7.4 Current Tables to Aggregates Mapping
+
+- **`job_stage_states`** → `JobPipelineState` aggregate. Already well-structured.
+  Target adds a `Queued` state and `Canceled` state to `STATE_VALUES`.
+- **`job_artifacts`** → Part of `MaterialsSet` aggregate. Existing schema is
+  adequate; target adds `generation` column for versioning.
+- **`job_events`** → Domain event store. Existing schema is adequate; target
+  standardizes `event_type` values to match domain event names.
+- **`apply_runs` + `apply_run_events`** → `ApplyRun` aggregate. Existing schema
+  is well-designed. No structural changes needed.
+
+---
+
+## 8. Consistency, Concurrency, and Failure Modes
+
+### 8.1 Transactional Boundaries
+
+**Rule: One aggregate per transaction.**
+
+Each command modifies exactly one aggregate and persists it within a single
+database transaction. Cross-aggregate consistency is achieved through domain
+events (eventual consistency within the same process in local-first mode;
+async events in hosted mode).
+
+Example: When `TailorResumeUseCase` succeeds:
+1. Transaction 1: `MaterialsSet` aggregate records the approved resume. Emits `ResumeApproved` event.
+2. Transaction 2 (triggered by event): `JobPipelineState` aggregate transitions the `tailor` stage to `Succeeded`.
+3. Transaction 3 (triggered by event): `ReadModelStore` updates the job list projection.
+
+In local-first mode, these three transactions happen synchronously in sequence
+within the same process. In hosted mode, transactions 2 and 3 happen
+asynchronously via message queue.
+
+### 8.2 Idempotency for Retries
+
+Every command handler is idempotent:
+
+- **Stage commands** include an `attemptNumber`. Re-processing the same attempt
+  is a no-op (the repository checks if the attempt already exists).
+- **Event handlers** use the event's `eventId` (auto-incrementing from
+  `job_events.event_id`) as a deduplication key. Processing the same event
+  twice produces the same result.
+- **Apply runs** use `run_id` as an idempotency key. The
+  `ApplyRunRepository.save()` uses `INSERT OR REPLACE` (upsert) semantics.
+
+### 8.3 Saga / Process Manager: Apply Submission
+
+The apply flow is a long-running process that spans multiple external interactions
+(Chrome launch, page navigation, form filling, submission verification). This
+is modeled as a **process manager** within the Apply Automation context:
+
+```mermaid
+stateDiagram-v2
+    [*] --> AcquireJob: SubmitApplicationCommand
+    AcquireJob --> LaunchBrowser: job acquired & eligible
+    AcquireJob --> Rejected: job not eligible
+    LaunchBrowser --> StartAgent: Chrome ready
+    LaunchBrowser --> BrowserFailed: Chrome failed to launch
+    StartAgent --> Monitoring: Claude Code started
+    Monitoring --> ParseResult: Claude Code exited
+    ParseResult --> Succeeded: application confirmed
+    ParseResult --> Failed: error detected
+    ParseResult --> Captcha: CAPTCHA detected
+    ParseResult --> Manual: manual steps required
+    Monitoring --> TimedOut: timeout exceeded
+    TimedOut --> Failed
+    Succeeded --> CleanupBrowser
+    Failed --> CleanupBrowser
+    Captcha --> CleanupBrowser
+    Manual --> CleanupBrowser
+    BrowserFailed --> ReportFailure
+    CleanupBrowser --> ReportResult
+    ReportResult --> [*]
+    ReportFailure --> [*]
+    Rejected --> [*]
+```
+
+**Compensation actions:**
+- If Chrome fails to launch: clean up worker directory, report failure.
+- If Claude Code times out: kill the subprocess, kill Chrome, clean up.
+- If the process crashes mid-apply: on next startup, detect orphaned
+  `in_progress` apply runs and transition them to `failed` with
+  `error_code: ORPHANED`.
+
+### 8.4 Saga / Process Manager: Multi-Stage Pipeline Run
+
+A pipeline run (e.g., `jobhunter run --stream`) is a process manager that
+coordinates multiple stages:
+
+```
+PipelineRunManager:
+  for each stage in requested_stages:
+    wait for upstream stages to complete
+    for each eligible job:
+      dispatch StageCommand to processing context
+      on StageCompleted: update JobPipelineState, check next stage
+      on StageFailed: update JobPipelineState, check retry eligibility
+      on StageExhausted: update JobPipelineState, mark exhausted
+```
+
+In streaming mode, stages run concurrently. The process manager uses the
+`_StageTracker` pattern (already in `pipeline.py`) to coordinate: each stage
+polls for pending work, processes a batch, and signals completion when upstream
+is done and no work remains.
+
+**Cloud mode:** The `PipelineRunManager` is implemented as a **Temporal
+workflow**. Each stage dispatch is a Temporal activity with configurable
+retries, timeouts, and heartbeats. Saga compensation (e.g., cleaning up
+browser workers after apply failure) uses Temporal's built-in compensation
+mechanism. The `_StageTracker` pattern maps to Temporal's workflow state,
+which is durable across process restarts. Streaming mode maps to parallel
+Temporal activities with a `ContinueAsNew` pattern for long-running pipelines.
+**Evolution trigger:** multi-machine worker deployment or need for durable
+pipeline recovery across process restarts (see Section 9.4).
+
+### 8.5 Stage State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: stage initialized
+    Pending --> Queued: enqueued for processing
+    Pending --> Running: processing started (skip queue)
+    Pending --> Skipped: below score threshold / not applicable
+    Pending --> Blocked: upstream dependency not met
+    Queued --> Running: processing started
+    Queued --> Canceled: user cancels
+    Running --> Succeeded: processing completed successfully
+    Running --> Failed: processing error
+    Running --> Canceled: user cancels
+    Failed --> Pending: retry requested
+    Failed --> Exhausted: max attempts reached
+    Blocked --> Pending: upstream dependency resolved
+    Exhausted --> Pending: reset with --reset-attempts
+    Canceled --> Pending: retry requested
+    Stale --> Pending: re-process requested
+    Succeeded --> Stale: upstream data changed (re-enrichment, re-score)
+```
+
+**Terminal states:** `Succeeded`, `Skipped`, `Exhausted` (until manually reset),
+`Canceled` (until retried).
+
+**Transition rules enforced by `StageStateMachine`:**
+
+| From | To | Trigger | Guard |
+|---|---|---|---|
+| `Pending` | `Queued` | Enqueued for processing | Stage is eligible; worker queue is used |
+| `Pending` | `Running` | Stage command dispatched (skip queue) | Upstream stages are `Succeeded` or `Skipped`; direct dispatch mode |
+| `Pending` | `Blocked` | Upstream check | At least one upstream stage is not `Succeeded` or `Skipped` |
+| `Pending` | `Skipped` | Score below threshold / not applicable | Score exists and below `minScore`, or user skips |
+| `Queued` | `Running` | Processing started | Worker picks up from queue |
+| `Queued` | `Canceled` | User cancels | User action via `CancelStageUseCase` |
+| `Running` | `Succeeded` | Processing completes | Result is valid |
+| `Running` | `Failed` | Processing errors | Error is captured |
+| `Running` | `Canceled` | User cancels | For apply runs: kill Claude Code subprocess + Chrome cleanup. For other stages: set cancellation flag checked by stage runner between LLM calls. |
+| `Failed` | `Pending` | Retry requested | `attemptCount < maxAttempts` or `resetAttempts` |
+| `Failed` | `Exhausted` | Max attempts reached | `attemptCount >= maxAttempts` |
+| `Blocked` | `Pending` | Upstream resolved | All upstream stages are `Succeeded` or `Skipped` |
+| `Exhausted` | `Pending` | Manual reset | `resetAttempts = true` |
+| `Canceled` | `Pending` | Retry requested | User action via `RetryStageUseCase` |
+| `Succeeded` | `Stale` | Upstream data changed | Upstream stage re-ran (e.g., re-enrichment triggers stale score). Detected when Orchestration processes a `JobEnriched` event for a job that already has `score` in `Succeeded`. |
+| `Stale` | `Pending` | Re-process requested | User or Orchestration initiates re-processing |
+
+### 8.6 Concurrency Control
+
+**SQLite WAL mode** provides read-write concurrency for the local-first
+architecture. Specific controls:
+
+- **Job acquisition for apply:** Use `SELECT ... WHERE ... LIMIT 1 FOR UPDATE`
+  semantics (SQLite: `BEGIN IMMEDIATE` + read + update in same transaction)
+  to prevent two apply workers from acquiring the same job.
+- **Stage state updates:** The `ON CONFLICT DO UPDATE` pattern on
+  `(job_url, stage)` prevents duplicate state rows.
+- **Apply run creation:** The `run_id` primary key with `INSERT OR REPLACE`
+  prevents duplicate runs.
+
+---
+
+## 9. Cloud Deployment Architecture
+
+Cloud deployment is a **hard requirement**, not a future aspiration. The
+local-first phase validates the product; this section defines the target
+deployment model that ships to production.
+
+### What Changes
+
+| Concern | Local-First (validation) | Cloud (target) | Concrete Technology |
+|---|---|---|---|
+| **Database** | SQLite with WAL mode | Postgres with connection pooling | **AWS RDS Postgres 16** + **pgbouncer**. Tenant isolation via Row-Level Security (RLS) with `tenant_id` column on every table. Schema migrations via **Flyway**. |
+| **File storage** | Local filesystem (`~/.jobhunter/`) | Object storage with tenant-prefixed keys | **AWS S3** with bucket `jobhunter-artifacts`. Key pattern: `{tenantId}/{jobId}/{artifactType}/{filename}`. Presigned URLs for browser download (1-hour TTL). Lifecycle policy: move to Glacier after 90 days. |
+| **Event bus** | In-process synchronous dispatcher | Durable message queue with transactional outbox | **AWS SQS FIFO** queues (one per bounded context). Transactional outbox in Postgres (same DB as aggregate). Outbox poller runs as a sidecar process. Message group ID = `tenantId` for per-tenant ordering. Dead-letter queue for failed events. |
+| **Browser automation** | Local Chrome on CDP ports | Managed browser fleet | **Browserbase** managed sessions (primary). Fallback: headless Chromium in **Kubernetes pods** with Playwright, one pod per apply run, auto-scaled. Per-tenant concurrency cap enforced by Billing entitlements. |
+| **LLM calls** | Direct API calls (Gemini, OpenAI) | Managed LLM gateway | Internal **LLM Gateway Service** (FastAPI). Fronts Anthropic Claude API, Google Gemini, OpenAI. Per-tenant token metering, rate limiting, cost attribution. Gateway publishes `LlmUsageRecorded` events to Billing context. |
+| **Worker execution** | Subprocess (`uv run jobhunter ...`) | Durable workflow engine | **Temporal** (self-hosted on Kubernetes). Each pipeline run = Temporal workflow. Each stage = Temporal activity. Temporal provides retry, timeout, visibility, and saga compensation. Worker fleet auto-scales via **KEDA** based on queue depth. |
+| **Identity & auth** | Single user, no auth | Multi-tenant JWT/OAuth | **Auth0** (or AWS Cognito) for authentication. JWT tokens with `tenant_id` and `user_id` claims. API gateway validates JWT and injects `TenantContext` into every request. |
+| **Secrets** | macOS Keychain / `.env` | Encrypted vault | **AWS Secrets Manager**. Credentials for LLM APIs, job board accounts, and ATS login stored per-tenant. `SecretPort` adapter fetches at runtime; secrets never persisted in application state. |
+| **API binding** | Loopback (127.0.0.1) | Public endpoint with TLS + auth | **AWS ALB** → **Kubernetes Ingress** → Fastify API pods. TLS termination at ALB. Rate limiting via **AWS WAF**. |
+| **Audit log** | None (local trust model) | Append-only audit trail | **AWS CloudWatch Logs** structured JSON + dedicated `audit_events` Postgres table. Every write operation (command) is logged with `tenantId`, `userId`, `action`, `resourceId`, `timestamp`, `ipAddress`. Immutable; no DELETE access. |
+| **Billing** | None | Usage-based billing | **Stripe** for subscription and usage-based billing. Billing context tracks: LLM token usage, apply run count, browser session minutes, storage bytes. Entitlement checks gate pipeline execution (e.g., max apply runs per month). |
+| **Data residency** | Local disk (user controls) | Multi-region with tenant-level residency | Tenant metadata includes `data_region` (e.g., `us-east-1`, `eu-west-1`). Repository adapters route to region-specific RDS instances. S3 bucket replication configured per region. Cross-region queries prohibited at the adapter level. |
+
+### What Does NOT Change
+
+| Concern | Why it survives the transition | Verified? |
+|---|---|---|
+| **Domain types and logic** | Zero infrastructure imports. All I/O goes through ports. | Yes — every aggregate, value object, and domain service in Sections 4.1–4.8 has no infrastructure dependency. |
+| **Aggregate boundaries and invariants** | Transactional consistency rules are infrastructure-agnostic. Tenant scoping is already in the aggregate identity. | Yes — `TenantId` is threaded through all aggregate identities in this doc. |
+| **Domain events and their schemas** | Event shapes are domain facts. `tenantId` is already a first-class field. Only the transport changes (in-process dispatch → SQS FIFO). | Yes — every event definition includes `tenantId`. |
+| **Driven port interfaces** | `JobRepository.save(tenantId, job)` is the same contract for SQLite and Postgres. | Yes — the port interface is parameterized by `TenantId`; only the adapter implementation changes. |
+| **Stage state machine** | State transitions are pure logic, no infrastructure dependency. | Yes — `StageStateMachine` is a pure function. |
+| **Content validation** | Banned words, fabrication checks, structural validation are pure functions. | Yes — `ContentValidator`, `ScoreParser`, `ResumeAssembler` have no I/O. |
+| **Ubiquitous language** | Domain terminology is infrastructure-independent. | Yes — glossary terms are identical across environments. |
+| **JSON-RPC application protocol** | Same message shapes over different transports. | Yes — Section 6.5 defines transport-independent JSON-RPC messages. |
+
+**Moved from "does not change" to "changes":**
+- **Use case interfaces (driving ports):** Use case signatures *mostly* survive,
+  but the `tenantId` parameter is now explicit in every use case call. In local
+  mode it was implicit (singleton). This is a signature change, not a logic
+  change. The domain logic inside the use case is unchanged.
+
+### Platform Bounded Contexts (Cloud-Only)
+
+These contexts do not exist in local-first mode. They are **cross-cutting
+platform services** that interact with the core domain through well-defined
+seams.
+
+#### Identity & Access Context
+
+**Purpose:** Authenticate users, issue JWT tokens, manage tenant membership,
+enforce authorization policies.
+
+**Integration pattern:** Middleware / API gateway filter. The Fastify API (or
+its cloud successor) validates the JWT on every request and injects a
+`TenantContext { tenantId, userId, roles }` into the request context. All
+downstream use case calls receive `TenantContext` as their first parameter.
+
+**Technology:** Auth0 (managed) or AWS Cognito. RBAC with roles:
+`owner | admin | member | viewer`.
+
+**What it does NOT own:** Domain authorization (e.g., "can this user retry this
+stage?"). That is the domain's responsibility via entitlement checks. Identity
+& Access only answers "who is this user and what tenant are they in?"
+
+#### Billing & Entitlements Context
+
+**Purpose:** Track usage, enforce subscription limits, meter costs, manage
+Stripe subscriptions.
+
+**Integration pattern:** The Billing context exposes an `EntitlementPort` driven
+port that processing contexts call before executing expensive operations:
+
+```
+EntitlementPort.check(tenantId, operation: "apply_run") -> Allowed | Denied(reason)
+EntitlementPort.check(tenantId, operation: "llm_call", tokens: 50000) -> Allowed | Denied(reason)
+```
+
+Usage is metered asynchronously via domain events: `LlmUsageRecorded`,
+`ApplyRunCompleted`, `ArtifactStored`. The Billing context subscribes to these
+events and updates usage counters.
+
+**Technology:** Stripe Billing with usage-based pricing. Internal usage ledger
+in Postgres.
+
+#### Audit Log Context
+
+**Purpose:** Provide an immutable, append-only record of all write operations
+for compliance, debugging, and support.
+
+**Integration pattern:** Event sink. The Audit context subscribes to **all**
+domain events (fan-out from SQS) and writes structured audit records. It also
+receives HTTP request metadata (IP, user agent, etc.) from the API gateway
+middleware.
+
+**Technology:** Postgres `audit_events` table (immutable, no UPDATE/DELETE
+grants) + AWS CloudWatch Logs for real-time streaming + optional S3 export for
+long-term retention.
+
+#### Secret Management Context
+
+**Purpose:** Store and retrieve per-tenant credentials (LLM API keys, job board
+accounts, ATS login credentials) securely.
+
+**Integration pattern:** Driven port `SecretPort` consumed by Discovery,
+Enrichment, and Apply Automation:
+
+```
+SecretPort.get(tenantId, secretName: "openai_api_key") -> SecretValue
+SecretPort.get(tenantId, secretName: "greenhouse_login") -> SecretValue
+```
+
+Local adapter reads from `.env` / macOS Keychain. Cloud adapter reads from
+AWS Secrets Manager with tenant-scoped paths
+(`/jobhunter/{tenantId}/{secretName}`).
+
+**Technology:** AWS Secrets Manager with IAM-based access control. Secrets
+cached in-memory for 5 minutes (configurable TTL). Never logged or persisted
+outside Secrets Manager.
+
+### How the Seams Absorb the Change
+
+1. **Database migration:** Swap `SqliteJobRepository` for `PostgresJobRepository`.
+   The repository port interface is unchanged. Postgres adapter adds: connection
+   pooling (pgbouncer), RLS for tenant isolation, Flyway migrations, and
+   `tenant_id` column on every table.
+
+2. **File storage migration:** Swap `LocalFilesystemAdapter` for `S3ArtifactAdapter`.
+   The `ArtifactStoragePort` interface is unchanged. S3 adapter adds: presigned
+   URLs, tenant-prefixed keys, lifecycle policies, and cross-region replication.
+
+3. **Event bus migration:** Swap `InProcessEventBus` for transactional outbox +
+   SQS FIFO. The `EventPublisher` and `EventSubscriber` port interfaces are
+   unchanged. Outbox guarantees no events are lost between aggregate commit and
+   queue delivery.
+
+4. **Browser fleet migration:** Swap `LocalChromeAdapter` for `BrowserbaseAdapter`.
+   The `BrowserPort` interface is unchanged. Hosted adapter adds: session pool
+   management, per-tenant concurrency limits, and automatic cleanup on timeout.
+
+5. **Worker fleet migration:** Swap `InProcessDispatcher` for
+   `TemporalWorkflowAdapter`. The `StageCommandDispatcher` port interface is
+   unchanged. Temporal adds: durable retry, timeout, visibility dashboards, and
+   saga compensation without changing the domain's command/event contracts.
+
+6. **Multi-tenancy:** `TenantId` is already a first-class domain concept in
+   every aggregate identity, every domain event, and every port call (see
+   Sections 4 and 6). Repository adapters enforce isolation via Postgres RLS.
+   S3 adapters enforce isolation via tenant-prefixed keys. SQS enforces
+   per-tenant ordering via message group IDs.
+
+7. **Auth, billing, audit, secrets:** These are new platform contexts with their
+   own bounded context boundaries, not modifications to existing domain
+   contexts. They interact through well-defined ports (`EntitlementPort`,
+   `SecretPort`, `AuditSink`) and middleware (`TenantContext` injection).
+
+### 9.4 Evolution Triggers (Fitness Functions)
+
+Each local-mode design choice has a **concrete, testable trigger** that
+initiates the evolution to its cloud variant. These triggers are the fitness
+functions that tell the team *when* to swap adapters — not "when we go to the
+cloud" (circular), but measurable conditions.
+
+| Local design choice | Cloud equivalent | Evolution trigger | Notes |
+|---|---|---|---|
+| SQLite with WAL mode | AWS RDS Postgres 16 + pgbouncer | Concurrent active users > 1 **OR** DB size > 10 GB **OR** multi-process writes required | SQLite's single-writer lock is the hard limit. 10 GB is a practical performance ceiling for WAL mode with full-text queries. |
+| In-process synchronous event bus | Transactional outbox + SQS FIFO | Multi-process deployment (> 1 API instance **OR** > 1 worker instance) | In-process dispatch cannot cross process boundaries. The outbox pattern is the minimum viable distributed event bus. |
+| Subprocess JSON-RPC (`uv run jobhunter rpc`) | HTTP JSON-RPC / Temporal activities | Worker fleet > 1 machine **OR** apply queue depth consistently > 10 pending jobs **OR** pipeline run > 30 min (exceeds saga recovery window of subprocess) | Subprocess can't survive host restarts. Temporal provides durable retry. |
+| Local Chrome on CDP ports | Browserbase managed sessions | **Any** cloud deployment | Chrome requires elevated container privileges or `--no-sandbox` (security risk). Browserbase eliminates this entirely. This is a day-1 cloud blocker, not a gradual migration. |
+| `profile.json` file | Postgres `profiles` table | Multi-tenant deployment **OR** concurrent profile editors | Single JSON file has no concurrency control. |
+| `LocalFilesystemAdapter` (tailored resumes, PDFs) | S3 with tenant-prefixed keys | Multi-node deployment (no shared filesystem) **OR** artifact size > 1 GB per tenant | Local filesystem doesn't span nodes. |
+| macOS Keychain / `.env` | AWS Secrets Manager | Non-macOS deployment **OR** multi-tenant **OR** credential rotation requirement | Keychain is macOS-only. `.env` is unencrypted. |
+| `TenantId = "local"` (constant) | `TenantId` from JWT claims | Multi-tenant deployment | Domain types already carry `TenantId`. Only the source of the value changes (constant → JWT). Mechanical change. |
+| No auth | Auth0 / Cognito JWT | Any public-facing deployment | Local loopback assumption breaks when API is remotely accessible. |
+| No billing / entitlements | Stripe + `EntitlementPort` | First paying customer | Until then, all entitlements return `Allowed`. The `EntitlementPort` exists as a no-op adapter locally. |
+| No audit log | Postgres `audit_events` + CloudWatch | First compliance requirement (SOC2, GDPR data access log) | The `AuditSink` port is a no-op locally. |
+| `pdflatex` subprocess | Tectonic / Typst in container | Rendering spike conclusion **OR** cloud deployment (TeX Live is 4 GB, too large for containers) | `PdfRendererPort` absorbs any engine. |
+
+### 9.5 Strangler-Friendly Context Migration
+
+Each bounded context's adapters can be swapped **independently** without
+freezing the rest of the system. This is critical because the current
+architecture shares one SQLite file across all contexts — the migration must
+break this shared-state coupling context by context.
+
+**Migration order (recommended):**
+
+1. **Pipeline Orchestration** — First: the `job_stage_states` table is already
+   well-structured and maps cleanly to a standalone repository. Migrate this
+   context to Postgres first to establish the RDS infrastructure.
+
+2. **Scoring** — Second: extract scoring columns from the wide `jobs` table
+   into `job_scores` (new table). Scoring context reads from its own repository;
+   Operations projection reads from both old and new tables during transition.
+
+3. **Materials Generation** — Third: similar extraction of tailor/cover/pdf
+   columns into `job_materials` + enriched `job_artifacts`. Artifact storage
+   swaps from local filesystem to S3.
+
+4. **Job Enrichment** — Fourth: extract enrichment columns into
+   `job_enrichments`. Detail fetcher port swaps to Browserbase.
+
+5. **Job Discovery** — Fifth: narrow the `jobs` table to discovery-only columns.
+   At this point the wide table is fully decomposed.
+
+6. **Apply Automation** — Sixth: `apply_runs` + `apply_run_events` are already
+   separate tables. Browser port and agent port swap to cloud adapters.
+
+7. **Operations** — Last: switches from SQLite read model to Postgres read
+   replica once all write-side contexts are on Postgres.
+
+**During partial migration:** Contexts that have migrated to Postgres publish
+events to both the in-process bus (for local-mode contexts still on SQLite)
+and the SQS outbox (for cloud-mode consumers). This dual-publish pattern is
+temporary and removed once all contexts are migrated. The `EventPublisher`
+port's adapter handles this transparently.
+
+**Rollback safety:** Each context migration is a separate deployment. If
+Scoring on Postgres shows issues, it can be rolled back to SQLite by
+switching the adapter config. The repository port interface is unchanged;
+only the adapter binding changes.
+
+---
+
+## 10. Risk & Open Questions
+
+### Risks
+
+1. **Event schema evolution.** As domain events become the integration backbone,
+   backward-compatible event schema evolution becomes critical. Breaking changes
+   to event payloads could corrupt read-model projections. **Mitigation:**
+   Adopt event versioning (e.g., `JobScored.v1`, `JobScored.v2`) and use
+   upcasters to transform old events to new schemas.
+
+2. **SQLite single-writer bottleneck.** The local-first architecture relies on
+   SQLite's WAL mode for concurrent reads, but writes are still serialized.
+   Under heavy apply workloads (multiple parallel workers), write contention
+   could degrade performance. **Mitigation:** Keep transactions short (one
+   aggregate per transaction). Use `PRAGMA busy_timeout=10000` (already in place).
+   Monitor for `SQLITE_BUSY` errors.
+
+3. **Legacy data migration complexity.** The wide `jobs` table has ~800+ days of
+   production data. Backfilling new tables from legacy columns will require
+   careful handling of NULL semantics, inconsistent timestamps, and partial
+   state. **Mitigation:** The `LegacyStateDeriver` serves as the migration
+   bridge; it can run incrementally and idempotently.
+
+4. **In-process event bus reliability.** The synchronous in-process event bus
+   means a crash between "command succeeded" and "projection updated" leaves
+   the read model stale. **Mitigation:** On startup, run a reconciliation pass
+   that replays unprocessed events. Keep the event store (`job_events`) as the
+   source of truth for rebuilding projections.
+
+5. **Two-language domain model drift.** TypeScript contracts and Python domain
+   types can drift if not kept in sync. **Mitigation:** The shared event schema
+   package (`packages/events`) with code generation for both languages. CI
+   validates that Python dataclasses and TypeScript types are structurally
+   compatible.
+
+6. **Over-engineering risk.** DDD + hexagonal architecture adds indirection. For
+   a local-first single-user product, this indirection must pay for itself in
+   testability and maintainability. **Mitigation:** Start with the contexts
+   that have the most pain (Materials Generation, Apply Automation, Pipeline
+   Orchestration). Leave simpler contexts (Discovery, Profile) with lightweight
+   port/adapter structure.
+
+7. **Materials Generation aggregate size.** Grouping tailor + cover + pdf in one
+   aggregate could make it too large if many artifact versions accumulate.
+   **Mitigation:** The aggregate tracks only the *current generation*; historical
+   artifacts are owned by the `ArtifactStoragePort` and queryable through the
+   Operations read model.
+
+8. **Temporal operational complexity.** Self-hosting Temporal on Kubernetes adds
+   significant operational surface: Cassandra/Postgres persistence backend,
+   history service sizing, worker fleet tuning, visibility store queries.
+   **Mitigation:** Start with Temporal Cloud (managed) to defer ops burden.
+   Migrate to self-hosted only if cost or compliance requires it. Keep workflow
+   definitions simple (sequential activities, not deeply nested child workflows).
+
+9. **Row-Level Security (RLS) performance.** Postgres RLS policies add a
+   predicate to every query. On tables with millions of rows across hundreds
+   of tenants, poorly indexed `tenant_id` columns or complex RLS policies can
+   degrade query performance significantly. **Mitigation:** Ensure `tenant_id`
+   is the leading column in all composite indexes. Use partition-by-tenant for
+   the `jobs` and `job_stage_states` tables if a single tenant exceeds 1M rows.
+   Benchmark RLS overhead in staging before production.
+
+10. **Outbox poller lag and ordering.** The transactional outbox pattern
+    introduces latency between aggregate commit and event delivery (poller
+    interval). Under high write throughput, the poller can fall behind.
+    **Mitigation:** Configure poller interval at 100ms with adaptive batching
+    (up to 100 events per poll). SQS FIFO's message group ID (`tenantId`)
+    guarantees per-tenant ordering; cross-tenant ordering is not required.
+    Monitor outbox table size; alert if unprocessed rows exceed 1000.
+
+11. **Cross-region data residency.** Tenant-level data residency
+    (e.g., EU tenants in `eu-west-1`) complicates deployment: region-specific
+    RDS instances, S3 buckets, and Temporal namespaces. Cross-region queries
+    are prohibited, but global features (admin dashboards, aggregate billing)
+    need data from all regions. **Mitigation:** Global-only data (billing
+    summaries, tenant metadata) lives in a single "control plane" region.
+    Domain data stays in the tenant's home region. Fan-out events publish to
+    a global SQS queue for billing/audit aggregation.
+
+12. **Secret rotation disruption.** Per-tenant secrets in AWS Secrets Manager
+    must be rotated without disrupting active pipeline runs. A rotation during
+    an apply run that uses ATS credentials could cause mid-flow login failure.
+    **Mitigation:** SecretPort adapter caches secrets with a TTL (5 min).
+    Rotation uses a staged approach: new version becomes `AWSCURRENT` while
+    old version remains as `AWSPREVIOUS`. Adapters fall back to `AWSPREVIOUS`
+    on auth failure before surfacing errors.
+
+13. **Entitlement check latency.** Every expensive operation (LLM call, apply
+    run, artifact store) must check entitlements before proceeding. Synchronous
+    calls to the Billing context add latency to the hot path. **Mitigation:**
+    Cache entitlement state per-tenant with 60-second TTL. Billing publishes
+    `EntitlementChanged` events; the cache invalidates on receipt. The
+    entitlement check is a fast in-memory lookup in the common case.
+
+### Open Questions
+
+1. **JobId format.** Should `JobId` be a UUID, a content-hash of
+   `(source, employer, title, postingUrl)`, or a sequential ID? UUIDs are
+   simplest but lose deduplication-by-content. Content hashes enable
+   cross-source dedup but are brittle to title changes. *Needs product input.*
+
+2. **Score correction feedback loop.** The backlog mentions using score
+   corrections to "personalize scoring for remaining jobs." How should this
+   work? Options: (a) fine-tune the scoring prompt with correction examples,
+   (b) adjust scoring rubric weights, (c) use corrections as few-shot examples.
+   *Needs product input.*
+
+3. **Resume rendering engine.** The backlog spike (LaTeX vs Tectonic vs Typst vs
+   HTML/CSS) is unresolved. The `PdfRendererPort` is designed to absorb any
+   choice, but the adapter implementation depends on the spike outcome. *Blocked
+   on spike results.*
+
+4. **Event streaming to the frontend.** The backlog calls for "event streaming or
+   targeted row patching so lists do not reload wholesale." Should this be SSE,
+   WebSocket, or polling with ETags? The Operations context's `EventSubscriber`
+   port supports all three; the choice is a UX/infrastructure decision. *Needs
+   product input.*
+
+5. **Apply telemetry granularity.** How much of the Claude Code conversation
+   should be captured in `ApplyRunEvent`s? Full transcript? Summary events only?
+   Token/cost totals? Current code captures cost totals; more granularity adds
+   observability but increases storage. *Needs product input.*
+
+---
+
+## 11. Glossary
+
+| Term | Context | Definition |
+|---|---|---|
+| **Aggregate** | DDD | A cluster of entities and value objects treated as a unit for data changes, with a single root entity. |
+| **AntiCorruptionLayer** | DDD | A translation layer that prevents external models from corrupting the internal domain model. Used at bounded context boundaries. |
+| **ApplicationUrl** | Enrichment | The direct URL where a candidate submits their application; may differ from the posting URL. |
+| **ApplyRun** | Apply Automation | A single attempt to submit a job application through browser automation. |
+| **AuditSink** | Platform (Audit Log) | A driven port that receives structured audit records for every write operation. Cloud adapter writes to Postgres `audit_events` + CloudWatch Logs. |
+| **Artifact** | Materials Generation | Any generated file (resume, cover letter, PDF) with provenance metadata. |
+| **ArtifactStatus** | Materials Generation | Lifecycle of an artifact: `candidate`, `approved`, `rejected`, `superseded`. |
+| **Attempt** | Pipeline Orchestration | A numbered try at completing a pipeline stage for a job. |
+| **BlockedReason** | Pipeline Orchestration | Why a stage cannot proceed (upstream dependency not met). |
+| **BrowserWorker** | Apply Automation | An isolated Chrome instance allocated for one apply run. |
+| **CoverLetter** | Materials Generation | A job-specific cover letter generated from the profile and tailored resume. |
+| **DataRegion** | Platform (Identity) | The AWS region where a tenant's data resides (e.g., `us-east-1`, `eu-west-1`). Determines which RDS instance, S3 bucket, and Temporal namespace serve the tenant. |
+| **DomainEvent** | DDD | An immutable record of something important that happened in the domain, named in past tense. |
+| **DryRun** | Apply Automation | An apply attempt that navigates the ATS but does not submit the application. |
+| **Employer** | Discovery | The hiring company, distinct from the source board where the job was found. |
+| **Entitlement** | Platform (Billing) | A tenant's right to perform a specific operation (e.g., apply run, LLM call) based on their subscription plan and current usage. |
+| **EntitlementPort** | Platform (Billing) | A driven port that processing contexts call to check whether a tenant is allowed to perform an expensive operation before executing it. |
+| **EnrichmentAttempt** | Enrichment | A child entity within `JobEnrichment`; records one try at extracting full description and application URL from a job's detail page. |
+| **EvolutionTrigger** | Evolutionary Architecture | A concrete, testable condition that initiates migration from a local-mode adapter to its cloud equivalent. See Section 9.4. |
+| **ExtractionTier** | Enrichment | The method used to extract job details: JSON-LD (Tier 1), CSS selectors (Tier 2), LLM-assisted (Tier 3). |
+| **FitScore** | Scoring | A 1-10 integer rating of candidate-job match quality. |
+| **FullDescription** | Enrichment | The complete job posting text extracted from the detail page. |
+| **Job** | Discovery | A job posting discovered from an external source, identified by a stable `JobId`. |
+| **JobEnrichment** | Enrichment | The aggregate root for enrichment of a single job. Contains multiple `EnrichmentAttempt` child entities. Identity: `(TenantId, JobId)`. |
+| **JobId** | Discovery | A system-generated stable identifier for a job (replaces URL-as-primary-key). |
+| **JobPipelineState** | Pipeline Orchestration | The collection of stage states for one job across all pipeline stages. |
+| **JudgeVerdict** | Materials Generation | LLM-as-judge evaluation of a tailored resume's quality and faithfulness. |
+| **MaterialsSet** | Materials Generation | The grouped artifacts (tailored resume, cover letter, PDFs) for one job application, tracked as a single aggregate. |
+| **MatchedKeywords** | Scoring | ATS keywords from the job description that match the candidate's profile. |
+| **McpConfig** | Apply Automation | Playwright MCP server configuration for a browser automation session. |
+| **MessageGroupId** | Platform (Events) | SQS FIFO message group ID, set to `tenantId` to guarantee per-tenant event ordering in the cloud event bus. |
+| **NextAction** | Pipeline Orchestration | The recommended CLI command or UI action to advance a blocked or failed stage. |
+| **Pipeline** | Pipeline Orchestration | The canonical sequence of stages: discover → enrich → score → tailor → cover → pdf → apply. |
+| **OutboxPoller** | Platform (Events) | A sidecar process that reads uncommitted domain events from the Postgres `outbox` table and publishes them to SQS FIFO. Guarantees at-least-once delivery with crash-consistency. |
+| **Port** | Hexagonal Architecture | An interface through which the application communicates with the outside world. Driving ports are use cases; driven ports are infrastructure dependencies. |
+| **PostingUrl** | Discovery | The original URL where a job was found on an external board. Dedup is global within a tenant (not per-source). |
+| **PublishedLanguage** | DDD | Types and schemas that a bounded context exports for consumption by other contexts. `ProfileSnapshot` and domain event schemas are examples. |
+| **Profile** | Candidate Profile | The complete candidate data document: resume baseline, experience, education, skills, tailoring policy, writing style. |
+| **ProfileSnapshot** | Candidate Profile | An immutable, validated copy of the Profile provided to consuming contexts. |
+| **Repository** | DDD | A port that provides the illusion of an in-memory collection of aggregates, abstracting persistence. |
+| **RetryPolicy** | Pipeline Orchestration | Configuration for max attempts and backoff rules per pipeline stage. |
+| **ScoreBreakdown** | Scoring | Structured explanation of why a job received its fit score (replaces raw reasoning strings). |
+| **ScoreCorrection** | Scoring | A user-provided override of an LLM-generated score, with rationale. |
+| **SecretPort** | Platform (Secrets) | A driven port for retrieving per-tenant credentials. Local adapter reads `.env`/Keychain; cloud adapter reads AWS Secrets Manager. |
+| **SearchStrategy** | Discovery | The extraction method used to find jobs: `jobspy`, `workday_api`, `smart_extract`, `manual`. |
+| **Source** | Discovery | The origin board or career site where a job was found (e.g., LinkedIn, Greenhouse). |
+| **Stage** | Pipeline Orchestration | A named step in the pipeline: `discover`, `enrich`, `score`, `tailor`, `cover`, `pdf`, `apply`. |
+| **StageState** | Pipeline Orchestration | The current status of a job within a stage: `pending`, `queued`, `running`, `succeeded`, `failed`, `blocked`, `skipped`, `exhausted`, `stale`, `canceled`. |
+| **SubmissionResult** | Apply Automation | The outcome of an apply attempt: `applied`, `failed`, `captcha`, `login_issue`, `expired`, `manual`, `dry_run`. |
+| **TailoredResume** | Materials Generation | A resume customized for a specific job, derived from the master baseline via LLM. |
+| **TenantContext** | Platform (Identity) | A request-scoped value object containing `tenantId`, `userId`, and `roles`, injected by the API gateway / auth middleware into every use case call. |
+| **TenantId** | Platform (Identity) | A globally unique identifier for a tenant (organization or individual account). First-class domain concept threaded through all aggregates, events, and port calls. In local mode, a singleton constant. |
+| **TailoringPolicy** | Candidate Profile | Rules governing what the LLM may modify during resume tailoring (rewrite titles, reorder skills, etc.). |
+| **TokenUsage** | Apply Automation | LLM token consumption and cost tracking for an apply run. |
+| **TransactionalOutbox** | Platform (Events) | A Postgres table (`outbox`) where domain events are written in the same transaction as the aggregate mutation, guaranteeing crash-consistent event delivery. |
+| **ValidationResult** | Materials Generation | Output of content validation: banned words check, fabrication check, structural integrity check. |
+| **WritingStyle** | Candidate Profile | Stylistic constraints for generated content: tone, verbosity, bullet style, keyword density. |

--- a/docs/plans/proposed/ddd-target-plan.md
+++ b/docs/plans/proposed/ddd-target-plan.md
@@ -1,0 +1,2296 @@
+# DDD Target-State Migration Plan
+
+## 1. Purpose & Scope
+
+### Purpose
+
+This plan describes the **canonical migration path** from JobHunter's current
+architecture to the target-state DDD + Hexagonal Architecture defined in
+`docs/ddd-target.md`. It sequences every structural change into independently
+shippable PRs that never break the local product.
+
+The plan covers:
+
+- Introduction of shared domain types and the `TenantId` seam.
+- Extraction of bounded contexts: Pipeline Orchestration, Candidate Profile,
+  Scoring, Materials Generation, Job Discovery, Job Enrichment, Apply
+  Automation, and Operations / Read-Side.
+- Domain event infrastructure and the in-process event bus.
+- Repository ports and SQLite adapters for every aggregate.
+- New normalized tables (`job_scores`, `job_materials`, `job_enrichments`) with
+  backfill from legacy `jobs` columns.
+- The JSON-RPC 2.0 integration protocol between the TS API and Python worker.
+- TS API hosting simple state-transition commands directly (§6.8).
+- TS API read-model projection replacement.
+
+### What This Plan Explicitly Defers
+
+- **Cloud adapter implementations.** No Postgres, S3, SQS, Browserbase,
+  Temporal, Auth0, Stripe, or Secrets Manager code is written. Only port
+  interfaces are defined; cloud adapters are named and documented for future
+  implementation (see Section 8).
+- **Multi-tenant enforcement.** `TenantId` lands as a domain type with a
+  `"local"` singleton. Isolation policies, RLS, and auth middleware are
+  deferred.
+- **TypeSpec IDL.** The target names TypeSpec as the contract IDL. This plan
+  uses Zod schemas (TS) and frozen dataclasses (Python) for the local-first
+  phase. A CI compatibility check validates structural parity between the two.
+  TypeSpec adoption is triggered when the CI check fails frequently enough to
+  justify single-source generation (see Section 8).
+- **Resume rendering spike.** The `PdfRendererPort` is introduced, but the
+  adapter stays `LatexPdfAdapter` (current `pdflatex`). The spike comparing
+  Tectonic/Typst/HTML-CSS is a separate backlog item.
+- **UI/frontend changes.** React component restructuring, TanStack Router
+  migration, and frontend tests are out of scope unless a plan step changes an
+  API contract that requires a client update.
+
+---
+
+## 2. Plan Principles
+
+1. **Evolutionary architecture.** The target document is the contract; this
+   plan walks there one PR at a time (§2, Evolutionary Architecture).
+2. **Strangler pattern.** Replace old code path by path while the old path
+   keeps serving. Legacy columns, legacy materialization, and legacy imports
+   remain readable until their explicit removal step.
+3. **Ship-each-PR-green.** Every step is independently shippable. The system
+   works end-to-end after every merge. `pnpm test`, `pytest`, and the
+   `docs/local-reliability-qa.md` matrix never regress.
+4. **No big-bang cutover.** No step requires coordinated changes across more
+   than one bounded context. New tables coexist with legacy columns.
+5. **Target as contract.** Every step cites the target section it advances.
+   Steps that supersede existing decisions in `docs/decisions.md` call it out.
+6. **Local-first value.** Each step is justified by today's value (correctness,
+   simplicity, testability, parity with target). Cloud machinery is not imported.
+7. **Compatibility preservation.** Per AGENTS.md, existing compatibility
+   behavior is preserved unless explicitly authorized. The legacy `jobs` table,
+   CLI surface, API, and UI keep working through every step.
+8. **One aggregate per transaction.** Per §8.1, each command modifies exactly
+   one aggregate in a single DB transaction. Cross-aggregate consistency uses
+   domain events dispatched after the transaction commits. Every step that
+   introduces new write paths must honor this rule.
+9. **Idempotent command handlers.** Per §8.2, every stage command, event
+   handler, and apply run is idempotent. Steps that add new handlers must
+   include deduplication logic (attempt number, event ID, or run ID).
+
+---
+
+## 3. Pre-flight Checks
+
+Before Step S-01 begins:
+
+- [ ] `main` is clean and up to date (`git fetch origin main && git switch main && git pull --ff-only`).
+- [ ] `pnpm test` passes on main.
+- [ ] `uv --project workers/automation run --extra dev pytest -q` passes on main.
+- [ ] `uv --project workers/automation run --extra dev ruff check .` passes on main.
+- [ ] `git diff --check` is clean.
+- [ ] Team has read `docs/ddd-target.md` end-to-end.
+- [ ] Team has read this plan end-to-end.
+- [ ] This plan is accepted and merged to `main` under `docs/plans/proposed/`.
+
+---
+
+## 4. Phase Breakdown
+
+### Phase 1: Foundation — Shared Domain Types & TenantId Seam
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Lay the type foundation that every subsequent phase builds on. |
+| **Target sections** | §2 (Modeling Principles), §4.1–4.8 (TenantId in aggregate identities), §6.5 (shared contract). |
+| **Exit criteria** | Both TS and Python domain types compile/import. Existing tests pass unchanged. `TenantId("local")` usable in new code. Domain event base type defined. Integration point: at least one existing module can `import` the new types without error (verified by a smoke test in CI). |
+| **Effort** | Small — pure additions, no behavioral changes. |
+| **Dependencies** | Pre-flight checks. |
+
+### Phase 2: Pipeline Orchestration — State Machine & Repository
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Formalize the stage state machine as a pure function and extract the first repository port. Pipeline Orchestration is the "spine" every other context depends on. |
+| **Target sections** | §3.7, §4.7, §5.7, §8.5, §7.4. |
+| **Exit criteria** | `StageStateMachine` has dedicated unit tests covering all transitions from §8.5. `PipelineStateRepository` port + SQLite adapter extracted. `Queued` and `Canceled` states added. Legacy derivation still works. All existing state tests pass. |
+| **Effort** | Medium — refactors `state.py` (~815 LOC) into domain types + repository + ACL. |
+| **Dependencies** | Phase 1 (shared types). |
+
+### Phase 3: Infrastructure Backbone — Events, JSON-RPC & TS Simple Commands
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Stand up the three infrastructure pillars that all subsequent context extraction depends on: (1) the in-process event bus, (2) the JSON-RPC typed protocol between TS and Python, (3) TS API hosting simple commands directly via the shared state machine. This front-loads the cross-process integration contract so that context-specific phases can wire into an established backbone. |
+| **Target sections** | §6.1–§6.4 (event bus), §6.5 (JSON-RPC protocol), §6.8 (TS-hosted commands). |
+| **Exit criteria** | Events published through `EventPublisher` port. `job_events.event_type` standardized to domain event names (strangler dual-write with old names). Event watermark stub for projection replay. `jobhunter rpc` subcommand reads JSON-RPC from stdin/stdout. TS API performs `resetJobStage`, `markJobApplied`, `markJobSkipped` via `StageStateMachine` from `@jobhunter/domain-types` — no Python roundtrip. |
+| **Effort** | Medium — new infrastructure code, JSON-RPC server, TS write-model rewiring. |
+| **Dependencies** | Phase 1 (event base types), Phase 2 (stage event types, state machine). |
+
+### Phase 4: Candidate Profile Context — Aggregate & ProfileSnapshot
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Replace dict-passing of profile data with typed value objects and a repository port. Deliver `ProfileSnapshot` as published language. |
+| **Target sections** | §3.3, §4.3, §5.3. |
+| **Exit criteria** | All profile consumers use `ProfileSnapshot`. `ProfileRepository` port + `JsonFileProfileRepository` adapter. `profile.json` format unchanged. |
+| **Effort** | Medium — touches every module that reads the profile (tailor, cover, scorer, apply, profile_import). Note: these files will be restructured again in their respective context phases (5–8); this phase only changes how they receive profile data, not their internal wiring. |
+| **Dependencies** | Phase 1 (shared types). |
+
+### Phase 5: Scoring Context — Extraction & Ports
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Separate scoring into its own bounded context with typed value objects, a repository port, and an LLM port. |
+| **Target sections** | §3.4, §4.4, §5.4, §7.1 (`job_scores` table), §7.3. |
+| **Exit criteria** | Scoring writes to `job_scores` table. `LlmPort` for scoring extracted. Legacy `jobs` scoring columns read-only. Backfill migration works. All scoring tests pass. |
+| **Effort** | Medium — new table, backfill, refactor `scorer.py`. |
+| **Dependencies** | Phase 1, Phase 4 (ProfileSnapshot consumed by scoring). |
+
+### Phase 6: Materials Generation Context — Aggregate & Ports
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Extract the most painful context — tailor/cover/pdf — into a cohesive aggregate with proper port boundaries. |
+| **Target sections** | §3.5, §4.5, §5.5, §7.1 (`job_materials` table), §7.3. |
+| **Exit criteria** | `MaterialsSet` aggregate with `Artifact` entity. `ContentValidator`, `ResumeAssembler` as pure domain services. `PdfRendererPort`, `ArtifactStoragePort`, `LlmPort` extracted. New `job_materials` table with backfill. Legacy tailor/cover/pdf columns read-only. |
+| **Effort** | Large — the biggest extraction. `tailor.py` (820 LOC), `cover_letter.py`, `pdf.py` all refactored. |
+| **Dependencies** | Phase 1, Phase 3 (event bus), Phase 4 (ProfileSnapshot), Phase 5 (FitScore for eligibility). |
+
+### Phase 7: Discovery & Enrichment Contexts
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Extract Job Discovery and Job Enrichment into their own bounded contexts with aggregate roots, repositories, and port boundaries. Eliminate cross-context imports. |
+| **Target sections** | §3.1, §3.2, §4.1, §4.2, §5.1, §5.2, §7.1, §7.3. |
+| **Exit criteria** | `Job` aggregate with `PostingUrl`, `Source`, `Employer` separated. `JobEnrichment` aggregate with `ExtractionTier`. New `job_enrichments` table with backfill. `enrichment/detail.py` no longer imports from `discovery/`. |
+| **Effort** | Medium — two simpler contexts, new table for enrichment. |
+| **Dependencies** | Phase 1, Phase 3 (event bus). |
+
+### Phase 8: Apply Automation Context — Saga & Ports
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Extract Apply Automation into its own bounded context with the `ApplyRun` aggregate, browser and agent ports, and a process manager pattern. |
+| **Target sections** | §3.6, §4.6, §5.6, §8.3 (Apply saga). |
+| **Exit criteria** | `ApplyRun` aggregate with `SubmissionResult` discriminated union. `BrowserPort`, `AutonomousAgentPort` extracted. Apply process manager pattern. `ApplyRunRepository` wrapping existing tables. Apply telemetry unified. |
+| **Effort** | Large — `launcher.py` (1300 LOC) refactored. Complex subprocess and browser lifecycle. |
+| **Dependencies** | Phase 1, Phase 3 (event bus), Phase 4 (ProfileSnapshot). |
+
+### Phase 9: Operations Read-Side & Projections
+
+| Attribute | Value |
+|---|---|
+| **Theme** | Replace read-time derivation with event-driven projections. Wire the JSON-RPC adapter into `local-actions.ts` to formalize the TS↔Python transport. |
+| **Target sections** | §3.8, §4.8, §5.8, §6.6. |
+| **Exit criteria** | `ProjectionBuilder` consuming domain events. TS read-model queries projections instead of raw tables + legacy derivation. `SubprocessJsonRpcAdapter` replaces ad-hoc subprocess spawning in `local-actions.ts`. All QA matrix tests pass. |
+| **Effort** | Large — rewrites the TS API's core read path and the TS↔Python transport. |
+| **Dependencies** | All previous phases (all contexts must publish events for projections to consume). Phase 3 (JSON-RPC protocol defined). |
+
+---
+
+## 5. Step-by-Step Plan
+
+### Phase 1: Foundation — Shared Domain Types & TenantId Seam
+
+---
+
+#### S-01: feat: add `packages/domain-types` with shared value objects and TenantId
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 1 — Foundation |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §2 (Modeling Principles — TenantId first-class), §4.1 (TenantId in Job identity), §4.7 (Stage, StageState types). |
+| **Pain points** | Briefing #1 (no domain model — this starts one). |
+
+**Files touched:**
+
+- `packages/domain-types/` — **new** package directory.
+- `packages/domain-types/package.json` — **new**.
+- `packages/domain-types/tsconfig.json` — **new**.
+- `packages/domain-types/src/index.ts` — **new** barrel export.
+- `packages/domain-types/src/tenant.ts` — **new** `TenantId` value object.
+- `packages/domain-types/src/pipeline.ts` — **new** `Stage`, `StageState` discriminated union.
+- `packages/domain-types/src/identifiers.ts` — **new** `JobId` branded type.
+- `packages/domain-types/src/events.ts` — **new** `DomainEvent` base type.
+- `pnpm-workspace.yaml` — **refactor** to add `packages/domain-types`.
+
+**Approach:**
+Create a new `packages/domain-types` TypeScript package that owns the shared
+domain vocabulary. Define `TenantId` as a branded string type with a
+`LOCAL_TENANT` constant (`"local"`). Define `Stage` as a union literal type
+(matching existing `STAGES` in `packages/contracts`). Define `StageState` as a
+discriminated union (per §8.5 target state machine). Define `JobId` as a
+branded string. Define `DomainEvent` as a base interface with `eventType`,
+`tenantId`, `occurredAt`, and `payload`. These are pure type definitions with
+no runtime behavior. The existing `packages/contracts/src/schemas.ts` `STAGES`
+and `STAGE_STATES` arrays remain for Zod validation; `packages/domain-types`
+provides the domain-layer types that processing code imports.
+
+**Backward compatibility:** No existing code changes. Pure addition.
+
+**Tenancy implications:** Introduces `TenantId` as a domain type with
+`LOCAL_TENANT = "local"` default. No enforcement code.
+
+**Tests added:**
+- Unit: `packages/domain-types/test/tenant.test.ts` — `TenantId` creation,
+  `LOCAL_TENANT` value.
+- Unit: `packages/domain-types/test/pipeline.test.ts` — `Stage` and
+  `StageState` type completeness.
+
+**Verification commands:**
+
+```bash
+pnpm test
+pnpm --filter @jobhunter/domain-types build
+pnpm --filter @jobhunter/domain-types test
+```
+
+**Risk:** Low. Pure addition. If the package is misconfigured in the pnpm
+workspace, other packages won't resolve it. Mitigation: verify with
+`pnpm install` and `pnpm test` after creation.
+
+**Dependencies:** None (first step).
+
+**Out of scope:** Runtime validation (Zod schemas stay in `packages/contracts`).
+TypeSpec IDL. Cloud adapter types.
+
+---
+
+#### S-02: feat: add Python domain types module with TenantId and stage types
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 1 — Foundation |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §2 (Modeling Principles), §6.5 (shared contract, Python side). |
+| **Pain points** | Briefing #1 (no domain model in the worker). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/` — **new** package directory.
+- `workers/automation/src/jobhunter/domain/__init__.py` — **new** barrel.
+- `workers/automation/src/jobhunter/domain/tenant.py` — **new** `TenantId` value object.
+- `workers/automation/src/jobhunter/domain/pipeline.py` — **new** `Stage`, `StageState` enums/types.
+- `workers/automation/src/jobhunter/domain/identifiers.py` — **new** `JobId` type.
+- `workers/automation/src/jobhunter/domain/events.py` — **new** `DomainEvent` base dataclass.
+
+**Approach:**
+Create `workers/automation/src/jobhunter/domain/` as the Python domain types
+package mirroring the TS `packages/domain-types`. `TenantId` is a
+`NewType(str)` with a `LOCAL_TENANT` constant. `Stage` is a string enum
+matching the TS `Stage` union. `StageState` is defined as frozen dataclasses
+for each state variant (Pending, Queued, Running, Succeeded, Failed, Blocked,
+Skipped, Exhausted, Stale, Canceled) following the data-orientation principle
+from §2. `DomainEvent` is a frozen dataclass base with `event_type`,
+`tenant_id`, `occurred_at`, and `payload`. These types are pure data — no I/O
+imports, no database imports.
+
+**Backward compatibility:** No existing code changes. Pure addition.
+
+**Tenancy implications:** Same as S-01 — introduces `TenantId` with
+`LOCAL_TENANT = "local"`.
+
+**Tests added:**
+- Unit: `workers/automation/tests/test_domain_types.py` — `TenantId` creation,
+  `Stage` completeness against `state.STAGE_ORDER`, `StageState` variant
+  construction.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_domain_types.py -q
+uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/
+```
+
+**Risk:** Low. Pure addition.
+
+**Dependencies:** None (can run in parallel with S-01).
+
+**Out of scope:** Context-specific value objects. Repository ports. Event bus.
+
+---
+
+#### S-03: feat: add domain event schemas for all bounded contexts
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 1 — Foundation |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §4.1–§4.8 (all domain event definitions), §6.1 (integration backbone). |
+| **Pain points** | Briefing #13 (no event-driven integration — this defines the event vocabulary). |
+
+**Files touched:**
+
+- `packages/domain-types/src/events/` — **new** subdirectory.
+- `packages/domain-types/src/events/discovery.ts` — **new** `JobDiscovered`, `JobUpdated`, `JobDeleted`.
+- `packages/domain-types/src/events/enrichment.ts` — **new** `JobEnriched`, `EnrichmentFailed`.
+- `packages/domain-types/src/events/scoring.ts` — **new** `JobScored`, `ScoreCorrected`.
+- `packages/domain-types/src/events/materials.ts` — **new** `ResumeApproved`, `CoverLetterGenerated`, `PdfRendered`, `MaterialsExhausted`.
+- `packages/domain-types/src/events/apply.ts` — **new** `ApplicationSubmitted`, `ApplicationFailed`, `ApplyRunStarted`.
+- `packages/domain-types/src/events/orchestration.ts` — **new** `StageStarted`, `StageCompleted`, `StageFailed`, `StageExhausted`, `StageReset`, `StageBlocked`, `StageSkipped`.
+- `packages/domain-types/src/events/profile.ts` — **new** `ProfileUpdated`, `ProfileImported`.
+- `packages/domain-types/src/events/index.ts` — **new** barrel.
+- `workers/automation/src/jobhunter/domain/events/` — **new** Python mirror of above.
+
+**Approach:**
+Define every domain event from §4.1–§4.8 as a TypeScript interface and a
+matching Python frozen dataclass. Each event extends `DomainEvent` (from S-01
+and S-02) and adds context-specific fields. All events carry `tenantId` as
+mandated by §2. Event names use past tense per §2. Events carry identifiers
+(`jobId`, `runId`, `artifactId`) but not file paths (paths are infrastructure
+concerns per §4.5 design note). Both language implementations are structurally
+parallel; CI will validate they match in a future step.
+
+**CI parity check:** Add `scripts/check-domain-type-parity.sh` (or
+`.ts`/`.py`) that verifies TS `packages/domain-types` exports and Python
+`jobhunter.domain` exports have matching type names and event field sets.
+Fails CI if a type exists in one language but not the other. This serves as
+the sensor for the TypeSpec evolution trigger in §8 — without it, two-language
+drift (Risk §10.5) can happen silently.
+
+**Backward compatibility:** Pure addition. Existing `record_job_event()` calls
+in `state.py` continue using string `event_type` values. Phase 3 will wire
+them to the new typed events.
+
+**Tenancy implications:** Every event type includes `tenantId` field.
+
+**Tests added:**
+- Unit: `packages/domain-types/test/events.test.ts` — event construction,
+  required fields present, `tenantId` always set.
+- Unit: `workers/automation/tests/test_domain_events.py` — same for Python.
+- CI: `scripts/check-domain-type-parity` — verifies TS and Python domain type
+  exports match (type names, event field sets). TypeSpec evolution sensor.
+
+**Verification commands:**
+
+```bash
+pnpm test
+uv --project workers/automation run --extra dev pytest tests/test_domain_events.py -q
+scripts/check-domain-type-parity
+```
+
+**Risk:** Low. Only events explicitly listed in §4 sections are defined.
+
+**Dependencies:** S-01 (TS base type), S-02 (Python base type).
+
+**Out of scope:** Event bus wiring. Event persistence changes. Event versioning.
+
+---
+
+### Phase 2: Pipeline Orchestration — State Machine & Repository
+
+---
+
+#### S-04: feat: extract `StageStateMachine` as a pure function with transition tests
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 2 — Pipeline Orchestration |
+| **Bounded context** | Pipeline Orchestration |
+| **Target sections** | §4.7 (`StageStateMachine` domain service), §8.5 (state machine diagram and transition table). |
+| **Pain points** | Briefing #1 (no domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/orchestration/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/orchestration/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/domain/orchestration/state_machine.py` — **new** `StageStateMachine`.
+- `packages/domain-types/src/orchestration/state-machine.ts` — **new** TS mirror.
+
+**Approach:**
+Extract the stage state transition logic from `state.py`'s `set_stage_state()`
+into a pure, standalone `StageStateMachine` module. The machine is a function
+`transition(current: StageState, trigger: Trigger) -> StageState | InvalidTransition`.
+Implement every row from the §8.5 transition table. Add `Queued` and `Canceled`
+to the valid state set. The function has zero I/O. Existing `set_stage_state()`
+in `state.py` is NOT changed in this step.
+
+**Backward compatibility:** Pure addition. No behavioral change.
+
+**Tenancy implications:** None — pure logic.
+
+**Tests added:**
+- Unit: `workers/automation/tests/test_stage_state_machine.py` — one test per
+  transition row in §8.5. Invalid transitions verify rejection.
+- Unit: `packages/domain-types/test/state-machine.test.ts` — TS mirror tests.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_stage_state_machine.py -v
+pnpm --filter @jobhunter/domain-types test
+```
+
+**Risk:** Low. Transition table is well-defined in §8.5.
+
+**Dependencies:** S-01 (StageState types), S-02 (Python StageState types).
+
+**Out of scope:** Wiring into `state.py` (S-06). PipelineScheduler. Streaming mode.
+
+---
+
+#### S-05: feat: define `PipelineStateRepository` port and `SqlitePipelineStateRepository` adapter
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 2 — Pipeline Orchestration |
+| **Bounded context** | Pipeline Orchestration |
+| **Target sections** | §5.7 (`PipelineStateRepository` port), §7.4 (`job_stage_states` mapping). |
+| **Pain points** | Briefing #2 (persistence model = domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/orchestration/ports.py` — **new** `PipelineStateRepository` protocol.
+- `workers/automation/src/jobhunter/infrastructure/orchestration/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/infrastructure/orchestration/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/infrastructure/orchestration/sqlite_pipeline_state.py` — **new** adapter.
+
+**Approach:**
+Define `PipelineStateRepository` as a Python `Protocol` with methods:
+`get(tenant_id, job_id) -> JobPipelineState | None`,
+`save(tenant_id, state: JobPipelineState)`,
+`list_by_stage(tenant_id, stage, state_filter?) -> list[JobPipelineState]`.
+The port wraps CRUD operations only — state derivation logic stays in
+`LegacyStateDeriver` (S-07). The `SqlitePipelineStateRepository` adapter
+reads/writes the existing `job_stage_states` table without schema changes.
+
+**Backward compatibility:** Pure addition. Existing `state.py` functions unchanged.
+
+**Tenancy implications:** Repository accepts `TenantId` but ignores it locally.
+
+**Tests added:**
+- Unit: `workers/automation/tests/test_pipeline_state_repository.py` — round-trip
+  save/get, list by stage, NULL edge cases.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_pipeline_state_repository.py -q
+```
+
+**Risk:** Medium. Complex NULL handling in `job_stage_states`.
+
+**Dependencies:** S-02 (Python domain types), S-04 (StageState types).
+
+**Out of scope:** Wiring into `state.py` (S-06). `LegacyStateDeriver` (S-07).
+
+---
+
+#### S-06: refactor: wire `state.py` to use `StageStateMachine` and `PipelineStateRepository` internally
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 2 — Pipeline Orchestration |
+| **Bounded context** | Pipeline Orchestration |
+| **Target sections** | §4.7 (orchestration aggregate), §5.7 (repository port). |
+| **Pain points** | Briefing #1 (no domain model), #2 (persistence = domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/state.py` — **refactor** to delegate to `StageStateMachine` and `PipelineStateRepository`.
+
+**Approach:**
+Refactor `set_stage_state()` to: (1) read current state via repository, (2)
+compute new state via `StageStateMachine.transition()`, (3) persist via
+repository. External signature unchanged — callers still call
+`set_stage_state(job_url, stage, state, **kwargs)`. Invalid transitions now
+raise descriptive errors. Default `SqlitePipelineStateRepository` created if
+none provided (dependency injection via optional parameter). Per §8.1, each
+call modifies only the `JobPipelineState` aggregate in its own transaction.
+
+**Backward compatibility:** External signature unchanged. Invalid transition
+rejection is a correctness improvement.
+
+**Tenancy implications:** `TenantId` parameter added internally with default
+`LOCAL_TENANT`.
+
+**Tests added:**
+- Integration: update existing state tests to verify transitions through machine.
+- Unit: invalid transitions raise errors.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Medium-high. `state.py` is called by every stage module. Mitigation:
+external signature unchanged; full test suite.
+
+**Dependencies:** S-04 (state machine), S-05 (repository).
+
+**Out of scope:** Refactoring callers. Legacy state derivation (S-07).
+
+---
+
+#### S-07: refactor: formalize `LegacyStateDeriver` as an ACL with explicit removal criteria
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 2 — Pipeline Orchestration |
+| **Bounded context** | Pipeline Orchestration |
+| **Target sections** | §4.7 (`LegacyStateDeriver` service, removal criterion). |
+| **Pain points** | Briefing #1 (legacy materialization logic), #11 (duplicated state derivation). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/orchestration/legacy_deriver.py` — **new** `LegacyStateDeriver`.
+- `workers/automation/src/jobhunter/state.py` — **refactor** move `derive_legacy_stage_states`, `_materialize_legacy_stage_rows`, `_is_placeholder_state` to new module.
+- `apps/api/src/read-model.ts` — **refactor** add removal criterion comment.
+
+**Approach:**
+Move legacy state derivation into a dedicated `LegacyStateDeriver` class,
+documented as an Anti-Corruption Layer. Removal criterion from §4.7:
+`SELECT COUNT(*) FROM jobs WHERE url NOT IN (SELECT DISTINCT job_url FROM job_stage_states)` returns 0 AND legacy columns dropped. Called by the
+`SqlitePipelineStateRepository` to fill gaps on read. TS `read-model.ts`
+annotated with same criterion; actual TS replacement is Phase 9.
+
+**Backward compatibility:** Same behavior, different module structure.
+
+**Tenancy implications:** None.
+
+**Tests added:**
+- Unit: `tests/test_legacy_deriver.py` — column combinations → correct `StageState` variants.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Low. Pure extraction, no behavior change.
+
+**Dependencies:** S-06 (state.py refactored).
+
+**Out of scope:** Removing the deriver (future). TS-side replacement (Phase 9).
+
+---
+
+#### S-08: feat: add `Queued` and `Canceled` states to pipeline state model
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 2 — Pipeline Orchestration |
+| **Bounded context** | Pipeline Orchestration |
+| **Target sections** | §8.5 (state machine — both are target states). |
+| **Pain points** | Gap: current `STATE_VALUES` lacks `canceled`. |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/state.py` — **refactor** add `"queued"` and `"canceled"` to `STATE_VALUES`.
+- `workers/automation/src/jobhunter/domain/pipeline.py` — **refactor** add `Queued` and `Canceled` variants.
+- `packages/domain-types/src/pipeline.ts` — already includes both (from S-01).
+- `packages/contracts/src/schemas.ts` — already includes both in `STAGE_STATES`.
+- `workers/automation/src/jobhunter/database.py` — **refactor** document new state values (no schema change; TEXT column).
+- `apps/api/src/write-model.ts` — **verify** `cancelJobAction` can use `canceled` state.
+- `apps/api/src/read-model.ts` — **verify** state filters handle new values.
+
+**Approach:**
+Add `"queued"` and `"canceled"` to `STATE_VALUES` in `state.py`. The
+`StageStateMachine` from S-04 already handles transitions. `Queued` is not
+actively used yet (no queue infrastructure locally) but must exist for state
+machine completeness. `Canceled` enables the cancel action path. Verify
+`packages/contracts/src/schemas.ts` already includes both.
+
+**Backward compatibility:** Adding new state values is backward-compatible.
+No existing code writes them yet.
+
+**Tenancy implications:** None.
+
+**Tests added:**
+- Unit: verify `STATE_VALUES` is a superset of `StageStateMachine` valid states.
+- Integration: cancel action path uses `canceled` state.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Low. Adding enum values to a TEXT column is safe.
+
+**Dependencies:** S-04 (state machine), S-06 (state.py refactored).
+
+**Out of scope:** Queue infrastructure. Active `Queued` usage. Cancel for running stages.
+
+---
+
+### Phase 3: Infrastructure Backbone — Events, JSON-RPC & TS Simple Commands
+
+---
+
+#### S-09: feat: define `EventPublisher` port and `InProcessEventBus` adapter
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 3 — Infrastructure Backbone |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §6.1 (integration backbone), §6.3 (in-process synchronous bus). |
+| **Pain points** | Briefing #13 (no event-driven integration). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/ports/__init__.py` — **new** ports package.
+- `workers/automation/src/jobhunter/domain/ports/events.py` — **new** `EventPublisher`, `EventSubscriber` protocols.
+- `workers/automation/src/jobhunter/infrastructure/events/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/infrastructure/events/in_process_bus.py` — **new** `InProcessEventBus`.
+
+**Approach:**
+Define `EventPublisher` and `EventSubscriber` protocols. Implement
+`InProcessEventBus` as a synchronous singleton. Per §6.3, event dispatch
+happens **after** the producing transaction commits — the bus does not own
+the transaction. This upholds the one-aggregate-per-transaction rule (§8.1):
+each handler runs its own transaction. Handler errors are caught and logged
+without breaking other handlers. Per §8.2, handlers must be idempotent.
+
+**Backward compatibility:** Pure addition. Existing event recording unchanged.
+
+**Tenancy implications:** Events carry `tenantId` from `DomainEvent` base.
+
+**Tests added:**
+- Unit: `tests/test_event_bus.py` — publish, subscribe, handler invocation,
+  error isolation.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_event_bus.py -q
+```
+
+**Risk:** Low. Simple in-process bus.
+
+**Dependencies:** S-02 (DomainEvent base), S-03 (event schemas).
+
+**Out of scope:** Wiring existing code (S-10). Cloud event bus adapter.
+
+---
+
+#### S-10: refactor: wire `record_job_event` through `EventPublisher` and standardize event types
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 3 — Infrastructure Backbone |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §6.4 (`job_events` as event store, standardized `event_type`). |
+| **Pain points** | Briefing #13 (no event-driven integration). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/state.py` — **refactor** `record_job_event()` to publish through `EventPublisher`.
+- `workers/automation/src/jobhunter/infrastructure/events/event_store.py` — **new** handler persisting events to `job_events`.
+
+**Approach:**
+Refactor `record_job_event()` to construct typed `DomainEvent` instances and
+publish through `InProcessEventBus`. Register a default handler that persists
+to `job_events`. Event type standardization uses a **strangler dual-write**:
+new events are written with PascalCase domain event names (`StageStarted`,
+`StageCompleted`), while the existing snake_case values (`stage_started`,
+`stage_completed`) are also written to a `legacy_event_type` column (added via
+ALTER TABLE) for backward compatibility. Code that reads `event_type` is
+updated to use the new names; legacy queries can use `legacy_event_type` during
+the transition. External `record_job_event` signature unchanged.
+
+**Backward compatibility:** Signature unchanged. Event type values change from
+snake_case to PascalCase. Legacy column preserves old names during transition.
+
+**Tenancy implications:** Events carry `tenant_id = LOCAL_TENANT`.
+
+**Tests added:**
+- Unit: verify `record_job_event` publishes through bus.
+- Unit: verify dual-write of old and new event type names.
+- Integration: existing event queries work with new type names.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Medium. Changing event type strings; mitigated by dual-write.
+
+**Dependencies:** S-09 (event bus).
+
+**Out of scope:** Wiring all stage modules to publish typed events directly
+(per-context phases).
+
+---
+
+#### S-11: feat: add event watermark tracking for projection reconciliation
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 3 — Infrastructure Backbone |
+| **Bounded context** | Cross-cutting |
+| **Target sections** | §6.3 (crash recovery — startup reconciliation pass). |
+| **Pain points** | Briefing #13 (enables future projection replay). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/infrastructure/events/watermark.py` — **new** `WatermarkTracker`.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add `event_watermarks` table.
+
+**Approach:**
+Add `event_watermarks` table: `(projection_name TEXT PRIMARY KEY, last_event_id INTEGER, updated_at TEXT)`. The `WatermarkTracker` reads and updates watermarks.
+Projections (Phase 9) will track their last processed event ID. On startup,
+reconciliation replays events with `event_id > last_event_id`. This step only
+creates the table and tracker; projection wiring happens in Phase 9.
+
+**Backward compatibility:** New table, no existing behavior changed.
+
+**Tenancy implications:** None (watermarks are per-projection, not per-tenant locally).
+
+**Tests added:**
+- Unit: `test_watermark.py` — read/update watermark, initial watermark is 0.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_watermark.py -q
+```
+
+**Risk:** Low. New table, no behavioral change.
+
+**Dependencies:** S-10 (event store wiring).
+
+**Out of scope:** Projection builders (Phase 9). Startup reconciliation loop.
+
+---
+
+#### S-12: feat: define JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 3 — Infrastructure Backbone |
+| **Bounded context** | Cross-cutting (TS API ↔ Python Worker) |
+| **Target sections** | §6.5 (JSON-RPC 2.0 protocol, transport adapters, dispatch modes). |
+| **Pain points** | Briefing #7 (no typed contract between TS and Python), #9 (stringly-typed actions). |
+
+**Files touched:**
+
+- `packages/domain-types/src/protocol/` — **new** directory.
+- `packages/domain-types/src/protocol/json-rpc.ts` — **new** JSON-RPC request/response types.
+- `packages/domain-types/src/protocol/methods.ts` — **new** method definitions (`executeStage`, `importProfile`, etc.).
+- `workers/automation/src/jobhunter/rpc/` — **new** directory.
+- `workers/automation/src/jobhunter/rpc/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/rpc/server.py` — **new** JSON-RPC request handler.
+- `workers/automation/src/jobhunter/rpc/methods.py` — **new** method registry.
+- `workers/automation/src/jobhunter/cli.py` — **refactor** add `jobhunter rpc` subcommand.
+
+**Approach:**
+Define JSON-RPC 2.0 protocol per §6.5. TS types define request/response
+envelopes and method-specific params/results. Python implements a
+`json_rpc_handler(request_json) -> response_json` dispatcher. Add
+`jobhunter rpc` CLI subcommand that reads JSON-RPC from stdin and writes to
+stdout (local subprocess transport per §6.5). Three dispatch modes from §6.5:
+synchronous (profile_import), fire-and-forget (apply, discover), streaming
+(pipeline run). This step does NOT change `local-actions.ts` — that happens
+in Phase 9 (S-36). The protocol is front-loaded here so context extraction
+phases can define their RPC methods alongside their domain logic.
+
+**Backward compatibility:** Pure addition. `jobhunter rpc` is new.
+
+**Tenancy implications:** All RPC methods accept `tenantId` in params.
+
+**Tests added:**
+- Unit: `tests/test_rpc_handler.py` — request parsing, method routing, error
+  responses, `tenantId` injection.
+- Unit: `packages/domain-types/test/protocol.test.ts` — type validation.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_rpc_handler.py -q
+pnpm test
+```
+
+**Risk:** Medium. New protocol layer. Mitigation: keep initial method set small.
+
+**Dependencies:** S-01 (TS types), S-02 (Python types).
+
+**Out of scope:** Replacing `local-actions.ts` (S-36, Phase 9). HTTP transport.
+Temporal transport.
+
+---
+
+#### S-13: refactor: TS API hosts simple state-transition commands directly
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 3 — Infrastructure Backbone |
+| **Bounded context** | Pipeline Orchestration (hosted in TS) |
+| **Target sections** | §6.8 (TS API write operations — domain logic hosting). |
+| **Pain points** | Briefing #7 (roundtrip through Python for simple state changes). |
+
+**Files touched:**
+
+- `apps/api/src/write-model.ts` — **refactor** to use `StageStateMachine` from `@jobhunter/domain-types` for `resetJobStage`, `markJobApplied`, `markJobSkipped`.
+- `apps/api/src/contracts.ts` — **refactor** import state machine types.
+- `apps/api/package.json` — **refactor** add `@jobhunter/domain-types` dependency.
+
+**Approach:**
+Per §6.8, simple state-transition commands (`resetJobStage`, `markJobApplied`,
+`markJobSkipped`, `softDeleteJob`, `restoreJob`) are hosted directly in the TS
+API. Import `StageStateMachine` from `packages/domain-types` (S-04's TS mirror)
+and call `transition()` before writing to `job_stage_states`. Invalid
+transitions return typed errors. Complex commands (pipeline run, discovery,
+scoring, tailoring, apply) continue to go through Python. This step is
+front-loaded alongside JSON-RPC because it establishes the TS↔Python boundary:
+simple = TS, complex = Python (via JSON-RPC). The `StageStateMachine` exists
+in both TS and Python (hand-mirrored); a CI compatibility check validates they
+produce identical transitions for the same inputs.
+
+**Backward compatibility:** Same API behavior. Transition validation may reject
+previously-silent invalid transitions (correctness improvement).
+
+**Tenancy implications:** State machine accepts `TenantId` (ignored locally).
+
+**Tests added:**
+- Unit: `apps/api/test/write-model.test.ts` — valid transitions succeed,
+  invalid return error.
+- CI: `tests/test_state_machine_parity.ts` — run identical test cases against
+  both TS and Python implementations, verify outputs match.
+- Regression: `apps/api/test/server.test.ts` — action endpoints unchanged.
+
+**Verification commands:**
+
+```bash
+pnpm test
+pnpm api:test
+```
+
+**Risk:** Medium. Rejecting invalid transitions could break UI flows.
+Mitigation: review current `write-model.ts` tests for edge cases.
+
+**Dependencies:** S-04 (StageStateMachine TS mirror), S-01 (TS domain types).
+
+**Out of scope:** Hosting complex commands in TS. TypeSpec IDL.
+
+---
+
+### Phase 4: Candidate Profile Context — Aggregate & ProfileSnapshot
+
+---
+
+#### S-14: feat: define `Profile` aggregate with value objects
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 4 — Candidate Profile |
+| **Bounded context** | Candidate Profile |
+| **Target sections** | §3.3, §4.3 (Profile aggregate, invariants, value objects). |
+| **Pain points** | Briefing #8 (profile is dict-passing). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/profile/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/profile/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/domain/profile/aggregate.py` — **new** `Profile` aggregate root.
+- `workers/automation/src/jobhunter/domain/profile/value_objects.py` — **new** `ExperienceEntry`, `EducationEntry`, `SkillCategory`, `TailoringPolicy`, `WritingStyle`, `ApplicationDefaults`, `ExecutiveProfile`, `ResumeConstraints`.
+- `workers/automation/src/jobhunter/domain/profile/snapshot.py` — **new** `ProfileSnapshot` published language.
+
+**Approach:**
+Define the `Profile` aggregate per §4.3 with value objects. `ProfileSnapshot`
+is the published language — a frozen, immutable copy for consumption by
+Scoring, Materials, and Apply contexts. The snapshot is hand-mirrored in both
+Python (frozen dataclass) and TS (readonly interface in `packages/domain-types`);
+a CI check validates structural compatibility. Value objects are designed to
+map cleanly to/from `profile.json` schema.
+
+**Backward compatibility:** Pure addition. No existing code changed.
+
+**Tenancy implications:** Profile identity is `(TenantId, ProfileId)`.
+`ProfileId = "default"` locally.
+
+**Tests added:**
+- Unit: `tests/test_profile_aggregate.py` — invariant enforcement, snapshot
+  creation, snapshot immutability.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_profile_aggregate.py -q
+```
+
+**Risk:** Low. Pure types.
+
+**Dependencies:** S-02 (Python domain types, TenantId).
+
+**Out of scope:** Repository port (S-15). Replacing dict-passing (S-16).
+
+---
+
+#### S-15: feat: define `ProfileRepository` port and `JsonFileProfileRepository` adapter
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 4 — Candidate Profile |
+| **Bounded context** | Candidate Profile |
+| **Target sections** | §5.3 (`ProfileRepository` port, `JsonFileProfileRepository` adapter). |
+| **Pain points** | Briefing #8 (profile dict-passing), #5 (implicit filesystem I/O). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/profile/ports.py` — **new** `ProfileRepository` protocol.
+- `workers/automation/src/jobhunter/infrastructure/profile/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/profile/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/infrastructure/profile/json_file.py` — **new** `JsonFileProfileRepository`.
+
+**Approach:**
+Define `ProfileRepository` Protocol: `get()`, `save()`, `get_snapshot()`.
+The `JsonFileProfileRepository` reads/writes `profile.json` (and
+`resume_style.json`, `resume_template.tex`). Extra fields not modeled in the
+aggregate are preserved on write (forward compatibility). `get_snapshot()`
+creates an immutable `ProfileSnapshot`. This replaces `config.load_profile()`
+for new code.
+
+**Backward compatibility:** Pure addition. `config.load_profile()` unchanged.
+
+**Tenancy implications:** Repository accepts `TenantId` but ignores it locally.
+
+**Tests added:**
+- Unit: `tests/test_profile_repository.py` — round-trip, snapshot creation,
+  extra fields preserved.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_profile_repository.py -q
+```
+
+**Risk:** Low-medium. `profile.json` schema is complex.
+
+**Dependencies:** S-14 (Profile aggregate).
+
+**Out of scope:** Migrating existing callers (S-16). TS-side profile operations.
+
+---
+
+#### S-16: refactor: replace profile dict-passing with `ProfileSnapshot` in consumers
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 4 — Candidate Profile |
+| **Bounded context** | Cross-cutting (Profile → Scoring, Materials, Apply) |
+| **Target sections** | §3.3 (Conformist relationships), §4.3 (ProfileSnapshot published language). |
+| **Pain points** | Briefing #8 (profile is dict-passing — this closes it). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor** replace dict with `ProfileSnapshot`.
+- `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor** replace `config.load_profile()` with `ProfileSnapshot`.
+- `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor** replace `config.load_profile()` with `ProfileSnapshot`.
+- `workers/automation/src/jobhunter/apply/launcher.py` — **refactor** replace profile dict with `ProfileSnapshot`.
+- `workers/automation/src/jobhunter/resume_profile.py` — **refactor** dual-path accessors (dict + `ProfileSnapshot`).
+- `workers/automation/src/jobhunter/profile_import.py` — **refactor** return `Profile` aggregate alongside raw dict.
+
+**Approach:**
+Every module that calls `config.load_profile()` now receives a `ProfileSnapshot`
+from `ProfileRepository`. Dual-path accessors in `resume_profile.py` accept
+both dict and `ProfileSnapshot` for incremental migration. Pipeline entry
+points create the `ProfileSnapshot` once and pass it through.
+
+**Important:** The files modified here (`scorer.py`, `tailor.py`,
+`cover_letter.py`, `launcher.py`) will be restructured again in their
+respective context phases (5, 6, 8). This step only changes how they receive
+profile data — it does not refactor their internal wiring. This is intentional:
+decoupling the profile dependency first enables each context phase to proceed
+independently.
+
+**Backward compatibility:** Dict path continues to work. `profile.json` format
+unchanged.
+
+**Tenancy implications:** `ProfileSnapshot` carries `tenant_id` (ignored by consumers).
+
+**Tests added:**
+- Unit: update tailor, cover, scorer tests with `ProfileSnapshot` input.
+- Integration: profile import → `ProfileSnapshot` → tailor flow.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+```
+
+**Risk:** Medium-high. Touches many modules. Mitigation: dual-path accessors,
+full test suite.
+
+**Dependencies:** S-14 (Profile aggregate), S-15 (ProfileRepository).
+
+**Out of scope:** Removing dual-path accessors (future decommissioning).
+
+---
+
+### Phase 5: Scoring Context — Extraction & Ports
+
+---
+
+#### S-17: feat: define `JobScore` aggregate and scoring value objects
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 5 — Scoring |
+| **Bounded context** | Scoring |
+| **Target sections** | §4.4 (JobScore aggregate, invariants, value objects). |
+| **Pain points** | Briefing #12 (cross-context coupling). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/scoring/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/scoring/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/domain/scoring/aggregate.py` — **new** `JobScore` aggregate.
+- `workers/automation/src/jobhunter/domain/scoring/value_objects.py` — **new** `FitScore`, `ScoreBreakdown`, `MatchedKeywords`, `ScoreCorrection`, `ScoringCriteria`.
+- `workers/automation/src/jobhunter/domain/scoring/services.py` — **new** `ScoreParser`, `EligibilityChecker`.
+
+**Approach:**
+Define `FitScore` as constrained value object (int, [1,10]). `ScoreBreakdown`
+replaces raw reasoning strings with `technicalFit`, `experienceFit`,
+`reasoning` fields. Extract `_parse_score_response()` from `scorer.py` into
+`ScoreParser` domain service. Define `EligibilityChecker` per §4.4.
+
+**Backward compatibility:** Pure addition. `scorer.py` unchanged.
+
+**Tenancy implications:** `JobScore` identity includes `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_scoring_domain.py` — `FitScore` range, `ScoreParser`
+  output, `EligibilityChecker` threshold, aggregate invariants.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_scoring_domain.py -q
+```
+
+**Risk:** Low. Pure types.
+
+**Dependencies:** S-02 (domain types).
+
+**Out of scope:** Repository (S-18). LLM port (S-19). Scorer refactor (S-20).
+
+---
+
+#### S-18: feat: add `job_scores` table, `ScoreRepository` port, and SQLite adapter with backfill
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 5 — Scoring |
+| **Bounded context** | Scoring |
+| **Target sections** | §5.4 (`ScoreRepository`), §7.1 (`job_scores` table), §7.2, §7.3. |
+| **Pain points** | Briefing #2 (persistence = domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/scoring/ports.py` — **new** `ScoreRepository` protocol.
+- `workers/automation/src/jobhunter/infrastructure/scoring/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/scoring/sqlite_score.py` — **new** adapter.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add `job_scores` table + backfill migration.
+
+**Approach:**
+Add `job_scores` table per §7.2. Idempotent backfill from legacy columns:
+`INSERT OR IGNORE INTO job_scores SELECT url, 1, fit_score, ... FROM jobs WHERE fit_score IS NOT NULL`. Legacy columns remain readable during transition.
+
+**Backward compatibility:** Legacy scoring columns untouched. `read-model.ts`
+still reads from `jobs`.
+
+**Tenancy implications:** No `tenant_id` column yet. Port accepts `TenantId`
+but adapter ignores it.
+
+**Tests added:**
+- Unit: `tests/test_score_repository.py` — save, get, version incrementing,
+  backfill from legacy.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_score_repository.py -q
+```
+
+**Risk:** Medium. Backfill must handle NULL rows.
+
+**Dependencies:** S-17 (JobScore aggregate).
+
+**Out of scope:** Updating `scorer.py` (S-20). TS read-model changes (Phase 9).
+
+---
+
+#### S-19: feat: define `LlmPort` protocol for scoring context
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 5 — Scoring |
+| **Bounded context** | Scoring |
+| **Target sections** | §5.4 (`LlmPort`), §2 (ports own protocol semantics). |
+| **Pain points** | Briefing #5 (implicit ports — LLM imported directly). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/ports/llm.py` — **new** `LlmPort` protocol.
+- `workers/automation/src/jobhunter/infrastructure/llm/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/llm/current_adapter.py` — **new** thin wrapper over `jobhunter.llm.get_client()`.
+
+**Approach:**
+Define `LlmPort` as Protocol: `complete(prompt, system, schema) -> str`.
+Shared across scoring, materials, and enrichment contexts. `CurrentLlmAdapter`
+wraps existing unified LLM client.
+
+**Backward compatibility:** Pure addition. `llm.py` unchanged.
+
+**Tenancy implications:** None locally. Cloud: LLM gateway accepts `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_llm_port.py` — adapter satisfies protocol, mock test.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_llm_port.py -q
+```
+
+**Risk:** Low. Thin wrapper.
+
+**Dependencies:** S-02 (domain types).
+
+**Out of scope:** Per-context LLM config. Cloud LLM gateway.
+
+---
+
+#### S-20: refactor: update `scorer.py` to use scoring domain types, `ScoreRepository`, and `LlmPort`
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 5 — Scoring |
+| **Bounded context** | Scoring |
+| **Target sections** | §3.4, §4.4, §5.4. |
+| **Pain points** | Briefing #5 (implicit ports), #12 (cross-context coupling). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor**.
+
+**Approach:**
+Refactor to use `ProfileSnapshot` (from S-16), `LlmPort` (S-19),
+`ScoreParser` (S-17), `ScoreRepository` (S-18), and publish `JobScored` events
+via `EventPublisher` (S-09). Dual-write to both `job_scores` and legacy
+`jobs.fit_score` / `jobs.score_reasoning` / `jobs.scored_at` columns.
+Dependency injection via optional parameters with local defaults. Per §8.2,
+scoring is idempotent: rescoring the same job creates a new version.
+
+**Backward compatibility:** Dual-write. `pipeline.py` callers work unchanged.
+
+**Tenancy implications:** Uses `LOCAL_TENANT`.
+
+**Tests added:**
+- Unit: update scorer tests to verify `job_scores` populated.
+- Integration: mock LLM, verify score → domain → repository flow.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Medium. Mitigation: dual-write, dependency injection with defaults.
+
+**Dependencies:** S-16 (ProfileSnapshot), S-17, S-18, S-19.
+
+**Out of scope:** Removing legacy writes (decommissioning). Score corrections.
+
+---
+
+### Phase 6: Materials Generation Context — Aggregate & Ports
+
+---
+
+#### S-21: feat: define `MaterialsSet` aggregate and materials value objects
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §4.5 (MaterialsSet aggregate, invariants, lifecycle). |
+| **Pain points** | Briefing #4 (tailor.py mixed concerns). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/materials/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/materials/__init__.py` — **new**.
+- `workers/automation/src/jobhunter/domain/materials/aggregate.py` — **new** `MaterialsSet`.
+- `workers/automation/src/jobhunter/domain/materials/value_objects.py` — **new** `TailoredResume`, `CoverLetter`, `ValidationResult`, `JudgeVerdict`, `ArtifactType`, `ArtifactStatus`, `RenderFormat`.
+- `workers/automation/src/jobhunter/domain/materials/entities.py` — **new** `Artifact` child entity.
+
+**Approach:**
+Define `MaterialsSet` with identity `(TenantId, JobId, generation)` per §4.5.
+Lifecycle: `ResumeInProgress → ResumeApproved → CoverLetterReady → Complete`.
+Invariants from §4.5 enforced: resume before cover, docs before PDF, no banned
+words, no fabrication. Generation lifecycle per §4.5: new `MaterialsSet` for
+re-tailoring, previous artifacts marked `superseded`.
+
+**Backward compatibility:** Pure addition.
+
+**Tenancy implications:** Aggregate identity includes `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_materials_domain.py` — lifecycle, invariants, artifact status.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_materials_domain.py -q
+```
+
+**Risk:** Low. Pure types.
+
+**Dependencies:** S-02 (domain types).
+
+**Out of scope:** Repository (S-22). Ports (S-23, S-24). Tailor refactor (S-25).
+
+---
+
+#### S-22: feat: add `job_materials` table, `MaterialsRepository` port, and SQLite adapter with backfill
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §5.5, §7.1, §7.3. |
+| **Pain points** | Briefing #2 (persistence = domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/materials/ports.py` — **new** `MaterialsRepository`, `ArtifactStoragePort`, `PdfRendererPort` protocols.
+- `workers/automation/src/jobhunter/infrastructure/materials/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/materials/sqlite_materials.py` — **new** adapter.
+- `workers/automation/src/jobhunter/infrastructure/materials/local_storage.py` — **new** `LocalFilesystemAdapter`.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add `job_materials` table + `generation` column on `job_artifacts` + backfill.
+
+**Approach:**
+Add `job_materials` and backfill from legacy columns. Add `generation` column
+to `job_artifacts` (ALTER TABLE, default 1). Define repository, artifact
+storage, and PDF renderer port protocols. `LocalFilesystemAdapter` wraps
+current writes to `~/.jobhunter/tailored_resumes/` etc.
+
+**Backward compatibility:** Legacy columns untouched. Existing `job_artifacts`
+rows gain `generation = 1`.
+
+**Tenancy implications:** No `tenant_id` column locally.
+
+**Tests added:**
+- Unit: `tests/test_materials_repository.py` — save, get, generation, backfill.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_materials_repository.py -q
+uv --project workers/automation run --extra dev pytest -q
+```
+
+**Risk:** Medium. Backfill NULLs, ALTER TABLE idempotency.
+
+**Dependencies:** S-21 (MaterialsSet aggregate).
+
+**Out of scope:** Tailor/cover/pdf refactoring (S-25, S-26).
+
+---
+
+#### S-23: feat: extract `ContentValidator` and `ResumeAssembler` as pure domain services
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §4.5 (`ContentValidator`, `ResumeAssembler`). |
+| **Pain points** | Briefing #4 (tailor.py mixes validation with I/O). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/materials/services.py` — **new** `ContentValidator`, `ResumeAssembler`.
+- `workers/automation/src/jobhunter/scoring/validator.py` — unchanged (source of extraction).
+
+**Approach:**
+Extract pure validation functions from `scoring/validator.py` into
+`ContentValidator` domain service (zero I/O). Extract resume assembly logic
+from `tailor.py` into `ResumeAssembler`. `scoring/validator.py` preserved as
+compatibility shim delegating to `ContentValidator`.
+
+**Backward compatibility:** `scoring/validator.py` preserved as delegation layer.
+
+**Tenancy implications:** None.
+
+**Tests added:**
+- Unit: `tests/test_content_validator.py` — banned words, fabrication, structure.
+- Unit: `tests/test_resume_assembler.py` — header/education injection.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+```
+
+**Risk:** Low-medium. Pure extraction.
+
+**Dependencies:** S-21 (value objects for ValidationResult).
+
+**Out of scope:** Removing `scoring/validator.py` shim.
+
+---
+
+#### S-24: feat: extract `LatexPdfAdapter` and `PlaywrightHtmlPdfAdapter` behind `PdfRendererPort`
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §5.5 (`PdfRendererPort`, adapters). |
+| **Pain points** | Briefing #5 (subprocess in business logic). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/infrastructure/materials/latex_pdf.py` — **new** `LatexPdfAdapter`.
+- `workers/automation/src/jobhunter/infrastructure/materials/playwright_html_pdf.py` — **new** `PlaywrightHtmlPdfAdapter`.
+- `workers/automation/src/jobhunter/scoring/pdf.py` — unchanged (source).
+
+**Approach:**
+Extract `pdflatex` subprocess logic into `LatexPdfAdapter` and Playwright
+HTML-to-PDF into `PlaywrightHtmlPdfAdapter`. `scoring/pdf.py` remains as
+compatibility module. `PdfRendererPort` absorbs future rendering spike.
+
+**Backward compatibility:** `scoring/pdf.py` preserved.
+
+**Tenancy implications:** None.
+
+**Tests added:**
+- Unit: `tests/test_pdf_adapters.py` — interface compliance, error handling.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_pdf_adapters.py -q
+```
+
+**Risk:** Medium. Subprocess and temp file management.
+
+**Dependencies:** S-22 (PdfRendererPort protocol).
+
+**Out of scope:** Rendering spike. Tectonic/Typst adapters.
+
+---
+
+#### S-25: refactor: update `tailor.py` to use materials domain types, repository, and ports
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §3.5, §4.5, §5.5. |
+| **Pain points** | Briefing #4 (tailor.py 820 LOC — main extraction). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor**.
+
+**Approach:**
+Restructure to use `MaterialsSet` aggregate, `MaterialsRepository`, `LlmPort`,
+`PdfRendererPort`, `ArtifactStoragePort`, `ProfileSnapshot`, `ContentValidator`,
+`ResumeAssembler`. Dual-write to both `job_materials` and legacy `jobs`
+columns. Per §8.1, each tailor invocation modifies only its `MaterialsSet`
+aggregate; the pipeline state update happens via a `ResumeApproved` event
+handler in its own transaction. Per §8.2, re-tailoring creates a new
+generation (idempotent for the same generation).
+
+**Backward compatibility:** Dual-write. `pipeline.py` callers unchanged.
+
+**Tenancy implications:** Uses `LOCAL_TENANT`.
+
+**Tests added:**
+- Integration: mock LLM, verify tailor → validate → store → repository.
+- Regression: `test_cover_requirements.py`, `test_pdf_targets.py` must pass.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** High. Most complex module. Mitigation: dual-write, DI with defaults,
+full regression suite.
+
+**Dependencies:** S-16, S-21–S-24.
+
+**Out of scope:** Removing legacy writes. Changing prompt logic.
+
+---
+
+#### S-26: refactor: update `cover_letter.py` and `pdf.py` to use materials domain types and ports
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 6 — Materials Generation |
+| **Bounded context** | Materials Generation |
+| **Target sections** | §3.5, §4.5, §5.5. |
+| **Pain points** | Briefing #12 (tailor imports pdf — decoupled here). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor**.
+- `workers/automation/src/jobhunter/scoring/pdf.py` — **refactor** to delegate to adapters.
+
+**Approach:**
+Same pattern as S-25: `cover_letter.py` receives `ProfileSnapshot`, uses
+`LlmPort`, validates with `ContentValidator`, stores via `ArtifactStoragePort`,
+updates `MaterialsSet`, publishes events. `pdf.py` becomes thin orchestrator
+calling `PdfRendererPort`. Direct import of `pdf.py` from `tailor.py` is
+eliminated — called by orchestrator, not by tailor. Dual-write.
+
+**Backward compatibility:** Dual-write. `scoring/pdf.py` importable.
+
+**Tenancy implications:** Uses `LOCAL_TENANT`.
+
+**Tests added:**
+- Regression: `test_cover_requirements.py`, `test_pdf_targets.py`.
+- Integration: mock LLM, verify cover → validate → store flow.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** Medium. Cover and PDF are simpler than tailor.
+
+**Dependencies:** S-25 (tailor refactored first).
+
+**Out of scope:** Removing legacy writes. Rendering spike.
+
+---
+
+### Phase 7: Discovery & Enrichment Contexts
+
+---
+
+#### S-27: feat: define `Job` aggregate and discovery value objects
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 7 — Discovery & Enrichment |
+| **Bounded context** | Job Discovery |
+| **Target sections** | §3.1, §4.1. |
+| **Pain points** | Briefing #1 (no domain model). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/discovery/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/discovery/aggregate.py` — **new** `Job` aggregate.
+- `workers/automation/src/jobhunter/domain/discovery/value_objects.py` — **new** `PostingUrl`, `Source`, `Employer`, `SearchStrategy`, `JobMetadata`.
+- `workers/automation/src/jobhunter/domain/discovery/ports.py` — **new** `JobRepository`, `JobBoardScraperPort` protocols.
+
+**Approach:**
+Define `Job` aggregate per §4.1: identity `(TenantId, JobId)`. `Employer`
+separated from `Source` (maps `jobs.company` to `Employer.name`, `jobs.site`
+to `Source.board`). URL remains temporary `JobId` (stable `jobKey` deferred).
+`JobBoardScraperPort` defined for future adapter extraction.
+
+**Backward compatibility:** Pure addition. `jobs` table unchanged.
+
+**Tenancy implications:** Aggregate includes `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_discovery_domain.py` — aggregate creation, invariants,
+  Employer ≠ Source.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_discovery_domain.py -q
+```
+
+**Risk:** Low. Pure types.
+
+**Dependencies:** S-02.
+
+**Out of scope:** `JobId` migration. Discovery module refactoring. The
+`SqliteJobRepository` adapter is deferred — the existing `jobs` table and
+`database.py` queries serve as the implicit adapter until Discovery is fully
+extracted. See §8 Out-of-Scope.
+
+---
+
+#### S-28: feat: define `JobEnrichment` aggregate, `job_enrichments` table, and adapter with backfill
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 7 — Discovery & Enrichment |
+| **Bounded context** | Job Enrichment |
+| **Target sections** | §3.2, §4.2, §5.2, §7.1, §7.3. |
+| **Pain points** | Briefing #12 (enrichment imports discovery). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/enrichment/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/enrichment/aggregate.py` — **new** `JobEnrichment`.
+- `workers/automation/src/jobhunter/domain/enrichment/value_objects.py` — **new** VOs.
+- `workers/automation/src/jobhunter/domain/enrichment/ports.py` — **new** `EnrichmentRepository`, `DetailPageFetcherPort`.
+- `workers/automation/src/jobhunter/infrastructure/enrichment/sqlite_enrichment.py` — **new** adapter.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add `job_enrichments` table + backfill.
+
+**Approach:**
+Add `job_enrichments` table and backfill from legacy columns.
+`JobEnrichment` aggregate per §4.2 with `EnrichmentAttempt` child entities.
+`DetailPageFetcherPort` abstracts the three-tier extraction cascade.
+
+**Backward compatibility:** Legacy enrichment columns untouched.
+
+**Tenancy implications:** Aggregate includes `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_enrichment_domain.py`, `tests/test_enrichment_repository.py`.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_enrichment_domain.py tests/test_enrichment_repository.py -q
+```
+
+**Risk:** Medium. Backfill NULL handling.
+
+**Dependencies:** S-02.
+
+**Out of scope:** Refactoring `detail.py` (S-29). Decoupling discovery imports.
+
+---
+
+#### S-29: refactor: decouple `enrichment/detail.py` from `discovery/` imports and wire ports
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 7 — Discovery & Enrichment |
+| **Bounded context** | Job Enrichment |
+| **Target sections** | §3.2 (boundary — eliminate cross-context coupling). |
+| **Pain points** | Briefing #12 (detail.py imports discovery/smartextract and discovery/jobspy). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/enrichment/detail.py` — **refactor** remove discovery imports.
+- `workers/automation/src/jobhunter/infrastructure/enrichment/playwright_fetcher.py` — **new** `PlaywrightDetailPageFetcher`.
+
+**Approach:**
+Extract shared functionality into `DetailPageFetcherPort` adapter. Proxy
+parsing moves to adapter internals. After this step, `detail.py` imports only
+from `jobhunter.domain/` and `jobhunter.infrastructure/enrichment/`. Writes
+to `job_enrichments` via repository, publishes events. Dual-write to legacy.
+
+**Backward compatibility:** Dual-write. `pipeline.py` callers unchanged.
+
+**Tenancy implications:** Uses `LOCAL_TENANT`.
+
+**Tests added:**
+- Unit: verify no imports from `jobhunter.discovery.*`.
+- Regression: enrichment state tests pass.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+python -c "import ast; tree = ast.parse(open('workers/automation/src/jobhunter/enrichment/detail.py').read()); imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]; assert not any('discovery' in (getattr(n, 'module', '') or '') for n in imports), 'Cross-context import found'"
+```
+
+**Risk:** Medium. `detail.py` is 950 LOC.
+
+**Dependencies:** S-28 (enrichment domain types and repository).
+
+**Out of scope:** Refactoring discovery modules. Extraction algorithm changes.
+
+---
+
+### Phase 8: Apply Automation Context — Saga & Ports
+
+---
+
+#### S-30: feat: define `ApplyRun` aggregate and apply domain types
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 8 — Apply Automation |
+| **Bounded context** | Apply Automation |
+| **Target sections** | §3.6, §4.6 (ApplyRun aggregate, SubmissionResult). |
+| **Pain points** | Briefing #4 (launcher.py 1300 LOC), #10 (telemetry split). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/apply/` — **new** directory.
+- `workers/automation/src/jobhunter/domain/apply/aggregate.py` — **new** `ApplyRun`.
+- `workers/automation/src/jobhunter/domain/apply/value_objects.py` — **new** `SubmissionResult` (discriminated union), `BrowserWorkerConfig`, `ApplyPrompt`, `TokenUsage`.
+- `workers/automation/src/jobhunter/domain/apply/services.py` — **new** `ApplyEligibilityChecker`.
+- `workers/automation/src/jobhunter/domain/apply/ports.py` — **new** `BrowserPort`, `AutonomousAgentPort`, `ApplyRunRepository`.
+
+**Approach:**
+Define `ApplyRun` aggregate per §4.6 with `SubmissionResult` discriminated
+union. Enforce invariants: valid `JobId`, materials present, one `in_progress`
+per job, dry run never marks applied. Per §8.2, apply runs use `run_id` as
+idempotency key with upsert semantics.
+
+**Backward compatibility:** Pure addition.
+
+**Tenancy implications:** Aggregate includes `TenantId`.
+
+**Tests added:**
+- Unit: `tests/test_apply_domain.py` — lifecycle, SubmissionResult, eligibility,
+  dry-run invariant.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_apply_domain.py -q
+```
+
+**Risk:** Low. Pure types.
+
+**Dependencies:** S-02.
+
+**Out of scope:** Launcher refactoring (S-32). Process manager (S-33).
+
+---
+
+#### S-31: feat: extract `LocalChromeAdapter` and `ClaudeCodeCliAdapter` behind ports
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 8 — Apply Automation |
+| **Bounded context** | Apply Automation |
+| **Target sections** | §5.6 (`BrowserPort`, `AutonomousAgentPort`, seam justification). |
+| **Pain points** | Briefing #5 (Chrome and Claude Code subprocess in business logic). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/infrastructure/apply/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/apply/local_chrome.py` — **new** `LocalChromeAdapter`.
+- `workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py` — **new** `ClaudeCodeCliAdapter`.
+- `workers/automation/src/jobhunter/infrastructure/apply/sqlite_apply_run.py` — **new** `SqliteApplyRunRepository`.
+
+**Approach:**
+Extract Chrome lifecycle from `apply/chrome.py` into `LocalChromeAdapter`.
+Extract Claude Code subprocess logic into `ClaudeCodeCliAdapter`.
+`SqliteApplyRunRepository` wraps existing `apply_runs` + `apply_run_events`
+tables (already well-structured per §7.4). Existing modules preserved as
+compatibility imports.
+
+**Backward compatibility:** `apply/chrome.py` preserved as compatibility shim.
+
+**Tenancy implications:** None locally.
+
+**Tests added:**
+- Unit: `tests/test_apply_adapters.py` — interface compliance, repository
+  round-trip.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_apply_adapters.py -q
+```
+
+**Risk:** Medium. Chrome and subprocess management are complex.
+
+**Dependencies:** S-30 (apply domain types).
+
+**Out of scope:** Launcher refactoring (S-32). Cloud adapters.
+
+---
+
+#### S-32: refactor: update `launcher.py` to use apply domain types, repository, and ports
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 8 — Apply Automation |
+| **Bounded context** | Apply Automation |
+| **Target sections** | §3.6, §4.6, §5.6, §6.7 (apply result reporting). |
+| **Pain points** | Briefing #4 (launcher.py 1300 LOC), #10 (telemetry split), #12 (coupling). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/apply/launcher.py` — **refactor**.
+
+**Approach:**
+Refactor to use `ApplyRun` aggregate, `BrowserPort`, `AutonomousAgentPort`,
+`ApplyRunRepository`, `ProfileSnapshot`, `EventPublisher`. Rich dashboard
+continues working (presentation adapter). Telemetry writes go through
+`ApplyRunRepository`. Per §8.1, launcher modifies only the `ApplyRun` aggregate;
+pipeline state updated via `ApplicationSubmitted` event handler. Dual-write
+legacy columns. DI with defaults.
+
+**Backward compatibility:** Public API (`run_apply`, `run_job`) unchanged.
+Dual-write.
+
+**Tenancy implications:** Uses `LOCAL_TENANT`.
+
+**Tests added:**
+- Regression: `test_apply_regressions.py`.
+- Unit: mock ports, verify apply flow with domain types.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest -q
+pnpm test
+```
+
+**Risk:** High. Most complex module. Mitigation: DI with defaults, dual-write,
+full regression.
+
+**Dependencies:** S-16, S-30, S-31.
+
+**Out of scope:** Removing legacy writes. Process manager (S-33). Dashboard refactoring.
+
+---
+
+#### S-33: feat: formalize apply process manager with compensation actions
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 8 — Apply Automation |
+| **Bounded context** | Apply Automation |
+| **Target sections** | §8.3 (apply saga / process manager). |
+| **Pain points** | Briefing #4 (apply business rules tangled with infrastructure). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/domain/apply/process_manager.py` — **new** `ApplyProcessManager`.
+
+**Approach:**
+Formalize the apply flow from §8.3 as `ApplyProcessManager`: AcquireJob →
+LaunchBrowser → StartAgent → Monitoring → ParseResult → Cleanup → Report.
+Compensation actions: Chrome failure → cleanup + report; timeout → kill + cleanup;
+crash recovery → detect orphaned `in_progress` runs → transition to `failed`
+with `ORPHANED` error. Pure addition — `launcher.py` can optionally delegate.
+
+**Backward compatibility:** Pure addition.
+
+**Tenancy implications:** None.
+
+**Tests added:**
+- Unit: `tests/test_apply_process_manager.py` — happy path, browser failure,
+  timeout, orphaned run detection.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_apply_process_manager.py -q
+```
+
+**Risk:** Low. Pure addition.
+
+**Dependencies:** S-30, S-31.
+
+**Out of scope:** Full `launcher.py` rewrite. Temporal workflow.
+
+---
+
+### Phase 9: Operations Read-Side & Projections
+
+---
+
+#### S-34: feat: define read-model projections and `ProjectionBuilder`
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 9 — Operations & Projections |
+| **Bounded context** | Operations / Read-Side |
+| **Target sections** | §3.8, §4.8, §6.6. |
+| **Pain points** | Briefing #11 (state derivation duplicated in TS). |
+
+**Files touched:**
+
+- `workers/automation/src/jobhunter/infrastructure/operations/` — **new** directory.
+- `workers/automation/src/jobhunter/infrastructure/operations/projection_builder.py` — **new** `ProjectionBuilder`.
+- `workers/automation/src/jobhunter/infrastructure/operations/projections.py` — **new** projection definitions.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add projection tables.
+
+**Approach:**
+Add `job_list_view` and `dashboard_stats` projection tables.
+`ProjectionBuilder` subscribes to domain events from `InProcessEventBus` and
+updates projections. One-time backfill populates from existing data. On
+startup, replays from watermark (S-11). Per §8.2, projection updates are
+idempotent (check `eventId` watermark).
+
+**Backward compatibility:** New tables. `read-model.ts` unchanged in this step.
+
+**Tenancy implications:** Not tenant-scoped locally.
+
+**Tests added:**
+- Unit: `tests/test_projection_builder.py` — event → projection for each type.
+
+**Verification commands:**
+
+```bash
+uv --project workers/automation run --extra dev pytest tests/test_projection_builder.py -q
+```
+
+**Risk:** Medium. Projection correctness depends on all events handled.
+
+**Dependencies:** S-09, S-10, S-11, all event publishers from Phases 5–8.
+
+**Out of scope:** TS read-model changes (S-35). Event streaming to frontend.
+
+---
+
+#### S-35: refactor: update TS `read-model.ts` to query projections and use shared domain types
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 9 — Operations & Projections |
+| **Bounded context** | Operations / Read-Side |
+| **Target sections** | §3.8, §5.8, §6.6. |
+| **Pain points** | Briefing #6 (two writers one DB), #11 (duplicated state derivation). |
+
+**Files touched:**
+
+- `apps/api/src/read-model.ts` — **refactor** to query projection tables.
+- `apps/api/src/contracts.ts` — **refactor** import shared types.
+
+**Approach:**
+Rewrite `read-model.ts` queries to use `job_list_view` and `dashboard_stats`
+projections. Replace legacy state derivation with simple SELECTs. Import
+`Stage`, `StageState` from `@jobhunter/domain-types`. Fallback to legacy
+query path if projections are empty (transition safety net).
+
+**Backward compatibility:** API response shapes unchanged. Fallback to legacy.
+
+**Tenancy implications:** Types include `TenantId` for future use.
+
+**Tests added:**
+- Integration: existing read-model tests pass with projection-backed queries.
+- Unit: fallback to legacy when projections empty.
+
+**Verification commands:**
+
+```bash
+pnpm test
+pnpm api:test
+```
+
+**Risk:** High. Core read path. Mitigation: fallback + full test suite.
+
+**Dependencies:** S-34 (projections), S-01 (shared types).
+
+**Out of scope:** Removing legacy fallback. Event streaming.
+
+---
+
+#### S-36: refactor: replace `local-actions.ts` subprocess spawning with JSON-RPC adapter
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 9 — Operations & Projections |
+| **Bounded context** | Cross-cutting (TS API ↔ Python Worker) |
+| **Target sections** | §6.5 (SubprocessJsonRpcAdapter). |
+| **Pain points** | Briefing #7 (no typed contract), #9 (stringly-typed actions). |
+
+**Files touched:**
+
+- `apps/api/src/local-actions.ts` — **refactor** to use `SubprocessJsonRpcAdapter`.
+- `apps/api/src/json-rpc-adapter.ts` — **new** `SubprocessJsonRpcAdapter`.
+
+**Approach:**
+Create `SubprocessJsonRpcAdapter` that spawns `uv run jobhunter rpc` (S-12),
+writes JSON-RPC request to stdin, reads response from stdout. Replace
+`defaultActionDispatcher`. For fire-and-forget (apply, retry-stage), spawn
+detached and return `runId`. For synchronous (profile_import), wait for
+response. `buildActionResponse` compatibility shim wraps JSON-RPC response.
+Fallback to old dispatcher if JSON-RPC fails (transition safety).
+
+**Backward compatibility:** Same API endpoints, same response shapes.
+
+**Tenancy implications:** JSON-RPC requests include `tenantId: "local"`.
+
+**Tests added:**
+- Integration: action endpoints work with JSON-RPC.
+- Unit: `apps/api/test/json-rpc-adapter.test.ts` — request/response handling.
+
+**Verification commands:**
+
+```bash
+pnpm test
+pnpm api:test
+```
+
+**Risk:** Medium-high. Mitigation: fallback to old dispatcher.
+
+**Dependencies:** S-12 (JSON-RPC server).
+
+**Out of scope:** HTTP JSON-RPC transport. Temporal transport.
+
+---
+
+#### S-37: docs: update architecture, domain-model, and decisions for DDD migration
+
+| Attribute | Detail |
+|---|---|
+| **Phase** | 9 — Operations & Projections |
+| **Bounded context** | Documentation |
+| **Target sections** | All — documentation sweep. |
+| **Pain points** | None — documentation hygiene. |
+
+**Files touched:**
+
+- `docs/architecture.md` — **refactor** reflect hexagonal architecture.
+- `docs/domain-model.md` — **refactor** reference `docs/ddd-target.md`.
+- `docs/decisions.md` — **refactor** add DDD migration ADRs.
+- `docs/local-reliability-qa.md` — **refactor** update QA matrix.
+- `docs/backlog.md` — **refactor** mark completed, add discovered items.
+- `docs/delivered.md` — **refactor** add migration PR entries.
+
+**Approach:**
+Comprehensive documentation update per AGENTS.md requirements. New ADR
+entries: DDD + Hexagonal adopted, TenantId introduced, domain events as
+integration backbone, JSON-RPC protocol, projection-based read model.
+
+**Backward compatibility:** N/A — documentation only.
+
+**Tests added:** None.
+
+**Verification commands:**
+
+```bash
+git diff --check
+```
+
+**Risk:** Low. Documentation only.
+
+**Dependencies:** All previous steps.
+
+**Out of scope:** This plan is not moved to `docs/plans/implemented/` until
+all steps are delivered.
+
+---
+
+## 6. Cross-Cutting Workstreams
+
+### 6.1 TenantId Rollout
+
+| Step | What it does |
+|---|---|
+| S-01 | Introduces `TenantId` type in TS with `LOCAL_TENANT`. |
+| S-02 | Introduces `TenantId` type in Python with `LOCAL_TENANT`. |
+| S-03 | All domain events carry `tenantId`. |
+| S-05 | `PipelineStateRepository` port accepts `TenantId`. |
+| S-12 | JSON-RPC methods accept `tenantId` in params. |
+| S-13 | TS write-model passes `TenantId` to state machine. |
+| S-15 | `ProfileRepository` port accepts `TenantId`. |
+| S-18 | `ScoreRepository` port accepts `TenantId`. |
+| S-22 | `MaterialsRepository` port accepts `TenantId`. |
+| S-28 | `EnrichmentRepository` port accepts `TenantId`. |
+| S-31 | `ApplyRunRepository` port accepts `TenantId`. |
+
+### 6.2 Domain Event Bus Introduction
+
+| Step | What it does |
+|---|---|
+| S-09 | Defines `EventPublisher` port and `InProcessEventBus`. |
+| S-10 | Wires `record_job_event` through the bus. Standardizes event types (strangler dual-write). |
+| S-11 | Adds event watermark tracking for projection reconciliation. |
+| S-20 | Scoring publishes `JobScored` events. |
+| S-25 | Materials publishes `ResumeApproved`, `ResumeFailed` events. |
+| S-26 | Materials publishes `CoverLetterGenerated`, `PdfRendered` events. |
+| S-29 | Enrichment publishes `JobEnriched`, `EnrichmentFailed` events. |
+| S-32 | Apply publishes `ApplicationSubmitted`, `ApplicationFailed` events. |
+| S-34 | `ProjectionBuilder` subscribes to all events. |
+
+### 6.3 Repository Extraction Per Aggregate
+
+| Aggregate | Port Step | Adapter Step | Table |
+|---|---|---|---|
+| `JobPipelineState` | S-05 | S-05 | `job_stage_states` (existing) |
+| `Profile` | S-15 | S-15 | `profile.json` (existing) |
+| `JobScore` | S-18 | S-18 | `job_scores` (new) |
+| `MaterialsSet` | S-22 | S-22 | `job_materials` (new) + `job_artifacts` (existing) |
+| `JobEnrichment` | S-28 | S-28 | `job_enrichments` (new) |
+| `ApplyRun` | S-31 | S-31 | `apply_runs` + `apply_run_events` (existing) |
+| `Job` (Discovery) | S-27 | Deferred | `jobs` (existing, narrowed) |
+
+### 6.4 Stage State Machine Consolidation
+
+| Step | What it does |
+|---|---|
+| S-04 | Defines `StageStateMachine` as pure function in Python and TS. |
+| S-06 | Wires `state.py` to use the state machine internally. |
+| S-08 | Adds `Queued` and `Canceled` states. |
+| S-13 | TS write-model uses TS state machine for transition validation. |
+
+### 6.5 TS↔Python Typed Application Protocol
+
+| Step | What it does |
+|---|---|
+| S-12 | Defines JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand. |
+| S-13 | TS API hosts simple commands directly (no Python roundtrip). |
+| S-36 | Replaces `local-actions.ts` with `SubprocessJsonRpcAdapter`. |
+
+### 6.6 Apply Saga / Process Manager
+
+| Step | What it does |
+|---|---|
+| S-30 | Defines `ApplyRun` aggregate with `SubmissionResult`. |
+| S-31 | Extracts `BrowserPort` and `AutonomousAgentPort`. |
+| S-32 | Wires `launcher.py` to use domain types and ports. |
+| S-33 | Formalizes apply process manager with compensation actions. |
+
+### 6.7 Documentation and ADR Updates
+
+| Step | What it does |
+|---|---|
+| S-37 | Comprehensive documentation update. New ADR entries. |
+
+Note: Per AGENTS.md, individual PRs for steps S-04 through S-36 should include
+narrow doc updates for the specific surfaces they change. S-37 is the final
+sweep that ensures consistency across all docs.
+
+---
+
+## 7. Strangler Decommissioning Plan
+
+### 7.1 Legacy State Materialization (`state.py`)
+
+| What | Current location | Replacement step | Soak period | Removal step |
+|---|---|---|---|---|
+| `derive_legacy_stage_states()` | `state.py` → `legacy_deriver.py` (S-07) | S-06, S-07 | Until removal criterion met (§4.7). | Future step. |
+| TS `read-model.ts` legacy derivation | `read-model.ts` | S-35 (projection-based read model) | Until projections stable for 1 week. | Future step. |
+
+### 7.2 Wide Nullable `jobs` Columns
+
+| Column group | Replacement step | Soak period | Removal step |
+|---|---|---|---|
+| `fit_score`, `score_reasoning`, `scored_at` | S-18, S-20 | Until all queries read `job_scores`. | Future step. |
+| `tailored_resume_path`, `tailored_at`, `tailor_attempts` | S-22, S-25 | Until all queries read `job_materials`. | Future step. |
+| `cover_letter_path`, `cover_letter_at`, `cover_attempts` | S-22, S-26 | Same as above. | Future step. |
+| `full_description`, `application_url`, `detail_scraped_at`, `detail_error` | S-28, S-29 | Until all queries read `job_enrichments`. | Future step. |
+| `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, etc. | S-32 | Until all queries read `apply_runs`. | Future step. |
+
+### 7.3 Dict-Passing of Profile Data
+
+| What | Replacement step | Soak period | Removal step |
+|---|---|---|---|
+| `resume_profile.py` dual-path accessors | S-16 | Until all consumers use `ProfileSnapshot`. | Future step. |
+| `config.load_profile()` raw dict | S-16 | Same. | Future step. |
+
+### 7.4 Procedural `pipeline.py`
+
+| What | Replacement step | Soak period | Removal step |
+|---|---|---|---|
+| Direct stage function calls | S-06 + Phase 5–8 ports | Until all stages dispatch through ports. | Future step. |
+
+### 7.5 Cross-Context Imports
+
+| Import | Replacement step | Removal step |
+|---|---|---|
+| `enrichment/detail.py` → `discovery/smartextract.extract_json` | S-29 | S-29. |
+| `enrichment/detail.py` → `discovery/jobspy.parse_proxy` | S-29 | S-29. |
+| `scoring/tailor.py` → `scoring/pdf.py` | S-25 | S-25. |
+
+### 7.6 `local-actions.ts` Ad-Hoc Subprocess Spawning
+
+| What | Replacement step | Soak period | Removal step |
+|---|---|---|---|
+| `defaultActionDispatcher` | S-36 | Until all action endpoints use JSON-RPC. | Future step. |
+
+### 7.7 Event Type Naming (snake_case → PascalCase)
+
+| What | Replacement step | Soak period | Removal step |
+|---|---|---|---|
+| `legacy_event_type` column in `job_events` | S-10 (strangler dual-write) | Until no code reads `legacy_event_type`. | Future step. Drop column. |
+
+---
+
+## 8. Out-of-Scope (Deferred)
+
+Each item below is explicitly deferred. The evolution trigger from §9.4 is
+cited where applicable.
+
+| Deferred item | Target section | Evolution trigger (§9.4) | Notes |
+|---|---|---|---|
+| `PostgresJobRepository` and all Postgres adapters | §5.1–5.8 | Concurrent users > 1 OR DB > 10 GB OR multi-process writes | Ports defined; only SQLite adapters implemented. |
+| `S3ArtifactAdapter` | §5.5 | Multi-node deployment OR artifact > 1 GB/tenant | `ArtifactStoragePort` defined in S-22. |
+| `SqsEventPublisher` + transactional outbox | §6.3 | Multi-process deployment (> 1 API or worker) | `EventPublisher` defined in S-09. |
+| `BrowserbaseAdapter` | §5.6 | Any cloud deployment (day-1 blocker) | `BrowserPort` defined in S-30. |
+| `ClaudeApiAgentAdapter` | §5.6 | Worker fleet > 1 machine | `AutonomousAgentPort` defined in S-30. |
+| `TemporalWorkflowAdapter` | §5.7 | Worker fleet > 1 machine OR pipeline > 30 min | `StageCommandDispatcher` port deferred; pipeline.py remains procedural. |
+| Auth0 / Cognito JWT | §9 | Any public-facing deployment | `TenantId` seam in place from Phase 1. |
+| Stripe billing / `EntitlementPort` | §9 | First paying customer | No-op adapter not yet created. |
+| Audit log / `AuditSink` | §9 | First compliance requirement (SOC2, GDPR) | No-op adapter not yet created. |
+| AWS Secrets Manager / `SecretPort` | §9 | Non-macOS deployment OR multi-tenant OR credential rotation | macOS Keychain / `.env` unchanged. |
+| TypeSpec IDL | §6.5 | `scripts/check-domain-type-parity` (S-03) fails frequently | Zod + frozen dataclasses + CI check for now. |
+| `JobId` migration (URL → UUID) | §4.1 | Product decision on deduplication strategy | Open question in §10. URL remains PK. |
+| Score correction feedback loop | §4.4 | Product decision on personalization | Open question in §10. |
+| Resume rendering spike | §5.5 | Blocked on spike results OR cloud (TeX Live 4 GB) | `PdfRendererPort` defined; `LatexPdfAdapter` stays. |
+| Event streaming to frontend (SSE/WS) | §3.8 | Product decision on UX approach | Open question in §10. |
+| `StageCommandDispatcher` port | §5.7 | Pipeline refactoring beyond scope | `pipeline.py` remains procedural. |
+| Materialized `job_list_view` replacing all `jobs` reads | §4.8, §6.6 | All contexts publishing events reliably | Projections in S-34; full replacement deferred. |
+| `pdflatex` → Tectonic/Typst | §5.5 | Rendering spike conclusion OR cloud deployment | `PdfRendererPort` absorbs any engine. |
+| `TenantId` from JWT (multi-tenant) | §9 | Multi-tenant deployment | Domain types carry TenantId; only source changes (constant → JWT). |
+| No-op `EntitlementPort` adapter | §9 (Billing) | Feature gate before first paying customer | All entitlements return `Allowed` locally. |
+
+---
+
+## 9. QA & Reliability Gates
+
+### Phase 1: Foundation
+
+- **QA addition:** None. Pure types. Existing tests pass unchanged.
+- **Integration point:** Verify at least one existing module imports from the new
+  domain types package without error.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 2: Pipeline Orchestration
+
+- **QA addition:** `test_stage_state_machine.py` — comprehensive transition
+  table coverage. Add to `docs/local-reliability-qa.md` matrix:
+  "State machine rejects invalid transitions" → `test_stage_state_machine.py`.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 3: Infrastructure Backbone
+
+- **QA addition:** `test_event_bus.py`, `test_watermark.py`,
+  `test_rpc_handler.py`, `apps/api/test/write-model.test.ts` (transition
+  validation). State machine parity test (TS vs Python).
+  Add to matrix: "Events persist through bus" → `test_event_bus.py`.
+  "JSON-RPC roundtrip" → `test_rpc_handler.py`.
+  "TS/Python state machine parity" → `test_state_machine_parity.ts`.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 4: Profile
+
+- **QA addition:** `test_profile_aggregate.py`, `test_profile_repository.py`.
+  Existing profile import tests must pass. Add:
+  "Profile snapshot preserves all fields" → `test_profile_repository.py`.
+- **Verification:** `pytest -q`.
+
+### Phase 5: Scoring
+
+- **QA addition:** `test_scoring_domain.py`, `test_score_repository.py`. Add:
+  "Scores written to job_scores and legacy columns" → `test_score_repository.py`.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 6: Materials
+
+- **QA addition:** `test_materials_domain.py`, `test_materials_repository.py`,
+  `test_content_validator.py`, `test_resume_assembler.py`,
+  `test_pdf_adapters.py`. Existing `test_cover_requirements.py` and
+  `test_pdf_targets.py` must pass. Add: "Materials written to job_materials
+  and legacy columns" → `test_materials_repository.py`.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 7: Discovery & Enrichment
+
+- **QA addition:** `test_discovery_domain.py`, `test_enrichment_domain.py`,
+  `test_enrichment_repository.py`. Add: "No cross-context imports" → S-29 import audit.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 8: Apply
+
+- **QA addition:** `test_apply_domain.py`, `test_apply_adapters.py`,
+  `test_apply_process_manager.py`. Existing `test_apply_regressions.py` must
+  pass. Add: "Apply compensation cleans up browser" →
+  `test_apply_process_manager.py`.
+- **Verification:** `pnpm test`, `pytest -q`.
+
+### Phase 9: Operations & Projections
+
+- **QA addition:** `test_projection_builder.py`, `apps/api/test/json-rpc-adapter.test.ts`.
+  All existing API tests must pass.
+  Add: "Projections match legacy read model" → comparison test.
+- **Full QA gate:** `pnpm test`, `pnpm qa:test`, `pytest -q`, `ruff check .`,
+  `git diff --check`, browser smoke (per `docs/local-reliability-qa.md`).
+
+---
+
+## 10. Documentation Plan
+
+| Step | Docs updated | What changes |
+|---|---|---|
+| S-01 | None | Pure addition. |
+| S-04 | None | Internal domain logic. |
+| S-06 | `docs/architecture.md` | Note state machine formalization. |
+| S-08 | `docs/domain-model.md` | Add `Queued` and `Canceled` to canonical states. |
+| S-09 | `docs/architecture.md` | Note event bus introduction. |
+| S-12 | `docs/architecture.md`, `docs/decisions.md` | JSON-RPC protocol ADR. |
+| S-13 | `docs/decisions.md` | TS-hosted commands ADR. |
+| S-16 | None | Internal refactor. |
+| S-18 | `docs/architecture.md` | Note `job_scores` table. |
+| S-20 | `docs/decisions.md` | New ADR: "Scoring context with repository port." |
+| S-22 | `docs/architecture.md` | Note `job_materials` table. |
+| S-28 | `docs/architecture.md` | Note `job_enrichments` table. |
+| S-35 | `docs/architecture.md` | Projection-based read model. |
+| S-37 | All docs | Comprehensive final sweep. |
+
+**New ADR entries** (in `docs/decisions.md`):
+
+1. "DDD + Hexagonal Architecture adopted" — date of S-37 merge.
+2. "TenantId introduced as domain type" — date of S-01 merge.
+3. "Domain events as integration backbone" — date of S-09 merge.
+4. "JSON-RPC 2.0 as TS↔Python protocol" — date of S-12 merge.
+5. "TS API hosts simple state-transition commands" — date of S-13 merge.
+6. "Projection-based read model" — date of S-35 merge.
+
+**Superseded decisions:**
+- "Stage State Is The Operational Source Of Truth" (2026-05-02) is **advanced,
+  not superseded** — state machine formalization (S-04–S-08) strengthens it.
+
+---
+
+## 11. Worktree & Branching Convention
+
+Per AGENTS.md:
+
+- **Every step = one worktree = one PR.** S-01 through S-37 each get a dedicated
+  worktree on their own branch.
+- Branch naming: `ddd/s-{step_number}-{short-description}` (e.g.,
+  `ddd/s-01-domain-types`, `ddd/s-04-state-machine`).
+- Worktree created from up-to-date `main`.
+- Never edit code on `main`.
+- Each step is one PR with a conventional-commits title.
+- Steps within the same phase are stacked PRs (each rebased on the previous
+  step's merge to `main`).
+- Steps in different phases that have no dependency can run in parallel.
+
+**Parallel execution opportunities:**
+
+- S-01 and S-02 (TS and Python types are independent).
+- S-14 and S-17 (Profile and Scoring aggregates depend only on S-02).
+- S-27, S-28, and S-30 (Discovery, Enrichment, and Apply aggregates are
+  independent, all depend only on S-02).
+
+The canonical execution order is the step numbering (S-01 → S-37).
+
+---
+
+## 12. Glossary Diff
+
+**Terms introduced by this plan:**
+
+| Term | Definition |
+|---|---|
+| `LOCAL_TENANT` | The constant `TenantId` value (`"local"`) used in local-first mode. |
+| `packages/domain-types` | New TS package for shared domain value objects, event schemas, and state machine types. |
+| `jobhunter.domain` | New Python package for domain types, aggregates, value objects, and ports. |
+| `jobhunter.infrastructure` | New Python package for adapter implementations (SQLite, filesystem, LLM, browser). |
+| `jobhunter.rpc` | New Python package for JSON-RPC request handling. |
+| `InProcessEventBus` | The local-first synchronous event bus adapter for `EventPublisher`. |
+| `WatermarkTracker` | Infrastructure component tracking per-projection event processing progress. |
+| `ProjectionBuilder` | Infrastructure component subscribing to events and updating read-model projections. |
+| `SubprocessJsonRpcAdapter` | TS adapter that spawns `jobhunter rpc` and communicates via JSON-RPC over stdin/stdout. |
+| `CurrentLlmAdapter` | Thin adapter wrapping `jobhunter.llm.get_client()` behind `LlmPort`. |
+| `dual-write` | Transition pattern: new code writes to both new table and legacy columns simultaneously. |
+| `compatibility shim` | Thin delegation layer preserving old import path while delegating to new code. |
+| `strangler dual-write` | Variant of dual-write for renaming: new format is canonical, old format preserved in a transition column. |
+
+**Renaming from current code:**
+
+| Current name | Target name | Step |
+|---|---|---|
+| `state.STATE_VALUES` tuple | `Stage` enum + `StageState` discriminated union | S-02, S-04 |
+| `state.STAGE_ORDER` tuple | `Stage` enum with canonical order | S-02 |
+| `config.load_profile()` → raw dict | `ProfileRepository.get_snapshot()` → `ProfileSnapshot` | S-15, S-16 |
+| `record_job_event()` with string event_type | `EventPublisher.publish()` with typed `DomainEvent` | S-09, S-10 |
+| `_parse_score_response()` in scorer.py | `ScoreParser` domain service | S-17 |
+| `defaultActionDispatcher` in local-actions.ts | `SubprocessJsonRpcAdapter` | S-36 |

--- a/docs/plans/proposed/ddd-target-plan.md
+++ b/docs/plans/proposed/ddd-target-plan.md
@@ -324,11 +324,11 @@ uv --project workers/automation run --extra dev ruff check workers/automation/sr
 **Files touched:**
 
 - `packages/domain-types/src/events/` — **new** subdirectory.
-- `packages/domain-types/src/events/discovery.ts` — **new** `JobDiscovered`, `JobUpdated`, `JobDeleted`.
+- `packages/domain-types/src/events/discovery.ts` — **new** `JobDiscovered`, `JobUpdated`, `JobDeleted`, `JobRestored`.
 - `packages/domain-types/src/events/enrichment.ts` — **new** `JobEnriched`, `EnrichmentFailed`.
 - `packages/domain-types/src/events/scoring.ts` — **new** `JobScored`, `ScoreCorrected`.
-- `packages/domain-types/src/events/materials.ts` — **new** `ResumeApproved`, `CoverLetterGenerated`, `PdfRendered`, `MaterialsExhausted`.
-- `packages/domain-types/src/events/apply.ts` — **new** `ApplicationSubmitted`, `ApplicationFailed`, `ApplyRunStarted`.
+- `packages/domain-types/src/events/materials.ts` — **new** `ResumeApproved`, `ResumeFailed`, `CoverLetterGenerated`, `PdfRendered`, `MaterialsExhausted`.
+- `packages/domain-types/src/events/apply.ts` — **new** `ApplicationSubmitted`, `ApplicationFailed`, `ApplyRunStarted`, `ApplyRunEventRecorded`.
 - `packages/domain-types/src/events/orchestration.ts` — **new** `StageStarted`, `StageCompleted`, `StageFailed`, `StageExhausted`, `StageReset`, `StageBlocked`, `StageSkipped`.
 - `packages/domain-types/src/events/profile.ts` — **new** `ProfileUpdated`, `ProfileImported`.
 - `packages/domain-types/src/events/index.ts` — **new** barrel.
@@ -1231,11 +1231,11 @@ every importer in the same PR.
 uv --project workers/automation run --extra dev pytest -q
 ```
 
-**Risk:** Low-medium. Pure extraction.
+**Risk:** Low-medium. Pure extraction. `scoring/validator.py` deletion in this PR is a hard cut-over — every importer is updated in the same PR, so no shim remains.
 
 **Dependencies:** S-19 (value objects for ValidationResult).
 
-**Out of scope:** Removing `scoring/validator.py` shim.
+**Out of scope:** None — this is a self-contained extraction.
 
 ---
 

--- a/docs/plans/proposed/ddd-target-plan.md
+++ b/docs/plans/proposed/ddd-target-plan.md
@@ -7,7 +7,11 @@
 This plan describes the **canonical migration path** from JobHunter's current
 architecture to the target-state DDD + Hexagonal Architecture defined in
 `docs/ddd-target.md`. It sequences every structural change into independently
-shippable PRs that never break the local product.
+shippable PRs that ship green end-to-end after each merge.
+
+JobHunter has a single user; migrations are clean rip-and-replace. Steps remove
+the legacy code in the same PR that introduces the replacement. No dual-writes,
+no soak periods, no compatibility shims.
 
 The plan covers:
 
@@ -17,8 +21,9 @@ The plan covers:
   Automation, and Operations / Read-Side.
 - Domain event infrastructure and the in-process event bus.
 - Repository ports and SQLite adapters for every aggregate.
-- New normalized tables (`job_scores`, `job_materials`, `job_enrichments`) with
-  backfill from legacy `jobs` columns.
+- New normalized tables (`job_scores`, `job_materials`, `job_enrichments`)
+  populated from the legacy `jobs` columns, with the legacy columns dropped in
+  the same step.
 - The JSON-RPC 2.0 integration protocol between the TS API and Python worker.
 - TS API hosting simple state-transition commands directly (§6.8).
 - TS API read-model projection replacement.
@@ -28,7 +33,7 @@ The plan covers:
 - **Cloud adapter implementations.** No Postgres, S3, SQS, Browserbase,
   Temporal, Auth0, Stripe, or Secrets Manager code is written. Only port
   interfaces are defined; cloud adapters are named and documented for future
-  implementation (see Section 8).
+  implementation (see Section 7).
 - **Multi-tenant enforcement.** `TenantId` lands as a domain type with a
   `"local"` singleton. Isolation policies, RLS, and auth middleware are
   deferred.
@@ -36,7 +41,7 @@ The plan covers:
   uses Zod schemas (TS) and frozen dataclasses (Python) for the local-first
   phase. A CI compatibility check validates structural parity between the two.
   TypeSpec adoption is triggered when the CI check fails frequently enough to
-  justify single-source generation (see Section 8).
+  justify single-source generation (see Section 7).
 - **Resume rendering spike.** The `PdfRendererPort` is introduced, but the
   adapter stays `LatexPdfAdapter` (current `pdflatex`). The spike comparing
   Tectonic/Typst/HTML-CSS is a separate backlog item.
@@ -48,28 +53,32 @@ The plan covers:
 
 ## 2. Plan Principles
 
-1. **Evolutionary architecture.** The target document is the contract; this
-   plan walks there one PR at a time (§2, Evolutionary Architecture).
-2. **Strangler pattern.** Replace old code path by path while the old path
-   keeps serving. Legacy columns, legacy materialization, and legacy imports
-   remain readable until their explicit removal step.
-3. **Ship-each-PR-green.** Every step is independently shippable. The system
+JobHunter has a single user; migrations are clean rip-and-replace. Steps remove
+the legacy code in the same PR that introduces the replacement. No dual-writes,
+no soak periods, no compatibility shims.
+
+1. **Ship-each-PR-green.** Every step is independently shippable. The system
    works end-to-end after every merge. `pnpm test`, `pytest`, and the
    `docs/local-reliability-qa.md` matrix never regress.
-4. **No big-bang cutover.** No step requires coordinated changes across more
-   than one bounded context. New tables coexist with legacy columns.
-5. **Target as contract.** Every step cites the target section it advances.
+2. **One aggregate context per PR.** No step requires coordinated changes
+   across more than one bounded context. Each context's extraction lands in a
+   single PR that introduces the new aggregate, repository, ports, and removes
+   the legacy code path it supersedes.
+3. **Evolutionary architecture (cloud).** Cloud adapters are named and
+   documented per `docs/ddd-target.md` §9.4 evolution triggers, but not built
+   in this plan. The architecture supports later substitution without churn.
+4. **Target as contract.** Every step cites the target section it advances.
    Steps that supersede existing decisions in `docs/decisions.md` call it out.
-6. **Local-first value.** Each step is justified by today's value (correctness,
-   simplicity, testability, parity with target). Cloud machinery is not imported.
-7. **Compatibility preservation.** Per AGENTS.md, existing compatibility
-   behavior is preserved unless explicitly authorized. The legacy `jobs` table,
-   CLI surface, API, and UI keep working through every step.
-8. **One aggregate per transaction.** Per §8.1, each command modifies exactly
+5. **AGENTS.md PR conventions still in force.** Small reviewable PRs,
+   conventional commits, doc updates per surface, dedicated worktrees per
+   step. The "no compatibility removal" rule from AGENTS.md is waived for
+   this plan: every step is explicitly authorized to delete the code it
+   replaces.
+6. **One aggregate per transaction.** Per §8.1, each command modifies exactly
    one aggregate in a single DB transaction. Cross-aggregate consistency uses
    domain events dispatched after the transaction commits. Every step that
    introduces new write paths must honor this rule.
-9. **Idempotent command handlers.** Per §8.2, every stage command, event
+7. **Idempotent command handlers.** Per §8.2, every stage command, event
    handler, and apply run is idempotent. Steps that add new handlers must
    include deduplication logic (attempt number, event ID, or run ID).
 
@@ -108,7 +117,7 @@ Before Step S-01 begins:
 |---|---|
 | **Theme** | Formalize the stage state machine as a pure function and extract the first repository port. Pipeline Orchestration is the "spine" every other context depends on. |
 | **Target sections** | §3.7, §4.7, §5.7, §8.5, §7.4. |
-| **Exit criteria** | `StageStateMachine` has dedicated unit tests covering all transitions from §8.5. `PipelineStateRepository` port + SQLite adapter extracted. `Queued` and `Canceled` states added. Legacy derivation still works. All existing state tests pass. |
+| **Exit criteria** | `StageStateMachine` has dedicated unit tests covering all transitions from §8.5. `PipelineStateRepository` port + SQLite adapter extracted. `Queued` and `Canceled` states added. All existing state tests pass. |
 | **Effort** | Medium — refactors `state.py` (~815 LOC) into domain types + repository + ACL. |
 | **Dependencies** | Phase 1 (shared types). |
 
@@ -118,7 +127,7 @@ Before Step S-01 begins:
 |---|---|
 | **Theme** | Stand up the three infrastructure pillars that all subsequent context extraction depends on: (1) the in-process event bus, (2) the JSON-RPC typed protocol between TS and Python, (3) TS API hosting simple commands directly via the shared state machine. This front-loads the cross-process integration contract so that context-specific phases can wire into an established backbone. |
 | **Target sections** | §6.1–§6.4 (event bus), §6.5 (JSON-RPC protocol), §6.8 (TS-hosted commands). |
-| **Exit criteria** | Events published through `EventPublisher` port. `job_events.event_type` standardized to domain event names (strangler dual-write with old names). Event watermark stub for projection replay. `jobhunter rpc` subcommand reads JSON-RPC from stdin/stdout. TS API performs `resetJobStage`, `markJobApplied`, `markJobSkipped` via `StageStateMachine` from `@jobhunter/domain-types` — no Python roundtrip. |
+| **Exit criteria** | Events published through `EventPublisher` port. `job_events.event_type` migrated in-place to PascalCase domain event names. Event watermark stub for projection replay. `jobhunter rpc` subcommand reads JSON-RPC from stdin/stdout. TS API performs `resetJobStage`, `markJobApplied`, `markJobSkipped` via `StageStateMachine` from `@jobhunter/domain-types` — no Python roundtrip. |
 | **Effort** | Medium — new infrastructure code, JSON-RPC server, TS write-model rewiring. |
 | **Dependencies** | Phase 1 (event base types), Phase 2 (stage event types, state machine). |
 
@@ -138,7 +147,7 @@ Before Step S-01 begins:
 |---|---|
 | **Theme** | Separate scoring into its own bounded context with typed value objects, a repository port, and an LLM port. |
 | **Target sections** | §3.4, §4.4, §5.4, §7.1 (`job_scores` table), §7.3. |
-| **Exit criteria** | Scoring writes to `job_scores` table. `LlmPort` for scoring extracted. Legacy `jobs` scoring columns read-only. Backfill migration works. All scoring tests pass. |
+| **Exit criteria** | Scoring writes to `job_scores` table. `LlmPort` for scoring extracted. Legacy `jobs` scoring columns dropped after backfill. All scoring tests pass. |
 | **Effort** | Medium — new table, backfill, refactor `scorer.py`. |
 | **Dependencies** | Phase 1, Phase 4 (ProfileSnapshot consumed by scoring). |
 
@@ -148,7 +157,7 @@ Before Step S-01 begins:
 |---|---|
 | **Theme** | Extract the most painful context — tailor/cover/pdf — into a cohesive aggregate with proper port boundaries. |
 | **Target sections** | §3.5, §4.5, §5.5, §7.1 (`job_materials` table), §7.3. |
-| **Exit criteria** | `MaterialsSet` aggregate with `Artifact` entity. `ContentValidator`, `ResumeAssembler` as pure domain services. `PdfRendererPort`, `ArtifactStoragePort`, `LlmPort` extracted. New `job_materials` table with backfill. Legacy tailor/cover/pdf columns read-only. |
+| **Exit criteria** | `MaterialsSet` aggregate with `Artifact` entity. `ContentValidator`, `ResumeAssembler` as pure domain services. `PdfRendererPort`, `ArtifactStoragePort`, `LlmPort` extracted. New `job_materials` table with backfill. Legacy tailor/cover/pdf columns dropped after backfill. |
 | **Effort** | Large — the biggest extraction. `tailor.py` (820 LOC), `cover_letter.py`, `pdf.py` all refactored. |
 | **Dependencies** | Phase 1, Phase 3 (event bus), Phase 4 (ProfileSnapshot), Phase 5 (FitScore for eligibility). |
 
@@ -223,8 +232,6 @@ no runtime behavior. The existing `packages/contracts/src/schemas.ts` `STAGES`
 and `STAGE_STATES` arrays remain for Zod validation; `packages/domain-types`
 provides the domain-layer types that processing code imports.
 
-**Backward compatibility:** No existing code changes. Pure addition.
-
 **Tenancy implications:** Introduces `TenantId` as a domain type with
 `LOCAL_TENANT = "local"` default. No enforcement code.
 
@@ -281,8 +288,6 @@ Skipped, Exhausted, Stale, Canceled) following the data-orientation principle
 from §2. `DomainEvent` is a frozen dataclass base with `event_type`,
 `tenant_id`, `occurred_at`, and `payload`. These types are pure data — no I/O
 imports, no database imports.
-
-**Backward compatibility:** No existing code changes. Pure addition.
 
 **Tenancy implications:** Same as S-01 — introduces `TenantId` with
 `LOCAL_TENANT = "local"`.
@@ -342,12 +347,8 @@ parallel; CI will validate they match in a future step.
 `.ts`/`.py`) that verifies TS `packages/domain-types` exports and Python
 `jobhunter.domain` exports have matching type names and event field sets.
 Fails CI if a type exists in one language but not the other. This serves as
-the sensor for the TypeSpec evolution trigger in §8 — without it, two-language
+the sensor for the TypeSpec evolution trigger in §7 — without it, two-language
 drift (Risk §10.5) can happen silently.
-
-**Backward compatibility:** Pure addition. Existing `record_job_event()` calls
-in `state.py` continue using string `event_type` values. Phase 3 will wire
-them to the new typed events.
 
 **Tenancy implications:** Every event type includes `tenantId` field.
 
@@ -402,8 +403,6 @@ Implement every row from the §8.5 transition table. Add `Queued` and `Canceled`
 to the valid state set. The function has zero I/O. Existing `set_stage_state()`
 in `state.py` is NOT changed in this step.
 
-**Backward compatibility:** Pure addition. No behavioral change.
-
 **Tenancy implications:** None — pure logic.
 
 **Tests added:**
@@ -448,11 +447,9 @@ Define `PipelineStateRepository` as a Python `Protocol` with methods:
 `get(tenant_id, job_id) -> JobPipelineState | None`,
 `save(tenant_id, state: JobPipelineState)`,
 `list_by_stage(tenant_id, stage, state_filter?) -> list[JobPipelineState]`.
-The port wraps CRUD operations only — state derivation logic stays in
-`LegacyStateDeriver` (S-07). The `SqlitePipelineStateRepository` adapter
-reads/writes the existing `job_stage_states` table without schema changes.
-
-**Backward compatibility:** Pure addition. Existing `state.py` functions unchanged.
+The port wraps CRUD operations against `job_stage_states`. The
+`SqlitePipelineStateRepository` adapter reads/writes the existing
+`job_stage_states` table without schema changes.
 
 **Tenancy implications:** Repository accepts `TenantId` but ignores it locally.
 
@@ -470,7 +467,7 @@ uv --project workers/automation run --extra dev pytest tests/test_pipeline_state
 
 **Dependencies:** S-02 (Python domain types), S-04 (StageState types).
 
-**Out of scope:** Wiring into `state.py` (S-06). `LegacyStateDeriver` (S-07).
+**Out of scope:** Wiring into `state.py` (S-06).
 
 ---
 
@@ -496,9 +493,6 @@ raise descriptive errors. Default `SqlitePipelineStateRepository` created if
 none provided (dependency injection via optional parameter). Per §8.1, each
 call modifies only the `JobPipelineState` aggregate in its own transaction.
 
-**Backward compatibility:** External signature unchanged. Invalid transition
-rejection is a correctness improvement.
-
 **Tenancy implications:** `TenantId` parameter added internally with default
 `LOCAL_TENANT`.
 
@@ -513,60 +507,19 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** Medium-high. `state.py` is called by every stage module. Mitigation:
-external signature unchanged; full test suite.
+**Risk:** Medium-high. `state.py` is called by every stage module — if the new
+machine rejects a transition that the old code silently allowed, every caller
+that depends on that path breaks. Mitigation: the parity test in S-04 covers
+the §8.5 transition table; if a regression slips through, revert this PR — the
+domain types from S-04 stay in place and the next attempt can adjust.
 
 **Dependencies:** S-04 (state machine), S-05 (repository).
 
-**Out of scope:** Refactoring callers. Legacy state derivation (S-07).
+**Out of scope:** Refactoring callers.
 
 ---
 
-#### S-07: refactor: formalize `LegacyStateDeriver` as an ACL with explicit removal criteria
-
-| Attribute | Detail |
-|---|---|
-| **Phase** | 2 — Pipeline Orchestration |
-| **Bounded context** | Pipeline Orchestration |
-| **Target sections** | §4.7 (`LegacyStateDeriver` service, removal criterion). |
-| **Pain points** | Briefing #1 (legacy materialization logic), #11 (duplicated state derivation). |
-
-**Files touched:**
-
-- `workers/automation/src/jobhunter/domain/orchestration/legacy_deriver.py` — **new** `LegacyStateDeriver`.
-- `workers/automation/src/jobhunter/state.py` — **refactor** move `derive_legacy_stage_states`, `_materialize_legacy_stage_rows`, `_is_placeholder_state` to new module.
-- `apps/api/src/read-model.ts` — **refactor** add removal criterion comment.
-
-**Approach:**
-Move legacy state derivation into a dedicated `LegacyStateDeriver` class,
-documented as an Anti-Corruption Layer. Removal criterion from §4.7:
-`SELECT COUNT(*) FROM jobs WHERE url NOT IN (SELECT DISTINCT job_url FROM job_stage_states)` returns 0 AND legacy columns dropped. Called by the
-`SqlitePipelineStateRepository` to fill gaps on read. TS `read-model.ts`
-annotated with same criterion; actual TS replacement is Phase 9.
-
-**Backward compatibility:** Same behavior, different module structure.
-
-**Tenancy implications:** None.
-
-**Tests added:**
-- Unit: `tests/test_legacy_deriver.py` — column combinations → correct `StageState` variants.
-
-**Verification commands:**
-
-```bash
-uv --project workers/automation run --extra dev pytest -q
-pnpm test
-```
-
-**Risk:** Low. Pure extraction, no behavior change.
-
-**Dependencies:** S-06 (state.py refactored).
-
-**Out of scope:** Removing the deriver (future). TS-side replacement (Phase 9).
-
----
-
-#### S-08: feat: add `Queued` and `Canceled` states to pipeline state model
+#### S-07: feat: add `Queued` and `Canceled` states to pipeline state model
 
 | Attribute | Detail |
 |---|---|
@@ -591,9 +544,6 @@ Add `"queued"` and `"canceled"` to `STATE_VALUES` in `state.py`. The
 actively used yet (no queue infrastructure locally) but must exist for state
 machine completeness. `Canceled` enables the cancel action path. Verify
 `packages/contracts/src/schemas.ts` already includes both.
-
-**Backward compatibility:** Adding new state values is backward-compatible.
-No existing code writes them yet.
 
 **Tenancy implications:** None.
 
@@ -620,7 +570,7 @@ pnpm test
 
 ---
 
-#### S-09: feat: define `EventPublisher` port and `InProcessEventBus` adapter
+#### S-08: feat: define `EventPublisher` port and `InProcessEventBus` adapter
 
 | Attribute | Detail |
 |---|---|
@@ -644,8 +594,6 @@ the transaction. This upholds the one-aggregate-per-transaction rule (§8.1):
 each handler runs its own transaction. Handler errors are caught and logged
 without breaking other handlers. Per §8.2, handlers must be idempotent.
 
-**Backward compatibility:** Pure addition. Existing event recording unchanged.
-
 **Tenancy implications:** Events carry `tenantId` from `DomainEvent` base.
 
 **Tests added:**
@@ -662,11 +610,11 @@ uv --project workers/automation run --extra dev pytest tests/test_event_bus.py -
 
 **Dependencies:** S-02 (DomainEvent base), S-03 (event schemas).
 
-**Out of scope:** Wiring existing code (S-10). Cloud event bus adapter.
+**Out of scope:** Wiring existing code (S-09). Cloud event bus adapter.
 
 ---
 
-#### S-10: refactor: wire `record_job_event` through `EventPublisher` and standardize event types
+#### S-09: refactor: wire `record_job_event` through `EventPublisher` and standardize event types
 
 | Attribute | Detail |
 |---|---|
@@ -683,23 +631,17 @@ uv --project workers/automation run --extra dev pytest tests/test_event_bus.py -
 **Approach:**
 Refactor `record_job_event()` to construct typed `DomainEvent` instances and
 publish through `InProcessEventBus`. Register a default handler that persists
-to `job_events`. Event type standardization uses a **strangler dual-write**:
-new events are written with PascalCase domain event names (`StageStarted`,
-`StageCompleted`), while the existing snake_case values (`stage_started`,
-`stage_completed`) are also written to a `legacy_event_type` column (added via
-ALTER TABLE) for backward compatibility. Code that reads `event_type` is
-updated to use the new names; legacy queries can use `legacy_event_type` during
-the transition. External `record_job_event` signature unchanged.
-
-**Backward compatibility:** Signature unchanged. Event type values change from
-snake_case to PascalCase. Legacy column preserves old names during transition.
+to `job_events`. Event type values are migrated in-place from snake_case
+(`stage_started`) to PascalCase domain event names (`StageStarted`); the same
+PR runs a one-shot `UPDATE job_events SET event_type = ...` migration over
+existing rows and updates every reader to expect the PascalCase names.
+External `record_job_event` signature unchanged.
 
 **Tenancy implications:** Events carry `tenant_id = LOCAL_TENANT`.
 
 **Tests added:**
 - Unit: verify `record_job_event` publishes through bus.
-- Unit: verify dual-write of old and new event type names.
-- Integration: existing event queries work with new type names.
+- Integration: existing event queries return rows after the rename migration.
 
 **Verification commands:**
 
@@ -708,16 +650,21 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** Medium. Changing event type strings; mitigated by dual-write.
+**Risk:** Medium. The rename touches every reader of `job_events.event_type`;
+if a query is missed, that view goes empty. Mitigation: grep audit for the
+old snake_case strings as part of the PR; the migration script is idempotent
+so re-running is safe. If a reader is missed in production data, revert the
+PR and the migration script is reversible (PascalCase → snake_case is a pure
+mapping).
 
-**Dependencies:** S-09 (event bus).
+**Dependencies:** S-08 (event bus).
 
 **Out of scope:** Wiring all stage modules to publish typed events directly
 (per-context phases).
 
 ---
 
-#### S-11: feat: add event watermark tracking for projection reconciliation
+#### S-10: feat: add event watermark tracking for projection reconciliation
 
 | Attribute | Detail |
 |---|---|
@@ -737,8 +684,6 @@ Projections (Phase 9) will track their last processed event ID. On startup,
 reconciliation replays events with `event_id > last_event_id`. This step only
 creates the table and tracker; projection wiring happens in Phase 9.
 
-**Backward compatibility:** New table, no existing behavior changed.
-
 **Tenancy implications:** None (watermarks are per-projection, not per-tenant locally).
 
 **Tests added:**
@@ -752,13 +697,13 @@ uv --project workers/automation run --extra dev pytest tests/test_watermark.py -
 
 **Risk:** Low. New table, no behavioral change.
 
-**Dependencies:** S-10 (event store wiring).
+**Dependencies:** S-09 (event store wiring).
 
 **Out of scope:** Projection builders (Phase 9). Startup reconciliation loop.
 
 ---
 
-#### S-12: feat: define JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand
+#### S-11: feat: define JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand
 
 | Attribute | Detail |
 |---|---|
@@ -786,10 +731,8 @@ envelopes and method-specific params/results. Python implements a
 stdout (local subprocess transport per §6.5). Three dispatch modes from §6.5:
 synchronous (profile_import), fire-and-forget (apply, discover), streaming
 (pipeline run). This step does NOT change `local-actions.ts` — that happens
-in Phase 9 (S-36). The protocol is front-loaded here so context extraction
+in Phase 9 (S-34). The protocol is front-loaded here so context extraction
 phases can define their RPC methods alongside their domain logic.
-
-**Backward compatibility:** Pure addition. `jobhunter rpc` is new.
 
 **Tenancy implications:** All RPC methods accept `tenantId` in params.
 
@@ -809,12 +752,12 @@ pnpm test
 
 **Dependencies:** S-01 (TS types), S-02 (Python types).
 
-**Out of scope:** Replacing `local-actions.ts` (S-36, Phase 9). HTTP transport.
+**Out of scope:** Replacing `local-actions.ts` (S-34, Phase 9). HTTP transport.
 Temporal transport.
 
 ---
 
-#### S-13: refactor: TS API hosts simple state-transition commands directly
+#### S-12: refactor: TS API hosts simple state-transition commands directly
 
 | Attribute | Detail |
 |---|---|
@@ -840,9 +783,6 @@ front-loaded alongside JSON-RPC because it establishes the TS↔Python boundary:
 simple = TS, complex = Python (via JSON-RPC). The `StageStateMachine` exists
 in both TS and Python (hand-mirrored); a CI compatibility check validates they
 produce identical transitions for the same inputs.
-
-**Backward compatibility:** Same API behavior. Transition validation may reject
-previously-silent invalid transitions (correctness improvement).
 
 **Tenancy implications:** State machine accepts `TenantId` (ignored locally).
 
@@ -873,7 +813,7 @@ Mitigation: review current `write-model.ts` tests for edge cases.
 
 ---
 
-#### S-14: feat: define `Profile` aggregate with value objects
+#### S-13: feat: define `Profile` aggregate with value objects
 
 | Attribute | Detail |
 |---|---|
@@ -898,8 +838,6 @@ Python (frozen dataclass) and TS (readonly interface in `packages/domain-types`)
 a CI check validates structural compatibility. Value objects are designed to
 map cleanly to/from `profile.json` schema.
 
-**Backward compatibility:** Pure addition. No existing code changed.
-
 **Tenancy implications:** Profile identity is `(TenantId, ProfileId)`.
 `ProfileId = "default"` locally.
 
@@ -917,17 +855,17 @@ uv --project workers/automation run --extra dev pytest tests/test_profile_aggreg
 
 **Dependencies:** S-02 (Python domain types, TenantId).
 
-**Out of scope:** Repository port (S-15). Replacing dict-passing (S-16).
+**Out of scope:** Repository port and consumer migration (S-14).
 
 ---
 
-#### S-15: feat: define `ProfileRepository` port and `JsonFileProfileRepository` adapter
+#### S-14: feat: introduce `ProfileRepository` and switch all consumers to `ProfileSnapshot`
 
 | Attribute | Detail |
 |---|---|
 | **Phase** | 4 — Candidate Profile |
-| **Bounded context** | Candidate Profile |
-| **Target sections** | §5.3 (`ProfileRepository` port, `JsonFileProfileRepository` adapter). |
+| **Bounded context** | Candidate Profile (and consumers: Scoring, Materials, Apply) |
+| **Target sections** | §3.3 (Conformist relationships), §4.3 (ProfileSnapshot published language), §5.3 (`ProfileRepository` port, `JsonFileProfileRepository` adapter). |
 | **Pain points** | Briefing #8 (profile dict-passing), #5 (implicit filesystem I/O). |
 
 **Files touched:**
@@ -936,74 +874,36 @@ uv --project workers/automation run --extra dev pytest tests/test_profile_aggreg
 - `workers/automation/src/jobhunter/infrastructure/profile/` — **new** directory.
 - `workers/automation/src/jobhunter/infrastructure/profile/__init__.py` — **new**.
 - `workers/automation/src/jobhunter/infrastructure/profile/json_file.py` — **new** `JsonFileProfileRepository`.
+- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor** receive `ProfileSnapshot` only.
+- `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor** receive `ProfileSnapshot` only.
+- `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor** receive `ProfileSnapshot` only.
+- `workers/automation/src/jobhunter/apply/launcher.py` — **refactor** receive `ProfileSnapshot` only.
+- `workers/automation/src/jobhunter/resume_profile.py` — **refactor** accessors operate on `ProfileSnapshot` (dict path removed).
+- `workers/automation/src/jobhunter/profile_import.py` — **refactor** return `Profile` aggregate.
+- `workers/automation/src/jobhunter/config.py` — **refactor** `load_profile()` removed; callers go through `ProfileRepository.get_snapshot()`.
 
 **Approach:**
-Define `ProfileRepository` Protocol: `get()`, `save()`, `get_snapshot()`.
-The `JsonFileProfileRepository` reads/writes `profile.json` (and
+Define `ProfileRepository` Protocol: `get()`, `save()`, `get_snapshot()`. The
+`JsonFileProfileRepository` reads/writes `profile.json` (and
 `resume_style.json`, `resume_template.tex`). Extra fields not modeled in the
 aggregate are preserved on write (forward compatibility). `get_snapshot()`
-creates an immutable `ProfileSnapshot`. This replaces `config.load_profile()`
-for new code.
+creates an immutable `ProfileSnapshot`. In the same PR, every caller of the
+old `config.load_profile()` raw-dict accessor is converted to receive a
+`ProfileSnapshot` from the repository, and `config.load_profile()` is deleted.
+Pipeline entry points create the `ProfileSnapshot` once and pass it through.
 
-**Backward compatibility:** Pure addition. `config.load_profile()` unchanged.
+**Important:** The consumer files modified here (`scorer.py`, `tailor.py`,
+`cover_letter.py`, `launcher.py`) will be restructured further in their
+respective context phases (5, 6, 8). This step only changes how they receive
+profile data — it does not refactor their internal wiring. The dict-passing
+path is fully removed in this PR.
 
 **Tenancy implications:** Repository accepts `TenantId` but ignores it locally.
+`ProfileSnapshot` carries `tenant_id` (ignored by consumers).
 
 **Tests added:**
 - Unit: `tests/test_profile_repository.py` — round-trip, snapshot creation,
   extra fields preserved.
-
-**Verification commands:**
-
-```bash
-uv --project workers/automation run --extra dev pytest tests/test_profile_repository.py -q
-```
-
-**Risk:** Low-medium. `profile.json` schema is complex.
-
-**Dependencies:** S-14 (Profile aggregate).
-
-**Out of scope:** Migrating existing callers (S-16). TS-side profile operations.
-
----
-
-#### S-16: refactor: replace profile dict-passing with `ProfileSnapshot` in consumers
-
-| Attribute | Detail |
-|---|---|
-| **Phase** | 4 — Candidate Profile |
-| **Bounded context** | Cross-cutting (Profile → Scoring, Materials, Apply) |
-| **Target sections** | §3.3 (Conformist relationships), §4.3 (ProfileSnapshot published language). |
-| **Pain points** | Briefing #8 (profile is dict-passing — this closes it). |
-
-**Files touched:**
-
-- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor** replace dict with `ProfileSnapshot`.
-- `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor** replace `config.load_profile()` with `ProfileSnapshot`.
-- `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor** replace `config.load_profile()` with `ProfileSnapshot`.
-- `workers/automation/src/jobhunter/apply/launcher.py` — **refactor** replace profile dict with `ProfileSnapshot`.
-- `workers/automation/src/jobhunter/resume_profile.py` — **refactor** dual-path accessors (dict + `ProfileSnapshot`).
-- `workers/automation/src/jobhunter/profile_import.py` — **refactor** return `Profile` aggregate alongside raw dict.
-
-**Approach:**
-Every module that calls `config.load_profile()` now receives a `ProfileSnapshot`
-from `ProfileRepository`. Dual-path accessors in `resume_profile.py` accept
-both dict and `ProfileSnapshot` for incremental migration. Pipeline entry
-points create the `ProfileSnapshot` once and pass it through.
-
-**Important:** The files modified here (`scorer.py`, `tailor.py`,
-`cover_letter.py`, `launcher.py`) will be restructured again in their
-respective context phases (5, 6, 8). This step only changes how they receive
-profile data — it does not refactor their internal wiring. This is intentional:
-decoupling the profile dependency first enables each context phase to proceed
-independently.
-
-**Backward compatibility:** Dict path continues to work. `profile.json` format
-unchanged.
-
-**Tenancy implications:** `ProfileSnapshot` carries `tenant_id` (ignored by consumers).
-
-**Tests added:**
 - Unit: update tailor, cover, scorer tests with `ProfileSnapshot` input.
 - Integration: profile import → `ProfileSnapshot` → tailor flow.
 
@@ -1013,12 +913,14 @@ unchanged.
 uv --project workers/automation run --extra dev pytest -q
 ```
 
-**Risk:** Medium-high. Touches many modules. Mitigation: dual-path accessors,
-full test suite.
+**Risk:** Medium-high. Touches every profile consumer in one PR — if any caller
+is missed, it will fail to import. Mitigation: grep audit for the old
+`config.load_profile` symbol in CI; the test suite exercises every consumer
+path. Roll back the PR if a hidden caller is discovered after merge.
 
-**Dependencies:** S-14 (Profile aggregate), S-15 (ProfileRepository).
+**Dependencies:** S-13 (Profile aggregate).
 
-**Out of scope:** Removing dual-path accessors (future decommissioning).
+**Out of scope:** TS-side profile operations.
 
 ---
 
@@ -1026,7 +928,7 @@ full test suite.
 
 ---
 
-#### S-17: feat: define `JobScore` aggregate and scoring value objects
+#### S-15: feat: define `JobScore` aggregate and scoring value objects
 
 | Attribute | Detail |
 |---|---|
@@ -1049,8 +951,6 @@ replaces raw reasoning strings with `technicalFit`, `experienceFit`,
 `reasoning` fields. Extract `_parse_score_response()` from `scorer.py` into
 `ScoreParser` domain service. Define `EligibilityChecker` per §4.4.
 
-**Backward compatibility:** Pure addition. `scorer.py` unchanged.
-
 **Tenancy implications:** `JobScore` identity includes `TenantId`.
 
 **Tests added:**
@@ -1067,11 +967,11 @@ uv --project workers/automation run --extra dev pytest tests/test_scoring_domain
 
 **Dependencies:** S-02 (domain types).
 
-**Out of scope:** Repository (S-18). LLM port (S-19). Scorer refactor (S-20).
+**Out of scope:** Repository (S-16). LLM port (S-17). Scorer refactor (S-18).
 
 ---
 
-#### S-18: feat: add `job_scores` table, `ScoreRepository` port, and SQLite adapter with backfill
+#### S-16: feat: add `job_scores` table, `ScoreRepository` port, and SQLite adapter with backfill
 
 | Attribute | Detail |
 |---|---|
@@ -1085,21 +985,19 @@ uv --project workers/automation run --extra dev pytest tests/test_scoring_domain
 - `workers/automation/src/jobhunter/domain/scoring/ports.py` — **new** `ScoreRepository` protocol.
 - `workers/automation/src/jobhunter/infrastructure/scoring/` — **new** directory.
 - `workers/automation/src/jobhunter/infrastructure/scoring/sqlite_score.py` — **new** adapter.
-- `workers/automation/src/jobhunter/database.py` — **refactor** add `job_scores` table + backfill migration.
+- `workers/automation/src/jobhunter/database.py` — **refactor** add `job_scores` table + one-shot backfill migration.
 
 **Approach:**
-Add `job_scores` table per §7.2. Idempotent backfill from legacy columns:
-`INSERT OR IGNORE INTO job_scores SELECT url, 1, fit_score, ... FROM jobs WHERE fit_score IS NOT NULL`. Legacy columns remain readable during transition.
-
-**Backward compatibility:** Legacy scoring columns untouched. `read-model.ts`
-still reads from `jobs`.
+Add `job_scores` table per §7.2. Idempotent one-shot backfill from the legacy
+columns: `INSERT OR IGNORE INTO job_scores SELECT url, 1, fit_score, ... FROM jobs WHERE fit_score IS NOT NULL`. The legacy columns are dropped in S-18
+when the scorer is rewired to write only to `job_scores`.
 
 **Tenancy implications:** No `tenant_id` column yet. Port accepts `TenantId`
 but adapter ignores it.
 
 **Tests added:**
 - Unit: `tests/test_score_repository.py` — save, get, version incrementing,
-  backfill from legacy.
+  backfill from legacy data fixtures.
 
 **Verification commands:**
 
@@ -1109,13 +1007,13 @@ uv --project workers/automation run --extra dev pytest tests/test_score_reposito
 
 **Risk:** Medium. Backfill must handle NULL rows.
 
-**Dependencies:** S-17 (JobScore aggregate).
+**Dependencies:** S-15 (JobScore aggregate).
 
-**Out of scope:** Updating `scorer.py` (S-20). TS read-model changes (Phase 9).
+**Out of scope:** Updating `scorer.py` (S-18). TS read-model changes (Phase 9).
 
 ---
 
-#### S-19: feat: define `LlmPort` protocol for scoring context
+#### S-17: feat: define `LlmPort` protocol for scoring context
 
 | Attribute | Detail |
 |---|---|
@@ -1133,9 +1031,9 @@ uv --project workers/automation run --extra dev pytest tests/test_score_reposito
 **Approach:**
 Define `LlmPort` as Protocol: `complete(prompt, system, schema) -> str`.
 Shared across scoring, materials, and enrichment contexts. `CurrentLlmAdapter`
-wraps existing unified LLM client.
-
-**Backward compatibility:** Pure addition. `llm.py` unchanged.
+wraps existing unified LLM client. `llm.py` is left in place because every
+adapter currently delegates to it; subsequent context PRs replace direct
+`llm.get_client()` callers with `LlmPort` injection.
 
 **Tenancy implications:** None locally. Cloud: LLM gateway accepts `TenantId`.
 
@@ -1156,7 +1054,7 @@ uv --project workers/automation run --extra dev pytest tests/test_llm_port.py -q
 
 ---
 
-#### S-20: refactor: update `scorer.py` to use scoring domain types, `ScoreRepository`, and `LlmPort`
+#### S-18: refactor: update `scorer.py` to use scoring domain types, `ScoreRepository`, and `LlmPort`
 
 | Attribute | Detail |
 |---|---|
@@ -1167,23 +1065,27 @@ uv --project workers/automation run --extra dev pytest tests/test_llm_port.py -q
 
 **Files touched:**
 
-- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor**.
+- `workers/automation/src/jobhunter/scoring/scorer.py` — **refactor** to write `job_scores` only.
+- `workers/automation/src/jobhunter/database.py` — **refactor** drop legacy `fit_score`, `score_reasoning`, `scored_at` columns from `jobs`.
+- `apps/api/src/read-model.ts` — **refactor** read scoring fields from `job_scores`.
 
 **Approach:**
-Refactor to use `ProfileSnapshot` (from S-16), `LlmPort` (S-19),
-`ScoreParser` (S-17), `ScoreRepository` (S-18), and publish `JobScored` events
-via `EventPublisher` (S-09). Dual-write to both `job_scores` and legacy
-`jobs.fit_score` / `jobs.score_reasoning` / `jobs.scored_at` columns.
-Dependency injection via optional parameters with local defaults. Per §8.2,
-scoring is idempotent: rescoring the same job creates a new version.
-
-**Backward compatibility:** Dual-write. `pipeline.py` callers work unchanged.
+Refactor `scorer.py` to use `ProfileSnapshot` (from S-14), `LlmPort` (S-17),
+`ScoreParser` (S-15), `ScoreRepository` (S-16), and publish `JobScored` events
+via `EventPublisher` (S-08). The scorer writes only to `job_scores`. In the
+same PR, drop the legacy `jobs.fit_score`, `jobs.score_reasoning`,
+`jobs.scored_at` columns and update `read-model.ts` to read scoring fields
+from `job_scores`. Dependency injection via optional parameters with local
+defaults. Per §8.2, scoring is idempotent: rescoring the same job creates a
+new version.
 
 **Tenancy implications:** Uses `LOCAL_TENANT`.
 
 **Tests added:**
 - Unit: update scorer tests to verify `job_scores` populated.
 - Integration: mock LLM, verify score → domain → repository flow.
+- Integration: read-model returns scoring fields from `job_scores` after the
+  column drop.
 
 **Verification commands:**
 
@@ -1192,11 +1094,15 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** Medium. Mitigation: dual-write, dependency injection with defaults.
+**Risk:** Medium. The column drop is irreversible without a fresh migration —
+if the new repository or read-model query has a bug, scoring values disappear
+from the dashboard. Mitigation: the `test_score_repository.py` parity test
+from S-16 validates the new repository against the same fixtures the legacy
+columns held; if a bug is found post-merge, revert and re-attempt.
 
-**Dependencies:** S-16 (ProfileSnapshot), S-17, S-18, S-19.
+**Dependencies:** S-14 (ProfileSnapshot), S-15, S-16, S-17.
 
-**Out of scope:** Removing legacy writes (decommissioning). Score corrections.
+**Out of scope:** Score corrections.
 
 ---
 
@@ -1204,7 +1110,7 @@ pnpm test
 
 ---
 
-#### S-21: feat: define `MaterialsSet` aggregate and materials value objects
+#### S-19: feat: define `MaterialsSet` aggregate and materials value objects
 
 | Attribute | Detail |
 |---|---|
@@ -1228,8 +1134,6 @@ Invariants from §4.5 enforced: resume before cover, docs before PDF, no banned
 words, no fabrication. Generation lifecycle per §4.5: new `MaterialsSet` for
 re-tailoring, previous artifacts marked `superseded`.
 
-**Backward compatibility:** Pure addition.
-
 **Tenancy implications:** Aggregate identity includes `TenantId`.
 
 **Tests added:**
@@ -1245,11 +1149,11 @@ uv --project workers/automation run --extra dev pytest tests/test_materials_doma
 
 **Dependencies:** S-02 (domain types).
 
-**Out of scope:** Repository (S-22). Ports (S-23, S-24). Tailor refactor (S-25).
+**Out of scope:** Repository (S-20). Ports (S-21, S-22). Tailor refactor (S-23).
 
 ---
 
-#### S-22: feat: add `job_materials` table, `MaterialsRepository` port, and SQLite adapter with backfill
+#### S-20: feat: add `job_materials` table, `MaterialsRepository` port, and SQLite adapter with backfill
 
 | Attribute | Detail |
 |---|---|
@@ -1267,13 +1171,12 @@ uv --project workers/automation run --extra dev pytest tests/test_materials_doma
 - `workers/automation/src/jobhunter/database.py` — **refactor** add `job_materials` table + `generation` column on `job_artifacts` + backfill.
 
 **Approach:**
-Add `job_materials` and backfill from legacy columns. Add `generation` column
-to `job_artifacts` (ALTER TABLE, default 1). Define repository, artifact
-storage, and PDF renderer port protocols. `LocalFilesystemAdapter` wraps
-current writes to `~/.jobhunter/tailored_resumes/` etc.
-
-**Backward compatibility:** Legacy columns untouched. Existing `job_artifacts`
-rows gain `generation = 1`.
+Add `job_materials` and one-shot backfill from legacy columns. Add `generation`
+column to `job_artifacts` (ALTER TABLE, default 1). Define repository,
+artifact storage, and PDF renderer port protocols. `LocalFilesystemAdapter`
+wraps current writes to `~/.jobhunter/tailored_resumes/` etc. Legacy
+tailor/cover/pdf columns are dropped in S-23 when the tailor pipeline is
+rewired to write only to `job_materials`.
 
 **Tenancy implications:** No `tenant_id` column locally.
 
@@ -1289,13 +1192,13 @@ uv --project workers/automation run --extra dev pytest -q
 
 **Risk:** Medium. Backfill NULLs, ALTER TABLE idempotency.
 
-**Dependencies:** S-21 (MaterialsSet aggregate).
+**Dependencies:** S-19 (MaterialsSet aggregate).
 
-**Out of scope:** Tailor/cover/pdf refactoring (S-25, S-26).
+**Out of scope:** Tailor/cover/pdf refactoring (S-23, S-24).
 
 ---
 
-#### S-23: feat: extract `ContentValidator` and `ResumeAssembler` as pure domain services
+#### S-21: feat: extract `ContentValidator` and `ResumeAssembler` as pure domain services
 
 | Attribute | Detail |
 |---|---|
@@ -1307,15 +1210,14 @@ uv --project workers/automation run --extra dev pytest -q
 **Files touched:**
 
 - `workers/automation/src/jobhunter/domain/materials/services.py` — **new** `ContentValidator`, `ResumeAssembler`.
-- `workers/automation/src/jobhunter/scoring/validator.py` — unchanged (source of extraction).
+- `workers/automation/src/jobhunter/scoring/validator.py` — **deleted** (logic moved to `ContentValidator`).
+- All callers of `scoring/validator.py` — **refactor** to import `ContentValidator` from the materials domain service.
 
 **Approach:**
-Extract pure validation functions from `scoring/validator.py` into
-`ContentValidator` domain service (zero I/O). Extract resume assembly logic
-from `tailor.py` into `ResumeAssembler`. `scoring/validator.py` preserved as
-compatibility shim delegating to `ContentValidator`.
-
-**Backward compatibility:** `scoring/validator.py` preserved as delegation layer.
+Move pure validation functions from `scoring/validator.py` into
+`ContentValidator` domain service (zero I/O). Move resume assembly logic from
+`tailor.py` into `ResumeAssembler`. Delete `scoring/validator.py` and update
+every importer in the same PR.
 
 **Tenancy implications:** None.
 
@@ -1331,13 +1233,13 @@ uv --project workers/automation run --extra dev pytest -q
 
 **Risk:** Low-medium. Pure extraction.
 
-**Dependencies:** S-21 (value objects for ValidationResult).
+**Dependencies:** S-19 (value objects for ValidationResult).
 
 **Out of scope:** Removing `scoring/validator.py` shim.
 
 ---
 
-#### S-24: feat: extract `LatexPdfAdapter` and `PlaywrightHtmlPdfAdapter` behind `PdfRendererPort`
+#### S-22: feat: extract `LatexPdfAdapter` and `PlaywrightHtmlPdfAdapter` behind `PdfRendererPort`
 
 | Attribute | Detail |
 |---|---|
@@ -1350,14 +1252,18 @@ uv --project workers/automation run --extra dev pytest -q
 
 - `workers/automation/src/jobhunter/infrastructure/materials/latex_pdf.py` — **new** `LatexPdfAdapter`.
 - `workers/automation/src/jobhunter/infrastructure/materials/playwright_html_pdf.py` — **new** `PlaywrightHtmlPdfAdapter`.
-- `workers/automation/src/jobhunter/scoring/pdf.py` — unchanged (source).
+- `workers/automation/src/jobhunter/scoring/pdf.py` — **deleted** (logic lives in adapters).
+- `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor** swap `from .pdf import …` for `PdfRendererPort` injection (rest of the tailor rewrite is S-23).
+- `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor** swap `from .pdf import …` for `PdfRendererPort` injection (rest is S-24).
 
 **Approach:**
-Extract `pdflatex` subprocess logic into `LatexPdfAdapter` and Playwright
-HTML-to-PDF into `PlaywrightHtmlPdfAdapter`. `scoring/pdf.py` remains as
-compatibility module. `PdfRendererPort` absorbs future rendering spike.
-
-**Backward compatibility:** `scoring/pdf.py` preserved.
+Move `pdflatex` subprocess logic into `LatexPdfAdapter` and Playwright
+HTML-to-PDF into `PlaywrightHtmlPdfAdapter`. Delete `scoring/pdf.py` and
+update the two callers (`tailor.py`, `cover_letter.py`) to take a
+`PdfRendererPort` parameter (default-injected to the appropriate adapter)
+instead of importing `scoring/pdf.py`. The rest of the tailor and cover
+rewrites — domain types, repository, event publication — stay in S-23 and
+S-24 respectively. `PdfRendererPort` absorbs any future rendering spike.
 
 **Tenancy implications:** None.
 
@@ -1372,13 +1278,13 @@ uv --project workers/automation run --extra dev pytest tests/test_pdf_adapters.p
 
 **Risk:** Medium. Subprocess and temp file management.
 
-**Dependencies:** S-22 (PdfRendererPort protocol).
+**Dependencies:** S-20 (PdfRendererPort protocol).
 
 **Out of scope:** Rendering spike. Tectonic/Typst adapters.
 
 ---
 
-#### S-25: refactor: update `tailor.py` to use materials domain types, repository, and ports
+#### S-23: refactor: update `tailor.py` to use materials domain types, repository, and ports
 
 | Attribute | Detail |
 |---|---|
@@ -1390,23 +1296,27 @@ uv --project workers/automation run --extra dev pytest tests/test_pdf_adapters.p
 **Files touched:**
 
 - `workers/automation/src/jobhunter/scoring/tailor.py` — **refactor**.
+- `workers/automation/src/jobhunter/database.py` — **refactor** drop legacy `tailored_resume_path`, `tailored_at`, `tailor_attempts` columns from `jobs`.
+- `apps/api/src/read-model.ts` — **refactor** read tailor fields from `job_materials` + `job_artifacts`.
 
 **Approach:**
-Restructure to use `MaterialsSet` aggregate, `MaterialsRepository`, `LlmPort`,
-`PdfRendererPort`, `ArtifactStoragePort`, `ProfileSnapshot`, `ContentValidator`,
-`ResumeAssembler`. Dual-write to both `job_materials` and legacy `jobs`
-columns. Per §8.1, each tailor invocation modifies only its `MaterialsSet`
-aggregate; the pipeline state update happens via a `ResumeApproved` event
-handler in its own transaction. Per §8.2, re-tailoring creates a new
-generation (idempotent for the same generation).
-
-**Backward compatibility:** Dual-write. `pipeline.py` callers unchanged.
+Restructure `tailor.py` to use `MaterialsSet` aggregate, `MaterialsRepository`,
+`LlmPort`, `PdfRendererPort`, `ArtifactStoragePort`, `ProfileSnapshot`,
+`ContentValidator`, `ResumeAssembler`. The tailor writes only to
+`job_materials` + `job_artifacts`. In the same PR, drop the legacy
+`tailored_resume_path`, `tailored_at`, `tailor_attempts` columns and update
+`read-model.ts` to read tailor fields from `job_materials`. Per §8.1, each
+tailor invocation modifies only its `MaterialsSet` aggregate; the pipeline
+state update happens via a `ResumeApproved` event handler in its own
+transaction. Per §8.2, re-tailoring creates a new generation (idempotent for
+the same generation).
 
 **Tenancy implications:** Uses `LOCAL_TENANT`.
 
 **Tests added:**
 - Integration: mock LLM, verify tailor → validate → store → repository.
 - Regression: `test_cover_requirements.py`, `test_pdf_targets.py` must pass.
+- Integration: read-model returns tailor metadata from the new tables.
 
 **Verification commands:**
 
@@ -1415,16 +1325,21 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** High. Most complex module. Mitigation: dual-write, DI with defaults,
-full regression suite.
+**Risk:** High. Most complex module — and the column drop is irreversible. If
+the new aggregate, repository, or read-model query has a bug, tailor metadata
+disappears from the dashboard and re-tailoring may produce inconsistent
+artifacts. Mitigation: the `test_materials_repository.py` parity test from
+S-20 validates round-trip against legacy fixtures; full
+`test_cover_requirements.py` and `test_pdf_targets.py` regression suites must
+stay green. Revert the PR if a bug is found post-merge.
 
-**Dependencies:** S-16, S-21–S-24.
+**Dependencies:** S-14 (ProfileSnapshot), S-19–S-22.
 
-**Out of scope:** Removing legacy writes. Changing prompt logic.
+**Out of scope:** Changing prompt logic.
 
 ---
 
-#### S-26: refactor: update `cover_letter.py` and `pdf.py` to use materials domain types and ports
+#### S-24: refactor: update `cover_letter.py` to use materials domain types and ports
 
 | Attribute | Detail |
 |---|---|
@@ -1436,16 +1351,17 @@ full regression suite.
 **Files touched:**
 
 - `workers/automation/src/jobhunter/scoring/cover_letter.py` — **refactor**.
-- `workers/automation/src/jobhunter/scoring/pdf.py` — **refactor** to delegate to adapters.
+- `workers/automation/src/jobhunter/database.py` — **refactor** drop legacy `cover_letter_path`, `cover_letter_at`, `cover_attempts` columns from `jobs`.
+- `apps/api/src/read-model.ts` — **refactor** read cover-letter fields from `job_materials` + `job_artifacts`.
 
 **Approach:**
-Same pattern as S-25: `cover_letter.py` receives `ProfileSnapshot`, uses
-`LlmPort`, validates with `ContentValidator`, stores via `ArtifactStoragePort`,
-updates `MaterialsSet`, publishes events. `pdf.py` becomes thin orchestrator
-calling `PdfRendererPort`. Direct import of `pdf.py` from `tailor.py` is
-eliminated — called by orchestrator, not by tailor. Dual-write.
-
-**Backward compatibility:** Dual-write. `scoring/pdf.py` importable.
+Same pattern as S-23: `cover_letter.py` receives `ProfileSnapshot`, uses
+`LlmPort`, validates with `ContentValidator`, stores via
+`ArtifactStoragePort`, updates `MaterialsSet`, publishes events. PDF
+rendering is delegated to `PdfRendererPort` (the implementation lives in the
+adapters introduced in S-22). In the same PR, drop the legacy
+`cover_letter_path`, `cover_letter_at`, `cover_attempts` columns and update
+`read-model.ts` to read cover-letter fields from `job_materials`.
 
 **Tenancy implications:** Uses `LOCAL_TENANT`.
 
@@ -1460,11 +1376,13 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** Medium. Cover and PDF are simpler than tailor.
+**Risk:** Medium. Cover and PDF are simpler than tailor, but the column drop
+is irreversible. Mitigation: same fixture-based parity tests as S-23; revert
+the PR if dashboard cover metadata regresses.
 
-**Dependencies:** S-25 (tailor refactored first).
+**Dependencies:** S-23 (tailor refactored first; same column-drop pattern).
 
-**Out of scope:** Removing legacy writes. Rendering spike.
+**Out of scope:** Rendering spike.
 
 ---
 
@@ -1472,7 +1390,7 @@ pnpm test
 
 ---
 
-#### S-27: feat: define `Job` aggregate and discovery value objects
+#### S-25: feat: define `Job` aggregate and discovery value objects
 
 | Attribute | Detail |
 |---|---|
@@ -1494,8 +1412,6 @@ separated from `Source` (maps `jobs.company` to `Employer.name`, `jobs.site`
 to `Source.board`). URL remains temporary `JobId` (stable `jobKey` deferred).
 `JobBoardScraperPort` defined for future adapter extraction.
 
-**Backward compatibility:** Pure addition. `jobs` table unchanged.
-
 **Tenancy implications:** Aggregate includes `TenantId`.
 
 **Tests added:**
@@ -1515,11 +1431,11 @@ uv --project workers/automation run --extra dev pytest tests/test_discovery_doma
 **Out of scope:** `JobId` migration. Discovery module refactoring. The
 `SqliteJobRepository` adapter is deferred — the existing `jobs` table and
 `database.py` queries serve as the implicit adapter until Discovery is fully
-extracted. See §8 Out-of-Scope.
+extracted. See §7 Out-of-Scope.
 
 ---
 
-#### S-28: feat: define `JobEnrichment` aggregate, `job_enrichments` table, and adapter with backfill
+#### S-26: feat: define `JobEnrichment` aggregate, `job_enrichments` table, and adapter with backfill
 
 | Attribute | Detail |
 |---|---|
@@ -1538,11 +1454,12 @@ extracted. See §8 Out-of-Scope.
 - `workers/automation/src/jobhunter/database.py` — **refactor** add `job_enrichments` table + backfill.
 
 **Approach:**
-Add `job_enrichments` table and backfill from legacy columns.
+Add `job_enrichments` table and one-shot backfill from legacy columns.
 `JobEnrichment` aggregate per §4.2 with `EnrichmentAttempt` child entities.
-`DetailPageFetcherPort` abstracts the three-tier extraction cascade.
-
-**Backward compatibility:** Legacy enrichment columns untouched.
+`DetailPageFetcherPort` abstracts the three-tier extraction cascade. The
+legacy `full_description`, `application_url`, `detail_scraped_at`,
+`detail_error` columns on `jobs` are dropped in S-27 when `enrichment/detail.py`
+is rewired to write only to `job_enrichments`.
 
 **Tenancy implications:** Aggregate includes `TenantId`.
 
@@ -1559,11 +1476,11 @@ uv --project workers/automation run --extra dev pytest tests/test_enrichment_dom
 
 **Dependencies:** S-02.
 
-**Out of scope:** Refactoring `detail.py` (S-29). Decoupling discovery imports.
+**Out of scope:** Refactoring `detail.py` (S-27). Decoupling discovery imports.
 
 ---
 
-#### S-29: refactor: decouple `enrichment/detail.py` from `discovery/` imports and wire ports
+#### S-27: refactor: decouple `enrichment/detail.py` from `discovery/` imports and wire ports
 
 | Attribute | Detail |
 |---|---|
@@ -1581,26 +1498,35 @@ uv --project workers/automation run --extra dev pytest tests/test_enrichment_dom
 Extract shared functionality into `DetailPageFetcherPort` adapter. Proxy
 parsing moves to adapter internals. After this step, `detail.py` imports only
 from `jobhunter.domain/` and `jobhunter.infrastructure/enrichment/`. Writes
-to `job_enrichments` via repository, publishes events. Dual-write to legacy.
-
-**Backward compatibility:** Dual-write. `pipeline.py` callers unchanged.
+go only to `job_enrichments` via repository; events published via
+`EventPublisher`. In the same PR, drop the legacy `full_description`,
+`application_url`, `detail_scraped_at`, `detail_error` columns from `jobs`,
+and update `apps/api/src/read-model.ts` to read enrichment fields from
+`job_enrichments`.
 
 **Tenancy implications:** Uses `LOCAL_TENANT`.
 
 **Tests added:**
 - Unit: verify no imports from `jobhunter.discovery.*`.
 - Regression: enrichment state tests pass.
+- Integration: read-model returns enrichment fields from `job_enrichments`
+  after the column drop.
 
 **Verification commands:**
 
 ```bash
 uv --project workers/automation run --extra dev pytest -q
+pnpm test
 python -c "import ast; tree = ast.parse(open('workers/automation/src/jobhunter/enrichment/detail.py').read()); imports = [n for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))]; assert not any('discovery' in (getattr(n, 'module', '') or '') for n in imports), 'Cross-context import found'"
 ```
 
-**Risk:** Medium. `detail.py` is 950 LOC.
+**Risk:** Medium. `detail.py` is 950 LOC and the column drop is irreversible.
+If the new `EnrichmentRepository` or read-model query has a bug, enrichment
+metadata disappears from the dashboard. Mitigation: the
+`test_enrichment_repository.py` parity test from S-26 covers round-trip
+against legacy fixtures; revert the PR if regression is observed.
 
-**Dependencies:** S-28 (enrichment domain types and repository).
+**Dependencies:** S-26 (enrichment domain types and repository).
 
 **Out of scope:** Refactoring discovery modules. Extraction algorithm changes.
 
@@ -1610,7 +1536,7 @@ python -c "import ast; tree = ast.parse(open('workers/automation/src/jobhunter/e
 
 ---
 
-#### S-30: feat: define `ApplyRun` aggregate and apply domain types
+#### S-28: feat: define `ApplyRun` aggregate and apply domain types
 
 | Attribute | Detail |
 |---|---|
@@ -1633,8 +1559,6 @@ union. Enforce invariants: valid `JobId`, materials present, one `in_progress`
 per job, dry run never marks applied. Per §8.2, apply runs use `run_id` as
 idempotency key with upsert semantics.
 
-**Backward compatibility:** Pure addition.
-
 **Tenancy implications:** Aggregate includes `TenantId`.
 
 **Tests added:**
@@ -1651,11 +1575,11 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_domain.p
 
 **Dependencies:** S-02.
 
-**Out of scope:** Launcher refactoring (S-32). Process manager (S-33).
+**Out of scope:** Launcher refactoring (S-30). Process manager (S-31).
 
 ---
 
-#### S-31: feat: extract `LocalChromeAdapter` and `ClaudeCodeCliAdapter` behind ports
+#### S-29: feat: extract `LocalChromeAdapter` and `ClaudeCodeCliAdapter` behind ports
 
 | Attribute | Detail |
 |---|---|
@@ -1670,15 +1594,16 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_domain.p
 - `workers/automation/src/jobhunter/infrastructure/apply/local_chrome.py` — **new** `LocalChromeAdapter`.
 - `workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py` — **new** `ClaudeCodeCliAdapter`.
 - `workers/automation/src/jobhunter/infrastructure/apply/sqlite_apply_run.py` — **new** `SqliteApplyRunRepository`.
+- `workers/automation/src/jobhunter/apply/chrome.py` — **deleted** (Chrome lifecycle moved to `LocalChromeAdapter`).
+- `workers/automation/src/jobhunter/apply/launcher.py` — **refactor** swap `from .chrome import …` for `BrowserPort` / `AutonomousAgentPort` injection (the rest of the launcher rewrite is S-30).
 
 **Approach:**
-Extract Chrome lifecycle from `apply/chrome.py` into `LocalChromeAdapter`.
-Extract Claude Code subprocess logic into `ClaudeCodeCliAdapter`.
-`SqliteApplyRunRepository` wraps existing `apply_runs` + `apply_run_events`
-tables (already well-structured per §7.4). Existing modules preserved as
-compatibility imports.
-
-**Backward compatibility:** `apply/chrome.py` preserved as compatibility shim.
+Move Chrome lifecycle from `apply/chrome.py` into `LocalChromeAdapter`. Move
+Claude Code subprocess logic into `ClaudeCodeCliAdapter`. Delete
+`apply/chrome.py` and update `launcher.py` to receive injected
+`BrowserPort` / `AutonomousAgentPort` instances (default-bound to the local
+adapters). `SqliteApplyRunRepository` wraps existing `apply_runs` +
+`apply_run_events` tables (already well-structured per §7.4).
 
 **Tenancy implications:** None locally.
 
@@ -1694,13 +1619,13 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_adapters
 
 **Risk:** Medium. Chrome and subprocess management are complex.
 
-**Dependencies:** S-30 (apply domain types).
+**Dependencies:** S-28 (apply domain types).
 
-**Out of scope:** Launcher refactoring (S-32). Cloud adapters.
+**Out of scope:** Launcher refactoring (S-30). Cloud adapters.
 
 ---
 
-#### S-32: refactor: update `launcher.py` to use apply domain types, repository, and ports
+#### S-30: refactor: update `launcher.py` to use apply domain types, repository, and ports
 
 | Attribute | Detail |
 |---|---|
@@ -1714,21 +1639,23 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_adapters
 - `workers/automation/src/jobhunter/apply/launcher.py` — **refactor**.
 
 **Approach:**
-Refactor to use `ApplyRun` aggregate, `BrowserPort`, `AutonomousAgentPort`,
-`ApplyRunRepository`, `ProfileSnapshot`, `EventPublisher`. Rich dashboard
-continues working (presentation adapter). Telemetry writes go through
-`ApplyRunRepository`. Per §8.1, launcher modifies only the `ApplyRun` aggregate;
-pipeline state updated via `ApplicationSubmitted` event handler. Dual-write
-legacy columns. DI with defaults.
-
-**Backward compatibility:** Public API (`run_apply`, `run_job`) unchanged.
-Dual-write.
+Refactor `launcher.py` to use `ApplyRun` aggregate, `BrowserPort`,
+`AutonomousAgentPort`, `ApplyRunRepository`, `ProfileSnapshot`,
+`EventPublisher`. Rich dashboard continues working (presentation adapter).
+Telemetry writes go through `ApplyRunRepository`. Per §8.1, launcher modifies
+only the `ApplyRun` aggregate; pipeline state updated via
+`ApplicationSubmitted` event handler. In the same PR, drop the legacy
+`applied_at`, `apply_status`, `apply_error`, `apply_attempts`, `agent_id`
+columns from `jobs` and update `apps/api/src/read-model.ts` to read apply
+fields from `apply_runs`. DI with defaults.
 
 **Tenancy implications:** Uses `LOCAL_TENANT`.
 
 **Tests added:**
 - Regression: `test_apply_regressions.py`.
 - Unit: mock ports, verify apply flow with domain types.
+- Integration: read-model returns apply fields from `apply_runs` after the
+  column drop.
 
 **Verification commands:**
 
@@ -1737,16 +1664,21 @@ uv --project workers/automation run --extra dev pytest -q
 pnpm test
 ```
 
-**Risk:** High. Most complex module. Mitigation: DI with defaults, dual-write,
-full regression.
+**Risk:** High. Most complex module — Chrome lifecycle, Claude Code subprocess,
+and telemetry all change in one PR, plus the column drop is irreversible. If
+the new repository or read-model query has a bug, apply status disappears
+from the dashboard or the launcher fails to start a run. Mitigation: full
+`test_apply_regressions.py` must stay green; the apply-run repository
+fixtures from S-29 cover round-trip parity. Revert the PR if a regression is
+observed.
 
-**Dependencies:** S-16, S-30, S-31.
+**Dependencies:** S-14 (ProfileSnapshot), S-28, S-29.
 
-**Out of scope:** Removing legacy writes. Process manager (S-33). Dashboard refactoring.
+**Out of scope:** Process manager (S-31). Dashboard refactoring.
 
 ---
 
-#### S-33: feat: formalize apply process manager with compensation actions
+#### S-31: feat: formalize apply process manager with compensation actions
 
 | Attribute | Detail |
 |---|---|
@@ -1764,9 +1696,8 @@ Formalize the apply flow from §8.3 as `ApplyProcessManager`: AcquireJob →
 LaunchBrowser → StartAgent → Monitoring → ParseResult → Cleanup → Report.
 Compensation actions: Chrome failure → cleanup + report; timeout → kill + cleanup;
 crash recovery → detect orphaned `in_progress` runs → transition to `failed`
-with `ORPHANED` error. Pure addition — `launcher.py` can optionally delegate.
-
-**Backward compatibility:** Pure addition.
+with `ORPHANED` error. `launcher.py` from S-30 is updated in the same PR to
+delegate to the new process manager.
 
 **Tenancy implications:** None.
 
@@ -1782,7 +1713,7 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_process_
 
 **Risk:** Low. Pure addition.
 
-**Dependencies:** S-30, S-31.
+**Dependencies:** S-28, S-29.
 
 **Out of scope:** Full `launcher.py` rewrite. Temporal workflow.
 
@@ -1792,7 +1723,7 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_process_
 
 ---
 
-#### S-34: feat: define read-model projections and `ProjectionBuilder`
+#### S-32: feat: define read-model projections and `ProjectionBuilder`
 
 | Attribute | Detail |
 |---|---|
@@ -1812,10 +1743,9 @@ uv --project workers/automation run --extra dev pytest tests/test_apply_process_
 Add `job_list_view` and `dashboard_stats` projection tables.
 `ProjectionBuilder` subscribes to domain events from `InProcessEventBus` and
 updates projections. One-time backfill populates from existing data. On
-startup, replays from watermark (S-11). Per §8.2, projection updates are
-idempotent (check `eventId` watermark).
-
-**Backward compatibility:** New tables. `read-model.ts` unchanged in this step.
+startup, replays from watermark (S-10). Per §8.2, projection updates are
+idempotent (check `eventId` watermark). The TS read-model swap to query the
+projections is S-33.
 
 **Tenancy implications:** Not tenant-scoped locally.
 
@@ -1830,13 +1760,13 @@ uv --project workers/automation run --extra dev pytest tests/test_projection_bui
 
 **Risk:** Medium. Projection correctness depends on all events handled.
 
-**Dependencies:** S-09, S-10, S-11, all event publishers from Phases 5–8.
+**Dependencies:** S-08, S-09, S-10, all event publishers from Phases 5–8.
 
-**Out of scope:** TS read-model changes (S-35). Event streaming to frontend.
+**Out of scope:** TS read-model changes (S-33). Event streaming to frontend.
 
 ---
 
-#### S-35: refactor: update TS `read-model.ts` to query projections and use shared domain types
+#### S-33: refactor: update TS `read-model.ts` to query projections and use shared domain types
 
 | Attribute | Detail |
 |---|---|
@@ -1852,17 +1782,16 @@ uv --project workers/automation run --extra dev pytest tests/test_projection_bui
 
 **Approach:**
 Rewrite `read-model.ts` queries to use `job_list_view` and `dashboard_stats`
-projections. Replace legacy state derivation with simple SELECTs. Import
-`Stage`, `StageState` from `@jobhunter/domain-types`. Fallback to legacy
-query path if projections are empty (transition safety net).
-
-**Backward compatibility:** API response shapes unchanged. Fallback to legacy.
+projections. Replace the legacy state-derivation code path with simple
+SELECTs against the projection tables. Import `Stage`, `StageState` from
+`@jobhunter/domain-types`. The legacy derivation code is deleted in this PR.
+The S-32 backfill ensures projections are non-empty on first deploy.
 
 **Tenancy implications:** Types include `TenantId` for future use.
 
 **Tests added:**
 - Integration: existing read-model tests pass with projection-backed queries.
-- Unit: fallback to legacy when projections empty.
+- Unit: assert legacy derivation helpers are removed (`grep` check in CI).
 
 **Verification commands:**
 
@@ -1871,15 +1800,19 @@ pnpm test
 pnpm api:test
 ```
 
-**Risk:** High. Core read path. Mitigation: fallback + full test suite.
+**Risk:** High. Core read path — if a projection is missing data the S-32
+backfill should have populated, the dashboard goes blank. Mitigation: the
+S-32 step ships its own backfill verification; this PR includes a smoke test
+that compares row counts in `job_list_view` against expected values from
+`jobs` joined with `job_stage_states`. Revert if mismatch is found.
 
-**Dependencies:** S-34 (projections), S-01 (shared types).
+**Dependencies:** S-32 (projections), S-01 (shared types).
 
-**Out of scope:** Removing legacy fallback. Event streaming.
+**Out of scope:** Event streaming.
 
 ---
 
-#### S-36: refactor: replace `local-actions.ts` subprocess spawning with JSON-RPC adapter
+#### S-34: refactor: replace `local-actions.ts` subprocess spawning with JSON-RPC adapter
 
 | Attribute | Detail |
 |---|---|
@@ -1894,14 +1827,12 @@ pnpm api:test
 - `apps/api/src/json-rpc-adapter.ts` — **new** `SubprocessJsonRpcAdapter`.
 
 **Approach:**
-Create `SubprocessJsonRpcAdapter` that spawns `uv run jobhunter rpc` (S-12),
+Create `SubprocessJsonRpcAdapter` that spawns `uv run jobhunter rpc` (S-11),
 writes JSON-RPC request to stdin, reads response from stdout. Replace
-`defaultActionDispatcher`. For fire-and-forget (apply, retry-stage), spawn
-detached and return `runId`. For synchronous (profile_import), wait for
-response. `buildActionResponse` compatibility shim wraps JSON-RPC response.
-Fallback to old dispatcher if JSON-RPC fails (transition safety).
-
-**Backward compatibility:** Same API endpoints, same response shapes.
+`defaultActionDispatcher` outright; the old ad-hoc subprocess dispatcher is
+deleted in this PR. For fire-and-forget (apply, retry-stage), spawn detached
+and return `runId`. For synchronous (profile_import), wait for response.
+`buildActionResponse` is updated to consume the JSON-RPC response shape.
 
 **Tenancy implications:** JSON-RPC requests include `tenantId: "local"`.
 
@@ -1916,15 +1847,19 @@ pnpm test
 pnpm api:test
 ```
 
-**Risk:** Medium-high. Mitigation: fallback to old dispatcher.
+**Risk:** Medium-high. Every action endpoint switches transport in one PR; if
+the JSON-RPC adapter has a bug, every action button fails. Mitigation: the
+S-11 RPC server has its own integration tests; this PR covers each method via
+`apps/api/test/json-rpc-adapter.test.ts`. Revert the PR if any action
+regresses.
 
-**Dependencies:** S-12 (JSON-RPC server).
+**Dependencies:** S-11 (JSON-RPC server).
 
 **Out of scope:** HTTP JSON-RPC transport. Temporal transport.
 
 ---
 
-#### S-37: docs: update architecture, domain-model, and decisions for DDD migration
+#### S-35: docs: update architecture, domain-model, and decisions for DDD migration
 
 | Attribute | Detail |
 |---|---|
@@ -1946,8 +1881,6 @@ pnpm api:test
 Comprehensive documentation update per AGENTS.md requirements. New ADR
 entries: DDD + Hexagonal adopted, TenantId introduced, domain events as
 integration backbone, JSON-RPC protocol, projection-based read model.
-
-**Backward compatibility:** N/A — documentation only.
 
 **Tests added:** None.
 
@@ -1976,39 +1909,39 @@ all steps are delivered.
 | S-02 | Introduces `TenantId` type in Python with `LOCAL_TENANT`. |
 | S-03 | All domain events carry `tenantId`. |
 | S-05 | `PipelineStateRepository` port accepts `TenantId`. |
-| S-12 | JSON-RPC methods accept `tenantId` in params. |
-| S-13 | TS write-model passes `TenantId` to state machine. |
-| S-15 | `ProfileRepository` port accepts `TenantId`. |
-| S-18 | `ScoreRepository` port accepts `TenantId`. |
-| S-22 | `MaterialsRepository` port accepts `TenantId`. |
-| S-28 | `EnrichmentRepository` port accepts `TenantId`. |
-| S-31 | `ApplyRunRepository` port accepts `TenantId`. |
+| S-11 | JSON-RPC methods accept `tenantId` in params. |
+| S-12 | TS write-model passes `TenantId` to state machine. |
+| S-14 | `ProfileRepository` port accepts `TenantId`. |
+| S-16 | `ScoreRepository` port accepts `TenantId`. |
+| S-20 | `MaterialsRepository` port accepts `TenantId`. |
+| S-26 | `EnrichmentRepository` port accepts `TenantId`. |
+| S-29 | `ApplyRunRepository` port accepts `TenantId`. |
 
 ### 6.2 Domain Event Bus Introduction
 
 | Step | What it does |
 |---|---|
-| S-09 | Defines `EventPublisher` port and `InProcessEventBus`. |
-| S-10 | Wires `record_job_event` through the bus. Standardizes event types (strangler dual-write). |
-| S-11 | Adds event watermark tracking for projection reconciliation. |
-| S-20 | Scoring publishes `JobScored` events. |
-| S-25 | Materials publishes `ResumeApproved`, `ResumeFailed` events. |
-| S-26 | Materials publishes `CoverLetterGenerated`, `PdfRendered` events. |
-| S-29 | Enrichment publishes `JobEnriched`, `EnrichmentFailed` events. |
-| S-32 | Apply publishes `ApplicationSubmitted`, `ApplicationFailed` events. |
-| S-34 | `ProjectionBuilder` subscribes to all events. |
+| S-08 | Defines `EventPublisher` port and `InProcessEventBus`. |
+| S-09 | Wires `record_job_event` through the bus. Standardizes event types (snake_case → PascalCase rename migration). |
+| S-10 | Adds event watermark tracking for projection reconciliation. |
+| S-18 | Scoring publishes `JobScored` events. |
+| S-23 | Materials publishes `ResumeApproved`, `ResumeFailed` events. |
+| S-24 | Materials publishes `CoverLetterGenerated`, `PdfRendered` events. |
+| S-27 | Enrichment publishes `JobEnriched`, `EnrichmentFailed` events. |
+| S-30 | Apply publishes `ApplicationSubmitted`, `ApplicationFailed` events. |
+| S-32 | `ProjectionBuilder` subscribes to all events. |
 
 ### 6.3 Repository Extraction Per Aggregate
 
 | Aggregate | Port Step | Adapter Step | Table |
 |---|---|---|---|
 | `JobPipelineState` | S-05 | S-05 | `job_stage_states` (existing) |
-| `Profile` | S-15 | S-15 | `profile.json` (existing) |
-| `JobScore` | S-18 | S-18 | `job_scores` (new) |
-| `MaterialsSet` | S-22 | S-22 | `job_materials` (new) + `job_artifacts` (existing) |
-| `JobEnrichment` | S-28 | S-28 | `job_enrichments` (new) |
-| `ApplyRun` | S-31 | S-31 | `apply_runs` + `apply_run_events` (existing) |
-| `Job` (Discovery) | S-27 | Deferred | `jobs` (existing, narrowed) |
+| `Profile` | S-14 | S-14 | `profile.json` (existing) |
+| `JobScore` | S-16 | S-16 | `job_scores` (new) |
+| `MaterialsSet` | S-20 | S-20 | `job_materials` (new) + `job_artifacts` (existing) |
+| `JobEnrichment` | S-26 | S-26 | `job_enrichments` (new) |
+| `ApplyRun` | S-29 | S-29 | `apply_runs` + `apply_run_events` (existing) |
+| `Job` (Discovery) | S-25 | Deferred | `jobs` (existing, narrowed) |
 
 ### 6.4 Stage State Machine Consolidation
 
@@ -2016,93 +1949,39 @@ all steps are delivered.
 |---|---|
 | S-04 | Defines `StageStateMachine` as pure function in Python and TS. |
 | S-06 | Wires `state.py` to use the state machine internally. |
-| S-08 | Adds `Queued` and `Canceled` states. |
-| S-13 | TS write-model uses TS state machine for transition validation. |
+| S-07 | Adds `Queued` and `Canceled` states. |
+| S-12 | TS write-model uses TS state machine for transition validation. |
 
 ### 6.5 TS↔Python Typed Application Protocol
 
 | Step | What it does |
 |---|---|
-| S-12 | Defines JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand. |
-| S-13 | TS API hosts simple commands directly (no Python roundtrip). |
-| S-36 | Replaces `local-actions.ts` with `SubprocessJsonRpcAdapter`. |
+| S-11 | Defines JSON-RPC 2.0 protocol and `jobhunter rpc` subcommand. |
+| S-12 | TS API hosts simple commands directly (no Python roundtrip). |
+| S-34 | Replaces `local-actions.ts` with `SubprocessJsonRpcAdapter`. |
 
 ### 6.6 Apply Saga / Process Manager
 
 | Step | What it does |
 |---|---|
-| S-30 | Defines `ApplyRun` aggregate with `SubmissionResult`. |
-| S-31 | Extracts `BrowserPort` and `AutonomousAgentPort`. |
-| S-32 | Wires `launcher.py` to use domain types and ports. |
-| S-33 | Formalizes apply process manager with compensation actions. |
+| S-28 | Defines `ApplyRun` aggregate with `SubmissionResult`. |
+| S-29 | Extracts `BrowserPort` and `AutonomousAgentPort`. |
+| S-30 | Wires `launcher.py` to use domain types and ports. |
+| S-31 | Formalizes apply process manager with compensation actions. |
 
 ### 6.7 Documentation and ADR Updates
 
 | Step | What it does |
 |---|---|
-| S-37 | Comprehensive documentation update. New ADR entries. |
+| S-35 | Comprehensive documentation update. New ADR entries. |
 
-Note: Per AGENTS.md, individual PRs for steps S-04 through S-36 should include
-narrow doc updates for the specific surfaces they change. S-37 is the final
+Note: Per AGENTS.md, individual PRs for steps S-04 through S-34 should include
+narrow doc updates for the specific surfaces they change. S-35 is the final
 sweep that ensures consistency across all docs.
 
 ---
 
-## 7. Strangler Decommissioning Plan
-
-### 7.1 Legacy State Materialization (`state.py`)
-
-| What | Current location | Replacement step | Soak period | Removal step |
-|---|---|---|---|---|
-| `derive_legacy_stage_states()` | `state.py` → `legacy_deriver.py` (S-07) | S-06, S-07 | Until removal criterion met (§4.7). | Future step. |
-| TS `read-model.ts` legacy derivation | `read-model.ts` | S-35 (projection-based read model) | Until projections stable for 1 week. | Future step. |
-
-### 7.2 Wide Nullable `jobs` Columns
-
-| Column group | Replacement step | Soak period | Removal step |
-|---|---|---|---|
-| `fit_score`, `score_reasoning`, `scored_at` | S-18, S-20 | Until all queries read `job_scores`. | Future step. |
-| `tailored_resume_path`, `tailored_at`, `tailor_attempts` | S-22, S-25 | Until all queries read `job_materials`. | Future step. |
-| `cover_letter_path`, `cover_letter_at`, `cover_attempts` | S-22, S-26 | Same as above. | Future step. |
-| `full_description`, `application_url`, `detail_scraped_at`, `detail_error` | S-28, S-29 | Until all queries read `job_enrichments`. | Future step. |
-| `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, etc. | S-32 | Until all queries read `apply_runs`. | Future step. |
-
-### 7.3 Dict-Passing of Profile Data
-
-| What | Replacement step | Soak period | Removal step |
-|---|---|---|---|
-| `resume_profile.py` dual-path accessors | S-16 | Until all consumers use `ProfileSnapshot`. | Future step. |
-| `config.load_profile()` raw dict | S-16 | Same. | Future step. |
-
-### 7.4 Procedural `pipeline.py`
-
-| What | Replacement step | Soak period | Removal step |
-|---|---|---|---|
-| Direct stage function calls | S-06 + Phase 5–8 ports | Until all stages dispatch through ports. | Future step. |
-
-### 7.5 Cross-Context Imports
-
-| Import | Replacement step | Removal step |
-|---|---|---|
-| `enrichment/detail.py` → `discovery/smartextract.extract_json` | S-29 | S-29. |
-| `enrichment/detail.py` → `discovery/jobspy.parse_proxy` | S-29 | S-29. |
-| `scoring/tailor.py` → `scoring/pdf.py` | S-25 | S-25. |
-
-### 7.6 `local-actions.ts` Ad-Hoc Subprocess Spawning
-
-| What | Replacement step | Soak period | Removal step |
-|---|---|---|---|
-| `defaultActionDispatcher` | S-36 | Until all action endpoints use JSON-RPC. | Future step. |
-
-### 7.7 Event Type Naming (snake_case → PascalCase)
-
-| What | Replacement step | Soak period | Removal step |
-|---|---|---|---|
-| `legacy_event_type` column in `job_events` | S-10 (strangler dual-write) | Until no code reads `legacy_event_type`. | Future step. Drop column. |
-
----
-
-## 8. Out-of-Scope (Deferred)
+## 7. Out-of-Scope (Deferred)
 
 Each item below is explicitly deferred. The evolution trigger from §9.4 is
 cited where applicable.
@@ -2110,10 +1989,10 @@ cited where applicable.
 | Deferred item | Target section | Evolution trigger (§9.4) | Notes |
 |---|---|---|---|
 | `PostgresJobRepository` and all Postgres adapters | §5.1–5.8 | Concurrent users > 1 OR DB > 10 GB OR multi-process writes | Ports defined; only SQLite adapters implemented. |
-| `S3ArtifactAdapter` | §5.5 | Multi-node deployment OR artifact > 1 GB/tenant | `ArtifactStoragePort` defined in S-22. |
-| `SqsEventPublisher` + transactional outbox | §6.3 | Multi-process deployment (> 1 API or worker) | `EventPublisher` defined in S-09. |
-| `BrowserbaseAdapter` | §5.6 | Any cloud deployment (day-1 blocker) | `BrowserPort` defined in S-30. |
-| `ClaudeApiAgentAdapter` | §5.6 | Worker fleet > 1 machine | `AutonomousAgentPort` defined in S-30. |
+| `S3ArtifactAdapter` | §5.5 | Multi-node deployment OR artifact > 1 GB/tenant | `ArtifactStoragePort` defined in S-20. |
+| `SqsEventPublisher` + transactional outbox | §6.3 | Multi-process deployment (> 1 API or worker) | `EventPublisher` defined in S-08. |
+| `BrowserbaseAdapter` | §5.6 | Any cloud deployment (day-1 blocker) | `BrowserPort` defined in S-28. |
+| `ClaudeApiAgentAdapter` | §5.6 | Worker fleet > 1 machine | `AutonomousAgentPort` defined in S-28. |
 | `TemporalWorkflowAdapter` | §5.7 | Worker fleet > 1 machine OR pipeline > 30 min | `StageCommandDispatcher` port deferred; pipeline.py remains procedural. |
 | Auth0 / Cognito JWT | §9 | Any public-facing deployment | `TenantId` seam in place from Phase 1. |
 | Stripe billing / `EntitlementPort` | §9 | First paying customer | No-op adapter not yet created. |
@@ -2125,14 +2004,14 @@ cited where applicable.
 | Resume rendering spike | §5.5 | Blocked on spike results OR cloud (TeX Live 4 GB) | `PdfRendererPort` defined; `LatexPdfAdapter` stays. |
 | Event streaming to frontend (SSE/WS) | §3.8 | Product decision on UX approach | Open question in §10. |
 | `StageCommandDispatcher` port | §5.7 | Pipeline refactoring beyond scope | `pipeline.py` remains procedural. |
-| Materialized `job_list_view` replacing all `jobs` reads | §4.8, §6.6 | All contexts publishing events reliably | Projections in S-34; full replacement deferred. |
+| Materialized `job_list_view` replacing all `jobs` reads | §4.8, §6.6 | All contexts publishing events reliably | Projections in S-32; full replacement deferred. |
 | `pdflatex` → Tectonic/Typst | §5.5 | Rendering spike conclusion OR cloud deployment | `PdfRendererPort` absorbs any engine. |
 | `TenantId` from JWT (multi-tenant) | §9 | Multi-tenant deployment | Domain types carry TenantId; only source changes (constant → JWT). |
 | No-op `EntitlementPort` adapter | §9 (Billing) | Feature gate before first paying customer | All entitlements return `Allowed` locally. |
 
 ---
 
-## 9. QA & Reliability Gates
+## 8. QA & Reliability Gates
 
 ### Phase 1: Foundation
 
@@ -2168,7 +2047,7 @@ cited where applicable.
 ### Phase 5: Scoring
 
 - **QA addition:** `test_scoring_domain.py`, `test_score_repository.py`. Add:
-  "Scores written to job_scores and legacy columns" → `test_score_repository.py`.
+  "Scores written to and read from `job_scores`" → `test_score_repository.py`.
 - **Verification:** `pnpm test`, `pytest -q`.
 
 ### Phase 6: Materials
@@ -2176,14 +2055,14 @@ cited where applicable.
 - **QA addition:** `test_materials_domain.py`, `test_materials_repository.py`,
   `test_content_validator.py`, `test_resume_assembler.py`,
   `test_pdf_adapters.py`. Existing `test_cover_requirements.py` and
-  `test_pdf_targets.py` must pass. Add: "Materials written to job_materials
-  and legacy columns" → `test_materials_repository.py`.
+  `test_pdf_targets.py` must pass. Add: "Materials written to and read from
+  `job_materials`" → `test_materials_repository.py`.
 - **Verification:** `pnpm test`, `pytest -q`.
 
 ### Phase 7: Discovery & Enrichment
 
 - **QA addition:** `test_discovery_domain.py`, `test_enrichment_domain.py`,
-  `test_enrichment_repository.py`. Add: "No cross-context imports" → S-29 import audit.
+  `test_enrichment_repository.py`. Add: "No cross-context imports" → S-27 import audit.
 - **Verification:** `pnpm test`, `pytest -q`.
 
 ### Phase 8: Apply
@@ -2204,45 +2083,45 @@ cited where applicable.
 
 ---
 
-## 10. Documentation Plan
+## 9. Documentation Plan
 
 | Step | Docs updated | What changes |
 |---|---|---|
 | S-01 | None | Pure addition. |
 | S-04 | None | Internal domain logic. |
 | S-06 | `docs/architecture.md` | Note state machine formalization. |
-| S-08 | `docs/domain-model.md` | Add `Queued` and `Canceled` to canonical states. |
-| S-09 | `docs/architecture.md` | Note event bus introduction. |
-| S-12 | `docs/architecture.md`, `docs/decisions.md` | JSON-RPC protocol ADR. |
-| S-13 | `docs/decisions.md` | TS-hosted commands ADR. |
-| S-16 | None | Internal refactor. |
-| S-18 | `docs/architecture.md` | Note `job_scores` table. |
-| S-20 | `docs/decisions.md` | New ADR: "Scoring context with repository port." |
-| S-22 | `docs/architecture.md` | Note `job_materials` table. |
-| S-28 | `docs/architecture.md` | Note `job_enrichments` table. |
-| S-35 | `docs/architecture.md` | Projection-based read model. |
-| S-37 | All docs | Comprehensive final sweep. |
+| S-07 | `docs/domain-model.md` | Add `Queued` and `Canceled` to canonical states. |
+| S-08 | `docs/architecture.md` | Note event bus introduction. |
+| S-11 | `docs/architecture.md`, `docs/decisions.md` | JSON-RPC protocol ADR. |
+| S-12 | `docs/decisions.md` | TS-hosted commands ADR. |
+| S-14 | None | Internal refactor. |
+| S-16 | `docs/architecture.md` | Note `job_scores` table. |
+| S-18 | `docs/decisions.md` | New ADR: "Scoring context with repository port." |
+| S-20 | `docs/architecture.md` | Note `job_materials` table. |
+| S-26 | `docs/architecture.md` | Note `job_enrichments` table. |
+| S-33 | `docs/architecture.md` | Projection-based read model. |
+| S-35 | All docs | Comprehensive final sweep. |
 
 **New ADR entries** (in `docs/decisions.md`):
 
-1. "DDD + Hexagonal Architecture adopted" — date of S-37 merge.
+1. "DDD + Hexagonal Architecture adopted" — date of S-35 merge.
 2. "TenantId introduced as domain type" — date of S-01 merge.
-3. "Domain events as integration backbone" — date of S-09 merge.
-4. "JSON-RPC 2.0 as TS↔Python protocol" — date of S-12 merge.
-5. "TS API hosts simple state-transition commands" — date of S-13 merge.
-6. "Projection-based read model" — date of S-35 merge.
+3. "Domain events as integration backbone" — date of S-08 merge.
+4. "JSON-RPC 2.0 as TS↔Python protocol" — date of S-11 merge.
+5. "TS API hosts simple state-transition commands" — date of S-12 merge.
+6. "Projection-based read model" — date of S-33 merge.
 
 **Superseded decisions:**
 - "Stage State Is The Operational Source Of Truth" (2026-05-02) is **advanced,
-  not superseded** — state machine formalization (S-04–S-08) strengthens it.
+  not superseded** — state machine formalization (S-04–S-07) strengthens it.
 
 ---
 
-## 11. Worktree & Branching Convention
+## 10. Worktree & Branching Convention
 
 Per AGENTS.md:
 
-- **Every step = one worktree = one PR.** S-01 through S-37 each get a dedicated
+- **Every step = one worktree = one PR.** S-01 through S-35 each get a dedicated
   worktree on their own branch.
 - Branch naming: `ddd/s-{step_number}-{short-description}` (e.g.,
   `ddd/s-01-domain-types`, `ddd/s-04-state-machine`).
@@ -2256,15 +2135,15 @@ Per AGENTS.md:
 **Parallel execution opportunities:**
 
 - S-01 and S-02 (TS and Python types are independent).
-- S-14 and S-17 (Profile and Scoring aggregates depend only on S-02).
-- S-27, S-28, and S-30 (Discovery, Enrichment, and Apply aggregates are
+- S-13 and S-15 (Profile and Scoring aggregates depend only on S-02).
+- S-25, S-26, and S-28 (Discovery, Enrichment, and Apply aggregates are
   independent, all depend only on S-02).
 
-The canonical execution order is the step numbering (S-01 → S-37).
+The canonical execution order is the step numbering (S-01 → S-35).
 
 ---
 
-## 12. Glossary Diff
+## 11. Glossary Diff
 
 **Terms introduced by this plan:**
 
@@ -2280,9 +2159,6 @@ The canonical execution order is the step numbering (S-01 → S-37).
 | `ProjectionBuilder` | Infrastructure component subscribing to events and updating read-model projections. |
 | `SubprocessJsonRpcAdapter` | TS adapter that spawns `jobhunter rpc` and communicates via JSON-RPC over stdin/stdout. |
 | `CurrentLlmAdapter` | Thin adapter wrapping `jobhunter.llm.get_client()` behind `LlmPort`. |
-| `dual-write` | Transition pattern: new code writes to both new table and legacy columns simultaneously. |
-| `compatibility shim` | Thin delegation layer preserving old import path while delegating to new code. |
-| `strangler dual-write` | Variant of dual-write for renaming: new format is canonical, old format preserved in a transition column. |
 
 **Renaming from current code:**
 
@@ -2290,7 +2166,7 @@ The canonical execution order is the step numbering (S-01 → S-37).
 |---|---|---|
 | `state.STATE_VALUES` tuple | `Stage` enum + `StageState` discriminated union | S-02, S-04 |
 | `state.STAGE_ORDER` tuple | `Stage` enum with canonical order | S-02 |
-| `config.load_profile()` → raw dict | `ProfileRepository.get_snapshot()` → `ProfileSnapshot` | S-15, S-16 |
-| `record_job_event()` with string event_type | `EventPublisher.publish()` with typed `DomainEvent` | S-09, S-10 |
-| `_parse_score_response()` in scorer.py | `ScoreParser` domain service | S-17 |
-| `defaultActionDispatcher` in local-actions.ts | `SubprocessJsonRpcAdapter` | S-36 |
+| `config.load_profile()` → raw dict | `ProfileRepository.get_snapshot()` → `ProfileSnapshot` | S-14 |
+| `record_job_event()` with string event_type | `EventPublisher.publish()` with typed `DomainEvent` | S-08, S-09 |
+| `_parse_score_response()` in scorer.py | `ScoreParser` domain service | S-15 |
+| `defaultActionDispatcher` in local-actions.ts | `SubprocessJsonRpcAdapter` | S-34 |


### PR DESCRIPTION
## Summary

Adds two architecture documents authored and reviewed by paired Opus 4.7 agent teams (modeler/reviewer for the target, planner/reviewer for the plan), then revised by the orchestrator after user direction to drop strangler-pattern discipline (single-user JobHunter — no production users to protect through cutovers).

- **`docs/ddd-target.md`** (2,069 lines, 11 sections) — canonical target-state architecture (DDD + Hexagonal Architecture). 8 product bounded contexts + 4 platform contexts (cloud-only). 7 aggregates with `TenantId`-scoped identities. Driving/driven port tables with named local + cloud adapter pairs (RDS Postgres 16, SQS FIFO, Browserbase, Temporal, S3, Auth0, Stripe, AWS Secrets Manager, …). In-process event bus locally → transactional outbox in cloud. JSON-RPC over subprocess → JSON-RPC over HTTP/HTTPS in cloud. 16-transition stage state machine. Apply saga + pipeline process manager. Repository-per-aggregate persistence boundary. 13 evolution-trigger fitness functions in §9.4 plus context-by-context cloud migration order in §9.5.
- **`docs/plans/proposed/ddd-target-plan.md`** (2,172 lines, **35 steps across 9 phases**) — clean rip-and-replace migration plan from current shape to target. Each step is one PR that ships end-to-end-green. Steps cite the target sections they advance and the briefing's pain points they close. Cloud machinery is explicitly deferred behind §9.4 evolution triggers.

## Process

| Phase | Author | Reviewer | Rounds | Verdict |
|---|---|---|---|---|
| Target draft | `modeler@ddd-target` (Opus 4.7) | `reviewer@ddd-target` (Opus 4.7) | 3 | APPROVED |
| Plan draft | `planner@ddd-plan` (Opus 4.7) | `plan-reviewer@ddd-plan` (Opus 4.7) | 2 (after phasing pre-check) | APPROVED |
| Consistency | orchestrator | — | 1 | CONSISTENT WITH MINOR GAPS (no Blockers, no Highs) |
| Strangler removal | revision agent (Opus 4.7) | orchestrator | 1 | applied + verified |

Both teams used the `domain-driven-design` skill, hexagonal/ports-and-adapters principles, evolutionary architecture (Ford), and Hickey/Wlaschin data orientation.

## Strangler removal (post-approval revision)

After both teams converged, the user clarified that JobHunter has a single user and migration-safety constructs (strangler dual-writes, soak periods, backward-compatibility shims, decommissioning workstreams) are over-engineering. Revision applied to both docs:

- Removed all strangler / dual-write / compatibility-shim language across both documents.
- Plan §7 "Strangler Decommissioning Plan" deleted entirely; legacy code is removed in the same PR that introduces its replacement.
- "Backward compatibility" subsection removed from every plan step.
- 37 → 35 plan steps (old `S-07 LegacyStateDeriver` ACL deleted; `S-15`+`S-16` ProfileRepository port + adapter swap merged into one PR). All cross-references renumbered.
- Target §4.7 `LegacyStateDeriver` domain service removed.
- Target §9.5 "Strangler-Friendly Context Migration" renamed to "Cloud Migration Order" and rewritten to single-user stop/migrate/restart per context.
- Target §2 "Strangler-friendly migrations" principle replaced with "Independent context evolution" (just contextual independence, no preservation language).
- Per-step `Risk` entries rewritten where rip-and-replace replaces dual-write, naming the immediate failure mode and the parity-test + revert mitigation.

`TenantId` threading, evolutionary architecture (cloud adapters named-not-built), §9.4 evolution triggers, all aggregates/ports/events/state machine, the 9-phase structure, and `AGENTS.md` PR conventions are unchanged.

## Final consistency review

Pre-revision verdict was CONSISTENT WITH MINOR GAPS (no Blockers, no Highs). The Mediums/Lows below are notes for the implementer; none change architectural shape. They were not re-verified after the strangler-removal revision; the revision was scoped to remove transitional discipline, not to change events/ports/aggregates.

- **M-1**: `JobRestored` event referenced by `RestoreJobUseCase` in target §5.1 but not in plan S-03's discovery event roster. Add to S-03 or fold into `JobUpdated`.
- **M-2**: `ApplyRunEventRecorded` is in target §4.6 / §6.7 but missing from plan S-03's apply event roster.
- **M-3**: Target §5 names ~25 driving use cases (e.g. `DiscoverJobsUseCase`, `TailorResumeUseCase`); plan steps reference the underlying functions instead.
- **M-4**: `PdfParserPort` and `ProfileSnapshotPort` (target §5.3, §5.4–§5.6) are not in any plan step.
- **M-5**: `SubprocessJsonRpcAdapter` is introduced in S-12 (server) but the TS adapter ships in S-34; plan should add a one-line note in S-12 explaining the deferral.
- **M-6**: `StageCommandDispatcher` is foundational in target §6.8 but deferred in plan §7. Either rename `SubprocessJsonRpcAdapter` to `LocalStageCommandDispatcher` or note that it is the local-first realization of the named port.
- **L-1..L-4**: a handful of events not enumerated in plan §6.2 publication table; `JobBoardScraperPort` adapter extraction not in plan §7 deferrals; pain points #3, #9, #10 from the briefing addressed by plan steps but not cited; apply-telemetry-granularity (target §10 open question) not enumerated in plan §7.

## Test plan

- [ ] Architecture docs render correctly on GitHub (Mermaid diagrams in both).
- [ ] Verify the 35 step IDs in plan §5 are referenced consistently in §6 (cross-cutting workstreams), §8 (QA gates), §9 (documentation plan).
- [ ] Verify every cloud-only piece in plan §7 (out-of-scope deferrals) cites a §9.4 trigger from `docs/ddd-target.md`.
- [ ] No code or behavior change in this PR — `pnpm test` and `uv --project workers/automation run --extra dev pytest -q` should pass without re-running them.