### PR TITLE
feat(web,api): phase 5 — realtime (SSE endpoint + frontend consumer + 27 invalidation handlers)

### DIFF
--- a/apps/api/src/event-stream.ts
+++ b/apps/api/src/event-stream.ts
@@ -1,0 +1,337 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
+
+import { LOCAL_TENANT } from "@jobhunter/domain-types";
+
+import { databaseExists, openDatabase, type SqliteDatabase } from "./db.js";
+
+const POLL_DEFAULT_MS = 250;
+const KEEPALIVE_DEFAULT_MS = 15_000;
+const HEARTBEAT_DEFAULT_MS = 30_000;
+const EVENT_BATCH_LIMIT = 1000;
+const RETRY_BASELINE_MS = 5_000;
+
+export interface EventStreamOptions {
+  readonly dbPath: string;
+  readonly pollIntervalMs?: number;
+  readonly keepaliveIntervalMs?: number;
+  readonly heartbeatIntervalMs?: number;
+}
+
+interface EventRow {
+  readonly event_id: number;
+  readonly event_type: string | null;
+  readonly payload_json: string | null;
+  readonly occurred_at: string | null;
+}
+
+interface Subscriber {
+  readonly id: symbol;
+  readonly tenantId: string;
+  readonly reply: FastifyReply;
+  cursor: number;
+  readonly keepaliveTimer: NodeJS.Timeout;
+  readonly heartbeatTimer: NodeJS.Timeout;
+}
+
+export function registerEventStreamRoute(app: FastifyInstance, options: EventStreamOptions): void {
+  const pollIntervalMs = clampPositive(
+    parseEnvInt(process.env.JOBHUNTER_API_SSE_POLL_MS, options.pollIntervalMs ?? POLL_DEFAULT_MS),
+  );
+  const keepaliveIntervalMs = clampPositive(options.keepaliveIntervalMs ?? KEEPALIVE_DEFAULT_MS);
+  const heartbeatIntervalMs = clampPositive(options.heartbeatIntervalMs ?? HEARTBEAT_DEFAULT_MS);
+
+  const subscribers = new Map<symbol, Subscriber>();
+  let db: SqliteDatabase | null = null;
+  let indexEnsured = false;
+  let pollHandle: NodeJS.Timeout | null = null;
+
+  function getDb(): SqliteDatabase | null {
+    if (db) {
+      return db;
+    }
+    if (!databaseExists(options.dbPath)) {
+      return null;
+    }
+    db = openDatabase(options.dbPath);
+    return db;
+  }
+
+  function ensureIndex(connection: SqliteDatabase): void {
+    if (indexEnsured) {
+      return;
+    }
+    try {
+      // The `job_events` table is created by the Python worker
+      // (`workers/automation/src/jobhunter/database.py`); the API may
+      // start before any worker run materialises it.  The CREATE INDEX
+      // requires the base table — we swallow the error and retry on
+      // the next subscriber connect so the SSE route still serves
+      // keepalive/heartbeat traffic until the worker bootstraps.
+      connection.exec(
+        "CREATE INDEX IF NOT EXISTS idx_job_events_tenant_eid "
+          + "ON job_events(COALESCE(JSON_EXTRACT(payload_json, '$.tenantId'), 'local'), event_id)",
+      );
+      indexEnsured = true;
+    } catch {
+      indexEnsured = false;
+    }
+  }
+
+  function maxEventId(connection: SqliteDatabase, tenantId: string): number {
+    try {
+      const row = connection
+        .prepare(
+          "SELECT COALESCE(MAX(event_id), 0) AS max_id FROM job_events "
+            + "WHERE COALESCE(JSON_EXTRACT(payload_json, '$.tenantId'), 'local') = ?",
+        )
+        .get(tenantId) as { max_id: number | bigint | string } | undefined;
+      return row ? Number(row.max_id) : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  function tailEvents(connection: SqliteDatabase, tenantId: string, after: number): EventRow[] {
+    try {
+      return connection
+        .prepare(
+          "SELECT event_id, event_type, payload_json, occurred_at "
+            + "FROM job_events "
+            + "WHERE event_id > ? "
+            + "  AND COALESCE(JSON_EXTRACT(payload_json, '$.tenantId'), 'local') = ? "
+            + "ORDER BY event_id ASC LIMIT ?",
+        )
+        .all(after, tenantId, EVENT_BATCH_LIMIT) as EventRow[];
+    } catch {
+      return [];
+    }
+  }
+
+  function poll(): void {
+    if (subscribers.size === 0) {
+      return;
+    }
+    const connection = getDb();
+    if (!connection) {
+      return;
+    }
+    ensureIndex(connection);
+
+    const minCursorByTenant = new Map<string, number>();
+    for (const sub of subscribers.values()) {
+      const previous = minCursorByTenant.get(sub.tenantId);
+      if (previous === undefined || sub.cursor < previous) {
+        minCursorByTenant.set(sub.tenantId, sub.cursor);
+      }
+    }
+
+    for (const [tenantId, minCursor] of minCursorByTenant) {
+      const rows = tailEvents(connection, tenantId, minCursor);
+      if (rows.length === 0) {
+        continue;
+      }
+      for (const sub of subscribers.values()) {
+        if (sub.tenantId !== tenantId) {
+          continue;
+        }
+        for (const row of rows) {
+          if (row.event_id <= sub.cursor) {
+            continue;
+          }
+          writeEventRow(sub.reply, row);
+          sub.cursor = row.event_id;
+        }
+      }
+    }
+  }
+
+  function startPolling(): void {
+    if (pollHandle !== null) {
+      return;
+    }
+    pollHandle = setInterval(poll, pollIntervalMs);
+    // Don't keep the Node event loop alive for SSE polling alone — the
+    // Fastify server is the lifecycle anchor.
+    pollHandle.unref?.();
+  }
+
+  function stopPolling(): void {
+    if (pollHandle === null) {
+      return;
+    }
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+
+  function closeDb(): void {
+    if (!db) {
+      return;
+    }
+    try {
+      db.close();
+    } catch {
+      // best-effort
+    }
+    db = null;
+    indexEnsured = false;
+  }
+
+  function detach(sub: Subscriber): void {
+    if (!subscribers.has(sub.id)) {
+      return;
+    }
+    clearInterval(sub.keepaliveTimer);
+    clearInterval(sub.heartbeatTimer);
+    subscribers.delete(sub.id);
+    if (subscribers.size === 0) {
+      stopPolling();
+    }
+  }
+
+  app.addHook("onClose", async () => {
+    stopPolling();
+    for (const sub of subscribers.values()) {
+      clearInterval(sub.keepaliveTimer);
+      clearInterval(sub.heartbeatTimer);
+      try {
+        sub.reply.raw.end();
+      } catch {
+        // best-effort
+      }
+    }
+    subscribers.clear();
+    closeDb();
+  });
+
+  app.get("/v1/events/stream", async (request, reply) => {
+    const tenantId = resolveTenantId(request);
+    const requestedResume = parseResumePosition(request);
+
+    reply.hijack();
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no",
+      Connection: "keep-alive",
+    });
+    reply.raw.write(`retry: ${RETRY_BASELINE_MS}\n\n`);
+
+    const connection = getDb();
+    let cursor = requestedResume;
+    if (cursor === null && connection) {
+      ensureIndex(connection);
+      cursor = maxEventId(connection, tenantId);
+    } else if (cursor === null) {
+      cursor = 0;
+    }
+
+    const id = Symbol("sse-subscriber");
+    const sub: Subscriber = {
+      id,
+      tenantId,
+      reply,
+      cursor,
+      keepaliveTimer: setInterval(() => {
+        writeRaw(reply, ": keepalive\n\n");
+      }, keepaliveIntervalMs),
+      heartbeatTimer: setInterval(() => {
+        writeHeartbeat(reply, sub.cursor);
+      }, heartbeatIntervalMs),
+    };
+    sub.keepaliveTimer.unref?.();
+    sub.heartbeatTimer.unref?.();
+    subscribers.set(id, sub);
+    startPolling();
+
+    request.raw.on("close", () => detach(sub));
+    request.raw.on("error", () => detach(sub));
+  });
+}
+
+function resolveTenantId(request: FastifyRequest): string {
+  // Local-mode contract (target §7.8): the tenant resolves to
+  // LOCAL_TENANT regardless of the query string.  Hosted-mode wiring
+  // will read the tenant from the JWT and reject mismatched query
+  // values; that swap is named in target §9.4 and out of scope here.
+  const query = request.query as Record<string, unknown> | undefined;
+  const requested = typeof query?.tenantId === "string" ? query.tenantId.trim() : "";
+  return requested.length > 0 && requested === LOCAL_TENANT ? requested : LOCAL_TENANT;
+}
+
+function parseResumePosition(request: FastifyRequest): number | null {
+  const headerValue = request.headers["last-event-id"];
+  const headerString = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  const fromHeader = parseNonNegativeInt(headerString);
+  if (fromHeader !== null) {
+    return fromHeader;
+  }
+  const query = request.query as Record<string, unknown> | undefined;
+  const sinceRaw = typeof query?.since === "string" ? query.since : undefined;
+  return parseNonNegativeInt(sinceRaw);
+}
+
+function parseNonNegativeInt(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function parseEnvInt(raw: string | undefined, fallback: number): number {
+  if (raw === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function clampPositive(value: number): number {
+  return value > 0 ? value : POLL_DEFAULT_MS;
+}
+
+function writeEventRow(reply: FastifyReply, row: EventRow): void {
+  const eventType = row.event_type ?? "";
+  if (eventType.length === 0) {
+    return;
+  }
+  const dataLine = formatDataField(row.payload_json ?? "{}");
+  writeRaw(
+    reply,
+    `id: ${row.event_id}\nevent: ${eventType}\n${dataLine}\n\n`,
+  );
+}
+
+function writeHeartbeat(reply: FastifyReply, watermark: number): void {
+  const data = JSON.stringify({ watermark });
+  writeRaw(reply, `event: heartbeat\ndata: ${data}\n\n`);
+}
+
+function formatDataField(payload: string): string {
+  // SSE splits the data field on raw newlines.  payload_json is
+  // produced by JSON.stringify() upstream, which encodes embedded
+  // newlines as `\\n` literals — so a single `data:` line is correct.
+  // We split defensively in case a future writer inserts raw newlines.
+  if (!payload.includes("\n")) {
+    return `data: ${payload}`;
+  }
+  return payload
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+}
+
+function writeRaw(reply: FastifyReply, chunk: string): void {
+  try {
+    reply.raw.write(chunk);
+  } catch {
+    // Subscriber is detached on the request 'close' handler.
+  }
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -23,7 +23,8 @@ import {
   RetryStageRequestSchema,
   SettingsUpdateRequestSchema,
 } from "./contracts.js";
-import { databaseExists, openDatabase, openReadOnlyDatabase } from "./db.js";
+import { databaseExists, openDatabase } from "./db.js";
+import { registerEventStreamRoute } from "./event-stream.js";
 import { KeychainCredentialStore, type CredentialStore } from "./credentials.js";
 import {
   buildActionResponse,
@@ -117,6 +118,8 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     dbPath: options.dbPath,
     dbExists: databaseExists(options.dbPath),
   }));
+
+  registerEventStreamRoute(app, { dbPath: options.dbPath });
 
   app.get("/v1/dashboard/summary", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => buildDashboardSummary(db)),

--- a/apps/web/src/contexts/apply/handlers.ts
+++ b/apps/web/src/contexts/apply/handlers.ts
@@ -5,17 +5,50 @@ import type {
   ApplyRunStarted,
 } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { applyRunsKeys } from "../operations/applyRunsKeys.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import {
+  invalidate,
+  patchApplyRunEvent,
+  type InvalidationItem,
+} from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
 export const applyRunStartedHandler = (
-  _event: ApplyRunStarted,
-): readonly InvalidationItem[] => [];
+  event: ApplyRunStarted,
+): readonly InvalidationItem[] => [
+  invalidate(applyRunsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+// Per target §7.5 / §8.4: high-frequency apply-run timeline events
+// patch the cached projection in place rather than triggering a refetch
+// per per-second tick.  The patch is a no-op when the apply-run drawer
+// is closed (no cache entry yet); reopen re-fetches and reconciles.
 export const applyRunEventRecordedHandler = (
-  _event: ApplyRunEventRecorded,
-): readonly InvalidationItem[] => [];
+  event: ApplyRunEventRecorded,
+): readonly InvalidationItem[] => [
+  patchApplyRunEvent(event.tenantId, event.payload.runId, event),
+];
+
 export const applicationSubmittedHandler = (
-  _event: ApplicationSubmitted,
-): readonly InvalidationItem[] => [];
+  event: ApplicationSubmitted,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(applyRunsKeys.lists(event.tenantId)),
+  invalidate(applyRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const applicationFailedHandler = (
-  _event: ApplicationFailed,
-): readonly InvalidationItem[] => [];
+  event: ApplicationFailed,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(applyRunsKeys.lists(event.tenantId)),
+  invalidate(applyRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];

--- a/apps/web/src/contexts/discovery/handlers.ts
+++ b/apps/web/src/contexts/discovery/handlers.ts
@@ -5,9 +5,28 @@ import type {
   JobUpdated,
 } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
-export const jobDiscoveredHandler = (_event: JobDiscovered): readonly InvalidationItem[] => [];
-export const jobUpdatedHandler = (_event: JobUpdated): readonly InvalidationItem[] => [];
-export const jobDeletedHandler = (_event: JobDeleted): readonly InvalidationItem[] => [];
-export const jobRestoredHandler = (_event: JobRestored): readonly InvalidationItem[] => [];
+export const jobDiscoveredHandler = (event: JobDiscovered): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const jobUpdatedHandler = (event: JobUpdated): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+];
+
+export const jobDeletedHandler = (event: JobDeleted): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const jobRestoredHandler = (event: JobRestored): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];

--- a/apps/web/src/contexts/enrichment/handlers.ts
+++ b/apps/web/src/contexts/enrichment/handlers.ts
@@ -1,8 +1,19 @@
 import type { EnrichmentFailed, JobEnriched } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
-export const jobEnrichedHandler = (_event: JobEnriched): readonly InvalidationItem[] => [];
+export const jobEnrichedHandler = (event: JobEnriched): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const enrichmentFailedHandler = (
-  _event: EnrichmentFailed,
-): readonly InvalidationItem[] => [];
+  event: EnrichmentFailed,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];

--- a/apps/web/src/contexts/materials/handlers.ts
+++ b/apps/web/src/contexts/materials/handlers.ts
@@ -6,16 +6,46 @@ import type {
   ResumeFailed,
 } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { artifactsKeys } from "../operations/artifactsKeys.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
 export const resumeApprovedHandler = (
-  _event: ResumeApproved,
-): readonly InvalidationItem[] => [];
-export const resumeFailedHandler = (_event: ResumeFailed): readonly InvalidationItem[] => [];
+  event: ResumeApproved,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const resumeFailedHandler = (event: ResumeFailed): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const coverLetterGeneratedHandler = (
-  _event: CoverLetterGenerated,
-): readonly InvalidationItem[] => [];
-export const pdfRenderedHandler = (_event: PdfRendered): readonly InvalidationItem[] => [];
+  event: CoverLetterGenerated,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const pdfRenderedHandler = (event: PdfRendered): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const materialsExhaustedHandler = (
-  _event: MaterialsExhausted,
-): readonly InvalidationItem[] => [];
+  event: MaterialsExhausted,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];

--- a/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
@@ -4,14 +4,21 @@ import { useTenantId } from "../../../shared/providers/TenantProvider.js";
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
 import type { ApiHealthResponse } from "../../../shared/ports/ApiClientPort.js";
 import { healthKeys } from "../healthKeys.js";
+import { useEventStreamStatus } from "../providers/EventStreamProvider.js";
+
+const SSE_BACKSTOP_INTERVAL_MS = 30_000;
 
 export function useHealthQuery(): UseQueryResult<ApiHealthResponse> {
   const tenantId = useTenantId();
   const { api } = usePorts();
+  const streamStatus = useEventStreamStatus();
+  // SSE heartbeat covers liveness when the stream is open; HTTP polling
+  // only fires as a backstop while the stream is unhealthy (target §7.7).
+  const refetchInterval = streamStatus === "open" ? false : SSE_BACKSTOP_INTERVAL_MS;
   return useQuery({
     queryKey: healthKeys.live(tenantId),
     queryFn: () => api.health(),
-    refetchInterval: 15_000,
+    refetchInterval,
     staleTime: 10_000,
   });
 }

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -33,7 +33,9 @@ export {
   type InvalidationHandler,
   type InvalidationItem,
   type InvalidationRouter,
+  invalidate,
   invalidationRouter,
+  patchApplyRunEvent,
 } from "./invalidation-router.js";
 export { useInvalidationRouter } from "./hooks/useInvalidationRouter.js";
 

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -1,5 +1,8 @@
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
 
+import type { ApplyRunEventRecorded, TenantId } from "@jobhunter/domain-types";
+
+import { appendApplyRunEvent } from "../apply/selectors/applyRunSelectors.js";
 import {
   applicationFailedHandler,
   applicationSubmittedHandler,
@@ -32,13 +35,37 @@ import {
 } from "../pipeline/handlers.js";
 import { profileImportedHandler, profileUpdatedHandler } from "../profile/handlers.js";
 import { jobScoredHandler, scoreCorrectedHandler } from "../scoring/handlers.js";
+import { applyRunsKeys } from "./applyRunsKeys.js";
 import type { KnownDomainEvent, KnownDomainEventType } from "./types.js";
 
-export type InvalidationItem = QueryKey;
+export type InvalidationItem =
+  | { readonly kind: "invalidate"; readonly queryKey: QueryKey }
+  | {
+      readonly kind: "apply-run-event-append";
+      readonly tenantId: TenantId;
+      readonly runId: string;
+      readonly event: ApplyRunEventRecorded;
+    };
 
 export type InvalidationHandler<TEvent extends KnownDomainEvent = KnownDomainEvent> = (
   event: TEvent,
 ) => readonly InvalidationItem[];
+
+export const invalidate = (queryKey: QueryKey): InvalidationItem => ({
+  kind: "invalidate",
+  queryKey,
+});
+
+export const patchApplyRunEvent = (
+  tenantId: TenantId,
+  runId: string,
+  event: ApplyRunEventRecorded,
+): InvalidationItem => ({
+  kind: "apply-run-event-append",
+  tenantId,
+  runId,
+  event,
+});
 
 type HandlerMap = {
   readonly [K in KnownDomainEventType]: InvalidationHandler<
@@ -90,8 +117,17 @@ function dispatch<K extends KnownDomainEventType>(
 export const invalidationRouter: InvalidationRouter = {
   handle(event, queryClient) {
     const items = dispatch(event);
-    for (const key of items) {
-      void queryClient.invalidateQueries({ queryKey: key });
+    for (const item of items) {
+      if (item.kind === "invalidate") {
+        void queryClient.invalidateQueries({ queryKey: item.queryKey });
+        continue;
+      }
+      // High-frequency `ApplyRunEventRecorded` events patch the apply-run
+      // cache surgically per target §7.5; refetching per per-second event
+      // would saturate the API.
+      queryClient.setQueryData(applyRunsKeys.detail(item.tenantId, item.runId), (current) =>
+        appendApplyRunEvent(current as never, item.event),
+      );
     }
   },
 };

--- a/apps/web/src/contexts/operations/providers/EventStreamProvider.tsx
+++ b/apps/web/src/contexts/operations/providers/EventStreamProvider.tsx
@@ -1,5 +1,13 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import type { DomainEventEnvelope, EventStreamStatus } from "../../../shared/ports/EventStreamPort.js";
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
@@ -55,11 +63,33 @@ export function EventStreamProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const router = useInvalidationRouter();
   const [status, setStatus] = useState<EventStreamStatus>(eventStream.status);
+  // §7.7 backstop is "on reconnect" — fire once we've previously been
+  // open and recover to open after a drop.  The first
+  // connecting→open of the session is the initial connection, not a
+  // reconnection, and must not invalidate.
+  const hadOpenRef = useRef(false);
 
   useEffect(() => {
     const subscription = eventStream.subscribe({ tenantId });
     setStatus(subscription.status);
-    const offStatus = subscription.onStatusChange(setStatus);
+    // Reset on every (re-)subscription so a tenant switch behaves like
+    // a fresh first-connect rather than a reconnect.
+    hadOpenRef.current = subscription.status === "open";
+
+    const offStatus = subscription.onStatusChange((next) => {
+      setStatus(next);
+      if (next !== "open") {
+        return;
+      }
+      if (hadOpenRef.current) {
+        // A closed→open recovery may have missed events the
+        // EventSource couldn't resume via Last-Event-ID.  One-shot
+        // full invalidation pulls the cache back into line.
+        void queryClient.invalidateQueries();
+      } else {
+        hadOpenRef.current = true;
+      }
+    });
     const offEvent = subscription.on((envelope) => {
       if (!isKnownDomainEvent(envelope)) {
         telemetry.event("event-stream.unknown-event", {

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -9,19 +9,57 @@ import type {
   StageStarted,
 } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
-export const stageStartedHandler = (_event: StageStarted): readonly InvalidationItem[] => [];
+export const stageStartedHandler = (event: StageStarted): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+];
+
 export const stageCompletedHandler = (
-  _event: StageCompleted,
-): readonly InvalidationItem[] => [];
-export const stageFailedHandler = (_event: StageFailed): readonly InvalidationItem[] => [];
+  event: StageCompleted,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const stageFailedHandler = (event: StageFailed): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const stageExhaustedHandler = (
-  _event: StageExhausted,
-): readonly InvalidationItem[] => [];
-export const stageResetHandler = (_event: StageReset): readonly InvalidationItem[] => [];
-export const stageBlockedHandler = (_event: StageBlocked): readonly InvalidationItem[] => [];
-export const stageSkippedHandler = (_event: StageSkipped): readonly InvalidationItem[] => [];
+  event: StageExhausted,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const stageResetHandler = (event: StageReset): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+];
+
+export const stageBlockedHandler = (event: StageBlocked): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const stageSkippedHandler = (event: StageSkipped): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
 export const stageCanceledHandler = (
-  _event: StageCanceled,
-): readonly InvalidationItem[] => [];
+  event: StageCanceled,
+): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+];

--- a/apps/web/src/contexts/profile/handlers.ts
+++ b/apps/web/src/contexts/profile/handlers.ts
@@ -1,10 +1,12 @@
 import type { ProfileImported, ProfileUpdated } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { profileKeys } from "./queryKeys.js";
 
 export const profileUpdatedHandler = (
-  _event: ProfileUpdated,
-): readonly InvalidationItem[] => [];
+  event: ProfileUpdated,
+): readonly InvalidationItem[] => [invalidate(profileKeys.profile(event.tenantId))];
+
 export const profileImportedHandler = (
-  _event: ProfileImported,
-): readonly InvalidationItem[] => [];
+  event: ProfileImported,
+): readonly InvalidationItem[] => [invalidate(profileKeys.profile(event.tenantId))];

--- a/apps/web/src/contexts/scoring/handlers.ts
+++ b/apps/web/src/contexts/scoring/handlers.ts
@@ -1,6 +1,17 @@
 import type { JobScored, ScoreCorrected } from "@jobhunter/domain-types";
 
-import type { InvalidationItem } from "../operations/invalidation-router.js";
+import { dashboardKeys } from "../operations/dashboardKeys.js";
+import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
+import { jobsKeys } from "../operations/jobsKeys.js";
 
-export const jobScoredHandler = (_event: JobScored): readonly InvalidationItem[] => [];
-export const scoreCorrectedHandler = (_event: ScoreCorrected): readonly InvalidationItem[] => [];
+export const jobScoredHandler = (event: JobScored): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];
+
+export const scoreCorrectedHandler = (event: ScoreCorrected): readonly InvalidationItem[] => [
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(jobsKeys.lists(event.tenantId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
+];

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,11 +21,12 @@ import { ToasterProvider } from "./shared/providers/ToasterProvider.js";
 import { TooltipProvider } from "./shared/ui/tooltip.js";
 import "./styles/globals.css";
 
-const api = new FetchApiClientAdapter(import.meta.env.VITE_JOBHUNTER_API_BASE_URL ?? "");
+const apiBaseUrl = import.meta.env.VITE_JOBHUNTER_API_BASE_URL ?? "";
+const api = new FetchApiClientAdapter(apiBaseUrl);
 
 const ports: Ports = {
   api,
-  eventStream: new SseEventStreamAdapter(),
+  eventStream: new SseEventStreamAdapter(apiBaseUrl),
   storage: new LocalStorageAdapter("jh:"),
   session: new LocalSessionAdapter(),
   clipboard: new NavigatorClipboardAdapter(),

--- a/apps/web/src/shared/adapters/local/SseEventStreamAdapter.ts
+++ b/apps/web/src/shared/adapters/local/SseEventStreamAdapter.ts
@@ -1,18 +1,199 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
 import type {
+  DomainEventEnvelope,
   EventStreamPort,
   EventStreamStatus,
   EventStreamSubscription,
 } from "../../ports/EventStreamPort.js";
 
-export class SseEventStreamAdapter implements EventStreamPort {
-  readonly status: EventStreamStatus = "stub";
+const STREAM_PATH = "/v1/events/stream";
+const KNOWN_EVENT_TYPES: ReadonlyArray<string> = [
+  "JobDiscovered",
+  "JobUpdated",
+  "JobDeleted",
+  "JobRestored",
+  "JobEnriched",
+  "EnrichmentFailed",
+  "JobScored",
+  "ScoreCorrected",
+  "ResumeApproved",
+  "ResumeFailed",
+  "CoverLetterGenerated",
+  "PdfRendered",
+  "MaterialsExhausted",
+  "ApplyRunStarted",
+  "ApplyRunEventRecorded",
+  "ApplicationSubmitted",
+  "ApplicationFailed",
+  "StageStarted",
+  "StageCompleted",
+  "StageFailed",
+  "StageExhausted",
+  "StageReset",
+  "StageBlocked",
+  "StageSkipped",
+  "StageCanceled",
+  "ProfileUpdated",
+  "ProfileImported",
+];
 
-  subscribe(): EventStreamSubscription {
-    return {
-      status: "stub",
-      on: () => () => undefined,
-      onStatusChange: () => () => undefined,
-      close: () => undefined,
+export class SseEventStreamAdapter implements EventStreamPort {
+  private readonly baseUrl: string;
+  // Per target §6.4 the port has a coarse status; per-subscription state is
+  // owned by the SseSubscription. The aggregate status reported here is
+  // the most recent subscription's last-known state.
+  private currentStatus: EventStreamStatus = "connecting";
+
+  constructor(baseUrl = "") {
+    this.baseUrl = baseUrl.replace(/\/$/, "");
+  }
+
+  get status(): EventStreamStatus {
+    return this.currentStatus;
+  }
+
+  subscribe({ tenantId }: { tenantId: TenantId }): EventStreamSubscription {
+    const subscription = new SseSubscription(this.streamUrl(tenantId), (next) => {
+      this.currentStatus = next;
+    });
+    return subscription;
+  }
+
+  private streamUrl(tenantId: TenantId): string {
+    const search = new URLSearchParams({ tenantId }).toString();
+    return `${this.baseUrl}${STREAM_PATH}?${search}`;
+  }
+}
+
+class SseSubscription implements EventStreamSubscription {
+  private readonly eventHandlers = new Set<(event: DomainEventEnvelope) => void>();
+  private readonly statusHandlers = new Set<(status: EventStreamStatus) => void>();
+  private currentStatus: EventStreamStatus = "connecting";
+  private closed = false;
+  private readonly listenerCleanup: Array<() => void> = [];
+  private source: EventSource | null = null;
+
+  constructor(
+    private readonly url: string,
+    private readonly notifyParent: (status: EventStreamStatus) => void,
+  ) {
+    this.open();
+  }
+
+  get status(): EventStreamStatus {
+    return this.currentStatus;
+  }
+
+  on(handler: (event: DomainEventEnvelope) => void): () => void {
+    this.eventHandlers.add(handler);
+    return () => {
+      this.eventHandlers.delete(handler);
     };
   }
+
+  onStatusChange(handler: (status: EventStreamStatus) => void): () => void {
+    this.statusHandlers.add(handler);
+    return () => {
+      this.statusHandlers.delete(handler);
+    };
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const cleanup of this.listenerCleanup) {
+      cleanup();
+    }
+    this.listenerCleanup.length = 0;
+    this.source?.close();
+    this.source = null;
+    this.setStatus("closed");
+  }
+
+  private open(): void {
+    if (typeof EventSource === "undefined") {
+      this.setStatus("closed");
+      return;
+    }
+    const source = new EventSource(this.url);
+    this.source = source;
+    this.setStatus("connecting");
+
+    const onOpen = () => this.setStatus("open");
+    // EventSource uses 'error' to signal both transient drops (it
+    // auto-reconnects per the server's `retry:`) and permanent
+    // failures.  We surface 'closed' on every error tick; callers
+    // observe the next 'open' to learn that reconnect succeeded.
+    const onError = () => this.setStatus("closed");
+    source.addEventListener("open", onOpen);
+    source.addEventListener("error", onError);
+    this.listenerCleanup.push(() => source.removeEventListener("open", onOpen));
+    this.listenerCleanup.push(() => source.removeEventListener("error", onError));
+
+    for (const eventType of KNOWN_EVENT_TYPES) {
+      const listener = (raw: MessageEvent) => this.handleEvent(eventType, raw);
+      source.addEventListener(eventType, listener);
+      this.listenerCleanup.push(() => source.removeEventListener(eventType, listener));
+    }
+
+    const heartbeatListener = () => this.setStatus("open");
+    source.addEventListener("heartbeat", heartbeatListener);
+    this.listenerCleanup.push(() => source.removeEventListener("heartbeat", heartbeatListener));
+  }
+
+  private handleEvent(eventType: string, raw: MessageEvent): void {
+    if (this.closed) {
+      return;
+    }
+    const payload = parsePayload(raw.data);
+    if (!payload) {
+      return;
+    }
+    const tenantId = readTenantId(payload);
+    const envelope: DomainEventEnvelope = {
+      eventType,
+      tenantId,
+      payload,
+    };
+    for (const handler of this.eventHandlers) {
+      handler(envelope);
+    }
+  }
+
+  private setStatus(next: EventStreamStatus): void {
+    if (this.currentStatus === next) {
+      return;
+    }
+    this.currentStatus = next;
+    this.notifyParent(next);
+    for (const handler of this.statusHandlers) {
+      handler(next);
+    }
+  }
+}
+
+function parsePayload(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function readTenantId(payload: Record<string, unknown>): TenantId {
+  const candidate = payload["tenantId"];
+  return typeof candidate === "string" && candidate.length > 0
+    ? (candidate as TenantId)
+    : ("local" as TenantId);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/web/src/shared/layout/ConnectionStatusPill.tsx
+++ b/apps/web/src/shared/layout/ConnectionStatusPill.tsx
@@ -1,18 +1,52 @@
-import { useEventStreamStatus } from "../../contexts/operations/providers/EventStreamProvider.js";
+import { useEffect, useState } from "react";
 
-const STATUS_LABEL: Record<string, string> = {
-  stub: "stub mode",
+import { useEventStreamStatus } from "../../contexts/operations/providers/EventStreamProvider.js";
+import type { EventStreamStatus } from "../ports/EventStreamPort.js";
+
+const STATUS_LABEL: Record<EventStreamStatus, string> = {
   connecting: "connecting",
   open: "live",
-  closed: "offline",
+  closed: "reconnecting",
 };
+
+const CONNECTION_LOST_THRESHOLD_MS = 30_000;
 
 export function ConnectionStatusPill() {
   const status = useEventStreamStatus();
-  const label = STATUS_LABEL[status] ?? status;
+  const lostForLong = useDisconnectedLongerThan(status, CONNECTION_LOST_THRESHOLD_MS);
+  const label = lostForLong ? "offline" : STATUS_LABEL[status];
   return (
-    <span className="connection-pill" data-status={status} aria-live="polite">
-      {label}
-    </span>
+    <div className="connection-pill-group">
+      <span
+        className="connection-pill"
+        data-status={lostForLong ? "lost" : status}
+        aria-live="polite"
+      >
+        {label}
+      </span>
+      {lostForLong ? (
+        <div className="connection-banner" role="status" aria-live="polite">
+          Connection lost — events paused; data will refresh when reconnected.
+        </div>
+      ) : null}
+    </div>
   );
+}
+
+function useDisconnectedLongerThan(status: EventStreamStatus, thresholdMs: number): boolean {
+  const [tripped, setTripped] = useState(false);
+  useEffect(() => {
+    if (status === "open") {
+      setTripped(false);
+      return;
+    }
+    setTripped(false);
+    const handle = setTimeout(() => {
+      setTripped(true);
+    }, thresholdMs);
+    return () => {
+      clearTimeout(handle);
+    };
+  }, [status, thresholdMs]);
+  return tripped;
 }

--- a/apps/web/src/shared/ports/EventStreamPort.ts
+++ b/apps/web/src/shared/ports/EventStreamPort.ts
@@ -1,6 +1,6 @@
 import type { TenantId } from "@jobhunter/domain-types";
 
-export type EventStreamStatus = "stub" | "connecting" | "open" | "closed";
+export type EventStreamStatus = "connecting" | "open" | "closed";
 
 export interface DomainEventEnvelope {
   readonly eventType: string;


### PR DESCRIPTION
## Summary

Phase 5 of the frontend TanStack migration — adds the `GET /v1/events/stream` Fastify SSE endpoint on `apps/api/`, replaces the Phase 3 stub adapter with a real `EventSource` consumer, and populates all **27 `DomainEventUnion` variant** invalidation handlers. The dashboard / job drawer / artifacts list now update without manual refresh.

**Stacked PR position:** branched from `feat/frontend-phase-4-table-form` (PR #27). Phase 6 (Testing, S-21..S-25) branches from this commit.

## What landed (S-19 + S-20)

**S-19 — Backend SSE endpoint** (new `apps/api/src/event-stream.ts`)
- `GET /v1/events/stream` per target §7.1: `text/event-stream` headers, `retry: 5000`, 15s keepalive, 30s heartbeat with `watermark`
- Per-event framing: `event: <eventType>`, `data: <payload JSON>`, `id: <event_id>`
- Resume precedence: `Last-Event-ID` header → `?since=` query → `MAX(event_id)`
- **COALESCE tenant filter** (per Codex review fix from PR #23) in all 3 SQL sites — filter, expression index, tail query: `COALESCE(JSON_EXTRACT(payload_json, '$.tenantId'), 'local') = ?`. Captures legacy + post-migration writers that don't thread `tenantId` (`recordActionEvent`, `record_job_event`).
- Idempotent expression index `idx_job_events_tenant_eid` on the same expression
- Tail loop polls every `JOBHUNTER_API_SSE_POLL_MS` (default 250ms)

**S-20 — Frontend SSE consumer + handlers** (CUT-OVER)
- `SseEventStreamAdapter.ts` — real `EventSource` replacing the Phase 3 stub. `status: "stub"` removed from the `EventStreamStatus` enum.
- All **27 `DomainEventUnion`** variants now have non-trivial handlers in per-context `handlers.ts` files, cross-checked against target §8.4 invalidation map line-by-line (including the dashboard-omission rows and artifacts-lists rows).
- **`ApplyRunEventRecorded` uses `setQueryData(applyRunsKeys.detail, appendApplyRunEvent)`** — the high-frequency append path. Bypasses invalidation thrash via the Phase 4 selector.
- **Reconnect backstop**: `hadOpenRef` distinguishes first-connect from closed→open recovery; on recovery fires `queryClient.invalidateQueries()` once per target §7.7. Reset on `useEffect` re-run so tenant switches don't trigger spurious invalidates.
- `<ConnectionStatusPill>`: `connecting | live | reconnecting`; "Connection lost" banner via `useDisconnectedLongerThan` when status stays `reconnecting` > 30s
- `useHealthQuery` is now status-driven: `refetchInterval: false` when SSE is open, `30_000` otherwise. The Phase 3 hard-coded `15_000` is gone.

## Process

Two-agent team on `jobhunter-max-effort` (effort: max). **1 review round → PASS**, 0 deferred Blockers/Majors. Reviewer cross-checked all 27 handlers line-by-line against §8.4. 4 informational minors flagged, none blocking.

## Verification

- ✅ `pnpm --filter @jobhunter/api check` — green
- ✅ `pnpm --filter @jobhunter/api test` — 55/55 pass
- ✅ `pnpm --filter @jobhunter/web check` — green
- ✅ `pnpm --filter @jobhunter/web build` — green
- ✅ `pnpm test` — 588 python + 55 api pass
- ✅ COALESCE filter present in all 3 SQL sites; strict-equality grep: 0 hits
- ✅ `new EventSource(...)` opens at `SseEventStreamAdapter:121`
- ✅ `"stub"` string: 0 grep hits in `apps/web/src/`
- ✅ All 27 `DomainEventUnion` variants have non-trivial handler bodies
- ✅ Discriminator field is `eventType` everywhere

## Phase boundaries respected

- No tests (Phase 6 owns)
- No Storybook (Phase 7)
- No doc updates (Phase 8)

## Test plan

- [x] Gates green
- [x] Reviewer ran gates + cross-checked §8.4 invalidation map
- [x] All 27 handlers populated
- [x] Reconnect backstop wired
- [ ] Manual smoke: `pnpm --filter @jobhunter/api dev` + `pnpm --filter @jobhunter/web dev`, trigger an apply action, verify dashboard updates within 1s; kill API, verify pill flips to reconnecting, restart API, verify pill flips back to live and a one-shot full invalidate fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)