### PR TITLE
feat: add calibrated scoring policy model

### DIFF
--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -931,6 +931,7 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         CREATE INDEX IF NOT EXISTS idx_job_scores_job_version
         ON job_scores(job_url, version DESC)
     """)
+    ensure_scoring_policy_tables(conn)
 
     # One-shot backfill from the legacy columns. Only fires when
     # job_scores has no rows AND there are jobs with a legacy fit_score.
@@ -994,7 +995,39 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
                 )
 
     conn.commit()
-    return ["job_scores"]
+    return ["job_scores", "scoring_policies"]
+
+
+def ensure_scoring_policy_tables(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Create scoring-policy persistence tables.
+
+    The current policy lives outside ``job_scores`` so score rows can keep
+    an immutable trace of which policy version resolved them.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS scoring_policies (
+            tenant_id              TEXT NOT NULL,
+            version                INTEGER NOT NULL,
+            rubric_json            TEXT NOT NULL,
+            anchors_json           TEXT NOT NULL DEFAULT '[]',
+            created_at             TEXT NOT NULL,
+            created_from_event_id  INTEGER,
+            PRIMARY KEY (tenant_id, version)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_scoring_policies_current
+        ON scoring_policies(tenant_id, version DESC)
+        """
+    )
+    conn.commit()
+    return ["scoring_policies"]
 
 
 def ensure_materials_tables(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/src/jobhunter/domain/ports/scoring.py
+++ b/workers/automation/src/jobhunter/domain/ports/scoring.py
@@ -14,6 +14,7 @@ from typing import Protocol
 
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.policy import ScoringPolicy
 from jobhunter.domain.tenant import TenantId
 
 # Re-export the shared LLM port — Scoring is one of its consumers.
@@ -21,6 +22,7 @@ from jobhunter.domain.ports.llm import LlmMessage, LlmPort, LlmRole
 
 __all__ = [
     "ScoreRepository",
+    "ScoringPolicyRepository",
     "LlmPort",
     "LlmMessage",
     "LlmRole",
@@ -76,4 +78,20 @@ class ScoreRepository(Protocol):
         max_score: int = 10,
     ) -> list[JobScore]:
         """Return latest-version scores whose ``fit_score`` is within range."""
+        ...
+
+
+class ScoringPolicyRepository(Protocol):
+    """Persistence port for the current versioned scoring policy."""
+
+    def get_current(self, tenant_id: TenantId) -> ScoringPolicy:
+        """Return the current ``ScoringPolicy`` for the tenant.
+
+        Implementations may synthesize and persist the default policy when
+        none exists yet.
+        """
+        ...
+
+    def save(self, policy: ScoringPolicy) -> None:
+        """Persist a ``ScoringPolicy`` version."""
         ...

--- a/workers/automation/src/jobhunter/domain/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/domain/scoring/__init__.py
@@ -19,6 +19,7 @@ from jobhunter.domain.scoring.value_objects import (
 from jobhunter.domain.scoring.aggregate import JobScore
 from jobhunter.domain.scoring.policy import (
     CalibrationAnchor,
+    FitBandThreshold,
     ResolvedScore,
     ScoringPolicy,
     WeightedScoreDimension,
@@ -50,6 +51,7 @@ __all__ = [
     "ScoringCriteria",
     "JobScore",
     "CalibrationAnchor",
+    "FitBandThreshold",
     "ResolvedScore",
     "ScoringPolicy",
     "WeightedScoreDimension",

--- a/workers/automation/src/jobhunter/domain/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/domain/scoring/__init__.py
@@ -17,6 +17,12 @@ from jobhunter.domain.scoring.value_objects import (
     ScoringCriteria,
 )
 from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.policy import (
+    CalibrationAnchor,
+    ResolvedScore,
+    ScoringPolicy,
+    WeightedScoreDimension,
+)
 from jobhunter.domain.scoring.services import (
     ConstraintChecker,
     EligibilityChecker,
@@ -43,6 +49,10 @@ __all__ = [
     "ScoreTrace",
     "ScoringCriteria",
     "JobScore",
+    "CalibrationAnchor",
+    "ResolvedScore",
+    "ScoringPolicy",
+    "WeightedScoreDimension",
     "ConstraintChecker",
     "EligibilityChecker",
     "ScoreParser",

--- a/workers/automation/src/jobhunter/domain/scoring/policy.py
+++ b/workers/automation/src/jobhunter/domain/scoring/policy.py
@@ -1,0 +1,301 @@
+"""Versioned scoring policy model.
+
+The policy turns structured scoring evidence into the persisted
+``FitScore``. The LLM may still propose an overall score, but that score is
+input evidence only; deterministic policy resolution owns the final grade.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping as MappingABC
+from dataclasses import dataclass
+from typing import Any
+
+from jobhunter.domain.scoring.value_objects import FitScore, ScoreBreakdown
+from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
+
+DEFAULT_SCORING_POLICY_VERSION = 1
+DEFAULT_RUBRIC_VERSION = "default-scoring-rubric-v1"
+DEFAULT_DIMENSION_WEIGHTS: tuple[tuple[str, float], ...] = (
+    ("technical_fit", 0.45),
+    ("experience_fit", 0.30),
+    ("role_fit", 0.25),
+)
+
+
+@dataclass(frozen=True)
+class WeightedScoreDimension:
+    """One deterministic scoring input and its policy weight."""
+
+    name: str
+    weight: float
+
+    def __post_init__(self) -> None:
+        name = str(self.name or "").strip()
+        if not name:
+            raise ValueError("WeightedScoreDimension.name must be non-empty")
+        try:
+            weight = float(self.weight)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("WeightedScoreDimension.weight must be numeric") from exc
+        if weight <= 0:
+            raise ValueError("WeightedScoreDimension.weight must be positive")
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "weight", weight)
+
+    @classmethod
+    def from_dict(cls, data: MappingABC[str, Any]) -> "WeightedScoreDimension":
+        return cls(name=str(data.get("name") or ""), weight=float(data.get("weight") or 0))
+
+    def value_from(self, breakdown: ScoreBreakdown) -> int:
+        value = getattr(breakdown, self.name, None)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"ScoreBreakdown has no integer dimension {self.name!r}")
+        if value < 0 or value > 10:
+            raise ValueError(f"ScoreBreakdown.{self.name} must be in [0, 10], got {value}")
+        return value
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "weight": self.weight}
+
+
+@dataclass(frozen=True)
+class CalibrationAnchor:
+    """Persisted calibration reference.
+
+    This first policy PR stores anchors but does not learn from correction
+    signals yet. Future stacked PRs can populate this value object without
+    changing the policy persistence table.
+    """
+
+    anchor_id: str
+    job_id: str = ""
+    fit_score: FitScore | None = None
+    rationale: str = ""
+    dimensions: tuple[str, ...] = ()
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        anchor_id = str(self.anchor_id or "").strip()
+        if not anchor_id:
+            raise ValueError("CalibrationAnchor.anchor_id must be non-empty")
+        object.__setattr__(self, "anchor_id", anchor_id)
+        object.__setattr__(self, "job_id", str(self.job_id or "").strip())
+        object.__setattr__(self, "rationale", str(self.rationale or "").strip())
+        object.__setattr__(
+            self,
+            "dimensions",
+            tuple(str(value).strip() for value in self.dimensions if str(value).strip()),
+        )
+        object.__setattr__(self, "created_at", str(self.created_at or "").strip())
+
+    @classmethod
+    def from_dict(cls, data: MappingABC[str, Any]) -> "CalibrationAnchor":
+        score = FitScore.from_optional(data.get("fit_score", data.get("fitScore")))
+        raw_dimensions = data.get("dimensions", ())
+        dimensions = raw_dimensions if isinstance(raw_dimensions, list) else ()
+        return cls(
+            anchor_id=str(data.get("anchor_id", data.get("anchorId", ""))),
+            job_id=str(data.get("job_id", data.get("jobId", "")) or ""),
+            fit_score=score,
+            rationale=str(data.get("rationale") or ""),
+            dimensions=tuple(dimensions),
+            created_at=str(data.get("created_at", data.get("createdAt", "")) or ""),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "anchor_id": self.anchor_id,
+            "job_id": self.job_id,
+            "fit_score": self.fit_score.value if self.fit_score else None,
+            "rationale": self.rationale,
+            "dimensions": list(self.dimensions),
+            "created_at": self.created_at,
+        }
+
+
+@dataclass(frozen=True)
+class ResolvedDimensionScore:
+    """Dimension contribution used to produce one resolved score."""
+
+    name: str
+    value: int
+    weight: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "value": self.value, "weight": self.weight}
+
+
+@dataclass(frozen=True)
+class ResolvedScore:
+    """Deterministic policy result attached to the score trace."""
+
+    fit_score: FitScore
+    policy_version: int
+    rubric_version: str
+    raw_weighted_score: float
+    calibration_adjustment: float
+    anchor_ids: tuple[str, ...]
+    dimensions: tuple[ResolvedDimensionScore, ...]
+
+    def dimension_values(self) -> dict[str, int]:
+        return {dimension.name: dimension.value for dimension in self.dimensions}
+
+
+@dataclass(frozen=True)
+class ScoringPolicy:
+    """Versioned rule set that resolves final ``FitScore`` values."""
+
+    tenant_id: TenantId = LOCAL_TENANT
+    version: int = DEFAULT_SCORING_POLICY_VERSION
+    rubric_version: str = DEFAULT_RUBRIC_VERSION
+    dimensions: tuple[WeightedScoreDimension, ...] = ()
+    anchors: tuple[CalibrationAnchor, ...] = ()
+    created_at: str = ""
+    created_from_event_id: int | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tenant_id", TenantId(str(self.tenant_id)))
+        try:
+            version = int(self.version)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("ScoringPolicy.version must be an integer") from exc
+        if version < 1:
+            raise ValueError("ScoringPolicy.version must be >= 1")
+        object.__setattr__(self, "version", version)
+        rubric_version = str(self.rubric_version or "").strip() or DEFAULT_RUBRIC_VERSION
+        object.__setattr__(self, "rubric_version", rubric_version)
+        dimensions = self.dimensions or _default_dimensions()
+        if not dimensions:
+            raise ValueError("ScoringPolicy.dimensions must be non-empty")
+        names = [dimension.name for dimension in dimensions]
+        if len(names) != len(set(names)):
+            raise ValueError("ScoringPolicy dimensions must be unique by name")
+        object.__setattr__(self, "dimensions", tuple(dimensions))
+        object.__setattr__(self, "anchors", tuple(self.anchors))
+        object.__setattr__(self, "created_at", str(self.created_at or "").strip())
+        if self.created_from_event_id is not None:
+            object.__setattr__(self, "created_from_event_id", int(self.created_from_event_id))
+
+    @classmethod
+    def default(
+        cls,
+        tenant_id: TenantId = LOCAL_TENANT,
+        *,
+        created_at: str = "",
+    ) -> "ScoringPolicy":
+        return cls(
+            tenant_id=tenant_id,
+            version=DEFAULT_SCORING_POLICY_VERSION,
+            rubric_version=DEFAULT_RUBRIC_VERSION,
+            dimensions=_default_dimensions(),
+            anchors=(),
+            created_at=created_at,
+            created_from_event_id=None,
+        )
+
+    @classmethod
+    def from_persistence(
+        cls,
+        *,
+        tenant_id: TenantId,
+        version: int,
+        rubric: MappingABC[str, Any] | None,
+        anchors: list[Any] | None,
+        created_at: str,
+        created_from_event_id: int | None,
+    ) -> "ScoringPolicy":
+        rubric = rubric or {}
+        raw_dimensions = rubric.get("dimensions", ())
+        dimensions = (
+            tuple(
+                WeightedScoreDimension.from_dict(item)
+                for item in raw_dimensions
+                if isinstance(item, MappingABC)
+            )
+            if isinstance(raw_dimensions, list)
+            else ()
+        )
+        anchor_values = tuple(
+            CalibrationAnchor.from_dict(item)
+            for item in anchors or []
+            if isinstance(item, MappingABC)
+        )
+        return cls(
+            tenant_id=tenant_id,
+            version=version,
+            rubric_version=str(rubric.get("rubric_version", rubric.get("rubricVersion", DEFAULT_RUBRIC_VERSION))),
+            dimensions=dimensions,
+            anchors=anchor_values,
+            created_at=created_at,
+            created_from_event_id=created_from_event_id,
+        )
+
+    def resolve(self, breakdown: ScoreBreakdown) -> ResolvedScore:
+        """Resolve final score from validated structured evidence."""
+        dimensions = tuple(
+            ResolvedDimensionScore(
+                name=dimension.name,
+                value=dimension.value_from(breakdown),
+                weight=dimension.weight,
+            )
+            for dimension in self.dimensions
+        )
+        total_weight = sum(dimension.weight for dimension in dimensions)
+        if total_weight <= 0:
+            raise ValueError("ScoringPolicy dimensions must have a positive total weight")
+
+        raw_weighted_score = sum(
+            dimension.value * dimension.weight for dimension in dimensions
+        ) / total_weight
+        calibration_adjustment = 0.0
+        resolved_value = _fit_score_from_raw(raw_weighted_score + calibration_adjustment)
+        return ResolvedScore(
+            fit_score=FitScore.create(resolved_value),
+            policy_version=self.version,
+            rubric_version=self.rubric_version,
+            raw_weighted_score=round(raw_weighted_score, 4),
+            calibration_adjustment=calibration_adjustment,
+            anchor_ids=(),
+            dimensions=dimensions,
+        )
+
+    def to_rubric_dict(self) -> dict[str, Any]:
+        return {
+            "rubric_version": self.rubric_version,
+            "dimensions": [dimension.to_dict() for dimension in self.dimensions],
+            "rounding": "nearest_integer_half_up",
+            "fit_score_range": [1, 10],
+            "confidence_handling": "trace_only",
+            "eligibility_handling": "trace_only",
+        }
+
+    def to_anchors_list(self) -> list[dict[str, Any]]:
+        return [anchor.to_dict() for anchor in self.anchors]
+
+
+def _default_dimensions() -> tuple[WeightedScoreDimension, ...]:
+    return tuple(
+        WeightedScoreDimension(name=name, weight=weight)
+        for name, weight in DEFAULT_DIMENSION_WEIGHTS
+    )
+
+
+def _fit_score_from_raw(value: float) -> int:
+    rounded = int(value + 0.5)
+    if rounded < 1:
+        return 1
+    if rounded > 10:
+        return 10
+    return rounded
+
+
+__all__ = [
+    "CalibrationAnchor",
+    "DEFAULT_RUBRIC_VERSION",
+    "DEFAULT_SCORING_POLICY_VERSION",
+    "ResolvedDimensionScore",
+    "ResolvedScore",
+    "ScoringPolicy",
+    "WeightedScoreDimension",
+]

--- a/workers/automation/src/jobhunter/domain/scoring/policy.py
+++ b/workers/automation/src/jobhunter/domain/scoring/policy.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping as MappingABC
 from dataclasses import dataclass
 from typing import Any
 
-from jobhunter.domain.scoring.value_objects import FitScore, ScoreBreakdown
+from jobhunter.domain.scoring.value_objects import FIT_BANDS, FitScore, ScoreBreakdown
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 
 DEFAULT_SCORING_POLICY_VERSION = 1
@@ -20,6 +20,13 @@ DEFAULT_DIMENSION_WEIGHTS: tuple[tuple[str, float], ...] = (
     ("technical_fit", 0.45),
     ("experience_fit", 0.30),
     ("role_fit", 0.25),
+)
+DEFAULT_FIT_BAND_THRESHOLDS: tuple[tuple[str, int], ...] = (
+    ("excellent", 9),
+    ("strong", 7),
+    ("plausible", 5),
+    ("stretch", 3),
+    ("poor", 1),
 )
 
 
@@ -115,6 +122,39 @@ class CalibrationAnchor:
 
 
 @dataclass(frozen=True)
+class FitBandThreshold:
+    """Policy-owned lower bound for one resolved fit band."""
+
+    band: str
+    minimum_score: int
+
+    def __post_init__(self) -> None:
+        band = str(self.band or "").strip().lower()
+        if band not in FIT_BANDS:
+            raise ValueError(f"FitBandThreshold.band must be one of {FIT_BANDS}")
+        try:
+            minimum_score = int(self.minimum_score)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("FitBandThreshold.minimum_score must be an integer") from exc
+        if minimum_score < 1 or minimum_score > 10:
+            raise ValueError("FitBandThreshold.minimum_score must be in [1, 10]")
+        object.__setattr__(self, "band", band)
+        object.__setattr__(self, "minimum_score", minimum_score)
+
+    @classmethod
+    def from_dict(cls, data: MappingABC[str, Any]) -> "FitBandThreshold":
+        return cls(
+            band=str(data.get("band") or ""),
+            minimum_score=int(
+                data.get("minimum_score", data.get("minimumScore", 0)) or 0
+            ),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"band": self.band, "minimum_score": self.minimum_score}
+
+
+@dataclass(frozen=True)
 class ResolvedDimensionScore:
     """Dimension contribution used to produce one resolved score."""
 
@@ -123,7 +163,12 @@ class ResolvedDimensionScore:
     weight: float
 
     def to_dict(self) -> dict[str, Any]:
-        return {"name": self.name, "value": self.value, "weight": self.weight}
+        return {
+            "name": self.name,
+            "value": self.value,
+            "weight": self.weight,
+            "weighted_value": round(self.value * self.weight, 4),
+        }
 
 
 @dataclass(frozen=True)
@@ -131,12 +176,17 @@ class ResolvedScore:
     """Deterministic policy result attached to the score trace."""
 
     fit_score: FitScore
+    fit_band: str
+    policy_id: str
     policy_version: int
     rubric_version: str
     raw_weighted_score: float
     calibration_adjustment: float
     anchor_ids: tuple[str, ...]
     dimensions: tuple[ResolvedDimensionScore, ...]
+    fit_band_thresholds: tuple[FitBandThreshold, ...]
+    resolution_reason: str
+    evidence_summary: dict[str, Any]
 
     def dimension_values(self) -> dict[str, int]:
         return {dimension.name: dimension.value for dimension in self.dimensions}
@@ -150,6 +200,7 @@ class ScoringPolicy:
     version: int = DEFAULT_SCORING_POLICY_VERSION
     rubric_version: str = DEFAULT_RUBRIC_VERSION
     dimensions: tuple[WeightedScoreDimension, ...] = ()
+    fit_band_thresholds: tuple[FitBandThreshold, ...] = ()
     anchors: tuple[CalibrationAnchor, ...] = ()
     created_at: str = ""
     created_from_event_id: int | None = None
@@ -172,10 +223,19 @@ class ScoringPolicy:
         if len(names) != len(set(names)):
             raise ValueError("ScoringPolicy dimensions must be unique by name")
         object.__setattr__(self, "dimensions", tuple(dimensions))
+        object.__setattr__(
+            self,
+            "fit_band_thresholds",
+            _validated_fit_band_thresholds(self.fit_band_thresholds),
+        )
         object.__setattr__(self, "anchors", tuple(self.anchors))
         object.__setattr__(self, "created_at", str(self.created_at or "").strip())
         if self.created_from_event_id is not None:
             object.__setattr__(self, "created_from_event_id", int(self.created_from_event_id))
+
+    @property
+    def policy_id(self) -> str:
+        return f"{self.tenant_id}:scoring-policy-v{self.version}"
 
     @classmethod
     def default(
@@ -189,6 +249,7 @@ class ScoringPolicy:
             version=DEFAULT_SCORING_POLICY_VERSION,
             rubric_version=DEFAULT_RUBRIC_VERSION,
             dimensions=_default_dimensions(),
+            fit_band_thresholds=_default_fit_band_thresholds(),
             anchors=(),
             created_at=created_at,
             created_from_event_id=None,
@@ -216,6 +277,16 @@ class ScoringPolicy:
             if isinstance(raw_dimensions, list)
             else ()
         )
+        raw_thresholds = rubric.get("fit_band_thresholds", rubric.get("fitBandThresholds", ()))
+        fit_band_thresholds = (
+            tuple(
+                FitBandThreshold.from_dict(item)
+                for item in raw_thresholds
+                if isinstance(item, MappingABC)
+            )
+            if isinstance(raw_thresholds, list)
+            else ()
+        )
         anchor_values = tuple(
             CalibrationAnchor.from_dict(item)
             for item in anchors or []
@@ -226,6 +297,7 @@ class ScoringPolicy:
             version=version,
             rubric_version=str(rubric.get("rubric_version", rubric.get("rubricVersion", DEFAULT_RUBRIC_VERSION))),
             dimensions=dimensions,
+            fit_band_thresholds=fit_band_thresholds,
             anchors=anchor_values,
             created_at=created_at,
             created_from_event_id=created_from_event_id,
@@ -250,20 +322,36 @@ class ScoringPolicy:
         ) / total_weight
         calibration_adjustment = 0.0
         resolved_value = _fit_score_from_raw(raw_weighted_score + calibration_adjustment)
+        fit_score = FitScore.create(resolved_value)
         return ResolvedScore(
-            fit_score=FitScore.create(resolved_value),
+            fit_score=fit_score,
+            fit_band=self.fit_band_for_score(fit_score),
+            policy_id=self.policy_id,
             policy_version=self.version,
             rubric_version=self.rubric_version,
             raw_weighted_score=round(raw_weighted_score, 4),
             calibration_adjustment=calibration_adjustment,
             anchor_ids=(),
             dimensions=dimensions,
+            fit_band_thresholds=self.fit_band_thresholds,
+            resolution_reason=_resolution_reason(breakdown),
+            evidence_summary=_evidence_summary(breakdown),
         )
+
+    def fit_band_for_score(self, score: FitScore | int) -> str:
+        value = score.value if isinstance(score, FitScore) else int(score)
+        for threshold in self.fit_band_thresholds:
+            if value >= threshold.minimum_score:
+                return threshold.band
+        return "poor"
 
     def to_rubric_dict(self) -> dict[str, Any]:
         return {
             "rubric_version": self.rubric_version,
             "dimensions": [dimension.to_dict() for dimension in self.dimensions],
+            "fit_band_thresholds": [
+                threshold.to_dict() for threshold in self.fit_band_thresholds
+            ],
             "rounding": "nearest_integer_half_up",
             "fit_score_range": [1, 10],
             "confidence_handling": "trace_only",
@@ -281,6 +369,54 @@ def _default_dimensions() -> tuple[WeightedScoreDimension, ...]:
     )
 
 
+def _default_fit_band_thresholds() -> tuple[FitBandThreshold, ...]:
+    return tuple(
+        FitBandThreshold(band=band, minimum_score=minimum_score)
+        for band, minimum_score in DEFAULT_FIT_BAND_THRESHOLDS
+    )
+
+
+def _validated_fit_band_thresholds(
+    thresholds: tuple[FitBandThreshold, ...],
+) -> tuple[FitBandThreshold, ...]:
+    threshold_values = tuple(thresholds or _default_fit_band_thresholds())
+    bands = [threshold.band for threshold in threshold_values]
+    if set(bands) != set(FIT_BANDS) or len(bands) != len(FIT_BANDS):
+        raise ValueError(f"ScoringPolicy fit band thresholds must cover {FIT_BANDS}")
+    sorted_values = tuple(
+        sorted(threshold_values, key=lambda threshold: threshold.minimum_score, reverse=True)
+    )
+    minimums = [threshold.minimum_score for threshold in sorted_values]
+    if len(minimums) != len(set(minimums)):
+        raise ValueError("ScoringPolicy fit band thresholds must have unique minimum scores")
+    if sorted_values[-1].minimum_score != 1:
+        raise ValueError("ScoringPolicy fit band thresholds must include a floor of 1")
+    return sorted_values
+
+
+def _resolution_reason(breakdown: ScoreBreakdown) -> str:
+    reasons = ["weighted_dimensions"]
+    if breakdown.eligibility.hard_blockers or breakdown.eligibility.status == "blocked":
+        reasons.append("eligibility_blockers_traced")
+    if breakdown.confidence == "low":
+        reasons.append("low_confidence_traced")
+    if breakdown.missing_signals:
+        reasons.append("missing_signals_traced")
+    return "+".join(reasons)
+
+
+def _evidence_summary(breakdown: ScoreBreakdown) -> dict[str, Any]:
+    return {
+        "confidence": breakdown.confidence,
+        "eligibility_status": breakdown.eligibility.status,
+        "hard_blocker_count": len(breakdown.eligibility.hard_blockers),
+        "warning_count": len(breakdown.eligibility.warnings),
+        "matched_signal_count": len(breakdown.matched_signals),
+        "missing_signal_count": len(breakdown.missing_signals),
+        "transferable_signal_count": len(breakdown.transferable_signals),
+    }
+
+
 def _fit_score_from_raw(value: float) -> int:
     rounded = int(value + 0.5)
     if rounded < 1:
@@ -292,8 +428,10 @@ def _fit_score_from_raw(value: float) -> int:
 
 __all__ = [
     "CalibrationAnchor",
+    "DEFAULT_FIT_BAND_THRESHOLDS",
     "DEFAULT_RUBRIC_VERSION",
     "DEFAULT_SCORING_POLICY_VERSION",
+    "FitBandThreshold",
     "ResolvedDimensionScore",
     "ResolvedScore",
     "ScoringPolicy",

--- a/workers/automation/src/jobhunter/domain/scoring/policy.py
+++ b/workers/automation/src/jobhunter/domain/scoring/policy.py
@@ -383,15 +383,22 @@ def _validated_fit_band_thresholds(
     bands = [threshold.band for threshold in threshold_values]
     if set(bands) != set(FIT_BANDS) or len(bands) != len(FIT_BANDS):
         raise ValueError(f"ScoringPolicy fit band thresholds must cover {FIT_BANDS}")
-    sorted_values = tuple(
-        sorted(threshold_values, key=lambda threshold: threshold.minimum_score, reverse=True)
-    )
-    minimums = [threshold.minimum_score for threshold in sorted_values]
+    threshold_by_band = {threshold.band: threshold for threshold in threshold_values}
+    canonical_values = tuple(threshold_by_band[band] for band in FIT_BANDS)
+    minimums = [threshold.minimum_score for threshold in canonical_values]
     if len(minimums) != len(set(minimums)):
         raise ValueError("ScoringPolicy fit band thresholds must have unique minimum scores")
-    if sorted_values[-1].minimum_score != 1:
+    if canonical_values[-1].minimum_score != 1:
         raise ValueError("ScoringPolicy fit band thresholds must include a floor of 1")
-    return sorted_values
+    if any(
+        higher.minimum_score <= lower.minimum_score
+        for higher, lower in zip(canonical_values, canonical_values[1:])
+    ):
+        raise ValueError(
+            "ScoringPolicy fit band thresholds must follow "
+            "excellent > strong > plausible > stretch > poor == 1"
+        )
+    return canonical_values
 
 
 def _resolution_reason(breakdown: ScoreBreakdown) -> str:

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -49,7 +49,6 @@ from jobhunter.domain.scoring.value_objects import (
     ScoreCorrection,
     ScoreTrace,
     ScoringCriteria,
-    fit_band_for_score,
 )
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 
@@ -516,7 +515,7 @@ class ScoreJobUseCase:
             experience_fit=parse.breakdown.experience_fit,
             role_fit=parse.breakdown.role_fit,
             reasoning=parse.breakdown.reasoning,
-            fit_band=fit_band_for_score(resolved.fit_score.value),
+            fit_band=resolved.fit_band,
             confidence=parse.breakdown.confidence,
             eligibility=parse.breakdown.eligibility,
             matched_signals=parse.breakdown.matched_signals,

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -21,7 +21,7 @@ tests can swap fakes without monkey-patching.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import Any
 
@@ -37,9 +37,10 @@ from jobhunter.domain.events import (
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.llm import LlmMessage
-from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository
+from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository, ScoringPolicyRepository
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
 from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.policy import ScoringPolicy
 from jobhunter.domain.scoring.services import ConstraintChecker, ScoreParseResult, ScoreParser
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
@@ -48,6 +49,7 @@ from jobhunter.domain.scoring.value_objects import (
     ScoreCorrection,
     ScoreTrace,
     ScoringCriteria,
+    fit_band_for_score,
 )
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 
@@ -249,6 +251,8 @@ class ScoreJobUseCase:
         publisher: EventPublisher | None = None,
         parser: ScoreParser | None = None,
         constraints: ConstraintChecker | None = None,
+        policy_repository: ScoringPolicyRepository | None = None,
+        policy: ScoringPolicy | None = None,
         prompt: str = SCORE_PROMPT,
     ) -> None:
         self._repository = repository
@@ -256,6 +260,8 @@ class ScoreJobUseCase:
         self._publisher = publisher
         self._parser = parser or ScoreParser()
         self._constraints = constraints or ConstraintChecker()
+        self._policy_repository = policy_repository
+        self._policy = policy
         self._prompt = prompt
 
     # ------------------------------------------------------------------
@@ -348,11 +354,12 @@ class ScoreJobUseCase:
                 error=parse.error or "Unknown parse error",
             )
 
+        resolved_parse = self._resolve_with_policy(parse=parse, tenant_id=tenant_id)
         scored_at = _utc_now()
         new_score = self._build_aggregate(
             tenant_id=tenant_id,
             job=job,
-            parse=parse,
+            parse=resolved_parse,
             scored_at=scored_at,
         )
         self._repository.save(new_score)
@@ -490,6 +497,37 @@ class ScoreJobUseCase:
             scored_at=scored_at,
             criteria=parse.criteria,
             trace=parse.trace,
+        )
+
+    def _resolve_with_policy(
+        self,
+        *,
+        parse: ScoreParseResult,
+        tenant_id: TenantId,
+    ) -> ScoreParseResult:
+        policy = (
+            self._policy_repository.get_current(tenant_id)
+            if self._policy_repository is not None
+            else self._policy or ScoringPolicy.default(tenant_id)
+        )
+        resolved = policy.resolve(parse.breakdown)
+        breakdown = ScoreBreakdown(
+            technical_fit=parse.breakdown.technical_fit,
+            experience_fit=parse.breakdown.experience_fit,
+            role_fit=parse.breakdown.role_fit,
+            reasoning=parse.breakdown.reasoning,
+            fit_band=fit_band_for_score(resolved.fit_score.value),
+            confidence=parse.breakdown.confidence,
+            eligibility=parse.breakdown.eligibility,
+            matched_signals=parse.breakdown.matched_signals,
+            missing_signals=parse.breakdown.missing_signals,
+            transferable_signals=parse.breakdown.transferable_signals,
+        )
+        return replace(
+            parse,
+            fit_score=resolved.fit_score,
+            breakdown=breakdown,
+            trace=parse.trace.with_policy_resolution(resolved),
         )
 
     def _publish_scored(self, score: JobScore) -> None:

--- a/workers/automation/src/jobhunter/domain/scoring/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/scoring/value_objects.py
@@ -29,7 +29,7 @@ import hashlib
 import json
 from collections.abc import Iterable as IterableABC
 from collections.abc import Mapping as MappingABC
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
 from jobhunter.domain.tenant import TenantId
@@ -80,6 +80,20 @@ def _int_or_default(value: Any, default: int) -> int:
         return int(value)
     except (TypeError, ValueError):
         return default
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    parsed = _float_or_none(value)
+    return default if parsed is None else parsed
 
 
 def fit_band_for_score(score: int) -> str:
@@ -427,11 +441,16 @@ class ScoreTrace:
     model: str = "llm-port-default"
     criteria_version: str = ""
     profile_snapshot_version: int = 0
+    scoring_policy_version: int = 0
+    rubric_version: str = ""
+    raw_weighted_score: float | None = None
+    calibration_adjustment: float = 0.0
+    anchor_ids: tuple[str, ...] = ()
     parser_warnings: tuple[str, ...] = ()
     correction_history: tuple[dict[str, Any], ...] = ()
 
     def __post_init__(self) -> None:
-        for name in ("prompt_version", "schema_version", "model", "criteria_version"):
+        for name in ("prompt_version", "schema_version", "model", "criteria_version", "rubric_version"):
             value = str(getattr(self, name) or "").strip()
             object.__setattr__(self, name, value)
         try:
@@ -439,6 +458,18 @@ class ScoreTrace:
         except (TypeError, ValueError):
             profile_version = 0
         object.__setattr__(self, "profile_snapshot_version", profile_version)
+        object.__setattr__(
+            self,
+            "scoring_policy_version",
+            _int_or_default(self.scoring_policy_version, 0),
+        )
+        object.__setattr__(self, "raw_weighted_score", _float_or_none(self.raw_weighted_score))
+        object.__setattr__(
+            self,
+            "calibration_adjustment",
+            _float_or_default(self.calibration_adjustment, 0.0),
+        )
+        object.__setattr__(self, "anchor_ids", _clean_strings(self.anchor_ids))
         object.__setattr__(self, "parser_warnings", _clean_strings(self.parser_warnings))
         history = []
         for raw in self.correction_history:
@@ -458,6 +489,22 @@ class ScoreTrace:
                 data.get("profile_snapshot_version", data.get("profileSnapshotVersion", 0)),
                 0,
             ),
+            scoring_policy_version=_int_or_default(
+                data.get(
+                    "scoring_policy_version",
+                    data.get("scoringPolicyVersion", data.get("policy_version", data.get("policyVersion", 0))),
+                ),
+                0,
+            ),
+            rubric_version=str(data.get("rubric_version", data.get("rubricVersion", ""))),
+            raw_weighted_score=_float_or_none(
+                data.get("raw_weighted_score", data.get("rawWeightedScore"))
+            ),
+            calibration_adjustment=_float_or_default(
+                data.get("calibration_adjustment", data.get("calibrationAdjustment", 0.0)),
+                0.0,
+            ),
+            anchor_ids=_clean_strings(data.get("anchor_ids", data.get("anchorIds", ()))),
             parser_warnings=_clean_strings(data.get("parser_warnings", data.get("parserWarnings", ()))),
             correction_history=tuple(
                 item for item in data.get("correction_history", data.get("correctionHistory", ())) or ()
@@ -466,14 +513,22 @@ class ScoreTrace:
         )
 
     def with_parser_warnings(self, warnings: Iterable[Any]) -> "ScoreTrace":
-        return ScoreTrace(
-            prompt_version=self.prompt_version,
-            schema_version=self.schema_version,
-            model=self.model,
-            criteria_version=self.criteria_version,
-            profile_snapshot_version=self.profile_snapshot_version,
+        return replace(
+            self,
             parser_warnings=(*self.parser_warnings, *_clean_strings(warnings)),
-            correction_history=self.correction_history,
+        )
+
+    def with_policy_resolution(self, resolved_score: Any) -> "ScoreTrace":
+        return replace(
+            self,
+            scoring_policy_version=int(getattr(resolved_score, "policy_version", 0) or 0),
+            rubric_version=str(getattr(resolved_score, "rubric_version", "") or ""),
+            raw_weighted_score=_float_or_none(getattr(resolved_score, "raw_weighted_score", None)),
+            calibration_adjustment=_float_or_default(
+                getattr(resolved_score, "calibration_adjustment", 0.0),
+                0.0,
+            ),
+            anchor_ids=_clean_strings(getattr(resolved_score, "anchor_ids", ())),
         )
 
     def with_correction(
@@ -482,13 +537,8 @@ class ScoreTrace:
         original_score: int,
         correction: ScoreCorrection,
     ) -> "ScoreTrace":
-        return ScoreTrace(
-            prompt_version=self.prompt_version,
-            schema_version=self.schema_version,
-            model=self.model,
-            criteria_version=self.criteria_version,
-            profile_snapshot_version=self.profile_snapshot_version,
-            parser_warnings=self.parser_warnings,
+        return replace(
+            self,
             correction_history=(
                 *self.correction_history,
                 {
@@ -508,6 +558,11 @@ class ScoreTrace:
             "model": self.model,
             "criteria_version": self.criteria_version,
             "profile_snapshot_version": self.profile_snapshot_version,
+            "scoring_policy_version": self.scoring_policy_version,
+            "rubric_version": self.rubric_version,
+            "raw_weighted_score": self.raw_weighted_score,
+            "calibration_adjustment": self.calibration_adjustment,
+            "anchor_ids": list(self.anchor_ids),
             "parser_warnings": list(self.parser_warnings),
             "correction_history": list(self.correction_history),
         }

--- a/workers/automation/src/jobhunter/domain/scoring/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/scoring/value_objects.py
@@ -75,6 +75,26 @@ def _clean_mapping(value: Mapping[str, Any] | dict[str, Any] | None) -> dict[str
     return json.loads(json.dumps(dict(value), sort_keys=True, default=str))
 
 
+def _clean_mapping_tuple(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, IterableABC) or isinstance(value, (str, bytes, MappingABC)):
+        return ()
+    return tuple(_clean_mapping(item) for item in value if isinstance(item, MappingABC))
+
+
+def _policy_object_tuple_to_dicts(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, IterableABC) or isinstance(value, (str, bytes, MappingABC)):
+        return ()
+    entries: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, MappingABC):
+            entries.append(_clean_mapping(item))
+        elif hasattr(item, "to_dict"):
+            mapped = item.to_dict()
+            if isinstance(mapped, MappingABC):
+                entries.append(_clean_mapping(mapped))
+    return tuple(entries)
+
+
 def _int_or_default(value: Any, default: int) -> int:
     try:
         return int(value)
@@ -441,16 +461,31 @@ class ScoreTrace:
     model: str = "llm-port-default"
     criteria_version: str = ""
     profile_snapshot_version: int = 0
+    scoring_policy_id: str = ""
     scoring_policy_version: int = 0
     rubric_version: str = ""
     raw_weighted_score: float | None = None
     calibration_adjustment: float = 0.0
     anchor_ids: tuple[str, ...] = ()
+    resolved_fit_band: str = ""
+    resolution_reason: str = ""
+    resolved_dimensions: tuple[dict[str, Any], ...] = ()
+    fit_band_thresholds: tuple[dict[str, Any], ...] = ()
+    policy_evidence: dict[str, Any] = field(default_factory=dict)
     parser_warnings: tuple[str, ...] = ()
     correction_history: tuple[dict[str, Any], ...] = ()
 
     def __post_init__(self) -> None:
-        for name in ("prompt_version", "schema_version", "model", "criteria_version", "rubric_version"):
+        for name in (
+            "prompt_version",
+            "schema_version",
+            "model",
+            "criteria_version",
+            "scoring_policy_id",
+            "rubric_version",
+            "resolved_fit_band",
+            "resolution_reason",
+        ):
             value = str(getattr(self, name) or "").strip()
             object.__setattr__(self, name, value)
         try:
@@ -470,6 +505,17 @@ class ScoreTrace:
             _float_or_default(self.calibration_adjustment, 0.0),
         )
         object.__setattr__(self, "anchor_ids", _clean_strings(self.anchor_ids))
+        object.__setattr__(
+            self,
+            "resolved_dimensions",
+            _clean_mapping_tuple(self.resolved_dimensions),
+        )
+        object.__setattr__(
+            self,
+            "fit_band_thresholds",
+            _clean_mapping_tuple(self.fit_band_thresholds),
+        )
+        object.__setattr__(self, "policy_evidence", _clean_mapping(self.policy_evidence))
         object.__setattr__(self, "parser_warnings", _clean_strings(self.parser_warnings))
         history = []
         for raw in self.correction_history:
@@ -489,6 +535,13 @@ class ScoreTrace:
                 data.get("profile_snapshot_version", data.get("profileSnapshotVersion", 0)),
                 0,
             ),
+            scoring_policy_id=str(
+                data.get(
+                    "scoring_policy_id",
+                    data.get("scoringPolicyId", data.get("policy_id", data.get("policyId", ""))),
+                )
+                or ""
+            ),
             scoring_policy_version=_int_or_default(
                 data.get(
                     "scoring_policy_version",
@@ -505,6 +558,21 @@ class ScoreTrace:
                 0.0,
             ),
             anchor_ids=_clean_strings(data.get("anchor_ids", data.get("anchorIds", ()))),
+            resolved_fit_band=str(
+                data.get("resolved_fit_band", data.get("resolvedFitBand", "")) or ""
+            ),
+            resolution_reason=str(
+                data.get("resolution_reason", data.get("resolutionReason", "")) or ""
+            ),
+            resolved_dimensions=_clean_mapping_tuple(
+                data.get("resolved_dimensions", data.get("resolvedDimensions", ()))
+            ),
+            fit_band_thresholds=_clean_mapping_tuple(
+                data.get("fit_band_thresholds", data.get("fitBandThresholds", ()))
+            ),
+            policy_evidence=_clean_mapping(
+                data.get("policy_evidence", data.get("policyEvidence", {}))
+            ),
             parser_warnings=_clean_strings(data.get("parser_warnings", data.get("parserWarnings", ()))),
             correction_history=tuple(
                 item for item in data.get("correction_history", data.get("correctionHistory", ())) or ()
@@ -521,6 +589,7 @@ class ScoreTrace:
     def with_policy_resolution(self, resolved_score: Any) -> "ScoreTrace":
         return replace(
             self,
+            scoring_policy_id=str(getattr(resolved_score, "policy_id", "") or ""),
             scoring_policy_version=int(getattr(resolved_score, "policy_version", 0) or 0),
             rubric_version=str(getattr(resolved_score, "rubric_version", "") or ""),
             raw_weighted_score=_float_or_none(getattr(resolved_score, "raw_weighted_score", None)),
@@ -529,6 +598,17 @@ class ScoreTrace:
                 0.0,
             ),
             anchor_ids=_clean_strings(getattr(resolved_score, "anchor_ids", ())),
+            resolved_fit_band=str(getattr(resolved_score, "fit_band", "") or ""),
+            resolution_reason=str(getattr(resolved_score, "resolution_reason", "") or ""),
+            resolved_dimensions=_policy_object_tuple_to_dicts(
+                getattr(resolved_score, "dimensions", ())
+            ),
+            fit_band_thresholds=_policy_object_tuple_to_dicts(
+                getattr(resolved_score, "fit_band_thresholds", ())
+            ),
+            policy_evidence=_clean_mapping(
+                getattr(resolved_score, "evidence_summary", {})
+            ),
         )
 
     def with_correction(
@@ -558,11 +638,17 @@ class ScoreTrace:
             "model": self.model,
             "criteria_version": self.criteria_version,
             "profile_snapshot_version": self.profile_snapshot_version,
+            "scoring_policy_id": self.scoring_policy_id,
             "scoring_policy_version": self.scoring_policy_version,
             "rubric_version": self.rubric_version,
             "raw_weighted_score": self.raw_weighted_score,
             "calibration_adjustment": self.calibration_adjustment,
             "anchor_ids": list(self.anchor_ids),
+            "resolved_fit_band": self.resolved_fit_band,
+            "resolution_reason": self.resolution_reason,
+            "resolved_dimensions": list(self.resolved_dimensions),
+            "fit_band_thresholds": list(self.fit_band_thresholds),
+            "policy_evidence": self.policy_evidence,
             "parser_warnings": list(self.parser_warnings),
             "correction_history": list(self.correction_history),
         }

--- a/workers/automation/src/jobhunter/infrastructure/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/__init__.py
@@ -7,13 +7,17 @@ from jobhunter.infrastructure.scoring.feedback import (
     collect_feedback_signals,
     rank_jobs_with_feedback,
 )
-from jobhunter.infrastructure.scoring.sqlite_repository import SqliteScoreRepository
+from jobhunter.infrastructure.scoring.sqlite_repository import (
+    SqliteScoreRepository,
+    SqliteScoringPolicyRepository,
+)
 
 __all__ = [
     "FeedbackRankedJob",
     "LocalScoringCriteriaProvider",
     "ScoringFeedbackSignal",
     "SqliteScoreRepository",
+    "SqliteScoringPolicyRepository",
     "collect_feedback_signals",
     "rank_jobs_with_feedback",
 ]

--- a/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
@@ -18,10 +18,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from datetime import datetime, timezone
 from typing import Any
 
+from jobhunter.database import ensure_scoring_policy_tables
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.policy import ScoringPolicy
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
     MatchedKeywords,
@@ -62,6 +65,11 @@ class SqliteScoreRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """SQLite connection backing this repository."""
+        return self._conn
 
     # ------------------------------------------------------------------
     # Read
@@ -230,3 +238,80 @@ class SqliteScoreRepository:
             trace=ScoreTrace.from_dict(trace_data),
             correction=ScoreCorrection.from_dict(correction_data) if correction_data else None,
         )
+
+
+class SqliteScoringPolicyRepository:
+    """SQLite-backed current policy adapter for the Scoring context."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_scoring_policy_tables(conn)
+
+    def get_current(self, tenant_id: TenantId) -> ScoringPolicy:
+        row = self._conn.execute(
+            """
+            SELECT tenant_id, version, rubric_json, anchors_json, created_at,
+                   created_from_event_id
+            FROM scoring_policies
+            WHERE tenant_id = ?
+            ORDER BY version DESC
+            LIMIT 1
+            """,
+            (str(tenant_id),),
+        ).fetchone()
+        if row is not None:
+            return self._row_to_policy(row)
+
+        policy = ScoringPolicy.default(tenant_id, created_at=_utc_now())
+        self.save(policy)
+        return policy
+
+    def save(self, policy: ScoringPolicy) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO scoring_policies (
+                tenant_id, version, rubric_json, anchors_json, created_at,
+                created_from_event_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(policy.tenant_id),
+                policy.version,
+                json.dumps(policy.to_rubric_dict(), sort_keys=True),
+                json.dumps(policy.to_anchors_list(), sort_keys=True),
+                policy.created_at or _utc_now(),
+                policy.created_from_event_id,
+            ),
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def _row_to_policy(row: Any) -> ScoringPolicy:
+        if isinstance(row, sqlite3.Row):
+            tenant_id = row["tenant_id"]
+            version = row["version"]
+            rubric_json = row["rubric_json"]
+            anchors_json = row["anchors_json"]
+            created_at = row["created_at"]
+            created_from_event_id = row["created_from_event_id"]
+        else:
+            (
+                tenant_id,
+                version,
+                rubric_json,
+                anchors_json,
+                created_at,
+                created_from_event_id,
+            ) = row
+        return ScoringPolicy.from_persistence(
+            tenant_id=TenantId(str(tenant_id)),
+            version=int(version),
+            rubric=json.loads(rubric_json) if rubric_json else {},
+            anchors=json.loads(anchors_json) if anchors_json else [],
+            created_at=str(created_at),
+            created_from_event_id=created_from_event_id,
+        )
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -27,7 +27,7 @@ from typing import Any
 from jobhunter.config import RESUME_PATH
 from jobhunter.database import get_connection, get_jobs_by_stage
 from jobhunter.domain.ports.events import EventPublisher
-from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository
+from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository, ScoringPolicyRepository
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
 from jobhunter.domain.scoring.retrieval import (
     HybridSearchIndex,
@@ -41,7 +41,11 @@ from jobhunter.domain.scoring.value_objects import ScoringCriteria
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 from jobhunter.infrastructure.llm import get_llm_adapter
 from jobhunter.infrastructure.profile.factory import get_profile_repository
-from jobhunter.infrastructure.scoring import LocalScoringCriteriaProvider, SqliteScoreRepository
+from jobhunter.infrastructure.scoring import (
+    LocalScoringCriteriaProvider,
+    SqliteScoreRepository,
+    SqliteScoringPolicyRepository,
+)
 from jobhunter.state import (
     ensure_job_stage_rows,
     record_job_event,
@@ -60,6 +64,7 @@ log = logging.getLogger(__name__)
 def _build_use_case(
     *,
     repository: ScoreRepository | None = None,
+    policy_repository: ScoringPolicyRepository | None = None,
     llm_port: LlmPort | None = None,
     publisher: EventPublisher | None = None,
 ) -> ScoreJobUseCase:
@@ -70,10 +75,20 @@ def _build_use_case(
     until first use.
     """
     if repository is None:
-        repository = SqliteScoreRepository(get_connection())
+        conn = get_connection()
+        repository = SqliteScoreRepository(conn)
+        if policy_repository is None:
+            policy_repository = SqliteScoringPolicyRepository(conn)
+    elif policy_repository is None and isinstance(repository, SqliteScoreRepository):
+        policy_repository = SqliteScoringPolicyRepository(repository.connection)
     if llm_port is None:
         llm_port = get_llm_adapter()
-    return ScoreJobUseCase(repository=repository, llm=llm_port, publisher=publisher)
+    return ScoreJobUseCase(
+        repository=repository,
+        llm=llm_port,
+        publisher=publisher,
+        policy_repository=policy_repository,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -87,6 +102,7 @@ def score_job(
     *,
     use_case: ScoreJobUseCase | None = None,
     repository: ScoreRepository | None = None,
+    policy_repository: ScoringPolicyRepository | None = None,
     llm_port: LlmPort | None = None,
     publisher: EventPublisher | None = None,
     tenant_id: TenantId = LOCAL_TENANT,
@@ -103,6 +119,7 @@ def score_job(
     if use_case is None:
         use_case = _build_use_case(
             repository=repository,
+            policy_repository=policy_repository,
             llm_port=llm_port,
             publisher=publisher,
         )
@@ -121,6 +138,7 @@ def run_scoring(
     workers: int = 1,
     *,
     repository: ScoreRepository | None = None,
+    policy_repository: ScoringPolicyRepository | None = None,
     llm_port: LlmPort | None = None,
     publisher: EventPublisher | None = None,
     tenant_id: TenantId = LOCAL_TENANT,
@@ -150,9 +168,12 @@ def run_scoring(
     conn = get_connection()
     if repository is None:
         repository = SqliteScoreRepository(conn)
+    if policy_repository is None:
+        policy_repository = SqliteScoringPolicyRepository(conn)
 
     use_case = _build_use_case(
         repository=repository,
+        policy_repository=policy_repository,
         llm_port=llm_port,
         publisher=publisher,
     )

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -104,6 +104,11 @@ def test_save_and_load_round_trips_criteria_and_trace(conn: sqlite3.Connection) 
             model="fake-model",
             criteria_version="criteria-1",
             profile_snapshot_version=3,
+            scoring_policy_version=2,
+            rubric_version="default-scoring-rubric-v1",
+            raw_weighted_score=8.65,
+            calibration_adjustment=0.0,
+            anchor_ids=("anchor-a",),
             parser_warnings=("missing_confidence",),
         ),
     )
@@ -116,7 +121,44 @@ def test_save_and_load_round_trips_criteria_and_trace(conn: sqlite3.Connection) 
     assert loaded.criteria.profile_preferences["target_work_models"] == "remote"
     assert loaded.trace.model == "fake-model"
     assert loaded.trace.profile_snapshot_version == 3
+    assert loaded.trace.scoring_policy_version == 2
+    assert loaded.trace.rubric_version == "default-scoring-rubric-v1"
+    assert loaded.trace.raw_weighted_score == 8.65
+    assert loaded.trace.calibration_adjustment == 0.0
+    assert loaded.trace.anchor_ids == ("anchor-a",)
     assert loaded.trace.parser_warnings == ("missing_confidence",)
+
+
+def test_load_legacy_trace_without_policy_metadata(conn: sqlite3.Connection) -> None:
+    url = _seed_job(conn)
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json, criteria_json, trace_json
+        ) VALUES (?, 1, ?, 7, ?, ?, ?, NULL, ?, ?)
+        """,
+        (
+            url,
+            str(LOCAL_TENANT),
+            '{"technical_fit": 7, "experience_fit": 7, "role_fit": 7, "reasoning": "legacy"}',
+            '["python"]',
+            datetime.now(timezone.utc).isoformat(),
+            "{}",
+            '{"prompt_version": "legacy", "schema_version": "legacy", "model": "legacy"}',
+        ),
+    )
+    conn.commit()
+
+    loaded = SqliteScoreRepository(conn).load(LOCAL_TENANT, JobId(url))
+
+    assert loaded is not None
+    assert loaded.trace.prompt_version == "legacy"
+    assert loaded.trace.scoring_policy_version == 0
+    assert loaded.trace.rubric_version == ""
+    assert loaded.trace.raw_weighted_score is None
+    assert loaded.trace.calibration_adjustment == 0.0
+    assert loaded.trace.anchor_ids == ()
 
 
 def test_load_returns_none_when_no_score(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -104,11 +104,22 @@ def test_save_and_load_round_trips_criteria_and_trace(conn: sqlite3.Connection) 
             model="fake-model",
             criteria_version="criteria-1",
             profile_snapshot_version=3,
+            scoring_policy_id="local:scoring-policy-v2",
             scoring_policy_version=2,
             rubric_version="default-scoring-rubric-v1",
             raw_weighted_score=8.65,
             calibration_adjustment=0.0,
             anchor_ids=("anchor-a",),
+            resolved_fit_band="excellent",
+            resolution_reason="weighted_dimensions",
+            resolved_dimensions=(
+                {"name": "technical_fit", "value": 9, "weight": 0.45},
+            ),
+            fit_band_thresholds=(
+                {"band": "excellent", "minimum_score": 9},
+                {"band": "strong", "minimum_score": 7},
+            ),
+            policy_evidence={"confidence": "high", "eligibility_status": "eligible"},
             parser_warnings=("missing_confidence",),
         ),
     )
@@ -121,11 +132,25 @@ def test_save_and_load_round_trips_criteria_and_trace(conn: sqlite3.Connection) 
     assert loaded.criteria.profile_preferences["target_work_models"] == "remote"
     assert loaded.trace.model == "fake-model"
     assert loaded.trace.profile_snapshot_version == 3
+    assert loaded.trace.scoring_policy_id == "local:scoring-policy-v2"
     assert loaded.trace.scoring_policy_version == 2
     assert loaded.trace.rubric_version == "default-scoring-rubric-v1"
     assert loaded.trace.raw_weighted_score == 8.65
     assert loaded.trace.calibration_adjustment == 0.0
     assert loaded.trace.anchor_ids == ("anchor-a",)
+    assert loaded.trace.resolved_fit_band == "excellent"
+    assert loaded.trace.resolution_reason == "weighted_dimensions"
+    assert loaded.trace.resolved_dimensions == (
+        {"name": "technical_fit", "value": 9, "weight": 0.45},
+    )
+    assert loaded.trace.fit_band_thresholds == (
+        {"band": "excellent", "minimum_score": 9},
+        {"band": "strong", "minimum_score": 7},
+    )
+    assert loaded.trace.policy_evidence == {
+        "confidence": "high",
+        "eligibility_status": "eligible",
+    }
     assert loaded.trace.parser_warnings == ("missing_confidence",)
 
 
@@ -154,11 +179,17 @@ def test_load_legacy_trace_without_policy_metadata(conn: sqlite3.Connection) -> 
 
     assert loaded is not None
     assert loaded.trace.prompt_version == "legacy"
+    assert loaded.trace.scoring_policy_id == ""
     assert loaded.trace.scoring_policy_version == 0
     assert loaded.trace.rubric_version == ""
     assert loaded.trace.raw_weighted_score is None
     assert loaded.trace.calibration_adjustment == 0.0
     assert loaded.trace.anchor_ids == ()
+    assert loaded.trace.resolved_fit_band == ""
+    assert loaded.trace.resolution_reason == ""
+    assert loaded.trace.resolved_dimensions == ()
+    assert loaded.trace.fit_band_thresholds == ()
+    assert loaded.trace.policy_evidence == {}
 
 
 def test_load_returns_none_when_no_score(conn: sqlite3.Connection) -> None:

--- a/workers/automation/tests/test_score_use_cases.py
+++ b/workers/automation/tests/test_score_use_cases.py
@@ -430,9 +430,33 @@ def test_score_job_resolves_final_score_from_policy_not_llm_overall(profile_snap
     assert outcome.score is not None
     assert outcome.score.fit_score.value == 2
     assert outcome.score.breakdown.fit_band == "poor"
+    assert outcome.score.trace.scoring_policy_id == "local:scoring-policy-v1"
     assert outcome.score.trace.scoring_policy_version == 1
     assert outcome.score.trace.rubric_version == "default-scoring-rubric-v1"
     assert outcome.score.trace.raw_weighted_score == 2.0
+    assert outcome.score.trace.resolved_fit_band == "poor"
+    assert outcome.score.trace.resolution_reason == "weighted_dimensions+missing_signals_traced"
+    assert outcome.score.trace.resolved_dimensions == (
+        {"name": "technical_fit", "value": 2, "weight": 0.45, "weighted_value": 0.9},
+        {"name": "experience_fit", "value": 2, "weight": 0.3, "weighted_value": 0.6},
+        {"name": "role_fit", "value": 2, "weight": 0.25, "weighted_value": 0.5},
+    )
+    assert outcome.score.trace.fit_band_thresholds == (
+        {"band": "excellent", "minimum_score": 9},
+        {"band": "strong", "minimum_score": 7},
+        {"band": "plausible", "minimum_score": 5},
+        {"band": "stretch", "minimum_score": 3},
+        {"band": "poor", "minimum_score": 1},
+    )
+    assert outcome.score.trace.policy_evidence == {
+        "confidence": "high",
+        "eligibility_status": "eligible",
+        "hard_blocker_count": 0,
+        "warning_count": 0,
+        "matched_signal_count": 1,
+        "missing_signal_count": 2,
+        "transferable_signal_count": 0,
+    }
 
 
 def test_score_job_returns_error_on_unparseable_response(profile_snapshot) -> None:

--- a/workers/automation/tests/test_score_use_cases.py
+++ b/workers/automation/tests/test_score_use_cases.py
@@ -402,6 +402,39 @@ def test_score_job_keeps_hard_blockers_separate_from_high_score(profile_snapshot
     )
 
 
+def test_score_job_resolves_final_score_from_policy_not_llm_overall(profile_snapshot) -> None:
+    repo = _MemoryRepo()
+    llm = _ScriptedLlm(
+        {
+            "score": 10,
+            "technical_fit": 2,
+            "experience_fit": 2,
+            "role_fit": 2,
+            "fit_band": "excellent",
+            "confidence": "high",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python"],
+            "missing_signals": ["senior ownership", "platform depth"],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "The overall LLM score is inconsistent with its dimensions.",
+        }
+    )
+
+    outcome = ScoreJobUseCase(repository=repo, llm=llm).score(
+        job=_job("https://example.com/job/low-dimensions"),
+        profile_snapshot=profile_snapshot,
+    )
+
+    assert outcome.ok is True
+    assert outcome.score is not None
+    assert outcome.score.fit_score.value == 2
+    assert outcome.score.breakdown.fit_band == "poor"
+    assert outcome.score.trace.scoring_policy_version == 1
+    assert outcome.score.trace.rubric_version == "default-scoring-rubric-v1"
+    assert outcome.score.trace.raw_weighted_score == 2.0
+
+
 def test_score_job_returns_error_on_unparseable_response(profile_snapshot) -> None:
     repo = _MemoryRepo()
     # Payload missing the required ``score`` field — parser flags ok=False.

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -220,8 +220,12 @@ def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
     persisted = repo.load(LOCAL_TENANT, JobId(url))
     assert persisted is not None
     assert persisted.fit_score.value == 1
+    assert persisted.trace.scoring_policy_id == "local:scoring-policy-v2"
     assert persisted.trace.scoring_policy_version == 2
     assert persisted.trace.rubric_version == "technical-only-v2"
+    assert persisted.trace.resolved_dimensions == (
+        {"name": "technical_fit", "value": 1, "weight": 1.0, "weighted_value": 1.0},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -15,9 +15,12 @@ import pytest
 
 from jobhunter.database import init_db
 from jobhunter.domain.identifiers import JobId
-from jobhunter.domain.scoring import ScoringCriteria
+from jobhunter.domain.scoring import ScoringCriteria, ScoringPolicy, WeightedScoreDimension
 from jobhunter.domain.tenant import LOCAL_TENANT
-from jobhunter.infrastructure.scoring import SqliteScoreRepository
+from jobhunter.infrastructure.scoring import (
+    SqliteScoreRepository,
+    SqliteScoringPolicyRepository,
+)
 from jobhunter.scoring import scorer as scorer_module
 
 
@@ -176,6 +179,49 @@ def test_score_job_writes_only_to_job_scores(
     assert legacy_row["fit_score"] is None
     assert legacy_row["score_reasoning"] is None
     assert legacy_row["scored_at"] is None
+
+
+def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+) -> None:
+    url = "https://example.com/job/policy"
+    _seed_pending_job(conn, url)
+    repo = SqliteScoreRepository(conn)
+    SqliteScoringPolicyRepository(conn).save(
+        ScoringPolicy(
+            tenant_id=LOCAL_TENANT,
+            version=2,
+            rubric_version="technical-only-v2",
+            dimensions=(WeightedScoreDimension(name="technical_fit", weight=1.0),),
+            created_at="2024-01-01T00:00:00+00:00",
+        )
+    )
+    llm = _ScriptedLlm(
+        {
+            "score": 10,
+            "technical_fit": 1,
+            "experience_fit": 10,
+            "role_fit": 10,
+            "keywords": ["python"],
+            "reasoning": "Low technical fit despite high overall score.",
+        }
+    )
+
+    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
+    outcome = scorer_module.score_job(
+        profile_snapshot,
+        job_dict,
+        repository=repo,
+        llm_port=llm,
+    )
+
+    assert outcome.ok is True
+    persisted = repo.load(LOCAL_TENANT, JobId(url))
+    assert persisted is not None
+    assert persisted.fit_score.value == 1
+    assert persisted.trace.scoring_policy_version == 2
+    assert persisted.trace.rubric_version == "technical-only-v2"
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_scoring_policy.py
+++ b/workers/automation/tests/test_scoring_policy.py
@@ -1,0 +1,90 @@
+"""ScoringPolicy domain and SQLite persistence tests."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from jobhunter.database import init_db
+from jobhunter.domain.scoring import ScoreBreakdown, ScoringPolicy
+from jobhunter.domain.tenant import LOCAL_TENANT
+from jobhunter.infrastructure.scoring import SqliteScoringPolicyRepository
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    return init_db(tmp_path / "jobhunter.db")
+
+
+def test_default_policy_resolves_score_from_weighted_dimensions() -> None:
+    policy = ScoringPolicy.default(LOCAL_TENANT)
+    breakdown = ScoreBreakdown(
+        technical_fit=8,
+        experience_fit=6,
+        role_fit=4,
+        confidence="low",
+        reasoning="Dimension evidence is deterministic.",
+    )
+
+    resolved = policy.resolve(breakdown)
+
+    assert resolved.fit_score.value == 6
+    assert resolved.raw_weighted_score == pytest.approx(6.4)
+    assert resolved.calibration_adjustment == 0.0
+    assert resolved.anchor_ids == ()
+    assert resolved.dimension_values() == {
+        "technical_fit": 8,
+        "experience_fit": 6,
+        "role_fit": 4,
+    }
+
+
+def test_sqlite_policy_repository_seeds_default_policy(conn: sqlite3.Connection) -> None:
+    repo = SqliteScoringPolicyRepository(conn)
+
+    policy = repo.get_current(LOCAL_TENANT)
+
+    assert policy.version == 1
+    assert policy.rubric_version == "default-scoring-rubric-v1"
+    assert policy.created_at
+    row = conn.execute(
+        """
+        SELECT tenant_id, version, rubric_json, anchors_json, created_at,
+               created_from_event_id
+        FROM scoring_policies
+        WHERE tenant_id = ?
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchone()
+    assert row is not None
+    assert row["tenant_id"] == str(LOCAL_TENANT)
+    assert row["version"] == 1
+    assert json.loads(row["rubric_json"])["rubric_version"] == "default-scoring-rubric-v1"
+    assert json.loads(row["anchors_json"]) == []
+    assert row["created_at"]
+    assert row["created_from_event_id"] is None
+
+
+def test_sqlite_policy_repository_returns_highest_policy_version(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteScoringPolicyRepository(conn)
+    repo.save(ScoringPolicy.default(LOCAL_TENANT, created_at="2024-01-01T00:00:00+00:00"))
+    repo.save(
+        ScoringPolicy(
+            tenant_id=LOCAL_TENANT,
+            version=2,
+            rubric_version="rubric-v2",
+            created_at="2024-01-02T00:00:00+00:00",
+            created_from_event_id=42,
+        )
+    )
+
+    policy = repo.get_current(LOCAL_TENANT)
+
+    assert policy.version == 2
+    assert policy.rubric_version == "rubric-v2"
+    assert policy.created_from_event_id == 42

--- a/workers/automation/tests/test_scoring_policy.py
+++ b/workers/automation/tests/test_scoring_policy.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from jobhunter.database import init_db
-from jobhunter.domain.scoring import ScoreBreakdown, ScoringPolicy
+from jobhunter.domain.scoring import FitBandThreshold, ScoreBreakdown, ScoringPolicy
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.scoring import SqliteScoringPolicyRepository
 
@@ -32,6 +32,8 @@ def test_default_policy_resolves_score_from_weighted_dimensions() -> None:
     resolved = policy.resolve(breakdown)
 
     assert resolved.fit_score.value == 6
+    assert resolved.fit_band == "plausible"
+    assert resolved.policy_id == "local:scoring-policy-v1"
     assert resolved.raw_weighted_score == pytest.approx(6.4)
     assert resolved.calibration_adjustment == 0.0
     assert resolved.anchor_ids == ()
@@ -40,6 +42,39 @@ def test_default_policy_resolves_score_from_weighted_dimensions() -> None:
         "experience_fit": 6,
         "role_fit": 4,
     }
+    assert resolved.fit_band_thresholds[0].to_dict() == {
+        "band": "excellent",
+        "minimum_score": 9,
+    }
+    assert resolved.resolution_reason == "weighted_dimensions+low_confidence_traced"
+    assert resolved.evidence_summary == {
+        "confidence": "low",
+        "eligibility_status": "unknown",
+        "hard_blocker_count": 0,
+        "warning_count": 0,
+        "matched_signal_count": 0,
+        "missing_signal_count": 0,
+        "transferable_signal_count": 0,
+    }
+
+
+def test_policy_owned_fit_band_thresholds_are_deterministic() -> None:
+    policy = ScoringPolicy(
+        tenant_id=LOCAL_TENANT,
+        fit_band_thresholds=(
+            FitBandThreshold("poor", 1),
+            FitBandThreshold("excellent", 10),
+            FitBandThreshold("strong", 8),
+            FitBandThreshold("plausible", 6),
+            FitBandThreshold("stretch", 3),
+        ),
+    )
+
+    assert policy.fit_band_for_score(10) == "excellent"
+    assert policy.fit_band_for_score(8) == "strong"
+    assert policy.fit_band_for_score(6) == "plausible"
+    assert policy.fit_band_for_score(3) == "stretch"
+    assert policy.fit_band_for_score(1) == "poor"
 
 
 def test_sqlite_policy_repository_seeds_default_policy(conn: sqlite3.Connection) -> None:
@@ -63,6 +98,13 @@ def test_sqlite_policy_repository_seeds_default_policy(conn: sqlite3.Connection)
     assert row["tenant_id"] == str(LOCAL_TENANT)
     assert row["version"] == 1
     assert json.loads(row["rubric_json"])["rubric_version"] == "default-scoring-rubric-v1"
+    assert json.loads(row["rubric_json"])["fit_band_thresholds"] == [
+        {"band": "excellent", "minimum_score": 9},
+        {"band": "strong", "minimum_score": 7},
+        {"band": "plausible", "minimum_score": 5},
+        {"band": "stretch", "minimum_score": 3},
+        {"band": "poor", "minimum_score": 1},
+    ]
     assert json.loads(row["anchors_json"]) == []
     assert row["created_at"]
     assert row["created_from_event_id"] is None
@@ -88,3 +130,4 @@ def test_sqlite_policy_repository_returns_highest_policy_version(
     assert policy.version == 2
     assert policy.rubric_version == "rubric-v2"
     assert policy.created_from_event_id == 42
+    assert policy.fit_band_thresholds[-1].band == "poor"

--- a/workers/automation/tests/test_scoring_policy.py
+++ b/workers/automation/tests/test_scoring_policy.py
@@ -77,6 +77,20 @@ def test_policy_owned_fit_band_thresholds_are_deterministic() -> None:
     assert policy.fit_band_for_score(1) == "poor"
 
 
+def test_policy_rejects_inverted_fit_band_threshold_order() -> None:
+    with pytest.raises(ValueError, match="fit band thresholds must follow"):
+        ScoringPolicy(
+            tenant_id=LOCAL_TENANT,
+            fit_band_thresholds=(
+                FitBandThreshold("excellent", 7),
+                FitBandThreshold("strong", 9),
+                FitBandThreshold("plausible", 5),
+                FitBandThreshold("stretch", 3),
+                FitBandThreshold("poor", 1),
+            ),
+        )
+
+
 def test_sqlite_policy_repository_seeds_default_policy(conn: sqlite3.Connection) -> None:
     repo = SqliteScoringPolicyRepository(conn)
 


### PR DESCRIPTION
## Summary
- Add a pure `ScoringPolicy` domain model that resolves final `FitScore` deterministically from validated score dimensions instead of trusting the LLM overall score.
- Add policy-owned weighted dimensions, fit-band thresholds, optional calibration anchors, policy identity, and resolution metadata.
- Persist current scoring policies in SQLite with default-policy seeding behind a `ScoringPolicyRepository` port.
- Route `ScoreJobUseCase` through policy resolution before constructing and saving `JobScore`, while preserving LLM output as structured evidence.
- Extend `ScoreTrace` in a backward-compatible way with policy id/version, rubric version, raw weighted score, resolved dimensions, fit-band thresholds, compact evidence metadata, calibration adjustment, and anchor ids.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_score_repository.py workers/automation/tests/test_scoring_policy.py` -> 31 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/scoring workers/automation/src/jobhunter/infrastructure/scoring workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_score_repository.py workers/automation/tests/test_scoring_policy.py` -> All checks passed
- `git diff --check` -> passed
- Extra: `git diff --check docs/scoring-policy-rfc...HEAD` -> passed
- Extra: `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scorer.py` -> 6 passed
- Extra: `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/scoring/scorer.py workers/automation/tests/test_scorer.py` -> All checks passed

## Notes
No docs update: PR #76 owns the RFC text, and this slice adds the backend policy core without changing user-facing UI, CLI commands, runtime requirements, or public workflow instructions.