### PR TITLE
fix(profile): preserve list spaces and edit min fit

### DIFF
--- a/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
@@ -22,6 +22,7 @@ describe("<ProfileEditor>", () => {
 
     expect(await screen.findByRole("heading", { name: "Preferences" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Application defaults" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Minimum fit score")).toHaveValue(7);
     expect(screen.queryByText("Resume preview")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Resize profile and PDF preview panes")).not.toBeInTheDocument();
   });

--- a/apps/web/src/contexts/profile/components/ProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.tsx
@@ -1,11 +1,13 @@
-import { useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
 
 import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import type { DashboardSettings } from "../../operations/types.js";
 import { ProfileForm } from "../forms/profile-form.js";
 import { useProfileQuery } from "../hooks/useProfileQuery.js";
 import { useSettingsQuery } from "../hooks/useSettingsQuery.js";
+import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
 import { ResumePreviewIframe } from "./ResumePreviewIframe.js";
 
 const SPLIT_STORAGE_KEY = "profile-preview-split-width";
@@ -77,7 +79,9 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
           title={title}
           meta={
             settingsQuery.data
-              ? `min fit ${settingsQuery.data.settings.minFitScore}`
+              ? section === "preferences"
+                ? <MinimumFitScoreControl settings={settingsQuery.data.settings} />
+                : `min fit ${settingsQuery.data.settings.minFitScore}`
               : "loading"
           }
         />
@@ -115,6 +119,49 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
         </>
       ) : null}
     </div>
+  );
+}
+
+function MinimumFitScoreControl({ settings }: { settings: DashboardSettings }) {
+  const updateSettings = useUpdateSettingsMutation();
+  const [draft, setDraft] = useState(String(settings.minFitScore));
+
+  useEffect(() => {
+    setDraft(String(settings.minFitScore));
+  }, [settings.minFitScore]);
+
+  const commit = () => {
+    const parsed = Number(draft);
+    const next = Number.isFinite(parsed) ? Math.min(10, Math.max(0, Math.round(parsed))) : settings.minFitScore;
+    setDraft(String(next));
+    if (next !== settings.minFitScore) {
+      updateSettings.mutate({ minFitScore: next });
+    }
+  };
+
+  return (
+    <label className="min-fit-control">
+      <span>min fit</span>
+      <input
+        aria-label="Minimum fit score"
+        type="number"
+        min={0}
+        max={10}
+        step={1}
+        value={draft}
+        disabled={updateSettings.isPending}
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={commit}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") {
+            return;
+          }
+          event.preventDefault();
+          commit();
+          event.currentTarget.blur();
+        }}
+      />
+    </label>
   );
 }
 

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1085,10 +1085,12 @@ export function StructuredProfileEditor({
 
 function delimitedListAt(value: string): string[] {
   const withoutLegacyLabel = value.replace(/^\s*Target roles?:\s*/i, "");
-  if (!withoutLegacyLabel.trim()) {
+  if (!withoutLegacyLabel) {
     return [""];
   }
-  return withoutLegacyLabel.split(";").map((item) => item.trim());
+  return withoutLegacyLabel
+    .split(";")
+    .map((item, index) => (index === 0 ? item : item.replace(/^\s+/, "")));
 }
 
 function commaListAt(value: string): string[] {

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -101,6 +101,16 @@ describe("<ProfileForm>", () => {
     expect(screen.getByLabelText("Target roles 2")).toHaveFocus();
   });
 
+  it("preserves spaces while editing target roles", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);
+
+    const input = await screen.findByLabelText("Target roles 1");
+    await user.type(input, "Director of Engineering");
+
+    expect(input).toHaveValue("Director of Engineering");
+  });
+
   it("adds and focuses the next target location with Enter", async () => {
     const user = userEvent.setup();
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />);

--- a/apps/web/src/shared/ui/card-header.tsx
+++ b/apps/web/src/shared/ui/card-header.tsx
@@ -1,6 +1,8 @@
+import type { ReactNode } from "react";
+
 export interface CardHeaderProps {
   title: string;
-  meta?: string;
+  meta?: ReactNode;
 }
 
 export function CardHeader({ title, meta }: CardHeaderProps) {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -419,6 +419,21 @@ textarea {
   font-size: 11px;
 }
 
+.min-fit-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.min-fit-control input {
+  width: 48px;
+  height: 26px;
+  padding: 4px 6px;
+  text-align: center;
+}
+
 .bar {
   display: flex;
   height: 10px;


### PR DESCRIPTION
## Summary
- Preserve typed spaces in semicolon-backed profile preference list fields while keeping separator padding normalized.
- Add an editable minimum fit score control to the Preferences header using the existing settings mutation.
- Add focused component coverage for the target role space regression and the visible min-fit control.

## Validation
- Not run per request.
