### PR TITLE
feat(scoring): add hybrid search preselection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,22 @@ domain events and the **`SubprocessJsonRpcAdapter`** (Phase 9, S-34) for the
 TS↔Python integration protocol (§6.5 of `docs/ddd-target.md`). The pre-DDD
 "call out via `uv run jobhunter action ...` per request" pattern is gone.
 
+## Retrieval Before Scoring
+
+The Scoring context owns a local hybrid retrieval service under
+`workers/automation/src/jobhunter/domain/scoring/retrieval.py`. It builds an
+in-memory lexical index over normalized posting fields already produced by
+Discovery and Enrichment, then ranks candidate jobs before the scorer spends
+LLM calls. When `jobhunter run score --limit N` or equivalent pipeline calls
+cap scoring, the runner fetches a broader pending/enriched pool and lets hybrid
+retrieval choose the top N.
+
+Semantic search is optional. The `EmbeddingIndexPort` in
+`workers/automation/src/jobhunter/domain/ports/retrieval.py` is the adapter seam
+for a hosted or local embedding index; local mode defaults to
+`DisabledEmbeddingIndex`, so lexical retrieval and scoring continue to work
+without any external embedding service.
+
 ## Read-Model Projections (Phase 9)
 
 The Operations / Read-Side context maintains denormalised projection

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -46,6 +46,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Destructive UI workflows touch real user data | `apps/api/test/qa-workflow.test.ts` with `pnpm qa:seed` |
 | Source registry compatibility drops legacy discovery config | `workers/automation/tests/test_source_registry.py` covers packaged `sites.yaml` migration, `employers.yaml` migration, JobSpy `boards` selection, and the one-release legacy `sites` alias warning |
 | Source quality stops feeding discovery budgets or dashboard health | `workers/automation/tests/test_discovery_scheduler_pr4.py`; `workers/automation/tests/test_source_quality_projection_pr4.py`; `apps/web/src/views/dashboard/SourceHealthCard.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
+| Hybrid retrieval picks stale or weak candidates before LLM scoring | `workers/automation/tests/test_hybrid_search_index.py`; `workers/automation/tests/test_scorer.py::test_run_scoring_preselects_retrieval_top_k_before_llm` |
 
 ## Frontend QA
 

--- a/workers/automation/src/jobhunter/domain/ports/retrieval.py
+++ b/workers/automation/src/jobhunter/domain/ports/retrieval.py
@@ -1,0 +1,48 @@
+"""Retrieval ports used before expensive scoring work.
+
+The Scoring context consumes ranked job candidates, but semantic embedding
+storage is infrastructure. This port keeps local operation independent from
+hosted embedding services: callers may inject a concrete adapter, while the
+default disabled adapter lets lexical retrieval run on its own.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+
+
+@dataclass(frozen=True)
+class EmbeddingSearchResult:
+    """One semantic-search hit returned by an embedding adapter."""
+
+    job_id: str
+    score: float
+
+
+class EmbeddingIndexPort(Protocol):
+    """Optional semantic retrieval port.
+
+    ``document_texts`` maps JobId strings to normalized posting text. Adapters
+    can upsert/cache embeddings internally, call a hosted vector index, or
+    decline by returning ``enabled=False``. Domain retrieval treats this port as
+    advisory and falls back to lexical ranking if it is unavailable.
+    """
+
+    @property
+    def enabled(self) -> bool:
+        """Whether semantic retrieval is configured for the current run."""
+        ...
+
+    def rank(
+        self,
+        *,
+        query_text: str,
+        document_texts: Mapping[str, str],
+        top_k: int,
+    ) -> Sequence[EmbeddingSearchResult]:
+        """Return semantic hits sorted best-first."""
+        ...
+
+
+__all__ = ["EmbeddingIndexPort", "EmbeddingSearchResult"]

--- a/workers/automation/src/jobhunter/domain/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/domain/scoring/__init__.py
@@ -20,6 +20,16 @@ from jobhunter.domain.scoring.services import (
     ScoreParser,
     ScoreParseResult,
 )
+from jobhunter.domain.scoring.retrieval import (
+    DisabledEmbeddingIndex,
+    HybridSearchIndex,
+    PostingDocument,
+    RetrievedJobCandidate,
+    SearchQuery,
+    normalize_text,
+    preselect_jobs_for_scoring,
+    tokenize_text,
+)
 
 __all__ = [
     "FitScore",
@@ -31,4 +41,12 @@ __all__ = [
     "EligibilityChecker",
     "ScoreParser",
     "ScoreParseResult",
+    "DisabledEmbeddingIndex",
+    "HybridSearchIndex",
+    "PostingDocument",
+    "RetrievedJobCandidate",
+    "SearchQuery",
+    "normalize_text",
+    "preselect_jobs_for_scoring",
+    "tokenize_text",
 ]

--- a/workers/automation/src/jobhunter/domain/scoring/retrieval.py
+++ b/workers/automation/src/jobhunter/domain/scoring/retrieval.py
@@ -1,0 +1,534 @@
+"""Hybrid retrieval used to preselect jobs for scoring.
+
+This module is deliberately pure Python and in-memory. Discovery and
+Enrichment still own producing posting data; Scoring consumes their read-side
+job dictionaries as retrieval candidates before spending LLM calls.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Sequence
+
+from jobhunter.domain.ports.retrieval import EmbeddingIndexPort, EmbeddingSearchResult
+from jobhunter.domain.profile.snapshot import ProfileSnapshot
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9+#.-]*")
+_STOP_WORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "by",
+        "for",
+        "from",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "the",
+        "to",
+        "with",
+        "you",
+        "your",
+        "we",
+        "our",
+        "their",
+        "this",
+        "that",
+        "will",
+    }
+)
+
+
+def normalize_text(value: object) -> str:
+    """Normalize text for local lexical retrieval."""
+
+    if value is None:
+        return ""
+    text = unicodedata.normalize("NFKD", str(value))
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = text.casefold()
+    text = re.sub(r"[^a-z0-9+#.-]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def tokenize_text(value: object) -> tuple[str, ...]:
+    """Return normalized lexical tokens, excluding short stop words."""
+
+    normalized = normalize_text(value)
+    return tuple(
+        token
+        for token in _TOKEN_RE.findall(normalized)
+        if len(token) > 1 and token not in _STOP_WORDS
+    )
+
+
+@dataclass(frozen=True)
+class SearchQuery:
+    """Search text used by lexical and optional semantic retrieval."""
+
+    text: str
+
+    @classmethod
+    def from_profile_snapshot(
+        cls,
+        profile_snapshot: ProfileSnapshot,
+        *,
+        resume_text: str | None = None,
+        query_text: str | None = None,
+    ) -> "SearchQuery":
+        parts: list[str] = []
+        if query_text:
+            parts.append(query_text)
+        if resume_text:
+            parts.append(resume_text)
+
+        profile = profile_snapshot.as_dict()
+        resume = _as_mapping(profile.get("resume"))
+        executive = _as_mapping(resume.get("executive_profile"))
+        _append_text(parts, executive.get("baseline_text"))
+        for entry in _as_sequence(resume.get("experience_entries")):
+            _collect_profile_text(parts, entry)
+        for category in _as_sequence(resume.get("skill_categories")):
+            _collect_profile_text(parts, category)
+
+        for key in ("skills_boundary", "resume_facts", "work_authorization", "availability"):
+            _collect_profile_text(parts, profile.get(key))
+
+        return cls(text=" ".join(part for part in parts if part))
+
+
+@dataclass(frozen=True)
+class PostingDocument:
+    """Normalized job document consumed by the retrieval service."""
+
+    job_id: str
+    title: str = ""
+    company: str = ""
+    location: str = ""
+    description: str = ""
+    requirements: tuple[str, ...] = ()
+    responsibilities: tuple[str, ...] = ()
+    skills: tuple[str, ...] = ()
+    source_metadata: tuple[str, ...] = ()
+    discovered_at: str | None = None
+    source_trust: float = 0.0
+
+    @classmethod
+    def from_job(cls, job: Mapping[str, Any]) -> "PostingDocument":
+        job_id = str(job.get("url") or job.get("job_id") or job.get("id") or "").strip()
+        if not job_id:
+            raise ValueError("PostingDocument.from_job requires a url/job_id/id")
+
+        description = str(job.get("full_description") or job.get("description") or "")
+        metadata = tuple(
+            text
+            for text in (
+                job.get("site"),
+                job.get("strategy"),
+                job.get("source_id"),
+                job.get("source"),
+                job.get("salary"),
+                job.get("verification_confidence"),
+            )
+            if text
+        )
+        return cls(
+            job_id=job_id,
+            title=str(job.get("title") or ""),
+            company=str(job.get("company") or job.get("site") or ""),
+            location=str(job.get("location") or ""),
+            description=description,
+            requirements=_string_tuple(job.get("requirements")),
+            responsibilities=_string_tuple(job.get("responsibilities")),
+            skills=_string_tuple(job.get("skills")),
+            source_metadata=metadata,
+            discovered_at=str(job.get("discovered_at")) if job.get("discovered_at") else None,
+            source_trust=_source_trust(job),
+        )
+
+    def field_tokens(self) -> Mapping[str, tuple[str, ...]]:
+        return {
+            "title": tokenize_text(self.title),
+            "company": tokenize_text(self.company),
+            "location": tokenize_text(self.location),
+            "description": tokenize_text(self.description),
+            "requirements": tokenize_text(" ".join(self.requirements)),
+            "responsibilities": tokenize_text(" ".join(self.responsibilities)),
+            "skills": tokenize_text(" ".join(self.skills)),
+            "source_metadata": tokenize_text(" ".join(self.source_metadata)),
+        }
+
+    def embedding_text(self) -> str:
+        return normalize_text(
+            " ".join(
+                (
+                    self.title,
+                    self.company,
+                    self.location,
+                    self.description,
+                    " ".join(self.requirements),
+                    " ".join(self.responsibilities),
+                    " ".join(self.skills),
+                    " ".join(self.source_metadata),
+                )
+            )
+        )
+
+
+@dataclass(frozen=True)
+class RetrievedJobCandidate:
+    """Hybrid retrieval result for one job."""
+
+    job_id: str
+    rank: int
+    score: float
+    lexical_score: float
+    semantic_score: float
+    recency_score: float
+    source_trust_score: float
+    matched_terms: tuple[str, ...]
+
+
+class DisabledEmbeddingIndex:
+    """Default semantic adapter: no hosted service, lexical retrieval only."""
+
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def rank(
+        self,
+        *,
+        query_text: str,
+        document_texts: Mapping[str, str],
+        top_k: int,
+    ) -> Sequence[EmbeddingSearchResult]:
+        return ()
+
+
+class HybridSearchIndex:
+    """BM25-style lexical retrieval plus optional semantic reciprocal-rank fusion."""
+
+    _FIELD_WEIGHTS: Mapping[str, float] = {
+        "title": 4.0,
+        "skills": 3.0,
+        "requirements": 2.2,
+        "responsibilities": 1.6,
+        "description": 1.0,
+        "company": 0.8,
+        "location": 1.2,
+        "source_metadata": 0.5,
+    }
+
+    def __init__(
+        self,
+        *,
+        embedding_index: EmbeddingIndexPort | None = None,
+        lexical_weight: float = 1.0,
+        semantic_weight: float = 1.1,
+        recency_weight: float = 0.05,
+        source_trust_weight: float = 0.05,
+    ) -> None:
+        self._embedding_index = embedding_index or DisabledEmbeddingIndex()
+        self._lexical_weight = lexical_weight
+        self._semantic_weight = semantic_weight
+        self._recency_weight = recency_weight
+        self._source_trust_weight = source_trust_weight
+
+    def search(
+        self,
+        query: SearchQuery,
+        documents: Sequence[PostingDocument],
+        *,
+        top_k: int = 20,
+    ) -> list[RetrievedJobCandidate]:
+        if not documents:
+            return []
+
+        limit = len(documents) if top_k <= 0 else min(top_k, len(documents))
+        query_tokens = tokenize_text(query.text)
+        lexical_scores, matched_terms = self._lexical_scores(query_tokens, documents)
+        semantic_scores = self._semantic_scores(query, documents)
+        recency_scores = _recency_scores(documents)
+
+        if not query_tokens and not semantic_scores:
+            return [
+                RetrievedJobCandidate(
+                    job_id=doc.job_id,
+                    rank=rank,
+                    score=0.0,
+                    lexical_score=0.0,
+                    semantic_score=0.0,
+                    recency_score=recency_scores.get(doc.job_id, 0.0),
+                    source_trust_score=doc.source_trust,
+                    matched_terms=(),
+                )
+                for rank, doc in enumerate(documents[:limit], start=1)
+            ]
+
+        max_lexical = max(lexical_scores.values(), default=0.0)
+        max_semantic = max(semantic_scores.values(), default=0.0)
+
+        candidates: list[RetrievedJobCandidate] = []
+        for doc in documents:
+            lexical = lexical_scores.get(doc.job_id, 0.0)
+            semantic = semantic_scores.get(doc.job_id, 0.0)
+            score = self._lexical_weight * _normalise_component(lexical, max_lexical)
+            score += self._semantic_weight * _normalise_component(semantic, max_semantic)
+            recency = recency_scores.get(doc.job_id, 0.0)
+            score += self._recency_weight * recency
+            score += self._source_trust_weight * doc.source_trust
+            candidates.append(
+                RetrievedJobCandidate(
+                    job_id=doc.job_id,
+                    rank=0,
+                    score=score,
+                    lexical_score=lexical,
+                    semantic_score=semantic,
+                    recency_score=recency,
+                    source_trust_score=doc.source_trust,
+                    matched_terms=matched_terms.get(doc.job_id, ()),
+                )
+            )
+
+        ordered = sorted(
+            candidates,
+            key=lambda item: (
+                item.score,
+                item.lexical_score,
+                item.semantic_score,
+                item.recency_score,
+                item.source_trust_score,
+            ),
+            reverse=True,
+        )[:limit]
+        return [
+            RetrievedJobCandidate(
+                job_id=item.job_id,
+                rank=index,
+                score=item.score,
+                lexical_score=item.lexical_score,
+                semantic_score=item.semantic_score,
+                recency_score=item.recency_score,
+                source_trust_score=item.source_trust_score,
+                matched_terms=item.matched_terms,
+            )
+            for index, item in enumerate(ordered, start=1)
+        ]
+
+    def _lexical_scores(
+        self,
+        query_tokens: tuple[str, ...],
+        documents: Sequence[PostingDocument],
+    ) -> tuple[dict[str, float], dict[str, tuple[str, ...]]]:
+        if not query_tokens:
+            return {}, {}
+
+        doc_field_tokens = {doc.job_id: doc.field_tokens() for doc in documents}
+        document_frequencies: Counter[str] = Counter()
+        lengths: dict[str, int] = {}
+        for doc_id, fields in doc_field_tokens.items():
+            all_tokens: list[str] = []
+            for tokens in fields.values():
+                all_tokens.extend(tokens)
+            lengths[doc_id] = max(1, len(all_tokens))
+            document_frequencies.update(set(all_tokens))
+
+        total_docs = len(documents)
+        avg_len = sum(lengths.values()) / max(1, total_docs)
+        scores: dict[str, float] = {}
+        matches: dict[str, tuple[str, ...]] = {}
+        unique_query_terms = tuple(dict.fromkeys(query_tokens))
+
+        for doc in documents:
+            fields = doc_field_tokens[doc.job_id]
+            score = 0.0
+            matched: list[str] = []
+            for term in unique_query_terms:
+                term_score = 0.0
+                for field_name, tokens in fields.items():
+                    tf = Counter(tokens).get(term, 0)
+                    if not tf:
+                        continue
+                    field_weight = self._FIELD_WEIGHTS.get(field_name, 1.0)
+                    term_score += field_weight * tf
+                if term_score <= 0:
+                    continue
+                matched.append(term)
+                df = max(1, document_frequencies.get(term, 0))
+                idf = math.log(1 + (total_docs - df + 0.5) / (df + 0.5))
+                length_norm = 1.2 * (1 - 0.75 + 0.75 * lengths[doc.job_id] / max(avg_len, 1))
+                bm25_tf = (term_score * 2.2) / (term_score + length_norm)
+                score += idf * bm25_tf
+            if score > 0:
+                scores[doc.job_id] = score
+                matches[doc.job_id] = tuple(matched)
+
+        return scores, matches
+
+    def _semantic_scores(
+        self,
+        query: SearchQuery,
+        documents: Sequence[PostingDocument],
+    ) -> dict[str, float]:
+        if not self._embedding_index.enabled:
+            return {}
+        document_texts = {doc.job_id: doc.embedding_text() for doc in documents}
+        try:
+            results = self._embedding_index.rank(
+                query_text=normalize_text(query.text),
+                document_texts=document_texts,
+                top_k=len(documents),
+            )
+        except Exception:
+            return {}
+        return {
+            result.job_id: float(result.score)
+            for result in results
+            if result.job_id in document_texts and float(result.score) > 0
+        }
+
+
+def preselect_jobs_for_scoring(
+    jobs: Sequence[Mapping[str, Any]],
+    *,
+    profile_snapshot: ProfileSnapshot,
+    top_k: int = 0,
+    resume_text: str | None = None,
+    search_index: HybridSearchIndex | None = None,
+) -> list[Mapping[str, Any]]:
+    """Rank and optionally trim jobs before LLM scoring."""
+
+    if not jobs:
+        return []
+    documents = [PostingDocument.from_job(job) for job in jobs]
+    query = SearchQuery.from_profile_snapshot(profile_snapshot, resume_text=resume_text)
+    index = search_index or HybridSearchIndex()
+    results = index.search(query, documents, top_k=top_k or len(documents))
+    by_id = {doc.job_id: job for doc, job in zip(documents, jobs)}
+    selected = [by_id[result.job_id] for result in results if result.job_id in by_id]
+    if top_k > 0:
+        return selected[:top_k]
+    return selected
+
+
+def _normalise_component(value: float, maximum: float) -> float:
+    if value <= 0 or maximum <= 0:
+        return 0.0
+    return value / maximum
+
+
+def _source_trust(job: Mapping[str, Any]) -> float:
+    raw = normalize_text(
+        job.get("verification_confidence")
+        or job.get("source_quality")
+        or job.get("canonical_confidence")
+        or ""
+    )
+    if raw in {"verified", "high", "canonical", "trusted"}:
+        return 1.0
+    if raw in {"medium", "probable"}:
+        return 0.65
+    if raw in {"low", "unknown", "unverified"}:
+        return 0.25
+    if job.get("canonical_url") or job.get("application_url"):
+        return 0.55
+    return 0.35
+
+
+def _recency_scores(documents: Sequence[PostingDocument]) -> dict[str, float]:
+    parsed = {
+        doc.job_id: _parse_datetime(doc.discovered_at)
+        for doc in documents
+        if doc.discovered_at
+    }
+    parsed = {job_id: value for job_id, value in parsed.items() if value is not None}
+    if not parsed:
+        return {}
+    newest = max(parsed.values())
+    out: dict[str, float] = {}
+    for job_id, timestamp in parsed.items():
+        age_days = max(0.0, (newest - timestamp).total_seconds() / 86400)
+        out[job_id] = 1 / (1 + age_days / 30)
+    return out
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _collect_profile_text(parts: list[str], value: object) -> None:
+    if value is None:
+        return
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if str(key).casefold() in {
+                "email",
+                "phone",
+                "address",
+                "full_name",
+                "preferred_name",
+            }:
+                continue
+            _collect_profile_text(parts, item)
+    elif isinstance(value, str):
+        _append_text(parts, value)
+    elif isinstance(value, Iterable):
+        for item in value:
+            _collect_profile_text(parts, item)
+
+
+def _append_text(parts: list[str], value: object) -> None:
+    if isinstance(value, str) and value.strip():
+        parts.append(value.strip())
+
+
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_sequence(value: object) -> Sequence[object]:
+    return value if isinstance(value, Sequence) and not isinstance(value, str) else ()
+
+
+def _string_tuple(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Iterable):
+        return tuple(str(item) for item in value if item)
+    return (str(value),)
+
+
+__all__ = [
+    "DisabledEmbeddingIndex",
+    "HybridSearchIndex",
+    "PostingDocument",
+    "RetrievedJobCandidate",
+    "SearchQuery",
+    "normalize_text",
+    "preselect_jobs_for_scoring",
+    "tokenize_text",
+]

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -29,6 +29,10 @@ from jobhunter.database import get_connection, get_jobs_by_stage
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
+from jobhunter.domain.scoring.retrieval import (
+    HybridSearchIndex,
+    preselect_jobs_for_scoring,
+)
 from jobhunter.domain.scoring.use_cases import (
     ScoreJobOutcome,
     ScoreJobUseCase,
@@ -119,6 +123,7 @@ def run_scoring(
     tenant_id: TenantId = LOCAL_TENANT,
     profile_snapshot: ProfileSnapshot | None = None,
     resume_text: str | None = None,
+    search_index: HybridSearchIndex | None = None,
 ) -> dict:
     """Score unscored jobs that have full descriptions.
 
@@ -146,19 +151,31 @@ def run_scoring(
         publisher=publisher,
     )
 
+    source_limit = _retrieval_source_limit(limit)
     if rescore:
         # Phase 7 (S-26 round-1 review H1): bare ``full_description`` is
         # NULL on the new write path; route through ``get_jobs_by_stage``
         # which already COALESCEs over ``job_enrichments``. Use the
         # ``enriched`` selector instead of ``pending_score`` so already-
         # scored rows are included (rescore semantics).
-        jobs = get_jobs_by_stage(conn=conn, stage="enriched", limit=limit)
+        jobs = get_jobs_by_stage(conn=conn, stage="enriched", limit=source_limit)
     else:
-        jobs = get_jobs_by_stage(conn=conn, stage="pending_score", limit=limit)
+        jobs = get_jobs_by_stage(conn=conn, stage="pending_score", limit=source_limit)
 
     if not jobs:
         log.info("No unscored jobs with descriptions found.")
         return {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": []}
+
+    jobs = [
+        dict(job)
+        for job in preselect_jobs_for_scoring(
+            jobs,
+            profile_snapshot=profile_snapshot,
+            top_k=limit,
+            resume_text=resume_text,
+            search_index=search_index,
+        )
+    ]
 
     worker_count = max(1, workers)
     log.info("Scoring %d jobs with %d worker(s)...", len(jobs), worker_count)
@@ -308,6 +325,14 @@ def _score_distribution(
         counts[score.fit_score.value] = counts.get(score.fit_score.value, 0) + 1
     # Match the legacy distribution shape: highest score first.
     return sorted(counts.items(), key=lambda kv: kv[0], reverse=True)
+
+
+def _retrieval_source_limit(limit: int) -> int:
+    """Fetch a broader pool when scoring is capped, then let retrieval choose."""
+
+    if limit <= 0:
+        return 0
+    return max(limit * 5, 50)
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/fixtures/hybrid_search_topk.json
+++ b/workers/automation/tests/fixtures/hybrid_search_topk.json
@@ -1,0 +1,47 @@
+{
+  "cases": [
+    {
+      "name": "barcelona-platform-leadership",
+      "query": "Barcelona Spain platform engineering leadership Kubernetes reliability",
+      "profile": {
+        "summary": "Engineering leader with Kubernetes, SRE, platform, infrastructure, and reliability experience."
+      },
+      "expected_top_k": [
+        "job-sre-lead",
+        "job-platform-manager"
+      ],
+      "jobs": [
+        {
+          "id": "job-frontend",
+          "title": "Frontend Engineering Manager",
+          "company": "CanvasWorks",
+          "location": "Barcelona, Spain",
+          "description": "Manage React product teams building design-system surfaces."
+        },
+        {
+          "id": "job-platform-manager",
+          "title": "Senior Platform Engineering Manager",
+          "company": "Northstar",
+          "location": "Barcelona, Spain",
+          "verification_confidence": "high",
+          "description": "Engineering leadership for Kubernetes, cloud infrastructure, observability, and developer platform reliability."
+        },
+        {
+          "id": "job-sales",
+          "title": "Enterprise Sales Director",
+          "company": "RevenueGrid",
+          "location": "Madrid, Spain",
+          "description": "Own sales pipeline, account expansion, and revenue targets."
+        },
+        {
+          "id": "job-sre-lead",
+          "title": "SRE Lead",
+          "company": "HarborOps",
+          "location": "Barcelona, Spain",
+          "verification_confidence": "medium",
+          "description": "Lead reliability engineering, incident response, Kubernetes operations, and platform automation."
+        }
+      ]
+    }
+  ]
+}

--- a/workers/automation/tests/test_hybrid_search_index.py
+++ b/workers/automation/tests/test_hybrid_search_index.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from jobhunter.domain.ports.retrieval import EmbeddingSearchResult
+from jobhunter.domain.scoring.retrieval import (
+    DisabledEmbeddingIndex,
+    HybridSearchIndex,
+    PostingDocument,
+    SearchQuery,
+    normalize_text,
+    tokenize_text,
+)
+
+
+class _DisabledRaisingEmbeddingIndex:
+    @property
+    def enabled(self) -> bool:
+        return False
+
+    def rank(
+        self,
+        *,
+        query_text: str,
+        document_texts: Mapping[str, str],
+        top_k: int,
+    ) -> Sequence[EmbeddingSearchResult]:
+        raise AssertionError("disabled embedding index should not be called")
+
+
+class _ScriptedEmbeddingIndex:
+    def __init__(self, *results: EmbeddingSearchResult) -> None:
+        self._results = results
+
+    @property
+    def enabled(self) -> bool:
+        return True
+
+    def rank(
+        self,
+        *,
+        query_text: str,
+        document_texts: Mapping[str, str],
+        top_k: int,
+    ) -> Sequence[EmbeddingSearchResult]:
+        return self._results[:top_k]
+
+
+def test_lexical_normalization_and_ranking() -> None:
+    assert normalize_text("Líder de Ingeniería, KUBERNETES!") == "lider de ingenieria kubernetes"
+    assert "the" not in tokenize_text("the platform lead")
+
+    docs = [
+        PostingDocument(
+            job_id="platform",
+            title="Líder de Ingeniería de Plataforma",
+            location="Barcelona, Spain",
+            description="KUBERNETES reliability and platform teams.",
+        ),
+        PostingDocument(
+            job_id="sales",
+            title="Sales Manager",
+            location="Madrid, Spain",
+            description="Pipeline forecasting and enterprise sales.",
+        ),
+    ]
+
+    results = HybridSearchIndex(embedding_index=DisabledEmbeddingIndex()).search(
+        SearchQuery("ingenieria plataforma kubernetes barcelona"),
+        docs,
+        top_k=2,
+    )
+
+    assert [result.job_id for result in results] == ["platform", "sales"]
+    assert results[0].lexical_score > results[1].lexical_score
+    assert results[0].matched_terms == (
+        "ingenieria",
+        "plataforma",
+        "kubernetes",
+        "barcelona",
+    )
+
+
+def test_embedding_disabled_falls_back_to_lexical_ranking() -> None:
+    docs = [
+        PostingDocument(job_id="good", title="Platform Engineering Manager", description="Kubernetes SRE"),
+        PostingDocument(job_id="bad", title="Retail Operations Manager", description="Store staffing"),
+    ]
+
+    results = HybridSearchIndex(embedding_index=_DisabledRaisingEmbeddingIndex()).search(
+        SearchQuery("kubernetes platform leadership"),
+        docs,
+        top_k=2,
+    )
+
+    assert [result.job_id for result in results] == ["good", "bad"]
+    assert all(result.semantic_score == 0 for result in results)
+
+
+def test_hybrid_merge_combines_lexical_and_embedding_ranks() -> None:
+    docs = [
+        PostingDocument(
+            job_id="lexical-only",
+            title="Kubernetes Platform Architect",
+            description="Deep platform architecture role.",
+        ),
+        PostingDocument(
+            job_id="hybrid",
+            title="Platform Lead",
+            description="Engineering leadership for infrastructure teams.",
+        ),
+        PostingDocument(
+            job_id="other",
+            title="Frontend Manager",
+            description="React product delivery.",
+        ),
+    ]
+    semantic = _ScriptedEmbeddingIndex(
+        EmbeddingSearchResult("hybrid", 0.99),
+        EmbeddingSearchResult("lexical-only", 0.2),
+    )
+
+    results = HybridSearchIndex(embedding_index=semantic).search(
+        SearchQuery("kubernetes platform leadership"),
+        docs,
+        top_k=3,
+    )
+
+    assert results[0].job_id == "hybrid"
+    assert results[0].semantic_score == 0.99
+    assert results[0].lexical_score > 0
+
+
+def test_top_k_evaluation_fixture() -> None:
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "hybrid_search_topk.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    case = fixture["cases"][0]
+    docs = [PostingDocument.from_job(job) for job in case["jobs"]]
+
+    results = HybridSearchIndex().search(
+        SearchQuery(f"{case['query']} {case['profile']['summary']}"),
+        docs,
+        top_k=len(case["expected_top_k"]),
+    )
+
+    assert [result.job_id for result in results] == case["expected_top_k"]

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -87,6 +87,22 @@ def _seed_pending_job(conn: sqlite3.Connection, url: str) -> None:
     conn.commit()
 
 
+def _seed_pending_job_with_description(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    title: str,
+    description: str,
+    discovered_at: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (url, title, "Acme", description, discovered_at),
+    )
+    conn.commit()
+
+
 @pytest.fixture()
 def profile_snapshot(tmp_path):
     from jobhunter.infrastructure.events.in_process_bus import InProcessEventBus
@@ -241,3 +257,49 @@ def test_run_scoring_records_failure_state_when_llm_returns_garbage(
     ).fetchone()
     assert stage_row["state"] == "failed"
     assert "outside" in (stage_row["error_message"] or "").lower()
+
+
+def test_run_scoring_preselects_retrieval_top_k_before_llm(
+    conn: sqlite3.Connection, profile_snapshot, monkeypatch
+) -> None:
+    relevant_url = "https://example.com/job/platform"
+    stale_irrelevant_url = "https://example.com/job/retail"
+    _seed_pending_job_with_description(
+        conn,
+        url=stale_irrelevant_url,
+        title="Retail Operations Manager",
+        description="Store staffing, inventory, and sales operations.",
+        discovered_at="2026-01-02T00:00:00+00:00",
+    )
+    _seed_pending_job_with_description(
+        conn,
+        url=relevant_url,
+        title="Platform Engineering Manager",
+        description="Lead Kubernetes, SRE, infrastructure, and developer platform teams.",
+        discovered_at="2026-01-01T00:00:00+00:00",
+    )
+    repo = SqliteScoreRepository(conn)
+    llm = _ScriptedLlm(
+        {
+            "score": 9,
+            "technical_fit": 9,
+            "experience_fit": 9,
+            "role_fit": 9,
+            "keywords": ["kubernetes", "platform"],
+            "reasoning": "ok",
+        }
+    )
+
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+    summary = scorer_module.run_scoring(
+        limit=1,
+        profile_snapshot=profile_snapshot,
+        repository=repo,
+        llm_port=llm,
+        resume_text="Kubernetes platform engineering leadership.",
+    )
+
+    assert summary["scored"] == 1
+    assert summary["errors"] == 0
+    assert repo.load(LOCAL_TENANT, JobId(relevant_url)) is not None
+    assert repo.load(LOCAL_TENANT, JobId(stale_irrelevant_url)) is None


### PR DESCRIPTION
## Summary
- Adds a Scoring-owned hybrid retrieval service with lexical normalization/ranking over posting fields.
- Adds an optional EmbeddingIndexPort with a disabled default so local scoring works without hosted embeddings.
- Wires run_scoring(limit=N) to preselect top candidates before LLM scoring.
- Adds a synthetic top-k evaluation fixture plus docs/QA coverage.

## Validation
- uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_hybrid_search_index.py workers/automation/tests/test_scorer.py
- uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/ports/retrieval.py workers/automation/src/jobhunter/domain/scoring/retrieval.py workers/automation/src/jobhunter/scoring/scorer.py workers/automation/tests/test_hybrid_search_index.py workers/automation/tests/test_scorer.py
- corepack pnpm install --frozen-lockfile
- corepack pnpm check
- corepack pnpm test
- git diff --check

## Notes
- Scope is limited to indexing, retrieval, scoring preselection, and evaluation fixtures. No PR6 UI or product controls are included.