### PR TITLE
feat(scoring): expose score evidence

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -246,7 +246,7 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
 }
 
 /** Idempotently create the projection tables. Mirrors the Python schema. */
-export function ensureProjectionTables(db: SqliteDatabase): void {
+export function ensureProjectionTables(db: SqliteDatabase): boolean {
   db.exec(`
     CREATE TABLE IF NOT EXISTS event_watermarks (
       projection_name     TEXT PRIMARY KEY,
@@ -267,7 +267,11 @@ export function ensureProjectionTables(db: SqliteDatabase): void {
       description            TEXT NOT NULL DEFAULT '',
       full_description       TEXT NOT NULL DEFAULT '',
       fit_score              INTEGER,
+      score_breakdown_json   TEXT,
+      score_keywords_json    TEXT NOT NULL DEFAULT '[]',
       score_reasoning        TEXT NOT NULL DEFAULT '',
+      score_version          INTEGER,
+      scored_at              TEXT,
       current_stage          TEXT NOT NULL DEFAULT 'discover',
       current_state          TEXT NOT NULL DEFAULT 'pending',
       current_error_code     TEXT,
@@ -300,7 +304,11 @@ export function ensureProjectionTables(db: SqliteDatabase): void {
       tenant_id              TEXT NOT NULL DEFAULT 'local',
       job_id                 TEXT NOT NULL,
       description_preview    TEXT NOT NULL DEFAULT '',
+      score_breakdown_json   TEXT,
+      score_keywords_json    TEXT NOT NULL DEFAULT '[]',
       score_reasoning        TEXT NOT NULL DEFAULT '',
+      score_version          INTEGER,
+      scored_at              TEXT,
       stages_json            TEXT NOT NULL DEFAULT '[]',
       last_updated_at        TEXT,
       PRIMARY KEY (tenant_id, job_id)
@@ -335,6 +343,37 @@ export function ensureProjectionTables(db: SqliteDatabase): void {
       events_json            TEXT NOT NULL DEFAULT '[]'
     );
   `);
+  let schemaChanged = false;
+  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_breakdown_json", "TEXT") || schemaChanged;
+  schemaChanged =
+    ensureProjectionColumn(db, "job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'") ||
+    schemaChanged;
+  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "score_version", "INTEGER") || schemaChanged;
+  schemaChanged = ensureProjectionColumn(db, "job_list_projections", "scored_at", "TEXT") || schemaChanged;
+  schemaChanged =
+    ensureProjectionColumn(db, "job_detail_projections", "score_breakdown_json", "TEXT") || schemaChanged;
+  schemaChanged =
+    ensureProjectionColumn(db, "job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'") ||
+    schemaChanged;
+  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "score_version", "INTEGER") || schemaChanged;
+  schemaChanged = ensureProjectionColumn(db, "job_detail_projections", "scored_at", "TEXT") || schemaChanged;
+  return schemaChanged;
+}
+
+function ensureProjectionColumn(
+  db: SqliteDatabase,
+  tableName: string,
+  columnName: string,
+  definition: string,
+): boolean {
+  const columns = new Set(
+    allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name),
+  );
+  if (!columns.has(columnName)) {
+    db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition}`);
+    return true;
+  }
+  return false;
 }
 
 /** Read the watermark; returns 0 when missing. */
@@ -365,7 +404,7 @@ function setWatermark(db: SqliteDatabase, projection: string, eventId: number): 
  * worker writes (which also bump ``job_events``).
  */
 export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void {
-  ensureProjectionTables(db);
+  const projectionSchemaChanged = ensureProjectionTables(db);
   backfillLegacyStageStates(db);
 
   const watermark = readWatermark(db, PROJECTION_WATERMARK_NAME);
@@ -398,6 +437,12 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
       for (const job of jobs) {
         if (job.url) dirtyJobs.add(job.url);
       }
+    }
+  }
+  if (projectionSchemaChanged && tableExists(db, "jobs")) {
+    const jobs = allRows<{ url: string }>(db, "SELECT url FROM jobs");
+    for (const job of jobs) {
+      if (job.url) dirtyJobs.add(job.url);
     }
   }
 
@@ -480,36 +525,119 @@ function loadLatestMaterials(db: SqliteDatabase, jobUrl: string): MaterialsLates
   return latest;
 }
 
+interface ScoreBreakdownLatest {
+  technicalFit: number;
+  experienceFit: number;
+  roleFit: number;
+  reasoning: string;
+}
+
 interface ScoreLatest {
   fitScore: number | null;
+  breakdown: ScoreBreakdownLatest | null;
+  keywords: string[];
   reasoning: string;
+  version: number | null;
+  scoredAt: string | null;
 }
 
 function loadLatestScore(db: SqliteDatabase, jobUrl: string): ScoreLatest {
   if (!tableExists(db, "job_scores")) {
-    return { fitScore: null, reasoning: "" };
+    return emptyScore();
   }
-  const row = getRow<{ fit_score: number; breakdown_json: string | null }>(
+  const row = getRow<{
+    fit_score: number;
+    version: number;
+    breakdown_json: string | null;
+    keywords_json: string | null;
+    scored_at: string | null;
+  }>(
     db,
-    "SELECT fit_score, breakdown_json FROM job_scores WHERE job_url = ? ORDER BY version DESC LIMIT 1",
+    `SELECT fit_score, version, breakdown_json, keywords_json, scored_at
+     FROM job_scores WHERE job_url = ? ORDER BY version DESC LIMIT 1`,
     [jobUrl],
   );
   if (!row) {
-    return { fitScore: null, reasoning: "" };
+    return emptyScore();
   }
-  let reasoning = "";
-  if (row.breakdown_json) {
-    try {
-      const parsed: unknown = JSON.parse(row.breakdown_json);
-      if (parsed && typeof parsed === "object" && "reasoning" in parsed) {
-        const r = (parsed as { reasoning?: unknown }).reasoning;
-        if (typeof r === "string") reasoning = r;
-      }
-    } catch {
-      // ignore — broken JSON in job_scores doesn't take down the dashboard
-    }
+  const parsedBreakdown = parseScoreBreakdown(row.breakdown_json);
+  const keywords = parseScoreKeywords(row.keywords_json);
+  return {
+    fitScore: Number(row.fit_score),
+    breakdown: parsedBreakdown.legacy ? null : parsedBreakdown.breakdown,
+    keywords: parsedBreakdown.legacy && keywords.length === 1 && keywords[0] === "legacy" ? [] : keywords,
+    reasoning: parsedBreakdown.reasoning,
+    version: nullableNumber(row.version),
+    scoredAt: nullableString(row.scored_at),
+  };
+}
+
+function emptyScore(): ScoreLatest {
+  return {
+    fitScore: null,
+    breakdown: null,
+    keywords: [],
+    reasoning: "",
+    version: null,
+    scoredAt: null,
+  };
+}
+
+function parseScoreBreakdown(
+  value: string | null,
+): { breakdown: ScoreBreakdownLatest | null; reasoning: string; legacy: boolean } {
+  let parsed: unknown = null;
+  try {
+    parsed = value ? JSON.parse(value) : null;
+  } catch {
+    return { breakdown: null, reasoning: "", legacy: false };
   }
-  return { fitScore: Number(row.fit_score), reasoning };
+  if (!parsed || typeof parsed !== "object") {
+    return { breakdown: null, reasoning: "", legacy: false };
+  }
+  const record = parsed as Record<string, unknown>;
+  const reasoning = typeof record.reasoning === "string" ? record.reasoning : "";
+  if (record.legacy === true) {
+    return { breakdown: null, reasoning, legacy: true };
+  }
+  return {
+    breakdown: {
+      technicalFit: scoreDimension(record.technical_fit ?? record.technicalFit),
+      experienceFit: scoreDimension(record.experience_fit ?? record.experienceFit),
+      roleFit: scoreDimension(record.role_fit ?? record.roleFit),
+      reasoning,
+    },
+    reasoning,
+    legacy: false,
+  };
+}
+
+function parseScoreKeywords(value: string | null): string[] {
+  let parsed: unknown = [];
+  try {
+    parsed = value ? JSON.parse(value) : [];
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of parsed) {
+    const keyword = String(raw ?? "").trim();
+    const key = keyword.toLowerCase();
+    if (!keyword || seen.has(key)) continue;
+    seen.add(key);
+    out.push(keyword);
+  }
+  return out;
+}
+
+function scoreDimension(value: unknown): number {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 10) return 10;
+  return Math.trunc(n);
 }
 
 interface EnrichmentLatest {
@@ -732,6 +860,8 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 
   const fitScore = score.fitScore ?? nullableNumber(job.fit_score);
   const scoreReasoning = score.reasoning || stringField(job.score_reasoning);
+  const scoreBreakdownJson = score.breakdown ? JSON.stringify(score.breakdown) : null;
+  const scoreKeywordsJson = JSON.stringify(score.keywords);
 
   const tailorPath = materials.tailorPath ?? nullableString(job.tailored_resume_path);
   const coverPath = materials.coverPath ?? nullableString(job.cover_letter_path);
@@ -751,13 +881,14 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 
   db.prepare(
     `INSERT INTO job_list_projections (
-       tenant_id, job_id, title, employer, source, strategy, location,
-       salary, application_url, discovered_at, description, full_description,
-       fit_score, score_reasoning, current_stage, current_state,
+     tenant_id, job_id, title, employer, source, strategy, location,
+     salary, application_url, discovered_at, description, full_description,
+       fit_score, score_breakdown_json, score_keywords_json, score_reasoning,
+       score_version, scored_at, current_stage, current_state,
        current_error_code, current_error_message, current_next_action,
        has_resume, has_cover_letter, has_pdf, apply_status, applied_at,
        artifact_count, deleted_at, last_updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(tenant_id, job_id) DO UPDATE SET
        title                 = excluded.title,
        employer              = excluded.employer,
@@ -770,7 +901,11 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
        description           = excluded.description,
        full_description      = excluded.full_description,
        fit_score             = excluded.fit_score,
+       score_breakdown_json  = excluded.score_breakdown_json,
+       score_keywords_json   = excluded.score_keywords_json,
        score_reasoning       = excluded.score_reasoning,
+       score_version         = excluded.score_version,
+       scored_at             = excluded.scored_at,
        current_stage         = excluded.current_stage,
        current_state         = excluded.current_state,
        current_error_code    = excluded.current_error_code,
@@ -798,7 +933,11 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
     description,
     fullDescription,
     fitScore,
+    scoreBreakdownJson,
+    scoreKeywordsJson,
     scoreReasoning,
+    score.version,
+    score.scoredAt,
     firstActionable?.stage ?? "discover",
     firstActionable?.state ?? "pending",
     firstActionable?.error_code ?? null,
@@ -816,19 +955,28 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
 
   db.prepare(
     `INSERT INTO job_detail_projections (
-       tenant_id, job_id, description_preview, score_reasoning, stages_json,
-       last_updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?)
+       tenant_id, job_id, description_preview, score_breakdown_json,
+       score_keywords_json, score_reasoning, score_version, scored_at,
+       stages_json, last_updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(tenant_id, job_id) DO UPDATE SET
-       description_preview = excluded.description_preview,
-       score_reasoning     = excluded.score_reasoning,
-       stages_json         = excluded.stages_json,
-       last_updated_at     = excluded.last_updated_at`,
+       description_preview  = excluded.description_preview,
+       score_breakdown_json = excluded.score_breakdown_json,
+       score_keywords_json  = excluded.score_keywords_json,
+       score_reasoning      = excluded.score_reasoning,
+       score_version        = excluded.score_version,
+       scored_at            = excluded.scored_at,
+       stages_json          = excluded.stages_json,
+       last_updated_at      = excluded.last_updated_at`,
   ).run(
     tenantId,
     jobUrl,
     previewText(fullDescription || description, 6000),
+    scoreBreakdownJson,
+    scoreKeywordsJson,
     scoreReasoning,
+    score.version,
+    score.scoredAt,
     JSON.stringify(stages),
     lastUpdatedAt,
   );

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -29,6 +29,7 @@ import type {
   JobSummary,
   PaginatedResponse,
   ProfileShape,
+  ScoreBreakdown,
   SettingsResponse,
   Stage,
   StageState,
@@ -90,7 +91,11 @@ interface JobListProjectionRow extends Record<string, unknown> {
   description: string;
   full_description: string;
   fit_score: number | null;
+  score_breakdown_json: string | null;
+  score_keywords_json: string;
   score_reasoning: string;
+  score_version: number | null;
+  scored_at: string | null;
   current_stage: string;
   current_state: string;
   current_error_code: string | null;
@@ -110,7 +115,11 @@ interface JobDetailProjectionRow extends Record<string, unknown> {
   tenant_id: string;
   job_id: string;
   description_preview: string;
+  score_breakdown_json: string | null;
+  score_keywords_json: string;
   score_reasoning: string;
+  score_version: number | null;
+  scored_at: string | null;
   stages_json: string;
   last_updated_at: string | null;
 }
@@ -353,6 +362,11 @@ function rowToJobSummary(row: JobListProjectionRow): JobSummary {
     discoveredAt: row.discovered_at,
     applicationUrl: row.application_url,
     fitScore: row.fit_score === null || row.fit_score === undefined ? null : Number(row.fit_score),
+    scoreBreakdown: parseScoreBreakdown(row.score_breakdown_json),
+    scoreKeywords: parseScoreKeywords(row.score_keywords_json),
+    scoreReasoning: row.score_reasoning ?? "",
+    scoreVersion: nullableNumber(row.score_version),
+    scoredAt: nullableString(row.scored_at),
     currentStage: (isStage(row.current_stage) ? row.current_stage : "discover") as Stage,
     currentState: (isStageState(row.current_state) ? row.current_state : "pending") as StageState,
     errorCode: row.current_error_code,
@@ -363,6 +377,50 @@ function rowToJobSummary(row: JobListProjectionRow): JobSummary {
     appliedAt: row.applied_at,
     deletedAt: row.deleted_at,
   };
+}
+
+function parseScoreBreakdown(value: string | null): ScoreBreakdown | null {
+  let parsed: unknown = null;
+  try {
+    parsed = value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  return {
+    technicalFit: scoreDimension(parsed.technicalFit),
+    experienceFit: scoreDimension(parsed.experienceFit),
+    roleFit: scoreDimension(parsed.roleFit),
+    reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : "",
+  };
+}
+
+function parseScoreKeywords(value: string | null): string[] {
+  let parsed: unknown = [];
+  try {
+    parsed = value ? JSON.parse(value) : [];
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const seen = new Set<string>();
+  const keywords: string[] = [];
+  for (const raw of parsed) {
+    const keyword = String(raw ?? "").trim();
+    const key = keyword.toLowerCase();
+    if (!keyword || seen.has(key)) continue;
+    seen.add(key);
+    keywords.push(keyword);
+  }
+  return keywords;
+}
+
+function scoreDimension(value: unknown): number {
+  const n = Number(value ?? 0);
+  if (!Number.isFinite(n)) return 0;
+  if (n < 0) return 0;
+  if (n > 10) return 10;
+  return Math.trunc(n);
 }
 
 function rowToArtifactSummary(row: ArtifactProjectionRow): ArtifactSummary {

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -102,15 +102,59 @@ function seedSchema(dbPath: string): void {
       duration_ms INTEGER,
       events_json TEXT NOT NULL DEFAULT '[]'
     );
+    CREATE TABLE job_scores (
+      job_url TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      fit_score INTEGER NOT NULL,
+      breakdown_json TEXT NOT NULL,
+      keywords_json TEXT NOT NULL,
+      scored_at TEXT NOT NULL,
+      correction_json TEXT,
+      PRIMARY KEY (job_url, version)
+    );
   `);
   db.prepare(
-    "INSERT INTO jobs (url, title, site, fit_score, application_url) VALUES (?, ?, ?, ?, ?)",
+    "INSERT INTO jobs (url, title, site, fit_score, score_reasoning, application_url) VALUES (?, ?, ?, ?, ?, ?)",
   ).run(
     "https://example.com/jobs/event-driven",
     "Event-Driven Engineer",
     "ExampleCo",
     9,
+    "Legacy reasoning kept for old callers.",
     "https://example.com/apply/event",
+  );
+  db.prepare(
+    "INSERT INTO job_scores (job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(
+    "https://example.com/jobs/event-driven",
+    1,
+    "local",
+    7,
+    JSON.stringify({
+      technical_fit: 7,
+      experience_fit: 6,
+      role_fit: 7,
+      reasoning: "Older score evidence.",
+    }),
+    JSON.stringify(["python"]),
+    "2026-05-04T11:00:00+00:00",
+  );
+  db.prepare(
+    "INSERT INTO job_scores (job_url, version, tenant_id, fit_score, breakdown_json, keywords_json, scored_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).run(
+    "https://example.com/jobs/event-driven",
+    2,
+    "local",
+    8,
+    JSON.stringify({
+      technical_fit: 9,
+      experience_fit: 7,
+      role_fit: 8,
+      reasoning: "Latest structured score evidence.",
+    }),
+    JSON.stringify(["python", "fastapi"]),
+    "2026-05-05T09:30:00+00:00",
   );
   db.prepare(
     "INSERT INTO apply_run_projections (run_id, job_id, job_title, job_employer, status, result, dry_run, started_at, finished_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -179,6 +223,63 @@ describe("apply_run_projections without legacy apply_runs table", () => {
         expect(item).toBeDefined();
         expect(item.applyStatus).toBe("applied");
         expect(item.appliedAt).toBe("2026-05-04T13:05:00+00:00");
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("jobs endpoints expose latest score evidence from job_scores", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const app = buildApp({
+        dbPath,
+        profilePath: path.join(path.dirname(dbPath), "profile.json"),
+        resumeStylePath: path.join(path.dirname(dbPath), "resume_style.json"),
+        resumeTemplatePath: path.join(path.dirname(dbPath), "resume_template.tex"),
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        const listRes = await app.inject({ method: "GET", url: "/v1/jobs" });
+        expect(listRes.statusCode, listRes.body).toBe(200);
+        const item = listRes
+          .json()
+          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/event-driven");
+        expect(item).toMatchObject({
+          fitScore: 8,
+          scoreBreakdown: {
+            technicalFit: 9,
+            experienceFit: 7,
+            roleFit: 8,
+            reasoning: "Latest structured score evidence.",
+          },
+          scoreKeywords: ["python", "fastapi"],
+          scoreReasoning: "Latest structured score evidence.",
+          scoreVersion: 2,
+          scoredAt: "2026-05-05T09:30:00+00:00",
+        });
+
+        const detailRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs/https%3A%2F%2Fexample.com%2Fjobs%2Fevent-driven",
+        });
+        expect(detailRes.statusCode, detailRes.body).toBe(200);
+        expect(detailRes.json().job).toMatchObject({
+          fitScore: 8,
+          scoreBreakdown: {
+            technicalFit: 9,
+            experienceFit: 7,
+            roleFit: 8,
+            reasoning: "Latest structured score evidence.",
+          },
+          scoreKeywords: ["python", "fastapi"],
+          scoreReasoning: "Latest structured score evidence.",
+          scoreVersion: 2,
+          scoredAt: "2026-05-05T09:30:00+00:00",
+        });
       } finally {
         await app.close();
       }

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -489,11 +489,12 @@ export function StructuredProfileEditor({
         setPathValue(draft, workModelPath, nextRows.map((row) => row.workModel).join("; "));
       });
     };
+    const emptyRow = { location: "", workModel: "" };
     const insertRowAfter = (index: number, rowPatch: Partial<{ location: string; workModel: string }>) => {
       const insertionIndex = index + 1;
       const next = [...rows];
-      next[index] = { ...next[index], ...rowPatch };
-      next.splice(insertionIndex, 0, { location: "", workModel: "" });
+      next[index] = { ...(next[index] ?? emptyRow), ...rowPatch };
+      next.splice(insertionIndex, 0, emptyRow);
       focusAfterDraftUpdate(locationFocusKey(insertionIndex));
       updateRows(next);
     };
@@ -509,7 +510,7 @@ export function StructuredProfileEditor({
         selected.delete(value);
       }
       const next = [...rows];
-      next[index] = { ...next[index], workModel: Array.from(selected).join(", ") };
+      next[index] = { ...(next[index] ?? emptyRow), workModel: Array.from(selected).join(", ") };
       updateRows(next);
     };
 

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -123,7 +123,9 @@ describe("<ProfileForm>", () => {
   });
 
   it("clamps max bullets to the allowed positive range", async () => {
-    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />);
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      withRouter: true,
+    });
     const input = await screen.findByLabelText("Max bullets per role");
 
     fireEvent.change(input, { target: { value: "-1" } });

--- a/apps/web/src/contexts/scoring/components/ScoreBreakdown.stories.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBreakdown.stories.tsx
@@ -10,24 +10,42 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const KeywordOnly: Story = {
+export const Populated: Story = {
   args: {
-    fitScore: 6,
-    scoreReasoning: "platform engineering, distributed systems, sre",
+    fitScore: 8,
+    scoreBreakdown: {
+      technicalFit: 9,
+      experienceFit: 7,
+      roleFit: 8,
+      reasoning: "Strong fit on platform reliability and SRE leadership.",
+    },
+    scoreKeywords: ["kubernetes", "observability", "on-call leadership"],
+    scoreReasoning:
+      "Strong fit on platform reliability and SRE leadership. keywords: kubernetes, observability, on-call leadership",
+    scoreVersion: 2,
+    scoredAt: "2026-05-05T09:30:00+00:00",
   },
 };
 
-export const ReasonAndKeywords: Story = {
+export const LegacyReasoning: Story = {
   args: {
-    fitScore: 8,
+    fitScore: 6,
+    scoreBreakdown: null,
+    scoreKeywords: [],
     scoreReasoning:
       "Strong fit on platform reliability and SRE leadership. keywords: kubernetes, observability, on-call leadership",
+    scoreVersion: 1,
+    scoredAt: "2026-05-01T10:00:00+00:00",
   },
 };
 
 export const Unscored: Story = {
   args: {
     fitScore: null,
+    scoreBreakdown: null,
+    scoreKeywords: [],
     scoreReasoning: "",
+    scoreVersion: null,
+    scoredAt: null,
   },
 };

--- a/apps/web/src/contexts/scoring/components/ScoreBreakdown.test.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBreakdown.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ScoreBreakdown } from "./ScoreBreakdown.js";
+
+describe("<ScoreBreakdown>", () => {
+  it("renders typed score dimensions and keywords before legacy reasoning", () => {
+    render(
+      <ScoreBreakdown
+        fitScore={8}
+        scoreBreakdown={{
+          technicalFit: 9,
+          experienceFit: 7,
+          roleFit: 8,
+          reasoning: "Latest structured score evidence.",
+        }}
+        scoreKeywords={["python", "fastapi"]}
+        scoreReasoning="Legacy reasoning should not be the primary path."
+        scoreVersion={2}
+        scoredAt="2026-05-05T09:30:00+00:00"
+      />,
+    );
+
+    expect(screen.getByText("8 / 10 fit score")).toBeInTheDocument();
+    expect(screen.getByText("Latest structured score evidence.")).toBeInTheDocument();
+    expect(screen.queryByText("Legacy reasoning should not be the primary path.")).not.toBeInTheDocument();
+    expect(screen.getByText("Technical fit")).toBeInTheDocument();
+    expect(screen.getByText("Experience fit")).toBeInTheDocument();
+    expect(screen.getByText("Role fit")).toBeInTheDocument();
+    expect(screen.getByText("9 / 10")).toBeInTheDocument();
+    expect(screen.getByText("7 / 10")).toBeInTheDocument();
+    expect(screen.getByText("python")).toBeInTheDocument();
+    expect(screen.getByText("fastapi")).toBeInTheDocument();
+    expect(screen.getByText(/version 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/2026-05-05/)).toBeInTheDocument();
+  });
+
+  it("keeps the legacy scoreReasoning fallback for migrated rows", () => {
+    render(
+      <ScoreBreakdown
+        fitScore={8}
+        scoreBreakdown={null}
+        scoreKeywords={[]}
+        scoreReasoning="Strong legacy fit. keywords: kubernetes, sre"
+        scoreVersion={null}
+        scoredAt={null}
+      />,
+    );
+
+    expect(screen.getByText("Strong legacy fit.")).toBeInTheDocument();
+    expect(screen.getByText("kubernetes")).toBeInTheDocument();
+    expect(screen.getByText("sre")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx
@@ -1,12 +1,73 @@
 import type { JSX } from "react";
+import type { ScoreBreakdown as ScoreBreakdownValue } from "@jobhunter/contracts";
 
 import { ScoreReasoning } from "./ScoreReasoning.js";
+import { scoreTier } from "../lib/score-tier.js";
 
 export interface ScoreBreakdownProps {
-  scoreReasoning: string;
   fitScore: number | null;
+  scoreBreakdown?: ScoreBreakdownValue | null;
+  scoreKeywords?: readonly string[];
+  scoreReasoning: string;
+  scoreVersion?: number | null;
+  scoredAt?: string | null;
 }
 
-export function ScoreBreakdown({ scoreReasoning, fitScore }: ScoreBreakdownProps): JSX.Element {
-  return <ScoreReasoning text={scoreReasoning} fitScore={fitScore} />;
+type ScoreDimensionKey = "technicalFit" | "experienceFit" | "roleFit";
+
+const DIMENSIONS: ReadonlyArray<[ScoreDimensionKey, string]> = [
+  ["technicalFit", "Technical fit"],
+  ["experienceFit", "Experience fit"],
+  ["roleFit", "Role fit"],
+];
+
+export function ScoreBreakdown({
+  fitScore,
+  scoreBreakdown,
+  scoreKeywords = [],
+  scoreReasoning,
+  scoreVersion = null,
+  scoredAt = null,
+}: ScoreBreakdownProps): JSX.Element {
+  if (!scoreBreakdown) {
+    return <ScoreReasoning text={scoreReasoning} fitScore={fitScore} />;
+  }
+
+  const metadata = [scoreVersion ? `version ${scoreVersion}` : null, scoredAt]
+    .filter(Boolean)
+    .join(" | ");
+
+  return (
+    <div className="score-explainer">
+      <div className="score-line">
+        <span className={`fit ${scoreTier(fitScore)}`}>{fitScore ?? "-"}</span>
+        <span>
+          <b>{fitScore ?? "-"} / 10 fit score</b>
+          {metadata ? <small>{metadata}</small> : null}
+        </span>
+      </div>
+      {scoreBreakdown.reasoning ? (
+        <p>{scoreBreakdown.reasoning}</p>
+      ) : (
+        <p className="muted">No score rationale was stored for this score.</p>
+      )}
+      <div className="score-dimensions" aria-label="Score dimensions">
+        {DIMENSIONS.map(([key, label]) => (
+          <div className="score-dimension" key={key}>
+            <span>{label}</span>
+            <b>{scoreBreakdown[key]} / 10</b>
+          </div>
+        ))}
+      </div>
+      {scoreKeywords.length ? (
+        <div className="keyword-list" aria-label="Matched keywords">
+          {scoreKeywords.map((keyword) => (
+            <span className="tag info" key={keyword}>
+              {keyword}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -819,6 +819,31 @@ textarea {
   color: var(--muted);
 }
 
+.score-dimensions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 8px;
+}
+
+.score-dimension {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  padding: 8px;
+}
+
+.score-dimension span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.score-dimension b {
+  font-size: 14px;
+}
+
 .keyword-list {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -31,6 +31,16 @@ export const sampleJob: JobSummary = {
   discoveredAt: "2026-05-01T12:00:00Z",
   applicationUrl: "https://example.com/apply/1",
   fitScore: 8,
+  scoreBreakdown: {
+    technicalFit: 9,
+    experienceFit: 7,
+    roleFit: 8,
+    reasoning: "Strong fit on platform reliability.",
+  },
+  scoreKeywords: ["platform reliability", "sre"],
+  scoreReasoning: "Strong fit on platform reliability.",
+  scoreVersion: 2,
+  scoredAt: "2026-05-05T09:30:00Z",
   currentStage: "tailor",
   currentState: "running",
   errorCode: null,
@@ -78,7 +88,7 @@ export function makeJobDetail(job: JobSummary = sampleJob): JobDetail {
     job: {
       ...job,
       descriptionPreview: "Lead the platform engineering team...",
-      scoreReasoning: "Strong fit on platform reliability.",
+      scoreReasoning: job.scoreReasoning,
     },
     stages: [
       {

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -71,8 +71,12 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
             </Section>
             <Section title="Score breakdown">
               <ScoreBreakdown
-                scoreReasoning={detail.job.scoreReasoning}
                 fitScore={detail.job.fitScore}
+                scoreBreakdown={detail.job.scoreBreakdown}
+                scoreKeywords={detail.job.scoreKeywords}
+                scoreReasoning={detail.job.scoreReasoning}
+                scoreVersion={detail.job.scoreVersion}
+                scoredAt={detail.job.scoredAt}
               />
             </Section>
             <Section title="Description">

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -21,6 +21,11 @@ maintained by `apps/api/src/projections.ts` (TS-side mirror) and the Python
 Both processes refresh projections idempotently via the shared
 `event_watermarks.operations_projections` watermark.
 
+`/v1/jobs` and `/v1/jobs/:key` expose the latest persisted scoring evidence
+from `job_scores` as additive read-model fields: `scoreBreakdown`,
+`scoreKeywords`, `scoreVersion`, and `scoredAt`. `scoreReasoning` remains on
+the wire as a compatibility summary during the scoring evidence migration.
+
 `/v1/workflow-runs` (PR 5 of the Temporal stack) reads `apply_run_projections`
 and projects each row to a `WorkflowRunSummary`, including the Temporal
 workflow id (equal to `runId` for apply runs — the Python `ApplyWorkflow`

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -466,6 +466,13 @@ export interface StageSummary {
   nextAction: string | null;
 }
 
+export interface ScoreBreakdown {
+  technicalFit: number;
+  experienceFit: number;
+  roleFit: number;
+  reasoning: string;
+}
+
 export interface JobSummary {
   jobKey: string;
   url: string;
@@ -478,6 +485,11 @@ export interface JobSummary {
   discoveredAt: string | null;
   applicationUrl: string | null;
   fitScore: number | null;
+  scoreBreakdown: ScoreBreakdown | null;
+  scoreKeywords: string[];
+  scoreReasoning: string;
+  scoreVersion: number | null;
+  scoredAt: string | null;
   currentStage: Stage;
   currentState: StageState;
   errorCode: string | null;

--- a/packages/domain-types/src/operations/index.ts
+++ b/packages/domain-types/src/operations/index.ts
@@ -7,6 +7,7 @@
  * Pure data shapes — no I/O.
  */
 import type { TenantId } from "../tenant.js";
+import type { ScoreBreakdown } from "../scoring/index.js";
 
 export interface StageProjection {
   readonly stage: string;
@@ -38,7 +39,11 @@ export interface JobListProjection {
   readonly description: string;
   readonly fullDescription: string;
   readonly fitScore: number | null;
+  readonly scoreBreakdown: ScoreBreakdown | null;
+  readonly scoreKeywords: readonly string[];
   readonly scoreReasoning: string;
+  readonly scoreVersion: number | null;
+  readonly scoredAt: string | null;
   readonly currentStage: string;
   readonly currentState: string;
   readonly currentErrorCode: string | null;
@@ -82,7 +87,11 @@ export interface JobDetailProjection {
   readonly tenantId: TenantId;
   readonly jobId: string;
   readonly descriptionPreview: string;
+  readonly scoreBreakdown: ScoreBreakdown | null;
+  readonly scoreKeywords: readonly string[];
   readonly scoreReasoning: string;
+  readonly scoreVersion: number | null;
+  readonly scoredAt: string | null;
   readonly stages: readonly StageProjection[];
   readonly lastUpdatedAt: string | null;
 }

--- a/packages/domain-types/test/operations.test.ts
+++ b/packages/domain-types/test/operations.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import type { JobDetailProjection, JobListProjection } from "../src/operations/index.js";
+import { LOCAL_TENANT } from "../src/tenant.js";
+
+describe("Operations projection types", () => {
+  it("carry latest persisted score evidence", () => {
+    const listProjection: JobListProjection = {
+      tenantId: LOCAL_TENANT,
+      jobId: "https://example.com/job",
+      title: "Staff Engineer",
+      employer: "Acme",
+      source: "lever",
+      strategy: "ats:lever",
+      location: "Remote",
+      salary: "",
+      applicationUrl: null,
+      discoveredAt: "2026-05-01T00:00:00+00:00",
+      description: "",
+      fullDescription: "",
+      fitScore: 8,
+      scoreBreakdown: {
+        technicalFit: 9,
+        experienceFit: 7,
+        roleFit: 8,
+        reasoning: "Latest structured score evidence.",
+      },
+      scoreKeywords: ["python", "fastapi"],
+      scoreReasoning: "Latest structured score evidence.",
+      scoreVersion: 2,
+      scoredAt: "2026-05-05T09:30:00+00:00",
+      currentStage: "score",
+      currentState: "succeeded",
+      currentErrorCode: null,
+      currentErrorMessage: null,
+      currentNextAction: null,
+      hasResume: false,
+      hasCoverLetter: false,
+      hasPdf: false,
+      applyStatus: null,
+      appliedAt: null,
+      artifactCount: 0,
+      deletedAt: null,
+      lastUpdatedAt: "2026-05-05T09:31:00+00:00",
+    };
+    const detailProjection: JobDetailProjection = {
+      tenantId: LOCAL_TENANT,
+      jobId: listProjection.jobId,
+      descriptionPreview: "",
+      scoreBreakdown: listProjection.scoreBreakdown,
+      scoreKeywords: listProjection.scoreKeywords,
+      scoreReasoning: listProjection.scoreReasoning,
+      scoreVersion: listProjection.scoreVersion,
+      scoredAt: listProjection.scoredAt,
+      stages: [],
+      lastUpdatedAt: listProjection.lastUpdatedAt,
+    };
+
+    expect(listProjection.scoreBreakdown?.technicalFit).toBe(9);
+    expect(detailProjection.scoreKeywords).toEqual(["python", "fastapi"]);
+  });
+});

--- a/workers/automation/src/jobhunter/domain/operations/projections.py
+++ b/workers/automation/src/jobhunter/domain/operations/projections.py
@@ -75,7 +75,11 @@ class JobListProjection:
     description: str = ""
     full_description: str = ""
     fit_score: int | None = None
+    score_breakdown_json: str | None = None
+    score_keywords_json: str = "[]"
     score_reasoning: str = ""
+    score_version: int | None = None
+    scored_at: str | None = None
     current_stage: str = "discover"
     current_state: str = "pending"
     current_error_code: str | None = None
@@ -131,7 +135,11 @@ class JobDetailProjection:
     tenant_id: TenantId
     job_id: str
     description_preview: str = ""
+    score_breakdown_json: str | None = None
+    score_keywords_json: str = "[]"
     score_reasoning: str = ""
+    score_version: int | None = None
+    scored_at: str | None = None
     stages: tuple[StageProjection, ...] = ()
     last_updated_at: str | None = None
 

--- a/workers/automation/src/jobhunter/domain/scoring/services.py
+++ b/workers/automation/src/jobhunter/domain/scoring/services.py
@@ -96,9 +96,10 @@ class ScoreParser:
             )
 
         reasoning = str(payload.get("reasoning") or "").strip()
-        keywords_raw = payload.get("keywords") or []
-        keywords = MatchedKeywords.from_iterable(keywords_raw)
-        keywords_present = bool(keywords_raw)
+        keywords_raw = payload.get("keywords", [])
+        keywords = MatchedKeywords.from_iterable(
+            keywords_raw if isinstance(keywords_raw, list) else None
+        )
 
         score_raw = payload.get("score")
         fit_score = FitScore.from_optional(score_raw)
@@ -111,13 +112,29 @@ class ScoreParser:
                 error=f"score {score_raw!r} missing or outside [1, 10]",
             )
 
-        if not keywords_present:
+        if "keywords" not in payload:
             return ScoreParseResult(
                 ok=False,
                 fit_score=None,
                 breakdown=ScoreBreakdown(reasoning=reasoning or str(payload)[:2000]),
                 keywords=keywords,
                 error="LLM payload missing 'keywords' (required by schema)",
+            )
+        if not isinstance(keywords_raw, list):
+            return ScoreParseResult(
+                ok=False,
+                fit_score=None,
+                breakdown=ScoreBreakdown(reasoning=reasoning or str(payload)[:2000]),
+                keywords=keywords,
+                error="LLM payload 'keywords' must be an array",
+            )
+        if not _has_non_blank_keyword(keywords_raw):
+            return ScoreParseResult(
+                ok=False,
+                fit_score=None,
+                breakdown=ScoreBreakdown(reasoning=reasoning or str(payload)[:2000]),
+                keywords=keywords,
+                error="LLM payload 'keywords' must contain at least one non-blank entry",
             )
 
         breakdown = ScoreBreakdown(
@@ -152,6 +169,10 @@ def _clamp_dim(value: Any) -> int:
     if ivalue > 10:
         return 10
     return ivalue
+
+
+def _has_non_blank_keyword(values: list[Any]) -> bool:
+    return any(raw is not None and str(raw).strip() for raw in values)
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -374,6 +374,10 @@ class ProjectionBuilder:
         if fit_score is None:
             fit_score = _row_nullable_int(job_row, "fit_score")
         score_reasoning = score.get("reasoning") or _row_str(job_row, "score_reasoning")
+        score_breakdown_json = score.get("breakdown_json")
+        score_keywords_json = score.get("keywords_json") or "[]"
+        score_version = score.get("version")
+        scored_at = score.get("scored_at")
 
         # Materials presence:
         tailor_path = materials.get("tailor_path") or _row_nullable_str(
@@ -424,7 +428,11 @@ class ProjectionBuilder:
             description=description,
             full_description=full_description,
             fit_score=fit_score,
+            score_breakdown_json=score_breakdown_json,
+            score_keywords_json=score_keywords_json,
             score_reasoning=score_reasoning,
+            score_version=score_version,
+            scored_at=scored_at,
             current_stage=current_stage,
             current_state=current_state,
             current_error_code=current_error_code,
@@ -448,7 +456,11 @@ class ProjectionBuilder:
             description_preview=_preview_text(
                 full_description or description, 6000
             ),
+            score_breakdown_json=score_breakdown_json,
+            score_keywords_json=score_keywords_json,
             score_reasoning=score_reasoning,
+            score_version=score_version,
+            scored_at=scored_at,
             stages=tuple(stages),
             last_updated_at=last_updated_at,
         )
@@ -528,7 +540,8 @@ class ProjectionBuilder:
         try:
             row = self._conn.execute(
                 """
-                SELECT s.fit_score, s.scored_at, s.breakdown_json
+                SELECT s.version, s.fit_score, s.scored_at, s.breakdown_json,
+                       s.keywords_json
                 FROM job_scores s
                 WHERE s.job_url = ?
                 ORDER BY s.version DESC
@@ -542,11 +555,18 @@ class ProjectionBuilder:
             return {}
         breakdown = _json_loads(_row_nullable_str(row, "breakdown_json"), {})
         reasoning = ""
-        if isinstance(breakdown, dict) and isinstance(breakdown.get("reasoning"), str):
-            reasoning = breakdown["reasoning"]
+        legacy = False
+        if isinstance(breakdown, dict):
+            legacy = breakdown.get("legacy") is True
+            if isinstance(breakdown.get("reasoning"), str):
+                reasoning = breakdown["reasoning"]
+        keywords = _normalize_keywords(_json_loads(_row_nullable_str(row, "keywords_json"), []))
         return {
+            "version": _row_nullable_int(row, "version"),
             "fit_score": _row_nullable_int(row, "fit_score"),
             "scored_at": _row_nullable_str(row, "scored_at"),
+            "breakdown_json": None if legacy else json.dumps(_camel_score_breakdown(breakdown)),
+            "keywords_json": json.dumps([] if legacy and keywords == ["legacy"] else keywords),
             "reasoning": reasoning,
         }
 
@@ -1163,6 +1183,43 @@ def _preview_text(value: str, limit: int) -> str:
     if not value:
         return ""
     return value if len(value) <= limit else f"{value[:limit]}..."
+
+
+def _camel_score_breakdown(value) -> dict:
+    data = value if isinstance(value, dict) else {}
+    return {
+        "technicalFit": _score_dimension(data.get("technical_fit", data.get("technicalFit"))),
+        "experienceFit": _score_dimension(data.get("experience_fit", data.get("experienceFit"))),
+        "roleFit": _score_dimension(data.get("role_fit", data.get("roleFit"))),
+        "reasoning": data.get("reasoning") if isinstance(data.get("reasoning"), str) else "",
+    }
+
+
+def _score_dimension(value) -> int:
+    try:
+        number = int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+    if number < 0:
+        return 0
+    if number > 10:
+        return 10
+    return number
+
+
+def _normalize_keywords(value) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    seen: set[str] = set()
+    keywords: list[str] = []
+    for raw in value:
+        keyword = str(raw or "").strip()
+        key = keyword.lower()
+        if not keyword or key in seen:
+            continue
+        seen.add(key)
+        keywords.append(keyword)
+    return keywords
 
 
 def _company_name(site: str, posting_url: str) -> str:

--- a/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
@@ -63,7 +63,11 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             description            TEXT NOT NULL DEFAULT '',
             full_description       TEXT NOT NULL DEFAULT '',
             fit_score              INTEGER,
+            score_breakdown_json   TEXT,
+            score_keywords_json    TEXT NOT NULL DEFAULT '[]',
             score_reasoning        TEXT NOT NULL DEFAULT '',
+            score_version          INTEGER,
+            scored_at              TEXT,
             current_stage          TEXT NOT NULL DEFAULT 'discover',
             current_state          TEXT NOT NULL DEFAULT 'pending',
             current_error_code     TEXT,
@@ -110,7 +114,11 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             tenant_id              TEXT NOT NULL DEFAULT 'local',
             job_id                 TEXT NOT NULL,
             description_preview    TEXT NOT NULL DEFAULT '',
+            score_breakdown_json   TEXT,
+            score_keywords_json    TEXT NOT NULL DEFAULT '[]',
             score_reasoning        TEXT NOT NULL DEFAULT '',
+            score_version          INTEGER,
+            scored_at              TEXT,
             stages_json            TEXT NOT NULL DEFAULT '[]',
             last_updated_at        TEXT,
             PRIMARY KEY (tenant_id, job_id)
@@ -160,8 +168,30 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
         )
         """
     )
+    _ensure_column(conn, "job_list_projections", "score_breakdown_json", "TEXT")
+    _ensure_column(conn, "job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'")
+    _ensure_column(conn, "job_list_projections", "score_version", "INTEGER")
+    _ensure_column(conn, "job_list_projections", "scored_at", "TEXT")
+    _ensure_column(conn, "job_detail_projections", "score_breakdown_json", "TEXT")
+    _ensure_column(conn, "job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'")
+    _ensure_column(conn, "job_detail_projections", "score_version", "INTEGER")
+    _ensure_column(conn, "job_detail_projections", "scored_at", "TEXT")
     conn.commit()
     return list(PROJECTION_TABLES)
+
+
+def _ensure_column(
+    conn: sqlite3.Connection,
+    table_name: str,
+    column_name: str,
+    definition: str,
+) -> None:
+    columns = {
+        row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+    if column_name not in columns:
+        conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {definition}")
 
 
 class SqliteProjectionStore:
@@ -179,14 +209,16 @@ class SqliteProjectionStore:
             INSERT INTO job_list_projections (
                 tenant_id, job_id, title, employer, source, strategy, location,
                 salary, application_url, discovered_at, description,
-                full_description, fit_score, score_reasoning, current_stage,
-                current_state, current_error_code, current_error_message,
-                current_next_action, has_resume, has_cover_letter, has_pdf,
-                apply_status, applied_at, artifact_count, deleted_at,
+                full_description, fit_score, score_breakdown_json,
+                score_keywords_json, score_reasoning, score_version, scored_at,
+                current_stage, current_state, current_error_code,
+                current_error_message, current_next_action, has_resume,
+                has_cover_letter, has_pdf, apply_status, applied_at,
+                artifact_count, deleted_at,
                 last_updated_at
             ) VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
             ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 title                 = excluded.title,
@@ -200,7 +232,11 @@ class SqliteProjectionStore:
                 description           = excluded.description,
                 full_description      = excluded.full_description,
                 fit_score             = excluded.fit_score,
+                score_breakdown_json  = excluded.score_breakdown_json,
+                score_keywords_json   = excluded.score_keywords_json,
                 score_reasoning       = excluded.score_reasoning,
+                score_version         = excluded.score_version,
+                scored_at             = excluded.scored_at,
                 current_stage         = excluded.current_stage,
                 current_state         = excluded.current_state,
                 current_error_code    = excluded.current_error_code,
@@ -229,7 +265,11 @@ class SqliteProjectionStore:
                 projection.description,
                 projection.full_description,
                 projection.fit_score,
+                projection.score_breakdown_json,
+                projection.score_keywords_json,
                 projection.score_reasoning,
+                projection.score_version,
+                projection.scored_at,
                 projection.current_stage,
                 projection.current_state,
                 projection.current_error_code,
@@ -304,20 +344,29 @@ class SqliteProjectionStore:
         self._conn.execute(
             """
             INSERT INTO job_detail_projections (
-                tenant_id, job_id, description_preview, score_reasoning,
+                tenant_id, job_id, description_preview, score_breakdown_json,
+                score_keywords_json, score_reasoning, score_version, scored_at,
                 stages_json, last_updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tenant_id, job_id) DO UPDATE SET
-                description_preview = excluded.description_preview,
-                score_reasoning     = excluded.score_reasoning,
-                stages_json         = excluded.stages_json,
-                last_updated_at     = excluded.last_updated_at
+                description_preview  = excluded.description_preview,
+                score_breakdown_json = excluded.score_breakdown_json,
+                score_keywords_json  = excluded.score_keywords_json,
+                score_reasoning      = excluded.score_reasoning,
+                score_version        = excluded.score_version,
+                scored_at            = excluded.scored_at,
+                stages_json          = excluded.stages_json,
+                last_updated_at      = excluded.last_updated_at
             """,
             (
                 str(projection.tenant_id),
                 projection.job_id,
                 projection.description_preview,
+                projection.score_breakdown_json,
+                projection.score_keywords_json,
                 projection.score_reasoning,
+                projection.score_version,
+                projection.scored_at,
                 json.dumps(
                     [
                         {

--- a/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
@@ -43,6 +43,17 @@ PROJECTION_TABLES: tuple[str, ...] = (
     "apply_run_projections",
 )
 
+SCORE_EVIDENCE_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("job_list_projections", "score_breakdown_json", "TEXT"),
+    ("job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'"),
+    ("job_list_projections", "score_version", "INTEGER"),
+    ("job_list_projections", "scored_at", "TEXT"),
+    ("job_detail_projections", "score_breakdown_json", "TEXT"),
+    ("job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'"),
+    ("job_detail_projections", "score_version", "INTEGER"),
+    ("job_detail_projections", "scored_at", "TEXT"),
+)
+
 
 def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
     """Create the projection tables if they do not exist (idempotent)."""
@@ -168,14 +179,16 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
         )
         """
     )
-    _ensure_column(conn, "job_list_projections", "score_breakdown_json", "TEXT")
-    _ensure_column(conn, "job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'")
-    _ensure_column(conn, "job_list_projections", "score_version", "INTEGER")
-    _ensure_column(conn, "job_list_projections", "scored_at", "TEXT")
-    _ensure_column(conn, "job_detail_projections", "score_breakdown_json", "TEXT")
-    _ensure_column(conn, "job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'")
-    _ensure_column(conn, "job_detail_projections", "score_version", "INTEGER")
-    _ensure_column(conn, "job_detail_projections", "scored_at", "TEXT")
+    score_evidence_schema_changed = False
+    for table_name, column_name, definition in SCORE_EVIDENCE_COLUMNS:
+        score_evidence_schema_changed = (
+            _ensure_column(conn, table_name, column_name, definition)
+            or score_evidence_schema_changed
+        )
+    if score_evidence_schema_changed:
+        # Projection rows are fully derived; resetting them lets the next
+        # refresh rebuild migrated rows from canonical job_scores evidence.
+        _reset_score_evidence_projections(conn)
     conn.commit()
     return list(PROJECTION_TABLES)
 
@@ -185,13 +198,20 @@ def _ensure_column(
     table_name: str,
     column_name: str,
     definition: str,
-) -> None:
+) -> bool:
     columns = {
         row["name"] if isinstance(row, sqlite3.Row) else row[1]
         for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
     }
     if column_name not in columns:
         conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {definition}")
+        return True
+    return False
+
+
+def _reset_score_evidence_projections(conn: sqlite3.Connection) -> None:
+    conn.execute("DELETE FROM job_list_projections")
+    conn.execute("DELETE FROM job_detail_projections")
 
 
 class SqliteProjectionStore:

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -8,8 +8,12 @@ from pathlib import Path
 
 import pytest
 
-from jobhunter.database import close_connection, init_db
-from jobhunter.infrastructure.projections.projection_builder import ProjectionBuilder
+from jobhunter.database import close_connection, ensure_projection_tables_in_db, init_db
+from jobhunter.infrastructure.events.watermark import SqliteEventWatermarkRepository
+from jobhunter.infrastructure.projections.projection_builder import (
+    PROJECTION_NAME,
+    ProjectionBuilder,
+)
 from jobhunter.state import record_job_event, set_stage_state, utc_now
 
 
@@ -53,6 +57,60 @@ def _row_value(row, key, default=None):
     except (KeyError, IndexError, TypeError):
         return default
     return value if value is not None else default
+
+
+def _replace_score_evidence_projection_schema_with_legacy_shape(
+    conn: sqlite3.Connection,
+) -> None:
+    conn.execute("DROP TABLE job_list_projections")
+    conn.execute(
+        """
+        CREATE TABLE job_list_projections (
+            tenant_id              TEXT NOT NULL DEFAULT 'local',
+            job_id                 TEXT NOT NULL,
+            title                  TEXT NOT NULL DEFAULT '',
+            employer               TEXT NOT NULL DEFAULT '',
+            source                 TEXT NOT NULL DEFAULT '',
+            strategy               TEXT NOT NULL DEFAULT '',
+            location               TEXT NOT NULL DEFAULT '',
+            salary                 TEXT NOT NULL DEFAULT '',
+            application_url        TEXT,
+            discovered_at          TEXT,
+            description            TEXT NOT NULL DEFAULT '',
+            full_description       TEXT NOT NULL DEFAULT '',
+            fit_score              INTEGER,
+            score_reasoning        TEXT NOT NULL DEFAULT '',
+            current_stage          TEXT NOT NULL DEFAULT 'discover',
+            current_state          TEXT NOT NULL DEFAULT 'pending',
+            current_error_code     TEXT,
+            current_error_message  TEXT,
+            current_next_action    TEXT,
+            has_resume             INTEGER NOT NULL DEFAULT 0,
+            has_cover_letter       INTEGER NOT NULL DEFAULT 0,
+            has_pdf                INTEGER NOT NULL DEFAULT 0,
+            apply_status           TEXT,
+            applied_at             TEXT,
+            artifact_count         INTEGER NOT NULL DEFAULT 0,
+            deleted_at             TEXT,
+            last_updated_at        TEXT,
+            PRIMARY KEY (tenant_id, job_id)
+        )
+        """
+    )
+    conn.execute("DROP TABLE job_detail_projections")
+    conn.execute(
+        """
+        CREATE TABLE job_detail_projections (
+            tenant_id              TEXT NOT NULL DEFAULT 'local',
+            job_id                 TEXT NOT NULL,
+            description_preview    TEXT NOT NULL DEFAULT '',
+            score_reasoning        TEXT NOT NULL DEFAULT '',
+            stages_json            TEXT NOT NULL DEFAULT '[]',
+            last_updated_at        TEXT,
+            PRIMARY KEY (tenant_id, job_id)
+        )
+        """
+    )
 
 
 def test_discovered_job_appears_in_projection(conn: sqlite3.Connection) -> None:
@@ -160,6 +218,82 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
     assert json.loads(_row_value(detail, "score_keywords_json")) == ["python", "fastapi"]
     assert _row_value(detail, "score_version") == 1
     assert _row_value(detail, "scored_at")
+
+
+def test_score_evidence_schema_migration_backfills_existing_projection(
+    conn: sqlite3.Connection,
+) -> None:
+    url = "https://example.com/jobs/scored-before-migration"
+    _seed_job(conn, url)
+    conn.execute(
+        """
+        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+                                breakdown_json, keywords_json, scored_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            url,
+            1,
+            "local",
+            9,
+            json.dumps(
+                {
+                    "technical_fit": 8,
+                    "experience_fit": 9,
+                    "role_fit": 10,
+                    "reasoning": "Evidence should be projected",
+                }
+            ),
+            json.dumps(["python", "sqlite"]),
+            "2026-05-05T10:00:00+00:00",
+        ),
+    )
+    record_job_event(conn, url, "score", "JobScored")
+    latest_event_id = conn.execute("SELECT MAX(event_id) FROM job_events").fetchone()[0]
+    _replace_score_evidence_projection_schema_with_legacy_shape(conn)
+    conn.execute(
+        """
+        INSERT INTO job_list_projections (
+            tenant_id, job_id, title, employer, fit_score, score_reasoning
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        ("local", url, "Engineer", "ExampleCo", 9, "Legacy reasoning"),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_detail_projections (
+            tenant_id, job_id, description_preview, score_reasoning
+        ) VALUES (?, ?, ?, ?)
+        """,
+        ("local", url, "Short job description", "Legacy reasoning"),
+    )
+    conn.execute(
+        "INSERT INTO dashboard_projections (tenant_id, generated_at) VALUES (?, ?)",
+        ("local", "2026-05-05T09:00:00+00:00"),
+    )
+    conn.commit()
+    SqliteEventWatermarkRepository(conn).set(PROJECTION_NAME, int(latest_event_id))
+
+    ensure_projection_tables_in_db(conn)
+    processed = ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    assert processed == 1
+    row = conn.execute(
+        """
+        SELECT score_breakdown_json, score_keywords_json, score_version, scored_at
+        FROM job_list_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert json.loads(_row_value(row, "score_breakdown_json")) == {
+        "technicalFit": 8,
+        "experienceFit": 9,
+        "roleFit": 10,
+        "reasoning": "Evidence should be projected",
+    }
+    assert json.loads(_row_value(row, "score_keywords_json")) == ["python", "sqlite"]
+    assert _row_value(row, "score_version") == 1
+    assert _row_value(row, "scored_at") == "2026-05-05T10:00:00+00:00"
 
 
 def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_job_list_projection.py
+++ b/workers/automation/tests/test_job_list_projection.py
@@ -112,8 +112,15 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
             1,
             "local",
             8,
-            json.dumps({"reasoning": "Strong fit"}),
-            json.dumps([]),
+            json.dumps(
+                {
+                    "technical_fit": 9,
+                    "experience_fit": 7,
+                    "role_fit": 8,
+                    "reasoning": "Strong fit",
+                }
+            ),
+            json.dumps(["python", "fastapi"]),
             utc_now(),
         ),
     )
@@ -123,11 +130,36 @@ def test_score_event_populates_fit_score(conn: sqlite3.Connection) -> None:
     ProjectionBuilder(conn_factory=lambda: conn).refresh()
 
     row = conn.execute(
-        "SELECT fit_score, score_reasoning FROM job_list_projections WHERE job_id = ?",
+        """
+        SELECT fit_score, score_breakdown_json, score_keywords_json,
+               score_reasoning, score_version, scored_at
+        FROM job_list_projections WHERE job_id = ?
+        """,
         (url,),
     ).fetchone()
     assert _row_value(row, "fit_score") == 8
     assert _row_value(row, "score_reasoning") == "Strong fit"
+    assert json.loads(_row_value(row, "score_breakdown_json")) == {
+        "technicalFit": 9,
+        "experienceFit": 7,
+        "roleFit": 8,
+        "reasoning": "Strong fit",
+    }
+    assert json.loads(_row_value(row, "score_keywords_json")) == ["python", "fastapi"]
+    assert _row_value(row, "score_version") == 1
+    assert _row_value(row, "scored_at")
+
+    detail = conn.execute(
+        """
+        SELECT score_breakdown_json, score_keywords_json, score_version, scored_at
+        FROM job_detail_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert json.loads(_row_value(detail, "score_breakdown_json"))["technicalFit"] == 9
+    assert json.loads(_row_value(detail, "score_keywords_json")) == ["python", "fastapi"]
+    assert _row_value(detail, "score_version") == 1
+    assert _row_value(detail, "scored_at")
 
 
 def test_apply_run_succeeded_marks_applied(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_score_use_cases.py
+++ b/workers/automation/tests/test_score_use_cases.py
@@ -21,6 +21,7 @@ from jobhunter.domain.scoring import (
     MatchedKeywords,
     ScoreBreakdown,
 )
+from jobhunter.domain.scoring.services import ScoreParser
 from jobhunter.domain.scoring.use_cases import (
     CorrectScoreUseCase,
     ScoreJobUseCase,
@@ -169,6 +170,58 @@ def _job(url: str = "https://example.com/job/1") -> dict[str, Any]:
         "location": "Remote",
         "full_description": "We need a Python and FastAPI engineer.",
     }
+
+
+# ---------------------------------------------------------------------------
+# ScoreParser
+# ---------------------------------------------------------------------------
+
+
+def test_score_parser_rejects_missing_keyword_field() -> None:
+    result = ScoreParser().parse_json(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "reasoning": "Strong overlap.",
+        }
+    )
+
+    assert result.ok is False
+    assert "keywords" in result.error
+
+
+def test_score_parser_rejects_empty_keyword_array() -> None:
+    result = ScoreParser().parse_json(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "keywords": [],
+            "reasoning": "Strong overlap.",
+        }
+    )
+
+    assert result.ok is False
+    assert "keywords" in result.error
+
+
+def test_score_parser_rejects_blank_only_keyword_array() -> None:
+    result = ScoreParser().parse_json(
+        {
+            "score": 8,
+            "technical_fit": 8,
+            "experience_fit": 7,
+            "role_fit": 8,
+            "keywords": [" ", "\t", "\n"],
+            "reasoning": "Strong overlap.",
+        }
+    )
+
+    assert result.ok is False
+    assert "keywords" in result.error
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Expose latest persisted scoring evidence from `job_scores` through TS/Python projections, API read models, contracts, and domain operation types.
- Render typed score dimensions, keywords, score version, and scored timestamp in the jobs drawer while preserving the legacy `scoreReasoning` fallback.
- Harden `ScoreParser` so missing, empty, non-array, or blank-only `keywords` payloads fail parsing instead of normalizing to the legacy sentinel.
- Rebuild derived Python list/detail projections when the score-evidence projection columns are added, so existing scored jobs backfill evidence after migration.
- Add narrow verification unblockers for existing profile editor/test strictness issues so the required web checks can run cleanly.
- Document the additive `/v1/jobs` and `/v1/jobs/:key` score evidence fields.

## Stacked On

- Base branch: `docs/job-scoring-plan`
- Parent PR: #46

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_scorer.py` -> 12 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_job_list_projection.py::test_score_event_populates_fit_score` -> 1 passed
- `pnpm --filter @jobhunter/api exec vitest run test/projections.test.ts` -> 3 passed
- `pnpm --filter @jobhunter/web exec vitest run src/contexts/scoring/components/ScoreBreakdown.test.tsx` -> 2 passed
- `pnpm api:check` -> passed
- `pnpm web:check` -> passed
- `pnpm --filter @jobhunter/contracts check` -> passed
- `pnpm --filter @jobhunter/domain-types check` -> passed
- `pnpm --filter @jobhunter/domain-types test` -> 12 files / 133 tests passed
- `pnpm api:test` -> 5 files / 71 tests passed
- `pnpm --filter @jobhunter/web test` -> 78 files / 330 tests passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_job_list_projection.py workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_scorer.py` -> 19 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_job_list_projection.py workers/automation/tests/test_projection_builder.py` -> 14 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/scoring/services.py workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py workers/automation/tests/test_job_list_projection.py workers/automation/tests/test_score_use_cases.py` -> passed
- `pnpm web:build` -> built successfully
- `pnpm --filter @jobhunter/web exec playwright test --config=e2e/playwright.config.ts e2e/tests/jobs-drawer.spec.ts` -> 1 passed
- `pnpm check` -> passed
- `pnpm python:test` -> 688 passed
- `git diff --check` -> passed

## Notes

The two profile editor/test edits are narrow verification fixes: `pnpm web:check` and the full web test suite exposed pre-existing profile strictness/test setup issues unrelated to scoring. They are included so this PR can be fully verified rather than shipping with waived checks.