### PR TITLE
feat(profile): store candidate profile in sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,12 @@ By default, JobHunter writes user data under:
 
 Important local files include:
 
-- `profile.json`: structured candidate and application data.
+- `jobhunter.db`: local SQLite database, including normalized candidate profile,
+  jobs, events, projections, and artifact metadata.
 - `searches.yaml`: search targets and discovery configuration.
 - `.env`: API keys and local runtime settings.
-- `jobhunter.db`: local SQLite database.
-- `resume_template.tex` and `resume_style.json`: PDF rendering inputs.
+- `profile.json`, `resume_template.tex`, and `resume_style.json`: legacy
+  profile/rendering seed files imported into SQLite when no profile row exists.
 - `tailored_resumes/`, `cover_letters/`, `logs/`: generated artifacts.
 - `chrome-workers/`, `apply-workers/`: local browser/apply worker state.
 
@@ -275,8 +276,11 @@ edits.
 
 JobHunter uses local user configuration plus package-shipped registries:
 
-- `~/.jobhunter/profile.json`: candidate data, application defaults, resume
-  baseline, tailoring controls.
+- `~/.jobhunter/jobhunter.db`: candidate profile source of truth, application
+  defaults, resume baseline, tailoring controls, rendering settings, jobs,
+  events, and projections.
+- `~/.jobhunter/profile.json`: legacy seed path for first-time import when the
+  profile tables are empty.
 - `~/.jobhunter/searches.yaml`: searches and source settings.
 - `~/.jobhunter/.env`: provider keys and runtime environment.
 - `workers/automation/src/jobhunter/config/employers.yaml`: packaged employer registry.

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -76,9 +76,8 @@ export type ProfileImporter = (
 ) => Promise<ProfileImportResult>;
 
 export interface ProfilePreviewInput {
-  profilePath: string;
-  resumeStylePath: string;
-  resumeTemplatePath: string;
+  profile: unknown;
+  templateText: string;
 }
 
 export type ProfilePreviewRenderer = (
@@ -189,8 +188,14 @@ export const defaultProfileImporter: ProfileImporter = async (input, context) =>
 
 export const defaultProfilePreviewRenderer: ProfilePreviewRenderer = async (input, context) => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-profile-preview-"));
+  const profilePath = path.join(tempDir, "profile.json");
+  const templatePath = path.join(tempDir, "resume_template.tex");
   const outputPath = path.join(tempDir, "resume-preview.pdf");
   try {
+    fs.writeFileSync(profilePath, JSON.stringify(input.profile), "utf8");
+    if (input.templateText.trim()) {
+      fs.writeFileSync(templatePath, input.templateText, "utf8");
+    }
     await runCommand(
       "uv",
       [
@@ -200,8 +205,8 @@ export const defaultProfilePreviewRenderer: ProfilePreviewRenderer = async (inpu
         "python",
         "-c",
         PROFILE_PREVIEW_SCRIPT,
-        input.profilePath,
-        input.resumeTemplatePath,
+        profilePath,
+        templatePath,
         outputPath,
       ],
       context.appDir,

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -119,6 +119,8 @@ const ROOT_COLUMNS = [
   "experience_current_job_title",
   "experience_current_company",
   "experience_target_role",
+  "experience_target_locations",
+  "experience_target_work_models",
   "availability_earliest_start_date",
   "availability_full_time",
   "availability_contract",
@@ -188,6 +190,8 @@ export function ensureProfileTables(db: SqliteDatabase): void {
       experience_current_job_title TEXT NOT NULL DEFAULT '',
       experience_current_company TEXT NOT NULL DEFAULT '',
       experience_target_role TEXT NOT NULL DEFAULT '',
+      experience_target_locations TEXT NOT NULL DEFAULT '',
+      experience_target_work_models TEXT NOT NULL DEFAULT '',
       availability_earliest_start_date TEXT NOT NULL DEFAULT '',
       availability_full_time TEXT NOT NULL DEFAULT '',
       availability_contract TEXT NOT NULL DEFAULT '',
@@ -319,6 +323,26 @@ export function ensureProfileTables(db: SqliteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_candidate_profile_skill_order
       ON candidate_profile_skill_categories(tenant_id, profile_id, position_index);
   `);
+  ensureCandidateProfileColumns(db);
+}
+
+const CANDIDATE_PROFILE_COLUMN_MIGRATIONS: Record<string, string> = {
+  experience_target_locations: "TEXT NOT NULL DEFAULT ''",
+  experience_target_work_models: "TEXT NOT NULL DEFAULT ''",
+};
+
+function ensureCandidateProfileColumns(db: SqliteDatabase): void {
+  const existingColumns = new Set(
+    (db.prepare("PRAGMA table_info(candidate_profiles)").all() as Array<{ name: string }>).map(
+      (column) => column.name,
+    ),
+  );
+
+  for (const [column, definition] of Object.entries(CANDIDATE_PROFILE_COLUMN_MIGRATIONS)) {
+    if (!existingColumns.has(column)) {
+      db.exec(`ALTER TABLE candidate_profiles ADD COLUMN ${column} ${definition}`);
+    }
+  }
 }
 
 export function readProfileConfig(db: SqliteDatabase, paths: ProfilePaths): ProfileConfigResponse {
@@ -572,6 +596,8 @@ function rowToProfile(db: SqliteDatabase, row: ProfileRow): ProfileShape {
       current_job_title: stringColumn(row.experience_current_job_title),
       current_company: stringColumn(row.experience_current_company),
       target_role: stringColumn(row.experience_target_role),
+      target_locations: stringColumn(row.experience_target_locations),
+      target_work_models: stringColumn(row.experience_target_work_models),
     },
     eeo_voluntary: {
       gender: stringColumn(row.eeo_gender, "Decline to self-identify"),
@@ -754,6 +780,8 @@ function rootValues(
     text(experience.current_job_title),
     text(experience.current_company),
     text(experience.target_role),
+    text(experience.target_locations),
+    text(experience.target_work_models),
     text(availability.earliest_start_date),
     text(availability.available_for_full_time),
     text(availability.available_for_contract),

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -1,0 +1,853 @@
+import fs from "node:fs";
+
+import type { ProfileConfigResponse, ProfileShape, ProfileUpdateRequest } from "./contracts.js";
+import { ProfileSchema } from "./contracts.js";
+import type { SqliteDatabase } from "./db.js";
+
+const TENANT_ID = "local";
+const PROFILE_ID = "default";
+
+export class ProfileInputError extends Error {}
+
+export interface ProfilePaths {
+  profilePath: string;
+  resumeStylePath: string;
+  resumeTemplatePath: string;
+}
+
+const CHILD_TABLES = [
+  "candidate_profile_experience_bullets",
+  "candidate_profile_experience_entries",
+  "candidate_profile_education_entries",
+  "candidate_profile_skill_items",
+  "candidate_profile_skill_categories",
+  "candidate_profile_required_experience_entries",
+  "candidate_profile_required_education_entries",
+  "candidate_profile_required_skill_categories",
+  "candidate_profile_required_bullets",
+  "candidate_profile_required_skills",
+  "candidate_profile_resume_constraint_metrics",
+] as const;
+
+const STYLE_CHOICES = {
+  document_font_size: new Set(["10pt", "11pt", "12pt"]),
+  paper_size: new Set(["a4paper", "letterpaper"]),
+  font_family: new Set(["sans", "roman"]),
+  moderncv_style: new Set(["banking", "classic", "casual", "oldstyle", "fancy"]),
+  moderncv_color: new Set(["black", "blue", "burgundy", "green", "grey", "orange", "purple", "red"]),
+  body_alignment: new Set(["justified", "left"]),
+};
+
+const DEFAULT_STYLE = {
+  document_font_size: "11pt",
+  paper_size: "a4paper",
+  font_family: "sans",
+  moderncv_style: "banking",
+  moderncv_color: "black",
+  page_scale: 0.85,
+  hints_column_width_cm: 3.0,
+  body_alignment: "justified",
+};
+
+const ROOT_COLUMNS = [
+  "tenant_id",
+  "profile_id",
+  "personal_full_name",
+  "personal_preferred_name",
+  "personal_email",
+  "personal_phone",
+  "personal_address",
+  "personal_city",
+  "personal_province_state",
+  "personal_country",
+  "personal_postal_code",
+  "personal_linkedin_url",
+  "personal_github_url",
+  "personal_portfolio_url",
+  "personal_website_url",
+  "personal_password",
+  "work_legally_authorized_to_work",
+  "work_require_sponsorship",
+  "work_work_permit_type",
+  "compensation_salary_expectation",
+  "compensation_salary_currency",
+  "compensation_salary_range_min",
+  "compensation_salary_range_max",
+  "compensation_currency_note",
+  "experience_years_total",
+  "experience_education_level",
+  "experience_current_job_title",
+  "experience_current_company",
+  "experience_target_role",
+  "availability_earliest_start_date",
+  "availability_full_time",
+  "availability_contract",
+  "eeo_gender",
+  "eeo_race_ethnicity",
+  "eeo_veteran_status",
+  "eeo_disability_status",
+  "resume_baseline_text",
+  "tailoring_mode",
+  "tailoring_allow_title_reframing",
+  "tailoring_allow_achievement_rewriting",
+  "tailoring_allow_skill_reordering",
+  "tailoring_allow_summary_rewrite",
+  "tailoring_allow_minor_inference",
+  "writing_tone",
+  "writing_bullet_style",
+  "writing_verbosity",
+  "writing_keyword_density",
+  "writing_avoid_first_person",
+  "max_experience_bullets",
+  "custom_tailoring_prompt",
+  "resume_style_document_font_size",
+  "resume_style_paper_size",
+  "resume_style_font_family",
+  "resume_style_moderncv_style",
+  "resume_style_moderncv_color",
+  "resume_style_page_scale",
+  "resume_style_hints_column_width_cm",
+  "resume_style_body_alignment",
+  "resume_template_text",
+  "version",
+  "updated_at",
+] as const;
+
+type RootColumn = (typeof ROOT_COLUMNS)[number];
+type ProfileRow = Record<RootColumn, string | number | null>;
+
+export function ensureProfileTables(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS candidate_profiles (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      profile_id TEXT NOT NULL DEFAULT 'default',
+      personal_full_name TEXT NOT NULL DEFAULT '',
+      personal_preferred_name TEXT NOT NULL DEFAULT '',
+      personal_email TEXT NOT NULL DEFAULT '',
+      personal_phone TEXT NOT NULL DEFAULT '',
+      personal_address TEXT NOT NULL DEFAULT '',
+      personal_city TEXT NOT NULL DEFAULT '',
+      personal_province_state TEXT NOT NULL DEFAULT '',
+      personal_country TEXT NOT NULL DEFAULT '',
+      personal_postal_code TEXT NOT NULL DEFAULT '',
+      personal_linkedin_url TEXT NOT NULL DEFAULT '',
+      personal_github_url TEXT NOT NULL DEFAULT '',
+      personal_portfolio_url TEXT NOT NULL DEFAULT '',
+      personal_website_url TEXT NOT NULL DEFAULT '',
+      personal_password TEXT NOT NULL DEFAULT '',
+      work_legally_authorized_to_work TEXT NOT NULL DEFAULT '',
+      work_require_sponsorship TEXT NOT NULL DEFAULT '',
+      work_work_permit_type TEXT NOT NULL DEFAULT '',
+      compensation_salary_expectation TEXT NOT NULL DEFAULT '',
+      compensation_salary_currency TEXT NOT NULL DEFAULT 'USD',
+      compensation_salary_range_min TEXT NOT NULL DEFAULT '',
+      compensation_salary_range_max TEXT NOT NULL DEFAULT '',
+      compensation_currency_note TEXT NOT NULL DEFAULT '',
+      experience_years_total TEXT NOT NULL DEFAULT '',
+      experience_education_level TEXT NOT NULL DEFAULT '',
+      experience_current_job_title TEXT NOT NULL DEFAULT '',
+      experience_current_company TEXT NOT NULL DEFAULT '',
+      experience_target_role TEXT NOT NULL DEFAULT '',
+      availability_earliest_start_date TEXT NOT NULL DEFAULT '',
+      availability_full_time TEXT NOT NULL DEFAULT '',
+      availability_contract TEXT NOT NULL DEFAULT '',
+      eeo_gender TEXT NOT NULL DEFAULT 'Decline to self-identify',
+      eeo_race_ethnicity TEXT NOT NULL DEFAULT 'Decline to self-identify',
+      eeo_veteran_status TEXT NOT NULL DEFAULT 'Decline to self-identify',
+      eeo_disability_status TEXT NOT NULL DEFAULT 'Decline to self-identify',
+      resume_baseline_text TEXT NOT NULL DEFAULT '',
+      tailoring_mode TEXT NOT NULL DEFAULT 'balanced',
+      tailoring_allow_title_reframing INTEGER NOT NULL DEFAULT 0,
+      tailoring_allow_achievement_rewriting INTEGER NOT NULL DEFAULT 1,
+      tailoring_allow_skill_reordering INTEGER NOT NULL DEFAULT 1,
+      tailoring_allow_summary_rewrite INTEGER NOT NULL DEFAULT 1,
+      tailoring_allow_minor_inference INTEGER NOT NULL DEFAULT 0,
+      writing_tone TEXT NOT NULL DEFAULT 'direct',
+      writing_bullet_style TEXT NOT NULL DEFAULT 'balanced',
+      writing_verbosity TEXT NOT NULL DEFAULT 'balanced',
+      writing_keyword_density TEXT NOT NULL DEFAULT 'natural',
+      writing_avoid_first_person INTEGER NOT NULL DEFAULT 1,
+      max_experience_bullets INTEGER NOT NULL DEFAULT 4,
+      custom_tailoring_prompt TEXT NOT NULL DEFAULT '',
+      resume_style_document_font_size TEXT NOT NULL DEFAULT '11pt',
+      resume_style_paper_size TEXT NOT NULL DEFAULT 'a4paper',
+      resume_style_font_family TEXT NOT NULL DEFAULT 'sans',
+      resume_style_moderncv_style TEXT NOT NULL DEFAULT 'banking',
+      resume_style_moderncv_color TEXT NOT NULL DEFAULT 'black',
+      resume_style_page_scale REAL NOT NULL DEFAULT 0.85,
+      resume_style_hints_column_width_cm REAL NOT NULL DEFAULT 3.0,
+      resume_style_body_alignment TEXT NOT NULL DEFAULT 'justified',
+      resume_template_text TEXT NOT NULL DEFAULT '',
+      version INTEGER NOT NULL DEFAULT 1,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_experience_entries (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      date_range TEXT NOT NULL DEFAULT '',
+      title TEXT NOT NULL DEFAULT '',
+      company TEXT NOT NULL DEFAULT '',
+      location TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (tenant_id, profile_id, entry_id)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_experience_bullets (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      bullet_index INTEGER NOT NULL,
+      bullet_text TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_education_entries (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      date TEXT NOT NULL DEFAULT '',
+      degree TEXT NOT NULL DEFAULT '',
+      institution TEXT NOT NULL DEFAULT '',
+      location TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (tenant_id, profile_id, entry_id)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_skill_categories (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      category_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      label TEXT NOT NULL DEFAULT '',
+      PRIMARY KEY (tenant_id, profile_id, category_id)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_skill_items (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      category_id TEXT NOT NULL,
+      item_index INTEGER NOT NULL,
+      item_text TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, category_id, item_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_required_experience_entries (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      entry_id TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, position_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_required_education_entries (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      entry_id TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, position_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_required_skill_categories (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      position_index INTEGER NOT NULL,
+      category_id TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, position_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_required_bullets (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      bullet_index INTEGER NOT NULL,
+      bullet_text TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_required_skills (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      category_id TEXT NOT NULL,
+      skill_index INTEGER NOT NULL,
+      skill_text TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, category_id, skill_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_resume_constraint_metrics (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      metric_index INTEGER NOT NULL,
+      metric_text TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, profile_id, metric_index)
+    );
+    CREATE INDEX IF NOT EXISTS idx_candidate_profile_experience_order
+      ON candidate_profile_experience_entries(tenant_id, profile_id, position_index);
+    CREATE INDEX IF NOT EXISTS idx_candidate_profile_education_order
+      ON candidate_profile_education_entries(tenant_id, profile_id, position_index);
+    CREATE INDEX IF NOT EXISTS idx_candidate_profile_skill_order
+      ON candidate_profile_skill_categories(tenant_id, profile_id, position_index);
+  `);
+}
+
+export function readProfileConfig(db: SqliteDatabase, paths: ProfilePaths): ProfileConfigResponse {
+  ensureProfileTables(db);
+  importLegacyProfileIfNeeded(db, paths);
+  const row = getProfileRow(db);
+  if (!row) {
+    return { ok: true, profile: {}, style: DEFAULT_STYLE, templateText: "" };
+  }
+  return {
+    ok: true,
+    profile: rowToProfile(db, row),
+    style: styleFromRow(row),
+    templateText: String(row.resume_template_text ?? ""),
+  };
+}
+
+export function writeProfileConfig(
+  db: SqliteDatabase,
+  paths: ProfilePaths,
+  request: ProfileUpdateRequest,
+): ProfileConfigResponse {
+  ensureProfileTables(db);
+  importLegacyProfileIfNeeded(db, paths);
+
+  let wrote = false;
+  let profile: ProfileShape | undefined;
+  let style: Record<string, string | number> | undefined;
+  let templateText: string | undefined;
+
+  if (request.profile !== undefined || request.profileText !== undefined) {
+    profile = parseProfileInput(request.profile, request.profileText);
+    wrote = true;
+  }
+  if (request.style !== undefined || request.styleText !== undefined) {
+    style = normalizeStyle(parseJsonObjectInput(request.style, request.styleText, "resume style settings"));
+    wrote = true;
+  }
+  if (request.templateText !== undefined) {
+    if (!request.templateText.trim()) {
+      throw new ProfileInputError("resume template cannot be empty.");
+    }
+    templateText = request.templateText;
+    wrote = true;
+  }
+  if (!wrote) {
+    throw new ProfileInputError("At least one profile, style, or template field is required.");
+  }
+
+  const existing = getProfileRow(db);
+  if (!existing && !profile) {
+    throw new ProfileInputError("profile must be initialized before updating style or template settings.");
+  }
+  const nextProfile = profile ?? rowToProfile(db, existing as ProfileRow);
+  const nextStyle = style ?? (existing ? styleFromRow(existing) : DEFAULT_STYLE);
+  const nextTemplate = templateText ?? (existing ? String(existing.resume_template_text ?? "") : "");
+  const nextVersion = existing ? Number(existing.version ?? 0) + 1 : 1;
+
+  replaceProfile(db, nextProfile, nextStyle, nextTemplate, nextVersion);
+  return readProfileConfig(db, paths);
+}
+
+function importLegacyProfileIfNeeded(db: SqliteDatabase, paths: ProfilePaths): void {
+  if (getProfileRow(db) || !fs.existsSync(paths.profilePath)) {
+    return;
+  }
+  const profile = parseProfileInput(undefined, fs.readFileSync(paths.profilePath, "utf8"));
+  const style = fs.existsSync(paths.resumeStylePath)
+    ? normalizeStyle(parseJsonObjectInput(undefined, fs.readFileSync(paths.resumeStylePath, "utf8"), "resume style settings"))
+    : DEFAULT_STYLE;
+  const templateText = fs.existsSync(paths.resumeTemplatePath)
+    ? fs.readFileSync(paths.resumeTemplatePath, "utf8")
+    : "";
+  replaceProfile(db, profile, style, templateText, 1);
+}
+
+function replaceProfile(
+  db: SqliteDatabase,
+  profile: ProfileShape,
+  style: Record<string, string | number>,
+  templateText: string,
+  version: number,
+): void {
+  const transaction = db.transaction(() => {
+    for (const table of CHILD_TABLES) {
+      db.prepare(`DELETE FROM ${table} WHERE tenant_id = ? AND profile_id = ?`).run(TENANT_ID, PROFILE_ID);
+    }
+
+    const assignments = ROOT_COLUMNS
+      .filter((column) => column !== "tenant_id" && column !== "profile_id")
+      .map((column) => `${column} = excluded.${column}`)
+      .join(", ");
+    db.prepare(`
+      INSERT INTO candidate_profiles (${ROOT_COLUMNS.join(", ")})
+      VALUES (${ROOT_COLUMNS.map(() => "?").join(", ")})
+      ON CONFLICT(tenant_id, profile_id) DO UPDATE SET ${assignments}
+    `).run(...rootValues(profile, style, templateText, version));
+
+    insertChildren(db, profile);
+  });
+  transaction();
+}
+
+function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
+  const experienceEntries = asRecordArray(record(profile.resume).experience_entries);
+  const insertExperience = db.prepare(`
+    INSERT INTO candidate_profile_experience_entries (
+      tenant_id, profile_id, entry_id, position_index, date_range, title, company, location
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const insertBullet = db.prepare(`
+    INSERT INTO candidate_profile_experience_bullets (
+      tenant_id, profile_id, entry_id, bullet_index, bullet_text
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+  experienceEntries.forEach((entry, index) => {
+    const entryId = text(entry.id);
+    insertExperience.run(
+      TENANT_ID,
+      PROFILE_ID,
+      entryId,
+      index,
+      text(entry.date_range),
+      text(entry.title),
+      text(entry.company),
+      text(entry.location),
+    );
+    asTextArray(entry.bullets).forEach((bullet, bulletIndex) => {
+      insertBullet.run(TENANT_ID, PROFILE_ID, entryId, bulletIndex, bullet);
+    });
+  });
+
+  const insertEducation = db.prepare(`
+    INSERT INTO candidate_profile_education_entries (
+      tenant_id, profile_id, entry_id, position_index, date, degree, institution, location
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  asRecordArray(record(profile.resume).education_entries).forEach((entry, index) => {
+    insertEducation.run(
+      TENANT_ID,
+      PROFILE_ID,
+      text(entry.id),
+      index,
+      text(entry.date),
+      text(entry.degree),
+      text(entry.institution),
+      text(entry.location),
+    );
+  });
+
+  const insertCategory = db.prepare(`
+    INSERT INTO candidate_profile_skill_categories (
+      tenant_id, profile_id, category_id, position_index, label
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+  const insertSkillItem = db.prepare(`
+    INSERT INTO candidate_profile_skill_items (
+      tenant_id, profile_id, category_id, item_index, item_text
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+  asRecordArray(record(profile.resume).skill_categories).forEach((category, index) => {
+    const categoryId = text(category.id);
+    insertCategory.run(TENANT_ID, PROFILE_ID, categoryId, index, text(category.label));
+    asTextArray(category.items).forEach((item, itemIndex) => {
+      insertSkillItem.run(TENANT_ID, PROFILE_ID, categoryId, itemIndex, item);
+    });
+  });
+
+  const rules = record(record(profile.resume).tailoring_rules);
+  insertRequiredIds(db, "candidate_profile_required_experience_entries", "entry_id", asTextArray(rules.required_experience_entry_ids));
+  insertRequiredIds(db, "candidate_profile_required_education_entries", "entry_id", asTextArray(rules.required_education_entry_ids));
+  insertRequiredIds(db, "candidate_profile_required_skill_categories", "category_id", asTextArray(rules.required_skill_category_ids));
+
+  const insertRequiredBullet = db.prepare(`
+    INSERT INTO candidate_profile_required_bullets (
+      tenant_id, profile_id, entry_id, bullet_index, bullet_text
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+  for (const [entryId, bullets] of Object.entries(record(rules.required_bullets_by_experience_id))) {
+    asTextArray(bullets).forEach((bullet, index) => insertRequiredBullet.run(TENANT_ID, PROFILE_ID, entryId, index, bullet));
+  }
+
+  const insertRequiredSkill = db.prepare(`
+    INSERT INTO candidate_profile_required_skills (
+      tenant_id, profile_id, category_id, skill_index, skill_text
+    ) VALUES (?, ?, ?, ?, ?)
+  `);
+  for (const [categoryId, skills] of Object.entries(record(rules.required_skills_by_category_id))) {
+    asTextArray(skills).forEach((skill, index) => insertRequiredSkill.run(TENANT_ID, PROFILE_ID, categoryId, index, skill));
+  }
+
+  const insertMetric = db.prepare(`
+    INSERT INTO candidate_profile_resume_constraint_metrics (
+      tenant_id, profile_id, metric_index, metric_text
+    ) VALUES (?, ?, ?, ?)
+  `);
+  asTextArray(record(profile.resume_constraints).real_metrics).forEach((metric, index) => {
+    insertMetric.run(TENANT_ID, PROFILE_ID, index, metric);
+  });
+}
+
+function insertRequiredIds(db: SqliteDatabase, table: string, column: string, values: string[]): void {
+  const statement = db.prepare(`
+    INSERT INTO ${table} (tenant_id, profile_id, position_index, ${column})
+    VALUES (?, ?, ?, ?)
+  `);
+  values.forEach((value, index) => statement.run(TENANT_ID, PROFILE_ID, index, value));
+}
+
+function rowToProfile(db: SqliteDatabase, row: ProfileRow): ProfileShape {
+  const profile = {
+    personal: {
+      full_name: stringColumn(row.personal_full_name),
+      preferred_name: stringColumn(row.personal_preferred_name),
+      email: stringColumn(row.personal_email),
+      phone: stringColumn(row.personal_phone),
+      address: stringColumn(row.personal_address),
+      city: stringColumn(row.personal_city),
+      province_state: stringColumn(row.personal_province_state),
+      country: stringColumn(row.personal_country),
+      postal_code: stringColumn(row.personal_postal_code),
+      linkedin_url: stringColumn(row.personal_linkedin_url),
+      github_url: stringColumn(row.personal_github_url),
+      portfolio_url: stringColumn(row.personal_portfolio_url),
+      website_url: stringColumn(row.personal_website_url),
+      password: stringColumn(row.personal_password),
+    },
+    work_authorization: {
+      legally_authorized_to_work: stringColumn(row.work_legally_authorized_to_work),
+      require_sponsorship: stringColumn(row.work_require_sponsorship),
+      work_permit_type: stringColumn(row.work_work_permit_type),
+    },
+    availability: {
+      earliest_start_date: stringColumn(row.availability_earliest_start_date),
+      available_for_full_time: stringColumn(row.availability_full_time),
+      available_for_contract: stringColumn(row.availability_contract),
+    },
+    compensation: {
+      salary_expectation: stringColumn(row.compensation_salary_expectation),
+      salary_currency: stringColumn(row.compensation_salary_currency, "USD"),
+      salary_range_min: stringColumn(row.compensation_salary_range_min),
+      salary_range_max: stringColumn(row.compensation_salary_range_max),
+      currency_conversion_note: stringColumn(row.compensation_currency_note),
+    },
+    experience: {
+      years_of_experience_total: stringColumn(row.experience_years_total),
+      education_level: stringColumn(row.experience_education_level),
+      current_job_title: stringColumn(row.experience_current_job_title),
+      current_company: stringColumn(row.experience_current_company),
+      target_role: stringColumn(row.experience_target_role),
+    },
+    eeo_voluntary: {
+      gender: stringColumn(row.eeo_gender, "Decline to self-identify"),
+      race_ethnicity: stringColumn(row.eeo_race_ethnicity, "Decline to self-identify"),
+      veteran_status: stringColumn(row.eeo_veteran_status, "Decline to self-identify"),
+      disability_status: stringColumn(row.eeo_disability_status, "Decline to self-identify"),
+    },
+    resume: {
+      executive_profile: { baseline_text: stringColumn(row.resume_baseline_text) },
+      experience_entries: experienceRows(db),
+      education_entries: educationRows(db),
+      skill_categories: skillRows(db),
+      tailoring_rules: tailoringRules(db, row),
+    },
+    resume_constraints: {
+      real_metrics: orderedValues(db, "candidate_profile_resume_constraint_metrics", "metric_text", "metric_index"),
+    },
+  };
+  return ProfileSchema.parse(profile);
+}
+
+function experienceRows(db: SqliteDatabase): Array<Record<string, unknown>> {
+  const rows = db.prepare(`
+    SELECT entry_id, date_range, title, company, location
+    FROM candidate_profile_experience_entries
+    WHERE tenant_id = ? AND profile_id = ?
+    ORDER BY position_index, entry_id
+  `).all(TENANT_ID, PROFILE_ID) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    id: text(row.entry_id),
+    date_range: text(row.date_range),
+    title: text(row.title),
+    company: text(row.company),
+    location: text(row.location),
+    bullets: orderedValues(db, "candidate_profile_experience_bullets", "bullet_text", "bullet_index", "entry_id = ?", [text(row.entry_id)]),
+  }));
+}
+
+function educationRows(db: SqliteDatabase): Array<Record<string, unknown>> {
+  return (db.prepare(`
+    SELECT entry_id, date, degree, institution, location
+    FROM candidate_profile_education_entries
+    WHERE tenant_id = ? AND profile_id = ?
+    ORDER BY position_index, entry_id
+  `).all(TENANT_ID, PROFILE_ID) as Array<Record<string, unknown>>).map((row) => ({
+    id: text(row.entry_id),
+    date: text(row.date),
+    degree: text(row.degree),
+    institution: text(row.institution),
+    location: text(row.location),
+  }));
+}
+
+function skillRows(db: SqliteDatabase): Array<Record<string, unknown>> {
+  const rows = db.prepare(`
+    SELECT category_id, label
+    FROM candidate_profile_skill_categories
+    WHERE tenant_id = ? AND profile_id = ?
+    ORDER BY position_index, category_id
+  `).all(TENANT_ID, PROFILE_ID) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    id: text(row.category_id),
+    label: text(row.label),
+    items: orderedValues(db, "candidate_profile_skill_items", "item_text", "item_index", "category_id = ?", [text(row.category_id)]),
+  }));
+}
+
+function tailoringRules(db: SqliteDatabase, row: ProfileRow): Record<string, unknown> {
+  return {
+    required_experience_entry_ids: orderedValues(db, "candidate_profile_required_experience_entries", "entry_id", "position_index"),
+    required_education_entry_ids: orderedValues(db, "candidate_profile_required_education_entries", "entry_id", "position_index"),
+    required_skill_category_ids: orderedValues(db, "candidate_profile_required_skill_categories", "category_id", "position_index"),
+    required_bullets_by_experience_id: groupedValues(db, "candidate_profile_required_bullets", "entry_id", "bullet_text", "bullet_index"),
+    required_skills_by_category_id: groupedValues(db, "candidate_profile_required_skills", "category_id", "skill_text", "skill_index"),
+    max_experience_bullets: Number(row.max_experience_bullets ?? 4),
+    custom_tailoring_prompt: stringColumn(row.custom_tailoring_prompt),
+    tailoring_policy: {
+      mode: stringColumn(row.tailoring_mode, "balanced"),
+      allow_title_reframing: Boolean(Number(row.tailoring_allow_title_reframing ?? 0)),
+      allow_achievement_rewriting: Boolean(Number(row.tailoring_allow_achievement_rewriting ?? 1)),
+      allow_skill_reordering: Boolean(Number(row.tailoring_allow_skill_reordering ?? 1)),
+      allow_summary_rewrite: Boolean(Number(row.tailoring_allow_summary_rewrite ?? 1)),
+      allow_minor_inference: Boolean(Number(row.tailoring_allow_minor_inference ?? 0)),
+    },
+    writing_style: {
+      tone: stringColumn(row.writing_tone, "direct"),
+      bullet_style: stringColumn(row.writing_bullet_style, "balanced"),
+      verbosity: stringColumn(row.writing_verbosity, "balanced"),
+      keyword_density: stringColumn(row.writing_keyword_density, "natural"),
+      avoid_first_person: Boolean(Number(row.writing_avoid_first_person ?? 1)),
+    },
+  };
+}
+
+function orderedValues(
+  db: SqliteDatabase,
+  table: string,
+  valueColumn: string,
+  orderColumn: string,
+  extraWhere = "",
+  extraParams: string[] = [],
+): string[] {
+  const where = extraWhere ? ` AND ${extraWhere}` : "";
+  const rows = db.prepare(`
+    SELECT ${valueColumn} AS value
+    FROM ${table}
+    WHERE tenant_id = ? AND profile_id = ?${where}
+    ORDER BY ${orderColumn}
+  `).all(TENANT_ID, PROFILE_ID, ...extraParams) as Array<{ value: unknown }>;
+  return rows.map((row) => text(row.value));
+}
+
+function groupedValues(
+  db: SqliteDatabase,
+  table: string,
+  keyColumn: string,
+  valueColumn: string,
+  orderColumn: string,
+): Record<string, string[]> {
+  const rows = db.prepare(`
+    SELECT ${keyColumn} AS key, ${valueColumn} AS value
+    FROM ${table}
+    WHERE tenant_id = ? AND profile_id = ?
+    ORDER BY ${keyColumn}, ${orderColumn}
+  `).all(TENANT_ID, PROFILE_ID) as Array<{ key: unknown; value: unknown }>;
+  const grouped: Record<string, string[]> = {};
+  for (const row of rows) {
+    const key = text(row.key);
+    grouped[key] = grouped[key] ?? [];
+    grouped[key].push(text(row.value));
+  }
+  return grouped;
+}
+
+function rootValues(
+  profile: ProfileShape,
+  style: Record<string, string | number>,
+  templateText: string,
+  version: number,
+): unknown[] {
+  const personal = record(profile.personal);
+  const work = record(profile.work_authorization);
+  const compensation = record(profile.compensation);
+  const experience = record(profile.experience);
+  const availability = record(profile.availability);
+  const eeo = record(profile.eeo_voluntary);
+  const resume = record(profile.resume);
+  const executive = record(resume.executive_profile);
+  const rules = record(resume.tailoring_rules);
+  const policy = record(rules.tailoring_policy);
+  const writing = record(rules.writing_style);
+
+  return [
+    TENANT_ID,
+    PROFILE_ID,
+    text(personal.full_name),
+    text(personal.preferred_name),
+    text(personal.email),
+    text(personal.phone),
+    text(personal.address),
+    text(personal.city),
+    text(personal.province_state),
+    text(personal.country),
+    text(personal.postal_code),
+    text(personal.linkedin_url),
+    text(personal.github_url),
+    text(personal.portfolio_url),
+    text(personal.website_url),
+    text(personal.password),
+    text(work.legally_authorized_to_work),
+    text(work.require_sponsorship),
+    text(work.work_permit_type),
+    text(compensation.salary_expectation),
+    text(compensation.salary_currency, "USD"),
+    text(compensation.salary_range_min),
+    text(compensation.salary_range_max),
+    text(compensation.currency_conversion_note),
+    text(experience.years_of_experience_total),
+    text(experience.education_level),
+    text(experience.current_job_title),
+    text(experience.current_company),
+    text(experience.target_role),
+    text(availability.earliest_start_date),
+    text(availability.available_for_full_time),
+    text(availability.available_for_contract),
+    text(eeo.gender, "Decline to self-identify"),
+    text(eeo.race_ethnicity, "Decline to self-identify"),
+    text(eeo.veteran_status, "Decline to self-identify"),
+    text(eeo.disability_status, "Decline to self-identify"),
+    text(executive.baseline_text),
+    text(policy.mode, "balanced"),
+    boolInt(policy.allow_title_reframing, false),
+    boolInt(policy.allow_achievement_rewriting, true),
+    boolInt(policy.allow_skill_reordering, true),
+    boolInt(policy.allow_summary_rewrite, true),
+    boolInt(policy.allow_minor_inference, false),
+    text(writing.tone, "direct"),
+    text(writing.bullet_style, "balanced"),
+    text(writing.verbosity, "balanced"),
+    text(writing.keyword_density, "natural"),
+    boolInt(writing.avoid_first_person, true),
+    Number(rules.max_experience_bullets ?? 4),
+    text(rules.custom_tailoring_prompt),
+    style.document_font_size,
+    style.paper_size,
+    style.font_family,
+    style.moderncv_style,
+    style.moderncv_color,
+    style.page_scale,
+    style.hints_column_width_cm,
+    style.body_alignment,
+    templateText,
+    version,
+    new Date().toISOString(),
+  ];
+}
+
+function styleFromRow(row: ProfileRow): Record<string, string | number> {
+  return normalizeStyle({
+    document_font_size: row.resume_style_document_font_size,
+    paper_size: row.resume_style_paper_size,
+    font_family: row.resume_style_font_family,
+    moderncv_style: row.resume_style_moderncv_style,
+    moderncv_color: row.resume_style_moderncv_color,
+    page_scale: row.resume_style_page_scale,
+    hints_column_width_cm: row.resume_style_hints_column_width_cm,
+    body_alignment: row.resume_style_body_alignment,
+  });
+}
+
+function normalizeStyle(value: Record<string, unknown>): Record<string, string | number> {
+  const merged = { ...DEFAULT_STYLE, ...value };
+  return {
+    document_font_size: pickStyle("document_font_size", merged.document_font_size),
+    paper_size: pickStyle("paper_size", merged.paper_size),
+    font_family: pickStyle("font_family", merged.font_family),
+    moderncv_style: pickStyle("moderncv_style", merged.moderncv_style),
+    moderncv_color: pickStyle("moderncv_color", merged.moderncv_color),
+    page_scale: boundedNumber("page_scale", merged.page_scale, 0.7, 1.0),
+    hints_column_width_cm: boundedNumber("hints_column_width_cm", merged.hints_column_width_cm, 1.5, 5.0),
+    body_alignment: pickStyle("body_alignment", merged.body_alignment),
+  };
+}
+
+function pickStyle(key: keyof typeof STYLE_CHOICES, value: unknown): string {
+  const normalized = text(value, String(DEFAULT_STYLE[key]));
+  if (!STYLE_CHOICES[key].has(normalized)) {
+    throw new ProfileInputError(`${key} must be one of: ${[...STYLE_CHOICES[key]].sort().join(", ")}.`);
+  }
+  return normalized;
+}
+
+function boundedNumber(key: string, value: unknown, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new ProfileInputError(`${key} must be a number.`);
+  }
+  if (parsed < min || parsed > max) {
+    throw new ProfileInputError(`${key} must be between ${min} and ${max}.`);
+  }
+  return Math.round(parsed * 100) / 100;
+}
+
+function parseProfileInput(profile: unknown, profileText: string | undefined): ProfileShape {
+  const candidate = parseJsonObjectInput(profile, profileText, "profile data");
+  const validated = ProfileSchema.safeParse(candidate);
+  if (!validated.success) {
+    const issue = validated.error.issues[0];
+    const path = issue?.path.length ? issue.path.join(".") : "profile";
+    throw new ProfileInputError(`profile validation failed at ${path}: ${issue?.message ?? "invalid input"}`);
+  }
+  return validated.data;
+}
+
+function parseJsonObjectInput(value: unknown, textValue: string | undefined, label: string): Record<string, unknown> {
+  let candidate = value;
+  if (textValue !== undefined) {
+    try {
+      candidate = JSON.parse(textValue) as unknown;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "invalid JSON";
+      throw new ProfileInputError(`${label} is not valid JSON: ${message}`);
+    }
+  }
+  if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) {
+    throw new ProfileInputError(`${label} must be a JSON object.`);
+  }
+  return candidate as Record<string, unknown>;
+}
+
+function getProfileRow(db: SqliteDatabase): ProfileRow | undefined {
+  return db
+    .prepare("SELECT * FROM candidate_profiles WHERE tenant_id = ? AND profile_id = ?")
+    .get(TENANT_ID, PROFILE_ID) as ProfileRow | undefined;
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === "object" && !Array.isArray(item)) : [];
+}
+
+function asTextArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => text(item)).filter(Boolean) : [];
+}
+
+function text(value: unknown, fallback = ""): string {
+  return value === undefined || value === null ? fallback : String(value);
+}
+
+function stringColumn(value: string | number | null, fallback = ""): string {
+  return value === undefined || value === null || value === "" ? fallback : String(value);
+}
+
+function boolInt(value: unknown, fallback: boolean): number {
+  if (value === undefined || value === null) return fallback ? 1 : 0;
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (typeof value === "string") return ["true", "yes", "y", "1", "on"].includes(value.trim().toLowerCase()) ? 1 : 0;
+  return value ? 1 : 0;
+}

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -49,6 +49,46 @@ const DEFAULT_STYLE = {
   body_alignment: "justified",
 };
 
+const DEFAULT_RESUME_TEMPLATE = String.raw`\documentclass[11pt,a4paper,sans]{moderncv}
+
+\moderncvstyle{banking}
+\moderncvcolor{black}
+
+\usepackage[utf8]{inputenc}
+\usepackage[english]{babel}
+\usepackage[scale=0.85]{geometry}
+\usepackage{enumitem}
+
+\setlength{\hintscolumnwidth}{3cm}
+
+{{ personal_data }}
+
+\begin{document}
+
+\makecvtitle
+\vspace*{-1.5em}
+
+{{ resume_body }}
+
+\end{document}
+`;
+
+const SUPPORTED_PROFILE_TOP_LEVEL_KEYS = new Set([
+  "personal",
+  "work_authorization",
+  "availability",
+  "compensation",
+  "experience",
+  "eeo_voluntary",
+  "resume",
+  "resume_constraints",
+  // Legacy file metadata, not Candidate Profile data.
+  "schema_version",
+  // Legacy snapshot-only fields are derived from normalized profile sections.
+  "skills_boundary",
+  "resume_facts",
+]);
+
 const ROOT_COLUMNS = [
   "tenant_id",
   "profile_id",
@@ -286,13 +326,13 @@ export function readProfileConfig(db: SqliteDatabase, paths: ProfilePaths): Prof
   importLegacyProfileIfNeeded(db, paths);
   const row = getProfileRow(db);
   if (!row) {
-    return { ok: true, profile: {}, style: DEFAULT_STYLE, templateText: "" };
+    return { ok: true, profile: {}, style: DEFAULT_STYLE, templateText: DEFAULT_RESUME_TEMPLATE };
   }
   return {
     ok: true,
     profile: rowToProfile(db, row),
     style: styleFromRow(row),
-    templateText: String(row.resume_template_text ?? ""),
+    templateText: String(row.resume_template_text || DEFAULT_RESUME_TEMPLATE),
   };
 }
 
@@ -306,7 +346,7 @@ export function writeProfileConfig(
 
   let wrote = false;
   let profile: ProfileShape | undefined;
-  let style: Record<string, string | number> | undefined;
+  let stylePatch: Record<string, unknown> | undefined;
   let templateText: string | undefined;
 
   if (request.profile !== undefined || request.profileText !== undefined) {
@@ -314,7 +354,7 @@ export function writeProfileConfig(
     wrote = true;
   }
   if (request.style !== undefined || request.styleText !== undefined) {
-    style = normalizeStyle(parseJsonObjectInput(request.style, request.styleText, "resume style settings"));
+    stylePatch = parseJsonObjectInput(request.style, request.styleText, "resume style settings");
     wrote = true;
   }
   if (request.templateText !== undefined) {
@@ -333,8 +373,11 @@ export function writeProfileConfig(
     throw new ProfileInputError("profile must be initialized before updating style or template settings.");
   }
   const nextProfile = profile ?? rowToProfile(db, existing as ProfileRow);
-  const nextStyle = style ?? (existing ? styleFromRow(existing) : DEFAULT_STYLE);
-  const nextTemplate = templateText ?? (existing ? String(existing.resume_template_text ?? "") : "");
+  const existingStyle = existing ? styleFromRow(existing) : DEFAULT_STYLE;
+  const nextStyle = stylePatch ? normalizeStyle({ ...existingStyle, ...stylePatch }) : existingStyle;
+  const nextTemplate =
+    templateText ??
+    (existing ? String(existing.resume_template_text || DEFAULT_RESUME_TEMPLATE) : DEFAULT_RESUME_TEMPLATE);
   const nextVersion = existing ? Number(existing.version ?? 0) + 1 : 1;
 
   replaceProfile(db, nextProfile, nextStyle, nextTemplate, nextVersion);
@@ -351,8 +394,8 @@ function importLegacyProfileIfNeeded(db: SqliteDatabase, paths: ProfilePaths): v
     : DEFAULT_STYLE;
   const templateText = fs.existsSync(paths.resumeTemplatePath)
     ? fs.readFileSync(paths.resumeTemplatePath, "utf8")
-    : "";
-  replaceProfile(db, profile, style, templateText, 1);
+    : DEFAULT_RESUME_TEMPLATE;
+  replaceProfile(db, profile, style, templateText.trim() ? templateText : DEFAULT_RESUME_TEMPLATE, 1);
 }
 
 function replaceProfile(
@@ -794,6 +837,7 @@ function boundedNumber(key: string, value: unknown, min: number, max: number): n
 
 function parseProfileInput(profile: unknown, profileText: string | undefined): ProfileShape {
   const candidate = parseJsonObjectInput(profile, profileText, "profile data");
+  rejectUnsupportedProfileTopLevelFields(candidate);
   const validated = ProfileSchema.safeParse(candidate);
   if (!validated.success) {
     const issue = validated.error.issues[0];
@@ -801,6 +845,18 @@ function parseProfileInput(profile: unknown, profileText: string | undefined): P
     throw new ProfileInputError(`profile validation failed at ${path}: ${issue?.message ?? "invalid input"}`);
   }
   return validated.data;
+}
+
+function rejectUnsupportedProfileTopLevelFields(candidate: Record<string, unknown>): void {
+  const unsupported = Object.keys(candidate)
+    .filter((key) => !SUPPORTED_PROFILE_TOP_LEVEL_KEYS.has(key))
+    .sort();
+  if (unsupported.length) {
+    throw new ProfileInputError(
+      `profile contains unsupported top-level profile field(s): ${unsupported.join(", ")}. ` +
+        "SQLite profile storage only supports normalized Candidate Profile sections.",
+    );
+  }
 }
 
 function parseJsonObjectInput(value: unknown, textValue: string | undefined, label: string): Record<string, unknown> {

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -28,7 +28,6 @@ import type {
   JobListQuery,
   JobSummary,
   PaginatedResponse,
-  ProfileConfigResponse,
   ProfileShape,
   SettingsResponse,
   Stage,
@@ -323,26 +322,8 @@ export function getArtifactDetail(db: SqliteDatabase, artifactId: string): Artif
   return { ok: true, artifact: rowToArtifactSummary(row) };
 }
 
-export function readProfileConfig(paths: {
-  profilePath: string;
-  resumeStylePath: string;
-  resumeTemplatePath: string;
-}): ProfileConfigResponse {
-  return {
-    ok: true,
-    // Read returns the raw JSON so the web UI can edit even malformed
-    // profile.json files. Schema validation is enforced on PATCH (see
-    // ``writeProfileConfig``) — programmatic consumers should re-parse via
-    // ``ProfileSchema``.
-    profile: readJson(paths.profilePath, {}),
-    style: readJson(paths.resumeStylePath, {}),
-    templateText: readText(paths.resumeTemplatePath),
-  };
-}
-
 /** Validate a candidate profile JSON. Used by callers (e.g. tests, future
- * SDK helpers) that want to assert canonical shape before posting. Stays
- * unused by the GET path so corrupt profile.json files remain editable. */
+ * SDK helpers) that want to assert canonical shape before posting. */
 export function parseProfileShape(value: unknown): ProfileShape | null {
   const parsed = ProfileSchema.safeParse(value);
   return parsed.success ? parsed.data : null;
@@ -857,14 +838,6 @@ function readJson(filePath: string, fallback: unknown): unknown {
     return JSON.parse(fs.readFileSync(filePath, "utf8"));
   } catch {
     return fallback;
-  }
-}
-
-function readText(filePath: string): string {
-  try {
-    return fs.readFileSync(filePath, "utf8");
-  } catch {
-    return "";
   }
 }
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -45,9 +45,13 @@ import {
   listArtifacts,
   listJobs,
   listWorkflowRuns,
-  readProfileConfig,
   readSettingsConfig,
 } from "./read-model.js";
+import {
+  ProfileInputError,
+  readProfileConfig,
+  writeProfileConfig,
+} from "./profile-store.js";
 import {
   cancelJobAction,
   InputError,
@@ -59,7 +63,6 @@ import {
   resolveJobUrl,
   softDeleteJob,
   softDeleteJobs,
-  writeProfileConfig,
   writeSettingsConfig,
 } from "./write-model.js";
 
@@ -401,21 +404,32 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     };
   });
 
-  app.get("/v1/profile", async () =>
-    readProfileConfig({
-      profilePath: options.profilePath,
-      resumeStylePath: options.resumeStylePath,
-      resumeTemplatePath: options.resumeTemplatePath,
-    }),
+  app.get("/v1/profile", async (_request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      readProfileConfig(db, {
+        profilePath: options.profilePath,
+        resumeStylePath: options.resumeStylePath,
+        resumeTemplatePath: options.resumeTemplatePath,
+      }),
+    ),
   );
 
   app.get("/v1/profile/preview.pdf", async (_request, reply) => {
     try {
-      const pdfBytes = await profilePreviewRenderer(
-        {
+      const profileConfig = withDb(reply, options.dbPath, (db) =>
+        readProfileConfig(db, {
           profilePath: options.profilePath,
           resumeStylePath: options.resumeStylePath,
           resumeTemplatePath: options.resumeTemplatePath,
+        }),
+      );
+      if ("ok" in profileConfig && profileConfig.ok === false) {
+        return profileConfig;
+      }
+      const pdfBytes = await profilePreviewRenderer(
+        {
+          profile: profileConfig.profile,
+          templateText: profileConfig.templateText,
         },
         actionContext,
       );
@@ -438,8 +452,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!body) {
       return undefined;
     }
+    if (!databaseExists(options.dbPath)) {
+      void reply.code(503);
+      return { ok: false, error: "db_not_found", message: `No JobHunter database found at ${options.dbPath}` };
+    }
+    const db = openDatabase(options.dbPath);
     try {
       return writeProfileConfig(
+        db,
         {
           profilePath: options.profilePath,
           resumeStylePath: options.resumeStylePath,
@@ -448,11 +468,13 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         body,
       );
     } catch (error) {
-      if (error instanceof InputError) {
+      if (error instanceof InputError || error instanceof ProfileInputError) {
         void reply.code(400);
         return { ok: false, error: "invalid_profile", message: error.message };
       }
       throw error;
+    } finally {
+      db.close();
     }
   });
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -633,6 +633,14 @@ function withDb<T>(
     db = openDatabase(dbPath);
     return read(db);
   } catch (error) {
+    if (error instanceof ProfileInputError) {
+      void reply.code(400);
+      return {
+        ok: false,
+        error: "invalid_profile",
+        message: error.message,
+      };
+    }
     const opened = db !== null;
     void reply.code(opened ? 500 : 503);
     return {

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -6,30 +6,22 @@ import type {
   DeleteJobRequest,
   JobMutationResponse,
   MarkJobActionRequest,
-  ProfileConfigResponse,
-  ProfileUpdateRequest,
   SettingsResponse,
   SettingsUpdateRequest,
   Stage,
   StageState,
   StageSummary,
 } from "./contracts.js";
-import { ProfileSchema, STAGES } from "./contracts.js";
+import { STAGES } from "./contracts.js";
 import {
   isValidTransition,
   deserializeStageStateKind,
   type StageStateKind,
 } from "@jobhunter/domain-types";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
-import { matchingJobKeys, readProfileConfig, readSettingsConfig } from "./read-model.js";
+import { matchingJobKeys, readSettingsConfig } from "./read-model.js";
 
 export class InputError extends Error {}
-
-interface ProfilePaths {
-  profilePath: string;
-  resumeStylePath: string;
-  resumeTemplatePath: string;
-}
 
 const DEFAULT_MAX_ATTEMPTS: Record<Stage, number> = {
   discover: 1,
@@ -297,49 +289,6 @@ export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest)
   });
   transaction(jobKeys);
   return { ok: true, count: jobKeys.length, jobKeys };
-}
-
-export function writeProfileConfig(paths: ProfilePaths, request: ProfileUpdateRequest): ProfileConfigResponse {
-  let wrote = false;
-  let profile: Record<string, unknown> | undefined;
-  let style: Record<string, unknown> | undefined;
-  let templateText: string | undefined;
-
-  if (request.profile !== undefined || request.profileText !== undefined) {
-    const candidate = parseJsonObjectInput(request.profile, request.profileText, "profile.json");
-    const validated = ProfileSchema.safeParse(candidate);
-    if (!validated.success) {
-      const issue = validated.error.issues[0];
-      const path = issue?.path.length ? issue.path.join(".") : "profile";
-      throw new InputError(`profile.json validation failed at ${path}: ${issue?.message ?? "invalid input"}`);
-    }
-    profile = validated.data as Record<string, unknown>;
-    wrote = true;
-  }
-  if (request.style !== undefined || request.styleText !== undefined) {
-    style = parseJsonObjectInput(request.style, request.styleText, "resume_style.json");
-    wrote = true;
-  }
-  if (request.templateText !== undefined) {
-    if (!request.templateText.trim()) {
-      throw new InputError("resume_template.tex cannot be empty.");
-    }
-    templateText = request.templateText;
-    wrote = true;
-  }
-  if (!wrote) {
-    throw new InputError("At least one profile, style, or template field is required.");
-  }
-  if (profile !== undefined) {
-    writeJson(paths.profilePath, profile);
-  }
-  if (style !== undefined) {
-    writeJson(paths.resumeStylePath, style);
-  }
-  if (templateText !== undefined) {
-    writeText(paths.resumeTemplatePath, templateText);
-  }
-  return readProfileConfig(paths);
 }
 
 export function writeSettingsConfig(paths: { settingsPath: string }, request: SettingsUpdateRequest): SettingsResponse {

--- a/apps/api/test/qa-workflow.test.ts
+++ b/apps/api/test/qa-workflow.test.ts
@@ -201,7 +201,10 @@ describe("seeded local QA workflow", () => {
       payload: { profileText: JSON.stringify(profileDraft, null, 2) },
     });
     expect(updateProfile.statusCode, updateProfile.body).toBe(200);
-    expect(JSON.parse(fs.readFileSync(workspace.profilePath, "utf8")).personal.full_name).toBe("QA Candidate Edited");
+    const profileAfterUpdate = await app.inject({ method: "GET", url: "/v1/profile" });
+    expect(profileAfterUpdate.statusCode, profileAfterUpdate.body).toBe(200);
+    expect(profileAfterUpdate.json().profile.personal.full_name).toBe("QA Candidate Edited");
+    expect(JSON.parse(fs.readFileSync(workspace.profilePath, "utf8")).personal.full_name).toBe("QA Candidate");
 
     const preview = await app.inject({ method: "GET", url: "/v1/profile/preview.pdf" });
     expect(preview.statusCode, preview.body).toBe(200);

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1029,6 +1029,43 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("seeds a default resume template when the legacy template file is missing", async () => {
+    fs.rmSync(options.resumeTemplatePath, { force: true });
+    const app = buildApp(options);
+    const initial = await app.inject({ method: "GET", url: "/v1/profile" });
+
+    expect(initial.statusCode, initial.body).toBe(200);
+    const initialBody = initial.json();
+    expect(initialBody.templateText).toContain("{{ personal_data }}");
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: {
+        profile: validProfileFixture("Template Save"),
+        style: initialBody.style,
+        templateText: initialBody.templateText,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      profile: { personal: { full_name: "Template Save" } },
+    });
+    const db = new Database(options.dbPath);
+    try {
+      const row = db.prepare("SELECT resume_template_text FROM candidate_profiles").get() as {
+        resume_template_text: string;
+      };
+      expect(row.resume_template_text).toContain("{{ personal_data }}");
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
   it("persists profile, style, and template updates to relational rows without rewriting legacy files", async () => {
     const app = buildApp(options);
     const originalLegacyProfile = fs.readFileSync(options.profilePath, "utf8");
@@ -1068,6 +1105,69 @@ describe("local TypeScript API", () => {
     } finally {
       db.close();
     }
+
+    await app.close();
+  });
+
+  it("preserves existing non-default style fields during partial style updates", async () => {
+    fs.writeFileSync(options.resumeStylePath, JSON.stringify({ font_family: "roman", moderncv_color: "blue" }));
+    const app = buildApp(options);
+    await app.inject({ method: "GET", url: "/v1/profile" });
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: {
+        style: { moderncv_style: "classic" },
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      style: {
+        font_family: "roman",
+        moderncv_color: "blue",
+        moderncv_style: "classic",
+      },
+    });
+
+    await app.close();
+  });
+
+  it("rejects unsupported top-level profile fields before storing updates", async () => {
+    const app = buildApp(options);
+    const profile = { ...validProfileFixture("Future Candidate"), custom_section: { future: "thing" } };
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile },
+    });
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(response.json()).toMatchObject({
+      ok: false,
+      error: "invalid_profile",
+    });
+    expect(response.json().message).toContain("unsupported top-level profile field(s): custom_section");
+
+    await app.close();
+  });
+
+  it("rejects unsupported top-level legacy profile fields before import", async () => {
+    fs.writeFileSync(
+      options.profilePath,
+      JSON.stringify({ ...validProfileFixture("Future Legacy"), custom_section: { future: "thing" } }),
+    );
+    const app = buildApp(options);
+    const response = await app.inject({ method: "GET", url: "/v1/profile" });
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(response.json()).toMatchObject({
+      ok: false,
+      error: "invalid_profile",
+    });
+    expect(response.json().message).toContain("unsupported top-level profile field(s): custom_section");
 
     await app.close();
   });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -14,6 +14,28 @@ import { buildApp, type BuildAppOptions } from "../src/server.js";
 let tempDir = "";
 let options: BuildAppOptions;
 
+function validProfileFixture(fullName: string): Record<string, unknown> {
+  return {
+    personal: { full_name: fullName, email: "jordan@example.com" },
+    resume: {
+      executive_profile: { baseline_text: "Experienced platform leader." },
+      experience_entries: [
+        {
+          id: "role_1",
+          title: "Engineer",
+          company: "Example",
+          date_range: "2024 -- Present",
+          location: "Remote",
+          bullets: ["Shipped reliable systems."],
+        },
+      ],
+      education_entries: [],
+      skill_categories: [],
+      tailoring_rules: {},
+    },
+  };
+}
+
 beforeEach(() => {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-api-"));
   options = {
@@ -24,8 +46,8 @@ beforeEach(() => {
     settingsPath: path.join(tempDir, "dashboard.json"),
   };
   seedDatabase(options.dbPath);
-  fs.writeFileSync(options.profilePath, JSON.stringify({ personal: { full_name: "Jordan Candidate" } }));
-  fs.writeFileSync(options.resumeStylePath, JSON.stringify({ font_family: "moderncv" }));
+  fs.writeFileSync(options.profilePath, JSON.stringify(validProfileFixture("Jordan Candidate")));
+  fs.writeFileSync(options.resumeStylePath, JSON.stringify({ font_family: "sans" }));
   fs.writeFileSync(options.resumeTemplatePath, "\\documentclass{article}");
   fs.writeFileSync(
     options.settingsPath,
@@ -980,7 +1002,7 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("returns local profile, style, and template configuration", async () => {
+  it("imports legacy profile files once and returns relational profile configuration", async () => {
     const app = buildApp(options);
     const response = await app.inject({ method: "GET", url: "/v1/profile" });
 
@@ -989,37 +1011,34 @@ describe("local TypeScript API", () => {
     expect(body).toMatchObject({
       ok: true,
       profile: { personal: { full_name: "Jordan Candidate" } },
-      style: { font_family: "moderncv" },
+      style: { font_family: "sans" },
       templateText: "\\documentclass{article}",
     });
     expect(body.paths).toBeUndefined();
+    const db = new Database(options.dbPath);
+    try {
+      expect(db.prepare("SELECT COUNT(*) AS count FROM candidate_profiles").get()).toMatchObject({ count: 1 });
+      const rootColumns = db.prepare("PRAGMA table_info(candidate_profiles)").all() as Array<{ name: string }>;
+      expect(rootColumns.map((column) => column.name)).not.toEqual(
+        expect.arrayContaining(["profile_json", "style_json", "payload_json"]),
+      );
+    } finally {
+      db.close();
+    }
 
     await app.close();
   });
 
-  it("persists profile, style, and template updates with JSON validation", async () => {
+  it("persists profile, style, and template updates to relational rows without rewriting legacy files", async () => {
     const app = buildApp(options);
-    const validProfile = {
-      personal: { full_name: "Taylor Updated" },
-      resume: {
-        experience_entries: [
-          {
-            id: "role_1",
-            title: "Engineer",
-            company: "Example",
-            date_range: "2024 -- Present",
-            location: "Remote",
-            bullets: ["Shipped reliable systems."],
-          },
-        ],
-      },
-    };
+    const originalLegacyProfile = fs.readFileSync(options.profilePath, "utf8");
+    const validProfile = validProfileFixture("Taylor Updated");
     const response = await app.inject({
       method: "PATCH",
       url: "/v1/profile",
       payload: {
-        profileText: JSON.stringify(validProfile),
-        styleText: JSON.stringify({ font_family: "classic" }),
+        profile: validProfile,
+        style: { moderncv_style: "classic" },
         templateText: "\\documentclass{moderncv}",
       },
     });
@@ -1028,12 +1047,27 @@ describe("local TypeScript API", () => {
     expect(response.json()).toMatchObject({
       ok: true,
       profile: { personal: { full_name: "Taylor Updated" } },
-      style: { font_family: "classic" },
+      style: { moderncv_style: "classic" },
       templateText: "\\documentclass{moderncv}",
     });
-    expect(JSON.parse(fs.readFileSync(options.profilePath, "utf8"))).toMatchObject({
-      personal: { full_name: "Taylor Updated" },
-    });
+    expect(fs.readFileSync(options.profilePath, "utf8")).toBe(originalLegacyProfile);
+    const db = new Database(options.dbPath);
+    try {
+      expect(
+        db.prepare(
+          "SELECT personal_full_name, resume_style_font_family, resume_style_moderncv_style, resume_template_text FROM candidate_profiles",
+        ).get(),
+      ).toMatchObject({
+        personal_full_name: "Taylor Updated",
+        resume_style_moderncv_style: "classic",
+        resume_template_text: "\\documentclass{moderncv}",
+      });
+      expect(db.prepare("SELECT COUNT(*) AS count FROM candidate_profile_experience_bullets").get()).toMatchObject({
+        count: 1,
+      });
+    } finally {
+      db.close();
+    }
 
     await app.close();
   });
@@ -1052,15 +1086,18 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("validates all profile update inputs before writing any files", async () => {
+  it("validates all profile update inputs before changing relational rows", async () => {
     const app = buildApp(options);
     const originalProfile = fs.readFileSync(options.profilePath, "utf8");
     const originalStyle = fs.readFileSync(options.resumeStylePath, "utf8");
+    await app.inject({ method: "GET", url: "/v1/profile" });
+    const db = new Database(options.dbPath);
+    const before = db.prepare("SELECT personal_full_name FROM candidate_profiles").get();
     const response = await app.inject({
       method: "PATCH",
       url: "/v1/profile",
       payload: {
-        profileText: JSON.stringify({ personal: { full_name: "Should Not Persist" } }),
+        profile: validProfileFixture("Should Not Persist"),
         styleText: "{",
       },
     });
@@ -1069,6 +1106,8 @@ describe("local TypeScript API", () => {
     expect(response.json()).toMatchObject({ ok: false, error: "invalid_profile" });
     expect(fs.readFileSync(options.profilePath, "utf8")).toBe(originalProfile);
     expect(fs.readFileSync(options.resumeStylePath, "utf8")).toBe(originalStyle);
+    expect(db.prepare("SELECT personal_full_name FROM candidate_profiles").get()).toEqual(before);
+    db.close();
 
     await app.close();
   });
@@ -1139,9 +1178,8 @@ describe("local TypeScript API", () => {
     expect(response.rawPayload.subarray(0, 5).toString()).toBe("%PDF-");
     expect(renderer).toHaveBeenCalledWith(
       {
-        profilePath: options.profilePath,
-        resumeStylePath: options.resumeStylePath,
-        resumeTemplatePath: options.resumeTemplatePath,
+        profile: expect.objectContaining({ personal: expect.objectContaining({ full_name: "Jordan Candidate" }) }),
+        templateText: "\\documentclass{article}",
       },
       expect.objectContaining({ appDir: tempDir }),
     );

--- a/apps/web/e2e/tests/profile-edit.spec.ts
+++ b/apps/web/e2e/tests/profile-edit.spec.ts
@@ -1,16 +1,17 @@
 import { test, expect } from "@playwright/test";
 
-test("Profile edit + PDF preview: edit a field, save, iframe src updates with a new cache key", async ({
+test("Profile edit + PDF preview: edit a field, save, preview URL updates with a new cache key", async ({
   page,
 }) => {
   await page.goto("/profile");
 
   await expect(page.getByText(/Full name/i).first()).toBeVisible({ timeout: 30_000 });
 
-  const iframe = page.locator("iframe.pdf-preview-frame");
-  await expect(iframe).toBeVisible({ timeout: 30_000 });
-  const initialSrc = await iframe.getAttribute("src");
-  expect(initialSrc).toBeTruthy();
+  const previewLink = page.getByRole("link", { name: /open PDF/i });
+  await expect(page.getByText("Resume preview", { exact: true })).toBeVisible({ timeout: 30_000 });
+  await expect(previewLink).toBeVisible({ timeout: 30_000 });
+  const initialHref = await previewLink.getAttribute("href");
+  expect(initialHref).toContain("/v1/profile/preview.pdf");
 
   const fullNameLabel = page.getByText(/Full name/i).first();
   const fullNameInput = fullNameLabel.locator("xpath=following-sibling::input").first();
@@ -24,6 +25,6 @@ test("Profile edit + PDF preview: edit a field, save, iframe src updates with a 
   await expect(saveButton).toBeDisabled({ timeout: 30_000 });
 
   await expect
-    .poll(async () => iframe.getAttribute("src"), { timeout: 30_000 })
-    .not.toBe(initialSrc);
+    .poll(async () => previewLink.getAttribute("href"), { timeout: 30_000 })
+    .not.toBe(initialHref);
 });

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -4,6 +4,7 @@ import {
   asTextArray,
   cloneJsonRecord,
   defaultRepeatItem,
+  editableTextArrayAt,
   getPathValue,
   type JsonRecord,
   lines,
@@ -20,6 +21,7 @@ import {
   emptyProfileMonth,
   formatProfileDateRange,
   formatProfileMonth,
+  isProfileDateRangeChronological,
   parseProfileDateRange,
   parseProfileMonth,
   PROFILE_MONTHS,
@@ -139,7 +141,7 @@ export function StructuredProfileEditor({
   const addBullet = (entryIndex: number) => {
     updateProfileDraft((draft) => {
       const path = `resume.experience_entries.${entryIndex}.bullets`;
-      setPathValue(draft, path, [...textArrayAt(draft, path), ""]);
+      setPathValue(draft, path, [...editableTextArrayAt(draft, path), ""]);
     });
   };
 
@@ -149,7 +151,7 @@ export function StructuredProfileEditor({
       setPathValue(
         draft,
         path,
-        textArrayAt(draft, path).filter((_, index) => index !== bulletIndex),
+        editableTextArrayAt(draft, path).filter((_, index) => index !== bulletIndex),
       );
     });
   };
@@ -157,7 +159,7 @@ export function StructuredProfileEditor({
   const addSkill = (categoryIndex: number) => {
     updateProfileDraft((draft) => {
       const path = `resume.skill_categories.${categoryIndex}.items`;
-      setPathValue(draft, path, [...textArrayAt(draft, path), ""]);
+      setPathValue(draft, path, [...editableTextArrayAt(draft, path), ""]);
     });
   };
 
@@ -167,7 +169,7 @@ export function StructuredProfileEditor({
       setPathValue(
         draft,
         path,
-        textArrayAt(draft, path).filter((_, index) => index !== skillIndex),
+        editableTextArrayAt(draft, path).filter((_, index) => index !== skillIndex),
       );
     });
   };
@@ -270,20 +272,18 @@ export function StructuredProfileEditor({
 
   const dateRangeField = (path: string, label: string) => {
     const value = parseProfileDateRange(textAt(profile, path));
+    const hasError = !isProfileDateRangeChronological(value);
     const updateDateRange = (next: Partial<typeof value>) => {
       updateProfilePath(path, formatProfileDateRange({ ...value, ...next }));
     };
     return (
-      <div className="field date-range-field">
+      <div className="field date-range-field wide">
         <span>{label}</span>
-        <div className="date-range-body">
+        <div className={`date-range-body${hasError ? " invalid" : ""}`}>
           {monthSelector("Start", value.start, (start) => updateDateRange({ start }))}
-          {monthSelector(
-            "End",
-            value.present ? emptyProfileMonth() : value.end,
-            (end) => updateDateRange({ end, present: false }),
-            value.present,
-          )}
+          {value.present
+            ? null
+            : monthSelector("End", value.end, (end) => updateDateRange({ end, present: false }))}
           <label className="choice date-range-present">
             <input
               type="checkbox"
@@ -312,6 +312,7 @@ export function StructuredProfileEditor({
             clear
           </button>
         </div>
+        {hasError ? <span className="field-error">End date must be after start date.</span> : null}
       </div>
     );
   };
@@ -425,9 +426,6 @@ export function StructuredProfileEditor({
               {textField("personal.full_name", "Full name", "text", { required: true })}
               {textField("personal.preferred_name", "Preferred name")}
               {textField("personal.email", "Email", "email", { required: true })}
-              {textField("personal.password", "Application password", "password", {
-                autoComplete: "new-password",
-              })}
               {textField("personal.phone", "Phone", "tel")}
               {textField("personal.address", "Address")}
               {textField("personal.city", "City")}
@@ -462,7 +460,7 @@ export function StructuredProfileEditor({
         <div className="repeat-list">
           {experienceEntries.map((entry, index) => {
             const entryId = textFrom(entry["id"]);
-            const bullets = asTextArray(entry["bullets"]);
+            const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
             const requiredBullets = new Set(
               asTextArray(
                 recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
@@ -498,7 +496,6 @@ export function StructuredProfileEditor({
                   </div>
                 </div>
                 <div className="field-grid">
-                  {textField(`resume.experience_entries.${index}.id`, "Entry ID")}
                   {dateRangeField(`resume.experience_entries.${index}.date_range`, "Date range")}
                   {textField(`resume.experience_entries.${index}.title`, "Title")}
                   {textField(`resume.experience_entries.${index}.company`, "Company")}
@@ -595,7 +592,6 @@ export function StructuredProfileEditor({
                   </div>
                 </div>
                 <div className="field-grid">
-                  {textField(`resume.education_entries.${index}.id`, "Entry ID")}
                   {monthField(`resume.education_entries.${index}.date`, "Completion month")}
                   {textField(`resume.education_entries.${index}.degree`, "Degree")}
                   {textField(`resume.education_entries.${index}.institution`, "Institution")}
@@ -619,7 +615,7 @@ export function StructuredProfileEditor({
         <div className="repeat-list">
           {skillCategories.map((entry, index) => {
             const entryId = textFrom(entry["id"]);
-            const skills = asTextArray(entry["items"]);
+            const skills = editableTextArrayAt(profile, `resume.skill_categories.${index}.items`);
             const requiredSkills = new Set(
               asTextArray(
                 recordAt(profile, "resume.tailoring_rules.required_skills_by_category_id")[entryId],
@@ -655,7 +651,6 @@ export function StructuredProfileEditor({
                   </div>
                 </div>
                 <div className="field-grid">
-                  {textField(`resume.skill_categories.${index}.id`, "Category ID")}
                   {textField(`resume.skill_categories.${index}.label`, "Label")}
                 </div>
                 <div className="skill-list">
@@ -734,6 +729,9 @@ export function StructuredProfileEditor({
               ])}
               {selectField("work_authorization.require_sponsorship", "Requires sponsorship", ["No", "Yes"])}
               {textField("work_authorization.work_permit_type", "Work permit type")}
+              {textField("personal.password", "Job-site login password", "password", {
+                autoComplete: "new-password",
+              })}
               {textField("availability.earliest_start_date", "Earliest start date", "date")}
               {selectField("availability.available_for_full_time", "Available full-time", ["Yes", "No"])}
               {selectField("availability.available_for_contract", "Available for contract", ["No", "Yes"])}

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -418,33 +418,73 @@ export function StructuredProfileEditor({
     );
   };
 
-  const workModelField = () => {
-    const path = "experience.target_work_models";
-    const selected = new Set(delimitedListAt(textAt(profile, path)).filter(Boolean));
-    const updateWorkModels = (value: string, checked: boolean) => {
-      const next = new Set(selected);
-      if (checked) {
-        next.add(value);
-      } else {
-        next.delete(value);
-      }
-      updateProfilePath(path, Array.from(next).join("; "));
+  const targetLocationWorkModelField = () => {
+    const locationPath = "experience.target_locations";
+    const workModelPath = "experience.target_work_models";
+    const locations = delimitedListAt(textAt(profile, locationPath));
+    const workModels = delimitedListAt(textAt(profile, workModelPath));
+    const rowCount = Math.max(locations.length, workModels.length, 1);
+    const rows = Array.from({ length: rowCount }, (_, index) => ({
+      location: locations[index] ?? "",
+      workModel: workModels[index] ?? "",
+    }));
+
+    const updateRows = (nextRows: Array<{ location: string; workModel: string }>) => {
+      updateProfileDraft((draft) => {
+        setPathValue(draft, locationPath, nextRows.map((row) => row.location).join("; "));
+        setPathValue(draft, workModelPath, nextRows.map((row) => row.workModel).join("; "));
+      });
     };
 
     return (
-      <div className="field wide target-work-models">
-        <span>Target work model</span>
-        <div className="work-model-options">
-          {["Remote", "Hybrid", "On-site"].map((value) => (
-            <label className="work-model-choice" key={value}>
+      <div className="field wide target-location-model-field">
+        <span>Target location: target work model</span>
+        <div className="target-location-model-list">
+          {rows.map((row, index) => (
+            <div className="target-location-model-row" key={`${locationPath}-${index}`}>
               <input
-                type="checkbox"
-                checked={selected.has(value)}
-                onChange={(event) => updateWorkModels(value, event.target.checked)}
+                aria-label={`Target location ${index + 1}`}
+                value={row.location}
+                placeholder="Location"
+                onChange={(event) => {
+                  const next = [...rows];
+                  next[index] = { ...row, location: event.target.value };
+                  updateRows(next);
+                }}
               />
-              <span>{value}</span>
-            </label>
+              <select
+                aria-label={`Target work model ${index + 1}`}
+                value={row.workModel}
+                onChange={(event) => {
+                  const next = [...rows];
+                  next[index] = { ...row, workModel: event.target.value };
+                  updateRows(next);
+                }}
+              >
+                <option value="">Work model</option>
+                <option value="Remote">Remote</option>
+                <option value="Hybrid">Hybrid</option>
+                <option value="On-site">On-site</option>
+              </select>
+              <button
+                className="icon-button"
+                type="button"
+                aria-label={`Remove target location ${index + 1}`}
+                title="Remove"
+                onClick={() => updateRows(rows.filter((_, itemIndex) => itemIndex !== index))}
+              >
+                <Trash2 size={14} aria-hidden="true" />
+              </button>
+            </div>
           ))}
+          <button
+            className="tab add-bullet"
+            type="button"
+            onClick={() => updateRows([...rows, { location: "", workModel: "" }])}
+          >
+            <Plus size={14} aria-hidden="true" />
+            add location
+          </button>
         </div>
       </div>
     );
@@ -840,10 +880,7 @@ export function StructuredProfileEditor({
             <h3>Target search</h3>
             <div className="target-preferences-grid">
               {delimitedListField("experience.target_role", "Target roles", "add role", { compact: true })}
-              {delimitedListField("experience.target_locations", "Target locations", "add location", {
-                compact: true,
-              })}
-              {workModelField()}
+              {targetLocationWorkModelField()}
             </div>
           </section>
 

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Plus, Trash2 } from "lucide-react";
 
 import {
@@ -46,6 +47,36 @@ export function StructuredProfileEditor({
 }: StructuredProfileEditorProps) {
   const profile = parseJsonRecord(profileText);
   const style = parseJsonRecord(styleText);
+  const focusTargetsRef = useRef(new Map<string, HTMLInputElement | HTMLSelectElement>());
+  const pendingFocusKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const focusKey = pendingFocusKeyRef.current;
+    if (!focusKey) {
+      return;
+    }
+    const element = focusTargetsRef.current.get(focusKey);
+    if (!element) {
+      return;
+    }
+    pendingFocusKeyRef.current = null;
+    element.focus();
+    if (element instanceof HTMLInputElement) {
+      element.select();
+    }
+  }, [profileText]);
+
+  const registerFocusTarget = (key: string) => (element: HTMLInputElement | HTMLSelectElement | null) => {
+    if (element) {
+      focusTargetsRef.current.set(key, element);
+    } else {
+      focusTargetsRef.current.delete(key);
+    }
+  };
+
+  const focusAfterDraftUpdate = (key: string) => {
+    pendingFocusKeyRef.current = key;
+  };
 
   if (!profile || !style) {
     return (
@@ -380,8 +411,21 @@ export function StructuredProfileEditor({
     options: { compact?: boolean } = {},
   ) => {
     const values = delimitedListAt(textAt(profile, path));
+    const focusKey = (index: number) => `${path}:${index}`;
     const updateValues = (next: string[]) => {
       updateProfilePath(path, next.join("; "));
+    };
+    const insertValueAfter = (index: number, currentValue: string) => {
+      const insertionIndex = index + 1;
+      const next = [...values];
+      next[index] = currentValue;
+      next.splice(insertionIndex, 0, "");
+      focusAfterDraftUpdate(focusKey(insertionIndex));
+      updateValues(next);
+    };
+    const appendValue = () => {
+      focusAfterDraftUpdate(focusKey(values.length));
+      updateValues([...values, ""]);
     };
     return (
       <div className="field wide inline-list-field">
@@ -391,11 +435,19 @@ export function StructuredProfileEditor({
             <div className="inline-list-row" key={`${path}-${index}`}>
               <input
                 aria-label={`${label} ${index + 1}`}
+                ref={registerFocusTarget(focusKey(index))}
                 value={value}
                 onChange={(event) => {
                   const next = [...values];
                   next[index] = event.target.value;
                   updateProfilePath(path, next.join("; "));
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") {
+                    return;
+                  }
+                  event.preventDefault();
+                  insertValueAfter(index, event.currentTarget.value);
                 }}
               />
               <button
@@ -409,7 +461,7 @@ export function StructuredProfileEditor({
               </button>
             </div>
           ))}
-          <button className="tab add-bullet" type="button" onClick={() => updateValues([...values, ""])}>
+          <button className="tab add-bullet" type="button" onClick={appendValue}>
             <Plus size={14} aria-hidden="true" />
             {addLabel}
           </button>
@@ -428,12 +480,25 @@ export function StructuredProfileEditor({
       location: locations[index] ?? "",
       workModel: workModels[index] ?? "",
     }));
+    const locationFocusKey = (index: number) => `${locationPath}:location:${index}`;
 
     const updateRows = (nextRows: Array<{ location: string; workModel: string }>) => {
       updateProfileDraft((draft) => {
         setPathValue(draft, locationPath, nextRows.map((row) => row.location).join("; "));
         setPathValue(draft, workModelPath, nextRows.map((row) => row.workModel).join("; "));
       });
+    };
+    const insertRowAfter = (index: number, rowPatch: Partial<{ location: string; workModel: string }>) => {
+      const insertionIndex = index + 1;
+      const next = [...rows];
+      next[index] = { ...next[index], ...rowPatch };
+      next.splice(insertionIndex, 0, { location: "", workModel: "" });
+      focusAfterDraftUpdate(locationFocusKey(insertionIndex));
+      updateRows(next);
+    };
+    const appendRow = () => {
+      focusAfterDraftUpdate(locationFocusKey(rows.length));
+      updateRows([...rows, { location: "", workModel: "" }]);
     };
 
     return (
@@ -444,12 +509,20 @@ export function StructuredProfileEditor({
             <div className="target-location-model-row" key={`${locationPath}-${index}`}>
               <input
                 aria-label={`Target location ${index + 1}`}
+                ref={registerFocusTarget(locationFocusKey(index))}
                 value={row.location}
                 placeholder="Location"
                 onChange={(event) => {
                   const next = [...rows];
                   next[index] = { ...row, location: event.target.value };
                   updateRows(next);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") {
+                    return;
+                  }
+                  event.preventDefault();
+                  insertRowAfter(index, { location: event.currentTarget.value });
                 }}
               />
               <select
@@ -459,6 +532,13 @@ export function StructuredProfileEditor({
                   const next = [...rows];
                   next[index] = { ...row, workModel: event.target.value };
                   updateRows(next);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key !== "Enter") {
+                    return;
+                  }
+                  event.preventDefault();
+                  insertRowAfter(index, { workModel: event.currentTarget.value });
                 }}
               >
                 <option value="">Work model</option>
@@ -480,7 +560,7 @@ export function StructuredProfileEditor({
           <button
             className="tab add-bullet"
             type="button"
-            onClick={() => updateRows([...rows, { location: "", workModel: "" }])}
+            onClick={appendRow}
           >
             <Plus size={14} aria-hidden="true" />
             add location

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -481,6 +481,7 @@ export function StructuredProfileEditor({
       workModel: workModels[index] ?? "",
     }));
     const locationFocusKey = (index: number) => `${locationPath}:location:${index}`;
+    const workModelOptions = ["Remote", "Hybrid", "On-site"];
 
     const updateRows = (nextRows: Array<{ location: string; workModel: string }>) => {
       updateProfileDraft((draft) => {
@@ -499,6 +500,17 @@ export function StructuredProfileEditor({
     const appendRow = () => {
       focusAfterDraftUpdate(locationFocusKey(rows.length));
       updateRows([...rows, { location: "", workModel: "" }]);
+    };
+    const toggleWorkModel = (index: number, value: string, checked: boolean) => {
+      const selected = new Set(commaListAt(rows[index]?.workModel ?? ""));
+      if (checked) {
+        selected.add(value);
+      } else {
+        selected.delete(value);
+      }
+      const next = [...rows];
+      next[index] = { ...next[index], workModel: Array.from(selected).join(", ") };
+      updateRows(next);
     };
 
     return (
@@ -525,27 +537,22 @@ export function StructuredProfileEditor({
                   insertRowAfter(index, { location: event.currentTarget.value });
                 }}
               />
-              <select
-                aria-label={`Target work model ${index + 1}`}
-                value={row.workModel}
-                onChange={(event) => {
-                  const next = [...rows];
-                  next[index] = { ...row, workModel: event.target.value };
-                  updateRows(next);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== "Enter") {
-                    return;
-                  }
-                  event.preventDefault();
-                  insertRowAfter(index, { workModel: event.currentTarget.value });
-                }}
-              >
-                <option value="">Work model</option>
-                <option value="Remote">Remote</option>
-                <option value="Hybrid">Hybrid</option>
-                <option value="On-site">On-site</option>
-              </select>
+              <fieldset className="target-work-model-group" aria-label={`Target work model ${index + 1}`}>
+                {workModelOptions.map((value) => {
+                  const checkboxId = `target-work-model-${index}-${value.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+                  return (
+                    <label className="target-work-model-option" key={value} htmlFor={checkboxId}>
+                      <input
+                        id={checkboxId}
+                        type="checkbox"
+                        checked={commaListAt(row.workModel).includes(value)}
+                        onChange={(event) => toggleWorkModel(index, value, event.target.checked)}
+                      />
+                      <span>{value}</span>
+                    </label>
+                  );
+                })}
+              </fieldset>
               <button
                 className="icon-button"
                 type="button"
@@ -1082,4 +1089,11 @@ function delimitedListAt(value: string): string[] {
     return [""];
   }
   return withoutLegacyLabel.split(";").map((item) => item.trim());
+}
+
+function commaListAt(value: string): string[] {
+  if (!value.trim()) {
+    return [];
+  }
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
 }

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -373,6 +373,46 @@ export function StructuredProfileEditor({
     </label>
   );
 
+  const delimitedListField = (path: string, label: string, addLabel: string) => {
+    const values = delimitedListAt(textAt(profile, path));
+    const updateValues = (next: string[]) => {
+      updateProfilePath(path, next.join("; "));
+    };
+    return (
+      <div className="field wide inline-list-field">
+        <span>{label}</span>
+        <div className="inline-list">
+          {values.map((value, index) => (
+            <div className="inline-list-row" key={`${path}-${index}`}>
+              <input
+                aria-label={`${label} ${index + 1}`}
+                value={value}
+                onChange={(event) => {
+                  const next = [...values];
+                  next[index] = event.target.value;
+                  updateValues(next);
+                }}
+              />
+              <button
+                className="icon-button"
+                type="button"
+                aria-label={`Remove ${label.toLowerCase()} ${index + 1}`}
+                title="Remove"
+                onClick={() => updateValues(values.filter((_, itemIndex) => itemIndex !== index))}
+              >
+                <Trash2 size={14} aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+          <button className="tab add-bullet" type="button" onClick={() => updateValues([...values, ""])}>
+            <Plus size={14} aria-hidden="true" />
+            {addLabel}
+          </button>
+        </div>
+      </div>
+    );
+  };
+
   const styleSelect = (path: string, label: string, options: Array<[string, string]>) => (
     <label className="field">
       <span>{label}</span>
@@ -449,9 +489,16 @@ export function StructuredProfileEditor({
               {textField("experience.education_level", "Education level")}
               {textField("experience.current_job_title", "Current job title")}
               {textField("experience.current_company", "Current company")}
+              {textField(
+                "resume.tailoring_rules.max_experience_bullets",
+                "Max bullets per role",
+                "number",
+                { min: 1, max: 99, step: 1 },
+              )}
             </div>
             <div className="field-grid one">
               {textareaField("resume.executive_profile.baseline_text", "Executive profile baseline")}
+              {listField("resume_constraints.real_metrics", "Verified resume metrics")}
             </div>
           </section>
 
@@ -753,18 +800,9 @@ export function StructuredProfileEditor({
           </section>
 
           <section className="form-section">
-            <h3>Target preferences</h3>
-            <div className="field-grid">
-              {textField("experience.target_role", "Target role")}
-              {textField(
-                "resume.tailoring_rules.max_experience_bullets",
-                "Max bullets per role",
-                "number",
-                { min: 1, max: 99, step: 1 },
-              )}
-            </div>
+            <h3>Target roles</h3>
             <div className="field-grid one">
-              {listField("resume_constraints.real_metrics", "Real metrics the AI may reuse")}
+              {delimitedListField("experience.target_role", "Target roles", "add role")}
             </div>
           </section>
 
@@ -878,4 +916,12 @@ export function StructuredProfileEditor({
       )}
     </div>
   );
+}
+
+function delimitedListAt(value: string): string[] {
+  const withoutLegacyLabel = value.replace(/^\s*Target roles?:\s*/i, "");
+  if (!withoutLegacyLabel.trim()) {
+    return [""];
+  }
+  return withoutLegacyLabel.split(";").map((item) => item.trim());
 }

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -48,8 +48,7 @@ export function StructuredProfileEditor({
   if (!profile || !style) {
     return (
       <div className="banner inline">
-        The structured editor needs valid JSON. Switch to source, fix the invalid file, then return
-        to fields.
+        The structured editor needs valid profile data. Reload the profile after fixing the saved data.
       </div>
     );
   }

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -373,7 +373,12 @@ export function StructuredProfileEditor({
     </label>
   );
 
-  const delimitedListField = (path: string, label: string, addLabel: string) => {
+  const delimitedListField = (
+    path: string,
+    label: string,
+    addLabel: string,
+    options: { compact?: boolean } = {},
+  ) => {
     const values = delimitedListAt(textAt(profile, path));
     const updateValues = (next: string[]) => {
       updateProfilePath(path, next.join("; "));
@@ -381,7 +386,7 @@ export function StructuredProfileEditor({
     return (
       <div className="field wide inline-list-field">
         <span>{label}</span>
-        <div className="inline-list">
+        <div className={`inline-list${options.compact ? " compact" : ""}`}>
           {values.map((value, index) => (
             <div className="inline-list-row" key={`${path}-${index}`}>
               <input
@@ -390,7 +395,7 @@ export function StructuredProfileEditor({
                 onChange={(event) => {
                   const next = [...values];
                   next[index] = event.target.value;
-                  updateValues(next);
+                  updateProfilePath(path, next.join("; "));
                 }}
               />
               <button
@@ -408,6 +413,38 @@ export function StructuredProfileEditor({
             <Plus size={14} aria-hidden="true" />
             {addLabel}
           </button>
+        </div>
+      </div>
+    );
+  };
+
+  const workModelField = () => {
+    const path = "experience.target_work_models";
+    const selected = new Set(delimitedListAt(textAt(profile, path)).filter(Boolean));
+    const updateWorkModels = (value: string, checked: boolean) => {
+      const next = new Set(selected);
+      if (checked) {
+        next.add(value);
+      } else {
+        next.delete(value);
+      }
+      updateProfilePath(path, Array.from(next).join("; "));
+    };
+
+    return (
+      <div className="field wide target-work-models">
+        <span>Target work model</span>
+        <div className="work-model-options">
+          {["Remote", "Hybrid", "On-site"].map((value) => (
+            <label className="work-model-choice" key={value}>
+              <input
+                type="checkbox"
+                checked={selected.has(value)}
+                onChange={(event) => updateWorkModels(value, event.target.checked)}
+              />
+              <span>{value}</span>
+            </label>
+          ))}
         </div>
       </div>
     );
@@ -800,9 +837,13 @@ export function StructuredProfileEditor({
           </section>
 
           <section className="form-section">
-            <h3>Target roles</h3>
-            <div className="field-grid one">
-              {delimitedListField("experience.target_role", "Target roles", "add role")}
+            <h3>Target search</h3>
+            <div className="target-preferences-grid">
+              {delimitedListField("experience.target_role", "Target roles", "add role", { compact: true })}
+              {delimitedListField("experience.target_locations", "Target locations", "add location", {
+                compact: true,
+              })}
+              {workModelField()}
             </div>
           </section>
 

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -83,8 +83,10 @@ describe("<ProfileForm>", () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
 
     expect(await screen.findByRole("heading", { name: "Application defaults" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Target roles" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Target search" })).toBeInTheDocument();
     expect(screen.getByLabelText("Target roles 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Target locations 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Remote")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -86,7 +86,9 @@ describe("<ProfileForm>", () => {
     expect(screen.getByRole("heading", { name: "Target search" })).toBeInTheDocument();
     expect(screen.getByLabelText("Target roles 1")).toBeInTheDocument();
     expect(screen.getByLabelText("Target location 1")).toBeInTheDocument();
-    expect(screen.getByLabelText("Target work model 1")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Target work model 1" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Remote")).toBeInTheDocument();
+    expect(screen.getByLabelText("Hybrid")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 
@@ -106,7 +108,18 @@ describe("<ProfileForm>", () => {
     await user.type(await screen.findByLabelText("Target location 1"), "Barcelona{Enter}");
 
     expect(screen.getByLabelText("Target location 2")).toHaveFocus();
-    expect(screen.getByLabelText("Target work model 2")).toBeInTheDocument();
+    expect(screen.getByRole("group", { name: "Target work model 2" })).toBeInTheDocument();
+  });
+
+  it("allows multiple work models for a target location", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
+
+    await user.click(await screen.findByLabelText("Remote"));
+    await user.click(screen.getByLabelText("Hybrid"));
+
+    expect(screen.getByLabelText("Remote")).toBeChecked();
+    expect(screen.getByLabelText("Hybrid")).toBeChecked();
   });
 
   it("clamps max bullets to the allowed positive range", async () => {

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -90,6 +90,25 @@ describe("<ProfileForm>", () => {
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 
+  it("adds and focuses the next target role with Enter", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
+
+    await user.type(await screen.findByLabelText("Target roles 1"), "Director{Enter}");
+
+    expect(screen.getByLabelText("Target roles 2")).toHaveFocus();
+  });
+
+  it("adds and focuses the next target location with Enter", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
+
+    await user.type(await screen.findByLabelText("Target location 1"), "Barcelona{Enter}");
+
+    expect(screen.getByLabelText("Target location 2")).toHaveFocus();
+    expect(screen.getByLabelText("Target work model 2")).toBeInTheDocument();
+  });
+
   it("clamps max bullets to the allowed positive range", async () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} />);
     const input = await screen.findByLabelText("Max bullets per role");

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -83,13 +83,13 @@ describe("<ProfileForm>", () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
 
     expect(await screen.findByRole("heading", { name: "Application defaults" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Target preferences" })).toBeInTheDocument();
-    expect(screen.getByLabelText("Target role")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Target roles" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Target roles 1")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 
   it("clamps max bullets to the allowed positive range", async () => {
-    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />);
     const input = await screen.findByLabelText("Max bullets per role");
 
     fireEvent.change(input, { target: { value: "-1" } });

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -1,7 +1,9 @@
 import { fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
 import { sampleProfileResponse } from "../../../test/fixtures/projections.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
 import { renderWithProviders } from "../../../test/render.js";
 import { ProfileForm } from "./profile-form.js";
 
@@ -27,6 +29,54 @@ describe("<ProfileForm>", () => {
     expect(screen.queryByText("profile.json")).not.toBeInTheDocument();
     expect(screen.queryByText("resume_style.json")).not.toBeInTheDocument();
     expect(screen.queryByText("resume_template.tex")).not.toBeInTheDocument();
+  });
+
+  it("does not expose internal IDs or job-site passwords in the profile editor", async () => {
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      withRouter: true,
+    });
+
+    expect(await screen.findByRole("heading", { name: "Experience entries" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Entry ID")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Application password")).not.toBeInTheDocument();
+  });
+
+  it("adds a visible editable bullet row", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      withRouter: true,
+    });
+
+    await user.click(await screen.findByRole("button", { name: /add bullet/i }));
+
+    expect(screen.getByLabelText("Bullet 3")).toBeInTheDocument();
+  });
+
+  it("hides end date controls while an experience is marked present", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      withRouter: true,
+    });
+
+    await user.click(await screen.findByLabelText("Present"));
+
+    expect(screen.queryByLabelText("End month")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("End year")).not.toBeInTheDocument();
+  });
+
+  it("blocks saving when an experience end date is before the start date", async () => {
+    const user = userEvent.setup();
+    const updateProfile = vi.fn(async () => sampleProfileResponse);
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      ports: buildTestPorts({ api: { updateProfile } }),
+      withRouter: true,
+    });
+
+    await user.selectOptions(await screen.findByLabelText("End year"), "2021");
+    await user.click(screen.getByRole("button", { name: /^save all$/i }));
+
+    expect(await screen.findAllByText(/End date must be after start date/i)).not.toHaveLength(0);
+    expect(updateProfile).not.toHaveBeenCalled();
   });
 
   it("renders preferences as their own section", async () => {

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -17,6 +17,18 @@ describe("<ProfileForm>", () => {
     expect(screen.queryByRole("button", { name: "preferences" })).not.toBeInTheDocument();
   });
 
+  it("does not expose raw profile source editors", async () => {
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      withRouter: true,
+    });
+
+    expect(await screen.findByRole("heading", { name: "Personal information" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "source" })).not.toBeInTheDocument();
+    expect(screen.queryByText("profile.json")).not.toBeInTheDocument();
+    expect(screen.queryByText("resume_style.json")).not.toBeInTheDocument();
+    expect(screen.queryByText("resume_template.tex")).not.toBeInTheDocument();
+  });
+
   it("renders preferences as their own section", async () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
 

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -85,8 +85,8 @@ describe("<ProfileForm>", () => {
     expect(await screen.findByRole("heading", { name: "Application defaults" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Target search" })).toBeInTheDocument();
     expect(screen.getByLabelText("Target roles 1")).toBeInTheDocument();
-    expect(screen.getByLabelText("Target locations 1")).toBeInTheDocument();
-    expect(screen.getByLabelText("Remote")).toBeInTheDocument();
+    expect(screen.getByLabelText("Target location 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Target work model 1")).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/contexts/profile/forms/profile-form.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.tsx
@@ -5,12 +5,10 @@ import { useEffect, useState } from "react";
 
 import type { ProfileConfigResponse } from "../../operations/types.js";
 import { Empty } from "../../../shared/ui/empty.js";
-import { Editor } from "../components/Editor.js";
 import { StructuredProfileEditor } from "../components/StructuredProfileEditor.js";
 import { useUpdateProfileMutation } from "../hooks/useUpdateProfileMutation.js";
 
 export type ProfileSection = "profile" | "preferences";
-export type ProfileMode = "fields" | "source";
 
 export interface ProfileFormValues {
   profileText: string;
@@ -45,15 +43,15 @@ function tryParseJson(text: string): { ok: true; value: unknown } | { ok: false;
 function validateProfileForm(values: ProfileFormValues): string | undefined {
   const parsedProfile = tryParseJson(values.profileText);
   if (!parsedProfile.ok) {
-    return `profile.json: ${parsedProfile.error}`;
+    return `Profile data: ${parsedProfile.error}`;
   }
   const profileResult = ProfileSchema.safeParse(parsedProfile.value);
   if (!profileResult.success) {
-    return `profile.json: ${profileResult.error.issues[0]?.message ?? "invalid profile"}`;
+    return `Profile data: ${profileResult.error.issues[0]?.message ?? "invalid profile"}`;
   }
   const parsedStyle = tryParseJson(values.styleText);
   if (!parsedStyle.ok) {
-    return `resume_style.json: ${parsedStyle.error}`;
+    return `Resume style settings: ${parsedStyle.error}`;
   }
   return undefined;
 }
@@ -68,7 +66,6 @@ function toUpdateRequest(values: ProfileFormValues): ProfileUpdateRequest {
 
 export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) {
   const updateProfile = useUpdateProfileMutation();
-  const [mode, setMode] = useState<ProfileMode>("fields");
   const [statusMessage, setStatusMessage] = useState("");
   const isProfileSection = section === "profile";
 
@@ -129,71 +126,17 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
           </div>
         )}
       </form.Subscribe>
-      {isProfileSection ? (
-        <div className="profile-mode-tabs">
-          <button
-            className={`tab ${mode === "fields" ? "on" : ""}`}
-            type="button"
-            onClick={() => setMode("fields")}
-          >
-            fields
-          </button>
-          <button
-            className={`tab ${mode === "source" ? "on" : ""}`}
-            type="button"
-            onClick={() => setMode("source")}
-          >
-            source
-          </button>
-        </div>
-      ) : null}
       <form.Field name="profileText">
         {(profileField) => (
           <form.Field name="styleText">
             {(styleField) => (
-              <form.Field name="templateText">
-                {(templateField) =>
-                  !isProfileSection || mode !== "source" ? (
-                    <StructuredProfileEditor
-                      mode={section}
-                      profileText={profileField.state.value}
-                      styleText={styleField.state.value}
-                      onProfileTextChange={(value) => profileField.handleChange(value)}
-                      onStyleTextChange={(value) => styleField.handleChange(value)}
-                    />
-                  ) : (
-                    <>
-                      <Editor
-                        dirty={profileField.state.meta.isDirty}
-                        label="profile.json"
-                        saving={updateProfile.isPending}
-                        value={profileField.state.value}
-                        onChange={(value) => profileField.handleChange(value)}
-                        onDiscard={() => profileField.handleChange(initial.profile ? JSON.stringify(initial.profile, null, 2) : "")}
-                        onSave={() => void form.handleSubmit()}
-                      />
-                      <Editor
-                        dirty={styleField.state.meta.isDirty}
-                        label="resume_style.json"
-                        saving={updateProfile.isPending}
-                        value={styleField.state.value}
-                        onChange={(value) => styleField.handleChange(value)}
-                        onDiscard={() => styleField.handleChange(initial.style ? JSON.stringify(initial.style, null, 2) : "")}
-                        onSave={() => void form.handleSubmit()}
-                      />
-                      <Editor
-                        dirty={templateField.state.meta.isDirty}
-                        label="resume_template.tex"
-                        saving={updateProfile.isPending}
-                        value={templateField.state.value}
-                        onChange={(value) => templateField.handleChange(value)}
-                        onDiscard={() => templateField.handleChange(initial.templateText)}
-                        onSave={() => void form.handleSubmit()}
-                      />
-                    </>
-                  )
-                }
-              </form.Field>
+              <StructuredProfileEditor
+                mode={section}
+                profileText={profileField.state.value}
+                styleText={styleField.state.value}
+                onProfileTextChange={(value) => profileField.handleChange(value)}
+                onStyleTextChange={(value) => styleField.handleChange(value)}
+              />
             )}
           </form.Field>
         )}

--- a/apps/web/src/contexts/profile/forms/profile-form.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.tsx
@@ -1,4 +1,4 @@
-import { ProfileSchema, type ProfileUpdateRequest } from "@jobhunter/contracts";
+import { ProfileSchema, type ProfileShape, type ProfileUpdateRequest } from "@jobhunter/contracts";
 import { useForm } from "@tanstack/react-form";
 import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
@@ -7,6 +7,10 @@ import type { ProfileConfigResponse } from "../../operations/types.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { StructuredProfileEditor } from "../components/StructuredProfileEditor.js";
 import { useUpdateProfileMutation } from "../hooks/useUpdateProfileMutation.js";
+import {
+  isProfileDateRangeChronological,
+  parseProfileDateRange,
+} from "../lib/profile-date-fields.js";
 
 export type ProfileSection = "profile" | "preferences";
 
@@ -49,9 +53,24 @@ function validateProfileForm(values: ProfileFormValues): string | undefined {
   if (!profileResult.success) {
     return `Profile data: ${profileResult.error.issues[0]?.message ?? "invalid profile"}`;
   }
+  const profileDateError = validateProfileDateRanges(profileResult.data);
+  if (profileDateError) {
+    return profileDateError;
+  }
   const parsedStyle = tryParseJson(values.styleText);
   if (!parsedStyle.ok) {
     return `Resume style settings: ${parsedStyle.error}`;
+  }
+  return undefined;
+}
+
+function validateProfileDateRanges(profile: ProfileShape): string | undefined {
+  const entries = profile.resume.experience_entries;
+  for (const [index, entry] of entries.entries()) {
+    if (!isProfileDateRangeChronological(parseProfileDateRange(entry.date_range))) {
+      const label = entry.title || `Experience ${index + 1}`;
+      return `${label}: End date must be after start date.`;
+    }
   }
   return undefined;
 }

--- a/apps/web/src/contexts/profile/lib/json-record.ts
+++ b/apps/web/src/contexts/profile/lib/json-record.ts
@@ -62,6 +62,11 @@ export function textArrayAt(source: unknown, path: string): string[] {
   return asTextArray(getPathValue(source, path));
 }
 
+export function editableTextArrayAt(source: unknown, path: string): string[] {
+  const value = getPathValue(source, path);
+  return Array.isArray(value) ? value.map(textFrom) : [];
+}
+
 export function asTextArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map(textFrom).filter((item) => item.length > 0) : [];
 }

--- a/apps/web/src/contexts/profile/lib/profile-date-fields.test.ts
+++ b/apps/web/src/contexts/profile/lib/profile-date-fields.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   formatProfileDateRange,
   formatProfileMonth,
+  isProfileDateRangeChronological,
   parseProfileDateRange,
   parseProfileMonth,
 } from "./profile-date-fields.js";
@@ -34,5 +35,15 @@ describe("profile date field helpers", () => {
       present: false,
     });
     expect(formatProfileDateRange(parsed)).toBe("2022 -- 2025");
+  });
+
+  it("detects end dates that are before start dates", () => {
+    expect(isProfileDateRangeChronological(parseProfileDateRange("Sep 2020 -- Jan 2017"))).toBe(
+      false,
+    );
+    expect(isProfileDateRangeChronological(parseProfileDateRange("Sep 2020 -- Present"))).toBe(true);
+    expect(isProfileDateRangeChronological(parseProfileDateRange("Sep 2020 -- Oct 2020"))).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/contexts/profile/lib/profile-date-fields.ts
+++ b/apps/web/src/contexts/profile/lib/profile-date-fields.ts
@@ -144,6 +144,29 @@ export function formatProfileDateRange(value: ProfileDateRangeValue): string {
   return start || end;
 }
 
+export function isProfileDateRangeChronological(value: ProfileDateRangeValue): boolean {
+  if (value.present || !value.start.year || !value.end.year) {
+    return true;
+  }
+  const startYear = Number(value.start.year);
+  const endYear = Number(value.end.year);
+  if (!Number.isInteger(startYear) || !Number.isInteger(endYear)) {
+    return true;
+  }
+  if (endYear !== startYear) {
+    return endYear > startYear;
+  }
+  if (!value.start.month || !value.end.month) {
+    return true;
+  }
+  const startMonth = Number(value.start.month);
+  const endMonth = Number(value.end.month);
+  if (!Number.isInteger(startMonth) || !Number.isInteger(endMonth)) {
+    return true;
+  }
+  return endMonth >= startMonth;
+}
+
 function normalizeMonthNumber(value: string): string {
   const numeric = Number(value);
   if (!Number.isInteger(numeric) || numeric < 1 || numeric > 12) {

--- a/apps/web/src/contexts/profile/stores/profile-import-store.ts
+++ b/apps/web/src/contexts/profile/stores/profile-import-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
 
 interface ProfileImportState {
   filename: string;
@@ -18,6 +18,37 @@ const initialState = {
   importStyle: true,
 };
 
+function createMemoryStorage(): StateStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}
+
+const fallbackStorage = createMemoryStorage();
+
+function getStorage(): StateStorage {
+  if (typeof window === "undefined") {
+    return fallbackStorage;
+  }
+  const storage = window.localStorage as Partial<StateStorage> | undefined;
+  if (
+    storage &&
+    typeof storage.getItem === "function" &&
+    typeof storage.setItem === "function" &&
+    typeof storage.removeItem === "function"
+  ) {
+    return storage as StateStorage;
+  }
+  return fallbackStorage;
+}
+
 export const useProfileImportStore = create<ProfileImportState>()(
   persist(
     (set) => ({
@@ -28,6 +59,7 @@ export const useProfileImportStore = create<ProfileImportState>()(
     }),
     {
       name: "jh:profile-import",
+      storage: createJSONStorage(getStorage),
       version: 1,
     },
   ),

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1241,13 +1241,39 @@ textarea {
 
 .target-location-model-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(108px, 132px) auto;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.9fr) auto;
   gap: 8px;
   align-items: center;
 }
 
 .target-location-model-row .icon-button {
   grid-area: auto;
+}
+
+.target-work-model-group {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 6px;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.target-work-model-option {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  background: var(--paper-2);
+  padding: 6px 9px;
+  color: var(--muted);
+}
+
+.target-work-model-option input {
+  width: auto;
 }
 
 .skill-row {
@@ -1515,7 +1541,11 @@ textarea {
   }
 
   .target-location-model-row {
-    grid-template-columns: minmax(0, 1fr) minmax(108px, 132px) auto;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .target-work-model-group {
+    grid-column: 1 / -1;
   }
 
   .drawer {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1186,6 +1186,25 @@ textarea {
   gap: 8px;
 }
 
+.inline-list-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.inline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.inline-list-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
 .skill-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1233,30 +1233,21 @@ textarea {
   justify-content: center;
 }
 
-.target-preferences-grid .target-work-models {
-  grid-column: 1 / -1;
-}
-
-.work-model-options {
+.target-location-model-list {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 8px;
 }
 
-.work-model-choice {
-  display: inline-flex;
-  min-height: 32px;
+.target-location-model-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(108px, 132px) auto;
+  gap: 8px;
   align-items: center;
-  gap: 6px;
-  border: 1px solid var(--rule);
-  border-radius: 5px;
-  background: var(--paper-2);
-  padding: 6px 10px;
-  color: var(--muted);
 }
 
-.work-model-choice input {
-  width: auto;
+.target-location-model-row .icon-button {
+  grid-area: auto;
 }
 
 .skill-row {
@@ -1521,6 +1512,10 @@ textarea {
 
   .inline-list.compact {
     grid-template-columns: 1fr;
+  }
+
+  .target-location-model-row {
+    grid-template-columns: minmax(0, 1fr) minmax(108px, 132px) auto;
   }
 
   .drawer {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1214,20 +1214,39 @@ textarea {
 }
 
 .date-range-body {
+  align-items: stretch;
   flex-wrap: wrap;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper);
+  padding: 8px;
+}
+
+.date-range-body.invalid {
+  border-color: var(--danger);
+}
+
+.date-range-field .field-error {
+  color: var(--danger);
+  font-size: 12px;
 }
 
 .month-selector {
   display: flex;
-  min-width: 190px;
-  flex: 1 1 210px;
+  min-width: 180px;
+  flex: 1 1 220px;
   flex-direction: column;
   gap: 4px;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  background: var(--paper-2);
+  padding: 8px;
 }
 
 .month-selector > span {
-  color: var(--muted);
-  font-size: 11px;
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .month-selector select {
@@ -1243,8 +1262,12 @@ textarea {
 }
 
 .date-range-present {
+  align-self: center;
   min-height: 32px;
-  padding-bottom: 6px;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  background: var(--paper-2);
+  padding: 8px 10px;
 }
 
 .icon-button {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -293,6 +293,17 @@ textarea {
   grid-template-columns: 1fr;
 }
 
+.target-preferences-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px 16px;
+  padding: 14px 16px;
+}
+
+.target-preferences-grid .field.wide {
+  grid-column: auto;
+}
+
 .field {
   display: flex;
   min-width: 0;
@@ -1198,11 +1209,54 @@ textarea {
   gap: 8px;
 }
 
+.inline-list.compact {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr));
+  gap: 8px;
+}
+
 .inline-list-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
   align-items: center;
+}
+
+.inline-list-row .icon-button {
+  grid-area: auto;
+}
+
+.inline-list.compact .add-bullet {
+  width: 100%;
+  min-height: 32px;
+  align-self: stretch;
+  justify-content: center;
+}
+
+.target-preferences-grid .target-work-models {
+  grid-column: 1 / -1;
+}
+
+.work-model-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.work-model-choice {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--rule);
+  border-radius: 5px;
+  background: var(--paper-2);
+  padding: 6px 10px;
+  color: var(--muted);
+}
+
+.work-model-choice input {
+  width: auto;
 }
 
 .skill-row {
@@ -1457,10 +1511,15 @@ textarea {
   .kpis,
   .dashboard-grid,
   .field-grid,
+  .target-preferences-grid,
   .config-form,
   .import-panel,
   .credential-row,
   .credential-row-form {
+    grid-template-columns: 1fr;
+  }
+
+  .inline-list.compact {
     grid-template-columns: 1fr;
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -430,9 +430,10 @@ distributed-trace propagation across the TS↔Python JSON-RPC boundary
 ### SQLite And Files
 
 SQLite in `~/.jobhunter/jobhunter.db` is the local source of truth for jobs,
-stage states, events, artifacts, settings, normalized Candidate Profile data,
-profile rendering settings/template text, and run visibility. The five
-projection tables (above) are also stored here.
+stage states, events, artifacts, normalized Candidate Profile data, profile
+rendering settings/template text, and run visibility. The five projection
+tables (above) are also stored here. Dashboard settings remain file-backed
+until their own storage migration.
 
 Generated resumes, cover letters, PDFs, logs, and imported PDFs stay on the
 local filesystem. They are registered in `job_artifacts` and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -430,12 +430,15 @@ distributed-trace propagation across the TS↔Python JSON-RPC boundary
 ### SQLite And Files
 
 SQLite in `~/.jobhunter/jobhunter.db` is the local source of truth for jobs,
-stage states, events, artifacts, settings, and run visibility. The five
+stage states, events, artifacts, settings, normalized Candidate Profile data,
+profile rendering settings/template text, and run visibility. The five
 projection tables (above) are also stored here.
 
-Generated resumes, cover letters, PDFs, logs, templates, and imported PDFs stay
-on the local filesystem. They are registered in `job_artifacts` and
-`job_materials_artifacts` and surfaced via `artifact_list_projections`.
+Generated resumes, cover letters, PDFs, logs, and imported PDFs stay on the
+local filesystem. They are registered in `job_artifacts` and
+`job_materials_artifacts` and surfaced via `artifact_list_projections`. Legacy
+`profile.json`, `resume_style.json`, and `resume_template.tex` files are
+one-time seeds for empty profile tables, not canonical profile storage.
 The apply launcher records each per-worker agent log
 (`LOG_DIR/worker-{worker_id}.log`, written by `ClaudeCodeCliAdapter`) as a
 `job_artifacts` row of kind `apply_log` in the same transaction as the

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -189,10 +189,11 @@ Out of scope (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
   renderer. The spike should compare PDF fidelity, browser preview quality,
   editable profile UX, local packaging, performance, generated artifact
   compatibility, and migration cost.
-- Auto-suggest target roles in the Profile preferences editor based on the
-  candidate's experience entries, current title, and imported resume text.
-  Keep suggestions optional and user-editable so the target-role list remains
-  explicit profile data.
+- Auto-suggest target roles, target locations, and work-model preferences in
+  the Profile preferences editor based on the candidate's experience entries,
+  current title, location history, and imported resume text. Keep suggestions
+  optional and user-editable so the target-search lists remain explicit
+  profile data.
 - Add React component tests for persisted profile field save/discard
   behavior. `apps/web/src/contexts/profile/forms/` only has `*.a11y.test.tsx`
   files today (axe-only); the `useUpdateProfileMutation` /

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -189,6 +189,10 @@ Out of scope (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
   renderer. The spike should compare PDF fidelity, browser preview quality,
   editable profile UX, local packaging, performance, generated artifact
   compatibility, and migration cost.
+- Auto-suggest target roles in the Profile preferences editor based on the
+  candidate's experience entries, current title, and imported resume text.
+  Keep suggestions optional and user-editable so the target-role list remains
+  explicit profile data.
 - Add React component tests for persisted profile field save/discard
   behavior. `apps/web/src/contexts/profile/forms/` only has `*.a11y.test.tsx`
   files today (axe-only); the `useUpdateProfileMutation` /

--- a/docs/ddd-target.md
+++ b/docs/ddd-target.md
@@ -279,9 +279,10 @@ policies, and writing style preferences.
 
 **Boundary justification:** Profile is a single-user, single-document aggregate
 with its own lifecycle (user edits it independently of any job). Consuming
-contexts need a stable read-only view. *Current pain point addressed:*
-`profile.json` is loaded as a raw dict and threaded through tailor, cover,
-apply, wizard, and profile_import with no invariants enforced (briefing point 8).
+contexts need a stable read-only view. *Historical pain point addressed:*
+legacy `profile.json` was loaded as a raw dict and threaded through tailor,
+cover, apply, wizard, and profile_import with no invariants enforced (briefing
+point 8).
 
 ---
 
@@ -999,11 +1000,11 @@ Playwright for a hosted browser fleet without changing extraction logic.
 
 | Driven Port | Local Adapter (today) | Hosted Adapter (cloud) |
 |---|---|---|
-| `ProfileRepository` | `JsonFileProfileRepository` (reads/writes `profile.json`) | `PostgresProfileRepository` (RDS Postgres, keyed by `(tenant_id, profile_id)`) |
+| `ProfileRepository` | `SqliteProfileRepository` (normalized `candidate_profile*` tables; legacy profile/rendering files can seed empty tables once) | `PostgresProfileRepository` (RDS Postgres, keyed by `(tenant_id, profile_id)`) |
 | `PdfParserPort` | `PyPdfAdapter` | `PyPdfAdapter` (same library, runs in worker pod; no cloud service needed) |
 
-**Seam justification:** Profile storage is the simplest migration: `profile.json`
-becomes a Postgres row. The repository port makes this transparent.
+**Seam justification:** Profile storage is isolated behind the repository port:
+local SQLite and hosted Postgres adapters expose the same aggregate contract.
 
 ### 5.4 Scoring Context
 
@@ -1021,7 +1022,7 @@ becomes a Postgres row. The repository port makes this transparent.
 |---|---|---|
 | `LlmPort` | `GeminiAdapter`, `OpenAiAdapter`, `LocalLlmAdapter` | `CloudLlmGatewayAdapter` (see Enrichment; shared gateway service) |
 | `ScoreRepository` | `SqliteScoreRepository` | `PostgresScoreRepository` (RDS Postgres, tenant-scoped) |
-| `ProfileSnapshotPort` | `LocalProfileSnapshotAdapter` (reads profile.json) | `ProfileServiceGrpcClient` (internal **gRPC** call to Profile service; tenant context propagated via gRPC metadata) |
+| `ProfileSnapshotPort` | `LocalProfileSnapshotAdapter` (reads the SQLite-backed Profile repository) | `ProfileServiceGrpcClient` (internal **gRPC** call to Profile service; tenant context propagated via gRPC metadata) |
 
 ### 5.5 Materials Generation Context
 
@@ -1395,7 +1396,7 @@ commands are dispatched to the Python worker via JSON-RPC.
 | `markJobSkipped` | `SkipJobUseCase` (Pipeline Orchestration) | **TS API** | Simple stage state update. |
 | `softDeleteJob` | `DeleteJobUseCase` (Discovery) | **TS API** | Tombstone write. No Python needed. |
 | `restoreJob` | `RestoreJobUseCase` (Discovery) | **TS API** | Tombstone removal. |
-| `updateProfile` | `UpdateProfileUseCase` (Profile) | **TS API** | JSON validation and file write. |
+| `updateProfile` | `UpdateProfileUseCase` (Profile) | **TS API** | Shared schema validation and normalized SQLite write. |
 | pipeline run / discover / enrich / score / tailor / cover / apply | Stage commands via `StageCommandDispatcher` | **Python worker** (via JSON-RPC) | Requires LLM, browser, scraping infrastructure. |
 | profile import from PDF | `ImportProfileUseCase` (Profile) | **Python worker** (via JSON-RPC) | Requires `pypdf` + LLM extraction. |
 
@@ -1422,7 +1423,7 @@ commands go through Temporal instead of subprocess.
 |---|---|---|---|
 | `Job` (Discovery) | `JobRepository` | `jobs` (discovery columns only) | `jobs` (narrowed: jobId, postingUrl, employer, source, title, salary, description, location, discoveredAt) |
 | `JobEnrichment` | `EnrichmentRepository` | `jobs` (enrichment columns) | `job_enrichments` (new: jobId, fullDescription, applicationUrl, extractionTier, enrichedAt, error) |
-| `Profile` | `ProfileRepository` | `profile.json` file | `profile.json` (local) / `profiles` table (hosted) |
+| `Profile` | `ProfileRepository` | `candidate_profiles` + child `candidate_profile_*` tables | `profiles` + child profile tables (hosted) |
 | `JobScore` | `ScoreRepository` | `jobs` (scoring columns) | `job_scores` (new: jobId, version, fitScore, breakdown, keywords, scoredAt, correction) |
 | `MaterialsSet` | `MaterialsRepository` | `jobs` (tailor/cover columns) + `job_artifacts` | `job_materials` (new) + `job_artifacts` (existing, enriched) |
 | `ApplyRun` | `ApplyRunRepository` | `apply_runs` + `apply_run_events` | `apply_runs` + `apply_run_events` (existing, largely correct) |
@@ -1831,7 +1832,7 @@ cloud" (circular), but measurable conditions.
 | In-process synchronous event bus | Transactional outbox + SQS FIFO | Multi-process deployment (> 1 API instance **OR** > 1 worker instance) | In-process dispatch cannot cross process boundaries. The outbox pattern is the minimum viable distributed event bus. |
 | Subprocess JSON-RPC (`uv run jobhunter rpc`) | HTTP JSON-RPC / Temporal activities | Worker fleet > 1 machine **OR** apply queue depth consistently > 10 pending jobs **OR** pipeline run > 30 min (exceeds saga recovery window of subprocess) | Subprocess can't survive host restarts. Temporal provides durable retry. |
 | Local Chrome on CDP ports | Browserbase managed sessions | **Any** cloud deployment | Chrome requires elevated container privileges or `--no-sandbox` (security risk). Browserbase eliminates this entirely. This is a day-1 cloud blocker, not a gradual migration. |
-| `profile.json` file | Postgres `profiles` table | Multi-tenant deployment **OR** concurrent profile editors | Single JSON file has no concurrency control. |
+| SQLite Candidate Profile tables | Postgres `profiles` + child profile tables | Multi-tenant deployment **OR** concurrent profile editors | Local SQLite has a single-writer limit; hosted profile editing needs tenant-scoped concurrency control. |
 | `LocalFilesystemAdapter` (tailored resumes, PDFs) | S3 with tenant-prefixed keys | Multi-node deployment (no shared filesystem) **OR** artifact size > 1 GB per tenant | Local filesystem doesn't span nodes. |
 | macOS Keychain / `.env` | AWS Secrets Manager | Non-macOS deployment **OR** multi-tenant **OR** credential rotation requirement | Keychain is macOS-only. `.env` is unencrypted. |
 | `TenantId = "local"` (constant) | `TenantId` from JWT claims | Multi-tenant deployment | Domain types already carry `TenantId`. Only the source of the value changes (constant → JWT). Mechanical change. |

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -40,6 +40,9 @@ writing style.
 - **Domain events:** `ProfileUpdated`, `ProfileImported`
 - **Code:** `workers/automation/src/jobhunter/domain/profile/`,
   `workers/automation/src/jobhunter/infrastructure/profile/`
+- **Local adapter:** `SqliteProfileRepository` stores the aggregate in
+  normalized `candidate_profile*` tables and can seed them once from legacy
+  profile/rendering files when empty.
 
 ### Scoring (§3.4, §4.4)
 

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -2,10 +2,17 @@
 
 The local TypeScript API is the runnable backend app under `apps/api`.
 
-It owns product-facing JSON endpoints, reads the local SQLite database and
-local profile/style/template files, and invokes Python automation through the
-JSON-RPC 2.0 protocol over a long-lived `jobhunter rpc` subprocess. It is
-intentionally local-first and binds to `127.0.0.1` by default.
+It owns product-facing JSON endpoints, reads the local SQLite database, and
+invokes Python automation through the JSON-RPC 2.0 protocol over a long-lived
+`jobhunter rpc` subprocess. It is intentionally local-first and binds to
+`127.0.0.1` by default.
+
+`GET /v1/profile` and `PATCH /v1/profile` use the normalized Candidate
+Profile tables in `jobhunter.db` as the source of truth. When the profile
+tables are empty, the API can seed them once from legacy `profile.json`,
+`resume_style.json`, and `resume_template.tex`; subsequent writes update only
+SQLite and reconstruct the existing response object shape for frontend/client
+compatibility.
 
 Read-model endpoints (`/v1/dashboard/summary`, `/v1/jobs`, `/v1/jobs/:key`,
 `/v1/artifacts`, `/v1/workflow-runs`) read from the five `*_projections` tables

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -191,6 +191,8 @@ const ProfileExperienceMetadataSchema = z
     current_job_title: z.string().default(""),
     current_company: z.string().default(""),
     target_role: z.string().default(""),
+    target_locations: z.string().default(""),
+    target_work_models: z.string().default(""),
   })
   .partial();
 

--- a/profile.example.json
+++ b/profile.example.json
@@ -39,7 +39,7 @@
     "current_company": "Example Corp",
     "target_role": "backend software engineer",
     "target_locations": "Barcelona, Spain; Europe",
-    "target_work_models": "Hybrid; Remote"
+    "target_work_models": "Hybrid, Remote; Remote"
   },
   "resume": {
     "executive_profile": {

--- a/profile.example.json
+++ b/profile.example.json
@@ -37,7 +37,9 @@
     "education_level": "Bachelor's Degree",
     "current_job_title": "Software Engineer",
     "current_company": "Example Corp",
-    "target_role": "backend software engineer"
+    "target_role": "backend software engineer",
+    "target_locations": "Remote; Barcelona",
+    "target_work_models": "Remote; Hybrid"
   },
   "resume": {
     "executive_profile": {

--- a/profile.example.json
+++ b/profile.example.json
@@ -38,8 +38,8 @@
     "current_job_title": "Software Engineer",
     "current_company": "Example Corp",
     "target_role": "backend software engineer",
-    "target_locations": "Remote; Barcelona",
-    "target_work_models": "Remote; Hybrid"
+    "target_locations": "Barcelona, Spain; Europe",
+    "target_work_models": "Hybrid; Remote"
   },
   "resume": {
     "executive_profile": {

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -741,8 +741,10 @@ def apply(
     """Launch auto-apply to submit job applications."""
     _bootstrap()
 
-    from jobhunter.config import check_tier, PROFILE_PATH as _profile_path
+    from jobhunter.config import APP_DIR as _app_dir, check_tier
     from jobhunter.database import get_connection
+    from jobhunter.domain.tenant import LOCAL_TENANT
+    from jobhunter.infrastructure.profile import get_profile_repository
 
     # --- Utility modes (no Chrome/Claude needed) ---
 
@@ -770,7 +772,11 @@ def apply(
     check_tier(3, "auto-apply")
 
     # Check 2: Profile exists
-    if not _profile_path.exists():
+    try:
+        profile = get_profile_repository().load(LOCAL_TENANT)
+    except FileNotFoundError:
+        profile = None
+    if profile is None:
         console.print(
             "[red]Profile not found.[/red]\n"
             "Run [bold]jobhunter init[/bold] to create your profile first."
@@ -807,7 +813,7 @@ def apply(
         if not prompt_file:
             console.print("[red]No matching job found for that URL.[/red]")
             raise typer.Exit(code=1)
-        mcp_path = _profile_path.parent / ".mcp-apply-0.json"
+        mcp_path = _app_dir / ".mcp-apply-0.json"
         console.print(f"[green]Wrote prompt to:[/green] {prompt_file}")
         console.print("\n[bold]Run manually:[/bold]")
         console.print(
@@ -1218,9 +1224,11 @@ def doctor() -> None:
     """Check your setup and diagnose missing requirements."""
     import shutil
     from jobhunter.config import (
-        load_env, PROFILE_PATH, RESUME_PATH, RESUME_PDF_PATH,
+        load_env, DB_PATH, RESUME_PATH, RESUME_PDF_PATH,
         RESUME_TEMPLATE_PATH, SEARCH_CONFIG_PATH, get_chrome_path,
     )
+    from jobhunter.domain.tenant import LOCAL_TENANT
+    from jobhunter.infrastructure.profile import get_profile_repository
 
     load_env()
 
@@ -1232,10 +1240,16 @@ def doctor() -> None:
 
     # --- Tier 1 checks ---
     # Profile
-    if PROFILE_PATH.exists():
-        results.append(("profile.json", ok_mark, str(PROFILE_PATH)))
-    else:
-        results.append(("profile.json", fail_mark, "Run 'jobhunter init' to create"))
+    try:
+        profile = get_profile_repository().load(LOCAL_TENANT)
+        if profile is None:
+            results.append(("candidate profile", fail_mark, "Run 'jobhunter init' to create"))
+        else:
+            results.append(("candidate profile", ok_mark, f"SQLite source of truth at {DB_PATH}"))
+    except FileNotFoundError:
+        results.append(("candidate profile", fail_mark, "Run 'jobhunter init' to create"))
+    except Exception:  # noqa: BLE001 - doctor should report validation problems instead of crashing
+        results.append(("candidate profile", fail_mark, "Profile exists but failed validation"))
 
     # Resume
     if RESUME_PATH.exists():

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -141,6 +141,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     # Run migrations for any columns added after initial schema
     ensure_columns(conn)
     ensure_state_tables(conn)
+    ensure_profile_tables(conn)
     ensure_score_tables(conn)
     ensure_materials_tables(conn)
     ensure_enrichment_tables(conn)
@@ -408,6 +409,239 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
     _backfill_legacy_stage_states(conn)
     conn.commit()
     return ["job_stage_states", "job_events", "job_artifacts", "event_watermarks"]
+
+
+def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Create normalized Candidate Profile tables.
+
+    The canonical profile source now lives in relational rows.  The schema
+    deliberately has no ``profile_json`` / ``style_json`` escape hatch:
+    aggregate value objects live as typed columns on ``candidate_profiles``;
+    repeatable child entities and rule lists live in child tables.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profiles (
+            tenant_id                         TEXT NOT NULL DEFAULT 'local',
+            profile_id                        TEXT NOT NULL DEFAULT 'default',
+            personal_full_name                TEXT NOT NULL DEFAULT '',
+            personal_preferred_name           TEXT NOT NULL DEFAULT '',
+            personal_email                    TEXT NOT NULL DEFAULT '',
+            personal_phone                    TEXT NOT NULL DEFAULT '',
+            personal_address                  TEXT NOT NULL DEFAULT '',
+            personal_city                     TEXT NOT NULL DEFAULT '',
+            personal_province_state           TEXT NOT NULL DEFAULT '',
+            personal_country                  TEXT NOT NULL DEFAULT '',
+            personal_postal_code              TEXT NOT NULL DEFAULT '',
+            personal_linkedin_url             TEXT NOT NULL DEFAULT '',
+            personal_github_url               TEXT NOT NULL DEFAULT '',
+            personal_portfolio_url            TEXT NOT NULL DEFAULT '',
+            personal_website_url              TEXT NOT NULL DEFAULT '',
+            personal_password                 TEXT NOT NULL DEFAULT '',
+            work_legally_authorized_to_work   TEXT NOT NULL DEFAULT '',
+            work_require_sponsorship          TEXT NOT NULL DEFAULT '',
+            work_work_permit_type             TEXT NOT NULL DEFAULT '',
+            compensation_salary_expectation   TEXT NOT NULL DEFAULT '',
+            compensation_salary_currency      TEXT NOT NULL DEFAULT 'USD',
+            compensation_salary_range_min     TEXT NOT NULL DEFAULT '',
+            compensation_salary_range_max     TEXT NOT NULL DEFAULT '',
+            compensation_currency_note        TEXT NOT NULL DEFAULT '',
+            experience_years_total            TEXT NOT NULL DEFAULT '',
+            experience_education_level        TEXT NOT NULL DEFAULT '',
+            experience_current_job_title      TEXT NOT NULL DEFAULT '',
+            experience_current_company        TEXT NOT NULL DEFAULT '',
+            experience_target_role            TEXT NOT NULL DEFAULT '',
+            availability_earliest_start_date  TEXT NOT NULL DEFAULT '',
+            availability_full_time            TEXT NOT NULL DEFAULT '',
+            availability_contract             TEXT NOT NULL DEFAULT '',
+            eeo_gender                        TEXT NOT NULL DEFAULT 'Decline to self-identify',
+            eeo_race_ethnicity                TEXT NOT NULL DEFAULT 'Decline to self-identify',
+            eeo_veteran_status                TEXT NOT NULL DEFAULT 'Decline to self-identify',
+            eeo_disability_status             TEXT NOT NULL DEFAULT 'Decline to self-identify',
+            resume_baseline_text              TEXT NOT NULL DEFAULT '',
+            tailoring_mode                    TEXT NOT NULL DEFAULT 'balanced',
+            tailoring_allow_title_reframing   INTEGER NOT NULL DEFAULT 0,
+            tailoring_allow_achievement_rewriting INTEGER NOT NULL DEFAULT 1,
+            tailoring_allow_skill_reordering  INTEGER NOT NULL DEFAULT 1,
+            tailoring_allow_summary_rewrite   INTEGER NOT NULL DEFAULT 1,
+            tailoring_allow_minor_inference   INTEGER NOT NULL DEFAULT 0,
+            writing_tone                      TEXT NOT NULL DEFAULT 'direct',
+            writing_bullet_style              TEXT NOT NULL DEFAULT 'balanced',
+            writing_verbosity                 TEXT NOT NULL DEFAULT 'balanced',
+            writing_keyword_density           TEXT NOT NULL DEFAULT 'natural',
+            writing_avoid_first_person        INTEGER NOT NULL DEFAULT 1,
+            max_experience_bullets            INTEGER NOT NULL DEFAULT 4,
+            custom_tailoring_prompt           TEXT NOT NULL DEFAULT '',
+            resume_style_document_font_size   TEXT NOT NULL DEFAULT '11pt',
+            resume_style_paper_size           TEXT NOT NULL DEFAULT 'a4paper',
+            resume_style_font_family          TEXT NOT NULL DEFAULT 'sans',
+            resume_style_moderncv_style       TEXT NOT NULL DEFAULT 'banking',
+            resume_style_moderncv_color       TEXT NOT NULL DEFAULT 'black',
+            resume_style_page_scale           REAL NOT NULL DEFAULT 0.85,
+            resume_style_hints_column_width_cm REAL NOT NULL DEFAULT 3.0,
+            resume_style_body_alignment       TEXT NOT NULL DEFAULT 'justified',
+            resume_template_text              TEXT NOT NULL DEFAULT '',
+            version                           INTEGER NOT NULL DEFAULT 1,
+            updated_at                        TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_experience_entries (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            entry_id        TEXT NOT NULL,
+            position_index  INTEGER NOT NULL,
+            date_range      TEXT NOT NULL DEFAULT '',
+            title           TEXT NOT NULL DEFAULT '',
+            company         TEXT NOT NULL DEFAULT '',
+            location        TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (tenant_id, profile_id, entry_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_experience_bullets (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            entry_id        TEXT NOT NULL,
+            bullet_index    INTEGER NOT NULL,
+            bullet_text     TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_education_entries (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            entry_id        TEXT NOT NULL,
+            position_index  INTEGER NOT NULL,
+            date            TEXT NOT NULL DEFAULT '',
+            degree          TEXT NOT NULL DEFAULT '',
+            institution     TEXT NOT NULL DEFAULT '',
+            location        TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (tenant_id, profile_id, entry_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_skill_categories (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            category_id     TEXT NOT NULL,
+            position_index  INTEGER NOT NULL,
+            label           TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (tenant_id, profile_id, category_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_skill_items (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            category_id     TEXT NOT NULL,
+            item_index      INTEGER NOT NULL,
+            item_text       TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id, category_id, item_index)
+        )
+        """
+    )
+
+    for table, column in (
+        ("candidate_profile_required_experience_entries", "entry_id"),
+        ("candidate_profile_required_education_entries", "entry_id"),
+        ("candidate_profile_required_skill_categories", "category_id"),
+    ):
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {table} (
+                tenant_id       TEXT NOT NULL,
+                profile_id      TEXT NOT NULL,
+                position_index  INTEGER NOT NULL,
+                {column}        TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, profile_id, position_index)
+            )
+            """
+        )
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_required_bullets (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            entry_id        TEXT NOT NULL,
+            bullet_index    INTEGER NOT NULL,
+            bullet_text     TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_required_skills (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            category_id     TEXT NOT NULL,
+            skill_index     INTEGER NOT NULL,
+            skill_text      TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id, category_id, skill_index)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_resume_constraint_metrics (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            metric_index    INTEGER NOT NULL,
+            metric_text     TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, profile_id, metric_index)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_candidate_profile_experience_order
+        ON candidate_profile_experience_entries(tenant_id, profile_id, position_index)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_candidate_profile_education_order
+        ON candidate_profile_education_entries(tenant_id, profile_id, position_index)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_candidate_profile_skill_order
+        ON candidate_profile_skill_categories(tenant_id, profile_id, position_index)
+        """
+    )
+    conn.commit()
+    return [
+        "candidate_profiles",
+        "candidate_profile_experience_entries",
+        "candidate_profile_experience_bullets",
+        "candidate_profile_education_entries",
+        "candidate_profile_skill_categories",
+        "candidate_profile_skill_items",
+        "candidate_profile_required_experience_entries",
+        "candidate_profile_required_education_entries",
+        "candidate_profile_required_skill_categories",
+        "candidate_profile_required_bullets",
+        "candidate_profile_required_skills",
+        "candidate_profile_resume_constraint_metrics",
+    ]
 
 
 def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -454,6 +454,8 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             experience_current_job_title      TEXT NOT NULL DEFAULT '',
             experience_current_company        TEXT NOT NULL DEFAULT '',
             experience_target_role            TEXT NOT NULL DEFAULT '',
+            experience_target_locations       TEXT NOT NULL DEFAULT '',
+            experience_target_work_models     TEXT NOT NULL DEFAULT '',
             availability_earliest_start_date  TEXT NOT NULL DEFAULT '',
             availability_full_time            TEXT NOT NULL DEFAULT '',
             availability_contract             TEXT NOT NULL DEFAULT '',
@@ -627,6 +629,7 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         ON candidate_profile_skill_categories(tenant_id, profile_id, position_index)
         """
     )
+    _ensure_candidate_profile_columns(conn)
     conn.commit()
     return [
         "candidate_profiles",
@@ -642,6 +645,19 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         "candidate_profile_required_skills",
         "candidate_profile_resume_constraint_metrics",
     ]
+
+
+_PROFILE_COLUMN_MIGRATIONS: dict[str, str] = {
+    "experience_target_locations": "TEXT NOT NULL DEFAULT ''",
+    "experience_target_work_models": "TEXT NOT NULL DEFAULT ''",
+}
+
+
+def _ensure_candidate_profile_columns(conn: sqlite3.Connection) -> None:
+    existing_cols = {row[1] for row in conn.execute("PRAGMA table_info(candidate_profiles)").fetchall()}
+    for column, definition in _PROFILE_COLUMN_MIGRATIONS.items():
+        if column not in existing_cols:
+            conn.execute(f"ALTER TABLE candidate_profiles ADD COLUMN {column} {definition}")
 
 
 def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:

--- a/workers/automation/src/jobhunter/domain/profile/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/profile/value_objects.py
@@ -134,6 +134,8 @@ class ExperienceMetadata:
     current_job_title: str = ""
     current_company: str = ""
     target_role: str = ""
+    target_locations: str = ""
+    target_work_models: str = ""
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> "ExperienceMetadata":

--- a/workers/automation/src/jobhunter/infrastructure/profile/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/__init__.py
@@ -2,6 +2,7 @@
 
 from jobhunter.infrastructure.profile.json_file import JsonFileProfileRepository
 from jobhunter.infrastructure.profile.pdf_parser import PyPdfProfileParser
+from jobhunter.infrastructure.profile.sqlite_repository import SqliteProfileRepository
 from jobhunter.infrastructure.profile.factory import (
     build_profile_repository,
     get_profile_repository,
@@ -11,6 +12,7 @@ from jobhunter.infrastructure.profile.factory import (
 __all__ = [
     "JsonFileProfileRepository",
     "PyPdfProfileParser",
+    "SqliteProfileRepository",
     "build_profile_repository",
     "get_profile_repository",
     "reset_profile_repository",

--- a/workers/automation/src/jobhunter/infrastructure/profile/factory.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/factory.py
@@ -2,10 +2,10 @@
 
 The Phase-3 in-process event bus is a process-wide singleton owned by
 ``infrastructure.events.get_default_publisher``; the profile repository
-follows the same pattern: a single ``JsonFileProfileRepository`` is
+follows the same pattern: a single ``SqliteProfileRepository`` is
 shared across the worker process so callers in ``actions.py``,
-``pipeline.py``, and the CLI all see the same in-memory version counter
-and event publisher.
+``pipeline.py``, and the CLI all share the same SQLite-backed profile
+versioning and event publisher.
 
 Tests can override the singleton via ``reset_profile_repository`` plus a
 custom ``build_profile_repository`` invocation.
@@ -18,31 +18,41 @@ from pathlib import Path
 
 from jobhunter import config
 from jobhunter.domain.ports.events import EventPublisher
+from jobhunter.database import init_db
 from jobhunter.infrastructure.events import get_default_publisher, reset_default_publisher
-from jobhunter.infrastructure.profile.json_file import JsonFileProfileRepository
 from jobhunter.infrastructure.profile.pdf_parser import PyPdfProfileParser
+from jobhunter.infrastructure.profile.sqlite_repository import SqliteProfileRepository
 
 _lock = threading.Lock()
-_singleton: JsonFileProfileRepository | None = None
+_singleton: SqliteProfileRepository | None = None
 
 
 def build_profile_repository(
     *,
+    db_path: Path | None = None,
     profile_path: Path | None = None,
     publisher: EventPublisher | None = None,
-) -> JsonFileProfileRepository:
+) -> SqliteProfileRepository:
     """Construct a fresh repository — bypasses the singleton.
 
-    Tests should prefer this so each test gets an isolated bus + tmp file.
+    Tests should prefer this so each test gets an isolated bus + tmp DB.
+    ``profile_path`` is retained as the legacy-import seed path and, when
+    ``db_path`` is omitted, implies a sibling ``jobhunter.db``.
     """
-    return JsonFileProfileRepository(
-        profile_path=profile_path or config.PROFILE_PATH,
+    legacy_profile_path = profile_path or config.PROFILE_PATH
+    resolved_db_path = db_path or legacy_profile_path.parent / "jobhunter.db"
+    conn = init_db(resolved_db_path)
+    return SqliteProfileRepository(
+        conn,
         publisher=publisher or get_default_publisher(),
         pdf_parser=PyPdfProfileParser(),
+        legacy_profile_path=legacy_profile_path,
+        legacy_style_path=legacy_profile_path.parent / "resume_style.json",
+        legacy_template_path=legacy_profile_path.parent / "resume_template.tex",
     )
 
 
-def get_profile_repository() -> JsonFileProfileRepository:
+def get_profile_repository() -> SqliteProfileRepository:
     """Return the process-wide singleton repository.
 
     Initialises lazily so that import-time has no side effects (matches the

--- a/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
@@ -1,0 +1,868 @@
+"""SQLite-backed ProfileRepository adapter.
+
+The Candidate Profile aggregate is stored natively in relational SQLite rows:
+one root row for scalar value objects and child tables for experience,
+education, skills, tailoring requirements, and resume constraints.  Legacy
+``profile.json`` is a one-time seed only when the database has no profile row.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from jobhunter.database import ensure_profile_tables
+from jobhunter.domain.events import (
+    ProfileImportedPayload,
+    ProfileUpdatedPayload,
+    create_profile_imported,
+    create_profile_updated,
+)
+from jobhunter.domain.ports.events import EventPublisher
+from jobhunter.domain.profile.aggregate import DEFAULT_PROFILE_ID, InvalidProfileError, Profile
+from jobhunter.domain.profile.ports import PdfParserPort, ProfileImportResult
+from jobhunter.domain.profile.snapshot import ProfileSnapshot
+from jobhunter.domain.tenant import TenantId
+from jobhunter.infrastructure.materials.latex_pdf import (
+    DEFAULT_RESUME_LATEX_TEMPLATE,
+    normalize_resume_style,
+)
+
+logger = logging.getLogger(__name__)
+
+_CHILD_TABLES = (
+    "candidate_profile_experience_bullets",
+    "candidate_profile_experience_entries",
+    "candidate_profile_education_entries",
+    "candidate_profile_skill_items",
+    "candidate_profile_skill_categories",
+    "candidate_profile_required_experience_entries",
+    "candidate_profile_required_education_entries",
+    "candidate_profile_required_skill_categories",
+    "candidate_profile_required_bullets",
+    "candidate_profile_required_skills",
+    "candidate_profile_resume_constraint_metrics",
+)
+
+
+class SqliteProfileRepository:
+    """SQLite-backed implementation of ``ProfileRepository``."""
+
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        publisher: EventPublisher,
+        pdf_parser: PdfParserPort | None = None,
+        legacy_profile_path: Path | None = None,
+        legacy_style_path: Path | None = None,
+        legacy_template_path: Path | None = None,
+        profile_id: str = DEFAULT_PROFILE_ID,
+    ) -> None:
+        self._conn = conn
+        self._publisher = publisher
+        self._pdf_parser = pdf_parser
+        self._legacy_profile_path = Path(legacy_profile_path) if legacy_profile_path else None
+        self._legacy_style_path = Path(legacy_style_path) if legacy_style_path else None
+        self._legacy_template_path = Path(legacy_template_path) if legacy_template_path else None
+        self._profile_id = profile_id or DEFAULT_PROFILE_ID
+        ensure_profile_tables(self._conn)
+
+    # ------------------------------------------------------------------
+    # Load / save
+    # ------------------------------------------------------------------
+
+    def load(self, tenant_id: TenantId) -> Profile | None:
+        self._ensure_imported_from_legacy(tenant_id)
+        row = self._profile_row(tenant_id)
+        if row is None:
+            return None
+        return Profile.from_dict(tenant_id, self._row_to_profile_dict(tenant_id, row), profile_id=self._profile_id)
+
+    def save(self, tenant_id: TenantId, profile: Profile) -> ProfileSnapshot:
+        previous = self.load(tenant_id)
+        previous_dict = previous.to_dict() if previous is not None else {}
+
+        validated = Profile.from_dict(tenant_id, profile.to_dict(), profile_id=profile.profile_id or self._profile_id)
+        row = self._profile_row(tenant_id)
+        version = int(row["version"]) + 1 if row is not None else 1
+        rendering = self.load_rendering_settings(tenant_id)
+        self._replace_profile(tenant_id, validated, version=version, rendering=rendering)
+
+        snapshot = ProfileSnapshot.from_profile(validated, version=version)
+        changed_sections = _diff_top_level_sections(previous_dict, validated.to_dict())
+
+        try:
+            self._publisher.publish(
+                create_profile_updated(
+                    tenant_id,
+                    ProfileUpdatedPayload(
+                        changed_sections=changed_sections,
+                        updated_at=datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to publish ProfileUpdated event")
+
+        return snapshot
+
+    def load_snapshot(self, tenant_id: TenantId) -> ProfileSnapshot:
+        profile = self.load(tenant_id)
+        if profile is None:
+            location = self._legacy_profile_path or "candidate_profiles"
+            raise FileNotFoundError(f"Profile not found at {location}. Run `jobhunter init` first.")
+        row = self._profile_row(tenant_id)
+        version = int(row["version"]) if row is not None else 1
+        return ProfileSnapshot.from_profile(profile, version=version)
+
+    # ------------------------------------------------------------------
+    # Rendering settings
+    # ------------------------------------------------------------------
+
+    def load_rendering_settings(self, tenant_id: TenantId) -> dict[str, Any]:
+        self._ensure_imported_from_legacy(tenant_id)
+        row = self._profile_row(tenant_id)
+        if row is None:
+            return {
+                "style": normalize_resume_style(),
+                "template_text": DEFAULT_RESUME_LATEX_TEMPLATE,
+            }
+        return {
+            "style": _style_from_row(row),
+            "template_text": row["resume_template_text"] or DEFAULT_RESUME_LATEX_TEMPLATE,
+        }
+
+    # ------------------------------------------------------------------
+    # PDF import
+    # ------------------------------------------------------------------
+
+    def import_from_pdf(
+        self,
+        tenant_id: TenantId,
+        pdf_bytes: bytes,
+        *,
+        filename: str = "resume.pdf",
+    ) -> ProfileImportResult:
+        if self._pdf_parser is None:
+            raise RuntimeError(
+                "SqliteProfileRepository was constructed without a PdfParserPort; "
+                "cannot import from PDF. Inject one via the factory."
+            )
+
+        existing = self.load(tenant_id)
+        rendering = self.load_rendering_settings(tenant_id)
+        draft = self._pdf_parser.parse(
+            pdf_bytes,
+            filename=filename,
+            base_profile=existing.to_dict() if existing is not None else None,
+            base_style=rendering["style"],
+        )
+
+        result = ProfileImportResult(
+            profile=draft.get("profile", {}) if isinstance(draft, dict) else {},
+            style=draft.get("style", {}) if isinstance(draft, dict) else {},
+            source=draft.get("source", {}) if isinstance(draft, dict) else {},
+        )
+
+        try:
+            self._publisher.publish(
+                create_profile_imported(
+                    tenant_id,
+                    ProfileImportedPayload(
+                        source=filename or "resume.pdf",
+                        imported_sections=tuple(sorted(result.profile.keys())),
+                        imported_at=datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to publish ProfileImported event")
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _profile_row(self, tenant_id: TenantId) -> sqlite3.Row | None:
+        return self._conn.execute(
+            "SELECT * FROM candidate_profiles WHERE tenant_id = ? AND profile_id = ?",
+            (str(tenant_id), self._profile_id),
+        ).fetchone()
+
+    def _ensure_imported_from_legacy(self, tenant_id: TenantId) -> None:
+        if self._profile_row(tenant_id) is not None:
+            return
+        if self._legacy_profile_path is None or not self._legacy_profile_path.exists():
+            return
+        data = self._read_legacy_profile()
+        profile = Profile.from_dict(tenant_id, data, profile_id=self._profile_id)
+        style = self._read_legacy_style()
+        template_text = self._read_legacy_template()
+        self._replace_profile(
+            tenant_id,
+            profile,
+            version=1,
+            rendering={"style": style, "template_text": template_text},
+        )
+
+    def _replace_profile(
+        self,
+        tenant_id: TenantId,
+        profile: Profile,
+        *,
+        version: int,
+        rendering: dict[str, Any],
+    ) -> None:
+        profile_id = profile.profile_id or self._profile_id
+        profile_dict = profile.to_dict()
+        style = normalize_resume_style(rendering.get("style") if isinstance(rendering, dict) else None)
+        template_text = str(rendering.get("template_text") or DEFAULT_RESUME_LATEX_TEMPLATE)
+        now = datetime.now(timezone.utc).isoformat()
+
+        with self._conn:
+            for table in _CHILD_TABLES:
+                self._conn.execute(
+                    f"DELETE FROM {table} WHERE tenant_id = ? AND profile_id = ?",
+                    (str(tenant_id), profile_id),
+                )
+
+            self._conn.execute(
+                """
+                INSERT INTO candidate_profiles (
+                    tenant_id, profile_id,
+                    personal_full_name, personal_preferred_name, personal_email,
+                    personal_phone, personal_address, personal_city,
+                    personal_province_state, personal_country, personal_postal_code,
+                    personal_linkedin_url, personal_github_url, personal_portfolio_url,
+                    personal_website_url, personal_password,
+                    work_legally_authorized_to_work, work_require_sponsorship,
+                    work_work_permit_type,
+                    compensation_salary_expectation, compensation_salary_currency,
+                    compensation_salary_range_min, compensation_salary_range_max,
+                    compensation_currency_note,
+                    experience_years_total, experience_education_level,
+                    experience_current_job_title, experience_current_company,
+                    experience_target_role,
+                    availability_earliest_start_date, availability_full_time,
+                    availability_contract,
+                    eeo_gender, eeo_race_ethnicity, eeo_veteran_status,
+                    eeo_disability_status,
+                    resume_baseline_text,
+                    tailoring_mode, tailoring_allow_title_reframing,
+                    tailoring_allow_achievement_rewriting,
+                    tailoring_allow_skill_reordering, tailoring_allow_summary_rewrite,
+                    tailoring_allow_minor_inference,
+                    writing_tone, writing_bullet_style, writing_verbosity,
+                    writing_keyword_density, writing_avoid_first_person,
+                    max_experience_bullets, custom_tailoring_prompt,
+                    resume_style_document_font_size, resume_style_paper_size,
+                    resume_style_font_family, resume_style_moderncv_style,
+                    resume_style_moderncv_color, resume_style_page_scale,
+                    resume_style_hints_column_width_cm, resume_style_body_alignment,
+                    resume_template_text, version, updated_at
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                )
+                ON CONFLICT(tenant_id, profile_id) DO UPDATE SET
+                    personal_full_name = excluded.personal_full_name,
+                    personal_preferred_name = excluded.personal_preferred_name,
+                    personal_email = excluded.personal_email,
+                    personal_phone = excluded.personal_phone,
+                    personal_address = excluded.personal_address,
+                    personal_city = excluded.personal_city,
+                    personal_province_state = excluded.personal_province_state,
+                    personal_country = excluded.personal_country,
+                    personal_postal_code = excluded.personal_postal_code,
+                    personal_linkedin_url = excluded.personal_linkedin_url,
+                    personal_github_url = excluded.personal_github_url,
+                    personal_portfolio_url = excluded.personal_portfolio_url,
+                    personal_website_url = excluded.personal_website_url,
+                    personal_password = excluded.personal_password,
+                    work_legally_authorized_to_work = excluded.work_legally_authorized_to_work,
+                    work_require_sponsorship = excluded.work_require_sponsorship,
+                    work_work_permit_type = excluded.work_work_permit_type,
+                    compensation_salary_expectation = excluded.compensation_salary_expectation,
+                    compensation_salary_currency = excluded.compensation_salary_currency,
+                    compensation_salary_range_min = excluded.compensation_salary_range_min,
+                    compensation_salary_range_max = excluded.compensation_salary_range_max,
+                    compensation_currency_note = excluded.compensation_currency_note,
+                    experience_years_total = excluded.experience_years_total,
+                    experience_education_level = excluded.experience_education_level,
+                    experience_current_job_title = excluded.experience_current_job_title,
+                    experience_current_company = excluded.experience_current_company,
+                    experience_target_role = excluded.experience_target_role,
+                    availability_earliest_start_date = excluded.availability_earliest_start_date,
+                    availability_full_time = excluded.availability_full_time,
+                    availability_contract = excluded.availability_contract,
+                    eeo_gender = excluded.eeo_gender,
+                    eeo_race_ethnicity = excluded.eeo_race_ethnicity,
+                    eeo_veteran_status = excluded.eeo_veteran_status,
+                    eeo_disability_status = excluded.eeo_disability_status,
+                    resume_baseline_text = excluded.resume_baseline_text,
+                    tailoring_mode = excluded.tailoring_mode,
+                    tailoring_allow_title_reframing = excluded.tailoring_allow_title_reframing,
+                    tailoring_allow_achievement_rewriting = excluded.tailoring_allow_achievement_rewriting,
+                    tailoring_allow_skill_reordering = excluded.tailoring_allow_skill_reordering,
+                    tailoring_allow_summary_rewrite = excluded.tailoring_allow_summary_rewrite,
+                    tailoring_allow_minor_inference = excluded.tailoring_allow_minor_inference,
+                    writing_tone = excluded.writing_tone,
+                    writing_bullet_style = excluded.writing_bullet_style,
+                    writing_verbosity = excluded.writing_verbosity,
+                    writing_keyword_density = excluded.writing_keyword_density,
+                    writing_avoid_first_person = excluded.writing_avoid_first_person,
+                    max_experience_bullets = excluded.max_experience_bullets,
+                    custom_tailoring_prompt = excluded.custom_tailoring_prompt,
+                    resume_style_document_font_size = excluded.resume_style_document_font_size,
+                    resume_style_paper_size = excluded.resume_style_paper_size,
+                    resume_style_font_family = excluded.resume_style_font_family,
+                    resume_style_moderncv_style = excluded.resume_style_moderncv_style,
+                    resume_style_moderncv_color = excluded.resume_style_moderncv_color,
+                    resume_style_page_scale = excluded.resume_style_page_scale,
+                    resume_style_hints_column_width_cm = excluded.resume_style_hints_column_width_cm,
+                    resume_style_body_alignment = excluded.resume_style_body_alignment,
+                    resume_template_text = excluded.resume_template_text,
+                    version = excluded.version,
+                    updated_at = excluded.updated_at
+                """,
+                _root_values(str(tenant_id), profile_id, profile_dict, style, template_text, version, now),
+            )
+
+            self._insert_children(str(tenant_id), profile_id, profile)
+
+    def _insert_children(self, tenant_id: str, profile_id: str, profile: Profile) -> None:
+        for index, entry in enumerate(profile.experience_entries):
+            self._conn.execute(
+                """
+                INSERT INTO candidate_profile_experience_entries (
+                    tenant_id, profile_id, entry_id, position_index,
+                    date_range, title, company, location
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (tenant_id, profile_id, entry.id, index, entry.date_range, entry.title, entry.company, entry.location),
+            )
+            for bullet_index, bullet in enumerate(entry.bullets):
+                self._conn.execute(
+                    """
+                    INSERT INTO candidate_profile_experience_bullets (
+                        tenant_id, profile_id, entry_id, bullet_index, bullet_text
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (tenant_id, profile_id, entry.id, bullet_index, bullet),
+                )
+
+        for index, entry in enumerate(profile.education_entries):
+            self._conn.execute(
+                """
+                INSERT INTO candidate_profile_education_entries (
+                    tenant_id, profile_id, entry_id, position_index,
+                    date, degree, institution, location
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (tenant_id, profile_id, entry.id, index, entry.date, entry.degree, entry.institution, entry.location),
+            )
+
+        for index, category in enumerate(profile.skill_categories):
+            self._conn.execute(
+                """
+                INSERT INTO candidate_profile_skill_categories (
+                    tenant_id, profile_id, category_id, position_index, label
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (tenant_id, profile_id, category.id, index, category.label),
+            )
+            for item_index, item in enumerate(category.items):
+                self._conn.execute(
+                    """
+                    INSERT INTO candidate_profile_skill_items (
+                        tenant_id, profile_id, category_id, item_index, item_text
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (tenant_id, profile_id, category.id, item_index, item),
+                )
+
+        self._insert_required_ids(
+            "candidate_profile_required_experience_entries",
+            "entry_id",
+            tenant_id,
+            profile_id,
+            profile.tailoring_rules.required_experience_entry_ids,
+        )
+        self._insert_required_ids(
+            "candidate_profile_required_education_entries",
+            "entry_id",
+            tenant_id,
+            profile_id,
+            profile.tailoring_rules.required_education_entry_ids,
+        )
+        self._insert_required_ids(
+            "candidate_profile_required_skill_categories",
+            "category_id",
+            tenant_id,
+            profile_id,
+            profile.tailoring_rules.required_skill_category_ids,
+        )
+
+        for entry_id, bullets in profile.tailoring_rules.required_bullets_by_experience_id.items():
+            for index, bullet in enumerate(bullets):
+                self._conn.execute(
+                    """
+                    INSERT INTO candidate_profile_required_bullets (
+                        tenant_id, profile_id, entry_id, bullet_index, bullet_text
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (tenant_id, profile_id, entry_id, index, bullet),
+                )
+        for category_id, skills in profile.tailoring_rules.required_skills_by_category_id.items():
+            for index, skill in enumerate(skills):
+                self._conn.execute(
+                    """
+                    INSERT INTO candidate_profile_required_skills (
+                        tenant_id, profile_id, category_id, skill_index, skill_text
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (tenant_id, profile_id, category_id, index, skill),
+                )
+        for index, metric in enumerate(profile.resume_constraints.real_metrics):
+            self._conn.execute(
+                """
+                INSERT INTO candidate_profile_resume_constraint_metrics (
+                    tenant_id, profile_id, metric_index, metric_text
+                ) VALUES (?, ?, ?, ?)
+                """,
+                (tenant_id, profile_id, index, metric),
+            )
+
+    def _insert_required_ids(
+        self,
+        table: str,
+        column: str,
+        tenant_id: str,
+        profile_id: str,
+        values: tuple[str, ...],
+    ) -> None:
+        for index, value in enumerate(values):
+            self._conn.execute(
+                f"""
+                INSERT INTO {table} (tenant_id, profile_id, position_index, {column})
+                VALUES (?, ?, ?, ?)
+                """,
+                (tenant_id, profile_id, index, value),
+            )
+
+    def _row_to_profile_dict(self, tenant_id: TenantId, row: sqlite3.Row) -> dict[str, Any]:
+        tenant = str(tenant_id)
+        profile_id = str(row["profile_id"])
+        return {
+            "personal": {
+                "full_name": row["personal_full_name"],
+                "preferred_name": row["personal_preferred_name"],
+                "email": row["personal_email"],
+                "phone": row["personal_phone"],
+                "address": row["personal_address"],
+                "city": row["personal_city"],
+                "province_state": row["personal_province_state"],
+                "country": row["personal_country"],
+                "postal_code": row["personal_postal_code"],
+                "linkedin_url": row["personal_linkedin_url"],
+                "github_url": row["personal_github_url"],
+                "portfolio_url": row["personal_portfolio_url"],
+                "website_url": row["personal_website_url"],
+                "password": row["personal_password"],
+            },
+            "work_authorization": {
+                "legally_authorized_to_work": row["work_legally_authorized_to_work"],
+                "require_sponsorship": row["work_require_sponsorship"],
+                "work_permit_type": row["work_work_permit_type"],
+            },
+            "availability": {
+                "earliest_start_date": row["availability_earliest_start_date"],
+                "available_for_full_time": row["availability_full_time"],
+                "available_for_contract": row["availability_contract"],
+            },
+            "compensation": {
+                "salary_expectation": row["compensation_salary_expectation"],
+                "salary_currency": row["compensation_salary_currency"],
+                "salary_range_min": row["compensation_salary_range_min"],
+                "salary_range_max": row["compensation_salary_range_max"],
+                "currency_conversion_note": row["compensation_currency_note"],
+            },
+            "experience": {
+                "years_of_experience_total": row["experience_years_total"],
+                "education_level": row["experience_education_level"],
+                "current_job_title": row["experience_current_job_title"],
+                "current_company": row["experience_current_company"],
+                "target_role": row["experience_target_role"],
+            },
+            "eeo_voluntary": {
+                "gender": row["eeo_gender"],
+                "race_ethnicity": row["eeo_race_ethnicity"],
+                "veteran_status": row["eeo_veteran_status"],
+                "disability_status": row["eeo_disability_status"],
+            },
+            "resume": {
+                "executive_profile": {"baseline_text": row["resume_baseline_text"]},
+                "experience_entries": self._experience_entries(tenant, profile_id),
+                "education_entries": self._education_entries(tenant, profile_id),
+                "skill_categories": self._skill_categories(tenant, profile_id),
+                "tailoring_rules": self._tailoring_rules(tenant, profile_id, row),
+            },
+            "resume_constraints": {
+                "real_metrics": self._ordered_values(
+                    "candidate_profile_resume_constraint_metrics",
+                    "metric_text",
+                    "metric_index",
+                    tenant,
+                    profile_id,
+                )
+            },
+        }
+
+    def _experience_entries(self, tenant_id: str, profile_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT entry_id, date_range, title, company, location
+            FROM candidate_profile_experience_entries
+            WHERE tenant_id = ? AND profile_id = ?
+            ORDER BY position_index, entry_id
+            """,
+            (tenant_id, profile_id),
+        ).fetchall()
+        entries: list[dict[str, Any]] = []
+        for row in rows:
+            entries.append(
+                {
+                    "id": row["entry_id"],
+                    "date_range": row["date_range"],
+                    "title": row["title"],
+                    "company": row["company"],
+                    "location": row["location"],
+                    "bullets": self._ordered_values(
+                        "candidate_profile_experience_bullets",
+                        "bullet_text",
+                        "bullet_index",
+                        tenant_id,
+                        profile_id,
+                        where="entry_id = ?",
+                        params=(row["entry_id"],),
+                    ),
+                }
+            )
+        return entries
+
+    def _education_entries(self, tenant_id: str, profile_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT entry_id, date, degree, institution, location
+            FROM candidate_profile_education_entries
+            WHERE tenant_id = ? AND profile_id = ?
+            ORDER BY position_index, entry_id
+            """,
+            (tenant_id, profile_id),
+        ).fetchall()
+        return [
+            {
+                "id": row["entry_id"],
+                "date": row["date"],
+                "degree": row["degree"],
+                "institution": row["institution"],
+                "location": row["location"],
+            }
+            for row in rows
+        ]
+
+    def _skill_categories(self, tenant_id: str, profile_id: str) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT category_id, label
+            FROM candidate_profile_skill_categories
+            WHERE tenant_id = ? AND profile_id = ?
+            ORDER BY position_index, category_id
+            """,
+            (tenant_id, profile_id),
+        ).fetchall()
+        return [
+            {
+                "id": row["category_id"],
+                "label": row["label"],
+                "items": self._ordered_values(
+                    "candidate_profile_skill_items",
+                    "item_text",
+                    "item_index",
+                    tenant_id,
+                    profile_id,
+                    where="category_id = ?",
+                    params=(row["category_id"],),
+                ),
+            }
+            for row in rows
+        ]
+
+    def _tailoring_rules(self, tenant_id: str, profile_id: str, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "required_experience_entry_ids": self._ordered_values(
+                "candidate_profile_required_experience_entries",
+                "entry_id",
+                "position_index",
+                tenant_id,
+                profile_id,
+            ),
+            "required_education_entry_ids": self._ordered_values(
+                "candidate_profile_required_education_entries",
+                "entry_id",
+                "position_index",
+                tenant_id,
+                profile_id,
+            ),
+            "required_skill_category_ids": self._ordered_values(
+                "candidate_profile_required_skill_categories",
+                "category_id",
+                "position_index",
+                tenant_id,
+                profile_id,
+            ),
+            "required_bullets_by_experience_id": self._grouped_required(
+                "candidate_profile_required_bullets",
+                "entry_id",
+                "bullet_text",
+                "bullet_index",
+                tenant_id,
+                profile_id,
+            ),
+            "required_skills_by_category_id": self._grouped_required(
+                "candidate_profile_required_skills",
+                "category_id",
+                "skill_text",
+                "skill_index",
+                tenant_id,
+                profile_id,
+            ),
+            "max_experience_bullets": int(row["max_experience_bullets"]),
+            "custom_tailoring_prompt": row["custom_tailoring_prompt"],
+            "tailoring_policy": {
+                "mode": row["tailoring_mode"],
+                "allow_title_reframing": _as_bool(row["tailoring_allow_title_reframing"]),
+                "allow_achievement_rewriting": _as_bool(row["tailoring_allow_achievement_rewriting"]),
+                "allow_skill_reordering": _as_bool(row["tailoring_allow_skill_reordering"]),
+                "allow_summary_rewrite": _as_bool(row["tailoring_allow_summary_rewrite"]),
+                "allow_minor_inference": _as_bool(row["tailoring_allow_minor_inference"]),
+            },
+            "writing_style": {
+                "tone": row["writing_tone"],
+                "bullet_style": row["writing_bullet_style"],
+                "verbosity": row["writing_verbosity"],
+                "keyword_density": row["writing_keyword_density"],
+                "avoid_first_person": _as_bool(row["writing_avoid_first_person"]),
+            },
+        }
+
+    def _ordered_values(
+        self,
+        table: str,
+        value_column: str,
+        order_column: str,
+        tenant_id: str,
+        profile_id: str,
+        *,
+        where: str = "",
+        params: tuple[Any, ...] = (),
+    ) -> list[str]:
+        extra = f" AND {where}" if where else ""
+        rows = self._conn.execute(
+            f"""
+            SELECT {value_column}
+            FROM {table}
+            WHERE tenant_id = ? AND profile_id = ?{extra}
+            ORDER BY {order_column}
+            """,
+            (tenant_id, profile_id, *params),
+        ).fetchall()
+        return [str(row[value_column]) for row in rows]
+
+    def _grouped_required(
+        self,
+        table: str,
+        key_column: str,
+        value_column: str,
+        order_column: str,
+        tenant_id: str,
+        profile_id: str,
+    ) -> dict[str, list[str]]:
+        rows = self._conn.execute(
+            f"""
+            SELECT {key_column}, {value_column}
+            FROM {table}
+            WHERE tenant_id = ? AND profile_id = ?
+            ORDER BY {key_column}, {order_column}
+            """,
+            (tenant_id, profile_id),
+        ).fetchall()
+        grouped: dict[str, list[str]] = {}
+        for row in rows:
+            grouped.setdefault(str(row[key_column]), []).append(str(row[value_column]))
+        return grouped
+
+    def _read_legacy_profile(self) -> dict[str, Any]:
+        assert self._legacy_profile_path is not None
+        try:
+            data = json.loads(self._legacy_profile_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise InvalidProfileError(
+                [f"profile.json at {self._legacy_profile_path} is not valid JSON: {exc}"]
+            ) from exc
+        if not isinstance(data, dict):
+            raise InvalidProfileError(["profile.json must contain a top-level object."])
+        return data
+
+    def _read_legacy_style(self) -> dict[str, Any]:
+        if self._legacy_style_path is None or not self._legacy_style_path.exists():
+            return normalize_resume_style()
+        try:
+            data = json.loads(self._legacy_style_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            logger.warning("resume_style.json at %s is not valid JSON; using defaults.", self._legacy_style_path)
+            return normalize_resume_style()
+        return normalize_resume_style(data if isinstance(data, dict) else None)
+
+    def _read_legacy_template(self) -> str:
+        if self._legacy_template_path is None or not self._legacy_template_path.exists():
+            return DEFAULT_RESUME_LATEX_TEMPLATE
+        return self._legacy_template_path.read_text(encoding="utf-8")
+
+
+def _root_values(
+    tenant_id: str,
+    profile_id: str,
+    profile: dict[str, Any],
+    style: dict[str, Any],
+    template_text: str,
+    version: int,
+    updated_at: str,
+) -> tuple[Any, ...]:
+    personal = _record(profile.get("personal"))
+    work = _record(profile.get("work_authorization"))
+    compensation = _record(profile.get("compensation"))
+    experience = _record(profile.get("experience"))
+    availability = _record(profile.get("availability"))
+    eeo = _record(profile.get("eeo_voluntary"))
+    resume = _record(profile.get("resume"))
+    executive = _record(resume.get("executive_profile"))
+    rules = _record(resume.get("tailoring_rules"))
+    policy = _record(rules.get("tailoring_policy"))
+    writing = _record(rules.get("writing_style"))
+
+    return (
+        tenant_id,
+        profile_id,
+        _text(personal.get("full_name")),
+        _text(personal.get("preferred_name")),
+        _text(personal.get("email")),
+        _text(personal.get("phone")),
+        _text(personal.get("address")),
+        _text(personal.get("city")),
+        _text(personal.get("province_state")),
+        _text(personal.get("country")),
+        _text(personal.get("postal_code")),
+        _text(personal.get("linkedin_url")),
+        _text(personal.get("github_url")),
+        _text(personal.get("portfolio_url")),
+        _text(personal.get("website_url")),
+        _text(personal.get("password")),
+        _text(work.get("legally_authorized_to_work")),
+        _text(work.get("require_sponsorship")),
+        _text(work.get("work_permit_type")),
+        _text(compensation.get("salary_expectation")),
+        _text(compensation.get("salary_currency"), "USD"),
+        _text(compensation.get("salary_range_min")),
+        _text(compensation.get("salary_range_max")),
+        _text(compensation.get("currency_conversion_note")),
+        _text(experience.get("years_of_experience_total")),
+        _text(experience.get("education_level")),
+        _text(experience.get("current_job_title")),
+        _text(experience.get("current_company")),
+        _text(experience.get("target_role")),
+        _text(availability.get("earliest_start_date")),
+        _text(availability.get("available_for_full_time")),
+        _text(availability.get("available_for_contract")),
+        _text(eeo.get("gender"), "Decline to self-identify"),
+        _text(eeo.get("race_ethnicity"), "Decline to self-identify"),
+        _text(eeo.get("veteran_status"), "Decline to self-identify"),
+        _text(eeo.get("disability_status"), "Decline to self-identify"),
+        _text(executive.get("baseline_text")),
+        _text(policy.get("mode"), "balanced"),
+        _bool_int(policy.get("allow_title_reframing"), False),
+        _bool_int(policy.get("allow_achievement_rewriting"), True),
+        _bool_int(policy.get("allow_skill_reordering"), True),
+        _bool_int(policy.get("allow_summary_rewrite"), True),
+        _bool_int(policy.get("allow_minor_inference"), False),
+        _text(writing.get("tone"), "direct"),
+        _text(writing.get("bullet_style"), "balanced"),
+        _text(writing.get("verbosity"), "balanced"),
+        _text(writing.get("keyword_density"), "natural"),
+        _bool_int(writing.get("avoid_first_person"), True),
+        int(rules.get("max_experience_bullets") or 4),
+        _text(rules.get("custom_tailoring_prompt")),
+        style["document_font_size"],
+        style["paper_size"],
+        style["font_family"],
+        style["moderncv_style"],
+        style["moderncv_color"],
+        style["page_scale"],
+        style["hints_column_width_cm"],
+        style["body_alignment"],
+        template_text,
+        version,
+        updated_at,
+    )
+
+
+def _style_from_row(row: sqlite3.Row) -> dict[str, Any]:
+    return normalize_resume_style(
+        {
+            "document_font_size": row["resume_style_document_font_size"],
+            "paper_size": row["resume_style_paper_size"],
+            "font_family": row["resume_style_font_family"],
+            "moderncv_style": row["resume_style_moderncv_style"],
+            "moderncv_color": row["resume_style_moderncv_color"],
+            "page_scale": row["resume_style_page_scale"],
+            "hints_column_width_cm": row["resume_style_hints_column_width_cm"],
+            "body_alignment": row["resume_style_body_alignment"],
+        }
+    )
+
+
+def _record(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _text(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _bool_int(value: Any, default: bool) -> int:
+    if value is None:
+        return 1 if default else 0
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, str):
+        return 1 if value.strip().lower() in {"true", "yes", "y", "1", "on"} else 0
+    return 1 if bool(value) else 0
+
+
+def _as_bool(value: Any) -> bool:
+    return bool(int(value or 0))
+
+
+def _diff_top_level_sections(previous: dict[str, Any], current: dict[str, Any]) -> tuple[str, ...]:
+    keys = set(previous) | set(current)
+    return tuple(sorted(key for key in keys if previous.get(key) != current.get(key)))

--- a/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
@@ -252,7 +252,8 @@ class SqliteProfileRepository:
                     compensation_currency_note,
                     experience_years_total, experience_education_level,
                     experience_current_job_title, experience_current_company,
-                    experience_target_role,
+                    experience_target_role, experience_target_locations,
+                    experience_target_work_models,
                     availability_earliest_start_date, availability_full_time,
                     availability_contract,
                     eeo_gender, eeo_race_ethnicity, eeo_veteran_status,
@@ -274,7 +275,7 @@ class SqliteProfileRepository:
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
                 )
                 ON CONFLICT(tenant_id, profile_id) DO UPDATE SET
                     personal_full_name = excluded.personal_full_name,
@@ -304,6 +305,8 @@ class SqliteProfileRepository:
                     experience_current_job_title = excluded.experience_current_job_title,
                     experience_current_company = excluded.experience_current_company,
                     experience_target_role = excluded.experience_target_role,
+                    experience_target_locations = excluded.experience_target_locations,
+                    experience_target_work_models = excluded.experience_target_work_models,
                     availability_earliest_start_date = excluded.availability_earliest_start_date,
                     availability_full_time = excluded.availability_full_time,
                     availability_contract = excluded.availability_contract,
@@ -505,6 +508,8 @@ class SqliteProfileRepository:
                 "current_job_title": row["experience_current_job_title"],
                 "current_company": row["experience_current_company"],
                 "target_role": row["experience_target_role"],
+                "target_locations": row["experience_target_locations"],
+                "target_work_models": row["experience_target_work_models"],
             },
             "eeo_voluntary": {
                 "gender": row["eeo_gender"],
@@ -793,6 +798,8 @@ def _root_values(
         _text(experience.get("current_job_title")),
         _text(experience.get("current_company")),
         _text(experience.get("target_role")),
+        _text(experience.get("target_locations")),
+        _text(experience.get("target_work_models")),
         _text(availability.get("earliest_start_date")),
         _text(availability.get("available_for_full_time")),
         _text(availability.get("available_for_contract")),

--- a/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
@@ -48,6 +48,8 @@ _CHILD_TABLES = (
     "candidate_profile_resume_constraint_metrics",
 )
 
+_IGNORED_LEGACY_TOP_LEVEL_FIELDS = {"schema_version"}
+
 
 class SqliteProfileRepository:
     """SQLite-backed implementation of ``ProfileRepository``."""
@@ -88,6 +90,7 @@ class SqliteProfileRepository:
         previous_dict = previous.to_dict() if previous is not None else {}
 
         validated = Profile.from_dict(tenant_id, profile.to_dict(), profile_id=profile.profile_id or self._profile_id)
+        _reject_unsupported_top_level_fields(validated)
         row = self._profile_row(tenant_id)
         version = int(row["version"]) + 1 if row is not None else 1
         rendering = self.load_rendering_settings(tenant_id)
@@ -202,6 +205,7 @@ class SqliteProfileRepository:
             return
         data = self._read_legacy_profile()
         profile = Profile.from_dict(tenant_id, data, profile_id=self._profile_id)
+        _reject_unsupported_top_level_fields(profile)
         style = self._read_legacy_style()
         template_text = self._read_legacy_template()
         self._replace_profile(
@@ -822,6 +826,18 @@ def _root_values(
         version,
         updated_at,
     )
+
+
+def _reject_unsupported_top_level_fields(profile: Profile) -> None:
+    unsupported = sorted(str(key) for key in profile.extra if key not in _IGNORED_LEGACY_TOP_LEVEL_FIELDS)
+    if unsupported:
+        raise InvalidProfileError(
+            [
+                "profile contains unsupported top-level profile field(s): "
+                f"{', '.join(unsupported)}. SQLite profile storage only supports "
+                "normalized Candidate Profile sections."
+            ]
+        )
 
 
 def _style_from_row(row: sqlite3.Row) -> dict[str, Any]:

--- a/workers/automation/src/jobhunter/wizard/init.py
+++ b/workers/automation/src/jobhunter/wizard/init.py
@@ -2,7 +2,7 @@
 
 Interactive flow that creates ~/.jobhunter/ with:
   - resume.txt (and optionally resume.pdf)
-  - profile.json
+  - candidate profile in jobhunter.db
   - searches.yaml
   - .env (LLM API key)
 """
@@ -19,8 +19,8 @@ from rich.prompt import Confirm, Prompt
 
 from jobhunter.config import (
     APP_DIR,
+    DB_PATH,
     ENV_PATH,
-    PROFILE_PATH,
     RESUME_PATH,
     RESUME_PDF_PATH,
     SEARCH_CONFIG_PATH,
@@ -115,7 +115,7 @@ def _setup_structured_resume(profile: dict) -> None:
     console.print("\n[bold cyan]Structured Resume Template[/bold cyan]")
     console.print(
         "[dim]This is the canonical resume JobHunter tailors and renders with LaTeX. "
-        "You can edit profile.json later for more entries.[/dim]"
+        "You can edit the profile later in the local UI.[/dim]"
     )
 
     baseline = _prompt_required(
@@ -318,7 +318,7 @@ def _setup_profile() -> dict:
     repository = get_profile_repository()
     aggregate = Profile.from_dict(LOCAL_TENANT, profile)
     repository.save(LOCAL_TENANT, aggregate)
-    console.print(f"\n[green]Profile saved to {PROFILE_PATH}[/green]")
+    console.print(f"\n[green]Profile saved to SQLite at {DB_PATH}[/green]")
     return profile
 
 

--- a/workers/automation/tests/test_doctor_langfuse.py
+++ b/workers/automation/tests/test_doctor_langfuse.py
@@ -54,7 +54,7 @@ def test_doctor_reports_langfuse_missing_when_creds_absent(monkeypatch):
     monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
     monkeypatch.delenv("LANGFUSE_BASE_URL", raising=False)
 
-    with _stub_temporal():
+    with _stub_temporal(), patch("jobhunter.config.load_env", lambda: None):
         result = CliRunner().invoke(app, ["doctor"])
 
     assert result.exit_code == 0, result.output

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -1,0 +1,167 @@
+"""Tests for the SQLite-backed Candidate Profile repository."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from jobhunter.database import ensure_profile_tables
+from jobhunter.domain.events.base import DomainEvent
+from jobhunter.domain.profile.aggregate import Profile
+from jobhunter.domain.tenant import LOCAL_TENANT
+from jobhunter.infrastructure.events.in_process_bus import InProcessEventBus
+from jobhunter.infrastructure.profile.sqlite_repository import SqliteProfileRepository
+
+
+def _valid_profile() -> dict:
+    return {
+        "personal": {"full_name": "Jordan Candidate", "email": "jordan@example.com"},
+        "work_authorization": {"legally_authorized_to_work": "Yes"},
+        "compensation": {"salary_expectation": "120000", "salary_currency": "USD"},
+        "experience": {"years_of_experience_total": "5", "target_role": "Platform"},
+        "availability": {"earliest_start_date": "Immediately"},
+        "eeo_voluntary": {"gender": "Decline to self-identify"},
+        "resume": {
+            "executive_profile": {"baseline_text": "Backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "role_1",
+                    "title": "Software Engineer",
+                    "company": "Acme",
+                    "date_range": "2022 -- Present",
+                    "location": "Remote",
+                    "bullets": ["Built APIs.", "Reduced incidents 40%."],
+                }
+            ],
+            "education_entries": [
+                {
+                    "id": "edu_1",
+                    "degree": "BS CS",
+                    "institution": "State U",
+                    "location": "Springfield",
+                    "date": "2019",
+                }
+            ],
+            "skill_categories": [
+                {"id": "lang", "label": "Languages", "items": ["Python", "Go"]}
+            ],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["role_1"],
+                "required_education_entry_ids": ["edu_1"],
+                "required_skill_category_ids": ["lang"],
+                "required_bullets_by_experience_id": {"role_1": ["Built APIs."]},
+                "required_skills_by_category_id": {"lang": ["Python"]},
+                "max_experience_bullets": 3,
+                "tailoring_policy": {"mode": "balanced"},
+                "writing_style": {"tone": "technical"},
+            },
+        },
+        "resume_constraints": {"real_metrics": ["40%"]},
+    }
+
+
+def _new_repo(tmp_path: Path) -> tuple[SqliteProfileRepository, sqlite3.Connection, list[DomainEvent]]:
+    conn = sqlite3.connect(tmp_path / "jobhunter.db")
+    conn.row_factory = sqlite3.Row
+    ensure_profile_tables(conn)
+    bus = InProcessEventBus()
+    events: list[DomainEvent] = []
+    bus.subscribe(None, events.append)
+    repo = SqliteProfileRepository(
+        conn,
+        legacy_profile_path=tmp_path / "profile.json",
+        legacy_style_path=tmp_path / "resume_style.json",
+        legacy_template_path=tmp_path / "resume_template.tex",
+        publisher=bus,
+    )
+    return repo, conn, events
+
+
+def test_profile_schema_is_normalized_without_profile_json_escape_hatch(tmp_path):
+    _, conn, _ = _new_repo(tmp_path)
+
+    tables = {
+        row["name"]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'candidate_profile%'"
+        )
+    }
+    assert {
+        "candidate_profiles",
+        "candidate_profile_experience_entries",
+        "candidate_profile_experience_bullets",
+        "candidate_profile_education_entries",
+        "candidate_profile_skill_categories",
+        "candidate_profile_skill_items",
+        "candidate_profile_required_experience_entries",
+        "candidate_profile_required_education_entries",
+        "candidate_profile_required_skill_categories",
+        "candidate_profile_required_bullets",
+        "candidate_profile_required_skills",
+        "candidate_profile_resume_constraint_metrics",
+    }.issubset(tables)
+
+    root_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(candidate_profiles)")
+    }
+    forbidden = {"profile_json", "style_json", "json_blob", "payload_json"}
+    assert root_columns.isdisjoint(forbidden)
+
+
+def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
+    repo, conn, events = _new_repo(tmp_path)
+
+    snapshot = repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, _valid_profile()))
+
+    assert snapshot.personal["full_name"] == "Jordan Candidate"
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profiles").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_experience_entries").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_experience_bullets").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_skill_items").fetchone()[0] == 2
+    root = conn.execute(
+        "SELECT writing_tone, max_experience_bullets FROM candidate_profiles"
+    ).fetchone()
+    assert root["writing_tone"] == "technical"
+    assert root["max_experience_bullets"] == 3
+
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    assert loaded.to_dict() == Profile.from_dict(LOCAL_TENANT, _valid_profile()).to_dict()
+    assert [event.event_type for event in events] == ["ProfileUpdated"]
+
+
+def test_legacy_profile_json_seeds_sqlite_once_and_writes_stay_in_sqlite(tmp_path):
+    repo, conn, _ = _new_repo(tmp_path)
+    legacy_profile = tmp_path / "profile.json"
+    legacy_profile.write_text(json.dumps(_valid_profile()), encoding="utf-8")
+    (tmp_path / "resume_style.json").write_text(
+        json.dumps({"moderncv_style": "classic", "moderncv_color": "blue"}),
+        encoding="utf-8",
+    )
+    (tmp_path / "resume_template.tex").write_text("\\documentclass{moderncv}", encoding="utf-8")
+
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    assert loaded.personal.full_name == "Jordan Candidate"
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profiles").fetchone()[0] == 1
+    rendering = repo.load_rendering_settings(LOCAL_TENANT)
+    assert rendering["style"]["moderncv_style"] == "classic"
+    assert rendering["style"]["moderncv_color"] == "blue"
+    assert rendering["template_text"] == "\\documentclass{moderncv}"
+
+    changed_legacy = _valid_profile()
+    changed_legacy["personal"]["full_name"] = "Legacy File Changed"
+    legacy_profile.write_text(json.dumps(changed_legacy), encoding="utf-8")
+
+    loaded_again = repo.load(LOCAL_TENANT)
+    assert loaded_again is not None
+    assert loaded_again.personal.full_name == "Jordan Candidate"
+
+    updated = _valid_profile()
+    updated["personal"]["full_name"] = "SQLite Updated"
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, updated))
+
+    assert json.loads(legacy_profile.read_text(encoding="utf-8"))["personal"]["full_name"] == "Legacy File Changed"
+    assert repo.load(LOCAL_TENANT).personal.full_name == "SQLite Updated"  # type: ignore[union-attr]
+    assert repo.load_rendering_settings(LOCAL_TENANT)["template_text"] == "\\documentclass{moderncv}"

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -6,9 +6,11 @@ import json
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from jobhunter.database import ensure_profile_tables
 from jobhunter.domain.events.base import DomainEvent
-from jobhunter.domain.profile.aggregate import Profile
+from jobhunter.domain.profile.aggregate import InvalidProfileError, Profile
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.events.in_process_bus import InProcessEventBus
 from jobhunter.infrastructure.profile.sqlite_repository import SqliteProfileRepository
@@ -165,3 +167,26 @@ def test_legacy_profile_json_seeds_sqlite_once_and_writes_stay_in_sqlite(tmp_pat
     assert json.loads(legacy_profile.read_text(encoding="utf-8"))["personal"]["full_name"] == "Legacy File Changed"
     assert repo.load(LOCAL_TENANT).personal.full_name == "SQLite Updated"  # type: ignore[union-attr]
     assert repo.load_rendering_settings(LOCAL_TENANT)["template_text"] == "\\documentclass{moderncv}"
+
+
+def test_save_rejects_unsupported_top_level_profile_fields(tmp_path):
+    repo, conn, _ = _new_repo(tmp_path)
+    raw = _valid_profile()
+    raw["custom_section"] = {"future": "thing"}
+
+    with pytest.raises(InvalidProfileError, match="unsupported top-level profile field\\(s\\): custom_section"):
+        repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, raw))
+
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profiles").fetchone()[0] == 0
+
+
+def test_legacy_profile_rejects_unsupported_top_level_fields_before_import(tmp_path):
+    repo, conn, _ = _new_repo(tmp_path)
+    legacy = _valid_profile()
+    legacy["custom_section"] = {"future": "thing"}
+    (tmp_path / "profile.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    with pytest.raises(InvalidProfileError, match="unsupported top-level profile field\\(s\\): custom_section"):
+        repo.load(LOCAL_TENANT)
+
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profiles").fetchone()[0] == 0


### PR DESCRIPTION
## Summary

- Add normalized SQLite Candidate Profile storage for the TypeScript API and Python worker, including one-time import from existing local profile files when the profile tables are empty.
- Route profile read/write and resume preview generation through the database-backed profile store.
- Replace the Python profile repository factory with the SQLite repository while keeping the legacy JSON file repository for compatibility tests.
- Remove the Profile UI source/config JSON display and keep the form focused on structured profile editing and preview.
- Update docs to describe `jobhunter.db` as the local profile/application database and legacy profile files as seed inputs.

## Validation

- `pnpm api:check` passed
- `pnpm api:test` passed: 5 files, 66 tests
- `pnpm web:check` passed
- `pnpm --filter @jobhunter/web test -- src/contexts/profile` passed: 77 files, 320 tests
- `pnpm --filter @jobhunter/web e2e -- tests/profile-edit.spec.ts` passed: 1 test
- `pnpm web:build` passed
- `pnpm --filter @jobhunter/web test-d` passed: 10 tests
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_profile_aggregate.py workers/automation/tests/test_profile_use_cases.py workers/automation/tests/test_json_file_profile_repository.py workers/automation/tests/test_sqlite_profile_repository.py` passed: 29 tests
- `uv --project workers/automation run --extra dev pytest -q` passed: 683 tests
- `uv --project workers/automation run --extra dev ruff check .` passed
- `uv --project workers/automation run --extra dev python -m compileall workers/automation/src/jobhunter` passed
- `git diff --check` passed