### PR TITLE
feat(workers): add local Temporal foundation (client + worker + doctor)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ To be defined as a complete, single source of truth. Until this is finalized, in
 Known local commands:
 
 - Python CLI: `uv --project workers/automation run jobhunter doctor`, `uv --project workers/automation run jobhunter run`, or targeted `uv --project workers/automation run jobhunter <command>` after dependencies are installed.
+- Temporal worker: `uv --project workers/automation run jobhunter worker` (long-lived workflow worker; needs `temporal server start-dev` running).
 - TypeScript API: `pnpm api:dev`.
 - Web app: `pnpm web:dev`.
 - Web preview after build: `pnpm web:preview`.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Core pipeline:
   Gemini, OpenAI, and local HTTP-backed providers are supported through
   environment variables.
 - A TeX distribution with `pdflatex` for PDF output.
+- Temporal dev server (`temporal server start-dev`) for the workflow engine
+  the Python worker runs against. See `docs/local-development.md`.
 
 Local API and web UI:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -333,6 +333,24 @@ its aggregate, repository (in `infrastructure/<context>/`), and ports (in
 `domain/ports/`). The CLI is the human-facing driving adapter; the JSON-RPC
 server (`jobhunter rpc`) is the API-facing driving adapter.
 
+### Workflow Orchestration (Local Temporal)
+
+A local Temporal dev server (`temporal server start-dev`) is the workflow
+engine for the Python worker. The infrastructure split lives under
+`workers/automation/src/jobhunter/infrastructure/temporal/`:
+
+- `client.py` — `get_temporal_client()` connects to `TEMPORAL_ADDRESS`
+  (default `localhost:7233`) and `TEMPORAL_NAMESPACE` (default `default`).
+- `worker.py` — `build_worker(client, *, workflows, activities)` returns a
+  `temporalio.worker.Worker` bound to `JOBHUNTER_TASK_QUEUE`.
+- `task_queues.py` — single `JOBHUNTER_TASK_QUEUE = "jobhunter-default"`.
+
+`jobhunter worker` is the long-lived process that runs the worker loop.
+Pipeline workflows + activities are introduced in later PRs of this stack;
+this layer is the substrate they bind to. Live workflow state — running
+workflows, history, signals, retries — is visible at
+`http://127.0.0.1:8233` in the Temporal Web UI.
+
 ### SQLite And Files
 
 SQLite in `~/.jobhunter/jobhunter.db` is the local source of truth for jobs,

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -20,6 +20,27 @@ uv --project workers/automation run jobhunter doctor
 
 The Vite web dev server proxies `/v1/*` to the local API by default.
 
+### Local Temporal dev server
+
+The Python worker uses [Temporal](https://docs.temporal.io/) as its workflow
+engine. Start the dev server in its own terminal:
+
+```bash
+temporal server start-dev
+```
+
+That binds the frontend gRPC service on `127.0.0.1:7233` and the Web UI on
+`http://127.0.0.1:8233`. With it running, `jobhunter doctor` reports
+`Temporal: reachable` and the worker process can connect:
+
+```bash
+uv --project workers/automation run jobhunter worker
+```
+
+`jobhunter worker` is the long-lived process that picks up workflow + activity
+tasks from the `jobhunter-default` queue. Run it alongside `pnpm api:dev` and
+`pnpm web:dev` whenever you want the full local stack live.
+
 ## Verify
 
 ```bash

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -27,10 +27,11 @@ dependencies = [
     "pypdf>=5.0",
     "pyyaml>=6.0",
     "pandas>=2.0",
+    "temporalio>=1.6",
     ]
 
 [project.optional-dependencies]
-dev = ["build>=1.2", "pytest>=7.0", "ruff>=0.1"]
+dev = ["build>=1.2", "pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.1"]
 
 [project.scripts]
 jobhunter = "jobhunter.cli:app"
@@ -53,3 +54,6 @@ artifacts = ["src/jobhunter/config/*.yaml"]
 [tool.ruff]
 target-version = "py311"
 line-length = 120
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -57,3 +57,10 @@ line-length = 120
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"
+extraPaths = ["src"]
+include = ["src", "tests"]
+pythonVersion = "3.11"

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -1140,6 +1141,37 @@ def rpc() -> None:
 
 
 @app.command()
+def worker(
+    task_queue: Optional[str] = typer.Option(
+        None,
+        "--task-queue",
+        help="Override the Temporal task queue (defaults to JOBHUNTER_TASK_QUEUE).",
+    ),
+) -> None:
+    """Run the long-lived JobHunter Temporal worker."""
+    _bootstrap()
+
+    from jobhunter.infrastructure.temporal import (
+        JOBHUNTER_TASK_QUEUE,
+        build_worker,
+        get_temporal_client,
+    )
+
+    queue = task_queue or JOBHUNTER_TASK_QUEUE
+
+    async def _run() -> None:
+        client = await get_temporal_client()
+        worker = build_worker(client, workflows=[], activities=[], task_queue=queue)
+        console.print(
+            f"[bold blue]JobHunter worker[/bold blue] running on task queue "
+            f"[bold]{queue}[/bold] — Ctrl-C to stop."
+        )
+        await worker.run()
+
+    asyncio.run(_run())
+
+
+@app.command()
 def doctor() -> None:
     """Check your setup and diagnose missing requirements."""
     import shutil
@@ -1247,6 +1279,16 @@ def doctor() -> None:
     else:
         results.append(("CapSolver API key", "[dim]optional[/dim]",
                         "Set CAPSOLVER_API_KEY in .env for CAPTCHA solving"))
+
+    # Temporal dev server (workflow engine)
+    from jobhunter.infrastructure.temporal import get_temporal_client
+
+    try:
+        asyncio.run(get_temporal_client())
+        results.append(("Temporal", ok_mark, "reachable"))
+    except Exception:  # noqa: BLE001 — surface any connect failure as unreachable
+        results.append(("Temporal", fail_mark,
+                        "unreachable (start with: temporal server start-dev)"))
 
     # --- Render results ---
     console.print()

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1283,10 +1283,13 @@ def doctor() -> None:
     # Temporal dev server (workflow engine)
     from jobhunter.infrastructure.temporal import get_temporal_client
 
+    async def _probe_temporal() -> None:
+        await asyncio.wait_for(get_temporal_client(), timeout=3.0)
+
     try:
-        asyncio.run(get_temporal_client())
+        asyncio.run(_probe_temporal())
         results.append(("Temporal", ok_mark, "reachable"))
-    except Exception:  # noqa: BLE001 — surface any connect failure as unreachable
+    except (Exception, asyncio.TimeoutError):  # noqa: BLE001 — any failure ⇒ unreachable
         results.append(("Temporal", fail_mark,
                         "unreachable (start with: temporal server start-dev)"))
 

--- a/workers/automation/src/jobhunter/infrastructure/temporal/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/__init__.py
@@ -1,0 +1,7 @@
+"""Temporal infrastructure — client + worker bootstrap."""
+
+from jobhunter.infrastructure.temporal.client import get_temporal_client
+from jobhunter.infrastructure.temporal.task_queues import JOBHUNTER_TASK_QUEUE
+from jobhunter.infrastructure.temporal.worker import build_worker
+
+__all__ = ["JOBHUNTER_TASK_QUEUE", "build_worker", "get_temporal_client"]

--- a/workers/automation/src/jobhunter/infrastructure/temporal/client.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/client.py
@@ -1,0 +1,17 @@
+"""Temporal client factory."""
+
+from __future__ import annotations
+
+import os
+
+from temporalio.client import Client
+
+DEFAULT_ADDRESS = "localhost:7233"
+DEFAULT_NAMESPACE = "default"
+
+
+async def get_temporal_client() -> Client:
+    """Connect to the Temporal frontend defined by ``TEMPORAL_ADDRESS`` / ``TEMPORAL_NAMESPACE``."""
+    address = os.environ.get("TEMPORAL_ADDRESS", DEFAULT_ADDRESS)
+    namespace = os.environ.get("TEMPORAL_NAMESPACE", DEFAULT_NAMESPACE)
+    return await Client.connect(address, namespace=namespace)

--- a/workers/automation/src/jobhunter/infrastructure/temporal/task_queues.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/task_queues.py
@@ -1,0 +1,7 @@
+"""Task queue identifiers used by the JobHunter Temporal worker."""
+
+from __future__ import annotations
+
+from typing import Final
+
+JOBHUNTER_TASK_QUEUE: Final[str] = "jobhunter-default"

--- a/workers/automation/src/jobhunter/infrastructure/temporal/worker.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/worker.py
@@ -1,0 +1,41 @@
+"""Temporal worker bootstrap."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from temporalio import workflow
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+from jobhunter.infrastructure.temporal.task_queues import JOBHUNTER_TASK_QUEUE
+
+
+@workflow.defn(name="JobHunterBootstrapNoOp")
+class _BootstrapNoOpWorkflow:
+    """Placeholder workflow so the worker can boot before pipeline workflows land."""
+
+    @workflow.run
+    async def run(self) -> str:
+        return "noop"
+
+
+def build_worker(
+    client: Client,
+    *,
+    workflows: Sequence[type],
+    activities: Sequence[Any],
+    task_queue: str = JOBHUNTER_TASK_QUEUE,
+) -> Worker:
+    """Build a ``temporalio.worker.Worker`` bound to the JobHunter task queue."""
+    workflow_list: list[type] = list(workflows)
+    activity_list: list[Any] = list(activities)
+    if not workflow_list and not activity_list:
+        workflow_list.append(_BootstrapNoOpWorkflow)
+    return Worker(
+        client,
+        task_queue=task_queue,
+        workflows=workflow_list,
+        activities=activity_list,
+    )

--- a/workers/automation/tests/test_doctor_temporal.py
+++ b/workers/automation/tests/test_doctor_temporal.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from jobhunter.cli import app
+
+
+def test_doctor_reports_temporal_reachable():
+    sentinel = object()
+    with patch(
+        "jobhunter.infrastructure.temporal.client.Client.connect",
+        new=AsyncMock(return_value=sentinel),
+    ):
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Temporal" in result.output
+    assert "reachable" in result.output
+
+
+def test_doctor_reports_temporal_unreachable():
+    with patch(
+        "jobhunter.infrastructure.temporal.client.Client.connect",
+        new=AsyncMock(side_effect=RuntimeError("connection refused")),
+    ):
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Temporal" in result.output
+    assert "unreachable" in result.output
+    # Rich may soft-wrap the hint; collapse whitespace before asserting.
+    assert "temporal server start-dev" in " ".join(result.output.split())

--- a/workers/automation/tests/test_temporal_client.py
+++ b/workers/automation/tests/test_temporal_client.py
@@ -1,0 +1,37 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from jobhunter.infrastructure.temporal import get_temporal_client
+
+
+@pytest.mark.asyncio
+async def test_get_temporal_client_uses_default_address_and_namespace(monkeypatch):
+    monkeypatch.delenv("TEMPORAL_ADDRESS", raising=False)
+    monkeypatch.delenv("TEMPORAL_NAMESPACE", raising=False)
+
+    sentinel = object()
+    with patch(
+        "jobhunter.infrastructure.temporal.client.Client.connect",
+        new=AsyncMock(return_value=sentinel),
+    ) as connect_mock:
+        client = await get_temporal_client()
+
+    assert client is sentinel
+    connect_mock.assert_awaited_once_with("localhost:7233", namespace="default")
+
+
+@pytest.mark.asyncio
+async def test_get_temporal_client_honours_environment(monkeypatch):
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "temporal.example:7777")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "jobhunter")
+
+    sentinel = object()
+    with patch(
+        "jobhunter.infrastructure.temporal.client.Client.connect",
+        new=AsyncMock(return_value=sentinel),
+    ) as connect_mock:
+        client = await get_temporal_client()
+
+    assert client is sentinel
+    connect_mock.assert_awaited_once_with("temporal.example:7777", namespace="jobhunter")

--- a/workers/automation/tests/test_temporal_worker.py
+++ b/workers/automation/tests/test_temporal_worker.py
@@ -1,0 +1,28 @@
+import pytest
+from temporalio.testing import WorkflowEnvironment
+
+from jobhunter.infrastructure.temporal import (
+    JOBHUNTER_TASK_QUEUE,
+    build_worker,
+)
+
+
+@pytest.mark.asyncio
+async def test_build_worker_binds_to_jobhunter_task_queue():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        worker = build_worker(env.client, workflows=[], activities=[])
+
+        assert worker.task_queue == JOBHUNTER_TASK_QUEUE
+
+
+@pytest.mark.asyncio
+async def test_build_worker_accepts_explicit_task_queue_override():
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        worker = build_worker(
+            env.client,
+            workflows=[],
+            activities=[],
+            task_queue="custom-queue",
+        )
+
+        assert worker.task_queue == "custom-queue"

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-22T15:58:11.885362Z"
+exclude-newer = "2026-04-29T18:15:39.730491Z"
 exclude-newer-span = "P8D"
 
 [[package]]
@@ -216,6 +216,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "temporalio" },
     { name = "typer" },
 ]
 
@@ -223,6 +224,7 @@ dependencies = [
 dev = [
     { name = "build" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -235,10 +237,12 @@ requires-dist = [
     { name = "playwright", specifier = ">=1.40" },
     { name = "pypdf", specifier = ">=5.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
+    { name = "temporalio", specifier = ">=1.6" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
 provides-extras = ["dev"]
@@ -262,6 +266,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "nexus-rpc"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/d5/cd1ffb202b76ebc1b33c1332a3416e55a39929006982adc2b1eb069aaa9b/nexus_rpc-1.4.0.tar.gz", hash = "sha256:3b8b373d4865671789cc43623e3dc0bcbf192562e40e13727e17f1c149050fba", size = 82367, upload-time = "2026-02-25T22:01:34.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/52/6327a5f4fda01207205038a106a99848a41c83e933cd23ea2cab3d2ebc6c/nexus_rpc-1.4.0-py3-none-any.whl", hash = "sha256:14c953d3519113f8ccec533a9efdb6b10c28afef75d11cdd6d422640c40b3a49", size = 29645, upload-time = "2026-02-25T22:01:33.122Z" },
 ]
 
 [[package]]
@@ -380,6 +396,21 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -432,6 +463,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -585,6 +629,25 @@ wheels = [
 ]
 
 [[package]]
+name = "temporalio"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nexus-rpc" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/d4/fa21150a225393f87732ed6fef3cc9735d9e751edc6be415fe6e375105c6/temporalio-1.26.0.tar.gz", hash = "sha256:f4bfb35125e6f5e8c7f7ed1277c7354d812c6fac7ed5f8dbd50536cf289aaaa7", size = 2388994, upload-time = "2026-04-15T23:43:00.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/27/8c421c622d18cc8e034247d5d72b89e6456937344b5bec1de40abef3c085/temporalio-1.26.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5489040c0cf621edeb36984199dd9e4fbd2b3a07d61a4f2a8da1f2cb9820ef26", size = 14221070, upload-time = "2026-04-15T23:42:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7c/d2b691d16ec5db87198c2e08dbfba58e286c096faee15753613a581abdce/temporalio-1.26.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b18dd85771509c19ef059a31908bcd4e6130d1f67037c4db519702f3f2ad6d4a", size = 13583991, upload-time = "2026-04-15T23:42:34.357Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ca/b8728451320ca9d8bb6e1680b9bd23767118f86d5b8644edf2304d533f1b/temporalio-1.26.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46187d5f82ca2ae81f35ea5916a76db0e2f067210dc6b1852c3749475721946e", size = 13808036, upload-time = "2026-04-15T23:42:42.757Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/54/3113f5e0ac58655790abac64656373e06191b351d74bfb94692e81bd6784/temporalio-1.26.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:03300c3e5237443367ac61bb20bd726c656b3daa50310bdd436599d5bdc7cf97", size = 14336604, upload-time = "2026-04-15T23:42:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9b/c50840a26af3587c0c8d9af04d9976743e22496996dc1a377efc75dcd316/temporalio-1.26.0-cp310-abi3-win_amd64.whl", hash = "sha256:1c4a0d82f0a3796cbf78864c799f8dca0b94cdaec68e7b8b224c859005686ec4", size = 14525849, upload-time = "2026-04-15T23:42:57.589Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -597,6 +660,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "6.32.1.20260221"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/e2/9aa4a3b2469508bd7b4e2ae11cbedaf419222a09a1b94daffcd5efca4023/types_protobuf-6.32.1.20260221.tar.gz", hash = "sha256:6d5fb060a616bfb076cbb61b4b3c3969f5fc8bec5810f9a2f7e648ee5cbcbf6e", size = 64408, upload-time = "2026-02-21T03:55:13.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/e8/1fd38926f9cf031188fbc5a96694203ea6f24b0e34bd64a225ec6f6291ba/types_protobuf-6.32.1.20260221-py3-none-any.whl", hash = "sha256:da7cdd947975964a93c30bfbcc2c6841ee646b318d3816b033adc2c4eb6448e4", size = 77956, upload-time = "2026-02-21T03:55:12.894Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds **Local Temporal** as the workflow-engine substrate for the Python worker. Purely additive infrastructure — no pipeline activities, no `JobPipelineWorkflow`, no JSON-RPC change.

- New module `workers/automation/src/jobhunter/infrastructure/temporal/` with three files: `client.py` (async `get_temporal_client()` reading `TEMPORAL_ADDRESS` / `TEMPORAL_NAMESPACE`), `worker.py` (`build_worker(client, *, workflows, activities, task_queue=...)` returning a `temporalio.worker.Worker` bound to `JOBHUNTER_TASK_QUEUE`; registers a private bootstrap no-op workflow when both registries are empty so the worker can boot before pipeline workflows land), and `task_queues.py` (`JOBHUNTER_TASK_QUEUE = 'jobhunter-default'`).
- New CLI command `jobhunter worker` that connects, builds the Worker with empty registries, prints a startup line, and runs forever. `--task-queue` overrides the queue.
- `jobhunter doctor` gains a `Temporal` row that reports `reachable` / `unreachable (start with: temporal server start-dev)`.
- `temporalio>=1.6` added to `workers/automation/pyproject.toml` (resolved to 1.26.0). `pytest-asyncio>=0.23` added to the dev extras with `asyncio_mode = strict` so async tests opt in explicitly.
- Tests: `test_temporal_client.py`, `test_temporal_worker.py`, `test_doctor_temporal.py` cover env handling, queue binding, and both doctor code paths.
- Docs: `docs/local-development.md` gains a "Local Temporal dev server" subsection; `docs/architecture.md` gains a "Workflow Orchestration (Local Temporal)" subsection under Runtime Boundaries; `README.md` Requirements gains the dev-server line; `AGENTS.md` lists `jobhunter worker`.

## Why

Sourced from `docs/backlog.md` -> "Workflow Orchestration (Local Temporal)" and the stack plan at `docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md`. **This is PR 1 of 7 in that stack** — it lays the worker-bootstrap substrate so the next PR can land pipeline activities + `JobPipelineWorkflow` against a working Worker registry.

## What's NOT in this PR

Deliberately out of scope (each is a future stacked PR):

- **No activities** — the per-context `*/activities.py` modules land in PR 2.
- **No `JobPipelineWorkflow` or `ApplyWorkflow`** — workflow definitions land in PR 2.
- **No JSON-RPC change** — the `fire_and_forget` deletion + `mode="workflow"` cut-over is PR 3.
- **No apply-runs migration** — collapsing `apply_runs` into workflow-run projections is PR 4.
- **No UI** — the Workflow Runs view + Temporal Web UI deep-link is PR 5.
- **No worker-reliability fixes** — the second stage-state write path (PR 6) and logs-as-artifacts (PR 7) come later.

The bootstrap no-op workflow registered inside `build_worker` is **not** production wiring — it only exists so the Temporal SDK accepts a Worker construction with no real workflows yet. PR 2 ships the real registry; the no-op stays bundled with `build_worker` for the empty-registry case but is harmless once `workflows=[...]` is non-empty.

## How to test locally

```bash
# Terminal 1 — Temporal dev server (frontend gRPC :7233, Web UI :8233)
temporal server start-dev

# Terminal 2 — JobHunter worker bound to jobhunter-default
uv --project workers/automation run jobhunter worker

# Terminal 3 — confirm doctor surfaces the Temporal row
uv --project workers/automation run jobhunter doctor
# Expect: "Temporal  OK  reachable"
```

Stop the Temporal dev server and re-run `jobhunter doctor`; the row flips to `MISSING  unreachable (start with: temporal server start-dev)`.

## Verification

All commands run inside the worktree; all passed:

- `uv --project workers/automation sync` — clean.
- `uv --project workers/automation run --extra dev pytest -q` — **596 passed** (4 new Temporal tests + 2 new doctor tests + the existing suite).
- `uv --project workers/automation run --extra dev ruff check .` — All checks passed.
- `pnpm api:check` — clean (`tsc --noEmit`).
- `pnpm api:test` — **55 passed** (3 files).
- `git diff --check` — clean.