### PR TITLE
docs: update proposed plan status

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -16,31 +16,21 @@ This is the authoritative roadmap. Keep detailed historical proposals under
 
 ### Worker Reliability
 
-- Eliminate the second stage-state write path in
-  `workers/automation/src/jobhunter/infrastructure/pipeline/sqlite_repository.py:249,296`
-  that issues ad-hoc `UPDATE/INSERT INTO job_stage_states`. The canonical
-  helper `state.set_stage_state` is used by every stage runner
-  (`enrichment/detail.py:436`, `scoring/scorer.py:171`, `apply/launcher.py`,
-  RPC handlers, …) — the repository should route through it too so all
-  writes share validation and event emission.
-- Extend the `apply_runs` canonical run-record table to non-apply local
-  actions. Today only `apply` produces a row; `run_stage` and
-  `profile_import` are sync RPCs that emit `job_events` and return an
-  in-memory `LocalActionResult` (`workers/automation/src/jobhunter/actions.py:48`)
-  without persisting a run record. Without a uniform run record, the
-  dashboard cannot show running / queued / failed status for non-apply
-  work. (PR 4 in the Workflow Orchestration stack collapses this onto
-  Temporal workflow runs.)
-- Add cancellation for queued or running non-workflow local actions.
-  `apply` and other workflow-mode RPCs already cooperatively cancel via
-  `cancel_run` (PR #36), but `run_stage` / `profile_import` still run
-  synchronously inside the JSON-RPC handler and have no cancel surface,
-  and `cancel_stage`
+- Extend workflow-run records to non-apply local actions. `apply` now runs
+  through Temporal and is visible through `apply_run_projections` /
+  `/v1/workflow-runs`, but `run_stage` and `profile_import` are still sync
+  RPCs that emit `job_events` and return an in-memory `LocalActionResult`
+  (`workers/automation/src/jobhunter/actions.py:48`) without a durable
+  workflow-run record. Without a uniform run record, the dashboard cannot show
+  running / queued / failed status for non-apply work.
+- Add cancellation for queued or running non-apply local actions. `apply`
+  cooperatively cancels via `cancel_run` (PR #36), but `run_stage` /
+  `profile_import` still run synchronously inside the JSON-RPC handler and have
+  no cancel surface, and `cancel_stage`
   (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`) only
   flips the stage row to `canceled` post-hoc. Migrating these handlers to
-  workflows (PR 4 / per-job runners) gets cooperative cancel for free; a
-  shorter-term option is to add a cancel token surface for the in-process
-  sync handlers.
+  workflows gets cooperative cancel for free; a shorter-term option is to add a
+  cancel token surface for the in-process sync handlers.
 - Record `score_report` artifacts. PR 7 of the Temporal stack wired
   `state.record_job_artifact` into `apply.launcher.mark_result` so the
   per-worker agent log (`LOG_DIR/worker-{worker_id}.log`) lands in
@@ -62,55 +52,19 @@ This is the authoritative roadmap. Keep detailed historical proposals under
 
 ### Workflow Orchestration (Local Temporal)
 
-Adopt Temporal as the orchestration engine for the Python worker, run
-**locally** for now (Temporal dev server / `docker compose` profile, no
-managed service). The trigger is that several Worker Reliability items
-above are converging on a small, badly-scaled workflow engine —
-re-implementing durable retries, cancellation, and run records inside
-SQLite is more expensive than adopting Temporal and pointing it at the
-existing aggregates.
+Delivered by
+[`docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md`](plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md).
+The local Temporal foundation, activity registry, `ApplyWorkflow`, JSON-RPC
+workflow mode, `cancel_run`, `apply_runs` collapse, Workflow Runs view,
+canonical stage-state writer cleanup, apply-log artifact registration, and
+Langfuse/OpenTelemetry wiring have landed.
 
-This work subsumes three of the Worker Reliability items above:
+Remaining local reliability work is tracked in the Worker Reliability bullets
+above: non-apply `run_stage` / `profile_import` still need durable workflow-run
+records and cooperative cancellation if the UI must show or stop them like
+apply runs.
 
-- "Add cancellation for queued or running local actions" — native
-  workflow + activity cancellation. (Apply: delivered in PR #36 via
-  `cancel_run`. Non-apply RPCs follow PR 4.)
-- "Extend the `apply_runs` canonical run-record table to non-apply
-  local actions" — the Temporal workflow execution ID becomes the
-  canonical run record for every action. (PR 4.)
-- The ad-hoc `fire_and_forget` dispatch mode is deleted (PR #36): the
-  JSON-RPC server now exposes `mode="workflow"`, starts a Temporal
-  workflow, and returns `{runId, workflowId, firstExecutionRunId}` as
-  the run handle.
-
-Scope:
-
-- Add `temporalio` to `workers/automation/pyproject.toml` and a
-  `temporal` service to a local `docker compose` profile (or document
-  the `temporal server start-dev` workflow in
-  `docs/local-development.md`).
-- Each pipeline stage (discover, enrich, score, tailor, cover, pdf,
-  apply) becomes a Temporal **Activity** owned by its bounded context
-  under `workers/automation/src/jobhunter/<context>/activities.py`.
-- A `JobPipelineWorkflow` (one per `(TenantId, JobId)`) orchestrates
-  the stages, owns the retry policies that today live in
-  `state.set_stage_state` defaults, and consults the existing
-  `StageStateMachine` for transition validity.
-- `apply_runs` collapses into a workflow run; the read-side projection
-  sources from a Temporal completion sink (or workflow history query)
-  rather than the bespoke table.
-- The `JsonRpcServer` now dispatches `mode="workflow"` handlers
-  (`apply` is the first; PR 4 migrates `run_stage` /
-  `profile_import`); each starts a Temporal workflow and returns
-  `{runId, workflowId, firstExecutionRunId}`. The existing JSON-RPC
-  contract (`run_stage`, `apply`, `profile_import`, `cancel_run`, …)
-  is preserved.
-- Add a Workflow Runs view in the UI that surfaces in-progress /
-  failed / completed runs with a deep-link to the Temporal Web UI
-  (`http://127.0.0.1:8233` by default) for live debugging during the
-  local-dev phase.
-
-Out of scope (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
+Out of scope for the local stack (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
 
 - Managed Temporal Cloud,
 - distributed worker fleet (multi-machine task queues),

--- a/docs/ddd-target.md
+++ b/docs/ddd-target.md
@@ -415,8 +415,9 @@ interaction with ATS portals.
 **Boundary justification:** Apply is the most complex and most isolated context.
 It manages subprocesses (Claude Code), browser processes (Chrome), MCP servers
 (Playwright), and durable telemetry — none of which any other context touches.
-Its `ApplyRun` aggregate has its own lifecycle and persistence (the `apply_runs`
-+ `apply_run_events` tables). *Current pain point addressed:* `apply/launcher.py`
+Its `ApplyRun` aggregate has its own lifecycle and local persistence through
+`job_events` plus the `apply_run_projections` read model keyed by the Temporal
+workflow run id. *Current pain point addressed:* `apply/launcher.py`
 (1300 LOC) tangles subprocess spawning, Chrome management, telemetry, DB writes,
 dashboard updates, and business rules — hexagonal ports separate each concern.
 
@@ -1372,10 +1373,10 @@ mutating shared state:
 3. `ApplicationSubmitted` or `ApplicationFailed` — Pipeline Orchestration
    transitions the `apply` stage state. Operations updates the job list.
 
-This eliminates the current coupling where `launcher.py` directly writes to
-the `jobs` table, `apply_runs` table, `apply_run_events` table, `job_events`
-table, and `job_stage_states` table while also updating the in-memory Rich
-dashboard — all in the same function.
+This eliminates the former coupling where `launcher.py` directly wrote to
+the `jobs` table, bespoke apply-run tables, `job_events`, and
+`job_stage_states` while also updating the in-memory Rich dashboard — all in
+the same function.
 
 ### 6.8 TS API Write Operations — Domain Logic Hosting
 
@@ -1426,7 +1427,7 @@ commands go through Temporal instead of subprocess.
 | `Profile` | `ProfileRepository` | `candidate_profiles` + child `candidate_profile_*` tables | `profiles` + child profile tables (hosted) |
 | `JobScore` | `ScoreRepository` | `jobs` (scoring columns) | `job_scores` (new: jobId, version, fitScore, breakdown, keywords, scoredAt, correction) |
 | `MaterialsSet` | `MaterialsRepository` | `jobs` (tailor/cover columns) + `job_artifacts` | `job_materials` (new) + `job_artifacts` (existing, enriched) |
-| `ApplyRun` | `ApplyRunRepository` | `apply_runs` + `apply_run_events` | `apply_runs` + `apply_run_events` (existing, largely correct) |
+| `ApplyRun` | `ApplyRunRepository` / workflow-run projection | `job_events` + `apply_run_projections` | `job_events` + workflow-run projections keyed by Temporal workflow id |
 | `JobPipelineState` | `PipelineStateRepository` | `job_stage_states` | `job_stage_states` (existing, largely correct) |
 | Read-model projections | `ReadModelStore` | Computed at read time from `jobs` + `job_stage_states` | `job_list_view` (materialized/denormalized), `dashboard_stats` (materialized) |
 
@@ -1480,7 +1481,7 @@ The current wide `jobs` table is narrowed in the target:
 | `fit_score`, `score_reasoning`, `scored_at` | Scoring | `job_scores` |
 | `tailored_resume_path`, `tailored_at`, `tailor_attempts` | Materials Generation | `job_materials` + `job_artifacts` |
 | `cover_letter_path`, `cover_letter_at`, `cover_attempts` | Materials Generation | `job_materials` + `job_artifacts` |
-| `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, `agent_id`, etc. | Apply Automation | `apply_runs` (existing) |
+| `applied_at`, `apply_status`, `apply_error`, `apply_attempts`, `agent_id`, etc. | Apply Automation | `job_events` + `apply_run_projections` |
 
 The migration creates new tables, backfills them from the wide `jobs` table in
 the same change, and drops the legacy columns. Each context's extraction PR
@@ -1494,8 +1495,9 @@ migrates its data and removes the corresponding `jobs` columns in one step.
   adequate; target adds `generation` column for versioning.
 - **`job_events`** → Domain event store. Existing schema is adequate; target
   standardizes `event_type` values to match domain event names.
-- **`apply_runs` + `apply_run_events`** → `ApplyRun` aggregate. Existing schema
-  is well-designed. No structural changes needed.
+- **`job_events` + `apply_run_projections`** → `ApplyRun` lifecycle and
+  telemetry read model. The bespoke `apply_runs` / `apply_run_events` tables
+  have been retired; workflow ids are the durable run handles.
 
 ---
 
@@ -1867,8 +1869,9 @@ on the new adapter." There is no parallel old/new traffic.
 
 5. **Job Discovery** — Fifth: move the narrowed `jobs` table into Postgres.
 
-6. **Apply Automation** — Sixth: move `apply_runs` + `apply_run_events` into
-   Postgres. Browser port and agent port swap to cloud adapters.
+6. **Apply Automation** — Sixth: move `job_events` and workflow-run
+   projections for apply telemetry into Postgres. Browser port and agent port
+   swap to cloud adapters.
 
 7. **Operations** — Last: switches from SQLite read model to Postgres read
    replica once all write-side contexts are on Postgres.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -584,4 +584,4 @@ Consequences:
   `SubmitApplicationUseCase` / `ApplySaga`; persistence happens via
   `record_job_event`.
 
-Cites: `docs/plans/proposed/2026-05-07-temporal-and-worker-reliability-stack.md` PR 4.
+Cites: `docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md` PR 4.

--- a/docs/delivered.md
+++ b/docs/delivered.md
@@ -3,6 +3,20 @@
 This is the per-PR delivery archive. It records what changed and where to find
 the detailed implementation plan or QA notes.
 
+## 2026-05-07: Temporal + Worker Reliability Stack
+
+Plan: `docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md`
+
+Delivered (PRs #34-#40 plus follow-up hardening):
+
+- Local Temporal foundation, worker bootstrap, `jobhunter worker`, and doctor checks.
+- Pipeline activities, `JobPipelineWorkflow`, and `ApplyWorkflow`.
+- JSON-RPC workflow dispatch for apply plus cooperative `cancel_run`.
+- `apply_runs` / `apply_run_events` collapse into workflow-backed `apply_run_projections`.
+- Workflow Runs API, web view, Temporal Web UI deep links, and workflow-run invalidation keys.
+- Canonical stage-state writer cleanup and apply-log artifact registration.
+- OpenTelemetry / Langfuse wiring for LLM, Temporal, and JSON-RPC spans.
+
 ## 2026-05-06: Frontend TanStack Migration (8 phases)
 
 Plan: `docs/plans/implemented/2026-05-06-frontend-tanstack-migration.md`

--- a/docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md
+++ b/docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md
@@ -1,6 +1,6 @@
 # Temporal + Worker Reliability Stack
 
-> **Status:** proposed.
+> **Status:** implemented.
 > **Source:** `docs/backlog.md` → "Workflow Orchestration (Local Temporal)"
 > and the surrounding "Worker Reliability" items.
 > **Style:** rip-and-replace per `MEMORY.md` — each PR removes the legacy

--- a/docs/plans/proposed/2026-05-10-job-scoring-intelligence.md
+++ b/docs/plans/proposed/2026-05-10-job-scoring-intelligence.md
@@ -1,6 +1,6 @@
 # Job Scoring Intelligence Plan
 
-> **Status:** proposed.
+> **Status:** proposed; partially implemented.
 > **Research date:** 2026-05-10.
 > **Source:** user request to compare current JobHunter scoring against practical job-matching approaches and define the next PR stack.
 
@@ -10,7 +10,7 @@ Move JobHunter scoring from a single opaque LLM-generated fit grade into an expl
 
 ## Executive Summary
 
-Current scoring is a solid DDD foundation but an incomplete product signal. The worker now has a `JobScore` aggregate, versioned `job_scores` persistence, structured LLM output, typed dimensions, keyword evidence, and a `CorrectScoreUseCase`. The user-facing product still behaves like a legacy score: API projections expose only `fitScore` plus one `scoreReasoning` string, the web UI renders the reasoning as free text, `scoreCriteria` is saved but not consumed by the scorer, and corrections are not wired end to end.
+Current scoring is a solid DDD foundation but an incomplete product signal. The worker now has a `JobScore` aggregate, versioned `job_scores` persistence, structured LLM output, typed dimensions, keyword evidence, and a `CorrectScoreUseCase`. PR 1 exposed the already-persisted score evidence through the API, contracts, and jobs drawer (`scoreBreakdown`, `scoreKeywords`, `scoreVersion`, and `scoredAt`) and hardened blank-keyword parsing. The remaining product gaps are criteria-aware scoring, hard eligibility blockers, score corrections, a local evaluation harness, feedback personalization, and score-governance reporting.
 
 Practical job matching is not done as an opaque LLM grade. The common pattern is hybrid:
 
@@ -35,9 +35,10 @@ The recommended direction is to keep the DDD `JobScore` aggregate and still reso
   - `technical_fit`, `experience_fit`, and `role_fit`,
   - matched `keywords`,
   - short `reasoning`.
-- `ScoreParser` validates the overall score, requires the raw keyword field to be present, clamps component dimensions into 0..10, and returns typed value objects. A follow-up should harden blank-only keyword arrays so they cannot normalize to the legacy sentinel.
+- `ScoreParser` validates the overall score, requires the raw keyword field to be present, rejects missing, empty, and blank-only keyword arrays, clamps component dimensions into 0..10, and returns typed value objects.
 - `job_scores` stores versioned scores with `breakdown_json`, `keywords_json`, `scored_at`, and optional correction metadata.
 - `CorrectScoreUseCase` exists and emits `ScoreCorrected`.
+- Operations projections, shared read-model types, and the web jobs drawer expose the typed score evidence already persisted: `scoreBreakdown`, `scoreKeywords`, `scoreVersion`, and `scoredAt`.
 
 Key code:
 
@@ -47,14 +48,15 @@ Key code:
 - `workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py`
 - `workers/automation/tests/test_score_use_cases.py`
 - `workers/automation/tests/test_scorer.py`
+- `apps/api/src/read-model.ts`
+- `packages/domain-types/src/operations/index.ts`
+- `apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx`
 
 ### Gaps
 
 - `scoreCriteria` is saved in profile settings but is not passed into `ScoreJobUseCase`, the prompt, or the persisted score criteria.
 - The LLM sees mostly resume baseline text plus title, company, location, and description. It does not explicitly receive the structured profile fields that matter for fit, such as work authorization, compensation, target roles, target locations, target work models, and negative preferences.
-- The API projection path reads only `fit_score` and `breakdown_json.reasoning`; it drops typed dimensions and keywords.
-- `packages/contracts` and `packages/domain-types` define only the richer domain mirror; the read-model wire contract does not expose the richer score.
-- The web `ScoreBreakdown` component wraps free text rather than rendering typed dimensions, evidence, missing qualifications, confidence, or criteria.
+- The typed score surface is still limited to the existing three dimensions, keywords, version, and timestamp; it does not yet expose eligibility, evidence, missing qualifications, transferable signals, confidence, criteria version, or fit band.
 - `useCorrectScoreMutation` throws `NotImplementedError`; no API route or UI writes score corrections.
 - There is no offline scoring evaluation set, no ranking metrics, no calibration report, and no regression matrix for prompt or model changes.
 - There is no feedback loop using corrections, apply/save/dismiss behavior, or downstream outcomes to improve ranking.
@@ -139,27 +141,7 @@ Use the LLM as a structured extractor and reasoner, not as the sole source of tr
 - Parser rejects missing required evidence, malformed dimensions, impossible scores, or unsupported claims.
 - Observability records prompt version, model, response schema version, parse outcome, token/cost metadata, and score version.
 
-## Proposed PR Stack
-
-### PR 1 - Expose The Score Evidence Already Persisted
-
-Branch: `scoring/evidence-contract`.
-
-- Extend Operations projections to carry `scoreBreakdown`, `scoreKeywords`, `scoreVersion`, and `scoredAt` from latest `job_scores`.
-- Extend `packages/contracts` and `packages/domain-types` read-model types to expose these fields.
-- Replace web free-text parsing with typed rendering in `apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx`.
-- Keep `scoreReasoning` as compatibility output only while projections and fixtures migrate.
-- Harden `ScoreParser` so blank-only keyword arrays fail parsing instead of normalizing to the `legacy` sentinel used for backfilled rows.
-- Tests:
-  - `apps/api/test/projections.test.ts` for typed dimensions and keywords.
-  - parser regression coverage for missing, empty, and blank-only keywords.
-  - contract/type tests for the new read-model shape.
-  - React component tests and Storybook stories for populated, missing, and legacy score states.
-- QA:
-  - `pnpm api:test`
-  - `pnpm --filter @jobhunter/web test`
-  - `pnpm web:check`
-  - browser smoke on a seeded job drawer showing score dimensions and keywords.
+## Pending PR Stack
 
 ### PR 2 - Make Scoring Criteria-Aware And Constraint-Aware
 
@@ -275,3 +257,17 @@ Branch: `scoring/governance`.
 - Should score corrections feed the next score immediately as few-shot examples, or only after a minimum number of corrections prevents overfitting?
 - Should O*NET or ESCO be the first canonical skill taxonomy, or should JobHunter start with a lightweight local alias table and defer taxonomy adoption?
 - Should `scoreCriteria` stay free text, or become a weighted rubric editor after PR 2 proves the target dimensions?
+
+## Completed Work
+
+### PR 1 - Expose The Score Evidence Already Persisted
+
+Status: done. Landed via PR #48 (`scoring/evidence-contract`).
+
+- Extended Operations projections to carry `scoreBreakdown`, `scoreKeywords`, `scoreVersion`, and `scoredAt` from latest `job_scores`.
+- Extended shared read-model types to expose these fields.
+- Replaced web free-text-only score rendering with typed rendering in `apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx`.
+- Kept `scoreReasoning` as compatibility output while projections and fixtures migrated.
+- Hardened `ScoreParser` so missing, empty, and blank-only keyword arrays fail parsing instead of normalizing to the `legacy` sentinel used for backfilled rows.
+- Tests added or updated for API projections, parser keyword validation, read-model typing, React score rendering, and Storybook score states.
+- Validation at the time of the PR covered API tests, web tests, web typecheck, and a seeded jobs-drawer smoke showing dimensions and keywords.

--- a/docs/plans/proposed/2026-05-12-job-search-discovery-rfc.md
+++ b/docs/plans/proposed/2026-05-12-job-search-discovery-rfc.md
@@ -1,6 +1,6 @@
 # RFC: Ideal Job Search Discovery Setup
 
-> **Status:** proposed RFC.
+> **Status:** proposed RFC; partially implemented.
 > **Date:** 2026-05-12.
 > **Owner:** JobHunter.
 > **Scope:** job discovery, source indexing, content acquisition, deduplication,
@@ -32,6 +32,116 @@ The ideal setup has six operating principles:
    duplicate rate, full-description rate, canonical URL rate, apply URL success,
    and user feedback.
 
+## Implementation Status
+
+### Pending
+
+- Production source locator behavior is not wired. The domain/events/API queue
+  model exists, but no production component probes careers paths, backtraces
+  aggregator leads, runs search discovery, or writes
+  `SourceLocationCandidateDiscovered` candidates.
+- The canonical ATS adapter write path is incomplete. Greenhouse, Lever, and
+  Ashby adapters exist, but production registry generation and scheduling still
+  center on Smart Extract, Workday, and JobSpy, and the pipeline still calls the
+  legacy scraper lanes directly.
+- `PostingSnapshotSet` and snapshot value objects are modeled, but recurring
+  snapshot persistence and production enrichment wiring are still pending.
+- Manual capture, quarantine, and locator review have API/UI surfaces, but
+  production workers do not yet populate those queues, and imported manual
+  captures do not yet run the full extraction, dedupe, active-verification,
+  scoring, and provenance pipeline.
+- The source-quality and product-control surfaces need production feeding from
+  the full locator, canonical adapter, snapshot, and manual-capture pipeline
+  before the RFC can be considered complete.
+
+### In Flight
+
+- PR #57 (`feat(discovery): expand manual capture controls`) expands the
+  manual-capture UI path from copied URLs to copied URL, current-page URL,
+  saved HTML, pasted text, and email import modes. Once merged, it reduces the
+  product-control/UI part of the manual-capture gap. It does not close the
+  remaining production gaps around worker-created `manual_action_required`
+  queue rows, full extraction/dedupe/active-verification/scoring handoff, or
+  source-quality feeding.
+
+### Done Or Partially Delivered
+
+- Source registry and config compatibility landed: `boards` is the stable
+  public key, legacy `sites` remains compatible, and packaged Smart Extract,
+  Workday, and JobSpy sources are generated as registry entries.
+- Source policy, source registry, locator candidate, source-quality, and
+  manual-action data models exist in the Python and TypeScript domain layers.
+- Discovery/domain event types for locator candidates, registry changes,
+  discovery runs, canonical identity, duplicate links, snapshots, and feedback
+  are represented with frontend invalidation coverage.
+- Canonical identity, source observations, duplicate-link handling, and URL
+  compatibility lookup exist in the Discovery repository/use-case layer.
+- Workday, Greenhouse, Lever, and Ashby adapter classes exist with test
+  coverage for canonical URL/source-native identity parsing.
+- Source-quality reducers, scheduler decisions, hybrid retrieval preselection,
+  and local product controls have landed as substantial slices.
+
+## Remaining Completion Plan
+
+The remaining RFC work should land as small, reviewable PRs. PR D should be the
+acceptance gate before moving this RFC to `implemented`; PR A should introduce
+the first acceptance-report fixture so A-C cannot each pass locally while still
+missing the RFC outcome.
+
+### PR A: Production Queue Seeding And Deterministic Locator
+
+- Add Python-side schema/repositories, or shared repository adapters, for
+  `source_locator_candidates`, `manual_capture_queue`, quarantine entries, and
+  source-control tables that workers need to write.
+- Hook discovery workers so blocked Smart Extract paths enqueue
+  `manual_action_required` items with reason, original URL, source id, retry
+  context, and provenance.
+- Add a deterministic source locator pass that emits
+  `SourceLocationCandidateDiscovered` from configured seeds and broad-board or
+  aggregator observations.
+- Seed the first Barcelona/Spain tech-leadership acceptance-report fixture with
+  expected fields and source-quality metrics, even if the first PR only
+  populates the queue/locator subset.
+- Acceptance: existing API/UI queues show worker-generated rows, not only test
+  or manually inserted rows.
+
+### PR B: Canonical ATS Scheduling
+
+- Generate and run Greenhouse, Lever, and Ashby registry entries through the
+  scheduler.
+- Route those adapters through the Discovery use case so canonical identity,
+  source observations, duplicate-link decisions, and events use the domain
+  boundary instead of legacy direct scraper writes.
+- Keep Workday semantics intact while adding these canonical ATS lanes.
+- Acceptance: scheduled ATS runs can create or update canonical job records via
+  the Discovery use case, and low-confidence matches are quarantined rather
+  than merged.
+
+### PR C: Snapshot And Manual-Capture Production Pipeline
+
+- Wire `PostingSnapshotSet` persistence into enrichment refreshes for recurring
+  detail/content captures and active-state changes.
+- Make manual-capture imports run the normal pipeline: extraction, dedupe,
+  active verification, scoring handoff, and provenance labeling as
+  `source_kind=user_mediated_capture`.
+- Preserve the bounded-context split: Discovery confirms identity/dedupe,
+  Enrichment owns snapshots and active state, and Scoring is a downstream
+  handoff rather than embedded in manual capture.
+- Acceptance: a manual capture can create or update a canonical job with
+  provenance, snapshot history, active-state evidence, and scoring eligibility.
+
+### PR D: RFC Acceptance Evidence
+
+- Complete the Barcelona/Spain tech-leadership acceptance fixture/report started
+  in PR A.
+- Report lead yield, candidate sources, manual-action count, canonical
+  verification rate, duplicate/quarantine counts, source-quality updates, and
+  scoring handoff count.
+- Update this RFC to `implemented` only when A-C evidence passes against the
+  fixture/report.
+- Acceptance: the report proves source-quality feeding and end-to-end
+  RFC-relevant behavior, not only isolated unit behavior.
+
 ## Current State
 
 JobHunter currently has three discovery lanes:
@@ -55,16 +165,21 @@ directly to storage.
 
 Important gaps:
 
-- `searches.example.yaml` uses `boards`, but `jobspy.run_discovery()` reads
-  `sites`; source selection is therefore not yet a clean product contract.
-- Source health is implicit in logs rather than stored as queryable data.
-- Discovery stores a posting, but canonical verification and full content
-  acquisition are split across later enrichment paths without a versioned
-  content snapshot lifecycle.
-- Smart Extract has useful reach, but arbitrary web extraction should be
-  source-health gated and policy-labeled so it does not pollute the job set.
+- The `boards` / legacy `sites` configuration contract has landed, but
+  production discovery still enters through the existing JobSpy, Workday, and
+  Smart Extract lanes rather than a unified source-registry scheduler for every
+  source kind.
+- Source health is now represented in projections and scheduler inputs, but it
+  is not yet fed by the full locator, canonical adapter, snapshot, and manual
+  capture pipeline.
+- Discovery has canonical identity/source-observation storage, but canonical
+  verification and full content acquisition are still split across later
+  enrichment paths without production `PostingSnapshotSet` persistence.
+- Smart Extract has useful reach and policy metadata, but arbitrary web
+  extraction still needs production source-health gating, quarantine feeding,
+  and policy-labeled repeat crawling.
 - Broad boards can produce stale, duplicated, incomplete, or redirected jobs;
-  they need downstream canonicalization instead of direct trust.
+  they still need production downstream canonicalization before direct trust.
 
 ## Goals
 
@@ -150,7 +265,7 @@ Expected behavior:
 The locator runs before a promoted source has a `SourcePolicy`, so it needs its
 own conservative policy envelope:
 
-- Use a declared regular browser user agent. 
+- Use a declared regular browser user agent.
 - Enforce a locator-level per-domain budget independent of
   `SourcePolicy.max_pages_per_run`. The default should be a small number of
   HEAD/GET requests per domain per run with backoff on 429, 403.
@@ -159,7 +274,6 @@ own conservative policy envelope:
   employer-domain match is present. Otherwise, store a candidate for manual
   confirmation.
 
-  
 ## Source Hierarchy
 
 ### Tier 1: Canonical ATS And Employer APIs
@@ -315,9 +429,9 @@ Not allowed:
 
 Blocked sources should not become dead ends. When a lead looks useful but the
 autonomous path hits CAPTCHA, login, paywall, bot-detection,
-rate-limit, or another access boundary, JobHunter should first try to circumvent 
-the blockage, and, if not, ccreate a`manual_action_required` item instead of silently 
-discarding the lead.
+rate-limit, or another access boundary, JobHunter should not try to circumvent
+the blockage. It should create a `manual_action_required` item instead of
+silently discarding the lead.
 
 The manual path:
 
@@ -845,6 +959,10 @@ Rollback rules:
   artifacts.
 
 ## Proposed PR Stack
+
+The stack below is partially implemented. The implementation status section
+above is the authoritative current state: pending work stays first, and landed
+or partial slices are summarized after it.
 
 ### PR 1: Source Locator, Registry, And Config Contract
 


### PR DESCRIPTION
## Summary
- Move the completed Temporal + Worker Reliability plan into implemented and update delivered/backlog/DDD references to match the landed workflow-run model.
- Mark the job-search-discovery RFC and scoring intelligence plan as partially implemented, with pending work first and completed slices below.
- Add the remaining A-D completion plan for the job-search-discovery RFC and account for draft PR #57's manual-capture UI work as in-flight, not complete.

## Why
The proposed-plan archive was stale after the discovery and Temporal stacks landed in several slices. PR #57 also changes the discovery RFC status slightly by reducing the manual-capture UI gap, while leaving production queue seeding, the full manual-capture pipeline, and acceptance evidence pending.

## Validation
- `git diff --cached --check`
- `rg -n '[ \\t]+$' docs/backlog.md docs/ddd-target.md docs/decisions.md docs/delivered.md docs/plans/implemented/2026-05-07-temporal-and-worker-reliability-stack.md docs/plans/proposed/2026-05-10-job-scoring-intelligence.md docs/plans/proposed/2026-05-12-job-search-discovery-rfc.md` -> no matches
- `git diff --check HEAD~1 HEAD`