### PR TITLE
feat(workers): register apply logs and score reports as job artifacts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -391,6 +391,11 @@ projection tables (above) are also stored here.
 Generated resumes, cover letters, PDFs, logs, templates, and imported PDFs stay
 on the local filesystem. They are registered in `job_artifacts` and
 `job_materials_artifacts` and surfaced via `artifact_list_projections`.
+The apply launcher records each per-worker agent log
+(`LOG_DIR/worker-{worker_id}.log`, written by `ClaudeCodeCliAdapter`) as a
+`job_artifacts` row of kind `apply_log` in the same transaction as the
+terminal `ApplicationSubmitted` / `ApplicationFailed` / `DryRunCompleted`
+event (PR 7 of the Temporal stack).
 
 ## Core Data Flow
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -41,11 +41,16 @@ This is the authoritative roadmap. Keep detailed historical proposals under
   workflows (PR 4 / per-job runners) gets cooperative cancel for free; a
   shorter-term option is to add a cancel token surface for the in-process
   sync handlers.
-- Record generated logs and reports as artifacts. `record_job_artifact`
-  (`workers/automation/src/jobhunter/state.py:304`) exists but is never
-  called; apply log files are only kept on disk and stored as a string in
-  `apply_runs.log_path`. Wire the helper into the apply / materials /
-  scoring writers so logs and reports show up in the artifacts list.
+- Record `score_report` artifacts. PR 7 of the Temporal stack wired
+  `state.record_job_artifact` into `apply.launcher.mark_result` so the
+  per-worker agent log (`LOG_DIR/worker-{worker_id}.log`) lands in
+  `job_artifacts` as kind `apply_log`; tailor / cover_letter / PDF were
+  already registering their primary outputs through
+  `SqliteMaterialsRepository`. Scoring still writes no on-disk files —
+  reasoning lives in `job_scores` only — so a dedicated `score_report`
+  artifact requires a behaviour change (introducing a per-job report
+  file) that PR 7 deliberately did not take. File this when an operator
+  asks for an exportable score report.
 - Refactor non-apply stage runners to accept a single `job_url` so
   `JobPipelineWorkflow` can drive per-job batches. Today the runners are
   batch-only — they walk DB selectors over the entire `jobs` table — and

--- a/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
+++ b/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
@@ -243,17 +243,49 @@ QA: skipped — automation-only.
 Branch: `worker-reliability/logs-as-artifacts` off
 `worker-reliability/single-stage-state-writer`.
 
-- Wire `state.record_job_artifact` (currently dead-code per the
-  backlog) into the apply / materials / scoring writers so the log
-  files and report files they produce show up in the artifacts list.
-- Drop the `apply_runs.log_path` string field from the workflow-runs
-  projector (PR 4) — log paths now live in `job_artifacts`.
-- TS read-model: `artifact_list_projections` automatically picks
-  these up via the existing projection.
-- Tests: a successful apply run produces an artifact row of kind
-  `apply_log`; a successful score run produces an artifact row of
-  kind `score_report`; UI integration coverage stays at the
-  read-model boundary (no new UI in this PR).
+- Wire `state.record_job_artifact` (previously dead-code per the
+  backlog) into `apply.launcher.mark_result` so the per-worker agent
+  log file (`LOG_DIR/worker-{worker_id}.log`, written by
+  `ClaudeCodeCliAdapter`) shows up as a `job_artifacts` row of kind
+  `apply_log` in the same transaction as the terminal
+  `ApplicationSubmitted` / `ApplicationFailed` / `DryRunCompleted`
+  event. The UPSERT key on `(job_url, stage, artifact_type, path)`
+  keeps the call idempotent across the worker's job sequence.
+- Producer survey for the rest of the pipeline:
+  - `scoring.scorer` writes no files — reasoning lives in `job_scores`
+    only. No artifact to register; deferred to a follow-up if/when the
+    scorer starts emitting an on-disk report.
+  - `scoring.tailor`, `scoring.cover_letter`, and the
+    `LatexPdfAdapter` / `PlaywrightHtmlPdfAdapter` PDF renderers
+    already register their primary outputs (resume `.txt`, cover
+    letter `.txt`, resume PDF, cover letter PDF) through
+    `SqliteMaterialsRepository` into `job_materials_artifacts`, which
+    `ProjectionBuilder._load_artifacts` already merges into
+    `artifact_list_projections`. No additional wiring needed.
+- TS read-model: `artifact_list_projections` automatically picks the
+  new `apply_log` rows up via the existing projection — no schema
+  change.
+- Tests: per-writer coverage in
+  `tests/test_apply_log_artifact_registration.py` —
+  `mark_result(applied)`, `mark_result(failed)`, and
+  `mark_result(dry_run)` each record an `apply_log` artifact (and the
+  `applied` test refreshes the projection and asserts the row appears
+  in `artifact_list_projections`); a manual `mark_result` without a
+  `worker_id` does NOT fabricate an artifact; two consecutive runs
+  from the same worker UPSERT to a single row whose `size_bytes`
+  reflects the appended file.
+
+Out of scope:
+- `score_report` registration — scoring is in-memory + DB only today;
+  introducing on-disk reports just to register them is a behaviour
+  change that exceeds this PR.
+- Auxiliary tailor side-files (`{prefix}_REPORT.json`,
+  `{prefix}_JOB.txt`) and the LaTeX `.tex` source emitted next to the
+  resume PDF — primary tailored materials are already registered;
+  surfacing the auxiliaries would require a new artifact kind.
+- Vestigial `apply_runs.log_path` cleanup — already done in PR 4 (the
+  table is dropped).
+- `DryRunComplete` event addition (Frontend Tooling backlog).
 
 QA: skipped — automation-only writer changes; artifacts list is
 already fully tested.

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -75,7 +75,12 @@ from jobhunter.database import (
 from jobhunter.domain.apply.services import ApplyPromptBuilder
 from jobhunter.domain.apply.value_objects import ApplyPrompt, ApplyRunId, new_apply_run_id
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
-from jobhunter.state import ensure_job_stage_rows, record_job_event, set_stage_state
+from jobhunter.state import (
+    ensure_job_stage_rows,
+    record_job_artifact,
+    record_job_event,
+    set_stage_state,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -363,6 +368,32 @@ def acquire_job(
         raise
 
 
+def _register_apply_log_artifact(
+    conn,
+    url: str,
+    *,
+    worker_id: int | None,
+    run_id: str,
+    occurred_at: str,
+) -> None:
+    """Record the per-worker apply log (``LOG_DIR/worker-{worker_id}.log``,
+    written by :class:`ClaudeCodeCliAdapter`) as a ``job_artifacts`` row;
+    no-op when ``worker_id`` is ``None`` (manual ``mark_result`` calls)."""
+    if worker_id is None:
+        return
+    log_path = config.LOG_DIR / f"worker-{int(worker_id)}.log"
+    record_job_artifact(
+        conn,
+        url,
+        "apply",
+        "apply_log",
+        log_path,
+        status="active",
+        created_at=occurred_at,
+        metadata={"run_id": str(run_id), "worker_id": int(worker_id)},
+    )
+
+
 def mark_result(
     url: str,
     status: str,
@@ -374,11 +405,13 @@ def mark_result(
 ) -> None:
     """Update a job's apply outcome.
 
-    Writes go to ``job_stage_states.apply`` (canonical lifecycle row)
-    and a terminal ``ApplicationSubmitted`` / ``ApplicationFailed`` /
+    Writes go to ``job_stage_states.apply`` (canonical lifecycle row),
+    a terminal ``ApplicationSubmitted`` / ``ApplicationFailed`` /
     ``DryRunCompleted`` event whose payload feeds
-    ``apply_run_projections``. The legacy ``jobs.apply_*`` columns are
-    NOT touched.
+    ``apply_run_projections``, and — when the run carries a
+    ``worker_id`` — a ``job_artifacts`` row pointing at the agent's
+    per-worker log file (kind ``apply_log``). The legacy
+    ``jobs.apply_*`` columns are NOT touched.
     """
     conn = get_connection()
     now = _utc_now()
@@ -476,6 +509,9 @@ def mark_result(
             },
         )
 
+    _register_apply_log_artifact(
+        conn, url, worker_id=worker_id, run_id=str(run_id), occurred_at=now
+    )
     conn.commit()
 
 

--- a/workers/automation/tests/test_apply_log_artifact_registration.py
+++ b/workers/automation/tests/test_apply_log_artifact_registration.py
@@ -1,0 +1,298 @@
+"""PR 7 of the Temporal stack — apply logs as ``job_artifacts`` rows.
+
+The launcher now registers each apply run's per-worker log file
+(``LOG_DIR/worker-{worker_id}.log`` — written by
+``ClaudeCodeCliAdapter``) as a ``job_artifacts`` row of kind
+``apply_log`` so the artifacts list reflects what the agent produced
+on disk. The legacy ``apply_runs.log_path`` string column was dropped
+in PR 4; this PR replaces it with a real artifact row that the
+existing ``artifact_list_projections`` projector picks up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jobhunter import config
+from jobhunter.apply.launcher import mark_result
+from jobhunter.database import close_connection, get_connection, init_db
+from jobhunter.infrastructure.projections.projection_builder import ProjectionBuilder
+from jobhunter.state import ensure_job_stage_rows, set_stage_state
+
+
+def _insert_running_apply_job(
+    conn, *, url: str = "https://example.com/job"
+) -> None:
+    """Seed a job whose apply stage is already ``running`` — the only
+    state from which ``mark_result`` can validly transition to
+    succeeded / failed per the §8.5 state machine table."""
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, title, site, full_description, application_url,
+            fit_score, tailored_resume_path, cover_letter_path
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            url,
+            "Platform Engineer",
+            "ExampleCo",
+            "Build distributed systems.",
+            "https://example.com/apply",
+            9,
+            "/tmp/resume.txt",
+            "/tmp/cover.txt",
+        ),
+    )
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(conn, url, "apply", "running", attempt_count=1)
+    conn.commit()
+
+
+def test_mark_result_applied_registers_apply_log_artifact(
+    tmp_path, monkeypatch
+):
+    """A successful apply run records its per-worker log file as a
+    ``job_artifacts`` row of kind ``apply_log``, with the worker_id
+    surfaced in metadata, and the artifact appears in
+    ``artifact_list_projections`` after the projection refresh fires.
+    """
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+    # Simulate the on-disk log file that ``ClaudeCodeCliAdapter`` would
+    # have appended during the run.
+    (log_dir / "worker-3.log").write_text("agent ran here\n", encoding="utf-8")
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        mark_result(
+            "https://example.com/job",
+            "applied",
+            duration_ms=1234,
+            task_id="run-applied",
+            run_ctx={"run_id": "run-applied", "worker_id": 3, "model": "haiku"},
+        )
+
+        artifact_row = conn.execute(
+            "SELECT job_url, stage, artifact_type, status, path, size_bytes "
+            "FROM job_artifacts WHERE job_url = ? AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert artifact_row is not None
+        assert artifact_row["stage"] == "apply"
+        assert artifact_row["status"] == "active"
+        assert artifact_row["path"] == str(log_dir / "worker-3.log")
+        assert artifact_row["size_bytes"] == len("agent ran here\n")
+
+        ProjectionBuilder(conn_factory=lambda: get_connection(db_path)).refresh()
+        proj_rows = conn.execute(
+            "SELECT artifact_type, local_path, size_bytes "
+            "FROM artifact_list_projections "
+            "WHERE job_id = ? AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchall()
+        assert len(proj_rows) == 1
+        assert proj_rows[0]["local_path"] == str(log_dir / "worker-3.log")
+        assert proj_rows[0]["size_bytes"] == len("agent ran here\n")
+    finally:
+        close_connection(db_path)
+
+
+def test_mark_result_failed_registers_apply_log_artifact(tmp_path, monkeypatch):
+    """A failed apply run also registers its per-worker log file —
+    failure logs are exactly when an operator most wants the artifact
+    surfaced in the UI.
+    """
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+    (log_dir / "worker-7.log").write_text("agent crashed\n", encoding="utf-8")
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        mark_result(
+            "https://example.com/job",
+            "failed",
+            error="captcha",
+            permanent=True,
+            duration_ms=5678,
+            task_id="run-failed",
+            run_ctx={"run_id": "run-failed", "worker_id": 7},
+        )
+
+        row = conn.execute(
+            "SELECT path, size_bytes FROM job_artifacts "
+            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert row is not None
+        assert row["path"] == str(log_dir / "worker-7.log")
+        assert row["size_bytes"] == len("agent crashed\n")
+    finally:
+        close_connection(db_path)
+
+
+def test_mark_result_dry_run_registers_apply_log_artifact(
+    tmp_path, monkeypatch
+):
+    """Dry-run completions also surface the worker log so the operator
+    can inspect what the agent did without applying.
+    """
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+    (log_dir / "worker-0.log").write_text("dry run\n", encoding="utf-8")
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        mark_result(
+            "https://example.com/job",
+            "dry_run",
+            duration_ms=42,
+            task_id="run-dry",
+            run_ctx={"run_id": "run-dry", "worker_id": 0, "dry_run": True},
+        )
+
+        row = conn.execute(
+            "SELECT path FROM job_artifacts "
+            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert row is not None
+        assert row["path"] == str(log_dir / "worker-0.log")
+    finally:
+        close_connection(db_path)
+
+
+def test_mark_result_without_worker_id_skips_artifact_registration(
+    tmp_path, monkeypatch
+):
+    """Manual ``mark_result`` calls (``actions.py``, ``mark_job``) do
+    not carry a ``worker_id`` and therefore have no derivable on-disk
+    log path. The launcher must NOT fabricate a fake artifact row in
+    that case — leave ``job_artifacts`` empty.
+    """
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        # No run_ctx -> worker_id is None.
+        mark_result(
+            "https://example.com/job",
+            "applied",
+            duration_ms=0,
+            task_id="run-manual",
+        )
+
+        rows = conn.execute(
+            "SELECT 1 FROM job_artifacts WHERE job_url = ? "
+            "AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchall()
+        assert rows == []
+    finally:
+        close_connection(db_path)
+
+
+def test_mark_result_apply_log_registration_is_idempotent(
+    tmp_path, monkeypatch
+):
+    """Two apply runs from the same worker share one log file (the
+    adapter appends to ``worker-{id}.log``). The artifact row must
+    UPSERT — exactly one ``apply_log`` artifact per (job, path) survives,
+    with the latest size_bytes reflected.
+    """
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+    log_path = log_dir / "worker-1.log"
+    log_path.write_text("first run\n", encoding="utf-8")
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        mark_result(
+            "https://example.com/job",
+            "failed",
+            error="captcha",
+            duration_ms=10,
+            task_id="run-1",
+            run_ctx={"run_id": "run-1", "worker_id": 1},
+        )
+
+        # Reset back to running so the second mark_result is a valid
+        # state-machine transition (the canonical lifecycle is
+        # acquire_job -> mark_result -> reset -> acquire_job -> mark_result;
+        # this test compresses those steps).
+        set_stage_state(
+            conn,
+            "https://example.com/job",
+            "apply",
+            "pending",
+            validate_transition=False,
+        )
+        set_stage_state(
+            conn,
+            "https://example.com/job",
+            "apply",
+            "running",
+            attempt_count=2,
+        )
+        conn.commit()
+
+        # Append more bytes to the same log (mimicking a second apply
+        # run on the same worker).
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write("second run\n")
+
+        mark_result(
+            "https://example.com/job",
+            "applied",
+            duration_ms=20,
+            task_id="run-2",
+            run_ctx={"run_id": "run-2", "worker_id": 1},
+        )
+
+        rows = conn.execute(
+            "SELECT path, size_bytes FROM job_artifacts "
+            "WHERE job_url = ? AND artifact_type = 'apply_log'",
+            ("https://example.com/job",),
+        ).fetchall()
+        assert len(rows) == 1
+        # Reflects the appended file size.
+        assert rows[0]["size_bytes"] == log_path.stat().st_size
+    finally:
+        close_connection(db_path)


### PR DESCRIPTION
## Summary

Wires the previously-dead `state.record_job_artifact` helper into
`apply.launcher.mark_result` so each per-worker agent log
(`LOG_DIR/worker-{worker_id}.log`, written by `ClaudeCodeCliAdapter`)
lands in `job_artifacts` as kind `apply_log` in the same transaction
as the terminal `ApplicationSubmitted` / `ApplicationFailed` /
`DryRunCompleted` event. The existing `ProjectionBuilder._load_artifacts`
join already merges `job_artifacts` into `artifact_list_projections`,
so the new rows surface in the artifacts list without any UI or
projection-schema change.

## Stack context

PR 7 of 7 in the [Temporal + Worker Reliability stack](../docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md).
Last PR in the stack — base = `worker-reliability/single-stage-state-writer` (NOT `main`).
Open PRs ahead of this: #34, #35, #36, #37, #38, #39.

## Producer -> artifact-recorder map

| Producer | File path | Status before PR 7 | Action in PR 7 |
|---|---|---|---|
| `apply.launcher` (via `ClaudeCodeCliAdapter`) | `LOG_DIR/worker-{worker_id}.log` | Not registered (dead-code helper) | **Wired** -- `record_job_artifact(kind="apply_log")` from `mark_result` |
| `scoring.scorer` | (writes no file -- in-memory + `job_scores` row) | N/A | **N/A** -- documented as deferred (would require introducing an on-disk score report file) |
| `scoring.tailor` (via `TailorResumeUseCase`) | `TAILORED_DIR/{prefix}.txt` (resume) | Registered via `job_materials_artifacts` | **No-op** (already wired) |
| `scoring.cover_letter` (via `GenerateCoverLetterUseCase`) | `COVER_LETTER_DIR/{prefix}_CL.txt` | Registered via `job_materials_artifacts` | **No-op** (already wired) |
| `infrastructure/materials/latex_pdf.LatexPdfAdapter` | `<resume_path>.pdf` | Registered via `job_materials_artifacts` | **No-op** (already wired) |
| `infrastructure/materials/playwright_html_pdf.PlaywrightHtmlPdfAdapter` | `<cover_path>.pdf` | Registered via `job_materials_artifacts` | **No-op** (already wired) |

Auxiliary side files NOT registered (intentionally out of scope):
- `TAILORED_DIR/{prefix}_REPORT.json` and `{prefix}_JOB.txt` (written by the tailor use case)
- `<resume_path>.tex` source emitted next to the resume PDF (written by `LatexPdfAdapter`)

These would each require a new artifact kind. The brief explicitly limited
scope to the canonical `apply_log` (and `score_report`, which is N/A here).

## Behavior change

- **New:** every apply run with a `worker_id` produces one `job_artifacts`
  row per (job, worker log path); the row appears in
  `artifact_list_projections` after the next projection refresh fires
  (the existing `ApplicationSubmitted` / `ApplicationFailed` /
  `DryRunCompleted` event already triggers it).
- **Idempotent:** `record_job_artifact` UPSERTs on
  `(job_url, stage, artifact_type, path)`; consecutive runs from the
  same worker collapse to one artifact row whose `size_bytes` reflects
  the appended file.
- **Manual `mark_result` calls** (`actions.py`, `mark_job`) carry no
  `worker_id` -- artifact registration is skipped in that case so we
  don't fabricate a fake row.
- **No new event types**: the existing apply terminal events drive the
  projection refresh.
- **No `apply_runs.log_path` mention anywhere** -- the table was already
  dropped in PR 4, no vestigial references survived to clean up.
- **Existing artifacts unchanged**: tailor/cover/PDF still register
  through `SqliteMaterialsRepository` -> `job_materials_artifacts`.

## Verification

All commands run from `/Users/eloibarti/Github/JobHunter-worktrees/wr-logs-as-artifacts`:

| Command | Result |
|---|---|
| `uv --project workers/automation run --extra dev pytest -q` | **654 passed** (5 new in `test_apply_log_artifact_registration.py`) |
| `uv --project workers/automation run --extra dev ruff check .` | **All checks passed!** |
| `pnpm api:check` | clean (`tsc --noEmit`) |
| `pnpm api:test` | **66 passed** |
| `pnpm -r check` | clean across `domain-types`, `contracts`, `api-client`, `api`, `web` |
| `git diff --check` | clean |

## What's NOT in this PR

- **`score_report` artifact registration** -- scoring is in-memory + DB
  only today; introducing an on-disk score report file just to
  register it is a behaviour change beyond PR 7's scope. Tracked in
  `docs/backlog.md` as a follow-up.
- **The deferred `DryRunComplete` domain-event addition** (Frontend
  Tooling backlog).
- **UI changes for the new `apply_log` artifact kind** -- the existing
  artifacts view picks the rows up automatically; no per-kind styling
  change shipped here.
- **Cleanup of vestigial `log_path` references** -- already gone with
  PR 4's table drop; nothing left to remove.
- **Auxiliary tailor side-files / LaTeX `.tex` source registration** --
  primary tailored materials are already registered; new artifact kinds
  for the auxiliaries would expand scope.

## Test plan

- [x] `uv --project workers/automation run --extra dev pytest -q` -- 654 passed
- [x] `uv --project workers/automation run --extra dev ruff check .` -- clean
- [x] `pnpm api:check && pnpm api:test` -- clean + 66 passed
- [x] `pnpm -r check` -- clean
- [x] `git diff --check` -- clean