### PR TITLE
feat(web): add job filters and artifact labels

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -893,12 +893,13 @@ function collectArtifacts(
     );
     for (const row of rows) {
       if (!row.path) continue;
-      const key = `${row.artifact_type}:${row.path}`;
+      const artifactType = canonicalArtifactType(row.artifact_type);
+      const key = `${artifactType}:${row.path}`;
       if (seen.has(key)) continue;
       seen.add(key);
       out.push({
         artifactId: row.artifact_id || key,
-        artifactType: row.artifact_type || "artifact",
+        artifactType,
         status: row.status || "active",
         localPath: row.path,
         sizeBytes: nullableNumber(row.size_bytes),
@@ -923,12 +924,13 @@ function collectArtifacts(
     );
     for (const row of rows) {
       if (!row.path) continue;
-      const key = `${row.artifact_type || "artifact"}:${row.path}`;
+      const artifactType = canonicalArtifactType(row.artifact_type);
+      const key = `${artifactType}:${row.path}`;
       if (seen.has(key)) continue;
       seen.add(key);
       out.push({
         artifactId: String(row.row_id ?? key),
-        artifactType: row.artifact_type || "artifact",
+        artifactType,
         status: row.status || "active",
         localPath: row.path,
         sizeBytes: nullableNumber(row.size_bytes),
@@ -974,6 +976,13 @@ function collectArtifacts(
     });
   }
   return out;
+}
+
+function canonicalArtifactType(value: string | null | undefined): string {
+  if (value === "tailored_resume") return "tailored_resume_txt";
+  if (value === "resume_pdf") return "tailored_resume_pdf";
+  if (value === "cover_letter") return "cover_letter_txt";
+  return value || "artifact";
 }
 
 function pdfSibling(value: string | null | undefined): string | null {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -25,6 +25,8 @@ import type {
   DashboardSummary,
   JobDeletedFilter,
   JobDetail,
+  JobFacetsQuery,
+  JobFacetsResponse,
   JobListQuery,
   JobSummary,
   PaginatedResponse,
@@ -111,6 +113,14 @@ interface JobDetailProjectionRow extends Record<string, unknown> {
   score_reasoning: string;
   stages_json: string;
   last_updated_at: string | null;
+}
+
+interface JobFacetProjectionRow extends Record<string, unknown> {
+  title: string;
+  employer: string;
+  location: string;
+  discovered_at: string | null;
+  fit_score: number | null;
 }
 
 interface ArtifactProjectionRow extends Record<string, unknown> {
@@ -224,6 +234,37 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
   return paginate(filtered, query.page, query.pageSize, query.sort, query.dir, jobFilterPayload(query));
 }
 
+export function listJobFacets(db: SqliteDatabase, query: JobFacetsQuery): JobFacetsResponse {
+  refreshProjections(db, DEFAULT_TENANT);
+  const filter = deletedSqlFilter(query.deleted);
+  const rows = allRows<JobFacetProjectionRow>(
+    db,
+    `SELECT title, employer, location, discovered_at, fit_score FROM job_list_projections${filter.where}`,
+    filter.params,
+  );
+  const scores = rows
+    .map((row) => nullableNumber(row.fit_score))
+    .filter((score): score is number => score !== null);
+  const discovered = rows
+    .map((row) => nullableString(row.discovered_at))
+    .filter((value): value is string => value !== null && value !== "");
+  discovered.sort();
+  return {
+    ok: true,
+    locations: sortedUnique(rows.map((row) => row.location)),
+    companies: sortedUnique(rows.map((row) => row.employer)),
+    titles: sortedUnique(rows.map((row) => row.title)),
+    fitScore: {
+      min: scores.length ? Math.min(...scores) : null,
+      max: scores.length ? Math.max(...scores) : null,
+    },
+    discoveredAt: {
+      min: discovered[0] ?? null,
+      max: discovered.at(-1) ?? null,
+    },
+  };
+}
+
 export function matchingJobKeys(db: SqliteDatabase, filter: Partial<BulkJobMutationFilter> = {}): string[] {
   const query = normalizeMutationFilter(filter);
   refreshProjections(db, DEFAULT_TENANT);
@@ -293,9 +334,9 @@ export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): Pag
      WHERE ap.tenant_id = ?${deletedWhere}`,
     [DEFAULT_TENANT],
   );
-  const artifacts = rows.map(rowToArtifactSummary).filter((artifact) => {
+  const artifacts = dedupeArtifacts(rows.map(rowToArtifactSummary)).filter((artifact) => {
     if (query.status && artifact.status !== query.status) return false;
-    if (query.type && artifact.type !== query.type) return false;
+    if (query.type && artifact.type !== canonicalArtifactTypeFilter(query.type)) return false;
     if (!normalizedQuery) return true;
     return [artifact.title, artifact.company, artifact.type, artifact.status, artifact.localPath].some((value) =>
       value.toLowerCase().includes(normalizedQuery),
@@ -307,6 +348,13 @@ export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): Pag
     status: query.status,
     type: query.type,
   });
+}
+
+function canonicalArtifactTypeFilter(value: string | null | undefined): string {
+  if (value === "resume_pdf") return "tailored_resume_pdf";
+  if (value === "tailored_resume") return "tailored_resume_txt";
+  if (value === "cover_letter") return "cover_letter_txt";
+  return value || "artifact";
 }
 
 export function getArtifactDetail(db: SqliteDatabase, artifactId: string): ArtifactDetail | null {
@@ -396,7 +444,7 @@ function rowToArtifactSummary(row: ArtifactProjectionRow): ArtifactSummary {
     jobKey: row.job_id,
     title: row.job_title || "Untitled",
     company: row.job_employer || "Unknown company",
-    type: row.artifact_type || "artifact",
+    type: canonicalArtifactTypeFilter(row.artifact_type),
     status,
     localPath,
     createdAt: row.created_at,
@@ -534,7 +582,19 @@ function artifactsForJob(db: SqliteDatabase, jobId: string): ArtifactSummary[] {
     "SELECT * FROM artifact_list_projections WHERE tenant_id = ? AND job_id = ?",
     [DEFAULT_TENANT, jobId],
   );
-  return rows.map(rowToArtifactSummary);
+  return dedupeArtifacts(rows.map(rowToArtifactSummary));
+}
+
+function dedupeArtifacts(artifacts: ArtifactSummary[]): ArtifactSummary[] {
+  const seen = new Set<string>();
+  const out: ArtifactSummary[] = [];
+  for (const artifact of artifacts) {
+    const key = [artifact.jobKey, artifact.type, artifact.localPath || artifact.artifactId].join("\0");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(artifact);
+  }
+  return out;
 }
 
 // ================================================================ filters
@@ -551,19 +611,31 @@ function normalizeMutationFilter(filter: Partial<BulkJobMutationFilter>): JobLis
     deleted: filter.deleted ?? "active",
     source: filter.source ?? "",
     company: filter.company ?? "",
+    companies: filter.companies ?? [],
+    location: filter.location ?? [],
+    title: filter.title ?? [],
+    discoveredFrom: filter.discoveredFrom ?? "",
+    discoveredTo: filter.discoveredTo ?? "",
     minFitScore: filter.minFitScore,
     maxFitScore: filter.maxFitScore,
   };
 }
 
-function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue[] } {
+function deletedSqlFilter(deleted: JobDeletedFilter): { where: string; params: SqliteValue[] } {
   const clauses: string[] = ["tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
-  if (query.deleted === "active") {
+  if (deleted === "active") {
     clauses.push("deleted_at IS NULL");
-  } else if (query.deleted === "deleted") {
+  } else if (deleted === "deleted") {
     clauses.push("deleted_at IS NOT NULL");
   }
+  return { where: ` WHERE ${clauses.join(" AND ")}`, params };
+}
+
+function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue[] } {
+  const filter = deletedSqlFilter(query.deleted);
+  const clauses = filter.where.replace(/^ WHERE /, "").split(" AND ");
+  const params = [...filter.params];
   if (query.stage) {
     clauses.push("current_stage = ?");
     params.push(query.stage);
@@ -580,13 +652,28 @@ function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue
     clauses.push("LOWER(employer) LIKE ?");
     params.push(`%${query.company.toLowerCase()}%`);
   }
-  if (query.minFitScore !== undefined) {
-    clauses.push("COALESCE(fit_score, -1) >= ?");
-    params.push(query.minFitScore);
+  appendInFilter(clauses, params, "location", query.location);
+  appendInFilter(clauses, params, "employer", query.companies);
+  appendInFilter(clauses, params, "title", query.title);
+  if (query.discoveredFrom) {
+    clauses.push("discovered_at IS NOT NULL AND date(discovered_at) >= date(?)");
+    params.push(query.discoveredFrom);
   }
-  if (query.maxFitScore !== undefined) {
-    clauses.push("COALESCE(fit_score, 999) <= ?");
-    params.push(query.maxFitScore);
+  if (query.discoveredTo) {
+    clauses.push("discovered_at IS NOT NULL AND date(discovered_at) <= date(?)");
+    params.push(query.discoveredTo);
+  }
+  const fitRange = normalizedFitRange(query);
+  if (fitRange.narrowed) {
+    clauses.push("fit_score IS NOT NULL");
+    if (fitRange.min > 0) {
+      clauses.push("fit_score >= ?");
+      params.push(fitRange.min);
+    }
+    if (fitRange.max < 10) {
+      clauses.push("fit_score <= ?");
+      params.push(fitRange.max);
+    }
   }
   return { where: ` WHERE ${clauses.join(" AND ")}`, params };
 }
@@ -598,6 +685,11 @@ function jobFilterPayload(query: JobListQuery): Record<string, unknown> {
     state: query.state ?? "",
     source: query.source,
     company: query.company,
+    companies: query.companies,
+    location: query.location,
+    title: query.title,
+    discoveredFrom: query.discoveredFrom,
+    discoveredTo: query.discoveredTo,
     minFitScore: query.minFitScore ?? null,
     maxFitScore: query.maxFitScore ?? null,
     deleted: query.deleted,
@@ -621,12 +713,58 @@ function filterJob(job: JobSummary, query: JobListQuery, normalizedQuery: string
   if (query.state && job.currentState !== query.state) return false;
   if (query.source && !job.source.toLowerCase().includes(query.source.toLowerCase())) return false;
   if (query.company && !job.company.toLowerCase().includes(query.company.toLowerCase())) return false;
-  if (query.minFitScore !== undefined && (job.fitScore ?? -1) < query.minFitScore) return false;
-  if (query.maxFitScore !== undefined && (job.fitScore ?? 999) > query.maxFitScore) return false;
+  if (query.location.length && !matchesOneOf(job.location, query.location)) return false;
+  if (query.companies.length && !matchesOneOf(job.company, query.companies)) return false;
+  if (query.title.length && !matchesOneOf(job.title, query.title)) return false;
+  if (query.discoveredFrom && (!job.discoveredAt || dateKey(job.discoveredAt) < query.discoveredFrom)) return false;
+  if (query.discoveredTo && (!job.discoveredAt || dateKey(job.discoveredAt) > query.discoveredTo)) return false;
+  const fitRange = normalizedFitRange(query);
+  if (fitRange.narrowed) {
+    if (job.fitScore === null) return false;
+    if (fitRange.min > 0 && job.fitScore < fitRange.min) return false;
+    if (fitRange.max < 10 && job.fitScore > fitRange.max) return false;
+  }
   if (!normalizedQuery) return true;
   return [job.title, job.company, job.url, job.location, job.strategy, job.currentStage, job.currentState].some((value) =>
     value.toLowerCase().includes(normalizedQuery),
   );
+}
+
+function appendInFilter(
+  clauses: string[],
+  params: SqliteValue[],
+  column: "employer" | "location" | "title",
+  values: string[],
+): void {
+  const normalized = sortedUnique(values);
+  if (!normalized.length) {
+    return;
+  }
+  clauses.push(`LOWER(${column}) IN (${normalized.map(() => "?").join(", ")})`);
+  params.push(...normalized.map((value) => value.toLowerCase()));
+}
+
+function normalizedFitRange(query: Pick<JobListQuery, "maxFitScore" | "minFitScore">): {
+  min: number;
+  max: number;
+  narrowed: boolean;
+} {
+  const min = query.minFitScore ?? 0;
+  const max = query.maxFitScore ?? 10;
+  return {
+    min,
+    max,
+    narrowed: min > 0 || max < 10,
+  };
+}
+
+function matchesOneOf(value: string, options: string[]): boolean {
+  const normalized = value.toLowerCase();
+  return options.some((option) => option.toLowerCase() === normalized);
+}
+
+function dateKey(value: string): string {
+  return value.slice(0, 10);
 }
 
 function compareJobs(left: JobSummary, right: JobSummary, field: string, direction: "asc" | "desc"): number {
@@ -808,6 +946,12 @@ function compareValues(left: unknown, right: unknown): number {
   if (right === null || right === undefined || right === "") return 1;
   if (typeof left === "number" && typeof right === "number") return left - right;
   return String(left).localeCompare(String(right));
+}
+
+function sortedUnique(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.map((value) => String(value ?? "").trim()).filter(Boolean))).sort((left, right) =>
+    left.localeCompare(right),
+  );
 }
 
 function isStage(value: unknown): value is Stage {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import {
   CredentialUpdateRequestSchema,
   DeleteJobRequestSchema,
   GenerateMaterialsRequestSchema,
+  JobFacetsQuerySchema,
   JobListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
@@ -40,6 +41,7 @@ import {
   buildDashboardSummary,
   getArtifactDetail,
   getJobDetail,
+  listJobFacets,
   listArtifacts,
   listJobs,
   readProfileConfig,
@@ -124,6 +126,10 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.get("/v1/jobs", async (request, reply) =>
     withDb(reply, options.dbPath, (db) => listJobs(db, JobListQuerySchema.parse(request.query))),
+  );
+
+  app.get("/v1/jobs/facets", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) => listJobFacets(db, JobFacetsQuerySchema.parse(request.query))),
   );
 
   app.post("/v1/jobs/bulk-delete", async (request, reply) => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -293,6 +293,49 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("returns job facets and filters jobs by exact multi-value filters, dates, and fit score range", async () => {
+    const app = buildApp(options);
+
+    const facets = await app.inject({ method: "GET", url: "/v1/jobs/facets" });
+    expect(facets.statusCode, facets.body).toBe(200);
+    expect(facets.json()).toMatchObject({
+      companies: ["Acme", "ExampleCo"],
+      locations: ["Remote"],
+      fitScore: { min: 6, max: 9 },
+      discoveredAt: {
+        min: "2026-04-29T10:00:00+00:00",
+        max: "2026-04-29T10:00:00+00:00",
+      },
+    });
+    expect(facets.json().titles).toEqual(["Backend Engineer", "Frontend Engineer", "Platform Engineer"]);
+
+    const legacyCompanySearch = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?company=example&sort=title&dir=asc",
+    });
+    expect(legacyCompanySearch.statusCode, legacyCompanySearch.body).toBe(200);
+    expect(legacyCompanySearch.json().pagination.total).toBe(2);
+
+    const filtered = await app.inject({
+      method: "GET",
+      url:
+        "/v1/jobs?companies=ExampleCo&title=Backend%20Engineer&location=Remote"
+        + "&discoveredFrom=2026-04-29&discoveredTo=2026-04-29&minFitScore=8&maxFitScore=8",
+    });
+
+    expect(filtered.statusCode, filtered.body).toBe(200);
+    expect(filtered.json().pagination.total).toBe(1);
+    expect(filtered.json().items[0]).toMatchObject({
+      jobKey: "https://example.com/jobs/failed-score",
+      company: "ExampleCo",
+      location: "Remote",
+      title: "Backend Engineer",
+      fitScore: 8,
+    });
+
+    await app.close();
+  });
+
   it("soft-deletes jobs, hides them from active lists, and restores them", async () => {
     const app = buildApp(options);
     const readyKey = encodeURIComponent("https://example.com/jobs/ready");
@@ -592,6 +635,117 @@ describe("local TypeScript API", () => {
       path: artifact.localPath,
     });
     expect(opened).toEqual([artifact.localPath]);
+
+    await app.close();
+  });
+
+  it("canonicalizes duplicate resume PDF artifact rows for a job", async () => {
+    const pdfPath = path.join(tempDir, "ready-resume.pdf");
+    fs.writeFileSync(pdfPath, "%PDF test");
+    const db = new Database(options.dbPath);
+    db.prepare(
+      "INSERT INTO job_artifacts (job_url, stage, artifact_type, status, path, created_at, size_bytes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "https://example.com/jobs/ready",
+      "pdf",
+      "resume_pdf",
+      "active",
+      pdfPath,
+      "2026-04-29T10:06:00+00:00",
+      9,
+    );
+    db.prepare(
+      "INSERT INTO job_artifacts (job_url, stage, artifact_type, status, path, created_at, size_bytes) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "https://example.com/jobs/ready",
+      "pdf",
+      "tailored_resume_pdf",
+      "active",
+      pdfPath,
+      "2026-04-29T10:07:00+00:00",
+      9,
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({ method: "GET", url: "/v1/artifacts?type=tailored_resume_pdf&pageSize=20" });
+    const legacyResponse = await app.inject({ method: "GET", url: "/v1/artifacts?type=resume_pdf&pageSize=20" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(legacyResponse.statusCode, legacyResponse.body).toBe(200);
+    const readyPdfs = response
+      .json()
+      .items.filter((artifact: { jobKey: string }) => artifact.jobKey === "https://example.com/jobs/ready");
+    expect(readyPdfs).toHaveLength(1);
+    expect(readyPdfs[0]).toMatchObject({
+      type: "tailored_resume_pdf",
+      localPath: pdfPath,
+    });
+    expect(legacyResponse.json().items).toEqual(response.json().items);
+
+    await app.close();
+  });
+
+  it("normalizes stale artifact projection rows on read", async () => {
+    const stalePdfPath = path.join(tempDir, "stale-ready-resume.pdf");
+    fs.writeFileSync(stalePdfPath, "%PDF stale");
+    const app = buildApp(options);
+    const warmupResponse = await app.inject({ method: "GET", url: "/v1/artifacts" });
+    expect(warmupResponse.statusCode, warmupResponse.body).toBe(200);
+
+    const db = new Database(options.dbPath);
+    const insertProjection = db.prepare(`
+      INSERT INTO artifact_list_projections (
+        artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
+        status, local_path, size_bytes, created_at, generation
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insertProjection.run(
+      "stale-resume-pdf",
+      "local",
+      "https://example.com/jobs/ready",
+      "Platform Engineer",
+      "ExampleCo",
+      "resume_pdf",
+      "active",
+      stalePdfPath,
+      10,
+      "2026-04-29T10:06:00+00:00",
+      null,
+    );
+    insertProjection.run(
+      "stale-tailored-resume-pdf",
+      "local",
+      "https://example.com/jobs/ready",
+      "Platform Engineer",
+      "ExampleCo",
+      "tailored_resume_pdf",
+      "active",
+      stalePdfPath,
+      10,
+      "2026-04-29T10:07:00+00:00",
+      null,
+    );
+    db.close();
+
+    const listResponse = await app.inject({ method: "GET", url: "/v1/artifacts?type=resume_pdf&pageSize=20" });
+    const detailResponse = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent("https://example.com/jobs/ready")}`,
+    });
+
+    expect(listResponse.statusCode, listResponse.body).toBe(200);
+    expect(detailResponse.statusCode, detailResponse.body).toBe(200);
+    const staleListArtifacts = listResponse
+      .json()
+      .items.filter((artifact: { localPath: string }) => artifact.localPath === stalePdfPath);
+    const staleDetailArtifacts = detailResponse
+      .json()
+      .artifacts.filter((artifact: { localPath: string }) => artifact.localPath === stalePdfPath);
+    expect(staleListArtifacts).toHaveLength(1);
+    expect(staleDetailArtifacts).toHaveLength(1);
+    expect(staleListArtifacts[0]).toMatchObject({ type: "tailored_resume_pdf", localPath: stalePdfPath });
+    expect(staleDetailArtifacts[0]).toMatchObject({ type: "tailored_resume_pdf", localPath: stalePdfPath });
 
     await app.close();
   });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
   type DashboardSummary,
   type DashboardSettings,
   type JobDetail,
+  type JobFacetsResponse,
   type JobSummary,
   type JobSortField,
   type PaginatedResponse,
@@ -56,6 +57,19 @@ const artifactSortFields = [
   ["status", "Status"],
   ["size_bytes", "Size"],
 ] as const;
+
+const currentStateOptions: Array<readonly [StageState | "all", string]> = [
+  ["all", "all current states"],
+  ["pending", "pending"],
+  ["queued", "queued"],
+  ["running", "running"],
+  ["failed", "failed"],
+  ["blocked", "blocked"],
+  ["exhausted", "exhausted"],
+  ["stale", "stale"],
+  ["canceled", "canceled"],
+  ["skipped", "skipped"],
+];
 
 export function App(): JSX.Element {
   const [view, setView] = useState<View>("dashboard");
@@ -358,9 +372,17 @@ function JobsView({
   onOpenJob: (jobKey: string) => void;
 }): JSX.Element {
   const [data, setData] = useState<PaginatedResponse<JobSummary> | null>(null);
+  const [facets, setFacets] = useState<JobFacetsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [stage, setStage] = useState<Stage | "all">("all");
   const [state, setState] = useState<StageState | "all">("all");
+  const [locationFilter, setLocationFilter] = useState<string[]>([]);
+  const [companyFilter, setCompanyFilter] = useState<string[]>([]);
+  const [titleFilter, setTitleFilter] = useState<string[]>([]);
+  const [discoveredFrom, setDiscoveredFrom] = useState("");
+  const [discoveredTo, setDiscoveredTo] = useState("");
+  const [minFitScore, setMinFitScore] = useState("");
+  const [maxFitScore, setMaxFitScore] = useState("");
   const [deleted, setDeleted] = useState<"active" | "deleted">("active");
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(() => new Set());
   const [allMatchingSelected, setAllMatchingSelected] = useState(false);
@@ -386,6 +408,13 @@ function JobsView({
         deleted,
         stage: stage === "all" ? undefined : stage,
         state: state === "all" ? undefined : state,
+        location: locationFilter,
+        companies: companyFilter,
+        title: titleFilter,
+        discoveredFrom,
+        discoveredTo,
+        minFitScore: scoreFilterValue(minFitScore),
+        maxFitScore: scoreFilterValue(maxFitScore),
       });
       if (requestId === requestSeq.current) {
         setData(nextData);
@@ -400,11 +429,39 @@ function JobsView({
         setLoading(false);
       }
     }
-  }, [deleted, dir, globalQuery, page, pageSize, sort, stage, state]);
+  }, [
+    companyFilter,
+    deleted,
+    dir,
+    discoveredFrom,
+    discoveredTo,
+    globalQuery,
+    locationFilter,
+    maxFitScore,
+    minFitScore,
+    page,
+    pageSize,
+    sort,
+    stage,
+    state,
+    titleFilter,
+  ]);
+
+  const loadFacets = useCallback(async () => {
+    try {
+      setFacets(await api.jobFacets({ deleted }));
+    } catch {
+      setFacets(null);
+    }
+  }, [deleted]);
 
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    void loadFacets();
+  }, [loadFacets]);
 
   useEffect(() => {
     const listener = (event: Event) => {
@@ -431,12 +488,28 @@ function JobsView({
 
   useEffect(() => {
     setPage(1);
-  }, [globalQuery]);
+  }, [companyFilter, discoveredFrom, discoveredTo, globalQuery, locationFilter, maxFitScore, minFitScore, titleFilter]);
 
   useEffect(() => {
     setSelectedJobs(new Set());
     setAllMatchingSelected(false);
-  }, [deleted, dir, globalQuery, page, pageSize, sort, stage, state]);
+  }, [
+    companyFilter,
+    deleted,
+    dir,
+    discoveredFrom,
+    discoveredTo,
+    globalQuery,
+    locationFilter,
+    maxFitScore,
+    minFitScore,
+    page,
+    pageSize,
+    sort,
+    stage,
+    state,
+    titleFilter,
+  ]);
 
   const toggleSelection = (jobKey: string, selected: boolean) => {
     setAllMatchingSelected(false);
@@ -472,7 +545,20 @@ function JobsView({
       deleted,
       source: "",
       company: "",
+      location: locationFilter,
+      companies: companyFilter,
+      title: titleFilter,
+      discoveredFrom,
+      discoveredTo,
     };
+    const parsedMinFitScore = scoreFilterValue(minFitScore);
+    const parsedMaxFitScore = scoreFilterValue(maxFitScore);
+    if (parsedMinFitScore !== undefined) {
+      filter.minFitScore = parsedMinFitScore;
+    }
+    if (parsedMaxFitScore !== undefined) {
+      filter.maxFitScore = parsedMaxFitScore;
+    }
     if (stage !== "all") {
       filter.stage = stage;
     }
@@ -515,7 +601,7 @@ function JobsView({
         await api.deleteJobs(payload);
       }
       clearSelection();
-      await Promise.all([load(), onJobsChanged()]);
+      await Promise.all([load(), loadFacets(), onJobsChanged()]);
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : `Unable to ${action} selected jobs.`);
     } finally {
@@ -524,6 +610,25 @@ function JobsView({
   };
 
   const selectedCount = allMatchingSelected ? data?.pagination.total ?? 0 : selectedJobs.size;
+  const filtersActive = Boolean(
+    locationFilter.length
+      || companyFilter.length
+      || titleFilter.length
+      || discoveredFrom
+      || discoveredTo
+      || minFitScore
+      || maxFitScore,
+  );
+  const clearFilters = () => {
+    setLocationFilter([]);
+    setCompanyFilter([]);
+    setTitleFilter([]);
+    setDiscoveredFrom("");
+    setDiscoveredTo("");
+    setMinFitScore("");
+    setMaxFitScore("");
+    setPage(1);
+  };
 
   return (
     <section className="card full">
@@ -551,12 +656,64 @@ function JobsView({
             setPage(1);
           }}
         >
-          {["all", "pending", "running", "succeeded", "failed", "blocked", "exhausted", "stale"].map((item) => (
+          {currentStateOptions.map(([item, label]) => (
             <option key={item} value={item}>
-              {item} states
+              {label}
             </option>
           ))}
         </select>
+        <MultiSelectFilter
+          label="location"
+          options={facets?.locations ?? []}
+          values={locationFilter}
+          onChange={(values) => setLocationFilter(values)}
+        />
+        <MultiSelectFilter
+          label="company"
+          options={facets?.companies ?? []}
+          values={companyFilter}
+          onChange={(values) => setCompanyFilter(values)}
+        />
+        <MultiSelectFilter
+          label="job"
+          options={facets?.titles ?? []}
+          values={titleFilter}
+          onChange={(values) => setTitleFilter(values)}
+        />
+        <label className="inline-field">
+          <span>discovered from</span>
+          <input type="date" value={discoveredFrom} onChange={(event) => setDiscoveredFrom(event.target.value)} />
+        </label>
+        <label className="inline-field">
+          <span>to</span>
+          <input type="date" value={discoveredTo} onChange={(event) => setDiscoveredTo(event.target.value)} />
+        </label>
+        <label className="inline-field score-range-field">
+          <span>fit</span>
+          <input
+            aria-label="Minimum fit score"
+            inputMode="numeric"
+            max={10}
+            min={0}
+            placeholder="0"
+            type="number"
+            value={minFitScore}
+            onChange={(event) => setMinFitScore(clampScoreInput(event.target.value))}
+          />
+        </label>
+        <label className="inline-field score-range-field">
+          <span>to</span>
+          <input
+            aria-label="Maximum fit score"
+            inputMode="numeric"
+            max={10}
+            min={0}
+            placeholder="10"
+            type="number"
+            value={maxFitScore}
+            onChange={(event) => setMaxFitScore(clampScoreInput(event.target.value))}
+          />
+        </label>
         <PageSize
           value={pageSize}
           onChange={(value) => {
@@ -566,6 +723,9 @@ function JobsView({
         />
         <button className="tab" onClick={() => void load()} type="button">
           refresh
+        </button>
+        <button className="tab" disabled={!filtersActive} onClick={clearFilters} type="button">
+          clear filters
         </button>
       </div>
       <div className="bulk-bar">
@@ -714,7 +874,7 @@ function ArtifactsView({
     setOpenStatus("");
     try {
       const response = await api.openArtifact(artifact.artifactId);
-      setOpenStatus(`opened ${response.artifact.type}`);
+      setOpenStatus(`opened ${artifactDisplayLabel(response.artifact.type)}`);
     } catch (requestError) {
       setError(requestError instanceof Error ? requestError.message : "Unable to open artifact.");
     }
@@ -789,7 +949,7 @@ function ArtifactsView({
                   type="button"
                 >
                   <span className={`tag ${artifactStatusTone(artifact.status)}`}>{artifactKind(artifact.type)}</span>
-                  <span>{artifactVersionLabel(artifact.type)}</span>
+                  <span>{artifactDisplayLabel(artifact.type)}</span>
                   <span className="mono">{artifact.size}</span>
                 </button>
               ))}
@@ -2308,6 +2468,54 @@ function SelectPairs<T extends string>({
   );
 }
 
+function MultiSelectFilter({
+  label,
+  options,
+  values,
+  onChange,
+}: {
+  label: string;
+  options: string[];
+  values: string[];
+  onChange: (values: string[]) => void;
+}): JSX.Element {
+  const selected = new Set(values);
+  const toggle = (value: string, checked: boolean) => {
+    const next = new Set(selected);
+    if (checked) {
+      next.add(value);
+    } else {
+      next.delete(value);
+    }
+    onChange(options.filter((option) => next.has(option)));
+  };
+  return (
+    <details className="multi-filter">
+      <summary>{multiSelectSummary(label, values)}</summary>
+      <div className="multi-filter-menu">
+        <div className="multi-filter-head">
+          <span className="meta">{options.length} available</span>
+          <button className="tab" disabled={!values.length} onClick={() => onChange([])} type="button">
+            clear
+          </button>
+        </div>
+        <div className="multi-filter-options">
+          {options.length ? (
+            options.map((option) => (
+              <label className="multi-filter-option" key={option}>
+                <input checked={selected.has(option)} type="checkbox" onChange={(event) => toggle(option, event.target.checked)} />
+                <span>{option}</span>
+              </label>
+            ))
+          ) : (
+            <span className="empty compact">No values.</span>
+          )}
+        </div>
+      </div>
+    </details>
+  );
+}
+
 function DirectionSelect({ value, onChange }: { value: Direction; onChange: (value: Direction) => void }): JSX.Element {
   return (
     <select value={value} onChange={(event) => onChange(event.target.value as Direction)}>
@@ -2327,6 +2535,41 @@ function PageSize({ value, onChange }: { value: number; onChange: (value: number
       ))}
     </select>
   );
+}
+
+function multiSelectSummary(label: string, values: string[]): string {
+  if (!values.length) {
+    return `all ${pluralFilterLabel(label)}`;
+  }
+  if (values.length === 1) {
+    return `${label}: ${values[0]}`;
+  }
+  return `${label}: ${values.length} selected`;
+}
+
+function pluralFilterLabel(label: string): string {
+  if (label === "company") return "companies";
+  if (label === "job") return "jobs";
+  return `${label}s`;
+}
+
+function scoreFilterValue(value: string): number | undefined {
+  if (value === "") {
+    return undefined;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function clampScoreInput(value: string): string {
+  if (value === "") {
+    return "";
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    return "";
+  }
+  return String(Math.min(10, Math.max(0, Math.trunc(parsed))));
 }
 
 function StatusDot({ state }: { state: string }): JSX.Element {
@@ -2461,7 +2704,13 @@ function formatCompanySource(company: string, source: string): string {
 
 function groupArtifacts(artifacts: ArtifactSummary[]): ArtifactGroup[] {
   const groups = new Map<string, ArtifactGroup>();
+  const seen = new Set<string>();
   for (const artifact of artifacts) {
+    const artifactKey = `${artifact.jobKey}:${canonicalArtifactVariantType(artifact.type)}:${artifact.localPath}`;
+    if (seen.has(artifactKey)) {
+      continue;
+    }
+    seen.add(artifactKey);
     const groupKey = artifact.jobKey || `${artifact.title}:${artifact.company}`;
     const group = groups.get(groupKey) ?? {
       groupKey,
@@ -2480,7 +2729,9 @@ function groupArtifacts(artifacts: ArtifactSummary[]): ArtifactGroup[] {
 }
 
 function compareArtifactVersions(left: ArtifactSummary, right: ArtifactSummary): number {
-  return artifactVersionRank(left.type) - artifactVersionRank(right.type) || left.type.localeCompare(right.type);
+  const leftType = canonicalArtifactVariantType(left.type);
+  const rightType = canonicalArtifactVariantType(right.type);
+  return artifactVersionRank(leftType) - artifactVersionRank(rightType) || leftType.localeCompare(rightType);
 }
 
 function artifactVersionRank(type: string): number {
@@ -2503,14 +2754,20 @@ function artifactKind(type: string): string {
   return type.includes("cover") ? "cover" : type.includes("resume") ? "resume" : "artifact";
 }
 
-function artifactVersionLabel(type: string): string {
-  if (type.endsWith("_pdf")) {
-    return "PDF";
-  }
-  if (type.endsWith("_txt")) {
-    return "TXT";
-  }
-  return type.replaceAll("_", " ");
+function artifactDisplayLabel(type: string): string {
+  const normalized = canonicalArtifactVariantType(type);
+  if (normalized === "tailored_resume_pdf") return "tailored resume PDF";
+  if (normalized === "tailored_resume_txt") return "tailored resume text";
+  if (normalized === "cover_letter_pdf") return "cover letter PDF";
+  if (normalized === "cover_letter_txt") return "cover letter text";
+  return normalized.replaceAll("_", " ");
+}
+
+function canonicalArtifactVariantType(type: string): string {
+  if (type === "resume_pdf") return "tailored_resume_pdf";
+  if (type === "tailored_resume") return "tailored_resume_txt";
+  if (type === "cover_letter") return "cover_letter_txt";
+  return type;
 }
 
 async function fileToBase64(file: File): Promise<string> {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -273,9 +273,106 @@ textarea {
   border-bottom: 1px solid var(--rule);
 }
 
-.toolbar input {
+.toolbar > input {
   min-width: min(420px, 100%);
   flex: 1;
+}
+
+.inline-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.inline-field input {
+  min-width: 136px;
+}
+
+.score-range-field input {
+  width: 58px;
+  min-width: 58px;
+}
+
+.multi-filter {
+  position: relative;
+}
+
+.multi-filter summary {
+  min-width: 132px;
+  max-width: 260px;
+  overflow: hidden;
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  background: var(--paper);
+  padding: 7px 28px 7px 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  list-style: none;
+}
+
+.multi-filter summary::-webkit-details-marker {
+  display: none;
+}
+
+.multi-filter summary::after {
+  position: absolute;
+  right: 9px;
+  content: "v";
+  color: var(--muted);
+}
+
+.multi-filter-menu {
+  position: absolute;
+  top: calc(100% + 5px);
+  left: 0;
+  z-index: 30;
+  display: flex;
+  width: min(420px, 78vw);
+  max-height: 360px;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  background: var(--paper);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.14);
+}
+
+.multi-filter-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--rule);
+  padding: 8px 10px;
+}
+
+.multi-filter-options {
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+  padding: 6px;
+}
+
+.multi-filter-option {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  border-radius: 5px;
+  padding: 6px;
+}
+
+.multi-filter-option:hover {
+  background: var(--paper-2);
+}
+
+.multi-filter-option span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .config-layout {
@@ -699,6 +796,11 @@ textarea {
   padding: 28px 16px;
   color: var(--muted);
   text-align: center;
+}
+
+.empty.compact {
+  padding: 8px 10px;
+  text-align: left;
 }
 
 .banner {

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -7,12 +7,18 @@ local profile/style/template files, and invokes Python automation through the
 JSON-RPC 2.0 protocol over a long-lived `jobhunter rpc` subprocess. It is
 intentionally local-first and binds to `127.0.0.1` by default.
 
-Read-model endpoints (`/v1/dashboard/summary`, `/v1/jobs`, `/v1/jobs/:key`,
-`/v1/artifacts`) read from the five `*_projections` tables maintained by
+Read-model endpoints (`/v1/dashboard/summary`, `/v1/jobs`, `/v1/jobs/facets`,
+`/v1/jobs/:key`, `/v1/artifacts`) read from the five `*_projections` tables maintained by
 `apps/api/src/projections.ts` (TS-side mirror) and the Python
 `ProjectionBuilder` (`workers/automation/src/jobhunter/infrastructure/projections/`).
 Both processes refresh projections idempotently via the shared
 `event_watermarks.operations_projections` watermark.
+
+`/v1/jobs` supports exact multi-value filters through repeated query
+parameters for `location`, `companies`, and `title`, plus `discoveredFrom`,
+`discoveredTo`, `minFitScore`, and `maxFitScore`. The legacy scalar `company`
+query parameter remains a partial company search. `/v1/jobs/facets` returns the
+available location, company, and title values for the local dashboard filters.
 
 ## Related Packages
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -14,6 +14,7 @@ import type {
   DeleteJobRequest,
   GenerateMaterialsRequest,
   JobDetail,
+  JobFacetsResponse,
   JobListQuery,
   JobMutationResponse,
   JobSummary,
@@ -29,6 +30,7 @@ import type {
 } from "@jobhunter/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
+type QueryParamValue = QueryValue | readonly QueryValue[];
 const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
 
 export interface HealthResponse {
@@ -54,6 +56,10 @@ export class JobHunterApiClient {
 
   jobs(query: Partial<JobListQuery> = {}): Promise<PaginatedResponse<JobSummary>> {
     return this.get("/v1/jobs", query);
+  }
+
+  jobFacets(query: Pick<Partial<JobListQuery>, "deleted"> = {}): Promise<JobFacetsResponse> {
+    return this.get("/v1/jobs/facets", query);
   }
 
   job(jobKey: string): Promise<JobDetail> {
@@ -153,7 +159,7 @@ export class JobHunterApiClient {
     return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/actions/mark-skipped`, body);
   }
 
-  private async get<T>(path: string, query?: Record<string, QueryValue>): Promise<T> {
+  private async get<T>(path: string, query?: Record<string, QueryParamValue>): Promise<T> {
     return this.request("GET", path, query ? { query } : {});
   }
 
@@ -172,12 +178,15 @@ export class JobHunterApiClient {
   private async request<T>(
     method: "DELETE" | "GET" | "PATCH" | "POST",
     path: string,
-    options: { body?: unknown; query?: Record<string, QueryValue> } = {},
+    options: { body?: unknown; query?: Record<string, QueryParamValue> } = {},
   ): Promise<T> {
     const url = new URL(`${this.baseUrl}${path}`, this.baseUrl ? undefined : "http://jobhunter.local");
     for (const [key, value] of Object.entries(options.query ?? {})) {
-      if (value !== undefined && value !== null && value !== "") {
-        url.searchParams.set(key, String(value));
+      const values = Array.isArray(value) ? value : [value];
+      for (const item of values) {
+        if (item !== undefined && item !== null && item !== "") {
+          url.searchParams.append(key, String(item));
+        }
       }
     }
     const href = this.baseUrl ? url.href : `${url.pathname}${url.search}`;

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -45,7 +45,26 @@ const optionalText = z
   .catch("")
   .transform((value) => value ?? "");
 
-const optionalNumber = z.coerce.number().int().optional().catch(undefined);
+const optionalFitScore = z.coerce.number().int().min(0).max(10).optional().catch(undefined);
+const optionalDateText = z
+  .string()
+  .trim()
+  .max(40)
+  .optional()
+  .catch("")
+  .transform((value) => value ?? "");
+const optionalTextList = z
+  .preprocess((value) => {
+    if (value === undefined || value === null) {
+      return [];
+    }
+    const values = Array.isArray(value) ? value : [value];
+    return values
+      .flatMap((item) => String(item).split(","))
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }, z.array(z.string().trim().min(1).max(500)))
+  .catch([]);
 
 export const RetryStageRequestSchema = z
   .object({
@@ -105,8 +124,13 @@ export const BulkJobMutationFilterSchema = z
     deleted: z.enum(JOB_DELETED_FILTERS).default("active").catch("active"),
     source: optionalText,
     company: optionalText,
-    minFitScore: optionalNumber,
-    maxFitScore: optionalNumber,
+    companies: optionalTextList,
+    location: optionalTextList,
+    title: optionalTextList,
+    discoveredFrom: optionalDateText,
+    discoveredTo: optionalDateText,
+    minFitScore: optionalFitScore,
+    maxFitScore: optionalFitScore,
   })
   .strict();
 export type BulkJobMutationFilter = z.infer<typeof BulkJobMutationFilterSchema>;
@@ -354,8 +378,13 @@ export const JobListQuerySchema = z
     deleted: z.enum(JOB_DELETED_FILTERS).default("active").catch("active"),
     source: optionalText,
     company: optionalText,
-    minFitScore: optionalNumber,
-    maxFitScore: optionalNumber,
+    companies: optionalTextList,
+    location: optionalTextList,
+    title: optionalTextList,
+    discoveredFrom: optionalDateText,
+    discoveredTo: optionalDateText,
+    minFitScore: optionalFitScore,
+    maxFitScore: optionalFitScore,
   })
   .transform((value) => ({
     ...value,
@@ -363,6 +392,12 @@ export const JobListQuerySchema = z
   }));
 
 export type JobListQuery = z.infer<typeof JobListQuerySchema>;
+
+export const JobFacetsQuerySchema = z.object({
+  deleted: z.enum(JOB_DELETED_FILTERS).default("active").catch("active"),
+});
+
+export type JobFacetsQuery = z.infer<typeof JobFacetsQuerySchema>;
 
 export const ArtifactListQuerySchema = z
   .object({
@@ -419,6 +454,21 @@ export interface JobSummary {
   applyStatus: string | null;
   appliedAt: string | null;
   deletedAt: string | null;
+}
+
+export interface JobFacetsResponse {
+  ok: true;
+  locations: string[];
+  companies: string[];
+  titles: string[];
+  fitScore: {
+    min: number | null;
+    max: number | null;
+  };
+  discoveredAt: {
+    min: string | null;
+    max: string | null;
+  };
 }
 
 export interface ArtifactSummary {

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -83,6 +83,16 @@ DEFAULT_MAX_ATTEMPTS: dict[str, int] = {
 _SOURCE_BOARD_NAMES = {"greenhouse", "linkedin", "talent.com"}
 
 
+def _canonical_artifact_type(value: str | None) -> str:
+    if value == "tailored_resume":
+        return "tailored_resume_txt"
+    if value == "resume_pdf":
+        return "tailored_resume_pdf"
+    if value == "cover_letter":
+        return "cover_letter_txt"
+    return value or "artifact"
+
+
 class ProjectionBuilder:
     """In-process projection materialiser.
 
@@ -551,7 +561,7 @@ class ProjectionBuilder:
                 (job_url,),
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
-                atype = _row_nullable_str(row, "artifact_type") or ""
+                atype = _canonical_artifact_type(_row_nullable_str(row, "artifact_type"))
                 if not local_path:
                     continue
                 key = (atype, local_path)
@@ -583,7 +593,7 @@ class ProjectionBuilder:
                 (job_url,),
             ).fetchall():
                 local_path = _row_nullable_str(row, "path") or ""
-                atype = _row_nullable_str(row, "artifact_type") or "artifact"
+                atype = _canonical_artifact_type(_row_nullable_str(row, "artifact_type"))
                 if not local_path:
                     continue
                 key = (atype, local_path)

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -220,3 +220,64 @@ def test_refresh_is_idempotent(conn: sqlite3.Connection) -> None:
         "SELECT COUNT(*) FROM job_list_projections WHERE job_id = ?", (url,)
     ).fetchone()
     assert rows[0] == 1
+
+
+def test_artifact_projection_canonicalizes_legacy_types_and_deduplicates(
+    conn: sqlite3.Connection,
+) -> None:
+    url = "https://example.com/jobs/artifacts"
+    _seed_job(conn, url)
+    now = utc_now()
+    resume_pdf = "/tmp/job-artifacts/resume.pdf"
+    cover_txt = "/tmp/job-artifacts/cover.txt"
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            job_url, generation, status, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (url, 1, "complete", now, now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            job_url, generation, artifact_type, artifact_id, status, path,
+            render_format, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (url, 1, "resume_pdf", "resume-legacy", "approved", resume_pdf, "pdf", now),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            job_url, stage, artifact_type, status, path, created_at, size_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (url, "pdf", "tailored_resume_pdf", "active", resume_pdf, now, 128),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_artifacts (
+            job_url, stage, artifact_type, status, path, created_at, size_bytes
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (url, "cover", "cover_letter", "active", cover_txt, now, 32),
+    )
+    record_job_event(conn, url, "pdf", "PdfRendered")
+    conn.commit()
+
+    ProjectionBuilder(conn).refresh()
+
+    rows = conn.execute(
+        """
+        SELECT artifact_type, local_path
+        FROM artifact_list_projections
+        WHERE job_id = ?
+        ORDER BY artifact_type, local_path
+        """,
+        (url,),
+    ).fetchall()
+    assert [(row["artifact_type"], row["local_path"]) for row in rows] == [
+        ("cover_letter_txt", cover_txt),
+        ("tailored_resume_pdf", resume_pdf),
+    ]


### PR DESCRIPTION
## Summary
- add projection-backed job facets and exact multi-value/date/fit score filters
- update the Jobs toolbar with location, company, job title, discovered date, and fit score controls
- canonicalize duplicate resume PDF artifacts and show explicit tailored resume labels

## Validation
- pnpm api:test
- pnpm web:build
- pnpm check
- Browser: verified Jobs filters and Artifacts labels at http://127.0.0.1:5173/ against API port 8767
