### PR TITLE
refactor(workers): collapse dual stage-state write path through canonical helper

### DIFF
--- a/workers/automation/src/jobhunter/infrastructure/pipeline/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/pipeline/sqlite_repository.py
@@ -1,18 +1,20 @@
 """SqlitePipelineStateRepository — adapter for persisting JobPipelineState in SQLite.
 
 Maps domain StageState PascalCase variants to/from the lowercase serialized
-strings stored in the ``job_stage_states`` table.  Implements optimistic
-locking via the ``version`` column (ddd-target.md S8.6).
+strings stored in the ``job_stage_states`` table.  Persistence is delegated
+to :func:`jobhunter.state.set_stage_state` so all stage-state writes share
+the same SQL, validation, and per-row event emission.  Optimistic locking
+uses the ``version`` column (ddd-target.md S8.6) via the helper's
+``expected_version`` parameter.
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import datetime, timezone
 from typing import Any
 
-from jobhunter.domain.pipeline.aggregate import JobPipelineState, OptimisticLockError
+from jobhunter.domain.pipeline.aggregate import JobPipelineState
 from jobhunter.domain.pipeline_types import (
     Blocked,
     Canceled,
@@ -31,10 +33,7 @@ from jobhunter.domain.pipeline_types import (
     serialize_stage_state,
 )
 from jobhunter.domain.tenant import TenantId
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+from jobhunter.state import record_job_event, set_stage_state
 
 
 def _json_loads(value: str | None, default: Any) -> Any:
@@ -44,12 +43,6 @@ def _json_loads(value: str | None, default: Any) -> Any:
         return json.loads(value)
     except Exception:
         return default
-
-
-def _json_dumps(value: Any) -> str | None:
-    if value in (None, "", [], {}, ()):
-        return None
-    return json.dumps(value, sort_keys=True)
 
 
 # ---------------------------------------------------------------------------
@@ -120,69 +113,108 @@ def _row_to_stage_state(row: dict[str, Any]) -> StageState:
     return Pending()
 
 
-def _stage_state_to_row(stage: Stage, state: StageState, job_url: str) -> dict[str, Any]:
-    """Convert a domain Stage + StageState into a dict suitable for SQL INSERT."""
-    now = _utc_now()
-    base: dict[str, Any] = {
-        "job_url": job_url,
-        "stage": serialize_stage(stage),
-        "state": serialize_stage_state(state),
-        "updated_at": now,
-        "attempt_count": 0,
-        "max_attempts": None,
-        "started_at": None,
-        "finished_at": None,
-        "duration_ms": None,
-        "error_code": None,
-        "error_message": None,
-        "retryable": 1,
-        "blocked_by_json": None,
-        "next_action": None,
-        "metadata_json": None,
-    }
+# ---------------------------------------------------------------------------
+# Stage-state -> set_stage_state kwargs
+# ---------------------------------------------------------------------------
 
+
+def _stage_state_to_kwargs(state: StageState) -> dict[str, Any]:
+    """Translate a domain StageState into ``set_stage_state`` keyword args."""
     if isinstance(state, Pending):
-        base["attempt_count"] = state.attempt_count
-        base["max_attempts"] = state.max_attempts if state.max_attempts != 0 else None
-        base["next_action"] = state.next_action
-    elif isinstance(state, Queued):
-        base["started_at"] = state.queued_at if state.queued_at else None
-    elif isinstance(state, Running):
-        base["attempt_count"] = state.attempt_count
-        base["started_at"] = state.started_at if state.started_at else None
-    elif isinstance(state, Succeeded):
-        base["attempt_count"] = state.attempt_count
-        base["finished_at"] = state.finished_at if state.finished_at else None
-        base["duration_ms"] = state.duration_ms  # preserve 0
-    elif isinstance(state, Failed):
-        base["attempt_count"] = state.attempt_count
-        base["max_attempts"] = state.max_attempts if state.max_attempts != 0 else None
-        base["error_code"] = state.error_code if state.error_code else None
-        base["error_message"] = state.error_message if state.error_message else None
-        base["retryable"] = int(state.retryable)
-        base["next_action"] = state.next_action
-    elif isinstance(state, Blocked):
-        base["blocked_by_json"] = _json_dumps([serialize_stage(s) for s in state.blocked_by])
-        base["error_code"] = state.error_code if state.error_code else None
-        base["error_message"] = state.error_message if state.error_message else None
-        base["retryable"] = 0
-    elif isinstance(state, Skipped):
-        base["error_message"] = state.reason if state.reason else None
-        base["retryable"] = 0
-    elif isinstance(state, Exhausted):
-        base["attempt_count"] = state.attempt_count
-        base["max_attempts"] = state.max_attempts if state.max_attempts != 0 else None
-        base["error_code"] = state.error_code if state.error_code else None
-        base["error_message"] = state.error_message if state.error_message else None
-        base["next_action"] = state.next_action
-    elif isinstance(state, Stale):
-        base["error_message"] = state.reason if state.reason else None
-    elif isinstance(state, Canceled):
-        base["finished_at"] = state.canceled_at if state.canceled_at else None
-        base["error_message"] = state.reason
-        base["retryable"] = 0
+        return {
+            "attempt_count": state.attempt_count,
+            "max_attempts": state.max_attempts if state.max_attempts != 0 else None,
+            "next_action": state.next_action,
+        }
+    if isinstance(state, Queued):
+        return {"started_at": state.queued_at or None}
+    if isinstance(state, Running):
+        return {
+            "attempt_count": state.attempt_count,
+            "started_at": state.started_at or None,
+        }
+    if isinstance(state, Succeeded):
+        return {
+            "attempt_count": state.attempt_count,
+            "finished_at": state.finished_at or None,
+            "duration_ms": state.duration_ms,
+        }
+    if isinstance(state, Failed):
+        return {
+            "attempt_count": state.attempt_count,
+            "max_attempts": state.max_attempts if state.max_attempts != 0 else None,
+            "error_code": state.error_code or None,
+            "error_message": state.error_message or None,
+            "retryable": state.retryable,
+            "next_action": state.next_action,
+        }
+    if isinstance(state, Blocked):
+        blocked = [serialize_stage(s) for s in state.blocked_by]
+        return {
+            "blocked_by": blocked or None,
+            "error_code": state.error_code or None,
+            "error_message": state.error_message or None,
+            "retryable": False,
+        }
+    if isinstance(state, Skipped):
+        return {
+            "error_message": state.reason or None,
+            "retryable": False,
+        }
+    if isinstance(state, Exhausted):
+        return {
+            "attempt_count": state.attempt_count,
+            "max_attempts": state.max_attempts if state.max_attempts != 0 else None,
+            "error_code": state.error_code or None,
+            "error_message": state.error_message or None,
+        }
+    if isinstance(state, Stale):
+        return {"error_message": state.reason or None}
+    if isinstance(state, Canceled):
+        return {
+            "finished_at": state.canceled_at or None,
+            "error_message": state.reason,
+            "retryable": False,
+        }
+    return {}
 
-    return base
+
+# ---------------------------------------------------------------------------
+# State-kind -> (event_type, level) for repository-driven event emission.
+# Mirrors the per-stage events that runners emit through ``record_job_event``
+# (see e.g. scoring/scorer.py, enrichment/detail.py).
+# ---------------------------------------------------------------------------
+
+
+_EVENTS_BY_KIND: dict[str, tuple[str, str]] = {
+    "Queued": ("StageQueued", "info"),
+    "Running": ("StageStarted", "info"),
+    "Succeeded": ("StageCompleted", "info"),
+    "Failed": ("StageFailed", "error"),
+    "Blocked": ("StageBlocked", "warn"),
+    "Skipped": ("StageSkipped", "info"),
+    "Exhausted": ("StageExhausted", "error"),
+    "Stale": ("StageStale", "info"),
+    "Canceled": ("StageCanceled", "info"),
+    "Pending": ("StageReset", "info"),
+}
+
+
+def _event_message(state: StageState) -> str:
+    """Short message attached to the per-stage event."""
+    if isinstance(state, Failed):
+        return state.error_message or state.error_code or "Stage failed"
+    if isinstance(state, Exhausted):
+        return state.error_message or "Stage attempts exhausted"
+    if isinstance(state, Blocked):
+        return state.error_message or "Stage blocked"
+    if isinstance(state, Skipped):
+        return state.reason or "Stage skipped"
+    if isinstance(state, Stale):
+        return state.reason or "Stage marked stale"
+    if isinstance(state, Canceled):
+        return state.reason or "Stage canceled"
+    return f"Stage {state.kind.lower()}"
 
 
 # ---------------------------------------------------------------------------
@@ -232,95 +264,45 @@ class SqlitePipelineStateRepository:
         )
 
     def save(self, state: JobPipelineState) -> None:
-        """Persist all stage rows for the aggregate.
+        """Persist all stage rows for the aggregate via the canonical writer.
 
-        Optimistic locking: each row is written with ``version = old + 1``
-        and a WHERE guard on the current version.  If any row fails the guard,
-        ``OptimisticLockError`` is raised and no changes are committed.
+        Each stage is written through :func:`jobhunter.state.set_stage_state`
+        with ``expected_version=state.version`` to preserve optimistic-lock
+        semantics; on version mismatch the helper raises
+        ``OptimisticLockError`` and no further rows are written.  When a row's
+        persisted state actually changes, a per-stage event is emitted via
+        :func:`jobhunter.state.record_job_event` so the read-model stays in
+        sync with the same fan-out used by the per-stage runners.
         """
-        new_version = state.version + 1
+        existing_states = self._existing_state_strings(state.job_url)
 
         for stage, stage_state in state.stages.items():
-            row = _stage_state_to_row(stage, stage_state, state.job_url)
+            stage_str = serialize_stage(stage)
+            new_state_str = serialize_stage_state(stage_state)
 
-            # Try UPDATE with version guard first
-            cur = self._conn.execute(
-                """
-                UPDATE job_stage_states
-                SET state = ?, attempt_count = ?, max_attempts = ?,
-                    started_at = COALESCE(?, started_at),
-                    updated_at = ?, finished_at = COALESCE(?, finished_at),
-                    duration_ms = COALESCE(?, duration_ms),
-                    error_code = ?, error_message = ?,
-                    retryable = ?, blocked_by_json = ?,
-                    next_action = ?, metadata_json = ?,
-                    version = ?
-                WHERE job_url = ? AND stage = ? AND version = ?
-                """,
-                (
-                    row["state"],
-                    row["attempt_count"],
-                    row["max_attempts"],
-                    row["started_at"],
-                    row["updated_at"],
-                    row["finished_at"],
-                    row["duration_ms"],
-                    row["error_code"],
-                    row["error_message"],
-                    row["retryable"],
-                    row["blocked_by_json"],
-                    row["next_action"],
-                    row["metadata_json"],
-                    new_version,
-                    state.job_url,
-                    serialize_stage(stage),
-                    state.version,
-                ),
+            set_stage_state(
+                self._conn,
+                state.job_url,
+                stage_str,
+                new_state_str,
+                expected_version=state.version,
+                validate_transition=False,
+                **_stage_state_to_kwargs(stage_state),
             )
 
-            if cur.rowcount == 0:
-                # Either the row doesn't exist (INSERT) or version mismatch (conflict).
-                # Check if the row exists to distinguish.
-                existing = self._conn.execute(
-                    "SELECT version FROM job_stage_states WHERE job_url = ? AND stage = ?",
-                    (state.job_url, serialize_stage(stage)),
-                ).fetchone()
+            if existing_states.get(stage_str) == new_state_str:
+                continue
+            event_type, level = _EVENTS_BY_KIND[stage_state.kind]
+            record_job_event(
+                self._conn,
+                state.job_url,
+                stage_str,
+                event_type,
+                level=level,
+                message=_event_message(stage_state),
+            )
 
-                if existing is not None:
-                    actual_ver = existing[0] if isinstance(existing[0], int) else (existing["version"] or 0)
-                    raise OptimisticLockError(state.job_url, state.version, actual_ver)
-
-                # Row doesn't exist — insert
-                self._conn.execute(
-                    """
-                    INSERT INTO job_stage_states (
-                        job_url, stage, state, attempt_count, max_attempts,
-                        started_at, updated_at, finished_at, duration_ms,
-                        error_code, error_message, retryable,
-                        blocked_by_json, next_action, metadata_json, version
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    (
-                        row["job_url"],
-                        row["stage"],
-                        row["state"],
-                        row["attempt_count"],
-                        row["max_attempts"],
-                        row["started_at"],
-                        row["updated_at"],
-                        row["finished_at"],
-                        row["duration_ms"],
-                        row["error_code"],
-                        row["error_message"],
-                        row["retryable"],
-                        row["blocked_by_json"],
-                        row["next_action"],
-                        row["metadata_json"],
-                        new_version,
-                    ),
-                )
-
-        state.version = new_version
+        state.version = state.version + 1
 
     def list_by_stage(
         self,
@@ -348,6 +330,14 @@ class SqlitePipelineStateRepository:
         return results
 
     # -- helpers --------------------------------------------------------------
+
+    def _existing_state_strings(self, job_url: str) -> dict[str, str]:
+        """Return the persisted ``stage -> state`` map for change detection."""
+        rows = self._conn.execute(
+            "SELECT stage, state FROM job_stage_states WHERE job_url = ?",
+            (job_url,),
+        ).fetchall()
+        return {row["stage"]: row["state"] for row in rows}
 
     @staticmethod
     def _row_to_dict(row: Any) -> dict[str, Any]:

--- a/workers/automation/src/jobhunter/state.py
+++ b/workers/automation/src/jobhunter/state.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from jobhunter import config
 from jobhunter.domain.events.base import create_domain_event
+from jobhunter.domain.pipeline.aggregate import OptimisticLockError
 from jobhunter.domain.pipeline.state_machine import is_valid_transition
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.tenant import LOCAL_TENANT
@@ -180,6 +181,7 @@ def set_stage_state(
     next_action: str | None = None,
     metadata: dict[str, Any] | None = None,
     validate_transition: bool = True,
+    expected_version: int | None = None,
 ) -> None:
     """Upsert one job/stage state row.
 
@@ -188,6 +190,14 @@ def set_stage_state(
     per the §8.5 state machine table.  If the transition is invalid, a
     ``ValueError`` is raised.  Pass ``validate_transition=False`` to bypass
     (e.g. during initial row creation or legacy migration).
+
+    When *expected_version* is supplied, the write is guarded by the row's
+    current ``version`` column (optimistic locking) and the new row is written
+    at ``version = expected_version + 1``.  If the existing row's version does
+    not match, ``OptimisticLockError`` is raised.  If no row exists yet the
+    INSERT is performed at the same bumped version.  Callers leave this as
+    ``None`` (the default) for the unguarded UPSERT path used by stage
+    runners.
     """
     if stage not in STAGE_ORDER:
         raise ValueError(f"unknown stage: {stage}")
@@ -201,14 +211,28 @@ def set_stage_state(
     max_attempts = MAX_ATTEMPTS.get(stage) if max_attempts is None else max_attempts
     retry_value = None if retryable is None else int(retryable)
     duration = duration_ms if duration_ms is not None else _duration_ms(started_at, finished_at)
+    blocked_by_json = _json_dumps(blocked_by)
+    metadata_json = _json_dumps(metadata)
 
-    conn.execute(
-        """
+    new_version = 0 if expected_version is None else expected_version + 1
+    version_guard = (
+        " WHERE job_stage_states.version = :expected_version"
+        if expected_version is not None
+        else ""
+    )
+
+    cur = conn.execute(
+        f"""
         INSERT INTO job_stage_states (
             job_url, stage, state, attempt_count, max_attempts, started_at, updated_at,
             finished_at, duration_ms, error_code, error_message, retryable,
-            blocked_by_json, next_action, metadata_json
-        ) VALUES (?, ?, ?, COALESCE(?, 0), ?, ?, ?, ?, ?, ?, ?, COALESCE(?, 1), ?, ?, ?)
+            blocked_by_json, next_action, metadata_json, version
+        ) VALUES (
+            :job_url, :stage, :state, COALESCE(:attempt_count, 0), :max_attempts,
+            :started_at, :now, :finished_at, :duration, :error_code, :error_message,
+            COALESCE(:retry_value, 1), :blocked_by_json, :next_action, :metadata_json,
+            :new_version
+        )
         ON CONFLICT(job_url, stage) DO UPDATE SET
             state = excluded.state,
             attempt_count = COALESCE(excluded.attempt_count, job_stage_states.attempt_count),
@@ -222,26 +246,43 @@ def set_stage_state(
             retryable = excluded.retryable,
             blocked_by_json = excluded.blocked_by_json,
             next_action = excluded.next_action,
-            metadata_json = excluded.metadata_json
+            metadata_json = excluded.metadata_json,
+            version = CASE
+                WHEN :expected_version IS NULL THEN job_stage_states.version
+                ELSE excluded.version
+            END
+        {version_guard}
         """,
-        (
-            job_url,
-            stage,
-            state,
-            attempt_count,
-            max_attempts,
-            started_at,
-            now,
-            finished_at,
-            duration,
-            error_code,
-            error_message,
-            retry_value,
-            _json_dumps(blocked_by),
-            next_action,
-            _json_dumps(metadata),
-        ),
+        {
+            "job_url": job_url,
+            "stage": stage,
+            "state": state,
+            "attempt_count": attempt_count,
+            "max_attempts": max_attempts,
+            "started_at": started_at,
+            "now": now,
+            "finished_at": finished_at,
+            "duration": duration,
+            "error_code": error_code,
+            "error_message": error_message,
+            "retry_value": retry_value,
+            "blocked_by_json": blocked_by_json,
+            "next_action": next_action,
+            "metadata_json": metadata_json,
+            "new_version": new_version,
+            "expected_version": expected_version,
+        },
     )
+
+    if expected_version is not None and cur.rowcount == 0:
+        existing = conn.execute(
+            "SELECT version FROM job_stage_states WHERE job_url = ? AND stage = ?",
+            (job_url, stage),
+        ).fetchone()
+        actual = 0 if existing is None else (
+            existing[0] if not isinstance(existing, dict) else existing["version"]
+        )
+        raise OptimisticLockError(job_url, expected_version, actual or 0)
 
 
 def record_job_event(

--- a/workers/automation/tests/test_pipeline_repository.py
+++ b/workers/automation/tests/test_pipeline_repository.py
@@ -201,7 +201,7 @@ def test_save_emits_event_per_changed_stage(db):
     repo.save(agg)
 
     events = _job_events(db, "https://example.com/job")
-    stages_with_events = sorted({stage for _, stage, _ in events})
+    stages_with_events = sorted({stage for _, stage, _ in events if stage is not None})
     assert stages_with_events == ["enrich", "score"], events
     types_by_stage = {stage: event_type for event_type, stage, _ in events}
     assert types_by_stage["enrich"] == "StageStarted"
@@ -325,15 +325,18 @@ def test_save_attempts_counter_progresses_across_calls(db):
 
     reloaded = repo.load(LOCAL_TENANT, "https://example.com/job")
     assert reloaded is not None
-    assert isinstance(reloaded.get_stage_state(Stage.Enrich), Running)
-    assert reloaded.get_stage_state(Stage.Enrich).attempt_count == 1
+    enrich_state = reloaded.get_stage_state(Stage.Enrich)
+    assert isinstance(enrich_state, Running)
+    assert enrich_state.attempt_count == 1
 
     reloaded.set_stage_state(Stage.Enrich, Running(attempt_count=2, started_at="2026-05-01T00:02:00Z"))
     repo.save(reloaded)
 
     final = repo.load(LOCAL_TENANT, "https://example.com/job")
     assert final is not None
-    assert final.get_stage_state(Stage.Enrich).attempt_count == 2
+    final_state = final.get_stage_state(Stage.Enrich)
+    assert isinstance(final_state, Running)
+    assert final_state.attempt_count == 2
 
 
 def test_save_blocked_state_round_trip(db):

--- a/workers/automation/tests/test_pipeline_repository.py
+++ b/workers/automation/tests/test_pipeline_repository.py
@@ -9,14 +9,17 @@ import pytest
 from jobhunter.database import close_connection, init_db
 from jobhunter.domain.pipeline.aggregate import JobPipelineState, OptimisticLockError
 from jobhunter.domain.pipeline_types import (
+    Blocked,
+    Canceled,
     Failed,
     Running,
+    Skipped,
     Stage,
     Succeeded,
 )
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.pipeline.sqlite_repository import SqlitePipelineStateRepository
-from jobhunter.state import ensure_job_stage_rows
+from jobhunter.state import ensure_job_stage_rows, set_stage_state
 
 
 def _insert_job(conn, url: str = "https://example.com/job") -> None:
@@ -167,3 +170,323 @@ def test_save_creates_new_rows_for_new_job(db):
     assert reloaded is not None
     assert reloaded.version == 1
     assert isinstance(reloaded.get_stage_state(Stage.Discover), Succeeded)
+
+
+# ---------------------------------------------------------------------------
+# PR 6: shared write path through state.set_stage_state
+# ---------------------------------------------------------------------------
+
+
+def _job_events(conn, job_url: str) -> list[tuple[str, str | None, str | None]]:
+    """Return (event_type, stage, level) rows for one job ordered by id."""
+    rows = conn.execute(
+        "SELECT event_type, stage, level FROM job_events "
+        "WHERE job_url = ? ORDER BY event_id",
+        (job_url,),
+    ).fetchall()
+    return [(r["event_type"], r["stage"], r["level"]) for r in rows]
+
+
+def test_save_emits_event_per_changed_stage(db):
+    """save() emits exactly one event per stage whose state changed."""
+    repo = SqlitePipelineStateRepository(db)
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    agg.set_stage_state(Stage.Score, Running(attempt_count=1, started_at="2026-05-01T00:01:00Z"))
+    repo.save(agg)
+
+    events = _job_events(db, "https://example.com/job")
+    stages_with_events = sorted({stage for _, stage, _ in events})
+    assert stages_with_events == ["enrich", "score"], events
+    types_by_stage = {stage: event_type for event_type, stage, _ in events}
+    assert types_by_stage["enrich"] == "StageStarted"
+    assert types_by_stage["score"] == "StageStarted"
+
+
+def test_save_does_not_emit_for_idempotent_writes(db):
+    """save() must not emit an event when the persisted state is unchanged."""
+    repo = SqlitePipelineStateRepository(db)
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    repo.save(agg)
+
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    # Re-load + save without changing anything.
+    reloaded = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert reloaded is not None
+    repo.save(reloaded)
+
+    events = _job_events(db, "https://example.com/job")
+    assert events == [], events
+
+
+def test_save_emits_state_specific_event_types(db):
+    """Each terminal state has a dedicated event type."""
+    repo = SqlitePipelineStateRepository(db)
+
+    # Set up: drive enrich Pending -> Running -> Failed in two saves.
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    repo.save(agg)
+
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    agg.set_stage_state(
+        Stage.Enrich,
+        Failed(
+            attempt_count=1,
+            max_attempts=5,
+            error_code="TIMEOUT",
+            error_message="timed out",
+            retryable=True,
+        ),
+    )
+    repo.save(agg)
+
+    events = _job_events(db, "https://example.com/job")
+    assert events == [("StageFailed", "enrich", "error")], events
+
+
+def test_save_event_emission_matches_canonical_helper(db):
+    """A repo.save() flow produces the same row state as a sequence of canonical
+    set_stage_state() calls would (regression: dual write path is gone).
+    """
+    repo = SqlitePipelineStateRepository(db)
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    # Path A: write Enrich Running -> Succeeded via the repository.
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    repo.save(agg)
+    agg.set_stage_state(
+        Stage.Enrich,
+        Succeeded(attempt_count=1, finished_at="2026-05-01T00:01:00Z", duration_ms=60000),
+    )
+    repo.save(agg)
+    repo_row = db.execute(
+        "SELECT state, attempt_count, started_at, finished_at, duration_ms "
+        "FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        ("https://example.com/job",),
+    ).fetchone()
+
+    # Path B: identical writes via canonical set_stage_state on a sibling job.
+    _insert_job(db, url="https://example.com/twin")
+    ensure_job_stage_rows(db, "https://example.com/twin", discovered_at="2026-04-29T10:00:00+00:00")
+    db.commit()
+    set_stage_state(
+        db,
+        "https://example.com/twin",
+        "enrich",
+        "running",
+        attempt_count=1,
+        started_at="2026-05-01T00:00:00Z",
+    )
+    set_stage_state(
+        db,
+        "https://example.com/twin",
+        "enrich",
+        "succeeded",
+        attempt_count=1,
+        started_at="2026-05-01T00:00:00Z",
+        finished_at="2026-05-01T00:01:00Z",
+        duration_ms=60000,
+    )
+    db.commit()
+    twin_row = db.execute(
+        "SELECT state, attempt_count, started_at, finished_at, duration_ms "
+        "FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        ("https://example.com/twin",),
+    ).fetchone()
+
+    assert dict(repo_row) == dict(twin_row)
+
+
+def test_save_attempts_counter_progresses_across_calls(db):
+    """The attempt_count is preserved across successive save() calls."""
+    repo = SqlitePipelineStateRepository(db)
+
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    repo.save(agg)
+
+    reloaded = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert reloaded is not None
+    assert isinstance(reloaded.get_stage_state(Stage.Enrich), Running)
+    assert reloaded.get_stage_state(Stage.Enrich).attempt_count == 1
+
+    reloaded.set_stage_state(Stage.Enrich, Running(attempt_count=2, started_at="2026-05-01T00:02:00Z"))
+    repo.save(reloaded)
+
+    final = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert final is not None
+    assert final.get_stage_state(Stage.Enrich).attempt_count == 2
+
+
+def test_save_blocked_state_round_trip(db):
+    """Blocked persists blocked_by + emits StageBlocked."""
+    repo = SqlitePipelineStateRepository(db)
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(
+        Stage.Enrich,
+        Blocked(
+            blocked_by=(Stage.Discover,),
+            error_code="BLOCKED",
+            error_message="upstream not done",
+        ),
+    )
+    repo.save(agg)
+
+    reloaded = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert reloaded is not None
+    state = reloaded.get_stage_state(Stage.Enrich)
+    assert isinstance(state, Blocked)
+    assert state.blocked_by == (Stage.Discover,)
+
+    events = _job_events(db, "https://example.com/job")
+    assert ("StageBlocked", "enrich", "warn") in events
+
+
+def test_save_skipped_state_emits_stage_skipped(db):
+    repo = SqlitePipelineStateRepository(db)
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(Stage.Enrich, Skipped(reason="below threshold"))
+    repo.save(agg)
+
+    events = _job_events(db, "https://example.com/job")
+    assert ("StageSkipped", "enrich", "info") in events
+
+
+def test_save_canceled_state_emits_stage_canceled(db):
+    repo = SqlitePipelineStateRepository(db)
+    # Cancel is a valid transition only from Queued/Running, so seed Running.
+    agg = repo.load(LOCAL_TENANT, "https://example.com/job")
+    assert agg is not None
+    agg.set_stage_state(Stage.Enrich, Running(attempt_count=1, started_at="2026-05-01T00:00:00Z"))
+    repo.save(agg)
+
+    db.execute("DELETE FROM job_events")
+    db.commit()
+
+    agg.set_stage_state(
+        Stage.Enrich,
+        Canceled(canceled_at="2026-05-01T00:01:00Z", reason="user canceled"),
+    )
+    repo.save(agg)
+
+    events = _job_events(db, "https://example.com/job")
+    assert ("StageCanceled", "enrich", "info") in events
+
+
+def test_save_does_not_use_legacy_dual_write_path(db):
+    """Regression: the bespoke UPDATE/INSERT INTO job_stage_states blocks are gone.
+
+    Asserts the repository module no longer contains literal 'INSERT INTO
+    job_stage_states' or 'UPDATE job_stage_states' SQL — it must call into
+    the canonical helper instead.
+    """
+    import inspect
+
+    from jobhunter.infrastructure.pipeline import sqlite_repository
+
+    source = inspect.getsource(sqlite_repository)
+    assert "INSERT INTO job_stage_states" not in source, source
+    assert "UPDATE job_stage_states" not in source, source
+
+
+def test_set_stage_state_with_expected_version_round_trip(db):
+    """state.set_stage_state honours expected_version when supplied."""
+    set_stage_state(
+        db,
+        "https://example.com/job",
+        "enrich",
+        "running",
+        attempt_count=1,
+        started_at="2026-05-01T00:00:00Z",
+        expected_version=0,
+        validate_transition=False,
+    )
+    db.commit()
+
+    row = db.execute(
+        "SELECT state, version FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        ("https://example.com/job",),
+    ).fetchone()
+    assert row["state"] == "running"
+    assert row["version"] == 1
+
+
+def test_set_stage_state_expected_version_mismatch_raises(db):
+    """state.set_stage_state raises OptimisticLockError on stale expected_version."""
+    # Bump version to 1.
+    set_stage_state(
+        db,
+        "https://example.com/job",
+        "enrich",
+        "running",
+        attempt_count=1,
+        started_at="2026-05-01T00:00:00Z",
+        expected_version=0,
+        validate_transition=False,
+    )
+    db.commit()
+
+    with pytest.raises(OptimisticLockError) as exc:
+        set_stage_state(
+            db,
+            "https://example.com/job",
+            "enrich",
+            "succeeded",
+            attempt_count=1,
+            started_at="2026-05-01T00:00:00Z",
+            finished_at="2026-05-01T00:01:00Z",
+            duration_ms=60000,
+            expected_version=0,  # stale
+            validate_transition=False,
+        )
+    assert exc.value.expected_version == 0
+    assert exc.value.actual_version == 1
+
+
+def test_set_stage_state_expected_version_inserts_when_missing(db):
+    """When the row does not exist, expected_version=0 inserts at version 1."""
+    _insert_job(db, url="https://example.com/fresh")
+    db.commit()
+
+    set_stage_state(
+        db,
+        "https://example.com/fresh",
+        "enrich",
+        "pending",
+        expected_version=0,
+        validate_transition=False,
+    )
+    db.commit()
+
+    row = db.execute(
+        "SELECT state, version FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        ("https://example.com/fresh",),
+    ).fetchone()
+    assert row["state"] == "pending"
+    assert row["version"] == 1


### PR DESCRIPTION
## Summary

Eliminates the second runtime write path into `job_stage_states`.
`SqlitePipelineStateRepository.save` no longer emits its own bespoke
`UPDATE/INSERT INTO job_stage_states` SQL — it now routes every stage
through `state.set_stage_state` so the canonical helper is the single
source of truth for stage-state writes (validation, COALESCE semantics,
event-bus fan-out, and now optimistic locking too).

After this change `grep -rn "INSERT INTO job_stage_states\|UPDATE
job_stage_states" workers/automation/src/jobhunter/` returns exactly one
hit — the canonical helper's UPSERT.

## Stack context

PR 6 of 7 in the [Temporal + Worker Reliability stack](../blob/main/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md).
Sits on top of `temporal/runs-view` (PR 5).  PR 7 (logs/reports as
artifacts) builds on this branch next.

## Approach choice

**Extension of `set_stage_state` with `expected_version: int | None`.**
The canonical helper grows one optional keyword: when supplied, the upsert
is guarded by the row's current `version` column and the new row is
written at `version = expected_version + 1`; on mismatch
`OptimisticLockError` is raised.  When `None` (the default), the existing
unguarded UPSERT path is preserved exactly for stage runners that do not
need versioning.

I picked this over the "extract a private `_write_stage_row` helper"
alternative because the diff is smaller (no new abstraction layer), the
SQL stays in one function, and every existing caller of
`set_stage_state` keeps the same signature.  The repository becomes a
thin loop over `state.stages.items()` — `_stage_state_to_kwargs` plus the
helper plus a per-stage event emission.

## Behavior preserved

- Optimistic locking: the same `OptimisticLockError(job_url,
  expected_version, actual_version)` is raised on version conflict.  The
  pre-existing `test_optimistic_lock_conflict` regression still holds
  unchanged.
- Per-row UPSERT semantics (COALESCE on partial updates) unchanged.
- `state.version` still bumps to `state.version + 1` after a successful
  save().
- `save()` now emits one `record_job_event` per stage that actually
  changed state — type/level mapped from the StageState kind
  (`StageStarted`, `StageCompleted`, `StageFailed`, `StageBlocked`,
  `StageSkipped`, `StageExhausted`, `StageCanceled`, `StageReset`,
  `StageStale`).  Idempotent saves emit nothing.

## What's NOT in this PR

- Registering log/report files as artifacts via `record_job_artifact` —
  that is PR 7 (`worker-reliability/logs-as-artifacts`).
- Any change to the per-stage runners (they still pair `set_stage_state`
  with their own `record_job_event` calls — no double-events because the
  repo's emission only fires when called from the new aggregate path).
- Any change to `database.py`'s `_backfill_jobs_to_stage_states` — that
  is a one-shot init migration, not a runtime write path.

## Verification

Run inside the worktree (`/Users/eloibarti/Github/JobHunter-worktrees/wr-single-stage-writer`):

| Command | Result |
| --- | --- |
| `uv --project workers/automation run --extra dev pytest -q` | 649 passed |
| `uv --project workers/automation run --extra dev ruff check .` | All checks passed |
| `pnpm api:check && pnpm api:test` | tsc clean, 66 vitest passed |
| `pnpm -r check` | 6/6 workspace projects clean |
| `git diff --check` | clean |
| `grep -rn "INSERT INTO job_stage_states\|UPDATE job_stage_states" workers/automation/src/jobhunter/` | 1 hit (`state.py:226` — the canonical helper) |