### PR TITLE
fix: respect regional remote job filters

### DIFF
--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -14,17 +14,23 @@ from datetime import datetime, timezone
 
 from jobhunter import config
 from jobhunter.database import get_connection, init_db
+
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobhunter.infrastructure.network`` so the Enrichment context's
 # Playwright fetcher can import it without depending on this Discovery
 # module. Imported here for the local call sites in ``_run_one_search``
 # / ``_full_crawl``.
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
 from jobhunter.infrastructure.network.proxy import parse_proxy
 
 log = logging.getLogger(__name__)
 
 
 # -- Retry wrapper -----------------------------------------------------------
+
 
 def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
     """Call scrape_jobs with retry on transient failures."""
@@ -53,46 +59,26 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
 
 # -- Location filtering ------------------------------------------------------
 
+
 def _load_location_config(search_cfg: dict) -> tuple[list[str], list[str]]:
     """Extract accept/reject location lists from search config.
 
     Falls back to sensible defaults if not defined in the YAML.
     """
-    accept = search_cfg.get("location_accept", [])
-    reject = search_cfg.get("location_reject_non_remote", [])
-    return accept, reject
+    return configured_location_filters(search_cfg)
 
 
 def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> bool:
     """Check if a job location passes the user's location filter.
 
-    Remote jobs are always accepted. Non-remote jobs must match an accept
-    pattern and not match a reject pattern.
+    Remote jobs are accepted only after explicit reject geography is checked.
+    Non-remote jobs must match an accept pattern and not match a reject pattern.
     """
-    if not location:
-        return True  # unknown location -- keep it, let scorer decide
-
-    loc = location.lower()
-
-    # Remote jobs always OK
-    if any(r in loc for r in ("remote", "anywhere", "work from home", "wfh", "distributed")):
-        return True
-
-    # Reject non-remote matches
-    for r in reject:
-        if r.lower() in loc:
-            return False
-
-    # Accept matches
-    for a in accept:
-        if a.lower() in loc:
-            return True
-
-    # No match -- reject unknown
-    return False
+    return location_matches_target(location, accept=accept, reject=reject)
 
 
 # -- DB storage (JobSpy DataFrame -> SQLite) ---------------------------------
+
 
 def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit: int = 0) -> tuple[int, int]:
     """Store JobSpy DataFrame results into the DB. Returns (new, existing)."""
@@ -149,8 +135,19 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
                 "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at, "
                 "full_description, application_url, detail_scraped_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (url, title, salary, description, location_str, site_label, strategy, now,
-                 full_description, apply_url, detail_scraped_at),
+                (
+                    url,
+                    title,
+                    salary,
+                    description,
+                    location_str,
+                    site_label,
+                    strategy,
+                    now,
+                    full_description,
+                    apply_url,
+                    detail_scraped_at,
+                ),
             )
             new += 1
         except sqlite3.IntegrityError:
@@ -161,6 +158,7 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
 
 
 # -- Single search execution -------------------------------------------------
+
 
 def _run_one_search(
     search: dict,
@@ -177,7 +175,7 @@ def _run_one_search(
 ) -> dict:
     """Run a single search query and store results in DB."""
     s = search
-    label = f"\"{s['query']}\" in {s['location']} {'(remote)' if s.get('remote') else ''}"
+    label = f'"{s["query"]}" in {s["location"]} {"(remote)" if s.get("remote") else ""}'
     if "tier" in s:
         label += f" [tier {s['tier']}]"
 
@@ -239,6 +237,7 @@ def _run_one_search(
 
     import pandas as pd
     import warnings
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", FutureWarning)
         df = pd.concat(all_dfs, ignore_index=True) if len(all_dfs) > 1 else all_dfs[0]
@@ -249,10 +248,16 @@ def _run_one_search(
 
     # Filter by location before storing
     before = len(df)
-    df = df[df.apply(lambda row: _location_ok(
-        str(row.get("location", "")) if str(row.get("location", "")) != "nan" else None,
-        accept_locs, reject_locs,
-    ), axis=1)]
+    df = df[
+        df.apply(
+            lambda row: _location_ok(
+                str(row.get("location", "")) if str(row.get("location", "")) != "nan" else None,
+                accept_locs,
+                reject_locs,
+            ),
+            axis=1,
+        )
+    ]
     filtered = before - len(df)
 
     conn = get_connection()
@@ -267,6 +272,7 @@ def _run_one_search(
 
 
 # -- Single query search -----------------------------------------------------
+
 
 def search_jobs(
     query: str,
@@ -284,7 +290,7 @@ def search_jobs(
 
     proxy_config = parse_proxy(proxy) if proxy else None
 
-    log.info("Search: \"%s\" in %s | sites=%s | remote=%s", query, location, sites, remote_only)
+    log.info('Search: "%s" in %s | sites=%s | remote=%s', query, location, sites, remote_only)
 
     kwargs = {
         "site_name": sites,
@@ -336,6 +342,7 @@ def search_jobs(
 
 # -- Full crawl (all queries x all locations) --------------------------------
 
+
 def _full_crawl(
     search_cfg: dict,
     tiers: list[int] | None = None,
@@ -369,18 +376,19 @@ def _full_crawl(
     searches = []
     for q in queries:
         for loc in locs:
-            searches.append({
-                "query": q["query"],
-                "location": loc["location"],
-                "remote": loc.get("remote", False),
-                "tier": q.get("tier", 0),
-            })
+            searches.append(
+                {
+                    "query": q["query"],
+                    "location": loc["location"],
+                    "remote": loc.get("remote", False),
+                    "tier": q.get("tier", 0),
+                }
+            )
 
     proxy_config = parse_proxy(proxy) if proxy else None
 
     log.info("Full crawl: %d search combinations", len(searches))
-    log.info("Sites: %s | Results/site: %d | Hours old: %d",
-             ", ".join(sites), results_per_site, hours_old)
+    log.info("Sites: %s | Results/site: %d | Hours old: %d", ", ".join(sites), results_per_site, hours_old)
 
     # Ensure DB schema is ready
     init_db()
@@ -395,9 +403,16 @@ def _full_crawl(
         if limit > 0 and remaining <= 0:
             break
         result = _run_one_search(
-            s, sites, min(results_per_site, remaining) if limit > 0 else results_per_site, hours_old,
-            proxy_config, defaults, max_retries,
-            accept_locs, reject_locs, glassdoor_map,
+            s,
+            sites,
+            min(results_per_site, remaining) if limit > 0 else results_per_site,
+            hours_old,
+            proxy_config,
+            defaults,
+            max_retries,
+            accept_locs,
+            reject_locs,
+            glassdoor_map,
             limit=remaining if limit > 0 else 0,
         )
         completed += 1
@@ -406,15 +421,26 @@ def _full_crawl(
         total_errors += result["errors"]
 
         if completed % 5 == 0 or completed == len(searches):
-            log.info("Progress: %d/%d queries done (%d new, %d dupes, %d errors)",
-                     completed, len(searches), total_new, total_existing, total_errors)
+            log.info(
+                "Progress: %d/%d queries done (%d new, %d dupes, %d errors)",
+                completed,
+                len(searches),
+                total_new,
+                total_existing,
+                total_errors,
+            )
 
     # Final stats
     conn = get_connection()
     db_total = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
 
-    log.info("Full crawl complete: %d new | %d dupes | %d errors | %d total in DB",
-             total_new, total_existing, total_errors, db_total)
+    log.info(
+        "Full crawl complete: %d new | %d dupes | %d errors | %d total in DB",
+        total_new,
+        total_existing,
+        total_errors,
+        db_total,
+    )
 
     return {
         "new": total_new,
@@ -426,6 +452,7 @@ def _full_crawl(
 
 
 # -- Public entry point ------------------------------------------------------
+
 
 def run_discovery(cfg: dict | None = None, limit: int = 0) -> dict:
     """Main entry point for JobSpy-based job discovery.

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -29,6 +29,10 @@ from playwright.sync_api import sync_playwright
 from jobhunter import config
 from jobhunter.config import CONFIG_DIR
 from jobhunter.database import init_db, get_stats
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
 from jobhunter.llm import get_client
 
 log = logging.getLogger(__name__)
@@ -46,32 +50,21 @@ UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
 
 # -- Location filtering -------------------------------------------------------
 
+
 def _load_location_filter(search_cfg: dict | None = None):
     """Load location accept/reject lists from search config."""
     if search_cfg is None:
         search_cfg = config.load_search_config()
-    accept = search_cfg.get("location_accept", [])
-    reject = search_cfg.get("location_reject_non_remote", [])
-    return accept, reject
+    return configured_location_filters(search_cfg)
 
 
 def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> bool:
     """Check if a job location passes the user's location filter."""
-    if not location:
-        return True
-    loc = location.lower()
-    if any(r in loc for r in ("remote", "anywhere", "work from home", "wfh", "distributed")):
-        return True
-    for r in reject:
-        if r.lower() in loc:
-            return False
-    for a in accept:
-        if a.lower() in loc:
-            return True
-    return False
+    return location_matches_target(location, accept=accept, reject=reject)
 
 
 # -- Site configuration from YAML --------------------------------------------
+
 
 def load_sites() -> list[dict]:
     """Load scraping target sites from config/sites.yaml."""
@@ -111,8 +104,16 @@ def _store_jobs_filtered(
             conn.execute(
                 "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (url, job.get("title"), job.get("salary"), job.get("description"),
-                 job.get("location"), site, strategy, now),
+                (
+                    url,
+                    job.get("title"),
+                    job.get("salary"),
+                    job.get("description"),
+                    job.get("location"),
+                    site,
+                    strategy,
+                    now,
+                ),
             )
             new += 1
         except sqlite3.IntegrityError:
@@ -125,6 +126,7 @@ def _store_jobs_filtered(
 
 
 # -- Page intelligence collector ---------------------------------------------
+
 
 def collect_page_intelligence(url: str, headless: bool = True) -> dict:
     """Load a page with Playwright and collect every signal a scraping engineer
@@ -153,12 +155,14 @@ def collect_page_intelligence(url: str, headless: bool = True) -> dict:
                     data = json.loads(body)
                 except Exception:
                     data = None
-                captured_responses.append({
-                    "url": rurl,
-                    "status": response.status,
-                    "size": len(body),
-                    "data": data,
-                })
+                captured_responses.append(
+                    {
+                        "url": rurl,
+                        "status": response.status,
+                        "size": len(body),
+                        "data": data,
+                    }
+                )
             except Exception:
                 pass
 
@@ -333,6 +337,7 @@ def collect_page_intelligence(url: str, headless: bool = True) -> dict:
                             summary[f"nested_{path}"] = info
                         elif isinstance(val, dict) and depth < 3:
                             _explore_nested(val, path, depth + 1)
+
                 _explore_nested(data, "")
         intel["api_responses"].append(summary)
 
@@ -398,8 +403,7 @@ def judge_api_responses(api_responses: list[dict]) -> list[dict]:
             verdict = extract_json(raw)
             is_relevant = verdict.get("relevant", False)
             reason = verdict.get("reason", "?")
-            log.info("Judge: %s -> %s (%s)", resp.get("url", "?")[:80],
-                     "KEEP" if is_relevant else "DROP", reason)
+            log.info("Judge: %s -> %s (%s)", resp.get("url", "?")[:80], "KEEP" if is_relevant else "DROP", reason)
             if is_relevant:
                 relevant.append(resp)
         except Exception as e:
@@ -410,6 +414,7 @@ def judge_api_responses(api_responses: list[dict]) -> list[dict]:
 
 
 # -- Phase 1: strategy selection ---------------------------------------------
+
 
 def format_strategy_briefing(intel: dict) -> str:
     """Lightweight briefing for strategy selection. No raw DOM."""
@@ -437,7 +442,9 @@ def format_strategy_briefing(intel: dict) -> str:
         sections.append(f"\nAPI RESPONSES INTERCEPTED: {len(intel['api_responses'])} calls")
         for resp in intel["api_responses"]:
             sections.append(f"\n  URL: {resp['url']}")
-            sections.append(f"  Status: {resp['status']} | Size: {resp['size']:,} chars | Type: {resp.get('type', '?')}")
+            sections.append(
+                f"  Status: {resp['status']} | Size: {resp['size']:,} chars | Type: {resp.get('type', '?')}"
+            )
             if "first_item_keys" in resp:
                 sections.append(f"  Item keys: {resp['first_item_keys']}")
                 sections.append(f"  Sample: {json.dumps(resp.get('first_item_sample', {}), indent=2)[:1000]}")
@@ -455,7 +462,9 @@ def format_strategy_briefing(intel: dict) -> str:
                             if "count" in sv:
                                 sections.append(f"    .{arr_name}[0].{sub_name}: array of {sv['count']} items")
                                 sections.append(f"      Item keys: {sv['first_item_keys']}")
-                                sections.append(f"      Sample: {json.dumps(sv.get('first_item_sample', {}), indent=2)[:1500]}")
+                                sections.append(
+                                    f"      Sample: {json.dumps(sv.get('first_item_sample', {}), indent=2)[:1500]}"
+                                )
                             elif "keys" in sv:
                                 sections.append(f"    .{arr_name}[0].{sub_name}: object with keys {sv['keys']}")
                                 sections.append(f"      Sample: {json.dumps(sv.get('sample', {}), indent=2)[:1500]}")
@@ -466,24 +475,28 @@ def format_strategy_briefing(intel: dict) -> str:
     if intel["data_testids"]:
         sections.append(f"\nDATA-TESTID ATTRIBUTES: {len(intel['data_testids'])} elements")
         for dt in intel["data_testids"][:15]:
-            text_preview = dt['text'].replace('\n', ' ')[:60]
-            sections.append(f"  <{dt['tag']} data-testid=\"{dt['testid']}\"> {text_preview}")
+            text_preview = dt["text"].replace("\n", " ")[:60]
+            sections.append(f'  <{dt["tag"]} data-testid="{dt["testid"]}"> {text_preview}')
     else:
         sections.append("\nDATA-TESTID: none found")
 
     # DOM stats
     stats = intel.get("dom_stats", {})
-    sections.append(f"\nDOM STATS: {stats.get('total_elements', '?')} elements, "
-                    f"{stats.get('links', '?')} links, {stats.get('headings', '?')} headings, "
-                    f"{stats.get('tables', '?')} tables, {stats.get('articles', '?')} articles, "
-                    f"{stats.get('has_data_ids', '?')} data-id elements")
+    sections.append(
+        f"\nDOM STATS: {stats.get('total_elements', '?')} elements, "
+        f"{stats.get('links', '?')} links, {stats.get('headings', '?')} headings, "
+        f"{stats.get('tables', '?')} tables, {stats.get('articles', '?')} articles, "
+        f"{stats.get('has_data_ids', '?')} data-id elements"
+    )
 
     # Card candidates
     if intel["card_candidates"]:
         sections.append(f"\nREPEATING ELEMENTS DETECTED: {len(intel['card_candidates'])} candidate groups")
         for i, cand in enumerate(intel["card_candidates"]):
-            sections.append(f"  [{i}] parent={cand['parent_selector']} child={cand['child_selector']} "
-                          f"count={cand['total_children']} with_text={cand['with_text']} with_links={cand['with_links']}")
+            sections.append(
+                f"  [{i}] parent={cand['parent_selector']} child={cand['child_selector']} "
+                f"count={cand['total_children']} with_text={cand['with_text']} with_links={cand['with_links']}"
+            )
     else:
         sections.append("\nREPEATING ELEMENTS: none detected")
 
@@ -526,8 +539,20 @@ INTELLIGENCE BRIEFING:
 
 # -- Card HTML cleaning (allowlist approach) ----------------------------------
 
-_ALLOWED_ATTRS = {"id", "href", "data-testid", "data-id", "data-type", "data-slug",
-                  "role", "aria-label", "aria-labelledby", "type", "name", "for"}
+_ALLOWED_ATTRS = {
+    "id",
+    "href",
+    "data-testid",
+    "data-id",
+    "data-type",
+    "data-slug",
+    "role",
+    "aria-label",
+    "aria-labelledby",
+    "type",
+    "name",
+    "for",
+}
 _ALLOWED_PREFIXES = ("data-", "aria-")
 _UTILITY_CLASS_RE = re.compile(
     r"^("
@@ -579,8 +604,7 @@ def clean_page_html(html: str, max_chars: int = 150_000) -> str:
     if main and len(str(main)) > 1000:
         soup = BeautifulSoup(str(main), "html.parser")
 
-    for tag in soup.find_all(["script", "style", "svg", "noscript", "iframe",
-                              "link", "meta", "head", "footer", "nav"]):
+    for tag in soup.find_all(["script", "style", "svg", "noscript", "iframe", "link", "meta", "head", "footer", "nav"]):
         tag.decompose()
 
     for tag in soup.find_all(True):
@@ -639,6 +663,7 @@ PAGE HTML:
 
 # -- LLM helpers -------------------------------------------------------------
 
+
 def ask_llm(prompt: str) -> tuple[str, float, dict]:
     """Send prompt to LLM. Returns (response_text, seconds_taken, metadata)."""
     client = get_client()
@@ -661,6 +686,7 @@ from jobhunter.domain.extraction import extract_json  # noqa: E402
 
 
 # -- JSON path resolution ---------------------------------------------------
+
 
 def resolve_json_path_raw(data, path: str):
     """Navigate a JSON path and return whatever is there (including lists/dicts)."""
@@ -709,6 +735,7 @@ def resolve_json_path(data, path: str):
 
 
 # -- Extraction executors ----------------------------------------------------
+
 
 def execute_json_ld(intel: dict, plan: dict) -> list[dict]:
     """Extract jobs from JSON-LD JobPosting entries."""
@@ -783,7 +810,7 @@ def execute_css_selectors(intel: dict) -> tuple[dict, list[dict]]:
         log.error("LLM_ERROR in Phase 2: %s", e)
         return {}, []
 
-    log.info("Phase 2 LLM: %d chars, %.1fs", meta['response_chars'], elapsed)
+    log.info("Phase 2 LLM: %d chars, %.1fs", meta["response_chars"], elapsed)
 
     try:
         selectors = extract_json(raw)
@@ -831,6 +858,7 @@ def execute_css_selectors(intel: dict) -> tuple[dict, list[dict]]:
 
 # -- Main per-site extraction ------------------------------------------------
 
+
 def _run_one_site(name: str, url: str) -> dict:
     """Run full smart extraction pipeline on one site URL."""
     log.info("=" * 60)
@@ -841,22 +869,38 @@ def _run_one_site(name: str, url: str) -> dict:
     t0 = time.time()
     intel = collect_page_intelligence(url)
     collect_time = time.time() - t0
-    log.info("Done in %.1fs | JSON-LD: %d | API: %d | testids: %d | cards: %d",
-             collect_time, len(intel["json_ld"]), len(intel["api_responses"]),
-             len(intel["data_testids"]), len(intel["card_candidates"]))
+    log.info(
+        "Done in %.1fs | JSON-LD: %d | API: %d | testids: %d | cards: %d",
+        collect_time,
+        len(intel["json_ld"]),
+        len(intel["api_responses"]),
+        len(intel["data_testids"]),
+        len(intel["card_candidates"]),
+    )
 
     # Headful retry if page content is tiny
     full_html = intel.get("full_html", "")
     cleaned_check = clean_page_html(full_html) if full_html else ""
-    _captcha_signals = ["captcha", "are you a human", "verify you", "unusual requests",
-                        "access denied", "please verify", "bot detection"]
+    _captcha_signals = [
+        "captcha",
+        "are you a human",
+        "verify you",
+        "unusual requests",
+        "access denied",
+        "please verify",
+        "bot detection",
+    ]
     _is_captcha = any(s in full_html.lower() for s in _captcha_signals) if full_html else False
     if len(cleaned_check) < 5000 and full_html and not _is_captcha:
         log.info("Cleaned HTML only %s chars -- retrying headful...", f"{len(cleaned_check):,}")
         intel = collect_page_intelligence(url, headless=False)
         collect_time = time.time() - t0
-        log.info("Headful done in %.1fs | JSON-LD: %d | API: %d",
-                 collect_time, len(intel["json_ld"]), len(intel["api_responses"]))
+        log.info(
+            "Headful done in %.1fs | JSON-LD: %d | API: %d",
+            collect_time,
+            len(intel["json_ld"]),
+            len(intel["api_responses"]),
+        )
     elif _is_captcha:
         log.warning("CAPTCHA/rate-limit detected -- skipping headful retry")
 
@@ -917,14 +961,23 @@ def _run_one_site(name: str, url: str) -> dict:
     urls = sum(1 for j in jobs if j.get("url"))
     salaries = sum(1 for j in jobs if j.get("salary"))
     descs = sum(1 for j in jobs if j.get("description"))
-    log.info("RESULT: %s -- %d jobs, %d titles, %d urls, %d salaries, %d descriptions",
-             status, total, titles, urls, salaries, descs)
+    log.info(
+        "RESULT: %s -- %d jobs, %d titles, %d urls, %d salaries, %d descriptions",
+        status,
+        total,
+        titles,
+        urls,
+        salaries,
+        descs,
+    )
 
     for j in jobs[:3]:
-        log.info("  - %s | loc: %s | salary: %s",
-                 str(j.get("title") or "?")[:55],
-                 str(j.get("location") or "?")[:25],
-                 str(j.get("salary") or "-")[:20])
+        log.info(
+            "  - %s | loc: %s | salary: %s",
+            str(j.get("title") or "?")[:55],
+            str(j.get("location") or "?")[:25],
+            str(j.get("salary") or "-")[:20],
+        )
 
     return {
         "name": name,
@@ -939,6 +992,7 @@ def _run_one_site(name: str, url: str) -> dict:
 
 
 # -- Target building --------------------------------------------------------
+
 
 def build_scrape_targets(
     sites: list[dict] | None = None,
@@ -977,24 +1031,29 @@ def build_scrape_targets(
                 expanded_url = expanded_url.replace("{query_encoded}", quote_plus(query))
                 expanded_url = expanded_url.replace("{query}", quote_plus(query))
                 expanded_url = expanded_url.replace("{location_encoded}", quote_plus(default_location))
-                targets.append({
-                    "name": site_name,
-                    "url": expanded_url,
-                    "query": query,
-                })
+                targets.append(
+                    {
+                        "name": site_name,
+                        "url": expanded_url,
+                        "query": query,
+                    }
+                )
         else:
             expanded_url = site_url
             expanded_url = expanded_url.replace("{location_encoded}", quote_plus(default_location))
-            targets.append({
-                "name": site_name,
-                "url": expanded_url,
-                "query": None,
-            })
+            targets.append(
+                {
+                    "name": site_name,
+                    "url": expanded_url,
+                    "query": None,
+                }
+            )
 
     return targets
 
 
 # -- Run all sites -----------------------------------------------------------
+
 
 def _run_all(
     targets: list[dict],
@@ -1010,8 +1069,9 @@ def _run_all(
     """
     conn = init_db()
     pre_stats = get_stats(conn)
-    log.info("Database: %d jobs already stored, %d pending detail scrape",
-             pre_stats["total"], pre_stats["pending_detail"])
+    log.info(
+        "Database: %d jobs already stored, %d pending detail scrape", pre_stats["total"], pre_stats["pending_detail"]
+    )
 
     results: list[dict] = []
     total_new = 0
@@ -1028,10 +1088,15 @@ def _run_all(
             return
         jobs = r.get("jobs", [])
         if jobs:
-            new, existing = _store_jobs_filtered(conn, jobs, target["name"],
-                                                  r.get("strategy", "?"),
-                                                  accept_locs, reject_locs,
-                                                  limit=remaining if limit > 0 else 0)
+            new, existing = _store_jobs_filtered(
+                conn,
+                jobs,
+                target["name"],
+                r.get("strategy", "?"),
+                accept_locs,
+                reject_locs,
+                limit=remaining if limit > 0 else 0,
+            )
             total_new += new
             total_existing += existing
             log.info("DB: +%d new, %d already existed", new, existing)
@@ -1039,10 +1104,7 @@ def _run_all(
     if workers > 1 and len(targets) > 1:
         # Parallel mode
         with ThreadPoolExecutor(max_workers=min(workers, len(targets))) as pool:
-            future_to_target = {
-                pool.submit(_run_one_site, target["name"], target["url"]): target
-                for target in targets
-            }
+            future_to_target = {pool.submit(_run_one_site, target["name"], target["url"]): target for target in targets}
             for future in as_completed(future_to_target):
                 target = future_to_target[future]
                 r = future.result()
@@ -1074,11 +1136,11 @@ def _run_all(
     passed = sum(1 for r in results if r["status"] == "PASS")
     log.info("%d/%d PASS", passed, len(results))
 
-    return {"total_new": total_new, "total_existing": total_existing,
-            "passed": passed, "total": len(results)}
+    return {"total_new": total_new, "total_existing": total_existing, "passed": passed, "total": len(results)}
 
 
 # -- Public entry point ------------------------------------------------------
+
 
 def run_smart_extract(
     sites: list[dict] | None = None,
@@ -1108,7 +1170,12 @@ def run_smart_extract(
 
     search_sites = sum(1 for s in (sites or load_sites()) if s.get("type") == "search")
     static_sites = sum(1 for s in (sites or load_sites()) if s.get("type") != "search")
-    log.info("Sites: %d searchable, %d static | Total targets: %d (workers=%d)",
-             search_sites, static_sites, len(targets), workers)
+    log.info(
+        "Sites: %d searchable, %d static | Total targets: %d (workers=%d)",
+        search_sites,
+        static_sites,
+        len(targets),
+        workers,
+    )
 
     return _run_all(targets, accept_locs, reject_locs, workers=workers, limit=limit)

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -20,11 +20,16 @@ from html.parser import HTMLParser
 from jobhunter import config
 from jobhunter.config import CONFIG_DIR
 from jobhunter.database import get_connection, init_db
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
 
 log = logging.getLogger(__name__)
 
 
 # -- Employer registry from YAML --------------------------------------------
+
 
 def load_employers() -> dict:
     """Load Workday employer registry from config/employers.yaml."""
@@ -37,38 +42,22 @@ def load_employers() -> dict:
 
 # -- Location filtering from search config -----------------------------------
 
+
 def _load_location_filter(search_cfg: dict | None = None):
     """Load location accept/reject lists from search config."""
     if search_cfg is None:
         search_cfg = config.load_search_config()
 
-    accept = search_cfg.get("location_accept", [])
-    reject = search_cfg.get("location_reject_non_remote", [])
-    return accept, reject
+    return configured_location_filters(search_cfg)
 
 
 def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> bool:
     """Check if a job location passes the user's location filter."""
-    if not location:
-        return True
-
-    loc = location.lower()
-
-    if any(r in loc for r in ("remote", "anywhere", "work from home", "wfh", "distributed")):
-        return True
-
-    for r in reject:
-        if r.lower() in loc:
-            return False
-
-    for a in accept:
-        if a.lower() in loc:
-            return True
-
-    return False
+    return location_matches_target(location, accept=accept, reject=reject)
 
 
 # -- HTML stripper -----------------------------------------------------------
+
 
 class _HTMLStripper(HTMLParser):
     """Strip HTML tags, keep text content."""
@@ -133,10 +122,12 @@ def setup_proxy(proxy_str: str | None) -> None:
         _opener = urllib.request.build_opener()
         return
 
-    proxy_handler = urllib.request.ProxyHandler({
-        "http": proxy_url,
-        "https": proxy_url,
-    })
+    proxy_handler = urllib.request.ProxyHandler(
+        {
+            "http": proxy_url,
+            "https": proxy_url,
+        }
+    )
     _opener = urllib.request.build_opener(proxy_handler)
     log.info("Proxy configured: %s:%s", parts[0], parts[1])
 
@@ -150,15 +141,18 @@ def _urlopen(req, timeout=30):
 
 # -- Workday API -------------------------------------------------------------
 
+
 def workday_search(employer: dict, search_text: str, limit: int = 20, offset: int = 0) -> dict:
     """Search jobs via Workday CXS API. Returns JSON with total + jobPostings."""
     url = f"{employer['base_url']}/wday/cxs/{employer['tenant']}/{employer['site_id']}/jobs"
-    payload = json.dumps({
-        "appliedFacets": {},
-        "limit": limit,
-        "offset": offset,
-        "searchText": search_text,
-    }).encode()
+    payload = json.dumps(
+        {
+            "appliedFacets": {},
+            "limit": limit,
+            "offset": offset,
+            "searchText": search_text,
+        }
+    ).encode()
 
     req = urllib.request.Request(url, data=payload, method="POST")
     req.add_header("Content-Type", "application/json")
@@ -183,6 +177,7 @@ def workday_detail(employer: dict, external_path: str) -> dict:
 
 # -- Search + paginate -------------------------------------------------------
 
+
 def search_employer(
     employer_key: str,
     employer: dict,
@@ -193,7 +188,7 @@ def search_employer(
     reject_locs: list[str] | None = None,
 ) -> list[dict]:
     """Search an employer, paginate through all results, optionally filter by location."""
-    log.info("%s: searching \"%s\"...", employer["name"], search_text)
+    log.info('%s: searching "%s"...', employer["name"], search_text)
 
     all_jobs: list[dict] = []
     offset = 0
@@ -222,14 +217,16 @@ def search_employer(
                 if not _location_ok(loc, accept_locs, reject_locs):
                     continue
 
-            all_jobs.append({
-                "title": j.get("title", ""),
-                "location": loc,
-                "posted": j.get("postedOn", ""),
-                "external_path": j.get("externalPath", ""),
-                "employer_key": employer_key,
-                "employer_name": employer["name"],
-            })
+            all_jobs.append(
+                {
+                    "title": j.get("title", ""),
+                    "location": loc,
+                    "posted": j.get("postedOn", ""),
+                    "external_path": j.get("externalPath", ""),
+                    "employer_key": employer_key,
+                    "employer_name": employer["name"],
+                }
+            )
 
         offset += page_size
         page_num = offset // page_size
@@ -242,12 +239,12 @@ def search_employer(
             all_jobs = all_jobs[:max_results]
             break
 
-    log.info("%s: %d jobs found%s", employer["name"], len(all_jobs),
-             " (filtered)" if location_filter else "")
+    log.info("%s: %d jobs found%s", employer["name"], len(all_jobs), " (filtered)" if location_filter else "")
     return all_jobs
 
 
 # -- Fetch details -----------------------------------------------------------
+
 
 def _fetch_one_detail(employer: dict, job: dict) -> dict:
     """Fetch detail for a single job."""
@@ -287,8 +284,7 @@ def fetch_details(employer: dict, jobs: list[dict]) -> list[dict]:
         if completed % 20 == 0 or completed == len(jobs):
             elapsed = time.time() - t0
             rate = completed / elapsed if elapsed > 0 else 0
-            log.info("%s: %d/%d (%d errors) [%.1f jobs/sec]",
-                     employer["name"], completed, len(jobs), errors, rate)
+            log.info("%s: %d/%d (%d errors) [%.1f jobs/sec]", employer["name"], completed, len(jobs), errors, rate)
 
     elapsed = time.time() - t0
     log.info("%s: done in %.1fs (%.1f jobs/sec)", employer["name"], elapsed, len(jobs) / elapsed if elapsed > 0 else 0)
@@ -296,6 +292,7 @@ def fetch_details(employer: dict, jobs: list[dict]) -> list[dict]:
 
 
 # -- DB storage --------------------------------------------------------------
+
 
 def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict, limit: int = 0) -> tuple[int, int]:
     """Store corporate jobs in DB. Returns (new, existing)."""
@@ -328,8 +325,20 @@ def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict, l
                 "INSERT INTO jobs (url, title, salary, description, location, site, strategy, "
                 "discovered_at, full_description, application_url, detail_scraped_at, detail_error) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (url, job.get("title"), None, short_desc, job.get("location"),
-                 site, strategy, now, full_description, url, detail_scraped_at, detail_error),
+                (
+                    url,
+                    job.get("title"),
+                    None,
+                    short_desc,
+                    job.get("location"),
+                    site,
+                    strategy,
+                    now,
+                    full_description,
+                    url,
+                    detail_scraped_at,
+                    detail_error,
+                ),
             )
             new += 1
         except sqlite3.IntegrityError:
@@ -353,7 +362,9 @@ def _process_one(
 
     try:
         jobs = search_employer(
-            employer_key, emp, search_text,
+            employer_key,
+            emp,
+            search_text,
             location_filter=location_filter,
             max_results=limit,
             accept_locs=accept_locs,
@@ -361,12 +372,10 @@ def _process_one(
         )
     except Exception as e:
         log.error("%s: ERROR searching '%s': %s", emp["name"], search_text, e)
-        return {"employer": emp["name"], "query": search_text,
-                "found": 0, "new": 0, "existing": 0, "error": str(e)}
+        return {"employer": emp["name"], "query": search_text, "found": 0, "new": 0, "existing": 0, "error": str(e)}
 
     if not jobs:
-        return {"employer": emp["name"], "query": search_text,
-                "found": 0, "new": 0, "existing": 0}
+        return {"employer": emp["name"], "query": search_text, "found": 0, "new": 0, "existing": 0}
 
     try:
         jobs = fetch_details(emp, jobs)
@@ -377,11 +386,11 @@ def _process_one(
     new, existing = store_results(conn, jobs, employers, limit=limit)
     log.info("%s: %d new, %d already in DB", emp["name"], new, existing)
 
-    return {"employer": emp["name"], "query": search_text,
-            "found": len(jobs), "new": new, "existing": existing}
+    return {"employer": emp["name"], "query": search_text, "found": len(jobs), "new": new, "existing": existing}
 
 
 # -- Main orchestrator -------------------------------------------------------
+
 
 def scrape_employers(
     search_text: str,
@@ -427,8 +436,13 @@ def scrape_employers(
         with ThreadPoolExecutor(max_workers=min(workers, len(valid_keys))) as pool:
             futures = {
                 pool.submit(
-                    _process_one, key, employers, search_text,
-                    location_filter, accept_locs, reject_locs,
+                    _process_one,
+                    key,
+                    employers,
+                    search_text,
+                    location_filter,
+                    accept_locs,
+                    reject_locs,
                     0,
                 ): key
                 for key in valid_keys
@@ -444,8 +458,16 @@ def scrape_employers(
 
                 if completed % 10 == 0 or completed == len(valid_keys):
                     elapsed = time.time() - t0
-                    log.info("[%s] Progress: %d/%d employers (%d new, %d dupes, %d errors) [%.0fs]",
-                             search_text, completed, len(valid_keys), total_new, total_existing, errors, elapsed)
+                    log.info(
+                        "[%s] Progress: %d/%d employers (%d new, %d dupes, %d errors) [%.0fs]",
+                        search_text,
+                        completed,
+                        len(valid_keys),
+                        total_new,
+                        total_existing,
+                        errors,
+                        elapsed,
+                    )
     else:
         # Sequential mode (default)
         completed = 0
@@ -454,8 +476,12 @@ def scrape_employers(
             if limit > 0 and remaining <= 0:
                 break
             result = _process_one(
-                key, employers, search_text,
-                location_filter, accept_locs, reject_locs,
+                key,
+                employers,
+                search_text,
+                location_filter,
+                accept_locs,
+                reject_locs,
                 remaining if limit > 0 else 0,
             )
             completed += 1
@@ -467,17 +493,27 @@ def scrape_employers(
 
             if completed % 10 == 0 or completed == len(valid_keys):
                 elapsed = time.time() - t0
-                log.info("[%s] Progress: %d/%d employers (%d new, %d dupes, %d errors) [%.0fs]",
-                         search_text, completed, len(valid_keys), total_new, total_existing, errors, elapsed)
+                log.info(
+                    "[%s] Progress: %d/%d employers (%d new, %d dupes, %d errors) [%.0fs]",
+                    search_text,
+                    completed,
+                    len(valid_keys),
+                    total_new,
+                    total_existing,
+                    errors,
+                    elapsed,
+                )
 
     elapsed = time.time() - t0
-    log.info("[%s] Done: %d found, %d new, %d dupes in %.0fs",
-             search_text, total_found, total_new, total_existing, elapsed)
+    log.info(
+        "[%s] Done: %d found, %d new, %d dupes in %.0fs", search_text, total_found, total_new, total_existing, elapsed
+    )
 
     return {"found": total_found, "new": total_new, "existing": total_existing}
 
 
 # -- Public entry point ------------------------------------------------------
+
 
 def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit: int = 0) -> dict:
     """Main entry point for Workday-based corporate job discovery.
@@ -532,7 +568,7 @@ def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit
         remaining = max(limit - grand_found, 0) if limit > 0 else 0
         if limit > 0 and remaining <= 0:
             break
-        log.info("Query %d/%d: \"%s\"", i, len(queries), query)
+        log.info('Query %d/%d: "%s"', i, len(queries), query)
         result = scrape_employers(
             search_text=query,
             employers=employers,
@@ -546,8 +582,14 @@ def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit
         grand_existing += result["existing"]
         grand_found += result["found"]
 
-    log.info("Workday crawl done: %d found, %d new, %d existing across %d queries x %d employers",
-             grand_found, grand_new, grand_existing, len(queries), len(employers))
+    log.info(
+        "Workday crawl done: %d found, %d new, %d existing across %d queries x %d employers",
+        grand_found,
+        grand_new,
+        grand_existing,
+        len(queries),
+        len(employers),
+    )
 
     return {
         "found": grand_found,

--- a/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
@@ -42,6 +42,7 @@ from jobhunter.domain.discovery.value_objects import (
 )
 from jobhunter.domain.ports.discovery import ScrapedJobPosting
 from jobhunter.domain.tenant import TenantId
+from jobhunter.infrastructure.discovery.location_filter import location_matches_target
 from jobhunter.infrastructure.observability.adapter_spans import adapter_fetch_span
 
 log = logging.getLogger(__name__)
@@ -138,12 +139,16 @@ class WorkdayBoardAdapter:
         http: HttpFetcher | None = None,
         page_size: int = 20,
         max_pages: int = 25,
+        location_accept: Iterable[str] = (),
+        location_reject: Iterable[str] = (),
     ) -> None:
         self._source_id = source_id
         self._employer = employer
         self._http = http or default_http_fetcher
         self._page_size = page_size
         self._max_pages = max_pages
+        self._location_accept = tuple(location_accept)
+        self._location_reject = tuple(location_reject)
 
     @property
     def source_id(self) -> str:
@@ -184,10 +189,7 @@ class WorkdayBoardAdapter:
     _last_page_count: int = 0
 
     def _iter_postings(self, *, query: str, location: str) -> Iterator[ScrapedJobPosting]:
-        url = (
-            f"{self._employer.base_url}/wday/cxs/{self._employer.tenant}/"
-            f"{self._employer.site_id}/jobs"
-        )
+        url = f"{self._employer.base_url}/wday/cxs/{self._employer.tenant}/{self._employer.site_id}/jobs"
         offset = 0
         pages = 0
         while pages < self._max_pages:
@@ -205,9 +207,7 @@ class WorkdayBoardAdapter:
             if not postings:
                 break
             for posting in postings:
-                yielded = self._to_scraped(
-                    posting, query=query, location_filter=location
-                )
+                yielded = self._to_scraped(posting, query=query, location_filter=location)
                 if yielded is not None:
                     yield yielded
             pages += 1
@@ -234,15 +234,14 @@ class WorkdayBoardAdapter:
         # "yield postings matching the query".
         if query.strip() and query.strip().lower() not in title.lower():
             return None
-        canonical_url = (
-            f"{self._employer.base_url}/{self._employer.site_id}{external_path}"
-        )
+        canonical_url = f"{self._employer.base_url}/{self._employer.site_id}{external_path}"
         source_native_id = external_path.split("/")[-1] or external_path
         location = str(posting.get("locationsText") or "").strip()
-        if (
-            location_filter.strip()
-            and location
-            and location_filter.strip().lower() not in location.lower()
+        if not location_matches_target(
+            location,
+            accept=self._location_accept,
+            reject=self._location_reject,
+            search_location=location_filter,
         ):
             return None
         return ScrapedJobPosting(
@@ -283,11 +282,15 @@ class GreenhouseBoardAdapter:
         board_token: str,
         http: HttpFetcher | None = None,
         company: str | None = None,
+        location_accept: Iterable[str] = (),
+        location_reject: Iterable[str] = (),
     ) -> None:
         self._source_id = source_id
         self._board_token = board_token
         self._http = http or default_http_fetcher
         self._company = company
+        self._location_accept = tuple(location_accept)
+        self._location_reject = tuple(location_reject)
 
     @property
     def source_id(self) -> str:
@@ -295,9 +298,7 @@ class GreenhouseBoardAdapter:
 
     @property
     def url(self) -> str:
-        return (
-            f"https://boards-api.greenhouse.io/v1/boards/{self._board_token}/jobs"
-        )
+        return f"https://boards-api.greenhouse.io/v1/boards/{self._board_token}/jobs"
 
     def scrape(
         self,
@@ -348,7 +349,12 @@ class GreenhouseBoardAdapter:
             loc = str(loc_obj.get("name") or "").strip()
         elif isinstance(loc_obj, str):
             loc = loc_obj.strip()
-        if location and loc and location.lower() not in loc.lower():
+        if not location_matches_target(
+            loc,
+            accept=self._location_accept,
+            reject=self._location_reject,
+            search_location=location,
+        ):
             return None
         company = str(raw.get("company_name") or self._company or "").strip()
         return ScrapedJobPosting(
@@ -388,11 +394,15 @@ class LeverBoardAdapter:
         site: str,
         http: HttpFetcher | None = None,
         company: str | None = None,
+        location_accept: Iterable[str] = (),
+        location_reject: Iterable[str] = (),
     ) -> None:
         self._source_id = source_id
         self._site = site
         self._http = http or default_http_fetcher
         self._company = company
+        self._location_accept = tuple(location_accept)
+        self._location_reject = tuple(location_reject)
 
     @property
     def source_id(self) -> str:
@@ -443,7 +453,12 @@ class LeverBoardAdapter:
             return None
         cats = raw.get("categories") or {}
         loc = str(cats.get("location") or "").strip() if isinstance(cats, dict) else ""
-        if location and loc and location.lower() not in loc.lower():
+        if not location_matches_target(
+            loc,
+            accept=self._location_accept,
+            reject=self._location_reject,
+            search_location=location,
+        ):
             return None
         company = self._company or f"lever:{self._site}"
         return ScrapedJobPosting(
@@ -482,11 +497,15 @@ class AshbyBoardAdapter:
         board_name: str,
         http: HttpFetcher | None = None,
         company: str | None = None,
+        location_accept: Iterable[str] = (),
+        location_reject: Iterable[str] = (),
     ) -> None:
         self._source_id = source_id
         self._board_name = board_name
         self._http = http or default_http_fetcher
         self._company = company
+        self._location_accept = tuple(location_accept)
+        self._location_reject = tuple(location_reject)
 
     @property
     def source_id(self) -> str:
@@ -494,9 +513,7 @@ class AshbyBoardAdapter:
 
     @property
     def url(self) -> str:
-        return (
-            f"https://api.ashbyhq.com/posting-api/job-board/{self._board_name}"
-        )
+        return f"https://api.ashbyhq.com/posting-api/job-board/{self._board_name}"
 
     def scrape(
         self,
@@ -538,7 +555,12 @@ class AshbyBoardAdapter:
         if query.strip() and query.strip().lower() not in title.lower():
             return None
         loc = str(raw.get("location") or raw.get("locationName") or "").strip()
-        if location and loc and location.lower() not in loc.lower():
+        if not location_matches_target(
+            loc,
+            accept=self._location_accept,
+            reject=self._location_reject,
+            search_location=location,
+        ):
             return None
         company = self._company or f"ashby:{self._board_name}"
         return ScrapedJobPosting(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -8,6 +8,12 @@ from typing import Any
 
 
 REMOTE_MARKERS = ("remote", "anywhere", "work from home", "wfh", "distributed")
+REJECT_ALIASES = {
+    "usa": ("usa", "us", "u.s.", "u.s.a.", "united states"),
+    "u.s.": ("usa", "us", "u.s.", "u.s.a.", "united states"),
+    "u.s.a.": ("usa", "us", "u.s.", "u.s.a.", "united states"),
+    "united states": ("usa", "us", "u.s.", "u.s.a.", "united states"),
+}
 
 
 def configured_location_filters(search_cfg: Mapping[str, Any]) -> tuple[list[str], list[str]]:
@@ -39,7 +45,7 @@ def location_matches_target(
         return True
 
     normalized = _normalize(location)
-    if _matches_any(normalized, reject):
+    if _matches_reject(normalized, reject):
         return False
 
     if search_location and _matches(normalized, search_location):
@@ -70,6 +76,14 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 def _matches_any(location: str, patterns: Sequence[str]) -> bool:
     return any(_matches(location, pattern) for pattern in patterns)
+
+
+def _matches_reject(location: str, patterns: Sequence[str]) -> bool:
+    for pattern in patterns:
+        aliases = REJECT_ALIASES.get(_normalize(pattern), (pattern,))
+        if _matches_any(location, aliases):
+            return True
+    return False
 
 
 def _matches(location: str, pattern: str | None) -> bool:

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -1,0 +1,85 @@
+"""Shared location filtering for discovery adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import re
+from typing import Any
+
+
+REMOTE_MARKERS = ("remote", "anywhere", "work from home", "wfh", "distributed")
+
+
+def configured_location_filters(search_cfg: Mapping[str, Any]) -> tuple[list[str], list[str]]:
+    """Return accepted and rejected location patterns from either config shape."""
+
+    accept = [*_string_list(search_cfg.get("location_accept"))]
+    reject = [*_string_list(search_cfg.get("location_reject_non_remote"))]
+    nested = search_cfg.get("location")
+    if isinstance(nested, Mapping):
+        accept.extend(_string_list(nested.get("accept_patterns")))
+        reject.extend(_string_list(nested.get("reject_patterns")))
+    return _dedupe(accept), _dedupe(reject)
+
+
+def location_matches_target(
+    location: str | None,
+    *,
+    accept: Sequence[str],
+    reject: Sequence[str],
+    search_location: str | None = None,
+) -> bool:
+    """Return whether a posting location fits the configured target.
+
+    Explicit reject geography wins first, so "Remote, United States" is
+    rejected for a Spain/Europe search while "Remote EMEA" still passes.
+    """
+
+    if not location:
+        return True
+
+    normalized = _normalize(location)
+    if _matches_any(normalized, reject):
+        return False
+
+    if search_location and _matches(normalized, search_location):
+        return True
+
+    if _matches_any(normalized, accept):
+        return True
+
+    return _matches_any(normalized, REMOTE_MARKERS)
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    return [item.strip() for item in (str(item) for item in value) if item.strip()]
+
+
+def _dedupe(values: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        key = value.casefold()
+        if key not in seen:
+            seen.add(key)
+            result.append(value)
+    return result
+
+
+def _matches_any(location: str, patterns: Sequence[str]) -> bool:
+    return any(_matches(location, pattern) for pattern in patterns)
+
+
+def _matches(location: str, pattern: str | None) -> bool:
+    normalized = _normalize(pattern)
+    if not normalized:
+        return False
+    if normalized.isalnum() and len(normalized) <= 3:
+        return re.search(rf"(?<![a-z0-9]){re.escape(normalized)}(?![a-z0-9])", location) is not None
+    return normalized in location
+
+
+def _normalize(value: str | None) -> str:
+    return " ".join(str(value or "").casefold().split())

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -61,6 +61,7 @@ from jobhunter.infrastructure.discovery.ats_adapters import (
     HttpFetcher,
     LeverBoardAdapter,
 )
+from jobhunter.infrastructure.discovery.location_filter import configured_location_filters
 from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobhunter.infrastructure.enrichment import (
     SqliteEnrichmentRepository,
@@ -293,10 +294,7 @@ def enqueue_manual_action_for_sources(
         source_id = str(getattr(source, "source_id", "")).strip()
         adapter_config = dict(getattr(source, "adapter_config", {}) or {})
         url = str(
-            adapter_config.get("url")
-            or adapter_config.get("seed_url")
-            or adapter_config.get("base_url")
-            or ""
+            adapter_config.get("url") or adapter_config.get("seed_url") or adapter_config.get("base_url") or ""
         ).strip()
         if not url or not _looks_protected(url):
             continue
@@ -330,7 +328,7 @@ def run_scheduled_ats_sources(
     """Run Greenhouse, Lever, and Ashby through the Discovery use case."""
     ensure_worker_discovery_tables(conn)
     runnable = tuple(source for source in sources if getattr(source, "should_run", True))
-    adapters = tuple(_adapter_for_source(source, http=http) for source in runnable)
+    adapters = tuple(_adapter_for_source(source, http=http, search_cfg=search_cfg) for source in runnable)
     adapters = tuple(adapter for adapter in adapters if adapter is not None)
     if not adapters:
         return ScheduledAtsSummary().to_result_dict()
@@ -460,9 +458,7 @@ def import_manual_capture_item(
         promote_to_job_enrichment=True,
     )
     quarantine_reason = (
-        outcome.snapshot_set.latest_snapshot.quarantine_reason.value
-        if outcome.snapshot_set.latest_snapshot
-        else ""
+        outcome.snapshot_set.latest_snapshot.quarantine_reason.value if outcome.snapshot_set.latest_snapshot else ""
     )
     if outcome.ok and quarantine_reason and quarantine_reason != QuarantineReason.NONE.value:
         _upsert_quarantine_entry(
@@ -559,9 +555,7 @@ def build_discovery_acceptance_report(
         "SELECT COUNT(DISTINCT job_url) FROM job_canonical_identities WHERE tenant_id = ?",
         (tenant,),
     )
-    canonical_verification_rate = (
-        round(canonical_jobs / lead_yield, 4) if lead_yield else 0.0
-    )
+    canonical_verification_rate = round(canonical_jobs / lead_yield, 4) if lead_yield else 0.0
     duplicate_count = _scalar_int(
         conn,
         "SELECT COUNT(*) FROM job_duplicate_links WHERE tenant_id = ?",
@@ -639,11 +633,7 @@ def _candidates_from_registry(
         }:
             continue
         protected = _looks_protected(seed_url)
-        reason = (
-            ManualActionReason.PROTECTED_INTERNAL_SITE
-            if protected
-            else None
-        )
+        reason = ManualActionReason.PROTECTED_INTERNAL_SITE if protected else None
         candidate_url = seed_url
         confidence = 0.88 if detected else 0.55
         yield _source_location_candidate(
@@ -757,11 +747,7 @@ def _upsert_locator_candidate(
             candidate.confidence,
             candidate.evidence.detected_ats_kind,
             1 if candidate.evidence.employer_domain_matched else 0,
-            (
-                candidate.manual_action_required.reason.value
-                if candidate.manual_action_required
-                else None
-            ),
+            (candidate.manual_action_required.reason.value if candidate.manual_action_required else None),
             candidate.discovered_at,
         ),
     )
@@ -782,11 +768,7 @@ def _promote_locator_candidate(
         (str(candidate.tenant_id), source_id),
     ).fetchone()
     if existing is None:
-        kind = (
-            SourceKind.ATS_API.value
-            if candidate.evidence.detected_ats_kind
-            else candidate.source_kind.value
-        )
+        kind = SourceKind.ATS_API.value if candidate.evidence.detected_ats_kind else candidate.source_kind.value
         policy_id = _policy_id_for_promoted_source(source_id, candidate)
         conn.execute(
             """
@@ -992,15 +974,15 @@ def _enqueue_manual_action_from_candidate(
     candidate: SourceLocationCandidate,
 ) -> None:
     manual = candidate.manual_action_required
-    reason = (
-        manual.reason.value
+    reason = manual.reason.value if manual else ManualActionReason.AMBIGUOUS_CAREER_SYSTEM.value
+    retry_context = (
+        manual.retry_context
         if manual
-        else ManualActionReason.AMBIGUOUS_CAREER_SYSTEM.value
+        else {
+            "source": "locator_candidate",
+            "candidate_id": candidate.candidate_id,
+        }
     )
-    retry_context = manual.retry_context if manual else {
-        "source": "locator_candidate",
-        "candidate_id": candidate.candidate_id,
-    }
     _enqueue_manual_capture(
         conn,
         originating_url=candidate.candidate_url,
@@ -1171,12 +1153,18 @@ def _record_ats_source_failure(
     conn.commit()
 
 
-def _adapter_for_source(source: Any, *, http: HttpFetcher | None) -> Any | None:
+def _adapter_for_source(
+    source: Any,
+    *,
+    http: HttpFetcher | None,
+    search_cfg: Mapping[str, Any],
+) -> Any | None:
     source_id = str(getattr(source, "source_id", "")).strip()
     if source_id.startswith("workday:"):
         return None
     adapter_config = dict(getattr(source, "adapter_config", {}) or {})
     ats_kind = _source_ats_kind(source_id, adapter_config)
+    location_accept, location_reject = configured_location_filters(search_cfg)
     if ats_kind is AtsKind.GREENHOUSE:
         board_token = _board_token(source_id, adapter_config)
         return GreenhouseBoardAdapter(
@@ -1184,6 +1172,8 @@ def _adapter_for_source(source: Any, *, http: HttpFetcher | None) -> Any | None:
             board_token=board_token,
             company=_company_name(source, adapter_config),
             http=http,
+            location_accept=location_accept,
+            location_reject=location_reject,
         )
     if ats_kind is AtsKind.LEVER:
         site = _site_token(source_id, adapter_config)
@@ -1192,6 +1182,8 @@ def _adapter_for_source(source: Any, *, http: HttpFetcher | None) -> Any | None:
             site=site,
             company=_company_name(source, adapter_config),
             http=http,
+            location_accept=location_accept,
+            location_reject=location_reject,
         )
     if ats_kind is AtsKind.ASHBY:
         board_name = _board_name(source_id, adapter_config)
@@ -1200,6 +1192,8 @@ def _adapter_for_source(source: Any, *, http: HttpFetcher | None) -> Any | None:
             board_name=board_name,
             company=_company_name(source, adapter_config),
             http=http,
+            location_accept=location_accept,
+            location_reject=location_reject,
         )
     return None
 
@@ -1212,11 +1206,7 @@ def _query_location_pairs(search_cfg: Mapping[str, Any]) -> Iterable[tuple[str, 
         if isinstance(item, Mapping) and int(item.get("tier") or 99) <= int(search_cfg.get("ats_max_tier") or 2)
     ]
     if not queries:
-        queries = [
-            str(item.get("query") or "").strip()
-            for item in queries_cfg
-            if isinstance(item, Mapping)
-        ]
+        queries = [str(item.get("query") or "").strip() for item in queries_cfg if isinstance(item, Mapping)]
     queries = [query for query in queries if query] or [""]
     locations_cfg = search_cfg.get("locations", [])
     locations = [
@@ -1402,25 +1392,19 @@ def _source_ats_kind(source_id: str, adapter_config: Mapping[str, Any]) -> AtsKi
 
 def _board_token(source_id: str, adapter_config: Mapping[str, Any]) -> str:
     return str(
-        adapter_config.get("board_token")
-        or _token_from_seed_url(adapter_config)
-        or source_id.split(":", 1)[-1]
+        adapter_config.get("board_token") or _token_from_seed_url(adapter_config) or source_id.split(":", 1)[-1]
     ).strip()
 
 
 def _site_token(source_id: str, adapter_config: Mapping[str, Any]) -> str:
     return str(
-        adapter_config.get("site")
-        or _token_from_seed_url(adapter_config)
-        or source_id.split(":", 1)[-1]
+        adapter_config.get("site") or _token_from_seed_url(adapter_config) or source_id.split(":", 1)[-1]
     ).strip()
 
 
 def _board_name(source_id: str, adapter_config: Mapping[str, Any]) -> str:
     return str(
-        adapter_config.get("board_name")
-        or _token_from_seed_url(adapter_config)
-        or source_id.split(":", 1)[-1]
+        adapter_config.get("board_name") or _token_from_seed_url(adapter_config) or source_id.split(":", 1)[-1]
     ).strip()
 
 
@@ -1449,12 +1433,12 @@ def _token_from_seed_url(adapter_config: Mapping[str, Any]) -> str:
 
 
 def _company_name(source: Any, adapter_config: Mapping[str, Any]) -> str | None:
-    return str(
-        adapter_config.get("company")
-        or adapter_config.get("name")
-        or getattr(source, "display_name", "")
-        or ""
-    ).strip() or None
+    return (
+        str(
+            adapter_config.get("company") or adapter_config.get("name") or getattr(source, "display_name", "") or ""
+        ).strip()
+        or None
+    )
 
 
 def _looks_protected(url: str) -> bool:

--- a/workers/automation/tests/test_ats_adapters.py
+++ b/workers/automation/tests/test_ats_adapters.py
@@ -64,10 +64,51 @@ def test_workday_adapter_maps_cxs_payload_to_scraped_posting() -> None:
     assert posting.source_id == "workday:acme"
     assert posting.source_native_id == "Senior-Platform-Engineer_JR-123"
     assert posting.canonical_url == (
-        "https://acme.wd1.myworkdayjobs.com/External/job/Remote-USA/"
-        "Senior-Platform-Engineer_JR-123"
+        "https://acme.wd1.myworkdayjobs.com/External/job/Remote-USA/Senior-Platform-Engineer_JR-123"
     )
     assert posting.ats_kind is AtsKind.WORKDAY
+
+
+def test_workday_adapter_rejects_country_scoped_remote_locations() -> None:
+    def http(
+        url: str,
+        *,
+        method: str = "GET",
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "total": 2,
+            "jobPostings": [
+                {
+                    "title": "Senior Platform Engineer",
+                    "externalPath": "/job/Remote-USA/Senior-Platform-Engineer_JR-123",
+                    "locationsText": "Remote, United States",
+                },
+                {
+                    "title": "Principal Platform Engineer",
+                    "externalPath": "/job/Remote-EMEA/Principal-Platform-Engineer_JR-456",
+                    "locationsText": "Remote EMEA",
+                },
+            ],
+        }
+
+    adapter = WorkdayBoardAdapter(
+        source_id="workday:acme",
+        employer=WorkdayEmployer(
+            employer_key="acme",
+            name="Acme Corp",
+            base_url="https://acme.wd1.myworkdayjobs.com",
+            tenant="acme",
+            site_id="External",
+        ),
+        http=http,
+        location_accept=["Remote", "Spain", "Europe", "EMEA"],
+        location_reject=["United States", "USA"],
+    )
+
+    postings = list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Platform", location="Remote"))
+
+    assert [posting.metadata.location for posting in postings] == ["Remote EMEA"]
 
 
 def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
@@ -157,9 +198,7 @@ def test_ashby_adapter_maps_public_board_payload_to_scraped_posting() -> None:
         http=http,
     )
 
-    postings = list(
-        adapter.scrape(tenant_id=LOCAL_TENANT, query="Infrastructure", location="Remote")
-    )
+    postings = list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Infrastructure", location="Remote"))
 
     assert len(postings) == 1
     posting = postings[0]

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
+
+
+EUROPE_ACCEPT = ["Remote", "Barcelona", "Spain", "Europe", "EMEA", "EU"]
+EUROPE_REJECT = ["United States", "USA", "Canada", "North America", "Brazil"]
+
+
+def test_remote_country_scoped_locations_do_not_bypass_reject_patterns() -> None:
+    for location in (
+        "Remote, United States",
+        "USA, Remote",
+        "Remote Canada",
+        "North America Remote",
+        "Brazil Remote Work",
+    ):
+        assert not location_matches_target(
+            location,
+            accept=EUROPE_ACCEPT,
+            reject=EUROPE_REJECT,
+            search_location="Remote",
+        )
+
+
+def test_remote_region_locations_pass_when_region_is_accepted() -> None:
+    for location in (
+        "Remote EMEA",
+        "Europe Remote",
+        "Barcelona, Spain (Remote)",
+    ):
+        assert location_matches_target(
+            location,
+            accept=EUROPE_ACCEPT,
+            reject=EUROPE_REJECT,
+            search_location="Remote",
+        )
+
+
+def test_short_accept_patterns_match_tokens_not_substrings() -> None:
+    assert location_matches_target("EU Remote", accept=EUROPE_ACCEPT, reject=[])
+    assert not location_matches_target("Neuenstein, DE", accept=["EU"], reject=[])
+
+
+def test_configured_location_filters_reads_nested_and_legacy_shapes() -> None:
+    accept, reject = configured_location_filters(
+        {
+            "location_accept": ["Remote", "Spain"],
+            "location_reject_non_remote": ["USA"],
+            "location": {
+                "accept_patterns": ["EMEA"],
+                "reject_patterns": ["Brazil"],
+            },
+        }
+    )
+
+    assert accept == ["Remote", "Spain", "EMEA"]
+    assert reject == ["USA", "Brazil"]

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -13,7 +13,11 @@ EUROPE_REJECT = ["United States", "USA", "Canada", "North America", "Brazil"]
 def test_remote_country_scoped_locations_do_not_bypass_reject_patterns() -> None:
     for location in (
         "Remote, United States",
+        "Remote US",
+        "US Remote",
+        "Remote - US",
         "USA, Remote",
+        "U.S. Remote",
         "Remote Canada",
         "North America Remote",
         "Brazil Remote Work",


### PR DESCRIPTION
## What changed

- Centralized discovery location matching so reject geography is applied before remote markers are accepted.
- Applied the shared matcher to legacy JobSpy, Workday, and Smart Extract paths, plus the newer ATS API adapters.
- Passed configured accept/reject location filters into scheduled ATS adapters.
- Added regression coverage for country-scoped remote locations such as `Remote, United States` and accepted regional remote locations such as `Remote EMEA`.

## Why

Remote postings were treated as valid as soon as the location text contained `remote`, before the Spain/Europe target reject patterns could exclude country-scoped remote jobs. That allowed postings like USA remote roles to pass a Spain/Europe search.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_ats_adapters.py workers/automation/tests/test_discovery_production_wiring.py workers/automation/tests/test_target_search_preferences.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/src/jobhunter/discovery/workday.py workers/automation/src/jobhunter/discovery/smartextract.py workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_ats_adapters.py`