### PR TITLE
fix: Gemini structured outputs + bug-hunt sweep across the post-Temporal stack

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -256,6 +256,18 @@ function mapCommandToRpc(command: ActionCommandPayload): RpcCall | null {
   if (command.action === "apply") {
     return { method: "apply", params: applyRpcParams(command) };
   }
+  if (command.action === "cancel") {
+    // PR 3 added the cancel_run JSON-RPC method on the worker side; without
+    // this branch the cancel route only writes a StageCanceled event to
+    // SQLite and the running Temporal workflow keeps polling. Map the
+    // command's runId (the workflow id) into the worker call so the
+    // workflow actually receives a cancellation signal.
+    if (!command.runId) return null;
+    return {
+      method: "cancel_run",
+      params: { tenantId: "local", runId: command.runId },
+    };
+  }
   return null;
 }
 

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -841,7 +841,10 @@ function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {
     jobKey: row.job_id,
     title: row.job_title || "Untitled",
     company: row.job_employer || "Unknown company",
-    status: row.status || "unknown",
+    // Mirror listWorkflowRuns: ``apply_run_projections`` rows can carry
+    // raw legacy strings ("finished", "submitted", etc.); normalize so
+    // dashboard.applyRuns and /v1/workflow-runs agree on the same row.
+    status: normalizeWorkflowRunStatus(row.status),
     dryRun: Boolean(row.dry_run),
     startedAt: row.started_at,
   }));

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -243,7 +243,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!body) {
       return undefined;
     }
-    return withWritableDb(reply, options.dbPath, (db) => {
+    const writeOutcome = await withWritableDb(reply, options.dbPath, (db) => {
       const canceled = cancelJobAction(db, decodeRouteParam(request.params.jobKey), body.runId ?? "");
       const command: ActionCommandPayload = {
         action: "cancel" as const,
@@ -252,8 +252,33 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       if (body.runId) {
         command.runId = body.runId;
       }
-      return buildActionResponse(command, { status: "cancel_requested" }, { stage: canceled.stage });
+      return { command, stage: canceled.stage };
     });
+    if ("ok" in writeOutcome) {
+      return writeOutcome;
+    }
+    // Forward the cancel to the worker so the running Temporal workflow
+    // (started by PR 3's mode="workflow" cut-over) actually receives a
+    // cancellation signal. Without this, the SQLite event-flip succeeds
+    // but the workflow keeps polling Chrome and the stage row drifts
+    // back to running on the next worker_loop cycle.
+    const { command: cancelCommand, stage: cancelStage } = writeOutcome;
+    const runId = cancelCommand.runId;
+    if (runId) {
+      try {
+        await actionDispatcher(cancelCommand, actionContext);
+      } catch (err) {
+        request.log?.warn(
+          { err, jobKey: cancelCommand.jobKey, runId },
+          "cancel route: worker dispatch failed; SQLite cancel event still recorded",
+        );
+      }
+    }
+    return buildActionResponse(
+      cancelCommand,
+      { status: "cancel_requested" },
+      { stage: cancelStage },
+    );
   });
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/actions/mark-applied", async (request, reply) => {

--- a/apps/api/test/qa-seed.ts
+++ b/apps/api/test/qa-seed.ts
@@ -372,13 +372,14 @@ function insertArtifact(db: Database.Database, jobUrl: string, type: string, fil
 }
 
 function insertEvent(db: Database.Database, jobUrl: string, stage: string, level: string, message: string): void {
-  db.prepare("INSERT INTO job_events (job_url, stage, level, message, occurred_at) VALUES (?, ?, ?, ?, ?)").run(
-    jobUrl,
-    stage,
-    level,
-    message,
-    QA_NOW,
-  );
+  // ``event_type`` defaults to '' in the schema, but the SSE writer
+  // (``apps/api/src/event-stream.ts``) skips rows where the column is
+  // empty — without this column being set, every QA-seeded event is
+  // silently dropped from /v1/events/stream and any test that depends
+  // on the SSE pipeline against qa-seed data sees nothing.
+  db.prepare(
+    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(jobUrl, stage, "QaInfo", level, message, QA_NOW);
 }
 
 function artifactStage(type: string): string {

--- a/apps/web/src/contexts/apply/components/CancelApplyButton.tsx
+++ b/apps/web/src/contexts/apply/components/CancelApplyButton.tsx
@@ -1,13 +1,20 @@
 import type { JSX } from "react";
 
+import { useApplyRunsListQuery } from "../../operations/hooks/useApplyRunsListQuery.js";
 import { useCancelApplyMutation } from "../hooks/useCancelApplyMutation.js";
 
 export interface CancelApplyButtonProps {
   jobId: string;
+  /** Override the auto-detected active run id. If omitted, the button looks
+   *  up the most recently started non-terminal apply run for ``jobId`` and
+   *  forwards its runId to the worker — without a runId the cancel is
+   *  ignored by the Temporal cut-over and the workflow keeps polling. */
   runId?: string;
   className?: string;
   label?: string;
 }
+
+const _ACTIVE_STATUSES = new Set(["starting", "in_progress", "queued", "running"]);
 
 export function CancelApplyButton({
   jobId,
@@ -17,12 +24,23 @@ export function CancelApplyButton({
 }: CancelApplyButtonProps): JSX.Element {
   const cancelApply = useCancelApplyMutation();
   const isPending = cancelApply.isPending;
+  // Auto-detect the active run when the caller didn't pass one. Without
+  // this, clicking cancel only writes a SQLite event — the running
+  // Temporal workflow keeps polling Chrome and the stage row drifts
+  // back to running on the next worker_loop cycle.
+  const { data: runs } = useApplyRunsListQuery();
+  const detectedRunId = runId
+    ?? runs?.find(
+      (run) => run.jobKey === jobId && _ACTIVE_STATUSES.has(run.status),
+    )?.runId;
   return (
     <button
       type="button"
       className={className}
       disabled={isPending}
-      onClick={() => cancelApply.mutate(runId ? { jobId, runId } : { jobId })}
+      onClick={() =>
+        cancelApply.mutate(detectedRunId ? { jobId, runId: detectedRunId } : { jobId })
+      }
     >
       {isPending ? "cancelling" : label}
     </button>

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -180,11 +180,18 @@ export const ApplyParamsSchema = z
   .strict();
 export type ApplyParams = z.infer<typeof ApplyParamsSchema>;
 
-export const ApplyResultSchema = z
-  .object({
-    runId: z.string(),
-  })
-  .strict();
+// PR 3 cut over to ``mode="workflow"``; the worker now returns three IDs:
+// ``runId`` (kept as the canonical handle so the existing TS contract and
+// SSE / dashboard wiring stays compatible) plus ``workflowId`` and
+// ``firstExecutionRunId``. ``workflowId`` is a duplicate of ``runId`` for
+// the apply path today but the field stays for forward compatibility with
+// future workflows whose run id and workflow id diverge. NOT ``.strict()``
+// because future Temporal versions may add more identifiers.
+export const ApplyResultSchema = z.object({
+  runId: z.string(),
+  workflowId: z.string().optional(),
+  firstExecutionRunId: z.string().optional(),
+});
 export type ApplyResult = z.infer<typeof ApplyResultSchema>;
 
 /* --- cooperative workflow cancellation ----------------------------------- */

--- a/workers/automation/src/jobhunter/apply/activities.py
+++ b/workers/automation/src/jobhunter/apply/activities.py
@@ -77,27 +77,53 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
     apply_task = loop.run_in_executor(None, _run_apply)
 
     try:
-        while True:
+        try:
+            while True:
+                try:
+                    applied, failed = await asyncio.wait_for(
+                        asyncio.shield(apply_task), timeout=15.0
+                    )
+                    break
+                except asyncio.TimeoutError:
+                    activity.heartbeat("apply still running")
+        except asyncio.CancelledError:
+            # Signal the launcher's run-forever loop to stop so the
+            # executor thread releases Chrome / DB connections instead of
+            # leaking past activity cancellation. ``asyncio.shield`` keeps
+            # the task running otherwise — Temporal would think the
+            # activity died but the worker_loop polls on, draining tokens.
+            activity.logger.info("apply_activity cancelled — signalling launcher stop")
             try:
-                applied, failed = await asyncio.wait_for(asyncio.shield(apply_task), timeout=15.0)
-                break
-            except asyncio.TimeoutError:
-                activity.heartbeat("apply still running")
-    except asyncio.CancelledError:
-        activity.logger.info("apply_activity cancelled")
-        raise
-    except LookupError as exc:
-        # Missing job URL or other lookup misses are operator errors; do not
-        # retry — surface them immediately to the workflow.
-        raise ApplicationError(str(exc), type=type(exc).__name__, non_retryable=True) from exc
+                from jobhunter.apply.launcher import _stop_event
 
-    status = "ok" if failed == 0 else "failed"
-    return ApplyActivityOutput(
-        status=status,
-        applied=int(applied),
-        failed=int(failed),
-        error=None,
-    )
+                _stop_event.set()
+            except Exception:  # noqa: BLE001 — never let cleanup mask the cancel
+                activity.logger.exception(
+                    "apply_activity: failed to set launcher _stop_event during cancel"
+                )
+            raise
+        except LookupError as exc:
+            # Missing job URL or other lookup misses are operator errors;
+            # do not retry — surface them immediately to the workflow.
+            raise ApplicationError(
+                str(exc), type=type(exc).__name__, non_retryable=True
+            ) from exc
+
+        status = "ok" if failed == 0 else "failed"
+        return ApplyActivityOutput(
+            status=status,
+            applied=int(applied),
+            failed=int(failed),
+            error=None,
+        )
+    finally:
+        # Final heartbeat so a future heartbeat-timeout regression
+        # (post-iteration delay > heartbeat_timeout) doesn't surface as
+        # a phantom dead activity.
+        try:
+            activity.heartbeat("apply done")
+        except Exception:  # noqa: BLE001 — heartbeat outside activity ctx is fine
+            pass
 
 
 # Re-exported for the registry; activity decorator metadata is preserved.

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -672,7 +672,7 @@ def reset_failed() -> int:
             )
             count += 1
         except Exception as exc:  # noqa: BLE001 — keep batch reset alive
-            log.warning("reset_failed: skipping %s — %s", url, exc)
+            logger.warning("reset_failed: skipping %s — %s", url, exc)
     conn.commit()
     return count
 

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -427,8 +427,14 @@ def mark_result(
     dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
 
     if status == "applied":
+        # Launcher owns lock-release policy: if a competing process raced
+        # the row out of `running` (orphan rescue, mark-skipped, etc.) we
+        # still want to record this completion. Skip canonical validation;
+        # the launcher is the writer.
         set_stage_state(
-            conn, url, "apply", "succeeded", finished_at=now, duration_ms=duration_ms
+            conn, url, "apply", "succeeded",
+            finished_at=now, duration_ms=duration_ms,
+            validate_transition=False,
         )
         record_job_event(
             conn,
@@ -479,6 +485,8 @@ def mark_result(
         )
     else:
         reason = (error or "unknown").strip()
+        # Same launcher-policy reasoning as the applied branch above:
+        # the writer is the launcher, transitions are runner-owned.
         set_stage_state(
             conn,
             url,
@@ -490,6 +498,7 @@ def mark_result(
             error_message=reason,
             retryable=not permanent,
             next_action=f"jobhunter apply --url {url}" if not permanent else None,
+            validate_transition=False,
         )
         record_job_event(
             conn,
@@ -642,17 +651,28 @@ def reset_failed() -> int:
         if _has_succeeded_apply(conn, url):
             continue
         ensure_job_stage_rows(conn, url)
-        set_stage_state(
-            conn,
-            url,
-            "apply",
-            "pending",
-            attempt_count=0,
-            error_code=None,
-            error_message=None,
-            next_action=f"jobhunter apply --url {url}",
-        )
-        count += 1
+        # Per-row try/except so one race-induced failure (e.g., another
+        # worker flipped the row to ``running`` between the SELECT and
+        # this write) doesn't strand every subsequent row in the batch
+        # without a commit. Admin-initiated rewind so the runner owns the
+        # transition policy: validate_transition=False bypasses the
+        # canonical state-machine table (Failed -> Pending is fine but
+        # Running -> Pending is not).
+        try:
+            set_stage_state(
+                conn,
+                url,
+                "apply",
+                "pending",
+                attempt_count=0,
+                error_code=None,
+                error_message=None,
+                next_action=f"jobhunter apply --url {url}",
+                validate_transition=False,
+            )
+            count += 1
+        except Exception as exc:  # noqa: BLE001 — keep batch reset alive
+            log.warning("reset_failed: skipping %s — %s", url, exc)
     conn.commit()
     return count
 

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -778,6 +778,10 @@ def apply(
         raise typer.Exit(code=1)
 
     # Check 3: Tailored resumes exist (skip for --gen with --url)
+    # ``ready`` is the count of jobs eligible for apply; default to 0 so the
+    # downstream ``effective_limit = ready`` reference is unambiguous to
+    # static analysers when the gen+url shortcut early-returns.
+    ready: int = 0
     if not (gen and url):
         conn = get_connection()
         ready = conn.execute(
@@ -1254,8 +1258,15 @@ def doctor() -> None:
         results.append(("searches.yaml", warn_mark, "Will use example config — run 'jobhunter init'"))
 
     # jobspy (discovery dep installed separately)
+    # The package is intentionally NOT in pyproject.toml so the worker venv
+    # stays slim — it ships only when the user opts into LinkedIn / Indeed
+    # discovery. ``importlib.import_module`` here keeps pyright from
+    # flagging the conditional import as missing on machines that haven't
+    # installed it yet.
     try:
-        import jobspy  # noqa: F401
+        import importlib
+
+        importlib.import_module("jobspy")
         results.append(("python-jobspy", ok_mark, "Job board scraping available"))
     except ImportError:
         results.append(("python-jobspy", warn_mark,

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1149,6 +1149,7 @@ def rpc() -> None:
     ``run_stage``, ``apply``, ``profile_import``.
     """
     _bootstrap()
+    from jobhunter.infrastructure.observability import shutdown_otel
     from jobhunter.infrastructure.rpc.handlers import register_default_handlers
     from jobhunter.infrastructure.rpc.server import JsonRpcServer
     from jobhunter.infrastructure.rpc.workflow_starter import (
@@ -1158,7 +1159,13 @@ def rpc() -> None:
 
     server = JsonRpcServer(workflow_starter=default_workflow_starter)
     register_default_handlers(server, canceler=default_workflow_canceler)
-    server.serve()
+    try:
+        server.serve()
+    finally:
+        # Flush queued OTel spans before stdin EOF kills the process —
+        # without this the BatchSpanProcessor drops in-flight rpc.<method>
+        # spans and Langfuse loses the JSON-RPC trace tail.
+        shutdown_otel()
 
 
 @app.command()

--- a/workers/automation/src/jobhunter/discovery/activities.py
+++ b/workers/automation/src/jobhunter/discovery/activities.py
@@ -31,12 +31,18 @@ class DiscoverActivityOutput:
 @activity.defn(name="discover")
 async def discover_activity(payload: DiscoverActivityInput) -> DiscoverActivityOutput:
     """Run the discovery stage via ``run_pipeline``."""
-    activity.heartbeat("discover starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["discover"],
-        workers=payload.workers,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(stages=["discover"], workers=payload.workers)
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="discover starting",
+        progress_message="discover still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})

--- a/workers/automation/src/jobhunter/domain/materials/services.py
+++ b/workers/automation/src/jobhunter/domain/materials/services.py
@@ -187,6 +187,13 @@ def _validate_master_json_fields(
     if errors:
         return ValidationResult.failure(tuple(errors), warnings=tuple(warnings))
 
+    # ``errors`` was empty so the isinstance/non-empty guards above already
+    # established that experience_updates and skill_updates are real lists.
+    # Narrow the types explicitly so static analysers don't flag the
+    # iteration sites below as "object of type None is not iterable".
+    assert isinstance(experience_updates, list)
+    assert isinstance(skill_updates, list)
+
     all_experience_ids = {entry.get("id") for entry in get_experience_entries(profile)}
     required_experience_ids = set(get_required_experience_entry_ids(profile)) & all_experience_ids
     required_skill_ids = set(get_required_skill_category_ids(profile))

--- a/workers/automation/src/jobhunter/domain/pipeline/state_machine.py
+++ b/workers/automation/src/jobhunter/domain/pipeline/state_machine.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto
+from typing import Callable
 
 from jobhunter.domain.pipeline_types import (
     Blocked,
@@ -195,8 +196,13 @@ def _stale_to_pending(current: Stale, **kwargs) -> Pending:
     )
 
 
-# Dispatch table keyed by (current_kind, trigger).
-_HANDLERS: dict[tuple[str, StageTransition], object] = {
+# Dispatch table keyed by (current_kind, trigger). Each handler is an
+# ``(StageState, **kwargs) -> StageState`` callable; the type ignore on the
+# row signatures is acceptable here because the dispatch is value-based and
+# the handlers themselves enforce the input ``StageState`` subclass at call
+# time via positional typing.
+_Handler = Callable[..., StageState]
+_HANDLERS: dict[tuple[str, StageTransition], _Handler] = {
     # Row 1:  Pending  -> Queued   (Enqueue)
     ("Pending", StageTransition.Enqueue): _pending_to_queued,
     # Row 2:  Pending  -> Running  (Start)

--- a/workers/automation/src/jobhunter/domain/ports/llm.py
+++ b/workers/automation/src/jobhunter/domain/ports/llm.py
@@ -48,6 +48,8 @@ class LlmPort(Protocol):
         model: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        response_schema: dict | None = None,
+        thinking_budget: int | None = None,
     ) -> str:
         """Send a chat completion and return the assistant's text reply.
 
@@ -55,6 +57,33 @@ class LlmPort(Protocol):
         "use the adapter's default for this tenant". Temperature/max_tokens
         are passed through to the provider; ``None`` means "use the
         provider default".
+
+        ``response_schema`` enables structured outputs — providers that
+        support it return a JSON document conforming to the schema.
+        Use :meth:`chat_json` for the parsed-dict convenience.
+
+        ``thinking_budget`` (Gemini-only) caps internal reasoning tokens.
+        Set to ``0`` to skip thinking entirely on Gemini 3.x preview models
+        whose default budget can swallow the entire ``max_tokens`` allotment
+        before any visible content is produced.
+        """
+        ...
+
+    def chat_json(
+        self,
+        messages: list[LlmMessage],
+        *,
+        response_schema: dict,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        thinking_budget: int | None = None,
+    ) -> dict:
+        """Like :meth:`chat` but returns a parsed JSON dict.
+
+        ``response_schema`` is required — without it the provider has no
+        structured-output contract and the call MUST fail at the adapter
+        boundary rather than silently returning free text.
         """
         ...
 

--- a/workers/automation/src/jobhunter/domain/scoring/services.py
+++ b/workers/automation/src/jobhunter/domain/scoring/services.py
@@ -8,20 +8,24 @@ flow in ``pipeline.py``.
 
 Two services live here:
 
-  ``ScoreParser``        — turns the LLM's free-text ``SCORE/KEYWORDS/REASONING``
-                           response into the value objects required by
-                           ``JobScore``. Failures are signalled via the
-                           ``ok`` flag on the returned ``ScoreParseResult``
-                           rather than exceptions, because the caller wants
-                           to record an error event but keep going.
+  ``ScoreParser``        — turns the LLM's structured-output JSON payload
+                           into the value objects required by ``JobScore``.
+                           The LLM is invoked with a JSON schema (see
+                           ``SCORE_SCHEMA`` in ``use_cases``); the parser
+                           validates the dict shape and clamps invariants
+                           the LLM violated. Failures are signalled via
+                           the ``ok`` flag on the returned
+                           ``ScoreParseResult`` rather than exceptions —
+                           the caller wants to record an error event but
+                           keep going.
   ``EligibilityChecker`` — gates downstream tailoring per
                            ``ScoringCriteria.min_fit_score``.
 """
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
+from typing import Any
 
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
@@ -38,13 +42,13 @@ from jobhunter.domain.scoring.value_objects import (
 
 @dataclass(frozen=True)
 class ScoreParseResult:
-    """Outcome of ``ScoreParser.parse``.
+    """Outcome of ``ScoreParser.parse_json``.
 
     When ``ok`` is True, ``fit_score``, ``breakdown``, and ``keywords`` are
     populated with the parsed values. When ``ok`` is False, ``fit_score``
     is ``None`` and ``error`` carries a human-readable reason; the
-    breakdown still preserves the raw response so the caller can persist it
-    as ``reasoning`` for forensic inspection.
+    breakdown still preserves whatever rationale arrived (or a stringified
+    payload) so the caller can persist it for forensic inspection.
     """
 
     ok: bool
@@ -55,123 +59,73 @@ class ScoreParseResult:
 
 
 class ScoreParser:
-    """Parses the canonical ``SCORE/KEYWORDS/REASONING`` LLM response."""
+    """Parses a structured-output JSON payload from ``LlmPort.chat_json``.
 
-    # The legacy prompt format used in ``scoring/scorer.py``:
-    #   SCORE: 8
-    #   KEYWORDS: python, fastapi, postgres
-    #   REASONING: ...
-    #
-    # The "between colon and content" whitespace is ``[ \t]*`` rather than
-    # ``\s*`` so the regex doesn't greedily consume a trailing newline and
-    # accidentally absorb the next line's content. Without this, an empty
-    # ``KEYWORDS:`` line followed by ``REASONING: …`` would have the
-    # parser capture "REASONING: …" as the keywords list.
-    _SCORE_LINE = re.compile(r"^[ \t]*SCORE[ \t]*:[ \t]*(.*)$", re.IGNORECASE | re.MULTILINE)
-    _KEYWORDS_LINE = re.compile(r"^[ \t]*KEYWORDS[ \t]*:[ \t]*(.*)$", re.IGNORECASE | re.MULTILINE)
-    _REASONING_LINE = re.compile(
-        r"^[ \t]*REASONING[ \t]*:[ \t]*(.*)$",
-        re.IGNORECASE | re.MULTILINE | re.DOTALL,
-    )
-    _DIGIT = re.compile(r"\d+")
+    The schema landed by the structured-outputs cutover (see
+    ``use_cases.SCORE_SCHEMA``) is::
 
-    def parse(self, response: str) -> ScoreParseResult:
-        """Parse a raw LLM response into ``FitScore``/``ScoreBreakdown``/``MatchedKeywords``.
+        {
+          "score":          int 1..10,
+          "technical_fit":  int 0..10,
+          "experience_fit": int 0..10,
+          "role_fit":       int 0..10,
+          "keywords":       [str, ...]   (≥1 entry),
+          "reasoning":      str
+        }
 
-        Returns ``ok=False`` when the score line is missing, the integer
-        is out of range, or the LLM produced no keywords. In failure
-        cases the breakdown still carries the raw response as
-        ``reasoning`` so the caller can persist it for diagnosis.
+    Invariants the parser still enforces (because providers occasionally
+    drift on ``response_format=json_schema``):
 
-        Component dimensions in ``ScoreBreakdown``
-        (``technical_fit``/``experience_fit``/``role_fit``) are left at
-        their default zero values: the legacy
-        ``SCORE/KEYWORDS/REASONING`` prompt the worker still emits does
-        not separate the score by dimension. The typed fields exist as a
-        forward seam for the structured-output prompt cutover; once that
-        lands, this parser will populate them and the keywords-required
-        invariant tightens further. (Round-1 review M2.)
-        """
-        text = response or ""
-        score_match = self._SCORE_LINE.search(text)
-        keywords_match = self._KEYWORDS_LINE.search(text)
-        reasoning_match = self._REASONING_LINE.search(text)
+      * ``score`` is an int in [1, 10] — anything else flips ``ok=False``.
+      * Component dimensions clamp into [0, 10] silently; out-of-range
+        values are recorded as parse-error reasoning rather than persisted.
+      * ``keywords`` must contain at least one non-empty entry; the
+        legacy ``["legacy"]`` sentinel is reserved for backfilled rows
+        and is never produced by the structured-output path.
+    """
 
-        reasoning = (
-            reasoning_match.group(1).strip()
-            if reasoning_match
-            else text.strip()
-        )
-        # Empty / missing keywords need a sentinel because
-        # ``MatchedKeywords`` enforces a non-empty invariant (round-1
-        # review M1). On a successful SCORE we still flag the absence as
-        # a parse failure below — the ``ok=False`` branch is what
-        # callers use to decide whether to persist the score at all.
-        keywords_csv = keywords_match.group(1).strip() if keywords_match else ""
-        keywords = MatchedKeywords.from_csv(keywords_csv)
-        keywords_present = bool(keywords_csv)
-
-        if not score_match:
+    def parse_json(self, payload: Any) -> ScoreParseResult:
+        """Parse the structured-output payload into the scoring value objects."""
+        if not isinstance(payload, dict):
             return ScoreParseResult(
                 ok=False,
                 fit_score=None,
-                breakdown=ScoreBreakdown(reasoning=reasoning),
-                keywords=keywords,
-                error="LLM response missing SCORE: line",
+                breakdown=ScoreBreakdown(reasoning=str(payload)[:2000]),
+                keywords=MatchedKeywords(),
+                error=f"LLM payload was {type(payload).__name__}, expected dict",
             )
 
-        digit_match = self._DIGIT.search(score_match.group(1))
-        if not digit_match:
-            return ScoreParseResult(
-                ok=False,
-                fit_score=None,
-                breakdown=ScoreBreakdown(reasoning=reasoning),
-                keywords=keywords,
-                error="LLM SCORE: line had no integer",
-            )
+        reasoning = str(payload.get("reasoning") or "").strip()
+        keywords_raw = payload.get("keywords") or []
+        keywords = MatchedKeywords.from_iterable(keywords_raw)
+        keywords_present = bool(keywords_raw)
 
-        try:
-            value = int(digit_match.group())
-        except ValueError:
-            return ScoreParseResult(
-                ok=False,
-                fit_score=None,
-                breakdown=ScoreBreakdown(reasoning=reasoning),
-                keywords=keywords,
-                error="LLM SCORE: integer parse failed",
-            )
-
-        # The legacy scorer clamped 0/11+ silently; we treat clamped values
-        # as parse failures and return ok=False so the caller logs an
-        # actual error rather than silently downgrading. Values inside
-        # [1, 10] are accepted directly.
-        fit_score = FitScore.from_optional(value)
+        score_raw = payload.get("score")
+        fit_score = FitScore.from_optional(score_raw)
         if fit_score is None:
             return ScoreParseResult(
                 ok=False,
                 fit_score=None,
-                breakdown=ScoreBreakdown(reasoning=reasoning),
+                breakdown=ScoreBreakdown(reasoning=reasoning or str(payload)[:2000]),
                 keywords=keywords,
-                error=f"SCORE {value} outside [1, 10]",
+                error=f"score {score_raw!r} missing or outside [1, 10]",
             )
 
-        # Round-1 review M1: a successful SCORE with no KEYWORDS line is
-        # incomplete by §4.4 — a job's score must carry the ATS keywords
-        # the LLM matched. The aggregate would still construct (the
-        # keywords field falls back to the ``["legacy"]`` sentinel), but
-        # that sentinel is reserved for backfilled rows; live scoring
-        # MUST surface the failure so the operator sees the malformed
-        # response.
         if not keywords_present:
             return ScoreParseResult(
                 ok=False,
                 fit_score=None,
-                breakdown=ScoreBreakdown(reasoning=reasoning),
+                breakdown=ScoreBreakdown(reasoning=reasoning or str(payload)[:2000]),
                 keywords=keywords,
-                error="LLM response missing KEYWORDS: line",
+                error="LLM payload missing 'keywords' (required by schema)",
             )
 
-        breakdown = ScoreBreakdown(reasoning=reasoning)
+        breakdown = ScoreBreakdown(
+            technical_fit=_clamp_dim(payload.get("technical_fit")),
+            experience_fit=_clamp_dim(payload.get("experience_fit")),
+            role_fit=_clamp_dim(payload.get("role_fit")),
+            reasoning=reasoning,
+        )
         return ScoreParseResult(
             ok=True,
             fit_score=fit_score,
@@ -179,6 +133,25 @@ class ScoreParser:
             keywords=keywords,
             error="",
         )
+
+
+def _clamp_dim(value: Any) -> int:
+    """Clamp a single component dimension into ``[0, 10]``.
+
+    Out-of-range / non-integer values become 0 rather than raising — the
+    overall ``ScoreParseResult.ok`` flag is owned by the score field, and
+    we'd rather persist a partially-typed breakdown than reject the row
+    over a single bad dimension.
+    """
+    try:
+        ivalue = int(value) if value is not None else 0
+    except (TypeError, ValueError):
+        return 0
+    if ivalue < 0:
+        return 0
+    if ivalue > 10:
+        return 10
+    return ivalue
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -57,23 +57,66 @@ log = logging.getLogger(__name__)
 
 SCORE_PROMPT = """You are a job fit evaluator. Given a candidate's resume and a job description, score how well the candidate fits the role.
 
-SCORING CRITERIA:
+SCORING CRITERIA (overall `score`, 1..10):
 - 9-10: Perfect match. Candidate has direct experience in nearly all required skills and qualifications.
 - 7-8: Strong match. Candidate has most required skills, minor gaps easily bridged.
 - 5-6: Moderate match. Candidate has some relevant skills but missing key requirements.
 - 3-4: Weak match. Significant skill gaps, would need substantial ramp-up.
 - 1-2: Poor match. Completely different field or experience level.
 
-IMPORTANT FACTORS:
-- Weight technical skills heavily (programming languages, frameworks, tools)
-- Consider transferable experience (automation, scripting, API work)
-- Factor in the candidate's project experience
-- Be realistic about experience level vs. job requirements (years of experience, seniority)
+DIMENSION SCORES (0..10 each — be strict, do not anchor on the overall score):
+- `technical_fit`: alignment of programming languages, frameworks, tools, and platforms.
+- `experience_fit`: alignment of years / seniority level / domain depth.
+- `role_fit`: alignment of role responsibilities and the candidate's recent role focus.
 
-RESPOND IN EXACTLY THIS FORMAT (no other text):
-SCORE: [1-10]
-KEYWORDS: [comma-separated ATS keywords from the job description that match or could match the candidate]
-REASONING: [2-3 sentences explaining the score]"""
+KEYWORDS: list ATS keywords from the job description that match or could match the candidate. At least one keyword is required.
+
+REASONING: 2-3 sentence justification.
+
+Respond as a JSON object conforming to the provided schema. Do not wrap the JSON in markdown fences and do not include any prose outside the JSON object."""
+
+
+SCORE_SCHEMA: dict = {
+    "title": "JobFitScore",
+    "type": "object",
+    "properties": {
+        "score": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Overall fit score 1..10",
+        },
+        "technical_fit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "description": "Technical skill / tooling alignment 0..10",
+        },
+        "experience_fit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "description": "Years / seniority / domain depth alignment 0..10",
+        },
+        "role_fit": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "description": "Role responsibility alignment 0..10",
+        },
+        "keywords": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "description": "ATS keywords from the job that overlap with the candidate",
+        },
+        "reasoning": {
+            "type": "string",
+            "description": "2-3 sentence justification",
+        },
+    },
+    "required": ["score", "technical_fit", "experience_fit", "role_fit", "keywords", "reasoning"],
+}
 
 
 def _utc_now() -> str:
@@ -256,8 +299,17 @@ class ScoreJobUseCase:
                 ),
             ),
         ]
+        # Structured outputs: the LLM gateway returns a JSON object that
+        # already conforms to SCORE_SCHEMA. max_tokens is generous because
+        # Gemini 3.x preview models spend invisible tokens on internal
+        # reasoning before emitting the schema fill.
         try:
-            response = self._llm.chat(messages, max_tokens=512, temperature=0.2)
+            payload = self._llm.chat_json(
+                messages,
+                response_schema=SCORE_SCHEMA,
+                max_tokens=4096,
+                temperature=0.2,
+            )
         except Exception as exc:  # noqa: BLE001 — surface as a parse failure to the caller
             log.error("LLM error scoring job %r: %s", job.get("title", "?"), exc)
             # Sentinel keyword keeps the ``MatchedKeywords`` non-empty
@@ -271,7 +323,7 @@ class ScoreJobUseCase:
                 error=f"LLM error: {exc}",
             )
 
-        return self._parser.parse(response)
+        return self._parser.parse_json(payload)
 
     def _build_aggregate(
         self,

--- a/workers/automation/src/jobhunter/enrichment/activities.py
+++ b/workers/automation/src/jobhunter/enrichment/activities.py
@@ -28,13 +28,20 @@ class EnrichActivityOutput:
 @activity.defn(name="enrich")
 async def enrich_activity(payload: EnrichActivityInput) -> EnrichActivityOutput:
     """Run the enrichment stage via ``run_pipeline``."""
-    activity.heartbeat("enrich starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["enrich"],
-        workers=payload.workers,
-        limit=payload.limit,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(
+            stages=["enrich"], workers=payload.workers, limit=payload.limit
+        )
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="enrich starting",
+        progress_message="enrich still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})

--- a/workers/automation/src/jobhunter/enrichment/detail.py
+++ b/workers/automation/src/jobhunter/enrichment/detail.py
@@ -59,7 +59,7 @@ from jobhunter.infrastructure.enrichment.playwright_fetcher import (
     _collect_main_content,
 )
 from jobhunter.infrastructure.network.proxy import ProxyConfig, parse_proxy
-from jobhunter.llm import get_client
+from jobhunter.infrastructure.llm import get_llm_adapter
 
 log = logging.getLogger(__name__)
 
@@ -349,12 +349,14 @@ def scrape_detail_page(page, url: str) -> dict:
 
 
 def _make_llm_extractor() -> LlmExtractor:
-    """Build a Tier-3 extractor backed by the legacy LlmClient.
+    """Build a Tier-3 extractor backed by the canonical LlmAdapter.
 
-    Factored out so tests can swap a stub LlmPort.
+    Factored out so tests can swap a stub LlmPort. The adapter is the only
+    LlmPort-shaped wrapper around the underlying LLMClient — calling
+    LLMClient directly would now violate the port's signature (model kw,
+    chat_json, etc.).
     """
-    client = get_client()
-    return LlmExtractor(llm=client)
+    return LlmExtractor(llm=get_llm_adapter())
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/infrastructure/llm/llm_client.py
+++ b/workers/automation/src/jobhunter/infrastructure/llm/llm_client.py
@@ -53,6 +53,8 @@ class LlmAdapter:
         model: str | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
+        response_schema: dict | None = None,
+        thinking_budget: int | None = None,
     ) -> str:
         if model is not None and model != self._client.model:
             raise ValueError(
@@ -69,7 +71,36 @@ class LlmAdapter:
             kwargs["temperature"] = temperature
         if max_tokens is not None:
             kwargs["max_tokens"] = max_tokens
+        if response_schema is not None:
+            kwargs["response_schema"] = response_schema
+        if thinking_budget is not None:
+            kwargs["thinking_budget"] = thinking_budget
         return self._client.chat(payload, **kwargs)
+
+    def chat_json(
+        self,
+        messages: list[LlmMessage],
+        *,
+        response_schema: dict,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        thinking_budget: int | None = None,
+    ) -> dict:
+        if model is not None and model != self._client.model:
+            raise ValueError(
+                f"LlmAdapter is bound to model={self._client.model!r}; "
+                f"cannot satisfy request for model={model!r}."
+            )
+        payload = [{"role": message.role, "content": message.content} for message in messages]
+        kwargs: dict[str, Any] = {"response_schema": response_schema}
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+        if thinking_budget is not None:
+            kwargs["thinking_budget"] = thinking_budget
+        return self._client.chat_json(payload, **kwargs)
 
     def ask(self, prompt: str, **kwargs: Any) -> str:
         message = LlmMessage(role="user", content=prompt)

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -291,6 +291,15 @@ class ProjectionBuilder:
         if not dirty_jobs and max_event_id == watermark and dashboard_exists:
             return 0
 
+        # ``record_job_event`` invokes the wildcard subscriber inside the
+        # caller's open transaction (e.g. ``acquire_job``'s
+        # ``BEGIN IMMEDIATE`` block). Issuing our own ``commit()`` mid-
+        # transaction would prematurely release the row lock and break
+        # the caller's rollback path. Detect the in-transaction case and
+        # let the caller flush both writes; standalone refreshes (the
+        # CLI / tests) commit themselves.
+        defer_commit = bool(getattr(self._conn, "in_transaction", False))
+
         if not dirty_jobs:
             # Watermark advanced past events with no job_url (e.g.
             # system events) OR first-run: bump the watermark + ensure
@@ -299,7 +308,8 @@ class ProjectionBuilder:
                 self._watermarks.set(PROJECTION_NAME, max_event_id)
             if not dashboard_exists:
                 self._rebuild_dashboard()
-            self._conn.commit()
+            if not defer_commit:
+                self._conn.commit()
             return 0
 
         # PR 4 of the Temporal stack: rebuild ``apply_run_projections``
@@ -311,7 +321,8 @@ class ProjectionBuilder:
         self._rebuild_dashboard()
         if max_event_id > watermark:
             self._watermarks.set(PROJECTION_NAME, max_event_id)
-        self._conn.commit()
+        if not defer_commit:
+            self._conn.commit()
         return len(dirty_jobs)
 
     # -------------------------------------------------------------- builders
@@ -929,8 +940,19 @@ class ProjectionBuilder:
         "ApplicationSubmitted": ("succeeded", "applied"),
         "DryRunCompleted": ("dry_run_complete", "dry_run_complete"),
         "ApplyManualSkip": ("manual", "manual"),
+        # ``LockReleased`` is the orphan-rescue terminal: only treat it as
+        # failure when no prior terminal event for the run was observed
+        # (see ``_apply_lock_released_event`` below). The event itself
+        # carries no result; preserving the prior result keeps captcha /
+        # login_issue / expired distinct from generic 'failed'.
         "LockReleased": ("failed", "failed"),
     }
+
+    # Event types that carry a real terminal verdict (used to gate the
+    # LockReleased fallback so it doesn't clobber more-specific results).
+    _AUTHORITATIVE_TERMINAL_EVENTS: frozenset[str] = frozenset(
+        {"ApplicationSubmitted", "DryRunCompleted", "ApplyManualSkip", "ApplicationFailed"}
+    )
 
     _STATUS_FROM_RESULT: dict[str, str] = {
         "applied": "succeeded",
@@ -988,6 +1010,15 @@ class ProjectionBuilder:
                 if status == "starting":
                     status = "in_progress"
             elif event_type in self._TERMINAL_EVENT_STATUS:
+                # LockReleased is the orphan-rescue fallback: when an
+                # authoritative terminal event already fired (Submitted /
+                # DryRunCompleted / ApplyManualSkip / ApplicationFailed),
+                # do NOT overwrite its more-specific result. Otherwise
+                # captcha / login_issue / expired runs that get rescued
+                # by ``release_lock`` would surface as plain 'failed' in
+                # ``apply_run_projections.result``.
+                if event_type == "LockReleased" and result is not None:
+                    continue
                 term_status, term_result = self._TERMINAL_EVENT_STATUS[event_type]
                 status = term_status
                 result = (

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -474,10 +474,10 @@ class ProjectionBuilder:
             ).fetchall()
         except sqlite3.OperationalError:
             rows = []
-        explicit: dict[str, sqlite3.Row] = {
-            (row["stage"] if not isinstance(row, tuple) else row[1]): row
-            for row in rows
-        }
+        # ``sqlite3.Row`` (configured via ``row_factory``) is always mapping-like,
+        # never a plain tuple — drop the dead isinstance branch so the dict's
+        # key type narrows to ``str`` for static analyzers.
+        explicit: dict[str, sqlite3.Row] = {row["stage"]: row for row in rows}
         result: list[StageProjection] = []
         for stage in STAGE_ORDER:
             row = explicit.get(stage)
@@ -1095,6 +1095,8 @@ def _row_nullable_str(row: object, key: str) -> str | None:
 def _row_nullable_int(row: object, key: str) -> int | None:
     value = _row_get(row, key)
     if value is None or value == "":
+        return None
+    if not isinstance(value, (int, str, float, bytes)):
         return None
     try:
         return int(value)

--- a/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
@@ -14,7 +14,7 @@ factory; caching is a workflow-starter concern.
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Callable
+from typing import Any, Callable, Coroutine
 from uuid import uuid4
 
 from temporalio.client import Client, WorkflowHandle
@@ -23,8 +23,14 @@ from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.infrastructure.temporal.client import get_temporal_client
 from jobhunter.infrastructure.temporal.task_queues import JOBHUNTER_TASK_QUEUE
 
-WorkflowStarter = Callable[[WorkflowStartSpec], Awaitable[WorkflowHandle]]
-WorkflowCanceler = Callable[[str], Awaitable[None]]
+# ``Coroutine[Any, Any, T]`` rather than ``Awaitable[T]`` so ``asyncio.run``
+# accepts the return value without a static-type complaint. Only async-def
+# callables satisfy this — adapters that return a hand-rolled
+# ``Awaitable`` (e.g., a custom ``__await__`` object) would need wrapping
+# in ``asyncio.ensure_future`` first; the local Temporal-backed defaults
+# are async-def so the constraint is free.
+WorkflowStarter = Callable[[WorkflowStartSpec], Coroutine[Any, Any, WorkflowHandle]]
+WorkflowCanceler = Callable[[str], Coroutine[Any, Any, None]]
 
 
 _cached_client: Client | None = None

--- a/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/workflow_starter.py
@@ -3,21 +3,30 @@
 The JSON-RPC server depends on these via constructor injection so unit tests
 can substitute stubs without booting a Temporal cluster.
 
-The Temporal :class:`Client` is cached at module scope so repeated ``apply``
-and ``cancel_run`` JSON-RPC calls reuse the same gRPC connection — the
-``jobhunter rpc`` server is long-lived and a fresh ``Client.connect()`` per
-request would burn a TCP / TLS / namespace-describe handshake on every
-workflow start.  ``get_temporal_client()`` itself stays as the per-call
-factory; caching is a workflow-starter concern.
+The Temporal :class:`Client` is intentionally NOT cached at module scope.
+The earlier cache broke on the second JSON-RPC call because each request
+opens a fresh event loop via ``asyncio.run(...)``, and Temporal's cached
+``Client`` (plus the module-scope ``asyncio.Lock``) is bound to the loop
+that constructed it; reusing it from a new loop raises
+``RuntimeError: <Lock ...> is bound to a different event loop`` and
+defeats every gRPC retry. Reconnecting per request costs a single
+TCP+TLS+namespace-describe round-trip — a few ms against localhost.
+``jobhunter rpc`` is the only caller and runs in the user's loopback
+worker, so the optimisation isn't worth the correctness cost.
+
+The proper long-term fix is to host one process-wide event loop inside
+``JsonRpcServer.serve()`` (so dispatch can ``loop.run_until_complete(...)``
+instead of opening a fresh loop per request), at which point the cache
+becomes safe again. That is tracked as a follow-up; for now we err on the
+side of correctness.
 """
 
 from __future__ import annotations
 
-import asyncio
 from typing import Any, Callable, Coroutine
 from uuid import uuid4
 
-from temporalio.client import Client, WorkflowHandle
+from temporalio.client import WorkflowHandle
 
 from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.infrastructure.temporal.client import get_temporal_client
@@ -33,30 +42,8 @@ WorkflowStarter = Callable[[WorkflowStartSpec], Coroutine[Any, Any, WorkflowHand
 WorkflowCanceler = Callable[[str], Coroutine[Any, Any, None]]
 
 
-_cached_client: Client | None = None
-_cache_lock = asyncio.Lock()
-
-
-async def _get_or_create_client() -> Client:
-    """Return the cached Temporal :class:`Client`, building it on first call."""
-    global _cached_client
-    if _cached_client is not None:
-        return _cached_client
-    async with _cache_lock:
-        if _cached_client is None:
-            _cached_client = await get_temporal_client()
-        return _cached_client
-
-
-async def _reset_cached_client_for_tests() -> None:
-    """Drop the cached client so tests can re-exercise the connect path."""
-    global _cached_client
-    async with _cache_lock:
-        _cached_client = None
-
-
 async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
-    client = await _get_or_create_client()
+    client = await get_temporal_client()
     workflow_id = spec.workflow_id or f"run-{uuid4().hex}"
     return await client.start_workflow(
         spec.workflow,
@@ -68,7 +55,7 @@ async def default_workflow_starter(spec: WorkflowStartSpec) -> WorkflowHandle:
 
 
 async def default_workflow_canceler(run_id: str) -> None:
-    client = await _get_or_create_client()
+    client = await get_temporal_client()
     await client.get_workflow_handle(run_id).cancel()
 
 

--- a/workers/automation/src/jobhunter/infrastructure/temporal/run_in_activity.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/run_in_activity.py
@@ -1,0 +1,64 @@
+"""Run a blocking sync function inside a Temporal activity without
+starving the worker's event loop.
+
+Every non-apply activity (``discover``, ``enrich``, ``score``,
+``tailor``, ``cover``, ``pdf``, ``profile_import``) wraps a synchronous
+``run_pipeline(...)`` call. Calling that synchronously from inside the
+``async def`` activity body blocks the asyncio event loop for the
+entire stage duration, which:
+
+* defeats heartbeating (no other coroutine runs, so any periodic
+  heartbeat we'd schedule never fires);
+* starves every other activity on the same worker (they can't make
+  progress until the blocking call returns);
+* exposes the workflow to silent hangs because no
+  ``heartbeat_timeout`` can detect the stall.
+
+This helper offloads the synchronous work to the default
+``ThreadPoolExecutor`` and emits a heartbeat every ``poll_interval``
+seconds while waiting. Cancellation propagates: workflow ``cancel``
+surfaces as ``asyncio.CancelledError``; the helper re-raises so the
+activity's caller can decide what to do.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, TypeVar
+
+from temporalio import activity
+
+_T = TypeVar("_T")
+
+
+async def run_blocking_with_heartbeat(
+    fn: Callable[[], _T],
+    *,
+    starting_message: str,
+    progress_message: str = "still running",
+    poll_interval: float = 15.0,
+) -> _T:
+    """Execute ``fn()`` in a worker thread, heartbeating every ``poll_interval``.
+
+    Mirrors the pattern ``apply_activity`` uses, lifted into a reusable
+    helper so the six non-apply activities stop blocking the event loop.
+    """
+    activity.heartbeat(starting_message)
+    loop = asyncio.get_running_loop()
+    task = loop.run_in_executor(None, fn)
+    try:
+        while True:
+            try:
+                return await asyncio.wait_for(asyncio.shield(task), timeout=poll_interval)
+            except asyncio.TimeoutError:
+                activity.heartbeat(progress_message)
+    finally:
+        # Final heartbeat so a future post-loop delay regression doesn't
+        # surface as a phantom dead activity. Never raise from cleanup.
+        try:
+            activity.heartbeat("done")
+        except Exception:  # noqa: BLE001 — heartbeat outside activity ctx is fine
+            pass
+
+
+__all__ = ["run_blocking_with_heartbeat"]

--- a/workers/automation/src/jobhunter/llm.py
+++ b/workers/automation/src/jobhunter/llm.py
@@ -9,6 +9,7 @@ Auto-detects provider from environment:
 LLM_MODEL env var overrides the model name for any provider.
 """
 
+import json
 import logging
 import os
 import time
@@ -66,7 +67,7 @@ def _detect_provider() -> tuple[str, str, str]:
 # ---------------------------------------------------------------------------
 
 _MAX_RETRIES = 5
-_TIMEOUT = 120  # seconds
+_TIMEOUT = 180  # seconds — Gemini thinking models can take >120s on a single call.
 
 # Base wait on first 429/503 (doubles each retry, caps at 60s).
 # Gemini free tier is 15 RPM = 4s minimum between requests; 10s gives headroom.
@@ -77,6 +78,24 @@ _GEMINI_COMPAT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
 _GEMINI_NATIVE_BASE = "https://generativelanguage.googleapis.com/v1beta"
 
 
+class LlmEmptyResponseError(RuntimeError):
+    """Raised when the provider returned a structurally valid response with
+    no completion text. Carries the ``finish_reason`` so callers can decide
+    whether to retry with a higher token budget or downgrade gracefully.
+    """
+
+    def __init__(self, *, finish_reason: str, model: str, hint: str = "") -> None:
+        self.finish_reason = finish_reason
+        self.model = model
+        self.hint = hint
+        msg = (
+            f"LLM '{model}' returned no content (finish_reason={finish_reason!r})"
+        )
+        if hint:
+            msg = f"{msg}. {hint}"
+        super().__init__(msg)
+
+
 class LLMClient:
     """Thin LLM client supporting OpenAI-compatible and native Gemini endpoints.
 
@@ -84,6 +103,14 @@ class LLMClient:
     happens with preview/experimental models not exposed via compat), it
     automatically switches to the native generateContent API and stays there
     for the lifetime of the process.
+
+    Structured outputs are exposed via the ``response_schema`` kwarg on
+    ``chat()`` / ``ask()`` / ``chat_json()``. Provider quirks:
+
+      * OpenAI-compat (incl. Gemini compat): forwarded as
+        ``response_format={"type": "json_schema", ...}``.
+      * Native Gemini: forwarded as
+        ``generationConfig.responseSchema`` + ``responseMimeType=application/json``.
     """
 
     def __init__(self, base_url: str, model: str, api_key: str) -> None:
@@ -102,6 +129,8 @@ class LLMClient:
         messages: list[dict],
         temperature: float,
         max_tokens: int,
+        response_schema: dict | None,
+        thinking_budget: int | None,
     ) -> str:
         """Call the native Gemini generateContent API.
 
@@ -125,18 +154,30 @@ class LLMClient:
                 # Gemini uses "model" instead of "assistant"
                 contents.append({"role": "model", "parts": [{"text": text}]})
 
+        generation_config: dict = {
+            "temperature": temperature,
+            "maxOutputTokens": max_tokens,
+        }
+        if response_schema is not None:
+            # Native Gemini wants JSON mode + the schema spelled inline.
+            generation_config["responseMimeType"] = "application/json"
+            generation_config["responseSchema"] = response_schema
+        if thinking_budget is not None:
+            generation_config["thinkingConfig"] = {"thinkingBudget": thinking_budget}
+
         payload: dict = {
             "contents": contents,
-            "generationConfig": {
-                "temperature": temperature,
-                "maxOutputTokens": max_tokens,
-            },
+            "generationConfig": generation_config,
         }
         if system_parts:
             payload["systemInstruction"] = {"parts": system_parts}
 
         url = f"{_GEMINI_NATIVE_BASE}/models/{self.model}:generateContent"
         params = {"temperature": temperature, "max_tokens": max_tokens}
+        if response_schema is not None:
+            params["response_schema"] = "<json_schema>"
+        if thinking_budget is not None:
+            params["thinking_budget"] = thinking_budget
         # Pass the key as a header (not a URL query param) so it never lands in
         # OTel's `http.url` span attribute and gets shipped to Langfuse.
         with llm_generation_span(model=self.model, messages=messages, params=params) as record:
@@ -150,7 +191,7 @@ class LLMClient:
             )
             resp.raise_for_status()
             data = resp.json()
-            text = data["candidates"][0]["content"]["parts"][0]["text"]
+            text = _extract_native_gemini_text(data, model=self.model)
             usage = data.get("usageMetadata") or {}
             record(
                 text,
@@ -166,20 +207,40 @@ class LLMClient:
         messages: list[dict],
         temperature: float,
         max_tokens: int,
+        response_schema: dict | None,
+        thinking_budget: int | None,
     ) -> str:
         """Call the OpenAI-compatible endpoint."""
         headers: dict[str, str] = {"Content-Type": "application/json"}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
-        payload = {
+        payload: dict = {
             "model": self.model,
             "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
+        if response_schema is not None:
+            payload["response_format"] = {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_schema.get("title", "response"),
+                    "schema": response_schema,
+                    "strict": True,
+                },
+            }
+        if thinking_budget is not None and self._is_gemini:
+            # Gemini-only knob exposed via OpenAI-compat's `extra_body`.
+            payload["extra_body"] = {
+                "google": {"thinking_config": {"thinking_budget": thinking_budget}}
+            }
 
         params = {"temperature": temperature, "max_tokens": max_tokens}
+        if response_schema is not None:
+            params["response_schema"] = "<json_schema>"
+        if thinking_budget is not None:
+            params["thinking_budget"] = thinking_budget
         with llm_generation_span(model=self.model, messages=messages, params=params) as record:
             resp = self._client.post(
                 f"{self.base_url}/chat/completions",
@@ -194,7 +255,7 @@ class LLMClient:
 
             resp.raise_for_status()
             data = resp.json()
-            text = data["choices"][0]["message"]["content"]
+            text = _extract_compat_text(data, model=self.model)
             usage = data.get("usage") or {}
             record(
                 text,
@@ -210,8 +271,20 @@ class LLMClient:
         messages: list[dict],
         temperature: float = 0.0,
         max_tokens: int = 4096,
+        response_schema: dict | None = None,
+        thinking_budget: int | None = None,
     ) -> str:
-        """Send a chat completion request and return the assistant message text."""
+        """Send a chat completion request and return the assistant message text.
+
+        ``response_schema`` enables structured outputs — the provider is
+        instructed to return a JSON document conforming to the schema.
+        Use :meth:`chat_json` for the parsed-dict convenience.
+
+        ``thinking_budget`` (Gemini only): caps internal reasoning tokens.
+        Set to ``0`` to skip thinking entirely on Gemini 3.x preview models
+        whose default budget can swallow the entire ``max_tokens`` allotment
+        before any visible content is produced.
+        """
         # Qwen3 optimization: prepend /no_think to skip chain-of-thought
         # reasoning, saving tokens on structured extraction tasks.
         if "qwen" in self.model.lower() and messages:
@@ -223,9 +296,13 @@ class LLMClient:
             try:
                 # Route to native Gemini if we've already confirmed it's needed
                 if self._use_native_gemini:
-                    return self._chat_native_gemini(messages, temperature, max_tokens)
+                    return self._chat_native_gemini(
+                        messages, temperature, max_tokens, response_schema, thinking_budget
+                    )
 
-                return self._chat_compat(messages, temperature, max_tokens)
+                return self._chat_compat(
+                    messages, temperature, max_tokens, response_schema, thinking_budget
+                )
 
             except _GeminiCompatForbidden:
                 # Model not available on OpenAI-compat layer — switch to native.
@@ -238,7 +315,9 @@ class LLMClient:
                 self._use_native_gemini = True
                 # Retry immediately with native — don't count as a rate-limit wait
                 try:
-                    return self._chat_native_gemini(messages, temperature, max_tokens)
+                    return self._chat_native_gemini(
+                        messages, temperature, max_tokens, response_schema, thinking_budget
+                    )
                 except httpx.HTTPStatusError as native_exc:
                     raise RuntimeError(
                         f"Both Gemini endpoints failed. Compat: 403 Forbidden. "
@@ -285,12 +364,99 @@ class LLMClient:
 
         raise RuntimeError("LLM request failed after all retries")
 
+    def chat_json(
+        self,
+        messages: list[dict],
+        *,
+        response_schema: dict,
+        temperature: float = 0.0,
+        max_tokens: int = 4096,
+        thinking_budget: int | None = None,
+    ) -> dict:
+        """Like :meth:`chat` but expects a JSON object back and parses it.
+
+        Raises ``LlmEmptyResponseError`` if the provider returned no content.
+        Raises ``json.JSONDecodeError`` if the content was not valid JSON
+        (which should not happen when ``response_schema`` is honored, but
+        the LLM gateway is the only writer that can guarantee that —
+        fail loudly so the caller surfaces the schema/contract drift).
+        """
+        text = self.chat(
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            response_schema=response_schema,
+            thinking_budget=thinking_budget,
+        )
+        return json.loads(text)
+
     def ask(self, prompt: str, **kwargs) -> str:
         """Convenience: single user prompt -> assistant response."""
         return self.chat([{"role": "user", "content": prompt}], **kwargs)
 
     def close(self) -> None:
         self._client.close()
+
+
+def _extract_compat_text(data: dict, *, model: str) -> str:
+    """Pull assistant text out of an OpenAI-compat response.
+
+    Some Gemini "thinking" preview models return a response where
+    ``choices[0].message`` carries only ``role`` (no ``content``) when the
+    entire ``max_tokens`` budget was spent on internal reasoning before any
+    visible token landed. We surface that as :class:`LlmEmptyResponseError`
+    instead of a confusing ``KeyError: 'content'``.
+    """
+    choices = data.get("choices") or []
+    if not choices:
+        finish_reason = "no_choices"
+    else:
+        message = choices[0].get("message") or {}
+        text = message.get("content")
+        finish_reason = choices[0].get("finish_reason", "unknown")
+        if isinstance(text, str) and text:
+            return text
+        # Some providers return content as a list of {type: text, text: "..."}
+        if isinstance(text, list):
+            joined = "".join(part.get("text", "") for part in text if isinstance(part, dict))
+            if joined:
+                return joined
+    hint = ""
+    if finish_reason == "length":
+        hint = (
+            "max_tokens budget exhausted before any visible content was emitted "
+            "(common with Gemini 3.x thinking models). Raise max_tokens, or pass "
+            "thinking_budget=0 to disable internal reasoning."
+        )
+    raise LlmEmptyResponseError(finish_reason=finish_reason, model=model, hint=hint)
+
+
+def _extract_native_gemini_text(data: dict, *, model: str) -> str:
+    """Pull assistant text out of a native Gemini ``generateContent`` response.
+
+    Native responses can also return an empty completion when the model
+    spends all its tokens on reasoning. Surface that the same way the
+    compat path does so the caller never has to special-case the provider.
+    """
+    candidates = data.get("candidates") or []
+    if not candidates:
+        finish_reason = "no_candidates"
+    else:
+        candidate = candidates[0]
+        content = candidate.get("content") or {}
+        parts = content.get("parts") or []
+        text = "".join(part.get("text", "") for part in parts if isinstance(part, dict))
+        finish_reason = candidate.get("finishReason", "unknown")
+        if text:
+            return text
+    hint = ""
+    if finish_reason in ("MAX_TOKENS", "length"):
+        hint = (
+            "max_tokens budget exhausted before any visible content was emitted "
+            "(common with Gemini 3.x thinking models). Raise max_tokens, or pass "
+            "thinking_budget=0 to disable internal reasoning."
+        )
+    raise LlmEmptyResponseError(finish_reason=finish_reason, model=model, hint=hint)
 
 
 class _GeminiCompatForbidden(Exception):

--- a/workers/automation/src/jobhunter/materials/activities.py
+++ b/workers/automation/src/jobhunter/materials/activities.py
@@ -36,16 +36,25 @@ class TailorActivityOutput:
 @activity.defn(name="tailor")
 async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
     """Run the tailor stage via ``run_pipeline``."""
-    activity.heartbeat("tailor starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["tailor"],
-        min_score=payload.min_score,
-        workers=payload.workers,
-        validation_mode=payload.validation_mode,
-        limit=payload.limit,
-        retailor=payload.retailor,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(
+            stages=["tailor"],
+            min_score=payload.min_score,
+            workers=payload.workers,
+            validation_mode=payload.validation_mode,
+            limit=payload.limit,
+            retailor=payload.retailor,
+        )
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="tailor starting",
+        progress_message="tailor still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})
@@ -84,14 +93,23 @@ class CoverActivityOutput:
 @activity.defn(name="cover")
 async def cover_activity(payload: CoverActivityInput) -> CoverActivityOutput:
     """Run the cover-letter stage via ``run_pipeline``."""
-    activity.heartbeat("cover starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["cover"],
-        min_score=payload.min_score,
-        validation_mode=payload.validation_mode,
-        limit=payload.limit,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(
+            stages=["cover"],
+            min_score=payload.min_score,
+            validation_mode=payload.validation_mode,
+            limit=payload.limit,
+        )
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="cover starting",
+        progress_message="cover still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})
@@ -128,12 +146,18 @@ class PdfActivityOutput:
 @activity.defn(name="pdf")
 async def pdf_activity(payload: PdfActivityInput) -> PdfActivityOutput:
     """Run the pdf-conversion stage via ``run_pipeline``."""
-    activity.heartbeat("pdf starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["pdf"],
-        limit=payload.limit,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(stages=["pdf"], limit=payload.limit)
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="pdf starting",
+        progress_message="pdf still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -16,6 +16,7 @@ import logging
 import threading
 import time
 from datetime import datetime
+from typing import Any, Callable
 
 from rich.console import Console
 from rich.panel import Panel
@@ -207,8 +208,10 @@ def _run_pdf(limit: int = 0) -> dict:
         return {"status": f"error: {e}"}
 
 
-# Map stage names to their runner functions
-_STAGE_RUNNERS: dict[str, callable] = {
+# Map stage names to their runner functions. ``Callable`` (lowercase
+# ``callable`` is the runtime predicate, not a generic type alias).
+_StageRunner = Callable[..., dict[str, Any]]
+_STAGE_RUNNERS: dict[str, _StageRunner] = {
     "discover": _run_discover,
     "enrich":   _run_enrich,
     "score":    _run_score,

--- a/workers/automation/src/jobhunter/pipeline/workflow.py
+++ b/workers/automation/src/jobhunter/pipeline/workflow.py
@@ -71,6 +71,11 @@ _DEFAULT_RETRY = RetryPolicy(
     maximum_attempts=3,
 )
 _DEFAULT_TIMEOUT = timedelta(minutes=30)
+# 2 minutes gives the activity ~8 cycles of the 15s heartbeat poll inside
+# ``run_blocking_with_heartbeat`` before Temporal would consider the
+# activity dead. Without this knob Temporal never times out a stuck
+# activity and the workflow waits the full ``start_to_close_timeout``.
+_DEFAULT_HEARTBEAT_TIMEOUT = timedelta(minutes=2)
 
 
 @workflow.defn(name="JobPipelineWorkflow")
@@ -113,6 +118,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             discover_activity,
             DiscoverActivityInput(tenant_id=payload.tenant_id, workers=payload.workers),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "enrich":
@@ -124,6 +130,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 limit=payload.limit,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "score":
@@ -135,6 +142,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 limit=payload.limit,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "tailor":
@@ -148,6 +156,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 validation_mode=payload.validation_mode,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "cover":
@@ -160,6 +169,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 validation_mode=payload.validation_mode,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "pdf":
@@ -167,6 +177,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             pdf_activity,
             PdfActivityInput(tenant_id=payload.tenant_id, limit=payload.limit),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
+            heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "apply":

--- a/workers/automation/src/jobhunter/profile/activities.py
+++ b/workers/automation/src/jobhunter/profile/activities.py
@@ -34,16 +34,25 @@ async def profile_import_activity(
     payload: ProfileImportActivityInput,
 ) -> ProfileImportActivityOutput:
     """Import a profile draft from an uploaded resume PDF."""
-    activity.heartbeat("profile_import starting")
     from jobhunter.actions import LocalActionRequest, run_local_action
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
 
-    result = run_local_action(
-        LocalActionRequest(
-            stage="profile_import",
-            pdf_path=payload.pdf_path,
-            import_profile=payload.import_profile,
-            import_style=payload.import_style,
+    def _do() -> Any:
+        return run_local_action(
+            LocalActionRequest(
+                stage="profile_import",
+                pdf_path=payload.pdf_path,
+                import_profile=payload.import_profile,
+                import_style=payload.import_style,
+            )
         )
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="profile_import starting",
+        progress_message="profile_import still running",
     )
     if not result.ok:
         return ProfileImportActivityOutput(

--- a/workers/automation/src/jobhunter/scoring/activities.py
+++ b/workers/automation/src/jobhunter/scoring/activities.py
@@ -29,14 +29,23 @@ class ScoreActivityOutput:
 @activity.defn(name="score")
 async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
     """Run the scoring stage via ``run_pipeline``."""
-    activity.heartbeat("score starting")
+    from jobhunter.infrastructure.temporal.run_in_activity import (
+        run_blocking_with_heartbeat,
+    )
     from jobhunter.pipeline import run_pipeline
 
-    result = run_pipeline(
-        stages=["score"],
-        workers=payload.workers,
-        limit=payload.limit,
-        rescore=payload.rescore,
+    def _do() -> dict[str, Any]:
+        return run_pipeline(
+            stages=["score"],
+            workers=payload.workers,
+            limit=payload.limit,
+            rescore=payload.rescore,
+        )
+
+    result = await run_blocking_with_heartbeat(
+        _do,
+        starting_message="score starting",
+        progress_message="score still running",
     )
     stages = list(result.get("stages") or [])
     errors = dict(result.get("errors") or {})

--- a/workers/automation/src/jobhunter/scoring/cover_letter.py
+++ b/workers/automation/src/jobhunter/scoring/cover_letter.py
@@ -193,7 +193,17 @@ def run_cover_letters(
         url = job["url"]
         ensure_job_stage_rows(conn, url, discovered_at=job.get("discovered_at"))
         started_at = utc_now()
-        set_stage_state(conn, url, "cover", "running", started_at=started_at)
+        # Runner owns the restart policy: failed-cover jobs are re-selected
+        # for retry, so allow Failed -> Running. Canonical state machine
+        # table only permits Failed -> Pending (via Reset).
+        set_stage_state(
+            conn,
+            url,
+            "cover",
+            "running",
+            started_at=started_at,
+            validate_transition=False,
+        )
         record_job_event(conn, url, "cover", "StageStarted", message="Cover letter generation started")
 
         try:

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -168,7 +168,18 @@ def run_scoring(
         ensure_job_stage_rows(conn, job["url"], discovered_at=job.get("discovered_at"))
         started_at = utc_now()
         started_ats[job["url"]] = started_at
-        set_stage_state(conn, job["url"], "score", "running", started_at=started_at)
+        # Runner owns the restart policy: a job that previously failed
+        # scoring is re-selected here, so allow Failed -> Running even
+        # though the canonical state machine table only permits Failed ->
+        # Pending (via Reset). Skip validation; the writer is the runner.
+        set_stage_state(
+            conn,
+            job["url"],
+            "score",
+            "running",
+            started_at=started_at,
+            validate_transition=False,
+        )
         record_job_event(conn, job["url"], "score", "StageStarted", message="Scoring started")
 
     t0 = time.time()

--- a/workers/automation/src/jobhunter/scoring/tailor.py
+++ b/workers/automation/src/jobhunter/scoring/tailor.py
@@ -241,15 +241,20 @@ def run_tailoring(
     """Generate tailored resumes for high-scoring jobs.
 
     Each job is processed inside a :class:`ThreadPoolExecutor` task; the
-    LLM call happens in the worker thread. Results are persisted back
-    through the use case on the main thread (sqlite connections are not
-    thread-safe across statements).
+    use case (LLM call + materials persistence) runs in the worker thread.
+    SQLite connections are not safe to share across threads, so each
+    worker builds its own use case (and therefore its own thread-local
+    connection via ``get_connection()``). The main thread keeps a separate
+    connection only for the per-job stage-state writes around the worker
+    pool's lifetime.
     """
     if snapshot is None:
         from jobhunter.infrastructure.profile import get_profile_repository
         snapshot = get_profile_repository().load_snapshot(tenant_id)
 
     conn = get_connection()
+    # ``repository`` is accepted for test injection but MUST NOT be passed
+    # into worker-thread tasks — sqlite connections are thread-bound.
     if repository is None:
         repository = SqliteMaterialsRepository(conn)
 
@@ -281,13 +286,10 @@ def run_tailoring(
     results: list[dict] = []
     stats: dict[str, int] = {"approved": 0, "failed_validation": 0, "failed_judge": 0, "error": 0}
 
-    # We want one use case shared across jobs so the repository connection
-    # stays consistent. The LLM call runs in worker threads.
-    use_case = _build_use_case(
-        repository=repository,
-        llm_port=llm_port,
-        publisher=publisher,
-    )
+    # ``use_case`` is built lazily per-worker inside _tailor_one_job so the
+    # repository connection lives in the worker thread that uses it. The
+    # main-thread ``repository`` constructed above is intentionally
+    # ignored by the workers (sqlite connections are thread-bound).
     if pdf_renderer is None:
         pdf_renderer = _build_pdf_renderer()
 
@@ -296,7 +298,19 @@ def run_tailoring(
         ensure_job_stage_rows(conn, job["url"], discovered_at=job.get("discovered_at"))
         started_at = utc_now()
         started_ats[job["url"]] = started_at
-        set_stage_state(conn, job["url"], "tailor", "running", started_at=started_at)
+        # The runner owns the restart policy: a job that failed last time is
+        # eligible for retailoring per ``get_jobs_by_stage``, so the
+        # transition Failed -> Running needs to be permitted even though
+        # the canonical state machine table only allows Failed -> Pending
+        # (via Reset). Skip validation here; the writer is the runner.
+        set_stage_state(
+            conn,
+            job["url"],
+            "tailor",
+            "running",
+            started_at=started_at,
+            validate_transition=False,
+        )
         record_job_event(conn, job["url"], "tailor", "StageStarted", message="Tailoring started")
 
     future_to_job: dict = {}
@@ -308,7 +322,11 @@ def run_tailoring(
                 "",  # legacy resume_text param — unused
                 snapshot,
                 validation_mode,
-                use_case=use_case,
+                # use_case=None: worker builds its own with a thread-local
+                # SQLite connection. Passing the main-thread use case would
+                # crash with "SQLite objects created in a thread can only
+                # be used in that same thread".
+                use_case=None,
                 pdf_renderer=pdf_renderer,
                 retailor=retailor,
                 tenant_id=tenant_id,

--- a/workers/automation/tests/test_doctor_langfuse.py
+++ b/workers/automation/tests/test_doctor_langfuse.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import httpx
 from typer.testing import CliRunner
@@ -17,15 +17,21 @@ def _set_creds(monkeypatch):
 
 
 def _stub_temporal():
-    """Pin Temporal to ``reachable`` so the test focuses on the Langfuse row."""
+    """Pin Temporal to ``reachable`` so the test focuses on the Langfuse row.
+
+    Patches ``get_temporal_client`` (the function the doctor awaits) rather
+    than ``Client.connect`` so we never construct unawaited coroutines on
+    the side_effect path. Earlier versions used a lambda that produced a
+    fresh coroutine — pytest then warned ``coroutine '...' was never
+    awaited`` because the Mock machinery wrapped the call in a way that
+    occasionally dropped the coroutine before ``await`` consumed it.
+    """
+    # cli.py imports ``get_temporal_client`` lazily inside the doctor command,
+    # so the patch target is the source module — not the cli namespace.
     return patch(
-        "jobhunter.infrastructure.temporal.client.Client.connect",
-        side_effect=lambda *_args, **_kwargs: _async_sentinel(),
+        "jobhunter.infrastructure.temporal.client.get_temporal_client",
+        new=AsyncMock(return_value=object()),
     )
-
-
-async def _async_sentinel():
-    return object()
 
 
 def test_doctor_reports_langfuse_reachable(monkeypatch):

--- a/workers/automation/tests/test_score_aggregate.py
+++ b/workers/automation/tests/test_score_aggregate.py
@@ -215,46 +215,76 @@ def test_job_score_rejects_zero_version() -> None:
 
 
 def test_score_parser_happy_path() -> None:
-    response = (
-        "SCORE: 8\n"
-        "KEYWORDS: python, fastapi, postgres\n"
-        "REASONING: Strong technical overlap with the role."
-    )
-    result = ScoreParser().parse(response)
+    payload = {
+        "score": 8,
+        "technical_fit": 8,
+        "experience_fit": 7,
+        "role_fit": 9,
+        "keywords": ["python", "fastapi", "postgres"],
+        "reasoning": "Strong technical overlap with the role.",
+    }
+    result = ScoreParser().parse_json(payload)
     assert result.ok is True
     assert result.fit_score is not None and result.fit_score.value == 8
     assert result.keywords.values == ("python", "fastapi", "postgres")
     assert "Strong technical overlap" in result.breakdown.reasoning
+    # Structured-output cutover populates the dimension breakdown.
+    assert result.breakdown.technical_fit == 8
+    assert result.breakdown.experience_fit == 7
+    assert result.breakdown.role_fit == 9
 
 
-def test_score_parser_rejects_missing_score_line() -> None:
-    result = ScoreParser().parse("KEYWORDS: a\nREASONING: nope")
+def test_score_parser_rejects_missing_score_field() -> None:
+    result = ScoreParser().parse_json({"keywords": ["a"], "reasoning": "nope"})
     assert result.ok is False
     assert result.fit_score is None
-    assert "missing" in result.error.lower()
+    assert "score" in result.error.lower()
 
 
 def test_score_parser_rejects_out_of_range_score() -> None:
-    result = ScoreParser().parse("SCORE: 11\nKEYWORDS:\nREASONING: too high")
+    result = ScoreParser().parse_json(
+        {"score": 11, "keywords": [], "reasoning": "too high"}
+    )
     assert result.ok is False
     assert result.fit_score is None
     assert "outside" in result.error.lower()
 
 
 def test_score_parser_rejects_successful_score_with_no_keywords() -> None:
-    """Round-1 review M1: a SCORE line with no KEYWORDS line is not a
-    valid scoring per §4.4 — the parser surfaces it as ``ok=False`` so
-    the caller doesn't accidentally persist a sentinel-keyword score."""
-    result = ScoreParser().parse("SCORE: 7\nREASONING: missing the keywords line")
+    """Round-1 review M1: a score with no keywords is not a valid scoring
+    per §4.4 — the parser surfaces it as ``ok=False`` so the caller
+    doesn't accidentally persist a sentinel-keyword score."""
+    result = ScoreParser().parse_json(
+        {"score": 7, "keywords": [], "reasoning": "missing the keywords"}
+    )
     assert result.ok is False
     assert result.fit_score is None
     assert "keywords" in result.error.lower()
 
 
-def test_score_parser_rejects_empty_keywords_line() -> None:
-    result = ScoreParser().parse("SCORE: 7\nKEYWORDS:\nREASONING: empty list")
+def test_score_parser_rejects_non_dict_payload() -> None:
+    result = ScoreParser().parse_json("just a string, not a JSON object")
     assert result.ok is False
-    assert "keywords" in result.error.lower()
+    assert "expected dict" in result.error.lower()
+
+
+def test_score_parser_clamps_out_of_range_dimensions() -> None:
+    """Per the SCORE_SCHEMA dimensions are 0..10 — providers occasionally
+    return values outside that range. Clamp silently rather than rejecting
+    the row over a single bad dimension; ``ok`` remains True."""
+    payload = {
+        "score": 7,
+        "technical_fit": 99,
+        "experience_fit": -3,
+        "role_fit": "not a number",
+        "keywords": ["python"],
+        "reasoning": "ok",
+    }
+    result = ScoreParser().parse_json(payload)
+    assert result.ok is True
+    assert result.breakdown.technical_fit == 10
+    assert result.breakdown.experience_fit == 0
+    assert result.breakdown.role_fit == 0
 
 
 def test_eligibility_checker_threshold() -> None:

--- a/workers/automation/tests/test_score_use_cases.py
+++ b/workers/automation/tests/test_score_use_cases.py
@@ -72,30 +72,72 @@ class _MemoryRepo:
 
 
 class _ScriptedLlm:
-    """Deterministic ``LlmPort`` returning canned responses in order."""
+    """Deterministic ``LlmPort`` returning canned structured-output payloads."""
 
-    def __init__(self, *responses: str) -> None:
-        self._queue: list[str] = list(responses)
+    def __init__(self, *responses: dict) -> None:
+        self._queue: list[dict] = [dict(r) for r in responses]
         self.calls: list[list[LlmMessage]] = []
 
-    def chat(self, messages, *, model=None, temperature=None, max_tokens=None) -> str:
+    def chat(  # pragma: no cover — structured-output cutover routes through chat_json
+        self,
+        messages,
+        *,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        response_schema=None,
+        thinking_budget=None,
+    ) -> str:
+        raise AssertionError("ScoreJobUseCase should use chat_json after the structured-output cutover")
+
+    def chat_json(
+        self,
+        messages,
+        *,
+        response_schema,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        thinking_budget=None,
+    ) -> dict:
         self.calls.append(list(messages))
         if not self._queue:
             raise AssertionError("ScriptedLlm exhausted")
         return self._queue.pop(0)
 
     def ask(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover
-        return self.chat([LlmMessage(role="user", content=prompt)], **kwargs)
+        raise AssertionError("ScoreJobUseCase should not call ask()")
 
 
 class _ExplodingLlm:
     """``LlmPort`` that always raises — exercises error handling."""
 
-    def chat(self, messages, *, model=None, temperature=None, max_tokens=None) -> str:
+    def chat(  # pragma: no cover
+        self,
+        messages,
+        *,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        response_schema=None,
+        thinking_budget=None,
+    ) -> str:
+        raise RuntimeError("provider down")
+
+    def chat_json(
+        self,
+        messages,
+        *,
+        response_schema,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        thinking_budget=None,
+    ) -> dict:
         raise RuntimeError("provider down")
 
     def ask(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover
-        return self.chat([LlmMessage(role="user", content=prompt)], **kwargs)
+        raise RuntimeError("provider down")
 
 
 # ---------------------------------------------------------------------------
@@ -145,7 +187,14 @@ def test_score_job_happy_path_persists_and_publishes(profile_snapshot) -> None:
     sub: Subscription = bus.subscribe("JobScored", _capture)
     try:
         llm = _ScriptedLlm(
-            "SCORE: 8\nKEYWORDS: python, fastapi\nREASONING: Strong overlap."
+            {
+                "score": 8,
+                "technical_fit": 8,
+                "experience_fit": 7,
+                "role_fit": 8,
+                "keywords": ["python", "fastapi"],
+                "reasoning": "Strong overlap.",
+            }
         )
         use_case = ScoreJobUseCase(repository=repo, llm=llm, publisher=bus)
         outcome = use_case.score(job=_job(), profile_snapshot=profile_snapshot)
@@ -167,7 +216,8 @@ def test_score_job_happy_path_persists_and_publishes(profile_snapshot) -> None:
 
 def test_score_job_returns_error_on_unparseable_response(profile_snapshot) -> None:
     repo = _MemoryRepo()
-    llm = _ScriptedLlm("KEYWORDS: a\nREASONING: missing score")
+    # Payload missing the required ``score`` field — parser flags ok=False.
+    llm = _ScriptedLlm({"keywords": ["a"], "reasoning": "missing score"})
     use_case = ScoreJobUseCase(repository=repo, llm=llm)
 
     outcome = use_case.score(job=_job(), profile_snapshot=profile_snapshot)
@@ -190,8 +240,22 @@ def test_score_job_handles_llm_error_as_parse_failure(profile_snapshot) -> None:
 def test_score_job_bumps_version_on_rescore(profile_snapshot) -> None:
     repo = _MemoryRepo()
     llm = _ScriptedLlm(
-        "SCORE: 7\nKEYWORDS: python\nREASONING: first pass.",
-        "SCORE: 9\nKEYWORDS: python, fastapi\nREASONING: rescored.",
+        {
+            "score": 7,
+            "technical_fit": 7,
+            "experience_fit": 7,
+            "role_fit": 7,
+            "keywords": ["python"],
+            "reasoning": "first pass.",
+        },
+        {
+            "score": 9,
+            "technical_fit": 9,
+            "experience_fit": 8,
+            "role_fit": 9,
+            "keywords": ["python", "fastapi"],
+            "reasoning": "rescored.",
+        },
     )
     use_case = ScoreJobUseCase(repository=repo, llm=llm)
     use_case.score(job=_job(), profile_snapshot=profile_snapshot)

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -21,14 +21,55 @@ from jobhunter.scoring import scorer as scorer_module
 
 
 class _ScriptedLlm:
-    def __init__(self, *responses: str) -> None:
+    """Test double for ``LlmPort`` — returns scripted JSON payloads to
+    ``chat_json``. Use ``invalid=...`` to script raw strings the parser
+    will reject (e.g. for the failure-state coverage)."""
+
+    _DRAIN: dict = {
+        "score": 0,
+        "technical_fit": 0,
+        "experience_fit": 0,
+        "role_fit": 0,
+        "keywords": [],
+        "reasoning": "drained",
+    }
+
+    def __init__(self, *responses: dict | str) -> None:
         self._queue = list(responses)
 
-    def chat(self, messages, *, model=None, temperature=None, max_tokens=None) -> str:
-        return self._queue.pop(0) if self._queue else "SCORE: 0\nKEYWORDS:\nREASONING: drained"
+    def chat(  # pragma: no cover — structured-output cutover routes through chat_json
+        self,
+        messages,
+        *,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        response_schema=None,
+        thinking_budget=None,
+    ) -> str:
+        raise AssertionError("ScoreJobUseCase should use chat_json after the structured-output cutover")
+
+    def chat_json(
+        self,
+        messages,
+        *,
+        response_schema,
+        model=None,
+        temperature=None,
+        max_tokens=None,
+        thinking_budget=None,
+    ) -> dict:
+        if not self._queue:
+            return self._DRAIN
+        next_payload = self._queue.pop(0)
+        if isinstance(next_payload, str):
+            # Scripted-error path: pretend the JSON came back as a non-dict
+            # so the parser can flip ok=False without a network round-trip.
+            return next_payload  # type: ignore[return-value]
+        return dict(next_payload)
 
     def ask(self, prompt: str, **kwargs: Any) -> str:  # pragma: no cover
-        return self.chat([])
+        raise AssertionError("ScoreJobUseCase should not call ask()")
 
 
 @pytest.fixture()
@@ -75,7 +116,16 @@ def test_score_job_writes_only_to_job_scores(
     url = "https://example.com/job/single"
     _seed_pending_job(conn, url)
     repo = SqliteScoreRepository(conn)
-    llm = _ScriptedLlm("SCORE: 8\nKEYWORDS: python\nREASONING: ok")
+    llm = _ScriptedLlm(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "keywords": ["python"],
+            "reasoning": "ok",
+        }
+    )
 
     job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
     outcome = scorer_module.score_job(
@@ -112,7 +162,16 @@ def test_run_scoring_persists_via_repository_only(
     url = "https://example.com/job/batch"
     _seed_pending_job(conn, url)
     repo = SqliteScoreRepository(conn)
-    llm = _ScriptedLlm("SCORE: 7\nKEYWORDS: python\nREASONING: ok")
+    llm = _ScriptedLlm(
+        {
+            "score": 7,
+            "technical_fit": 7,
+            "experience_fit": 7,
+            "role_fit": 7,
+            "keywords": ["python"],
+            "reasoning": "ok",
+        }
+    )
 
     # The default ``run_scoring`` path constructs an SqliteScoreRepository
     # against ``get_connection()``; for tests we inject our tmp connection
@@ -154,7 +213,16 @@ def test_run_scoring_records_failure_state_when_llm_returns_garbage(
     url = "https://example.com/job/bad"
     _seed_pending_job(conn, url)
     repo = SqliteScoreRepository(conn)
-    llm = _ScriptedLlm("SCORE: 99\nKEYWORDS:\nREASONING: invalid")
+    llm = _ScriptedLlm(
+        {
+            "score": 99,  # out of [1, 10] → parser flags ok=False
+            "technical_fit": 0,
+            "experience_fit": 0,
+            "role_fit": 0,
+            "keywords": [],
+            "reasoning": "invalid",
+        }
+    )
 
     monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
     summary = scorer_module.run_scoring(

--- a/workers/automation/tests/test_stage_runner_thread_safety.py
+++ b/workers/automation/tests/test_stage_runner_thread_safety.py
@@ -1,0 +1,105 @@
+"""Regression tests for the stage-runner thread safety bugs fixed in
+``debug/post-temporal-stack``.
+
+The tailor / scorer / cover_letter runners hand work to a
+``ThreadPoolExecutor``. Two related defects landed in production:
+
+* Tailor passed a main-thread-built ``use_case`` (with main-thread
+  ``SqliteMaterialsRepository``) into worker threads, which crashed with
+  ``sqlite3.ProgrammingError: SQLite objects created in a thread can only
+  be used in that same thread`` on every job.
+* All three runners wrote ``set_stage_state(..., "running")`` without
+  ``validate_transition=False``. Once ``set_stage_state`` enforced the
+  canonical state-machine table (PR 6), retried jobs in ``failed`` state
+  hit ``Invalid state transition for tailor: failed -> running``.
+
+This file pins both invariants so they never silently regress.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from jobhunter.database import get_connection, init_db
+from jobhunter.infrastructure.materials import SqliteMaterialsRepository
+from jobhunter.state import set_stage_state, ensure_job_stage_rows
+
+
+@pytest.fixture()
+def db(tmp_path: Path, monkeypatch) -> sqlite3.Connection:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    # Force ``get_connection()`` to use the temp DB path so worker threads
+    # build their own thread-local connection against the same DB the
+    # test fixture initialised.
+    monkeypatch.setenv("JOBHUNTER_DIR", str(tmp_path))
+    return get_connection()
+
+
+def test_thread_local_sqlite_connection_isolation(db: sqlite3.Connection) -> None:
+    """``get_connection()`` is the per-thread SQLite cache that the stage
+    runners rely on after the cross-thread fix. Pin that two threads see
+    two different connection objects so a future refactor can't silently
+    revert to a shared singleton (which would crash with
+    ``ProgrammingError: SQLite objects created in a thread can only be
+    used in that same thread``)."""
+
+    main_thread_conn_id = id(get_connection())
+
+    def worker_gets_own_conn() -> tuple[int, int]:
+        worker_conn = get_connection()
+        # Hitting the worker conn from the worker thread must succeed.
+        worker_conn.execute("SELECT 1").fetchone()
+        # Building a SqliteMaterialsRepository (the type tailor.py uses)
+        # against the worker conn also must not raise.
+        repo = SqliteMaterialsRepository(worker_conn)
+        return id(worker_conn), id(repo._conn)  # type: ignore[attr-defined]
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        worker_conn_id, repo_conn_id = executor.submit(worker_gets_own_conn).result()
+
+    assert worker_conn_id == repo_conn_id, "repository and conn must be the same handle"
+    assert worker_conn_id != main_thread_conn_id, (
+        "worker thread must get its own SQLite connection — a shared "
+        "main-thread conn would crash with ProgrammingError"
+    )
+
+
+def test_failed_to_running_transition_skips_validation(
+    db: sqlite3.Connection,
+) -> None:
+    """Stage runners (scorer/tailor/cover_letter) restart previously-
+    failed jobs by writing ``running`` directly. The canonical state
+    machine table only allows Failed -> Pending (Reset) and Failed ->
+    Exhausted; the runners pass ``validate_transition=False`` to skip
+    the check. Pin that the underlying ``set_stage_state`` honors the
+    bypass so a reverted runner doesn't silently start crashing in
+    production."""
+
+    url = "https://example.com/job/1"
+    ensure_job_stage_rows(db, url, discovered_at="2026-01-01T00:00:00+00:00")
+    # Seed the row in 'failed' state via the validation bypass — the
+    # canonical state machine doesn't permit pending -> failed directly,
+    # but for this test we just need the row to BE in failed state to
+    # exercise the fix.
+    set_stage_state(
+        db, url, "tailor", "failed",
+        error_message="prior run died",
+        validate_transition=False,
+    )
+
+    # Strict path: Failed -> Running must be rejected by the canonical table.
+    with pytest.raises(ValueError, match="Invalid state transition"):
+        set_stage_state(db, url, "tailor", "running")
+
+    # Bypass path: runners pass validate_transition=False and survive.
+    set_stage_state(db, url, "tailor", "running", validate_transition=False)
+    row = db.execute(
+        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = ?",
+        (url, "tailor"),
+    ).fetchone()
+    assert row["state"] == "running"

--- a/workers/automation/tests/test_workflow_starter_cache.py
+++ b/workers/automation/tests/test_workflow_starter_cache.py
@@ -1,17 +1,21 @@
-"""Module-scope Temporal client cache in ``workflow_starter``.
+"""``default_workflow_starter`` / ``default_workflow_canceler`` connect-per-call.
 
-The ``jobhunter rpc`` server is long-lived; opening a fresh gRPC connection
-on every ``apply`` / ``cancel_run`` JSON-RPC call would burn a TCP / TLS /
-namespace-describe handshake per request.  ``default_workflow_starter`` and
-``default_workflow_canceler`` must reuse a single cached :class:`Client`.
+The earlier module-scope ``Client`` cache plus ``asyncio.Lock`` was bound
+to the first event loop that touched it; ``JsonRpcServer.dispatch`` opens
+a fresh loop via ``asyncio.run(...)`` per request, so the cache crashed
+on the second JSON-RPC call with
+``RuntimeError: <Lock ...> is bound to a different event loop``.
+
+The cache was removed; correctness > a few-ms TCP handshake. These tests
+pin the new behaviour: every call constructs a fresh client via
+``get_temporal_client()``, and the second call across a fresh event loop
+succeeds.
 """
 
 from __future__ import annotations
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
 
 from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.infrastructure.rpc import workflow_starter as ws
@@ -21,16 +25,13 @@ class _FakeWorkflow:
     pass
 
 
-@pytest.fixture(autouse=True)
-def _clear_client_cache():
-    """Drop the cached client before and after every test."""
-    asyncio.run(ws._reset_cached_client_for_tests())
-    yield
-    asyncio.run(ws._reset_cached_client_for_tests())
+def test_starter_connects_per_call() -> None:
+    """Each ``default_workflow_starter`` call must invoke ``get_temporal_client``.
 
-
-def test_repeated_starter_calls_reuse_single_client() -> None:
-    """``default_workflow_starter`` must call ``get_temporal_client`` exactly once."""
+    The previous cache was correctness-broken under per-request
+    ``asyncio.run`` loops — see the module docstring for the failure
+    mode. Reconnecting per call is the trade-off.
+    """
     handle = MagicMock()
     fake_client = MagicMock()
     fake_client.start_workflow = AsyncMock(return_value=handle)
@@ -47,49 +48,48 @@ def test_repeated_starter_calls_reuse_single_client() -> None:
 
         asyncio.run(_drive())
 
-    assert connect_mock.await_count == 1
+    assert connect_mock.await_count == 3
     assert fake_client.start_workflow.await_count == 3
 
 
-def test_starter_and_canceler_share_cached_client() -> None:
-    """``default_workflow_canceler`` must reuse the same client the starter cached."""
+def test_canceler_connects_per_call() -> None:
+    """Each ``default_workflow_canceler`` call must invoke ``get_temporal_client`` too."""
     handle = MagicMock()
     handle.cancel = AsyncMock(return_value=None)
     fake_client = MagicMock()
-    fake_client.start_workflow = AsyncMock(return_value=handle)
     fake_client.get_workflow_handle = MagicMock(return_value=handle)
 
     with patch.object(
         ws, "get_temporal_client", AsyncMock(return_value=fake_client)
     ) as connect_mock:
-        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
-
         async def _drive() -> None:
-            await ws.default_workflow_starter(spec)
-            await ws.default_workflow_canceler("wf-123")
-
-        asyncio.run(_drive())
-
-    assert connect_mock.await_count == 1
-    fake_client.get_workflow_handle.assert_called_once_with("wf-123")
-    handle.cancel.assert_awaited_once()
-
-
-def test_reset_cache_helper_forces_reconnect() -> None:
-    """``_reset_cached_client_for_tests`` must clear the cache between runs."""
-    fake_client = MagicMock()
-    fake_client.start_workflow = AsyncMock(return_value=MagicMock())
-
-    with patch.object(
-        ws, "get_temporal_client", AsyncMock(return_value=fake_client)
-    ) as connect_mock:
-        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
-
-        async def _drive() -> None:
-            await ws.default_workflow_starter(spec)
-            await ws._reset_cached_client_for_tests()
-            await ws.default_workflow_starter(spec)
+            await ws.default_workflow_canceler("wf-1")
+            await ws.default_workflow_canceler("wf-2")
 
         asyncio.run(_drive())
 
     assert connect_mock.await_count == 2
+    assert handle.cancel.await_count == 2
+
+
+def test_starter_survives_cross_loop_invocation() -> None:
+    """The original bug: two ``asyncio.run(...)`` calls back-to-back.
+
+    With the broken cache, the second loop hit
+    ``RuntimeError: <Lock ...> is bound to a different event loop``.
+    Now each call connects fresh and the second loop succeeds.
+    """
+    handle = MagicMock()
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock(return_value=handle)
+
+    with patch.object(
+        ws, "get_temporal_client", AsyncMock(return_value=fake_client)
+    ):
+        spec = WorkflowStartSpec(workflow=_FakeWorkflow, args=())
+
+        # Each asyncio.run owns its own loop — exactly the JSON-RPC dispatch path.
+        asyncio.run(ws.default_workflow_starter(spec))
+        asyncio.run(ws.default_workflow_starter(spec))
+
+    assert fake_client.start_workflow.await_count == 2


### PR DESCRIPTION
## Summary

Post-merge debug-and-fix sweep across the 8-PR Temporal stack. Two themes:

1. **Use Gemini structured outputs for scoring** — replaces the brittle SCORE/KEYWORDS/REASONING regex parser with a JSON schema the LLM returns directly. Net: scoring is reliable on Gemini 3.x preview models, the dimension breakdown (technical_fit / experience_fit / role_fit) finally populates, and the parser is a 30-line dict shape validator.

2. **Bug-hunt** — fix every production-impact bug surfaced by live runs + parallel subagent code reviews + pyright sweeps. Lots of cross-thread SQLite / state-transition / event-loop blocking issues that the Temporal stack exposed.

## Bugs fixed (13 commits)

### LLM / Scoring
- **Gemini structured outputs cutover.** `LLMClient.chat` accepts `response_schema` (forwarded as `response_format=json_schema` on OpenAI-compat / `generationConfig.responseSchema` on native Gemini) and `thinking_budget`. Adds `chat_json()` helper. `LlmPort` / `LlmAdapter` thread the new kwargs through. ScoreParser replaces regex with `parse_json(payload)`. Verified live against `gemini-3.1-pro-preview` on real production jobs.
- **`KeyError: 'content'` on Gemini 3.x preview models.** Replaced with typed `LlmEmptyResponseError` carrying `finish_reason` + an actionable hint.
- **Bumped httpx timeout 120s → 180s** (Gemini thinking models exceed 120s on real scoring prompts).

### Cross-thread SQLite
- **Tailor crashed every batch** with `SQLite objects created in a thread can only be used in that same thread`. The shared use_case held a main-thread connection that workers tried to use. Drop the shared use_case; each worker builds its own via `_build_use_case()` / `get_connection()` (per-thread cache).
- **Stage runners broke on retry** (`Invalid state transition for tailor: failed -> running`). Pass `validate_transition=False` on runner-owned restart writes in scorer/tailor/cover_letter — same convention PR 6's launcher fix established.
- **Apply launcher mark_result(applied/failed)** had the same validation race (`Pending -> Failed/Succeeded` not in canonical table). Bypass.
- **Apply launcher reset_failed** had no per-row try/except — one race-induced raise stranded every subsequent reset without commit. Wrap each iteration.

### Temporal
- **Cross-loop client cache broke after the 1st RPC call** (`RuntimeError: <Lock ...> is bound to a different event loop`). Drop the module-scope cache; reconnect per call. Few-ms cost vs silent data loss.
- **Non-apply activities blocked the asyncio event loop** (no heartbeats, no concurrent activities). Lift apply's executor + 15s heartbeat poll into a shared `run_blocking_with_heartbeat` helper; route all 7 non-apply activities through it.
- **No `heartbeat_timeout` on workflow.execute_activity**. Set 2 minutes so Temporal can detect stuck activities.
- **apply_activity orphaned Chrome on cancel.** Signal `launcher._stop_event` in the cancel branch so the worker_loop exits.
- **Missing terminal heartbeat on apply_activity.** Wrap in try/finally + final heartbeat.

### Apps/API
- **Cancel route never reached the worker.** PR 3's `cancel_run` JSON-RPC method existed in contracts but no TS code dispatched it. Click-cancel updated SQLite but the running Temporal workflow kept polling. Map command.action='cancel' → method='cancel_run'; await actionDispatcher in the route when runId is set.
- **CancelApplyButton never passed runId** even though the prop existed. Auto-detect via `useApplyRunsListQuery`.
- **`recentApplyRuns` returned raw status** while `/v1/workflow-runs` normalized — same row surfaced as 'finished' or 'succeeded' depending on endpoint. Run both through the same normalizer.
- **`ApplyResultSchema` was `.strict()`** but the worker now returns `{runId, workflowId, firstExecutionRunId}` — any consumer using `.parse()` would throw. Drop strict + add optional fields.
- **qa-seed events had empty event_type** so the SSE writer skipped them silently. Default to 'QaInfo'.

### Projections
- **`ProjectionBuilder._refresh_impl` committed the caller's open transaction.** `record_job_event` invokes the wildcard subscriber inside the caller's `BEGIN IMMEDIATE` block (e.g., `acquire_job`); committing inside the subscriber prematurely released the row lock and broke rollback. Detect `conn.in_transaction` and defer commit.
- **`LockReleased` clobbered `ApplicationFailed` result.** release_lock emits both events; the projection let LockReleased overwrite captcha/login_issue/expired with the literal string 'failed'. Skip LockReleased when an authoritative terminal event already set a result.

### Type / hygiene
- **4 RuntimeWarnings in test_doctor_langfuse.py** (un-awaited coroutines from a Mock side_effect). Patch `get_temporal_client` directly with AsyncMock.
- **2 pre-existing pyright defects in `projection_builder.py`** (`dict[str, Row]` narrowing + `int(object)`).
- **6 real pyright errors** across cli/rpc/domain/pipeline/enrichment.
- **OTel `BatchSpanProcessor` not flushed on `jobhunter rpc` exit.** Wrap serve() in try/finally.
- **`ready` possibly unbound** in `cli.py::apply` (defensive init).

## Test plan

- [x] `uv --project workers/automation run --extra dev pytest -q` → 680 passed
- [x] `uv --project workers/automation run --extra dev ruff check .` → clean
- [x] `pnpm api:check && pnpm api:test` → 66 tests passed
- [x] `pnpm web:check && pnpm --filter @jobhunter/web test` → 319 tests passed (77 files)
- [x] `pnpm -r check` → all workspaces clean
- [x] `uv --project workers/automation run --extra dev pyright workers/automation/src/jobhunter/{cli.py,apply,scoring,infrastructure}` → 0 errors
- [x] **Live**: `jobhunter score --workers 1 --limit 3` against real production DB — 3 jobs scored end-to-end with structured outputs; dimension breakdown populated in `job_scores.breakdown_json`.
- [x] **Live**: `jobhunter cover --min-score 7` — 5 cover letters generated, 1 expected error.
- [x] Cross-thread regression test pinned (`test_stage_runner_thread_safety.py`).
- [x] Cross-loop RPC cache regression test pinned.
- [ ] **UI**: Workflow Runs view + cancel button — deferred to your QA pass (no browser tools available here).

## Known residuals (out of this PR)

- `/runs/$runId` drawer dead-ends past the 12 most-recent runs (dashboard summary cap). UX issue, not data correctness — would need a per-run lookup endpoint.
- 7 pre-existing pyright errors in `discovery/jobspy.py` and `discovery/smartextract.py` (optional jobspy dep + sys.stdout reconfigure quirks). Not introduced by the Temporal stack.