### PR TITLE
feat(workers/rpc): cut over apply to Temporal workflow mode (delete fire_and_forget)

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -114,7 +114,7 @@ export function createActionDispatcher(dispatcher?: JsonRpcDispatcher): ActionDi
       };
     }
     if (rpcCall.method === "apply") {
-      // fire_and_forget — server returns { runId }.
+      // workflow start — server returns { runId } (the Temporal workflow id).
       const runId = extractRunId(response.result);
       const result: ActionDispatchResult = {
         status: "queued",

--- a/apps/api/test/rpc-contracts.test.ts
+++ b/apps/api/test/rpc-contracts.test.ts
@@ -1,0 +1,55 @@
+/**
+ * RPC contract schema coverage — keeps the TS contract package in sync with
+ * the Python worker handler set.  Each new RPC method gets a parse + reject
+ * pair here so type drift between TS and Python surfaces in CI.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  CancelRunParamsSchema,
+  CancelRunResultSchema,
+  RpcMethods,
+} from "../src/contracts.js";
+
+describe("cancel_run RPC contract", () => {
+  it("registers cancel_run in RpcMethods", () => {
+    expect(RpcMethods.CancelRun).toBe("cancel_run");
+  });
+
+  it("parses a known-good request payload", () => {
+    const parsed = CancelRunParamsSchema.parse({
+      tenantId: "local",
+      runId: "wf-123",
+    });
+    expect(parsed).toEqual({ tenantId: "local", runId: "wf-123" });
+  });
+
+  it("defaults tenantId to 'local' when omitted", () => {
+    const parsed = CancelRunParamsSchema.parse({ runId: "wf-123" });
+    expect(parsed.tenantId).toBe("local");
+  });
+
+  it("rejects a request missing runId", () => {
+    expect(() => CancelRunParamsSchema.parse({ tenantId: "local" })).toThrow();
+  });
+
+  it("rejects an empty runId", () => {
+    expect(() =>
+      CancelRunParamsSchema.parse({ tenantId: "local", runId: "" }),
+    ).toThrow();
+  });
+
+  it("parses a known-good response payload", () => {
+    const parsed = CancelRunResultSchema.parse({
+      runId: "wf-123",
+      status: "canceling",
+    });
+    expect(parsed).toEqual({ runId: "wf-123", status: "canceling" });
+  });
+
+  it("rejects responses with the wrong status literal", () => {
+    expect(() =>
+      CancelRunResultSchema.parse({ runId: "wf-123", status: "canceled" }),
+    ).toThrow();
+  });
+});

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -24,17 +24,23 @@ This is the authoritative roadmap. Keep detailed historical proposals under
   RPC handlers, …) — the repository should route through it too so all
   writes share validation and event emission.
 - Extend the `apply_runs` canonical run-record table to non-apply local
-  actions. Today only `apply` produces a row; `run_stage`, `profile_import`,
-  and other JSON-RPC fire-and-forget actions only emit `job_events` and
-  return an in-memory `LocalActionResult` (`workers/automation/src/jobhunter/actions.py:48`).
-  Without a uniform run record, the dashboard cannot show running / queued /
-  failed status for non-apply work.
-- Add cancellation for queued or running local actions. `cancel_stage`
-  (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py:112`)
-  only flips the stage row to `canceled`; the JSON-RPC `fire_and_forget`
-  thread (`server.py:90-96`) keeps no handle and the apply launcher has no
-  cooperative cancel check. Add a cancel token surface (queue-side and
-  in-process) so the UI cancel buttons actually interrupt work.
+  actions. Today only `apply` produces a row; `run_stage` and
+  `profile_import` are sync RPCs that emit `job_events` and return an
+  in-memory `LocalActionResult` (`workers/automation/src/jobhunter/actions.py:48`)
+  without persisting a run record. Without a uniform run record, the
+  dashboard cannot show running / queued / failed status for non-apply
+  work. (PR 4 in the Workflow Orchestration stack collapses this onto
+  Temporal workflow runs.)
+- Add cancellation for queued or running non-workflow local actions.
+  `apply` and other workflow-mode RPCs already cooperatively cancel via
+  `cancel_run` (PR #36), but `run_stage` / `profile_import` still run
+  synchronously inside the JSON-RPC handler and have no cancel surface,
+  and `cancel_stage`
+  (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`) only
+  flips the stage row to `canceled` post-hoc. Migrating these handlers to
+  workflows (PR 4 / per-job runners) gets cooperative cancel for free; a
+  shorter-term option is to add a cancel token surface for the in-process
+  sync handlers.
 - Record generated logs and reports as artifacts. `record_job_artifact`
   (`workers/automation/src/jobhunter/state.py:304`) exists but is never
   called; apply log files are only kept on disk and stored as a string in
@@ -62,14 +68,15 @@ existing aggregates.
 This work subsumes three of the Worker Reliability items above:
 
 - "Add cancellation for queued or running local actions" — native
-  workflow + activity cancellation.
+  workflow + activity cancellation. (Apply: delivered in PR #36 via
+  `cancel_run`. Non-apply RPCs follow PR 4.)
 - "Extend the `apply_runs` canonical run-record table to non-apply
   local actions" — the Temporal workflow execution ID becomes the
-  canonical run record for every action.
-- The ad-hoc `fire_and_forget` thread in
-  `apps/api → workers/automation/.../server.py:90-96` and the TS
-  `BackgroundQueue` go away — JSON-RPC starts a workflow instead and
-  returns the workflow ID as the run handle.
+  canonical run record for every action. (PR 4.)
+- The ad-hoc `fire_and_forget` dispatch mode is deleted (PR #36): the
+  JSON-RPC server now exposes `mode="workflow"`, starts a Temporal
+  workflow, and returns `{runId, workflowId, firstExecutionRunId}` as
+  the run handle.
 
 Scope:
 
@@ -87,10 +94,12 @@ Scope:
 - `apply_runs` collapses into a workflow run; the read-side projection
   sources from a Temporal completion sink (or workflow history query)
   rather than the bespoke table.
-- The `JsonRpcServer.fire_and_forget` path in
-  `workers/automation/src/jobhunter/infrastructure/rpc/server.py:90`
-  starts a workflow and returns the workflow ID; the existing JSON-RPC
-  contract (`run_stage`, `apply`, `profile_import`, …) is preserved.
+- The `JsonRpcServer` now dispatches `mode="workflow"` handlers
+  (`apply` is the first; PR 4 migrates `run_stage` /
+  `profile_import`); each starts a Temporal workflow and returns
+  `{runId, workflowId, firstExecutionRunId}`. The existing JSON-RPC
+  contract (`run_stage`, `apply`, `profile_import`, `cancel_run`, …)
+  is preserved.
 - Add a Workflow Runs view in the UI that surfaces in-progress /
   failed / completed runs with a deep-link to the Temporal Web UI
   (`http://127.0.0.1:8233` by default) for live debugging during the

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -269,7 +269,7 @@ Rationale:
   subprocess per request (~400 ms cold start), with stringly-typed action
   names parsed via Typer and stdout-scraped for results
 - JSON-RPC gives us typed request/response envelopes, three dispatch modes
-  (`sync`, `fire_and_forget`, `streaming`), and a single long-lived worker
+  (`sync`, `workflow`, `streaming`), and a single long-lived worker
   per API process
 - the protocol matches what we'd ship to a hosted gRPC / HTTP transport
   later — Section 9 of `docs/ddd-target.md` names the swap
@@ -281,6 +281,13 @@ Consequences:
 - the worker ships the `jobhunter rpc` Typer command (Phase 3 / S-11)
 - TS-side JSON-RPC dispatcher is testable in isolation without spawning the
   Python worker (`apps/api/test/json-rpc-adapter.test.ts`)
+
+2026-05-07 update (PR #36): the `fire_and_forget` dispatch mode is deleted
+in favour of `workflow`. The JSON-RPC server now starts a Temporal workflow
+through an injected `WorkflowStarter` and returns
+`{runId, workflowId, firstExecutionRunId}`; cooperative cancellation is
+handled by a new `cancel_run` method that signals the in-flight workflow.
+The supported modes are now `(sync, workflow, streaming)`.
 
 ## 2026-05-06: TanStack Family Adopted For The Frontend
 

--- a/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
+++ b/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
@@ -100,33 +100,39 @@ Branch: `temporal/jsonrpc-cutover` off `temporal/pipeline-workflow`.
 - Delete the `fire_and_forget` mode in
   `workers/automation/src/jobhunter/infrastructure/rpc/server.py`
   (the `threading.Thread` shortcut on lines 87–97). Replace it with a
-  `workflow` dispatch mode where the handler returns a workflow
-  invocation tuple `(workflow, args)` and the server starts the
-  workflow via the Temporal client and returns
-  `{ "workflowId": ..., "runId": ... }` (preserving the existing
-  `runId` field name in the response so the TS contract stays the
-  same).
+  `workflow` dispatch mode where the handler returns a
+  `WorkflowStartSpec(workflow, args, workflow_id?, retry_policy?)`
+  and the server starts the workflow via an injected `WorkflowStarter`
+  (default: `get_temporal_client().start_workflow(...)`) and returns
+  `{ "runId": ..., "workflowId": ..., "firstExecutionRunId": ... }`
+  (preserving the existing `runId` field name in the response so the
+  TS contract stays the same).
 - Re-register `apply` as `mode="workflow"` mapping to
-  `ApplyWorkflow.run`.
-- Re-register `run_stage` and `profile_import` as `mode="workflow"`
-  too (they are sync today only because there is nowhere to enqueue
-  them — Temporal is now that place).
+  `ApplyWorkflow`.
+- **Scope narrowed:** `run_stage` and `profile_import` stay
+  `mode="sync"` for now. They are sync today and the TS callers
+  expect synchronous result shapes (e.g. `defaultProfileImporter`
+  extracts a profile draft from the response). Converting them
+  changes existing sync contracts and deserves its own follow-up —
+  in PR 3, only `apply` flips to `workflow` mode.
 - TS `apps/api/src/local-actions.ts` keeps its `{ runId }` shape and
   the existing `status: "queued"` translation — the comment about
   `fire_and_forget` becomes "workflow start — server returns
   `{ runId }` (the Temporal workflow id)".
 - New JSON-RPC method `cancel_run` (`mode=sync`) that takes a
-  `runId` (workflow id) and calls `client.cancel_workflow(...)` so
-  the existing TS cancel surface (`cancelJobAction`) works against
-  in-flight workflows. The current `cancel_stage` handler stays as
-  the post-hoc state-flip; `cancel_run` is the cooperative path.
+  `runId` (workflow id) and calls
+  `client.get_workflow_handle(run_id).cancel()` so the existing TS
+  cancel surface (`cancelJobAction`) works against in-flight
+  workflows. The current `cancel_stage` handler stays as the
+  post-hoc state-flip; `cancel_run` is the cooperative path.
 - Tests: (a) `apply` via JSON-RPC starts a workflow and returns a
   workflow id, (b) `cancel_run` propagates to a running workflow,
   (c) the deleted `fire_and_forget` path is gone — assert the mode
   is no longer accepted by `JsonRpcServer.register`.
 
 Out of scope: collapsing the `apply_runs` table into workflow runs;
-UI surfaces.
+UI surfaces; converting `run_stage` / `profile_import` to workflows
+(deferred to a follow-up — see scope narrowing above).
 
 QA: skipped — automation-only at the wire level. Existing TS `{ runId }`
 contract is preserved, so the UI continues to function unchanged.

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -67,6 +67,7 @@ export const RpcMethods = {
   RunStage: "run_stage",
   Apply: "apply",
   ProfileImport: "profile_import",
+  CancelRun: "cancel_run",
 } as const;
 export type RpcMethod = (typeof RpcMethods)[keyof typeof RpcMethods];
 
@@ -185,6 +186,24 @@ export const ApplyResultSchema = z
   })
   .strict();
 export type ApplyResult = z.infer<typeof ApplyResultSchema>;
+
+/* --- cooperative workflow cancellation ----------------------------------- */
+
+export const CancelRunParamsSchema = z
+  .object({
+    tenantId: TenantParam,
+    runId: z.string().min(1),
+  })
+  .strict();
+export type CancelRunParams = z.infer<typeof CancelRunParamsSchema>;
+
+export const CancelRunResultSchema = z
+  .object({
+    runId: z.string(),
+    status: z.literal("canceling"),
+  })
+  .strict();
+export type CancelRunResult = z.infer<typeof CancelRunResultSchema>;
 
 export const ProfileImportParamsSchema = z
   .object({

--- a/workers/automation/src/jobhunter/apply/activities.py
+++ b/workers/automation/src/jobhunter/apply/activities.py
@@ -28,6 +28,10 @@ class ApplyActivityInput:
     headless: bool = False
     dry_run: bool = False
     workers: int = 1
+    # Run-forever poll mode — when True, the activity calls ``apply_main``
+    # with ``limit=0`` (the launcher's run-forever sentinel) and ignores
+    # ``limit``.  Otherwise ``max(1, limit)`` jobs are processed.
+    continuous: bool = False
 
 
 @dataclass(frozen=True)
@@ -54,8 +58,12 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
     def _run_apply() -> tuple[int, int]:
         from jobhunter.apply.launcher import main as apply_main
 
+        # ``continuous=True`` selects the launcher's run-forever poll mode,
+        # which it activates via ``limit == 0``.  Otherwise enforce a floor
+        # of one to keep ``limit < 1`` calls from no-oping.
+        effective_limit = 0 if payload.continuous else max(1, payload.limit)
         return apply_main(
-            limit=max(1, payload.limit),
+            limit=effective_limit,
             target_url=payload.job_url,
             min_score=payload.min_score,
             headless=payload.headless,

--- a/workers/automation/src/jobhunter/apply/workflow.py
+++ b/workers/automation/src/jobhunter/apply/workflow.py
@@ -33,6 +33,9 @@ class ApplyWorkflowInput:
     min_score: int = 7
     workers: int = 1
     limit: int = 1
+    # Run-forever poll mode — when True, the activity translates to the
+    # ``apply.launcher`` ``limit=0`` sentinel that drives the continuous loop.
+    continuous: bool = False
 
 
 @dataclass(frozen=True)
@@ -66,12 +69,13 @@ class ApplyWorkflow:
                 ApplyActivityInput(
                     tenant_id=payload.tenant_id,
                     job_url=payload.job_url,
-                    limit=max(1, payload.limit),
+                    limit=payload.limit,
                     min_score=payload.min_score,
                     model=payload.model,
                     headless=payload.headless,
                     dry_run=payload.dry_run,
                     workers=payload.workers,
+                    continuous=payload.continuous,
                 ),
                 start_to_close_timeout=_APPLY_TIMEOUT,
                 retry_policy=_APPLY_RETRY,

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1134,9 +1134,13 @@ def rpc() -> None:
     _bootstrap()
     from jobhunter.infrastructure.rpc.handlers import register_default_handlers
     from jobhunter.infrastructure.rpc.server import JsonRpcServer
+    from jobhunter.infrastructure.rpc.workflow_starter import (
+        default_workflow_canceler,
+        default_workflow_starter,
+    )
 
-    server = JsonRpcServer()
-    register_default_handlers(server)
+    server = JsonRpcServer(workflow_starter=default_workflow_starter)
+    register_default_handlers(server, canceler=default_workflow_canceler)
     server.serve()
 
 

--- a/workers/automation/src/jobhunter/domain/rpc/messages.py
+++ b/workers/automation/src/jobhunter/domain/rpc/messages.py
@@ -10,7 +10,10 @@ reads newline-delimited responses from stdout.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — import only for type hints
+    from temporalio.common import RetryPolicy
 
 # JSON-RPC 2.0 reserved error codes (https://www.jsonrpc.org/specification).
 PARSE_ERROR: int = -32700
@@ -96,3 +99,18 @@ class JsonRpcResponse:
     @classmethod
     def failure(cls, request_id: str | int | None, error: JsonRpcError) -> "JsonRpcResponse":
         return cls(id=request_id, error=error)
+
+
+@dataclass(frozen=True)
+class WorkflowStartSpec:
+    """Return value of a ``workflow``-mode JSON-RPC handler.
+
+    The handler converts JSON-RPC params into the workflow input shape and
+    hands the spec to the server, which starts the workflow via the injected
+    ``WorkflowStarter``.
+    """
+
+    workflow: type
+    args: tuple[Any, ...]
+    workflow_id: str | None = None
+    retry_policy: "RetryPolicy | None" = None

--- a/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
@@ -198,6 +198,7 @@ def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
         min_score=int(params.get("minScore", 7)),
         workers=int(params.get("workers", 1)),
         limit=int(params.get("limit", 1)),
+        continuous=bool(params.get("continuous", False)),
     )
     return WorkflowStartSpec(workflow=ApplyWorkflow, args=(payload,))
 

--- a/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
@@ -6,8 +6,13 @@ Per S-11 the initial method set covers:
   ``mark_skipped``, ``cancel_stage``.  These mutate ``job_stage_states``
   through the same write API the TS surface uses (``state.reset_job_stage``
   / ``state.set_stage_state``).
-* Existing local-action wrappers — ``run_stage``, ``apply``,
-  ``profile_import``.  These delegate to ``actions.run_local_action``.
+* Existing local-action wrappers — ``run_stage``, ``profile_import``.
+  These delegate to ``actions.run_local_action``.
+* Workflow starters — ``apply`` returns a :class:`WorkflowStartSpec` for
+  :class:`ApplyWorkflow`; the server starts it on the Temporal task queue
+  and ships back ``{"runId", "workflowId", "firstExecutionRunId"}``.
+* Cooperative cancellation — ``cancel_run`` cancels an in-flight workflow
+  via the injected canceler.
 
 Every method accepts ``params.tenantId``; if it is missing the handler logs
 a warning and substitutes ``LOCAL_TENANT`` (single-user / local-first per
@@ -16,13 +21,17 @@ target §6.5).
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 from jobhunter.actions import LocalActionRequest, run_local_action
+from jobhunter.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
 from jobhunter.database import get_connection
+from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.rpc.server import JsonRpcServer, invalid_params
+from jobhunter.infrastructure.rpc.workflow_starter import WorkflowCanceler
 from jobhunter.state import record_job_event, reset_job_stage, set_stage_state, utc_now
 
 logger = logging.getLogger(__name__)
@@ -109,6 +118,9 @@ def mark_skipped(params: dict[str, Any]) -> dict[str, Any]:
     return {"jobUrl": job_url, "stage": stage, "state": "skipped"}
 
 
+# Post-hoc state-flip path — marks the stage canceled in SQLite without
+# touching the workflow runtime.  Pair with ``cancel_run`` for the
+# cooperative path that signals an in-flight workflow.
 def cancel_stage(params: dict[str, Any]) -> dict[str, Any]:
     _tenant_id(params)
     job_url = str(_require(params, "jobUrl"))
@@ -157,22 +169,6 @@ def run_stage(params: dict[str, Any]) -> dict[str, Any]:
     return run_local_action(request).to_dict()
 
 
-def apply_action(params: dict[str, Any]) -> dict[str, Any]:
-    _tenant_id(params)
-    request = LocalActionRequest(
-        stage="apply",
-        job_url=params.get("jobUrl"),
-        limit=int(params.get("limit", 1)),
-        workers=int(params.get("workers", 1)),
-        min_score=int(params.get("minScore", 7)),
-        dry_run=bool(params.get("dryRun", False)),
-        model=str(params.get("model", "haiku")),
-        headless=bool(params.get("headless", False)),
-        continuous=bool(params.get("continuous", False)),
-    )
-    return run_local_action(request).to_dict()
-
-
 def profile_import(params: dict[str, Any]) -> dict[str, Any]:
     _tenant_id(params)
     pdf_path = str(_require(params, "pdfPath"))
@@ -186,19 +182,60 @@ def profile_import(params: dict[str, Any]) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Workflow handlers
+# ---------------------------------------------------------------------------
+
+
+def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
+    """Build a :class:`WorkflowStartSpec` for :class:`ApplyWorkflow`."""
+    tenant_id = _tenant_id(params)
+    payload = ApplyWorkflowInput(
+        tenant_id=tenant_id,
+        job_url=params.get("jobUrl"),
+        dry_run=bool(params.get("dryRun", False)),
+        headless=bool(params.get("headless", False)),
+        model=str(params.get("model", "haiku")),
+        min_score=int(params.get("minScore", 7)),
+        workers=int(params.get("workers", 1)),
+        limit=int(params.get("limit", 1)),
+    )
+    return WorkflowStartSpec(workflow=ApplyWorkflow, args=(payload,))
+
+
+def make_cancel_run(canceler: WorkflowCanceler):
+    """Build a ``cancel_run`` handler bound to *canceler*.
+
+    Cooperative cancellation path — signals the workflow runtime to cancel
+    the in-flight run.  See :func:`cancel_stage` for the post-hoc state-flip
+    path that does not touch the workflow runtime.
+    """
+
+    def cancel_run(params: dict[str, Any]) -> dict[str, Any]:
+        _tenant_id(params)
+        run_id = str(_require(params, "runId"))
+        asyncio.run(canceler(run_id))
+        return {"runId": run_id, "status": "canceling"}
+
+    return cancel_run
+
+
+# ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
 
 
-def register_default_handlers(server: JsonRpcServer) -> None:
+def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCanceler) -> None:
     """Wire the default JobHunter method set onto *server*."""
     # Simple state-transition commands — synchronous.
     server.register("reset_stage", reset_stage, mode="sync")
     server.register("mark_applied", mark_applied, mode="sync")
     server.register("mark_skipped", mark_skipped, mode="sync")
     server.register("cancel_stage", cancel_stage, mode="sync")
-    # Local-action wrappers — sync for now (the TS API can stream via the
-    # ``streaming`` mode in Phase 9).
+    # Local-action wrappers — sync; ``run_stage`` and ``profile_import`` keep
+    # their sync result shape until a follow-up converts them to workflows.
     server.register("run_stage", run_stage, mode="sync")
-    server.register("apply", apply_action, mode="fire_and_forget")
     server.register("profile_import", profile_import, mode="sync")
+    # Workflow starters.
+    server.register("apply", apply_action, mode="workflow")
+    # Cooperative cancellation of in-flight workflows.
+    server.register("cancel_run", make_cancel_run(canceler), mode="sync")

--- a/workers/automation/src/jobhunter/infrastructure/rpc/server.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/server.py
@@ -1,11 +1,12 @@
 """JSON-RPC 2.0 stdin/stdout server (local subprocess transport, ddd-target.md §6.5).
 
-Three dispatch modes are supported per §6.5:
+Three dispatch modes are supported:
 
-* ``sync``           — handler returns a result; it ships back as ``result``.
-* ``fire_and_forget`` — handler is launched on a background thread; the
-  server immediately returns ``{ "runId": ... }`` so the TS API can poll.
-* ``streaming``      — handler is a generator that yields zero or more
+* ``sync``      — handler returns a result; it ships back as ``result``.
+* ``workflow``  — handler returns a :class:`WorkflowStartSpec`; the server
+  starts the workflow via the injected :data:`WorkflowStarter` and returns
+  ``{"runId", "workflowId", "firstExecutionRunId"}``.
+* ``streaming`` — handler is a generator that yields zero or more
   intermediate JSON-RPC notifications, optionally followed by a final
   response value.
 
@@ -16,13 +17,12 @@ with the error string in ``data``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sys
-import threading
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, TextIO
-from uuid import uuid4
 
 from jobhunter.domain.rpc.messages import (
     INTERNAL_ERROR,
@@ -33,7 +33,9 @@ from jobhunter.domain.rpc.messages import (
     JsonRpcError,
     JsonRpcRequest,
     JsonRpcResponse,
+    WorkflowStartSpec,
 )
+from jobhunter.infrastructure.rpc.workflow_starter import WorkflowStarter
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +48,7 @@ class HandlerSpec:
     """Registered handler + its dispatch mode."""
 
     fn: HandlerFn
-    mode: str  # "sync" | "fire_and_forget" | "streaming"
+    mode: str  # "sync" | "workflow" | "streaming"
 
 
 class JsonRpcServer:
@@ -58,13 +60,14 @@ class JsonRpcServer:
     newline-delimited envelopes.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, workflow_starter: WorkflowStarter | None = None) -> None:
         self._handlers: dict[str, HandlerSpec] = {}
+        self._workflow_starter = workflow_starter
 
     # ------------------------------------------------------------------ register
 
     def register(self, method: str, fn: HandlerFn, *, mode: str = "sync") -> None:
-        if mode not in ("sync", "fire_and_forget", "streaming"):
+        if mode not in ("sync", "workflow", "streaming"):
             raise ValueError(f"unknown dispatch mode: {mode}")
         self._handlers[method] = HandlerSpec(fn=fn, mode=mode)
 
@@ -73,9 +76,9 @@ class JsonRpcServer:
     def dispatch(self, request: JsonRpcRequest) -> JsonRpcResponse | None:
         """Dispatch a single parsed request to its handler.
 
-        Returns the response, or ``None`` for notifications and
-        fire-and-forget calls without an id.  Streaming handlers should be
-        driven via :meth:`serve` instead of this entry point.
+        Returns the response, or ``None`` for notifications.  Streaming
+        handlers should be driven via :meth:`serve` instead of this entry
+        point.
         """
         spec = self._handlers.get(request.method)
         if spec is None:
@@ -84,17 +87,8 @@ class JsonRpcServer:
                 JsonRpcError(METHOD_NOT_FOUND, f"Method not found: {request.method}"),
             )
 
-        if spec.mode == "fire_and_forget":
-            run_id = f"run-{uuid4().hex}"
-
-            def _runner() -> None:
-                try:
-                    spec.fn({**request.params, "_runId": run_id})
-                except Exception:  # noqa: BLE001 — background errors must not crash server
-                    logger.exception("Background handler %s failed", request.method)
-
-            threading.Thread(target=_runner, daemon=True).start()
-            return JsonRpcResponse.success(request.id, {"runId": run_id})
+        if spec.mode == "workflow":
+            return self._dispatch_workflow(request, spec)
 
         # sync — streaming is handled separately in serve()
         try:
@@ -112,6 +106,65 @@ class JsonRpcServer:
             )
         if request.id is None:
             # Notification — no response.
+            return None
+        return JsonRpcResponse.success(request.id, result)
+
+    # ------------------------------------------------------------------ workflow
+
+    def _dispatch_workflow(
+        self,
+        request: JsonRpcRequest,
+        spec: HandlerSpec,
+    ) -> JsonRpcResponse | None:
+        if self._workflow_starter is None:
+            logger.error("Workflow handler %s invoked without a workflow_starter", request.method)
+            return JsonRpcResponse.failure(
+                request.id,
+                JsonRpcError(
+                    INTERNAL_ERROR,
+                    "Internal error",
+                    data="workflow_starter is not configured",
+                ),
+            )
+
+        try:
+            start_spec = spec.fn(request.params)
+        except _RpcParamError as exc:
+            return JsonRpcResponse.failure(
+                request.id,
+                JsonRpcError(INVALID_PARAMS, str(exc)),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Workflow handler %s raised while building spec", request.method)
+            return JsonRpcResponse.failure(
+                request.id,
+                JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
+            )
+
+        if not isinstance(start_spec, WorkflowStartSpec):
+            return JsonRpcResponse.failure(
+                request.id,
+                JsonRpcError(
+                    INTERNAL_ERROR,
+                    f"Workflow handler {request.method} did not return a WorkflowStartSpec",
+                ),
+            )
+
+        try:
+            handle = asyncio.run(self._workflow_starter(start_spec))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Workflow start failed for %s", request.method)
+            return JsonRpcResponse.failure(
+                request.id,
+                JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
+            )
+
+        result = {
+            "runId": handle.id,
+            "workflowId": handle.id,
+            "firstExecutionRunId": handle.first_execution_run_id,
+        }
+        if request.id is None:
             return None
         return JsonRpcResponse.success(request.id, result)
 

--- a/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
@@ -2,14 +2,22 @@
 
 The JSON-RPC server depends on these via constructor injection so unit tests
 can substitute stubs without booting a Temporal cluster.
+
+The Temporal :class:`Client` is cached at module scope so repeated ``apply``
+and ``cancel_run`` JSON-RPC calls reuse the same gRPC connection — the
+``jobhunter rpc`` server is long-lived and a fresh ``Client.connect()`` per
+request would burn a TCP / TLS / namespace-describe handshake on every
+workflow start.  ``get_temporal_client()`` itself stays as the per-call
+factory; caching is a workflow-starter concern.
 """
 
 from __future__ import annotations
 
+import asyncio
 from typing import Awaitable, Callable
 from uuid import uuid4
 
-from temporalio.client import WorkflowHandle
+from temporalio.client import Client, WorkflowHandle
 
 from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.infrastructure.temporal.client import get_temporal_client
@@ -19,8 +27,30 @@ WorkflowStarter = Callable[[WorkflowStartSpec], Awaitable[WorkflowHandle]]
 WorkflowCanceler = Callable[[str], Awaitable[None]]
 
 
+_cached_client: Client | None = None
+_cache_lock = asyncio.Lock()
+
+
+async def _get_or_create_client() -> Client:
+    """Return the cached Temporal :class:`Client`, building it on first call."""
+    global _cached_client
+    if _cached_client is not None:
+        return _cached_client
+    async with _cache_lock:
+        if _cached_client is None:
+            _cached_client = await get_temporal_client()
+        return _cached_client
+
+
+async def _reset_cached_client_for_tests() -> None:
+    """Drop the cached client so tests can re-exercise the connect path."""
+    global _cached_client
+    async with _cache_lock:
+        _cached_client = None
+
+
 async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
-    client = await get_temporal_client()
+    client = await _get_or_create_client()
     workflow_id = spec.workflow_id or f"run-{uuid4().hex}"
     return await client.start_workflow(
         spec.workflow,
@@ -32,7 +62,7 @@ async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
 
 
 async def default_workflow_canceler(run_id: str) -> None:
-    client = await get_temporal_client()
+    client = await _get_or_create_client()
     await client.get_workflow_handle(run_id).cancel()
 
 

--- a/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
@@ -1,0 +1,44 @@
+"""Default Temporal-backed implementations of the workflow start / cancel seams.
+
+The JSON-RPC server depends on these via constructor injection so unit tests
+can substitute stubs without booting a Temporal cluster.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+from uuid import uuid4
+
+from temporalio.client import WorkflowHandle
+
+from jobhunter.domain.rpc.messages import WorkflowStartSpec
+from jobhunter.infrastructure.temporal.client import get_temporal_client
+from jobhunter.infrastructure.temporal.task_queues import JOBHUNTER_TASK_QUEUE
+
+WorkflowStarter = Callable[[WorkflowStartSpec], Awaitable[WorkflowHandle]]
+WorkflowCanceler = Callable[[str], Awaitable[None]]
+
+
+async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
+    client = await get_temporal_client()
+    workflow_id = spec.workflow_id or f"run-{uuid4().hex}"
+    return await client.start_workflow(
+        spec.workflow,
+        *spec.args,
+        id=workflow_id,
+        task_queue=JOBHUNTER_TASK_QUEUE,
+        retry_policy=spec.retry_policy,
+    )
+
+
+async def default_workflow_canceler(run_id: str) -> None:
+    client = await get_temporal_client()
+    await client.get_workflow_handle(run_id).cancel()
+
+
+__all__ = [
+    "WorkflowCanceler",
+    "WorkflowStarter",
+    "default_workflow_canceler",
+    "default_workflow_starter",
+]

--- a/workers/automation/tests/test_activity_apply.py
+++ b/workers/automation/tests/test_activity_apply.py
@@ -71,3 +71,63 @@ async def test_apply_activity_invokes_apply_main_and_returns_ok():
     assert output.applied == 2
     assert output.failed == 0
     assert output.error is None
+
+
+@pytest.mark.asyncio
+async def test_apply_activity_continuous_calls_apply_main_with_limit_zero():
+    """``continuous=True`` must drive ``apply_main`` with ``limit=0`` (run-forever sentinel)."""
+    queue = f"apply-{uuid.uuid4()}"
+
+    with patch(
+        "jobhunter.apply.launcher.main",
+        return_value=(0, 0),
+    ) as apply_main_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[_ApplyHarness],
+                activities=[apply_activity],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    _ApplyHarness.run,
+                    ApplyActivityInput(
+                        tenant_id="local",
+                        limit=5,  # ignored when continuous=True
+                        continuous=True,
+                    ),
+                    id=f"apply-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    apply_main_mock.assert_called_once()
+    assert apply_main_mock.call_args.kwargs["limit"] == 0
+
+
+@pytest.mark.asyncio
+async def test_apply_activity_non_continuous_floors_limit_at_one():
+    """``continuous=False`` keeps ``max(1, limit)`` semantics — ``limit=0`` becomes 1."""
+    queue = f"apply-{uuid.uuid4()}"
+
+    with patch(
+        "jobhunter.apply.launcher.main",
+        return_value=(0, 0),
+    ) as apply_main_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[_ApplyHarness],
+                activities=[apply_activity],
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    _ApplyHarness.run,
+                    ApplyActivityInput(tenant_id="local", limit=0, continuous=False),
+                    id=f"apply-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    apply_main_mock.assert_called_once()
+    assert apply_main_mock.call_args.kwargs["limit"] == 1

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -19,6 +19,20 @@ from jobhunter.infrastructure.rpc.handlers import register_default_handlers
 from jobhunter.infrastructure.rpc.server import JsonRpcServer
 
 
+class _StubHandle:
+    def __init__(self, workflow_id: str, run_id: str = "first-run") -> None:
+        self.id = workflow_id
+        self.first_execution_run_id = run_id
+
+
+async def _stub_starter(spec):
+    return _StubHandle("wf-stub")
+
+
+async def _stub_canceler(_run_id: str) -> None:  # pragma: no cover — never invoked here
+    return None
+
+
 @pytest.fixture
 def tmp_db(tmp_path: Path, monkeypatch):
     db_path = tmp_path / "jobs.db"
@@ -29,8 +43,8 @@ def tmp_db(tmp_path: Path, monkeypatch):
 
 
 def _server() -> JsonRpcServer:
-    server = JsonRpcServer()
-    register_default_handlers(server)
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=_stub_canceler)
     return server
 
 
@@ -55,6 +69,7 @@ def test_default_handlers_are_registered() -> None:
         "mark_applied",
         "mark_skipped",
         "cancel_stage",
+        "cancel_run",
         "run_stage",
         "apply",
         "profile_import",
@@ -250,39 +265,6 @@ def test_run_stage_delegates_to_run_local_action(tmp_db: Path, monkeypatch) -> N
     assert captured[0].stage == "score"
     assert captured[0].limit == 5
     assert captured[0].workers == 2
-
-
-def test_apply_handler_returns_run_id(tmp_db: Path, monkeypatch) -> None:
-    """apply is registered as fire_and_forget — returns runId immediately."""
-
-    def fake_run(request: LocalActionRequest) -> LocalActionResult:
-        return LocalActionResult(
-            ok=True,
-            action_id="act-1",
-            stage=request.stage,
-            status="succeeded",
-            started_at="t0",
-            finished_at="t1",
-            duration_ms=1,
-        )
-
-    monkeypatch.setattr(handlers_mod, "run_local_action", fake_run)
-
-    server = _server()
-    response = server.dispatch(
-        JsonRpcRequest(
-            method="apply",
-            params={
-                "tenantId": "local",
-                "jobUrl": "https://example.com/job/1",
-                "limit": 1,
-            },
-            id=2,
-        )
-    )
-    assert response is not None
-    body = response.to_dict()
-    assert "runId" in body["result"]
 
 
 def test_profile_import_requires_pdf_path(tmp_db: Path) -> None:

--- a/workers/automation/tests/test_jsonrpc_server.py
+++ b/workers/automation/tests/test_jsonrpc_server.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import io
 import json
-import threading
-import time
 
 from jobhunter.domain.rpc.messages import (
     INTERNAL_ERROR,
@@ -84,28 +82,6 @@ def test_notification_returns_no_response() -> None:
 
     assert response is None
     assert seen == [{"a": 1}]
-
-
-# ---------------------------------------------------------------------------
-# fire-and-forget
-# ---------------------------------------------------------------------------
-
-
-def test_fire_and_forget_returns_run_id() -> None:
-    server = JsonRpcServer()
-    fired = threading.Event()
-
-    def slow(params):
-        # Simulate background work.
-        fired.set()
-
-    server.register("slow", slow, mode="fire_and_forget")
-
-    response = server.dispatch(_request("slow", {}))
-    assert response is not None
-    body = response.to_dict()
-    assert body["result"]["runId"].startswith("run-")
-    assert fired.wait(timeout=2.0)
 
 
 # ---------------------------------------------------------------------------
@@ -197,7 +173,3 @@ def test_serve_handles_missing_method_gracefully() -> None:
     server.serve(stdin=stdin, stdout=stdout)
     body = json.loads(stdout.getvalue().strip())
     assert body["error"]["code"] == INVALID_REQUEST
-
-
-# Quiet imports we don't end up using in every test path.
-_ = time

--- a/workers/automation/tests/test_rpc_cancel_run.py
+++ b/workers/automation/tests/test_rpc_cancel_run.py
@@ -1,0 +1,49 @@
+"""``cancel_run`` JSON-RPC handler — cooperative workflow cancellation."""
+
+from __future__ import annotations
+
+from jobhunter.domain.rpc.messages import INVALID_PARAMS, JsonRpcRequest
+from jobhunter.infrastructure.rpc.handlers import register_default_handlers
+from jobhunter.infrastructure.rpc.server import JsonRpcServer
+
+
+async def _stub_starter(_spec):  # pragma: no cover — not invoked in cancel tests
+    raise AssertionError("starter must not be called")
+
+
+def test_cancel_run_calls_canceler_with_run_id() -> None:
+    cancelled: list[str] = []
+
+    async def canceler(run_id: str) -> None:
+        cancelled.append(run_id)
+
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=canceler)
+
+    response = server.dispatch(
+        JsonRpcRequest(
+            method="cancel_run",
+            params={"tenantId": "local", "runId": "wf-123"},
+            id=1,
+        )
+    )
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["result"] == {"runId": "wf-123", "status": "canceling"}
+    assert cancelled == ["wf-123"]
+
+
+def test_cancel_run_missing_run_id_returns_invalid_params() -> None:
+    async def canceler(_run_id: str) -> None:  # pragma: no cover — not reached
+        return None
+
+    server = JsonRpcServer(workflow_starter=_stub_starter)
+    register_default_handlers(server, canceler=canceler)
+
+    response = server.dispatch(
+        JsonRpcRequest(method="cancel_run", params={"tenantId": "local"}, id=1)
+    )
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INVALID_PARAMS

--- a/workers/automation/tests/test_rpc_handlers_apply_workflow.py
+++ b/workers/automation/tests/test_rpc_handlers_apply_workflow.py
@@ -1,0 +1,89 @@
+"""``apply`` JSON-RPC handler returns a :class:`WorkflowStartSpec`."""
+
+from __future__ import annotations
+
+from jobhunter.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
+from jobhunter.domain.rpc.messages import JsonRpcRequest, WorkflowStartSpec
+from jobhunter.infrastructure.rpc.handlers import apply_action, register_default_handlers
+from jobhunter.infrastructure.rpc.server import JsonRpcServer
+
+
+class _FakeHandle:
+    def __init__(self, workflow_id: str = "apply-wf", run_id: str = "first-run") -> None:
+        self.id = workflow_id
+        self.first_execution_run_id = run_id
+
+
+async def _stub_canceler(_run_id: str) -> None:  # pragma: no cover — not invoked
+    return None
+
+
+def test_apply_handler_returns_workflow_start_spec() -> None:
+    spec = apply_action(
+        {
+            "tenantId": "local",
+            "jobUrl": "https://example.com/job/1",
+            "limit": 2,
+            "model": "sonnet",
+            "dryRun": True,
+            "headless": True,
+            "minScore": 8,
+            "workers": 3,
+        }
+    )
+
+    assert isinstance(spec, WorkflowStartSpec)
+    assert spec.workflow is ApplyWorkflow
+    (payload,) = spec.args
+    assert isinstance(payload, ApplyWorkflowInput)
+    assert payload == ApplyWorkflowInput(
+        tenant_id="local",
+        job_url="https://example.com/job/1",
+        dry_run=True,
+        headless=True,
+        model="sonnet",
+        min_score=8,
+        workers=3,
+        limit=2,
+    )
+
+
+def test_apply_via_jsonrpc_starts_workflow() -> None:
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _FakeHandle:
+        seen.append(spec)
+        return _FakeHandle("apply-wf-123", "first-exec-run-id")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    response = server.dispatch(
+        JsonRpcRequest(
+            method="apply",
+            params={
+                "tenantId": "local",
+                "jobUrl": "https://example.com/job/1",
+                "limit": 1,
+                "model": "haiku",
+                "dryRun": False,
+                "headless": False,
+            },
+            id=42,
+        )
+    )
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["result"] == {
+        "runId": "apply-wf-123",
+        "workflowId": "apply-wf-123",
+        "firstExecutionRunId": "first-exec-run-id",
+    }
+    assert len(seen) == 1
+    assert seen[0].workflow is ApplyWorkflow
+    (payload,) = seen[0].args
+    assert payload.tenant_id == "local"
+    assert payload.job_url == "https://example.com/job/1"
+    assert payload.limit == 1
+    assert payload.model == "haiku"

--- a/workers/automation/tests/test_rpc_handlers_apply_workflow.py
+++ b/workers/automation/tests/test_rpc_handlers_apply_workflow.py
@@ -87,3 +87,22 @@ def test_apply_via_jsonrpc_starts_workflow() -> None:
     assert payload.job_url == "https://example.com/job/1"
     assert payload.limit == 1
     assert payload.model == "haiku"
+
+
+def test_apply_handler_forwards_continuous_flag() -> None:
+    """``continuous=True`` must reach :class:`ApplyWorkflowInput`."""
+    spec = apply_action({"tenantId": "local", "continuous": True})
+
+    assert isinstance(spec, WorkflowStartSpec)
+    (payload,) = spec.args
+    assert isinstance(payload, ApplyWorkflowInput)
+    assert payload.continuous is True
+
+
+def test_apply_handler_continuous_defaults_to_false() -> None:
+    """Omitted ``continuous`` must default to ``False`` (single-shot)."""
+    spec = apply_action({"tenantId": "local"})
+
+    (payload,) = spec.args
+    assert isinstance(payload, ApplyWorkflowInput)
+    assert payload.continuous is False

--- a/workers/automation/tests/test_rpc_server_workflow_mode.py
+++ b/workers/automation/tests/test_rpc_server_workflow_mode.py
@@ -1,0 +1,104 @@
+"""``mode='workflow'`` dispatch in ``JsonRpcServer``."""
+
+from __future__ import annotations
+
+import pytest
+
+from jobhunter.domain.rpc.messages import (
+    INTERNAL_ERROR,
+    JsonRpcRequest,
+    WorkflowStartSpec,
+)
+from jobhunter.infrastructure.rpc.server import JsonRpcServer
+
+
+class _FakeWorkflow:
+    pass
+
+
+class _FakeHandle:
+    def __init__(self, workflow_id: str, run_id: str) -> None:
+        self.id = workflow_id
+        self.first_execution_run_id = run_id
+
+
+def _request(method: str, params=None, rid: int | str | None = 1) -> JsonRpcRequest:
+    return JsonRpcRequest(method=method, params=params or {}, id=rid)
+
+
+def test_register_rejects_legacy_fire_and_forget_mode() -> None:
+    """The deleted ``fire_and_forget`` mode must no longer register."""
+    server = JsonRpcServer()
+    with pytest.raises(ValueError):
+        server.register("legacy", lambda _p: None, mode="fire_and_forget")
+
+
+def test_workflow_mode_calls_starter_and_returns_run_id() -> None:
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _FakeHandle:
+        seen.append(spec)
+        return _FakeHandle("wf-id", "first-run-id")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=("payload",))
+    server.register("start", lambda _params: spec, mode="workflow")
+
+    response = server.dispatch(_request("start"))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["result"] == {
+        "runId": "wf-id",
+        "workflowId": "wf-id",
+        "firstExecutionRunId": "first-run-id",
+    }
+    assert seen == [spec]
+
+
+def test_workflow_mode_starter_failure_surfaces_internal_error() -> None:
+    async def starter(_spec: WorkflowStartSpec) -> _FakeHandle:
+        raise RuntimeError("temporal-down")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    server.register(
+        "start",
+        lambda _params: WorkflowStartSpec(workflow=_FakeWorkflow, args=()),
+        mode="workflow",
+    )
+
+    response = server.dispatch(_request("start"))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INTERNAL_ERROR
+    assert body["error"]["data"] == "temporal-down"
+
+
+def test_workflow_mode_handler_returning_non_spec_is_internal_error() -> None:
+    async def starter(_spec: WorkflowStartSpec) -> _FakeHandle:  # pragma: no cover
+        raise AssertionError("starter must not be called")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    server.register("start", lambda _params: {"not": "a spec"}, mode="workflow")
+
+    response = server.dispatch(_request("start"))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INTERNAL_ERROR
+
+
+def test_workflow_mode_without_starter_is_internal_error() -> None:
+    server = JsonRpcServer()  # no workflow_starter wired
+    server.register(
+        "start",
+        lambda _p: WorkflowStartSpec(workflow=_FakeWorkflow, args=()),
+        mode="workflow",
+    )
+
+    response = server.dispatch(_request("start"))
+    assert response is not None
+    body = response.to_dict()
+    assert body["error"]["code"] == INTERNAL_ERROR
+    assert "workflow_starter" in body["error"]["data"]

--- a/workers/automation/tests/test_workflow_starter_cache.py
+++ b/workers/automation/tests/test_workflow_starter_cache.py
@@ -1,0 +1,95 @@
+"""Module-scope Temporal client cache in ``workflow_starter``.
+
+The ``jobhunter rpc`` server is long-lived; opening a fresh gRPC connection
+on every ``apply`` / ``cancel_run`` JSON-RPC call would burn a TCP / TLS /
+namespace-describe handshake per request.  ``default_workflow_starter`` and
+``default_workflow_canceler`` must reuse a single cached :class:`Client`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from jobhunter.domain.rpc.messages import WorkflowStartSpec
+from jobhunter.infrastructure.rpc import workflow_starter as ws
+
+
+class _FakeWorkflow:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_client_cache():
+    """Drop the cached client before and after every test."""
+    asyncio.run(ws._reset_cached_client_for_tests())
+    yield
+    asyncio.run(ws._reset_cached_client_for_tests())
+
+
+def test_repeated_starter_calls_reuse_single_client() -> None:
+    """``default_workflow_starter`` must call ``get_temporal_client`` exactly once."""
+    handle = MagicMock()
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock(return_value=handle)
+
+    with patch.object(
+        ws, "get_temporal_client", AsyncMock(return_value=fake_client)
+    ) as connect_mock:
+        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+
+        async def _drive() -> None:
+            await ws.default_workflow_starter(spec)
+            await ws.default_workflow_starter(spec)
+            await ws.default_workflow_starter(spec)
+
+        asyncio.run(_drive())
+
+    assert connect_mock.await_count == 1
+    assert fake_client.start_workflow.await_count == 3
+
+
+def test_starter_and_canceler_share_cached_client() -> None:
+    """``default_workflow_canceler`` must reuse the same client the starter cached."""
+    handle = MagicMock()
+    handle.cancel = AsyncMock(return_value=None)
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock(return_value=handle)
+    fake_client.get_workflow_handle = MagicMock(return_value=handle)
+
+    with patch.object(
+        ws, "get_temporal_client", AsyncMock(return_value=fake_client)
+    ) as connect_mock:
+        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+
+        async def _drive() -> None:
+            await ws.default_workflow_starter(spec)
+            await ws.default_workflow_canceler("wf-123")
+
+        asyncio.run(_drive())
+
+    assert connect_mock.await_count == 1
+    fake_client.get_workflow_handle.assert_called_once_with("wf-123")
+    handle.cancel.assert_awaited_once()
+
+
+def test_reset_cache_helper_forces_reconnect() -> None:
+    """``_reset_cached_client_for_tests`` must clear the cache between runs."""
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock(return_value=MagicMock())
+
+    with patch.object(
+        ws, "get_temporal_client", AsyncMock(return_value=fake_client)
+    ) as connect_mock:
+        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+
+        async def _drive() -> None:
+            await ws.default_workflow_starter(spec)
+            await ws._reset_cached_client_for_tests()
+            await ws.default_workflow_starter(spec)
+
+        asyncio.run(_drive())
+
+    assert connect_mock.await_count == 2


### PR DESCRIPTION
## Summary

Replaces the JSON-RPC ``fire_and_forget`` background-thread shortcut with a
``workflow`` dispatch mode. Handlers in ``workflow`` mode return a
``WorkflowStartSpec(workflow, args, workflow_id?, retry_policy?)``; the
``JsonRpcServer`` starts the workflow via an injected ``WorkflowStarter``
(default: ``client.start_workflow(...)`` against ``JOBHUNTER_TASK_QUEUE``)
and returns ``{ runId, workflowId, firstExecutionRunId }``. ``apply`` is
re-registered against ``ApplyWorkflow``. A new ``cancel_run`` JSON-RPC
method gives the existing TS cancel surface a cooperative path against
in-flight workflows.

The threading shortcut and the ``fire_and_forget`` mode constant are
deleted — rip-and-replace per ``MEMORY.md``.

## Stack context

- Stack plan: [`docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md`](docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md).
- This is **PR 3 of 7**.
- Base = ``temporal/pipeline-workflow`` (PR 2, #35).
- PR 1 (#34) and PR 2 (#35) are still open. Will rebase to ``main`` once
  both land.

## Scope narrowing

The original plan said ``run_stage`` and ``profile_import`` would also
flip to ``mode=workflow``. They stay ``mode=sync`` in this PR — both
return synchronous result shapes the TS callers parse (e.g.
``defaultProfileImporter`` extracts a profile draft from the
``profile_import`` response). Converting them changes existing sync
contracts and is deferred to its own follow-up. The plan entry has been
updated to reflect this; see the updated [PR 3 entry](docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md#pr-3--cut-over-json-rpc-to-workflows).

## Behavior change

- ``apply`` JSON-RPC now starts a Temporal workflow instead of a
  background thread. Response shape is
  ``{ runId, workflowId, firstExecutionRunId }``; existing TS callers
  reading ``result.runId`` are unaffected (the comment in
  ``apps/api/src/local-actions.ts`` is updated to reflect the new
  source).
- New ``cancel_run`` method: ``params.runId`` is the workflow id;
  the handler calls ``client.get_workflow_handle(run_id).cancel()``
  and returns ``{ runId, status: "canceling" }``. ``cancel_stage``
  remains as the post-hoc state-flip path.
- **Operational note:** the server requires a running Temporal worker
  (PR 1's ``jobhunter worker``) to actually execute ``apply``. Without
  it, the workflow stays in ``Scheduled`` state — the JSON-RPC call
  still returns a ``runId`` immediately, but no work happens until a
  worker polls the task queue.

## What's NOT in this PR

- Collapsing ``apply_runs`` into workflow runs (PR 4).
- UI Workflow Runs view (PR 5).
- Worker reliability cleanups (PR 6 / 7).
- Converting ``run_stage`` / ``profile_import`` to ``mode=workflow``
  — deferred (see scope narrowing above).

## How to test locally

1. ``temporal server start-dev`` (Temporal frontend on ``127.0.0.1:7233``).
2. ``uv --project workers/automation run jobhunter worker`` — boots the
   worker bound to ``JOBHUNTER_TASK_QUEUE``.
3. From the TS API, dispatching an ``apply`` action now returns a
   ``runId`` (the Temporal workflow id) and the worker picks the run
   up. ``cancelJobAction`` against the same ``runId`` should cancel the
   in-flight workflow cooperatively.

## Verification

Run inside the worktree (``/Users/eloibarti/Github/JobHunter-worktrees/temporal-jsonrpc-cutover``):

- ``uv --project workers/automation run --extra dev pytest -q`` -> **625 passed**
- ``uv --project workers/automation run --extra dev ruff check .`` -> **All checks passed**
- ``pnpm api:check && pnpm api:test`` -> **tsc clean, 55 tests passed**
- ``git diff --check`` -> **clean**

Tests added:
- ``workers/automation/tests/test_rpc_server_workflow_mode.py`` — pins
  the deletion of ``fire_and_forget`` and covers the new dispatch path
  (success / starter failure / non-spec return / missing starter).
- ``workers/automation/tests/test_rpc_handlers_apply_workflow.py`` —
  ``apply_action`` returns a ``WorkflowStartSpec(ApplyWorkflow, ...)``;
  end-to-end via ``JsonRpcServer`` with a stub starter.
- ``workers/automation/tests/test_rpc_cancel_run.py`` — ``cancel_run``
  invokes the injected canceler with the right runId and returns
  ``INVALID_PARAMS`` when ``runId`` is missing.

QA: skipped — automation-only, TS contract preserved.