### PR TITLE
feat: add hidden jobs lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ pnpm web:dev
 The Vite dev server proxies `/v1/*` to the local API by default. Set
 `VITE_JOBHUNTER_API_BASE_URL` when the API runs on a different local origin.
 
+The Jobs tab separates temporary removal from permanent suppression. Deleting a
+job moves it to the Deleted tab; a later discovery run can resurface that job if
+the posting is found again. Hiding a job moves it to the Hidden tab and keeps it
+hidden across future discovery runs until you select it there and use **unhide
+selected**.
+
 The Pipelines tab includes global stage starts. Each stage (`discover`,
 `enrich`, `score`, `tailor`, `cover`, `pdf`, `apply`) has its own tab with
 persisted local config, and the tab only shows controls that the selected stage

--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ For development of the local TypeScript API and current React/Vite shell:
 pnpm test
 ```
 
-Discovery can use `python-jobspy` when installed. If `jobhunter doctor` reports
-that JobSpy is missing, install it with the command shown by the doctor output.
+Discovery includes `python-jobspy` for broad-board scraping through JobSpy.
+If `jobhunter doctor` reports JobSpy is missing, rerun
+`uv --project workers/automation sync`.
 
 ## First-Time Setup
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,10 @@ The Jobs tab separates temporary removal from permanent suppression. Deleting a
 job moves it to the Deleted tab; a later discovery run can resurface that job if
 the posting is found again. Hiding a job moves it to the Hidden tab and keeps it
 hidden across future discovery runs until you select it there and use **unhide
-selected**.
+selected**. Deleted and hidden rows can also be permanently deleted from the
+local database; discovery can add the same posting again later because that
+action clears the delete/hide tombstones instead of creating a new suppression
+record.
 
 The Pipelines tab includes global stage starts. Each stage (`discover`,
 `enrich`, `score`, `tailor`, `cover`, `pdf`, `apply`) has its own tab with

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -45,6 +45,8 @@ export interface ActionDispatchResult {
   status: string;
   actionId?: string;
   runId?: string;
+  workflowId?: string;
+  firstExecutionRunId?: string;
   result?: unknown;
   message?: string;
 }
@@ -124,15 +126,32 @@ export function createActionDispatcher(
     }
     if (rpcCall.method === "apply") {
       // workflow start — server returns { runId } (the Temporal workflow id).
-      const runId = extractRunId(response.result);
+      const workflowStart = extractWorkflowStart(response.result);
       const result: ActionDispatchResult = {
         status: "queued",
         result: response.result,
       };
-      if (runId) result.runId = runId;
+      if (workflowStart.runId) result.runId = workflowStart.runId;
+      if (workflowStart.workflowId) result.workflowId = workflowStart.workflowId;
+      if (workflowStart.firstExecutionRunId) {
+        result.firstExecutionRunId = workflowStart.firstExecutionRunId;
+      }
       return result;
     }
     if (rpcCall.method === "run_stage") {
+      const workflowStart = extractWorkflowStart(response.result);
+      if (workflowStart.runId) {
+        const result: ActionDispatchResult = {
+          status: "queued",
+          runId: workflowStart.runId,
+          result: response.result,
+        };
+        if (workflowStart.workflowId) result.workflowId = workflowStart.workflowId;
+        if (workflowStart.firstExecutionRunId) {
+          result.firstExecutionRunId = workflowStart.firstExecutionRunId;
+        }
+        return result;
+      }
       const status = extractStatus(response.result) ?? "succeeded";
       const result: ActionDispatchResult = {
         status,
@@ -260,6 +279,12 @@ export function buildActionResponse(
   if (dispatch.message) {
     response.message = dispatch.message;
   }
+  if (dispatch.workflowId) {
+    response.workflowId = dispatch.workflowId;
+  }
+  if (dispatch.firstExecutionRunId) {
+    response.firstExecutionRunId = dispatch.firstExecutionRunId;
+  }
   if (extra.stage) {
     response.stage = extra.stage;
   }
@@ -303,9 +328,16 @@ function mapCommandToRpc(command: ActionCommandPayload): RpcCall | null {
 }
 
 function runStageRpcParams(command: ActionCommandPayload): Record<string, unknown> {
+  const stages =
+    command.stages && command.stages.length > 0
+      ? command.stages
+      : command.stage
+        ? [command.stage]
+        : [];
   const params: Record<string, unknown> = {
     tenantId: "local",
     stage: command.stage,
+    stages,
     limit: command.limit ?? 25,
     workers: command.workers ?? 1,
     minScore: command.minScore ?? 7,
@@ -313,6 +345,9 @@ function runStageRpcParams(command: ActionCommandPayload): Record<string, unknow
     dryRun: command.dryRun ?? false,
     rescore: Boolean(command.rescore),
     retailor: Boolean(command.retailor),
+    headless: Boolean(command.headless),
+    model: command.model ?? "haiku",
+    continuous: Boolean(command.continuous),
   };
   if (command.jobKey !== PIPELINE_ACTION_JOB_KEY) {
     params.jobUrl = command.jobKey;
@@ -337,10 +372,19 @@ function applyRpcParams(command: ActionCommandPayload): Record<string, unknown> 
   return params;
 }
 
-function extractRunId(result: unknown): string | null {
-  if (!isRecord(result)) return null;
-  const runId = result.runId;
-  return typeof runId === "string" ? runId : null;
+function extractWorkflowStart(result: unknown): {
+  runId: string | null;
+  workflowId: string | null;
+  firstExecutionRunId: string | null;
+} {
+  if (!isRecord(result)) {
+    return { runId: null, workflowId: null, firstExecutionRunId: null };
+  }
+  const runId = typeof result.runId === "string" ? result.runId : null;
+  const workflowId = typeof result.workflowId === "string" ? result.workflowId : null;
+  const firstExecutionRunId =
+    typeof result.firstExecutionRunId === "string" ? result.firstExecutionRunId : null;
+  return { runId, workflowId, firstExecutionRunId };
 }
 
 function extractActionId(result: unknown): string | null {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -515,6 +515,20 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
       if (job.url) dirtyJobs.add(job.url);
     }
   }
+  if (tableExists(db, "jobs")) {
+    const missingProjectedJobs = allRows<{ url: string }>(
+      db,
+      `SELECT j.url
+       FROM jobs j
+       LEFT JOIN job_list_projections p
+         ON p.tenant_id = ? AND p.job_id = j.url
+       WHERE p.job_id IS NULL`,
+      [tenantId],
+    );
+    for (const job of missingProjectedJobs) {
+      if (job.url) dirtyJobs.add(job.url);
+    }
+  }
 
   // L5 (round-1 review): nothing dirty AND no new events ⇒ skip the
   // O(jobs × stages) dashboard / apply-run rebuilds.

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1290,6 +1290,12 @@ function pdfSibling(value: string | null | undefined): string | null {
 }
 
 function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void {
+  const hiddenWhere = tableExists(db, "jobhunter_hidden_jobs")
+    ? `AND NOT EXISTS (
+         SELECT 1 FROM jobhunter_hidden_jobs h
+         WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
+       )`
+    : "";
   const rows = allRows<{
     job_id: string;
     current_stage: string;
@@ -1303,7 +1309,9 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
     db,
     `SELECT job_id, current_stage, current_state, apply_status, applied_at,
             deleted_at, fit_score, source
-     FROM job_list_projections WHERE tenant_id = ?`,
+     FROM job_list_projections jlp
+     WHERE tenant_id = ?
+       ${hiddenWhere}`,
     [tenantId],
   );
   const active = rows.filter((row) => !row.deleted_at);
@@ -1320,12 +1328,21 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
   ).length;
   let dryRuns = 0;
   if (tableExists(db, "apply_run_projections")) {
-    if (tableExists(db, "jobhunter_deleted_jobs")) {
+    if (tableExists(db, "jobhunter_deleted_jobs") || tableExists(db, "jobhunter_hidden_jobs")) {
+      const deletedJoin = tableExists(db, "jobhunter_deleted_jobs")
+        ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = arp.job_id AND d.restored_at IS NULL"
+        : "";
+      const hiddenJoin = tableExists(db, "jobhunter_hidden_jobs")
+        ? " LEFT JOIN jobhunter_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
+        : "";
+      const hiddenWhere = [
+        tableExists(db, "jobhunter_deleted_jobs") ? "d.job_url IS NULL" : "",
+        tableExists(db, "jobhunter_hidden_jobs") ? "h.job_url IS NULL" : "",
+      ].filter(Boolean).join(" AND ");
       const dryRunsRow = getRow<{ c: number }>(
         db,
-        `SELECT COUNT(*) AS c FROM apply_run_projections arp
-         LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = arp.job_id AND d.restored_at IS NULL
-         WHERE arp.dry_run = 1 AND d.job_url IS NULL`,
+        `SELECT COUNT(*) AS c FROM apply_run_projections arp${deletedJoin}${hiddenJoin}
+         WHERE arp.dry_run = 1 AND ${hiddenWhere}`,
       );
       dryRuns = dryRunsRow ? Number(dryRunsRow.c) : 0;
     } else {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1012,7 +1012,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const title = stringField(job.title) || "Untitled";
   const site = stringField(job.site);
   const applicationUrl = enrichment.applicationUrl ?? nullableString(job.application_url);
-  const employer = companyName(site, applicationUrl ?? jobUrl);
+  const employer = stringField(job.company) || companyName(site, applicationUrl ?? jobUrl);
 
   const firstActionable =
     stages.find((s) => !["succeeded", "skipped"].includes(s.state)) ?? stages[stages.length - 1];

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -111,6 +111,7 @@ interface JobListProjectionRow extends Record<string, unknown> {
   applied_at: string | null;
   artifact_count: number;
   deleted_at: string | null;
+  hidden_at: string | null;
   last_updated_at: string | null;
 }
 
@@ -230,7 +231,8 @@ export function buildDashboardSummary(db: SqliteDatabase): DashboardSummary {
 export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResponse<JobSummary> {
   refreshProjections(db, DEFAULT_TENANT);
   const sortColumn = SQL_JOB_SORT_COLUMNS[query.sort] ?? "discovered_at";
-  const filter = jobSqlFilter(query);
+  const filter = jobSqlFilter(db, query);
+  const projectionSelect = jobProjectionSelect(db);
 
   if (!query.q) {
     const total = countJobProjections(db, filter);
@@ -240,7 +242,7 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
     const direction = query.dir === "asc" ? "ASC" : "DESC";
     const rows = allRows<JobListProjectionRow>(
       db,
-      `SELECT * FROM job_list_projections${filter.where} ORDER BY ${sortColumn} ${direction}, job_id ASC LIMIT ? OFFSET ?`,
+      `SELECT ${projectionSelect} FROM job_list_projections${filter.where} ORDER BY ${sortColumn} ${direction}, job_id ASC LIMIT ? OFFSET ?`,
       [...filter.params, query.pageSize, offset],
     );
     const summaries = rows.map(rowToJobSummary);
@@ -251,7 +253,7 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
   // projection table makes this cheap — it's already denormalised).
   const allMatching = allRows<JobListProjectionRow>(
     db,
-    `SELECT * FROM job_list_projections${filter.where}`,
+    `SELECT ${projectionSelect} FROM job_list_projections${filter.where}`,
     filter.params,
   );
   const normalizedQuery = query.q.toLowerCase();
@@ -263,10 +265,10 @@ export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResp
 export function matchingJobKeys(db: SqliteDatabase, filter: Partial<BulkJobMutationFilter> = {}): string[] {
   const query = normalizeMutationFilter(filter);
   refreshProjections(db, DEFAULT_TENANT);
-  const sqlFilter = jobSqlFilter(query);
+  const sqlFilter = jobSqlFilter(db, query);
   const rows = allRows<JobListProjectionRow>(
     db,
-    `SELECT * FROM job_list_projections${sqlFilter.where}`,
+    `SELECT ${jobProjectionSelect(db)} FROM job_list_projections${sqlFilter.where}`,
     sqlFilter.params,
   );
   const normalizedQuery = query.q.toLowerCase();
@@ -302,7 +304,7 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
 function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRow | null {
   const direct = getRow<JobListProjectionRow>(
     db,
-    "SELECT * FROM job_list_projections WHERE tenant_id = ? AND job_id = ?",
+    `SELECT ${jobProjectionSelect(db)} FROM job_list_projections WHERE tenant_id = ? AND job_id = ?`,
     [DEFAULT_TENANT, jobKey],
   );
   if (direct) return direct;
@@ -310,7 +312,7 @@ function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRo
   return (
     getRow<JobListProjectionRow>(
       db,
-      "SELECT * FROM job_list_projections WHERE tenant_id = ? AND application_url = ? LIMIT 1",
+      `SELECT ${jobProjectionSelect(db)} FROM job_list_projections WHERE tenant_id = ? AND application_url = ? LIMIT 1`,
       [DEFAULT_TENANT, jobKey],
     ) ?? null
   );
@@ -322,11 +324,15 @@ export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): Pag
   const deletedJoin = tableExists(db, "jobhunter_deleted_jobs")
     ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = ap.job_id AND d.restored_at IS NULL"
     : "";
+  const hiddenJoin = tableExists(db, "jobhunter_hidden_jobs")
+    ? " LEFT JOIN jobhunter_hidden_jobs h ON h.job_url = ap.job_id AND h.unhidden_at IS NULL"
+    : "";
   const deletedWhere = tableExists(db, "jobhunter_deleted_jobs") ? " AND d.job_url IS NULL" : "";
+  const hiddenWhere = tableExists(db, "jobhunter_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ArtifactProjectionRow>(
     db,
-    `SELECT ap.* FROM artifact_list_projections ap${deletedJoin}
-     WHERE ap.tenant_id = ?${deletedWhere}`,
+    `SELECT ap.* FROM artifact_list_projections ap${deletedJoin}${hiddenJoin}
+     WHERE ap.tenant_id = ?${deletedWhere}${hiddenWhere}`,
     [DEFAULT_TENANT],
   );
   const artifacts = rows.map(rowToArtifactSummary).filter((artifact) => {
@@ -404,6 +410,7 @@ function rowToJobSummary(row: JobListProjectionRow): JobSummary {
     applyStatus: row.apply_status,
     appliedAt: row.applied_at,
     deletedAt: row.deleted_at,
+    hiddenAt: row.hidden_at,
   };
 }
 
@@ -763,13 +770,26 @@ function normalizeMutationFilter(filter: Partial<BulkJobMutationFilter>): JobLis
   };
 }
 
-function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue[] } {
+function jobSqlFilter(db: SqliteDatabase, query: JobListQuery): { where: string; params: SqliteValue[] } {
   const clauses: string[] = ["tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
+  const hasHiddenTable = tableExists(db, "jobhunter_hidden_jobs");
   if (query.deleted === "active") {
     clauses.push("deleted_at IS NULL");
+    if (hasHiddenTable) {
+      clauses.push("NOT EXISTS (SELECT 1 FROM jobhunter_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)");
+    }
   } else if (query.deleted === "deleted") {
     clauses.push("deleted_at IS NOT NULL");
+    if (hasHiddenTable) {
+      clauses.push("NOT EXISTS (SELECT 1 FROM jobhunter_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)");
+    }
+  } else if (query.deleted === "hidden") {
+    clauses.push(
+      hasHiddenTable
+        ? "EXISTS (SELECT 1 FROM jobhunter_hidden_jobs h WHERE h.job_url = job_id AND h.unhidden_at IS NULL)"
+        : "1 = 0",
+    );
   }
   if (query.stage) {
     clauses.push("current_stage = ?");
@@ -796,6 +816,18 @@ function jobSqlFilter(query: JobListQuery): { where: string; params: SqliteValue
     params.push(query.maxFitScore);
   }
   return { where: ` WHERE ${clauses.join(" AND ")}`, params };
+}
+
+function jobProjectionSelect(db: SqliteDatabase): string {
+  if (!tableExists(db, "jobhunter_hidden_jobs")) {
+    return "job_list_projections.*, NULL AS hidden_at";
+  }
+  return `job_list_projections.*,
+          (SELECT h.hidden_at
+             FROM jobhunter_hidden_jobs h
+            WHERE h.job_url = job_list_projections.job_id
+              AND h.unhidden_at IS NULL
+            LIMIT 1) AS hidden_at`;
 }
 
 function jobFilterPayload(query: JobListQuery): Record<string, unknown> {
@@ -922,7 +954,14 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
   const hideDeletedJoin = tableExists(db, "jobhunter_deleted_jobs")
     ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = e.job_url AND d.restored_at IS NULL"
     : "";
-  const hideDeletedWhere = tableExists(db, "jobhunter_deleted_jobs") ? "WHERE d.job_url IS NULL" : "";
+  const hideHiddenJoin = tableExists(db, "jobhunter_hidden_jobs")
+    ? " LEFT JOIN jobhunter_hidden_jobs h ON h.job_url = e.job_url AND h.unhidden_at IS NULL"
+    : "";
+  const hiddenClauses = [
+    tableExists(db, "jobhunter_deleted_jobs") ? "d.job_url IS NULL" : "",
+    tableExists(db, "jobhunter_hidden_jobs") ? "h.job_url IS NULL" : "",
+  ].filter(Boolean);
+  const hiddenWhere = hiddenClauses.length ? `WHERE ${hiddenClauses.join(" AND ")}` : "";
   const sql = `
     SELECT
       e.event_id,
@@ -937,7 +976,8 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
     FROM job_events e
     LEFT JOIN job_list_projections jp ON jp.tenant_id = ? AND jp.job_id = e.job_url
     ${hideDeletedJoin}
-    ${hideDeletedWhere}
+    ${hideHiddenJoin}
+    ${hiddenWhere}
     ORDER BY e.occurred_at DESC, e.event_id DESC
     LIMIT 20`;
   return allRows<Record<string, unknown>>(db, sql, [DEFAULT_TENANT]).map((row) => ({
@@ -982,15 +1022,21 @@ export function listWorkflowRuns(
   const deletedJoin = tableExists(db, "jobhunter_deleted_jobs")
     ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = arp.job_id AND d.restored_at IS NULL"
     : "";
+  const hiddenJoin = tableExists(db, "jobhunter_hidden_jobs")
+    ? " LEFT JOIN jobhunter_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
+    : "";
   const where: string[] = ["arp.tenant_id = ?"];
   const params: SqliteValue[] = [DEFAULT_TENANT];
   if (tableExists(db, "jobhunter_deleted_jobs")) {
     where.push("d.job_url IS NULL");
   }
+  if (tableExists(db, "jobhunter_hidden_jobs")) {
+    where.push("h.job_url IS NULL");
+  }
   const whereSql = where.length ? ` WHERE ${where.join(" AND ")}` : "";
   const rows = allRows<ApplyRunProjectionRow>(
     db,
-    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}${whereSql}
+    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}${hiddenJoin}${whereSql}
      ORDER BY arp.started_at DESC, arp.run_id DESC`,
     params,
   );
@@ -1041,11 +1087,15 @@ function recentApplyRuns(db: SqliteDatabase): DashboardSummary["applyRuns"] {
   const deletedJoin = tableExists(db, "jobhunter_deleted_jobs")
     ? " LEFT JOIN jobhunter_deleted_jobs d ON d.job_url = arp.job_id AND d.restored_at IS NULL"
     : "";
+  const hiddenJoin = tableExists(db, "jobhunter_hidden_jobs")
+    ? " LEFT JOIN jobhunter_hidden_jobs h ON h.job_url = arp.job_id AND h.unhidden_at IS NULL"
+    : "";
   const deletedWhere = tableExists(db, "jobhunter_deleted_jobs") ? " AND d.job_url IS NULL" : "";
+  const hiddenWhere = tableExists(db, "jobhunter_hidden_jobs") ? " AND h.job_url IS NULL" : "";
   const rows = allRows<ApplyRunProjectionRow>(
     db,
-    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}
-     WHERE arp.tenant_id = ?${deletedWhere}
+    `SELECT arp.* FROM apply_run_projections arp${deletedJoin}${hiddenJoin}
+     WHERE arp.tenant_id = ?${deletedWhere}${hiddenWhere}
      ORDER BY arp.started_at DESC LIMIT 12`,
     [DEFAULT_TENANT],
   );

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -87,6 +87,8 @@ import {
 import {
   cancelJobAction,
   correctScore,
+  hideJob,
+  hideJobs,
   InputError,
   markJobApplied,
   markJobSkipped,
@@ -96,6 +98,8 @@ import {
   resolveJobUrl,
   softDeleteJob,
   softDeleteJobs,
+  unhideJob,
+  unhideJobs,
   writeSettingsConfig,
 } from "./write-model.js";
 
@@ -373,6 +377,22 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     return withWritableDb(reply, options.dbPath, (db) => restoreJobs(db, body));
   });
 
+  app.post("/v1/jobs/bulk-hide", async (request, reply) => {
+    const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => hideJobs(db, body));
+  });
+
+  app.post("/v1/jobs/bulk-unhide", async (request, reply) => {
+    const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => unhideJobs(db, body));
+  });
+
   app.get<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) =>
     withDb(reply, options.dbPath, (db) => {
       const detail = getJobDetail(db, decodeRouteParam(request.params.jobKey));
@@ -413,6 +433,18 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/restore", async (request, reply) =>
     withWritableDb(reply, options.dbPath, (db) => restoreJob(db, decodeRouteParam(request.params.jobKey))),
+  );
+
+  app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/hide", async (request, reply) => {
+    const body = parseBody(reply, DeleteJobRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => hideJob(db, decodeRouteParam(request.params.jobKey), body));
+  });
+
+  app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/unhide", async (request, reply) =>
+    withWritableDb(reply, options.dbPath, (db) => unhideJob(db, decodeRouteParam(request.params.jobKey))),
   );
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/actions/retry-stage", async (request, reply) => {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -34,6 +34,7 @@ import {
   SourceLocatorDecisionSchema,
   SourceStatePatchSchema,
   SourceUpsertRequestSchema,
+  type Stage,
   WorkflowRunsListQuerySchema,
 } from "./contracts.js";
 import { databaseExists, openDatabase } from "./db.js";
@@ -310,48 +311,35 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       return undefined;
     }
     const actions: ActionRunResponse[] = [];
-    let applyQueued = false;
-    for (const stage of body.stages) {
-      const command: ActionCommandPayload =
-        stage === "apply"
-          ? {
-              action: "apply" as const,
-              jobKey: PIPELINE_ACTION_JOB_KEY,
-              stage,
-              limit: body.limit,
-              workers: body.workers,
-              minScore: body.minScore,
-              dryRun: body.dryRun,
-              headless: body.headless,
-              model: body.model,
-              continuous: body.continuous,
-            }
-          : {
-              action: "run_stage" as const,
-              jobKey: PIPELINE_ACTION_JOB_KEY,
-              stage,
-              limit: body.limit,
-              workers: body.workers,
-              minScore: body.minScore,
-              validationMode: body.validationMode,
-              dryRun: body.dryRun,
-              rescore: body.rescore,
-              retailor: body.retailor,
-            };
-      const dispatch = await actionDispatcher(command, actionContext);
-      actions.push(buildActionResponse(command, dispatch));
-      if (command.action === "apply" && dispatch.status === "queued") {
-        applyQueued = true;
-      }
-      if (dispatch.status === "failed") {
-        break;
-      }
+    const firstStage = body.stages[0] as Stage | undefined;
+    if (!firstStage) {
+      void reply.code(400);
+      return undefined;
     }
-    void reply.code(applyQueued ? 202 : 200);
+    const command: ActionCommandPayload = {
+      action: "run_stage" as const,
+      jobKey: PIPELINE_ACTION_JOB_KEY,
+      stage: firstStage,
+      stages: body.stages,
+      limit: body.limit,
+      workers: body.workers,
+      minScore: body.minScore,
+      validationMode: body.validationMode,
+      dryRun: body.dryRun,
+      rescore: body.rescore,
+      retailor: body.retailor,
+      headless: body.headless,
+      model: body.model,
+      continuous: body.continuous,
+    };
+    const dispatch = await actionDispatcher(command, actionContext);
+    actions.push(buildActionResponse(command, dispatch));
+    const status = stageRunStatus(actions);
+    void reply.code(dispatch.status === "queued" && status !== "failed" ? 202 : 200);
     return {
       ok: true,
       action: "run_stage",
-      status: stageRunStatus(actions),
+      status,
       jobKey: PIPELINE_ACTION_JOB_KEY,
       count: actions.length,
       command: body,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -92,6 +92,8 @@ import {
   InputError,
   markJobApplied,
   markJobSkipped,
+  permanentlyDeleteJob,
+  permanentlyDeleteJobs,
   resetJobStage,
   restoreJob,
   restoreJobs,
@@ -369,6 +371,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     return withWritableDb(reply, options.dbPath, (db) => softDeleteJobs(db, body));
   });
 
+  app.post("/v1/jobs/bulk-delete-permanent", async (request, reply) => {
+    const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => permanentlyDeleteJobs(db, body));
+  });
+
   app.post("/v1/jobs/bulk-restore", async (request, reply) => {
     const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
     if (!body) {
@@ -430,6 +440,10 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     }
     return withWritableDb(reply, options.dbPath, (db) => softDeleteJob(db, decodeRouteParam(request.params.jobKey), body));
   });
+
+  app.delete<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/permanent", async (request, reply) =>
+    withWritableDb(reply, options.dbPath, (db) => permanentlyDeleteJob(db, decodeRouteParam(request.params.jobKey))),
+  );
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/restore", async (request, reply) =>
     withWritableDb(reply, options.dbPath, (db) => restoreJob(db, decodeRouteParam(request.params.jobKey))),

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -361,6 +361,65 @@ export function restoreJobs(db: SqliteDatabase, request: BulkJobMutationRequest)
   return { ok: true, count: jobKeys.length, jobKeys };
 }
 
+export function hideJob(db: SqliteDatabase, jobKey: string, request: DeleteJobRequest = {}): JobMutationResponse {
+  return hideJobs(db, { allMatching: false, jobKeys: [jobKey], reason: request.reason });
+}
+
+export function hideJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
+  ensureHiddenJobsTable(db);
+  const hiddenAt = new Date().toISOString();
+  const jobKeys = mutableJobKeys(db, request);
+  const statement = db.prepare(`
+    INSERT INTO jobhunter_hidden_jobs (job_url, hidden_at, reason, unhidden_at)
+    VALUES (?, ?, ?, NULL)
+    ON CONFLICT(job_url) DO UPDATE SET
+      hidden_at = excluded.hidden_at,
+      reason = excluded.reason,
+      unhidden_at = NULL
+  `);
+  const transaction = db.transaction((keys: string[]) => {
+    for (const jobUrl of keys) {
+      statement.run(jobUrl, hiddenAt, request.reason ?? null);
+      recordActionEvent(db, {
+        jobUrl,
+        stage: currentMutableStage(db, jobUrl),
+        eventType: "JobHidden",
+        level: "info",
+        message: "Job hidden from the local API.",
+        payload: { reason: request.reason ?? "" },
+      });
+    }
+  });
+  transaction(jobKeys);
+  return { ok: true, count: jobKeys.length, jobKeys };
+}
+
+export function unhideJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
+  return unhideJobs(db, { allMatching: false, jobKeys: [jobKey] });
+}
+
+export function unhideJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
+  ensureHiddenJobsTable(db);
+  const unhiddenAt = new Date().toISOString();
+  const jobKeys = mutableJobKeys(db, request);
+  const statement = db.prepare("UPDATE jobhunter_hidden_jobs SET unhidden_at = ? WHERE job_url = ? AND unhidden_at IS NULL");
+  const transaction = db.transaction((keys: string[]) => {
+    for (const jobUrl of keys) {
+      statement.run(unhiddenAt, jobUrl);
+      recordActionEvent(db, {
+        jobUrl,
+        stage: currentMutableStage(db, jobUrl),
+        eventType: "JobUnhidden",
+        level: "info",
+        message: "Job unhidden from hidden jobs.",
+        payload: {},
+      });
+    }
+  });
+  transaction(jobKeys);
+  return { ok: true, count: jobKeys.length, jobKeys };
+}
+
 export function writeSettingsConfig(paths: { settingsPath: string }, request: SettingsUpdateRequest): SettingsResponse {
   const next = readJsonObject(paths.settingsPath);
   let wrote = false;
@@ -483,6 +542,18 @@ function ensureDeletedJobsTable(db: SqliteDatabase): void {
       deleted_at TEXT NOT NULL,
       reason TEXT,
       restored_at TEXT,
+      FOREIGN KEY(job_url) REFERENCES jobs(url)
+    )`,
+  ).run();
+}
+
+function ensureHiddenJobsTable(db: SqliteDatabase): void {
+  db.prepare(
+    `CREATE TABLE IF NOT EXISTS jobhunter_hidden_jobs (
+      job_url TEXT PRIMARY KEY,
+      hidden_at TEXT NOT NULL,
+      reason TEXT,
+      unhidden_at TEXT,
       FOREIGN KEY(job_url) REFERENCES jobs(url)
     )`,
   ).run();

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -13,7 +13,7 @@ import type {
   StageState,
   StageSummary,
 } from "./contracts.js";
-import { STAGES } from "./contracts.js";
+import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
 import {
   isValidTransition,
   deserializeStageStateKind,
@@ -420,6 +420,22 @@ export function unhideJobs(db: SqliteDatabase, request: BulkJobMutationRequest):
   return { ok: true, count: jobKeys.length, jobKeys };
 }
 
+export function permanentlyDeleteJob(db: SqliteDatabase, jobKey: string): JobMutationResponse {
+  return permanentlyDeleteJobs(db, { allMatching: false, jobKeys: [jobKey] });
+}
+
+export function permanentlyDeleteJobs(db: SqliteDatabase, request: BulkJobMutationRequest): JobMutationResponse {
+  const jobKeys = mutableJobKeys(db, request);
+  const transaction = db.transaction((keys: string[]) => {
+    for (const jobUrl of keys) {
+      purgeJobRows(db, jobUrl);
+    }
+    invalidateOperationsProjections(db);
+  });
+  transaction(jobKeys);
+  return { ok: true, count: jobKeys.length, jobKeys };
+}
+
 export function writeSettingsConfig(paths: { settingsPath: string }, request: SettingsUpdateRequest): SettingsResponse {
   const next = readJsonObject(paths.settingsPath);
   let wrote = false;
@@ -570,6 +586,50 @@ function mutableJobKeys(db: SqliteDatabase, request: BulkJobMutationRequest): st
 
 function uniqueJobKeys(jobKeys: string[]): string[] {
   return Array.from(new Set(jobKeys.map((jobKey) => jobKey.trim()).filter(Boolean)));
+}
+
+function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
+  deleteWhere(db, "jobhunter_deleted_jobs", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "jobhunter_hidden_jobs", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_stage_states", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_scores", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_source_observations", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_canonical_identities", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_duplicate_links", "surviving_job_id = ? OR superseded_job_or_observation_id = ?", [
+    jobUrl,
+    jobUrl,
+  ]);
+  deleteWhere(db, "apply_run_projections", "job_id = ?", [jobUrl]);
+  deleteWhere(db, "artifact_list_projections", "job_id = ?", [jobUrl]);
+  deleteWhere(db, "job_detail_projections", "job_id = ?", [jobUrl]);
+  deleteWhere(db, "job_list_projections", "job_id = ?", [jobUrl]);
+  deleteWhere(db, "discovery_quarantine_entries", "job_id = ? OR job_key = ? OR posting_url = ?", [
+    jobUrl,
+    jobUrl,
+    jobUrl,
+  ]);
+  deleteWhere(db, "discovery_feedback", "job_key = ?", [jobUrl]);
+  deleteWhere(db, "jobs", "url = ?", [jobUrl]);
+}
+
+function invalidateOperationsProjections(db: SqliteDatabase): void {
+  deleteWhere(db, "job_list_projections", "1 = 1", []);
+  deleteWhere(db, "job_detail_projections", "1 = 1", []);
+  deleteWhere(db, "artifact_list_projections", "1 = 1", []);
+  deleteWhere(db, "dashboard_projections", "1 = 1", []);
+  deleteWhere(db, "event_watermarks", "projection_name = ?", [PROJECTION_WATERMARK_NAME]);
+}
+
+function deleteWhere(db: SqliteDatabase, tableName: string, whereSql: string, params: SqliteValue[]): void {
+  if (!tableExists(db, tableName)) {
+    return;
+  }
+  db.prepare(`DELETE FROM ${tableName} WHERE ${whereSql}`).run(...params);
 }
 
 function ensureJobScoresTable(db: SqliteDatabase): void {

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -89,21 +89,15 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
     expect(result.status).toBe("queued");
   });
 
-  it("maps a global run-stage action to the run_stage RPC method", async () => {
+  it("maps a global run-stage workflow start to a queued action", async () => {
     const fake = new FakeDispatcher();
     fake.setResponse({
       jsonrpc: "2.0",
       id: 1,
       result: {
-        ok: true,
-        action_id: "act-worker-score",
-        stage: "score",
-        status: "dry_run",
-        started_at: "2026-05-10T11:00:00.000Z",
-        finished_at: "2026-05-10T11:00:00.000Z",
-        duration_ms: 0,
-        dry_run: true,
-        result: { planned: 3 },
+        runId: "pipeline-wf",
+        workflowId: "pipeline-wf",
+        firstExecutionRunId: "first-exec-run-id",
       },
     } as JsonRpcResponse);
     const dispatcher = createActionDispatcher(fake);
@@ -130,6 +124,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       params: {
         tenantId: "local",
         stage: "score",
+        stages: ["score"],
         limit: 20,
         workers: 4,
         minScore: 8,
@@ -137,14 +132,18 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         dryRun: true,
         rescore: true,
         retailor: false,
+        headless: false,
+        model: "haiku",
+        continuous: false,
       },
     });
     expect(result).toMatchObject({
-      actionId: "act-worker-score",
-      status: "dry_run",
+      status: "queued",
+      runId: "pipeline-wf",
       result: {
-        status: "dry_run",
-        result: { planned: 3 },
+        runId: "pipeline-wf",
+        workflowId: "pipeline-wf",
+        firstExecutionRunId: "first-exec-run-id",
       },
     });
   });

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -271,6 +271,52 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it("backfills legacy jobs inserted after the first projection refresh", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const app = buildApp({
+        dbPath,
+        profilePath: path.join(path.dirname(dbPath), "profile.json"),
+        resumeStylePath: path.join(path.dirname(dbPath), "resume_style.json"),
+        resumeTemplatePath: path.join(path.dirname(dbPath), "resume_template.tex"),
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        const firstRes = await app.inject({ method: "GET", url: "/v1/jobs" });
+        expect(firstRes.statusCode, firstRes.body).toBe(200);
+
+        const db = new Database(dbPath);
+        db.prepare(
+          "INSERT INTO jobs (url, title, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run(
+          "https://example.com/jobs/late-legacy",
+          "Late Legacy Engineer",
+          "Workday",
+          "workday_api",
+          "Barcelona, Spain",
+          "2026-05-06T09:00:00+00:00",
+        );
+        db.close();
+
+        const secondRes = await app.inject({ method: "GET", url: "/v1/jobs" });
+        expect(secondRes.statusCode, secondRes.body).toBe(200);
+        const late = secondRes
+          .json()
+          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/late-legacy");
+        expect(late).toMatchObject({
+          title: "Late Legacy Engineer",
+          source: "Workday",
+          location: "Barcelona, Spain",
+        });
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("jobs endpoints expose latest score evidence from job_scores", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -28,6 +28,7 @@ function seedSchema(dbPath: string): void {
     CREATE TABLE jobs (
       url TEXT PRIMARY KEY,
       title TEXT,
+      company TEXT,
       site TEXT,
       strategy TEXT,
       location TEXT,
@@ -308,6 +309,50 @@ describe("apply_run_projections without legacy apply_runs table", () => {
           title: "Late Legacy Engineer",
           source: "Workday",
           location: "Barcelona, Spain",
+        });
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("uses explicit company from discovered jobs before source inference", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      db.prepare(
+        "INSERT INTO jobs (url, title, company, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        "https://www.linkedin.com/jobs/view/1",
+        "Head of Engineering",
+        "Keyrock",
+        "linkedin",
+        "jobspy",
+        "Barcelona, Spain",
+        "2026-05-06T09:00:00+00:00",
+      );
+      db.close();
+
+      const app = buildApp({
+        dbPath,
+        profilePath: path.join(path.dirname(dbPath), "profile.json"),
+        resumeStylePath: path.join(path.dirname(dbPath), "resume_style.json"),
+        resumeTemplatePath: path.join(path.dirname(dbPath), "resume_template.tex"),
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        const res = await app.inject({ method: "GET", url: "/v1/jobs" });
+        expect(res.statusCode, res.body).toBe(200);
+        const item = res
+          .json()
+          .items.find((j: { jobKey: string }) => j.jobKey === "https://www.linkedin.com/jobs/view/1");
+        expect(item).toMatchObject({
+          title: "Head of Engineering",
+          company: "Keyrock",
+          source: "linkedin",
         });
       } finally {
         await app.close();

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -420,6 +420,57 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("hides jobs in a separate tab and unhides them without using deleted state", async () => {
+    const app = buildApp(options);
+
+    const hide = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-hide",
+      payload: {
+        allMatching: false,
+        jobKeys: ["https://example.com/jobs/blocked-tailor"],
+        reason: "never show again",
+      },
+    });
+    expect(hide.statusCode, hide.body).toBe(200);
+    expect(hide.json()).toMatchObject({ ok: true, count: 1 });
+
+    const active = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&sort=title&dir=asc" });
+    expect(active.statusCode, active.body).toBe(200);
+    expect(active.json().pagination.total).toBe(2);
+    expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).not.toContain(
+      "https://example.com/jobs/blocked-tailor",
+    );
+
+    const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted" });
+    expect(deleted.statusCode, deleted.body).toBe(200);
+    expect(deleted.json().pagination.total).toBe(0);
+
+    const hidden = await app.inject({ method: "GET", url: "/v1/jobs?deleted=hidden" });
+    expect(hidden.statusCode, hidden.body).toBe(200);
+    expect(hidden.json().pagination.total).toBe(1);
+    expect(hidden.json().items[0]).toMatchObject({
+      jobKey: "https://example.com/jobs/blocked-tailor",
+      hiddenAt: expect.any(String),
+      deletedAt: null,
+    });
+
+    const unhide = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-unhide",
+      payload: { allMatching: true, filter: { deleted: "hidden" }, jobKeys: [] },
+    });
+    expect(unhide.statusCode, unhide.body).toBe(200);
+    expect(unhide.json()).toMatchObject({ ok: true, count: 1 });
+
+    const restoredActive = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active" });
+    expect(restoredActive.json().pagination.total).toBe(3);
+    const emptyHidden = await app.inject({ method: "GET", url: "/v1/jobs?deleted=hidden" });
+    expect(emptyHidden.json().pagination.total).toBe(0);
+
+    await app.close();
+  });
+
   it("derives apply state from apply_run_projections when legacy jobs columns are NULL", async () => {
     // PR 4 of the Temporal stack: ``apply_run_projections`` (sourced
     // from ``job_events`` by the Python projection builder) is the

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1228,7 +1228,7 @@ describe("local TypeScript API", () => {
       action: "run_stage",
       status: "queued",
       jobKey: "pipeline",
-      count: 3,
+      count: 1,
       actions: [
         {
           action: "run_stage",
@@ -1238,27 +1238,14 @@ describe("local TypeScript API", () => {
             action: "run_stage",
             jobKey: "pipeline",
             stage: "score",
+            stages: ["score", "tailor", "apply"],
             limit: 12,
             workers: 3,
             minScore: 8,
             validationMode: "strict",
             dryRun: true,
             rescore: true,
-          },
-        },
-        {
-          action: "run_stage",
-          command: {
-            stage: "tailor",
             retailor: true,
-          },
-        },
-        {
-          action: "apply",
-          command: {
-            action: "apply",
-            stage: "apply",
-            dryRun: true,
             headless: true,
             model: "sonnet",
             continuous: true,
@@ -1266,26 +1253,36 @@ describe("local TypeScript API", () => {
         },
       ],
     });
-    await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(3));
+    await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(1));
     expect(dispatch).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ action: "run_stage", stage: "score", jobKey: "pipeline" }),
-      expect.objectContaining({ appDir: tempDir }),
-    );
-    expect(dispatch).toHaveBeenNthCalledWith(
-      3,
-      expect.objectContaining({ action: "apply", stage: "apply", dryRun: true, jobKey: "pipeline" }),
+      expect.objectContaining({
+        action: "run_stage",
+        stage: "score",
+        stages: ["score", "tailor", "apply"],
+        dryRun: true,
+        headless: true,
+        model: "sonnet",
+        continuous: true,
+        jobKey: "pipeline",
+      }),
       expect.objectContaining({ appDir: tempDir }),
     );
 
     await app.close();
   });
 
-  it("returns synchronous non-apply global stage results as 200", async () => {
+  it("returns queued non-apply global stage workflow starts as 202", async () => {
     const dispatch = vi.fn(async () => ({
-      status: "dry_run",
-      actionId: "act-worker-score",
-      result: { planned: 4 },
+      status: "queued",
+      runId: "pipeline-wf",
+      workflowId: "pipeline-wf",
+      firstExecutionRunId: "first-exec-run-id",
+      result: {
+        runId: "pipeline-wf",
+        workflowId: "pipeline-wf",
+        firstExecutionRunId: "first-exec-run-id",
+      },
     }));
     const app = buildApp({ ...options, actionDispatcher: dispatch });
 
@@ -1295,18 +1292,24 @@ describe("local TypeScript API", () => {
       payload: { stages: ["score"], dryRun: true },
     });
 
-    expect(response.statusCode, response.body).toBe(200);
+    expect(response.statusCode, response.body).toBe(202);
     expect(response.json()).toMatchObject({
       ok: true,
-      status: "dry_run",
+      status: "queued",
       count: 1,
       actions: [
         {
           action: "run_stage",
-          actionId: "act-worker-score",
-          runId: "act-worker-score",
-          status: "dry_run",
-          result: { planned: 4 },
+          actionId: "pipeline-wf",
+          runId: "pipeline-wf",
+          workflowId: "pipeline-wf",
+          firstExecutionRunId: "first-exec-run-id",
+          status: "queued",
+          result: {
+            runId: "pipeline-wf",
+            workflowId: "pipeline-wf",
+            firstExecutionRunId: "first-exec-run-id",
+          },
           command: { action: "run_stage", stage: "score", dryRun: true },
         },
       ],
@@ -1319,16 +1322,10 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("runs selected non-apply global stages sequentially before queuing apply", async () => {
-    const dispatches = {
-      score: deferred<ActionDispatchResult>(),
-      tailor: deferred<ActionDispatchResult>(),
-      apply: deferred<ActionDispatchResult>(),
-    };
+  it("starts one ordered pipeline workflow for mixed stage requests", async () => {
+    const pipelineDispatch = deferred<ActionDispatchResult>();
     const dispatch = vi.fn((command: ActionCommandPayload) => {
-      if (command.stage === "score") return dispatches.score.promise;
-      if (command.stage === "tailor") return dispatches.tailor.promise;
-      if (command.stage === "apply") return dispatches.apply.promise;
+      if (command.action === "run_stage") return pipelineDispatch.promise;
       throw new Error(`Unexpected stage ${String(command.stage)}`);
     });
     const app = buildApp({ ...options, actionDispatcher: dispatch });
@@ -1340,75 +1337,11 @@ describe("local TypeScript API", () => {
 
     try {
       await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(1));
-      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ action: "run_stage", stage: "score" });
-
-      dispatches.score.resolve({ status: "dry_run", actionId: "act-score", result: { planned: 2 } });
-      await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(2));
-      expect(dispatch.mock.calls[1]?.[0]).toMatchObject({ action: "run_stage", stage: "tailor" });
-
-      dispatches.tailor.resolve({ status: "succeeded", actionId: "act-tailor", result: { updated: 2 } });
-      await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(3));
-      expect(dispatch.mock.calls[2]?.[0]).toMatchObject({ action: "apply", stage: "apply", dryRun: true });
-
-      dispatches.apply.resolve({ status: "queued", actionId: "act-apply", runId: "run-apply" });
-      const response = await responsePromise;
-      expect(response.statusCode, response.body).toBe(202);
-      expect(response.json()).toMatchObject({
-        ok: true,
-        status: "accepted",
-        count: 3,
-        actions: [
-          {
-            action: "run_stage",
-            actionId: "act-score",
-            status: "dry_run",
-            result: { planned: 2 },
-            command: { action: "run_stage", stage: "score", dryRun: true },
-          },
-          {
-            action: "run_stage",
-            actionId: "act-tailor",
-            status: "succeeded",
-            result: { updated: 2 },
-            command: { action: "run_stage", stage: "tailor", dryRun: true },
-          },
-          {
-            action: "apply",
-            actionId: "act-apply",
-            runId: "run-apply",
-            status: "queued",
-            command: { action: "apply", stage: "apply", dryRun: true },
-          },
-        ],
+      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({
+        action: "run_stage",
+        stage: "score",
+        stages: ["score", "tailor", "apply"],
       });
-    } finally {
-      dispatches.score.resolve({ status: "dry_run", actionId: "act-score" });
-      dispatches.tailor.resolve({ status: "succeeded", actionId: "act-tailor" });
-      dispatches.apply.resolve({ status: "queued", actionId: "act-apply", runId: "run-apply" });
-      await responsePromise.catch(() => undefined);
-      await app.close();
-    }
-  });
-
-  it("queues apply only after preceding non-apply global stages resolve", async () => {
-    const scoreDispatch = deferred<ActionDispatchResult>();
-    const applyDispatch = deferred<ActionDispatchResult>();
-    const dispatch = vi.fn((command: ActionCommandPayload) => {
-      if (command.action === "run_stage") {
-        return scoreDispatch.promise;
-      }
-      return applyDispatch.promise;
-    });
-    const app = buildApp({ ...options, actionDispatcher: dispatch });
-    const responsePromise = app.inject({
-      method: "POST",
-      url: "/v1/pipeline/actions/run-stage",
-      payload: { stages: ["score", "apply"], dryRun: true },
-    });
-
-    try {
-      await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(1));
-      expect(dispatch.mock.calls[0]?.[0]).toMatchObject({ action: "run_stage", stage: "score" });
 
       const earlyResponse = await Promise.race([
         responsePromise,
@@ -1416,49 +1349,32 @@ describe("local TypeScript API", () => {
       ]);
       expect(earlyResponse).toBe("not-yet");
 
-      scoreDispatch.resolve({ status: "succeeded", actionId: "act-score", result: { updated: 1 } });
-      await waitForExpectation(() => expect(dispatch).toHaveBeenCalledTimes(2));
-      expect(dispatch.mock.calls[1]?.[0]).toMatchObject({ action: "apply", stage: "apply" });
-
-      applyDispatch.resolve({ status: "queued", actionId: "act-apply", runId: "run-apply" });
+      pipelineDispatch.resolve({ status: "queued", runId: "run-pipeline" });
       const response = await responsePromise;
       expect(response.statusCode, response.body).toBe(202);
       expect(response.json()).toMatchObject({
         ok: true,
-        status: "accepted",
-        count: 2,
+        status: "queued",
+        count: 1,
         actions: [
           {
             action: "run_stage",
-            actionId: "act-score",
-            status: "succeeded",
-            result: { updated: 1 },
-            command: { action: "run_stage", stage: "score", dryRun: true },
-          },
-          {
-            action: "apply",
+            actionId: "run-pipeline",
+            runId: "run-pipeline",
             status: "queued",
-            jobKey: "pipeline",
-            actionId: "act-apply",
-            runId: "run-apply",
-            command: { action: "apply", stage: "apply", dryRun: true },
+            command: { action: "run_stage", stage: "score", stages: ["score", "tailor", "apply"], dryRun: true },
           },
         ],
       });
-      expect(dispatch.mock.calls.map(([command]) => command.action)).toEqual(["run_stage", "apply"]);
     } finally {
-      scoreDispatch.resolve({ status: "succeeded", actionId: "act-score" });
-      applyDispatch.resolve({ status: "queued", actionId: "act-apply", runId: "run-apply" });
+      pipelineDispatch.resolve({ status: "queued", runId: "run-pipeline" });
       await responsePromise.catch(() => undefined);
       await app.close();
     }
   });
 
-  it("does not return accepted when mixed apply dispatch fails", async () => {
-    const dispatch = vi.fn(async (command: ActionCommandPayload): Promise<ActionDispatchResult> => {
-      if (command.action === "run_stage") {
-        return { status: "succeeded", actionId: "act-score", result: { updated: 1 } };
-      }
+  it("does not return accepted when mixed pipeline workflow dispatch fails", async () => {
+    const dispatch = vi.fn(async (_command: ActionCommandPayload): Promise<ActionDispatchResult> => {
       return {
         status: "failed",
         message: "Temporal workflow start failed.",
@@ -1477,31 +1393,24 @@ describe("local TypeScript API", () => {
     expect(response.json()).toMatchObject({
       ok: true,
       status: "failed",
-      count: 2,
+      count: 1,
       actions: [
         {
           action: "run_stage",
-          actionId: "act-score",
-          status: "succeeded",
-          result: { updated: 1 },
-          command: { action: "run_stage", stage: "score", dryRun: true },
-        },
-        {
-          action: "apply",
           status: "failed",
           message: "Temporal workflow start failed.",
           result: { code: "TEMPORAL_UNAVAILABLE" },
-          command: { action: "apply", stage: "apply", dryRun: true },
+          command: { action: "run_stage", stage: "score", stages: ["score", "apply"], dryRun: true },
         },
       ],
     });
-    expect(dispatch.mock.calls.map(([command]) => command.action)).toEqual(["run_stage", "apply"]);
+    expect(dispatch.mock.calls.map(([command]) => command.action)).toEqual(["run_stage"]);
 
     await app.close();
   });
 
   it("defaults global apply stage starts to dry-run when dryRun is omitted", async () => {
-    const dispatch = vi.fn(async () => ({ status: "queued", actionId: "act-apply", runId: "run-apply" }));
+    const dispatch = vi.fn(async () => ({ status: "queued", runId: "run-pipeline" }));
     const app = buildApp({ ...options, actionDispatcher: dispatch });
 
     const response = await app.inject({
@@ -1516,17 +1425,17 @@ describe("local TypeScript API", () => {
       status: "queued",
       actions: [
         {
-          action: "apply",
-          actionId: "act-apply",
-          runId: "run-apply",
+          action: "run_stage",
+          actionId: "run-pipeline",
+          runId: "run-pipeline",
           status: "queued",
-          command: { dryRun: true, limit: 25, workers: 1, minScore: 7 },
+          command: { action: "run_stage", stage: "apply", stages: ["apply"], dryRun: true, limit: 25, workers: 1, minScore: 7 },
         },
       ],
     });
     await waitForExpectation(() => expect(dispatch).toHaveBeenCalled());
     expect(dispatch).toHaveBeenCalledWith(
-      expect.objectContaining({ action: "apply", dryRun: true, jobKey: "pipeline" }),
+      expect.objectContaining({ action: "run_stage", stage: "apply", stages: ["apply"], dryRun: true, jobKey: "pipeline" }),
       expect.objectContaining({ appDir: tempDir }),
     );
 

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -471,6 +471,81 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("permanently deletes job rows and clears delete/hide tombstones so rediscovery can add them again", async () => {
+    const app = buildApp(options);
+    const readyUrl = "https://example.com/jobs/ready";
+    const blockedUrl = "https://example.com/jobs/blocked-tailor";
+
+    const softDelete = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete",
+      payload: { allMatching: false, jobKeys: [readyUrl] },
+    });
+    const hide = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-hide",
+      payload: { allMatching: false, jobKeys: [blockedUrl] },
+    });
+    expect(softDelete.statusCode, softDelete.body).toBe(200);
+    expect(hide.statusCode, hide.body).toBe(200);
+
+    const permanentDelete = await app.inject({
+      method: "POST",
+      url: "/v1/jobs/bulk-delete-permanent",
+      payload: { allMatching: false, jobKeys: [readyUrl, blockedUrl] },
+    });
+    expect(permanentDelete.statusCode, permanentDelete.body).toBe(200);
+    expect(permanentDelete.json()).toMatchObject({ ok: true, count: 2, jobKeys: [readyUrl, blockedUrl] });
+
+    const active = await app.inject({ method: "GET", url: "/v1/jobs?deleted=active&sort=title&dir=asc" });
+    expect(active.statusCode, active.body).toBe(200);
+    expect(active.json().pagination.total).toBe(1);
+    expect(active.json().items.map((job: { jobKey: string }) => job.jobKey)).toEqual([
+      "https://example.com/jobs/failed-score",
+    ]);
+
+    const deleted = await app.inject({ method: "GET", url: "/v1/jobs?deleted=deleted" });
+    expect(deleted.json().pagination.total).toBe(0);
+    const hidden = await app.inject({ method: "GET", url: "/v1/jobs?deleted=hidden" });
+    expect(hidden.json().pagination.total).toBe(0);
+
+    const detail = await app.inject({ method: "GET", url: `/v1/jobs/${encodeURIComponent(readyUrl)}` });
+    expect(detail.statusCode, detail.body).toBe(404);
+
+    const db = new Database(options.dbPath);
+    expect(countRows(db, "jobs", "url", readyUrl)).toBe(0);
+    expect(countRows(db, "jobhunter_deleted_jobs", "job_url", readyUrl)).toBe(0);
+    expect(countRows(db, "jobhunter_hidden_jobs", "job_url", blockedUrl)).toBe(0);
+    expect(countRows(db, "job_stage_states", "job_url", readyUrl)).toBe(0);
+    expect(countRows(db, "job_scores", "job_url", readyUrl)).toBe(0);
+
+    insertJob(db, {
+      url: readyUrl,
+      title: "Rediscovered Engineer",
+      site: "ExampleCo",
+      fitScore: null,
+    });
+    db.prepare(
+      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(readyUrl, "discover", "JobDiscovered", "info", "Rediscovered after permanent delete.", "2026-04-30T10:00:00+00:00");
+    db.close();
+
+    const rediscovered = await app.inject({
+      method: "GET",
+      url: "/v1/jobs?deleted=active&q=rediscovered&sort=title&dir=asc",
+    });
+    expect(rediscovered.statusCode, rediscovered.body).toBe(200);
+    expect(rediscovered.json().pagination.total).toBe(1);
+    expect(rediscovered.json().items[0]).toMatchObject({
+      jobKey: readyUrl,
+      title: "Rediscovered Engineer",
+      deletedAt: null,
+      hiddenAt: null,
+    });
+
+    await app.close();
+  });
+
   it("derives apply state from apply_run_projections when legacy jobs columns are NULL", async () => {
     // PR 4 of the Temporal stack: ``apply_run_projections`` (sourced
     // from ``job_events`` by the Python projection builder) is the
@@ -2211,6 +2286,13 @@ function insertJob(
     job.tailoredPath ?? null,
     job.tailoredPath ? "2026-04-29T10:03:00+00:00" : null,
   );
+}
+
+function countRows(db: Database.Database, tableName: string, columnName: string, value: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${tableName} WHERE ${columnName} = ?`).get(value) as {
+    count: number;
+  };
+  return Number(row.count);
 }
 
 function insertScore(

--- a/apps/web/src/contexts/discovery/hooks/useHideJobsBulkMutation.test.ts
+++ b/apps/web/src/contexts/discovery/hooks/useHideJobsBulkMutation.test.ts
@@ -1,0 +1,55 @@
+import { LOCAL_TENANT } from "@jobhunter/domain-types";
+import { http, HttpResponse } from "msw";
+import { waitFor } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/msw/server.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { useHideJobsBulkMutation } from "./useHideJobsBulkMutation.js";
+
+const initialList = {
+  ok: true,
+  items: [
+    { jobKey: "job-1", title: "A", company: "X" },
+    { jobKey: "job-2", title: "B", company: "Y" },
+  ],
+  pagination: { page: 1, pageSize: 50, total: 2, pages: 1 },
+  sort: { field: "discovered_at", dir: "desc" },
+  filter: {},
+};
+
+describe("useHideJobsBulkMutation", () => {
+  it("removes hidden jobs from the cached list optimistically", async () => {
+    const { result, queryClient } = renderHookWithProviders(() => useHideJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-2"], allMatching: false });
+      await Promise.resolve();
+    });
+
+    const optimistic = queryClient.getQueryData<{ items: Array<{ jobKey: string }> }>(
+      jobsKeys.list(LOCAL_TENANT, {}),
+    );
+    expect(optimistic?.items.map((item) => item.jobKey)).toEqual(["job-1"]);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back the optimistic patch when bulk-hide fails", async () => {
+    server.use(
+      http.post("*/v1/jobs/bulk-hide", () =>
+        new HttpResponse(JSON.stringify({ ok: false }), { status: 500 }),
+      ),
+    );
+    const { result, queryClient } = renderHookWithProviders(() => useHideJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-1"], allMatching: false });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(jobsKeys.list(LOCAL_TENANT, {}))).toEqual(initialList);
+  });
+});

--- a/apps/web/src/contexts/discovery/hooks/useHideJobsBulkMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useHideJobsBulkMutation.ts
@@ -1,0 +1,36 @@
+import type { BulkJobMutationRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export function useHideJobsBulkMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  BulkJobMutationRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, BulkJobMutationRequest>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: (body) => api.hideJobs(body),
+      optimisticUpdates: (body) =>
+        body.allMatching
+          ? []
+          : [
+              {
+                queryKey: jobsKeys.lists(tenantId),
+                exact: false,
+                patch: (current) => patchListRemove(current, new Set(body.jobKeys)),
+              },
+            ],
+      settle: () => [jobsKeys.lists(tenantId), dashboardKeys.summary(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/hooks/usePermanentlyDeleteJobsBulkMutation.test.ts
+++ b/apps/web/src/contexts/discovery/hooks/usePermanentlyDeleteJobsBulkMutation.test.ts
@@ -1,0 +1,55 @@
+import { waitFor } from "@testing-library/react";
+import { LOCAL_TENANT } from "@jobhunter/domain-types";
+import { http, HttpResponse } from "msw";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/msw/server.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { usePermanentlyDeleteJobsBulkMutation } from "./usePermanentlyDeleteJobsBulkMutation.js";
+
+const initialList = {
+  ok: true,
+  items: [
+    { jobKey: "job-1", title: "A", company: "X" },
+    { jobKey: "job-2", title: "B", company: "Y" },
+  ],
+  pagination: { page: 1, pageSize: 50, total: 2, pages: 1 },
+  sort: { field: "discovered_at", dir: "desc" },
+  filter: {},
+};
+
+describe("usePermanentlyDeleteJobsBulkMutation", () => {
+  it("removes purged jobs from the cached list optimistically", async () => {
+    const { result, queryClient } = renderHookWithProviders(() => usePermanentlyDeleteJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-2"], allMatching: false });
+      await Promise.resolve();
+    });
+
+    const optimistic = queryClient.getQueryData<{ items: Array<{ jobKey: string }> }>(
+      jobsKeys.list(LOCAL_TENANT, {}),
+    );
+    expect(optimistic?.items.map((item) => item.jobKey)).toEqual(["job-1"]);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back the optimistic patch when permanent delete fails", async () => {
+    server.use(
+      http.post("*/v1/jobs/bulk-delete-permanent", () =>
+        new HttpResponse(JSON.stringify({ ok: false }), { status: 500 }),
+      ),
+    );
+    const { result, queryClient } = renderHookWithProviders(() => usePermanentlyDeleteJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-1"], allMatching: false });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(jobsKeys.list(LOCAL_TENANT, {}))).toEqual(initialList);
+  });
+});

--- a/apps/web/src/contexts/discovery/hooks/usePermanentlyDeleteJobsBulkMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/usePermanentlyDeleteJobsBulkMutation.ts
@@ -1,0 +1,36 @@
+import type { BulkJobMutationRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export function usePermanentlyDeleteJobsBulkMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  BulkJobMutationRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, BulkJobMutationRequest>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: (body) => api.permanentlyDeleteJobs(body),
+      optimisticUpdates: (body) =>
+        body.allMatching
+          ? []
+          : [
+              {
+                queryKey: jobsKeys.lists(tenantId),
+                exact: false,
+                patch: (current) => patchListRemove(current, new Set(body.jobKeys)),
+              },
+            ],
+      settle: () => [jobsKeys.lists(tenantId), dashboardKeys.summary(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/hooks/useUnhideJobsBulkMutation.test.ts
+++ b/apps/web/src/contexts/discovery/hooks/useUnhideJobsBulkMutation.test.ts
@@ -1,0 +1,55 @@
+import { LOCAL_TENANT } from "@jobhunter/domain-types";
+import { http, HttpResponse } from "msw";
+import { waitFor } from "@testing-library/react";
+import { act } from "react";
+import { describe, expect, it } from "vitest";
+
+import { server } from "../../../test/msw/server.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { useUnhideJobsBulkMutation } from "./useUnhideJobsBulkMutation.js";
+
+const initialList = {
+  ok: true,
+  items: [
+    { jobKey: "job-1", title: "A", company: "X" },
+    { jobKey: "job-2", title: "B", company: "Y" },
+  ],
+  pagination: { page: 1, pageSize: 50, total: 2, pages: 1 },
+  sort: { field: "discovered_at", dir: "desc" },
+  filter: {},
+};
+
+describe("useUnhideJobsBulkMutation", () => {
+  it("removes unhidden jobs from the cached hidden list optimistically", async () => {
+    const { result, queryClient } = renderHookWithProviders(() => useUnhideJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-2"], allMatching: false });
+      await Promise.resolve();
+    });
+
+    const optimistic = queryClient.getQueryData<{ items: Array<{ jobKey: string }> }>(
+      jobsKeys.list(LOCAL_TENANT, {}),
+    );
+    expect(optimistic?.items.map((item) => item.jobKey)).toEqual(["job-1"]);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back the optimistic patch when bulk-unhide fails", async () => {
+    server.use(
+      http.post("*/v1/jobs/bulk-unhide", () =>
+        new HttpResponse(JSON.stringify({ ok: false }), { status: 500 }),
+      ),
+    );
+    const { result, queryClient } = renderHookWithProviders(() => useUnhideJobsBulkMutation());
+    queryClient.setQueryData(jobsKeys.list(LOCAL_TENANT, {}), initialList);
+
+    await act(async () => {
+      result.current.mutate({ jobKeys: ["job-1"], allMatching: false });
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(jobsKeys.list(LOCAL_TENANT, {}))).toEqual(initialList);
+  });
+});

--- a/apps/web/src/contexts/discovery/hooks/useUnhideJobsBulkMutation.ts
+++ b/apps/web/src/contexts/discovery/hooks/useUnhideJobsBulkMutation.ts
@@ -1,0 +1,36 @@
+import type { BulkJobMutationRequest, JobMutationResponse } from "@jobhunter/contracts";
+import { useMutation, useQueryClient, type UseMutationResult } from "@tanstack/react-query";
+
+import { createOptimisticMutation } from "../../../shared/lib/createOptimisticMutation.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { dashboardKeys } from "../../operations/dashboardKeys.js";
+import { jobsKeys } from "../../operations/jobsKeys.js";
+import { patchListRemove } from "../lib/jobListPatches.js";
+
+export function useUnhideJobsBulkMutation(): UseMutationResult<
+  JobMutationResponse,
+  Error,
+  BulkJobMutationRequest
+> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  const queryClient = useQueryClient();
+  return useMutation(
+    createOptimisticMutation<JobMutationResponse, BulkJobMutationRequest>(queryClient, {
+      mutationKey: jobsKeys.all(tenantId),
+      mutationFn: (body) => api.unhideJobs(body),
+      optimisticUpdates: (body) =>
+        body.allMatching
+          ? []
+          : [
+              {
+                queryKey: jobsKeys.lists(tenantId),
+                exact: false,
+                patch: (current) => patchListRemove(current, new Set(body.jobKeys)),
+              },
+            ],
+      settle: () => [jobsKeys.lists(tenantId), dashboardKeys.summary(tenantId)],
+    }),
+  );
+}

--- a/apps/web/src/contexts/discovery/index.ts
+++ b/apps/web/src/contexts/discovery/index.ts
@@ -15,6 +15,7 @@ export { useDeleteJobMutation } from "./hooks/useDeleteJobMutation.js";
 export { useDeleteJobsBulkMutation } from "./hooks/useDeleteJobsBulkMutation.js";
 export { useHideJobsBulkMutation } from "./hooks/useHideJobsBulkMutation.js";
 export { useImportJobMutation } from "./hooks/useImportJobMutation.js";
+export { usePermanentlyDeleteJobsBulkMutation } from "./hooks/usePermanentlyDeleteJobsBulkMutation.js";
 export { useRestoreJobMutation } from "./hooks/useRestoreJobMutation.js";
 export { useRestoreJobsBulkMutation } from "./hooks/useRestoreJobsBulkMutation.js";
 export { useUnhideJobsBulkMutation } from "./hooks/useUnhideJobsBulkMutation.js";

--- a/apps/web/src/contexts/discovery/index.ts
+++ b/apps/web/src/contexts/discovery/index.ts
@@ -13,9 +13,11 @@ export {
 
 export { useDeleteJobMutation } from "./hooks/useDeleteJobMutation.js";
 export { useDeleteJobsBulkMutation } from "./hooks/useDeleteJobsBulkMutation.js";
+export { useHideJobsBulkMutation } from "./hooks/useHideJobsBulkMutation.js";
 export { useImportJobMutation } from "./hooks/useImportJobMutation.js";
 export { useRestoreJobMutation } from "./hooks/useRestoreJobMutation.js";
 export { useRestoreJobsBulkMutation } from "./hooks/useRestoreJobsBulkMutation.js";
+export { useUnhideJobsBulkMutation } from "./hooks/useUnhideJobsBulkMutation.js";
 
 export {
   jobDeletedHandler,

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -210,24 +210,33 @@ export function StructuredProfileEditor({
     label: string,
     type = "text",
     attrs: Record<string, unknown> = {},
-  ) => (
-    <label className="field">
-      <span>{label}</span>
-      <input
-        {...attrs}
-        type={type}
-        value={textAt(profile, path)}
-        onChange={(event) =>
-          updateProfilePath(
-            path,
-            type === "number" ? constrainedNumberOrEmpty(event.target.value, attrs) : event.target.value,
-          )
-        }
-      />
-    </label>
-  );
+  ) => {
+    const { valueKind, ...inputAttrs } = attrs;
+    return (
+      <label className="field">
+        <span>{label}</span>
+        <input
+          {...inputAttrs}
+          type={type}
+          value={textAt(profile, path)}
+          onChange={(event) =>
+            updateProfilePath(
+              path,
+              type === "number"
+                ? constrainedNumberOrEmpty(event.target.value, attrs, valueKind === "text")
+                : event.target.value,
+            )
+          }
+        />
+      </label>
+    );
+  };
 
-  const constrainedNumberOrEmpty = (value: string, attrs: Record<string, unknown>) => {
+  const constrainedNumberOrEmpty = (
+    value: string,
+    attrs: Record<string, unknown>,
+    keepText = false,
+  ) => {
     const parsed = numberOrEmpty(value);
     if (parsed === "" || typeof parsed !== "number") {
       return parsed;
@@ -237,7 +246,8 @@ export function StructuredProfileEditor({
     }
     const min = typeof attrs["min"] === "number" ? attrs["min"] : undefined;
     const max = typeof attrs["max"] === "number" ? attrs["max"] : undefined;
-    return Math.min(max ?? parsed, Math.max(min ?? parsed, parsed));
+    const constrained = Math.min(max ?? parsed, Math.max(min ?? parsed, parsed));
+    return keepText ? String(constrained) : constrained;
   };
 
   const years = profileYearOptions();
@@ -650,6 +660,7 @@ export function StructuredProfileEditor({
               {textField("experience.years_of_experience_total", "Total years of experience", "number", {
                 min: 0,
                 step: 1,
+                valueKind: "text",
               })}
               {textField("experience.education_level", "Education level")}
               {textField("experience.current_job_title", "Current job title")}
@@ -949,16 +960,19 @@ export function StructuredProfileEditor({
               {selectField("availability.available_for_contract", "Available for contract", ["No", "Yes"])}
               {textField("compensation.salary_expectation", "Salary expectation", "number", {
                 min: 0,
-                step: 1000,
+                step: 1,
+                valueKind: "text",
               })}
               {textField("compensation.salary_currency", "Salary currency")}
               {textField("compensation.salary_range_min", "Salary range min", "number", {
                 min: 0,
-                step: 1000,
+                step: 1,
+                valueKind: "text",
               })}
               {textField("compensation.salary_range_max", "Salary range max", "number", {
                 min: 0,
-                step: 1000,
+                step: 1,
+                valueKind: "text",
               })}
               {textField("compensation.currency_conversion_note", "Currency note")}
             </div>

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -130,6 +130,27 @@ describe("<ProfileForm>", () => {
 
     expect(screen.getByLabelText("Remote")).toBeChecked();
     expect(screen.getByLabelText("Hybrid")).toBeChecked();
+  });
+
+  it("saves edited compensation number fields as profile strings", async () => {
+    const user = userEvent.setup();
+    const updateProfile = vi.fn(async (request) => ({
+      ...sampleProfileResponse,
+      profile: JSON.parse(request.profileText),
+    }));
+    renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="preferences" />, {
+      ports: buildTestPorts({ api: { updateProfile } }),
+    });
+
+    const salaryRangeMin = await screen.findByLabelText("Salary range min");
+    await user.clear(salaryRangeMin);
+    await user.type(salaryRangeMin, "165001");
+    expect(salaryRangeMin).toBeValid();
+    await user.click(screen.getByRole("button", { name: /^save all$/i }));
+
+    await waitFor(() => expect(updateProfile).toHaveBeenCalledTimes(1));
+    const request = updateProfile.mock.calls[0]?.[0];
+    expect(JSON.parse(request.profileText).compensation.salary_range_min).toBe("165001");
   });
 
   it("clamps max bullets to the allowed positive range", async () => {

--- a/apps/web/src/routes/-jobs.search.ts
+++ b/apps/web/src/routes/-jobs.search.ts
@@ -8,7 +8,7 @@ export const jobsSearchSchema = z.object({
   q: z.string().default(""),
   stage: z.enum(STAGE_OR_ALL).default("all"),
   state: z.enum(STATE_OR_ALL).default("all"),
-  deleted: z.enum(["active", "deleted"]).default("active"),
+  deleted: z.enum(["active", "deleted", "hidden"]).default("active"),
   sort: z.enum(JOB_SORT_FIELDS).default("discovered_at"),
   dir: z.enum(["asc", "desc"]).default("desc"),
   page: z.number().int().min(1).default(1),

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -80,6 +80,12 @@ export class FetchApiClientAdapter implements ApiClientPort {
   deleteJobs(body: Parameters<JobHunterApiClient["deleteJobs"]>[0]) {
     return this.client.deleteJobs(body);
   }
+  permanentlyDeleteJob(jobKey: string) {
+    return this.client.permanentlyDeleteJob(jobKey);
+  }
+  permanentlyDeleteJobs(body: Parameters<JobHunterApiClient["permanentlyDeleteJobs"]>[0]) {
+    return this.client.permanentlyDeleteJobs(body);
+  }
   restoreJob(jobKey: string) {
     return this.client.restoreJob(jobKey);
   }

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -86,6 +86,18 @@ export class FetchApiClientAdapter implements ApiClientPort {
   restoreJobs(body: Parameters<JobHunterApiClient["restoreJobs"]>[0]) {
     return this.client.restoreJobs(body);
   }
+  hideJob(jobKey: string, body: Parameters<JobHunterApiClient["hideJob"]>[1] = {}) {
+    return this.client.hideJob(jobKey, body);
+  }
+  hideJobs(body: Parameters<JobHunterApiClient["hideJobs"]>[0]) {
+    return this.client.hideJobs(body);
+  }
+  unhideJob(jobKey: string) {
+    return this.client.unhideJob(jobKey);
+  }
+  unhideJobs(body: Parameters<JobHunterApiClient["unhideJobs"]>[0]) {
+    return this.client.unhideJobs(body);
+  }
   correctScore(jobKey: string, body: Parameters<JobHunterApiClient["correctScore"]>[1]) {
     return this.client.correctScore(jobKey, body);
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -97,6 +97,8 @@ export interface ApiClientPort {
   job(jobKey: string): Promise<JobDetail>;
   deleteJob(jobKey: string, body?: DeleteJobRequest): Promise<JobMutationResponse>;
   deleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
+  permanentlyDeleteJob(jobKey: string): Promise<JobMutationResponse>;
+  permanentlyDeleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
   restoreJob(jobKey: string): Promise<JobMutationResponse>;
   restoreJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
   hideJob(jobKey: string, body?: DeleteJobRequest): Promise<JobMutationResponse>;

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -99,6 +99,10 @@ export interface ApiClientPort {
   deleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
   restoreJob(jobKey: string): Promise<JobMutationResponse>;
   restoreJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
+  hideJob(jobKey: string, body?: DeleteJobRequest): Promise<JobMutationResponse>;
+  hideJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
+  unhideJob(jobKey: string): Promise<JobMutationResponse>;
+  unhideJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse>;
   correctScore(jobKey: string, body: CorrectScoreRequest): Promise<CorrectScoreResponse>;
 
   workflowRuns(query?: Partial<WorkflowRunsListQuery>): Promise<PaginatedResponse<WorkflowRunSummary>>;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1473,9 +1473,38 @@ textarea {
   max-width: 72ch;
 }
 
-.description-text p {
+.description-text h4,
+.description-text p,
+.description-text ul,
+.description-text ol {
   margin: 0;
+}
+
+.description-text h4 {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.description-text p,
+.description-text li {
   line-height: 1.45;
+}
+
+.description-text ul,
+.description-text ol {
+  padding-left: 20px;
+}
+
+.description-text a {
+  color: var(--info);
+}
+
+.description-text code {
+  border: 1px solid var(--rule);
+  border-radius: 4px;
+  background: var(--paper-2);
+  padding: 0 4px;
+  font-size: 0.92em;
 }
 
 .profile-layout {

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -72,6 +72,7 @@ export const sampleJob: JobSummary = {
   applyStatus: null,
   appliedAt: null,
   deletedAt: null,
+  hiddenAt: null,
 };
 
 export const sampleSecondaryJob: JobSummary = {

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -214,6 +214,14 @@ export const handlers = [
     const body = (await request.json()) as { jobKeys?: string[] };
     return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
   }),
+  http.post("*/v1/jobs/bulk-hide", async ({ request }) => {
+    const body = (await request.json()) as { jobKeys?: string[] };
+    return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
+  }),
+  http.post("*/v1/jobs/bulk-unhide", async ({ request }) => {
+    const body = (await request.json()) as { jobKeys?: string[] };
+    return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
+  }),
   http.get("*/v1/jobs/:jobKey", ({ params }) =>
     HttpResponse.json(makeJobDetail({
       ...makeJobsPage().items[0]!,
@@ -224,6 +232,12 @@ export const handlers = [
     HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
   ),
   http.post("*/v1/jobs/:jobKey/restore", ({ params }) =>
+    HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
+  ),
+  http.post("*/v1/jobs/:jobKey/hide", ({ params }) =>
+    HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
+  ),
+  http.post("*/v1/jobs/:jobKey/unhide", ({ params }) =>
     HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
   ),
   http.post("*/v1/jobs/:jobKey/score-correction", async ({ params, request }) => {

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -210,6 +210,10 @@ export const handlers = [
     const body = (await request.json()) as { jobKeys?: string[] };
     return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
   }),
+  http.post("*/v1/jobs/bulk-delete-permanent", async ({ request }) => {
+    const body = (await request.json()) as { jobKeys?: string[] };
+    return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
+  }),
   http.post("*/v1/jobs/bulk-restore", async ({ request }) => {
     const body = (await request.json()) as { jobKeys?: string[] };
     return HttpResponse.json(jobMutationResponse(body.jobKeys ?? []));
@@ -229,6 +233,9 @@ export const handlers = [
     })),
   ),
   http.delete("*/v1/jobs/:jobKey", ({ params }) =>
+    HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
+  ),
+  http.delete("*/v1/jobs/:jobKey/permanent", ({ params }) =>
     HttpResponse.json(jobMutationResponse([String(params["jobKey"])])),
   ),
   http.post("*/v1/jobs/:jobKey/restore", ({ params }) =>

--- a/apps/web/src/views/jobs/JobBulkActions.stories.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.stories.tsx
@@ -18,7 +18,8 @@ const meta = {
     onSelectPage: () => {},
     onSelectAllMatching: () => {},
     onClearSelection: () => {},
-    onMutateSelected: () => {},
+    onPrimaryAction: () => {},
+    onHideSelected: () => {},
   },
 } satisfies Meta<typeof JobBulkActions>;
 
@@ -35,6 +36,13 @@ export const RestoringDeleted: Story = {
   args: {
     search: { ...baseSearch, deleted: "deleted" },
     selectedCount: 5,
+  },
+};
+
+export const HiddenJobs: Story = {
+  args: {
+    search: { ...baseSearch, deleted: "hidden" },
+    selectedCount: 2,
   },
 };
 

--- a/apps/web/src/views/jobs/JobBulkActions.stories.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
     onClearSelection: () => {},
     onPrimaryAction: () => {},
     onHideSelected: () => {},
+    onPermanentlyDeleteSelected: () => {},
   },
 } satisfies Meta<typeof JobBulkActions>;
 

--- a/apps/web/src/views/jobs/JobBulkActions.test.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.test.tsx
@@ -30,7 +30,8 @@ describe("<JobBulkActions>", () => {
         onSelectPage={() => {}}
         onSelectAllMatching={() => {}}
         onClearSelection={() => {}}
-        onMutateSelected={onMutate}
+        onPrimaryAction={onMutate}
+        onHideSelected={() => {}}
       />,
     );
     await user.click(screen.getByRole("button", { name: /delete selected/i }));
@@ -49,7 +50,8 @@ describe("<JobBulkActions>", () => {
         onSelectPage={() => {}}
         onSelectAllMatching={() => {}}
         onClearSelection={() => {}}
-        onMutateSelected={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /delete selected/i })).toBeDisabled();
@@ -67,10 +69,53 @@ describe("<JobBulkActions>", () => {
         onSelectPage={() => {}}
         onSelectAllMatching={() => {}}
         onClearSelection={() => {}}
-        onMutateSelected={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /restore selected/i })).toBeInTheDocument();
+  });
+
+  it("flips to an unhide label when the hidden tab is active", () => {
+    render(
+      <JobBulkActions
+        search={{ ...baseSearch, deleted: "hidden" }}
+        selectedCount={2}
+        hasItems
+        hasAnyMatching
+        loading={false}
+        onSetDeleted={() => {}}
+        onSelectPage={() => {}}
+        onSelectAllMatching={() => {}}
+        onClearSelection={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /unhide selected/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^hide selected$/i })).not.toBeInTheDocument();
+  });
+
+  it("invokes onHideSelected from active jobs", async () => {
+    const user = userEvent.setup();
+    const onHide = vi.fn();
+    render(
+      <JobBulkActions
+        search={baseSearch}
+        selectedCount={1}
+        hasItems
+        hasAnyMatching
+        loading={false}
+        onSetDeleted={() => {}}
+        onSelectPage={() => {}}
+        onSelectAllMatching={() => {}}
+        onClearSelection={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={onHide}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /hide selected/i }));
+    expect(onHide).toHaveBeenCalledTimes(1);
   });
 
   it("calls onSetDeleted when switching tabs", async () => {
@@ -87,10 +132,13 @@ describe("<JobBulkActions>", () => {
         onSelectPage={() => {}}
         onSelectAllMatching={() => {}}
         onClearSelection={() => {}}
-        onMutateSelected={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={() => {}}
       />,
     );
     await user.click(screen.getByRole("button", { name: /deleted jobs/i }));
     expect(onSet).toHaveBeenCalledWith("deleted");
+    await user.click(screen.getByRole("button", { name: /hidden jobs/i }));
+    expect(onSet).toHaveBeenCalledWith("hidden");
   });
 });

--- a/apps/web/src/views/jobs/JobBulkActions.test.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.test.tsx
@@ -32,6 +32,7 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={onMutate}
         onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     await user.click(screen.getByRole("button", { name: /delete selected/i }));
@@ -52,6 +53,7 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={() => {}}
         onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /delete selected/i })).toBeDisabled();
@@ -71,6 +73,7 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={() => {}}
         onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /restore selected/i })).toBeInTheDocument();
@@ -90,6 +93,7 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={() => {}}
         onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     expect(screen.getByRole("button", { name: /unhide selected/i })).toBeInTheDocument();
@@ -112,10 +116,34 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={() => {}}
         onHideSelected={onHide}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     await user.click(screen.getByRole("button", { name: /hide selected/i }));
     expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes permanent delete from deleted jobs", async () => {
+    const user = userEvent.setup();
+    const onPermanentDelete = vi.fn();
+    render(
+      <JobBulkActions
+        search={{ ...baseSearch, deleted: "deleted" }}
+        selectedCount={1}
+        hasItems
+        hasAnyMatching
+        loading={false}
+        onSetDeleted={() => {}}
+        onSelectPage={() => {}}
+        onSelectAllMatching={() => {}}
+        onClearSelection={() => {}}
+        onPrimaryAction={() => {}}
+        onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={onPermanentDelete}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /delete permanently selected/i }));
+    expect(onPermanentDelete).toHaveBeenCalledTimes(1);
   });
 
   it("calls onSetDeleted when switching tabs", async () => {
@@ -134,6 +162,7 @@ describe("<JobBulkActions>", () => {
         onClearSelection={() => {}}
         onPrimaryAction={() => {}}
         onHideSelected={() => {}}
+        onPermanentlyDeleteSelected={() => {}}
       />,
     );
     await user.click(screen.getByRole("button", { name: /deleted jobs/i }));

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -10,7 +10,8 @@ export interface JobBulkActionsProps {
   onSelectPage: () => void;
   onSelectAllMatching: () => void;
   onClearSelection: () => void;
-  onMutateSelected: () => void;
+  onPrimaryAction: () => void;
+  onHideSelected: () => void;
 }
 
 export function JobBulkActions({
@@ -23,9 +24,12 @@ export function JobBulkActions({
   onSelectPage,
   onSelectAllMatching,
   onClearSelection,
-  onMutateSelected,
+  onPrimaryAction,
+  onHideSelected,
 }: JobBulkActionsProps) {
   const restoring = search.deleted === "deleted";
+  const hidden = search.deleted === "hidden";
+  const primaryLabel = hidden ? "unhide selected" : restoring ? "restore selected" : "delete selected";
   return (
     <div className="bulk-bar">
       <div className="tabs">
@@ -43,6 +47,13 @@ export function JobBulkActions({
         >
           deleted jobs
         </button>
+        <button
+          className={`tab ${hidden ? "on" : ""}`}
+          type="button"
+          onClick={() => onSetDeleted("hidden")}
+        >
+          hidden jobs
+        </button>
       </div>
       <span className="meta">
         {selectedCount ? `${selectedCount} selected` : "select jobs to manage"}
@@ -56,13 +67,23 @@ export function JobBulkActions({
       <button className="tab" type="button" disabled={!selectedCount} onClick={onClearSelection}>
         clear selected
       </button>
+      {!hidden ? (
+        <button
+          className="tab danger-action"
+          type="button"
+          disabled={!selectedCount || loading}
+          onClick={onHideSelected}
+        >
+          hide selected
+        </button>
+      ) : null}
       <button
-        className={`tab ${restoring ? "on" : "danger-action"}`}
+        className={`tab ${restoring || hidden ? "on" : "danger-action"}`}
         type="button"
         disabled={!selectedCount || loading}
-        onClick={onMutateSelected}
+        onClick={onPrimaryAction}
       >
-        {restoring ? "restore selected" : "delete selected"}
+        {primaryLabel}
       </button>
     </div>
   );

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -12,6 +12,7 @@ export interface JobBulkActionsProps {
   onClearSelection: () => void;
   onPrimaryAction: () => void;
   onHideSelected: () => void;
+  onPermanentlyDeleteSelected: () => void;
 }
 
 export function JobBulkActions({
@@ -26,6 +27,7 @@ export function JobBulkActions({
   onClearSelection,
   onPrimaryAction,
   onHideSelected,
+  onPermanentlyDeleteSelected,
 }: JobBulkActionsProps) {
   const restoring = search.deleted === "deleted";
   const hidden = search.deleted === "hidden";
@@ -75,6 +77,16 @@ export function JobBulkActions({
           onClick={onHideSelected}
         >
           hide selected
+        </button>
+      ) : null}
+      {restoring || hidden ? (
+        <button
+          className="tab danger-action"
+          type="button"
+          disabled={!selectedCount || loading}
+          onClick={onPermanentlyDeleteSelected}
+        >
+          delete permanently selected
         </button>
       ) : null}
       <button

--- a/apps/web/src/views/jobs/JobDescription.stories.tsx
+++ b/apps/web/src/views/jobs/JobDescription.stories.tsx
@@ -27,6 +27,19 @@ export const ManyParagraphs: Story = {
   },
 };
 
+export const Markdown: Story = {
+  args: {
+    text: [
+      "**Welcome to the good side of tech 👋**",
+      "Build [patient-facing products](https://example.com) with a platform-as-product mindset.",
+      "",
+      "- Lead engineering teams",
+      "- Keep 75% hands-on coding",
+      "- Improve `SDLC` automation",
+    ].join("\n"),
+  },
+};
+
 export const Empty: Story = {
   args: { text: "" },
 };

--- a/apps/web/src/views/jobs/JobDescription.test.tsx
+++ b/apps/web/src/views/jobs/JobDescription.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { JobDescription } from "./JobDescription.js";
+
+describe("JobDescription", () => {
+  it("renders captured markdown without injecting raw html", () => {
+    render(
+      <JobDescription
+        text={[
+          "**Welcome to the good side of tech 👋**",
+          "Build [patient-facing products](https://example.com) with a platform-as-product mindset.",
+          "",
+          "- Lead engineering teams",
+          "- Improve `SDLC` automation",
+          "",
+          "<script>alert('xss')</script>",
+        ].join("\n")}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Welcome to the good side of tech 👋" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "patient-facing products" })).toHaveAttribute(
+      "href",
+      "https://example.com",
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByText("SDLC")).toBeInTheDocument();
+    expect(screen.getByText("<script>alert('xss')</script>")).toBeInTheDocument();
+    expect(document.querySelector("script")).toBeNull();
+  });
+});

--- a/apps/web/src/views/jobs/JobDescription.tsx
+++ b/apps/web/src/views/jobs/JobDescription.tsx
@@ -1,19 +1,181 @@
+import type { ReactNode } from "react";
+
 import { descriptionBlocks } from "../../contexts/operations/selectors/jobDescriptionSelectors.js";
 
 export interface JobDescriptionProps {
   text: string;
 }
 
+type DescriptionBlock =
+  | { kind: "heading"; text: string }
+  | { kind: "paragraph"; text: string }
+  | { kind: "unordered-list"; items: string[] }
+  | { kind: "ordered-list"; items: string[] };
+
 export function JobDescription({ text }: JobDescriptionProps) {
-  const blocks = descriptionBlocks(text);
+  const blocks = markdownDescriptionBlocks(text);
   if (!blocks.length) {
     return <p className="muted">No description captured.</p>;
   }
   return (
     <div className="description-text">
-      {blocks.map((block, index) => (
-        <p key={`${block.slice(0, 40)}-${index}`}>{block}</p>
-      ))}
+      {blocks.map((block, index) => renderBlock(block, index))}
     </div>
   );
+}
+
+function renderBlock(block: DescriptionBlock, index: number): ReactNode {
+  const key = `${block.kind}-${index}`;
+  if (block.kind === "heading") {
+    return <h4 key={key}>{renderInlineMarkdown(block.text)}</h4>;
+  }
+  if (block.kind === "unordered-list") {
+    return (
+      <ul key={key}>
+        {block.items.map((item, itemIndex) => (
+          <li key={`${key}-${itemIndex}`}>{renderInlineMarkdown(item)}</li>
+        ))}
+      </ul>
+    );
+  }
+  if (block.kind === "ordered-list") {
+    return (
+      <ol key={key}>
+        {block.items.map((item, itemIndex) => (
+          <li key={`${key}-${itemIndex}`}>{renderInlineMarkdown(item)}</li>
+        ))}
+      </ol>
+    );
+  }
+  return <p key={key}>{renderInlineMarkdown(block.text)}</p>;
+}
+
+function markdownDescriptionBlocks(text: string): DescriptionBlock[] {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) {
+    return [];
+  }
+
+  const lines = normalized.split("\n");
+  const blocks: DescriptionBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index]?.trim() ?? "";
+    if (!line) {
+      index += 1;
+      continue;
+    }
+
+    const heading = markdownHeadingText(line);
+    if (heading) {
+      blocks.push({ kind: "heading", text: heading });
+      index += 1;
+      continue;
+    }
+
+    const unordered = line.match(/^[-*+]\s+(.+)$/);
+    if (unordered) {
+      const items: string[] = [];
+      while (index < lines.length) {
+        const item = (lines[index] ?? "").trim().match(/^[-*+]\s+(.+)$/);
+        if (!item) break;
+        items.push(item[1] ?? "");
+        index += 1;
+      }
+      blocks.push({ kind: "unordered-list", items });
+      continue;
+    }
+
+    const ordered = line.match(/^\d+[.)]\s+(.+)$/);
+    if (ordered) {
+      const items: string[] = [];
+      while (index < lines.length) {
+        const item = (lines[index] ?? "").trim().match(/^\d+[.)]\s+(.+)$/);
+        if (!item) break;
+        items.push(item[1] ?? "");
+        index += 1;
+      }
+      blocks.push({ kind: "ordered-list", items });
+      continue;
+    }
+
+    const paragraphLines: string[] = [];
+    while (index < lines.length) {
+      const current = lines[index]?.trim() ?? "";
+      if (!current) break;
+      const startsNewBlock =
+        markdownHeadingText(current) || /^[-*+]\s+/.test(current) || /^\d+[.)]\s+/.test(current);
+      if (paragraphLines.length && startsNewBlock) {
+        break;
+      }
+      paragraphLines.push(current);
+      index += 1;
+    }
+    const paragraph = paragraphLines.join(" ").trim();
+    if (paragraph) {
+      blocks.push({ kind: "paragraph", text: paragraph });
+    }
+  }
+
+  if (blocks.length === 1 && blocks[0]?.kind === "paragraph" && blocks[0].text.length > 700) {
+    return descriptionBlocks(blocks[0].text).map((block) => ({ kind: "paragraph", text: block }));
+  }
+
+  return blocks;
+}
+
+function markdownHeadingText(line: string): string | null {
+  const atx = line.match(/^#{1,4}\s+(.+)$/);
+  if (atx?.[1]) {
+    return trimMarkdownMarkers(atx[1]);
+  }
+  const boldOnly = line.match(/^\*\*(.+)\*\*$/);
+  if (boldOnly?.[1] && boldOnly[1].length <= 140) {
+    return trimMarkdownMarkers(boldOnly[1]);
+  }
+  return null;
+}
+
+function renderInlineMarkdown(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const pattern =
+    /(\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|\*\*([^*]+)\*\*|__([^_]+)__|`([^`]+)`)/g;
+  let cursor = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > cursor) {
+      nodes.push(unescapeMarkdown(text.slice(cursor, match.index)));
+    }
+    if (match[2] && match[3]) {
+      nodes.push(
+        <a href={match[3]} key={`${match.index}-link`} rel="noreferrer" target="_blank">
+          {unescapeMarkdown(match[2])}
+        </a>,
+      );
+    } else if (match[4] || match[5]) {
+      nodes.push(
+        <strong key={`${match.index}-strong`}>
+          {unescapeMarkdown(match[4] ?? match[5] ?? "")}
+        </strong>,
+      );
+    } else if (match[6]) {
+      nodes.push(<code key={`${match.index}-code`}>{unescapeMarkdown(match[6])}</code>);
+    }
+    cursor = match.index + match[0].length;
+  }
+
+  if (cursor < text.length) {
+    nodes.push(unescapeMarkdown(text.slice(cursor)));
+  }
+  return nodes;
+}
+
+function trimMarkdownMarkers(text: string): string {
+  return unescapeMarkdown(text.replace(/\*\*/g, "").replace(/__/g, "").trim());
+}
+
+function unescapeMarkdown(text: string): string {
+  return text.replace(/\\([\\`*_{}\[\]()#+\-.!>])/g, "$1");
 }

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -117,6 +117,74 @@ describe("<JobsView> bulk delete integration", () => {
     await user.click(screen.getByRole("button", { name: /delete selected/i }));
     expect(calls.length).toBe(0);
   });
+
+  it("posts selected active jobs to /v1/jobs/bulk-hide", async () => {
+    const user = userEvent.setup();
+    const calls: Array<{ jobKeys?: string[] }> = [];
+    server.use(
+      http.post("*/v1/jobs/bulk-hide", async ({ request }) => {
+        const body = (await request.json()) as { jobKeys?: string[] };
+        calls.push(body);
+        return HttpResponse.json({ ok: true, count: body.jobKeys?.length ?? 0, jobKeys: body.jobKeys ?? [] });
+      }),
+    );
+
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    const { container } = render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText(/Acme Corp/i)).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+
+    const checkboxes = container.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    const rowCheckbox = Array.from(checkboxes).find(
+      (input) => input.getAttribute("aria-label")?.includes("Select row") ?? false,
+    ) ?? checkboxes[1]!;
+    await user.click(rowCheckbox);
+    await waitFor(() => expect(screen.getByText(/1 selected/i)).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /hide selected/i }));
+
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0]?.jobKeys?.length).toBe(1);
+  });
+
+  it("shows a hidden tab and posts selected hidden jobs to /v1/jobs/bulk-unhide", async () => {
+    const user = userEvent.setup();
+    const calls: Array<{ jobKeys?: string[] }> = [];
+    server.use(
+      http.post("*/v1/jobs/bulk-unhide", async ({ request }) => {
+        const body = (await request.json()) as { jobKeys?: string[] };
+        calls.push(body);
+        return HttpResponse.json({ ok: true, count: body.jobKeys?.length ?? 0, jobKeys: body.jobKeys ?? [] });
+      }),
+    );
+
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    const { container } = render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /hidden jobs/i })).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+    await user.click(screen.getByRole("button", { name: /hidden jobs/i }));
+    await waitFor(() => expect(screen.getByText(/Acme Corp/i)).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+
+    const checkboxes = container.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    const rowCheckbox = Array.from(checkboxes).find(
+      (input) => input.getAttribute("aria-label")?.includes("Select row") ?? false,
+    ) ?? checkboxes[1]!;
+    await user.click(rowCheckbox);
+    await waitFor(() => expect(screen.getByText(/1 selected/i)).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /unhide selected/i }));
+
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0]?.jobKeys?.length).toBe(1);
+  });
 });
 
 void vi;

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -185,6 +185,42 @@ describe("<JobsView> bulk delete integration", () => {
     await waitFor(() => expect(calls.length).toBe(1));
     expect(calls[0]?.jobKeys?.length).toBe(1);
   });
+
+  it("posts selected deleted jobs to /v1/jobs/bulk-delete-permanent", async () => {
+    const user = userEvent.setup();
+    const calls: Array<{ jobKeys?: string[] }> = [];
+    server.use(
+      http.post("*/v1/jobs/bulk-delete-permanent", async ({ request }) => {
+        const body = (await request.json()) as { jobKeys?: string[] };
+        calls.push(body);
+        return HttpResponse.json({ ok: true, count: body.jobKeys?.length ?? 0, jobKeys: body.jobKeys ?? [] });
+      }),
+    );
+
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    const { container } = render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /deleted jobs/i })).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+    await user.click(screen.getByRole("button", { name: /deleted jobs/i }));
+    await waitFor(() => expect(screen.getByText(/Acme Corp/i)).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+
+    const checkboxes = container.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    const rowCheckbox = Array.from(checkboxes).find(
+      (input) => input.getAttribute("aria-label")?.includes("Select row") ?? false,
+    ) ?? checkboxes[1]!;
+    await user.click(rowCheckbox);
+    await waitFor(() => expect(screen.getByText(/1 selected/i)).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: /delete permanently selected/i }));
+
+    await waitFor(() => expect(calls.length).toBe(1));
+    expect(calls[0]?.jobKeys?.length).toBe(1);
+  });
 });
 
 void vi;

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -4,7 +4,9 @@ import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useEffect, useMemo, useState } from "react";
 
 import { useDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/useDeleteJobsBulkMutation.js";
+import { useHideJobsBulkMutation } from "../../contexts/discovery/hooks/useHideJobsBulkMutation.js";
 import { useRestoreJobsBulkMutation } from "../../contexts/discovery/hooks/useRestoreJobsBulkMutation.js";
+import { useUnhideJobsBulkMutation } from "../../contexts/discovery/hooks/useUnhideJobsBulkMutation.js";
 import { useJobsListQuery } from "../../contexts/operations/hooks/useJobsListQuery.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
@@ -45,7 +47,9 @@ export function JobsView() {
 
   const { data, isFetching, error } = useJobsListQuery(jobsListInput(search));
   const deleteJobs = useDeleteJobsBulkMutation();
+  const hideJobs = useHideJobsBulkMutation();
   const restoreJobs = useRestoreJobsBulkMutation();
+  const unhideJobs = useUnhideJobsBulkMutation();
   const message = error instanceof Error ? error.message : null;
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -133,29 +137,38 @@ export function JobsView() {
   };
 
   const restoring = search.deleted === "deleted";
-  const mutation = restoring ? restoreJobs : deleteJobs;
-  const mutateBusy = mutation.isPending;
+  const hidden = search.deleted === "hidden";
+  const primaryMutation = hidden ? unhideJobs : restoring ? restoreJobs : deleteJobs;
+  const mutateBusy =
+    deleteJobs.isPending || hideJobs.isPending || restoreJobs.isPending || unhideJobs.isPending;
 
-  const mutateSelected = () => {
+  const selectedPayload = (): BulkJobMutationRequest =>
+    allMatchingSelected
+      ? { allMatching: true, filter: currentJobFilter(), jobKeys: [] }
+      : { allMatching: false, jobKeys: selectedKeys };
+
+  const mutateSelected = (
+    mutation: typeof deleteJobs,
+    label: string,
+  ) => {
     const count = allMatchingSelected ? (data?.pagination.total ?? 0) : selectedKeys.length;
     if (!count) {
       return;
     }
-    if (
-      !window.confirm(
-        `${restoring ? "Restore" : "Soft delete"} ${count} selected job${
-          count === 1 ? "" : "s"
-        }?`,
-      )
-    ) {
+    if (!window.confirm(`${label} ${count} selected job${count === 1 ? "" : "s"}?`)) {
       return;
     }
-    const payload: BulkJobMutationRequest = allMatchingSelected
-      ? { allMatching: true, filter: currentJobFilter(), jobKeys: [] }
-      : { allMatching: false, jobKeys: selectedKeys };
-    mutation.mutate(payload, {
+    mutation.mutate(selectedPayload(), {
       onSuccess: () => clearSelection(),
     });
+  };
+
+  const mutatePrimarySelected = () => {
+    mutateSelected(primaryMutation, hidden ? "Unhide" : restoring ? "Restore" : "Delete");
+  };
+
+  const hideSelected = () => {
+    mutateSelected(hideJobs, "Hide");
   };
 
   const selectedCount = allMatchingSelected
@@ -186,7 +199,8 @@ export function JobsView() {
           onSelectPage={selectPage}
           onSelectAllMatching={selectAllMatching}
           onClearSelection={clearSelection}
-          onMutateSelected={mutateSelected}
+          onPrimaryAction={mutatePrimarySelected}
+          onHideSelected={hideSelected}
         />
         <JobsTable
           data={data ?? null}

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/useDeleteJobsBulkMutation.js";
 import { useHideJobsBulkMutation } from "../../contexts/discovery/hooks/useHideJobsBulkMutation.js";
+import { usePermanentlyDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/usePermanentlyDeleteJobsBulkMutation.js";
 import { useRestoreJobsBulkMutation } from "../../contexts/discovery/hooks/useRestoreJobsBulkMutation.js";
 import { useUnhideJobsBulkMutation } from "../../contexts/discovery/hooks/useUnhideJobsBulkMutation.js";
 import { useJobsListQuery } from "../../contexts/operations/hooks/useJobsListQuery.js";
@@ -48,6 +49,7 @@ export function JobsView() {
   const { data, isFetching, error } = useJobsListQuery(jobsListInput(search));
   const deleteJobs = useDeleteJobsBulkMutation();
   const hideJobs = useHideJobsBulkMutation();
+  const permanentlyDeleteJobs = usePermanentlyDeleteJobsBulkMutation();
   const restoreJobs = useRestoreJobsBulkMutation();
   const unhideJobs = useUnhideJobsBulkMutation();
   const message = error instanceof Error ? error.message : null;
@@ -140,7 +142,11 @@ export function JobsView() {
   const hidden = search.deleted === "hidden";
   const primaryMutation = hidden ? unhideJobs : restoring ? restoreJobs : deleteJobs;
   const mutateBusy =
-    deleteJobs.isPending || hideJobs.isPending || restoreJobs.isPending || unhideJobs.isPending;
+    deleteJobs.isPending ||
+    hideJobs.isPending ||
+    permanentlyDeleteJobs.isPending ||
+    restoreJobs.isPending ||
+    unhideJobs.isPending;
 
   const selectedPayload = (): BulkJobMutationRequest =>
     allMatchingSelected
@@ -169,6 +175,10 @@ export function JobsView() {
 
   const hideSelected = () => {
     mutateSelected(hideJobs, "Hide");
+  };
+
+  const permanentlyDeleteSelected = () => {
+    mutateSelected(permanentlyDeleteJobs, "Permanently delete");
   };
 
   const selectedCount = allMatchingSelected
@@ -201,6 +211,7 @@ export function JobsView() {
           onClearSelection={clearSelection}
           onPrimaryAction={mutatePrimarySelected}
           onHideSelected={hideSelected}
+          onPermanentlyDeleteSelected={permanentlyDeleteSelected}
         />
         <JobsTable
           data={data ?? null}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,7 +219,7 @@ truth per fact; components consume state through hooks (never raw stores or the
 
 | Frontend folder | Owns | Backend mirror |
 |---|---|---|
-| `discovery/` | `useDeleteJobMutation`, `useDeleteJobsBulkMutation`, `useRestoreJobMutation`, `useRestoreJobsBulkMutation`; future `useImportJobMutation`. | Job Discovery |
+| `discovery/` | `useDeleteJobMutation`, `useDeleteJobsBulkMutation`, `useRestoreJobMutation`, `useRestoreJobsBulkMutation`, `useHideJobsBulkMutation`, `useUnhideJobsBulkMutation`; future `useImportJobMutation`. | Job Discovery |
 | `enrichment/` | `JobEnriched` / `EnrichmentFailed` invalidation handlers; future `useEnrichmentRetryMutation`. | Job Enrichment |
 | `profile/` | `useProfileQuery`, `useUpdateProfileMutation`, `useImportResumeMutation`, settings + credentials hooks, profile-import wizard store, profile editor + resume preview components. | Candidate Profile |
 | `scoring/` | `<ScoreBadge>`, `<ScoreBreakdown>`; future `useCorrectScoreMutation`. | Scoring |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,7 +219,7 @@ truth per fact; components consume state through hooks (never raw stores or the
 
 | Frontend folder | Owns | Backend mirror |
 |---|---|---|
-| `discovery/` | `useDeleteJobMutation`, `useDeleteJobsBulkMutation`, `useRestoreJobMutation`, `useRestoreJobsBulkMutation`, `useHideJobsBulkMutation`, `useUnhideJobsBulkMutation`; future `useImportJobMutation`. | Job Discovery |
+| `discovery/` | `useDeleteJobMutation`, `useDeleteJobsBulkMutation`, `useRestoreJobMutation`, `useRestoreJobsBulkMutation`, `useHideJobsBulkMutation`, `useUnhideJobsBulkMutation`, `usePermanentlyDeleteJobsBulkMutation`; future `useImportJobMutation`. | Job Discovery |
 | `enrichment/` | `JobEnriched` / `EnrichmentFailed` invalidation handlers; future `useEnrichmentRetryMutation`. | Job Enrichment |
 | `profile/` | `useProfileQuery`, `useUpdateProfileMutation`, `useImportResumeMutation`, settings + credentials hooks, profile-import wizard store, profile editor + resume preview components. | Candidate Profile |
 | `scoring/` | `<ScoreBadge>`, `<ScoreBreakdown>`; future `useCorrectScoreMutation`. | Scoring |

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -32,21 +32,18 @@ deferred until the local product is solid.
 
 ### Worker Reliability
 
-- Extend workflow-run records to non-apply local actions. `apply` now runs
-  through Temporal and is visible through `apply_run_projections` /
-  `/v1/workflow-runs`, but `run_stage` and `profile_import` are still sync
-  RPCs that emit `job_events` and return an in-memory `LocalActionResult`
-  (`workers/automation/src/jobhunter/actions.py:48`) without a durable
-  workflow-run record. Without a uniform run record, the dashboard cannot show
-  running / queued / failed status for non-apply work.
-- Add cancellation for queued or running non-apply local actions. `apply`
-  cooperatively cancels via `cancel_run` (PR #36), but `run_stage` /
-  `profile_import` still run synchronously inside the JSON-RPC handler and have
-  no cancel surface, and `cancel_stage`
-  (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`) only
-  flips the stage row to `canceled` post-hoc. Migrating these handlers to
-  workflows gets cooperative cancel for free; a shorter-term option is to add a
-  cancel token surface for the in-process sync handlers.
+- Extend workflow-run projections beyond apply. Global `run_stage` now starts
+  `JobPipelineWorkflow` and returns a workflow ID to the API, and apply steps
+  inside that pipeline run as child `ApplyWorkflow` executions. However,
+  `/v1/workflow-runs` is still backed by apply-run projections. A uniform
+  workflow-run projection is still needed if the dashboard should list
+  discover/enrich/score/tailor/cover/pdf workflow lifecycle rows alongside
+  apply runs.
+- Add cancellation UX for queued or running non-apply local actions.
+  `run_stage` now has a Temporal workflow ID, so cooperative cancellation can
+  use `cancel_run`, but the UI still needs a first-class cancel control for
+  those pipeline runs. `profile_import` remains synchronous inside the JSON-RPC
+  handler and still has no cancel surface.
 - Record `score_report` artifacts. PR 7 of the Temporal stack wired
   `state.record_job_artifact` into `apply.launcher.mark_result` so the
   per-worker agent log (`LOG_DIR/worker-{worker_id}.log`) lands in
@@ -76,9 +73,9 @@ canonical stage-state writer cleanup, apply-log artifact registration, and
 Langfuse/OpenTelemetry wiring have landed.
 
 Remaining local reliability work is tracked in the Worker Reliability bullets
-above: non-apply `run_stage` / `profile_import` still need durable workflow-run
-records and cooperative cancellation if the UI must show or stop them like
-apply runs.
+above: non-apply `run_stage` now uses Temporal but still needs workflow-run
+projection parity and UI cancellation; `profile_import` remains the synchronous
+JSON-RPC local action.
 
 Out of scope for the local stack (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)):
 

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -42,7 +42,7 @@ implementations where possible, but they differ in orchestration.
 
 | Surface | Entry point | Execution model | Stages |
 | --- | --- | --- | --- |
-| Pipelines UI | `POST /v1/pipeline/actions/run-stage` | TS API dispatches each selected stage. Non-apply calls JSON-RPC `run_stage`; apply calls JSON-RPC `apply`. | All user-facing stages |
+| Pipelines UI | `POST /v1/pipeline/actions/run-stage` | TS API sends the ordered stage list to JSON-RPC `run_stage`, which starts one `JobPipelineWorkflow`; apply steps run as child `ApplyWorkflow` executions. | All user-facing stages |
 | CLI batch run | `jobhunter run ...` | Python `run_pipeline()` executes stages sequentially or streaming. | Non-apply stages |
 | Temporal pipeline workflow | `JobPipelineWorkflow` | Serial workflow that dispatches each non-apply stage as a Temporal activity. | Non-apply stages |
 | Temporal apply workflow | `ApplyWorkflow` | Per-job apply workflow with one activity and apply-specific retry policy. | Apply |
@@ -58,9 +58,9 @@ sequenceDiagram
     participant Dispatcher as defaultActionDispatcher
     participant JsonRpc as SubprocessJsonRpcAdapter
     participant Rpc as jobhunter rpc<br/>JsonRpcServer
-    participant Action as run_local_action
-    participant Runner as pipeline.runner
     participant Temporal as Temporal
+    participant Activity as Stage activity
+    participant Runner as pipeline.runner
     participant DB as SQLite
     participant SSE as SSE / projections
 
@@ -68,27 +68,25 @@ sequenceDiagram
     Web->>Api: POST /v1/pipeline/actions/run-stage
     Api->>Dispatcher: Build ActionCommandPayload per stage
 
-    alt discover/enrich/score/tailor/cover/pdf
-        Dispatcher->>JsonRpc: call("run_stage", params)
-        JsonRpc->>Rpc: JSON-RPC line over stdin/stdout
-        Rpc->>Action: run_stage handler
-        Action->>Runner: run_pipeline(stages=[stage])
+    Dispatcher->>JsonRpc: call("run_stage", ordered stages)
+    JsonRpc->>Rpc: JSON-RPC line over stdin/stdout
+    Rpc->>Temporal: start JobPipelineWorkflow(stages)
+    Temporal-->>Rpc: workflow handle
+    Rpc-->>JsonRpc: {runId, workflowId}
+
+    alt discover/enrich/score/tailor/cover/pdf step
+        Temporal->>Activity: execute stage activity
+        Activity->>Runner: run_pipeline(stages=[stage])
         Runner->>DB: stage writes, events, artifacts
-        Runner-->>Action: LocalActionResult
-        Action-->>Rpc: JSON-RPC result
-        Rpc-->>JsonRpc: response
-        JsonRpc-->>Dispatcher: dispatch result
-    else apply
-        Dispatcher->>JsonRpc: call("apply", params)
-        JsonRpc->>Rpc: JSON-RPC line over stdin/stdout
-        Rpc->>Temporal: start ApplyWorkflow
-        Temporal-->>Rpc: workflow handle
-        Rpc-->>JsonRpc: {runId, workflowId}
+    else apply step
+        Temporal->>Temporal: execute child ApplyWorkflow
         Temporal->>DB: ApplyRun* events while workflow runs
     end
 
+    JsonRpc-->>Dispatcher: dispatch result
+
     Dispatcher-->>Api: action response
-    Api-->>Web: 200 for sync stages, 202 if apply queued
+    Api-->>Web: 202 if workflow queued, 200 if start failed
     DB->>SSE: projections refresh / events stream
     SSE-->>Web: invalidate query cache and update UI
 ```
@@ -206,9 +204,12 @@ instead of submitting applications.
   for pending work and finish only when their upstream producers are done and
   they have no remaining work.
 
-The UI `run-stage` endpoint dispatches selected stages in request order from
-the TS API. Each non-apply stage call still enters the Python runner as a
-single-stage `run_pipeline(stages=[stage])` invocation.
+The UI `run-stage` endpoint preserves request order by starting one
+`JobPipelineWorkflow` for the selected stage list. Non-apply stages run
+serially as Temporal activities; each activity still enters the Python runner
+as a single-stage `run_pipeline(stages=[stage])` invocation. `apply` remains
+the dedicated `ApplyWorkflow`, executed as a child workflow when it appears in
+the ordered pipeline list.
 
 ## Phase 1: Discover
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -43,7 +43,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Cover letters use the wrong resume | `workers/automation/tests/test_cover_requirements.py` |
 | Profile PDF import corrupts defaults | `workers/automation/tests/test_profile_import.py` |
 | API list filtering/sorting/pagination regresses | `apps/api/test/server.test.ts` |
-| Jobs delete/hide lifecycle regresses, causing temporary deletes not to resurface or hidden jobs to leak into active/deleted views | `apps/api/test/server.test.ts`; `workers/automation/tests/test_discovery_identity.py`; `apps/web/src/views/jobs/JobBulkActions.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
+| Jobs delete/hide lifecycle regresses, causing temporary deletes not to resurface, hidden jobs to leak into active/deleted views, or permanent deletes to leave suppressing tombstones behind | `apps/api/test/server.test.ts`; `workers/automation/tests/test_discovery_identity.py`; `apps/web/src/views/jobs/JobBulkActions.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
 | Destructive UI workflows touch real user data | `apps/api/test/qa-workflow.test.ts` with `pnpm qa:seed` |
 | Source registry compatibility drops legacy discovery config | `workers/automation/tests/test_source_registry.py` covers packaged `sites.yaml` migration, `employers.yaml` migration, JobSpy `boards` selection, and the one-release legacy `sites` alias warning |
 | Source quality stops feeding discovery budgets or dashboard health | `workers/automation/tests/test_discovery_scheduler_pr4.py`; `workers/automation/tests/test_source_quality_projection_pr4.py`; `apps/web/src/views/dashboard/SourceHealthCard.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -43,6 +43,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Cover letters use the wrong resume | `workers/automation/tests/test_cover_requirements.py` |
 | Profile PDF import corrupts defaults | `workers/automation/tests/test_profile_import.py` |
 | API list filtering/sorting/pagination regresses | `apps/api/test/server.test.ts` |
+| Jobs delete/hide lifecycle regresses, causing temporary deletes not to resurface or hidden jobs to leak into active/deleted views | `apps/api/test/server.test.ts`; `workers/automation/tests/test_discovery_identity.py`; `apps/web/src/views/jobs/JobBulkActions.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
 | Destructive UI workflows touch real user data | `apps/api/test/qa-workflow.test.ts` with `pnpm qa:seed` |
 | Source registry compatibility drops legacy discovery config | `workers/automation/tests/test_source_registry.py` covers packaged `sites.yaml` migration, `employers.yaml` migration, JobSpy `boards` selection, and the one-release legacy `sites` alias warning |
 | Source quality stops feeding discovery budgets or dashboard health | `workers/automation/tests/test_discovery_scheduler_pr4.py`; `workers/automation/tests/test_source_quality_projection_pr4.py`; `apps/web/src/views/dashboard/SourceHealthCard.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -25,6 +25,14 @@ Both processes refresh projections idempotently via the shared
 from `job_scores` as additive read-model fields: `scoreBreakdown`,
 `scoreKeywords`, `scoreVersion`, and `scoredAt`. `scoreReasoning` remains on
 the wire as a compatibility summary during the scoring evidence migration.
+The jobs list `deleted` filter accepts `active`, `deleted`, `hidden`, or `all`.
+Deleted jobs are temporary removals: discovery clears the delete tombstone when
+the same posting is observed again. Hidden jobs use a separate
+`jobhunter_hidden_jobs` tombstone and remain suppressed from active/deleted
+lists, dashboard totals, artifacts, workflow runs, and activity until an unhide
+mutation clears that hidden tombstone. The API exposes bulk hide/unhide routes
+at `POST /v1/jobs/bulk-hide` and `POST /v1/jobs/bulk-unhide`, plus single-job
+`POST /v1/jobs/:key/hide` and `POST /v1/jobs/:key/unhide`.
 
 `/v1/dashboard/summary` includes `sourceHealth[]`, sourced from
 `source_quality_stats`. The projection is rebuilt from discovery run,

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -87,15 +87,14 @@ uses `info.workflow_id` as the timeline key). The web Workflow Runs view at
 `POST /v1/pipeline/actions/run-stage` starts global/batch pipeline stage runs
 from the UI. The request accepts `stages`, `limit`, `workers`, `minScore`,
 `validationMode`, `dryRun`, score/tailor flags (`rescore`, `retailor`), and
-apply flags (`headless`, `model`, `continuous`). The route dispatches
-non-apply stages to JSON-RPC `run_stage` and global apply to JSON-RPC `apply`;
-it uses the command key `pipeline` only as the local action response handle,
-not as a fake job URL. Selected stages run in request order. Non-apply-only
-batches are synchronous and return `200` with the worker's real action IDs,
-statuses (`dry_run`, `succeeded`, or `failed`), and results. Batches that
-include `apply` first run preceding non-apply stages synchronously, then return
-`202` only if the apply workflow is actually queued; if apply dispatch fails,
-the response is `200` and preserves the dispatcher-derived failed apply action.
+apply flags (`headless`, `model`, `continuous`). The route dispatches the
+ordered stage list to JSON-RPC `run_stage`, which starts `JobPipelineWorkflow`;
+if the list includes `apply`, that workflow delegates the apply step to
+`ApplyWorkflow` as a child workflow after preceding stages complete. The route
+uses the command key `pipeline` only as the local action response handle, not
+as a fake job URL. Successful workflow starts return `202` with the queued
+workflow ID. Workflow-start failures return `200` with the dispatcher-derived
+failed action.
 `dryRun` defaults to `true`, preserving apply safety.
 
 The `limit` field is forwarded to every stage. For `discover`, the Python

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -32,7 +32,11 @@ the same posting is observed again. Hidden jobs use a separate
 lists, dashboard totals, artifacts, workflow runs, and activity until an unhide
 mutation clears that hidden tombstone. The API exposes bulk hide/unhide routes
 at `POST /v1/jobs/bulk-hide` and `POST /v1/jobs/bulk-unhide`, plus single-job
-`POST /v1/jobs/:key/hide` and `POST /v1/jobs/:key/unhide`.
+`POST /v1/jobs/:key/hide` and `POST /v1/jobs/:key/unhide`. Permanent delete is
+available at `POST /v1/jobs/bulk-delete-permanent` and
+`DELETE /v1/jobs/:key/permanent`; it removes the job row plus job-scoped state,
+projection rows, and delete/hide tombstones. It does not write a new suppression
+record, so rediscovery can add the same posting again later.
 
 `/v1/dashboard/summary` includes `sourceHealth[]`, sourced from
 `source_quality_stats`. The projection is rebuilt from discovery run,

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -176,6 +176,22 @@ export class JobHunterApiClient {
     return this.post("/v1/jobs/bulk-restore", body);
   }
 
+  hideJob(jobKey: string, body: DeleteJobRequest = {}): Promise<JobMutationResponse> {
+    return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/hide`, body);
+  }
+
+  hideJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
+    return this.post("/v1/jobs/bulk-hide", body);
+  }
+
+  unhideJob(jobKey: string): Promise<JobMutationResponse> {
+    return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/unhide`);
+  }
+
+  unhideJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
+    return this.post("/v1/jobs/bulk-unhide", body);
+  }
+
   correctScore(jobKey: string, body: CorrectScoreRequest): Promise<CorrectScoreResponse> {
     return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/score-correction`, body);
   }

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -168,6 +168,14 @@ export class JobHunterApiClient {
     return this.post("/v1/jobs/bulk-delete", body);
   }
 
+  permanentlyDeleteJob(jobKey: string): Promise<JobMutationResponse> {
+    return this.delete(`/v1/jobs/${encodeURIComponent(jobKey)}/permanent`);
+  }
+
+  permanentlyDeleteJobs(body: BulkJobMutationRequest): Promise<JobMutationResponse> {
+    return this.post("/v1/jobs/bulk-delete-permanent", body);
+  }
+
   restoreJob(jobKey: string): Promise<JobMutationResponse> {
     return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/restore`);
   }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -153,6 +153,7 @@ export const RunStageParamsSchema = z
   .object({
     tenantId: TenantParam,
     stage: z.enum(STAGES),
+    stages: z.array(z.enum(STAGES)).min(1).max(STAGES.length).optional(),
     jobUrl: z.string().optional(),
     limit: z.number().int().min(0).default(0),
     workers: z.number().int().min(1).default(1),
@@ -161,6 +162,9 @@ export const RunStageParamsSchema = z
     dryRun: z.boolean().default(false),
     rescore: z.boolean().default(false),
     retailor: z.boolean().default(false),
+    headless: z.boolean().default(false),
+    model: z.string().trim().min(1).max(80).default("haiku"),
+    continuous: z.boolean().default(false),
   })
   .strict();
 export type RunStageParams = z.infer<typeof RunStageParamsSchema>;

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -22,7 +22,7 @@ export const STAGE_STATES = [
   "stale",
 ] as const;
 export type StageState = (typeof STAGE_STATES)[number];
-export const JOB_DELETED_FILTERS = ["active", "deleted", "all"] as const;
+export const JOB_DELETED_FILTERS = ["active", "deleted", "hidden", "all"] as const;
 export type JobDeletedFilter = (typeof JOB_DELETED_FILTERS)[number];
 
 export const JOB_SORT_FIELDS = [
@@ -563,6 +563,7 @@ export interface JobSummary {
   applyStatus: string | null;
   appliedAt: string | null;
   deletedAt: string | null;
+  hiddenAt: string | null;
 }
 
 export interface ArtifactSummary {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -711,7 +711,7 @@ export interface ActionCommandPayload {
     | "profile_import";
   jobKey: string;
   stage?: Stage;
-  stages?: MaterialStage[];
+  stages?: Stage[];
   resetAttempts?: boolean;
   runAfter?: boolean;
   dryRun?: boolean;
@@ -731,6 +731,8 @@ export interface ActionCommandPayload {
 export interface ActionRunResponse {
   ok: true;
   runId: string;
+  workflowId?: string;
+  firstExecutionRunId?: string;
   actionId: string;
   action: ActionCommandPayload["action"];
   status: string;

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
     "opentelemetry-sdk>=1.27",
     "opentelemetry-exporter-otlp-proto-http>=1.27",
     "opentelemetry-instrumentation-httpx>=0.48b0",
-    ]
+    "python-jobspy>=1.1.82",
+]
 
 [project.optional-dependencies]
 dev = ["build>=1.2", "pytest>=7.0", "pytest-asyncio>=0.23", "ruff>=0.1"]

--- a/workers/automation/src/jobhunter/apply/activities.py
+++ b/workers/automation/src/jobhunter/apply/activities.py
@@ -55,9 +55,11 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
       policy can fire on transient browser / network / executor failures.
     """
 
-    def _run_apply() -> tuple[int, int]:
-        from jobhunter.apply.launcher import main as apply_main
+    # ``apply.launcher`` installs process signal handlers at import time; import
+    # it on the activity event-loop thread before handing work to the executor.
+    from jobhunter.apply.launcher import main as apply_main
 
+    def _run_apply() -> tuple[int, int]:
         # ``continuous=True`` selects the launcher's run-forever poll mode,
         # which it activates via ``limit == 0``.  Otherwise enforce a floor
         # of one to keep ``limit < 1`` calls from no-oping.
@@ -70,6 +72,7 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
             model=payload.model,
             dry_run=payload.dry_run,
             workers=payload.workers,
+            install_signal_handlers=False,
         )
 
     activity.heartbeat("apply starting")

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -98,7 +98,7 @@ _claude_procs: dict[int, subprocess.Popen] = {}
 _claude_lock = threading.Lock()
 
 atexit.register(cleanup_on_exit)
-if platform.system() != "Windows":
+if platform.system() != "Windows" and threading.current_thread() is threading.main_thread():
     signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 
 
@@ -1220,6 +1220,7 @@ def main(
     poll_interval: int = 60,
     workers: int = 1,
     snapshot: ProfileSnapshot | None = None,
+    install_signal_handlers: bool = True,
 ) -> tuple[int, int]:
     global POLL_INTERVAL
     POLL_INTERVAL = poll_interval
@@ -1281,7 +1282,8 @@ def main(
             kill_all_chrome()
             raise KeyboardInterrupt
 
-    signal.signal(signal.SIGINT, _sigint_handler)
+    if install_signal_handlers:
+        signal.signal(signal.SIGINT, _sigint_handler)
 
     try:
         with Live(render_full(), console=console, refresh_per_second=2) as live:

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -73,8 +73,7 @@ _EUROPE_LOCATION_ACCEPTS = (
     "Europe",
     "European Union",
     "EU",
-    "Remote",
-    "Anywhere",
+    "EMEA",
 )
 
 _AMERICA_LOCATION_REJECTS = (
@@ -203,6 +202,7 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
         next_cfg["ats_max_tier"] = 1
 
     if locations:
+        location_accept = _dedupe_strings([*locations])
         next_cfg["locations"] = [
             {
                 "label": _source_slug(location),
@@ -212,6 +212,10 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
             for index, location in enumerate(locations)
         ]
         next_cfg["location_labels"] = [_source_slug(location) for location in locations]
+        next_cfg["location_accept"] = location_accept
+        location_cfg = dict(next_cfg.get("location") or {})
+        location_cfg["accept_patterns"] = location_accept
+        next_cfg["location"] = location_cfg
 
     if _target_prefers_europe_from_values(locations):
         defaults = dict(next_cfg.get("defaults") or {})
@@ -219,9 +223,13 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
         next_cfg["defaults"] = defaults
         next_cfg["country"] = "Spain"
         next_cfg["target_region"] = "europe"
+        location_accept = _dedupe_strings([*locations, *_EUROPE_LOCATION_ACCEPTS])
         next_cfg["location_accept"] = _dedupe_strings(
-            [*_string_list(next_cfg.get("location_accept")), *locations, *_EUROPE_LOCATION_ACCEPTS]
+            location_accept
         )
+        location_cfg = dict(next_cfg.get("location") or {})
+        location_cfg["accept_patterns"] = location_accept
+        next_cfg["location"] = location_cfg
         next_cfg["location_reject_non_remote"] = _dedupe_strings(
             [*_string_list(next_cfg.get("location_reject_non_remote")), *_AMERICA_LOCATION_REJECTS]
         )

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -603,12 +603,17 @@ def _adapter_config_from_row(row: sqlite3.Row) -> dict:
     if not seed_url:
         return {}
     display_name = str(row["display_name"] or row["source_id"]).strip()
+    source_type = "search" if _url_has_search_placeholder(seed_url) else "static"
     return {
         "name": display_name,
         "url": seed_url,
-        "type": "static",
+        "type": source_type,
         "base_url": seed_url,
     }
+
+
+def _url_has_search_placeholder(url: str) -> bool:
+    return "{query_encoded}" in url or "{query}" in url
 
 
 def _merge_local_source_registry(

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -20,6 +20,7 @@ from jobhunter.domain.discovery.source_registry import (
     SourceRegistryEntry,
     SourceState,
 )
+from jobhunter.discovery.title_filter import normalize_query
 from jobhunter.infrastructure.observability import source_validation_span
 
 log = logging.getLogger(__name__)
@@ -197,7 +198,8 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
 
     next_cfg = dict(search_cfg)
     if roles:
-        next_cfg["queries"] = [{"query": role, "tier": 1} for role in roles]
+        role_queries = _dedupe_strings(normalize_query(role) for role in roles)
+        next_cfg["queries"] = [{"query": role, "tier": 1} for role in role_queries]
         next_cfg["workday_max_tier"] = 1
         next_cfg["ats_max_tier"] = 1
 

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -35,7 +35,7 @@ def get_connection(db_path: Path | str | None = None) -> sqlite3.Connection:
     """
     path = str(db_path or DB_PATH)
 
-    if not hasattr(_local, 'connections'):
+    if not hasattr(_local, "connections"):
         _local.connections = {}
 
     conn = _local.connections.get(path)
@@ -57,7 +57,7 @@ def get_connection(db_path: Path | str | None = None) -> sqlite3.Connection:
 def close_connection(db_path: Path | str | None = None) -> None:
     """Close the cached connection for the current thread."""
     path = str(db_path or DB_PATH)
-    if hasattr(_local, 'connections'):
+    if hasattr(_local, "connections"):
         conn = _local.connections.pop(path, None)
         if conn is not None:
             conn.close()
@@ -742,12 +742,17 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
     now = datetime.now(timezone.utc).isoformat()
     max_attempts = {"discover": 1, "enrich": 3, "score": 3, "tailor": 5, "cover": 5, "pdf": 3, "apply": 3}
 
-    def _insert(job_url: str, stage: str, state: str, *,
-                attempt_count: int = 0,
-                error_code: str | None = None,
-                error_message: str | None = None,
-                started_at: str | None = None,
-                finished_at: str | None = None) -> None:
+    def _insert(
+        job_url: str,
+        stage: str,
+        state: str,
+        *,
+        attempt_count: int = 0,
+        error_code: str | None = None,
+        error_message: str | None = None,
+        started_at: str | None = None,
+        finished_at: str | None = None,
+    ) -> None:
         conn.execute(
             """
             INSERT OR IGNORE INTO job_stage_states (
@@ -758,9 +763,16 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, NULL, NULL, NULL, 0)
             """,
             (
-                job_url, stage, state, attempt_count, max_attempts.get(stage),
-                started_at, now, finished_at,
-                error_code, error_message,
+                job_url,
+                stage,
+                state,
+                attempt_count,
+                max_attempts.get(stage),
+                started_at,
+                now,
+                finished_at,
+                error_code,
+                error_message,
                 0 if state == "blocked" else 1,
             ),
         )
@@ -783,15 +795,12 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
         apply_error = row["apply_error"] if isinstance(row, sqlite3.Row) else row[15]
 
         # discover — always succeeded if the row exists.
-        _insert(url, "discover", "succeeded",
-                attempt_count=1, finished_at=discovered_at or now)
+        _insert(url, "discover", "succeeded", attempt_count=1, finished_at=discovered_at or now)
 
         # enrich
         has_enrichment = bool(full_description) or bool(detail_scraped_at)
         if detail_error and not has_enrichment:
-            _insert(url, "enrich", "failed",
-                    error_code="LEGACY_DETAIL_ERROR",
-                    error_message=str(detail_error))
+            _insert(url, "enrich", "failed", error_code="LEGACY_DETAIL_ERROR", error_message=str(detail_error))
             enrich_succeeded = False
         elif has_enrichment:
             _insert(url, "enrich", "succeeded", finished_at=detail_scraped_at or now)
@@ -806,9 +815,7 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
             _insert(url, "score", "succeeded", finished_at=now)
             score_succeeded = True
         elif not enrich_succeeded:
-            _insert(url, "score", "blocked",
-                    error_code="BLOCKED",
-                    error_message="Enrichment has not completed.")
+            _insert(url, "score", "blocked", error_code="BLOCKED", error_message="Enrichment has not completed.")
             score_succeeded = False
         else:
             _insert(url, "score", "pending")
@@ -821,15 +828,17 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
             _insert(url, "tailor", "succeeded", attempt_count=attempts, finished_at=now)
             tailor_succeeded = True
         elif not score_succeeded:
-            _insert(url, "tailor", "blocked",
-                    error_code="BLOCKED",
-                    error_message="score has not completed.")
+            _insert(url, "tailor", "blocked", error_code="BLOCKED", error_message="score has not completed.")
             tailor_succeeded = False
         elif attempts >= max_attempts["tailor"]:
-            _insert(url, "tailor", "exhausted",
-                    attempt_count=attempts,
-                    error_code="EXHAUSTED",
-                    error_message="tailor attempts exhausted.")
+            _insert(
+                url,
+                "tailor",
+                "exhausted",
+                attempt_count=attempts,
+                error_code="EXHAUSTED",
+                error_message="tailor attempts exhausted.",
+            )
             tailor_succeeded = False
         else:
             _insert(url, "tailor", "pending", attempt_count=attempts)
@@ -841,14 +850,16 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
         if has_cover:
             _insert(url, "cover", "succeeded", attempt_count=c_attempts, finished_at=now)
         elif not tailor_succeeded:
-            _insert(url, "cover", "blocked",
-                    error_code="BLOCKED",
-                    error_message="tailor has not completed.")
+            _insert(url, "cover", "blocked", error_code="BLOCKED", error_message="tailor has not completed.")
         elif c_attempts >= max_attempts["cover"]:
-            _insert(url, "cover", "exhausted",
-                    attempt_count=c_attempts,
-                    error_code="EXHAUSTED",
-                    error_message="cover attempts exhausted.")
+            _insert(
+                url,
+                "cover",
+                "exhausted",
+                attempt_count=c_attempts,
+                error_code="EXHAUSTED",
+                error_message="cover attempts exhausted.",
+            )
         else:
             _insert(url, "cover", "pending", attempt_count=c_attempts)
 
@@ -856,9 +867,7 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
         if tailor_succeeded:
             _insert(url, "pdf", "succeeded", finished_at=now)
         else:
-            _insert(url, "pdf", "blocked",
-                    error_code="BLOCKED",
-                    error_message="tailor has not completed.")
+            _insert(url, "pdf", "blocked", error_code="BLOCKED", error_message="tailor has not completed.")
 
         # apply
         if applied_at or (apply_status and str(apply_status).lower() == "applied"):
@@ -866,13 +875,9 @@ def _backfill_legacy_stage_states(conn: sqlite3.Connection) -> None:
         elif apply_status and str(apply_status).lower() == "in_progress":
             _insert(url, "apply", "running")
         elif apply_error:
-            _insert(url, "apply", "failed",
-                    error_code="LEGACY_APPLY_ERROR",
-                    error_message=str(apply_error))
+            _insert(url, "apply", "failed", error_code="LEGACY_APPLY_ERROR", error_message=str(apply_error))
         elif not tailor_succeeded:
-            _insert(url, "apply", "blocked",
-                    error_code="BLOCKED",
-                    error_message="Materials are not ready.")
+            _insert(url, "apply", "blocked", error_code="BLOCKED", error_message="Materials are not ready.")
         else:
             _insert(url, "apply", "pending")
 
@@ -911,9 +916,7 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
         )
     """)
-    existing_score_cols = {
-        row[1] for row in conn.execute("PRAGMA table_info(job_scores)").fetchall()
-    }
+    existing_score_cols = {row[1] for row in conn.execute("PRAGMA table_info(job_scores)").fetchall()}
     if "criteria_json" not in existing_score_cols:
         conn.execute("ALTER TABLE job_scores ADD COLUMN criteria_json TEXT NOT NULL DEFAULT '{}'")
     if "trace_json" not in existing_score_cols:
@@ -929,9 +932,7 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
 
     # One-shot backfill from the legacy columns. Only fires when
     # job_scores has no rows AND there are jobs with a legacy fit_score.
-    backfill_count = conn.execute(
-        "SELECT COUNT(*) FROM job_scores"
-    ).fetchone()[0]
+    backfill_count = conn.execute("SELECT COUNT(*) FROM job_scores").fetchone()[0]
     if backfill_count == 0:
         legacy_rows = conn.execute(
             """
@@ -946,16 +947,8 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             for row in legacy_rows:
                 url = row["url"] if isinstance(row, sqlite3.Row) else row[0]
                 fit = row["fit_score"] if isinstance(row, sqlite3.Row) else row[1]
-                reasoning = (
-                    row["score_reasoning"]
-                    if isinstance(row, sqlite3.Row)
-                    else row[2]
-                )
-                scored_at = (
-                    row["scored_at"]
-                    if isinstance(row, sqlite3.Row)
-                    else row[3]
-                )
+                reasoning = row["score_reasoning"] if isinstance(row, sqlite3.Row) else row[2]
+                scored_at = row["scored_at"] if isinstance(row, sqlite3.Row) else row[3]
                 breakdown_json = json.dumps(
                     {
                         "technical_fit": 0,
@@ -1081,9 +1074,7 @@ def ensure_materials_tables(conn: sqlite3.Connection | None = None) -> list[str]
 
     # Idempotent backfill from the legacy ``jobs`` columns. Fires only
     # when ``job_materials`` is empty.
-    backfill_count = conn.execute(
-        "SELECT COUNT(*) FROM job_materials"
-    ).fetchone()[0]
+    backfill_count = conn.execute("SELECT COUNT(*) FROM job_materials").fetchone()[0]
     if backfill_count == 0:
         legacy_rows = conn.execute(
             """
@@ -1173,21 +1164,13 @@ def _backfill_one_materials_row(
 
     artifacts: list[tuple[str, str, str, int | None, str]] = []
     if tailor_path:
-        artifacts.append(
-            ("tailored_resume", tailor_path, "text", _size(tailor_path), tailor_at)
-        )
+        artifacts.append(("tailored_resume", tailor_path, "text", _size(tailor_path), tailor_at))
     if resume_pdf:
-        artifacts.append(
-            ("resume_pdf", resume_pdf, "latex_pdf", _size(resume_pdf), tailor_at)
-        )
+        artifacts.append(("resume_pdf", resume_pdf, "latex_pdf", _size(resume_pdf), tailor_at))
     if cover_path:
-        artifacts.append(
-            ("cover_letter", cover_path, "text", _size(cover_path), cover_at)
-        )
+        artifacts.append(("cover_letter", cover_path, "text", _size(cover_path), cover_at))
     if cover_pdf:
-        artifacts.append(
-            ("cover_letter_pdf", cover_pdf, "html_pdf", _size(cover_pdf), cover_at)
-        )
+        artifacts.append(("cover_letter_pdf", cover_pdf, "html_pdf", _size(cover_pdf), cover_at))
 
     for artifact_type, path, render_format, size, created in artifacts:
         conn.execute(
@@ -1260,9 +1243,7 @@ def ensure_enrichment_tables(conn: sqlite3.Connection | None = None) -> list[str
     )
 
     # Idempotent one-shot backfill from the legacy columns.
-    backfill_count = conn.execute(
-        "SELECT COUNT(*) FROM job_enrichments"
-    ).fetchone()[0]
+    backfill_count = conn.execute("SELECT COUNT(*) FROM job_enrichments").fetchone()[0]
     if backfill_count == 0:
         legacy_rows = conn.execute(
             """
@@ -1625,13 +1606,9 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
 
     # Idempotent one-shot backfill: every existing jobs row gets one
     # observation row using its legacy URL / site / discovered_at.
-    backfilled = conn.execute(
-        "SELECT COUNT(*) FROM job_source_observations"
-    ).fetchone()[0]
+    backfilled = conn.execute("SELECT COUNT(*) FROM job_source_observations").fetchone()[0]
     if backfilled == 0:
-        legacy_jobs = conn.execute(
-            "SELECT url, site, strategy, discovered_at FROM jobs"
-        ).fetchall()
+        legacy_jobs = conn.execute("SELECT url, site, strategy, discovered_at FROM jobs").fetchall()
         if legacy_jobs:
             now = datetime.now(timezone.utc).isoformat()
             for row in legacy_jobs:
@@ -1667,9 +1644,7 @@ def _backfill_one_observation_row(
 
     url = row["url"] if isinstance(row, sqlite3.Row) else row[0]
     site = (row["site"] if isinstance(row, sqlite3.Row) else row[1]) or "unknown"
-    discovered_at = (
-        row["discovered_at"] if isinstance(row, sqlite3.Row) else row[3]
-    ) or now
+    discovered_at = (row["discovered_at"] if isinstance(row, sqlite3.Row) else row[3]) or now
     if not url:
         return
     source_native_id = url  # fall back to the URL when we have nothing better
@@ -1711,21 +1686,13 @@ _ENRICHMENT_JOIN: str = (
     "ON jss_enrich.job_url = jobs.url AND jss_enrich.stage = 'enrich'"
 )
 
-_EFFECTIVE_FULL_DESCRIPTION: str = (
-    "COALESCE(je.full_description, jobs.full_description)"
-)
-_EFFECTIVE_APPLICATION_URL: str = (
-    "COALESCE(je.application_url, jobs.application_url)"
-)
-_EFFECTIVE_DETAIL_SCRAPED_AT: str = (
-    "COALESCE(je.enriched_at, jobs.detail_scraped_at)"
-)
+_EFFECTIVE_FULL_DESCRIPTION: str = "COALESCE(je.full_description, jobs.full_description)"
+_EFFECTIVE_APPLICATION_URL: str = "COALESCE(je.application_url, jobs.application_url)"
+_EFFECTIVE_DETAIL_SCRAPED_AT: str = "COALESCE(je.enriched_at, jobs.detail_scraped_at)"
 # Per §7.1 the canonical "this job has been enriched" predicate is the
 # aggregate's terminal status; un-backfilled rows fall back to the legacy
 # detail_scraped_at column.
-_ENRICHMENT_DONE: str = (
-    "(je.current_status = 'enriched' OR jobs.detail_scraped_at IS NOT NULL)"
-)
+_ENRICHMENT_DONE: str = "(je.current_status = 'enriched' OR jobs.detail_scraped_at IS NOT NULL)"
 # Phase 7 (S-26 round-1 review M3): the aggregate status is the primary
 # enrichment signal, but the live local DB can contain historical jobs with
 # legacy description columns and a canonical ``job_stage_states.enrich =
@@ -1850,8 +1817,7 @@ _LATEST_SCORE_JOIN: str = (
 
 _EFFECTIVE_FIT_SCORE: str = "COALESCE(js.js_fit_score, jobs.fit_score)"
 _SCORE_ELIGIBLE_FOR_DOWNSTREAM: str = (
-    "(COALESCE(js.js_eligibility_status, '') != 'blocked' "
-    "AND COALESCE(js.js_hard_blocker_count, 0) = 0)"
+    "(COALESCE(js.js_eligibility_status, '') != 'blocked' AND COALESCE(js.js_hard_blocker_count, 0) = 0)"
 )
 
 
@@ -1883,10 +1849,7 @@ _LATEST_APPLY_RUN_JOIN: str = (
 
 # Applied = any apply run with status='succeeded' for the job (we
 # COALESCE with the legacy column so historical rows stay visible).
-_EFFECTIVE_APPLIED_AT: str = (
-    "CASE WHEN ar.ar_status = 'succeeded' THEN ar.ar_finished_at "
-    "ELSE jobs.applied_at END"
-)
+_EFFECTIVE_APPLIED_AT: str = "CASE WHEN ar.ar_status = 'succeeded' THEN ar.ar_finished_at ELSE jobs.applied_at END"
 
 # Apply status string suitable for read-model consumption — collapses
 # ``starting`` / ``in_progress`` into the historical ``in_progress``
@@ -1978,9 +1941,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     stats["total"] = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
 
     # By site breakdown
-    rows = conn.execute(
-        "SELECT site, COUNT(*) as cnt FROM jobs GROUP BY site ORDER BY cnt DESC"
-    ).fetchall()
+    rows = conn.execute("SELECT site, COUNT(*) as cnt FROM jobs GROUP BY site ORDER BY cnt DESC").fetchall()
     stats["by_site"] = [(row[0], row[1]) for row in rows]
 
     # Enrichment stage — Phase 7 (S-26): read through the
@@ -1992,8 +1953,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     ).fetchone()[0]
 
     stats["with_description"] = conn.execute(
-        f"SELECT COUNT(*) FROM jobs {_ENRICHMENT_JOIN} "
-        f"WHERE {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL"
+        f"SELECT COUNT(*) FROM jobs {_ENRICHMENT_JOIN} WHERE {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL"
     ).fetchone()[0]
 
     stats["detail_errors"] = conn.execute(
@@ -2006,8 +1966,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     # reflect new scores written through ScoreRepository (jobs.fit_score is
     # now NULL on the new path).
     stats["scored"] = conn.execute(
-        f"SELECT COUNT(*) FROM jobs {_LATEST_SCORE_JOIN} "
-        f"WHERE {_EFFECTIVE_FIT_SCORE} IS NOT NULL"
+        f"SELECT COUNT(*) FROM jobs {_LATEST_SCORE_JOIN} WHERE {_EFFECTIVE_FIT_SCORE} IS NOT NULL"
     ).fetchone()[0]
 
     stats["unscored"] = conn.execute(
@@ -2033,8 +1992,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     # signal that lives in ``job_stage_states``. Without these joins the
     # dashboard would freeze at the backfill snapshot value.
     stats["tailored"] = conn.execute(
-        f"SELECT COUNT(*) FROM jobs {_LATEST_MATERIALS_JOIN} "
-        f"WHERE {_EFFECTIVE_TAILOR_PATH} IS NOT NULL"
+        f"SELECT COUNT(*) FROM jobs {_LATEST_MATERIALS_JOIN} WHERE {_EFFECTIVE_TAILOR_PATH} IS NOT NULL"
     ).fetchone()[0]
 
     stats["untailored_eligible"] = conn.execute(
@@ -2053,8 +2011,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     ).fetchone()[0]
 
     stats["with_cover_letter"] = conn.execute(
-        f"SELECT COUNT(*) FROM jobs {_LATEST_MATERIALS_JOIN} "
-        f"WHERE {_EFFECTIVE_COVER_PATH} IS NOT NULL"
+        f"SELECT COUNT(*) FROM jobs {_LATEST_MATERIALS_JOIN} WHERE {_EFFECTIVE_COVER_PATH} IS NOT NULL"
     ).fetchone()[0]
 
     stats["cover_exhausted"] = conn.execute(
@@ -2067,8 +2024,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     # join so dashboard counts reflect lifecycle events (jobs.applied_at /
     # apply_status / apply_error are NULL on the new write path).
     stats["applied"] = conn.execute(
-        f"SELECT COUNT(*) FROM jobs {_LATEST_APPLY_RUN_JOIN} "
-        f"WHERE {_EFFECTIVE_APPLIED_AT} IS NOT NULL"
+        f"SELECT COUNT(*) FROM jobs {_LATEST_APPLY_RUN_JOIN} WHERE {_EFFECTIVE_APPLIED_AT} IS NOT NULL"
     ).fetchone()[0]
 
     stats["apply_errors"] = conn.execute(
@@ -2091,8 +2047,7 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
     return stats
 
 
-def store_jobs(conn: sqlite3.Connection, jobs: list[dict],
-               site: str, strategy: str) -> tuple[int, int]:
+def store_jobs(conn: sqlite3.Connection, jobs: list[dict], site: str, strategy: str) -> tuple[int, int]:
     """Store discovered jobs, skipping duplicates by URL.
 
     Args:
@@ -2116,8 +2071,16 @@ def store_jobs(conn: sqlite3.Connection, jobs: list[dict],
             conn.execute(
                 "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at) "
                 "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (url, job.get("title"), job.get("salary"), job.get("description"),
-                 job.get("location"), site, strategy, now),
+                (
+                    url,
+                    job.get("title"),
+                    job.get("salary"),
+                    job.get("description"),
+                    job.get("location"),
+                    site,
+                    strategy,
+                    now,
+                ),
             )
             from jobhunter.state import ensure_job_stage_rows, record_job_event, set_stage_state
 
@@ -2141,10 +2104,46 @@ def store_jobs(conn: sqlite3.Connection, jobs: list[dict],
             )
             new += 1
         except sqlite3.IntegrityError:
+            resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
     conn.commit()
     return new, existing
+
+
+def resurface_deleted_job(conn: sqlite3.Connection, job_url: str, *, resurfaced_at: str) -> None:
+    """Clear a temporary delete tombstone when Discovery sees a job again.
+
+    Hidden jobs are tracked in a separate table and are intentionally not
+    touched here, so a hidden job remains suppressed across discoveries.
+    """
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobhunter_deleted_jobs (
+            job_url TEXT PRIMARY KEY,
+            deleted_at TEXT NOT NULL,
+            reason TEXT,
+            restored_at TEXT,
+            FOREIGN KEY(job_url) REFERENCES jobs(url)
+        )
+        """
+    )
+    cursor = conn.execute(
+        "UPDATE jobhunter_deleted_jobs SET restored_at = ? WHERE job_url = ? AND restored_at IS NULL",
+        (resurfaced_at, job_url),
+    )
+    if cursor.rowcount:
+        from jobhunter.state import record_job_event
+
+        record_job_event(
+            conn,
+            job_url,
+            "discover",
+            "JobRestored",
+            message="Job resurfaced because discovery observed it again.",
+            occurred_at=resurfaced_at,
+            payload={"reason": "rediscovered"},
+        )
 
 
 def load_job_with_enrichment(
@@ -2209,11 +2208,13 @@ def load_job_with_enrichment(
     return record
 
 
-def get_jobs_by_stage(conn: sqlite3.Connection | None = None,
-                      stage: str = "discovered",
-                      min_score: int | None = None,
-                      limit: int = 100,
-                      retailor: bool = False) -> list[dict]:
+def get_jobs_by_stage(
+    conn: sqlite3.Connection | None = None,
+    stage: str = "discovered",
+    min_score: int | None = None,
+    limit: int = 100,
+    retailor: bool = False,
+) -> list[dict]:
     """Fetch jobs filtered by pipeline stage.
 
     Args:
@@ -2268,8 +2269,8 @@ def get_jobs_by_stage(conn: sqlite3.Connection | None = None,
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
         f"AND {_TAILOR_NOT_EXHAUSTED} "
         f"AND ({_EFFECTIVE_TAILOR_PATH} IS NOT NULL OR {_EFFECTIVE_TAILOR_ATTEMPTS} < 5)"
-        if retailor else
-        f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
+        if retailor
+        else f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
         f"AND {_EFFECTIVE_TAILOR_PATH} IS NULL "
         f"AND {_TAILOR_NOT_EXHAUSTED} "
@@ -2280,10 +2281,7 @@ def get_jobs_by_stage(conn: sqlite3.Connection | None = None,
         "discovered": "1=1",
         "pending_detail": _ENRICHMENT_PENDING,
         "enriched": f"{_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL",
-        "pending_score": (
-            f"{_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
-            f"AND {_EFFECTIVE_FIT_SCORE} IS NULL"
-        ),
+        "pending_score": (f"{_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL AND {_EFFECTIVE_FIT_SCORE} IS NULL"),
         "scored": f"{_EFFECTIVE_FIT_SCORE} IS NOT NULL",
         "pending_tailor": pending_tailor_where,
         "pending_cover": (
@@ -2326,11 +2324,7 @@ def get_jobs_by_stage(conn: sqlite3.Connection | None = None,
     # Optional post-filter — also routed through the join so it sees new
     # rows. Triggered by callers passing ``min_score=N`` for the
     # "scored / tailored / applied" stages.
-    if (
-        min_score is not None
-        and stage in ("scored", "tailored", "applied")
-        and _EFFECTIVE_FIT_SCORE not in where
-    ):
+    if min_score is not None and stage in ("scored", "tailored", "applied") and _EFFECTIVE_FIT_SCORE not in where:
         where += f" AND {_EFFECTIVE_FIT_SCORE} >= ?"
         params.append(min_score)
 

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -70,7 +70,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     so it won't destroy existing data.
 
     Schema columns by stage:
-      - Discovery:  url, title, salary, description, location, site, strategy, discovered_at
+      - Discovery:  url, title, company, salary, description, location, site, strategy, discovered_at
       - Enrichment: full_description, application_url, detail_scraped_at, detail_error
       - Scoring:    fit_score, score_reasoning, scored_at
       - Tailoring:  tailored_resume_path, tailored_at, tailor_attempts
@@ -96,6 +96,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
             -- Discovery stage (smart_extract / job_search)
             url                   TEXT PRIMARY KEY,
             title                 TEXT,
+            company               TEXT,
             salary                TEXT,
             description           TEXT,
             location              TEXT,
@@ -211,6 +212,7 @@ _ALL_COLUMNS: dict[str, str] = {
     # Discovery
     "url": "TEXT PRIMARY KEY",
     "title": "TEXT",
+    "company": "TEXT",
     "salary": "TEXT",
     "description": "TEXT",
     "location": "TEXT",
@@ -2069,11 +2071,12 @@ def store_jobs(conn: sqlite3.Connection, jobs: list[dict], site: str, strategy: 
             continue
         try:
             conn.execute(
-                "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     url,
                     job.get("title"),
+                    job.get("company"),
                     job.get("salary"),
                     job.get("description"),
                     job.get("location"),
@@ -2104,6 +2107,24 @@ def store_jobs(conn: sqlite3.Connection, jobs: list[dict], site: str, strategy: 
             )
             new += 1
         except sqlite3.IntegrityError:
+            company = str(job.get("company") or "").strip()
+            if company:
+                cursor = conn.execute(
+                    "UPDATE jobs SET company = ? WHERE url = ? AND (company IS NULL OR company = '')",
+                    (company, url),
+                )
+                if cursor.rowcount:
+                    from jobhunter.state import record_job_event
+
+                    record_job_event(
+                        conn,
+                        url,
+                        "discover",
+                        "JobMetadataUpdated",
+                        message=f"Job company backfilled from {site}",
+                        payload={"company": company, "source": site},
+                        occurred_at=now,
+                    )
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 

--- a/workers/automation/src/jobhunter/discovery/activities.py
+++ b/workers/automation/src/jobhunter/discovery/activities.py
@@ -19,6 +19,7 @@ class DiscoverActivityInput:
     tenant_id: str
     limit: int = 0
     workers: int = 1
+    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -38,7 +39,12 @@ async def discover_activity(payload: DiscoverActivityInput) -> DiscoverActivityO
     from jobhunter.pipeline import run_pipeline
 
     def _do() -> dict[str, Any]:
-        return run_pipeline(stages=["discover"], workers=payload.workers, limit=payload.limit)
+        return run_pipeline(
+            stages=["discover"],
+            workers=payload.workers,
+            limit=payload.limit,
+            dry_run=payload.dry_run,
+        )
 
     result = await run_blocking_with_heartbeat(
         _do,

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -24,6 +24,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.network.proxy import parse_proxy
 
 log = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
             continue
 
         title = str(row.get("title", "")) if str(row.get("title", "")) != "nan" else None
+        company = _nullable_str(row.get("company"))
         location_str = str(row.get("location", "")) if str(row.get("location", "")) != "nan" else None
 
         # Build salary string from min/max
@@ -132,12 +134,13 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
 
         try:
             conn.execute(
-                "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at, "
+                "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at, "
                 "full_description, application_url, detail_scraped_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     url,
                     title,
+                    company,
                     salary,
                     description,
                     location_str,
@@ -151,11 +154,39 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
             )
             new += 1
         except sqlite3.IntegrityError:
+            if company:
+                cursor = conn.execute(
+                    "UPDATE jobs SET company = ? WHERE url = ? AND (company IS NULL OR company = '')",
+                    (company, url),
+                )
+                if cursor.rowcount:
+                    from jobhunter.state import record_job_event
+
+                    record_job_event(
+                        conn,
+                        url,
+                        "discover",
+                        "JobMetadataUpdated",
+                        message="Job company backfilled from JobSpy",
+                        payload={"company": company, "source": site_label},
+                        occurred_at=now,
+                    )
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
     conn.commit()
     return new, existing
+
+
+def _nullable_str(value: object) -> str | None:
+    text = str(value).strip()
+    if not text or text == "nan":
+        return None
+    return text
+
+
+def _title_ok(title: str | None, query: str | None) -> bool:
+    return title_matches_query(title, query)
 
 
 # -- Single search execution -------------------------------------------------
@@ -208,6 +239,8 @@ def _run_one_search(
         try:
             df = _scrape_with_retry(kwargs, max_retries=max_retries)
             all_dfs.append(df)
+        except ImportError:
+            raise
         except Exception as e:
             log.error("[%s] (non-gd): %s", label, e)
 
@@ -229,6 +262,8 @@ def _run_one_search(
         try:
             gd_df = _scrape_with_retry(gd_kwargs, max_retries=max_retries)
             all_dfs.append(gd_df)
+        except ImportError:
+            raise
         except Exception as e:
             log.error("[%s] (glassdoor): %s", label, e)
 
@@ -247,7 +282,7 @@ def _run_one_search(
         log.info("[%s] 0 results", label)
         return {"new": 0, "existing": 0, "errors": 0, "filtered": 0, "total": 0, "label": label}
 
-    # Filter by location before storing
+    # Filter by role title and location before storing.
     before = len(df)
     df = df[
         df.apply(
@@ -259,14 +294,28 @@ def _run_one_search(
             axis=1,
         )
     ]
-    filtered = before - len(df)
+    location_filtered = before - len(df)
+    after_location = len(df)
+    df = df[
+        df.apply(
+            lambda row: _title_ok(
+                str(row.get("title", "")) if str(row.get("title", "")) != "nan" else None,
+                s["query"],
+            ),
+            axis=1,
+        )
+    ]
+    title_filtered = after_location - len(df)
+    filtered = location_filtered + title_filtered
 
     conn = get_connection()
     new, existing = store_jobspy_results(conn, df, s["query"], limit=limit)
 
     msg = f"[{label}] {before} results -> {new} new, {existing} dupes"
-    if filtered:
-        msg += f", {filtered} filtered (location)"
+    if location_filtered:
+        msg += f", {location_filtered} filtered (location)"
+    if title_filtered:
+        msg += f", {title_filtered} filtered (title)"
     log.info(msg)
 
     return {"new": new, "existing": existing, "errors": 0, "filtered": filtered, "total": before, "label": label}
@@ -358,8 +407,6 @@ def _full_crawl(
     """Run all search queries from search config across all locations."""
     if sites is None:
         sites = ["indeed", "linkedin", "zip_recruiter"]
-    if limit > 0 and sites:
-        sites = sites[:1]
 
     # Build search combinations from config
     queries = search_cfg.get("queries", [])
@@ -397,6 +444,8 @@ def _full_crawl(
     total_new = 0
     total_existing = 0
     total_errors = 0
+    total_found = 0
+    total_filtered = 0
     completed = 0
 
     for s in searches:
@@ -420,6 +469,8 @@ def _full_crawl(
         total_new += result["new"]
         total_existing += result["existing"]
         total_errors += result["errors"]
+        total_found += result.get("total", 0)
+        total_filtered += result.get("filtered", 0)
 
         if completed % 5 == 0 or completed == len(searches):
             log.info(
@@ -442,11 +493,16 @@ def _full_crawl(
         total_errors,
         db_total,
     )
+    if completed > 0 and total_errors == completed and total_new + total_existing == 0:
+        raise RuntimeError(f"JobSpy failed for all {completed} search combination(s)")
 
     return {
+        "total": total_new + total_existing,
+        "raw_total": total_found,
         "new": total_new,
         "existing": total_existing,
         "errors": total_errors,
+        "filtered": total_filtered,
         "db_total": db_total,
         "queries": completed,
     }

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -13,7 +13,7 @@ import time
 from datetime import datetime, timezone
 
 from jobhunter import config
-from jobhunter.database import get_connection, init_db
+from jobhunter.database import get_connection, init_db, resurface_deleted_job
 
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobhunter.infrastructure.network`` so the Enrichment context's
@@ -151,6 +151,7 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
             )
             new += 1
         except sqlite3.IntegrityError:
+            resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
     conn.commit()

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -107,11 +107,12 @@ def _store_jobs_filtered(
             continue
         try:
             conn.execute(
-                "INSERT INTO jobs (url, title, salary, description, location, site, strategy, discovered_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
                     url,
                     job.get("title"),
+                    job.get("company"),
                     job.get("salary"),
                     job.get("description"),
                     job.get("location"),
@@ -122,6 +123,24 @@ def _store_jobs_filtered(
             )
             new += 1
         except sqlite3.IntegrityError:
+            company = str(job.get("company") or "").strip()
+            if company:
+                cursor = conn.execute(
+                    "UPDATE jobs SET company = ? WHERE url = ? AND (company IS NULL OR company = '')",
+                    (company, url),
+                )
+                if cursor.rowcount:
+                    from jobhunter.state import record_job_event
+
+                    record_job_event(
+                        conn,
+                        url,
+                        "discover",
+                        "JobMetadataUpdated",
+                        message="Job company backfilled from SmartExtract",
+                        payload={"company": company, "source": site},
+                        occurred_at=now,
+                    )
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -20,7 +20,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urljoin
 
 import yaml
 from bs4 import BeautifulSoup
@@ -86,17 +86,19 @@ def _store_jobs_filtered(
     reject_locs: list[str],
     query: str | list[str] | None = None,
     limit: int = 0,
+    source_url: str | None = None,
 ) -> tuple[int, int]:
-    """Store jobs with title and location filtering. Returns (new, existing)."""
+    """Store usable jobs with title, location, and description filtering."""
     now = datetime.now(timezone.utc).isoformat()
     new = 0
     existing = 0
     filtered = 0
+    missing_description = 0
 
     for job in jobs:
         if limit > 0 and new + existing >= limit:
             break
-        url = job.get("url")
+        url = _normalize_job_url(job.get("url"), source_url)
         if not url:
             continue
         if not _location_ok(job.get("location"), accept_locs, reject_locs):
@@ -104,6 +106,10 @@ def _store_jobs_filtered(
             continue
         if not _title_matches_target_query(job.get("title"), query):
             filtered += 1
+            continue
+        description = _job_description_text(job)
+        if not description:
+            missing_description += 1
             continue
         try:
             conn.execute(
@@ -114,7 +120,7 @@ def _store_jobs_filtered(
                     job.get("title"),
                     job.get("company"),
                     job.get("salary"),
-                    job.get("description"),
+                    description,
                     job.get("location"),
                     site,
                     strategy,
@@ -124,10 +130,26 @@ def _store_jobs_filtered(
             new += 1
         except sqlite3.IntegrityError:
             company = str(job.get("company") or "").strip()
+            update_fields: list[str] = []
+            update_values: list[str] = []
             if company:
+                update_fields.append("company = CASE WHEN company IS NULL OR company = '' THEN ? ELSE company END")
+                update_values.append(company)
+            if description:
+                update_fields.append(
+                    "description = CASE WHEN description IS NULL OR description = '' THEN ? ELSE description END"
+                )
+                update_values.append(description)
+            if update_fields:
+                update_predicates: list[str] = []
+                if company:
+                    update_predicates.append("(company IS NULL OR company = '')")
+                if description:
+                    update_predicates.append("(description IS NULL OR description = '')")
                 cursor = conn.execute(
-                    "UPDATE jobs SET company = ? WHERE url = ? AND (company IS NULL OR company = '')",
-                    (company, url),
+                    f"UPDATE jobs SET {', '.join(update_fields)} WHERE url = ? "
+                    f"AND ({' OR '.join(update_predicates)})",
+                    (*update_values, url),
                 )
                 if cursor.rowcount:
                     from jobhunter.state import record_job_event
@@ -137,8 +159,8 @@ def _store_jobs_filtered(
                         url,
                         "discover",
                         "JobMetadataUpdated",
-                        message="Job company backfilled from SmartExtract",
-                        payload={"company": company, "source": site},
+                        message="Job metadata backfilled from SmartExtract",
+                        payload={"company": company or None, "description": bool(description), "source": site},
                         occurred_at=now,
                     )
             resurface_deleted_job(conn, url, resurfaced_at=now)
@@ -146,6 +168,8 @@ def _store_jobs_filtered(
 
     if filtered:
         log.info("Filtered %d jobs (wrong title/location)", filtered)
+    if missing_description:
+        log.info("Filtered %d jobs (missing description)", missing_description)
     conn.commit()
     return new, existing
 
@@ -156,6 +180,24 @@ def _title_matches_target_query(title: str | None, query: str | list[str] | None
             return True
         return any(title_matches_query(title, item) for item in query)
     return title_matches_query(title, query)
+
+
+def _job_description_text(job: dict) -> str | None:
+    """Return the best usable discovered description for a job."""
+    for key in ("description", "full_description"):
+        value = str(job.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
+def _normalize_job_url(url: object, source_url: str | None = None) -> str | None:
+    value = str(url or "").strip()
+    if not value:
+        return None
+    if source_url:
+        return urljoin(source_url, value)
+    return value
 
 
 # -- Page intelligence collector ---------------------------------------------
@@ -543,7 +585,7 @@ Below is a lightweight intelligence briefing -- JSON-LD data, intercepted API re
 Pick the BEST strategy:
 
 1. "json_ld" -- ONLY if briefing shows JobPosting JSON-LD entries (it will say "usable!")
-2. "api_response" -- ONLY if an intercepted API response has job-like fields (name, title, salary, description, location, slug)
+2. "api_response" -- ONLY if an intercepted API response has job-like fields (name, title, company, salary, description, location, slug)
 3. "css_selectors" -- when neither JSON-LD nor API data has job data
 
 HOW TO THINK:
@@ -556,10 +598,10 @@ HOW TO THINK:
 Return ONLY valid JSON:
 
 For json_ld:
-{{"strategy":"json_ld","reasoning":"...","extraction":{{"title":"title","salary":"baseSalary_path_or_null","description":"description","location":"jobLocation[0].address.addressCountry","url":"url_field"}}}}
+{{"strategy":"json_ld","reasoning":"...","extraction":{{"title":"title","company":"hiringOrganization.name","salary":"baseSalary_path_or_null","description":"description","location":"jobLocation[0].address.addressCountry","url":"url_field"}}}}
 
 For api_response:
-{{"strategy":"api_response","reasoning":"...","extraction":{{"url_pattern":"actual.url.substring","items_path":"path.to.the.array","title":"field_in_each_item","salary":"salary_field_or_null","description":"description_field_or_null","location":"location_path","url":"url_field"}}}}
+{{"strategy":"api_response","reasoning":"...","extraction":{{"url_pattern":"actual.url.substring","items_path":"path.to.the.array","title":"field_in_each_item","company":"company_field_or_null","salary":"salary_field_or_null","description":"description_field_or_null","location":"location_path","url":"url_field"}}}}
 
 For css_selectors:
 {{"strategy":"css_selectors","reasoning":"...","extraction":{{}}}}
@@ -673,6 +715,7 @@ Your task:
 Return a JSON object:
 - "job_card": CSS selector matching each job card (MUST match ALL cards on the page)
 - "title": selector RELATIVE to the card for the job title
+- "company": selector relative to card for the employer name, or null
 - "salary": selector relative to card for salary, or null
 - "description": selector relative to card for description snippet, or null
 - "location": selector relative to card for location, or null
@@ -778,7 +821,7 @@ def execute_json_ld(intel: dict, plan: dict) -> list[dict]:
         if not isinstance(entry, dict) or entry.get("@type") != "JobPosting":
             continue
         job: dict = {}
-        for field in ["title", "salary", "description", "location", "url"]:
+        for field in ["title", "company", "salary", "description", "location", "url"]:
             path = ext.get(field)
             if not path or path == "null":
                 job[field] = None
@@ -814,7 +857,7 @@ def execute_api_response(intel: dict, plan: dict) -> list[dict]:
         if not isinstance(item, dict):
             continue
         job: dict = {}
-        for field in ["title", "salary", "description", "location", "url"]:
+        for field in ["title", "company", "salary", "description", "location", "url"]:
             path = ext.get(field)
             if not path or path == "null":
                 job[field] = None
@@ -871,7 +914,7 @@ def execute_css_selectors(intel: dict) -> tuple[dict, list[dict]]:
     jobs: list[dict] = []
     for card in cards:
         job: dict = {}
-        for field in ["title", "salary", "description", "location", "url"]:
+        for field in ["title", "company", "salary", "description", "location", "url"]:
             sel = selectors.get(field)
             if not sel or sel == "null":
                 job[field] = None
@@ -989,15 +1032,16 @@ def _run_one_site(name: str, url: str) -> dict:
     # Step 4: Report
     titles = sum(1 for j in jobs if j.get("title"))
     total = len(jobs)
-    status = "PASS" if total > 0 and titles / max(total, 1) >= 0.8 else "FAIL" if total == 0 else "PARTIAL"
-
     urls = sum(1 for j in jobs if j.get("url"))
     salaries = sum(1 for j in jobs if j.get("salary"))
-    descs = sum(1 for j in jobs if j.get("description"))
+    descs = sum(1 for j in jobs if _job_description_text(j))
+    usable = sum(1 for j in jobs if j.get("title") and j.get("url") and _job_description_text(j))
+    status = "PASS" if total > 0 and usable / max(total, 1) >= 0.8 else "FAIL" if total == 0 or usable == 0 else "PARTIAL"
     log.info(
-        "RESULT: %s -- %d jobs, %d titles, %d urls, %d salaries, %d descriptions",
+        "RESULT: %s -- %d jobs, %d usable, %d titles, %d urls, %d salaries, %d descriptions",
         status,
         total,
+        usable,
         titles,
         urls,
         salaries,
@@ -1131,6 +1175,7 @@ def _run_all(
                 reject_locs,
                 query=target.get("query") or target.get("queries"),
                 limit=remaining if limit > 0 else 0,
+                source_url=target.get("url"),
             )
             total_new += new
             total_existing += existing

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -1102,13 +1102,28 @@ def _run_all(
             total_existing += existing
             log.info("DB: +%d new, %d already existed", new, existing)
 
+    def _site_error_result(target: dict, exc: Exception) -> dict:
+        name = str(target.get("name") or "Unknown")
+        log.error("%s failed: %s", name, exc)
+        return {
+            "name": name,
+            "status": "ERROR",
+            "strategy": "?",
+            "total": 0,
+            "titles": 0,
+            "error": str(exc),
+        }
+
     if workers > 1 and len(targets) > 1:
         # Parallel mode
         with ThreadPoolExecutor(max_workers=min(workers, len(targets))) as pool:
             future_to_target = {pool.submit(_run_one_site, target["name"], target["url"]): target for target in targets}
             for future in as_completed(future_to_target):
                 target = future_to_target[future]
-                r = future.result()
+                try:
+                    r = future.result()
+                except Exception as exc:
+                    r = _site_error_result(target, exc)
                 results.append(r)
                 _process_result(r, target)
     else:
@@ -1121,7 +1136,10 @@ def _run_all(
                 label = f"{target['name']} [{target['query']}]"
             log.info("[%d/%d] %s", i + 1, len(targets), label)
 
-            r = _run_one_site(target["name"], target["url"])
+            try:
+                r = _run_one_site(target["name"], target["url"])
+            except Exception as exc:
+                r = _site_error_result(target, exc)
             results.append(r)
             _process_result(r, target)
 
@@ -1135,9 +1153,16 @@ def _run_all(
         log.info("%-10s | %-25s | %s", r["status"], r["name"], detail)
 
     passed = sum(1 for r in results if r["status"] == "PASS")
+    errors = sum(1 for r in results if r["status"] == "ERROR")
     log.info("%d/%d PASS", passed, len(results))
 
-    return {"total_new": total_new, "total_existing": total_existing, "passed": passed, "total": len(results)}
+    return {
+        "total_new": total_new,
+        "total_existing": total_existing,
+        "passed": passed,
+        "errors": errors,
+        "total": len(results),
+    }
 
 
 # -- Public entry point ------------------------------------------------------

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -28,7 +28,7 @@ from playwright.sync_api import sync_playwright
 
 from jobhunter import config
 from jobhunter.config import CONFIG_DIR
-from jobhunter.database import init_db, get_stats
+from jobhunter.database import get_stats, init_db, resurface_deleted_job
 from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
@@ -117,6 +117,7 @@ def _store_jobs_filtered(
             )
             new += 1
         except sqlite3.IntegrityError:
+            resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
     if filtered:

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -33,6 +33,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.llm import get_client
 
 log = logging.getLogger(__name__)
@@ -83,9 +84,10 @@ def _store_jobs_filtered(
     strategy: str,
     accept_locs: list[str],
     reject_locs: list[str],
+    query: str | list[str] | None = None,
     limit: int = 0,
 ) -> tuple[int, int]:
-    """Store jobs with location filtering. Returns (new, existing)."""
+    """Store jobs with title and location filtering. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
     new = 0
     existing = 0
@@ -98,6 +100,9 @@ def _store_jobs_filtered(
         if not url:
             continue
         if not _location_ok(job.get("location"), accept_locs, reject_locs):
+            filtered += 1
+            continue
+        if not _title_matches_target_query(job.get("title"), query):
             filtered += 1
             continue
         try:
@@ -121,9 +126,17 @@ def _store_jobs_filtered(
             existing += 1
 
     if filtered:
-        log.info("Filtered %d jobs (wrong location)", filtered)
+        log.info("Filtered %d jobs (wrong title/location)", filtered)
     conn.commit()
     return new, existing
+
+
+def _title_matches_target_query(title: str | None, query: str | list[str] | None) -> bool:
+    if isinstance(query, list):
+        if not query:
+            return True
+        return any(title_matches_query(title, item) for item in query)
+    return title_matches_query(title, query)
 
 
 # -- Page intelligence collector ---------------------------------------------
@@ -1037,6 +1050,7 @@ def build_scrape_targets(
                         "name": site_name,
                         "url": expanded_url,
                         "query": query,
+                        "queries": [query],
                     }
                 )
         else:
@@ -1047,6 +1061,7 @@ def build_scrape_targets(
                     "name": site_name,
                     "url": expanded_url,
                     "query": None,
+                    "queries": queries,
                 }
             )
 
@@ -1079,7 +1094,6 @@ def _run_all(
     total_existing = 0
 
     if limit > 0:
-        workers = 1
         targets = targets[:limit]
 
     def _process_result(r: dict, target: dict) -> None:
@@ -1096,6 +1110,7 @@ def _run_all(
                 r.get("strategy", "?"),
                 accept_locs,
                 reject_locs,
+                query=target.get("query") or target.get("queries"),
                 limit=remaining if limit > 0 else 0,
             )
             total_new += new

--- a/workers/automation/src/jobhunter/discovery/title_filter.py
+++ b/workers/automation/src/jobhunter/discovery/title_filter.py
@@ -1,0 +1,70 @@
+"""Title/query matching helpers for discovery adapters."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+
+_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "for",
+    "if",
+    "in",
+    "model",
+    "of",
+    "on",
+    "onsite",
+    "preferred",
+    "remote",
+    "required",
+    "role",
+    "roles",
+    "site",
+    "the",
+    "to",
+    "work",
+}
+
+_TOKEN_ALIASES: dict[str, tuple[tuple[str, ...], ...]] = {
+    "vp": (("vp",), ("vice", "president")),
+    "svp": (("svp",), ("senior", "vice", "president")),
+    "evp": (("evp",), ("executive", "vice", "president")),
+    "ciso": (("ciso",), ("chief", "information", "security", "officer")),
+    "cio": (("cio",), ("chief", "information", "officer")),
+    "cto": (("cto",), ("chief", "technology", "officer")),
+    "it": (("it",), ("information",), ("technology",)),
+}
+
+
+def title_matches_query(title: str | None, query: str | None) -> bool:
+    """Return whether a posting title satisfies a target search query."""
+    normalized_query = normalize_query(query)
+    if not normalized_query:
+        return True
+    title_tokens = set(_tokens(title))
+    if not title_tokens:
+        return False
+    query_tokens = [token for token in _tokens(normalized_query) if token not in _STOPWORDS]
+    if not query_tokens:
+        return False
+    return all(_token_matches_title(token, title_tokens) for token in query_tokens)
+
+
+def normalize_query(query: str | None) -> str:
+    """Strip profile notes from a role query while preserving the role itself."""
+    raw = str(query or "").strip()
+    if not raw:
+        return ""
+    return raw.split("|", 1)[0].strip()
+
+
+def _token_matches_title(token: str, title_tokens: set[str]) -> bool:
+    alternatives: Sequence[tuple[str, ...]] = _TOKEN_ALIASES.get(token, ((token,),))
+    return any(all(part in title_tokens for part in alternative) for alternative in alternatives)
+
+
+def _tokens(value: str | None) -> list[str]:
+    return re.findall(r"[a-z0-9]+", str(value or "").casefold())

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -19,7 +19,7 @@ from html.parser import HTMLParser
 
 from jobhunter import config
 from jobhunter.config import CONFIG_DIR
-from jobhunter.database import get_connection, init_db
+from jobhunter.database import get_connection, init_db, resurface_deleted_job
 from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
@@ -342,6 +342,7 @@ def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict, l
             )
             new += 1
         except sqlite3.IntegrityError:
+            resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
     conn.commit()

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -30,6 +30,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobhunter.state import record_job_event
 
@@ -192,6 +193,7 @@ def search_employer(
     search_text: str,
     location_filter: bool = True,
     max_results: int = 0,
+    max_pages: int = 25,
     accept_locs: list[str] | None = None,
     reject_locs: list[str] | None = None,
 ) -> list[dict]:
@@ -201,7 +203,7 @@ def search_employer(
     all_jobs: list[dict] = []
     offset = 0
     page_size = 20
-    max_pages = 25  # Cap at 500 results
+    max_pages = max(1, max_pages)  # Workday pages are 20 postings each.
     total = None
 
     while True:
@@ -220,6 +222,9 @@ def search_employer(
             break
 
         for j in postings:
+            title = j.get("title", "")
+            if not title_matches_query(title, search_text):
+                continue
             loc = j.get("locationsText", "")
             if location_filter and accept_locs is not None and reject_locs is not None:
                 if not _location_ok(loc, accept_locs, reject_locs):
@@ -227,7 +232,7 @@ def search_employer(
 
             all_jobs.append(
                 {
-                    "title": j.get("title", ""),
+                    "title": title,
                     "location": loc,
                     "posted": j.get("postedOn", ""),
                     "external_path": j.get("externalPath", ""),
@@ -440,9 +445,42 @@ def _process_one(
     accept_locs: list[str],
     reject_locs: list[str],
     limit: int = 0,
+    max_pages_per_employer: int = 25,
     run_id: str | None = None,
 ) -> dict:
     """Search one employer, fetch details, store results."""
+    result = _search_and_fetch_one(
+        employer_key,
+        employers,
+        search_text,
+        location_filter,
+        accept_locs,
+        reject_locs,
+        limit=limit,
+        max_pages_per_employer=max_pages_per_employer,
+    )
+    jobs = result.pop("jobs", [])
+    if not jobs:
+        return result
+
+    conn = get_connection()
+    new, existing = store_results(conn, jobs, employers, limit=limit, run_id=run_id)
+    log.info("%s: %d new, %d already in DB", result["employer"], new, existing)
+
+    return {**result, "new": new, "existing": existing}
+
+
+def _search_and_fetch_one(
+    employer_key: str,
+    employers: dict,
+    search_text: str,
+    location_filter: bool,
+    accept_locs: list[str],
+    reject_locs: list[str],
+    limit: int = 0,
+    max_pages_per_employer: int = 25,
+) -> dict:
+    """Search one employer and fetch details without writing to storage."""
     emp = employers[employer_key]
 
     try:
@@ -452,6 +490,7 @@ def _process_one(
             search_text,
             location_filter=location_filter,
             max_results=limit,
+            max_pages=max_pages_per_employer,
             accept_locs=accept_locs,
             reject_locs=reject_locs,
         )
@@ -467,11 +506,7 @@ def _process_one(
     except Exception as e:
         log.error("%s: ERROR fetching details for '%s': %s", emp["name"], search_text, e)
 
-    conn = get_connection()
-    new, existing = store_results(conn, jobs, employers, limit=limit, run_id=run_id)
-    log.info("%s: %d new, %d already in DB", emp["name"], new, existing)
-
-    return {"employer": emp["name"], "query": search_text, "found": len(jobs), "new": new, "existing": existing}
+    return {"employer": emp["name"], "query": search_text, "found": len(jobs), "new": 0, "existing": 0, "jobs": jobs}
 
 
 # -- Main orchestrator -------------------------------------------------------
@@ -487,6 +522,7 @@ def scrape_employers(
     reject_locs: list[str] | None = None,
     workers: int = 1,
     limit: int = 0,
+    max_pages_per_employer: int = 25,
     run_id: str | None = None,
 ) -> dict:
     """Run full scrape: search -> filter -> detail -> store.
@@ -513,30 +549,58 @@ def scrape_employers(
 
     valid_keys = [k for k in employer_keys if k in employers]
 
-    if limit > 0:
-        workers = 1
-
     if workers > 1 and len(valid_keys) > 1:
         # Parallel mode
         completed = 0
         with ThreadPoolExecutor(max_workers=min(workers, len(valid_keys))) as pool:
-            futures = {
-                pool.submit(
-                    _process_one,
-                    key,
-                    employers,
-                    search_text,
-                    location_filter,
-                    accept_locs,
-                    reject_locs,
-                    0,
-                    run_id,
-                ): key
-                for key in valid_keys
-            }
+            if limit > 0:
+                futures = {
+                    pool.submit(
+                        _search_and_fetch_one,
+                        key,
+                        employers,
+                        search_text,
+                        location_filter,
+                        accept_locs,
+                        reject_locs,
+                        limit,
+                        max_pages_per_employer,
+                    ): key
+                    for key in valid_keys
+                }
+            else:
+                futures = {
+                    pool.submit(
+                        _process_one,
+                        key,
+                        employers,
+                        search_text,
+                        location_filter,
+                        accept_locs,
+                        reject_locs,
+                        0,
+                        max_pages_per_employer,
+                        run_id,
+                    ): key
+                    for key in valid_keys
+                }
             for future in as_completed(futures):
                 result = future.result()
                 completed += 1
+                jobs = result.pop("jobs", [])
+                if jobs:
+                    remaining = max(limit - total_found, 0) if limit > 0 else 0
+                    if limit <= 0 or remaining > 0:
+                        jobs_to_store = jobs[:remaining] if limit > 0 else jobs
+                        conn = get_connection()
+                        new, existing = store_results(
+                            conn,
+                            jobs_to_store,
+                            employers,
+                            limit=remaining if limit > 0 else 0,
+                            run_id=run_id,
+                        )
+                        result = {**result, "found": len(jobs_to_store), "new": new, "existing": existing}
                 total_new += result["new"]
                 total_existing += result["existing"]
                 total_found += result["found"]
@@ -555,6 +619,10 @@ def scrape_employers(
                         errors,
                         elapsed,
                     )
+                if limit > 0 and total_found >= limit:
+                    for pending in futures:
+                        pending.cancel()
+                    break
     else:
         # Sequential mode (default)
         completed = 0
@@ -570,6 +638,7 @@ def scrape_employers(
                 accept_locs,
                 reject_locs,
                 remaining if limit > 0 else 0,
+                max_pages_per_employer,
                 run_id,
             )
             completed += 1
@@ -650,6 +719,7 @@ def run_workday_discovery(
         setup_proxy(proxy)
 
     location_filter = search_cfg.get("workday_location_filter", True)
+    max_pages_per_employer = _workday_max_pages_per_employer(search_cfg, limit=limit)
 
     log.info("Workday crawl: %d queries x %d employers (workers=%d)", len(queries), len(employers), workers)
 
@@ -670,6 +740,7 @@ def run_workday_discovery(
             reject_locs=reject_locs,
             workers=workers,
             limit=remaining if limit > 0 else 0,
+            max_pages_per_employer=max_pages_per_employer,
             run_id=run_id,
         )
         grand_new += result["new"]
@@ -691,3 +762,19 @@ def run_workday_discovery(
         "existing": grand_existing,
         "queries": len(queries),
     }
+
+
+def _workday_max_pages_per_employer(search_cfg: dict, *, limit: int) -> int:
+    configured = _positive_int(search_cfg.get("workday_max_pages_per_employer"), 25)
+    if limit <= 0:
+        return configured
+    limited = _positive_int(search_cfg.get("workday_limited_max_pages_per_employer"), 1)
+    return min(configured, limited)
+
+
+def _positive_int(value: object, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -19,11 +19,19 @@ from html.parser import HTMLParser
 
 from jobhunter import config
 from jobhunter.config import CONFIG_DIR
-from jobhunter.database import get_connection, init_db, resurface_deleted_job
+from jobhunter.database import get_connection, init_db
+from jobhunter.domain.discovery.identity import AtsKind
+from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase
+from jobhunter.domain.discovery.value_objects import JobMetadata, PostingUrl, SearchStrategy, Source
+from jobhunter.domain.events.base import DomainEvent
+from jobhunter.domain.ports.discovery import ScrapedJobPosting
+from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
+from jobhunter.state import record_job_event
 
 log = logging.getLogger(__name__)
 
@@ -294,59 +302,134 @@ def fetch_details(employer: dict, jobs: list[dict]) -> list[dict]:
 # -- DB storage --------------------------------------------------------------
 
 
-def store_results(conn: sqlite3.Connection, jobs: list[dict], employers: dict, limit: int = 0) -> tuple[int, int]:
-    """Store corporate jobs in DB. Returns (new, existing)."""
+class _DiscoveryEventPublisher:
+    """Persist Workday discovery domain events for API projections."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+
+    def publish(self, event: DomainEvent) -> None:
+        payload = {"tenantId": str(event.tenant_id), **event.payload}
+        job_url = (
+            payload.get("job_id")
+            or payload.get("jobId")
+            or payload.get("posting_url")
+            or payload.get("postingUrl")
+        )
+        record_job_event(
+            self._conn,
+            str(job_url) if job_url else None,
+            "discover",
+            event.event_type,
+            message=event.event_type,
+            payload=payload,
+            occurred_at=event.occurred_at,
+        )
+        self._conn.commit()
+
+
+def _job_url(job: dict, employers: dict) -> str:
+    url = str(job.get("apply_url") or "").strip()
+    if url:
+        return url
+    emp = employers.get(job.get("employer_key", ""), {})
+    if emp and job.get("external_path"):
+        return f"{emp['base_url']}/{emp['site_id']}{job['external_path']}"
+    return ""
+
+
+def _source_id(job: dict, employers: dict) -> str:
+    employer_key = str(job.get("employer_key") or "").strip()
+    employer = employers.get(employer_key, {}) if employer_key else {}
+    configured = str(employer.get("_source_id") or "").strip() if isinstance(employer, dict) else ""
+    if configured:
+        return configured
+    slug = re.sub(r"[^a-z0-9]+", "-", employer_key.lower()).strip("-")
+    return f"workday:{slug or 'unknown'}"
+
+
+def _posting_from_job(job: dict, employers: dict) -> ScrapedJobPosting | None:
+    url = _job_url(job, employers)
+    if not url:
+        return None
+    description = str(job.get("full_description") or "")
+    return ScrapedJobPosting(
+        posting_url=PostingUrl(value=url),
+        source=Source(board=str(job.get("employer_name") or "Workday")),
+        metadata=JobMetadata(
+            title=str(job.get("title") or ""),
+            salary="",
+            description=description[:500] if description else "",
+            location=str(job.get("location") or ""),
+        ),
+        strategy=SearchStrategy.WORKDAY_API,
+        source_id=_source_id(job, employers),
+        source_native_id=str(job.get("job_req_id") or job.get("external_path") or url),
+        canonical_url=url,
+        ats_kind=AtsKind.WORKDAY,
+    )
+
+
+def _update_detail_columns(conn: sqlite3.Connection, job: dict, url: str, now: str) -> None:
+    description = str(job.get("full_description") or "")
+    full_description = description if len(description) > 200 else None
+    conn.execute(
+        """
+        UPDATE jobs
+        SET full_description = COALESCE(?, full_description),
+            application_url = COALESCE(?, application_url),
+            detail_scraped_at = COALESCE(?, detail_scraped_at),
+            detail_error = COALESCE(?, detail_error)
+        WHERE url = ?
+        """,
+        (
+            full_description,
+            url,
+            now if full_description else None,
+            job.get("detail_error"),
+            url,
+        ),
+    )
+
+
+def store_results(
+    conn: sqlite3.Connection,
+    jobs: list[dict],
+    employers: dict,
+    limit: int = 0,
+    run_id: str | None = None,
+) -> tuple[int, int]:
+    """Store corporate jobs through the Discovery write boundary."""
     now = datetime.now(timezone.utc).isoformat()
-    new = 0
-    existing = 0
+    postings: list[ScrapedJobPosting] = []
+    detail_updates: list[tuple[dict, str]] = []
 
     for job in jobs:
-        if limit > 0 and new + existing >= limit:
+        if limit > 0 and len(postings) >= limit:
             break
-        url = job.get("apply_url", "")
-        if not url:
-            emp = employers.get(job.get("employer_key", ""), {})
-            if emp and job.get("external_path"):
-                url = f"{emp['base_url']}/{emp['site_id']}{job['external_path']}"
-        if not url:
+        posting = _posting_from_job(job, employers)
+        if posting is None:
             continue
+        postings.append(posting)
+        detail_updates.append((job, posting.posting_url.value))
 
-        description = job.get("full_description", "")
-        short_desc = description[:500] if description else None
-        full_description = description if len(description) > 200 else None
-        detail_scraped_at = now if full_description else None
-        detail_error = job.get("detail_error")
+    if not postings:
+        return 0, 0
 
-        site = job.get("employer_name", "Corporate")
-        strategy = "workday_api"
+    summary = DiscoverJobsUseCase(
+        repository=SqliteJobRepository(conn),
+        publisher=_DiscoveryEventPublisher(conn),
+    ).execute(
+        tenant_id=LOCAL_TENANT,
+        postings=postings,
+        run_id=run_id,
+    )
 
-        try:
-            conn.execute(
-                "INSERT INTO jobs (url, title, salary, description, location, site, strategy, "
-                "discovered_at, full_description, application_url, detail_scraped_at, detail_error) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    url,
-                    job.get("title"),
-                    None,
-                    short_desc,
-                    job.get("location"),
-                    site,
-                    strategy,
-                    now,
-                    full_description,
-                    url,
-                    detail_scraped_at,
-                    detail_error,
-                ),
-            )
-            new += 1
-        except sqlite3.IntegrityError:
-            resurface_deleted_job(conn, url, resurfaced_at=now)
-            existing += 1
+    for job, url in detail_updates:
+        _update_detail_columns(conn, job, url, now)
 
     conn.commit()
-    return new, existing
+    return summary.new_jobs, summary.observed
 
 
 def _process_one(
@@ -357,6 +440,7 @@ def _process_one(
     accept_locs: list[str],
     reject_locs: list[str],
     limit: int = 0,
+    run_id: str | None = None,
 ) -> dict:
     """Search one employer, fetch details, store results."""
     emp = employers[employer_key]
@@ -384,7 +468,7 @@ def _process_one(
         log.error("%s: ERROR fetching details for '%s': %s", emp["name"], search_text, e)
 
     conn = get_connection()
-    new, existing = store_results(conn, jobs, employers, limit=limit)
+    new, existing = store_results(conn, jobs, employers, limit=limit, run_id=run_id)
     log.info("%s: %d new, %d already in DB", emp["name"], new, existing)
 
     return {"employer": emp["name"], "query": search_text, "found": len(jobs), "new": new, "existing": existing}
@@ -403,6 +487,7 @@ def scrape_employers(
     reject_locs: list[str] | None = None,
     workers: int = 1,
     limit: int = 0,
+    run_id: str | None = None,
 ) -> dict:
     """Run full scrape: search -> filter -> detail -> store.
 
@@ -445,6 +530,7 @@ def scrape_employers(
                     accept_locs,
                     reject_locs,
                     0,
+                    run_id,
                 ): key
                 for key in valid_keys
             }
@@ -484,6 +570,7 @@ def scrape_employers(
                 accept_locs,
                 reject_locs,
                 remaining if limit > 0 else 0,
+                run_id,
             )
             completed += 1
             total_new += result["new"]
@@ -516,7 +603,12 @@ def scrape_employers(
 # -- Public entry point ------------------------------------------------------
 
 
-def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit: int = 0) -> dict:
+def run_workday_discovery(
+    employers: dict | None = None,
+    workers: int = 1,
+    limit: int = 0,
+    run_id: str | None = None,
+) -> dict:
     """Main entry point for Workday-based corporate job discovery.
 
     Loads employer registry from config/employers.yaml (or uses the provided
@@ -578,6 +670,7 @@ def run_workday_discovery(employers: dict | None = None, workers: int = 1, limit
             reject_locs=reject_locs,
             workers=workers,
             limit=remaining if limit > 0 else 0,
+            run_id=run_id,
         )
         grand_new += result["new"]
         grand_existing += result["existing"]

--- a/workers/automation/src/jobhunter/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/discovery/use_cases.py
@@ -185,8 +185,7 @@ class DiscoverJobsUseCase:
         materialised = list(postings)
         run_id = run_id or self._run_id_factory()
         decisions: list[DiscoveryDecision] = [
-            self._ingest_one(tenant_id=tenant_id, posting=p, run_id=run_id)
-            for p in materialised
+            self._ingest_one(tenant_id=tenant_id, posting=p, run_id=run_id) for p in materialised
         ]
         return DiscoveryRunSummary(
             total=len(decisions),
@@ -352,10 +351,7 @@ class DiscoverJobsUseCase:
     ) -> DiscoveryDecision:
         observed_url = identity.canonical_url or posting.posting_url.value
         normalized_observed = normalize_observed_url(observed_url)
-        is_distinct_url = (
-            normalized_observed != normalize_observed_url(str(owner_id))
-            and normalized_observed != ""
-        )
+        is_distinct_url = normalized_observed != normalize_observed_url(str(owner_id)) and normalized_observed != ""
 
         if identity.confidence < MIN_AUTO_MERGE_CONFIDENCE and is_distinct_url:
             duplicate_link_id = f"dup:{uuid.uuid4().hex}"
@@ -394,6 +390,9 @@ class DiscoverJobsUseCase:
             result="observed",
             confidence=identity.confidence,
         ):
+            existing = self._repository.load(tenant_id, owner_id)
+            if existing is not None and existing.is_deleted:
+                self._repository.save(existing.restore())
             self._repository.attach_source_observation(
                 tenant_id,
                 owner_id,
@@ -428,9 +427,7 @@ class DiscoverJobsUseCase:
                 duplicate_link_id=duplicate_link_id,
                 surviving_job_id=str(owner_id),
                 superseded_job_or_observation_id=observation_id,
-                reason="canonical_url_match"
-                if identity.canonical_url
-                else "source_native_id_match",
+                reason="canonical_url_match" if identity.canonical_url else "source_native_id_match",
                 confidence=identity.confidence,
                 linked_at=observed_at,
             )

--- a/workers/automation/src/jobhunter/enrichment/activities.py
+++ b/workers/automation/src/jobhunter/enrichment/activities.py
@@ -15,6 +15,7 @@ class EnrichActivityInput:
     tenant_id: str
     limit: int = 0
     workers: int = 1
+    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -35,7 +36,10 @@ async def enrich_activity(payload: EnrichActivityInput) -> EnrichActivityOutput:
 
     def _do() -> dict[str, Any]:
         return run_pipeline(
-            stages=["enrich"], workers=payload.workers, limit=payload.limit
+            stages=["enrich"],
+            workers=payload.workers,
+            limit=payload.limit,
+            dry_run=payload.dry_run,
         )
 
     result = await run_blocking_with_heartbeat(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
@@ -43,6 +43,7 @@ from jobhunter.domain.discovery.value_objects import (
 from jobhunter.domain.ports.discovery import ScrapedJobPosting
 from jobhunter.domain.tenant import TenantId
 from jobhunter.infrastructure.discovery.location_filter import location_matches_target
+from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.observability.adapter_spans import adapter_fetch_span
 
 log = logging.getLogger(__name__)
@@ -232,7 +233,7 @@ class WorkdayBoardAdapter:
         # filtered set (the API treats ``searchText`` as a soft hint).
         # Re-apply the filter on title so the adapter contract holds:
         # "yield postings matching the query".
-        if query.strip() and query.strip().lower() not in title.lower():
+        if not title_matches_query(title, query):
             return None
         canonical_url = f"{self._employer.base_url}/{self._employer.site_id}{external_path}"
         source_native_id = external_path.split("/")[-1] or external_path
@@ -337,7 +338,7 @@ class GreenhouseBoardAdapter:
         gh_id = raw.get("id")
         if not title or not absolute_url or gh_id is None:
             return None
-        if query.strip() and query.strip().lower() not in title.lower():
+        if not title_matches_query(title, query):
             # Lightweight server-side filter so callers can pass a
             # non-empty query without the API raising.
             return None
@@ -449,7 +450,7 @@ class LeverBoardAdapter:
         posting_id = str(raw.get("id") or "").strip()
         if not text or not hosted_url or not posting_id:
             return None
-        if query.strip() and query.strip().lower() not in text.lower():
+        if not title_matches_query(text, query):
             return None
         cats = raw.get("categories") or {}
         loc = str(cats.get("location") or "").strip() if isinstance(cats, dict) else ""
@@ -552,7 +553,7 @@ class AshbyBoardAdapter:
         posting_id = str(raw.get("id") or "").strip()
         if not title or not job_url or not posting_id:
             return None
-        if query.strip() and query.strip().lower() not in title.lower():
+        if not title_matches_query(title, query):
             return None
         loc = str(raw.get("location") or raw.get("locationName") or "").strip()
         if not location_matches_target(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -8,11 +8,157 @@ from typing import Any
 
 
 REMOTE_MARKERS = ("remote", "anywhere", "work from home", "wfh", "distributed")
+US_LOCATION_ALIASES = (
+    "usa",
+    "us",
+    "u.s.",
+    "u.s.a.",
+    "united states",
+    "alabama",
+    "alaska",
+    "arizona",
+    "arkansas",
+    "california",
+    "colorado",
+    "connecticut",
+    "delaware",
+    "florida",
+    "georgia",
+    "hawaii",
+    "idaho",
+    "illinois",
+    "indiana",
+    "iowa",
+    "kansas",
+    "kentucky",
+    "louisiana",
+    "maine",
+    "maryland",
+    "massachusetts",
+    "michigan",
+    "minnesota",
+    "mississippi",
+    "missouri",
+    "montana",
+    "nebraska",
+    "nevada",
+    "new hampshire",
+    "new jersey",
+    "new mexico",
+    "new york",
+    "north carolina",
+    "north dakota",
+    "ohio",
+    "oklahoma",
+    "oregon",
+    "pennsylvania",
+    "rhode island",
+    "south carolina",
+    "south dakota",
+    "tennessee",
+    "texas",
+    "utah",
+    "vermont",
+    "virginia",
+    "washington",
+    "washington dc",
+    "west virginia",
+    "wisconsin",
+    "wyoming",
+    "al",
+    "ak",
+    "az",
+    "ar",
+    "ca",
+    "co",
+    "ct",
+    "de",
+    "fl",
+    "ga",
+    "hi",
+    "id",
+    "il",
+    "in",
+    "ia",
+    "ks",
+    "ky",
+    "la",
+    "me",
+    "md",
+    "ma",
+    "mi",
+    "mn",
+    "ms",
+    "mo",
+    "mt",
+    "ne",
+    "nv",
+    "nh",
+    "nj",
+    "nm",
+    "ny",
+    "nc",
+    "nd",
+    "oh",
+    "ok",
+    "or",
+    "pa",
+    "ri",
+    "sc",
+    "sd",
+    "tn",
+    "tx",
+    "ut",
+    "vt",
+    "va",
+    "wa",
+    "dc",
+    "wv",
+    "wi",
+    "wy",
+)
+CANADA_LOCATION_ALIASES = (
+    "canada",
+    "canadian",
+    "can",
+    "ca",
+    "alberta",
+    "british columbia",
+    "manitoba",
+    "new brunswick",
+    "newfoundland",
+    "newfoundland and labrador",
+    "northwest territories",
+    "nova scotia",
+    "nunavut",
+    "ontario",
+    "prince edward island",
+    "quebec",
+    "québec",
+    "saskatchewan",
+    "yukon",
+    "ab",
+    "bc",
+    "mb",
+    "nb",
+    "nl",
+    "nt",
+    "ns",
+    "nu",
+    "on",
+    "pe",
+    "qc",
+    "sk",
+    "yt",
+)
 REJECT_ALIASES = {
-    "usa": ("usa", "us", "u.s.", "u.s.a.", "united states"),
-    "u.s.": ("usa", "us", "u.s.", "u.s.a.", "united states"),
-    "u.s.a.": ("usa", "us", "u.s.", "u.s.a.", "united states"),
-    "united states": ("usa", "us", "u.s.", "u.s.a.", "united states"),
+    "usa": US_LOCATION_ALIASES,
+    "us": US_LOCATION_ALIASES,
+    "u.s.": US_LOCATION_ALIASES,
+    "u.s.a.": US_LOCATION_ALIASES,
+    "united states": US_LOCATION_ALIASES,
+    "canada": CANADA_LOCATION_ALIASES,
+    "canada only": CANADA_LOCATION_ALIASES,
 }
 
 
@@ -41,20 +187,21 @@ def location_matches_target(
     rejected for a Spain/Europe search while "Remote EMEA" still passes.
     """
 
+    concrete_accept = _concrete_accept_patterns(accept)
     if not location:
-        return True
+        return not concrete_accept
 
     normalized = _normalize(location)
     if _matches_reject(normalized, reject):
         return False
 
-    if search_location and _matches(normalized, search_location):
+    if search_location and _matches(normalized, search_location) and not concrete_accept:
         return True
 
-    if _matches_any(normalized, accept):
+    if _matches_any(normalized, concrete_accept):
         return True
 
-    return _matches_any(normalized, REMOTE_MARKERS)
+    return not concrete_accept and _matches_any(normalized, REMOTE_MARKERS)
 
 
 def _string_list(value: object) -> list[str]:
@@ -76,6 +223,10 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 def _matches_any(location: str, patterns: Sequence[str]) -> bool:
     return any(_matches(location, pattern) for pattern in patterns)
+
+
+def _concrete_accept_patterns(patterns: Sequence[str]) -> list[str]:
+    return [pattern for pattern in patterns if _normalize(pattern) not in REMOTE_MARKERS]
 
 
 def _matches_reject(location: str, patterns: Sequence[str]) -> bool:

--- a/workers/automation/src/jobhunter/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/sqlite_repository.py
@@ -250,6 +250,7 @@ class SqliteJobRepository:
                 """
                 UPDATE jobs SET
                     title = ?,
+                    company = COALESCE(NULLIF(company, ''), ?),
                     salary = ?,
                     description = ?,
                     location = ?,
@@ -260,6 +261,7 @@ class SqliteJobRepository:
                 """,
                 (
                     job.metadata.title,
+                    None if job.employer.is_unknown() else job.employer.name,
                     job.metadata.salary,
                     job.metadata.description,
                     job.metadata.location,
@@ -273,13 +275,14 @@ class SqliteJobRepository:
             self._conn.execute(
                 """
                 INSERT INTO jobs (
-                    url, title, salary, description, location,
+                    url, title, company, salary, description, location,
                     site, strategy, discovered_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     job.posting_url.value,
                     job.metadata.title,
+                    None if job.employer.is_unknown() else job.employer.name,
                     job.metadata.salary,
                     job.metadata.description,
                     job.metadata.location,

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -377,7 +377,7 @@ class ProjectionBuilder:
             enrichment.get("application_url")
             or _row_nullable_str(job_row, "application_url")
         )
-        employer = _company_name(site, application_url or job_url)
+        employer = _row_str(job_row, "company") or _company_name(site, application_url or job_url)
 
         # currentStage/State: first non-succeeded/non-skipped stage.
         current_stage = "discover"
@@ -1145,7 +1145,7 @@ class ProjectionBuilder:
         # "Untitled" / "Unknown company".
         try:
             meta = self._conn.execute(
-                "SELECT title, site FROM jobs WHERE url = ? LIMIT 1",
+                "SELECT title, site, company FROM jobs WHERE url = ? LIMIT 1",
                 (job_url,),
             ).fetchone()
         except sqlite3.OperationalError:
@@ -1154,7 +1154,8 @@ class ProjectionBuilder:
             title = _row_str(meta, "title") or title
             site = _row_str(meta, "site") or site
 
-        employer = _company_name(site, job_url)
+        employer = _row_str(meta, "company") if meta is not None else ""
+        employer = employer or _company_name(site, job_url)
 
         events_payload: list[dict] = []
         for event in events:

--- a/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
@@ -6,11 +6,12 @@ Per S-11 the initial method set covers:
   ``mark_skipped``, ``cancel_stage``.  These mutate ``job_stage_states``
   through the same write API the TS surface uses (``state.reset_job_stage``
   / ``state.set_stage_state``).
-* Existing local-action wrappers — ``run_stage``, ``profile_import``.
-  These delegate to ``actions.run_local_action``.
+* Existing local-action wrappers — ``profile_import`` delegates to
+  ``actions.run_local_action``.
 * Workflow starters — ``apply`` returns a :class:`WorkflowStartSpec` for
-  :class:`ApplyWorkflow`; the server starts it on the Temporal task queue
-  and ships back ``{"runId", "workflowId", "firstExecutionRunId"}``.
+  :class:`ApplyWorkflow`; ``run_stage`` returns one for
+  :class:`JobPipelineWorkflow`. The server starts them on the Temporal task
+  queue and ships back ``{"runId", "workflowId", "firstExecutionRunId"}``.
 * Cooperative cancellation — ``cancel_run`` cancels an in-flight workflow
   via the injected canceler.
 
@@ -32,9 +33,11 @@ from jobhunter.domain.rpc.messages import WorkflowStartSpec
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.rpc.server import JsonRpcServer, invalid_params
 from jobhunter.infrastructure.rpc.workflow_starter import WorkflowCanceler
+from jobhunter.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
 from jobhunter.state import record_job_event, reset_job_stage, set_stage_state, utc_now
 
 logger = logging.getLogger(__name__)
+WORKFLOW_STAGES = {"discover", "enrich", "score", "tailor", "cover", "pdf", "apply"}
 
 
 def _tenant_id(params: dict[str, Any]) -> str:
@@ -152,21 +155,37 @@ def cancel_stage(params: dict[str, Any]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def run_stage(params: dict[str, Any]) -> dict[str, Any]:
-    _tenant_id(params)
-    stage = str(_require(params, "stage"))
-    request = LocalActionRequest(
-        stage=stage,
-        job_url=params.get("jobUrl"),
-        limit=int(params.get("limit", 0)),
-        workers=int(params.get("workers", 1)),
+def _stage_list(params: dict[str, Any]) -> list[str]:
+    raw_stages = params.get("stages")
+    if isinstance(raw_stages, list) and raw_stages:
+        stages = [str(stage) for stage in raw_stages]
+    else:
+        stages = [str(_require(params, "stage"))]
+    invalid = [stage for stage in stages if stage not in WORKFLOW_STAGES]
+    if invalid:
+        raise invalid_params(f"unsupported pipeline stage for workflow: {', '.join(invalid)}")
+    return stages
+
+
+def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
+    tenant_id = _tenant_id(params)
+    stages = _stage_list(params)
+    payload = JobPipelineWorkflowInput(
+        tenant_id=tenant_id,
+        stages=stages,
         min_score=int(params.get("minScore", 7)),
+        workers=int(params.get("workers", 1)),
+        limit=int(params.get("limit", 0)),
         validation_mode=str(params.get("validationMode", "normal")),
         dry_run=bool(params.get("dryRun", False)),
         rescore=bool(params.get("rescore", False)),
         retailor=bool(params.get("retailor", False)),
+        job_url=params.get("jobUrl") if params.get("jobUrl") else None,
+        headless=bool(params.get("headless", False)),
+        model=str(params.get("model", "haiku")),
+        continuous=bool(params.get("continuous", False)),
     )
-    return run_local_action(request).to_dict()
+    return WorkflowStartSpec(workflow=JobPipelineWorkflow, args=(payload,))
 
 
 def profile_import(params: dict[str, Any]) -> dict[str, Any]:
@@ -232,11 +251,11 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register("mark_applied", mark_applied, mode="sync")
     server.register("mark_skipped", mark_skipped, mode="sync")
     server.register("cancel_stage", cancel_stage, mode="sync")
-    # Local-action wrappers — sync; ``run_stage`` and ``profile_import`` keep
-    # their sync result shape until a follow-up converts them to workflows.
-    server.register("run_stage", run_stage, mode="sync")
+    # Local-action wrapper — synchronous import until the profile workflow
+    # becomes the API path.
     server.register("profile_import", profile_import, mode="sync")
     # Workflow starters.
+    server.register("run_stage", run_stage, mode="workflow")
     server.register("apply", apply_action, mode="workflow")
     # Cooperative cancellation of in-flight workflows.
     server.register("cancel_run", make_cancel_run(canceler), mode="sync")

--- a/workers/automation/src/jobhunter/materials/activities.py
+++ b/workers/automation/src/jobhunter/materials/activities.py
@@ -22,6 +22,7 @@ class TailorActivityInput:
     limit: int = 0
     workers: int = 1
     validation_mode: str = "normal"
+    dry_run: bool = False
     retailor: bool = False
 
 
@@ -48,6 +49,7 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
             workers=payload.workers,
             validation_mode=payload.validation_mode,
             limit=payload.limit,
+            dry_run=payload.dry_run,
             retailor=payload.retailor,
         )
 
@@ -80,6 +82,7 @@ class CoverActivityInput:
     min_score: int = 7
     limit: int = 0
     validation_mode: str = "normal"
+    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -104,6 +107,7 @@ async def cover_activity(payload: CoverActivityInput) -> CoverActivityOutput:
             min_score=payload.min_score,
             validation_mode=payload.validation_mode,
             limit=payload.limit,
+            dry_run=payload.dry_run,
         )
 
     result = await run_blocking_with_heartbeat(
@@ -133,6 +137,7 @@ class PdfActivityInput:
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
     limit: int = 0
+    dry_run: bool = False
 
 
 @dataclass(frozen=True)
@@ -152,7 +157,11 @@ async def pdf_activity(payload: PdfActivityInput) -> PdfActivityOutput:
     from jobhunter.pipeline import run_pipeline
 
     def _do() -> dict[str, Any]:
-        return run_pipeline(stages=["pdf"], limit=payload.limit)
+        return run_pipeline(
+            stages=["pdf"],
+            limit=payload.limit,
+            dry_run=payload.dry_run,
+        )
 
     result = await run_blocking_with_heartbeat(
         _do,

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -702,21 +702,11 @@ def _discover_limit_reached(start_count: int, limit: int) -> bool:
     return limit > 0 and _pipeline_job_count() - start_count >= limit
 
 
-def _discovery_result_count(result: Any) -> int:
+def _discovery_new_result_count(result: Any) -> int:
     if not isinstance(result, dict):
         return 0
-    if "found" in result:
-        return int(result.get("found") or 0)
     count = 0
-    for key in (
-        "new",
-        "existing",
-        "total_new",
-        "total_existing",
-        "new_jobs",
-        "existing_jobs",
-        "observed_jobs",
-    ):
+    for key in ("new", "total_new", "new_jobs"):
         count += int(result.get(key) or 0)
     return count
 
@@ -724,7 +714,7 @@ def _discovery_result_count(result: Any) -> int:
 def _discover_limit_consumed(start_count: int, limit: int, source_result: Any = None) -> bool:
     if limit <= 0:
         return False
-    if _discovery_result_count(source_result) >= limit:
+    if _discovery_new_result_count(source_result) >= limit:
         return True
     return _discover_limit_reached(start_count, limit)
 
@@ -811,7 +801,9 @@ def _workday_employers_for_sources(sources: tuple[ScheduledSource, ...]) -> dict
             continue
         employer_key = str(source.adapter_config.get("employer_key") or "").strip()
         if employer_key and employer_key in employers:
-            selected[employer_key] = employers[employer_key]
+            employer_config = dict(employers[employer_key])
+            employer_config["_source_id"] = source.source_id
+            selected[employer_key] = employer_config
     return selected
 
 
@@ -959,13 +951,14 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
     # Workday corporate scraper
     workday_sources = schedule.for_prefix("workday")
 
-    def run_workday() -> dict:
+    def run_workday(run_id: str | None = None) -> dict:
         console.print("  [cyan]Workday corporate scraper...[/cyan]")
         from jobhunter.discovery.workday import run_workday_discovery
         source_results["workday"] = run_workday_discovery(
             employers=_workday_employers_for_sources(workday_sources),
             workers=bounded_workers,
             limit=_scheduled_limit(schedule, "workday", limit),
+            run_id=run_id,
         )
         return source_results["workday"]
 

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -719,6 +719,12 @@ def _discover_limit_consumed(start_count: int, limit: int, source_result: Any = 
     return _discover_limit_reached(start_count, limit)
 
 
+def _discover_remaining_limit(start_count: int, limit: int) -> int:
+    if limit <= 0:
+        return 0
+    return max(limit - (_pipeline_job_count() - start_count), 0)
+
+
 def _load_source_quality_snapshots() -> tuple[SourceQualitySnapshot, ...]:
     try:
         conn = get_connection()
@@ -837,10 +843,19 @@ def _smart_extract_sites(sources: tuple[ScheduledSource, ...]) -> list[dict]:
             {
                 "name": str(source.adapter_config.get("name") or source.display_name),
                 "url": url,
-                "type": str(source.adapter_config.get("type") or "static"),
+                "type": _smart_extract_site_type(source.adapter_config, url),
             }
         )
     return sites
+
+
+def _smart_extract_site_type(adapter_config: dict[str, object], url: str) -> str:
+    configured_type = str(adapter_config.get("type") or "").strip()
+    if configured_type:
+        return configured_type
+    if "{query_encoded}" in url or "{query}" in url:
+        return "search"
+    return "static"
 
 
 def _optional_float(value: object) -> float | None:
@@ -931,7 +946,7 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
                 ats_sources,
                 search_cfg=search_cfg,
                 run_id=run_id or f"discovery:ats_api:{uuid.uuid4().hex}",
-                limit=_scheduled_limit_for_sources(ats_sources, limit),
+                limit=_scheduled_limit_for_sources(ats_sources, _discover_remaining_limit(start_count, limit)),
             )
             return source_results["ats_api"]
 
@@ -957,7 +972,7 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
         source_results["workday"] = run_workday_discovery(
             employers=_workday_employers_for_sources(workday_sources),
             workers=bounded_workers,
-            limit=_scheduled_limit(schedule, "workday", limit),
+            limit=_scheduled_limit(schedule, "workday", _discover_remaining_limit(start_count, limit)),
             run_id=run_id,
         )
         return source_results["workday"]
@@ -984,7 +999,10 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
         source_results["smartextract"] = run_smart_extract(
             sites=_smart_extract_sites(smart_extract_sources),
             workers=bounded_workers,
-            limit=_scheduled_limit_for_sources(smart_extract_sources, limit),
+            limit=_scheduled_limit_for_sources(
+                smart_extract_sources,
+                _discover_remaining_limit(start_count, limit),
+            ),
         )
         return source_results["smartextract"]
 

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -872,7 +872,7 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
     except Exception:
         log.debug("Failed to seed discovery control queues", exc_info=True)
     schedule = _plan_discovery_schedule(limit)
-    bounded_workers = 1 if limit > 0 else workers
+    bounded_workers = max(1, workers)
     start_count = _pipeline_job_count() if limit > 0 else 0
 
     # JobSpy — skip if disabled in config or module not installed

--- a/workers/automation/src/jobhunter/pipeline/workflow.py
+++ b/workers/automation/src/jobhunter/pipeline/workflow.py
@@ -11,6 +11,7 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError
 
 with workflow.unsafe.imports_passed_through():
+    from jobhunter.apply.workflow import ApplyWorkflow, ApplyWorkflowInput
     from jobhunter.discovery.activities import (
         DiscoverActivityInput,
         discover_activity,
@@ -43,9 +44,9 @@ class JobPipelineWorkflowInput:
     single ``(TenantId, JobId)`` for the discover/enrich/score/tailor/cover/pdf
     stages.
 
-    The per-job apply path lives in ``ApplyWorkflow`` (``apply/workflow.py``);
-    passing ``"apply"`` in ``stages`` raises a non-retryable
-    ``ApplicationError``.
+    The apply step is delegated to ``ApplyWorkflow`` as a child workflow so
+    mixed requests such as ``score -> tailor -> apply`` preserve request-order
+    semantics while all work still runs under Temporal.
     """
 
     tenant_id: str
@@ -54,6 +55,13 @@ class JobPipelineWorkflowInput:
     workers: int = 1
     limit: int = 0
     validation_mode: str = "normal"
+    dry_run: bool = False
+    rescore: bool = False
+    retailor: bool = False
+    job_url: str | None = None
+    headless: bool = False
+    model: str = "haiku"
+    continuous: bool = False
 
 
 @dataclass(frozen=True)
@@ -120,6 +128,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 tenant_id=payload.tenant_id,
                 workers=payload.workers,
                 limit=payload.limit,
+                dry_run=payload.dry_run,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -132,6 +141,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 tenant_id=payload.tenant_id,
                 workers=payload.workers,
                 limit=payload.limit,
+                dry_run=payload.dry_run,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -144,6 +154,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 tenant_id=payload.tenant_id,
                 workers=payload.workers,
                 limit=payload.limit,
+                dry_run=payload.dry_run,
+                rescore=payload.rescore,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -158,6 +170,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 workers=payload.workers,
                 limit=payload.limit,
                 validation_mode=payload.validation_mode,
+                dry_run=payload.dry_run,
+                retailor=payload.retailor,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -171,6 +185,7 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 min_score=payload.min_score,
                 limit=payload.limit,
                 validation_mode=payload.validation_mode,
+                dry_run=payload.dry_run,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -179,15 +194,30 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
     if stage == "pdf":
         return await workflow.execute_activity(
             pdf_activity,
-            PdfActivityInput(tenant_id=payload.tenant_id, limit=payload.limit),
+            PdfActivityInput(
+                tenant_id=payload.tenant_id,
+                limit=payload.limit,
+                dry_run=payload.dry_run,
+            ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
             heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
             retry_policy=_DEFAULT_RETRY,
         )
     if stage == "apply":
-        raise ApplicationError(
-            "apply is not orchestrated by JobPipelineWorkflow; use ApplyWorkflow",
-            non_retryable=True,
+        return await workflow.execute_child_workflow(
+            ApplyWorkflow.run,
+            ApplyWorkflowInput(
+                tenant_id=payload.tenant_id,
+                job_url=payload.job_url,
+                dry_run=payload.dry_run,
+                headless=payload.headless,
+                model=payload.model,
+                min_score=payload.min_score,
+                workers=payload.workers,
+                limit=payload.limit,
+                continuous=payload.continuous,
+            ),
+            id=f"{workflow.info().workflow_id}-apply",
         )
     raise ApplicationError(
         f"Unknown stage: {stage}",

--- a/workers/automation/src/jobhunter/scoring/activities.py
+++ b/workers/automation/src/jobhunter/scoring/activities.py
@@ -15,6 +15,7 @@ class ScoreActivityInput:
     tenant_id: str
     limit: int = 0
     workers: int = 1
+    dry_run: bool = False
     rescore: bool = False
 
 
@@ -39,6 +40,7 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
             stages=["score"],
             workers=payload.workers,
             limit=payload.limit,
+            dry_run=payload.dry_run,
             rescore=payload.rescore,
         )
 

--- a/workers/automation/tests/test_activity_apply.py
+++ b/workers/automation/tests/test_activity_apply.py
@@ -67,6 +67,7 @@ async def test_apply_activity_invokes_apply_main_and_returns_ok():
     assert kwargs["min_score"] == 8
     assert kwargs["headless"] is True
     assert kwargs["model"] == "haiku"
+    assert kwargs["install_signal_handlers"] is False
     assert output.status == "ok"
     assert output.applied == 2
     assert output.failed == 0

--- a/workers/automation/tests/test_ats_adapters.py
+++ b/workers/automation/tests/test_ats_adapters.py
@@ -111,6 +111,47 @@ def test_workday_adapter_rejects_country_scoped_remote_locations() -> None:
     assert [posting.metadata.location for posting in postings] == ["Remote EMEA"]
 
 
+def test_workday_adapter_rejects_loose_title_matches() -> None:
+    def http(
+        url: str,
+        *,
+        method: str = "GET",
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "total": 2,
+            "jobPostings": [
+                {
+                    "title": "Independent Trauma Counsellor",
+                    "externalPath": "/job/EMEA/Independent-Trauma-Counsellor_JR-123",
+                    "locationsText": "Remote EMEA",
+                },
+                {
+                    "title": "Director of Engineering",
+                    "externalPath": "/job/EMEA/Director-of-Engineering_JR-456",
+                    "locationsText": "Remote EMEA",
+                },
+            ],
+        }
+
+    adapter = WorkdayBoardAdapter(
+        source_id="workday:acme",
+        employer=WorkdayEmployer(
+            employer_key="acme",
+            name="Acme Corp",
+            base_url="https://acme.wd1.myworkdayjobs.com",
+            tenant="acme",
+            site_id="External",
+        ),
+        http=http,
+        location_accept=["Spain", "Europe", "EMEA"],
+    )
+
+    postings = list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Director of Engineering", location="Remote"))
+
+    assert [posting.metadata.title for posting in postings] == ["Director of Engineering"]
+
+
 def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
     def http(url: str) -> dict[str, Any]:
         assert url == "https://boards-api.greenhouse.io/v1/boards/acme/jobs"

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -389,6 +389,40 @@ def test_discover_jobs_use_case_observes_existing_job_and_links_duplicate(
     assert duplicate_row["reason"] == "canonical_url_match"
 
 
+def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+    use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    repo.soft_delete(
+        LOCAL_TENANT,
+        JobId("https://boards.greenhouse.io/acme/jobs/123"),
+        reason="not relevant right now",
+        deleted_at="2026-05-13T00:00:00Z",
+    )
+
+    summary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-2")
+
+    assert summary.total == 1
+    assert summary.new_jobs == 0
+    assert summary.observed == 1
+    resurfaced = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    assert resurfaced is not None
+    assert resurfaced.is_deleted is False
+    tombstone = conn.execute(
+        "SELECT restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
+        ("https://boards.greenhouse.io/acme/jobs/123",),
+    ).fetchone()
+    assert tombstone is not None
+    assert tombstone["restored_at"] == "2026-05-12T00:00:00Z"
+
+
 def test_discover_jobs_use_case_rejects_low_confidence_duplicate(
     conn: sqlite3.Connection,
 ) -> None:
@@ -435,7 +469,10 @@ def test_discover_jobs_use_case_rejects_low_confidence_duplicate(
     rejected = publisher.events[0]
     assert rejected.payload["candidate_ids"][0] == "https://boards.greenhouse.io/acme/jobs/123"
     assert rejected.payload["reason"] == "confidence_below_threshold"
-    assert repo.list_observations(
-        LOCAL_TENANT,
-        JobId("https://boards.greenhouse.io/acme/jobs/123"),
-    )[0].run_id == "run-1"
+    assert (
+        repo.list_observations(
+            LOCAL_TENANT,
+            JobId("https://boards.greenhouse.io/acme/jobs/123"),
+        )[0].run_id
+        == "run-1"
+    )

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pandas as pd
+import pytest
+
+from jobhunter.database import close_connection, init_db
 from jobhunter.discovery import jobspy
 
 
-def test_jobspy_limit_runs_one_query_against_one_board(monkeypatch):
+def test_jobspy_limit_runs_one_query_against_scheduled_boards(monkeypatch):
     calls: list[tuple[str, str, list[str], int, int]] = []
 
     def fake_run_one_search(
@@ -37,5 +41,120 @@ def test_jobspy_limit_runs_one_query_against_one_board(monkeypatch):
         limit=1,
     )
 
-    assert calls == [("platform engineer", "Remote", ["indeed"], 1, 1)]
+    assert calls == [("platform engineer", "Remote", ["indeed", "linkedin"], 1, 1)]
     assert result["queries"] == 1
+
+
+def test_jobspy_filters_results_by_target_title(monkeypatch):
+    stored_titles: list[str] = []
+
+    def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
+        return pd.DataFrame(
+            [
+                {
+                    "job_url": "https://example.test/marketing",
+                    "title": "CRM Marketer",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+                {
+                    "job_url": "https://example.test/director-engineering",
+                    "title": "Director of Engineering",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+            ]
+        )
+
+    def fake_store(_conn, df, _source_label: str, limit: int = 0) -> tuple[int, int]:
+        stored_titles.extend(df["title"].tolist())
+        return len(df), 0
+
+    monkeypatch.setattr(jobspy, "_scrape_with_retry", fake_scrape)
+    monkeypatch.setattr(jobspy, "get_connection", lambda: object())
+    monkeypatch.setattr(jobspy, "store_jobspy_results", fake_store)
+
+    result = jobspy._run_one_search(
+        {"query": "Director of Engineering", "location": "Barcelona, Spain", "remote": True},
+        ["indeed"],
+        10,
+        72,
+        None,
+        {"country_indeed": "spain"},
+        0,
+        ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+        ["United States", "Canada"],
+        {},
+        limit=10,
+    )
+
+    assert stored_titles == ["Director of Engineering"]
+    assert result["new"] == 1
+    assert result["filtered"] == 1
+
+
+def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        first = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/1",
+                    "title": "Head of Engineering",
+                    "company": "Keyrock",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, first, "Head of Engineering", limit=10) == (1, 0)
+        row = conn.execute("SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)).fetchone()
+        assert row["company"] == "Keyrock"
+
+        conn.execute("UPDATE jobs SET company = '' WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",))
+        conn.commit()
+        duplicate = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/1",
+                    "title": "Head of Engineering",
+                    "company": "Keyrock",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, duplicate, "Head of Engineering", limit=10) == (0, 1)
+        row = conn.execute("SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)).fetchone()
+        assert row["company"] == "Keyrock"
+        event = conn.execute(
+            "SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",
+            ("https://www.linkedin.com/jobs/view/1",),
+        ).fetchone()
+        assert event["event_type"] == "JobMetadataUpdated"
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch):
+    def missing_jobspy(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
+        raise ImportError("python-jobspy is not installed")
+
+    monkeypatch.setattr(jobspy, "_scrape_with_retry", missing_jobspy)
+
+    with pytest.raises(ImportError, match="python-jobspy"):
+        jobspy._run_one_search(
+            {"query": "Director of Engineering", "location": "Barcelona, Spain", "remote": True},
+            ["indeed"],
+            10,
+            72,
+            None,
+            {"country_indeed": "spain"},
+            0,
+            ["Barcelona, Spain"],
+            [],
+            {},
+            limit=10,
+        )

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -18,7 +18,12 @@ def test_remote_country_scoped_locations_do_not_bypass_reject_patterns() -> None
         "Remote - US",
         "USA, Remote",
         "U.S. Remote",
+        "Remote Texas",
+        "California - Remote",
+        "Remote New Jersey",
+        "Virginia - Washington DC Metro - Remote",
         "Remote Canada",
+        "CAN, Quebec - Full Time Remote",
         "North America Remote",
         "Brazil Remote Work",
     ):
@@ -42,6 +47,21 @@ def test_remote_region_locations_pass_when_region_is_accepted() -> None:
             reject=EUROPE_REJECT,
             search_location="Remote",
         )
+
+
+def test_generic_remote_does_not_match_when_specific_locations_are_configured() -> None:
+    assert not location_matches_target(
+        "Remote",
+        accept=EUROPE_ACCEPT,
+        reject=EUROPE_REJECT,
+        search_location="Remote",
+    )
+    assert not location_matches_target(
+        "",
+        accept=EUROPE_ACCEPT,
+        reject=EUROPE_REJECT,
+        search_location="Remote",
+    )
 
 
 def test_short_accept_patterns_match_tokens_not_substrings() -> None:

--- a/workers/automation/tests/test_discovery_title_filter.py
+++ b/workers/automation/tests/test_discovery_title_filter.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from jobhunter.discovery.title_filter import title_matches_query
+
+
+def test_title_filter_matches_leadership_aliases() -> None:
+    assert title_matches_query("Vice President, Engineering", "VP of Engineering")
+    assert title_matches_query("Chief Information Security Officer", "CISO")
+    assert title_matches_query("Director, Information Security", "Director of IT & Security")
+
+
+def test_title_filter_rejects_loose_workday_results() -> None:
+    assert not title_matches_query("Independent Trauma Counsellor", "Director of Engineering")
+    assert not title_matches_query("Director, Investment Consulting", "Director of IT & Security")

--- a/workers/automation/tests/test_job_repository.py
+++ b/workers/automation/tests/test_job_repository.py
@@ -13,7 +13,7 @@ import sqlite3
 
 import pytest
 
-from jobhunter.database import init_db
+from jobhunter.database import init_db, resurface_deleted_job
 from jobhunter.domain.discovery import (
     Employer,
     Job,
@@ -89,9 +89,7 @@ def test_save_idempotent_preserves_discovered_at(conn: sqlite3.Connection) -> No
     original = _make_job()
     repo.save(original)
 
-    rediscovered = original.with_metadata(
-        JobMetadata(title="Staff Engineer", salary="$250k", location="Remote")
-    )
+    rediscovered = original.with_metadata(JobMetadata(title="Staff Engineer", salary="$250k", location="Remote"))
     # Bump the discovered_at on the in-memory aggregate; the persisted
     # row should keep the original timestamp.
     rediscovered = Job.discover(
@@ -194,8 +192,7 @@ def test_soft_delete_writes_tombstone_row(conn: sqlite3.Connection) -> None:
     assert deleted is not None and deleted.is_deleted
 
     row = conn.execute(
-        "SELECT deleted_at, reason, restored_at FROM jobhunter_deleted_jobs "
-        "WHERE job_url = ?",
+        "SELECT deleted_at, reason, restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
         (str(job.job_id),),
     ).fetchone()
     assert row is not None
@@ -247,6 +244,34 @@ def test_restore_clears_tombstone(conn: sqlite3.Connection) -> None:
     ).fetchone()
     assert row is not None
     assert row["restored_at"] is not None
+
+
+def test_resurface_deleted_job_clears_tombstone_and_records_event(conn: sqlite3.Connection) -> None:
+    repo = SqliteJobRepository(conn)
+    job = _make_job()
+    repo.save(job)
+    repo.soft_delete(
+        LOCAL_TENANT,
+        job.job_id,
+        reason="not right now",
+        deleted_at="2026-05-02T00:00:00+00:00",
+    )
+
+    resurface_deleted_job(conn, str(job.job_id), resurfaced_at="2026-05-03T00:00:00+00:00")
+
+    row = conn.execute(
+        "SELECT restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
+        (str(job.job_id),),
+    ).fetchone()
+    assert row is not None
+    assert row["restored_at"] == "2026-05-03T00:00:00+00:00"
+    event = conn.execute(
+        "SELECT event_type, message FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",
+        (str(job.job_id),),
+    ).fetchone()
+    assert event is not None
+    assert event["event_type"] == "JobRestored"
+    assert event["message"] == "Job resurfaced because discovery observed it again."
 
 
 def test_restore_is_noop_for_undeleted_job(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -6,17 +6,18 @@ from pathlib import Path
 
 import pytest
 
-from jobhunter import actions
 from jobhunter.actions import LocalActionRequest, LocalActionResult
 from jobhunter.database import close_connection, get_connection, init_db
 from jobhunter.domain.rpc.messages import (
     INVALID_PARAMS,
     METHOD_NOT_FOUND,
     JsonRpcRequest,
+    WorkflowStartSpec,
 )
 from jobhunter.infrastructure.rpc import handlers as handlers_mod
 from jobhunter.infrastructure.rpc.handlers import register_default_handlers
 from jobhunter.infrastructure.rpc.server import JsonRpcServer
+from jobhunter.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
 
 
 class _StubHandle:
@@ -230,41 +231,100 @@ def test_missing_tenant_id_falls_back_to_local(tmp_db: Path, caplog) -> None:
 
 
 # ---------------------------------------------------------------------------
-# run_stage / apply / profile_import — delegate to actions.run_local_action
+# run_stage / apply / profile_import
 # ---------------------------------------------------------------------------
 
 
-def test_run_stage_delegates_to_run_local_action(tmp_db: Path, monkeypatch) -> None:
+def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        seen.append(spec)
+        return _StubHandle("pipeline-wf", "pipeline-run")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    response = server.dispatch(
+        JsonRpcRequest(
+            method="run_stage",
+            params={
+                "tenantId": "local",
+                "stage": "score",
+                "stages": ["score", "tailor"],
+                "limit": 5,
+                "workers": 2,
+                "minScore": 8,
+                "validationMode": "strict",
+                "dryRun": True,
+                "rescore": True,
+                "retailor": True,
+            },
+            id=1,
+        )
+    )
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["result"] == {
+        "runId": "pipeline-wf",
+        "workflowId": "pipeline-wf",
+        "firstExecutionRunId": "pipeline-run",
+    }
+    assert len(seen) == 1
+    assert seen[0].workflow is JobPipelineWorkflow
+    (payload,) = seen[0].args
+    assert payload == JobPipelineWorkflowInput(
+        tenant_id="local",
+        stages=["score", "tailor"],
+        min_score=8,
+        workers=2,
+        limit=5,
+        validation_mode="strict",
+        dry_run=True,
+        rescore=True,
+        retailor=True,
+    )
+
+
+def test_profile_import_remains_sync_local_action(tmp_db: Path, monkeypatch) -> None:
     captured: list[LocalActionRequest] = []
+    started_workflows: list[WorkflowStartSpec] = []
 
     def fake_run(request: LocalActionRequest) -> LocalActionResult:
         captured.append(request)
         return LocalActionResult(
             ok=True,
-            action_id="act-1",
+            action_id="act-profile",
             stage=request.stage,
             status="succeeded",
             started_at="t0",
             finished_at="t1",
             duration_ms=1,
+            result={"draft": {}},
         )
 
-    monkeypatch.setattr(handlers_mod, "run_local_action", fake_run)
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        started_workflows.append(spec)
+        return _StubHandle("unexpected-wf")
 
-    server = _server()
+    monkeypatch.setattr(handlers_mod, "run_local_action", fake_run)
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
     response = server.dispatch(
         JsonRpcRequest(
-            method="run_stage",
-            params={"tenantId": "local", "stage": "score", "limit": 5, "workers": 2},
+            method="profile_import",
+            params={"tenantId": "local", "pdfPath": "/tmp/resume.pdf"},
             id=1,
         )
     )
     assert response is not None
     body = response.to_dict()
     assert body["result"]["ok"] is True
-    assert captured[0].stage == "score"
-    assert captured[0].limit == 5
-    assert captured[0].workers == 2
+    assert captured[0].stage == "profile_import"
+    assert captured[0].pdf_path == "/tmp/resume.pdf"
+    assert started_workflows == []
 
 
 def test_profile_import_requires_pdf_path(tmp_db: Path) -> None:
@@ -272,7 +332,3 @@ def test_profile_import_requires_pdf_path(tmp_db: Path) -> None:
     response = server.dispatch(JsonRpcRequest(method="profile_import", params={"tenantId": "local"}, id=1))
     assert response is not None
     assert response.to_dict()["error"]["code"] == INVALID_PARAMS
-
-
-# Silence unused-import warnings.
-_ = actions

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -130,8 +130,8 @@ def test_discover_limit_propagates_to_sources(monkeypatch):
     assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
     assert calls == [
         ("jobspy", 1, None),
-        ("workday", 1, 1),
-        ("smartextract", 1, 1),
+        ("workday", 1, 4),
+        ("smartextract", 1, 4),
     ]
 
 

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -135,6 +135,43 @@ def test_discover_limit_propagates_to_sources(monkeypatch):
     ]
 
 
+def test_discover_passes_remaining_limit_to_downstream_sources(monkeypatch):
+    calls: list[tuple[str, int]] = []
+    job_count = {"value": 100}
+
+    def run_jobspy(cfg=None, limit=0):
+        calls.append(("jobspy", limit))
+        job_count["value"] = 106
+        return {"new": 6, "existing": 0, "errors": 0}
+
+    def run_workday(employers=None, workers=1, limit=0, run_id=None):
+        calls.append(("workday", limit))
+        job_count["value"] = 108
+        return {"new": 2, "existing": 0, "errors": 0}
+
+    monkeypatch.setattr(runner.config, "load_search_config", lambda: {})
+    monkeypatch.setattr(runner, "_pipeline_job_count", lambda: job_count["value"], raising=False)
+    monkeypatch.setitem(sys.modules, "jobhunter.discovery.jobspy", SimpleNamespace(run_discovery=run_jobspy))
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.workday",
+        SimpleNamespace(run_workday_discovery=run_workday),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "jobhunter.discovery.smartextract",
+        SimpleNamespace(
+            run_smart_extract=lambda sites=None, workers=1, limit=0: calls.append(("smartextract", limit))
+        ),
+    )
+    monkeypatch.setattr(runner, "_record_pipeline_event", lambda *_args, **_kwargs: None)
+
+    result = runner._run_discover(workers=4, limit=10)
+
+    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
+    assert calls == [("jobspy", 10), ("workday", 4), ("smartextract", 2)]
+
+
 def test_discover_filters_adapter_inputs_to_runnable_sources(monkeypatch):
     calls: dict[str, object] = {}
 
@@ -221,6 +258,32 @@ def test_discover_filters_adapter_inputs_to_runnable_sources(monkeypatch):
     runner._run_discover(workers=4, limit=0)
 
     assert calls == {"boards": ["linkedin"], "employers": ["acme"]}
+
+
+def test_smart_extract_sites_infer_search_type_from_query_placeholder() -> None:
+    source = runner.ScheduledSource(
+        source_id="smart_extract:welcometothejungle",
+        display_name="WelcomeToTheJungle",
+        source_kind=SourceKind.SMART_EXTRACT,
+        priority=SourcePriority.FALLBACK,
+        configured_state=SourceState.EXPERIMENTAL,
+        crawl_budget=1,
+        decision="run",
+        reason="test",
+        recommended_state="normal",
+        adapter_config={
+            "name": "WelcomeToTheJungle",
+            "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
+        },
+    )
+
+    assert runner._smart_extract_sites((source,)) == [
+        {
+            "name": "WelcomeToTheJungle",
+            "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
+            "type": "search",
+        }
+    ]
 
 
 def test_discover_limit_skips_remaining_sources_after_cap(monkeypatch):

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -72,7 +72,7 @@ def test_discover_emits_source_events(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "jobhunter.discovery.workday",
-        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0: None),
+        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0, run_id=None: None),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -109,7 +109,7 @@ def test_discover_limit_propagates_to_sources(monkeypatch):
         sys.modules,
         "jobhunter.discovery.workday",
         SimpleNamespace(
-            run_workday_discovery=lambda employers=None, workers=1, limit=0: calls.append(
+            run_workday_discovery=lambda employers=None, workers=1, limit=0, run_id=None: calls.append(
                 ("workday", limit, workers)
             )
         ),
@@ -205,7 +205,7 @@ def test_discover_filters_adapter_inputs_to_runnable_sources(monkeypatch):
         sys.modules,
         "jobhunter.discovery.workday",
         SimpleNamespace(
-            run_workday_discovery=lambda employers=None, workers=1, limit=0: calls.setdefault(
+            run_workday_discovery=lambda employers=None, workers=1, limit=0, run_id=None: calls.setdefault(
                 "employers",
                 sorted((employers or {}).keys()),
             )
@@ -237,7 +237,7 @@ def test_discover_limit_skips_remaining_sources_after_cap(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "jobhunter.discovery.workday",
-        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0: calls.append("workday")),
+        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0, run_id=None: calls.append("workday")),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -252,7 +252,7 @@ def test_discover_limit_skips_remaining_sources_after_cap(monkeypatch):
     assert result == {"jobspy": "ok", "workday": "skipped_limit", "smartextract": "skipped_limit"}
 
 
-def test_discover_limit_skips_remaining_sources_after_existing_candidate(monkeypatch):
+def test_discover_limit_does_not_skip_remaining_sources_after_existing_candidate(monkeypatch):
     calls: list[str] = []
 
     monkeypatch.setattr(runner.config, "load_search_config", lambda: {})
@@ -269,7 +269,7 @@ def test_discover_limit_skips_remaining_sources_after_existing_candidate(monkeyp
     monkeypatch.setitem(
         sys.modules,
         "jobhunter.discovery.workday",
-        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0: calls.append("workday")),
+        SimpleNamespace(run_workday_discovery=lambda employers=None, workers=1, limit=0, run_id=None: calls.append("workday")),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -280,8 +280,8 @@ def test_discover_limit_skips_remaining_sources_after_existing_candidate(monkeyp
 
     result = runner._run_discover(workers=4, limit=1)
 
-    assert calls == ["jobspy"]
-    assert result == {"jobspy": "ok", "workday": "skipped_limit", "smartextract": "skipped_limit"}
+    assert calls == ["jobspy", "workday", "smartextract"]
+    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
 
 
 def test_enrich_limit_propagates_to_runner(monkeypatch):

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -96,6 +96,38 @@ def test_backfill_from_empty(conn: sqlite3.Connection) -> None:
     ]
 
 
+def test_job_projection_uses_explicit_company_before_source(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (url, title, company, site, strategy, location, salary,
+                          discovered_at, application_url, description)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "https://www.linkedin.com/jobs/view/1",
+            "Head of Engineering",
+            "Keyrock",
+            "linkedin",
+            "jobspy",
+            "Barcelona, Spain",
+            "",
+            utc_now(),
+            "https://www.linkedin.com/jobs/view/1",
+            "x",
+        ),
+    )
+    conn.commit()
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    row = conn.execute(
+        "SELECT employer FROM job_list_projections WHERE job_id = ?",
+        ("https://www.linkedin.com/jobs/view/1",),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "Keyrock"
+
+
 def test_feedback_only_history_rebuilds_source_quality(conn: sqlite3.Connection) -> None:
     record_job_event(
         conn,

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -31,6 +31,7 @@ def test_smart_extract_store_filters_title_and_location(
             {
                 "url": "https://example.com/director-engineering",
                 "title": "Director of Engineering",
+                "company": "ExampleCo",
                 "location": "Remote EMEA",
             },
         ]
@@ -45,8 +46,8 @@ def test_smart_extract_store_filters_title_and_location(
             query="Director of Engineering",
         ) == (1, 0)
 
-        stored = conn.execute("SELECT title FROM jobs").fetchall()
-        assert [row[0] if isinstance(row, tuple) else row["title"] for row in stored] == ["Director of Engineering"]
+        stored = conn.execute("SELECT title, company FROM jobs").fetchall()
+        assert [(row["title"], row["company"]) for row in stored] == [("Director of Engineering", "ExampleCo")]
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jobhunter import config
+from jobhunter.database import close_connection, init_db
+from jobhunter.discovery import smartextract
+
+
+def test_smart_extract_store_filters_title_and_location(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        jobs = [
+            {
+                "url": "https://example.com/trauma-counsellor",
+                "title": "Independent Trauma Counsellor",
+                "location": "Remote EMEA",
+            },
+            {
+                "url": "https://example.com/director-investment",
+                "title": "Director, Investment Consulting",
+                "location": "CAN, Quebec - Full Time Remote",
+            },
+            {
+                "url": "https://example.com/director-engineering",
+                "title": "Director of Engineering",
+                "location": "Remote EMEA",
+            },
+        ]
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            jobs,
+            "Example",
+            "api_response",
+            ["Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Director of Engineering",
+        ) == (1, 0)
+
+        stored = conn.execute("SELECT title FROM jobs").fetchall()
+        assert [row[0] if isinstance(row, tuple) else row["title"] for row in stored] == ["Director of Engineering"]
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_static_site_filters_against_all_target_queries(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        jobs = [
+            {
+                "url": "https://example.com/crm-marketer",
+                "title": "CRM Marketer",
+                "location": "Barcelona, Spain",
+            },
+            {
+                "url": "https://example.com/head-engineering",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+            },
+        ]
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            jobs,
+            "Techstars Jobs",
+            "static",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query=["Director of Engineering", "Head of Engineering"],
+        ) == (1, 0)
+
+        stored = conn.execute("SELECT title FROM jobs").fetchall()
+        assert [row[0] if isinstance(row, tuple) else row["title"] for row in stored] == ["Head of Engineering"]
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -33,6 +33,7 @@ def test_smart_extract_store_filters_title_and_location(
                 "title": "Director of Engineering",
                 "company": "ExampleCo",
                 "location": "Remote EMEA",
+                "description": "Lead engineering teams building reliable distributed systems.",
             },
         ]
 
@@ -70,6 +71,7 @@ def test_smart_extract_static_site_filters_against_all_target_queries(
                 "url": "https://example.com/head-engineering",
                 "title": "Head of Engineering",
                 "location": "Barcelona, Spain",
+                "description": "Lead engineering managers and platform teams in Barcelona.",
             },
         ]
 
@@ -87,3 +89,123 @@ def test_smart_extract_static_site_filters_against_all_target_queries(
         assert [row[0] if isinstance(row, tuple) else row["title"] for row in stored] == ["Head of Engineering"]
     finally:
         close_connection(db_path)
+
+
+def test_smart_extract_store_filters_jobs_without_descriptions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        jobs = [
+            {
+                "url": "https://example.com/head-engineering-empty",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+                "description": "",
+            },
+            {
+                "url": "https://example.com/head-engineering",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+                "description": "Lead engineering teams and own platform delivery.",
+            },
+        ]
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            jobs,
+            "Startup.jobs",
+            "api_response",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Head of Engineering",
+        ) == (1, 0)
+
+        stored = conn.execute("SELECT url, description FROM jobs").fetchall()
+        assert [(row["url"], row["description"]) for row in stored] == [
+            ("https://example.com/head-engineering", "Lead engineering teams and own platform delivery.")
+        ]
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_store_normalizes_relative_urls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        jobs = [
+            {
+                "url": "/head-of-platform-engineering-dlocal-7946484",
+                "title": "Head of Platform Engineering",
+                "company": "dLocal",
+                "location": "Spain",
+                "description": "Lead platform engineering teams for payment infrastructure.",
+            },
+        ]
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            jobs,
+            "Startup.jobs",
+            "api_response",
+            ["Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Head of Platform Engineering",
+            source_url="https://startup.jobs/?q=Head+of+Platform+Engineering&remote=true",
+        ) == (1, 0)
+
+        row = conn.execute("SELECT url, company FROM jobs").fetchone()
+        assert row["url"] == "https://startup.jobs/head-of-platform-engineering-dlocal-7946484"
+        assert row["company"] == "dLocal"
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_api_response_extracts_company() -> None:
+    intel = {
+        "api_responses": [
+            {
+                "url": "https://startup.jobs/api/search",
+                "_raw_data": {
+                    "jobs": [
+                        {
+                            "title": "Director of Engineering",
+                            "company": {"name": "ExampleCo"},
+                            "description": "Lead engineering teams.",
+                            "location": "Spain",
+                            "slug": "/director-engineering-exampleco",
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    plan = {
+        "extraction": {
+            "url_pattern": "/api/search",
+            "items_path": "jobs",
+            "title": "title",
+            "company": "company",
+            "description": "description",
+            "location": "location",
+            "url": "slug",
+        }
+    }
+
+    assert smartextract.execute_api_response(intel, plan) == [
+        {
+            "title": "Director of Engineering",
+            "company": "ExampleCo",
+            "salary": None,
+            "description": "Lead engineering teams.",
+            "location": "Spain",
+            "url": "/director-engineering-exampleco",
+        }
+    ]

--- a/workers/automation/tests/test_smartextract_resilience.py
+++ b/workers/automation/tests/test_smartextract_resilience.py
@@ -73,8 +73,18 @@ def test_limited_smart_extract_uses_requested_workers(
             "total": 2,
             "titles": 2,
             "jobs": [
-                {"url": f"{url}/one", "title": "Head of Engineering", "location": "Barcelona, Spain"},
-                {"url": f"{url}/two", "title": "Director of Engineering", "location": "Barcelona, Spain"},
+                {
+                    "url": f"{url}/one",
+                    "title": "Head of Engineering",
+                    "location": "Barcelona, Spain",
+                    "description": "Lead engineering teams.",
+                },
+                {
+                    "url": f"{url}/two",
+                    "title": "Director of Engineering",
+                    "location": "Barcelona, Spain",
+                    "description": "Own engineering delivery.",
+                },
             ],
         }
 

--- a/workers/automation/tests/test_smartextract_resilience.py
+++ b/workers/automation/tests/test_smartextract_resilience.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from jobhunter import config
+from jobhunter.database import close_connection, init_db
 from jobhunter.discovery import smartextract
 
 
@@ -45,3 +47,59 @@ def test_smart_extract_counts_site_timeouts_without_aborting_run(
         "errors": 1,
         "total": 2,
     }
+
+
+def test_limited_smart_extract_uses_requested_workers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(smartextract, "init_db", lambda: init_db(db_path))
+    init_db(db_path)
+    close_connection(db_path)
+
+    observed_max_workers: list[int | None] = []
+
+    def recording_executor(*args, **kwargs):
+        observed_max_workers.append(kwargs.get("max_workers") if "max_workers" in kwargs else args[0])
+        return RealThreadPoolExecutor(*args, **kwargs)
+
+    def fake_run_one_site(name: str, url: str) -> dict:
+        return {
+            "name": name,
+            "status": "PASS",
+            "strategy": "api_response",
+            "total": 2,
+            "titles": 2,
+            "jobs": [
+                {"url": f"{url}/one", "title": "Head of Engineering", "location": "Barcelona, Spain"},
+                {"url": f"{url}/two", "title": "Director of Engineering", "location": "Barcelona, Spain"},
+            ],
+        }
+
+    monkeypatch.setattr(smartextract, "ThreadPoolExecutor", recording_executor)
+    monkeypatch.setattr(smartextract, "_run_one_site", fake_run_one_site)
+
+    result = smartextract._run_all(
+        [
+            {"name": "Board A", "url": "https://a.example/jobs", "queries": ["Head of Engineering"]},
+            {"name": "Board B", "url": "https://b.example/jobs", "queries": ["Director of Engineering"]},
+            {"name": "Board C", "url": "https://c.example/jobs", "queries": ["VP of Engineering"]},
+        ],
+        accept_locs=["Barcelona, Spain"],
+        reject_locs=[],
+        workers=4,
+        limit=2,
+    )
+
+    conn = init_db(db_path)
+    try:
+        stored_count = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0]
+    finally:
+        close_connection(db_path)
+
+    assert observed_max_workers == [2]
+    assert result["total_new"] == 2
+    assert result["total"] == 2
+    assert stored_count == 2

--- a/workers/automation/tests/test_smartextract_resilience.py
+++ b/workers/automation/tests/test_smartextract_resilience.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jobhunter import config
+from jobhunter.discovery import smartextract
+
+
+def test_smart_extract_counts_site_timeouts_without_aborting_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "jobhunter.db")
+
+    def fake_run_one_site(name: str, url: str) -> dict:
+        if name == "Slow Board":
+            raise TimeoutError("Timeout 30000ms exceeded.")
+        return {
+            "name": name,
+            "status": "FAIL",
+            "strategy": "css_selectors",
+            "total": 0,
+            "titles": 0,
+            "jobs": [],
+        }
+
+    monkeypatch.setattr(smartextract, "_run_one_site", fake_run_one_site)
+
+    result = smartextract._run_all(
+        [
+            {"name": "Slow Board", "url": "https://slow.example/jobs"},
+            {"name": "Empty Board", "url": "https://empty.example/jobs"},
+        ],
+        accept_locs=[],
+        reject_locs=[],
+        workers=1,
+    )
+
+    assert result == {
+        "total_new": 0,
+        "total_existing": 0,
+        "passed": 0,
+        "errors": 1,
+        "total": 2,
+    }

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import sqlite3
 
 from jobhunter import config
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
 
 
 def test_profile_target_search_overrides_discovery_queries_and_locations() -> None:
@@ -31,6 +35,34 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
     assert merged["defaults"]["country_indeed"] == "spain"
     assert "Barcelona, Spain" in merged["location_accept"]
     assert "Canada" in merged["location_reject_non_remote"]
+
+
+def test_profile_target_locations_replace_legacy_location_accept_patterns() -> None:
+    merged = config._apply_profile_target_search(
+        {
+            "queries": [{"query": "software engineer", "tier": 1}],
+            "locations": [{"label": "zurich", "location": "Zurich"}],
+            "location_accept": ["Switzerland", "Zurich"],
+            "location": {
+                "accept_patterns": ["Remote", "Switzerland", "Zurich", "Europe", "EMEA"],
+                "reject_patterns": ["United States"],
+            },
+        },
+        {
+            "roles": ["Director of Engineering"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Remote, Hybrid"],
+        },
+    )
+
+    accept, reject = configured_location_filters(merged)
+
+    assert "Barcelona, Spain" in accept
+    assert "Switzerland" not in accept
+    assert "Zurich" not in accept
+    assert location_matches_target("Barcelona, Spain (Remote)", accept=accept, reject=reject)
+    assert location_matches_target("Remote EMEA", accept=accept, reject=reject)
+    assert not location_matches_target("Switzerland - Zurich", accept=accept, reject=reject)
 
 
 def test_load_search_config_reads_profile_target_search_from_db(tmp_path, monkeypatch) -> None:

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -173,3 +173,67 @@ def test_source_registry_filters_america_only_sources_for_europe_target() -> Non
     by_id = {entry.source_id for entry in registry}
     assert "smart_extract:job-bank-canada" not in by_id
     assert "smart_extract:welcometothejungle" in by_id
+
+
+def test_local_source_registry_row_preserves_search_site_type(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE source_registry_entries (
+          tenant_id TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          display_name TEXT NOT NULL,
+          owner TEXT NOT NULL,
+          priority TEXT NOT NULL,
+          state TEXT NOT NULL,
+          policy_id TEXT NOT NULL,
+          seed_url TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, source_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO source_registry_entries (
+          tenant_id, source_id, kind, display_name, owner, priority,
+          state, policy_id, seed_url, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            "smart_extract:welcometothejungle",
+            "smart_extract",
+            "WelcomeToTheJungle",
+            "system",
+            "fallback",
+            "experimental",
+            "smart_extract_experimental",
+            "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
+            "2026-05-18T00:00:00Z",
+            "2026-05-18T00:00:00Z",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+
+    registry = config.load_source_registry(
+        search_cfg={"target_region": "europe", "boards": ["linkedin"]},
+        sites_cfg={
+            "sites": [
+                {
+                    "name": "WelcomeToTheJungle",
+                    "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
+                    "type": "search",
+                }
+            ]
+        },
+        employers_cfg={"employers": {}},
+    )
+
+    by_id = {entry.source_id: entry for entry in registry}
+    assert by_id["smart_extract:welcometothejungle"].adapter_config["type"] == "search"

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -37,6 +37,25 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
     assert "Canada" in merged["location_reject_non_remote"]
 
 
+def test_profile_target_search_strips_role_notes_from_queries() -> None:
+    merged = config._apply_profile_target_search(
+        {"queries": [{"query": "software engineer", "tier": 1}]},
+        {
+            "roles": [
+                "Head of Platform | Preferred work model: Remote | Onsite if required: Barcelona, Spain",
+                "CISO",
+            ],
+            "locations": [],
+            "work_models": [],
+        },
+    )
+
+    assert merged["queries"] == [
+        {"query": "Head of Platform", "tier": 1},
+        {"query": "CISO", "tier": 1},
+    ]
+
+
 def test_profile_target_locations_replace_legacy_location_accept_patterns() -> None:
     merged = config._apply_profile_target_search(
         {

--- a/workers/automation/tests/test_workday_discovery.py
+++ b/workers/automation/tests/test_workday_discovery.py
@@ -9,6 +9,7 @@ import pytest
 
 from jobhunter import config
 from jobhunter.database import close_connection, init_db
+from jobhunter.discovery import workday
 from jobhunter.discovery.workday import store_results
 
 
@@ -69,3 +70,149 @@ def test_workday_store_results_publishes_discovery_events(
         "SELECT payload_json FROM job_events WHERE event_type = 'JobSourceObserved'"
     ).fetchone()
     assert json.loads(observed["payload_json"])["source_id"] == "workday:acme"
+
+
+def test_workday_search_rejects_loose_title_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_search(_employer: dict, _search_text: str, *, limit: int, offset: int) -> dict:
+        assert limit == 20
+        assert offset == 0
+        return {
+            "total": 3,
+            "jobPostings": [
+                {
+                    "title": "Independent Trauma Counsellor",
+                    "locationsText": "EMEA - United Kingdom - Remote",
+                    "externalPath": "/job/EMEA/Independent-Trauma-Counsellor_R-1",
+                },
+                {
+                    "title": "Director, Investment Consulting",
+                    "locationsText": "CAN, Quebec - Full Time Remote",
+                    "externalPath": "/job/Canada/Director-Investment-Consulting_R-2",
+                },
+                {
+                    "title": "Director of Engineering",
+                    "locationsText": "Remote EMEA",
+                    "externalPath": "/job/EMEA/Director-of-Engineering_R-3",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(workday, "workday_search", fake_search)
+
+    jobs = workday.search_employer(
+        "acme",
+        {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "tenant": "acme",
+            "site_id": "External",
+        },
+        "Director of Engineering",
+        accept_locs=["Spain", "Europe", "EMEA"],
+        reject_locs=["United States", "Canada"],
+    )
+
+    assert [job["title"] for job in jobs] == ["Director of Engineering"]
+
+
+def test_limited_workday_search_respects_page_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    offsets: list[int] = []
+
+    def fake_search(_employer: dict, _search_text: str, *, limit: int, offset: int) -> dict:
+        offsets.append(offset)
+        return {
+            "total": 100,
+            "jobPostings": [
+                {
+                    "title": "Independent Trauma Counsellor",
+                    "locationsText": "Remote EMEA",
+                    "externalPath": f"/job/EMEA/Independent-Trauma-Counsellor_{offset}",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(workday, "workday_search", fake_search)
+
+    jobs = workday.search_employer(
+        "acme",
+        {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "tenant": "acme",
+            "site_id": "External",
+        },
+        "Director of Engineering",
+        max_pages=1,
+        accept_locs=["Europe", "EMEA"],
+        reject_locs=[],
+    )
+
+    assert jobs == []
+    assert offsets == [0]
+
+
+def test_limited_workday_crawl_uses_bounded_page_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert workday._workday_max_pages_per_employer({}, limit=10) == 1
+    assert workday._workday_max_pages_per_employer({"workday_limited_max_pages_per_employer": 3}, limit=10) == 3
+    assert workday._workday_max_pages_per_employer({"workday_max_pages_per_employer": 5}, limit=0) == 5
+
+
+def test_parallel_limited_workday_scrape_enforces_global_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    employers = {
+        key: {
+            "name": key.upper(),
+            "base_url": f"https://{key}.wd1.myworkdayjobs.com",
+            "tenant": key,
+            "site_id": "External",
+        }
+        for key in ("acme", "globex", "initech")
+    }
+    stored_jobs: list[dict] = []
+
+    def fake_search_and_fetch_one(
+        employer_key: str,
+        _employers: dict,
+        _search_text: str,
+        _location_filter: bool,
+        _accept_locs: list[str],
+        _reject_locs: list[str],
+        limit: int = 0,
+        max_pages_per_employer: int = 25,
+    ) -> dict:
+        assert limit == 2
+        assert max_pages_per_employer == 1
+        jobs = [
+            {"title": f"Director of Engineering {employer_key} {index}", "employer_key": employer_key}
+            for index in range(2)
+        ]
+        return {"employer": employer_key, "query": "Director of Engineering", "found": len(jobs), "new": 0, "existing": 0, "jobs": jobs}
+
+    def fake_store_results(
+        _conn: object,
+        jobs: list[dict],
+        _employers: dict,
+        *,
+        limit: int = 0,
+        run_id: str | None = None,
+    ) -> tuple[int, int]:
+        assert limit == 2
+        assert run_id == "run-1"
+        stored_jobs.extend(jobs)
+        return len(jobs), 0
+
+    monkeypatch.setattr(workday, "init_db", lambda: None)
+    monkeypatch.setattr(workday, "get_connection", lambda: object())
+    monkeypatch.setattr(workday, "_search_and_fetch_one", fake_search_and_fetch_one)
+    monkeypatch.setattr(workday, "store_results", fake_store_results)
+
+    result = workday.scrape_employers(
+        "Director of Engineering",
+        employers,
+        workers=3,
+        limit=2,
+        max_pages_per_employer=1,
+        run_id="run-1",
+    )
+
+    assert result == {"found": 2, "new": 2, "existing": 0}
+    assert len(stored_jobs) == 2

--- a/workers/automation/tests/test_workday_discovery.py
+++ b/workers/automation/tests/test_workday_discovery.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from jobhunter import config
+from jobhunter.database import close_connection, init_db
+from jobhunter.discovery.workday import store_results
+
+
+@pytest.fixture
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[sqlite3.Connection]:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    connection = init_db(db_path)
+    yield connection
+    close_connection(db_path)
+
+
+def test_workday_store_results_publishes_discovery_events(
+    conn: sqlite3.Connection,
+) -> None:
+    jobs = [
+        {
+            "title": "Director of Engineering",
+            "location": "Barcelona, Spain",
+            "external_path": "/External/job/Barcelona/Director-of-Engineering_JR-123",
+            "apply_url": "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-123",
+            "job_req_id": "JR-123",
+            "employer_key": "acme",
+            "employer_name": "Acme",
+            "full_description": "Lead engineering teams building local-first products.",
+        }
+    ]
+    employers = {
+        "acme": {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "site_id": "External",
+            "_source_id": "workday:acme",
+        }
+    }
+
+    new, existing = store_results(
+        conn,
+        jobs,
+        employers,
+        run_id="discovery:workday:test",
+    )
+
+    assert (new, existing) == (1, 0)
+    assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
+    assert (
+        conn.execute("SELECT COUNT(*) FROM job_source_observations").fetchone()[0]
+        == 1
+    )
+    event_types = [
+        row["event_type"]
+        for row in conn.execute(
+            "SELECT event_type FROM job_events ORDER BY event_id"
+        ).fetchall()
+    ]
+    assert "JobDiscovered" in event_types
+    observed = conn.execute(
+        "SELECT payload_json FROM job_events WHERE event_type = 'JobSourceObserved'"
+    ).fetchone()
+    assert json.loads(observed["payload_json"])["source_id"] == "workday:acme"

--- a/workers/automation/tests/test_workflow_job_pipeline.py
+++ b/workers/automation/tests/test_workflow_job_pipeline.py
@@ -19,6 +19,8 @@ from temporalio.exceptions import ApplicationError, CancelledError
 from temporalio.testing import WorkflowEnvironment
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
+from jobhunter.apply.activities import apply_activity
+from jobhunter.apply.workflow import ApplyWorkflow
 from jobhunter.discovery.activities import discover_activity
 from jobhunter.enrichment.activities import enrich_activity
 from jobhunter.materials.activities import (
@@ -48,6 +50,7 @@ def _all_activities():
         tailor_activity,
         cover_activity,
         pdf_activity,
+        apply_activity,
     ]
 
 
@@ -116,33 +119,47 @@ async def test_pipeline_workflow_rejects_unknown_stage_as_non_retryable():
 
 
 @pytest.mark.asyncio
-async def test_pipeline_workflow_rejects_apply_stage_with_pointer_to_apply_workflow():
-    """Passing ``apply`` is rejected with a clear pointer to ``ApplyWorkflow``."""
-    queue = f"pipeline-apply-rejected-{uuid.uuid4()}"
+async def test_pipeline_workflow_runs_apply_as_child_workflow():
+    """Passing ``apply`` delegates to ``ApplyWorkflow`` while preserving order."""
+    queue = f"pipeline-apply-{uuid.uuid4()}"
 
-    async with await WorkflowEnvironment.start_time_skipping() as env:
-        async with Worker(
-            env.client,
-            task_queue=queue,
-            workflows=[JobPipelineWorkflow],
-            activities=_all_activities(),
-            workflow_runner=UnsandboxedWorkflowRunner(),
-        ):
-            with pytest.raises(WorkflowFailureError) as exc_info:
-                await env.client.execute_workflow(
+    with patch("jobhunter.apply.launcher.main", return_value=(1, 0)) as apply_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow, ApplyWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                result = await env.client.execute_workflow(
                     JobPipelineWorkflow.run,
                     JobPipelineWorkflowInput(
                         tenant_id="local",
                         stages=["apply"],
+                        dry_run=True,
+                        model="sonnet",
+                        headless=True,
+                        min_score=8,
+                        limit=2,
+                        workers=3,
                     ),
-                    id=f"pipeline-apply-rejected-wf-{uuid.uuid4()}",
+                    id=f"pipeline-apply-wf-{uuid.uuid4()}",
                     task_queue=queue,
                 )
 
-    cause = exc_info.value.cause
-    assert isinstance(cause, ApplicationError)
-    assert cause.non_retryable is True
-    assert "ApplyWorkflow" in str(cause.message)
+    assert result.stages_completed == ["apply"]
+    assert result.stages_failed == []
+    assert apply_mock.call_args.kwargs == {
+        "limit": 2,
+        "target_url": None,
+        "min_score": 8,
+        "headless": True,
+        "model": "sonnet",
+        "dry_run": True,
+        "workers": 3,
+        "install_signal_handlers": False,
+    }
 
 
 @pytest.mark.asyncio
@@ -217,6 +234,45 @@ async def test_pipeline_workflow_forwards_validation_mode_to_tailor_and_cover():
         for call in runner_mock.call_args_list
     }
     assert by_stage == {"tailor": "lenient", "cover": "lenient"}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_workflow_preserves_stage_options():
+    queue = f"pipeline-options-{uuid.uuid4()}"
+
+    with patch(
+        "jobhunter.pipeline.run_pipeline",
+        return_value=_OK_RESULT,
+    ) as runner_mock:
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue=queue,
+                workflows=[JobPipelineWorkflow],
+                activities=_all_activities(),
+                workflow_runner=UnsandboxedWorkflowRunner(),
+            ):
+                await env.client.execute_workflow(
+                    JobPipelineWorkflow.run,
+                    JobPipelineWorkflowInput(
+                        tenant_id="local",
+                        stages=["score", "tailor"],
+                        dry_run=True,
+                        rescore=True,
+                        retailor=True,
+                    ),
+                    id=f"pipeline-options-wf-{uuid.uuid4()}",
+                    task_queue=queue,
+                )
+
+    by_stage = {
+        call.kwargs["stages"][0]: call.kwargs
+        for call in runner_mock.call_args_list
+    }
+    assert by_stage["score"]["dry_run"] is True
+    assert by_stage["score"]["rescore"] is True
+    assert by_stage["tailor"]["dry_run"] is True
+    assert by_stage["tailor"]["retailor"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -27,6 +27,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +340,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pypdf" },
     { name = "python-dotenv" },
+    { name = "python-jobspy" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "temporalio" },
@@ -360,6 +370,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-jobspy", specifier = ">=1.1.82" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1" },
@@ -378,6 +389,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/5a/bd1b685ee9efbfb0b22774a30188dfb4048c64e8a6c80a65a7f207af4ea1/markdownify-0.13.1.tar.gz", hash = "sha256:ab257f9e6bd4075118828a28c9d02f8a4bfeb7421f558834aa79b2dfeb32a098", size = 13609, upload-time = "2024-07-14T20:41:57.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/e9/6e2757a670b8c48bc48eff1c20cb9d71f1476e844038bdbdb76f17e6a12b/markdownify-0.13.1-py3-none-any.whl", hash = "sha256:1d181d43d20902bcc69d7be85b5316ed174d0dda72ff56e14ae4c95a4a407d22", size = 10800, upload-time = "2024-07-14T20:41:56.043Z" },
 ]
 
 [[package]]
@@ -654,6 +678,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -743,6 +884,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jobspy"
+version = "1.1.82"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "tls-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b2/c909850134f45751aeb49075afa4121a2952f627030367dd683a43eb6781/python_jobspy-1.1.82.tar.gz", hash = "sha256:32efb486da5eb60dc54a574bb4a1fb66838fdee75699a7a601aae763637dc8ea", size = 42388, upload-time = "2025-07-28T15:18:56.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/2b/18863fcd3c544a69d81e351381a50036a33c21b61cc1c6de2a8f25931237/python_jobspy-1.1.82-py3-none-any.whl", hash = "sha256:93d638b35ffd30a714253e065907f68c5bac624e3937a3ad2ba09f618a072ee9", size = 52833, upload-time = "2025-07-28T15:18:54.84Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2026.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -804,6 +964,59 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2024.11.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5f/bd69653fbfb76cf8604468d3b4ec4c403197144c7bfe0e6a5fc9e02a07cb/regex-2024.11.6.tar.gz", hash = "sha256:7ab159b063c52a0333c884e4679f8d7a85112ee3078fe3d9004b2dd875585519", size = 399494, upload-time = "2024-11-06T20:12:31.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/58/7e4d9493a66c88a7da6d205768119f51af0f684fe7be7bac8328e217a52c/regex-2024.11.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5478c6962ad548b54a591778e93cd7c456a7a29f8eca9c49e4f9a806dcc5d638", size = 482669, upload-time = "2024-11-06T20:09:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4c/8f8e631fcdc2ff978609eaeef1d6994bf2f028b59d9ac67640ed051f1218/regex-2024.11.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2c89a8cc122b25ce6945f0423dc1352cb9593c68abd19223eebbd4e56612c5b7", size = 287684, upload-time = "2024-11-06T20:09:32.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1b/f0e4d13e6adf866ce9b069e191f303a30ab1277e037037a365c3aad5cc9c/regex-2024.11.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:94d87b689cdd831934fa3ce16cc15cd65748e6d689f5d2b8f4f4df2065c9fa20", size = 284589, upload-time = "2024-11-06T20:09:35.504Z" },
+    { url = "https://files.pythonhosted.org/packages/25/4d/ab21047f446693887f25510887e6820b93f791992994f6498b0318904d4a/regex-2024.11.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1062b39a0a2b75a9c694f7a08e7183a80c63c0d62b301418ffd9c35f55aaa114", size = 792121, upload-time = "2024-11-06T20:09:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ee/c867e15cd894985cb32b731d89576c41a4642a57850c162490ea34b78c3b/regex-2024.11.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:167ed4852351d8a750da48712c3930b031f6efdaa0f22fa1933716bfcd6bf4a3", size = 831275, upload-time = "2024-11-06T20:09:40.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/12/b0f480726cf1c60f6536fa5e1c95275a77624f3ac8fdccf79e6727499e28/regex-2024.11.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d548dafee61f06ebdb584080621f3e0c23fff312f0de1afc776e2a2ba99a74f", size = 818257, upload-time = "2024-11-06T20:09:43.059Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ce/0d0e61429f603bac433910d99ef1a02ce45a8967ffbe3cbee48599e62d88/regex-2024.11.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2a19f302cd1ce5dd01a9099aaa19cae6173306d1302a43b627f62e21cf18ac0", size = 792727, upload-time = "2024-11-06T20:09:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c1/243c83c53d4a419c1556f43777ccb552bccdf79d08fda3980e4e77dd9137/regex-2024.11.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bec9931dfb61ddd8ef2ebc05646293812cb6b16b60cf7c9511a832b6f1854b55", size = 780667, upload-time = "2024-11-06T20:09:49.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f4/75eb0dd4ce4b37f04928987f1d22547ddaf6c4bae697623c1b05da67a8aa/regex-2024.11.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9714398225f299aa85267fd222f7142fcb5c769e73d7733344efc46f2ef5cf89", size = 776963, upload-time = "2024-11-06T20:09:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5d/95c568574e630e141a69ff8a254c2f188b4398e813c40d49228c9bbd9875/regex-2024.11.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:202eb32e89f60fc147a41e55cb086db2a3f8cb82f9a9a88440dcfc5d37faae8d", size = 784700, upload-time = "2024-11-06T20:09:53.982Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/f8495c7917f15cc6fee1e7f395e324ec3e00ab3c665a7dc9d27562fd5290/regex-2024.11.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:4181b814e56078e9b00427ca358ec44333765f5ca1b45597ec7446d3a1ef6e34", size = 848592, upload-time = "2024-11-06T20:09:56.222Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/80/6dd7118e8cb212c3c60b191b932dc57db93fb2e36fb9e0e92f72a5909af9/regex-2024.11.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:068376da5a7e4da51968ce4c122a7cd31afaaec4fccc7856c92f63876e57b51d", size = 852929, upload-time = "2024-11-06T20:09:58.642Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9b/5a05d2040297d2d254baf95eeeb6df83554e5e1df03bc1a6687fc4ba1f66/regex-2024.11.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ac10f2c4184420d881a3475fb2c6f4d95d53a8d50209a2500723d831036f7c45", size = 781213, upload-time = "2024-11-06T20:10:00.867Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b7/b14e2440156ab39e0177506c08c18accaf2b8932e39fb092074de733d868/regex-2024.11.6-cp311-cp311-win32.whl", hash = "sha256:c36f9b6f5f8649bb251a5f3f66564438977b7ef8386a52460ae77e6070d309d9", size = 261734, upload-time = "2024-11-06T20:10:03.361Z" },
+    { url = "https://files.pythonhosted.org/packages/80/32/763a6cc01d21fb3819227a1cc3f60fd251c13c37c27a73b8ff4315433a8e/regex-2024.11.6-cp311-cp311-win_amd64.whl", hash = "sha256:02e28184be537f0e75c1f9b2f8847dc51e08e6e171c6bde130b2687e0c33cf60", size = 274052, upload-time = "2024-11-06T20:10:05.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/30/9a87ce8336b172cc232a0db89a3af97929d06c11ceaa19d97d84fa90a8f8/regex-2024.11.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:52fb28f528778f184f870b7cf8f225f5eef0a8f6e3778529bdd40c7b3920796a", size = 483781, upload-time = "2024-11-06T20:10:07.07Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e8/00008ad4ff4be8b1844786ba6636035f7ef926db5686e4c0f98093612add/regex-2024.11.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdd6028445d2460f33136c55eeb1f601ab06d74cb3347132e1c24250187500d9", size = 288455, upload-time = "2024-11-06T20:10:09.117Z" },
+    { url = "https://files.pythonhosted.org/packages/60/85/cebcc0aff603ea0a201667b203f13ba75d9fc8668fab917ac5b2de3967bc/regex-2024.11.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:805e6b60c54bf766b251e94526ebad60b7de0c70f70a4e6210ee2891acb70bf2", size = 284759, upload-time = "2024-11-06T20:10:11.155Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/701a4b0585cb05472a4da28ee28fdfe155f3638f5e1ec92306d924e5faf0/regex-2024.11.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b85c2530be953a890eaffde05485238f07029600e8f098cdf1848d414a8b45e4", size = 794976, upload-time = "2024-11-06T20:10:13.24Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/bf/fa87e563bf5fee75db8915f7352e1887b1249126a1be4813837f5dbec965/regex-2024.11.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb26437975da7dc36b7efad18aa9dd4ea569d2357ae6b783bf1118dabd9ea577", size = 833077, upload-time = "2024-11-06T20:10:15.37Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/56/7295e6bad94b047f4d0834e4779491b81216583c00c288252ef625c01d23/regex-2024.11.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:abfa5080c374a76a251ba60683242bc17eeb2c9818d0d30117b4486be10c59d3", size = 823160, upload-time = "2024-11-06T20:10:19.027Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/13/e3b075031a738c9598c51cfbc4c7879e26729c53aa9cca59211c44235314/regex-2024.11.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70b7fa6606c2881c1db9479b0eaa11ed5dfa11c8d60a474ff0e095099f39d98e", size = 796896, upload-time = "2024-11-06T20:10:21.85Z" },
+    { url = "https://files.pythonhosted.org/packages/24/56/0b3f1b66d592be6efec23a795b37732682520b47c53da5a32c33ed7d84e3/regex-2024.11.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c32f75920cf99fe6b6c539c399a4a128452eaf1af27f39bce8909c9a3fd8cbe", size = 783997, upload-time = "2024-11-06T20:10:24.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/a1/eb378dada8b91c0e4c5f08ffb56f25fcae47bf52ad18f9b2f33b83e6d498/regex-2024.11.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:982e6d21414e78e1f51cf595d7f321dcd14de1f2881c5dc6a6e23bbbbd68435e", size = 781725, upload-time = "2024-11-06T20:10:28.067Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f2/033e7dec0cfd6dda93390089864732a3409246ffe8b042e9554afa9bff4e/regex-2024.11.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a7c2155f790e2fb448faed6dd241386719802296ec588a8b9051c1f5c481bc29", size = 789481, upload-time = "2024-11-06T20:10:31.612Z" },
+    { url = "https://files.pythonhosted.org/packages/83/23/15d4552ea28990a74e7696780c438aadd73a20318c47e527b47a4a5a596d/regex-2024.11.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:149f5008d286636e48cd0b1dd65018548944e495b0265b45e1bffecce1ef7f39", size = 852896, upload-time = "2024-11-06T20:10:34.054Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/39/ed4416bc90deedbfdada2568b2cb0bc1fdb98efe11f5378d9892b2a88f8f/regex-2024.11.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e5364a4502efca094731680e80009632ad6624084aff9a23ce8c8c6820de3e51", size = 860138, upload-time = "2024-11-06T20:10:36.142Z" },
+    { url = "https://files.pythonhosted.org/packages/93/2d/dd56bb76bd8e95bbce684326302f287455b56242a4f9c61f1bc76e28360e/regex-2024.11.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0a86e7eeca091c09e021db8eb72d54751e527fa47b8d5787caf96d9831bd02ad", size = 787692, upload-time = "2024-11-06T20:10:38.394Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/55/31877a249ab7a5156758246b9c59539abbeba22461b7d8adc9e8475ff73e/regex-2024.11.6-cp312-cp312-win32.whl", hash = "sha256:32f9a4c643baad4efa81d549c2aadefaeba12249b2adc5af541759237eee1c54", size = 262135, upload-time = "2024-11-06T20:10:40.367Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ec/ad2d7de49a600cdb8dd78434a1aeffe28b9d6fc42eb36afab4a27ad23384/regex-2024.11.6-cp312-cp312-win_amd64.whl", hash = "sha256:a93c194e2df18f7d264092dc8539b8ffb86b45b899ab976aa15d48214138e81b", size = 273567, upload-time = "2024-11-06T20:10:43.467Z" },
+    { url = "https://files.pythonhosted.org/packages/90/73/bcb0e36614601016552fa9344544a3a2ae1809dc1401b100eab02e772e1f/regex-2024.11.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a6ba92c0bcdf96cbf43a12c717eae4bc98325ca3730f6b130ffa2e3c3c723d84", size = 483525, upload-time = "2024-11-06T20:10:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3f/f1a082a46b31e25291d830b369b6b0c5576a6f7fb89d3053a354c24b8a83/regex-2024.11.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:525eab0b789891ac3be914d36893bdf972d483fe66551f79d3e27146191a37d4", size = 288324, upload-time = "2024-11-06T20:10:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c9/4e68181a4a652fb3ef5099e077faf4fd2a694ea6e0f806a7737aff9e758a/regex-2024.11.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:086a27a0b4ca227941700e0b31425e7a28ef1ae8e5e05a33826e17e47fbfdba0", size = 284617, upload-time = "2024-11-06T20:10:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fd/37868b75eaf63843165f1d2122ca6cb94bfc0271e4428cf58c0616786dce/regex-2024.11.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bde01f35767c4a7899b7eb6e823b125a64de314a8ee9791367c9a34d56af18d0", size = 795023, upload-time = "2024-11-06T20:10:51.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/7c/d4cd9c528502a3dedb5c13c146e7a7a539a3853dc20209c8e75d9ba9d1b2/regex-2024.11.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b583904576650166b3d920d2bcce13971f6f9e9a396c673187f49811b2769dc7", size = 833072, upload-time = "2024-11-06T20:10:52.926Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/db/46f563a08f969159c5a0f0e722260568425363bea43bb7ae370becb66a67/regex-2024.11.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c4de13f06a0d54fa0d5ab1b7138bfa0d883220965a29616e3ea61b35d5f5fc7", size = 823130, upload-time = "2024-11-06T20:10:54.828Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/1eeca2074f5b87df394fccaa432ae3fc06c9c9bfa97c5051aed70e6e00c2/regex-2024.11.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3cde6e9f2580eb1665965ce9bf17ff4952f34f5b126beb509fee8f4e994f143c", size = 796857, upload-time = "2024-11-06T20:10:56.634Z" },
+    { url = "https://files.pythonhosted.org/packages/10/db/ac718a08fcee981554d2f7bb8402f1faa7e868c1345c16ab1ebec54b0d7b/regex-2024.11.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0d7f453dca13f40a02b79636a339c5b62b670141e63efd511d3f8f73fba162b3", size = 784006, upload-time = "2024-11-06T20:10:59.369Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/41/7da3fe70216cea93144bf12da2b87367590bcf07db97604edeea55dac9ad/regex-2024.11.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:59dfe1ed21aea057a65c6b586afd2a945de04fc7db3de0a6e3ed5397ad491b07", size = 781650, upload-time = "2024-11-06T20:11:02.042Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d5/880921ee4eec393a4752e6ab9f0fe28009435417c3102fc413f3fe81c4e5/regex-2024.11.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b97c1e0bd37c5cd7902e65f410779d39eeda155800b65fc4d04cc432efa9bc6e", size = 789545, upload-time = "2024-11-06T20:11:03.933Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/96/53770115e507081122beca8899ab7f5ae28ae790bfcc82b5e38976df6a77/regex-2024.11.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f9d1e379028e0fc2ae3654bac3cbbef81bf3fd571272a42d56c24007979bafb6", size = 853045, upload-time = "2024-11-06T20:11:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d3/1372add5251cc2d44b451bd94f43b2ec78e15a6e82bff6a290ef9fd8f00a/regex-2024.11.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:13291b39131e2d002a7940fb176e120bec5145f3aeb7621be6534e46251912c4", size = 860182, upload-time = "2024-11-06T20:11:09.06Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e3/c446a64984ea9f69982ba1a69d4658d5014bc7a0ea468a07e1a1265db6e2/regex-2024.11.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f51f88c126370dcec4908576c5a627220da6c09d0bff31cfa89f2523843316d", size = 787733, upload-time = "2024-11-06T20:11:11.256Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f1/e40c8373e3480e4f29f2692bd21b3e05f296d3afebc7e5dcf21b9756ca1c/regex-2024.11.6-cp313-cp313-win32.whl", hash = "sha256:63b13cfd72e9601125027202cad74995ab26921d8cd935c25f09c630436348ff", size = 262122, upload-time = "2024-11-06T20:11:13.161Z" },
+    { url = "https://files.pythonhosted.org/packages/45/94/bc295babb3062a731f52621cdc992d123111282e291abaf23faa413443ea/regex-2024.11.6-cp313-cp313-win_amd64.whl", hash = "sha256:2b3361af3198667e99927da8b84c1b010752fa4b1115ee30beaa332cabc3ef1a", size = 273545, upload-time = "2024-11-06T20:11:15Z" },
 ]
 
 [[package]]
@@ -906,6 +1119,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tls-client"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/6ec27c66a836a11a085e841f825d2f5bd289092f3bcd2f645558f587c89f/tls_client-1.0.1.tar.gz", hash = "sha256:dad797f3412bb713606e0765d489f547ffb580c5ffdb74aed47a183ce8505ff5", size = 16414, upload-time = "2024-02-02T18:55:55.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/cd/5c735818692927e07980357445569adb6ee204c3332d19c516bae01c6cfa/tls_client-1.0.1-py3-none-any.whl", hash = "sha256:2f8915c0642c2226c9e33120072a2af082812f6310d32f4ea4da322db7d3bb1c", size = 41287556, upload-time = "2024-02-02T18:55:52.226Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 source = { registry = "https://pypi.org/simple" }
@@ -936,6 +1158,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Added a separate hidden-job lifecycle alongside existing deleted-job handling.
- Added API support for `deleted=hidden`, bulk/single hide, and bulk/single unhide.
- Added permanent job deletion via `POST /v1/jobs/bulk-delete-permanent` and `DELETE /v1/jobs/:key/permanent`.
- Permanent delete removes the job row, job-scoped state/projection rows, and delete/hide tombstones so later discovery can add the posting again.
- Updated active/deleted read models so hidden jobs stay out of active/deleted lists, dashboard totals, artifacts, workflow runs, and activity.
- Updated the Jobs UI with a Hidden tab, `unhide selected`, `hide selected`, and `delete permanently selected` from Deleted/Hidden tabs.
- Changed rediscovery behavior so a job that was temporarily deleted is resurfaced when discovery observes it again, while hidden jobs remain hidden.
- Routes ordered pipeline stage runs through Temporal via `JobPipelineWorkflow` instead of synchronous local JSON-RPC execution.
- Runs `apply` from ordered pipeline requests as a child `ApplyWorkflow`, preserving stage order while keeping apply-specific retry/cancel behavior.
- Propagates run-stage options (`dryRun`, `rescore`, `retailor`, `headless`, `model`, `continuous`) through the API, JSON-RPC contract, workflow input, and activities.
- Keeps profile import as a synchronous local action because it is not a pipeline stage.
- Disables interactive signal handlers when the apply launcher runs inside a Temporal activity thread, while preserving CLI signal handling.
- Documented the delete, hide, permanent-delete behavior, API routes, and Temporal-backed pipeline stage execution.

## Why

Deleted jobs are temporary removals and should not permanently suppress rediscovered postings. Hidden jobs represent an explicit user decision to keep a posting out of sight across future discovery runs. Permanent delete is for clearing local database rows without creating a new suppression record.

Pipeline stage execution should also be observable and cancellable through the Temporal worker path. The previous `run_stage` action path still executed several stages synchronously through local JSON-RPC, which meant browser/API-triggered pipeline runs could bypass Temporal even while the worker was available.

## Validation

- `uv --project workers/automation run --extra dev pytest -q` -> 823 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_activity_apply.py workers/automation/tests/test_workflow_apply.py workers/automation/tests/test_workflow_job_pipeline.py workers/automation/tests/test_jsonrpc_handlers.py workers/automation/tests/test_rpc_server_workflow_mode.py` -> 30 passed
- `corepack pnpm api:test -- --run apps/api/test/server.test.ts apps/api/test/json-rpc-adapter.test.ts` -> 97 passed
- `corepack pnpm api:check` -> passed
- `corepack pnpm web:check` -> passed
- `corepack pnpm --filter @jobhunter/contracts check` -> passed
- `corepack pnpm web:build` -> passed, with the existing Vite chunk-size warning
- `uv --project workers/automation run --extra dev ruff check .` -> passed
- `git diff --check` -> passed
- Live Temporal/API check: `POST /v1/pipeline/actions/run-stage` with stages `discover,enrich,score,tailor,cover,pdf,apply`, `dryRun=true`, `limit=1`, `workers=1`, `minScore=10`, `headless=true` returned 202 and queued `run-530183e0503f42f197b35b2f7192c549`; Temporal shows completed parent `JobPipelineWorkflow` and child `ApplyWorkflow` (`run-530183e0503f42f197b35b2f7192c549-apply`).

## Notes

- Ruff reformatted several legacy Python discovery files touched by this change, so the Python diff is noisier than the logical behavior change.
- Temporal server is expected for workflow-backed stage execution; the local dev worker listens on task queue `jobhunter-default`.