### PR TITLE
feat: advance jobhunter backlog item add react

### DIFF
--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { ProfileSchema, type ProfileUpdateRequest } from "@jobhunter/contracts";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -8,6 +9,83 @@ import { renderWithProviders } from "../../../test/render.js";
 import { ProfileForm } from "./profile-form.js";
 
 describe("<ProfileForm>", () => {
+  it("saves edited persisted profile fields and resets to the saved response", async () => {
+    const user = userEvent.setup();
+    const editedFullName = "Jordan Saved";
+    const initialProfile = ProfileSchema.parse(sampleProfileResponse.profile);
+    const savedProfile = {
+      ...sampleProfileResponse,
+      profile: {
+        ...initialProfile,
+        personal: {
+          ...initialProfile.personal,
+          full_name: editedFullName,
+        },
+      },
+    };
+    const updateProfile = vi.fn(async (_body: ProfileUpdateRequest) => savedProfile);
+
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      ports: buildTestPorts({ api: { updateProfile } }),
+      withRouter: true,
+    });
+
+    const fullName = await screen.findByLabelText("Full name");
+    const saveButton = screen.getByRole("button", { name: /^save all$/i });
+    const discardButton = screen.getByRole("button", { name: /^discard all$/i });
+
+    expect(saveButton).toBeDisabled();
+    expect(discardButton).toBeDisabled();
+
+    await user.clear(fullName);
+    await user.type(fullName, editedFullName);
+
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    expect(discardButton).toBeEnabled();
+
+    await user.click(saveButton);
+
+    expect(await screen.findByText("profile saved")).toBeInTheDocument();
+    expect(updateProfile).toHaveBeenCalledTimes(1);
+    const submitted = updateProfile.mock.calls[0]?.[0];
+    if (!submitted?.profileText) {
+      throw new Error("Expected profileText to be submitted");
+    }
+    const submittedProfile = ProfileSchema.parse(JSON.parse(submitted.profileText));
+    expect(submittedProfile.personal.full_name).toBe(editedFullName);
+    expect(fullName).toHaveValue(editedFullName);
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(discardButton).toBeDisabled();
+  });
+
+  it("discards edited persisted profile fields without saving", async () => {
+    const user = userEvent.setup();
+    const initialProfile = ProfileSchema.parse(sampleProfileResponse.profile);
+    const updateProfile = vi.fn(async (_body: ProfileUpdateRequest) => sampleProfileResponse);
+
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
+      ports: buildTestPorts({ api: { updateProfile } }),
+      withRouter: true,
+    });
+
+    const fullName = await screen.findByLabelText("Full name");
+    const saveButton = screen.getByRole("button", { name: /^save all$/i });
+    const discardButton = screen.getByRole("button", { name: /^discard all$/i });
+
+    await user.clear(fullName);
+    await user.type(fullName, "Jordan Unsaved");
+
+    await waitFor(() => expect(discardButton).toBeEnabled());
+    expect(saveButton).toBeEnabled();
+
+    await user.click(discardButton);
+
+    expect(fullName).toHaveValue(initialProfile.personal.full_name);
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(discardButton).toBeDisabled();
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
   it("keeps preference controls out of the profile section", async () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} />, {
       withRouter: true,

--- a/apps/web/src/contexts/profile/forms/profile-form.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.tsx
@@ -1,7 +1,7 @@
 import { ProfileSchema, type ProfileShape, type ProfileUpdateRequest } from "@jobhunter/contracts";
 import { useForm } from "@tanstack/react-form";
 import { Link } from "@tanstack/react-router";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { ProfileConfigResponse } from "../../operations/types.js";
 import { Empty } from "../../../shared/ui/empty.js";
@@ -86,10 +86,12 @@ function toUpdateRequest(values: ProfileFormValues): ProfileUpdateRequest {
 export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) {
   const updateProfile = useUpdateProfileMutation();
   const [statusMessage, setStatusMessage] = useState("");
+  const [persistedValues, setPersistedValues] = useState(() => toProfileFormValues(initial));
+  const previousInitial = useRef(initial);
   const isProfileSection = section === "profile";
 
   const form = useForm({
-    defaultValues: toProfileFormValues(initial),
+    defaultValues: persistedValues,
     validators: {
       onBlur: ({ value }) => validateProfileForm(value),
       onSubmit: ({ value }) => validateProfileForm(value),
@@ -97,13 +99,21 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
     onSubmit: async ({ value, formApi }) => {
       setStatusMessage("");
       const response = await updateProfile.mutateAsync(toUpdateRequest(value));
-      formApi.reset(toProfileFormValues(response));
+      const nextValues = toProfileFormValues(response);
+      setPersistedValues(nextValues);
+      formApi.reset(nextValues);
       setStatusMessage(isProfileSection ? "profile saved" : "preferences saved");
     },
   });
 
   useEffect(() => {
-    form.reset(toProfileFormValues(initial));
+    if (previousInitial.current === initial) {
+      return;
+    }
+    previousInitial.current = initial;
+    const nextValues = toProfileFormValues(initial);
+    setPersistedValues(nextValues);
+    form.reset(nextValues);
   }, [form, initial]);
 
   return (
@@ -115,7 +125,7 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
       }}
       onReset={(event) => {
         event.preventDefault();
-        form.reset(toProfileFormValues(initial));
+        form.reset(persistedValues);
         setStatusMessage("");
       }}
     >

--- a/apps/web/src/contexts/profile/forms/settings-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/settings-form.test.tsx
@@ -1,0 +1,76 @@
+import type { SettingsUpdateRequest } from "@jobhunter/contracts";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { sampleSettingsResponse } from "../../../test/fixtures/projections.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { SettingsForm } from "./settings-form.js";
+
+describe("<SettingsForm>", () => {
+  it("saves edited persisted settings fields and resets to the saved response", async () => {
+    const user = userEvent.setup();
+    const editedTargetRole = "Director of Platform";
+    const savedSettings = {
+      ...sampleSettingsResponse,
+      settings: {
+        ...sampleSettingsResponse.settings,
+        targetRole: editedTargetRole,
+      },
+    };
+    const updateSettings = vi.fn(async (_body: SettingsUpdateRequest) => savedSettings);
+
+    renderWithProviders(<SettingsForm initial={sampleSettingsResponse.settings} />, {
+      ports: buildTestPorts({ api: { updateSettings } }),
+    });
+
+    const targetRole = await screen.findByLabelText("Target role");
+    const saveButton = screen.getByRole("button", { name: /^save$/i });
+    const resetButton = screen.getByRole("button", { name: /^reset$/i });
+
+    expect(saveButton).toBeDisabled();
+    expect(resetButton).toBeDisabled();
+
+    await user.clear(targetRole);
+    await user.type(targetRole, editedTargetRole);
+
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    expect(resetButton).toBeEnabled();
+
+    await user.click(saveButton);
+
+    expect(await screen.findByText("settings saved")).toBeInTheDocument();
+    expect(updateSettings).toHaveBeenCalledTimes(1);
+    expect(updateSettings.mock.calls[0]?.[0].targetRole).toBe(editedTargetRole);
+    expect(targetRole).toHaveValue(editedTargetRole);
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(resetButton).toBeDisabled();
+  });
+
+  it("resets edited persisted settings fields without saving", async () => {
+    const user = userEvent.setup();
+    const updateSettings = vi.fn(async (_body: SettingsUpdateRequest) => sampleSettingsResponse);
+
+    renderWithProviders(<SettingsForm initial={sampleSettingsResponse.settings} />, {
+      ports: buildTestPorts({ api: { updateSettings } }),
+    });
+
+    const targetRole = await screen.findByLabelText("Target role");
+    const saveButton = screen.getByRole("button", { name: /^save$/i });
+    const resetButton = screen.getByRole("button", { name: /^reset$/i });
+
+    await user.clear(targetRole);
+    await user.type(targetRole, "Unsaved Role");
+
+    await waitFor(() => expect(resetButton).toBeEnabled());
+    expect(saveButton).toBeEnabled();
+
+    await user.click(resetButton);
+
+    expect(targetRole).toHaveValue(sampleSettingsResponse.settings.targetRole);
+    await waitFor(() => expect(saveButton).toBeDisabled());
+    expect(resetButton).toBeDisabled();
+    expect(updateSettings).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/contexts/profile/forms/settings-form.tsx
+++ b/apps/web/src/contexts/profile/forms/settings-form.tsx
@@ -3,7 +3,7 @@ import {
   type SettingsUpdateRequest,
 } from "@jobhunter/contracts";
 import { useForm } from "@tanstack/react-form";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { DashboardSettings } from "../../operations/types.js";
 import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
@@ -27,9 +27,11 @@ function toFormValues(values: DashboardSettings): SettingsUpdateRequest {
 export function SettingsForm({ initial }: SettingsFormProps) {
   const updateSettings = useUpdateSettingsMutation();
   const [statusMessage, setStatusMessage] = useState("");
+  const [persistedValues, setPersistedValues] = useState(() => toFormValues(initial));
+  const previousInitial = useRef(initial);
 
   const form = useForm({
-    defaultValues: toFormValues(initial),
+    defaultValues: persistedValues,
     validators: {
       onSubmit: ({ value }) => {
         const result = SettingsUpdateRequestSchema.safeParse(value);
@@ -39,13 +41,21 @@ export function SettingsForm({ initial }: SettingsFormProps) {
     onSubmit: async ({ value, formApi }) => {
       setStatusMessage("");
       const response = await updateSettings.mutateAsync(value);
-      formApi.reset(toFormValues(response.settings));
+      const nextValues = toFormValues(response.settings);
+      setPersistedValues(nextValues);
+      formApi.reset(nextValues);
       setStatusMessage("settings saved");
     },
   });
 
   useEffect(() => {
-    form.reset(toFormValues(initial));
+    if (previousInitial.current === initial) {
+      return;
+    }
+    previousInitial.current = initial;
+    const nextValues = toFormValues(initial);
+    setPersistedValues(nextValues);
+    form.reset(nextValues);
   }, [form, initial]);
 
   return (
@@ -58,7 +68,7 @@ export function SettingsForm({ initial }: SettingsFormProps) {
       }}
       onReset={(event) => {
         event.preventDefault();
-        form.reset(toFormValues(initial));
+        form.reset(persistedValues);
         setStatusMessage("");
       }}
     >

--- a/docs/plans/proposed/2026-05-17-jobhunter-backlog-item-add-react.md
+++ b/docs/plans/proposed/2026-05-17-jobhunter-backlog-item-add-react.md
@@ -1,0 +1,85 @@
+# Add React Component Tests For Profile Save And Discard
+
+## Goal
+
+Add focused React component coverage for persisted profile form save/discard behavior from the UI Quality backlog item:
+
+- `ProfileForm` should prove that editing a persisted profile field enables the actions, saving sends the updated profile payload through `useUpdateProfileMutation`, resets the dirty state to the persisted response, and shows the saved status.
+- `ProfileForm` should prove that discarding after an edit restores the originally provided persisted value, disables the actions again, and does not call the update API.
+- `SettingsForm` should prove the same save/reset interaction for persisted settings fields through `useUpdateSettingsMutation`.
+
+The scope stays inside `apps/web/src/contexts/profile/forms/`. This is a test-only change; it must not redesign the profile UI or change production form behavior unless a test exposes a real defect that blocks the backlog item.
+
+## Current Evidence
+
+- `docs/backlog.md` says the gap is specifically that profile form folders have axe-only coverage for this behavior and mutation hooks are tested in isolation, but no test drives save/reset interactions through the rendered forms.
+- `apps/web/src/contexts/profile/forms/profile-form.test.tsx` already contains component tests for visible profile and preference editor behavior, so adding interaction cases there is the lowest-friction path for `ProfileForm`.
+- `apps/web/src/contexts/profile/forms/settings-form.tsx` has no colocated component test yet, only a11y coverage, so the settings interaction coverage should be added as `settings-form.test.tsx`.
+- Existing test helpers already support this without new infrastructure:
+  - `renderWithProviders`
+  - `buildTestPorts({ api: { updateProfile, updateSettings } })`
+  - `sampleProfileResponse`
+  - `sampleSettingsResponse`
+
+## Proposed Implementation
+
+1. Extend `profile-form.test.tsx` with two component tests.
+   - Save path:
+     - Render `<ProfileForm initial={sampleProfileResponse} />` with a fake `updateProfile`.
+     - Edit a visible persisted field such as `Full name`.
+     - Assert `save all` and `discard all` become enabled.
+     - Click `save all`.
+     - Assert the fake API receives a request whose serialized `profileText` contains the edited `personal.full_name`.
+     - Return a response with the edited full name and assert `profile saved` appears and the action buttons return to disabled.
+   - Discard path:
+     - Render with a fake `updateProfile`.
+     - Edit the same visible persisted field.
+     - Click `discard all`.
+     - Assert the field value returns to `sampleProfileResponse.profile.personal.full_name`, buttons are disabled, and `updateProfile` was not called.
+
+2. Add `settings-form.test.tsx` beside `settings-form.tsx`.
+   - Save path:
+     - Render `<SettingsForm initial={sampleSettingsResponse.settings} />` with a fake `updateSettings`.
+     - Edit a persisted field such as `Target role`.
+     - Assert `save` and `reset` become enabled.
+     - Click `save`.
+     - Assert `updateSettings` receives the edited `targetRole`.
+     - Return a `SettingsResponse` containing the edited role, then assert `settings saved` appears and actions are disabled.
+   - Reset path:
+     - Render with a fake `updateSettings`.
+     - Edit `Target role`.
+     - Click `reset`.
+     - Assert the field returns to `sampleSettingsResponse.settings.targetRole`, actions are disabled, and `updateSettings` was not called.
+
+3. Keep assertions user-facing where possible.
+   - Prefer labels and button names over implementation selectors.
+   - Only inspect serialized payloads at the API boundary where the form intentionally submits `profileText`, `styleText`, and `templateText`.
+
+## Rejected Alternatives
+
+- Do not add broad E2E coverage for this backlog item. The defect surface is local form state plus mutation wiring, and component tests can isolate it without requiring the API server or browser workflow.
+- Do not add tests to the mutation hook specs for this gap. Those already cover hook-level success/rollback behavior and cannot prove the rendered form save/reset controls work together.
+- Do not introduce new MSW handlers or global test providers. Existing port injection gives precise API assertions with less setup.
+- Do not redesign the profile editor controls or change form labels as part of this work. That would broaden a test backlog item into UI behavior work.
+
+## Verification
+
+Run the narrow web component tests first:
+
+```sh
+pnpm --filter @jobhunter/web test -- profile-form.test.tsx settings-form.test.tsx
+```
+
+If the narrow command passes, run the profile context web test surface if time allows:
+
+```sh
+pnpm --filter @jobhunter/web test -- src/contexts/profile
+```
+
+No README or architecture documentation updates are expected because this is a test-only backlog item with no product behavior, API, command, or architecture change.
+
+## Risks And Notes
+
+- The `ProfileForm` test depends on stable accessible labels from `StructuredProfileEditor`. If labels differ from the expected field names, use the current accessible label rather than adding test IDs.
+- The save tests should wait for status messages or disabled button state to avoid racing TanStack Form's async submit state.
+- TODO: If implementation reveals that reset leaves fields dirty after `form.reset(...)`, fix the production form behavior in the same small scope and keep the new component test as the regression guard.


### PR DESCRIPTION
**Final:** reviewer_accepted

## Summary
- Goal: Implement JobHunter backlog item: add React component tests for persisted profile field save/discard behavior.
- Implementer: `gpt-5.5`
- Reviewer: `claude-opus-4-7`
- Design doc: `docs/plans/proposed/2026-05-17-jobhunter-backlog-item-add-react.md`

_Round summaries and findings are posted as PR comments below; inline findings are on the touched lines._