### PR TITLE
fix(pipeline): surface stage observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,11 @@ the local API. The panel reports when the request is waiting on the local
 worker, whether the start was queued, completed, dry-run, or failed, and the
 returned run/action id when one is available. Longer-running progress appears in
 the dashboard pipeline, apply runs, and recent activity cards after the API
-invalidates those read models. Tabs default to dry-run mode so apply automation
-does not submit applications unless you explicitly clear dry run.
+invalidates those read models. Non-apply stages emit pipeline lifecycle events;
+Discover also emits source-step events for JobSpy, Workday, and Smart Extract
+so a stuck source is visible before the request finishes. Tabs default to
+dry-run mode so apply automation does not submit applications unless you
+explicitly clear dry run.
 
 ## Inspecting Progress
 
@@ -314,6 +317,8 @@ Common environment variables:
   without exporting. Set `LANGFUSE_DISABLE=1` to opt out even when
   credentials are present. Enabling this exports every LLM prompt and
   completion to the configured Langfuse instance.
+- `LANGFUSE_OTEL_TIMEOUT_SECONDS`: optional OTLP/HTTP export timeout for
+  Langfuse; defaults to `5.0`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -262,9 +262,11 @@ returned run/action id when one is available. Longer-running progress appears in
 the dashboard pipeline, apply runs, and recent activity cards after the API
 invalidates those read models. Non-apply stages emit pipeline lifecycle events;
 Discover also emits source-step events for JobSpy, Workday, and Smart Extract
-so a stuck source is visible before the request finishes. Tabs default to
-dry-run mode so apply automation does not submit applications unless you
-explicitly clear dry run.
+so a stuck source is visible before the request finishes. The `limit` control
+is honored by every stage tab, including `discover` and `enrich`, so local
+debug runs can be bounded to one job. A bounded Discover run stops remaining
+sources once the cap is reached. Tabs default to dry-run mode so apply
+automation does not submit applications unless you explicitly clear dry run.
 
 ## Inspecting Progress
 

--- a/apps/api/src/event-stream.ts
+++ b/apps/api/src/event-stream.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { LOCAL_TENANT } from "@jobhunter/domain-types";
 
 import { databaseExists, openDatabase, type SqliteDatabase } from "./db.js";
+import { resolveLoopbackCorsOrigin } from "./local-origin.js";
 
 const POLL_DEFAULT_MS = 250;
 const KEEPALIVE_DEFAULT_MS = 15_000;
@@ -206,14 +207,20 @@ export function registerEventStreamRoute(app: FastifyInstance, options: EventStr
   app.get("/v1/events/stream", async (request, reply) => {
     const tenantId = resolveTenantId(request);
     const requestedResume = parseResumePosition(request);
-
-    reply.hijack();
-    reply.raw.writeHead(200, {
+    const corsOrigin = resolveLoopbackCorsOrigin(request.headers.origin);
+    const headers: Record<string, string> = {
       "Content-Type": "text/event-stream; charset=utf-8",
       "Cache-Control": "no-cache, no-transform",
       "X-Accel-Buffering": "no",
       Connection: "keep-alive",
-    });
+    };
+    if (corsOrigin) {
+      headers["Access-Control-Allow-Origin"] = corsOrigin;
+      headers.Vary = "Origin";
+    }
+
+    reply.hijack();
+    reply.raw.writeHead(200, headers);
     reply.raw.write(`retry: ${RETRY_BASELINE_MS}\n\n`);
 
     const connection = getDb();

--- a/apps/api/src/json-rpc-adapter.ts
+++ b/apps/api/src/json-rpc-adapter.ts
@@ -179,10 +179,24 @@ export class SubprocessJsonRpcAdapter implements JsonRpcDispatcher {
  * ``buildApp`` and never touch the singleton.
  */
 let _defaultDispatcher: SubprocessJsonRpcAdapter | null = null;
+let _defaultDispatcherKey: string | null = null;
 
-export function getDefaultJsonRpcDispatcher(): SubprocessJsonRpcAdapter {
-  if (_defaultDispatcher === null) {
-    _defaultDispatcher = new SubprocessJsonRpcAdapter();
+function dispatcherKey(options: JsonRpcCallOptions = {}): string {
+  return JSON.stringify({
+    appDir: options.appDir ?? AUTOMATION_PROJECT_DIR,
+    projectDir: options.projectDir ?? AUTOMATION_PROJECT_DIR,
+    uvBinary: options.uvBinary ?? "uv",
+  });
+}
+
+export function getDefaultJsonRpcDispatcher(options: JsonRpcCallOptions = {}): SubprocessJsonRpcAdapter {
+  const key = dispatcherKey(options);
+  if (_defaultDispatcher === null || _defaultDispatcherKey !== key) {
+    if (_defaultDispatcher !== null) {
+      void _defaultDispatcher.close();
+    }
+    _defaultDispatcher = new SubprocessJsonRpcAdapter(options);
+    _defaultDispatcherKey = key;
   }
   return _defaultDispatcher;
 }
@@ -193,4 +207,5 @@ export function resetDefaultJsonRpcDispatcher(): void {
     void _defaultDispatcher.close();
   }
   _defaultDispatcher = null;
+  _defaultDispatcherKey = null;
 }

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -53,6 +53,7 @@ export type ActionDispatcher = (
   command: ActionCommandPayload,
   context: ActionDispatchContext,
 ) => Promise<ActionDispatchResult>;
+export type JsonRpcDispatcherFactory = (context: ActionDispatchContext) => JsonRpcDispatcher;
 
 export type ArtifactOpener = (artifactPath: string) => Promise<void>;
 
@@ -91,9 +92,13 @@ export type ProfilePreviewRenderer = (
 ) => Promise<Buffer>;
 
 /** Build the production action dispatcher backed by ``SubprocessJsonRpcAdapter``. */
-export function createActionDispatcher(dispatcher?: JsonRpcDispatcher): ActionDispatcher {
-  return async (command, _context) => {
-    const rpc = dispatcher ?? getDefaultJsonRpcDispatcher();
+export function createActionDispatcher(
+  dispatcher?: JsonRpcDispatcher,
+  dispatcherFactory: JsonRpcDispatcherFactory = (context) =>
+    getDefaultJsonRpcDispatcher({ appDir: context.appDir }),
+): ActionDispatcher {
+  return async (command, context) => {
+    const rpc = dispatcher ?? dispatcherFactory(context);
     if (command.action === "retry_stage" && !command.runAfter) {
       // Pure-reset path — handled by write-model.ts.  The dispatcher is
       // only invoked when ``runAfter`` is set (i.e. user explicitly
@@ -168,7 +173,7 @@ export const defaultProfileImporter: ProfileImporter = async (input, context) =>
       jobKey: "profile",
     };
     const actionId = `act-${randomUUID()}`;
-    const dispatcher = getDefaultJsonRpcDispatcher();
+    const dispatcher = getDefaultJsonRpcDispatcher({ appDir: context.appDir });
     const response = await dispatcher.call("profile_import", {
       tenantId: "local",
       pdfPath,

--- a/apps/api/src/local-origin.ts
+++ b/apps/api/src/local-origin.ts
@@ -1,0 +1,61 @@
+export const LOCAL_ORIGIN_PATTERNS = [
+  /^https?:\/\/localhost(?::\d+)?$/,
+  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/,
+  /^https?:\/\/\[::1\](?::\d+)?$/,
+];
+
+export const LOCAL_CORS_METHODS = ["DELETE", "GET", "HEAD", "POST", "PATCH"];
+
+export function isTrustedMutationSource(
+  originHeader: string | string[] | undefined,
+  refererHeader: string | string[] | undefined,
+): boolean {
+  const origins = [
+    ...headerValues(originHeader).map(parseOriginHeader),
+    ...headerValues(refererHeader).map(parseRefererOrigin),
+  ];
+  if (origins.length === 0) {
+    return true;
+  }
+  return origins.every((origin) => origin !== null && isLoopbackOrigin(origin));
+}
+
+export function resolveLoopbackCorsOrigin(originHeader: string | string[] | undefined): string | undefined {
+  for (const raw of headerValues(originHeader)) {
+    const origin = parseOriginHeader(raw);
+    if (origin && isLoopbackOrigin(origin)) {
+      return origin;
+    }
+  }
+  return undefined;
+}
+
+export function isLoopbackOrigin(origin: string): boolean {
+  return LOCAL_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
+}
+
+function headerValues(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value ? [value] : [];
+}
+
+function parseOriginHeader(value: string): string | null {
+  if (!value || value === "null") {
+    return null;
+  }
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function parseRefererOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -752,6 +752,8 @@ function paginateWithTotal<T>(
 
 function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
   if (!tableExists(db, "job_events")) return [];
+  const eventColumns = columnNames(db, "job_events");
+  const eventTypeSelect = eventColumns.has("event_type") ? "e.event_type" : "'Event' AS event_type";
   const hideDeletedJoin = tableExists(db, "jobhunter_deleted_jobs")
     ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = e.job_url AND d.restored_at IS NULL"
     : "";
@@ -759,6 +761,7 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
   const sql = `
     SELECT
       e.event_id,
+      ${eventTypeSelect},
       e.job_url,
       e.stage,
       e.level,
@@ -774,6 +777,7 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
     LIMIT 20`;
   return allRows<Record<string, unknown>>(db, sql, [DEFAULT_TENANT]).map((row) => ({
     eventId: stringField(row.event_id),
+    eventType: stringField(row.event_type) || "Event",
     jobKey: nullableString(row.job_url),
     title: nullableString(row.title),
     company: nullableString(row.employer),
@@ -782,6 +786,11 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
     message: stringField(row.message) || "event",
     at: nullableString(row.occurred_at),
   }));
+}
+
+function columnNames(db: SqliteDatabase, tableName: string): Set<string> {
+  if (!tableExists(db, tableName)) return new Set();
+  return new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name));
 }
 
 /**

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -51,6 +51,7 @@ import {
   listWorkflowRuns,
   readSettingsConfig,
 } from "./read-model.js";
+import { isTrustedMutationSource, LOCAL_CORS_METHODS, LOCAL_ORIGIN_PATTERNS } from "./local-origin.js";
 import {
   ProfileInputError,
   readProfileConfig,
@@ -70,12 +71,6 @@ import {
   writeSettingsConfig,
 } from "./write-model.js";
 
-const LOCAL_ORIGIN_PATTERNS = [
-  /^https?:\/\/localhost(?::\d+)?$/,
-  /^https?:\/\/127\.0\.0\.1(?::\d+)?$/,
-  /^https?:\/\/\[::1\](?::\d+)?$/,
-];
-const LOCAL_CORS_METHODS = ["DELETE", "GET", "HEAD", "POST", "PATCH"];
 const UNSAFE_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
 
 export interface BuildAppOptions {
@@ -609,50 +604,6 @@ function decodeRouteParam(value: string): string {
   } catch {
     return value;
   }
-}
-
-function isTrustedMutationSource(
-  originHeader: string | string[] | undefined,
-  refererHeader: string | string[] | undefined,
-): boolean {
-  const origins = [
-    ...headerValues(originHeader).map(parseOriginHeader),
-    ...headerValues(refererHeader).map(parseRefererOrigin),
-  ];
-  if (origins.length === 0) {
-    return true;
-  }
-  return origins.every((origin) => origin !== null && isLoopbackOrigin(origin));
-}
-
-function headerValues(value: string | string[] | undefined): string[] {
-  if (Array.isArray(value)) {
-    return value;
-  }
-  return value ? [value] : [];
-}
-
-function parseOriginHeader(value: string): string | null {
-  if (!value || value === "null") {
-    return null;
-  }
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
-
-function parseRefererOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
-
-function isLoopbackOrigin(origin: string): boolean {
-  return LOCAL_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
 }
 
 function unsupportedPerJobMaterialAction(jobKey?: string): {

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -11,6 +11,7 @@ import {
   buildActionResponse,
   createActionDispatcher,
   type ActionDispatchResult,
+  type JsonRpcDispatcherFactory,
 } from "../src/local-actions.js";
 import type {
   JsonRpcDispatcher,
@@ -146,6 +147,25 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         result: { planned: 3 },
       },
     });
+  });
+
+  it("creates the production JSON-RPC dispatcher with the API runtime appDir", async () => {
+    const fake = new FakeDispatcher();
+    const factory = vi.fn<JsonRpcDispatcherFactory>(() => fake);
+    const dispatcher = createActionDispatcher(undefined, factory);
+
+    await dispatcher(
+      {
+        action: "run_stage",
+        jobKey: "pipeline",
+        stage: "discover",
+        dryRun: false,
+      },
+      { appDir: "/tmp/jobhunter-runtime" },
+    );
+
+    expect(factory).toHaveBeenCalledWith({ appDir: "/tmp/jobhunter-runtime" });
+    expect(fake.calls[0]?.method).toBe("run_stage");
   });
 
   it("maps a failed global run-stage LocalActionResult error into the action message", async () => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -145,6 +145,25 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("allows loopback browser access to the event stream", async () => {
+    const app = buildApp(options);
+    await app.listen({ host: "127.0.0.1", port: 0 });
+    const address = app.server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected local test server address");
+    }
+
+    const response = await fetch(`http://127.0.0.1:${address.port}/v1/events/stream?tenantId=local`, {
+      headers: { origin: "http://127.0.0.1:5175" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("http://127.0.0.1:5175");
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await response.body?.cancel();
+    await app.close();
+  });
+
   it("allows loopback browser preflight for local profile saves", async () => {
     const app = buildApp(options);
     const response = await app.inject({

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -291,6 +291,7 @@ describe("local TypeScript API", () => {
     });
     expect(body.activity[0]).toMatchObject({
       eventId: "1",
+      eventType: "ActionFailed",
       jobKey: "https://example.com/jobs/failed-score",
       title: "Backend Engineer",
       company: "ExampleCo",
@@ -1923,6 +1924,7 @@ function seedDatabase(dbPath: string): void {
       event_id INTEGER PRIMARY KEY AUTOINCREMENT,
       job_url TEXT,
       stage TEXT,
+      event_type TEXT NOT NULL DEFAULT '',
       level TEXT,
       message TEXT,
       occurred_at TEXT
@@ -1999,9 +2001,12 @@ function seedDatabase(dbPath: string): void {
     "2026-04-29T10:05:00+00:00",
     12,
   );
-  db.prepare("INSERT INTO job_events (job_url, stage, level, message, occurred_at) VALUES (?, ?, ?, ?, ?)").run(
+  db.prepare(
+    "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+  ).run(
     "https://example.com/jobs/failed-score",
     "score",
+    "ActionFailed",
     "error",
     "Score failed",
     "2026-04-29T10:10:00+00:00",

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -103,7 +103,11 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     workflowRunsKeys.detail(LOCAL_TENANT, RUN_ID),
     dashboardKeys.summary(LOCAL_TENANT),
   ],
-  StageStarted: [jobsKeys.lists(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
+  StageStarted: [
+    jobsKeys.lists(LOCAL_TENANT),
+    jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+    dashboardKeys.summary(LOCAL_TENANT),
+  ],
   StageCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "../../../test/render.js";
+import { sampleDashboardSummary } from "../../../test/fixtures/projections.js";
 import { buildTestPorts } from "../../../test/testPorts.js";
 import { useStageTriggerStore } from "../stores/stage-trigger-store.js";
 import { StageTriggerPanel } from "./StageTriggerPanel.js";
@@ -186,6 +187,69 @@ describe("StageTriggerPanel", () => {
 
     expect(await screen.findByRole("status")).toHaveTextContent(
       "Starting Discover... waiting for local worker response.",
+    );
+  });
+
+  it("replaces the local starting label with the latest backend stage event", async () => {
+    const user = userEvent.setup();
+    const runPipelineStages = vi.fn(() => new Promise<PipelineStageRunResponse>(() => undefined));
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({
+        api: {
+          dashboardSummary: vi.fn(async () => ({
+            ...sampleDashboardSummary,
+            activity: [
+              {
+                eventId: "538",
+                eventType: "StageStarted",
+                jobKey: "pipeline",
+                title: null,
+                company: null,
+                stage: "discover",
+                level: "info",
+                message: "Discovery source workday started",
+                at: new Date().toISOString(),
+              },
+            ],
+          })),
+          runPipelineStages,
+        },
+      }),
+    });
+
+    await user.click(screen.getByRole("button", { name: "Run Discover" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Discover in progress: Discovery source workday started (#538).",
+    );
+  });
+
+  it("shows the latest backend stage event even without local mutation state", async () => {
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({
+        api: {
+          dashboardSummary: vi.fn(async () => ({
+            ...sampleDashboardSummary,
+            activity: [
+              {
+                eventId: "539",
+                eventType: "StageStarted",
+                jobKey: "pipeline",
+                title: null,
+                company: null,
+                stage: "discover",
+                level: "info",
+                message: "Discovery source smart extract started",
+                at: new Date().toISOString(),
+              },
+            ],
+          })),
+        },
+      }),
+    });
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Discover in progress: Discovery source smart extract started (#539).",
     );
   });
 

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -43,8 +43,8 @@ describe("StageTriggerPanel", () => {
     renderWithProviders(<StageTriggerPanel />);
 
     expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.getByLabelText("Limit")).toBeInTheDocument();
     expect(screen.getByLabelText("Dry run")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Limit")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Minimum score")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Validation mode")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Apply model")).not.toBeInTheDocument();
@@ -52,6 +52,14 @@ describe("StageTriggerPanel", () => {
     expect(screen.queryByLabelText("Retailor")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Headless browser")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Continuous")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Enrich" }));
+    expect(screen.getByLabelText("Limit")).toBeInTheDocument();
+    expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Minimum score")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Validation mode")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Apply model")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Headless browser")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: "Score" }));
     expect(screen.getByLabelText("Limit")).toBeInTheDocument();
@@ -97,6 +105,54 @@ describe("StageTriggerPanel", () => {
     expect(screen.queryByLabelText("Validation mode")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Rescore")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Retailor")).not.toBeInTheDocument();
+  });
+
+  it("submits a bounded Discover run from the stage tab", async () => {
+    const user = userEvent.setup();
+    const runPipelineStages = vi.fn(async (): Promise<PipelineStageRunResponse> => ({
+      ok: true as const,
+      action: "run_stage" as const,
+      status: "succeeded",
+      jobKey: "pipeline",
+      count: 1,
+      command: {
+        stages: ["discover"],
+        limit: 1,
+        workers: 1,
+        minScore: 7,
+        validationMode: "normal" as const,
+        dryRun: false,
+        rescore: false,
+        retailor: false,
+        headless: false,
+        model: "haiku",
+        continuous: false,
+      },
+      actions: [],
+    }));
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({ api: { runPipelineStages } }),
+    });
+
+    await user.clear(screen.getByLabelText("Limit"));
+    await user.type(screen.getByLabelText("Limit"), "1");
+    await user.click(screen.getByLabelText("Dry run"));
+    await user.click(screen.getByRole("button", { name: "Run Discover" }));
+
+    await waitFor(() => expect(runPipelineStages).toHaveBeenCalledTimes(1));
+    expect(runPipelineStages).toHaveBeenCalledWith({
+      stages: ["discover"],
+      limit: 1,
+      workers: 1,
+      minScore: 7,
+      validationMode: "normal",
+      dryRun: false,
+      rescore: false,
+      retailor: false,
+      headless: false,
+      model: "haiku",
+      continuous: false,
+    });
   });
 
   it("submits the active stage and its persisted options through the pipeline mutation", async () => {

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -138,8 +138,8 @@ const BASE_CONTROLS: StageControlSet = {
 };
 
 const STAGE_CONTROLS: Record<Stage, StageControlSet> = {
-  discover: { ...BASE_CONTROLS, workers: true },
-  enrich: { ...BASE_CONTROLS, workers: true },
+  discover: { ...BASE_CONTROLS, limit: true, workers: true },
+  enrich: { ...BASE_CONTROLS, limit: true, workers: true },
   score: { ...BASE_CONTROLS, limit: true, workers: true, rescore: true },
   tailor: {
     ...BASE_CONTROLS,

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -12,8 +12,12 @@ import { type FormEvent, useState } from "react";
 import { Button } from "../../../shared/ui/button.js";
 import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../shared/ui/tabs.js";
+import { useDashboardSummaryQuery } from "../../operations/hooks/useDashboardSummaryQuery.js";
+import type { DashboardSummary } from "../../operations/types.js";
 import { useRunPipelineStagesMutation } from "../hooks/useRunPipelineStagesMutation.js";
 import { useStageTriggerStore, type StageTriggerConfig } from "../stores/stage-trigger-store.js";
+
+type StageActivity = DashboardSummary["activity"][number];
 
 function labelForStage(stage: Stage): string {
   return stage === "pdf" ? "PDF" : `${stage.charAt(0).toUpperCase()}${stage.slice(1)}`;
@@ -74,6 +78,37 @@ function pipelineRunStatusLine(stage: Stage, response: PipelineStageRunResponse)
 
 function pipelineRequestErrorLine(stage: Stage, error: Error): string {
   return `${labelForStage(stage)} failed to start: ${error.message}`;
+}
+
+function latestStageActivity(summary: DashboardSummary | undefined, stage: Stage): StageActivity | null {
+  return summary?.activity.find((activity) => activity.stage === stage) ?? null;
+}
+
+function isActivityAfter(activity: StageActivity, timestamp: number | null): boolean {
+  if (timestamp === null || activity.at === null) return true;
+  const occurredAt = Date.parse(activity.at);
+  return Number.isNaN(occurredAt) || occurredAt >= timestamp - 5000;
+}
+
+function isRunningActivity(activity: StageActivity): boolean {
+  return activity.eventType === "ActionStarted" || activity.eventType === "StageStarted";
+}
+
+function isFailedActivity(activity: StageActivity): boolean {
+  return activity.level === "error" || activity.eventType === "ActionFailed" || activity.eventType === "StageFailed";
+}
+
+function stageActivityStatusLine(stage: Stage, activity: StageActivity): string {
+  const stageLabel = labelForStage(stage);
+  const eventReference = activity.eventId ? ` (#${activity.eventId})` : "";
+
+  if (isRunningActivity(activity)) {
+    return `${stageLabel} in progress: ${activity.message}${eventReference}.`;
+  }
+  if (isFailedActivity(activity)) {
+    return `${stageLabel} latest failure: ${activity.message}${eventReference}.`;
+  }
+  return `${stageLabel} latest event: ${activity.message}${eventReference}.`;
 }
 
 const APPLY_MODEL_OPTIONS = ["haiku", "sonnet", "opus"] as const;
@@ -137,6 +172,8 @@ function applyModelValue(model: string): (typeof APPLY_MODEL_OPTIONS)[number] {
 export function StageTriggerPanel() {
   const runStages = useRunPipelineStagesMutation();
   const [submittedStage, setSubmittedStage] = useState<Stage | null>(null);
+  const [submittedAt, setSubmittedAt] = useState<number | null>(null);
+  const dashboardSummary = useDashboardSummaryQuery();
   const activeStage = useStageTriggerStore((state) => state.activeStage);
   const config = useStageTriggerStore((state) => state.configs[state.activeStage]);
   const setActiveStage = useStageTriggerStore((state) => state.setActiveStage);
@@ -144,6 +181,10 @@ export function StageTriggerPanel() {
   const controls = STAGE_CONTROLS[activeStage];
   const selectedApplyModel = applyModelValue(config.model);
   const statusStage = submittedStage ?? activeStage;
+  const stageActivity = latestStageActivity(dashboardSummary.data, statusStage);
+  const relevantPendingActivity =
+    runStages.isPending && stageActivity && isActivityAfter(stageActivity, submittedAt) ? stageActivity : null;
+  const visibleStageActivity = relevantPendingActivity ?? (!runStages.isPending ? stageActivity : null);
   const headerMeta = runStages.isPending ? "starting" : (runStages.data?.status ?? (runStages.error ? "failed" : "ready"));
 
   const patchConfig = (patch: Partial<StageTriggerConfig>) => {
@@ -153,6 +194,7 @@ export function StageTriggerPanel() {
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setSubmittedStage(activeStage);
+    setSubmittedAt(Date.now());
     runStages.mutate({
       stages: [activeStage],
       limit: controls.limit ? numberValue(config.limit, 25) : 25,
@@ -299,7 +341,9 @@ export function StageTriggerPanel() {
         </Button>
         {runStages.isPending ? (
           <span className="status-line" role="status">
-            {pendingStageStatusLine(statusStage)}
+            {relevantPendingActivity
+              ? stageActivityStatusLine(statusStage, relevantPendingActivity)
+              : pendingStageStatusLine(statusStage)}
           </span>
         ) : runStages.data ? (
           <span className={runStages.data.status === "failed" ? "status-line danger-action" : "status-line"} role="status">
@@ -308,6 +352,10 @@ export function StageTriggerPanel() {
         ) : runStages.error ? (
           <span className="status-line danger-action" role="status">
             {pipelineRequestErrorLine(statusStage, runStages.error)}
+          </span>
+        ) : visibleStageActivity ? (
+          <span className={isFailedActivity(visibleStageActivity) ? "status-line danger-action" : "status-line"} role="status">
+            {stageActivityStatusLine(statusStage, visibleStageActivity)}
           </span>
         ) : null}
       </div>

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -16,6 +16,7 @@ import { jobsKeys } from "../operations/jobsKeys.js";
 export const stageStartedHandler = (event: StageStarted): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  invalidate(dashboardKeys.summary(event.tenantId)),
 ];
 
 export const stageCompletedHandler = (

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -179,6 +179,7 @@ export const sampleDashboardSummary: DashboardSummary = {
   activity: [
     {
       eventId: "evt-1",
+      eventType: "JobScored",
       jobKey: "job-1",
       title: sampleJob.title,
       company: sampleJob.company,

--- a/apps/web/src/views/dashboard/ActivityFeed.stories.tsx
+++ b/apps/web/src/views/dashboard/ActivityFeed.stories.tsx
@@ -27,6 +27,7 @@ export const ErrorActivity: Story = {
       activity: [
         {
           eventId: "evt-2",
+          eventType: "StageFailed",
           jobKey: "job-1",
           title: "Staff Software Engineer",
           company: "Acme Corp",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -419,7 +419,10 @@ Pipeline stages and Discover source steps also emit short
 `StageStarted` / `StageCompleted` / `StageFailed` lifecycle records. The same
 lifecycle records are persisted to `job_events`, which makes long-running or
 stuck stages visible through SSE/recent activity even before the synchronous
-JSON-RPC request returns.
+JSON-RPC request returns. The stage runner forwards the caller's `limit` to
+every stage. Discovery sources use that limit as a bounded debug crawl cap,
+switch to sequential source execution when a cap is present, and skip remaining
+sources after the cap is reached.
 
 The `TracingInterceptor` is registered both client-side
 (`infrastructure/temporal/client.py`) and worker-side

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -396,6 +396,8 @@ Langfuse instance for LLM tracing. The wiring lives under
   `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` / `LANGFUSE_BASE_URL` is
   unset, init logs a warning and the worker continues without exporting.
   `LANGFUSE_DISABLE=1` opts out even when credentials are present.
+  `LANGFUSE_OTEL_TIMEOUT_SECONDS` bounds each OTLP export request and defaults
+  to `5.0`.
 - `llm_spans.py` — `llm_generation_span(...)` context manager that opens a
   `langfuse.observation.type=generation` span around each LLM call. It also
   sets the GenAI semantic-conventions attributes (`gen_ai.request.model`,
@@ -409,6 +411,15 @@ Three sources emit spans:
 | Every LLM call (`jobhunter.llm.LLMClient.chat`) | `llm.<model>` | `generation` |
 | Every Temporal workflow + activity (via `temporalio.contrib.opentelemetry.TracingInterceptor`) | workflow / activity name | `span` (default) |
 | Every JSON-RPC dispatch (`jobhunter.infrastructure.rpc.server.JsonRpcServer.dispatch`) | `rpc.<method>` | `span` |
+| Every pipeline stage (`jobhunter.pipeline.runner`) | `pipeline.stage.<stage>` | `span` |
+| Discover source steps (`jobspy`, `workday`, `smartextract`) | `pipeline.source.discover.<source>` | `span` |
+
+Pipeline stages and Discover source steps also emit short
+`langfuse.observation.type=event` observations for their
+`StageStarted` / `StageCompleted` / `StageFailed` lifecycle records. The same
+lifecycle records are persisted to `job_events`, which makes long-running or
+stuck stages visible through SSE/recent activity even before the synchronous
+JSON-RPC request returns.
 
 The `TracingInterceptor` is registered both client-side
 (`infrastructure/temporal/client.py`) and worker-side
@@ -470,7 +481,9 @@ event (PR 7 of the Temporal stack).
    `apply_run_projections` via `GET /v1/workflow-runs` and deep-links each
    row to the local Temporal Web UI (`http://127.0.0.1:8233`).
 8. UI actions are routed through JSON-RPC for complex commands or executed
-   inline for simple state transitions.
+   inline for simple state transitions. JSON-RPC worker subprocesses inherit
+   the API runtime `JOBHUNTER_DIR`, so action writes land in the same
+   database the API and web UI read.
 
 ## Local Commands
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -38,6 +38,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Targeted apply skips fresh jobs | `workers/automation/tests/test_apply_regressions.py` |
 | Stages cannot be retried individually | `workers/automation/tests/test_state_dashboard.py` |
 | Explicit stage state loses to legacy columns | `workers/automation/tests/test_state_dashboard.py` |
+| Pipeline actions write events to a different DB or hide running stages | `apps/api/test/json-rpc-adapter.test.ts`; `workers/automation/tests/test_pipeline_observability.py`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
 | PDF conversion publishes stray files | `workers/automation/tests/test_pdf_targets.py` |
 | Cover letters use the wrong resume | `workers/automation/tests/test_cover_requirements.py` |
 | Profile PDF import corrupts defaults | `workers/automation/tests/test_profile_import.py` |

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -38,7 +38,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Targeted apply skips fresh jobs | `workers/automation/tests/test_apply_regressions.py` |
 | Stages cannot be retried individually | `workers/automation/tests/test_state_dashboard.py` |
 | Explicit stage state loses to legacy columns | `workers/automation/tests/test_state_dashboard.py` |
-| Pipeline actions write events to a different DB or hide running stages | `apps/api/test/json-rpc-adapter.test.ts`; `workers/automation/tests/test_pipeline_observability.py`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
+| Pipeline actions write events to a different DB, hide running stages, or ignore bounded stage limits | `apps/api/test/json-rpc-adapter.test.ts`; `workers/automation/tests/test_pipeline_observability.py`; `apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
 | PDF conversion publishes stray files | `workers/automation/tests/test_pdf_targets.py` |
 | Cover letters use the wrong resume | `workers/automation/tests/test_cover_requirements.py` |
 | Profile PDF import corrupts defaults | `workers/automation/tests/test_profile_import.py` |

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -47,6 +47,13 @@ include `apply` first run preceding non-apply stages synchronously, then return
 the response is `200` and preserves the dispatcher-derived failed apply action.
 `dryRun` defaults to `true`, preserving apply safety.
 
+The `limit` field is forwarded to every stage. For `discover`, the Python
+runner passes it into JobSpy, Workday, and Smart Extract and forces bounded
+source crawls to run sequentially, skipping remaining sources once the cap is
+reached so `limit: 1` is usable for local debugging. For `enrich`, the same
+field caps pending detail jobs instead of falling back to the enrichment default
+batch size.
+
 The JSON-RPC worker is launched with the API runtime `appDir` as
 `JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same
 local SQLite database. Non-apply pipeline runs also emit pipeline-level

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -47,6 +47,19 @@ include `apply` first run preceding non-apply stages synchronously, then return
 the response is `200` and preserves the dispatcher-derived failed apply action.
 `dryRun` defaults to `true`, preserving apply safety.
 
+The JSON-RPC worker is launched with the API runtime `appDir` as
+`JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same
+local SQLite database. Non-apply pipeline runs also emit pipeline-level
+`StageStarted` / `StageCompleted` / `StageFailed` rows, and Discover emits
+the same lifecycle rows for its JobSpy, Workday, and Smart Extract source
+steps. Those event types are part of the SSE domain catalog, so the dashboard
+can refresh recent activity while a long synchronous stage request is still
+running.
+
+`GET /v1/dashboard/summary` includes `activity[].eventType` for those rows so
+the web UI can render started, completed, and failed stage states from backend
+events instead of local button state alone.
+
 ## Related Packages
 
 - `apps/api`: Fastify API app.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -576,6 +576,7 @@ export interface DashboardSummary {
   }>;
   activity: Array<{
     eventId: string;
+    eventType: string;
     jobKey: string | null;
     title: string | null;
     company: string | null;

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -570,6 +570,7 @@ def run(
     ),
     stream: bool = typer.Option(False, "--stream", help="Run stages concurrently (streaming mode)."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview stages without executing."),
+    limit: int = typer.Option(0, "--limit", help="Maximum records to process per stage. 0 means no explicit cap."),
     validation: str = typer.Option(
         "normal",
         "--validation",
@@ -623,6 +624,7 @@ def run(
         stream=stream,
         workers=workers,
         validation_mode=validation,
+        limit=limit,
         retailor=retailor,
     )
 
@@ -633,19 +635,21 @@ def run(
 @app.command()
 def discover(
     workers: int = typer.Option(1, "--workers", "-w", help="Parallel threads for discovery backends."),
+    limit: int = typer.Option(0, "--limit", help="Maximum jobs to discover. 0 means all eligible jobs."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview the stage without executing."),
 ) -> None:
     """Run only the discovery stage."""
-    _run_stage_command("discover", workers=workers, dry_run=dry_run)
+    _run_stage_command("discover", workers=workers, limit=limit, dry_run=dry_run)
 
 
 @app.command()
 def enrich(
     workers: int = typer.Option(1, "--workers", "-w", help="Parallel threads for detail enrichment."),
+    limit: int = typer.Option(0, "--limit", help="Maximum jobs to enrich. 0 means all eligible jobs."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview the stage without executing."),
 ) -> None:
     """Run only the enrichment stage."""
-    _run_stage_command("enrich", workers=workers, dry_run=dry_run)
+    _run_stage_command("enrich", workers=workers, limit=limit, dry_run=dry_run)
 
 
 @app.command()

--- a/workers/automation/src/jobhunter/discovery/activities.py
+++ b/workers/automation/src/jobhunter/discovery/activities.py
@@ -17,6 +17,7 @@ class DiscoverActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    limit: int = 0
     workers: int = 1
 
 
@@ -37,7 +38,7 @@ async def discover_activity(payload: DiscoverActivityInput) -> DiscoverActivityO
     from jobhunter.pipeline import run_pipeline
 
     def _do() -> dict[str, Any]:
-        return run_pipeline(stages=["discover"], workers=payload.workers)
+        return run_pipeline(stages=["discover"], workers=payload.workers, limit=payload.limit)
 
     result = await run_blocking_with_heartbeat(
         _do,

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -94,13 +94,15 @@ def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> 
 
 # -- DB storage (JobSpy DataFrame -> SQLite) ---------------------------------
 
-def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str) -> tuple[int, int]:
+def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit: int = 0) -> tuple[int, int]:
     """Store JobSpy DataFrame results into the DB. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
     new = 0
     existing = 0
 
     for _, row in df.iterrows():
+        if limit > 0 and new + existing >= limit:
+            break
         url = str(row.get("job_url", ""))
         if not url or url == "nan":
             continue
@@ -171,6 +173,7 @@ def _run_one_search(
     accept_locs: list[str],
     reject_locs: list[str],
     glassdoor_map: dict,
+    limit: int = 0,
 ) -> dict:
     """Run a single search query and store results in DB."""
     s = search
@@ -253,7 +256,7 @@ def _run_one_search(
     filtered = before - len(df)
 
     conn = get_connection()
-    new, existing = store_jobspy_results(conn, df, s["query"])
+    new, existing = store_jobspy_results(conn, df, s["query"], limit=limit)
 
     msg = f"[{label}] {before} results -> {new} new, {existing} dupes"
     if filtered:
@@ -342,10 +345,13 @@ def _full_crawl(
     hours_old: int = 72,
     proxy: str | None = None,
     max_retries: int = 2,
+    limit: int = 0,
 ) -> dict:
     """Run all search queries from search config across all locations."""
     if sites is None:
         sites = ["indeed", "linkedin", "zip_recruiter"]
+    if limit > 0 and sites:
+        sites = sites[:1]
 
     # Build search combinations from config
     queries = search_cfg.get("queries", [])
@@ -384,10 +390,14 @@ def _full_crawl(
     completed = 0
 
     for s in searches:
+        remaining = max(limit - (total_new + total_existing), 0) if limit > 0 else 0
+        if limit > 0 and remaining <= 0:
+            break
         result = _run_one_search(
-            s, sites, results_per_site, hours_old,
+            s, sites, min(results_per_site, remaining) if limit > 0 else results_per_site, hours_old,
             proxy_config, defaults, max_retries,
             accept_locs, reject_locs, glassdoor_map,
+            limit=remaining if limit > 0 else 0,
         )
         completed += 1
         total_new += result["new"]
@@ -410,13 +420,13 @@ def _full_crawl(
         "existing": total_existing,
         "errors": total_errors,
         "db_total": db_total,
-        "queries": len(searches),
+        "queries": completed,
     }
 
 
 # -- Public entry point ------------------------------------------------------
 
-def run_discovery(cfg: dict | None = None) -> dict:
+def run_discovery(cfg: dict | None = None, limit: int = 0) -> dict:
     """Main entry point for JobSpy-based job discovery.
 
     Loads search queries and locations from the user's search config YAML,
@@ -451,4 +461,5 @@ def run_discovery(cfg: dict | None = None) -> dict:
         results_per_site=results_per_site,
         hours_old=hours_old,
         proxy=proxy,
+        limit=limit,
     )

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -90,6 +90,7 @@ def _store_jobs_filtered(
     strategy: str,
     accept_locs: list[str],
     reject_locs: list[str],
+    limit: int = 0,
 ) -> tuple[int, int]:
     """Store jobs with location filtering. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
@@ -98,6 +99,8 @@ def _store_jobs_filtered(
     filtered = 0
 
     for job in jobs:
+        if limit > 0 and new + existing >= limit:
+            break
         url = job.get("url")
         if not url:
             continue
@@ -998,6 +1001,7 @@ def _run_all(
     accept_locs: list[str],
     reject_locs: list[str],
     workers: int = 1,
+    limit: int = 0,
 ) -> dict:
     """Run smart extract on all targets.
 
@@ -1013,13 +1017,21 @@ def _run_all(
     total_new = 0
     total_existing = 0
 
+    if limit > 0:
+        workers = 1
+        targets = targets[:limit]
+
     def _process_result(r: dict, target: dict) -> None:
         nonlocal total_new, total_existing
+        remaining = max(limit - (total_new + total_existing), 0) if limit > 0 else 0
+        if limit > 0 and remaining <= 0:
+            return
         jobs = r.get("jobs", [])
         if jobs:
             new, existing = _store_jobs_filtered(conn, jobs, target["name"],
                                                   r.get("strategy", "?"),
-                                                  accept_locs, reject_locs)
+                                                  accept_locs, reject_locs,
+                                                  limit=remaining if limit > 0 else 0)
             total_new += new
             total_existing += existing
             log.info("DB: +%d new, %d already existed", new, existing)
@@ -1039,6 +1051,8 @@ def _run_all(
     else:
         # Sequential mode (default)
         for i, target in enumerate(targets):
+            if limit > 0 and total_new + total_existing >= limit:
+                break
             label = target["name"]
             if target.get("query"):
                 label = f"{target['name']} [{target['query']}]"
@@ -1069,6 +1083,7 @@ def _run_all(
 def run_smart_extract(
     sites: list[dict] | None = None,
     workers: int = 1,
+    limit: int = 0,
 ) -> dict:
     """Main entry point for AI-powered smart extraction.
 
@@ -1096,4 +1111,4 @@ def run_smart_extract(
     log.info("Sites: %d searchable, %d static | Total targets: %d (workers=%d)",
              search_sites, static_sites, len(targets), workers)
 
-    return _run_all(targets, accept_locs, reject_locs, workers=workers)
+    return _run_all(targets, accept_locs, reject_locs, workers=workers, limit=limit)

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -300,13 +300,15 @@ def fetch_details(employer: dict, jobs: list[dict]) -> list[dict]:
 
 # -- DB storage --------------------------------------------------------------
 
-def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict) -> tuple[int, int]:
+def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict, limit: int = 0) -> tuple[int, int]:
     """Store corporate jobs in DB. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
     new = 0
     existing = 0
 
     for job in jobs:
+        if limit > 0 and new + existing >= limit:
+            break
         url = job.get("apply_url", "")
         if not url:
             emp = employers.get(job.get("employer_key", ""), {})
@@ -347,6 +349,7 @@ def _process_one(
     location_filter: bool,
     accept_locs: list[str],
     reject_locs: list[str],
+    limit: int = 0,
 ) -> dict:
     """Search one employer, fetch details, store results."""
     emp = employers[employer_key]
@@ -355,6 +358,7 @@ def _process_one(
         jobs = search_employer(
             employer_key, emp, search_text,
             location_filter=location_filter,
+            max_results=limit,
             accept_locs=accept_locs,
             reject_locs=reject_locs,
         )
@@ -373,7 +377,7 @@ def _process_one(
         log.error("%s: ERROR fetching details for '%s': %s", emp["name"], search_text, e)
 
     conn = get_connection()
-    new, existing = store_results(conn, jobs, employers)
+    new, existing = store_results(conn, jobs, employers, limit=limit)
     log.info("%s: %d new, %d already in DB", emp["name"], new, existing)
 
     return {"employer": emp["name"], "query": search_text,
@@ -391,6 +395,7 @@ def scrape_employers(
     accept_locs: list[str] | None = None,
     reject_locs: list[str] | None = None,
     workers: int = 1,
+    limit: int = 0,
 ) -> dict:
     """Run full scrape: search -> filter -> detail -> store.
 
@@ -416,6 +421,9 @@ def scrape_employers(
 
     valid_keys = [k for k in employer_keys if k in employers]
 
+    if limit > 0:
+        workers = 1
+
     if workers > 1 and len(valid_keys) > 1:
         # Parallel mode
         completed = 0
@@ -424,6 +432,7 @@ def scrape_employers(
                 pool.submit(
                     _process_one, key, employers, search_text,
                     location_filter, accept_locs, reject_locs,
+                    0,
                 ): key
                 for key in valid_keys
             }
@@ -444,9 +453,13 @@ def scrape_employers(
         # Sequential mode (default)
         completed = 0
         for key in valid_keys:
+            remaining = max(limit - total_found, 0) if limit > 0 else 0
+            if limit > 0 and remaining <= 0:
+                break
             result = _process_one(
                 key, employers, search_text,
                 location_filter, accept_locs, reject_locs,
+                remaining if limit > 0 else 0,
             )
             completed += 1
             total_new += result["new"]
@@ -469,7 +482,7 @@ def scrape_employers(
 
 # -- Public entry point ------------------------------------------------------
 
-def run_workday_discovery(employers: dict | None = None, workers: int = 1) -> dict:
+def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit: int = 0) -> dict:
     """Main entry point for Workday-based corporate job discovery.
 
     Loads employer registry from config/employers.yaml (or uses the provided
@@ -519,6 +532,9 @@ def run_workday_discovery(employers: dict | None = None, workers: int = 1) -> di
     grand_found = 0
 
     for i, query in enumerate(queries, 1):
+        remaining = max(limit - grand_found, 0) if limit > 0 else 0
+        if limit > 0 and remaining <= 0:
+            break
         log.info("Query %d/%d: \"%s\"", i, len(queries), query)
         result = scrape_employers(
             search_text=query,
@@ -527,6 +543,7 @@ def run_workday_discovery(employers: dict | None = None, workers: int = 1) -> di
             accept_locs=accept_locs,
             reject_locs=reject_locs,
             workers=workers,
+            limit=remaining if limit > 0 else 0,
         )
         grand_new += result["new"]
         grand_existing += result["existing"]

--- a/workers/automation/src/jobhunter/infrastructure/observability/otel.py
+++ b/workers/automation/src/jobhunter/infrastructure/observability/otel.py
@@ -29,6 +29,7 @@ _exporter: OTLPSpanExporter | None = None
 
 _OTLP_PATH = "/api/public/otel/v1/traces"
 _DISABLE_TRUTHY = frozenset({"1", "true", "yes"})
+_DEFAULT_EXPORT_TIMEOUT_SECONDS = 5.0
 
 
 def langfuse_disabled() -> bool:
@@ -80,6 +81,7 @@ def init_otel(*, service_name: str = "jobhunter", environment: str | None = None
             "Authorization": f"Basic {auth}",
             "x-langfuse-ingestion-version": "4",
         },
+        timeout=_export_timeout_seconds(),
     )
     provider = TracerProvider(resource=resource)
     provider.add_span_processor(BatchSpanProcessor(exporter))
@@ -147,3 +149,18 @@ def shutdown_otel() -> None:
 def is_otel_enabled() -> bool:
     """True iff ``init_otel()`` configured a real provider."""
     return _provider is not None
+
+
+def _export_timeout_seconds() -> float:
+    raw = os.environ.get("LANGFUSE_OTEL_TIMEOUT_SECONDS", "").strip()
+    if not raw:
+        return _DEFAULT_EXPORT_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        log.warning("Invalid LANGFUSE_OTEL_TIMEOUT_SECONDS=%r; using %.1fs.", raw, _DEFAULT_EXPORT_TIMEOUT_SECONDS)
+        return _DEFAULT_EXPORT_TIMEOUT_SECONDS
+    if value <= 0:
+        log.warning("LANGFUSE_OTEL_TIMEOUT_SECONDS must be positive; using %.1fs.", _DEFAULT_EXPORT_TIMEOUT_SECONDS)
+        return _DEFAULT_EXPORT_TIMEOUT_SECONDS
+    return value

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -312,13 +312,61 @@ def _run_discovery_source(source: str, label: str, run: Callable[[], str]) -> st
         return status
 
 
+def _skip_discovery_source(source: str, label: str, reason: str) -> str:
+    status = "skipped_limit"
+    _record_pipeline_event(
+        "discover",
+        "StageCompleted",
+        "info",
+        f"Discovery source {source} skipped: {reason}",
+        {"source": source, "sourceLabel": label, "status": status, "reason": reason},
+    )
+    return status
+
+
+def _pipeline_job_count() -> int:
+    try:
+        conn = get_connection()
+        row = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+        return int(row[0] or 0) if row else 0
+    except Exception:
+        log.debug("Failed to count jobs for bounded discover limit", exc_info=True)
+        return 0
+
+
+def _discover_limit_reached(start_count: int, limit: int) -> bool:
+    return limit > 0 and _pipeline_job_count() - start_count >= limit
+
+
+def _discovery_result_count(result: Any) -> int:
+    if not isinstance(result, dict):
+        return 0
+    if "found" in result:
+        return int(result.get("found") or 0)
+    count = 0
+    for key in ("new", "existing", "total_new", "total_existing"):
+        count += int(result.get(key) or 0)
+    return count
+
+
+def _discover_limit_consumed(start_count: int, limit: int, source_result: Any = None) -> bool:
+    if limit <= 0:
+        return False
+    if _discovery_result_count(source_result) >= limit:
+        return True
+    return _discover_limit_reached(start_count, limit)
+
+
 # ---------------------------------------------------------------------------
 # Individual stage runners
 # ---------------------------------------------------------------------------
 
-def _run_discover(workers: int = 1) -> dict:
+def _run_discover(workers: int = 1, limit: int = 0) -> dict:
     """Stage: Job discovery — JobSpy, Workday, and smart-extract scrapers."""
     stats: dict = {"jobspy": None, "workday": None, "smartextract": None}
+    source_results: dict[str, Any] = {}
+    bounded_workers = 1 if limit > 0 else workers
+    start_count = _pipeline_job_count() if limit > 0 else 0
 
     # JobSpy — skip if disabled in config or module not installed
     search_cfg = config.load_search_config() or {}
@@ -332,29 +380,36 @@ def _run_discover(workers: int = 1) -> dict:
         except ImportError:
             console.print("  [dim]JobSpy not installed — skipping[/dim]")
             return "not_installed"
-        run_discovery()
+        source_results["jobspy"] = run_discovery(limit=limit)
         return "ok"
 
     stats["jobspy"] = _run_discovery_source("jobspy", "JobSpy", run_jobspy)
     if isinstance(stats["jobspy"], str) and stats["jobspy"].startswith("error"):
         console.print(f"  [red]JobSpy error:[/red] {stats['jobspy'][7:]}")
+    if _discover_limit_consumed(start_count, limit, source_results.get("jobspy")):
+        stats["workday"] = _skip_discovery_source("workday", "Workday scraper", "limit reached")
+        stats["smartextract"] = _skip_discovery_source("smartextract", "Smart extract", "limit reached")
+        return stats
 
     # Workday corporate scraper
     def run_workday() -> str:
         console.print("  [cyan]Workday corporate scraper...[/cyan]")
         from jobhunter.discovery.workday import run_workday_discovery
-        run_workday_discovery(workers=workers)
+        source_results["workday"] = run_workday_discovery(workers=bounded_workers, limit=limit)
         return "ok"
 
     stats["workday"] = _run_discovery_source("workday", "Workday scraper", run_workday)
     if isinstance(stats["workday"], str) and stats["workday"].startswith("error"):
         console.print(f"  [red]Workday error:[/red] {stats['workday'][7:]}")
+    if _discover_limit_consumed(start_count, limit, source_results.get("workday")):
+        stats["smartextract"] = _skip_discovery_source("smartextract", "Smart extract", "limit reached")
+        return stats
 
     # Smart extract
     def run_smart_extract_source() -> str:
         console.print("  [cyan]Smart extract (AI-powered scraping)...[/cyan]")
         from jobhunter.discovery.smartextract import run_smart_extract
-        run_smart_extract(workers=workers)
+        source_results["smartextract"] = run_smart_extract(workers=bounded_workers, limit=limit)
         return "ok"
 
     stats["smartextract"] = _run_discovery_source(
@@ -368,11 +423,11 @@ def _run_discover(workers: int = 1) -> dict:
     return stats
 
 
-def _run_enrich(workers: int = 1) -> dict:
+def _run_enrich(workers: int = 1, limit: int = 0) -> dict:
     """Stage: Detail enrichment — scrape full descriptions and apply URLs."""
     try:
         from jobhunter.enrichment.detail import run_enrichment
-        run_enrichment(workers=workers)
+        run_enrichment(limit=limit, workers=workers)
         return {"status": "ok"}
     except Exception as e:
         log.error("Enrichment failed: %s", e)
@@ -494,8 +549,9 @@ def _build_stage_kwargs(
 
     if stage in ("discover", "enrich", "score"):
         kwargs["workers"] = workers
-    if stage == "score":
+    if stage in ("discover", "enrich", "score"):
         kwargs["limit"] = limit
+    if stage == "score":
         kwargs["rescore"] = rescore
     elif stage in ("tailor", "cover"):
         kwargs["min_score"] = min_score

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -18,6 +18,8 @@ import time
 from datetime import datetime
 from typing import Any, Callable
 
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -26,9 +28,12 @@ from jobhunter import config
 from jobhunter.config import load_env, ensure_dirs
 from jobhunter import database as db_module
 from jobhunter.database import init_db, get_connection, get_stats
+from jobhunter.state import record_job_event, utc_now
 
 log = logging.getLogger(__name__)
 console = Console()
+
+_PIPELINE_JOB_ID = "pipeline"
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +64,255 @@ _UPSTREAMS: dict[str, tuple[str, ...]] = {
 
 
 # ---------------------------------------------------------------------------
+# Observability helpers
+# ---------------------------------------------------------------------------
+
+def _pipeline_tracer():
+    return trace.get_tracer("jobhunter.pipeline")
+
+
+def _record_pipeline_event(
+    stage: str,
+    event_type: str,
+    level: str,
+    message: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Emit a durable pipeline-level event plus a short Langfuse event observation."""
+    now = utc_now()
+    enriched = _pipeline_event_payload(stage, event_type, now, payload)
+    _record_pipeline_observation_event(stage, event_type, level, message, enriched)
+
+    try:
+        conn = get_connection()
+        record_job_event(
+            conn,
+            None,
+            stage,
+            event_type,
+            level=level,
+            message=message,
+            payload=enriched,
+        )
+        conn.commit()
+    except Exception:
+        log.exception("Failed to record pipeline event %s for stage %s", event_type, stage)
+
+
+def _pipeline_event_payload(
+    stage: str,
+    event_type: str,
+    occurred_at: str,
+    payload: dict[str, Any] | None,
+) -> dict[str, Any]:
+    enriched: dict[str, Any] = {
+        "jobId": _PIPELINE_JOB_ID,
+        "stage": stage,
+        "component": "pipeline",
+        **(payload or {}),
+    }
+    if event_type == "StageStarted":
+        enriched.setdefault("attemptNumber", int(enriched.get("passNumber") or 1))
+        enriched.setdefault("startedAt", occurred_at)
+    elif event_type == "StageCompleted":
+        enriched.setdefault("finishedAt", occurred_at)
+        enriched.setdefault("durationMs", int(enriched.get("durationMs") or 0))
+    elif event_type == "StageFailed":
+        enriched.setdefault("errorCode", "pipeline_stage_failed")
+        enriched.setdefault("errorMessage", str(enriched.get("error") or "Pipeline stage failed"))
+        enriched.setdefault("retryable", True)
+        enriched.setdefault("attemptNumber", int(enriched.get("passNumber") or 1))
+    return enriched
+
+
+def _record_pipeline_observation_event(
+    stage: str,
+    event_type: str,
+    level: str,
+    message: str,
+    payload: dict[str, Any],
+) -> None:
+    try:
+        with _pipeline_tracer().start_as_current_span(f"pipeline.event.{stage}.{event_type}") as span:
+            _set_pipeline_span_attributes(span, stage, observation_type="event")
+            span.set_attribute("jobhunter.pipeline.event_type", event_type)
+            span.set_attribute("jobhunter.pipeline.message", message)
+            span.set_attribute("langfuse.observation.level", _langfuse_level(level))
+            span.set_attribute("langfuse.observation.status_message", message)
+            for key, value in payload.items():
+                if isinstance(value, str | int | float | bool):
+                    span.set_attribute(f"langfuse.observation.metadata.{key}", value)
+    except Exception:
+        log.debug("Failed to emit pipeline OTel event for %s/%s", stage, event_type, exc_info=True)
+
+
+def _set_pipeline_span_attributes(span, stage: str, *, observation_type: str = "span") -> None:  # type: ignore[no-untyped-def]
+    span.set_attribute("jobhunter.pipeline.stage", stage)
+    span.set_attribute("jobhunter.pipeline.job_id", _PIPELINE_JOB_ID)
+    span.set_attribute("langfuse.trace.name", "jobhunter.pipeline")
+    span.set_attribute("langfuse.observation.type", observation_type)
+    span.set_attribute("langfuse.observation.metadata.stage", stage)
+    span.set_attribute("langfuse.observation.metadata.job_id", _PIPELINE_JOB_ID)
+
+
+def _langfuse_level(level: str) -> str:
+    normalized = level.strip().lower()
+    if normalized == "error":
+        return "ERROR"
+    if normalized in {"warn", "warning"}:
+        return "WARNING"
+    if normalized == "debug":
+        return "DEBUG"
+    return "DEFAULT"
+
+
+def _stage_status(stage: str, result: dict[str, Any] | None) -> str:
+    status = "ok"
+    if isinstance(result, dict):
+        status = str(result.get("status", "ok"))
+        if stage == "discover":
+            sub_errors = [
+                f"{k}: {v}" for k, v in result.items()
+                if isinstance(v, str) and v.startswith("error")
+            ]
+            if sub_errors:
+                status = "partial"
+    return status
+
+
+def _run_stage_observed(
+    stage: str,
+    runner: _StageRunner,
+    kwargs: dict[str, Any],
+    *,
+    mode: str,
+    pass_number: int = 1,
+) -> tuple[dict[str, Any], float, str]:
+    """Run one pipeline stage with durable events and Langfuse-compatible spans."""
+    started = utc_now()
+    _record_pipeline_event(
+        stage,
+        "StageStarted",
+        "info",
+        f"{stage} stage started",
+        {"mode": mode, "passNumber": pass_number, "startedAt": started},
+    )
+    t0 = time.time()
+    with _pipeline_tracer().start_as_current_span(f"pipeline.stage.{stage}") as span:
+        _set_pipeline_span_attributes(span, stage)
+        span.set_attribute("jobhunter.pipeline.mode", mode)
+        span.set_attribute("jobhunter.pipeline.pass_number", pass_number)
+        try:
+            result = runner(**kwargs)
+        except Exception as exc:
+            elapsed = time.time() - t0
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            _record_pipeline_event(
+                stage,
+                "StageFailed",
+                "error",
+                f"{stage} stage failed: {exc}",
+                {
+                    "mode": mode,
+                    "passNumber": pass_number,
+                    "durationMs": int(elapsed * 1000),
+                    "error": str(exc),
+                    "errorCode": type(exc).__name__,
+                    "errorMessage": str(exc),
+                },
+            )
+            raise
+
+        elapsed = time.time() - t0
+        status = _stage_status(stage, result)
+        span.set_attribute("jobhunter.pipeline.status", status)
+        span.set_attribute("jobhunter.pipeline.duration_ms", int(elapsed * 1000))
+        if status not in ("ok", "partial", "skipped"):
+            span.set_status(Status(StatusCode.ERROR, status))
+            _record_pipeline_event(
+                stage,
+                "StageFailed",
+                "error",
+                f"{stage} stage failed: {status}",
+                {
+                    "mode": mode,
+                    "passNumber": pass_number,
+                    "durationMs": int(elapsed * 1000),
+                    "error": status,
+                    "errorCode": "stage_status_failed",
+                    "errorMessage": status,
+                },
+            )
+        else:
+            _record_pipeline_event(
+                stage,
+                "StageCompleted",
+                "warn" if status == "partial" else "info",
+                f"{stage} stage {status}",
+                {
+                    "mode": mode,
+                    "passNumber": pass_number,
+                    "durationMs": int(elapsed * 1000),
+                    "status": status,
+                },
+            )
+        return result, elapsed, status
+
+
+def _run_discovery_source(source: str, label: str, run: Callable[[], str]) -> str:
+    _record_pipeline_event(
+        "discover",
+        "StageStarted",
+        "info",
+        f"Discovery source {source} started",
+        {"source": source, "sourceLabel": label},
+    )
+    t0 = time.time()
+    with _pipeline_tracer().start_as_current_span(f"pipeline.source.discover.{source}") as span:
+        _set_pipeline_span_attributes(span, "discover")
+        span.set_attribute("jobhunter.pipeline.source", source)
+        try:
+            status = run()
+        except Exception as exc:
+            elapsed = time.time() - t0
+            log.error("%s failed: %s", label, exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            span.record_exception(exc)
+            _record_pipeline_event(
+                "discover",
+                "StageFailed",
+                "error",
+                f"Discovery source {source} failed: {exc}",
+                {
+                    "source": source,
+                    "sourceLabel": label,
+                    "durationMs": int(elapsed * 1000),
+                    "error": str(exc),
+                    "errorCode": type(exc).__name__,
+                    "errorMessage": str(exc),
+                },
+            )
+            return f"error: {exc}"
+
+        elapsed = time.time() - t0
+        span.set_attribute("jobhunter.pipeline.source_status", status)
+        _record_pipeline_event(
+            "discover",
+            "StageCompleted",
+            "info",
+            f"Discovery source {source} {status}",
+            {
+                "source": source,
+                "sourceLabel": label,
+                "durationMs": int(elapsed * 1000),
+                "status": status,
+            },
+        )
+        return status
+
+
+# ---------------------------------------------------------------------------
 # Individual stage runners
 # ---------------------------------------------------------------------------
 
@@ -68,44 +322,48 @@ def _run_discover(workers: int = 1) -> dict:
 
     # JobSpy — skip if disabled in config or module not installed
     search_cfg = config.load_search_config() or {}
-    if search_cfg.get("disable_jobspy", False):
-        console.print("  [dim]JobSpy disabled in searches.yaml[/dim]")
-        stats["jobspy"] = "disabled"
-    else:
+    def run_jobspy() -> str:
+        if search_cfg.get("disable_jobspy", False):
+            console.print("  [dim]JobSpy disabled in searches.yaml[/dim]")
+            return "disabled"
         console.print("  [cyan]JobSpy full crawl...[/cyan]")
         try:
             from jobhunter.discovery.jobspy import run_discovery
-            run_discovery()
-            stats["jobspy"] = "ok"
         except ImportError:
             console.print("  [dim]JobSpy not installed — skipping[/dim]")
-            stats["jobspy"] = "not_installed"
-        except Exception as e:
-            log.error("JobSpy crawl failed: %s", e)
-            console.print(f"  [red]JobSpy error:[/red] {e}")
-            stats["jobspy"] = f"error: {e}"
+            return "not_installed"
+        run_discovery()
+        return "ok"
+
+    stats["jobspy"] = _run_discovery_source("jobspy", "JobSpy", run_jobspy)
+    if isinstance(stats["jobspy"], str) and stats["jobspy"].startswith("error"):
+        console.print(f"  [red]JobSpy error:[/red] {stats['jobspy'][7:]}")
 
     # Workday corporate scraper
-    console.print("  [cyan]Workday corporate scraper...[/cyan]")
-    try:
+    def run_workday() -> str:
+        console.print("  [cyan]Workday corporate scraper...[/cyan]")
         from jobhunter.discovery.workday import run_workday_discovery
         run_workday_discovery(workers=workers)
-        stats["workday"] = "ok"
-    except Exception as e:
-        log.error("Workday scraper failed: %s", e)
-        console.print(f"  [red]Workday error:[/red] {e}")
-        stats["workday"] = f"error: {e}"
+        return "ok"
+
+    stats["workday"] = _run_discovery_source("workday", "Workday scraper", run_workday)
+    if isinstance(stats["workday"], str) and stats["workday"].startswith("error"):
+        console.print(f"  [red]Workday error:[/red] {stats['workday'][7:]}")
 
     # Smart extract
-    console.print("  [cyan]Smart extract (AI-powered scraping)...[/cyan]")
-    try:
+    def run_smart_extract_source() -> str:
+        console.print("  [cyan]Smart extract (AI-powered scraping)...[/cyan]")
         from jobhunter.discovery.smartextract import run_smart_extract
         run_smart_extract(workers=workers)
-        stats["smartextract"] = "ok"
-    except Exception as e:
-        log.error("Smart extract failed: %s", e)
-        console.print(f"  [red]Smart extract error:[/red] {e}")
-        stats["smartextract"] = f"error: {e}"
+        return "ok"
+
+    stats["smartextract"] = _run_discovery_source(
+        "smartextract",
+        "Smart extract",
+        run_smart_extract_source,
+    )
+    if isinstance(stats["smartextract"], str) and stats["smartextract"].startswith("error"):
+        console.print(f"  [red]Smart extract error:[/red] {stats['smartextract'][7:]}")
 
     return stats
 
@@ -440,7 +698,13 @@ def _run_stage_streaming(
     if stage == "discover":
         # Discover runs once (its sub-scrapers already do their full crawl)
         try:
-            result = runner(**kwargs)
+            result, _elapsed, _status = _run_stage_observed(
+                stage,
+                runner,
+                kwargs,
+                mode="streaming",
+                pass_number=1,
+            )
             tracker.mark_done(stage, result)
         except Exception as e:
             log.exception("Stage '%s' crashed", stage)
@@ -456,7 +720,13 @@ def _run_stage_streaming(
 
         if pending > 0:
             try:
-                runner(**kwargs)
+                _result, _elapsed, _status = _run_stage_observed(
+                    stage,
+                    runner,
+                    kwargs,
+                    mode="streaming",
+                    pass_number=passes + 1,
+                )
                 passes += 1
                 after = _count_pending(stage, min_score, retailor=retailor)
                 if upstream_done and after >= pending:
@@ -524,19 +794,13 @@ def _run_sequential(ordered: list[str], min_score: int, workers: int = 1,
                 rescore=rescore,
                 retailor=retailor,
             )
-            result = runner(**kwargs)
-            elapsed = time.time() - t0
-
-            status = "ok"
-            if isinstance(result, dict):
-                status = result.get("status", "ok")
-                if name == "discover":
-                    sub_errors = [
-                        f"{k}: {v}" for k, v in result.items()
-                        if isinstance(v, str) and v.startswith("error")
-                    ]
-                    if sub_errors:
-                        status = "partial"
+            result, elapsed, status = _run_stage_observed(
+                name,
+                runner,
+                kwargs,
+                mode="sequential",
+                pass_number=1,
+            )
 
         except Exception as e:
             elapsed = time.time() - t0

--- a/workers/automation/src/jobhunter/pipeline/workflow.py
+++ b/workers/automation/src/jobhunter/pipeline/workflow.py
@@ -116,7 +116,11 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
     if stage == "discover":
         return await workflow.execute_activity(
             discover_activity,
-            DiscoverActivityInput(tenant_id=payload.tenant_id, workers=payload.workers),
+            DiscoverActivityInput(
+                tenant_id=payload.tenant_id,
+                workers=payload.workers,
+                limit=payload.limit,
+            ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,

--- a/workers/automation/tests/test_actions.py
+++ b/workers/automation/tests/test_actions.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
-from jobhunter import actions
+from jobhunter import actions, cli
 from jobhunter.actions import LocalActionRequest, run_local_action
 from jobhunter.apply import launcher
 from jobhunter.cli import app
@@ -238,6 +238,26 @@ def test_action_cli_prints_json(tmp_path, monkeypatch):
         assert '"ok": true' in result.stdout
     finally:
         close_connection(db_path)
+
+
+def test_stage_cli_commands_accept_limits(monkeypatch):
+    calls = []
+
+    def fake_pipeline(**kwargs):
+        calls.append(kwargs)
+        stage = kwargs["stages"][0]
+        return {"stages": [{"stage": stage, "status": "ok", "elapsed": 0.01}], "errors": {}, "elapsed": 0.01}
+
+    monkeypatch.setattr(cli, "_bootstrap", lambda: None)
+    monkeypatch.setattr(cli, "run_pipeline", fake_pipeline)
+
+    runner = CliRunner()
+    for command in (["discover", "--limit", "1"], ["enrich", "--limit", "1"], ["run", "discover", "--limit", "1"]):
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0
+
+    assert [call["stages"] for call in calls] == [["discover"], ["enrich"], ["discover"]]
+    assert [call["limit"] for call in calls] == [1, 1, 1]
 
 
 def test_action_cli_reports_validation_errors_without_traceback(tmp_path, monkeypatch):

--- a/workers/automation/tests/test_activity_discover.py
+++ b/workers/automation/tests/test_activity_discover.py
@@ -52,7 +52,7 @@ async def test_discover_activity_invokes_run_pipeline_with_discover_stage():
             ):
                 output: DiscoverActivityOutput = await env.client.execute_workflow(
                     _DiscoverHarness.run,
-                    DiscoverActivityInput(tenant_id="local", workers=2),
+                    DiscoverActivityInput(tenant_id="local", limit=5, workers=2),
                     id=f"discover-wf-{uuid.uuid4()}",
                     task_queue=queue,
                 )
@@ -61,5 +61,6 @@ async def test_discover_activity_invokes_run_pipeline_with_discover_stage():
     kwargs = runner_mock.call_args.kwargs
     assert kwargs["stages"] == ["discover"]
     assert kwargs["workers"] == 2
+    assert kwargs["limit"] == 5
     assert output.status == "ok"
     assert output.elapsed == pytest.approx(0.1)

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from jobhunter.discovery import jobspy
+
+
+def test_jobspy_limit_runs_one_query_against_one_board(monkeypatch):
+    calls: list[tuple[str, str, list[str], int, int]] = []
+
+    def fake_run_one_search(
+        search: dict,
+        sites: list[str],
+        results_per_site: int,
+        *_args,
+        limit: int = 0,
+        **_kwargs,
+    ) -> dict:
+        calls.append((search["query"], search["location"], sites, results_per_site, limit))
+        return {"new": 1, "existing": 0, "errors": 0}
+
+    monkeypatch.setattr(jobspy, "init_db", lambda: None)
+    monkeypatch.setattr(
+        jobspy,
+        "get_connection",
+        lambda: SimpleNamespace(execute=lambda *_args, **_kwargs: SimpleNamespace(fetchone=lambda: [1])),
+    )
+    monkeypatch.setattr(jobspy, "_run_one_search", fake_run_one_search)
+
+    result = jobspy._full_crawl(
+        {
+            "queries": [{"query": "platform engineer"}, {"query": "product engineer"}],
+            "locations": [{"label": "remote", "location": "Remote"}],
+            "defaults": {"results_per_site": 100},
+        },
+        sites=["indeed", "linkedin"],
+        limit=1,
+    )
+
+    assert calls == [("platform engineer", "Remote", ["indeed"], 1, 1)]
+    assert result["queries"] == 1

--- a/workers/automation/tests/test_otel_init.py
+++ b/workers/automation/tests/test_otel_init.py
@@ -59,6 +59,18 @@ def test_init_otel_with_full_creds_configures_provider(monkeypatch):
     expected = base64.b64encode(b"pk-test:sk-test").decode("ascii")
     assert _header(otel_mod._exporter, "Authorization") == f"Basic {expected}"
     assert _header(otel_mod._exporter, "x-langfuse-ingestion-version") == "4"
+    assert otel_mod._exporter._timeout == 5.0
+
+
+def test_init_otel_honors_export_timeout_env(monkeypatch):
+    _set_creds(monkeypatch)
+    monkeypatch.setenv("LANGFUSE_OTEL_TIMEOUT_SECONDS", "1.5")
+    from jobhunter.infrastructure.observability import otel as otel_mod
+
+    otel_mod.init_otel()
+
+    assert otel_mod._exporter is not None
+    assert otel_mod._exporter._timeout == 1.5
 
 
 def test_init_otel_is_idempotent(monkeypatch):

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -1,0 +1,94 @@
+"""Pipeline-level event and OTel observability regressions."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
+
+from jobhunter.pipeline import runner
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
+
+
+def test_sequential_stage_emits_pipeline_span_and_stage_events(monkeypatch, in_memory_exporter):
+    events: list[tuple[str, str, str, dict]] = []
+
+    monkeypatch.setitem(runner._STAGE_RUNNERS, "score", lambda **_kwargs: {"status": "ok"})
+    monkeypatch.setattr(
+        runner,
+        "_record_pipeline_event",
+        lambda stage, event_type, level, message, payload=None: events.append(
+            (stage, event_type, level, {**(payload or {}), "message": message})
+        ),
+        raising=False,
+    )
+
+    result = runner._run_sequential(["score"], min_score=7, limit=1)
+
+    assert result["errors"] == {}
+    assert [(event[0], event[1], event[2]) for event in events] == [
+        ("score", "StageStarted", "info"),
+        ("score", "StageCompleted", "info"),
+    ]
+    spans = {span.name: dict(span.attributes or {}) for span in in_memory_exporter.get_finished_spans()}
+    assert "pipeline.stage.score" in spans
+    assert spans["pipeline.stage.score"]["jobhunter.pipeline.stage"] == "score"
+    assert spans["pipeline.stage.score"]["langfuse.observation.type"] == "span"
+
+
+def test_discover_emits_source_events(monkeypatch):
+    events: list[tuple[str, str, str, dict]] = []
+
+    monkeypatch.setattr(runner.config, "load_search_config", lambda: {"disable_jobspy": True})
+    monkeypatch.setattr(
+        runner,
+        "_record_pipeline_event",
+        lambda stage, event_type, level, message, payload=None: events.append(
+            (stage, event_type, level, {**(payload or {}), "message": message})
+        ),
+        raising=False,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.workday",
+        SimpleNamespace(run_workday_discovery=lambda workers=1: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.smartextract",
+        SimpleNamespace(run_smart_extract=lambda workers=1: None),
+    )
+
+    result = runner._run_discover(workers=2)
+
+    assert result["workday"] == "ok"
+    assert result["smartextract"] == "ok"
+    source_events = [(event_type, payload.get("source")) for _, event_type, _, payload in events]
+    assert source_events == [
+        ("StageStarted", "jobspy"),
+        ("StageCompleted", "jobspy"),
+        ("StageStarted", "workday"),
+        ("StageCompleted", "workday"),
+        ("StageStarted", "smartextract"),
+        ("StageCompleted", "smartextract"),
+    ]

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -71,12 +71,12 @@ def test_discover_emits_source_events(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "jobhunter.discovery.workday",
-        SimpleNamespace(run_workday_discovery=lambda workers=1: None),
+        SimpleNamespace(run_workday_discovery=lambda workers=1, limit=0: None),
     )
     monkeypatch.setitem(
         sys.modules,
         "jobhunter.discovery.smartextract",
-        SimpleNamespace(run_smart_extract=lambda workers=1: None),
+        SimpleNamespace(run_smart_extract=lambda workers=1, limit=0: None),
     )
 
     result = runner._run_discover(workers=2)
@@ -92,3 +92,114 @@ def test_discover_emits_source_events(monkeypatch):
         ("StageStarted", "smartextract"),
         ("StageCompleted", "smartextract"),
     ]
+
+
+def test_discover_limit_propagates_to_sources(monkeypatch):
+    calls: list[tuple[str, int, int | None]] = []
+
+    monkeypatch.setattr(runner.config, "load_search_config", lambda: {})
+    monkeypatch.setattr(runner, "_pipeline_job_count", lambda: 0, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.jobspy",
+        SimpleNamespace(run_discovery=lambda limit=0: calls.append(("jobspy", limit, None))),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.workday",
+        SimpleNamespace(
+            run_workday_discovery=lambda workers=1, limit=0: calls.append(("workday", limit, workers))
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.smartextract",
+        SimpleNamespace(run_smart_extract=lambda workers=1, limit=0: calls.append(("smartextract", limit, workers))),
+    )
+    monkeypatch.setattr(runner, "_record_pipeline_event", lambda *_args, **_kwargs: None)
+
+    result = runner._run_discover(workers=4, limit=1)
+
+    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
+    assert calls == [
+        ("jobspy", 1, None),
+        ("workday", 1, 1),
+        ("smartextract", 1, 1),
+    ]
+
+
+def test_discover_limit_skips_remaining_sources_after_cap(monkeypatch):
+    calls: list[str] = []
+    job_counts = iter([10, 11])
+
+    monkeypatch.setattr(runner.config, "load_search_config", lambda: {})
+    monkeypatch.setattr(runner, "_pipeline_job_count", lambda: next(job_counts), raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.jobspy",
+        SimpleNamespace(run_discovery=lambda limit=0: calls.append("jobspy")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.workday",
+        SimpleNamespace(run_workday_discovery=lambda workers=1, limit=0: calls.append("workday")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.smartextract",
+        SimpleNamespace(run_smart_extract=lambda workers=1, limit=0: calls.append("smartextract")),
+    )
+    monkeypatch.setattr(runner, "_record_pipeline_event", lambda *_args, **_kwargs: None)
+
+    result = runner._run_discover(workers=4, limit=1)
+
+    assert calls == ["jobspy"]
+    assert result == {"jobspy": "ok", "workday": "skipped_limit", "smartextract": "skipped_limit"}
+
+
+def test_discover_limit_skips_remaining_sources_after_existing_candidate(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(runner.config, "load_search_config", lambda: {})
+    monkeypatch.setattr(runner, "_pipeline_job_count", lambda: 10, raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.jobspy",
+        SimpleNamespace(
+            run_discovery=lambda limit=0: (calls.append("jobspy") or {"new": 0, "existing": 1, "errors": 0})
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.workday",
+        SimpleNamespace(run_workday_discovery=lambda workers=1, limit=0: calls.append("workday")),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.smartextract",
+        SimpleNamespace(run_smart_extract=lambda workers=1, limit=0: calls.append("smartextract")),
+    )
+    monkeypatch.setattr(runner, "_record_pipeline_event", lambda *_args, **_kwargs: None)
+
+    result = runner._run_discover(workers=4, limit=1)
+
+    assert calls == ["jobspy"]
+    assert result == {"jobspy": "ok", "workday": "skipped_limit", "smartextract": "skipped_limit"}
+
+
+def test_enrich_limit_propagates_to_runner(monkeypatch):
+    calls: list[dict[str, int]] = []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.enrichment.detail",
+        SimpleNamespace(run_enrichment=lambda limit=0, workers=1: calls.append({"limit": limit, "workers": workers})),
+    )
+
+    assert runner._run_enrich(workers=3, limit=1) == {"status": "ok"}
+    assert calls == [{"limit": 1, "workers": 3}]
+
+
+def test_stage_kwargs_include_limits_for_discover_and_enrich():
+    assert runner._build_stage_kwargs("discover", workers=2, limit=1) == {"workers": 2, "limit": 1}
+    assert runner._build_stage_kwargs("enrich", workers=2, limit=1) == {"workers": 2, "limit": 1}


### PR DESCRIPTION
## Summary
- Run JSON-RPC stage actions with the API runtime app dir so worker events land in the same local SQLite database the UI reads.
- Add pipeline stage and Discover source lifecycle events with Langfuse-compatible OpenTelemetry spans and bounded OTLP export timeout.
- Surface backend activity event types in the dashboard summary and stage trigger panel so long-running stages show source-level progress across tabs.
- Honor `limit` for every pipeline stage path, including Discover and Enrich; bounded Discover runs pass the cap into JobSpy, Workday, and Smart Extract, run bounded sources sequentially, and skip remaining Discover sources once the cap is consumed.
- Add explicit loopback CORS headers to the raw SSE response so dashboard EventSource progress streams work when web and API run on different local ports.

## Validation
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/pipeline/runner.py workers/automation/src/jobhunter/cli.py workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/src/jobhunter/discovery/workday.py workers/automation/src/jobhunter/discovery/smartextract.py workers/automation/src/jobhunter/discovery/activities.py workers/automation/src/jobhunter/pipeline/workflow.py workers/automation/tests/test_pipeline_observability.py workers/automation/tests/test_activity_discover.py workers/automation/tests/test_actions.py workers/automation/tests/test_discovery_limits.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_actions.py workers/automation/tests/test_activity_discover.py workers/automation/tests/test_pipeline_observability.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_otel_init.py workers/automation/tests/test_rpc_otel.py`
- `uv --project workers/automation run --extra dev pytest -q`
- `pnpm --filter @jobhunter/api test -- test/json-rpc-adapter.test.ts test/server.test.ts`
- `pnpm --filter @jobhunter/api test -- test/server.test.ts -t "allows loopback browser access to the event stream"`
- `pnpm --filter @jobhunter/api test -- test/server.test.ts test/json-rpc-adapter.test.ts`
- `pnpm api:check`
- `pnpm --filter @jobhunter/web test -- src/contexts/pipeline/components/StageTriggerPanel.test.tsx src/contexts/operations/invalidation-router.test.ts src/contexts/operations/every-event-has-handler.test.ts`
- `pnpm --filter @jobhunter/web test-d`
- `pnpm web:check`
- `pnpm web:build`
- `pnpm test`
- `git diff --check`
- Real `POST /v1/pipeline/actions/run-stage` with `stages:["discover"]`, `limit:1`, and `dryRun:false` returned HTTP 200. It wrote `job_events` 555-563, including `Discovery source smartextract skipped: limit reached`, and Langfuse trace `f5bf5fcd5917f211713f3c0ef41afdb2` contains the matching pipeline/source observations.
- Real `GET /v1/events/stream?tenantId=local` with `Origin: http://127.0.0.1:5175` returned `Access-Control-Allow-Origin: http://127.0.0.1:5175`.