### PR TITLE
chore: add local dev stack launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ Core pipeline:
   Gemini, OpenAI, and local HTTP-backed providers are supported through
   environment variables.
 - A TeX distribution with `pdflatex` for PDF output.
-- Temporal dev server (`temporal server start-dev`) for the workflow engine
-  the Python worker runs against. See `docs/local-development.md`.
+- Temporal CLI with dev server support (`temporal server start-dev`) for the
+  workflow engine the Python worker runs against. The local dev launcher starts
+  it for you; see `docs/local-development.md`.
 
 Local API and web UI:
 
@@ -105,12 +106,24 @@ functionality is available on your machine.
 ```bash
 git clone https://github.com/ebarti/JobHunter.git
 cd JobHunter
-corepack pnpm install
-uv --project workers/automation sync
+pnpm dev:setup
 uv --project workers/automation run jobhunter doctor
 ```
 
-For development of the local TypeScript API and current React/Vite shell:
+Start the full local dev stack for UI/API job runs:
+
+```bash
+pnpm dev
+```
+
+`pnpm dev:setup` installs the Node workspace dependencies and syncs the
+uv-managed Python automation environment, including `python-jobspy` and its
+locked transitive dependencies plus the Python dev extras used by local checks.
+`pnpm dev` also invokes the Python worker through `uv run`, which re-syncs the
+worker environment if needed, but first-time setup should use `pnpm dev:setup`
+so dependency failures are separated from process startup.
+
+For verification:
 
 ```bash
 pnpm test
@@ -244,16 +257,30 @@ structured success or failure data.
 
 ## Local UI
 
-Run the local TypeScript API:
+Start the full local development stack:
 
 ```bash
-pnpm api:dev
+pnpm dev
 ```
 
-Run the current React/Vite web shell:
+That launches the Temporal dev server, local TypeScript API, React/Vite web app,
+and JobHunter Temporal worker. The launcher defaults to `~/.jobhunter`,
+`127.0.0.1:8766` for the API, and `127.0.0.1:5173` for the web app. Inspect or
+stop the stack with:
 
 ```bash
+pnpm dev:status
+pnpm dev:logs worker
+pnpm dev:stop
+```
+
+For troubleshooting, run individual components in separate terminals:
+
+```bash
+temporal server start-dev
+pnpm api:dev
 pnpm web:dev
+uv --project workers/automation run jobhunter worker
 ```
 
 The Vite dev server proxies `/v1/*` to the local API by default. Set
@@ -380,8 +407,7 @@ Common environment variables:
 Install dependencies:
 
 ```bash
-corepack pnpm install
-uv --project workers/automation sync --extra dev
+pnpm dev:setup
 ```
 
 Run the standard checks:
@@ -409,8 +435,7 @@ flows without touching `~/.jobhunter`:
 
 ```bash
 pnpm qa:seed -- /tmp/jobhunter-qa
-JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm api:dev
-VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
+JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
 ```
 
 Build the Python package:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -6,40 +6,53 @@ worker.
 ## Install
 
 ```bash
-corepack pnpm install
-uv --project workers/automation sync --extra dev
+pnpm dev:setup
 ```
+
+`pnpm dev:setup` installs the Node workspace dependencies and runs
+`uv --project workers/automation sync --extra dev`, which installs the Python
+automation worker, `python-jobspy`, JobSpy's locked transitive dependencies, and
+the Python dev tools used by local checks.
 
 ## Run
 
 ```bash
-pnpm api:dev
-pnpm web:dev
-uv --project workers/automation run jobhunter doctor
+pnpm dev
 ```
 
-The Vite web dev server proxies `/v1/*` to the local API by default.
+`pnpm dev` starts the full local fleet in dependency order: Temporal dev server,
+TypeScript API, Vite web app, and the JobHunter Temporal worker. The launcher
+tracks PIDs under `.dev/pids/`, writes logs under `.dev/logs/`, and defaults to:
 
-### Local Temporal dev server
+- API data dir: `JOBHUNTER_DIR=${HOME}/.jobhunter`
+- API bind: `JOBHUNTER_API_HOST=127.0.0.1`,
+  `JOBHUNTER_API_PORT=8766`
+- Web API base URL: `VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766`
+- Web port: `5173` (`JOBHUNTER_WEB_PORT` can override it)
 
-The Python worker uses [Temporal](https://docs.temporal.io/) as its workflow
-engine. Start the dev server in its own terminal:
+Use the launcher for day-to-day process management:
+
+```bash
+pnpm dev:status
+pnpm dev:logs worker
+pnpm dev:stop
+scripts/dev list
+```
+
+Run individual components only when troubleshooting a specific process:
 
 ```bash
 temporal server start-dev
-```
-
-That binds the frontend gRPC service on `127.0.0.1:7233` and the Web UI on
-`http://127.0.0.1:8233`. With it running, `jobhunter doctor` reports
-`Temporal: reachable` and the worker process can connect:
-
-```bash
+pnpm api:dev
+pnpm web:dev
 uv --project workers/automation run jobhunter worker
+uv --project workers/automation run jobhunter doctor
 ```
 
-`jobhunter worker` is the long-lived process that picks up workflow + activity
-tasks from the `jobhunter-default` queue. Run it alongside `pnpm api:dev` and
-`pnpm web:dev` whenever you want the full local stack live.
+The Temporal dev server binds the frontend gRPC service on `127.0.0.1:7233` and
+the Web UI on `http://127.0.0.1:8233`. With it running, `jobhunter doctor`
+reports `Temporal: reachable`. The Vite web dev server proxies `/v1/*` to the
+local API by default.
 
 ## Verify
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
     "node": ">=20.19.0"
   },
   "scripts": {
+    "dev": "scripts/dev start",
+    "dev:setup": "scripts/dev setup",
+    "dev:status": "scripts/dev status",
+    "dev:stop": "scripts/dev stop",
+    "dev:logs": "scripts/dev logs",
     "api:dev": "corepack pnpm --filter @jobhunter/api dev",
     "api:start": "corepack pnpm --filter @jobhunter/api start",
     "api:check": "corepack pnpm --filter @jobhunter/api check",

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/dev — JobHunter local dev fleet launcher.
 #
-# Daemonizes api / web / worker into background processes, tracks each by
+# Daemonizes temporal / api / web / worker into background processes, tracks each by
 # PID file under .dev/pids/, captures stdout+stderr to .dev/logs/, and
 # exposes individual start/stop/restart/logs so you can bounce one
 # without nuking the others.
@@ -12,6 +12,7 @@
 #   scripts/dev restart [name...]  Stop then start
 #   scripts/dev status             Show pid + alive state for all known
 #   scripts/dev logs <name>        tail -f the log file for one process
+#   scripts/dev setup              Install/sync Node and Python dependencies
 #   scripts/dev list               Print the process registry
 #   scripts/dev help               Show this message
 
@@ -25,14 +26,15 @@ mkdir -p "$PID_DIR" "$LOG_DIR"
 
 # Process registry. To add a process: extend `process_names` and add a
 # matching arm in `process_command`.
-process_names() { echo "api web worker"; }
+process_names() { echo "temporal api web worker"; }
 
 process_command() {
   case "$1" in
-    api)    echo "pnpm --filter @jobhunter/api dev" ;;
-    web)    echo "pnpm --filter @jobhunter/web dev" ;;
-    worker) echo "uv --project workers/automation run jobhunter worker" ;;
-    *)      return 1 ;;
+    temporal) echo "temporal server start-dev" ;;
+    api)      echo "pnpm --filter @jobhunter/api dev" ;;
+    web)      echo 'pnpm --filter @jobhunter/web dev -- --port "$JOBHUNTER_WEB_PORT"' ;;
+    worker)   echo "uv --project workers/automation run jobhunter worker" ;;
+    *)        return 1 ;;
   esac
 }
 
@@ -77,6 +79,14 @@ load_env_file() {
   # shellcheck disable=SC1090,SC1091
   source "$ROOT/.env"
   set +a
+}
+
+set_default_env() {
+  export JOBHUNTER_DIR="${JOBHUNTER_DIR:-$HOME/.jobhunter}"
+  export JOBHUNTER_API_HOST="${JOBHUNTER_API_HOST:-127.0.0.1}"
+  export JOBHUNTER_API_PORT="${JOBHUNTER_API_PORT:-8766}"
+  export VITE_JOBHUNTER_API_BASE_URL="${VITE_JOBHUNTER_API_BASE_URL:-http://${JOBHUNTER_API_HOST}:${JOBHUNTER_API_PORT}}"
+  export JOBHUNTER_WEB_PORT="${JOBHUNTER_WEB_PORT:-5173}"
 }
 
 start_one() {
@@ -132,6 +142,7 @@ stop_one() {
 
 cmd_start() {
   load_env_file
+  set_default_env
   local targets=("$@")
   if [[ ${#targets[@]} -eq 0 ]]; then
     for n in $(process_names); do targets+=("$n"); done
@@ -184,6 +195,11 @@ cmd_logs() {
   exec tail -F "$log"
 }
 
+cmd_setup() {
+  ( cd "$ROOT" && corepack pnpm install )
+  ( cd "$ROOT" && uv --project workers/automation sync --extra dev )
+}
+
 cmd_list() {
   for n in $(process_names); do
     printf "%-10s %s\n" "$n" "$(process_command "$n")"
@@ -203,6 +219,7 @@ main() {
     restart) cmd_restart "$@" ;;
     status)  cmd_status ;;
     logs)    cmd_logs "$@" ;;
+    setup)   cmd_setup ;;
     list)    cmd_list ;;
     help|-h|--help) cmd_help ;;
     *) echo "dev: unknown command '$sub'" >&2; cmd_help; exit 2 ;;


### PR DESCRIPTION
## Summary
- Add Temporal to the managed `scripts/dev` process registry and make the default startup order `temporal api web worker`.
- Export shared launcher defaults for `JOBHUNTER_DIR`, API host/port, web API base URL, and web port before starting child processes.
- Add `pnpm dev:setup` / `scripts/dev setup` to install Node workspace dependencies and sync the uv-managed automation worker, including JobSpy dependencies.
- Add root `pnpm dev` process-management scripts and document the single-command local dev path.

## Validation
- `bash -n scripts/dev`
- `scripts/dev list`
- `node -e "const pkg=JSON.parse(require('fs').readFileSync('package.json','utf8')); if(pkg.scripts['dev:setup'] !== 'scripts/dev setup') process.exit(1); console.log('dev:setup ok')"`
- `git diff --check HEAD^ HEAD`
- `pnpm dev:status`

## Notes
- `pnpm dev:setup` was added so first-time dependency failures are separated from process startup; `pnpm dev` still launches the worker through `uv run`, which re-syncs the Python environment if needed.
- This does not run auto-apply, browser submission, or any application-submission flow.
