### PR TITLE
feat(web): phase 3 — query (TanStack Query, per-context hooks, ports, EventStream scaffold)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,8 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@tanstack/react-query": "^5.100.9",
+    "@tanstack/react-query-devtools": "^5.100.9",
     "@tanstack/react-router": "^1.93.0",
     "@tanstack/react-router-devtools": "^1.93.0",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { type QueryClient } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import type { JSX } from "react";
 
@@ -5,8 +6,12 @@ import { router } from "./router.js";
 import { usePorts } from "./shared/providers/PortsProvider.js";
 import { useTenantId } from "./shared/providers/TenantProvider.js";
 
-export function App(): JSX.Element {
+export interface AppProps {
+  queryClient: QueryClient;
+}
+
+export function App({ queryClient }: AppProps): JSX.Element {
   const ports = usePorts();
   const tenantId = useTenantId();
-  return <RouterProvider router={router} context={{ ports, tenantId }} />;
+  return <RouterProvider router={router} context={{ ports, tenantId, queryClient }} />;
 }

--- a/apps/web/src/contexts/apply/handlers.ts
+++ b/apps/web/src/contexts/apply/handlers.ts
@@ -1,0 +1,21 @@
+import type {
+  ApplicationFailed,
+  ApplicationSubmitted,
+  ApplyRunEventRecorded,
+  ApplyRunStarted,
+} from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const applyRunStartedHandler = (
+  _event: ApplyRunStarted,
+): readonly InvalidationItem[] => [];
+export const applyRunEventRecordedHandler = (
+  _event: ApplyRunEventRecorded,
+): readonly InvalidationItem[] => [];
+export const applicationSubmittedHandler = (
+  _event: ApplicationSubmitted,
+): readonly InvalidationItem[] => [];
+export const applicationFailedHandler = (
+  _event: ApplicationFailed,
+): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/apply/hooks/useApplyJobMutation.ts
+++ b/apps/web/src/contexts/apply/hooks/useApplyJobMutation.ts
@@ -1,0 +1,34 @@
+import type { ActionRunResponse, ApplyJobRequest } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface ApplyJobVariables {
+  readonly jobId: JobId;
+  readonly body?: Partial<ApplyJobRequest>;
+}
+
+export function useApplyJobMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  ApplyJobVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, ApplyJobVariables>(queryClient, {
+      mutationFn: ({ jobId, body }) => api.applyJob(jobId, body ?? {}),
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/apply/hooks/useCancelApplyMutation.ts
+++ b/apps/web/src/contexts/apply/hooks/useCancelApplyMutation.ts
@@ -1,0 +1,35 @@
+import type { ActionRunResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface CancelApplyVariables {
+  readonly jobId: JobId;
+  readonly runId?: string;
+}
+
+export function useCancelApplyMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  CancelApplyVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, CancelApplyVariables>(queryClient, {
+      mutationFn: ({ jobId, runId }) =>
+        api.cancelJobAction(jobId, runId ? { runId } : {}),
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/apply/hooks/useDryRunApplyMutation.ts
+++ b/apps/web/src/contexts/apply/hooks/useDryRunApplyMutation.ts
@@ -1,0 +1,33 @@
+import type { ActionRunResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface DryRunApplyVariables {
+  readonly jobId: JobId;
+}
+
+export function useDryRunApplyMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  DryRunApplyVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, DryRunApplyVariables>(queryClient, {
+      mutationFn: ({ jobId }) => api.applyJob(jobId, { dryRun: true }),
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/apply/index.ts
+++ b/apps/web/src/contexts/apply/index.ts
@@ -1,0 +1,12 @@
+export { applyKeys } from "./queryKeys.js";
+
+export { useApplyJobMutation } from "./hooks/useApplyJobMutation.js";
+export { useCancelApplyMutation } from "./hooks/useCancelApplyMutation.js";
+export { useDryRunApplyMutation } from "./hooks/useDryRunApplyMutation.js";
+
+export {
+  applicationFailedHandler,
+  applicationSubmittedHandler,
+  applyRunEventRecordedHandler,
+  applyRunStartedHandler,
+} from "./handlers.js";

--- a/apps/web/src/contexts/apply/queryKeys.ts
+++ b/apps/web/src/contexts/apply/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const applyKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "apply"] as const,
+};

--- a/apps/web/src/contexts/discovery/handlers.ts
+++ b/apps/web/src/contexts/discovery/handlers.ts
@@ -1,0 +1,13 @@
+import type {
+  JobDeleted,
+  JobDiscovered,
+  JobRestored,
+  JobUpdated,
+} from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const jobDiscoveredHandler = (_event: JobDiscovered): readonly InvalidationItem[] => [];
+export const jobUpdatedHandler = (_event: JobUpdated): readonly InvalidationItem[] => [];
+export const jobDeletedHandler = (_event: JobDeleted): readonly InvalidationItem[] => [];
+export const jobRestoredHandler = (_event: JobRestored): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/discovery/hooks/useDeleteJobMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useDeleteJobMutation.ts
@@ -1,0 +1,43 @@
+import type { DeleteJobRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export interface DeleteJobVariables {
+  readonly jobId: JobId;
+  readonly body?: DeleteJobRequest;
+}
+
+export function useDeleteJobMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  DeleteJobVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, DeleteJobVariables>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: ({ jobId, body }) => api.deleteJob(jobId, body ?? {}),
+      optimisticUpdates: ({ jobId }) => [
+        {
+          queryKey: jobsKeys.lists(tenantId),
+          exact: false,
+          patch: (current) => patchListRemove(current, new Set([jobId])),
+        },
+      ],
+      settle: ({ jobId }) => [
+        jobsKeys.lists(tenantId),
+        jobsKeys.detail(tenantId, jobId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/hooks/useDeleteJobsBulkMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useDeleteJobsBulkMutation.ts
@@ -1,0 +1,38 @@
+import type { BulkJobMutationRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export function useDeleteJobsBulkMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  BulkJobMutationRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, BulkJobMutationRequest>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: (body) => api.deleteJobs(body),
+      // allMatching mode is unbounded server-side — skip optimistic patch and
+      // rely on settle invalidation. Explicit jobKeys list patches optimistically.
+      optimisticUpdates: (body) =>
+        body.allMatching
+          ? []
+          : [
+              {
+                queryKey: jobsKeys.lists(tenantId),
+                exact: false,
+                patch: (current) => patchListRemove(current, new Set(body.jobKeys)),
+              },
+            ],
+      settle: () => [jobsKeys.lists(tenantId), dashboardKeys.summary(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/hooks/useImportJobMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useImportJobMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+
+import { NotImplementedError } from "../../../shared/lib/errors.js";
+
+export interface ImportJobVariables {
+  readonly url: string;
+}
+
+export function useImportJobMutation(): UseMutationResult<never, Error, ImportJobVariables> {
+  return useMutation({
+    mutationFn: () => {
+      throw new NotImplementedError("useImportJobMutation");
+    },
+  });
+}

--- a/apps/web/src/contexts/discovery/hooks/useRestoreJobMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useRestoreJobMutation.ts
@@ -1,0 +1,44 @@
+import type { JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export interface RestoreJobVariables {
+  readonly jobId: JobId;
+}
+
+export function useRestoreJobMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  RestoreJobVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, RestoreJobVariables>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: ({ jobId }) => api.restoreJob(jobId),
+      // Restoring a job moves it from the "deleted" tab to the "active" tab —
+      // from the currently-viewed list it disappears, same as delete.
+      optimisticUpdates: ({ jobId }) => [
+        {
+          queryKey: jobsKeys.lists(tenantId),
+          exact: false,
+          patch: (current) => patchListRemove(current, new Set([jobId])),
+        },
+      ],
+      settle: ({ jobId }) => [
+        jobsKeys.lists(tenantId),
+        jobsKeys.detail(tenantId, jobId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/hooks/useRestoreJobsBulkMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useRestoreJobsBulkMutation.ts
@@ -1,0 +1,36 @@
+import type { BulkJobMutationRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export function useRestoreJobsBulkMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  BulkJobMutationRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, BulkJobMutationRequest>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: (body) => api.restoreJobs(body),
+      optimisticUpdates: (body) =>
+        body.allMatching
+          ? []
+          : [
+              {
+                queryKey: jobsKeys.lists(tenantId),
+                exact: false,
+                patch: (current) => patchListRemove(current, new Set(body.jobKeys)),
+              },
+            ],
+      settle: () => [jobsKeys.lists(tenantId), dashboardKeys.summary(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/index.ts
+++ b/apps/web/src/contexts/discovery/index.ts
@@ -1,0 +1,14 @@
+export { discoveryKeys } from "./queryKeys.js";
+
+export { useDeleteJobMutation } from "./hooks/useDeleteJobMutation.js";
+export { useDeleteJobsBulkMutation } from "./hooks/useDeleteJobsBulkMutation.js";
+export { useImportJobMutation } from "./hooks/useImportJobMutation.js";
+export { useRestoreJobMutation } from "./hooks/useRestoreJobMutation.js";
+export { useRestoreJobsBulkMutation } from "./hooks/useRestoreJobsBulkMutation.js";
+
+export {
+  jobDeletedHandler,
+  jobDiscoveredHandler,
+  jobRestoredHandler,
+  jobUpdatedHandler,
+} from "./handlers.js";

--- a/apps/web/src/contexts/discovery/lib/jobListPatches.ts
+++ b/apps/web/src/contexts/discovery/lib/jobListPatches.ts
@@ -1,0 +1,29 @@
+import type { JobSummary, PaginatedResponse } from "../../operations/types.js";
+
+function isJobsPage(value: unknown): value is PaginatedResponse<JobSummary> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "items" in value &&
+    "pagination" in value &&
+    Array.isArray((value as PaginatedResponse<JobSummary>).items)
+  );
+}
+
+export function patchListRemove(current: unknown, jobIds: ReadonlySet<string>): unknown {
+  if (!isJobsPage(current)) {
+    return current;
+  }
+  const removed = current.items.filter((job) => jobIds.has(job.jobKey));
+  if (removed.length === 0) {
+    return current;
+  }
+  return {
+    ...current,
+    items: current.items.filter((job) => !jobIds.has(job.jobKey)),
+    pagination: {
+      ...current.pagination,
+      total: Math.max(0, current.pagination.total - removed.length),
+    },
+  };
+}

--- a/apps/web/src/contexts/discovery/queryKeys.ts
+++ b/apps/web/src/contexts/discovery/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const discoveryKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "discovery"] as const,
+};

--- a/apps/web/src/contexts/enrichment/handlers.ts
+++ b/apps/web/src/contexts/enrichment/handlers.ts
@@ -1,0 +1,8 @@
+import type { EnrichmentFailed, JobEnriched } from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const jobEnrichedHandler = (_event: JobEnriched): readonly InvalidationItem[] => [];
+export const enrichmentFailedHandler = (
+  _event: EnrichmentFailed,
+): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/enrichment/hooks/useEnrichmentRetryMutation.ts
+++ b/apps/web/src/contexts/enrichment/hooks/useEnrichmentRetryMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+
+import { NotImplementedError } from "../../../shared/lib/errors.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface EnrichmentRetryVariables {
+  readonly jobId: JobId;
+}
+
+export function useEnrichmentRetryMutation(): UseMutationResult<
+  never,
+  Error,
+  EnrichmentRetryVariables
+> {
+  return useMutation({
+    mutationFn: () => {
+      throw new NotImplementedError("useEnrichmentRetryMutation");
+    },
+  });
+}

--- a/apps/web/src/contexts/enrichment/index.ts
+++ b/apps/web/src/contexts/enrichment/index.ts
@@ -1,0 +1,5 @@
+export { enrichmentKeys } from "./queryKeys.js";
+
+export { useEnrichmentRetryMutation } from "./hooks/useEnrichmentRetryMutation.js";
+
+export { enrichmentFailedHandler, jobEnrichedHandler } from "./handlers.js";

--- a/apps/web/src/contexts/enrichment/queryKeys.ts
+++ b/apps/web/src/contexts/enrichment/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const enrichmentKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "enrichment"] as const,
+};

--- a/apps/web/src/contexts/materials/handlers.ts
+++ b/apps/web/src/contexts/materials/handlers.ts
@@ -1,0 +1,21 @@
+import type {
+  CoverLetterGenerated,
+  MaterialsExhausted,
+  PdfRendered,
+  ResumeApproved,
+  ResumeFailed,
+} from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const resumeApprovedHandler = (
+  _event: ResumeApproved,
+): readonly InvalidationItem[] => [];
+export const resumeFailedHandler = (_event: ResumeFailed): readonly InvalidationItem[] => [];
+export const coverLetterGeneratedHandler = (
+  _event: CoverLetterGenerated,
+): readonly InvalidationItem[] => [];
+export const pdfRenderedHandler = (_event: PdfRendered): readonly InvalidationItem[] => [];
+export const materialsExhaustedHandler = (
+  _event: MaterialsExhausted,
+): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/materials/hooks/useGenerateMaterialsMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useGenerateMaterialsMutation.ts
@@ -1,0 +1,20 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+
+import { NotImplementedError } from "../../../shared/lib/errors.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface GenerateMaterialsVariables {
+  readonly jobId: JobId;
+}
+
+export function useGenerateMaterialsMutation(): UseMutationResult<
+  never,
+  Error,
+  GenerateMaterialsVariables
+> {
+  return useMutation({
+    mutationFn: () => {
+      throw new NotImplementedError("useGenerateMaterialsMutation");
+    },
+  });
+}

--- a/apps/web/src/contexts/materials/hooks/useOpenArtifactMutation.ts
+++ b/apps/web/src/contexts/materials/hooks/useOpenArtifactMutation.ts
@@ -1,0 +1,19 @@
+import type { ArtifactOpenResponse } from "@jobhunter/contracts";
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+
+export interface OpenArtifactVariables {
+  readonly artifactId: string;
+}
+
+export function useOpenArtifactMutation(): UseMutationResult<
+  ArtifactOpenResponse,
+  Error,
+  OpenArtifactVariables
+> {
+  const { api } = usePorts();
+  return useMutation({
+    mutationFn: ({ artifactId }) => api.openArtifact(artifactId),
+  });
+}

--- a/apps/web/src/contexts/materials/index.ts
+++ b/apps/web/src/contexts/materials/index.ts
@@ -1,0 +1,12 @@
+export { materialsKeys } from "./queryKeys.js";
+
+export { useGenerateMaterialsMutation } from "./hooks/useGenerateMaterialsMutation.js";
+export { useOpenArtifactMutation } from "./hooks/useOpenArtifactMutation.js";
+
+export {
+  coverLetterGeneratedHandler,
+  materialsExhaustedHandler,
+  pdfRenderedHandler,
+  resumeApprovedHandler,
+  resumeFailedHandler,
+} from "./handlers.js";

--- a/apps/web/src/contexts/materials/queryKeys.ts
+++ b/apps/web/src/contexts/materials/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const materialsKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "materials"] as const,
+};

--- a/apps/web/src/contexts/operations/applyRunsKeys.ts
+++ b/apps/web/src/contexts/operations/applyRunsKeys.ts
@@ -1,0 +1,15 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+// The backend bundles apply runs in `DashboardSummary.applyRuns` rather than
+// exposing a dedicated `/v1/apply-runs` endpoint. Today's `useApplyRunsListQuery`
+// and `useApplyRunQuery` therefore key on `dashboardKeys.summary(tenantId)` and
+// derive via `select` (see hooks/useApplyRun*Query.ts). This factory is kept as
+// the seam for the future dedicated endpoint per target §4.1; the §8.4 event
+// → invalidation map will route `ApplyRun*` events here once the endpoint exists.
+export const applyRunsKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "applyRuns"] as const,
+  lists: (tenantId: TenantId) => [...applyRunsKeys.all(tenantId), "list"] as const,
+  details: (tenantId: TenantId) => [...applyRunsKeys.all(tenantId), "detail"] as const,
+  detail: (tenantId: TenantId, runId: string) =>
+    [...applyRunsKeys.details(tenantId), runId] as const,
+};

--- a/apps/web/src/contexts/operations/artifactsKeys.ts
+++ b/apps/web/src/contexts/operations/artifactsKeys.ts
@@ -1,0 +1,13 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+import type { ArtifactsListInput } from "./types.js";
+
+export const artifactsKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "artifacts"] as const,
+  lists: (tenantId: TenantId) => [...artifactsKeys.all(tenantId), "list"] as const,
+  list: (tenantId: TenantId, input: ArtifactsListInput) =>
+    [...artifactsKeys.lists(tenantId), input] as const,
+  details: (tenantId: TenantId) => [...artifactsKeys.all(tenantId), "detail"] as const,
+  detail: (tenantId: TenantId, artifactId: string) =>
+    [...artifactsKeys.details(tenantId), artifactId] as const,
+};

--- a/apps/web/src/contexts/operations/dashboardKeys.ts
+++ b/apps/web/src/contexts/operations/dashboardKeys.ts
@@ -1,0 +1,6 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const dashboardKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "dashboard"] as const,
+  summary: (tenantId: TenantId) => [...dashboardKeys.all(tenantId), "summary"] as const,
+};

--- a/apps/web/src/contexts/operations/healthKeys.ts
+++ b/apps/web/src/contexts/operations/healthKeys.ts
@@ -1,0 +1,6 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const healthKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "health"] as const,
+  live: (tenantId: TenantId) => [...healthKeys.all(tenantId), "live"] as const,
+};

--- a/apps/web/src/contexts/operations/hooks/useActivityEventQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useActivityEventQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { dashboardKeys } from "../dashboardKeys.js";
+import type { DashboardSummary } from "../types.js";
+
+export type ActivityEvent = DashboardSummary["activity"][number];
+
+export function useActivityEventQuery(eventId: string): UseQueryResult<ActivityEvent | null> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: dashboardKeys.summary(tenantId),
+    queryFn: () => api.dashboardSummary(),
+    select: (summary) =>
+      summary.activity.find((entry) => entry.eventId === eventId) ?? null,
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useApplyRunQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useApplyRunQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { dashboardKeys } from "../dashboardKeys.js";
+import type { DashboardSummary } from "../types.js";
+
+export type ApplyRunSummary = DashboardSummary["applyRuns"][number];
+
+export function useApplyRunQuery(runId: string): UseQueryResult<ApplyRunSummary | null> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: dashboardKeys.summary(tenantId),
+    queryFn: () => api.dashboardSummary(),
+    select: (summary) => summary.applyRuns.find((entry) => entry.runId === runId) ?? null,
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useApplyRunsListQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useApplyRunsListQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { dashboardKeys } from "../dashboardKeys.js";
+import type { DashboardSummary } from "../types.js";
+
+export type ApplyRunSummary = DashboardSummary["applyRuns"][number];
+
+export function useApplyRunsListQuery(): UseQueryResult<readonly ApplyRunSummary[]> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: dashboardKeys.summary(tenantId),
+    queryFn: () => api.dashboardSummary(),
+    select: (summary) => summary.applyRuns,
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useArtifactDetailQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useArtifactDetailQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { artifactsKeys } from "../artifactsKeys.js";
+import type { ArtifactDetail } from "../types.js";
+
+export function useArtifactDetailQuery(artifactId: string): UseQueryResult<ArtifactDetail> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: artifactsKeys.detail(tenantId, artifactId),
+    queryFn: () => api.artifact(artifactId),
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useArtifactsListQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useArtifactsListQuery.ts
@@ -1,0 +1,18 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { artifactsKeys } from "../artifactsKeys.js";
+import type { ArtifactsListInput, ArtifactSummary, PaginatedResponse } from "../types.js";
+
+export function useArtifactsListQuery(
+  input: ArtifactsListInput,
+): UseQueryResult<PaginatedResponse<ArtifactSummary>> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: artifactsKeys.list(tenantId, input),
+    queryFn: () => api.artifacts(input),
+    staleTime: 60_000,
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useDashboardSummaryQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useDashboardSummaryQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { dashboardKeys } from "../dashboardKeys.js";
+import type { DashboardSummary } from "../types.js";
+
+export function useDashboardSummaryQuery(): UseQueryResult<DashboardSummary> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: dashboardKeys.summary(tenantId),
+    queryFn: () => api.dashboardSummary(),
+    staleTime: 0,
+    refetchOnMount: "always",
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { ApiHealthResponse } from "../../../shared/ports/ApiClientPort.js";
+import { healthKeys } from "../healthKeys.js";
+
+export function useHealthQuery(): UseQueryResult<ApiHealthResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: healthKeys.live(tenantId),
+    queryFn: () => api.health(),
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useInvalidationRouter.ts
+++ b/apps/web/src/contexts/operations/hooks/useInvalidationRouter.ts
@@ -1,0 +1,8 @@
+import { invalidationRouter, type InvalidationRouter } from "../invalidation-router.js";
+
+// Module-level singleton — stable reference for EventStreamProvider effect
+// deps per target §7.3. If per-tenant routers ever ship, swap for a memoized
+// cache without changing the hook signature.
+export function useInvalidationRouter(): InvalidationRouter {
+  return invalidationRouter;
+}

--- a/apps/web/src/contexts/operations/hooks/useJobDetailQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useJobDetailQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { jobsKeys } from "../jobsKeys.js";
+import type { JobDetail, JobId } from "../types.js";
+
+export function useJobDetailQuery(jobId: JobId): UseQueryResult<JobDetail> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: jobsKeys.detail(tenantId, jobId),
+    queryFn: () => api.job(jobId),
+  });
+}

--- a/apps/web/src/contexts/operations/hooks/useJobsListQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useJobsListQuery.ts
@@ -1,0 +1,17 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { jobsKeys } from "../jobsKeys.js";
+import type { JobsListInput, JobSummary, PaginatedResponse } from "../types.js";
+
+export function useJobsListQuery(
+  input: JobsListInput,
+): UseQueryResult<PaginatedResponse<JobSummary>> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: jobsKeys.list(tenantId, input),
+    queryFn: () => api.jobs(input),
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -1,0 +1,50 @@
+export type {
+  ArtifactDetail,
+  ArtifactListQuery,
+  ArtifactSummary,
+  ArtifactsListInput,
+  CredentialsResponse,
+  DashboardSettings,
+  DashboardSummary,
+  JobDetail,
+  JobId,
+  JobListQuery,
+  JobSortField,
+  JobSummary,
+  JobsListInput,
+  KnownDomainEvent,
+  KnownDomainEventType,
+  PaginatedResponse,
+  ProfileConfigResponse,
+  SettingsResponse,
+  Stage,
+  StageOrAll,
+  StageState,
+  StageStateOrAll,
+} from "./types.js";
+
+export { applyRunsKeys } from "./applyRunsKeys.js";
+export { artifactsKeys } from "./artifactsKeys.js";
+export { dashboardKeys } from "./dashboardKeys.js";
+export { healthKeys } from "./healthKeys.js";
+export { jobsKeys } from "./jobsKeys.js";
+
+export {
+  type InvalidationHandler,
+  type InvalidationItem,
+  type InvalidationRouter,
+  invalidationRouter,
+} from "./invalidation-router.js";
+export { useInvalidationRouter } from "./hooks/useInvalidationRouter.js";
+
+export { useActivityEventQuery } from "./hooks/useActivityEventQuery.js";
+export { useApplyRunQuery } from "./hooks/useApplyRunQuery.js";
+export { useApplyRunsListQuery } from "./hooks/useApplyRunsListQuery.js";
+export { useArtifactDetailQuery } from "./hooks/useArtifactDetailQuery.js";
+export { useArtifactsListQuery } from "./hooks/useArtifactsListQuery.js";
+export { useDashboardSummaryQuery } from "./hooks/useDashboardSummaryQuery.js";
+export { useHealthQuery } from "./hooks/useHealthQuery.js";
+export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
+export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+
+export { EventStreamProvider, useEventStreamStatus } from "./providers/EventStreamProvider.js";

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -1,0 +1,97 @@
+import type { QueryClient, QueryKey } from "@tanstack/react-query";
+
+import {
+  applicationFailedHandler,
+  applicationSubmittedHandler,
+  applyRunEventRecordedHandler,
+  applyRunStartedHandler,
+} from "../apply/handlers.js";
+import {
+  jobDeletedHandler,
+  jobDiscoveredHandler,
+  jobRestoredHandler,
+  jobUpdatedHandler,
+} from "../discovery/handlers.js";
+import { enrichmentFailedHandler, jobEnrichedHandler } from "../enrichment/handlers.js";
+import {
+  coverLetterGeneratedHandler,
+  materialsExhaustedHandler,
+  pdfRenderedHandler,
+  resumeApprovedHandler,
+  resumeFailedHandler,
+} from "../materials/handlers.js";
+import {
+  stageBlockedHandler,
+  stageCanceledHandler,
+  stageCompletedHandler,
+  stageExhaustedHandler,
+  stageFailedHandler,
+  stageResetHandler,
+  stageSkippedHandler,
+  stageStartedHandler,
+} from "../pipeline/handlers.js";
+import { profileImportedHandler, profileUpdatedHandler } from "../profile/handlers.js";
+import { jobScoredHandler, scoreCorrectedHandler } from "../scoring/handlers.js";
+import type { KnownDomainEvent, KnownDomainEventType } from "./types.js";
+
+export type InvalidationItem = QueryKey;
+
+export type InvalidationHandler<TEvent extends KnownDomainEvent = KnownDomainEvent> = (
+  event: TEvent,
+) => readonly InvalidationItem[];
+
+type HandlerMap = {
+  readonly [K in KnownDomainEventType]: InvalidationHandler<
+    Extract<KnownDomainEvent, { eventType: K }>
+  >;
+};
+
+const handlers: HandlerMap = {
+  JobDiscovered: jobDiscoveredHandler,
+  JobUpdated: jobUpdatedHandler,
+  JobDeleted: jobDeletedHandler,
+  JobRestored: jobRestoredHandler,
+  JobEnriched: jobEnrichedHandler,
+  EnrichmentFailed: enrichmentFailedHandler,
+  JobScored: jobScoredHandler,
+  ScoreCorrected: scoreCorrectedHandler,
+  ResumeApproved: resumeApprovedHandler,
+  ResumeFailed: resumeFailedHandler,
+  CoverLetterGenerated: coverLetterGeneratedHandler,
+  PdfRendered: pdfRenderedHandler,
+  MaterialsExhausted: materialsExhaustedHandler,
+  ApplyRunStarted: applyRunStartedHandler,
+  ApplyRunEventRecorded: applyRunEventRecordedHandler,
+  ApplicationSubmitted: applicationSubmittedHandler,
+  ApplicationFailed: applicationFailedHandler,
+  StageStarted: stageStartedHandler,
+  StageCompleted: stageCompletedHandler,
+  StageFailed: stageFailedHandler,
+  StageExhausted: stageExhaustedHandler,
+  StageReset: stageResetHandler,
+  StageBlocked: stageBlockedHandler,
+  StageSkipped: stageSkippedHandler,
+  StageCanceled: stageCanceledHandler,
+  ProfileUpdated: profileUpdatedHandler,
+  ProfileImported: profileImportedHandler,
+};
+
+export interface InvalidationRouter {
+  handle(event: KnownDomainEvent, queryClient: QueryClient): void;
+}
+
+function dispatch<K extends KnownDomainEventType>(
+  event: Extract<KnownDomainEvent, { eventType: K }>,
+): readonly InvalidationItem[] {
+  const handler = handlers[event.eventType] as InvalidationHandler<typeof event>;
+  return handler(event);
+}
+
+export const invalidationRouter: InvalidationRouter = {
+  handle(event, queryClient) {
+    const items = dispatch(event);
+    for (const key of items) {
+      void queryClient.invalidateQueries({ queryKey: key });
+    }
+  },
+};

--- a/apps/web/src/contexts/operations/jobsKeys.ts
+++ b/apps/web/src/contexts/operations/jobsKeys.ts
@@ -1,0 +1,13 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+import type { JobId, JobsListInput } from "./types.js";
+
+export const jobsKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "jobs"] as const,
+  lists: (tenantId: TenantId) => [...jobsKeys.all(tenantId), "list"] as const,
+  list: (tenantId: TenantId, input: JobsListInput) =>
+    [...jobsKeys.lists(tenantId), input] as const,
+  details: (tenantId: TenantId) => [...jobsKeys.all(tenantId), "detail"] as const,
+  detail: (tenantId: TenantId, jobId: JobId) =>
+    [...jobsKeys.details(tenantId), jobId] as const,
+};

--- a/apps/web/src/contexts/operations/providers/EventStreamProvider.tsx
+++ b/apps/web/src/contexts/operations/providers/EventStreamProvider.tsx
@@ -1,0 +1,89 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+import type { DomainEventEnvelope, EventStreamStatus } from "../../../shared/ports/EventStreamPort.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { useInvalidationRouter } from "../hooks/useInvalidationRouter.js";
+import type { KnownDomainEvent, KnownDomainEventType } from "../types.js";
+
+interface EventStreamContextValue {
+  readonly status: EventStreamStatus;
+}
+
+const EventStreamContext = createContext<EventStreamContextValue | null>(null);
+
+const KNOWN_EVENT_TYPES: ReadonlySet<KnownDomainEventType> = new Set<KnownDomainEventType>([
+  "JobDiscovered",
+  "JobUpdated",
+  "JobDeleted",
+  "JobRestored",
+  "JobEnriched",
+  "EnrichmentFailed",
+  "JobScored",
+  "ScoreCorrected",
+  "ResumeApproved",
+  "ResumeFailed",
+  "CoverLetterGenerated",
+  "PdfRendered",
+  "MaterialsExhausted",
+  "ApplyRunStarted",
+  "ApplyRunEventRecorded",
+  "ApplicationSubmitted",
+  "ApplicationFailed",
+  "StageStarted",
+  "StageCompleted",
+  "StageFailed",
+  "StageExhausted",
+  "StageReset",
+  "StageBlocked",
+  "StageSkipped",
+  "StageCanceled",
+  "ProfileUpdated",
+  "ProfileImported",
+]);
+
+function isKnownDomainEvent(envelope: DomainEventEnvelope): envelope is DomainEventEnvelope & {
+  eventType: KnownDomainEventType;
+} {
+  return KNOWN_EVENT_TYPES.has(envelope.eventType as KnownDomainEventType);
+}
+
+export function EventStreamProvider({ children }: { children: ReactNode }) {
+  const tenantId = useTenantId();
+  const { eventStream, telemetry } = usePorts();
+  const queryClient = useQueryClient();
+  const router = useInvalidationRouter();
+  const [status, setStatus] = useState<EventStreamStatus>(eventStream.status);
+
+  useEffect(() => {
+    const subscription = eventStream.subscribe({ tenantId });
+    setStatus(subscription.status);
+    const offStatus = subscription.onStatusChange(setStatus);
+    const offEvent = subscription.on((envelope) => {
+      if (!isKnownDomainEvent(envelope)) {
+        telemetry.event("event-stream.unknown-event", {
+          eventType: envelope.eventType,
+        });
+        return;
+      }
+      router.handle(envelope as unknown as KnownDomainEvent, queryClient);
+    });
+    return () => {
+      offEvent();
+      offStatus();
+      subscription.close();
+    };
+  }, [tenantId, eventStream, queryClient, router, telemetry]);
+
+  const value = useMemo<EventStreamContextValue>(() => ({ status }), [status]);
+  return <EventStreamContext.Provider value={value}>{children}</EventStreamContext.Provider>;
+}
+
+export function useEventStreamStatus(): EventStreamStatus {
+  const ctx = useContext(EventStreamContext);
+  if (!ctx) {
+    throw new Error("useEventStreamStatus must be called within <EventStreamProvider>.");
+  }
+  return ctx.status;
+}

--- a/apps/web/src/contexts/operations/queryKeys.ts
+++ b/apps/web/src/contexts/operations/queryKeys.ts
@@ -1,0 +1,12 @@
+export { jobsKeys } from "./jobsKeys.js";
+export { dashboardKeys } from "./dashboardKeys.js";
+export { artifactsKeys } from "./artifactsKeys.js";
+export { applyRunsKeys } from "./applyRunsKeys.js";
+export { healthKeys } from "./healthKeys.js";
+export { profileKeys } from "../profile/queryKeys.js";
+export { discoveryKeys } from "../discovery/queryKeys.js";
+export { enrichmentKeys } from "../enrichment/queryKeys.js";
+export { scoringKeys } from "../scoring/queryKeys.js";
+export { materialsKeys } from "../materials/queryKeys.js";
+export { applyKeys } from "../apply/queryKeys.js";
+export { pipelineKeys } from "../pipeline/queryKeys.js";

--- a/apps/web/src/contexts/operations/types.ts
+++ b/apps/web/src/contexts/operations/types.ts
@@ -1,0 +1,47 @@
+import type {
+  ArtifactDetail,
+  ArtifactListQuery,
+  ArtifactSummary,
+  CredentialsResponse,
+  DashboardSettings,
+  DashboardSummary,
+  JobDetail,
+  JobListQuery,
+  JobSortField,
+  JobSummary,
+  PaginatedResponse,
+  ProfileConfigResponse,
+  SettingsResponse,
+  Stage,
+  StageState,
+} from "@jobhunter/contracts";
+import type { DomainEventUnion } from "@jobhunter/domain-types";
+
+export type {
+  ArtifactDetail,
+  ArtifactListQuery,
+  ArtifactSummary,
+  CredentialsResponse,
+  DashboardSettings,
+  DashboardSummary,
+  JobDetail,
+  JobListQuery,
+  JobSortField,
+  JobSummary,
+  PaginatedResponse,
+  ProfileConfigResponse,
+  SettingsResponse,
+  Stage,
+  StageState,
+};
+
+export type JobId = string;
+
+export type JobsListInput = Partial<JobListQuery>;
+export type ArtifactsListInput = Partial<ArtifactListQuery>;
+
+export type StageOrAll = Stage | "all";
+export type StageStateOrAll = StageState | "all";
+
+export type KnownDomainEvent = DomainEventUnion;
+export type KnownDomainEventType = KnownDomainEvent["eventType"];

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -1,0 +1,27 @@
+import type {
+  StageBlocked,
+  StageCanceled,
+  StageCompleted,
+  StageExhausted,
+  StageFailed,
+  StageReset,
+  StageSkipped,
+  StageStarted,
+} from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const stageStartedHandler = (_event: StageStarted): readonly InvalidationItem[] => [];
+export const stageCompletedHandler = (
+  _event: StageCompleted,
+): readonly InvalidationItem[] => [];
+export const stageFailedHandler = (_event: StageFailed): readonly InvalidationItem[] => [];
+export const stageExhaustedHandler = (
+  _event: StageExhausted,
+): readonly InvalidationItem[] => [];
+export const stageResetHandler = (_event: StageReset): readonly InvalidationItem[] => [];
+export const stageBlockedHandler = (_event: StageBlocked): readonly InvalidationItem[] => [];
+export const stageSkippedHandler = (_event: StageSkipped): readonly InvalidationItem[] => [];
+export const stageCanceledHandler = (
+  _event: StageCanceled,
+): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/pipeline/hooks/useCancelStageMutation.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useCancelStageMutation.ts
@@ -1,0 +1,42 @@
+import type { ActionRunResponse, Stage } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import { patchStageState } from "../lib/jobDetailPatches.js";
+
+export interface CancelStageVariables {
+  readonly jobId: JobId;
+  readonly stage: Stage;
+}
+
+export function useCancelStageMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  CancelStageVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, CancelStageVariables>(queryClient, {
+      mutationFn: ({ jobId }) => api.cancelJobAction(jobId, {}),
+      optimisticUpdates: ({ jobId, stage }) => [
+        {
+          queryKey: jobsKeys.detail(tenantId, jobId),
+          patch: (current) => patchStageState(current, stage, "stale"),
+        },
+      ],
+      // Cancellation can flip funnel counts (a running stage stops counting as running).
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/pipeline/hooks/useMarkAppliedMutation.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useMarkAppliedMutation.ts
@@ -1,0 +1,50 @@
+import type { ActionRunResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import {
+  patchDetailApplyStatus,
+  patchListApplyStatus,
+} from "../lib/jobDetailPatches.js";
+
+export interface MarkAppliedVariables {
+  readonly jobId: JobId;
+}
+
+export function useMarkAppliedMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  MarkAppliedVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, MarkAppliedVariables>(queryClient, {
+      mutationFn: ({ jobId }) => api.markApplied(jobId, {}),
+      optimisticUpdates: ({ jobId }) => [
+        {
+          queryKey: jobsKeys.detail(tenantId, jobId),
+          patch: (current) => patchDetailApplyStatus(current, "applied"),
+        },
+        {
+          queryKey: jobsKeys.lists(tenantId),
+          exact: false,
+          patch: (current) => patchListApplyStatus(current, jobId, "applied"),
+        },
+      ],
+      // Stage transitions also affect dashboard funnel counts; settle invalidation
+      // covers the broader recompute that §8.2's per-mutation list omits.
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/pipeline/hooks/useMarkSkippedMutation.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useMarkSkippedMutation.ts
@@ -1,0 +1,48 @@
+import type { ActionRunResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import {
+  patchDetailApplyStatus,
+  patchListApplyStatus,
+} from "../lib/jobDetailPatches.js";
+
+export interface MarkSkippedVariables {
+  readonly jobId: JobId;
+}
+
+export function useMarkSkippedMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  MarkSkippedVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, MarkSkippedVariables>(queryClient, {
+      mutationFn: ({ jobId }) => api.markSkipped(jobId, {}),
+      optimisticUpdates: ({ jobId }) => [
+        {
+          queryKey: jobsKeys.detail(tenantId, jobId),
+          patch: (current) => patchDetailApplyStatus(current, "skipped"),
+        },
+        {
+          queryKey: jobsKeys.lists(tenantId),
+          exact: false,
+          patch: (current) => patchListApplyStatus(current, jobId, "skipped"),
+        },
+      ],
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/pipeline/hooks/useRetryStageMutation.ts
+++ b/apps/web/src/contexts/pipeline/hooks/useRetryStageMutation.ts
@@ -1,0 +1,57 @@
+import type { ActionRunResponse, RetryStageRequest, Stage } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { JobId } from "../../operations/types.js";
+import { patchStageState } from "../lib/jobDetailPatches.js";
+
+export interface RetryStageVariables {
+  readonly jobId: JobId;
+  readonly stage: Stage;
+  readonly resetAttempts?: boolean;
+  readonly runAfter?: boolean;
+  readonly dryRun?: boolean;
+}
+
+function toRequest(variables: RetryStageVariables): RetryStageRequest {
+  return {
+    stage: variables.stage,
+    resetAttempts: variables.resetAttempts ?? false,
+    runAfter: variables.runAfter ?? false,
+    dryRun: variables.dryRun ?? false,
+  };
+}
+
+export function useRetryStageMutation(): UseMutationResult<
+  ActionRunResponse,
+  Error,
+  RetryStageVariables
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ActionRunResponse, RetryStageVariables>(queryClient, {
+      mutationFn: (variables) => api.retryStage(variables.jobId, toRequest(variables)),
+      // Retry without runAfter is sync; with runAfter it's async (202). Either
+      // way the user expects "this stage is now running" feedback. SSE in
+      // Phase 5 will reconcile to the true server state.
+      optimisticUpdates: ({ jobId, stage }) => [
+        {
+          queryKey: jobsKeys.detail(tenantId, jobId),
+          patch: (current) => patchStageState(current, stage, "running"),
+        },
+      ],
+      // Stage transitions feed dashboard funnel counts.
+      settle: ({ jobId }) => [
+        jobsKeys.detail(tenantId, jobId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/pipeline/index.ts
+++ b/apps/web/src/contexts/pipeline/index.ts
@@ -1,0 +1,17 @@
+export { pipelineKeys } from "./queryKeys.js";
+
+export { useCancelStageMutation } from "./hooks/useCancelStageMutation.js";
+export { useMarkAppliedMutation } from "./hooks/useMarkAppliedMutation.js";
+export { useMarkSkippedMutation } from "./hooks/useMarkSkippedMutation.js";
+export { useRetryStageMutation } from "./hooks/useRetryStageMutation.js";
+
+export {
+  stageBlockedHandler,
+  stageCanceledHandler,
+  stageCompletedHandler,
+  stageExhaustedHandler,
+  stageFailedHandler,
+  stageResetHandler,
+  stageSkippedHandler,
+  stageStartedHandler,
+} from "./handlers.js";

--- a/apps/web/src/contexts/pipeline/lib/jobDetailPatches.ts
+++ b/apps/web/src/contexts/pipeline/lib/jobDetailPatches.ts
@@ -1,0 +1,64 @@
+import type { Stage, StageState } from "@jobhunter/contracts";
+
+import type { JobDetail, JobSummary, PaginatedResponse } from "../../operations/types.js";
+
+function isJobDetail(value: unknown): value is JobDetail {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "job" in value &&
+    "stages" in value &&
+    Array.isArray((value as JobDetail).stages)
+  );
+}
+
+function isJobsPage(value: unknown): value is PaginatedResponse<JobSummary> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "items" in value &&
+    Array.isArray((value as PaginatedResponse<JobSummary>).items)
+  );
+}
+
+export function patchDetailApplyStatus(current: unknown, applyStatus: string): unknown {
+  if (!isJobDetail(current)) {
+    return current;
+  }
+  return {
+    ...current,
+    job: { ...current.job, applyStatus },
+  };
+}
+
+export function patchListApplyStatus(
+  current: unknown,
+  jobId: string,
+  applyStatus: string,
+): unknown {
+  if (!isJobsPage(current)) {
+    return current;
+  }
+  return {
+    ...current,
+    items: current.items.map((job) =>
+      job.jobKey === jobId ? { ...job, applyStatus } : job,
+    ),
+  };
+}
+
+export function patchStageState(
+  current: unknown,
+  stage: Stage,
+  state: StageState,
+): unknown {
+  if (!isJobDetail(current)) {
+    return current;
+  }
+  return {
+    ...current,
+    stages: current.stages.map((entry) =>
+      entry.stage === stage ? { ...entry, state } : entry,
+    ),
+  };
+}

--- a/apps/web/src/contexts/pipeline/queryKeys.ts
+++ b/apps/web/src/contexts/pipeline/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const pipelineKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "pipeline"] as const,
+};

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
@@ -1,11 +1,9 @@
-import {
-  type CredentialKey,
-  CredentialKeys,
-  type CredentialsResponse,
-} from "@jobhunter/contracts";
-import { useCallback, useEffect, useState } from "react";
+import { type CredentialKey, CredentialKeys } from "@jobhunter/contracts";
+import { useState } from "react";
 
-import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useCredentialsQuery } from "../hooks/useCredentialsQuery.js";
+import { useDeleteCredentialMutation } from "../hooks/useDeleteCredentialMutation.js";
+import { useUpdateCredentialMutation } from "../hooks/useUpdateCredentialMutation.js";
 import { CardHeader } from "../../../shared/ui/card-header.js";
 
 export function credentialLabel(key: CredentialKey): string {
@@ -25,79 +23,57 @@ const EMPTY_DRAFTS: Record<CredentialKey, string> = {
 };
 
 export function CredentialsPanel() {
-  const ports = usePorts();
-  const [credentials, setCredentials] = useState<CredentialsResponse["credentials"]>([]);
+  const credentialsQuery = useCredentialsQuery();
+  const updateCredential = useUpdateCredentialMutation();
+  const deleteCredential = useDeleteCredentialMutation();
+
   const [drafts, setDrafts] = useState<Record<CredentialKey, string>>(EMPTY_DRAFTS);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
-  const [busy, setBusy] = useState<CredentialKey | "">("");
+  const [statusMessage, setStatusMessage] = useState("");
+  const [busyKey, setBusyKey] = useState<CredentialKey | "">("");
 
-  const load = useCallback(async () => {
-    setError("");
-    setStatus("");
-    try {
-      const credentialsResponse = await ports.api.credentials();
-      setCredentials(credentialsResponse.credentials);
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : "Unable to load credentials.",
-      );
-    }
-  }, [ports.api]);
+  const credentials = credentialsQuery.data?.credentials ?? [];
+  const errorMessage =
+    credentialsQuery.error?.message ??
+    updateCredential.error?.message ??
+    deleteCredential.error?.message ??
+    "";
 
-  useEffect(() => {
-    void load();
-  }, [load]);
-
-  const saveCredential = async (key: CredentialKey) => {
+  const saveCredential = (key: CredentialKey) => {
     const value = drafts[key].trim();
     if (!value) {
       return;
     }
-    setBusy(key);
-    setError("");
-    setStatus("");
-    try {
-      const response = await ports.api.updateCredential({ key, value });
-      setCredentials(response.credentials);
-      setDrafts((current) => ({ ...current, [key]: "" }));
-      setStatus(`${credentialLabel(key)} saved in Keychain`);
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error
-          ? requestError.message
-          : `Unable to save ${credentialLabel(key)}.`,
-      );
-    } finally {
-      setBusy("");
-    }
+    setBusyKey(key);
+    setStatusMessage("");
+    updateCredential.mutate(
+      { key, value },
+      {
+        onSuccess: () => {
+          setDrafts((current) => ({ ...current, [key]: "" }));
+          setStatusMessage(`${credentialLabel(key)} saved in Keychain`);
+        },
+        onSettled: () => setBusyKey(""),
+      },
+    );
   };
 
-  const removeCredential = async (key: CredentialKey) => {
-    setBusy(key);
-    setError("");
-    setStatus("");
-    try {
-      const response = await ports.api.deleteCredential(key);
-      setCredentials(response.credentials);
-      setDrafts((current) => ({ ...current, [key]: "" }));
-      setStatus(`${credentialLabel(key)} removed from Keychain`);
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error
-          ? requestError.message
-          : `Unable to remove ${credentialLabel(key)}.`,
-      );
-    } finally {
-      setBusy("");
-    }
+  const removeCredential = (key: CredentialKey) => {
+    setBusyKey(key);
+    setStatusMessage("");
+    deleteCredential.mutate(key, {
+      onSuccess: () => {
+        setDrafts((current) => ({ ...current, [key]: "" }));
+        setStatusMessage(`${credentialLabel(key)} removed from Keychain`);
+      },
+      onSettled: () => setBusyKey(""),
+    });
   };
 
   return (
     <section className="card full">
       <CardHeader title="Credentials" meta="macOS Keychain" />
-      {error ? <div className="banner inline">{error}</div> : null}
-      {status ? <div className="status-line">{status}</div> : null}
+      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+      {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
       <div className="credential-list">
         {CredentialKeys.map((key) => {
           const credential = credentials.find((item) => item.key === key);
@@ -124,16 +100,16 @@ export function CredentialsPanel() {
                 <button
                   className="tab on"
                   type="button"
-                  disabled={!drafts[key].trim() || busy === key}
-                  onClick={() => void saveCredential(key)}
+                  disabled={!drafts[key].trim() || busyKey === key}
+                  onClick={() => saveCredential(key)}
                 >
                   save
                 </button>
                 <button
                   className="tab"
                   type="button"
-                  disabled={!configured || busy === key}
-                  onClick={() => void removeCredential(key)}
+                  disabled={!configured || busyKey === key}
+                  onClick={() => removeCredential(key)}
                 >
                   remove
                 </button>

--- a/apps/web/src/contexts/profile/components/ProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.tsx
@@ -1,8 +1,10 @@
-import type { ProfileConfigResponse, SettingsResponse } from "@jobhunter/contracts";
 import { Link } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { ProfileConfigResponse } from "../../operations/types.js";
+import { useProfileQuery } from "../hooks/useProfileQuery.js";
+import { useSettingsQuery } from "../hooks/useSettingsQuery.js";
+import { useUpdateProfileMutation } from "../hooks/useUpdateProfileMutation.js";
 import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { Editor } from "./Editor.js";
@@ -11,79 +13,79 @@ import { StructuredProfileEditor } from "./StructuredProfileEditor.js";
 
 type ProfileMode = "fields" | "source";
 
+interface ProfileDraft {
+  profileText: string;
+  styleText: string;
+  templateText: string;
+}
+
+function toDraft(profile: ProfileConfigResponse): ProfileDraft {
+  return {
+    profileText: JSON.stringify(profile.profile, null, 2),
+    styleText: JSON.stringify(profile.style, null, 2),
+    templateText: profile.templateText,
+  };
+}
+
 export function ProfileEditor() {
-  const ports = usePorts();
-  const [profile, setProfile] = useState<ProfileConfigResponse | null>(null);
-  const [settings, setSettings] = useState<SettingsResponse | null>(null);
-  const [profileText, setProfileText] = useState("");
-  const [styleText, setStyleText] = useState("");
-  const [templateText, setTemplateText] = useState("");
-  const [originalProfileText, setOriginalProfileText] = useState("");
-  const [originalStyleText, setOriginalStyleText] = useState("");
-  const [originalTemplateText, setOriginalTemplateText] = useState("");
-  const [loadError, setLoadError] = useState("");
-  const [saveStatus, setSaveStatus] = useState("");
-  const [busy, setBusy] = useState("");
-  const [previewVersion, setPreviewVersion] = useState(0);
+  const profileQuery = useProfileQuery();
+  const settingsQuery = useSettingsQuery();
+  const updateProfile = useUpdateProfileMutation();
+
+  const [draft, setDraft] = useState<ProfileDraft | null>(null);
+  const [original, setOriginal] = useState<ProfileDraft | null>(null);
+  const [busyLabel, setBusyLabel] = useState("");
   const [profileMode, setProfileMode] = useState<ProfileMode>("fields");
-
-  const applyProfileResponse = useCallback((profileResponse: ProfileConfigResponse) => {
-    const nextProfileText = JSON.stringify(profileResponse.profile, null, 2);
-    const nextStyleText = JSON.stringify(profileResponse.style, null, 2);
-    setProfile(profileResponse);
-    setProfileText(nextProfileText);
-    setStyleText(nextStyleText);
-    setTemplateText(profileResponse.templateText);
-    setOriginalProfileText(nextProfileText);
-    setOriginalStyleText(nextStyleText);
-    setOriginalTemplateText(profileResponse.templateText);
-    setPreviewVersion((version) => version + 1);
-  }, []);
-
-  const load = useCallback(async () => {
-    setLoadError("");
-    setSaveStatus("");
-    try {
-      const [profileResponse, settingsResponse] = await Promise.all([
-        ports.api.profile(),
-        ports.api.settings(),
-      ]);
-      applyProfileResponse(profileResponse);
-      setSettings(settingsResponse);
-    } catch (requestError) {
-      setLoadError(
-        requestError instanceof Error ? requestError.message : "Unable to load profile.",
-      );
-    }
-  }, [applyProfileResponse, ports.api]);
+  const [statusMessage, setStatusMessage] = useState("");
 
   useEffect(() => {
-    void load();
-  }, [load]);
-
-  const profileDirty = profileText !== originalProfileText;
-  const styleDirty = styleText !== originalStyleText;
-  const templateDirty = templateText !== originalTemplateText;
-  const anyDirty = profileDirty || styleDirty || templateDirty;
-
-  const savePatch = async (
-    label: string,
-    patch: Parameters<typeof ports.api.updateProfile>[0],
-  ) => {
-    setBusy(label);
-    setSaveStatus("");
-    setLoadError("");
-    try {
-      const response = await ports.api.updateProfile(patch);
-      applyProfileResponse(response);
-      setSaveStatus(`${label} saved`);
-    } catch (requestError) {
-      setLoadError(
-        requestError instanceof Error ? requestError.message : `Unable to save ${label}.`,
-      );
-    } finally {
-      setBusy("");
+    if (profileQuery.data && !draft) {
+      const next = toDraft(profileQuery.data);
+      setDraft(next);
+      setOriginal(next);
     }
+  }, [profileQuery.data, draft]);
+
+  const errorMessage =
+    profileQuery.error?.message ??
+    settingsQuery.error?.message ??
+    updateProfile.error?.message ??
+    "";
+
+  const profileDirty = Boolean(draft && original && draft.profileText !== original.profileText);
+  const styleDirty = Boolean(draft && original && draft.styleText !== original.styleText);
+  const templateDirty = Boolean(
+    draft && original && draft.templateText !== original.templateText,
+  );
+  const anyDirty = profileDirty || styleDirty || templateDirty;
+  const busy = Boolean(busyLabel) || updateProfile.isPending;
+
+  const savePatch = (label: string, patch: Parameters<typeof updateProfile.mutate>[0]) => {
+    setBusyLabel(label);
+    setStatusMessage("");
+    updateProfile.mutate(patch, {
+      onSuccess: (response) => {
+        const next = toDraft(response);
+        setDraft(next);
+        setOriginal(next);
+        setStatusMessage(`${label} saved`);
+      },
+      onSettled: () => setBusyLabel(""),
+    });
+  };
+
+  const reload = async () => {
+    setStatusMessage("");
+    const result = await profileQuery.refetch();
+    if (result.data) {
+      const next = toDraft(result.data);
+      setDraft(next);
+      setOriginal(next);
+    }
+  };
+
+  const updateField = <K extends keyof ProfileDraft>(key: K, value: ProfileDraft[K]) => {
+    setDraft((current) => (current ? { ...current, [key]: value } : current));
   };
 
   return (
@@ -91,10 +93,14 @@ export function ProfileEditor() {
       <section className="card">
         <CardHeader
           title="Profile"
-          meta={settings ? `min fit ${settings.settings.minFitScore}` : "loading"}
+          meta={
+            settingsQuery.data
+              ? `min fit ${settingsQuery.data.settings.minFitScore}`
+              : "loading"
+          }
         />
-        {loadError ? <div className="banner inline">{loadError}</div> : null}
-        {saveStatus ? <div className="status-line">{saveStatus}</div> : null}
+        {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+        {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
         <div className="editor-bulk-actions">
           <Link className="tab on" to="/profile/import/upload">
             import resume
@@ -102,26 +108,36 @@ export function ProfileEditor() {
           <button
             className="tab on"
             type="button"
-            disabled={!anyDirty || Boolean(busy)}
-            onClick={() =>
-              void savePatch("profile files", { profileText, styleText, templateText })
-            }
+            disabled={!anyDirty || busy || !draft}
+            onClick={() => {
+              if (!draft) return;
+              savePatch("profile files", {
+                profileText: draft.profileText,
+                styleText: draft.styleText,
+                templateText: draft.templateText,
+              });
+            }}
           >
             save all
           </button>
           <button
             className="tab"
             type="button"
-            disabled={!anyDirty || Boolean(busy)}
+            disabled={!anyDirty || busy || !original}
             onClick={() => {
-              setProfileText(originalProfileText);
-              setStyleText(originalStyleText);
-              setTemplateText(originalTemplateText);
+              if (original) {
+                setDraft(original);
+              }
             }}
           >
             discard all
           </button>
-          <button className="tab" type="button" disabled={Boolean(busy)} onClick={() => void load()}>
+          <button
+            className="tab"
+            type="button"
+            disabled={busy}
+            onClick={() => void reload()}
+          >
             reload
           </button>
         </div>
@@ -142,50 +158,54 @@ export function ProfileEditor() {
           </button>
         </div>
         {profileMode === "fields" ? (
-          profile ? (
+          draft ? (
             <StructuredProfileEditor
-              profileText={profileText}
-              styleText={styleText}
-              onProfileTextChange={setProfileText}
-              onStyleTextChange={setStyleText}
+              profileText={draft.profileText}
+              styleText={draft.styleText}
+              onProfileTextChange={(value) => updateField("profileText", value)}
+              onStyleTextChange={(value) => updateField("styleText", value)}
             />
           ) : (
             <Empty title="Loading profile." />
           )
-        ) : (
+        ) : draft ? (
           <>
             <Editor
               dirty={profileDirty}
               label="profile.json"
-              saving={busy === "profile.json"}
-              value={profileText}
-              onChange={setProfileText}
-              onDiscard={() => setProfileText(originalProfileText)}
-              onSave={() => void savePatch("profile.json", { profileText })}
+              saving={busyLabel === "profile.json"}
+              value={draft.profileText}
+              onChange={(value) => updateField("profileText", value)}
+              onDiscard={() => original && updateField("profileText", original.profileText)}
+              onSave={() => savePatch("profile.json", { profileText: draft.profileText })}
             />
             <Editor
               dirty={styleDirty}
               label="resume_style.json"
-              saving={busy === "resume_style.json"}
-              value={styleText}
-              onChange={setStyleText}
-              onDiscard={() => setStyleText(originalStyleText)}
-              onSave={() => void savePatch("resume_style.json", { styleText })}
+              saving={busyLabel === "resume_style.json"}
+              value={draft.styleText}
+              onChange={(value) => updateField("styleText", value)}
+              onDiscard={() => original && updateField("styleText", original.styleText)}
+              onSave={() => savePatch("resume_style.json", { styleText: draft.styleText })}
             />
             <Editor
               dirty={templateDirty}
               label="resume_template.tex"
-              saving={busy === "resume_template.tex"}
-              value={templateText}
-              onChange={setTemplateText}
-              onDiscard={() => setTemplateText(originalTemplateText)}
-              onSave={() => void savePatch("resume_template.tex", { templateText })}
+              saving={busyLabel === "resume_template.tex"}
+              value={draft.templateText}
+              onChange={(value) => updateField("templateText", value)}
+              onDiscard={() =>
+                original && updateField("templateText", original.templateText)
+              }
+              onSave={() => savePatch("resume_template.tex", { templateText: draft.templateText })}
             />
           </>
+        ) : (
+          <Empty title="Loading profile." />
         )}
       </section>
       <aside className="preview pdf-preview">
-        <ResumePreviewIframe cacheKey={previewVersion} />
+        <ResumePreviewIframe />
       </aside>
     </div>
   );

--- a/apps/web/src/contexts/profile/components/ResumePreviewIframe.tsx
+++ b/apps/web/src/contexts/profile/components/ResumePreviewIframe.tsx
@@ -1,16 +1,12 @@
-import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useProfilePdfPreviewUrl } from "../hooks/useProfilePdfPreviewUrl.js";
 
-export interface ResumePreviewIframeProps {
-  cacheKey: number | string;
-}
-
-export function ResumePreviewIframe({ cacheKey }: ResumePreviewIframeProps) {
-  const ports = usePorts();
+export function ResumePreviewIframe() {
+  const { url, cacheKey } = useProfilePdfPreviewUrl();
   return (
     <iframe
       className="pdf-preview-frame"
       key={cacheKey}
-      src={ports.api.profilePreviewPdfUrl(cacheKey)}
+      src={url}
       title="Rendered resume PDF preview"
     />
   );

--- a/apps/web/src/contexts/profile/components/SettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/SettingsPanel.tsx
@@ -1,76 +1,72 @@
-import type { DashboardSettings } from "@jobhunter/contracts";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { DashboardSettings } from "../../operations/types.js";
+import { useSettingsQuery } from "../hooks/useSettingsQuery.js";
+import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
 import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Empty } from "../../../shared/ui/empty.js";
 
 export function SettingsPanel() {
-  const ports = usePorts();
-  const [settings, setSettings] = useState<DashboardSettings | null>(null);
-  const [originalSettings, setOriginalSettings] = useState<DashboardSettings | null>(null);
-  const [status, setStatus] = useState("");
-  const [error, setError] = useState("");
-  const [busy, setBusy] = useState(false);
+  const settingsQuery = useSettingsQuery();
+  const updateSettings = useUpdateSettingsMutation();
 
-  const load = useCallback(async () => {
-    setError("");
-    setStatus("");
-    try {
-      const settingsResponse = await ports.api.settings();
-      setSettings(settingsResponse.settings);
-      setOriginalSettings(settingsResponse.settings);
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : "Unable to load settings.",
-      );
-    }
-  }, [ports.api]);
+  const [draft, setDraft] = useState<DashboardSettings | null>(null);
+  const [original, setOriginal] = useState<DashboardSettings | null>(null);
+  const [statusMessage, setStatusMessage] = useState("");
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    if (settingsQuery.data && !draft) {
+      setDraft(settingsQuery.data.settings);
+      setOriginal(settingsQuery.data.settings);
+    }
+  }, [settingsQuery.data, draft]);
+
+  const errorMessage =
+    settingsQuery.error?.message ?? updateSettings.error?.message ?? "";
 
   const update = <K extends keyof DashboardSettings>(key: K, value: DashboardSettings[K]) => {
-    setSettings((current) => (current ? { ...current, [key]: value } : current));
+    setDraft((current) => (current ? { ...current, [key]: value } : current));
   };
 
   const dirty = Boolean(
-    settings && originalSettings && JSON.stringify(settings) !== JSON.stringify(originalSettings),
+    draft && original && JSON.stringify(draft) !== JSON.stringify(original),
   );
+  const busy = updateSettings.isPending;
 
-  const save = async () => {
-    if (!settings) {
+  const save = () => {
+    if (!draft) {
       return;
     }
-    setBusy(true);
-    setError("");
-    setStatus("");
-    try {
-      const response = await ports.api.updateSettings(settings);
-      setSettings(response.settings);
-      setOriginalSettings(response.settings);
-      setStatus("settings saved");
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : "Unable to save settings.",
-      );
-    } finally {
-      setBusy(false);
+    setStatusMessage("");
+    updateSettings.mutate(draft, {
+      onSuccess: (response) => {
+        setDraft(response.settings);
+        setOriginal(response.settings);
+        setStatusMessage("settings saved");
+      },
+    });
+  };
+
+  const reload = async () => {
+    setStatusMessage("");
+    const result = await settingsQuery.refetch();
+    if (result.data) {
+      setDraft(result.data.settings);
+      setOriginal(result.data.settings);
     }
   };
 
   return (
     <section className="card full">
       <CardHeader title="Config" meta="scoring and targeting" />
-      {error ? <div className="banner inline">{error}</div> : null}
-      {status ? <div className="status-line">{status}</div> : null}
-      {settings ? (
+      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+      {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
+      {draft ? (
         <form
           className="config-form"
           onSubmit={(event) => {
             event.preventDefault();
-            void save();
+            save();
           }}
         >
           <label className="field">
@@ -80,7 +76,7 @@ export function SettingsPanel() {
               min={0}
               max={10}
               step={1}
-              value={settings.minFitScore}
+              value={draft.minFitScore}
               onChange={(event) => update("minFitScore", Number(event.target.value))}
             />
           </label>
@@ -91,21 +87,21 @@ export function SettingsPanel() {
               min={1}
               max={16}
               step={1}
-              value={settings.applyConcurrency}
+              value={draft.applyConcurrency}
               onChange={(event) => update("applyConcurrency", Number(event.target.value))}
             />
           </label>
           <label className="field">
             <span>Target role</span>
             <input
-              value={settings.targetRole}
+              value={draft.targetRole}
               onChange={(event) => update("targetRole", event.target.value)}
             />
           </label>
           <label className="field">
             <span>Location filter</span>
             <input
-              value={settings.locationFilter}
+              value={draft.locationFilter}
               onChange={(event) => update("locationFilter", event.target.value)}
             />
           </label>
@@ -113,7 +109,7 @@ export function SettingsPanel() {
             <span>Score criteria</span>
             <textarea
               placeholder="Criteria the scoring step should use when ranking jobs."
-              value={settings.scoreCriteria}
+              value={draft.scoreCriteria}
               onChange={(event) => update("scoreCriteria", event.target.value)}
             />
           </label>
@@ -121,14 +117,14 @@ export function SettingsPanel() {
             <span>Targeting criteria</span>
             <textarea
               placeholder="Role, company, location, seniority, and exclusion criteria for the search pipeline."
-              value={settings.targetCriteria}
+              value={draft.targetCriteria}
               onChange={(event) => update("targetCriteria", event.target.value)}
             />
           </label>
           <label className="field check">
             <input
               type="checkbox"
-              checked={settings.autoApply}
+              checked={draft.autoApply}
               onChange={(event) => update("autoApply", event.target.checked)}
             />
             <span>Auto apply</span>
@@ -140,12 +136,12 @@ export function SettingsPanel() {
             <button
               className="tab"
               type="button"
-              disabled={!dirty || busy || !originalSettings}
-              onClick={() => originalSettings && setSettings(originalSettings)}
+              disabled={!dirty || busy || !original}
+              onClick={() => original && setDraft(original)}
             >
               reset
             </button>
-            <button className="tab" type="button" disabled={busy} onClick={() => void load()}>
+            <button className="tab" type="button" disabled={busy} onClick={() => void reload()}>
               reload
             </button>
           </div>

--- a/apps/web/src/contexts/profile/handlers.ts
+++ b/apps/web/src/contexts/profile/handlers.ts
@@ -1,0 +1,10 @@
+import type { ProfileImported, ProfileUpdated } from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const profileUpdatedHandler = (
+  _event: ProfileUpdated,
+): readonly InvalidationItem[] => [];
+export const profileImportedHandler = (
+  _event: ProfileImported,
+): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/profile/hooks/useCredentialsQuery.ts
+++ b/apps/web/src/contexts/profile/hooks/useCredentialsQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { CredentialsResponse } from "../../operations/types.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useCredentialsQuery(): UseQueryResult<CredentialsResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: profileKeys.credentials(tenantId),
+    queryFn: () => api.credentials(),
+  });
+}

--- a/apps/web/src/contexts/profile/hooks/useDeleteCredentialMutation.ts
+++ b/apps/web/src/contexts/profile/hooks/useDeleteCredentialMutation.ts
@@ -1,0 +1,32 @@
+import type { CredentialKey } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import type { CredentialsResponse } from "../../operations/types.js";
+import { patchCredentialConfigured } from "../lib/profile-patches.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useDeleteCredentialMutation(): UseMutationResult<
+  CredentialsResponse,
+  Error,
+  CredentialKey
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<CredentialsResponse, CredentialKey>(queryClient, {
+      mutationKey: profileKeys.credentials(tenantId),
+      mutationFn: (key) => api.deleteCredential(key),
+      optimisticUpdates: (key) => [
+        {
+          queryKey: profileKeys.credentials(tenantId),
+          patch: (current) => patchCredentialConfigured(current, key, false),
+        },
+      ],
+      settle: () => [profileKeys.credentials(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/profile/hooks/useImportResumeMutation.ts
+++ b/apps/web/src/contexts/profile/hooks/useImportResumeMutation.ts
@@ -1,0 +1,24 @@
+import type { ProfileImportRequest, ProfileImportResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useImportResumeMutation(): UseMutationResult<
+  ProfileImportResponse,
+  Error,
+  ProfileImportRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ProfileImportResponse, ProfileImportRequest>(queryClient, {
+      mutationKey: profileKeys.profile(tenantId),
+      mutationFn: (body) => api.importResume(body),
+      settle: () => [profileKeys.profile(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/profile/hooks/useProfileMutationCount.ts
+++ b/apps/web/src/contexts/profile/hooks/useProfileMutationCount.ts
@@ -1,0 +1,16 @@
+import { useMutationState } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useProfileMutationCount(): number {
+  const tenantId = useTenantId();
+  const submittedAt = useMutationState({
+    filters: {
+      mutationKey: profileKeys.profile(tenantId),
+      status: "success",
+    },
+    select: (mutation) => mutation.state.submittedAt,
+  });
+  return submittedAt.length;
+}

--- a/apps/web/src/contexts/profile/hooks/useProfilePdfPreviewUrl.ts
+++ b/apps/web/src/contexts/profile/hooks/useProfilePdfPreviewUrl.ts
@@ -1,0 +1,8 @@
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useProfileMutationCount } from "./useProfileMutationCount.js";
+
+export function useProfilePdfPreviewUrl(): { url: string; cacheKey: number } {
+  const { api } = usePorts();
+  const cacheKey = useProfileMutationCount();
+  return { url: api.profilePreviewPdfUrl(cacheKey), cacheKey };
+}

--- a/apps/web/src/contexts/profile/hooks/useProfileQuery.ts
+++ b/apps/web/src/contexts/profile/hooks/useProfileQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { ProfileConfigResponse } from "../../operations/types.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useProfileQuery(): UseQueryResult<ProfileConfigResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: profileKeys.profile(tenantId),
+    queryFn: () => api.profile(),
+  });
+}

--- a/apps/web/src/contexts/profile/hooks/useSettingsQuery.ts
+++ b/apps/web/src/contexts/profile/hooks/useSettingsQuery.ts
@@ -1,0 +1,15 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { SettingsResponse } from "../../operations/types.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useSettingsQuery(): UseQueryResult<SettingsResponse> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: profileKeys.settings(tenantId),
+    queryFn: () => api.settings(),
+  });
+}

--- a/apps/web/src/contexts/profile/hooks/useUpdateCredentialMutation.ts
+++ b/apps/web/src/contexts/profile/hooks/useUpdateCredentialMutation.ts
@@ -1,0 +1,32 @@
+import type { CredentialUpdateRequest } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import type { CredentialsResponse } from "../../operations/types.js";
+import { patchCredentialConfigured } from "../lib/profile-patches.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useUpdateCredentialMutation(): UseMutationResult<
+  CredentialsResponse,
+  Error,
+  CredentialUpdateRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<CredentialsResponse, CredentialUpdateRequest>(queryClient, {
+      mutationKey: profileKeys.credentials(tenantId),
+      mutationFn: (body) => api.updateCredential(body),
+      optimisticUpdates: (body) => [
+        {
+          queryKey: profileKeys.credentials(tenantId),
+          patch: (current) => patchCredentialConfigured(current, body.key, true),
+        },
+      ],
+      settle: () => [profileKeys.credentials(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/profile/hooks/useUpdateProfileMutation.ts
+++ b/apps/web/src/contexts/profile/hooks/useUpdateProfileMutation.ts
@@ -1,0 +1,39 @@
+import type { ProfileUpdateRequest } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import type { ProfileConfigResponse } from "../../operations/types.js";
+import { patchProfileResponse } from "../lib/profile-patches.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useUpdateProfileMutation(): UseMutationResult<
+  ProfileConfigResponse,
+  Error,
+  ProfileUpdateRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<ProfileConfigResponse, ProfileUpdateRequest>(queryClient, {
+      mutationKey: profileKeys.profile(tenantId),
+      mutationFn: (body) => api.updateProfile(body),
+      optimisticUpdates: (body) => [
+        {
+          queryKey: profileKeys.profile(tenantId),
+          patch: (current) => patchProfileResponse(current, body),
+        },
+      ],
+      // Profile changes affect downstream scoring (job lists) and dashboard counts.
+      settle: () => [
+        profileKeys.profile(tenantId),
+        jobsKeys.lists(tenantId),
+        dashboardKeys.summary(tenantId),
+      ],
+    }),
+  );
+}

--- a/apps/web/src/contexts/profile/hooks/useUpdateSettingsMutation.ts
+++ b/apps/web/src/contexts/profile/hooks/useUpdateSettingsMutation.ts
@@ -1,0 +1,32 @@
+import type { SettingsUpdateRequest } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import type { SettingsResponse } from "../../operations/types.js";
+import { patchSettingsResponse } from "../lib/profile-patches.js";
+import { profileKeys } from "../queryKeys.js";
+
+export function useUpdateSettingsMutation(): UseMutationResult<
+  SettingsResponse,
+  Error,
+  SettingsUpdateRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<SettingsResponse, SettingsUpdateRequest>(queryClient, {
+      mutationKey: profileKeys.settings(tenantId),
+      mutationFn: (body) => api.updateSettings(body),
+      optimisticUpdates: (body) => [
+        {
+          queryKey: profileKeys.settings(tenantId),
+          patch: (current) => patchSettingsResponse(current, body),
+        },
+      ],
+      settle: () => [profileKeys.settings(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/profile/index.ts
+++ b/apps/web/src/contexts/profile/index.ts
@@ -1,0 +1,20 @@
+export { profileKeys } from "./queryKeys.js";
+
+export { useCredentialsQuery } from "./hooks/useCredentialsQuery.js";
+export { useDeleteCredentialMutation } from "./hooks/useDeleteCredentialMutation.js";
+export { useImportResumeMutation } from "./hooks/useImportResumeMutation.js";
+export { useProfileMutationCount } from "./hooks/useProfileMutationCount.js";
+export { useProfilePdfPreviewUrl } from "./hooks/useProfilePdfPreviewUrl.js";
+export { useProfileQuery } from "./hooks/useProfileQuery.js";
+export { useSettingsQuery } from "./hooks/useSettingsQuery.js";
+export { useUpdateCredentialMutation } from "./hooks/useUpdateCredentialMutation.js";
+export { useUpdateProfileMutation } from "./hooks/useUpdateProfileMutation.js";
+export { useUpdateSettingsMutation } from "./hooks/useUpdateSettingsMutation.js";
+
+export { CredentialsPanel } from "./components/CredentialsPanel.js";
+export { ProfileEditor } from "./components/ProfileEditor.js";
+export { ResumeImportWizard } from "./components/ResumeImportWizard.js";
+export { ResumePreviewIframe } from "./components/ResumePreviewIframe.js";
+export { SettingsPanel } from "./components/SettingsPanel.js";
+
+export { profileImportedHandler, profileUpdatedHandler } from "./handlers.js";

--- a/apps/web/src/contexts/profile/lib/profile-patches.ts
+++ b/apps/web/src/contexts/profile/lib/profile-patches.ts
@@ -1,0 +1,108 @@
+import type {
+  CredentialKey,
+  ProfileUpdateRequest,
+  SettingsUpdateRequest,
+} from "@jobhunter/contracts";
+
+import type {
+  CredentialsResponse,
+  ProfileConfigResponse,
+  SettingsResponse,
+} from "../../operations/types.js";
+
+function isProfileResponse(value: unknown): value is ProfileConfigResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "profile" in value &&
+    "style" in value &&
+    "templateText" in value
+  );
+}
+
+function isSettingsResponse(value: unknown): value is SettingsResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "settings" in value &&
+    typeof (value as SettingsResponse).settings === "object"
+  );
+}
+
+function isCredentialsResponse(value: unknown): value is CredentialsResponse {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "credentials" in value &&
+    Array.isArray((value as CredentialsResponse).credentials)
+  );
+}
+
+function tryParseObject(text: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+export function patchProfileResponse(
+  current: unknown,
+  body: ProfileUpdateRequest,
+): unknown {
+  if (!isProfileResponse(current)) {
+    return current;
+  }
+  const next: Record<string, unknown> = { ...current };
+  if (body.profileText !== undefined) {
+    const parsed = tryParseObject(body.profileText);
+    if (!parsed) {
+      return current;
+    }
+    next["profile"] = parsed;
+  }
+  if (body.styleText !== undefined) {
+    const parsed = tryParseObject(body.styleText);
+    if (!parsed) {
+      return current;
+    }
+    next["style"] = parsed;
+  }
+  if (body.templateText !== undefined) {
+    next["templateText"] = body.templateText;
+  }
+  return next;
+}
+
+export function patchSettingsResponse(current: unknown, body: SettingsUpdateRequest): unknown {
+  if (!isSettingsResponse(current)) {
+    return current;
+  }
+  const overrides = Object.fromEntries(
+    Object.entries(body).filter(([, value]) => value !== undefined),
+  );
+  return {
+    ...current,
+    settings: { ...current.settings, ...overrides },
+  };
+}
+
+export function patchCredentialConfigured(
+  current: unknown,
+  key: CredentialKey,
+  configured: boolean,
+): unknown {
+  if (!isCredentialsResponse(current)) {
+    return current;
+  }
+  return {
+    ...current,
+    credentials: current.credentials.map((entry) =>
+      entry.key === key ? { ...entry, configured } : entry,
+    ),
+  };
+}

--- a/apps/web/src/contexts/profile/queryKeys.ts
+++ b/apps/web/src/contexts/profile/queryKeys.ts
@@ -1,0 +1,8 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const profileKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "profile"] as const,
+  profile: (tenantId: TenantId) => [...profileKeys.all(tenantId), "profile"] as const,
+  settings: (tenantId: TenantId) => [...profileKeys.all(tenantId), "settings"] as const,
+  credentials: (tenantId: TenantId) => [...profileKeys.all(tenantId), "credentials"] as const,
+};

--- a/apps/web/src/contexts/scoring/handlers.ts
+++ b/apps/web/src/contexts/scoring/handlers.ts
@@ -1,0 +1,6 @@
+import type { JobScored, ScoreCorrected } from "@jobhunter/domain-types";
+
+import type { InvalidationItem } from "../operations/invalidation-router.js";
+
+export const jobScoredHandler = (_event: JobScored): readonly InvalidationItem[] => [];
+export const scoreCorrectedHandler = (_event: ScoreCorrected): readonly InvalidationItem[] => [];

--- a/apps/web/src/contexts/scoring/hooks/useCorrectScoreMutation.ts
+++ b/apps/web/src/contexts/scoring/hooks/useCorrectScoreMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
+
+import { NotImplementedError } from "../../../shared/lib/errors.js";
+import type { JobId } from "../../operations/types.js";
+
+export interface CorrectScoreVariables {
+  readonly jobId: JobId;
+  readonly correctedScore: number;
+  readonly reason: string;
+}
+
+export function useCorrectScoreMutation(): UseMutationResult<
+  never,
+  Error,
+  CorrectScoreVariables
+> {
+  return useMutation({
+    mutationFn: () => {
+      throw new NotImplementedError("useCorrectScoreMutation");
+    },
+  });
+}

--- a/apps/web/src/contexts/scoring/index.ts
+++ b/apps/web/src/contexts/scoring/index.ts
@@ -1,0 +1,7 @@
+export { scoringKeys } from "./queryKeys.js";
+
+export { useCorrectScoreMutation } from "./hooks/useCorrectScoreMutation.js";
+
+export { ScoreReasoning } from "./components/ScoreReasoning.js";
+
+export { jobScoredHandler, scoreCorrectedHandler } from "./handlers.js";

--- a/apps/web/src/contexts/scoring/queryKeys.ts
+++ b/apps/web/src/contexts/scoring/queryKeys.ts
@@ -1,0 +1,5 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+export const scoringKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "scoring"] as const,
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
+import { EventStreamProvider } from "./contexts/operations/providers/EventStreamProvider.js";
 import { ConsoleTelemetryAdapter } from "./shared/adapters/local/ConsoleTelemetryAdapter.js";
 import { FetchApiClientAdapter } from "./shared/adapters/local/FetchApiClientAdapter.js";
 import { LocalSessionAdapter } from "./shared/adapters/local/LocalSessionAdapter.js";
@@ -10,8 +11,10 @@ import { NavigatorClipboardAdapter } from "./shared/adapters/local/NavigatorClip
 import { OpenArtifactAdapter } from "./shared/adapters/local/OpenArtifactAdapter.js";
 import { SseEventStreamAdapter } from "./shared/adapters/local/SseEventStreamAdapter.js";
 import { StaticFeatureFlagAdapter } from "./shared/adapters/local/StaticFeatureFlagAdapter.js";
+import { createQueryClient } from "./shared/lib/queryClient.js";
 import { DensityProvider } from "./shared/providers/DensityProvider.js";
 import { PortsProvider, type Ports } from "./shared/providers/PortsProvider.js";
+import { QueryClientProvider } from "./shared/providers/QueryClientProvider.js";
 import { TenantProvider } from "./shared/providers/TenantProvider.js";
 import { ThemeProvider } from "./shared/providers/ThemeProvider.js";
 import { ToasterProvider } from "./shared/providers/ToasterProvider.js";
@@ -31,19 +34,25 @@ const ports: Ports = {
   featureFlags: new StaticFeatureFlagAdapter(),
 };
 
+const queryClient = createQueryClient();
+
 createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <PortsProvider ports={ports}>
       <TenantProvider>
-        <ThemeProvider>
-          <DensityProvider>
-            <TooltipProvider>
-              <ToasterProvider>
-                <App />
-              </ToasterProvider>
-            </TooltipProvider>
-          </DensityProvider>
-        </ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <EventStreamProvider>
+            <ThemeProvider>
+              <DensityProvider>
+                <TooltipProvider>
+                  <ToasterProvider>
+                    <App queryClient={queryClient} />
+                  </ToasterProvider>
+                </TooltipProvider>
+              </DensityProvider>
+            </ThemeProvider>
+          </EventStreamProvider>
+        </QueryClientProvider>
       </TenantProvider>
     </PortsProvider>
   </React.StrictMode>,

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,4 +1,5 @@
 import type { TenantId } from "@jobhunter/domain-types";
+import type { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 
 import type { Ports } from "./shared/providers/PortsProvider.js";
@@ -7,12 +8,13 @@ import { routeTree } from "./routeTree.gen.js";
 export interface RouterContext {
   ports: Ports;
   tenantId: TenantId;
+  queryClient: QueryClient;
 }
 
 export const router = createRouter({
   routeTree,
   defaultPreload: "intent",
-  context: { ports: undefined!, tenantId: undefined! },
+  context: { ports: undefined!, tenantId: undefined!, queryClient: undefined! },
 });
 
 declare module "@tanstack/react-router" {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,3 +1,4 @@
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { createRootRouteWithContext } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
@@ -14,7 +15,12 @@ function RootComponent() {
   return (
     <>
       <AppShell />
-      {import.meta.env.DEV ? <TanStackRouterDevtools position="bottom-right" /> : null}
+      {import.meta.env.DEV ? (
+        <>
+          <TanStackRouterDevtools position="bottom-right" />
+          <ReactQueryDevtools buttonPosition="bottom-left" />
+        </>
+      ) : null}
     </>
   );
 }

--- a/apps/web/src/routes/activity.$eventId.tsx
+++ b/apps/web/src/routes/activity.$eventId.tsx
@@ -1,13 +1,17 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
+import { dashboardKeys } from "../contexts/operations/dashboardKeys.js";
+import type { DashboardSummary } from "../contexts/operations/types.js";
 import { ActivityDetailDrawer } from "../views/dashboard/ActivityDetailDrawer.js";
 
 type ActivityEvent = DashboardSummary["activity"][number];
 
 export const Route = createFileRoute("/activity/$eventId")({
-  loader: async ({ params, context }): Promise<{ activity: ActivityEvent | null }> => {
-    const summary = await context.ports.api.dashboardSummary();
+  loader: async ({ params, context }): Promise<void> => {
+    const summary = await context.queryClient.ensureQueryData<DashboardSummary>({
+      queryKey: dashboardKeys.summary(context.tenantId),
+      queryFn: () => context.ports.api.dashboardSummary(),
+    });
     const activity =
       summary.activity.find((entry: ActivityEvent) => entry.eventId === params.eventId) ?? null;
     if (activity?.jobKey) {
@@ -17,13 +21,11 @@ export const Route = createFileRoute("/activity/$eventId")({
         replace: true,
       });
     }
-    return { activity };
   },
   component: ActivityRoute,
 });
 
 function ActivityRoute() {
-  const { activity } = Route.useLoaderData();
   const { eventId } = Route.useParams();
-  return <ActivityDetailDrawer eventId={eventId} activity={activity} />;
+  return <ActivityDetailDrawer eventId={eventId} />;
 }

--- a/apps/web/src/routes/artifacts.tsx
+++ b/apps/web/src/routes/artifacts.tsx
@@ -1,9 +1,29 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { artifactsKeys } from "../contexts/operations/artifactsKeys.js";
 import { ArtifactsView } from "../views/artifacts/ArtifactsView.js";
-import { artifactsSearchSchema } from "./-artifacts.search.js";
+import { artifactsSearchSchema, type ArtifactsSearch } from "./-artifacts.search.js";
+
+function artifactsListInput(search: ArtifactsSearch) {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    q: search.q,
+    sort: search.sort,
+    dir: search.dir,
+    status: search.status === "all" ? "" : search.status,
+  };
+}
 
 export const Route = createFileRoute("/artifacts")({
   validateSearch: (search) => artifactsSearchSchema.parse(search),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ deps, context }) => {
+    const input = artifactsListInput(deps.search);
+    return context.queryClient.ensureQueryData({
+      queryKey: artifactsKeys.list(context.tenantId, input),
+      queryFn: () => context.ports.api.artifacts(input),
+    });
+  },
   component: ArtifactsView,
 });

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,7 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { dashboardKeys } from "../contexts/operations/dashboardKeys.js";
 import { DashboardView } from "../views/dashboard/DashboardView.js";
 
 export const Route = createFileRoute("/dashboard")({
+  loader: ({ context }) =>
+    context.queryClient.ensureQueryData({
+      queryKey: dashboardKeys.summary(context.tenantId),
+      queryFn: () => context.ports.api.dashboardSummary(),
+    }),
   component: DashboardView,
 });

--- a/apps/web/src/routes/jobs.tsx
+++ b/apps/web/src/routes/jobs.tsx
@@ -1,9 +1,31 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { jobsKeys } from "../contexts/operations/jobsKeys.js";
 import { JobsView } from "../views/jobs/JobsView.js";
-import { jobsSearchSchema } from "./-jobs.search.js";
+import { jobsSearchSchema, type JobsSearch } from "./-jobs.search.js";
+
+function jobsListInput(search: JobsSearch) {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    q: search.q,
+    sort: search.sort,
+    dir: search.dir,
+    deleted: search.deleted,
+    ...(search.stage !== "all" ? { stage: search.stage } : {}),
+    ...(search.state !== "all" ? { state: search.state } : {}),
+  };
+}
 
 export const Route = createFileRoute("/jobs")({
   validateSearch: (search) => jobsSearchSchema.parse(search),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ deps, context }) => {
+    const input = jobsListInput(deps.search);
+    return context.queryClient.ensureQueryData({
+      queryKey: jobsKeys.list(context.tenantId, input),
+      queryFn: () => context.ports.api.jobs(input),
+    });
+  },
   component: JobsView,
 });

--- a/apps/web/src/routes/profile.import.confirm.tsx
+++ b/apps/web/src/routes/profile.import.confirm.tsx
@@ -1,8 +1,8 @@
 import { Link, createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
+import { useImportResumeMutation } from "../contexts/profile/hooks/useImportResumeMutation.js";
 import { useProfileImportStore } from "../contexts/profile/stores/profile-import-store.js";
-import { usePorts } from "../shared/providers/PortsProvider.js";
 import { Empty } from "../shared/ui/empty.js";
 
 export const Route = createFileRoute("/profile/import/confirm")({
@@ -10,7 +10,6 @@ export const Route = createFileRoute("/profile/import/confirm")({
 });
 
 function ResumeImportConfirmStep() {
-  const ports = usePorts();
   const navigate = useNavigate();
   const filename = useProfileImportStore((state) => state.filename);
   const pdfBase64 = useProfileImportStore((state) => state.pdfBase64);
@@ -18,9 +17,9 @@ function ResumeImportConfirmStep() {
   const importStyle = useProfileImportStore((state) => state.importStyle);
   const reset = useProfileImportStore((state) => state.reset);
 
-  const [error, setError] = useState("");
-  const [status, setStatus] = useState("");
-  const [busy, setBusy] = useState(false);
+  const importResume = useImportResumeMutation();
+  const [statusMessage, setStatusMessage] = useState("");
+  const errorMessage = importResume.error?.message ?? "";
 
   if (!filename || !pdfBase64) {
     return (
@@ -35,33 +34,24 @@ function ResumeImportConfirmStep() {
     );
   }
 
-  const submit = async () => {
-    setBusy(true);
-    setError("");
-    setStatus("");
-    try {
-      const response = await ports.api.importResume({
-        filename,
-        pdfBase64,
-        importProfile,
-        importStyle,
-      });
-      setStatus(`import draft ${response.action?.status ?? "ready"}`);
-      reset();
-      void navigate({ to: "/profile" });
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : "Unable to import resume.",
-      );
-    } finally {
-      setBusy(false);
-    }
+  const submit = () => {
+    setStatusMessage("");
+    importResume.mutate(
+      { filename, pdfBase64, importProfile, importStyle },
+      {
+        onSuccess: (response) => {
+          setStatusMessage(`import draft ${response.action?.status ?? "ready"}`);
+          reset();
+          void navigate({ to: "/profile" });
+        },
+      },
+    );
   };
 
   return (
     <div className="wizard-step">
-      {error ? <div className="banner inline">{error}</div> : null}
-      {status ? <div className="status-line">{status}</div> : null}
+      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+      {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
       <p>
         Importing <b>{filename}</b> with{" "}
         {importProfile && importStyle
@@ -74,8 +64,13 @@ function ResumeImportConfirmStep() {
         .
       </p>
       <div className="form-actions">
-        <button className="tab on" type="button" disabled={busy} onClick={() => void submit()}>
-          {busy ? "importing..." : "confirm import"}
+        <button
+          className="tab on"
+          type="button"
+          disabled={importResume.isPending}
+          onClick={submit}
+        >
+          {importResume.isPending ? "importing..." : "confirm import"}
         </button>
         <Link className="tab" to="/profile/import/preview">
           back

--- a/apps/web/src/routes/profile.index.tsx
+++ b/apps/web/src/routes/profile.index.tsx
@@ -1,7 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { ProfileEditor } from "../contexts/profile/components/ProfileEditor.js";
+import { profileKeys } from "../contexts/profile/queryKeys.js";
 
 export const Route = createFileRoute("/profile/")({
+  loader: ({ context }) =>
+    Promise.all([
+      context.queryClient.ensureQueryData({
+        queryKey: profileKeys.profile(context.tenantId),
+        queryFn: () => context.ports.api.profile(),
+      }),
+      context.queryClient.ensureQueryData({
+        queryKey: profileKeys.settings(context.tenantId),
+        queryFn: () => context.ports.api.settings(),
+      }),
+    ]),
   component: ProfileEditor,
 });

--- a/apps/web/src/shared/layout/ConnectionStatusPill.tsx
+++ b/apps/web/src/shared/layout/ConnectionStatusPill.tsx
@@ -1,4 +1,4 @@
-import { usePorts } from "../providers/PortsProvider.js";
+import { useEventStreamStatus } from "../../contexts/operations/providers/EventStreamProvider.js";
 
 const STATUS_LABEL: Record<string, string> = {
   stub: "stub mode",
@@ -8,8 +8,7 @@ const STATUS_LABEL: Record<string, string> = {
 };
 
 export function ConnectionStatusPill() {
-  const { eventStream } = usePorts();
-  const status = eventStream.status;
+  const status = useEventStreamStatus();
   const label = STATUS_LABEL[status] ?? status;
   return (
     <span className="connection-pill" data-status={status} aria-live="polite">

--- a/apps/web/src/shared/lib/createOptimisticMutation.ts
+++ b/apps/web/src/shared/lib/createOptimisticMutation.ts
@@ -1,0 +1,69 @@
+import {
+  type QueryClient,
+  type QueryKey,
+  type UseMutationOptions,
+} from "@tanstack/react-query";
+
+export interface OptimisticPatchSpec<TVariables> {
+  readonly queryKey: QueryKey;
+  readonly patch: (previous: unknown, variables: TVariables) => unknown;
+  readonly exact?: boolean;
+}
+
+export interface OptimisticMutationConfig<TData, TVariables> {
+  readonly mutationKey?: QueryKey;
+  readonly mutationFn: (variables: TVariables) => Promise<TData>;
+  readonly optimisticUpdates?: (variables: TVariables) => readonly OptimisticPatchSpec<TVariables>[];
+  readonly settle?: (variables: TVariables, data: TData | undefined) => readonly QueryKey[];
+  readonly meta?: Record<string, unknown>;
+}
+
+export interface OptimisticContext {
+  readonly snapshots: ReadonlyArray<readonly [QueryKey, unknown]>;
+}
+
+// Per-call `mutate(payload, { onSuccess, onSettled })` callbacks fire AFTER
+// the helper-level lifecycle (onMutate snapshot+patch → mutationFn → helper
+// onError rollback → helper onSettled invalidations) per TanStack Query v5
+// semantics. Per-call callbacks see the rolled-back / invalidated cache, never
+// the optimistic patch.
+export function createOptimisticMutation<TData, TVariables>(
+  queryClient: QueryClient,
+  config: OptimisticMutationConfig<TData, TVariables>,
+): UseMutationOptions<TData, Error, TVariables, OptimisticContext> {
+  return {
+    ...(config.mutationKey ? { mutationKey: config.mutationKey } : {}),
+    ...(config.meta ? { meta: config.meta } : {}),
+    mutationFn: config.mutationFn,
+    onMutate: async (variables) => {
+      const patches = config.optimisticUpdates?.(variables) ?? [];
+      const snapshots: Array<[QueryKey, unknown]> = [];
+      for (const spec of patches) {
+        const filters = { queryKey: spec.queryKey, exact: spec.exact ?? true };
+        await queryClient.cancelQueries(filters);
+        const tuples = queryClient.getQueriesData(filters);
+        for (const [key, previous] of tuples) {
+          snapshots.push([key, previous]);
+        }
+        queryClient.setQueriesData(filters, (current: unknown) =>
+          spec.patch(current, variables),
+        );
+      }
+      return { snapshots };
+    },
+    onError: (_error, _variables, context) => {
+      if (!context) {
+        return;
+      }
+      for (const [key, previous] of context.snapshots) {
+        queryClient.setQueryData(key, previous);
+      }
+    },
+    onSettled: (data, _error, variables) => {
+      const keys = config.settle?.(variables, data ?? undefined) ?? [];
+      for (const key of keys) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    },
+  };
+}

--- a/apps/web/src/shared/lib/errors.ts
+++ b/apps/web/src/shared/lib/errors.ts
@@ -1,0 +1,6 @@
+export class NotImplementedError extends Error {
+  constructor(feature: string) {
+    super(`${feature} is not implemented yet.`);
+    this.name = "NotImplementedError";
+  }
+}

--- a/apps/web/src/shared/lib/exhaustive.ts
+++ b/apps/web/src/shared/lib/exhaustive.ts
@@ -1,0 +1,3 @@
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminant: ${String(value)}`);
+}

--- a/apps/web/src/shared/lib/queryClient.ts
+++ b/apps/web/src/shared/lib/queryClient.ts
@@ -1,0 +1,45 @@
+import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
+
+import { useToastStore } from "../stores/toasts.js";
+
+export interface QueryMeta {
+  readonly suppressGlobalErrorToast?: boolean;
+}
+
+declare module "@tanstack/react-query" {
+  interface Register {
+    queryMeta: QueryMeta;
+    mutationMeta: QueryMeta;
+  }
+}
+
+function toastError(error: unknown, meta: QueryMeta | undefined): void {
+  if (meta?.suppressGlobalErrorToast) {
+    return;
+  }
+  const message = error instanceof Error ? error.message : "Unexpected error.";
+  useToastStore.getState().toast({ variant: "error", message });
+}
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+        refetchOnWindowFocus: true,
+        refetchOnReconnect: true,
+        retry: 1,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+    queryCache: new QueryCache({
+      onError: (error, query) => toastError(error, query.meta),
+    }),
+    mutationCache: new MutationCache({
+      onError: (error, _variables, _context, mutation) => toastError(error, mutation.meta),
+    }),
+  });
+}

--- a/apps/web/src/shared/providers/QueryClientProvider.tsx
+++ b/apps/web/src/shared/providers/QueryClientProvider.tsx
@@ -1,0 +1,11 @@
+import { type QueryClient, QueryClientProvider as TanStackQueryClientProvider } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+
+export interface QueryClientProviderProps {
+  client: QueryClient;
+  children: ReactNode;
+}
+
+export function QueryClientProvider({ client, children }: QueryClientProviderProps) {
+  return <TanStackQueryClientProvider client={client}>{children}</TanStackQueryClientProvider>;
+}

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -1,11 +1,11 @@
-import type { ArtifactDetail } from "@jobhunter/contracts";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 
+import { useOpenArtifactMutation } from "../../contexts/materials/hooks/useOpenArtifactMutation.js";
 import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status-tone.js";
+import { useArtifactDetailQuery } from "../../contexts/operations/hooks/useArtifactDetailQuery.js";
 import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 
@@ -14,7 +14,6 @@ export interface ArtifactDetailPanelProps {
 }
 
 export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
-  const ports = usePorts();
   const navigate = useNavigate();
   const search = useSearch({ from: "/artifacts" });
   const close = useCallback(() => {
@@ -22,50 +21,12 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   }, [navigate, search]);
   useEscapeKey(true, close);
 
-  const [detail, setDetail] = useState<ArtifactDetail | null>(null);
-  const [error, setError] = useState("");
-  const [busy, setBusy] = useState(false);
-  const requestSeq = useRef(0);
-
-  useEffect(() => {
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    setDetail(null);
-    setError("");
-    ports.api
-      .artifact(artifactId)
-      .then((response) => {
-        if (requestId === requestSeq.current) {
-          setDetail(response);
-        }
-      })
-      .catch((requestError: unknown) => {
-        if (requestId === requestSeq.current) {
-          setError(
-            requestError instanceof Error
-              ? requestError.message
-              : "Unable to load artifact.",
-          );
-        }
-      });
-  }, [artifactId, ports.api]);
-
-  const open = async () => {
-    if (!detail) {
-      return;
-    }
-    setBusy(true);
-    setError("");
-    try {
-      await ports.api.openArtifact(detail.artifact.artifactId);
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : "Unable to open artifact.",
-      );
-    } finally {
-      setBusy(false);
-    }
-  };
+  const { data: detail, error: queryError } = useArtifactDetailQuery(artifactId);
+  const openArtifact = useOpenArtifactMutation();
+  const errorMessage =
+    queryError instanceof Error
+      ? queryError.message
+      : openArtifact.error?.message ?? "";
 
   return (
     <div className="drawer-backdrop">
@@ -78,8 +39,8 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
         >
           x
         </button>
-        {error && !detail ? <Empty title={error} /> : null}
-        {!detail && !error ? <Empty title="Loading artifact." /> : null}
+        {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
+        {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
         {detail ? (
           <>
             <div className="drawer-head">
@@ -116,10 +77,10 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
               <button
                 className="tab on"
                 type="button"
-                disabled={busy || detail.artifact.status === "missing"}
-                onClick={() => void open()}
+                disabled={openArtifact.isPending || detail.artifact.status === "missing"}
+                onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
               >
-                {busy ? "opening" : "open"}
+                {openArtifact.isPending ? "opening" : "open"}
               </button>
               <button
                 className="tab"
@@ -135,6 +96,7 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
                 open related job
               </button>
             </Section>
+            {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
           </>
         ) : null}
       </aside>

--- a/apps/web/src/views/artifacts/ArtifactFilterBar.tsx
+++ b/apps/web/src/views/artifacts/ArtifactFilterBar.tsx
@@ -19,10 +19,9 @@ const SORT_OPTIONS = [
 
 export interface ArtifactFilterBarProps {
   search: ArtifactsSearch;
-  onRefresh: () => void;
 }
 
-export function ArtifactFilterBar({ search, onRefresh }: ArtifactFilterBarProps) {
+export function ArtifactFilterBar({ search }: ArtifactFilterBarProps) {
   const navigate = useNavigate({ from: "/artifacts" });
   const apply = (next: Partial<ArtifactsSearch>) => {
     void navigate({
@@ -48,9 +47,6 @@ export function ArtifactFilterBar({ search, onRefresh }: ArtifactFilterBarProps)
       />
       <DirectionSelect value={search.dir} onChange={(value) => apply({ dir: value })} />
       <PageSize value={search.pageSize} onChange={(value) => apply({ pageSize: value })} />
-      <button className="tab" type="button" onClick={onRefresh}>
-        refresh
-      </button>
     </div>
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactGroup.tsx
+++ b/apps/web/src/views/artifacts/ArtifactGroup.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "@tanstack/react-router";
 
+import { useOpenArtifactMutation } from "../../contexts/materials/hooks/useOpenArtifactMutation.js";
 import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status-tone.js";
-import { usePorts } from "../../shared/providers/PortsProvider.js";
 import {
   artifactKind,
   artifactVersionLabel,
@@ -10,23 +10,11 @@ import {
 
 export interface ArtifactGroupProps {
   group: ArtifactGroupShape;
-  onError: (message: string) => void;
-  onStatus: (message: string) => void;
 }
 
-export function ArtifactGroup({ group, onError, onStatus }: ArtifactGroupProps) {
-  const ports = usePorts();
+export function ArtifactGroup({ group }: ArtifactGroupProps) {
   const navigate = useNavigate();
-  const openArtifact = async (artifactId: string, type: string) => {
-    onError("");
-    onStatus("");
-    try {
-      await ports.api.openArtifact(artifactId);
-      onStatus(`opened ${type}`);
-    } catch (requestError) {
-      onError(requestError instanceof Error ? requestError.message : "Unable to open artifact.");
-    }
-  };
+  const openArtifact = useOpenArtifactMutation();
   return (
     <div className="data-row artifact-group">
       <span className="title-stack">
@@ -39,13 +27,13 @@ export function ArtifactGroup({ group, onError, onStatus }: ArtifactGroupProps) 
             key={artifact.artifactId}
             type="button"
             className="artifact-variant"
-            disabled={artifact.status === "missing"}
+            disabled={artifact.status === "missing" || openArtifact.isPending}
             title={
               artifact.status === "missing"
                 ? "Local file is missing; regenerate this artifact before opening it."
                 : artifact.localPath
             }
-            onClick={() => void openArtifact(artifact.artifactId, artifact.type)}
+            onClick={() => openArtifact.mutate({ artifactId: artifact.artifactId })}
           >
             <span className={`tag ${artifactStatusTone(artifact.status)}`}>
               {artifactKind(artifact.type)}

--- a/apps/web/src/views/artifacts/ArtifactsTable.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsTable.tsx
@@ -6,21 +6,14 @@ export interface ArtifactsTableProps {
   groups: ArtifactGroupShape[];
   loading: boolean;
   loaded: boolean;
-  onError: (message: string) => void;
-  onStatus: (message: string) => void;
 }
 
-export function ArtifactsTable({ groups, loading, loaded, onError, onStatus }: ArtifactsTableProps) {
+export function ArtifactsTable({ groups, loading, loaded }: ArtifactsTableProps) {
   return (
     <div className="table">
       {loading && !loaded ? <Empty title="Loading artifacts." /> : null}
       {groups.map((group) => (
-        <ArtifactGroup
-          key={group.groupKey}
-          group={group}
-          onError={onError}
-          onStatus={onStatus}
-        />
+        <ArtifactGroup key={group.groupKey} group={group} />
       ))}
       {loaded && groups.length === 0 ? <Empty title="No artifacts match." /> : null}
     </div>

--- a/apps/web/src/views/artifacts/ArtifactsView.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.tsx
@@ -1,67 +1,31 @@
-import type { ArtifactSummary, PaginatedResponse } from "@jobhunter/contracts";
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 
-import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { useArtifactsListQuery } from "../../contexts/operations/hooks/useArtifactsListQuery.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Pager } from "../../shared/ui/pager.js";
+import type { ArtifactsSearch } from "../../routes/-artifacts.search.js";
 import { ArtifactFilterBar } from "./ArtifactFilterBar.js";
 import { ArtifactsTable } from "./ArtifactsTable.js";
 import { groupArtifacts } from "./selectors/artifactSelectors.js";
 
+function artifactsListInput(search: ArtifactsSearch) {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    q: search.q,
+    sort: search.sort,
+    dir: search.dir,
+    status: search.status === "all" ? "" : search.status,
+  };
+}
+
 export function ArtifactsView() {
-  const ports = usePorts();
   const search = useSearch({ from: "/artifacts" });
   const navigate = useNavigate({ from: "/artifacts" });
 
-  const [data, setData] = useState<PaginatedResponse<ArtifactSummary> | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [openStatus, setOpenStatus] = useState("");
-  const requestSeq = useRef(0);
-
-  const load = useCallback(async () => {
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    setLoading(true);
-    setError("");
-    try {
-      const next = await ports.api.artifacts({
-        page: search.page,
-        pageSize: search.pageSize,
-        q: search.q,
-        sort: search.sort,
-        dir: search.dir,
-        status: search.status === "all" ? "" : search.status,
-      });
-      if (requestId === requestSeq.current) {
-        setData(next);
-      }
-    } catch (requestError) {
-      if (requestId === requestSeq.current) {
-        setData(null);
-        setError(
-          requestError instanceof Error ? requestError.message : "Unable to load artifacts.",
-        );
-      }
-    } finally {
-      if (requestId === requestSeq.current) {
-        setLoading(false);
-      }
-    }
-  }, [
-    ports.api,
-    search.dir,
-    search.page,
-    search.pageSize,
-    search.q,
-    search.sort,
-    search.status,
-  ]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
+  const { data, isFetching, error } = useArtifactsListQuery(artifactsListInput(search));
+  const message = error instanceof Error ? error.message : null;
 
   const setPage = (page: number) => {
     void navigate({ search: (prev) => ({ ...prev, page }) });
@@ -80,16 +44,9 @@ export function ArtifactsView() {
               : "loading"
           }
         />
-        {error ? <div className="banner inline">{error}</div> : null}
-        {openStatus ? <div className="status-line">{openStatus}</div> : null}
-        <ArtifactFilterBar search={search} onRefresh={() => void load()} />
-        <ArtifactsTable
-          groups={groups}
-          loading={loading}
-          loaded={data !== null}
-          onError={setError}
-          onStatus={setOpenStatus}
-        />
+        {message ? <div className="banner inline">{message}</div> : null}
+        <ArtifactFilterBar search={search} />
+        <ArtifactsTable groups={groups} loading={isFetching} loaded={data !== undefined} />
         <Pager pagination={data?.pagination} page={search.page} onPage={setPage} />
       </section>
       <Outlet />

--- a/apps/web/src/views/artifacts/selectors/artifactSelectors.ts
+++ b/apps/web/src/views/artifacts/selectors/artifactSelectors.ts
@@ -1,4 +1,4 @@
-import type { ArtifactSummary } from "@jobhunter/contracts";
+import type { ArtifactSummary } from "../../../contexts/operations/types.js";
 
 export interface ArtifactGroup {
   groupKey: string;

--- a/apps/web/src/views/dashboard/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/dashboard/ActivityDetailDrawer.tsx
@@ -1,25 +1,24 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
+import { useActivityEventQuery } from "../../contexts/operations/hooks/useActivityEventQuery.js";
 import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 
-type ActivityEvent = DashboardSummary["activity"][number];
-
 export interface ActivityDetailDrawerProps {
   eventId: string;
-  activity: ActivityEvent | null;
 }
 
-export function ActivityDetailDrawer({ eventId, activity }: ActivityDetailDrawerProps) {
+export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
   const navigate = useNavigate();
   const close = useCallback(() => {
     void navigate({ to: "/dashboard" });
   }, [navigate]);
   useEscapeKey(true, close);
+
+  const { data: activity } = useActivityEventQuery(eventId);
 
   return (
     <div className="drawer-backdrop">

--- a/apps/web/src/views/dashboard/ActivityFeed.tsx
+++ b/apps/web/src/views/dashboard/ActivityFeed.tsx
@@ -1,6 +1,6 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
 
+import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";

--- a/apps/web/src/views/dashboard/ApplyRunDrawer.tsx
+++ b/apps/web/src/views/dashboard/ApplyRunDrawer.tsx
@@ -1,16 +1,13 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 
+import { useApplyRunQuery } from "../../contexts/operations/hooks/useApplyRunQuery.js";
 import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 import { StatusDot } from "../../shared/ui/status-dot.js";
 import { ApplyRunTimeline } from "./ApplyRunTimeline.js";
-
-type ApplyRunSummary = DashboardSummary["applyRuns"][number];
 
 function applyRunDotState(status: string): string {
   if (status === "running") {
@@ -27,43 +24,15 @@ export interface ApplyRunDrawerProps {
 }
 
 export function ApplyRunDrawer({ runId }: ApplyRunDrawerProps) {
-  const ports = usePorts();
   const navigate = useNavigate();
   const close = useCallback(() => {
     void navigate({ to: "/dashboard" });
   }, [navigate]);
   useEscapeKey(true, close);
 
-  const [run, setRun] = useState<ApplyRunSummary | null>(null);
-  const [error, setError] = useState("");
-  const requestSeq = useRef(0);
-
-  useEffect(() => {
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    setRun(null);
-    setError("");
-    ports.api
-      .dashboardSummary()
-      .then((summary) => {
-        if (requestId !== requestSeq.current) {
-          return;
-        }
-        const match = summary.applyRuns.find((entry) => entry.runId === runId) ?? null;
-        if (!match) {
-          setError("Apply run is no longer in the recent list.");
-        }
-        setRun(match);
-      })
-      .catch((requestError: unknown) => {
-        if (requestId !== requestSeq.current) {
-          return;
-        }
-        setError(
-          requestError instanceof Error ? requestError.message : "Unable to load apply run.",
-        );
-      });
-  }, [ports.api, runId]);
+  const { data: run, isLoading, error } = useApplyRunQuery(runId);
+  const message = error instanceof Error ? error.message : null;
+  const notFound = !isLoading && !message && run === null;
 
   return (
     <div className="drawer-backdrop">
@@ -76,8 +45,9 @@ export function ApplyRunDrawer({ runId }: ApplyRunDrawerProps) {
         >
           x
         </button>
-        {error && !run ? <Empty title={error} /> : null}
-        {!run && !error ? <Empty title="Loading apply run." /> : null}
+        {message ? <Empty title={message} /> : null}
+        {!message && isLoading ? <Empty title="Loading apply run." /> : null}
+        {notFound ? <Empty title="Apply run is no longer in the recent list." /> : null}
         {run ? (
           <>
             <div className="drawer-head">

--- a/apps/web/src/views/dashboard/ApplyRunsCard.tsx
+++ b/apps/web/src/views/dashboard/ApplyRunsCard.tsx
@@ -1,6 +1,6 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
 
+import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,56 +1,17 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
-import { useCallback, useEffect, useRef, useState } from "react";
-
-import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { ActivityFeed } from "./ActivityFeed.js";
 import { ApplyRunsCard } from "./ApplyRunsCard.js";
 import { Funnel } from "./Funnel.js";
 import { KpiGrid, KpiSkeleton } from "./KpiGrid.js";
 
-type LoadState = "idle" | "loading" | "ready" | "error";
-
 export function DashboardView() {
-  const ports = usePorts();
-  const [status, setStatus] = useState<LoadState>("idle");
-  const [error, setError] = useState("");
-  const [summary, setSummary] = useState<DashboardSummary | null>(null);
-  const requestSeq = useRef(0);
-
-  const refresh = useCallback(async () => {
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    setStatus("loading");
-    setError("");
-    try {
-      await ports.api.health();
-      const next = await ports.api.dashboardSummary();
-      if (requestId !== requestSeq.current) {
-        return;
-      }
-      setSummary(next);
-      setStatus("ready");
-    } catch (requestError) {
-      if (requestId !== requestSeq.current) {
-        return;
-      }
-      setStatus("error");
-      setError(
-        requestError instanceof Error
-          ? requestError.message
-          : "Unable to reach JobHunter API.",
-      );
-    }
-  }, [ports.api]);
-
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
-
+  const { data: summary, isLoading, error } = useDashboardSummaryQuery();
+  const message = error instanceof Error ? error.message : null;
   return (
     <>
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
-      {error ? <div className="banner">{error}</div> : null}
+      {message ? <div className="banner">{message}</div> : null}
       {summary ? (
         <div className="dashboard-grid">
           <Funnel summary={summary} />
@@ -58,7 +19,7 @@ export function DashboardView() {
           <ActivityFeed summary={summary} />
         </div>
       ) : (
-        <Empty title={status === "loading" ? "Loading dashboard." : "No dashboard data."} />
+        <Empty title={isLoading ? "Loading dashboard." : "No dashboard data."} />
       )}
     </>
   );

--- a/apps/web/src/views/dashboard/Funnel.tsx
+++ b/apps/web/src/views/dashboard/Funnel.tsx
@@ -1,6 +1,6 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
 
+import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { SegmentBar } from "../../shared/ui/segment-bar.js";
 import { kpiSearchFor } from "./KpiGrid.js";

--- a/apps/web/src/views/dashboard/KpiGrid.tsx
+++ b/apps/web/src/views/dashboard/KpiGrid.tsx
@@ -1,6 +1,6 @@
-import type { DashboardSummary } from "@jobhunter/contracts";
 import { useNavigate } from "@tanstack/react-router";
 
+import type { DashboardSummary } from "../../contexts/operations/types.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
 
 export type KpiTarget = "all" | "failed" | "blocked" | "ready";

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -1,11 +1,16 @@
-import type { ArtifactSummary, JobDetail } from "@jobhunter/contracts";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
+import { useDryRunApplyMutation } from "../../contexts/apply/hooks/useDryRunApplyMutation.js";
 import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status-tone.js";
+import { useOpenArtifactMutation } from "../../contexts/materials/hooks/useOpenArtifactMutation.js";
+import { useJobDetailQuery } from "../../contexts/operations/hooks/useJobDetailQuery.js";
+import type { ArtifactSummary } from "../../contexts/operations/types.js";
+import { useMarkAppliedMutation } from "../../contexts/pipeline/hooks/useMarkAppliedMutation.js";
+import { useMarkSkippedMutation } from "../../contexts/pipeline/hooks/useMarkSkippedMutation.js";
+import { useRetryStageMutation } from "../../contexts/pipeline/hooks/useRetryStageMutation.js";
 import { ScoreReasoning } from "../../contexts/scoring/components/ScoreReasoning.js";
 import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
-import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 import { StatusDot } from "../../shared/ui/status-dot.js";
@@ -17,7 +22,6 @@ export interface JobDetailDrawerProps {
 }
 
 export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
-  const ports = usePorts();
   const navigate = useNavigate();
   const search = useSearch({ from: "/jobs" });
   const close = useCallback(() => {
@@ -25,47 +29,40 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
   }, [navigate, search]);
   useEscapeKey(true, close);
 
-  const [detail, setDetail] = useState<JobDetail | null>(null);
-  const [error, setError] = useState("");
+  const { data: detail, error: detailError } = useJobDetailQuery(jobId);
+  const retryStage = useRetryStageMutation();
+  const dryRun = useDryRunApplyMutation();
+  const markApplied = useMarkAppliedMutation();
+  const markSkipped = useMarkSkippedMutation();
+  const openArtifact = useOpenArtifactMutation();
   const [actionStatus, setActionStatus] = useState("");
-  const [actionBusy, setActionBusy] = useState("");
 
-  const loadDetail = useCallback(async () => {
-    setDetail(null);
-    setError("");
-    try {
-      setDetail(await ports.api.job(jobId));
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "Unable to load job.");
-    }
-  }, [jobId, ports.api]);
+  const errorMessage =
+    detailError instanceof Error
+      ? detailError.message
+      : retryStage.error?.message ||
+        dryRun.error?.message ||
+        markApplied.error?.message ||
+        markSkipped.error?.message ||
+        openArtifact.error?.message ||
+        "";
 
-  useEffect(() => {
-    void loadDetail();
-  }, [loadDetail]);
+  const actionBusy =
+    retryStage.isPending ||
+    dryRun.isPending ||
+    markApplied.isPending ||
+    markSkipped.isPending ||
+    openArtifact.isPending;
 
-  const runAction = async (label: string, action: () => Promise<{ status: string }>) => {
-    setActionBusy(label);
+  const handleOpenArtifact = (artifact: ArtifactSummary) => {
     setActionStatus("");
-    setError("");
-    try {
-      const result = await action();
-      setActionStatus(`${label} ${result.status}`);
-      await loadDetail();
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error ? requestError.message : `Unable to ${label}.`,
-      );
-    } finally {
-      setActionBusy("");
-    }
-  };
-
-  const openArtifact = async (artifact: ArtifactSummary) => {
-    await runAction("open artifact", async () => {
-      const result = await ports.api.openArtifact(artifact.artifactId);
-      return { status: result.opened ? "opened" : "failed" };
-    });
+    openArtifact.mutate(
+      { artifactId: artifact.artifactId },
+      {
+        onSuccess: (result) =>
+          setActionStatus(`open artifact ${result.opened ? "opened" : "failed"}`),
+      },
+    );
   };
 
   return (
@@ -79,8 +76,8 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
         >
           x
         </button>
-        {error ? <Empty title={error} /> : null}
-        {!detail && !error ? <Empty title="Loading job." /> : null}
+        {errorMessage ? <Empty title={errorMessage} /> : null}
+        {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
         {detail ? (
           <>
             <JobOverview detail={detail} />
@@ -94,49 +91,70 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
               <button
                 className="tab on"
                 type="button"
-                disabled={Boolean(actionBusy)}
-                onClick={() =>
-                  void runAction("retry stage", () =>
-                    ports.api.retryStage(detail.job.jobKey, {
+                disabled={actionBusy}
+                onClick={() => {
+                  setActionStatus("");
+                  retryStage.mutate(
+                    {
+                      jobId: detail.job.jobKey,
                       stage: detail.job.currentStage,
                       resetAttempts: false,
                       runAfter: false,
                       dryRun: false,
-                    }),
-                  )
-                }
+                    },
+                    {
+                      onSuccess: (result) => setActionStatus(`retry stage ${result.status}`),
+                    },
+                  );
+                }}
               >
                 retry
               </button>
               <button
                 className="tab"
                 type="button"
-                disabled={Boolean(actionBusy)}
-                onClick={() =>
-                  void runAction("apply dry-run", () =>
-                    ports.api.applyJob(detail.job.jobKey, { dryRun: true }),
-                  )
-                }
+                disabled={actionBusy}
+                onClick={() => {
+                  setActionStatus("");
+                  dryRun.mutate(
+                    { jobId: detail.job.jobKey },
+                    {
+                      onSuccess: (result) => setActionStatus(`apply dry-run ${result.status}`),
+                    },
+                  );
+                }}
               >
                 dry-run
               </button>
               <button
                 className="tab"
                 type="button"
-                disabled={Boolean(actionBusy)}
-                onClick={() =>
-                  void runAction("mark applied", () => ports.api.markApplied(detail.job.jobKey))
-                }
+                disabled={actionBusy}
+                onClick={() => {
+                  setActionStatus("");
+                  markApplied.mutate(
+                    { jobId: detail.job.jobKey },
+                    {
+                      onSuccess: (result) => setActionStatus(`mark applied ${result.status}`),
+                    },
+                  );
+                }}
               >
                 applied
               </button>
               <button
                 className="tab"
                 type="button"
-                disabled={Boolean(actionBusy)}
-                onClick={() =>
-                  void runAction("mark skipped", () => ports.api.markSkipped(detail.job.jobKey))
-                }
+                disabled={actionBusy}
+                onClick={() => {
+                  setActionStatus("");
+                  markSkipped.mutate(
+                    { jobId: detail.job.jobKey },
+                    {
+                      onSuccess: (result) => setActionStatus(`mark skipped ${result.status}`),
+                    },
+                  );
+                }}
               >
                 skip
               </button>
@@ -162,13 +180,13 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
                   <button
                     className="tab on"
                     type="button"
-                    disabled={Boolean(actionBusy) || artifact.status === "missing"}
+                    disabled={actionBusy || artifact.status === "missing"}
                     title={
                       artifact.status === "missing"
                         ? "Local file is missing; regenerate this artifact before opening it."
                         : undefined
                     }
-                    onClick={() => void openArtifact(artifact)}
+                    onClick={() => handleOpenArtifact(artifact)}
                   >
                     open
                   </button>

--- a/apps/web/src/views/jobs/JobFilterBar.tsx
+++ b/apps/web/src/views/jobs/JobFilterBar.tsx
@@ -17,10 +17,9 @@ const STATE_OPTIONS = [
 
 export interface JobFilterBarProps {
   search: JobsSearch;
-  onRefresh: () => void;
 }
 
-export function JobFilterBar({ search, onRefresh }: JobFilterBarProps) {
+export function JobFilterBar({ search }: JobFilterBarProps) {
   const navigate = useNavigate({ from: "/jobs" });
   const apply = (next: Partial<JobsSearch>) => {
     void navigate({ search: (prev: JobsSearch) => ({ ...prev, page: 1, ...next }) });
@@ -49,9 +48,6 @@ export function JobFilterBar({ search, onRefresh }: JobFilterBarProps) {
         ))}
       </select>
       <PageSize value={search.pageSize} onChange={(value) => apply({ pageSize: value })} />
-      <button className="tab" type="button" onClick={onRefresh}>
-        refresh
-      </button>
     </div>
   );
 }

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -1,5 +1,4 @@
-import type { JobDetail } from "@jobhunter/contracts";
-
+import type { JobDetail } from "../../contexts/operations/types.js";
 import { scoreTier } from "../../contexts/scoring/lib/score-tier.js";
 
 export interface JobOverviewProps {

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -1,6 +1,7 @@
-import type { JobSortField, JobSummary, PaginatedResponse } from "@jobhunter/contracts";
+import type { JobSortField } from "@jobhunter/contracts";
 
 import { stateTone } from "../../contexts/pipeline/lib/state-tone.js";
+import type { JobSummary, PaginatedResponse } from "../../contexts/operations/types.js";
 import { scoreTier } from "../../contexts/scoring/lib/score-tier.js";
 import { formatCompanySource } from "../../shared/lib/formatters.js";
 import { Empty } from "../../shared/ui/empty.js";

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -1,13 +1,10 @@
-import {
-  type BulkJobMutationRequest,
-  type JobSortField,
-  type JobSummary,
-  type PaginatedResponse,
-} from "@jobhunter/contracts";
+import { type BulkJobMutationRequest, type JobSortField } from "@jobhunter/contracts";
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { useDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/useDeleteJobsBulkMutation.js";
+import { useRestoreJobsBulkMutation } from "../../contexts/discovery/hooks/useRestoreJobsBulkMutation.js";
+import { useJobsListQuery } from "../../contexts/operations/hooks/useJobsListQuery.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Pager } from "../../shared/ui/pager.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
@@ -15,62 +12,30 @@ import { JobBulkActions } from "./JobBulkActions.js";
 import { JobFilterBar } from "./JobFilterBar.js";
 import { JobsTable, type JobSortColumn } from "./JobsTable.js";
 
+function jobsListInput(search: JobsSearch) {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    q: search.q,
+    sort: search.sort,
+    dir: search.dir,
+    deleted: search.deleted,
+    ...(search.stage !== "all" ? { stage: search.stage } : {}),
+    ...(search.state !== "all" ? { state: search.state } : {}),
+  };
+}
+
 export function JobsView() {
-  const ports = usePorts();
   const search = useSearch({ from: "/jobs" });
   const navigate = useNavigate({ from: "/jobs" });
 
-  const [data, setData] = useState<PaginatedResponse<JobSummary> | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const { data, isFetching, error } = useJobsListQuery(jobsListInput(search));
+  const deleteJobs = useDeleteJobsBulkMutation();
+  const restoreJobs = useRestoreJobsBulkMutation();
+  const message = error instanceof Error ? error.message : null;
+
   const [selectedJobs, setSelectedJobs] = useState<Set<string>>(() => new Set());
   const [allMatchingSelected, setAllMatchingSelected] = useState(false);
-  const requestSeq = useRef(0);
-
-  const load = useCallback(async () => {
-    const requestId = requestSeq.current + 1;
-    requestSeq.current = requestId;
-    setLoading(true);
-    setError("");
-    try {
-      const nextData = await ports.api.jobs({
-        page: search.page,
-        pageSize: search.pageSize,
-        q: search.q,
-        sort: search.sort,
-        dir: search.dir,
-        deleted: search.deleted,
-        ...(search.stage !== "all" ? { stage: search.stage } : {}),
-        ...(search.state !== "all" ? { state: search.state } : {}),
-      });
-      if (requestId === requestSeq.current) {
-        setData(nextData);
-      }
-    } catch (requestError) {
-      if (requestId === requestSeq.current) {
-        setData(null);
-        setError(requestError instanceof Error ? requestError.message : "Unable to load jobs.");
-      }
-    } finally {
-      if (requestId === requestSeq.current) {
-        setLoading(false);
-      }
-    }
-  }, [
-    ports.api,
-    search.deleted,
-    search.dir,
-    search.page,
-    search.pageSize,
-    search.q,
-    search.sort,
-    search.stage,
-    search.state,
-  ]);
-
-  useEffect(() => {
-    void load();
-  }, [load]);
 
   useEffect(() => {
     setSelectedJobs(new Set());
@@ -146,14 +111,16 @@ export function JobsView() {
     });
   };
 
-  const mutateSelected = async () => {
+  const restoring = search.deleted === "deleted";
+  const mutation = restoring ? restoreJobs : deleteJobs;
+  const mutateBusy = mutation.isPending;
+
+  const mutateSelected = () => {
     const jobKeys = Array.from(selectedJobs);
     const count = allMatchingSelected ? (data?.pagination.total ?? 0) : jobKeys.length;
     if (!count) {
       return;
     }
-    const restoring = search.deleted === "deleted";
-    const action = restoring ? "restore" : "delete";
     if (
       !window.confirm(
         `${restoring ? "Restore" : "Soft delete"} ${count} selected job${
@@ -163,28 +130,12 @@ export function JobsView() {
     ) {
       return;
     }
-    setLoading(true);
-    setError("");
-    try {
-      const payload: BulkJobMutationRequest = allMatchingSelected
-        ? { allMatching: true, filter: currentJobFilter(), jobKeys: [] }
-        : { allMatching: false, jobKeys };
-      if (restoring) {
-        await ports.api.restoreJobs(payload);
-      } else {
-        await ports.api.deleteJobs(payload);
-      }
-      clearSelection();
-      await load();
-    } catch (requestError) {
-      setError(
-        requestError instanceof Error
-          ? requestError.message
-          : `Unable to ${action} selected jobs.`,
-      );
-    } finally {
-      setLoading(false);
-    }
+    const payload: BulkJobMutationRequest = allMatchingSelected
+      ? { allMatching: true, filter: currentJobFilter(), jobKeys: [] }
+      : { allMatching: false, jobKeys };
+    mutation.mutate(payload, {
+      onSuccess: () => clearSelection(),
+    });
   };
 
   const selectedCount = allMatchingSelected
@@ -203,23 +154,23 @@ export function JobsView() {
     <>
       <section className="card full">
         <CardHeader title="Jobs" meta={data ? `${data.pagination.total} total` : "loading"} />
-        {error ? <div className="banner inline">{error}</div> : null}
-        <JobFilterBar search={search} onRefresh={() => void load()} />
+        {message ? <div className="banner inline">{message}</div> : null}
+        <JobFilterBar search={search} />
         <JobBulkActions
           search={search}
           selectedCount={selectedCount}
           hasItems={Boolean(data?.items.length)}
           hasAnyMatching={Boolean(data?.pagination.total)}
-          loading={loading}
+          loading={mutateBusy || isFetching}
           onSetDeleted={(deleted) => setSearch({ deleted, page: 1 })}
           onSelectPage={selectPage}
           onSelectAllMatching={selectAllMatching}
           onClearSelection={clearSelection}
-          onMutateSelected={() => void mutateSelected()}
+          onMutateSelected={mutateSelected}
         />
         <JobsTable
-          data={data}
-          loading={loading}
+          data={data ?? null}
+          loading={isFetching}
           sort={search.sort}
           dir={search.dir}
           selectedJobs={selectedJobs}

--- a/packages/domain-types/src/events/index.ts
+++ b/packages/domain-types/src/events/index.ts
@@ -105,3 +105,67 @@ export {
   type ProfileImported,
   createProfileImported,
 } from "./profile.js";
+
+import type {
+  JobDeleted,
+  JobDiscovered,
+  JobRestored,
+  JobUpdated,
+} from "./discovery.js";
+import type { EnrichmentFailed, JobEnriched } from "./enrichment.js";
+import type { JobScored, ScoreCorrected } from "./scoring.js";
+import type {
+  CoverLetterGenerated,
+  MaterialsExhausted,
+  PdfRendered,
+  ResumeApproved,
+  ResumeFailed,
+} from "./materials.js";
+import type {
+  ApplicationFailed,
+  ApplicationSubmitted,
+  ApplyRunEventRecorded,
+  ApplyRunStarted,
+} from "./apply.js";
+import type {
+  StageBlocked,
+  StageCanceled,
+  StageCompleted,
+  StageExhausted,
+  StageFailed,
+  StageReset,
+  StageSkipped,
+  StageStarted,
+} from "./orchestration.js";
+import type { ProfileImported, ProfileUpdated } from "./profile.js";
+
+export type DomainEventUnion =
+  | JobDiscovered
+  | JobUpdated
+  | JobDeleted
+  | JobRestored
+  | JobEnriched
+  | EnrichmentFailed
+  | JobScored
+  | ScoreCorrected
+  | ResumeApproved
+  | ResumeFailed
+  | CoverLetterGenerated
+  | PdfRendered
+  | MaterialsExhausted
+  | ApplyRunStarted
+  | ApplyRunEventRecorded
+  | ApplicationSubmitted
+  | ApplicationFailed
+  | StageStarted
+  | StageCompleted
+  | StageFailed
+  | StageExhausted
+  | StageReset
+  | StageBlocked
+  | StageSkipped
+  | StageCanceled
+  | ProfileUpdated
+  | ProfileImported;
+
+export type DomainEventType = DomainEventUnion["eventType"];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,12 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tanstack/react-query':
+        specifier: ^5.100.9
+        version: 5.100.9(react@19.2.5)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.100.9
+        version: 5.100.9(@tanstack/react-query@5.100.9(react@19.2.5))(react@19.2.5)
       '@tanstack/react-router':
         specifier: ^1.93.0
         version: 1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1201,6 +1207,23 @@ packages:
   '@tanstack/history@1.161.6':
     resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.100.9':
+    resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
+
+  '@tanstack/query-devtools@5.100.9':
+    resolution: {integrity: sha512-gqiptrTIhbK2PuCaPRHmWXfJG1NGYVFpAr0HqogEqiSBNB5xDz6fmesQt7w4WgMOqOQPnPHJ3ZDMuhDaXvNO8g==}
+
+  '@tanstack/react-query-devtools@5.100.9':
+    resolution: {integrity: sha512-mM3slaVGXJmz+pOLgXdANj75ikgQCyudyl3kmFvm6brI1JyVeY/+IeD17uDHIvZrD8hfoO2sdZ54RFsHdYAuhA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.100.9
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.100.9':
+    resolution: {integrity: sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-router-devtools@1.166.13':
     resolution: {integrity: sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA==}
@@ -3103,6 +3126,21 @@ snapshots:
       vite: 7.3.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@tanstack/history@1.161.6': {}
+
+  '@tanstack/query-core@5.100.9': {}
+
+  '@tanstack/query-devtools@5.100.9': {}
+
+  '@tanstack/react-query-devtools@5.100.9(@tanstack/react-query@5.100.9(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-devtools': 5.100.9
+      '@tanstack/react-query': 5.100.9(react@19.2.5)
+      react: 19.2.5
+
+  '@tanstack/react-query@5.100.9(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.9
+      react: 19.2.5
 
   '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.169.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@tanstack/router-core@1.169.2)(csstype@3.2.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:


### PR DESCRIPTION
## Summary

Phase 3 of the frontend TanStack migration — replaces every per-view `useState<DataShape>` + `useEffect(load)` + `useRef(0)` (`requestSeq`) data-loading ceremony with TanStack Query v5. Introduces per-context query-key factories (tenant-prefixed from day one), per-aggregate mutation hooks with real optimistic patchers, and the SSE plumbing scaffold.

**Stacked PR position:** branched from `feat/frontend-phase-2-router` (PR #25). Phase 4 (Table + Form, S-17..S-18) branches from this commit.

## What landed (S-10..S-16)

- **S-10** `@tanstack/react-query` + DevTools; `QueryClient` with target §5.4 defaults; provider tree wired in `main.tsx`.
- **S-11** Per-context query-key factories — all `["tenant", tenantId, ...] as const`. 8 contexts have `queryKeys.ts`.
- **S-12** `ApiClientPort` finalized (mirrors every `JobHunterApiClient` method); 8 Operations read hooks; ACL re-export of projection types in `contexts/operations/types.ts` so feature code never imports from `@jobhunter/contracts`.
- **S-13** Per-aggregate mutation hooks per target §4.4: discovery, profile, scoring, materials, apply, pipeline, enrichment. `createOptimisticMutation` in `shared/lib/`. **12 sync mutations supply real optimistic patchers** via 3 patcher modules (`discovery/lib/jobListPatches`, `pipeline/lib/jobDetailPatches`, `profile/lib/profile-patches`). 4 placeholder hooks throw `NotImplementedError` per target §3.2/§3.3/§3.5/§3.6.
- **S-14** Invalidation router scaffold — `Record<DomainEventUnion["eventType"], InvalidationHandler>` with empty handler bodies (Phase 5 / S-20 populates). **`DomainEventUnion` exported from `@jobhunter/domain-types/events/index.ts`** as the canonical union — backend additions structurally fail apps/web compile.
- **S-15** **CUT-OVER**: every per-view fetch ceremony deleted in this same commit. URL state moved out of `useState` into route `useSearch({ from: ... })`. Mutation→invalidate map matches target §8.2. Route loaders prefetch first paint on `/dashboard`, `/jobs`, `/artifacts`, `/profile/index`.
- **S-16** `EventStreamProvider` mounts the Phase-1 stub adapter; `ConnectionStatusPill` rewired to read `useEventStreamStatus()`. No `new EventSource(...)` in any adapter (Phase 5 / S-20 swaps).

## Process

Two-agent team on `jobhunter-max-effort` (effort: max). 2 review rounds → PASS, 0 deferred Blockers/Majors.

- Round 1: 0B / 6M / 8min
- Round 2: all 6 Majors + 8 Minors resolved

**Catch worth flagging:** round-1 reviewer found that `createOptimisticMutation` shipped with empty `optimisticUpdates` patchers — the helper's load-bearing feature was dead. Round 2 added 3 patcher modules and all 12 sync mutations now wire real type-guarded patchers.

## Verification

- ✅ `pnpm --filter @jobhunter/web check` — green
- ✅ `pnpm --filter @jobhunter/web build` — green (1.33s)
- ✅ `pnpm -r --filter '!@jobhunter/python-types' check` — green (5/5)
- ✅ Cut-over greps in `apps/web/src/views/` + `apps/web/src/contexts/` all 0 hits: `useRef(0)`, `useEffect.*\bload\b`, `await Promise.all([load`, `useState<DashboardSummary|JobSummary|PaginatedResponse|ArtifactSummary>`, direct `@jobhunter/api-client` imports in feature code, projection types from `@jobhunter/contracts` outside the ACL
- ✅ EventStream stays a stub: 0 hits for `new EventSource(...)` in any adapter

## Phase boundaries respected

- Hand-rolled sort/select/pagination JSX preserved (Phase 4 / S-17)
- Per-field form `useState` preserved (Phase 4 / S-18)
- No tests (Phase 6)
- No real SSE wire-up (Phase 5)

## Deferred (intentional, non-blocking)

- ESLint setup (`no-restricted-imports` for cross-folder boundaries; `pnpm web:lint` script). Not in the workspace toolchain today; revisit post-stack.
- CI grep guards from S-15 — same story; deferred.

## Test plan

- [x] Gates green
- [x] Reviewer ran gates + greps independently
- [x] All ports/hooks/keys/handlers per plan and target
- [x] Cut-over verified by grep
- [ ] Manual smoke: `pnpm --filter @jobhunter/web dev`, exercise all views, verify mutations refresh siblings via invalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)