### PR TITLE
docs(backlog): rewrite Local Product Validation + tooling items against code state

### DIFF
--- a/TODO_FUTURE.md
+++ b/TODO_FUTURE.md
@@ -261,28 +261,10 @@ Revisit when:
 
 ## Deferred Workflow Infrastructure
 
-### Managed Temporal Or Equivalent Hosted Workflow Engine
-
-Deferred as infrastructure, but not as a design direction.
-
-Future work:
-
-- introduce durable workflow orchestration,
-- model job workflows and batch workflows,
-- add durable retries, cancellation, and heartbeats,
-- separate workflow commands from worker execution,
-- expose workflow runs in the UI.
-
-Why deferred:
-
-The immediate local goal is reliable stage boundaries and recoverable state. That can be prototyped with the current process model or a local lightweight queue before committing to hosted workflow infrastructure.
-
-Revisit when:
-
-- local stages are reliable enough to formalize,
-- multiple workers need coordination,
-- runs need crash recovery,
-- hosted execution begins.
+> Local Temporal adoption was promoted out of this section into
+> [`docs/backlog.md`](docs/backlog.md) → "Workflow Orchestration
+> (Local Temporal)". Managed/hosted Temporal Cloud and the
+> distributed worker fleet remain deferred.
 
 ### Distributed Worker Fleet
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,6 +41,60 @@ This is the authoritative roadmap. Keep detailed historical proposals under
   `apply_runs.log_path`. Wire the helper into the apply / materials /
   scoring writers so logs and reports show up in the artifacts list.
 
+### Workflow Orchestration (Local Temporal)
+
+Adopt Temporal as the orchestration engine for the Python worker, run
+**locally** for now (Temporal dev server / `docker compose` profile, no
+managed service). The trigger is that several Worker Reliability items
+above are converging on a small, badly-scaled workflow engine —
+re-implementing durable retries, cancellation, and run records inside
+SQLite is more expensive than adopting Temporal and pointing it at the
+existing aggregates.
+
+This work subsumes three of the Worker Reliability items above:
+
+- "Add cancellation for queued or running local actions" — native
+  workflow + activity cancellation.
+- "Extend the `apply_runs` canonical run-record table to non-apply
+  local actions" — the Temporal workflow execution ID becomes the
+  canonical run record for every action.
+- The ad-hoc `fire_and_forget` thread in
+  `apps/api → workers/automation/.../server.py:90-96` and the TS
+  `BackgroundQueue` go away — JSON-RPC starts a workflow instead and
+  returns the workflow ID as the run handle.
+
+Scope:
+
+- Add `temporalio` to `workers/automation/pyproject.toml` and a
+  `temporal` service to a local `docker compose` profile (or document
+  the `temporal server start-dev` workflow in
+  `docs/local-development.md`).
+- Each pipeline stage (discover, enrich, score, tailor, cover, pdf,
+  apply) becomes a Temporal **Activity** owned by its bounded context
+  under `workers/automation/src/jobhunter/<context>/activities.py`.
+- A `JobPipelineWorkflow` (one per `(TenantId, JobId)`) orchestrates
+  the stages, owns the retry policies that today live in
+  `state.set_stage_state` defaults, and consults the existing
+  `StageStateMachine` for transition validity.
+- `apply_runs` collapses into a workflow run; the read-side projection
+  sources from a Temporal completion sink (or workflow history query)
+  rather than the bespoke table.
+- The `JsonRpcServer.fire_and_forget` path in
+  `workers/automation/src/jobhunter/infrastructure/rpc/server.py:90`
+  starts a workflow and returns the workflow ID; the existing JSON-RPC
+  contract (`run_stage`, `apply`, `profile_import`, …) is preserved.
+- Add a Workflow Runs view in the UI that surfaces in-progress /
+  failed / completed runs with a deep-link to the Temporal Web UI
+  (`http://127.0.0.1:8233` by default) for live debugging during the
+  local-dev phase.
+
+Out of scope (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
+
+- Managed Temporal Cloud,
+- distributed worker fleet (multi-machine task queues),
+- cross-tenant isolation in workflows,
+- Temporal-specific production observability stack.
+
 ### Data Model Cleanup
 
 - Cut the `jobs` table over from URL primary key to `JobId`. Domain has

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,34 +7,103 @@ This is the authoritative roadmap. Keep detailed historical proposals under
 
 ### Frontend/API Parity
 
-- Add event streaming or targeted row patching so lists do not reload wholesale.
+- Extend targeted row patching beyond the single `ApplyRunEventRecorded`
+  handler at `apps/web/src/contexts/operations/invalidation-router.ts:128`.
+  The SSE pipeline and invalidation router landed in Phase 5; every other
+  event still triggers `invalidateQueries` (full list reload). Per-event
+  `setQueryData` patches are the next step for jobs / artifacts / dashboard
+  lists so live updates do not lose scroll position or trigger spinners.
 
 ### Worker Reliability
 
-- Make every stage update `job_stage_states` through shared helpers.
-- Normalize run records for all local actions.
-- Add cancellation where practical for queued or running local actions.
-- Record generated logs and reports as artifacts.
-- Keep dry-run apply behavior covered by tests.
+- Eliminate the second stage-state write path in
+  `workers/automation/src/jobhunter/infrastructure/pipeline/sqlite_repository.py:249,296`
+  that issues ad-hoc `UPDATE/INSERT INTO job_stage_states`. The canonical
+  helper `state.set_stage_state` is used by every stage runner
+  (`enrichment/detail.py:436`, `scoring/scorer.py:171`, `apply/launcher.py`,
+  RPC handlers, …) — the repository should route through it too so all
+  writes share validation and event emission.
+- Extend the `apply_runs` canonical run-record table to non-apply local
+  actions. Today only `apply` produces a row; `run_stage`, `profile_import`,
+  and other JSON-RPC fire-and-forget actions only emit `job_events` and
+  return an in-memory `LocalActionResult` (`workers/automation/src/jobhunter/actions.py:48`).
+  Without a uniform run record, the dashboard cannot show running / queued /
+  failed status for non-apply work.
+- Add cancellation for queued or running local actions. `cancel_stage`
+  (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py:112`)
+  only flips the stage row to `canceled`; the JSON-RPC `fire_and_forget`
+  thread (`server.py:90-96`) keeps no handle and the apply launcher has no
+  cooperative cancel check. Add a cancel token surface (queue-side and
+  in-process) so the UI cancel buttons actually interrupt work.
+- Record generated logs and reports as artifacts. `record_job_artifact`
+  (`workers/automation/src/jobhunter/state.py:304`) exists but is never
+  called; apply log files are only kept on disk and stored as a string in
+  `apply_runs.log_path`. Wire the helper into the apply / materials /
+  scoring writers so logs and reports show up in the artifacts list.
 
 ### Data Model Cleanup
 
-- Introduce a stable `jobKey`.
-- Separate original job URL from final application URL.
-- Reduce reliance on legacy nullable `jobs` columns in read paths.
-- Ensure artifact records are created before files are shown or opened in the UI.
-- Split employer/company from source board in the job model so Greenhouse,
-  LinkedIn, Talent.com, and direct employer records do not overload `site`.
-- Index normalized scoring keywords per job, expose keyword filters/search, and
-  add aggregate views or plots for keyword distribution across the pipeline.
+- Cut the `jobs` table over from URL primary key to `JobId`. Domain has
+  `JobId` (`workers/automation/src/jobhunter/domain/identifiers.py:12`) and
+  the projections expose `jobKey`, but the storage layer still uses
+  `jobs.url TEXT PRIMARY KEY` (`database.py:97`) with cross-aggregate FKs
+  on `job_url` (`database.py:262, 345, 372, 385, 680, 787, 804`). The
+  read-model resolves `jobKey` via URL fallback (`apps/api/src/read-model.ts:266-280`).
+  Until the cut-over, `jobKey` is a projection alias for the URL, not a
+  stable independent identity.
+- Drop the legacy `jobs.application_url` column and the COALESCE fallback
+  at `apps/api/src/projections.ts:726`. Domain TS already separates
+  `Job.postingUrl` from `Enrichment.applicationUrl`
+  (`packages/domain-types/src/discovery/job.ts:110`,
+  `packages/domain-types/src/enrichment/enrichment.ts:108`); the storage
+  layer should follow.
+- Stop projection BUILDERS from sourcing legacy nullable `jobs.*` columns.
+  `apps/api/src/projections.ts:700-742` and the Python builder at
+  `workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py:208`
+  still fall back to `jobs.fit_score`, `jobs.application_url`,
+  `jobs.tailored_resume_path`, `jobs.cover_letter_path`, `jobs.applied_at`,
+  `jobs.apply_status`. The read-side already moved to projections in
+  Phase 9 (S-33); the build-side is the remaining half.
+- Stop `apps/api/src/projections.ts:946-975` from synthesising phantom
+  `*_pdf` artifact rows from sibling `.txt` files with no DB record. Only
+  real DB-backed artifacts should be exposed; the file-existence check at
+  `server.ts:358` is the only guard today and the synthesised rows are
+  indistinguishable from real ones in the UI.
+- Persist domain `Source.board` and `Employer.name` directly. The domain
+  types are split (`packages/domain-types/src/discovery/job.ts:44-52,111`)
+  and the projection table has both columns, but the values are still
+  populated from `jobs.site` (`projections.ts:725, 791`) and `companyName()`
+  infers the employer from URL slugs because the domain `Employer` is
+  never persisted. Until the storage layer captures both, "filter by
+  board" + "filter by employer" cannot be separated.
+- Index normalized scoring keywords per job. `keywords_json` is written
+  and read in `workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py`
+  but is unindexed, has no contract field
+  (`packages/contracts/src/schemas.ts` has zero `keywords` references),
+  no API filter, and no UI. The web parses keywords from a free-text
+  reasoning string (`apps/web/src/contexts/scoring/lib/parse-reasoning.ts:9`)
+  as a stop-gap. Promote keywords to a typed contract, expose
+  filter/search, and add aggregate views.
 
 ### Scoring Intelligence
 
-- Replace raw score reasoning strings with an explanatory score breakdown that
-  shows why a job received its exact fit score.
-- Let the user correct a job fit score, store the correction and rationale, and
-  use that feedback to personalize scoring for the remaining jobs based on
-  relevant signals to be defined.
+- Populate and expose the typed `ScoreBreakdown` dimensions
+  (`technical_fit` / `experience_fit` / `role_fit`,
+  `workers/automation/src/jobhunter/domain/scoring/value_objects.py:103-105`).
+  Today the parser leaves the components at zero
+  (`scoring/services.py:86-94, 174`); the contract only ships
+  `scoreReasoning: string` (`packages/contracts/src/schemas.ts:498`); and
+  the frontend `ScoreBreakdown.tsx` just wraps free text. Write the
+  components in the scorer, add them to the contract, and render them in
+  the jobs drawer.
+- Wire the user-correctable score path end-to-end. The `ScoreCorrected`
+  domain event and `JobScore.with_correction` exist; the frontend has a
+  handler (`apps/web/src/contexts/scoring/handlers.ts:13`); but
+  `useCorrectScoreMutation` throws `NotImplementedError`
+  (`apps/web/src/contexts/scoring/hooks/useCorrectScoreMutation.ts:19`),
+  there is no API endpoint in `apps/api/src/server.ts`, and no UI form.
+  Once the surface lands, define which signals (job text, employer, score
+  delta, rationale tokens) feed back into scoring for remaining jobs.
 
 ### UI Quality
 
@@ -44,10 +113,23 @@ This is the authoritative roadmap. Keep detailed historical proposals under
   renderer. The spike should compare PDF fidelity, browser preview quality,
   editable profile UX, local packaging, performance, generated artifact
   compatibility, and migration cost.
-- Add React tests for persisted profile field save/discard behavior.
-- Add React tests for artifact open behavior.
-- Add browser smoke coverage for action buttons and action status polling.
-- Preserve user filters, sort, page, and selection during live updates.
+- Add React component tests for persisted profile field save/discard
+  behavior. `apps/web/src/contexts/profile/forms/` only has `*.a11y.test.tsx`
+  files today (axe-only); the `useUpdateProfileMutation` /
+  `useUpdateSettingsMutation` hooks are tested in isolation but no test
+  drives the form's save and reset interactions together.
+- Add browser smoke for action-status polling. Bulk action buttons are
+  already covered by `apps/web/e2e/tests/jobs-bulk.spec.ts`; nothing
+  exercises the status-poll loop. `apps/web/e2e/tests/materials.spec.ts`
+  is `test.fixme`'d pending the generate-materials backend enablement
+  below.
+- Decide whether row selection should be URL-persisted or kept as client
+  state. Filters, sort, and page already survive live updates by virtue
+  of the TanStack Router URL-state architecture; selection lives in
+  `useState` in `apps/web/src/views/jobs/JobsView.tsx:51-66`, survives
+  SSE invalidations (TanStack Table preserves `rowSelection` across query
+  updates), and is cleared only on filter / sort / page change. If
+  shareable selections become a requirement, promote to URL state.
 - Add side-by-side artifact comparison in the app, including AI-assisted
   comparison for resume and cover-letter variants.
 
@@ -207,13 +289,15 @@ and are tracked here per the migration plan §"Deferred follow-ups":
   `apps/web/` today, and no `lint` script in either the web package or
   the root. Lands together with the ESLint setup item above.
 - **CI does not run `web:test`, `web:test-d`, or `web:e2e`.**
-  `.github/workflows/ci.yml` runs `pnpm -r check`,
+  `.github/workflows/typescript.yml` runs `pnpm -r check`,
   `pnpm --filter @jobhunter/api test`, `pnpm --filter @jobhunter/web build`,
   `pnpm --filter @jobhunter/web storybook:build`, and
-  `pnpm --filter @jobhunter/web storybook:test`. The Vitest unit / hook /
-  component suite, the type-level tests, and the Playwright specs are
-  developer-local only — a regression in any of those does not fail CI
-  today. Wire the three jobs into `ci.yml` once the root aliases land.
+  `pnpm --filter @jobhunter/web storybook:test` (with Playwright Chromium
+  installed for the Storybook test runner). The Vitest unit / hook /
+  component suite, the type-level tests, and the standalone Playwright e2e
+  specs at `apps/web/e2e/` are developer-local only — a regression in any
+  of those does not fail CI today. Wire the three jobs into
+  `typescript.yml` once the root aliases land.
 - **Frontend ACL `JobId` is unbranded** —
   `apps/web/src/contexts/operations/types.ts` exports
   `type JobId = string` rather than re-exporting the branded
@@ -226,8 +310,13 @@ and are tracked here per the migration plan §"Deferred follow-ups":
   reviewer follow-up. Playwright specs currently rely on text content for
   row selection, which is brittle as copy evolves.
 - **`apps/api/test/qa-seed.ts` schema bump** — Phase 6 reviewer follow-up.
-  The QA seed builder should track schema additions made during the
-  frontend migration so seeded fixtures cover every read-model field.
+  The seed currently creates only the legacy tables (`jobs`,
+  `job_stage_states`, `job_artifacts`, `job_events`, `apply_runs`). It is
+  missing `job_scores` (read at `apps/api/src/projections.ts:484`),
+  `job_materials` + `job_materials_artifacts` (lines 437, 442, 451),
+  `jobhunter_deleted_jobs` (line 598), and `job_enrichments`. The seeded
+  `job_stage_states` row also omits the `metadata_json` and `version`
+  columns expected at `projections.ts:114-115`.
 - **Generate-materials backend enablement** — `docs/frontend-target.md`
   §3.6 / migration plan §7. The `useGenerateMaterialsMutation` hook
   exists; the backend `GenerateMaterialsUseCase` exposure on the JSON-RPC


### PR DESCRIPTION
## Summary

Audited every bullet under **Local Product Validation**, **Scoring Intelligence**, **UI Quality**, and **Frontend Tooling + CI** in `docs/backlog.md` against the post-Phase-8 code. Reworded each item to reflect what is actually in place vs. what is genuinely missing, anchored every item to a `file:line` target, removed delivered items, fixed two doc-vs-code drifts, and promoted local Temporal adoption out of `TODO_FUTURE.md` into the active backlog.

## Notable changes

- **Frontend/API Parity** — acknowledges SSE + invalidation router landed in Phase 5; the open work is extending `setQueryData` patches beyond the single `ApplyRunEventRecorded` handler at `apps/web/src/contexts/operations/invalidation-router.ts:128`.
- **Worker Reliability** — calls out the second stage-state write path in `infrastructure/pipeline/sqlite_repository.py` that bypasses `state.set_stage_state`; clarifies that `apply_runs` is the canonical run record only for apply (other actions only emit `job_events`); pinpoints the missing cancel-token surface and the unused `record_job_artifact` helper. Removes the "keep dry-run apply behavior covered by tests" item — covered by `test_actions.py:68`, `test_apply_regressions.py:249`, `test_apply_saga.py:195`.
- **NEW — Workflow Orchestration (Local Temporal)** — promoted out of `TODO_FUTURE.md`. Scopes adopting Temporal as the Python worker orchestration engine, run locally (dev server / `docker compose`), with each pipeline stage as a Temporal Activity and a `JobPipelineWorkflow` per `(TenantId, JobId)`. Subsumes the cancellation, run-record normalization, and `fire_and_forget` thread items above. Managed Temporal Cloud and the distributed worker fleet stay in `TODO_FUTURE.md`.
- **Data Model Cleanup** — every item now points at the specific legacy fallback that needs deleting: `jobs.url` PK, `jobs.application_url` COALESCE in `projections.ts:726`, projection-builder fallbacks at `projections.ts:700-742`, the synthesised phantom `*_pdf` rows at `projections.ts:946-975`, the `jobs.site` + URL-slug employer inference, and the unindexed `keywords_json`.
- **Scoring Intelligence** — both items reworded around what exists (typed `ScoreBreakdown`, `ScoreCorrected` event, frontend handler) and what is missing (zero-valued breakdown components, no contract field, no API endpoint, `useCorrectScoreMutation` throws `NotImplementedError`).
- **UI Quality** — removes "React tests for artifact open" (covered by `OpenArtifactButton.test.tsx`); reframes the filters/sort/page/selection item now that URL state handles the first three (open question is just selection persistence); narrows browser-smoke to action-status polling (bulk action buttons are already covered by `jobs-bulk.spec.ts`).
- **Frontend Tooling + CI** — fixes the workflow filename (`ci.yml` → `typescript.yml`) and lists the specific tables/columns missing from `qa-seed.ts` (`job_scores`, `job_materials`, `jobhunter_deleted_jobs`, `job_enrichments`, `metadata_json`/`version`).

## Out of scope (no edits)

- **SaaS And Commercialization** — intentionally deferred until local validation is solid.
- **Frontend Cloud-Mode Adapters** — gated by fitness functions; ports already in place.
- **Frontend Accessibility Backlog** — none of the 13 in-repo or 4 Radix/cmdk deferrals have been fixed; table is accurate.

## Test plan

- [x] `docs/backlog.md` renders correctly on GitHub
- [x] Every `file:line` reference in the rewritten items resolves on `main`
- [x] `TODO_FUTURE.md` link to the new backlog section is correct