### PR TITLE
feat(web): add Workflow Runs view with Temporal Web UI deep-link

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -34,8 +34,11 @@ import type {
   Stage,
   StageState,
   StageSummary,
+  WorkflowRunStatus,
+  WorkflowRunSummary,
+  WorkflowRunsListQuery,
 } from "./contracts.js";
-import { ProfileSchema, STAGES } from "./contracts.js";
+import { ProfileSchema, STAGES, WORKFLOW_RUN_STATUSES } from "./contracts.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
 import { refreshProjections } from "./projections.js";
 
@@ -740,6 +743,83 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
     message: stringField(row.message) || "event",
     at: nullableString(row.occurred_at),
   }));
+}
+
+/**
+ * PR 5 of the Temporal stack — Workflow Runs view source.
+ *
+ * Reads `apply_run_projections` (now sourced from Temporal workflow
+ * histories per PR 4) and projects each row to a `WorkflowRunSummary`.
+ * The `runId` IS the Temporal `workflow_id` (see `ApplyWorkflow.run`),
+ * so the deep-link to the Temporal Web UI uses it verbatim. The
+ * `workflowId` field is kept distinct in the wire shape so future
+ * non-apply workflows can supply a different value without a breaking
+ * read-model change.
+ */
+export function listWorkflowRuns(
+  db: SqliteDatabase,
+  query: WorkflowRunsListQuery,
+): PaginatedResponse<WorkflowRunSummary> {
+  refreshProjections(db, DEFAULT_TENANT);
+  if (!tableExists(db, "apply_run_projections")) {
+    return paginate([], query.page, query.pageSize, "started_at", "desc", {
+      status: query.status,
+    });
+  }
+  const deletedJoin = tableExists(db, "jobhunter_deleted_jobs")
+    ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = arp.job_id AND d.restored_at IS NULL"
+    : "";
+  const where: string[] = ["arp.tenant_id = ?"];
+  const params: SqliteValue[] = [DEFAULT_TENANT];
+  if (tableExists(db, "jobhunter_deleted_jobs")) {
+    where.push("d.job_url IS NULL");
+  }
+  const whereSql = where.length ? ` WHERE ${where.join(" AND ")}` : "";
+  const rows = allRows<ApplyRunProjectionRow>(
+    db,
+    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}${whereSql}
+     ORDER BY arp.started_at DESC, arp.run_id DESC`,
+    params,
+  );
+  const all = rows
+    .map(rowToWorkflowRunSummary)
+    .filter((run) => query.status === "all" || run.status === query.status);
+  return paginate(all, query.page, query.pageSize, "started_at", "desc", {
+    status: query.status,
+  });
+}
+
+function rowToWorkflowRunSummary(row: ApplyRunProjectionRow): WorkflowRunSummary {
+  const runId = stringField(row.run_id);
+  return {
+    workflowId: runId,
+    runId,
+    jobKey: stringField(row.job_id),
+    title: stringField(row.job_title) || "Untitled",
+    company: stringField(row.job_employer) || "Unknown company",
+    status: normalizeWorkflowRunStatus(row.status),
+    result: nullableString(row.result),
+    dryRun: Boolean(row.dry_run),
+    model: nullableString(row.model),
+    startedAt: nullableString(row.started_at),
+    finishedAt: nullableString(row.finished_at),
+    durationMs: nullableNumber(row.duration_ms),
+  };
+}
+
+const WORKFLOW_RUN_STATUS_SET = new Set<string>(WORKFLOW_RUN_STATUSES);
+
+function normalizeWorkflowRunStatus(value: unknown): WorkflowRunStatus {
+  const raw = stringField(value);
+  if (WORKFLOW_RUN_STATUS_SET.has(raw)) {
+    return raw as WorkflowRunStatus;
+  }
+  // The legacy "finished" sentinel from earlier seeds → succeeded.
+  if (raw === "finished") {
+    return "succeeded";
+  }
+  // Unknown / "unknown" / blank → treat as in_progress so the row still renders.
+  return "in_progress";
 }
 
 function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -22,6 +22,7 @@ import {
   ProfileUpdateRequestSchema,
   RetryStageRequestSchema,
   SettingsUpdateRequestSchema,
+  WorkflowRunsListQuerySchema,
 } from "./contracts.js";
 import { databaseExists, openDatabase } from "./db.js";
 import { registerEventStreamRoute } from "./event-stream.js";
@@ -43,6 +44,7 @@ import {
   getJobDetail,
   listArtifacts,
   listJobs,
+  listWorkflowRuns,
   readProfileConfig,
   readSettingsConfig,
 } from "./read-model.js";
@@ -330,6 +332,12 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       },
     };
   });
+
+  app.get("/v1/workflow-runs", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listWorkflowRuns(db, WorkflowRunsListQuerySchema.parse(request.query)),
+    ),
+  );
 
   app.get("/v1/artifacts", async (request, reply) =>
     withDb(reply, options.dbPath, (db) => listArtifacts(db, ArtifactListQuerySchema.parse(request.query))),

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -531,6 +531,60 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("returns the workflow runs list from apply_run_projections", async () => {
+    // PR 5 of the Temporal stack: `/v1/workflow-runs` is the read-side
+    // surface for the new Workflow Runs view. The seed inserts a single
+    // `apply_run_projections` row (`run-1`, status `finished` ⇒
+    // normalized to `succeeded`), so the happy path returns one entry.
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/workflow-runs" });
+      expect(response.statusCode, response.body).toBe(200);
+      const body = response.json();
+      expect(body.ok).toBe(true);
+      expect(Array.isArray(body.items)).toBe(true);
+      expect(body.items.length).toBeGreaterThanOrEqual(1);
+      const run = body.items.find((r: { workflowId: string }) => r.workflowId === "run-1");
+      expect(run).toBeDefined();
+      expect(run).toMatchObject({
+        workflowId: "run-1",
+        runId: "run-1",
+        jobKey: "https://example.com/jobs/ready",
+        title: "Platform Engineer",
+        company: "ExampleCo",
+        // Seed inserts `status: "finished"`, the read-model normalizes
+        // it to the `WorkflowRunStatus` enum (`succeeded`).
+        status: "succeeded",
+        dryRun: true,
+      });
+      expect(body.pagination).toMatchObject({ page: 1, total: 1, pages: 1 });
+      expect(body.filter).toMatchObject({ status: "all" });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("filters workflow runs by status", async () => {
+    const app = buildApp(options);
+    try {
+      const succeeded = await app.inject({
+        method: "GET",
+        url: "/v1/workflow-runs?status=succeeded",
+      });
+      expect(succeeded.statusCode, succeeded.body).toBe(200);
+      expect(succeeded.json().items).toHaveLength(1);
+
+      const failed = await app.inject({
+        method: "GET",
+        url: "/v1/workflow-runs?status=failed",
+      });
+      expect(failed.statusCode, failed.body).toBe(200);
+      expect(failed.json().items).toHaveLength(0);
+    } finally {
+      await app.close();
+    }
+  });
+
   it("opens only a known existing artifact through the injected opener", async () => {
     const opened: string[] = [];
     const app = buildApp({

--- a/apps/web/e2e/tests/runs.spec.ts
+++ b/apps/web/e2e/tests/runs.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+test("Runs view: lists workflow runs and exposes a Temporal Web UI deep-link per row", async ({
+  page,
+}) => {
+  await page.goto("/runs");
+
+  // The seed inserts one apply_run_projections row (`qa-run-1` for the
+  // GitLab platform-director job). The view normalizes the legacy
+  // `finished` status to the canonical WorkflowRunStatus `succeeded`.
+  const card = page.getByRole("heading", { name: /Workflow runs/i });
+  await expect(card).toBeVisible({ timeout: 30_000 });
+
+  const link = page.getByRole("link", {
+    name: /Open workflow qa-run-1 in Temporal Web UI/i,
+  });
+  await expect(link).toBeVisible({ timeout: 30_000 });
+  await expect(link).toHaveAttribute(
+    "href",
+    "http://127.0.0.1:8233/namespaces/default/workflows/qa-run-1",
+  );
+  await expect(link).toHaveAttribute("target", "_blank");
+  const rel = await link.getAttribute("rel");
+  expect(rel ?? "").toContain("noopener");
+
+  // The job title hydrated from the seed must appear in the row.
+  await expect(page.getByText(/Director of Platform Engineering/i)).toBeVisible();
+});

--- a/apps/web/src/contexts/apply/components/RunStatusBadge.stories.tsx
+++ b/apps/web/src/contexts/apply/components/RunStatusBadge.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { WorkflowRunStatus } from "@jobhunter/contracts";
+
+import { RunStatusBadge } from "./RunStatusBadge.js";
+
+const meta = {
+  title: "Contexts/Apply/RunStatusBadge",
+  component: RunStatusBadge,
+} satisfies Meta<typeof RunStatusBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Starting: Story = { args: { status: "starting" } };
+export const InProgress: Story = { args: { status: "in_progress" } };
+export const Succeeded: Story = { args: { status: "succeeded" } };
+export const Failed: Story = { args: { status: "failed" } };
+export const Canceled: Story = { args: { status: "canceled" } };
+export const Terminated: Story = { args: { status: "terminated" } };
+export const TimedOut: Story = { args: { status: "timed_out" } };
+export const DryRunComplete: Story = { args: { status: "dry_run_complete" } };
+export const Captcha: Story = { args: { status: "captcha" } };
+export const LoginIssue: Story = { args: { status: "login_issue" } };
+export const Expired: Story = { args: { status: "expired" } };
+export const Manual: Story = { args: { status: "manual" } };
+
+// Adding a new WorkflowRunStatus value breaks compile here unless a story is
+// added above. The per-discriminant-arm pattern from ApplyRunBadge.stories.tsx.
+const _statusStories: Record<WorkflowRunStatus, Story> = {
+  starting: Starting,
+  in_progress: InProgress,
+  succeeded: Succeeded,
+  failed: Failed,
+  canceled: Canceled,
+  terminated: Terminated,
+  timed_out: TimedOut,
+  dry_run_complete: DryRunComplete,
+  captcha: Captcha,
+  login_issue: LoginIssue,
+  expired: Expired,
+  manual: Manual,
+};
+void _statusStories;

--- a/apps/web/src/contexts/apply/components/RunStatusBadge.test.tsx
+++ b/apps/web/src/contexts/apply/components/RunStatusBadge.test.tsx
@@ -1,0 +1,16 @@
+import { WORKFLOW_RUN_STATUSES } from "@jobhunter/contracts";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RunStatusBadge } from "./RunStatusBadge.js";
+
+describe("<RunStatusBadge>", () => {
+  for (const status of WORKFLOW_RUN_STATUSES) {
+    it(`renders the ${status} workflow-run status with a non-default tone`, () => {
+      const { container } = render(<RunStatusBadge status={status} />);
+      const span = container.querySelector("span");
+      expect(span?.className).toMatch(/tag /);
+      expect(span?.textContent ?? "").not.toBe("");
+    });
+  }
+});

--- a/apps/web/src/contexts/apply/components/RunStatusBadge.tsx
+++ b/apps/web/src/contexts/apply/components/RunStatusBadge.tsx
@@ -1,0 +1,61 @@
+import type { JSX } from "react";
+
+import type { WorkflowRunStatus } from "@jobhunter/contracts";
+
+import { assertNever } from "../../../shared/lib/exhaustive.js";
+import type { ApplyRunTone } from "../lib/apply-run-tone.js";
+
+export interface RunStatusBadgeProps {
+  status: WorkflowRunStatus;
+}
+
+/**
+ * Badge for the wider workflow-run state set (PR 5 of the Temporal stack).
+ *
+ * Reuses the same `tag <tone>` token vocabulary as `ApplyRunBadge`. Apply
+ * uses a narrower `ApplyRunStatus`; Temporal-driven workflow runs add
+ * `canceled` / `terminated` / `timed_out` lifecycle terminals.
+ */
+export function RunStatusBadge({ status }: RunStatusBadgeProps): JSX.Element {
+  const tone: ApplyRunTone = workflowRunStatusTone(status);
+  return <span className={`tag ${tone}`}>{statusLabel(status)}</span>;
+}
+
+function workflowRunStatusTone(status: WorkflowRunStatus): ApplyRunTone {
+  switch (status) {
+    case "succeeded":
+      return "ok";
+    case "starting":
+    case "in_progress":
+      return "info";
+    case "captcha":
+    case "login_issue":
+    case "manual":
+      return "warn";
+    case "failed":
+    case "expired":
+    case "terminated":
+    case "timed_out":
+      return "danger";
+    case "canceled":
+    case "dry_run_complete":
+      return "muted";
+    default:
+      return assertNever(status);
+  }
+}
+
+function statusLabel(status: WorkflowRunStatus): string {
+  switch (status) {
+    case "in_progress":
+      return "in progress";
+    case "dry_run_complete":
+      return "dry-run complete";
+    case "login_issue":
+      return "login issue";
+    case "timed_out":
+      return "timed out";
+    default:
+      return status;
+  }
+}

--- a/apps/web/src/contexts/apply/handlers.ts
+++ b/apps/web/src/contexts/apply/handlers.ts
@@ -13,11 +13,13 @@ import {
   type InvalidationItem,
 } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { workflowRunsKeys } from "../operations/workflowRunsKeys.js";
 
 export const applyRunStartedHandler = (
   event: ApplyRunStarted,
 ): readonly InvalidationItem[] => [
   invalidate(applyRunsKeys.lists(event.tenantId)),
+  invalidate(workflowRunsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
@@ -40,6 +42,8 @@ export const applicationSubmittedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(applyRunsKeys.lists(event.tenantId)),
   invalidate(applyRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(workflowRunsKeys.lists(event.tenantId)),
+  invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.runId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
 ];
 
@@ -50,5 +54,7 @@ export const applicationFailedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(applyRunsKeys.lists(event.tenantId)),
   invalidate(applyRunsKeys.detail(event.tenantId, event.payload.runId)),
+  invalidate(workflowRunsKeys.lists(event.tenantId)),
+  invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.runId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
 ];

--- a/apps/web/src/contexts/operations/hooks/useWorkflowRunsListQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/useWorkflowRunsListQuery.test.ts
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from "msw";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/msw/server.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { useWorkflowRunsListQuery } from "./useWorkflowRunsListQuery.js";
+
+describe("useWorkflowRunsListQuery", () => {
+  it("returns the MSW-mocked workflow-runs list", async () => {
+    const { result } = renderHookWithProviders(() => useWorkflowRunsListQuery());
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.items.length).toBeGreaterThan(0);
+    expect(result.current.data?.items[0]?.workflowId).toBe("apply-run-1");
+    // The deep-link uses `workflowId`; the read-model preserves the
+    // distinction between `runId` and `workflowId` so future non-apply
+    // workflows that key timeline events on a different id keep working.
+    expect(result.current.data?.items[0]?.runId).toBe("apply-run-1");
+  });
+
+  it("surfaces errors when the API responds with 500", async () => {
+    server.use(
+      http.get("*/v1/workflow-runs", () =>
+        new HttpResponse(JSON.stringify({ ok: false, error: "boom" }), { status: 500 }),
+      ),
+    );
+    const { result } = renderHookWithProviders(() => useWorkflowRunsListQuery());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toMatch(/500/);
+  });
+});

--- a/apps/web/src/contexts/operations/hooks/useWorkflowRunsListQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useWorkflowRunsListQuery.ts
@@ -1,0 +1,21 @@
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type {
+  PaginatedResponse,
+  WorkflowRunsListInput,
+  WorkflowRunSummary,
+} from "../types.js";
+import { workflowRunsKeys } from "../workflowRunsKeys.js";
+
+export function useWorkflowRunsListQuery(
+  input: WorkflowRunsListInput = {},
+): UseQueryResult<PaginatedResponse<WorkflowRunSummary>> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: workflowRunsKeys.list(tenantId, input),
+    queryFn: () => api.workflowRuns(input),
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -21,6 +21,11 @@ export type {
   StageOrAll,
   StageState,
   StageStateOrAll,
+  WorkflowRunStatus,
+  WorkflowRunStatusFilter,
+  WorkflowRunSummary,
+  WorkflowRunsListInput,
+  WorkflowRunsListQuery,
 } from "./types.js";
 
 export { applyRunsKeys } from "./applyRunsKeys.js";
@@ -28,6 +33,7 @@ export { artifactsKeys } from "./artifactsKeys.js";
 export { dashboardKeys } from "./dashboardKeys.js";
 export { healthKeys } from "./healthKeys.js";
 export { jobsKeys } from "./jobsKeys.js";
+export { workflowRunsKeys } from "./workflowRunsKeys.js";
 
 export {
   type InvalidationHandler,
@@ -48,5 +54,6 @@ export { useDashboardSummaryQuery } from "./hooks/useDashboardSummaryQuery.js";
 export { useHealthQuery } from "./hooks/useHealthQuery.js";
 export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
 export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";
 
 export { EventStreamProvider, useEventStreamStatus } from "./providers/EventStreamProvider.js";

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -8,6 +8,7 @@ import { artifactsKeys } from "./artifactsKeys.js";
 import { dashboardKeys } from "./dashboardKeys.js";
 import { invalidationRouter } from "./invalidation-router.js";
 import { jobsKeys } from "./jobsKeys.js";
+import { workflowRunsKeys } from "./workflowRunsKeys.js";
 import { profileKeys } from "../profile/queryKeys.js";
 
 type ExpectedKeys = readonly QueryKey[];
@@ -78,6 +79,7 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
   ],
   ApplyRunStarted: [
     applyRunsKeys.lists(LOCAL_TENANT),
+    workflowRunsKeys.lists(LOCAL_TENANT),
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
@@ -88,6 +90,8 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     applyRunsKeys.lists(LOCAL_TENANT),
     applyRunsKeys.detail(LOCAL_TENANT, RUN_ID),
+    workflowRunsKeys.lists(LOCAL_TENANT),
+    workflowRunsKeys.detail(LOCAL_TENANT, RUN_ID),
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   ApplicationFailed: [
@@ -95,6 +99,8 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     applyRunsKeys.lists(LOCAL_TENANT),
     applyRunsKeys.detail(LOCAL_TENANT, RUN_ID),
+    workflowRunsKeys.lists(LOCAL_TENANT),
+    workflowRunsKeys.detail(LOCAL_TENANT, RUN_ID),
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   StageStarted: [jobsKeys.lists(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],

--- a/apps/web/src/contexts/operations/queryKeys.ts
+++ b/apps/web/src/contexts/operations/queryKeys.ts
@@ -2,6 +2,7 @@ export { jobsKeys } from "./jobsKeys.js";
 export { dashboardKeys } from "./dashboardKeys.js";
 export { artifactsKeys } from "./artifactsKeys.js";
 export { applyRunsKeys } from "./applyRunsKeys.js";
+export { workflowRunsKeys } from "./workflowRunsKeys.js";
 export { healthKeys } from "./healthKeys.js";
 export { profileKeys } from "../profile/queryKeys.js";
 export { discoveryKeys } from "../discovery/queryKeys.js";

--- a/apps/web/src/contexts/operations/types.ts
+++ b/apps/web/src/contexts/operations/types.ts
@@ -14,6 +14,10 @@ import type {
   SettingsResponse,
   Stage,
   StageState,
+  WorkflowRunStatus,
+  WorkflowRunStatusFilter,
+  WorkflowRunSummary,
+  WorkflowRunsListQuery,
 } from "@jobhunter/contracts";
 import type { DomainEventUnion } from "@jobhunter/domain-types";
 
@@ -33,12 +37,17 @@ export type {
   SettingsResponse,
   Stage,
   StageState,
+  WorkflowRunStatus,
+  WorkflowRunStatusFilter,
+  WorkflowRunSummary,
+  WorkflowRunsListQuery,
 };
 
 export type JobId = string;
 
 export type JobsListInput = Partial<JobListQuery>;
 export type ArtifactsListInput = Partial<ArtifactListQuery>;
+export type WorkflowRunsListInput = Partial<WorkflowRunsListQuery>;
 
 export type StageOrAll = Stage | "all";
 export type StageStateOrAll = StageState | "all";

--- a/apps/web/src/contexts/operations/workflowRunsKeys.ts
+++ b/apps/web/src/contexts/operations/workflowRunsKeys.ts
@@ -1,0 +1,13 @@
+import type { TenantId } from "@jobhunter/domain-types";
+
+import type { WorkflowRunsListInput } from "./types.js";
+
+export const workflowRunsKeys = {
+  all: (tenantId: TenantId) => ["tenant", tenantId, "workflow-runs"] as const,
+  lists: (tenantId: TenantId) => [...workflowRunsKeys.all(tenantId), "list"] as const,
+  list: (tenantId: TenantId, input: WorkflowRunsListInput) =>
+    [...workflowRunsKeys.lists(tenantId), input] as const,
+  details: (tenantId: TenantId) => [...workflowRunsKeys.all(tenantId), "detail"] as const,
+  detail: (tenantId: TenantId, workflowId: string) =>
+    [...workflowRunsKeys.details(tenantId), workflowId] as const,
+};

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from "./routes/__root";
 import { Route as SettingsRouteImport } from "./routes/settings";
+import { Route as RunsRouteImport } from "./routes/runs";
 import { Route as ProfileRouteImport } from "./routes/profile";
 import { Route as PreferencesRouteImport } from "./routes/preferences";
 import { Route as JobsRouteImport } from "./routes/jobs";
@@ -17,6 +18,7 @@ import { Route as DashboardRouteImport } from "./routes/dashboard";
 import { Route as ArtifactsRouteImport } from "./routes/artifacts";
 import { Route as IndexRouteImport } from "./routes/index";
 import { Route as SettingsIndexRouteImport } from "./routes/settings.index";
+import { Route as RunsIndexRouteImport } from "./routes/runs.index";
 import { Route as ProfileIndexRouteImport } from "./routes/profile.index";
 import { Route as JobsIndexRouteImport } from "./routes/jobs.index";
 import { Route as ArtifactsIndexRouteImport } from "./routes/artifacts.index";
@@ -34,6 +36,11 @@ import { Route as JobsJobIdRunRunIdRouteImport } from "./routes/jobs.$jobId.run.
 const SettingsRoute = SettingsRouteImport.update({
   id: "/settings",
   path: "/settings",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const RunsRoute = RunsRouteImport.update({
+  id: "/runs",
+  path: "/runs",
   getParentRoute: () => rootRouteImport,
 } as any);
 const ProfileRoute = ProfileRouteImport.update({
@@ -71,6 +78,11 @@ const SettingsIndexRoute = SettingsIndexRouteImport.update({
   path: "/",
   getParentRoute: () => SettingsRoute,
 } as any);
+const RunsIndexRoute = RunsIndexRouteImport.update({
+  id: "/",
+  path: "/",
+  getParentRoute: () => RunsRoute,
+} as any);
 const ProfileIndexRoute = ProfileIndexRouteImport.update({
   id: "/",
   path: "/",
@@ -92,9 +104,9 @@ const SettingsCredentialsRoute = SettingsCredentialsRouteImport.update({
   getParentRoute: () => SettingsRoute,
 } as any);
 const RunsRunIdRoute = RunsRunIdRouteImport.update({
-  id: "/runs/$runId",
-  path: "/runs/$runId",
-  getParentRoute: () => rootRouteImport,
+  id: "/$runId",
+  path: "/$runId",
+  getParentRoute: () => RunsRoute,
 } as any);
 const ProfileImportRoute = ProfileImportRouteImport.update({
   id: "/import",
@@ -144,6 +156,7 @@ export interface FileRoutesByFullPath {
   "/jobs": typeof JobsRouteWithChildren;
   "/preferences": typeof PreferencesRoute;
   "/profile": typeof ProfileRouteWithChildren;
+  "/runs": typeof RunsRouteWithChildren;
   "/settings": typeof SettingsRouteWithChildren;
   "/activity/$eventId": typeof ActivityEventIdRoute;
   "/artifacts/$artifactId": typeof ArtifactsArtifactIdRoute;
@@ -154,6 +167,7 @@ export interface FileRoutesByFullPath {
   "/artifacts/": typeof ArtifactsIndexRoute;
   "/jobs/": typeof JobsIndexRoute;
   "/profile/": typeof ProfileIndexRoute;
+  "/runs/": typeof RunsIndexRoute;
   "/settings/": typeof SettingsIndexRoute;
   "/profile/import/confirm": typeof ProfileImportConfirmRoute;
   "/profile/import/preview": typeof ProfileImportPreviewRoute;
@@ -173,6 +187,7 @@ export interface FileRoutesByTo {
   "/artifacts": typeof ArtifactsIndexRoute;
   "/jobs": typeof JobsIndexRoute;
   "/profile": typeof ProfileIndexRoute;
+  "/runs": typeof RunsIndexRoute;
   "/settings": typeof SettingsIndexRoute;
   "/profile/import/confirm": typeof ProfileImportConfirmRoute;
   "/profile/import/preview": typeof ProfileImportPreviewRoute;
@@ -187,6 +202,7 @@ export interface FileRoutesById {
   "/jobs": typeof JobsRouteWithChildren;
   "/preferences": typeof PreferencesRoute;
   "/profile": typeof ProfileRouteWithChildren;
+  "/runs": typeof RunsRouteWithChildren;
   "/settings": typeof SettingsRouteWithChildren;
   "/activity/$eventId": typeof ActivityEventIdRoute;
   "/artifacts/$artifactId": typeof ArtifactsArtifactIdRoute;
@@ -197,6 +213,7 @@ export interface FileRoutesById {
   "/artifacts/": typeof ArtifactsIndexRoute;
   "/jobs/": typeof JobsIndexRoute;
   "/profile/": typeof ProfileIndexRoute;
+  "/runs/": typeof RunsIndexRoute;
   "/settings/": typeof SettingsIndexRoute;
   "/profile/import/confirm": typeof ProfileImportConfirmRoute;
   "/profile/import/preview": typeof ProfileImportPreviewRoute;
@@ -212,6 +229,7 @@ export interface FileRouteTypes {
     | "/jobs"
     | "/preferences"
     | "/profile"
+    | "/runs"
     | "/settings"
     | "/activity/$eventId"
     | "/artifacts/$artifactId"
@@ -222,6 +240,7 @@ export interface FileRouteTypes {
     | "/artifacts/"
     | "/jobs/"
     | "/profile/"
+    | "/runs/"
     | "/settings/"
     | "/profile/import/confirm"
     | "/profile/import/preview"
@@ -241,6 +260,7 @@ export interface FileRouteTypes {
     | "/artifacts"
     | "/jobs"
     | "/profile"
+    | "/runs"
     | "/settings"
     | "/profile/import/confirm"
     | "/profile/import/preview"
@@ -254,6 +274,7 @@ export interface FileRouteTypes {
     | "/jobs"
     | "/preferences"
     | "/profile"
+    | "/runs"
     | "/settings"
     | "/activity/$eventId"
     | "/artifacts/$artifactId"
@@ -264,6 +285,7 @@ export interface FileRouteTypes {
     | "/artifacts/"
     | "/jobs/"
     | "/profile/"
+    | "/runs/"
     | "/settings/"
     | "/profile/import/confirm"
     | "/profile/import/preview"
@@ -278,9 +300,9 @@ export interface RootRouteChildren {
   JobsRoute: typeof JobsRouteWithChildren;
   PreferencesRoute: typeof PreferencesRoute;
   ProfileRoute: typeof ProfileRouteWithChildren;
+  RunsRoute: typeof RunsRouteWithChildren;
   SettingsRoute: typeof SettingsRouteWithChildren;
   ActivityEventIdRoute: typeof ActivityEventIdRoute;
-  RunsRunIdRoute: typeof RunsRunIdRoute;
 }
 
 declare module "@tanstack/react-router" {
@@ -290,6 +312,13 @@ declare module "@tanstack/react-router" {
       path: "/settings";
       fullPath: "/settings";
       preLoaderRoute: typeof SettingsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/runs": {
+      id: "/runs";
+      path: "/runs";
+      fullPath: "/runs";
+      preLoaderRoute: typeof RunsRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/profile": {
@@ -341,6 +370,13 @@ declare module "@tanstack/react-router" {
       preLoaderRoute: typeof SettingsIndexRouteImport;
       parentRoute: typeof SettingsRoute;
     };
+    "/runs/": {
+      id: "/runs/";
+      path: "/";
+      fullPath: "/runs/";
+      preLoaderRoute: typeof RunsIndexRouteImport;
+      parentRoute: typeof RunsRoute;
+    };
     "/profile/": {
       id: "/profile/";
       path: "/";
@@ -371,10 +407,10 @@ declare module "@tanstack/react-router" {
     };
     "/runs/$runId": {
       id: "/runs/$runId";
-      path: "/runs/$runId";
+      path: "/$runId";
       fullPath: "/runs/$runId";
       preLoaderRoute: typeof RunsRunIdRouteImport;
-      parentRoute: typeof rootRouteImport;
+      parentRoute: typeof RunsRoute;
     };
     "/profile/import": {
       id: "/profile/import";
@@ -502,6 +538,18 @@ const ProfileRouteChildren: ProfileRouteChildren = {
 const ProfileRouteWithChildren =
   ProfileRoute._addFileChildren(ProfileRouteChildren);
 
+interface RunsRouteChildren {
+  RunsRunIdRoute: typeof RunsRunIdRoute;
+  RunsIndexRoute: typeof RunsIndexRoute;
+}
+
+const RunsRouteChildren: RunsRouteChildren = {
+  RunsRunIdRoute: RunsRunIdRoute,
+  RunsIndexRoute: RunsIndexRoute,
+};
+
+const RunsRouteWithChildren = RunsRoute._addFileChildren(RunsRouteChildren);
+
 interface SettingsRouteChildren {
   SettingsCredentialsRoute: typeof SettingsCredentialsRoute;
   SettingsIndexRoute: typeof SettingsIndexRoute;
@@ -523,9 +571,9 @@ const rootRouteChildren: RootRouteChildren = {
   JobsRoute: JobsRouteWithChildren,
   PreferencesRoute: PreferencesRoute,
   ProfileRoute: ProfileRouteWithChildren,
+  RunsRoute: RunsRouteWithChildren,
   SettingsRoute: SettingsRouteWithChildren,
   ActivityEventIdRoute: ActivityEventIdRoute,
-  RunsRunIdRoute: RunsRunIdRoute,
 };
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/-runs.search.ts
+++ b/apps/web/src/routes/-runs.search.ts
@@ -1,0 +1,10 @@
+import { WORKFLOW_RUN_STATUS_FILTERS } from "@jobhunter/contracts";
+import { z } from "zod";
+
+export const runsSearchSchema = z.object({
+  status: z.enum(WORKFLOW_RUN_STATUS_FILTERS).default("all"),
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(200).default(50),
+});
+
+export type RunsSearch = z.infer<typeof runsSearchSchema>;

--- a/apps/web/src/routes/runs.index.tsx
+++ b/apps/web/src/routes/runs.index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/runs/")({
+  component: RunsIndexComponent,
+});
+
+function RunsIndexComponent() {
+  return null;
+}

--- a/apps/web/src/routes/runs.tsx
+++ b/apps/web/src/routes/runs.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { workflowRunsKeys } from "../contexts/operations/workflowRunsKeys.js";
+import { RunsView } from "../views/runs/RunsView.js";
+import { runsSearchSchema, type RunsSearch } from "./-runs.search.js";
+
+function workflowRunsInput(search: RunsSearch) {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    status: search.status,
+  };
+}
+
+export const Route = createFileRoute("/runs")({
+  validateSearch: (search) => runsSearchSchema.parse(search),
+  loaderDeps: ({ search }) => ({ search }),
+  loader: ({ deps, context }) => {
+    const input = workflowRunsInput(deps.search);
+    return context.queryClient.ensureQueryData({
+      queryKey: workflowRunsKeys.list(context.tenantId, input),
+      queryFn: () => context.ports.api.workflowRuns(input),
+    });
+  },
+  component: RunsView,
+});

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -32,6 +32,9 @@ export class FetchApiClientAdapter implements ApiClientPort {
   restoreJobs(body: Parameters<JobHunterApiClient["restoreJobs"]>[0]) {
     return this.client.restoreJobs(body);
   }
+  workflowRuns(query: Parameters<JobHunterApiClient["workflowRuns"]>[0] = {}) {
+    return this.client.workflowRuns(query);
+  }
   artifacts(query: Parameters<JobHunterApiClient["artifacts"]>[0] = {}) {
     return this.client.artifacts(query);
   }

--- a/apps/web/src/shared/layout/NavBar.tsx
+++ b/apps/web/src/shared/layout/NavBar.tsx
@@ -2,10 +2,18 @@ import { Link } from "@tanstack/react-router";
 
 const NAV_ITEMS: ReadonlyArray<{
   readonly label: string;
-  readonly to: "/dashboard" | "/jobs" | "/artifacts" | "/profile" | "/preferences" | "/settings";
+  readonly to:
+    | "/dashboard"
+    | "/jobs"
+    | "/runs"
+    | "/artifacts"
+    | "/profile"
+    | "/preferences"
+    | "/settings";
 }> = [
   { label: "Dashboard", to: "/dashboard" },
   { label: "Jobs", to: "/jobs" },
+  { label: "Runs", to: "/runs" },
   { label: "Artifacts", to: "/artifacts" },
   { label: "Profile", to: "/profile" },
   { label: "Preferences", to: "/preferences" },

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -26,6 +26,8 @@ import type {
   RetryStageRequest,
   SettingsResponse,
   SettingsUpdateRequest,
+  WorkflowRunSummary,
+  WorkflowRunsListQuery,
 } from "@jobhunter/contracts";
 
 export interface ApiHealthResponse {
@@ -44,6 +46,8 @@ export interface ApiClientPort {
   deleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
   restoreJob(jobKey: string): Promise<JobMutationResponse>;
   restoreJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
+
+  workflowRuns(query?: Partial<WorkflowRunsListQuery>): Promise<PaginatedResponse<WorkflowRunSummary>>;
 
   artifacts(query?: Partial<ArtifactListQuery>): Promise<PaginatedResponse<ArtifactSummary>>;
   artifact(artifactId: string): Promise<ArtifactDetail>;

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -8,6 +8,7 @@ import type {
   PaginatedResponse,
   ProfileConfigResponse,
   SettingsResponse,
+  WorkflowRunSummary,
 } from "@jobhunter/contracts";
 
 import type { ApiHealthResponse } from "../../shared/ports/ApiClientPort.js";
@@ -228,6 +229,53 @@ export const sampleSettingsResponse: SettingsResponse = {
   },
   paths: { settingsPath: "/tmp/jobhunter-test/settings.json" },
 };
+
+export const sampleWorkflowRun: WorkflowRunSummary = {
+  workflowId: "apply-run-1",
+  runId: "apply-run-1",
+  jobKey: "job-1",
+  title: sampleJob.title,
+  company: sampleJob.company,
+  status: "in_progress",
+  result: null,
+  dryRun: false,
+  model: "haiku",
+  startedAt: "2026-05-06T07:45:00Z",
+  finishedAt: null,
+  durationMs: null,
+};
+
+export const sampleWorkflowRunCompleted: WorkflowRunSummary = {
+  workflowId: "apply-run-2",
+  runId: "apply-run-2",
+  jobKey: "job-2",
+  title: sampleSecondaryJob.title,
+  company: sampleSecondaryJob.company,
+  status: "succeeded",
+  result: "applied",
+  dryRun: false,
+  model: "haiku",
+  startedAt: "2026-05-06T06:30:00Z",
+  finishedAt: "2026-05-06T06:35:00Z",
+  durationMs: 300_000,
+};
+
+export function makeWorkflowRunsPage(
+  items: readonly WorkflowRunSummary[] = [sampleWorkflowRun, sampleWorkflowRunCompleted],
+): PaginatedResponse<WorkflowRunSummary> {
+  return {
+    ok: true,
+    items: [...items],
+    pagination: {
+      page: 1,
+      pageSize: 50,
+      total: items.length,
+      pages: 1,
+    },
+    sort: { field: "started_at", dir: "desc" },
+    filter: { status: "all" },
+  };
+}
 
 export const sampleCredentialsResponse: CredentialsResponse = {
   ok: true,

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -5,6 +5,7 @@ import {
   makeArtifactsPage,
   makeJobDetail,
   makeJobsPage,
+  makeWorkflowRunsPage,
   sampleCredentialsResponse,
   sampleDashboardSummary,
   sampleHealthResponse,
@@ -71,6 +72,8 @@ export const handlers = [
   http.post("*/v1/jobs/:jobKey/actions/mark-skipped", ({ params }) =>
     HttpResponse.json(actionRunResponse(String(params["jobKey"]), "mark_skipped")),
   ),
+
+  http.get("*/v1/workflow-runs", () => HttpResponse.json(makeWorkflowRunsPage())),
 
   http.get("*/v1/artifacts", () => HttpResponse.json(makeArtifactsPage())),
   http.get("*/v1/artifacts/:artifactId", ({ params }) =>

--- a/apps/web/src/views/runs/RunsFilterBar.tsx
+++ b/apps/web/src/views/runs/RunsFilterBar.tsx
@@ -1,0 +1,38 @@
+import { WORKFLOW_RUN_STATUS_FILTERS, type WorkflowRunStatusFilter } from "@jobhunter/contracts";
+import type { ChangeEvent } from "react";
+
+export interface RunsFilterBarProps {
+  status: WorkflowRunStatusFilter;
+  onStatusChange: (next: WorkflowRunStatusFilter) => void;
+}
+
+function statusLabel(value: WorkflowRunStatusFilter): string {
+  if (value === "all") return "all statuses";
+  return value.replace(/_/g, " ");
+}
+
+export function RunsFilterBar({ status, onStatusChange }: RunsFilterBarProps) {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value as WorkflowRunStatusFilter;
+    onStatusChange(next);
+  };
+  return (
+    <div className="filter-bar">
+      <label className="field">
+        <span>Status</span>
+        <select
+          aria-label="Filter workflow runs by status"
+          className="select"
+          value={status}
+          onChange={handleChange}
+        >
+          {WORKFLOW_RUN_STATUS_FILTERS.map((value) => (
+            <option key={value} value={value}>
+              {statusLabel(value)}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/apps/web/src/views/runs/RunsTable.test.tsx
+++ b/apps/web/src/views/runs/RunsTable.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  makeWorkflowRunsPage,
+  sampleWorkflowRun,
+  sampleWorkflowRunCompleted,
+} from "../../test/fixtures/projections.js";
+import { RunsTable } from "./RunsTable.js";
+
+describe("<RunsTable>", () => {
+  function renderTable(overrides: Partial<React.ComponentProps<typeof RunsTable>> = {}) {
+    return render(
+      <RunsTable
+        data={makeWorkflowRunsPage()}
+        loading={false}
+        page={1}
+        pageSize={50}
+        onPageChange={() => undefined}
+        onPageSizeChange={() => undefined}
+        onOpenRun={() => undefined}
+        {...overrides}
+      />,
+    );
+  }
+
+  it("renders a row per workflow run with the status badge and Temporal deep-link", () => {
+    renderTable();
+
+    expect(screen.getByText(sampleWorkflowRun.title)).toBeInTheDocument();
+    expect(screen.getByText(sampleWorkflowRunCompleted.title)).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link", { name: /Open workflow .* in Temporal Web UI/i });
+    expect(links).toHaveLength(2);
+    expect(links[0]?.getAttribute("href")).toBe(
+      `http://127.0.0.1:8233/namespaces/default/workflows/${encodeURIComponent(
+        sampleWorkflowRun.workflowId,
+      )}`,
+    );
+    expect(links[0]?.getAttribute("target")).toBe("_blank");
+    expect(links[0]?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("invokes onOpenRun with the workflow id when a row is activated", async () => {
+    const onOpenRun = vi.fn();
+    renderTable({ onOpenRun });
+
+    // Activate the row by clicking the title cell (the link cell stops
+    // propagation so it only opens the deep-link, not the row).
+    const titleCell = screen.getByText(sampleWorkflowRun.title);
+    titleCell.click();
+    // DataTable wires `onRowActivate` to the row container, so simulate
+    // the row click via the closest row element.
+    const row = titleCell.closest("tr") ?? titleCell.closest(".data-row");
+    if (row) {
+      (row as HTMLElement).click();
+    }
+    expect(onOpenRun).toHaveBeenCalledWith(sampleWorkflowRun.workflowId);
+  });
+
+  it("renders the loading state when no data has been fetched yet", () => {
+    renderTable({ data: null, loading: true });
+    expect(screen.getByText(/Loading workflow runs/i)).toBeInTheDocument();
+  });
+
+  it("renders the empty state with no items", () => {
+    renderTable({
+      data: {
+        ok: true,
+        items: [],
+        pagination: { page: 1, pageSize: 50, total: 0, pages: 1 },
+        sort: { field: "started_at", dir: "desc" },
+        filter: {},
+      },
+    });
+    expect(screen.getByText(/No workflow runs/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/runs/RunsTable.tsx
+++ b/apps/web/src/views/runs/RunsTable.tsx
@@ -1,0 +1,58 @@
+import type { SortingState } from "@tanstack/react-table";
+
+import type { PaginatedResponse, WorkflowRunSummary } from "../../contexts/operations/types.js";
+import { DataTable } from "../../shared/ui/data-table.js";
+import { TablePager } from "../../shared/ui/table-pager.js";
+import { workflowRunColumns } from "./columns.js";
+
+export interface RunsTableProps {
+  data: PaginatedResponse<WorkflowRunSummary> | null;
+  loading: boolean;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  onOpenRun: (workflowId: string) => void;
+}
+
+const NO_SORTING: SortingState = [];
+
+export function RunsTable({
+  data,
+  loading,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  onOpenRun,
+}: RunsTableProps) {
+  return (
+    <DataTable<WorkflowRunSummary>
+      data={data?.items ?? []}
+      columns={workflowRunColumns}
+      getRowId={(row) => row.workflowId}
+      loading={loading}
+      loaded={data !== null}
+      loadingMessage="Loading workflow runs."
+      emptyMessage="No workflow runs."
+      headerClassName="data-row run run-header"
+      rowClassName="data-row run"
+      sorting={NO_SORTING}
+      onSortingChange={() => undefined}
+      enableRowSelection={false}
+      rowSelection={{}}
+      onRowSelectionChange={() => undefined}
+      onRowActivate={(row) => onOpenRun(row.workflowId)}
+      footer={
+        <TablePager
+          page={page}
+          pageSize={pageSize}
+          totalPages={data?.pagination.pages ?? 1}
+          totalRows={data?.pagination.total}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
+      }
+    />
+  );
+}

--- a/apps/web/src/views/runs/RunsView.stories.tsx
+++ b/apps/web/src/views/runs/RunsView.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { http, HttpResponse } from "msw";
+import { useMemo } from "react";
+
+import { runsSearchSchema } from "../../routes/-runs.search.js";
+import {
+  makeWorkflowRunsPage,
+  sampleWorkflowRun,
+  sampleWorkflowRunCompleted,
+} from "../../test/fixtures/projections.js";
+import { RunsView } from "./RunsView.js";
+
+// RunsView mounts RunsTable (DataTable role-row issue, see
+// data-table.stories.tsx) + RunsFilterBar (bare <select> wrapped in a
+// <label> — the label provides the accessible name, but DataTable's
+// shared a11y defects still trip the addon when the table renders).
+// Both production-code defects predate Phase 7 and are out of scope.
+const meta = {
+  title: "Views/Runs/RunsView",
+  component: RunsView,
+  parameters: {
+    a11y: { test: "off" },
+  },
+} satisfies Meta<typeof RunsView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function RunsViewStoryHost() {
+  const router = useMemo(() => {
+    const root = createRootRoute({ component: () => <Outlet /> });
+    const runs = createRoute({
+      getParentRoute: () => root,
+      path: "/runs",
+      validateSearch: (search) => runsSearchSchema.parse(search),
+      component: RunsView,
+    });
+    const runDetail = createRoute({
+      getParentRoute: () => runs,
+      path: "$runId",
+      component: () => null,
+    });
+    return createRouter({
+      routeTree: root.addChildren([runs.addChildren([runDetail])]),
+      history: createMemoryHistory({ initialEntries: ["/runs"] }),
+    });
+  }, []);
+  return <RouterProvider router={router} />;
+}
+
+export const Populated: Story = {
+  render: () => <RunsViewStoryHost />,
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/workflow-runs", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 60_000));
+          return HttpResponse.json(makeWorkflowRunsPage());
+        }),
+      ],
+    },
+  },
+  render: () => <RunsViewStoryHost />,
+};
+
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get("*/v1/workflow-runs", () => HttpResponse.json(makeWorkflowRunsPage([])))],
+    },
+  },
+  render: () => <RunsViewStoryHost />,
+};
+
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/workflow-runs", () =>
+          HttpResponse.json({ ok: false, error: "internal" }, { status: 500 }),
+        ),
+      ],
+    },
+  },
+  render: () => <RunsViewStoryHost />,
+};
+
+export const ManyResults: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/workflow-runs", () =>
+          HttpResponse.json(
+            makeWorkflowRunsPage(
+              Array.from({ length: 18 }, (_, index) =>
+                index % 2 === 0
+                  ? { ...sampleWorkflowRun, workflowId: `wf-${index + 10}`, runId: `wf-${index + 10}` }
+                  : {
+                      ...sampleWorkflowRunCompleted,
+                      workflowId: `wf-${index + 10}`,
+                      runId: `wf-${index + 10}`,
+                    },
+              ),
+            ),
+          ),
+        ),
+      ],
+    },
+  },
+  render: () => <RunsViewStoryHost />,
+};

--- a/apps/web/src/views/runs/RunsView.test.tsx
+++ b/apps/web/src/views/runs/RunsView.test.tsx
@@ -1,0 +1,94 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { http, HttpResponse } from "msw";
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { runsSearchSchema } from "../../routes/-runs.search.js";
+import { server } from "../../test/msw/server.js";
+import { buildProviderHarness } from "../../test/render.js";
+import { RunsView } from "./RunsView.js";
+
+function buildRouter(harness: ReturnType<typeof buildProviderHarness>) {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const runsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/runs",
+    validateSearch: runsSearchSchema,
+    component: () => <RunsView />,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => runsRoute,
+    path: "/$runId",
+    component: () => null,
+  });
+  const router = createRouter({
+    routeTree: rootRoute.addChildren([runsRoute.addChildren([detailRoute])]),
+    history: createMemoryHistory({ initialEntries: ["/runs"] }),
+  });
+  return { router, queryClient: harness.queryClient, Wrapper: harness.Wrapper };
+}
+
+describe("<RunsView>", () => {
+  it("renders the workflow runs from the API and links each row to the Temporal Web UI", async () => {
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("2 total")).toBeInTheDocument());
+
+    expect(screen.getByText(/Staff Software Engineer/i)).toBeInTheDocument();
+    expect(screen.getByText(/Principal Platform Engineer/i)).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link", { name: /Open workflow .* in Temporal Web UI/i });
+    expect(links.length).toBe(2);
+    for (const link of links) {
+      expect(link.getAttribute("href")).toMatch(
+        /^http:\/\/127\.0\.0\.1:8233\/namespaces\/default\/workflows\/apply-run-/,
+      );
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toContain("noopener");
+    }
+  });
+
+  it("renders the empty state when no workflow runs exist", async () => {
+    server.use(
+      http.get("*/v1/workflow-runs", () =>
+        HttpResponse.json({
+          ok: true,
+          items: [],
+          pagination: { page: 1, pageSize: 50, total: 0, pages: 1 },
+          sort: { field: "started_at", dir: "desc" },
+          filter: { status: "all" },
+        }),
+      ),
+    );
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText("0 total")).toBeInTheDocument());
+    expect(screen.getByText(/No workflow runs/i)).toBeInTheDocument();
+  });
+
+  it("surfaces an error banner when the workflow-runs endpoint fails", async () => {
+    server.use(
+      http.get("*/v1/workflow-runs", () =>
+        new HttpResponse(JSON.stringify({ ok: false, error: "boom" }), { status: 500 }),
+      ),
+    );
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(screen.getByText(/JobHunter API request failed: 500/i)).toBeInTheDocument(),
+    );
+  });
+});

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -1,0 +1,64 @@
+import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+
+import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
+import type { WorkflowRunsListInput } from "../../contexts/operations/types.js";
+import type { RunsSearch } from "../../routes/-runs.search.js";
+import { CardHeader } from "../../shared/ui/card-header.js";
+import { RunsFilterBar } from "./RunsFilterBar.js";
+import { RunsTable } from "./RunsTable.js";
+
+// TODO(temporal): the JSON-RPC `cancel_run` handler + `CancelRunParamsSchema`
+// already exist (PR 3 fixer). Wiring an in-row "Cancel running workflow"
+// button is out of scope for PR 5 and lands in a follow-up.
+
+function workflowRunsInput(search: RunsSearch): WorkflowRunsListInput {
+  return {
+    page: search.page,
+    pageSize: search.pageSize,
+    status: search.status,
+  };
+}
+
+export function RunsView() {
+  const search = useSearch({ from: "/runs" });
+  const navigate = useNavigate({ from: "/runs" });
+  const { data, isFetching, error } = useWorkflowRunsListQuery(workflowRunsInput(search));
+  const message = error instanceof Error ? error.message : null;
+
+  const setSearch = (next: Partial<RunsSearch>) => {
+    void navigate({ search: (prev: RunsSearch) => ({ ...prev, ...next }) });
+  };
+
+  // The detail drawer route is `/runs/$runId`; clicking a row navigates
+  // there. The table's `onRowActivate` already supplies the workflow id
+  // (which equals `runId` for apply runs).
+  const openRun = (workflowId: string) => {
+    void navigate({ to: "/runs/$runId", params: { runId: workflowId } });
+  };
+
+  return (
+    <>
+      <section className="card full">
+        <CardHeader
+          title="Workflow runs"
+          meta={data ? `${data.pagination.total} total` : "loading"}
+        />
+        {message ? <div className="banner inline">{message}</div> : null}
+        <RunsFilterBar
+          status={search.status}
+          onStatusChange={(status) => setSearch({ status, page: 1 })}
+        />
+        <RunsTable
+          data={data ?? null}
+          loading={isFetching}
+          page={search.page}
+          pageSize={search.pageSize}
+          onPageChange={(page) => setSearch({ page })}
+          onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
+          onOpenRun={openRun}
+        />
+      </section>
+      <Outlet />
+    </>
+  );
+}

--- a/apps/web/src/views/runs/columns.tsx
+++ b/apps/web/src/views/runs/columns.tsx
@@ -1,0 +1,109 @@
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
+import type { WorkflowRunSummary } from "../../contexts/operations/types.js";
+import { formatDateTime } from "../../shared/lib/formatters.js";
+import { RelativeTime } from "../../shared/ui/relative-time.js";
+import { TitleStack } from "../../shared/ui/title-stack.js";
+import { temporalWebUiWorkflowUrl } from "./temporal-web-ui.js";
+
+function formatDurationMs(value: number | null): string {
+  if (value === null || value <= 0) return "-";
+  if (value < 1_000) return `${value}ms`;
+  const seconds = Math.round(value / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  if (minutes < 60) return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const minRemainder = minutes % 60;
+  return minRemainder ? `${hours}h ${minRemainder}m` : `${hours}h`;
+}
+
+export const workflowRunColumns: ColumnDef<WorkflowRunSummary>[] = [
+  {
+    id: "status",
+    header: "Status",
+    enableSorting: false,
+    accessorFn: (row) => row.status,
+    cell: ({ row }) => <RunStatusBadge status={row.original.status} />,
+  },
+  {
+    id: "title",
+    header: "Job",
+    enableSorting: false,
+    accessorFn: (row) => row.title,
+    cell: ({ row }) => (
+      <TitleStack primary={row.original.title} secondary={row.original.company} />
+    ),
+  },
+  {
+    id: "workflow",
+    header: "Workflow",
+    enableSorting: false,
+    accessorFn: (row) => row.workflowId,
+    cell: ({ row }) => (
+      <span className="mono" title={`Workflow id: ${row.original.workflowId}`}>
+        {row.original.workflowId}
+      </span>
+    ),
+  },
+  {
+    id: "model",
+    header: "Model",
+    enableSorting: false,
+    accessorFn: (row) => row.model,
+    cell: ({ row }) => <span>{row.original.model ?? "-"}</span>,
+  },
+  {
+    id: "dry_run",
+    header: "Mode",
+    enableSorting: false,
+    accessorFn: (row) => (row.dryRun ? "dry-run" : "live"),
+    cell: ({ row }) =>
+      row.original.dryRun ? <span className="tag info">dry-run</span> : <span>live</span>,
+  },
+  {
+    id: "started_at",
+    header: "Started",
+    enableSorting: false,
+    accessorFn: (row) => row.startedAt,
+    cell: ({ row }) => <RelativeTime value={row.original.startedAt} />,
+  },
+  {
+    id: "duration",
+    header: "Duration",
+    enableSorting: false,
+    accessorFn: (row) => row.durationMs,
+    cell: ({ row }) => <span className="mono">{formatDurationMs(row.original.durationMs)}</span>,
+  },
+  {
+    id: "finished_at",
+    header: "Finished",
+    enableSorting: false,
+    accessorFn: (row) => row.finishedAt,
+    cell: ({ row }) => (
+      <span className="mono" title={formatDateTime(row.original.finishedAt)}>
+        {row.original.finishedAt ? formatDateTime(row.original.finishedAt) : "-"}
+      </span>
+    ),
+  },
+  {
+    id: "temporal_link",
+    header: "Temporal Web UI",
+    enableSorting: false,
+    accessorFn: (row) => row.workflowId,
+    cell: ({ row }) => (
+      <a
+        className="btn ghost"
+        href={temporalWebUiWorkflowUrl(row.original.workflowId)}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Open workflow ${row.original.workflowId} in Temporal Web UI`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        Open in Temporal
+      </a>
+    ),
+  },
+];

--- a/apps/web/src/views/runs/temporal-web-ui.ts
+++ b/apps/web/src/views/runs/temporal-web-ui.ts
@@ -1,0 +1,17 @@
+/**
+ * Temporal Web UI deep-link helper (PR 5 of the Temporal stack).
+ *
+ * The local Temporal dev server (`temporal server start-dev`) ships its
+ * Web UI on `127.0.0.1:8233`. The default namespace is `default`. The
+ * workflow id is the row's `workflowId` (which equals `runId` for apply
+ * runs — the Python `ApplyWorkflow` uses `info.workflow_id` as the
+ * timeline key).
+ */
+const TEMPORAL_WEB_UI_BASE = "http://127.0.0.1:8233";
+const TEMPORAL_NAMESPACE = "default";
+
+export function temporalWebUiWorkflowUrl(workflowId: string): string {
+  return `${TEMPORAL_WEB_UI_BASE}/namespaces/${TEMPORAL_NAMESPACE}/workflows/${encodeURIComponent(
+    workflowId,
+  )}`;
+}

--- a/apps/web/test/types/useWorkflowRunsListQuery.test-d.ts
+++ b/apps/web/test/types/useWorkflowRunsListQuery.test-d.ts
@@ -1,0 +1,11 @@
+import type { PaginatedResponse, WorkflowRunSummary } from "@jobhunter/contracts";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { expectTypeOf, test } from "vitest";
+
+import { useWorkflowRunsListQuery } from "../../src/contexts/operations/hooks/useWorkflowRunsListQuery.js";
+
+test("useWorkflowRunsListQuery returns UseQueryResult<PaginatedResponse<WorkflowRunSummary>>", () => {
+  expectTypeOf(useWorkflowRunsListQuery).returns.toEqualTypeOf<
+    UseQueryResult<PaginatedResponse<WorkflowRunSummary>>
+  >();
+});

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -411,6 +411,9 @@ on the local filesystem. They are registered in `job_artifacts` and
    aggregate state. The Python builder owns `apply_run_projections`;
    the TS API reads it directly.
 7. The UI reads from the projection tables via the TS read-model — no joins.
+   The Workflow Runs view at `/runs` (PR 5 of the Temporal stack) reads
+   `apply_run_projections` via `GET /v1/workflow-runs` and deep-links each
+   row to the local Temporal Web UI (`http://127.0.0.1:8233`).
 8. UI actions are routed through JSON-RPC for complex commands or executed
    inline for simple state transitions.
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -308,7 +308,7 @@ no dual-mount, no compatibility shim.
 
 ## Frontend Accessibility Backlog (Phase 7 Deferrals)
 
-17 Storybook stories defer the a11y bar (`a11y: { test: "off" }`) because
+18 Storybook stories defer the a11y bar (`a11y: { test: "off" }`) because
 they exercise pre-existing production accessibility defects that are scoped
 out of the Phase 7 baseline. Each defect needs a follow-up production fix;
 once fixed, the deferral is removed from the corresponding story
@@ -322,6 +322,7 @@ parameters.
 | `apps/web/src/views/artifacts/ArtifactFilterBar.tsx` | Bare `<select>` element with no associated label. | `ArtifactFilterBar.stories.tsx` |
 | `apps/web/src/views/jobs/JobsView.tsx` (composes the above) | Inherits `DataTable` + `JobFilterBar` defects. | `JobsView.stories.tsx` |
 | `apps/web/src/views/artifacts/ArtifactsView.tsx` (composes the above) | Inherits `DataTable` + `ArtifactFilterBar` defects. | `ArtifactsView.stories.tsx` |
+| `apps/web/src/views/runs/RunsView.tsx` (composes `DataTable`) | Inherits `DataTable` defects. | `RunsView.stories.tsx` |
 | `apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx` | Bare `<select>` elements with no labels; icon-only buttons missing accessible names. | `StructuredProfileEditor.stories.tsx`, `ProfileEditor.stories.tsx` (composes it) |
 | `apps/web/src/contexts/apply/components/ApplyHistory.tsx` | TanStack Router `<Link>` rendered as a button without an accessible name. | `ApplyHistory.stories.tsx` |
 | Radix `DropdownMenu` portal | `aria-hidden-focus` violation reported during the open animation (Radix transient internal state). | `dropdown-menu.stories.tsx` |

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -8,11 +8,18 @@ JSON-RPC 2.0 protocol over a long-lived `jobhunter rpc` subprocess. It is
 intentionally local-first and binds to `127.0.0.1` by default.
 
 Read-model endpoints (`/v1/dashboard/summary`, `/v1/jobs`, `/v1/jobs/:key`,
-`/v1/artifacts`) read from the five `*_projections` tables maintained by
-`apps/api/src/projections.ts` (TS-side mirror) and the Python
+`/v1/artifacts`, `/v1/workflow-runs`) read from the five `*_projections` tables
+maintained by `apps/api/src/projections.ts` (TS-side mirror) and the Python
 `ProjectionBuilder` (`workers/automation/src/jobhunter/infrastructure/projections/`).
 Both processes refresh projections idempotently via the shared
 `event_watermarks.operations_projections` watermark.
+
+`/v1/workflow-runs` (PR 5 of the Temporal stack) reads `apply_run_projections`
+and projects each row to a `WorkflowRunSummary`, including the Temporal
+workflow id (equal to `runId` for apply runs — the Python `ApplyWorkflow`
+uses `info.workflow_id` as the timeline key). The web Workflow Runs view at
+`/runs` deep-links each row to the local Temporal Web UI
+(`http://127.0.0.1:8233`).
 
 ## Related Packages
 

--- a/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
+++ b/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
@@ -195,11 +195,29 @@ Branch: `temporal/runs-view` off `temporal/apply-runs-collapse`.
   `apps/web/src/contexts/operations/hooks/`.
 - Invalidation handler: extend
   `apps/web/src/contexts/operations/invalidation-router.ts` so
+  workflow-run lifecycle events from the SSE stream invalidate the runs
+  list. Implementation note: the worker does not yet emit dedicated
   `WorkflowStarted` / `WorkflowCompleted` / `WorkflowFailed` /
-  `WorkflowCanceled` events from the SSE stream invalidate the runs
-  list.
+  `WorkflowCanceled` event types; the existing apply-run lifecycle
+  events (`ApplyRunStarted` / `ApplicationSubmitted` /
+  `ApplicationFailed`) drive the same invalidation by also targeting
+  `workflowRunsKeys.lists` and `workflowRunsKeys.detail`. When the
+  worker grows non-apply workflows, add the `Workflow*` event types and
+  route them through the same `workflowRunsKeys` factory.
+- Backend surface: `GET /v1/workflow-runs` (paginated; `status` filter,
+  with `WorkflowRunStatus` widening beyond `ApplyRunStatus` to include
+  `canceled` / `terminated` / `timed_out`). Schema:
+  `WorkflowRunSummary` exposes both `runId` and `workflowId` as
+  distinct fields — today they are equal (the Python `ApplyWorkflow`
+  uses `info.workflow_id` as the timeline key); the seam is preserved
+  so future non-apply workflows that separate the two land without a
+  breaking read-model change.
+- Out-of-scope follow-up: the JSON-RPC `cancel_run` handler +
+  `CancelRunParamsSchema` already exist (PR 3 fixer). Wiring an
+  in-row "Cancel running workflow" UI button is a follow-up.
 - Tests: hook test + view component test + a Playwright spec covering
-  list → detail → "Open in Temporal Web UI" link presence.
+  list → "Open in Temporal Web UI" link presence (correct `href` and
+  `target="_blank"`).
 
 QA: **required** for this PR — UI surface change, new page, new
 invalidation routing. Run the full PR review/fix + QA loop per

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -26,6 +26,8 @@ import type {
   RetryStageRequest,
   SettingsUpdateRequest,
   SettingsResponse,
+  WorkflowRunSummary,
+  WorkflowRunsListQuery,
 } from "@jobhunter/contracts";
 
 type QueryValue = boolean | number | string | null | undefined;
@@ -74,6 +76,12 @@ export class JobHunterApiClient {
 
   restoreJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
     return this.post("/v1/jobs/bulk-restore", body);
+  }
+
+  workflowRuns(
+    query: Partial<WorkflowRunsListQuery> = {},
+  ): Promise<PaginatedResponse<WorkflowRunSummary>> {
+    return this.get("/v1/workflow-runs", query);
   }
 
   artifacts(query: Partial<ArtifactListQuery> = {}): Promise<PaginatedResponse<ArtifactSummary>> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -383,6 +383,71 @@ export const ArtifactListQuerySchema = z
 
 export type ArtifactListQuery = z.infer<typeof ArtifactListQuerySchema>;
 
+// ---------------------------------------------------------------------------
+// Workflow runs (PR 5 of the Temporal stack)
+//
+// `apply_run_projections` is the unified workflow-run row after PR 4. The
+// run id is the Temporal workflow id (see `ApplyWorkflow.run` —
+// `run_id=info.workflow_id`), so the deep-link uses it verbatim.
+// `WorkflowRunStatusSchema` widens beyond `ApplyRunStatus` so future non-
+// apply workflows can land here without another migration.
+// ---------------------------------------------------------------------------
+
+export const WORKFLOW_RUN_STATUSES = [
+  "starting",
+  "in_progress",
+  "succeeded",
+  "failed",
+  "canceled",
+  "terminated",
+  "timed_out",
+  "dry_run_complete",
+  "captcha",
+  "login_issue",
+  "expired",
+  "manual",
+] as const;
+export type WorkflowRunStatus = (typeof WORKFLOW_RUN_STATUSES)[number];
+
+export const WORKFLOW_RUN_STATUS_FILTERS = ["all", ...WORKFLOW_RUN_STATUSES] as const;
+export type WorkflowRunStatusFilter = (typeof WORKFLOW_RUN_STATUS_FILTERS)[number];
+
+export const WorkflowRunsListQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).default(1).catch(1),
+    pageSize: z.coerce.number().int().min(1).max(200).optional().catch(undefined),
+    page_size: z.coerce.number().int().min(1).max(200).optional().catch(undefined),
+    status: z.enum(WORKFLOW_RUN_STATUS_FILTERS).default("all").catch("all"),
+  })
+  .transform((value) => ({
+    page: value.page,
+    pageSize: value.pageSize ?? value.page_size ?? 50,
+    status: value.status,
+  }));
+export type WorkflowRunsListQuery = z.infer<typeof WorkflowRunsListQuerySchema>;
+
+export interface WorkflowRunSummary {
+  /** Temporal workflow id — drives the deep-link to the Temporal Web UI. */
+  readonly workflowId: string;
+  /**
+   * Logical run id surfaced by the read-model. Equal to `workflowId` for
+   * apply runs (the Python `ApplyWorkflow` sets `run_id = info.workflow_id`);
+   * preserved as a distinct field so future non-apply workflows that key
+   * timeline events on a different id keep working.
+   */
+  readonly runId: string;
+  readonly jobKey: string;
+  readonly title: string;
+  readonly company: string;
+  readonly status: WorkflowRunStatus;
+  readonly result: string | null;
+  readonly dryRun: boolean;
+  readonly model: string | null;
+  readonly startedAt: string | null;
+  readonly finishedAt: string | null;
+  readonly durationMs: number | null;
+}
+
 export interface StageSummary {
   stage: Stage;
   state: StageState;


### PR DESCRIPTION
## Summary

- Adds the **Workflow Runs view** at `/runs` — a new local web page that lists in-progress / failed / completed Temporal workflow runs (today: apply runs) and deep-links each row to the local Temporal Web UI for live debugging.
- Adds `GET /v1/workflow-runs` to the local TypeScript API, backed by `apply_run_projections` (now sourced from Temporal workflow histories per PR 4 of the stack).
- Adds the typed read path (`workflowRunsKeys` factory, `useWorkflowRunsListQuery` hook, `WorkflowRunSummary` schema) and wires the existing apply-run lifecycle events through the invalidation router so the table live-updates from the SSE stream.
- Adds a wider `<RunStatusBadge>` covering the full workflow-run state set (`canceled` / `terminated` / `timed_out` on top of the apply-run states).

## Stack context

- **Stack plan:** `docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md`.
- **PR 5 of 7.** Stack so far: PR 1–4 are open / queued ahead of this PR.
- **Base branch:** `temporal/apply-runs-collapse` (NOT `main`). PR 6 / PR 7 will branch off `temporal/runs-view`.

## What's NOT in this PR

- **In-row "Cancel running workflow" button.** The JSON-RPC `cancel_run` handler + `CancelRunParamsSchema` already exist (PR 3 fixer); wiring an in-row UI button is a follow-up. A `// TODO` in `RunsView.tsx` pins the contract.
- **Worker Reliability cleanups.** PR 6 collapses the second stage-state write path; PR 7 registers logs + reports as artifacts.
- **Dedicated `WorkflowStarted` / `WorkflowCompleted` / `WorkflowFailed` / `WorkflowCanceled` event types.** The worker does not emit them yet — the existing apply-run events (`ApplyRunStarted` / `ApplicationSubmitted` / `ApplicationFailed`) drive the runs-list invalidation. The seam is set up so adding the `Workflow*` types and routing them through `workflowRunsKeys` is mechanical.
- **`runId` ≠ `workflowId` for any workflow.** Today they are equal (the Python `ApplyWorkflow` uses `info.workflow_id` as the timeline key). The schema exposes both as distinct fields so future non-apply workflows that separate the two land without a breaking read-model change.

## QA note

UI surface change — new top-level page, new SSE invalidation routing, new endpoint. Per the in-flight conversation, the user will run QA themselves rather than gating on an automated QA loop here. Calling that out so the QA expectation is explicit.

## How to test locally

```bash
# Terminal 1: Temporal dev server (PR 1 dependency)
temporal server start-dev

# Terminal 2: Python worker (PR 1 / PR 2 / PR 3 wiring)
uv --project workers/automation run jobhunter worker

# Terminal 3: TypeScript API
pnpm api:dev

# Terminal 4: Web UI
pnpm web:dev
```

Then:

1. Visit `http://127.0.0.1:5173/runs` — the Workflow Runs view loads.
2. Run a dry-run apply against any job (e.g. via the Job drawer's Dry-run button). A new row appears in the runs table within a few seconds (SSE-driven invalidation).
3. Click the **"Open in Temporal"** button on the row — opens the Temporal Web UI for that workflow id (`http://127.0.0.1:8233/namespaces/default/workflows/<workflowId>`) in a new tab.
4. Use the **Status** filter to scope to `succeeded` / `failed` / `in_progress` etc.

## Verification

All commands run in the worktree at `/Users/eloibarti/Github/JobHunter-worktrees/temporal-runs-view`.

| Command | Result |
| --- | --- |
| `uv --project workers/automation run --extra dev pytest -q` | `637 passed in 7.45s` |
| `pnpm api:check` | green (no output, exit 0) |
| `pnpm api:test` | `Test Files 5 passed, Tests 66 passed` (added 2 new) |
| `pnpm web:check` | green (no output, exit 0) |
| `pnpm --filter @jobhunter/web test` | `Test Files 77 passed, Tests 319 passed` (added 4 new) |
| `pnpm --filter @jobhunter/web test-d` | `Test Files 10 passed, Tests 10 passed` (added 1 new) |
| `pnpm web:build` | green (Vite built in 1.89s) |
| `pnpm web:storybook:build` | green (Storybook built in 5.68s) |
| `pnpm --filter @jobhunter/web e2e --grep "Runs view"` | `1 passed (3.2s)` |
| `pnpm --filter @jobhunter/web e2e` | `7 passed, 1 failed (profile-edit), 1 skipped` — the `profile-edit` failure is pre-existing on `temporal/apply-runs-collapse` (verified by `git stash` + re-run); unrelated to this PR. |
| `pnpm -r check` | all 6 packages green |
| `git diff --check` | clean |