### PR TITLE
feat(workers): add Langfuse observability via OpenTelemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Use these repository documents before making architectural, workflow, or QA deci
 - `README.md`: user-facing product behavior, CLI commands, runtime requirements, generated local artifacts, and safety notes.
 - `docs/local-reliability-qa.md`: local QA checklist, regression matrix, known high-risk workflows that need test coverage, and the frontend test pyramid + a11y bar.
 - `docs/local-ts-api.md`: local TypeScript API, web app development commands, API/web verification, dashboard migration context, and the `GET /v1/events/stream` SSE contract.
-- `docs/architecture.md`: current TypeScript app/API plus Python worker architecture, eight bounded contexts, projection-backed read model, JSON-RPC TS↔Python protocol, local-first boundaries, and the frontend stack / state layers / ports / SSE realtime.
+- `docs/architecture.md`: current TypeScript app/API plus Python worker architecture, eight bounded contexts, projection-backed read model, JSON-RPC TS↔Python protocol, local-first boundaries, the frontend stack / state layers / ports / SSE realtime, and the OpenTelemetry → Langfuse observability layer for LLM, workflow, and JSON-RPC spans.
 - `docs/ddd-target.md`: canonical DDD + hexagonal target architecture (aggregates, ports, domain events, projection strategy, hosted-future seams). The implementation in this codebase realises this target — see `docs/plans/implemented/2026-05-06-ddd-migration.md`.
 - `docs/frontend-target.md`: canonical frontend architecture — three-layer state (server / URL / client), eight bounded contexts mirrored 1:1 from the backend, view-vs-context dichotomy, hexagonal frontend ports, SSE realtime + invalidation router, testing pyramid. The implementation in this codebase realises this target — see `docs/plans/implemented/2026-05-06-frontend-tanstack-migration.md`.
 - `docs/domain-model.md`: implementer's quick reference to the eight bounded contexts and their aggregates / repositories / events.
@@ -60,6 +60,7 @@ When a doc update is warranted:
 | Local QA expectations, regression matrix entries, high-risk workflows, or manually verified product paths | `docs/local-reliability-qa.md` |
 | Local TypeScript API behavior, web app development commands, API/web verification, or dashboard migration details | `docs/local-ts-api.md` |
 | TypeScript API plus Python worker architecture, local-first boundaries, orchestration, or phased migration constraints | `docs/architecture.md` |
+| Observability / OpenTelemetry / Langfuse export of LLM, workflow, or JSON-RPC spans | `docs/architecture.md` |
 | Frontend architecture (state layers, bounded contexts, ports, realtime, testing pyramid) | `docs/frontend-target.md` |
 | TypeScript/API/web scripts, package metadata, dependencies, or tooling commands | `package.json` |
 | Python package metadata, CLI entry point, Python version, optional dev dependencies, or Ruff config | `workers/automation/pyproject.toml` |

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ Common environment variables:
 - `CAPSOLVER_API_KEY`: enable CAPTCHA solving support.
 - `JOBHUNTER_API_HOST`, `JOBHUNTER_API_PORT`: local TypeScript API bind
   settings.
+- `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`:
+  enable OpenTelemetry export of LLM, workflow, and JSON-RPC spans to a
+  Langfuse instance. When any of these is unset the worker runs normally
+  without exporting. Set `LANGFUSE_DISABLE=1` to opt out even when
+  credentials are present. Enabling this exports every LLM prompt and
+  completion to the configured Langfuse instance.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -382,6 +382,51 @@ The pipeline package (`jobhunter/pipeline/`) is split into `runner.py`
 Live workflow state — running workflows, history, signals, retries — is
 visible at `http://127.0.0.1:8233` in the Temporal Web UI.
 
+### Observability
+
+The Python automation worker exports OpenTelemetry spans over OTLP/HTTP to a
+Langfuse instance for LLM tracing. The wiring lives under
+`workers/automation/src/jobhunter/infrastructure/observability/`:
+
+- `otel.py` — `init_otel()` configures a global `TracerProvider` with a
+  `BatchSpanProcessor` feeding an `OTLPSpanExporter`. Endpoint:
+  `${LANGFUSE_BASE_URL}/api/public/otel/v1/traces`. Authentication is HTTP
+  Basic with `base64(LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY)`. If any of
+  `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` is
+  unset, init logs a warning and the worker continues without exporting.
+  `LANGFUSE_DISABLE=1` opts out even when credentials are present.
+- `llm_spans.py` — `llm_generation_span(...)` context manager that opens a
+  `langfuse.observation.type=generation` span around each LLM call. It also
+  sets the GenAI semantic-conventions attributes (`gen_ai.request.model`,
+  `gen_ai.response.model`, `gen_ai.usage.input_tokens`,
+  `gen_ai.usage.output_tokens`) so OTel-native dashboards work too.
+
+Three sources emit spans:
+
+| Source | Span name | `langfuse.observation.type` |
+| --- | --- | --- |
+| Every LLM call (`jobhunter.llm.LLMClient.chat`) | `llm.<model>` | `generation` |
+| Every Temporal workflow + activity (via `temporalio.contrib.opentelemetry.TracingInterceptor`) | workflow / activity name | `span` (default) |
+| Every JSON-RPC dispatch (`jobhunter.infrastructure.rpc.server.JsonRpcServer.dispatch`) | `rpc.<method>` | `span` |
+
+The `TracingInterceptor` is registered both client-side
+(`infrastructure/temporal/client.py`) and worker-side
+(`infrastructure/temporal/worker.py`) so trace context propagates from the
+JSON-RPC handler that starts a workflow into the worker that runs it.
+
+`init_otel()` is called from `jobhunter.cli._bootstrap()`, so every CLI
+command (notably `jobhunter worker` and `jobhunter rpc`) configures
+exporting on startup. The `worker` command calls `shutdown_otel()` on
+exit so the `BatchSpanProcessor` flushes any in-flight spans.
+
+`jobhunter doctor` includes a `Langfuse` row that probes the OTLP endpoint
+with a `HEAD` request — `OK reachable`, `MISSING (set
+LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)`, or `unreachable`.
+
+Out of scope for this layer: TypeScript API / web instrumentation and
+distributed-trace propagation across the TS↔Python JSON-RPC boundary
+(would need TS to emit OTel context too).
+
 ### SQLite And Files
 
 SQLite in `~/.jobhunter/jobhunter.db` is the local source of truth for jobs,

--- a/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
+++ b/docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md
@@ -290,6 +290,79 @@ Out of scope:
 QA: skipped — automation-only writer changes; artifacts list is
 already fully tested.
 
+### PR 8 — Langfuse observability via OpenTelemetry
+
+Branch: `observability/langfuse-otel` off
+`worker-reliability/logs-as-artifacts`.
+
+- Add OpenTelemetry to `workers/automation/pyproject.toml`:
+  `opentelemetry-api`, `opentelemetry-sdk`,
+  `opentelemetry-exporter-otlp-proto-http`, plus the optional
+  `opentelemetry-instrumentation-httpx` for auto-instrumented LLM HTTP calls.
+- New module
+  `workers/automation/src/jobhunter/infrastructure/observability/`:
+  - `otel.py` — `init_otel(*, service_name, environment)`, `shutdown_otel()`,
+    and `is_otel_enabled()`. Reads `LANGFUSE_PUBLIC_KEY` /
+    `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` from `os.environ`,
+    builds an `OTLPSpanExporter` pointed at
+    `${LANGFUSE_BASE_URL}/api/public/otel/v1/traces` with
+    `Authorization: Basic <base64(pk:sk)>` and the
+    `x-langfuse-ingestion-version: 4` fast-preview header, wraps it in
+    a `BatchSpanProcessor`, and sets the global `TracerProvider`.
+    Idempotent. Degrades gracefully when env vars are missing.
+    Honours `LANGFUSE_DISABLE=1` as an explicit opt-out even when
+    credentials are present.
+  - `llm_spans.py` — `llm_generation_span(model, messages, params)`
+    context manager that opens a `langfuse.observation.type=generation`
+    span, sets the Langfuse-specific attributes
+    (`langfuse.observation.model.name`,
+    `langfuse.observation.model.parameters`,
+    `langfuse.observation.input`, `langfuse.observation.output`,
+    `langfuse.observation.usage_details`) plus the GenAI semantic
+    conventions (`gen_ai.request.model`, `gen_ai.response.model`,
+    `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`).
+- Wiring:
+  - `jobhunter.llm.LLMClient.chat` (both compat + native Gemini paths)
+    now wraps each call in `llm_generation_span`, extracting token
+    counts from the OpenAI-compat `usage` object and the native
+    Gemini `usageMetadata`.
+  - `jobhunter.infrastructure.temporal.client.get_temporal_client` now
+    constructs the `Client` with
+    `interceptors=[TracingInterceptor()]`.
+  - `jobhunter.infrastructure.temporal.worker.build_worker` now passes
+    the same `TracingInterceptor` into the `Worker` so workflow +
+    activity spans flow automatically with trace context preserved
+    across the workflow start.
+  - `jobhunter.infrastructure.rpc.server.JsonRpcServer.dispatch` now
+    opens a `rpc.<method>` span with `langfuse.trace.name=<method>`,
+    `langfuse.observation.type="span"`, `rpc.method`, and `rpc.id`
+    attributes; handler exceptions mark the span ERROR.
+  - `jobhunter.cli._bootstrap()` calls `init_otel()`, so every CLI
+    command configures exporting on startup. The `worker` command
+    calls `shutdown_otel()` in a `finally` so the
+    `BatchSpanProcessor` flushes on Ctrl-C.
+- `jobhunter doctor` gains a `Langfuse` row that probes the OTLP
+  endpoint with a 2 s `httpx.head` and reports
+  `OK reachable` / `MISSING (set LANGFUSE_*…)` / `unreachable`.
+- Tests: `test_otel_init.py` (idempotency, missing-creds graceful
+  degradation, `LANGFUSE_DISABLE` opt-out, payload-export warning,
+  endpoint + auth header shape), `test_llm_spans.py` (Langfuse span
+  attributes, unknown-token handling, exception status), `test_rpc_otel.py`
+  (dispatch span attributes + error status), `test_doctor_langfuse.py`
+  (reachable / missing / unreachable code paths).
+- Docs: `docs/architecture.md` gains an "Observability" section under
+  `Runtime Boundaries`. `README.md` `Configuration` section grows the
+  `LANGFUSE_*` env-var entry. `AGENTS.md` `Reference Index` and
+  `Documentation Requirements` table both gain an Observability row.
+
+Out of scope: TS/web instrumentation (`apps/api`, `apps/web`,
+`packages/`), distributed-trace propagation across the TS↔Python
+JSON-RPC boundary, dashboards / alerts / SLOs in Langfuse UI,
+prompt-versioning via Langfuse prompts, cost calculation overrides
+(Langfuse computes cost from token counts via its model registry).
+
+QA: skipped — automation/observability only.
+
 ## Sequencing rules
 
 - Each PR creates its own worktree off the previous branch.

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -28,6 +28,10 @@ dependencies = [
     "pyyaml>=6.0",
     "pandas>=2.0",
     "temporalio>=1.6",
+    "opentelemetry-api>=1.27",
+    "opentelemetry-sdk>=1.27",
+    "opentelemetry-exporter-otlp-proto-http>=1.27",
+    "opentelemetry-instrumentation-httpx>=0.48b0",
     ]
 
 [project.optional-dependencies]

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1328,8 +1328,9 @@ def doctor() -> None:
     # Skip the network probe entirely if LANGFUSE_DISABLE is set — it's the
     # opt-out switch users flip when they don't want export running and they
     # shouldn't see a misleading "MISSING" or "unreachable" row.
-    lf_disabled = os.environ.get("LANGFUSE_DISABLE", "").strip().lower() in {"1", "true", "yes"}
-    if lf_disabled:
+    from jobhunter.infrastructure.observability import langfuse_disabled
+
+    if langfuse_disabled():
         results.append(("Langfuse", "[dim]disabled[/dim]", "LANGFUSE_DISABLE=1"))
     else:
         lf_pub = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1325,31 +1325,38 @@ def doctor() -> None:
                         "unreachable (start with: temporal server start-dev)"))
 
     # Langfuse OTLP ingest (observability target)
-    lf_pub = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
-    lf_sec = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
-    lf_url = os.environ.get("LANGFUSE_BASE_URL", "").strip().rstrip("/")
-    if not (lf_pub and lf_sec and lf_url):
-        results.append((
-            "Langfuse",
-            fail_mark,
-            "MISSING (set LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)",
-        ))
+    # Skip the network probe entirely if LANGFUSE_DISABLE is set — it's the
+    # opt-out switch users flip when they don't want export running and they
+    # shouldn't see a misleading "MISSING" or "unreachable" row.
+    lf_disabled = os.environ.get("LANGFUSE_DISABLE", "").strip().lower() in {"1", "true", "yes"}
+    if lf_disabled:
+        results.append(("Langfuse", "[dim]disabled[/dim]", "LANGFUSE_DISABLE=1"))
     else:
-        try:
-            resp = httpx.head(f"{lf_url}/api/public/otel/v1/traces", timeout=2.0)
-            # Any non-server-error response means the endpoint is alive.
-            # 405 (Method Not Allowed on HEAD) and 401 (auth required) both
-            # confirm the route exists.
-            if resp.status_code < 500:
-                results.append(("Langfuse", ok_mark, "reachable"))
-            else:
-                results.append((
-                    "Langfuse",
-                    fail_mark,
-                    f"unreachable (status={resp.status_code})",
-                ))
-        except Exception:  # noqa: BLE001 — any failure ⇒ unreachable
-            results.append(("Langfuse", fail_mark, "unreachable"))
+        lf_pub = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+        lf_sec = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+        lf_url = os.environ.get("LANGFUSE_BASE_URL", "").strip().rstrip("/")
+        if not (lf_pub and lf_sec and lf_url):
+            results.append((
+                "Langfuse",
+                fail_mark,
+                "MISSING (set LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)",
+            ))
+        else:
+            try:
+                resp = httpx.head(f"{lf_url}/api/public/otel/v1/traces", timeout=2.0)
+                # Any non-server-error response means the endpoint is alive.
+                # 405 (Method Not Allowed on HEAD) and 401 (auth required) both
+                # confirm the route exists.
+                if resp.status_code < 500:
+                    results.append(("Langfuse", ok_mark, "reachable"))
+                else:
+                    results.append((
+                        "Langfuse",
+                        fail_mark,
+                        f"unreachable (status={resp.status_code})",
+                    ))
+            except Exception:  # noqa: BLE001 — any failure ⇒ unreachable
+                results.append(("Langfuse", fail_mark, "unreachable"))
 
     # --- Render results ---
     console.print()

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -8,6 +8,7 @@ import logging
 import time
 from typing import Optional
 
+import httpx
 import typer
 from rich.console import Console
 from rich.panel import Panel
@@ -65,6 +66,13 @@ def _bootstrap() -> None:
     load_env()
     ensure_dirs()
     init_db()
+    # Bootstrap OTel as early as possible so every span emitted by the
+    # rest of this CLI invocation flows to the configured Langfuse instance.
+    # init_otel() is idempotent and degrades gracefully when env vars are
+    # absent, so it's safe to call from every command.
+    from jobhunter.infrastructure.observability import init_otel
+
+    init_otel()
     try:
         # Pass a thread-local connection factory so the wildcard
         # subscriber (which fires on whichever thread published the
@@ -1184,7 +1192,14 @@ def worker(
         )
         await worker.run()
 
-    asyncio.run(_run())
+    from jobhunter.infrastructure.observability import shutdown_otel
+
+    try:
+        asyncio.run(_run())
+    finally:
+        # Flush any in-flight spans so the BatchSpanProcessor doesn't drop
+        # them on Ctrl-C.
+        shutdown_otel()
 
 
 @app.command()
@@ -1308,6 +1323,33 @@ def doctor() -> None:
     except (Exception, asyncio.TimeoutError):  # noqa: BLE001 — any failure ⇒ unreachable
         results.append(("Temporal", fail_mark,
                         "unreachable (start with: temporal server start-dev)"))
+
+    # Langfuse OTLP ingest (observability target)
+    lf_pub = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+    lf_sec = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+    lf_url = os.environ.get("LANGFUSE_BASE_URL", "").strip().rstrip("/")
+    if not (lf_pub and lf_sec and lf_url):
+        results.append((
+            "Langfuse",
+            fail_mark,
+            "MISSING (set LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)",
+        ))
+    else:
+        try:
+            resp = httpx.head(f"{lf_url}/api/public/otel/v1/traces", timeout=2.0)
+            # Any non-server-error response means the endpoint is alive.
+            # 405 (Method Not Allowed on HEAD) and 401 (auth required) both
+            # confirm the route exists.
+            if resp.status_code < 500:
+                results.append(("Langfuse", ok_mark, "reachable"))
+            else:
+                results.append((
+                    "Langfuse",
+                    fail_mark,
+                    f"unreachable (status={resp.status_code})",
+                ))
+        except Exception:  # noqa: BLE001 — any failure ⇒ unreachable
+            results.append(("Langfuse", fail_mark, "unreachable"))
 
     # --- Render results ---
     console.print()

--- a/workers/automation/src/jobhunter/infrastructure/observability/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/__init__.py
@@ -1,0 +1,10 @@
+"""OpenTelemetry → Langfuse observability layer."""
+
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
+from jobhunter.infrastructure.observability.otel import (
+    init_otel,
+    is_otel_enabled,
+    shutdown_otel,
+)
+
+__all__ = ["init_otel", "is_otel_enabled", "llm_generation_span", "shutdown_otel"]

--- a/workers/automation/src/jobhunter/infrastructure/observability/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/__init__.py
@@ -4,7 +4,14 @@ from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
 from jobhunter.infrastructure.observability.otel import (
     init_otel,
     is_otel_enabled,
+    langfuse_disabled,
     shutdown_otel,
 )
 
-__all__ = ["init_otel", "is_otel_enabled", "llm_generation_span", "shutdown_otel"]
+__all__ = [
+    "init_otel",
+    "is_otel_enabled",
+    "langfuse_disabled",
+    "llm_generation_span",
+    "shutdown_otel",
+]

--- a/workers/automation/src/jobhunter/infrastructure/observability/llm_spans.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/llm_spans.py
@@ -1,0 +1,67 @@
+"""Context manager that wraps a single LLM call in a Langfuse-shaped span."""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
+RecordResponse = Callable[..., None]
+
+
+@contextmanager
+def llm_generation_span(
+    *,
+    model: str,
+    messages: list[dict],
+    params: dict,
+    scope_name: str = "jobhunter.llm",
+) -> Iterator[RecordResponse]:
+    """Open a ``langfuse.observation.type=generation`` span around an LLM call.
+
+    Yields a ``record_response(text, *, input_tokens, output_tokens)`` callable
+    so the caller can attach the response payload + token counts after the
+    LLM returns. Exceptions raised inside the ``with`` block are recorded
+    on the span (StatusCode.ERROR) and re-raised.
+    """
+    tracer = trace.get_tracer(scope_name)
+    with tracer.start_as_current_span(f"llm.{model}") as span:
+        span.set_attribute("langfuse.observation.type", "generation")
+        span.set_attribute("langfuse.observation.model.name", model)
+        span.set_attribute("langfuse.observation.model.parameters", json.dumps(params))
+        span.set_attribute("langfuse.observation.input", json.dumps(messages))
+        span.set_attribute("gen_ai.request.model", model)
+
+        def record(
+            text: str,
+            *,
+            input_tokens: int | None = None,
+            output_tokens: int | None = None,
+        ) -> None:
+            span.set_attribute("langfuse.observation.output", text)
+            span.set_attribute("gen_ai.response.model", model)
+            if input_tokens is not None and output_tokens is not None:
+                span.set_attribute(
+                    "langfuse.observation.usage_details",
+                    json.dumps(
+                        {
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                            "total_tokens": input_tokens + output_tokens,
+                        }
+                    ),
+                )
+            if input_tokens is not None:
+                span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
+            if output_tokens is not None:
+                span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
+
+        try:
+            yield record
+        except Exception as exc:
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            raise

--- a/workers/automation/src/jobhunter/infrastructure/observability/otel.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/otel.py
@@ -1,0 +1,114 @@
+"""Bootstrap OpenTelemetry to ship spans to a Langfuse OTLP/HTTP endpoint.
+
+Reads ``LANGFUSE_PUBLIC_KEY`` / ``LANGFUSE_SECRET_KEY`` / ``LANGFUSE_BASE_URL``
+straight from ``os.environ`` so deployments can override values that
+``jobhunter.config.load_env()`` already populated from ``~/.jobhunter/.env``.
+If any credential is missing, init logs a warning and returns without
+configuring — every command continues to run, only export is off.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+import os
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from jobhunter import __version__ as JOBHUNTER_VERSION
+
+log = logging.getLogger(__name__)
+
+_initialized: bool = False
+_provider: TracerProvider | None = None
+_exporter: OTLPSpanExporter | None = None
+
+_OTLP_PATH = "/api/public/otel/v1/traces"
+
+
+def init_otel(*, service_name: str = "jobhunter", environment: str | None = None) -> None:
+    """Configure the global OTel ``TracerProvider`` once."""
+    global _initialized, _provider, _exporter
+
+    if _initialized:
+        return
+
+    if os.environ.get("LANGFUSE_DISABLE", "").strip().lower() in ("1", "true"):
+        log.info("Langfuse export disabled via LANGFUSE_DISABLE.")
+        _initialized = True
+        return
+
+    public_key = os.environ.get("LANGFUSE_PUBLIC_KEY", "").strip()
+    secret_key = os.environ.get("LANGFUSE_SECRET_KEY", "").strip()
+    base_url = os.environ.get("LANGFUSE_BASE_URL", "").strip().rstrip("/")
+    if not (public_key and secret_key and base_url):
+        log.warning(
+            "Langfuse OTel export disabled: set LANGFUSE_PUBLIC_KEY, "
+            "LANGFUSE_SECRET_KEY, and LANGFUSE_BASE_URL to enable."
+        )
+        _initialized = True
+        return
+
+    log.warning(
+        "Langfuse OTel export ENABLED — every LLM prompt + completion will be "
+        "shipped to %s. Set LANGFUSE_DISABLE=1 to opt out.",
+        base_url,
+    )
+
+    resource = Resource(
+        attributes={
+            "service.name": service_name,
+            "service.version": JOBHUNTER_VERSION,
+            "deployment.environment": environment or os.environ.get("JOBHUNTER_ENV", "local"),
+        }
+    )
+
+    auth = base64.b64encode(f"{public_key}:{secret_key}".encode("ascii")).decode("ascii")
+    exporter = OTLPSpanExporter(
+        endpoint=f"{base_url}{_OTLP_PATH}",
+        headers={
+            "Authorization": f"Basic {auth}",
+            "x-langfuse-ingestion-version": "4",
+        },
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    _provider = provider
+    _exporter = exporter
+    _initialized = True
+
+    # Auto-instrument httpx so the LLMClient's outbound requests get spans
+    # without any per-call wiring. Optional — ImportError means the user
+    # didn't install the extra package, which is fine.
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+        HTTPXClientInstrumentor().instrument()
+    except ImportError:
+        pass
+
+
+def shutdown_otel() -> None:
+    """Flush + shut down the active provider so tests / CLI exits don't leak threads."""
+    global _initialized, _provider, _exporter
+
+    if _provider is not None:
+        try:
+            _provider.shutdown()
+        except Exception:  # noqa: BLE001 — shutdown is best-effort
+            log.exception("OTel provider shutdown failed")
+
+    _provider = None
+    _exporter = None
+    _initialized = False
+
+
+def is_otel_enabled() -> bool:
+    """True iff ``init_otel()`` configured a real provider."""
+    return _provider is not None

--- a/workers/automation/src/jobhunter/infrastructure/observability/otel.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/otel.py
@@ -28,6 +28,12 @@ _provider: TracerProvider | None = None
 _exporter: OTLPSpanExporter | None = None
 
 _OTLP_PATH = "/api/public/otel/v1/traces"
+_DISABLE_TRUTHY = frozenset({"1", "true", "yes"})
+
+
+def langfuse_disabled() -> bool:
+    """Single source of truth for the LANGFUSE_DISABLE opt-out flag."""
+    return os.environ.get("LANGFUSE_DISABLE", "").strip().lower() in _DISABLE_TRUTHY
 
 
 def init_otel(*, service_name: str = "jobhunter", environment: str | None = None) -> None:
@@ -37,7 +43,7 @@ def init_otel(*, service_name: str = "jobhunter", environment: str | None = None
     if _initialized:
         return
 
-    if os.environ.get("LANGFUSE_DISABLE", "").strip().lower() in ("1", "true"):
+    if langfuse_disabled():
         log.info("Langfuse export disabled via LANGFUSE_DISABLE.")
         _initialized = True
         return
@@ -107,7 +113,7 @@ def _scrub_url_credentials(span, request) -> None:  # type: ignore[no-untyped-de
         url = str(request.url)
     except Exception:  # noqa: BLE001 — defensive: never break the request path
         return
-    if "key=" not in url:
+    if "key=" not in url.lower():
         return
     from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
 

--- a/workers/automation/src/jobhunter/infrastructure/observability/otel.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/otel.py
@@ -89,9 +89,38 @@ def init_otel(*, service_name: str = "jobhunter", environment: str | None = None
     try:
         from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 
-        HTTPXClientInstrumentor().instrument()
+        HTTPXClientInstrumentor().instrument(request_hook=_scrub_url_credentials)
     except ImportError:
         pass
+
+
+def _scrub_url_credentials(span, request) -> None:  # type: ignore[no-untyped-def]
+    """Replace ``http.url`` if it carries a ``?key=`` credential.
+
+    Belt-and-suspenders: every JobHunter call path should be passing the API
+    key as a header (e.g. ``x-goog-api-key``), but if any future caller
+    accidentally puts ``?key=...`` back in the URL it would otherwise be
+    captured into the ``http.url`` span attribute and shipped to Langfuse.
+    The hook strips that single query param while preserving everything else.
+    """
+    try:
+        url = str(request.url)
+    except Exception:  # noqa: BLE001 — defensive: never break the request path
+        return
+    if "key=" not in url:
+        return
+    from urllib.parse import urlencode, urlparse, urlunparse, parse_qsl
+
+    parsed = urlparse(url)
+    if not parsed.query:
+        return
+    pairs = parse_qsl(parsed.query, keep_blank_values=True)
+    scrubbed = [(k, "REDACTED" if k.lower() == "key" else v) for k, v in pairs]
+    if scrubbed == pairs:
+        return
+    cleaned = urlunparse(parsed._replace(query=urlencode(scrubbed)))
+    span.set_attribute("http.url", cleaned)
+    span.set_attribute("url.full", cleaned)
 
 
 def shutdown_otel() -> None:

--- a/workers/automation/src/jobhunter/infrastructure/rpc/server.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/server.py
@@ -24,6 +24,9 @@ import sys
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, TextIO
 
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
 from jobhunter.domain.rpc.messages import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -80,34 +83,45 @@ class JsonRpcServer:
         handlers should be driven via :meth:`serve` instead of this entry
         point.
         """
-        spec = self._handlers.get(request.method)
-        if spec is None:
-            return JsonRpcResponse.failure(
-                request.id,
-                JsonRpcError(METHOD_NOT_FOUND, f"Method not found: {request.method}"),
-            )
+        tracer = trace.get_tracer("jobhunter.rpc")
+        with tracer.start_as_current_span(f"rpc.{request.method}") as span:
+            span.set_attribute("rpc.method", request.method)
+            span.set_attribute("rpc.id", "" if request.id is None else str(request.id))
+            span.set_attribute("langfuse.trace.name", request.method)
+            span.set_attribute("langfuse.observation.type", "span")
 
-        if spec.mode == "workflow":
-            return self._dispatch_workflow(request, spec)
+            spec = self._handlers.get(request.method)
+            if spec is None:
+                span.set_status(Status(StatusCode.ERROR, "method not found"))
+                return JsonRpcResponse.failure(
+                    request.id,
+                    JsonRpcError(METHOD_NOT_FOUND, f"Method not found: {request.method}"),
+                )
 
-        # sync — streaming is handled separately in serve()
-        try:
-            result = spec.fn(request.params)
-        except _RpcParamError as exc:
-            return JsonRpcResponse.failure(
-                request.id,
-                JsonRpcError(INVALID_PARAMS, str(exc)),
-            )
-        except Exception as exc:  # noqa: BLE001 — surface as INTERNAL_ERROR
-            logger.exception("Handler %s raised", request.method)
-            return JsonRpcResponse.failure(
-                request.id,
-                JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
-            )
-        if request.id is None:
-            # Notification — no response.
-            return None
-        return JsonRpcResponse.success(request.id, result)
+            if spec.mode == "workflow":
+                return self._dispatch_workflow(request, spec)
+
+            # sync — streaming is handled separately in serve()
+            try:
+                result = spec.fn(request.params)
+            except _RpcParamError as exc:
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                return JsonRpcResponse.failure(
+                    request.id,
+                    JsonRpcError(INVALID_PARAMS, str(exc)),
+                )
+            except Exception as exc:  # noqa: BLE001 — surface as INTERNAL_ERROR
+                logger.exception("Handler %s raised", request.method)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                return JsonRpcResponse.failure(
+                    request.id,
+                    JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
+                )
+            if request.id is None:
+                # Notification — no response.
+                return None
+            return JsonRpcResponse.success(request.id, result)
 
     # ------------------------------------------------------------------ workflow
 

--- a/workers/automation/src/jobhunter/infrastructure/rpc/server.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/server.py
@@ -130,8 +130,14 @@ class JsonRpcServer:
         request: JsonRpcRequest,
         spec: HandlerSpec,
     ) -> JsonRpcResponse | None:
+        # The dispatch() caller already opened the rpc.<method> span; we mark
+        # ERROR status on it from each early-return failure branch so the
+        # exported trace tells the truth about failed workflow dispatches.
+        span = trace.get_current_span()
+
         if self._workflow_starter is None:
             logger.error("Workflow handler %s invoked without a workflow_starter", request.method)
+            span.set_status(Status(StatusCode.ERROR, "workflow_starter not configured"))
             return JsonRpcResponse.failure(
                 request.id,
                 JsonRpcError(
@@ -144,30 +150,34 @@ class JsonRpcServer:
         try:
             start_spec = spec.fn(request.params)
         except _RpcParamError as exc:
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
             return JsonRpcResponse.failure(
                 request.id,
                 JsonRpcError(INVALID_PARAMS, str(exc)),
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("Workflow handler %s raised while building spec", request.method)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
             return JsonRpcResponse.failure(
                 request.id,
                 JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
             )
 
         if not isinstance(start_spec, WorkflowStartSpec):
+            msg = f"Workflow handler {request.method} did not return a WorkflowStartSpec"
+            span.set_status(Status(StatusCode.ERROR, msg))
             return JsonRpcResponse.failure(
                 request.id,
-                JsonRpcError(
-                    INTERNAL_ERROR,
-                    f"Workflow handler {request.method} did not return a WorkflowStartSpec",
-                ),
+                JsonRpcError(INTERNAL_ERROR, msg),
             )
 
         try:
             handle = asyncio.run(self._workflow_starter(start_spec))
         except Exception as exc:  # noqa: BLE001
             logger.exception("Workflow start failed for %s", request.method)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
             return JsonRpcResponse.failure(
                 request.id,
                 JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)),
@@ -231,38 +241,51 @@ class JsonRpcServer:
         spec: HandlerSpec,
         stdout: TextIO,
     ) -> JsonRpcResponse | None:
-        try:
-            stream = spec.fn(request.params)
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Streaming handler %s failed to start", request.method)
-            return JsonRpcResponse.failure(request.id, JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)))
-        if not isinstance(stream, Iterable):
-            return JsonRpcResponse.failure(
-                request.id,
-                JsonRpcError(
-                    INTERNAL_ERROR,
-                    f"Streaming handler {request.method} did not return iterable",
-                ),
-            )
+        tracer = trace.get_tracer("jobhunter.rpc")
+        with tracer.start_as_current_span(f"rpc.{request.method}") as span:
+            span.set_attribute("rpc.method", request.method)
+            span.set_attribute("rpc.id", "" if request.id is None else str(request.id))
+            span.set_attribute("langfuse.trace.name", request.method)
+            span.set_attribute("langfuse.observation.type", "span")
 
-        final: Any = None
-        try:
-            for item in stream:
-                # Each yielded item is sent as a JSON-RPC notification.
-                notification = {
-                    "jsonrpc": "2.0",
-                    "method": f"{request.method}.progress",
-                    "params": item,
-                }
-                stdout.write(json.dumps(notification) + "\n")
-                stdout.flush()
-                final = item
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Streaming handler %s raised mid-stream", request.method)
-            return JsonRpcResponse.failure(request.id, JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc)))
-        if request.id is None:
-            return None
-        return JsonRpcResponse.success(request.id, final)
+            try:
+                stream = spec.fn(request.params)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Streaming handler %s failed to start", request.method)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                return JsonRpcResponse.failure(
+                    request.id, JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc))
+                )
+            if not isinstance(stream, Iterable):
+                msg = f"Streaming handler {request.method} did not return iterable"
+                span.set_status(Status(StatusCode.ERROR, msg))
+                return JsonRpcResponse.failure(
+                    request.id, JsonRpcError(INTERNAL_ERROR, msg)
+                )
+
+            final: Any = None
+            try:
+                for item in stream:
+                    # Each yielded item is sent as a JSON-RPC notification.
+                    notification = {
+                        "jsonrpc": "2.0",
+                        "method": f"{request.method}.progress",
+                        "params": item,
+                    }
+                    stdout.write(json.dumps(notification) + "\n")
+                    stdout.flush()
+                    final = item
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("Streaming handler %s raised mid-stream", request.method)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+                return JsonRpcResponse.failure(
+                    request.id, JsonRpcError(INTERNAL_ERROR, "Internal error", data=str(exc))
+                )
+            if request.id is None:
+                return None
+            return JsonRpcResponse.success(request.id, final)
 
 
 class _RpcParamError(ValueError):

--- a/workers/automation/src/jobhunter/infrastructure/temporal/client.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from temporalio.client import Client
+from temporalio.contrib.opentelemetry import TracingInterceptor
 
 DEFAULT_ADDRESS = "localhost:7233"
 DEFAULT_NAMESPACE = "default"
@@ -14,4 +15,8 @@ async def get_temporal_client() -> Client:
     """Connect to the Temporal frontend defined by ``TEMPORAL_ADDRESS`` / ``TEMPORAL_NAMESPACE``."""
     address = os.environ.get("TEMPORAL_ADDRESS", DEFAULT_ADDRESS)
     namespace = os.environ.get("TEMPORAL_NAMESPACE", DEFAULT_NAMESPACE)
-    return await Client.connect(address, namespace=namespace)
+    return await Client.connect(
+        address,
+        namespace=namespace,
+        interceptors=[TracingInterceptor()],
+    )

--- a/workers/automation/src/jobhunter/infrastructure/temporal/worker.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/worker.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from temporalio import workflow
 from temporalio.client import Client
+from temporalio.contrib.opentelemetry import TracingInterceptor
 from temporalio.worker import Worker
 from temporalio.worker.workflow_sandbox import (
     SandboxedWorkflowRunner,
@@ -65,4 +66,5 @@ def build_worker(
         workflow_runner=SandboxedWorkflowRunner(
             restrictions=_PASSTHROUGH_RESTRICTIONS,
         ),
+        interceptors=[TracingInterceptor()],
     )

--- a/workers/automation/src/jobhunter/llm.py
+++ b/workers/automation/src/jobhunter/llm.py
@@ -137,12 +137,16 @@ class LLMClient:
 
         url = f"{_GEMINI_NATIVE_BASE}/models/{self.model}:generateContent"
         params = {"temperature": temperature, "max_tokens": max_tokens}
+        # Pass the key as a header (not a URL query param) so it never lands in
+        # OTel's `http.url` span attribute and gets shipped to Langfuse.
         with llm_generation_span(model=self.model, messages=messages, params=params) as record:
             resp = self._client.post(
                 url,
                 json=payload,
-                headers={"Content-Type": "application/json"},
-                params={"key": self.api_key},
+                headers={
+                    "Content-Type": "application/json",
+                    "x-goog-api-key": self.api_key,
+                },
             )
             resp.raise_for_status()
             data = resp.json()

--- a/workers/automation/src/jobhunter/llm.py
+++ b/workers/automation/src/jobhunter/llm.py
@@ -15,6 +15,8 @@ import time
 
 import httpx
 
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
+
 log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -134,15 +136,24 @@ class LLMClient:
             payload["systemInstruction"] = {"parts": system_parts}
 
         url = f"{_GEMINI_NATIVE_BASE}/models/{self.model}:generateContent"
-        resp = self._client.post(
-            url,
-            json=payload,
-            headers={"Content-Type": "application/json"},
-            params={"key": self.api_key},
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        return data["candidates"][0]["content"]["parts"][0]["text"]
+        params = {"temperature": temperature, "max_tokens": max_tokens}
+        with llm_generation_span(model=self.model, messages=messages, params=params) as record:
+            resp = self._client.post(
+                url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                params={"key": self.api_key},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            text = data["candidates"][0]["content"]["parts"][0]["text"]
+            usage = data.get("usageMetadata") or {}
+            record(
+                text,
+                input_tokens=usage.get("promptTokenCount"),
+                output_tokens=usage.get("candidatesTokenCount"),
+            )
+            return text
 
     # -- OpenAI-compat API --------------------------------------------------
 
@@ -164,24 +175,29 @@ class LLMClient:
             "max_tokens": max_tokens,
         }
 
-        resp = self._client.post(
-            f"{self.base_url}/chat/completions",
-            json=payload,
-            headers=headers,
-        )
+        params = {"temperature": temperature, "max_tokens": max_tokens}
+        with llm_generation_span(model=self.model, messages=messages, params=params) as record:
+            resp = self._client.post(
+                f"{self.base_url}/chat/completions",
+                json=payload,
+                headers=headers,
+            )
 
-        # 403 on Gemini compat = model not available on compat layer.
-        # Raise a specific sentinel so chat() can switch to native API.
-        if resp.status_code == 403 and self._is_gemini:
-            raise _GeminiCompatForbidden(resp)
+            # 403 on Gemini compat = model not available on compat layer.
+            # Raise a specific sentinel so chat() can switch to native API.
+            if resp.status_code == 403 and self._is_gemini:
+                raise _GeminiCompatForbidden(resp)
 
-        return self._handle_compat_response(resp)
-
-    @staticmethod
-    def _handle_compat_response(resp: httpx.Response) -> str:
-        resp.raise_for_status()
-        data = resp.json()
-        return data["choices"][0]["message"]["content"]
+            resp.raise_for_status()
+            data = resp.json()
+            text = data["choices"][0]["message"]["content"]
+            usage = data.get("usage") or {}
+            record(
+                text,
+                input_tokens=usage.get("prompt_tokens"),
+                output_tokens=usage.get("completion_tokens"),
+            )
+            return text
 
     # -- public API ---------------------------------------------------------
 

--- a/workers/automation/tests/test_doctor_langfuse.py
+++ b/workers/automation/tests/test_doctor_langfuse.py
@@ -1,0 +1,71 @@
+"""Tests for the Langfuse row in ``jobhunter doctor``."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+from typer.testing import CliRunner
+
+from jobhunter.cli import app
+
+
+def _set_creds(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://example.test")
+
+
+def _stub_temporal():
+    """Pin Temporal to ``reachable`` so the test focuses on the Langfuse row."""
+    return patch(
+        "jobhunter.infrastructure.temporal.client.Client.connect",
+        side_effect=lambda *_args, **_kwargs: _async_sentinel(),
+    )
+
+
+async def _async_sentinel():
+    return object()
+
+
+def test_doctor_reports_langfuse_reachable(monkeypatch):
+    _set_creds(monkeypatch)
+    response = httpx.Response(status_code=405, request=httpx.Request("HEAD", "https://example.test"))
+
+    with _stub_temporal(), patch(
+        "jobhunter.cli.httpx.head",
+        return_value=response,
+    ):
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Langfuse" in result.output
+    assert "reachable" in result.output
+
+
+def test_doctor_reports_langfuse_missing_when_creds_absent(monkeypatch):
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+
+    with _stub_temporal():
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Langfuse" in result.output
+    assert "MISSING" in result.output
+    assert "LANGFUSE_PUBLIC_KEY" in result.output
+
+
+def test_doctor_reports_langfuse_unreachable(monkeypatch):
+    _set_creds(monkeypatch)
+
+    with _stub_temporal(), patch(
+        "jobhunter.cli.httpx.head",
+        side_effect=httpx.ConnectError("refused"),
+    ):
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Langfuse" in result.output
+    assert "unreachable" in result.output

--- a/workers/automation/tests/test_doctor_langfuse.py
+++ b/workers/automation/tests/test_doctor_langfuse.py
@@ -69,3 +69,24 @@ def test_doctor_reports_langfuse_unreachable(monkeypatch):
     assert result.exit_code == 0, result.output
     assert "Langfuse" in result.output
     assert "unreachable" in result.output
+
+
+def test_doctor_langfuse_row_when_disabled(monkeypatch):
+    """LANGFUSE_DISABLE=1 should short-circuit to a "disabled" row, no network probe."""
+    _set_creds(monkeypatch)
+    monkeypatch.setenv("LANGFUSE_DISABLE", "1")
+
+    # head() must not be called when disabled — patch to blow up if it is.
+    with _stub_temporal(), patch(
+        "jobhunter.cli.httpx.head",
+        side_effect=AssertionError("network probe must not run when disabled"),
+    ):
+        result = CliRunner().invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Langfuse" in result.output
+    assert "disabled" in result.output
+    assert "LANGFUSE_DISABLE=1" in result.output
+    # Confirm it doesn't also flag missing creds or unreachable.
+    assert "MISSING" not in result.output or "Langfuse" not in result.output.split("MISSING")[0].splitlines()[-1]
+    assert "unreachable" not in result.output

--- a/workers/automation/tests/test_llm_no_credential_leakage.py
+++ b/workers/automation/tests/test_llm_no_credential_leakage.py
@@ -1,0 +1,88 @@
+"""Regression: the Gemini API key MUST NOT appear in any exported span attribute.
+
+Originally the native Gemini path passed ``params={"key": self.api_key}`` to
+``httpx.post``. ``HTTPXClientInstrumentor`` then captured the full URL into
+``http.url`` and shipped it to Langfuse — exfiltrating the key on every call.
+
+This test wires an in-memory exporter and an instrumented ``httpx.Client`` whose
+transport is a ``MockTransport`` that serves a canned Gemini response. After one
+LLM call we walk every span attribute and assert no value contains the test
+API key substring.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
+from opentelemetry.util._once import Once
+
+_TEST_KEY = "TEST_KEY_DEADBEEFCAFE"
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """Stand up a TracerProvider piped to an in-memory exporter."""
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def test_gemini_native_path_does_not_leak_api_key(in_memory_exporter, monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", _TEST_KEY)
+
+    from jobhunter.llm import LLMClient
+
+    # Replace the LLMClient's internal httpx.Client with one we can instrument
+    # individually and whose transport is a MockTransport (so no network is hit).
+    def _gemini_response(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code=200,
+            json={
+                "candidates": [{"content": {"parts": [{"text": "ok"}]}}],
+                "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1},
+            },
+        )
+
+    client = LLMClient(
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        model="gemini-2.0-flash",
+        api_key=_TEST_KEY,
+    )
+    # Drop the production httpx.Client and install one with a MockTransport,
+    # then attach the OTel httpx instrumentor explicitly to that client so the
+    # spans the production code emits are still captured.
+    client._client.close()
+    client._client = httpx.Client(transport=httpx.MockTransport(_gemini_response))
+    HTTPXClientInstrumentor.instrument_client(client._client)
+    client._use_native_gemini = True  # force native generateContent path
+
+    try:
+        client.chat([{"role": "user", "content": "hello"}])
+    finally:
+        client.close()
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert spans, "expected at least one span (LLM generation + httpx client)"
+
+    leaks: list[tuple[str, str, str]] = []
+    for span in spans:
+        for key, value in (span.attributes or {}).items():
+            if _TEST_KEY in str(value):
+                leaks.append((span.name, key, str(value)))
+
+    assert not leaks, (
+        "API key leaked into span attributes:\n  "
+        + "\n  ".join(f"{name}.{k} = {v}" for name, k, v in leaks)
+    )

--- a/workers/automation/tests/test_llm_spans.py
+++ b/workers/automation/tests/test_llm_spans.py
@@ -1,0 +1,85 @@
+"""Tests for ``llm_generation_span`` — the Langfuse-shaped LLM span helper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """Stand up a TracerProvider piped to an in-memory exporter for assertions."""
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes or {})
+
+
+def test_llm_generation_span_sets_langfuse_attributes(in_memory_exporter):
+    from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
+
+    messages = [{"role": "user", "content": "hi"}]
+    params = {"temperature": 0.0, "max_tokens": 100}
+
+    with llm_generation_span(model="gemini-2.0-flash", messages=messages, params=params) as record:
+        record("hello world", input_tokens=5, output_tokens=2)
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = _attrs(spans[0])
+    assert attrs["langfuse.observation.type"] == "generation"
+    assert attrs["langfuse.observation.model.name"] == "gemini-2.0-flash"
+    assert json.loads(attrs["langfuse.observation.model.parameters"]) == params
+    assert json.loads(attrs["langfuse.observation.input"]) == messages
+    assert attrs["langfuse.observation.output"] == "hello world"
+    usage = json.loads(attrs["langfuse.observation.usage_details"])
+    assert usage == {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7}
+    # Mirror into GenAI semconv so Langfuse + OTel-native dashboards both work.
+    assert attrs["gen_ai.request.model"] == "gemini-2.0-flash"
+    assert attrs["gen_ai.response.model"] == "gemini-2.0-flash"
+    assert attrs["gen_ai.usage.input_tokens"] == 5
+    assert attrs["gen_ai.usage.output_tokens"] == 2
+
+
+def test_llm_generation_span_handles_unknown_tokens(in_memory_exporter):
+    from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
+
+    with llm_generation_span(model="gpt-4o-mini", messages=[], params={}) as record:
+        record("done", input_tokens=None, output_tokens=None)
+
+    spans = in_memory_exporter.get_finished_spans()
+    attrs = _attrs(spans[0])
+    assert "langfuse.observation.usage_details" not in attrs
+    assert "gen_ai.usage.input_tokens" not in attrs
+
+
+def test_llm_generation_span_records_exception(in_memory_exporter):
+    from opentelemetry.trace import StatusCode
+
+    from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
+
+    with pytest.raises(RuntimeError):
+        with llm_generation_span(model="m", messages=[], params={}):
+            raise RuntimeError("boom")
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "boom" in (spans[0].status.description or "")

--- a/workers/automation/tests/test_otel_init.py
+++ b/workers/automation/tests/test_otel_init.py
@@ -121,3 +121,36 @@ def test_shutdown_otel_resets_state(monkeypatch):
     otel_mod.shutdown_otel()
     assert otel_mod._provider is None
     assert otel_mod.is_otel_enabled() is False
+
+
+def test_init_otel_sets_resource_attributes(monkeypatch):
+    """The TracerProvider's Resource must carry the service identity Langfuse keys on."""
+    _set_creds(monkeypatch)
+    monkeypatch.setenv("JOBHUNTER_ENV", "test")
+
+    from jobhunter import __version__ as JOBHUNTER_VERSION
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    otel_mod.init_otel()
+
+    provider = otel_mod._provider
+    assert provider is not None
+    attrs = dict(provider.resource.attributes)
+    assert attrs["service.name"] == "jobhunter"
+    assert attrs["service.version"] == JOBHUNTER_VERSION
+    assert attrs["deployment.environment"] == "test"
+
+    # Reset and re-init without JOBHUNTER_ENV — defaults to "local".
+    otel_mod.shutdown_otel()
+    monkeypatch.delenv("JOBHUNTER_ENV", raising=False)
+    # Allow set_tracer_provider to succeed again.
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    otel_mod.init_otel()
+    provider = otel_mod._provider
+    assert provider is not None
+    assert dict(provider.resource.attributes)["deployment.environment"] == "local"

--- a/workers/automation/tests/test_otel_init.py
+++ b/workers/automation/tests/test_otel_init.py
@@ -1,0 +1,123 @@
+"""Tests for the OTel bootstrap that wires JobHunter into Langfuse."""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_otel_state(monkeypatch):
+    """Drop the cached provider so each test sees a fresh boot."""
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    monkeypatch.setattr(otel_mod, "_initialized", False)
+    monkeypatch.setattr(otel_mod, "_provider", None)
+    monkeypatch.setattr(otel_mod, "_exporter", None)
+    # The global TracerProvider is gated by ``_TRACER_PROVIDER_SET_ONCE`` —
+    # without resetting it between tests, the second ``set_tracer_provider``
+    # call is silently dropped and downstream spans go to the proxy tracer.
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+    yield
+    # Force shutdown so the BatchSpanProcessor thread doesn't outlive the test.
+    if otel_mod._provider is not None:
+        otel_mod.shutdown_otel()
+
+
+def _set_creds(monkeypatch):
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-test")
+    monkeypatch.setenv("LANGFUSE_BASE_URL", "https://example.test")
+
+
+def _header(exporter, name: str) -> str | None:
+    """Case-insensitive lookup against the exporter's session headers."""
+    headers = dict(exporter._session.headers)
+    for key, value in headers.items():
+        if key.lower() == name.lower():
+            return value
+    return None
+
+
+def test_init_otel_with_full_creds_configures_provider(monkeypatch):
+    _set_creds(monkeypatch)
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    otel_mod.init_otel()
+
+    assert otel_mod.is_otel_enabled() is True
+    assert otel_mod._provider is not None
+    assert otel_mod._exporter is not None
+    # Endpoint must be the documented Langfuse OTLP path.
+    assert otel_mod._exporter._endpoint.endswith("/api/public/otel/v1/traces")
+    # Authorization header must be HTTP Basic with the base64 of pk:sk.
+    expected = base64.b64encode(b"pk-test:sk-test").decode("ascii")
+    assert _header(otel_mod._exporter, "Authorization") == f"Basic {expected}"
+    assert _header(otel_mod._exporter, "x-langfuse-ingestion-version") == "4"
+
+
+def test_init_otel_is_idempotent(monkeypatch):
+    _set_creds(monkeypatch)
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    otel_mod.init_otel()
+    first_provider = otel_mod._provider
+    otel_mod.init_otel()
+    assert otel_mod._provider is first_provider
+
+
+def test_init_otel_with_missing_creds_does_not_configure(monkeypatch, caplog):
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    with caplog.at_level("WARNING"):
+        otel_mod.init_otel()
+
+    assert otel_mod.is_otel_enabled() is False
+    assert otel_mod._provider is None
+    # Warn the user so they know exports are off.
+    assert any("Langfuse" in rec.message or "LANGFUSE" in rec.message for rec in caplog.records)
+
+
+def test_init_otel_disabled_when_disable_env_set(monkeypatch, caplog):
+    _set_creds(monkeypatch)
+    monkeypatch.setenv("LANGFUSE_DISABLE", "1")
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    with caplog.at_level("INFO"):
+        otel_mod.init_otel()
+
+    assert otel_mod.is_otel_enabled() is False
+    assert otel_mod._provider is None
+
+
+def test_init_otel_warns_about_payload_export(monkeypatch, caplog):
+    _set_creds(monkeypatch)
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    with caplog.at_level("WARNING"):
+        otel_mod.init_otel()
+
+    # The user should know LLM prompts + completions are leaving the host.
+    assert any(
+        "prompts" in rec.message.lower() or "completion" in rec.message.lower()
+        for rec in caplog.records
+    )
+
+
+def test_shutdown_otel_resets_state(monkeypatch):
+    _set_creds(monkeypatch)
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    otel_mod.init_otel()
+    assert otel_mod._provider is not None
+    otel_mod.shutdown_otel()
+    assert otel_mod._provider is None
+    assert otel_mod.is_otel_enabled() is False

--- a/workers/automation/tests/test_rpc_otel.py
+++ b/workers/automation/tests/test_rpc_otel.py
@@ -1,0 +1,66 @@
+"""Tests for the JSON-RPC dispatch span emitted on every method call."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode, set_tracer_provider
+
+from jobhunter.domain.rpc.messages import JsonRpcRequest
+from jobhunter.infrastructure.rpc.server import JsonRpcServer
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def _attrs(span) -> dict:
+    return dict(span.attributes or {})
+
+
+def test_dispatch_emits_span_with_method_attributes(in_memory_exporter):
+    server = JsonRpcServer()
+    server.register("ping", lambda _params: "pong")
+
+    request = JsonRpcRequest(method="ping", params={}, id=42)
+    response = server.dispatch(request)
+
+    assert response is not None
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "rpc.ping"
+    attrs = _attrs(span)
+    assert attrs["rpc.method"] == "ping"
+    assert attrs["rpc.id"] == "42"
+    assert attrs["langfuse.trace.name"] == "ping"
+    assert attrs["langfuse.observation.type"] == "span"
+
+
+def test_dispatch_marks_error_status_on_handler_failure(in_memory_exporter):
+    server = JsonRpcServer()
+
+    def boom(_params):
+        raise RuntimeError("boom-rpc")
+
+    server.register("boom", boom)
+    server.dispatch(JsonRpcRequest(method="boom", params={}, id=1))
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "boom-rpc" in (spans[0].status.description or "")

--- a/workers/automation/tests/test_rpc_otel.py
+++ b/workers/automation/tests/test_rpc_otel.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import io
+
 import pytest
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode, set_tracer_provider
 
-from jobhunter.domain.rpc.messages import JsonRpcRequest
+from jobhunter.domain.rpc.messages import JsonRpcRequest, WorkflowStartSpec
 from jobhunter.infrastructure.rpc.server import JsonRpcServer
 
 
@@ -64,3 +66,123 @@ def test_dispatch_marks_error_status_on_handler_failure(in_memory_exporter):
     assert len(spans) == 1
     assert spans[0].status.status_code == StatusCode.ERROR
     assert "boom-rpc" in (spans[0].status.description or "")
+
+
+# --- Streaming dispatch ----------------------------------------------------
+
+
+def test_rpc_streaming_dispatch_emits_span(in_memory_exporter):
+    """A streaming-mode call must emit the same rpc.<method> span as sync."""
+    server = JsonRpcServer()
+
+    def stream(_params):
+        yield {"step": "one"}
+
+    server.register("watch", stream, mode="streaming")
+
+    stdout = io.StringIO()
+    line = '{"jsonrpc":"2.0","method":"watch","params":{},"id":7}'
+    response = server._handle_line(line, stdout)
+    assert response is not None
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "rpc.watch"
+    attrs = dict(span.attributes or {})
+    assert attrs["rpc.method"] == "watch"
+    assert attrs["rpc.id"] == "7"
+    assert attrs["langfuse.trace.name"] == "watch"
+    assert attrs["langfuse.observation.type"] == "span"
+
+
+def test_rpc_streaming_dispatch_marks_error_on_mid_stream_failure(in_memory_exporter):
+    server = JsonRpcServer()
+
+    def stream(_params):
+        yield {"ok": 1}
+        raise RuntimeError("stream-blew-up")
+
+    server.register("watch", stream, mode="streaming")
+
+    stdout = io.StringIO()
+    server._handle_line('{"jsonrpc":"2.0","method":"watch","params":{},"id":1}', stdout)
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "stream-blew-up" in (spans[0].status.description or "")
+
+
+# --- Workflow dispatch error markers ---------------------------------------
+
+
+class _FakeWorkflow:
+    pass
+
+
+def test_rpc_workflow_mode_marks_span_error_on_starter_failure(in_memory_exporter):
+    async def starter(_spec):
+        raise RuntimeError("temporal-down")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    server.register(
+        "start",
+        lambda _p: WorkflowStartSpec(workflow=_FakeWorkflow, args=()),
+        mode="workflow",
+    )
+
+    server.dispatch(JsonRpcRequest(method="start", params={}, id=1))
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "temporal-down" in (spans[0].status.description or "")
+
+
+def test_rpc_workflow_mode_marks_span_error_on_missing_starter(in_memory_exporter):
+    server = JsonRpcServer()  # no workflow_starter wired
+    server.register(
+        "start",
+        lambda _p: WorkflowStartSpec(workflow=_FakeWorkflow, args=()),
+        mode="workflow",
+    )
+
+    server.dispatch(JsonRpcRequest(method="start", params={}, id=1))
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "workflow_starter" in (spans[0].status.description or "")
+
+
+def test_rpc_workflow_mode_marks_span_error_on_handler_returning_non_spec(in_memory_exporter):
+    async def starter(_spec):  # pragma: no cover — must not be reached
+        raise AssertionError("starter must not be called")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    server.register("start", lambda _p: {"not": "a spec"}, mode="workflow")
+
+    server.dispatch(JsonRpcRequest(method="start", params={}, id=1))
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+
+
+def test_rpc_workflow_mode_marks_span_error_on_handler_raising_while_building_spec(in_memory_exporter):
+    async def starter(_spec):  # pragma: no cover
+        raise AssertionError("starter must not be called")
+
+    def handler(_params):
+        raise RuntimeError("spec-build-failed")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    server.register("start", handler, mode="workflow")
+
+    server.dispatch(JsonRpcRequest(method="start", params={}, id=1))
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code == StatusCode.ERROR
+    assert "spec-build-failed" in (spans[0].status.description or "")

--- a/workers/automation/tests/test_temporal_client.py
+++ b/workers/automation/tests/test_temporal_client.py
@@ -1,8 +1,20 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from temporalio.contrib.opentelemetry import TracingInterceptor
 
 from jobhunter.infrastructure.temporal import get_temporal_client
+
+
+def _assert_connect_call(connect_mock, *, address: str, namespace: str) -> None:
+    """Assert ``Client.connect`` was awaited with the expected args + interceptor."""
+    connect_mock.assert_awaited_once()
+    args, kwargs = connect_mock.await_args
+    assert args == (address,)
+    assert kwargs["namespace"] == namespace
+    interceptors = kwargs["interceptors"]
+    assert len(interceptors) == 1
+    assert isinstance(interceptors[0], TracingInterceptor)
 
 
 @pytest.mark.asyncio
@@ -18,7 +30,7 @@ async def test_get_temporal_client_uses_default_address_and_namespace(monkeypatc
         client = await get_temporal_client()
 
     assert client is sentinel
-    connect_mock.assert_awaited_once_with("localhost:7233", namespace="default")
+    _assert_connect_call(connect_mock, address="localhost:7233", namespace="default")
 
 
 @pytest.mark.asyncio
@@ -34,4 +46,4 @@ async def test_get_temporal_client_honours_environment(monkeypatch):
         client = await get_temporal_client()
 
     assert client is sentinel
-    connect_mock.assert_awaited_once_with("temporal.example:7777", namespace="jobhunter")
+    _assert_connect_call(connect_mock, address="temporal.example:7777", namespace="jobhunter")

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-29T18:15:39.730491Z"
+exclude-newer = "2026-04-29T23:43:49.259136Z"
 exclude-newer-span = "P8D"
 
 [[package]]
@@ -76,6 +76,95 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -94,6 +183,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
 ]
 
 [[package]]
@@ -195,6 +296,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -210,6 +323,10 @@ source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-sdk" },
     { name = "pandas" },
     { name = "playwright" },
     { name = "pypdf" },
@@ -233,6 +350,10 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "httpx", specifier = ">=0.24" },
+    { name = "opentelemetry-api", specifier = ">=1.27" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.48b0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "playwright", specifier = ">=1.40" },
     { name = "pypdf", specifier = ">=5.0" },
@@ -302,6 +423,128 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/17/196d1b92de1bd3ca1519586845c2607e4e1a8a60f442fa084b15794b449a/numpy-1.26.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8ed07a90f5450d99dad60d3799f9c03c6566709bd53b497eb9ccad9a55867f36", size = 17786475, upload-time = "2024-01-02T22:30:14.286Z" },
     { url = "https://files.pythonhosted.org/packages/3f/55/cd123e8d88a98d0bcc69a707f3dae8bfde64206040a826a030c241850014/numpy-1.26.3-cp312-cp312-win32.whl", hash = "sha256:f73497e8c38295aaa4741bdfa4fda1a5aedda5473074369eca10626835445511", size = 19999988, upload-time = "2024-01-02T22:30:47.32Z" },
     { url = "https://files.pythonhosted.org/packages/ad/11/52fbe97fd84c91105b651d25a122f8deed6d3519afb14f9771fac1c9b7de/numpy-1.26.3-cp312-cp312-win_amd64.whl", hash = "sha256:da4b0c6c699a0ad73c810736303f7fbae483bcb012e38d7eb06a5e3b432c981b", size = 15517532, upload-time = "2024-01-02T22:31:13.404Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/cb/7a418e69c7dad281803529cb4f6de1b747d802cca44c38032668690b4836/opentelemetry_instrumentation_httpx-0.62b1.tar.gz", hash = "sha256:a1fac9bcc3a6ef5996a7990563f1af0798468b2c146de535fd598369383fba7e", size = 24181, upload-time = "2026-04-24T13:22:52.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e0/eca824e9492ccec00e055bdd243aeda8eb7c5eda746d98af4d7a2d97ecf3/opentelemetry_instrumentation_httpx-0.62b1-py3-none-any.whl", hash = "sha256:88614015df451d61bc7e73f22524e6f223611f80b6caad2f6bdcbe05fa0df653", size = 17201, upload-time = "2026-04-24T13:21:58.072Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.62b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/1b/aa71b63e18d30a8384036b9937f40f7618f8030a7aa213155fb54f6f2b47/opentelemetry_util_http-0.62b1.tar.gz", hash = "sha256:adf6facbb89aef8f8bc566e2f04624942ba08a7b678b3479a91051a8f4dc70a3", size = 11393, upload-time = "2026-04-24T13:23:12.994Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/a9d9d32161c1ced61346267db4c9702da54f81ec5dc88214bc65c23f4e9d/opentelemetry_util_http-0.62b1-py3-none-any.whl", hash = "sha256:c57e8a6c19fc422c288e6074e882f506f85030b69b7376182f74f9257b9261f0", size = 9295, upload-time = "2026-04-24T13:22:28.078Z" },
 ]
 
 [[package]]
@@ -564,6 +807,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -687,4 +945,97 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/81/60c4471fce95afa5922ca09b88a25f03c93343f759aae0f31fb4412a85c7/wrapt-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:96159a0ee2b0277d44201c3b5be479a9979cf154e8c82fa5df49586a8e7679bb", size = 60666, upload-time = "2026-03-06T02:52:58.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/be/80e80e39e7cb90b006a0eaf11c73ac3a62bbfb3068469aec15cc0bc795de/wrapt-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:98ba61833a77b747901e9012072f038795de7fc77849f1faa965464f3f87ff2d", size = 61601, upload-time = "2026-03-06T02:53:00.487Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/be/d7c88cd9293c859fc74b232abdc65a229bb953997995d6912fc85af18323/wrapt-2.1.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:767c0dbbe76cae2a60dd2b235ac0c87c9cccf4898aef8062e57bead46b5f6894", size = 114057, upload-time = "2026-03-06T02:52:44.08Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/25/36c04602831a4d685d45a93b3abea61eca7fe35dab6c842d6f5d570ef94a/wrapt-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c691a6bc752c0cc4711cc0c00896fcd0f116abc253609ef64ef930032821842", size = 116099, upload-time = "2026-03-06T02:54:56.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4e/98a6eb417ef551dc277bec1253d5246b25003cf36fdf3913b65cb7657a56/wrapt-2.1.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f3b7d73012ea75aee5844de58c88f44cf62d0d62711e39da5a82824a7c4626a8", size = 112457, upload-time = "2026-03-06T02:53:52.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/a6/a6f7186a5297cad8ec53fd7578533b28f795fdf5372368c74bd7e6e9841c/wrapt-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:577dff354e7acd9d411eaf4bfe76b724c89c89c8fc9b7e127ee28c5f7bcb25b6", size = 115351, upload-time = "2026-03-06T02:53:32.684Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6f/06e66189e721dbebd5cf20e138acc4d1150288ce118462f2fcbff92d38db/wrapt-2.1.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d7b6fd105f8b24e5bd23ccf41cb1d1099796524bcc6f7fbb8fe576c44befbc9", size = 111748, upload-time = "2026-03-06T02:53:08.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/43/4808b86f499a51370fbdbdfa6cb91e9b9169e762716456471b619fca7a70/wrapt-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:866abdbf4612e0b34764922ef8b1c5668867610a718d3053d59e24a5e5fcfc15", size = 113783, upload-time = "2026-03-06T02:53:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2c/a3f28b8fa7ac2cefa01cfcaca3471f9b0460608d012b693998cd61ef43df/wrapt-2.1.2-cp311-cp311-win32.whl", hash = "sha256:5a0a0a3a882393095573344075189eb2d566e0fd205a2b6414e9997b1b800a8b", size = 57977, upload-time = "2026-03-06T02:53:27.844Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c3/2b1c7bd07a27b1db885a2fab469b707bdd35bddf30a113b4917a7e2139d2/wrapt-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:64a07a71d2730ba56f11d1a4b91f7817dc79bc134c11516b75d1921a7c6fcda1", size = 60336, upload-time = "2026-03-06T02:54:28.104Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/5c/76ece7b401b088daa6503d6264dd80f9a727df3e6042802de9a223084ea2/wrapt-2.1.2-cp311-cp311-win_arm64.whl", hash = "sha256:b89f095fe98bc12107f82a9f7d570dc83a0870291aeb6b1d7a7d35575f55d98a", size = 58756, upload-time = "2026-03-06T02:53:16.319Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary

Wires the Python automation worker into Langfuse via OpenTelemetry. Every
LLM call, every Temporal workflow + activity, and every JSON-RPC dispatch
is now captured as an OTel span and exported via OTLP/HTTP (protobuf) to
the user's Langfuse instance. Init is idempotent and degrades gracefully
when Langfuse env vars are absent — the worker keeps running, only export
is off.

## Stack context

This is **PR 8** of the Temporal + Worker Reliability stack (added on
top of the original 7-PR plan). Plan:
[docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md](docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md).

- **Base:** `worker-reliability/logs-as-artifacts` (PR 7), **not** `main`.
- PRs ahead of this in the stack: #34, #35, #36, #37, #38, #39, #40.
- Branch: `observability/langfuse-otel`.

## What's emitted

| Source | Span name | `langfuse.observation.type` | Notes |
| --- | --- | --- | --- |
| `LLMClient.chat` (compat + native Gemini paths) | `llm.<model>` | `generation` | Sets `langfuse.observation.{model.name, model.parameters, input, output, usage_details}` and the GenAI semconv attrs (`gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`). Token counts come from the OpenAI-compat `usage` block and the native Gemini `usageMetadata`. |
| Temporal workflow + activity execution | workflow / activity name | `span` (default) | Comes from `temporalio.contrib.opentelemetry.TracingInterceptor`, registered on both the **client** (`infrastructure/temporal/client.py`) and the **worker** (`infrastructure/temporal/worker.py`) so trace context propagates from the JSON-RPC dispatch span into the workflow run. |
| `JsonRpcServer.dispatch` | `rpc.<method>` | `span` | Sets `rpc.method`, `rpc.id`, `langfuse.trace.name=<method>`. Handler exceptions and method-not-found both flip the span to `StatusCode.ERROR`. |

The OTLP endpoint is `${LANGFUSE_BASE_URL}/api/public/otel/v1/traces`,
authentication is HTTP Basic over `base64(LANGFUSE_PUBLIC_KEY:LANGFUSE_SECRET_KEY)`,
and the `x-langfuse-ingestion-version: 4` fast-preview header is also
sent so traces show up in the Langfuse UI without ingestion lag.

## Behavior change

**Every LLM prompt and completion will be exported to the configured
Langfuse instance** when the credentials are present. `init_otel()` logs
a `WARNING` on startup so the user sees this before any LLM stage runs.
Opt-out paths:

- Unset any of `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` /
  `LANGFUSE_BASE_URL` — init logs a one-line warning and returns.
- Set `LANGFUSE_DISABLE=1` (or `true`) — init skips configuration even
  when credentials are present.

## What's NOT in this PR

- TS / web instrumentation (`apps/api`, `apps/web`, `packages/`).
- Distributed-trace propagation across the TS↔Python JSON-RPC boundary
  (would need TS to emit OTel context too — future PR).
- Dashboards / alerts / SLOs in the Langfuse UI.
- Prompt-versioning via Langfuse prompts.
- Cost calculation overrides — Langfuse computes cost from the token
  counts via its model registry.

## How to test locally

1. Set Langfuse credentials in `~/.jobhunter/.env`:

   ```env
   LANGFUSE_PUBLIC_KEY="pk-lf-..."
   LANGFUSE_SECRET_KEY="sk-lf-..."
   LANGFUSE_BASE_URL="https://us.cloud.langfuse.com"
   ```

2. Confirm the doctor row reports reachable:

   ```bash
   uv --project workers/automation run jobhunter doctor
   # ...
   # Langfuse  OK  reachable
   ```

3. Run any LLM-using command and check the Langfuse UI for the trace,
   for example:

   ```bash
   uv --project workers/automation run jobhunter score --limit 1
   ```

   Each `LLMClient.chat` call shows up in Langfuse as a generation with
   the prompt + completion + token usage attached. Workflow runs (when
   Temporal is up) appear with their activities as child spans.

4. Smoke-test the export path directly:

   ```bash
   uv --project workers/automation run python -c "
   from jobhunter.config import load_env; load_env()
   from jobhunter.infrastructure.observability import init_otel, shutdown_otel
   from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
   init_otel()
   with llm_generation_span(model='test', messages=[{'role':'user','content':'hi'}], params={}) as record:
       record('pong', input_tokens=2, output_tokens=1)
   shutdown_otel()
   "
   ```

   Confirms `POST /api/public/otel/v1/traces 200` against the Langfuse
   ingest endpoint.

## Verification

| Command | Result |
| --- | --- |
| `uv --project workers/automation sync` | OK (4 OTel packages installed) |
| `uv --project workers/automation run --extra dev pytest -q` | **668 passed**, 3 noise warnings |
| `uv --project workers/automation run --extra dev ruff check .` | **All checks passed** |
| `pnpm api:check && pnpm api:test` | check OK, **66/66 tests passed** |
| `pnpm -r check` | all 6 workspaces OK |
| `git diff --check` | clean |
| Live: `jobhunter doctor` with Langfuse env | `Langfuse  OK  reachable` |
| Live: `llm_generation_span` smoke export | `POST /api/public/otel/v1/traces HTTP/1.1 200` |

QA: skipped — automation/observability only, no UI surface change.