### PR TITLE
feat: learn scoring policy from corrections

### DIFF
--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import crypto from "node:crypto";
 
 import type {
   BulkJobMutationRequest,
@@ -33,6 +34,20 @@ const DEFAULT_MAX_ATTEMPTS: Record<Stage, number> = {
   pdf: 3,
   apply: 3,
 };
+
+const DEFAULT_SCORING_RUBRIC_VERSION = "default-scoring-rubric-v1";
+const DEFAULT_SCORING_DIMENSIONS = [
+  { name: "technical_fit", weight: 0.45 },
+  { name: "experience_fit", weight: 0.3 },
+  { name: "role_fit", weight: 0.25 },
+] as const;
+const DEFAULT_FIT_BAND_THRESHOLDS = [
+  { band: "excellent", minimum_score: 9 },
+  { band: "strong", minimum_score: 7 },
+  { band: "plausible", minimum_score: 5 },
+  { band: "stretch", minimum_score: 3 },
+  { band: "poor", minimum_score: 1 },
+] as const;
 
 /**
  * Validate a stage-state transition using the §8.5 state machine
@@ -284,6 +299,12 @@ export function correctScore(
     String(latest.criteria_json ?? "{}"),
     JSON.stringify(trace),
   );
+  persistScoringPolicyCorrection(db, {
+    jobUrl,
+    latest,
+    correctedScore: request.correctedScore,
+    correctedAt: now,
+  });
   recordActionEvent(db, {
     jobUrl,
     stage: "score",
@@ -657,6 +678,110 @@ function ensureJobScoresTable(db: SqliteDatabase): void {
   }
 }
 
+function ensureScoringPoliciesTable(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS scoring_policies (
+      tenant_id TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      rubric_json TEXT NOT NULL,
+      anchors_json TEXT NOT NULL DEFAULT '[]',
+      created_at TEXT NOT NULL,
+      created_from_event_id INTEGER,
+      PRIMARY KEY (tenant_id, version)
+    )
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_scoring_policies_current
+    ON scoring_policies(tenant_id, version DESC)
+  `);
+}
+
+function persistScoringPolicyCorrection(
+  db: SqliteDatabase,
+  input: {
+    jobUrl: string;
+    latest: Record<string, unknown>;
+    correctedScore: number;
+    correctedAt: string;
+  },
+): void {
+  ensureScoringPoliciesTable(db);
+  const current = getCurrentScoringPolicyRow(db, input.correctedAt);
+  const previousTrace = parseObjectOrDefault(String(input.latest.trace_json ?? "{}"));
+  const previousBreakdown = parseObjectOrDefault(String(input.latest.breakdown_json ?? "{}"));
+  const originalScore = Number(input.latest.fit_score ?? 0);
+  const correctionDelta = input.correctedScore - originalScore;
+  const anchor = sanitizePolicyAnchor({
+    anchor_id: correctionAnchorId({
+      tenant_id: "local",
+      job_id: input.jobUrl,
+      original_score: originalScore,
+      corrected_score: input.correctedScore,
+      corrected_at: input.correctedAt,
+      source_policy_version: Number(previousTrace.scoring_policy_version ?? 0),
+    }),
+    job_ref_hash: policyAnchorJobRefHash(input.jobUrl),
+    fit_score: input.correctedScore,
+    original_fit_score: originalScore,
+    corrected_fit_score: input.correctedScore,
+    correction_delta: correctionDelta,
+    correction_direction: correctionDirection(correctionDelta),
+    dimensions: extractDimensionNames(previousTrace, previousBreakdown),
+    dimension_scores: extractDimensionScores(previousTrace, previousBreakdown),
+    evidence_summary: extractPolicyEvidence(previousTrace, previousBreakdown),
+    source_policy_id: String(previousTrace.scoring_policy_id ?? ""),
+    source_policy_version: Number(previousTrace.scoring_policy_version ?? 0),
+    created_at: input.correctedAt,
+  });
+  const anchors = upsertAnchor(parseAnchorList(current.anchors_json), anchor);
+  db.prepare(
+    `INSERT INTO scoring_policies (
+       tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id
+     ) VALUES ('local', ?, ?, ?, ?, NULL)`,
+  ).run(
+    Number(current.version) + 1,
+    current.rubric_json,
+    JSON.stringify(anchors),
+    input.correctedAt,
+  );
+}
+
+function getCurrentScoringPolicyRow(
+  db: SqliteDatabase,
+  createdAt: string,
+): {
+  version: number;
+  rubric_json: string;
+  anchors_json: string;
+} {
+  const latest = getRow<{
+    version: number;
+    rubric_json: string;
+    anchors_json: string;
+  }>(
+    db,
+    `SELECT version, rubric_json, anchors_json
+     FROM scoring_policies
+     WHERE tenant_id = 'local'
+     ORDER BY version DESC
+     LIMIT 1`,
+  );
+  if (latest) {
+    return {
+      version: Number(latest.version),
+      rubric_json: normalizeRubricJson(latest.rubric_json),
+      anchors_json: latest.anchors_json || "[]",
+    };
+  }
+  const rubricJson = JSON.stringify(defaultScoringRubric());
+  db.prepare(
+    `INSERT INTO scoring_policies (
+       tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id
+     ) VALUES ('local', 1, ?, '[]', ?, NULL)`,
+  ).run(rubricJson, createdAt);
+  return { version: 1, rubric_json: rubricJson, anchors_json: "[]" };
+}
+
 function appendCorrectionHistory(
   rawTrace: unknown,
   correction: Record<string, unknown>,
@@ -686,6 +811,229 @@ function parseObjectOrDefault(text: string): Record<string, unknown> {
   } catch {
     return {};
   }
+}
+
+function defaultScoringRubric(): Record<string, unknown> {
+  return {
+    rubric_version: DEFAULT_SCORING_RUBRIC_VERSION,
+    dimensions: [...DEFAULT_SCORING_DIMENSIONS],
+    fit_band_thresholds: [...DEFAULT_FIT_BAND_THRESHOLDS],
+    rounding: "nearest_integer_half_up",
+    fit_score_range: [1, 10],
+    confidence_handling: "trace_only",
+    eligibility_handling: "trace_only",
+  };
+}
+
+function normalizeRubricJson(raw: unknown): string {
+  const text = String(raw ?? "");
+  if (!text) {
+    return JSON.stringify(defaultScoringRubric());
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return isRecord(parsed) ? JSON.stringify(parsed) : JSON.stringify(defaultScoringRubric());
+  } catch {
+    return JSON.stringify(defaultScoringRubric());
+  }
+}
+
+function parseAnchorList(raw: unknown): Record<string, unknown>[] {
+  try {
+    const parsed: unknown = JSON.parse(String(raw ?? "[]"));
+    return Array.isArray(parsed) ? parsed.filter(isRecord).map(sanitizePolicyAnchor) : [];
+  } catch {
+    return [];
+  }
+}
+
+function upsertAnchor(
+  anchors: Record<string, unknown>[],
+  anchor: Record<string, unknown>,
+): Record<string, unknown>[] {
+  const anchorId = String(anchor.anchor_id ?? "");
+  let replaced = false;
+  const next = anchors.map((existing) => {
+    if (String(existing.anchor_id ?? "") !== anchorId) {
+      return existing;
+    }
+    replaced = true;
+    return anchor;
+  });
+  return replaced ? next : [...next, anchor];
+}
+
+function correctionAnchorId(payload: Record<string, unknown>): string {
+  const digest = stablePolicyHash(payload).slice(0, 12);
+  return `correction-anchor-${digest}`;
+}
+
+function policyAnchorJobRefHash(jobUrl: string): string {
+  return `sha256:${stablePolicyHash({ tenant_id: "local", job_id: jobUrl })}`;
+}
+
+function stablePolicyHash(payload: Record<string, unknown>): string {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(payload, Object.keys(payload).sort()))
+    .digest("hex");
+}
+
+function correctionDirection(delta: number): "increased" | "decreased" | "unchanged" {
+  if (delta > 0) {
+    return "increased";
+  }
+  if (delta < 0) {
+    return "decreased";
+  }
+  return "unchanged";
+}
+
+function sanitizePolicyAnchor(anchor: Record<string, unknown>): Record<string, unknown> {
+  const originalScore = numberOrNull(anchor.original_fit_score ?? anchor.originalFitScore ?? anchor.original_score);
+  const correctedScore = numberOrNull(
+    anchor.corrected_fit_score ?? anchor.correctedFitScore ?? anchor.corrected_score ?? anchor.fit_score ?? anchor.fitScore,
+  );
+  const delta = numberOrNull(anchor.correction_delta ?? anchor.correctionDelta) ?? (
+    originalScore === null || correctedScore === null ? 0 : correctedScore - originalScore
+  );
+  const jobRefHash = String(anchor.job_ref_hash ?? anchor.jobRefHash ?? "").trim()
+    || legacyPolicyAnchorJobRefHash(String(anchor.job_id ?? anchor.jobId ?? "").trim());
+  return {
+    anchor_id: String(anchor.anchor_id ?? anchor.anchorId ?? ""),
+    ...(jobRefHash ? { job_ref_hash: jobRefHash } : {}),
+    fit_score: numberOrNull(anchor.fit_score ?? anchor.fitScore),
+    original_fit_score: originalScore,
+    corrected_fit_score: correctedScore,
+    correction_delta: delta,
+    correction_direction: correctionDirection(delta),
+    dimensions: anchorDimensions(anchor),
+    dimension_scores: sanitizeAnchorDimensionScores(anchor.dimension_scores ?? anchor.dimensionScores),
+    evidence_summary: sanitizeAnchorEvidence(anchor.evidence_summary ?? anchor.evidenceSummary),
+    source_policy_id: String(anchor.source_policy_id ?? anchor.sourcePolicyId ?? ""),
+    source_policy_version: numberOrNull(anchor.source_policy_version ?? anchor.sourcePolicyVersion) ?? 0,
+    created_at: String(anchor.created_at ?? anchor.createdAt ?? ""),
+  };
+}
+
+function legacyPolicyAnchorJobRefHash(jobUrl: string): string {
+  return jobUrl ? `sha256:${stablePolicyHash({ tenant_id: "", job_id: jobUrl })}` : "";
+}
+
+function extractDimensionScores(
+  trace: Record<string, unknown>,
+  breakdown: Record<string, unknown>,
+): Record<string, unknown>[] {
+  if (Array.isArray(trace.resolved_dimensions)) {
+    const dimensions = trace.resolved_dimensions.filter(isRecord).map(cleanJsonRecord);
+    if (dimensions.length) {
+      return dimensions;
+    }
+  }
+  return ["technical_fit", "experience_fit", "role_fit"].map((name) => ({
+    name,
+    value: Number(breakdown[name] ?? 0),
+  }));
+}
+
+function extractDimensionNames(
+  trace: Record<string, unknown>,
+  breakdown: Record<string, unknown>,
+): string[] {
+  return extractDimensionScores(trace, breakdown)
+    .map((dimension) => String(dimension.name ?? "").trim())
+    .filter((name) => name.length > 0);
+}
+
+function extractPolicyEvidence(
+  trace: Record<string, unknown>,
+  breakdown: Record<string, unknown>,
+): Record<string, unknown> {
+  if (isRecord(trace.policy_evidence)) {
+    return sanitizeAnchorEvidence(trace.policy_evidence);
+  }
+  const eligibility = isRecord(breakdown.eligibility) ? breakdown.eligibility : {};
+  return sanitizeAnchorEvidence({
+    confidence: String(breakdown.confidence ?? "medium"),
+    eligibility_status: String(eligibility.status ?? "unknown"),
+    hard_blocker_count: Array.isArray(eligibility.hard_blockers) ? eligibility.hard_blockers.length : 0,
+    warning_count: Array.isArray(eligibility.warnings) ? eligibility.warnings.length : 0,
+    matched_signal_count: Array.isArray(breakdown.matched_signals) ? breakdown.matched_signals.length : 0,
+    missing_signal_count: Array.isArray(breakdown.missing_signals) ? breakdown.missing_signals.length : 0,
+    transferable_signal_count: Array.isArray(breakdown.transferable_signals)
+      ? breakdown.transferable_signals.length
+      : 0,
+  });
+}
+
+function anchorDimensions(anchor: Record<string, unknown>): string[] {
+  if (Array.isArray(anchor.dimensions)) {
+    return anchor.dimensions.map((value) => String(value).trim()).filter((value) => value.length > 0);
+  }
+  return sanitizeAnchorDimensionScores(anchor.dimension_scores ?? anchor.dimensionScores)
+    .map((dimension) => String(dimension.name ?? "").trim())
+    .filter((name) => name.length > 0);
+}
+
+function sanitizeAnchorDimensionScores(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(isRecord).map((dimension) => {
+    const cleaned: Record<string, unknown> = {};
+    const name = String(dimension.name ?? "").trim();
+    if (name) {
+      cleaned.name = name;
+    }
+    for (const key of ["value", "weight", "weighted_value"] as const) {
+      const number = numberOrNull(dimension[key]);
+      if (number !== null) {
+        cleaned[key] = number;
+      }
+    }
+    return cleaned;
+  }).filter((dimension) => Object.keys(dimension).length > 0);
+}
+
+function sanitizeAnchorEvidence(value: unknown): Record<string, unknown> {
+  const raw = isRecord(value) ? value : {};
+  const cleaned: Record<string, unknown> = {};
+  const confidence = String(raw.confidence ?? "").trim().toLowerCase();
+  if (["low", "medium", "high"].includes(confidence)) {
+    cleaned.confidence = confidence;
+  }
+  const eligibilityStatus = String(raw.eligibility_status ?? raw.eligibilityStatus ?? "").trim().toLowerCase();
+  if (["eligible", "warning", "blocked", "unknown"].includes(eligibilityStatus)) {
+    cleaned.eligibility_status = eligibilityStatus;
+  }
+  for (const key of [
+    "hard_blocker_count",
+    "warning_count",
+    "matched_signal_count",
+    "missing_signal_count",
+    "transferable_signal_count",
+  ] as const) {
+    const number = numberOrNull(raw[key]);
+    if (number !== null) {
+      cleaned[key] = Math.max(Math.trunc(number), 0);
+    }
+  }
+  return cleaned;
+}
+
+function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined || typeof value === "boolean" || value === "") {
+    return null;
+  }
+  const number = Number(value);
+  if (!Number.isFinite(number)) {
+    return null;
+  }
+  return number;
+}
+
+function cleanJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
 
 /**

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -676,6 +676,56 @@ describe("local TypeScript API", () => {
   });
 
   it("corrects a score through the API and records correction evidence", async () => {
+    const legacyJobUrl = "https://example.com/jobs/private-legacy";
+    const legacyReason = "Legacy correction mentioned a private resume detail.";
+    const seedDb = new Database(options.dbPath);
+    seedDb.exec(`
+      CREATE TABLE IF NOT EXISTS scoring_policies (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        version INTEGER NOT NULL,
+        rubric_json TEXT NOT NULL,
+        anchors_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        created_from_event_id INTEGER,
+        PRIMARY KEY (tenant_id, version)
+      )
+    `);
+    seedDb
+      .prepare(
+        `INSERT INTO scoring_policies (
+           tenant_id, version, rubric_json, anchors_json, created_at, created_from_event_id
+         ) VALUES ('local', 1, ?, ?, ?, NULL)`,
+      )
+      .run(
+        JSON.stringify({
+          rubric_version: "default-scoring-rubric-v1",
+          dimensions: [
+            { name: "technical_fit", weight: 0.45 },
+            { name: "experience_fit", weight: 0.3 },
+            { name: "role_fit", weight: 0.25 },
+          ],
+          fit_band_thresholds: [
+            { band: "excellent", minimum_score: 9 },
+            { band: "strong", minimum_score: 7 },
+            { band: "plausible", minimum_score: 5 },
+            { band: "stretch", minimum_score: 3 },
+            { band: "poor", minimum_score: 1 },
+          ],
+        }),
+        JSON.stringify([
+          {
+            anchor_id: "legacy-anchor",
+            job_id: legacyJobUrl,
+            fit_score: 5,
+            rationale: legacyReason,
+            dimensions: ["technical_fit"],
+            created_at: "2026-04-29T10:03:00+00:00",
+          },
+        ]),
+        "2026-04-29T10:03:00+00:00",
+      );
+    seedDb.close();
+
     const app = buildApp(options);
     const jobKey = encodeURIComponent("https://example.com/jobs/ready");
     const response = await app.inject({
@@ -732,6 +782,54 @@ describe("local TypeScript API", () => {
         originalScore: 9,
         correctedScore: 6,
       });
+      const policies = db
+        .prepare(
+          `SELECT version, rubric_json, anchors_json
+           FROM scoring_policies
+           WHERE tenant_id = 'local'
+           ORDER BY version`,
+        )
+        .all() as Array<{ version: number; rubric_json: string; anchors_json: string }>;
+      expect(policies.map((policy) => policy.version)).toEqual([1, 2]);
+      const updatedPolicy = policies[1];
+      expect(updatedPolicy).toBeDefined();
+      expect(JSON.parse(updatedPolicy!.rubric_json)).toMatchObject({
+        rubric_version: "default-scoring-rubric-v1",
+        dimensions: [
+          { name: "technical_fit", weight: 0.45 },
+          { name: "experience_fit", weight: 0.3 },
+          { name: "role_fit", weight: 0.25 },
+        ],
+      });
+      expect(updatedPolicy!.anchors_json).not.toContain("https://example.com/jobs/ready");
+      expect(updatedPolicy!.anchors_json).not.toContain("Manual review found a seniority mismatch.");
+      const anchors = JSON.parse(updatedPolicy!.anchors_json) as Array<Record<string, unknown>>;
+      expect(updatedPolicy!.anchors_json).not.toContain(legacyJobUrl);
+      expect(updatedPolicy!.anchors_json).not.toContain(legacyReason);
+      expect(anchors).toHaveLength(2);
+      const anchor = anchors.find((item) => String(item.anchor_id ?? "").startsWith("correction-anchor-"));
+      expect(anchor).toBeDefined();
+      expect(anchor).toMatchObject({
+        job_ref_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        fit_score: 6,
+        original_fit_score: 9,
+        corrected_fit_score: 6,
+        correction_delta: -3,
+        correction_direction: "decreased",
+        source_policy_version: 0,
+      });
+      expect(anchor).not.toHaveProperty("job_id");
+      expect(anchor).not.toHaveProperty("rationale");
+      expect(anchor!.anchor_id).toMatch(/^correction-anchor-/);
+      expect(anchor!.dimensions).toEqual(["technical_fit", "experience_fit", "role_fit"]);
+      const legacyAnchor = anchors.find((item) => item.anchor_id === "legacy-anchor");
+      expect(legacyAnchor).toBeDefined();
+      expect(legacyAnchor).toMatchObject({
+        job_ref_hash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+        fit_score: 5,
+      });
+      expect(legacyAnchor).not.toHaveProperty("job_id");
+      expect(legacyAnchor).not.toHaveProperty("rationale");
     } finally {
       db.close();
       await app.close();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,10 @@ The score breakdown separates soft fit from hard eligibility. `fit_band`,
 are exposed through the local API and jobs drawer. User corrections create a new
 score version, preserve the correction rationale, publish `ScoreCorrected`, and
 can be read back as transparent feedback signals alongside existing job actions.
+They also create a non-sensitive correction signal that is persisted as a
+calibration anchor on the next `scoring_policies` version. The current policy
+keeps rubric weights and fit-band thresholds stable; subsequent scores load the
+latest policy version and include the active anchor IDs in `trace_json`.
 
 This is not an employer-side candidate selection system. If JobHunter is ever
 used to rank people for hiring decisions, the architecture needs a separate

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -490,6 +490,10 @@ classDiagram
 
 - Reads enriched job content and profile target preferences.
 - Writes versioned `job_scores` rows with criteria and trace metadata.
+- Writes versioned `scoring_policies` rows when user corrections create
+  correction-derived calibration anchors; current behavior preserves rubric
+  weights and thresholds while making later score traces cite the new policy
+  version and anchor IDs.
 - Updates legacy-compatible score fields where needed by queue selectors.
 - Publishes score events consumed by Pipeline and Operations.
 - Refreshes dashboard score distributions and job list score badges.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -25,6 +25,11 @@ Both processes refresh projections idempotently via the shared
 from `job_scores` as additive read-model fields: `scoreBreakdown`,
 `scoreKeywords`, `scoreVersion`, and `scoredAt`. `scoreReasoning` remains on
 the wire as a compatibility summary during the scoring evidence migration.
+`POST /v1/jobs/:key/score-correction` writes a new corrected `job_scores`
+version, records `ScoreCorrected`, and updates the versioned `scoring_policies`
+table with a correction-derived calibration anchor. It mirrors the Python
+`CorrectScoreUseCase` policy update path because this local API mutation writes
+directly to SQLite instead of crossing the Python JSON-RPC boundary.
 The jobs list `deleted` filter accepts `active`, `deleted`, `hidden`, or `all`.
 Deleted jobs are temporary removals: discovery clears the delete tombstone when
 the same posting is observed again. Hidden jobs use a separate

--- a/workers/automation/src/jobhunter/domain/ports/scoring.py
+++ b/workers/automation/src/jobhunter/domain/ports/scoring.py
@@ -14,7 +14,7 @@ from typing import Protocol
 
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.scoring.aggregate import JobScore
-from jobhunter.domain.scoring.policy import ScoringPolicy
+from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobhunter.domain.tenant import TenantId
 
 # Re-export the shared LLM port — Scoring is one of its consumers.
@@ -94,4 +94,8 @@ class ScoringPolicyRepository(Protocol):
 
     def save(self, policy: ScoringPolicy) -> None:
         """Persist a ``ScoringPolicy`` version."""
+        ...
+
+    def save_correction_signal(self, signal: CorrectionSignal) -> ScoringPolicy:
+        """Persist the next policy version derived from a correction signal."""
         ...

--- a/workers/automation/src/jobhunter/domain/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/domain/scoring/__init__.py
@@ -19,6 +19,7 @@ from jobhunter.domain.scoring.value_objects import (
 from jobhunter.domain.scoring.aggregate import JobScore
 from jobhunter.domain.scoring.policy import (
     CalibrationAnchor,
+    CorrectionSignal,
     FitBandThreshold,
     ResolvedScore,
     ScoringPolicy,
@@ -51,6 +52,7 @@ __all__ = [
     "ScoringCriteria",
     "JobScore",
     "CalibrationAnchor",
+    "CorrectionSignal",
     "FitBandThreshold",
     "ResolvedScore",
     "ScoringPolicy",

--- a/workers/automation/src/jobhunter/domain/scoring/policy.py
+++ b/workers/automation/src/jobhunter/domain/scoring/policy.py
@@ -7,11 +7,18 @@ input evidence only; deterministic policy resolution owns the final grade.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from collections.abc import Mapping as MappingABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
-from jobhunter.domain.scoring.value_objects import FIT_BANDS, FitScore, ScoreBreakdown
+from jobhunter.domain.scoring.value_objects import (
+    ELIGIBILITY_STATUSES,
+    FIT_BANDS,
+    FitScore,
+    ScoreBreakdown,
+)
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 
 DEFAULT_SCORING_POLICY_VERSION = 1
@@ -28,6 +35,100 @@ DEFAULT_FIT_BAND_THRESHOLDS: tuple[tuple[str, int], ...] = (
     ("stretch", 3),
     ("poor", 1),
 )
+
+
+@dataclass(frozen=True)
+class CorrectionSignal:
+    """Use-case input signal derived from a user score correction.
+
+    The signal may carry raw audit fields from the corrected score. Persisted
+    policy anchors must derive non-sensitive learning features from it.
+    """
+
+    tenant_id: TenantId
+    job_id: str
+    original_score: FitScore
+    corrected_score: FitScore
+    rationale: str
+    corrected_at: str
+    source_policy_id: str = ""
+    source_policy_version: int = 0
+    score_dimensions: tuple[dict[str, Any], ...] = ()
+    evidence_summary: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tenant_id", TenantId(str(self.tenant_id)))
+        job_id = str(self.job_id or "").strip()
+        if not job_id:
+            raise ValueError("CorrectionSignal.job_id must be non-empty")
+        object.__setattr__(self, "job_id", job_id)
+        original_score = _coerce_fit_score(self.original_score, "original_score")
+        corrected_score = _coerce_fit_score(self.corrected_score, "corrected_score")
+        object.__setattr__(self, "original_score", original_score)
+        object.__setattr__(self, "corrected_score", corrected_score)
+        rationale = " ".join(str(self.rationale or "").split())
+        if not rationale:
+            raise ValueError("CorrectionSignal.rationale must be non-empty")
+        object.__setattr__(self, "rationale", rationale[:500])
+        corrected_at = str(self.corrected_at or "").strip()
+        if not corrected_at:
+            raise ValueError("CorrectionSignal.corrected_at must be non-empty")
+        object.__setattr__(self, "corrected_at", corrected_at)
+        object.__setattr__(
+            self,
+            "source_policy_id",
+            str(self.source_policy_id or "").strip(),
+        )
+        object.__setattr__(
+            self,
+            "source_policy_version",
+            max(_int_or_default(self.source_policy_version, 0), 0),
+        )
+        object.__setattr__(
+            self,
+            "score_dimensions",
+            _clean_mapping_tuple(self.score_dimensions),
+        )
+        object.__setattr__(
+            self,
+            "evidence_summary",
+            _clean_mapping(self.evidence_summary),
+        )
+
+    @property
+    def anchor_id(self) -> str:
+        payload = {
+            "tenant_id": str(self.tenant_id),
+            "job_id": self.job_id,
+            "original_score": self.original_score.value,
+            "corrected_score": self.corrected_score.value,
+            "corrected_at": self.corrected_at,
+            "source_policy_version": self.source_policy_version,
+        }
+        digest = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return f"correction-anchor-{digest[:12]}"
+
+    def to_dict(self) -> dict[str, Any]:
+        correction_delta = self.corrected_score.value - self.original_score.value
+        return {
+            "anchor_id": self.anchor_id,
+            "tenant_id": str(self.tenant_id),
+            "job_ref_hash": _stable_job_ref_hash(
+                tenant_id=self.tenant_id,
+                job_id=self.job_id,
+            ),
+            "original_score": self.original_score.value,
+            "corrected_score": self.corrected_score.value,
+            "correction_delta": correction_delta,
+            "correction_direction": _correction_direction(correction_delta),
+            "corrected_at": self.corrected_at,
+            "source_policy_id": self.source_policy_id,
+            "source_policy_version": self.source_policy_version,
+            "score_dimensions": list(self.score_dimensions),
+            "evidence_summary": self.evidence_summary,
+        }
 
 
 @dataclass(frozen=True)
@@ -70,16 +171,25 @@ class WeightedScoreDimension:
 class CalibrationAnchor:
     """Persisted calibration reference.
 
-    This first policy PR stores anchors but does not learn from correction
-    signals yet. Future stacked PRs can populate this value object without
-    changing the policy persistence table.
+    Anchors are correction-derived calibration evidence. PR3 deliberately
+    traces them without changing weights or thresholds so one correction
+    cannot overfit the policy.
     """
 
     anchor_id: str
     job_id: str = ""
+    job_ref_hash: str = ""
     fit_score: FitScore | None = None
+    original_fit_score: FitScore | None = None
+    corrected_fit_score: FitScore | None = None
     rationale: str = ""
+    correction_delta: int | None = None
+    correction_direction: str = ""
     dimensions: tuple[str, ...] = ()
+    dimension_scores: tuple[dict[str, Any], ...] = ()
+    evidence_summary: dict[str, Any] = field(default_factory=dict)
+    source_policy_id: str = ""
+    source_policy_version: int = 0
     created_at: str = ""
 
     def __post_init__(self) -> None:
@@ -87,36 +197,177 @@ class CalibrationAnchor:
         if not anchor_id:
             raise ValueError("CalibrationAnchor.anchor_id must be non-empty")
         object.__setattr__(self, "anchor_id", anchor_id)
-        object.__setattr__(self, "job_id", str(self.job_id or "").strip())
+        job_id = str(self.job_id or "").strip()
+        object.__setattr__(self, "job_id", job_id)
+        job_ref_hash = str(self.job_ref_hash or "").strip()
+        if not job_ref_hash and job_id:
+            job_ref_hash = _stable_job_ref_hash(job_id=job_id)
+        object.__setattr__(self, "job_ref_hash", job_ref_hash)
+        fit_score = _coerce_optional_fit_score(
+            self.fit_score
+        ) or _coerce_optional_fit_score(self.corrected_fit_score)
+        corrected_fit_score = _coerce_optional_fit_score(
+            self.corrected_fit_score
+        ) or fit_score
+        object.__setattr__(self, "fit_score", fit_score)
+        object.__setattr__(
+            self,
+            "original_fit_score",
+            _coerce_optional_fit_score(self.original_fit_score),
+        )
+        object.__setattr__(
+            self,
+            "corrected_fit_score",
+            _coerce_optional_fit_score(corrected_fit_score),
+        )
         object.__setattr__(self, "rationale", str(self.rationale or "").strip())
+        delta = self.correction_delta
+        if delta is None:
+            delta = _correction_delta(
+                self.original_fit_score,
+                self.corrected_fit_score or self.fit_score,
+            )
+        object.__setattr__(self, "correction_delta", int(delta or 0))
+        direction = str(self.correction_direction or "").strip() or _correction_direction(
+            int(delta or 0)
+        )
+        object.__setattr__(self, "correction_direction", direction)
         object.__setattr__(
             self,
             "dimensions",
             tuple(str(value).strip() for value in self.dimensions if str(value).strip()),
+        )
+        object.__setattr__(
+            self,
+            "dimension_scores",
+            _clean_anchor_dimension_scores(self.dimension_scores),
+        )
+        object.__setattr__(
+            self,
+            "evidence_summary",
+            _clean_anchor_evidence_summary(self.evidence_summary),
+        )
+        object.__setattr__(
+            self,
+            "source_policy_id",
+            str(self.source_policy_id or "").strip(),
+        )
+        object.__setattr__(
+            self,
+            "source_policy_version",
+            max(_int_or_default(self.source_policy_version, 0), 0),
         )
         object.__setattr__(self, "created_at", str(self.created_at or "").strip())
 
     @classmethod
     def from_dict(cls, data: MappingABC[str, Any]) -> "CalibrationAnchor":
         score = FitScore.from_optional(data.get("fit_score", data.get("fitScore")))
+        original_score = FitScore.from_optional(
+            data.get(
+                "original_fit_score",
+                data.get("originalFitScore", data.get("original_score")),
+            )
+        )
+        corrected_score = FitScore.from_optional(
+            data.get(
+                "corrected_fit_score",
+                data.get("correctedFitScore", data.get("corrected_score")),
+            )
+        )
         raw_dimensions = data.get("dimensions", ())
-        dimensions = raw_dimensions if isinstance(raw_dimensions, list) else ()
+        dimensions: tuple[str, ...]
+        if isinstance(raw_dimensions, list):
+            dimensions = tuple(str(item) for item in raw_dimensions)
+        else:
+            raw_dimension_scores = data.get(
+                "dimension_scores",
+                data.get("dimensionScores", ()),
+            )
+            dimension_scores = _clean_mapping_tuple(raw_dimension_scores)
+            dimensions = tuple(
+                str(item.get("name", "")).strip()
+                for item in dimension_scores
+                if str(item.get("name", "")).strip()
+            )
         return cls(
             anchor_id=str(data.get("anchor_id", data.get("anchorId", ""))),
             job_id=str(data.get("job_id", data.get("jobId", "")) or ""),
+            job_ref_hash=str(data.get("job_ref_hash", data.get("jobRefHash", "")) or ""),
             fit_score=score,
+            original_fit_score=original_score,
+            corrected_fit_score=corrected_score,
             rationale=str(data.get("rationale") or ""),
-            dimensions=tuple(dimensions),
+            correction_delta=data.get(
+                "correction_delta",
+                data.get("correctionDelta"),
+            ),
+            correction_direction=str(
+                data.get("correction_direction", data.get("correctionDirection", ""))
+                or ""
+            ),
+            dimensions=dimensions,
+            dimension_scores=_clean_mapping_tuple(
+                data.get("dimension_scores", data.get("dimensionScores", ()))
+            ),
+            evidence_summary=_clean_mapping(
+                data.get("evidence_summary", data.get("evidenceSummary", {}))
+            ),
+            source_policy_id=str(
+                data.get("source_policy_id", data.get("sourcePolicyId", "")) or ""
+            ),
+            source_policy_version=_int_or_default(
+                data.get("source_policy_version", data.get("sourcePolicyVersion", 0)),
+                0,
+            ),
             created_at=str(data.get("created_at", data.get("createdAt", "")) or ""),
+        )
+
+    @classmethod
+    def from_signal(cls, signal: CorrectionSignal) -> "CalibrationAnchor":
+        dimensions = tuple(
+            str(item.get("name", "")).strip()
+            for item in signal.score_dimensions
+            if str(item.get("name", "")).strip()
+        )
+        return cls(
+            anchor_id=signal.anchor_id,
+            job_ref_hash=_stable_job_ref_hash(
+                tenant_id=signal.tenant_id,
+                job_id=signal.job_id,
+            ),
+            fit_score=signal.corrected_score,
+            original_fit_score=signal.original_score,
+            corrected_fit_score=signal.corrected_score,
+            correction_delta=signal.corrected_score.value - signal.original_score.value,
+            correction_direction=_correction_direction(
+                signal.corrected_score.value - signal.original_score.value
+            ),
+            dimensions=dimensions,
+            dimension_scores=signal.score_dimensions,
+            evidence_summary=signal.evidence_summary,
+            source_policy_id=signal.source_policy_id,
+            source_policy_version=signal.source_policy_version,
+            created_at=signal.corrected_at,
         )
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "anchor_id": self.anchor_id,
-            "job_id": self.job_id,
+            "job_ref_hash": self.job_ref_hash,
             "fit_score": self.fit_score.value if self.fit_score else None,
-            "rationale": self.rationale,
+            "original_fit_score": (
+                self.original_fit_score.value if self.original_fit_score else None
+            ),
+            "corrected_fit_score": (
+                self.corrected_fit_score.value if self.corrected_fit_score else None
+            ),
+            "correction_delta": self.correction_delta,
+            "correction_direction": self.correction_direction,
             "dimensions": list(self.dimensions),
+            "dimension_scores": list(self.dimension_scores),
+            "evidence_summary": self.evidence_summary,
+            "source_policy_id": self.source_policy_id,
+            "source_policy_version": self.source_policy_version,
             "created_at": self.created_at,
         }
 
@@ -331,11 +582,43 @@ class ScoringPolicy:
             rubric_version=self.rubric_version,
             raw_weighted_score=round(raw_weighted_score, 4),
             calibration_adjustment=calibration_adjustment,
-            anchor_ids=(),
+            anchor_ids=tuple(anchor.anchor_id for anchor in self.anchors),
             dimensions=dimensions,
             fit_band_thresholds=self.fit_band_thresholds,
             resolution_reason=_resolution_reason(breakdown),
             evidence_summary=_evidence_summary(breakdown),
+        )
+
+    def with_correction_signal(self, signal: CorrectionSignal) -> "ScoringPolicy":
+        """Return the next policy version with a correction-derived anchor.
+
+        PR3 keeps the deterministic rubric stable. The correction is
+        recorded as calibration evidence and surfaced through trace metadata
+        on subsequent scores; later policy versions can learn adjustments
+        from the accumulated anchors.
+        """
+        if signal.tenant_id != self.tenant_id:
+            raise ValueError("CorrectionSignal tenant must match ScoringPolicy tenant")
+        anchor = CalibrationAnchor.from_signal(signal)
+        anchors: list[CalibrationAnchor] = []
+        replaced = False
+        for existing in self.anchors:
+            if existing.anchor_id == anchor.anchor_id:
+                anchors.append(anchor)
+                replaced = True
+            else:
+                anchors.append(existing)
+        if not replaced:
+            anchors.append(anchor)
+        return ScoringPolicy(
+            tenant_id=self.tenant_id,
+            version=self.version + 1,
+            rubric_version=self.rubric_version,
+            dimensions=self.dimensions,
+            fit_band_thresholds=self.fit_band_thresholds,
+            anchors=tuple(anchors),
+            created_at=signal.corrected_at,
+            created_from_event_id=None,
         )
 
     def fit_band_for_score(self, score: FitScore | int) -> str:
@@ -367,6 +650,127 @@ def _default_dimensions() -> tuple[WeightedScoreDimension, ...]:
         WeightedScoreDimension(name=name, weight=weight)
         for name, weight in DEFAULT_DIMENSION_WEIGHTS
     )
+
+
+def _coerce_fit_score(value: FitScore | int, field_name: str) -> FitScore:
+    score = _coerce_optional_fit_score(value)
+    if score is None:
+        raise ValueError(f"CorrectionSignal.{field_name} must be a FitScore")
+    return score
+
+
+def _coerce_optional_fit_score(value: Any) -> FitScore | None:
+    if value is None:
+        return None
+    if isinstance(value, FitScore):
+        return value
+    return FitScore.from_optional(value)
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _clean_mapping(value: Any) -> dict[str, Any]:
+    if not isinstance(value, MappingABC):
+        return {}
+    return json.loads(json.dumps(dict(value), sort_keys=True, default=str))
+
+
+def _clean_mapping_tuple(value: Any) -> tuple[dict[str, Any], ...]:
+    if isinstance(value, (str, bytes, MappingABC)) or value is None:
+        return ()
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return ()
+    return tuple(_clean_mapping(item) for item in iterator if isinstance(item, MappingABC))
+
+
+def _stable_job_ref_hash(
+    *,
+    job_id: str,
+    tenant_id: TenantId | str | None = None,
+) -> str:
+    payload = {
+        "tenant_id": str(tenant_id or ""),
+        "job_id": str(job_id or "").strip(),
+    }
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    return f"sha256:{digest}"
+
+
+def _correction_delta(
+    original_score: FitScore | None,
+    corrected_score: FitScore | None,
+) -> int:
+    if original_score is None or corrected_score is None:
+        return 0
+    return corrected_score.value - original_score.value
+
+
+def _correction_direction(delta: int) -> str:
+    if delta > 0:
+        return "increased"
+    if delta < 0:
+        return "decreased"
+    return "unchanged"
+
+
+def _clean_anchor_dimension_scores(value: Any) -> tuple[dict[str, Any], ...]:
+    sanitized: list[dict[str, Any]] = []
+    for item in _clean_mapping_tuple(value):
+        name = str(item.get("name") or "").strip()
+        cleaned: dict[str, Any] = {}
+        if name:
+            cleaned["name"] = name
+        for key in ("value", "weight", "weighted_value"):
+            number = _number_or_none(item.get(key))
+            if number is not None:
+                cleaned[key] = number
+        if cleaned:
+            sanitized.append(cleaned)
+    return tuple(sanitized)
+
+
+def _clean_anchor_evidence_summary(value: Any) -> dict[str, Any]:
+    raw = _clean_mapping(value)
+    cleaned: dict[str, Any] = {}
+    confidence = str(raw.get("confidence") or "").strip().lower()
+    if confidence in {"low", "medium", "high"}:
+        cleaned["confidence"] = confidence
+    eligibility_status = str(raw.get("eligibility_status") or "").strip().lower()
+    if eligibility_status in ELIGIBILITY_STATUSES:
+        cleaned["eligibility_status"] = eligibility_status
+    for key in (
+        "hard_blocker_count",
+        "warning_count",
+        "matched_signal_count",
+        "missing_signal_count",
+        "transferable_signal_count",
+    ):
+        if key in raw:
+            cleaned[key] = max(_int_or_default(raw.get(key), 0), 0)
+    return cleaned
+
+
+def _number_or_none(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not (-1_000_000 <= number <= 1_000_000):
+        return None
+    if number.is_integer():
+        return int(number)
+    return number
 
 
 def _default_fit_band_thresholds() -> tuple[FitBandThreshold, ...]:
@@ -435,6 +839,7 @@ def _fit_score_from_raw(value: float) -> int:
 
 __all__ = [
     "CalibrationAnchor",
+    "CorrectionSignal",
     "DEFAULT_FIT_BAND_THRESHOLDS",
     "DEFAULT_RUBRIC_VERSION",
     "DEFAULT_SCORING_POLICY_VERSION",

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -40,7 +40,7 @@ from jobhunter.domain.ports.llm import LlmMessage
 from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository, ScoringPolicyRepository
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
 from jobhunter.domain.scoring.aggregate import JobScore
-from jobhunter.domain.scoring.policy import ScoringPolicy
+from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobhunter.domain.scoring.services import ConstraintChecker, ScoreParseResult, ScoreParser
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
@@ -571,9 +571,11 @@ class CorrectScoreUseCase:
         *,
         repository: ScoreRepository,
         publisher: EventPublisher | None = None,
+        policy_repository: ScoringPolicyRepository | None = None,
     ) -> None:
         self._repository = repository
         self._publisher = publisher
+        self._policy_repository = policy_repository
 
     def execute(
         self,
@@ -599,8 +601,40 @@ class CorrectScoreUseCase:
         )
         new_score = previous.with_correction(correction)
         self._repository.save(new_score)
+        self._persist_policy_correction_signal(previous=previous, correction=correction)
         self._publish_corrected(previous=previous, new=new_score)
         return new_score
+
+    def _persist_policy_correction_signal(
+        self,
+        *,
+        previous: JobScore,
+        correction: ScoreCorrection,
+    ) -> None:
+        if self._policy_repository is None:
+            return
+        signal = CorrectionSignal(
+            tenant_id=previous.tenant_id,
+            job_id=str(previous.job_id),
+            original_score=previous.fit_score,
+            corrected_score=correction.corrected_fit_score,
+            rationale=correction.rationale,
+            corrected_at=correction.corrected_at,
+            source_policy_id=previous.trace.scoring_policy_id,
+            source_policy_version=previous.trace.scoring_policy_version,
+            score_dimensions=_dimension_signal_from_score(previous),
+            evidence_summary=_policy_evidence_from_score(previous),
+        )
+        save_correction_signal = getattr(
+            self._policy_repository,
+            "save_correction_signal",
+            None,
+        )
+        if callable(save_correction_signal):
+            save_correction_signal(signal)
+            return
+        current = self._policy_repository.get_current(previous.tenant_id)
+        self._policy_repository.save(current.with_correction_signal(signal))
 
     def _publish_corrected(self, *, previous: JobScore, new: JobScore) -> None:
         if self._publisher is None or new.correction is None:
@@ -619,6 +653,30 @@ class CorrectScoreUseCase:
             self._publisher.publish(event)
         except Exception:  # noqa: BLE001
             log.exception("Failed to publish ScoreCorrected event for %s", new.job_id)
+
+
+def _dimension_signal_from_score(score: JobScore) -> tuple[dict[str, Any], ...]:
+    if score.trace.resolved_dimensions:
+        return score.trace.resolved_dimensions
+    return (
+        {"name": "technical_fit", "value": score.breakdown.technical_fit},
+        {"name": "experience_fit", "value": score.breakdown.experience_fit},
+        {"name": "role_fit", "value": score.breakdown.role_fit},
+    )
+
+
+def _policy_evidence_from_score(score: JobScore) -> dict[str, Any]:
+    if score.trace.policy_evidence:
+        return score.trace.policy_evidence
+    return {
+        "confidence": score.breakdown.confidence,
+        "eligibility_status": score.breakdown.eligibility.status,
+        "hard_blocker_count": len(score.breakdown.eligibility.hard_blockers),
+        "warning_count": len(score.breakdown.eligibility.warnings),
+        "matched_signal_count": len(score.breakdown.matched_signals),
+        "missing_signal_count": len(score.breakdown.missing_signals),
+        "transferable_signal_count": len(score.breakdown.transferable_signals),
+    }
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
@@ -24,7 +24,7 @@ from typing import Any
 from jobhunter.database import ensure_scoring_policy_tables
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.scoring.aggregate import JobScore
-from jobhunter.domain.scoring.policy import ScoringPolicy
+from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
     MatchedKeywords,
@@ -284,6 +284,12 @@ class SqliteScoringPolicyRepository:
             ),
         )
         self._conn.commit()
+
+    def save_correction_signal(self, signal: CorrectionSignal) -> ScoringPolicy:
+        current = self.get_current(signal.tenant_id)
+        next_policy = current.with_correction_signal(signal)
+        self.save(next_policy)
+        return next_policy
 
     @staticmethod
     def _row_to_policy(row: Any) -> ScoringPolicy:

--- a/workers/automation/tests/test_score_use_cases.py
+++ b/workers/automation/tests/test_score_use_cases.py
@@ -20,6 +20,7 @@ from jobhunter.domain.scoring import (
     JobScore,
     MatchedKeywords,
     ScoreBreakdown,
+    ScoringPolicy,
     ScoringCriteria,
 )
 from jobhunter.domain.scoring.services import ScoreParser
@@ -71,6 +72,30 @@ class _MemoryRepo:
             if min_score <= latest.fit_score.value <= max_score:
                 out.append(latest)
         return out
+
+
+class _MemoryPolicyRepo:
+    """In-memory ``ScoringPolicyRepository`` keyed by tenant."""
+
+    def __init__(self) -> None:
+        self._policies: dict[str, list[ScoringPolicy]] = {}
+
+    def get_current(self, tenant_id):
+        rows = self._policies.get(str(tenant_id))
+        if rows:
+            return rows[-1]
+        policy = ScoringPolicy.default(tenant_id, created_at="2024-01-01T00:00:00+00:00")
+        self.save(policy)
+        return policy
+
+    def save(self, policy: ScoringPolicy) -> None:
+        self._policies.setdefault(str(policy.tenant_id), []).append(policy)
+
+    def save_correction_signal(self, signal):
+        current = self.get_current(signal.tenant_id)
+        policy = current.with_correction_signal(signal)
+        self.save(policy)
+        return policy
 
 
 class _ScriptedLlm:
@@ -554,6 +579,73 @@ def test_correct_score_publishes_corrected_event_and_persists() -> None:
     assert received[0].event_type == "ScoreCorrected"
     assert received[0].payload["original_score"] == 5
     assert received[0].payload["corrected_score"] == 9
+
+
+def test_correct_score_updates_policy_and_subsequent_score_traces_anchor(
+    profile_snapshot,
+) -> None:
+    repo = _MemoryRepo()
+    policy_repo = _MemoryPolicyRepo()
+    url = "https://example.com/job/policy-correction"
+    llm = _ScriptedLlm(
+        {
+            "score": 5,
+            "technical_fit": 5,
+            "experience_fit": 5,
+            "role_fit": 5,
+            "fit_band": "plausible",
+            "confidence": "medium",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python"],
+            "missing_signals": ["platform leadership"],
+            "transferable_signals": [],
+            "keywords": ["python"],
+            "reasoning": "Initial policy-backed score.",
+        },
+        {
+            "score": 7,
+            "technical_fit": 7,
+            "experience_fit": 7,
+            "role_fit": 7,
+            "fit_band": "strong",
+            "confidence": "medium",
+            "eligibility": {"status": "eligible", "hard_blockers": [], "warnings": []},
+            "matched_signals": ["Python", "platform"],
+            "missing_signals": [],
+            "transferable_signals": [],
+            "keywords": ["python", "platform"],
+            "reasoning": "Subsequent score should cite the learned anchor.",
+        },
+    )
+    scorer = ScoreJobUseCase(repository=repo, llm=llm, policy_repository=policy_repo)
+
+    first = scorer.score(job=_job(url), profile_snapshot=profile_snapshot)
+    assert first.score is not None
+    assert first.score.trace.scoring_policy_version == 1
+
+    CorrectScoreUseCase(repository=repo, policy_repository=policy_repo).execute(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(url),
+        corrected_fit_score=FitScore.create(8),
+        rationale="Manual review found stronger platform evidence.",
+        corrected_at="2024-01-02T00:00:00+00:00",
+    )
+
+    policy = policy_repo.get_current(LOCAL_TENANT)
+    assert policy.version == 2
+    assert len(policy.anchors) == 1
+    assert policy.anchors[0].original_fit_score == FitScore.create(5)
+    assert policy.anchors[0].corrected_fit_score == FitScore.create(8)
+    assert policy.anchors[0].source_policy_version == 1
+
+    second = scorer.score(
+        job=_job("https://example.com/job/after-correction"),
+        profile_snapshot=profile_snapshot,
+    )
+
+    assert second.score is not None
+    assert second.score.trace.scoring_policy_version == 2
+    assert second.score.trace.anchor_ids == (policy.anchors[0].anchor_id,)
 
 
 def test_correct_score_raises_when_no_existing_score() -> None:

--- a/workers/automation/tests/test_scoring_policy.py
+++ b/workers/automation/tests/test_scoring_policy.py
@@ -9,7 +9,13 @@ from pathlib import Path
 import pytest
 
 from jobhunter.database import init_db
-from jobhunter.domain.scoring import FitBandThreshold, ScoreBreakdown, ScoringPolicy
+from jobhunter.domain.scoring import (
+    CorrectionSignal,
+    FitBandThreshold,
+    FitScore,
+    ScoreBreakdown,
+    ScoringPolicy,
+)
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.scoring import SqliteScoringPolicyRepository
 
@@ -56,6 +62,69 @@ def test_default_policy_resolves_score_from_weighted_dimensions() -> None:
         "missing_signal_count": 0,
         "transferable_signal_count": 0,
     }
+
+
+def test_policy_correction_signal_creates_next_version_anchor() -> None:
+    policy = ScoringPolicy.default(LOCAL_TENANT, created_at="2024-01-01T00:00:00+00:00")
+    signal = CorrectionSignal(
+        tenant_id=LOCAL_TENANT,
+        job_id="https://example.com/job/anchor",
+        original_score=FitScore.create(5),
+        corrected_score=FitScore.create(8),
+        rationale="Manual review found stronger platform evidence.",
+        corrected_at="2024-01-02T00:00:00+00:00",
+        source_policy_id=policy.policy_id,
+        source_policy_version=policy.version,
+        score_dimensions=(
+            {"name": "technical_fit", "value": 5, "weight": 0.45},
+            {"name": "experience_fit", "value": 5, "weight": 0.3},
+            {"name": "role_fit", "value": 5, "weight": 0.25},
+        ),
+        evidence_summary={"confidence": "medium", "missing_signal_count": 1},
+    )
+
+    updated = policy.with_correction_signal(signal)
+    serialized_signal = signal.to_dict()
+    serialized_signal_json = json.dumps(serialized_signal)
+    resolved = updated.resolve(
+        ScoreBreakdown(
+            technical_fit=7,
+            experience_fit=7,
+            role_fit=7,
+            reasoning="Later score.",
+        )
+    )
+
+    assert updated.version == 2
+    assert serialized_signal["job_ref_hash"].startswith("sha256:")
+    assert serialized_signal["correction_delta"] == 3
+    assert serialized_signal["correction_direction"] == "increased"
+    assert "https://example.com/job/anchor" not in serialized_signal_json
+    assert "Manual review found stronger platform evidence." not in serialized_signal_json
+    assert "job_id" not in serialized_signal
+    assert "rationale" not in serialized_signal
+    assert updated.dimensions == policy.dimensions
+    assert updated.fit_band_thresholds == policy.fit_band_thresholds
+    assert len(updated.anchors) == 1
+    anchor = updated.anchors[0]
+    assert anchor.anchor_id == signal.anchor_id
+    assert anchor.original_fit_score == FitScore.create(5)
+    assert anchor.corrected_fit_score == FitScore.create(8)
+    assert anchor.job_id == ""
+    assert anchor.rationale == ""
+    assert anchor.job_ref_hash.startswith("sha256:")
+    assert anchor.correction_delta == 3
+    assert anchor.correction_direction == "increased"
+    assert anchor.source_policy_version == 1
+    assert anchor.dimension_scores[0]["name"] == "technical_fit"
+    serialized_anchor = updated.to_anchors_list()[0]
+    serialized_anchor_json = json.dumps(serialized_anchor)
+    assert "https://example.com/job/anchor" not in serialized_anchor_json
+    assert "Manual review found stronger platform evidence." not in serialized_anchor_json
+    assert "job_id" not in serialized_anchor
+    assert "rationale" not in serialized_anchor
+    assert resolved.fit_score.value == 7
+    assert resolved.anchor_ids == (anchor.anchor_id,)
 
 
 def test_policy_owned_fit_band_thresholds_are_deterministic() -> None:
@@ -145,3 +214,84 @@ def test_sqlite_policy_repository_returns_highest_policy_version(
     assert policy.rubric_version == "rubric-v2"
     assert policy.created_from_event_id == 42
     assert policy.fit_band_thresholds[-1].band == "poor"
+
+
+def test_sqlite_policy_repository_persists_correction_signal_anchor(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteScoringPolicyRepository(conn)
+    current = repo.get_current(LOCAL_TENANT)
+    signal = CorrectionSignal(
+        tenant_id=LOCAL_TENANT,
+        job_id="https://example.com/job/sqlite-anchor",
+        original_score=FitScore.create(4),
+        corrected_score=FitScore.create(7),
+        rationale="Correction should become calibration evidence.",
+        corrected_at="2024-01-03T00:00:00+00:00",
+        source_policy_id=current.policy_id,
+        source_policy_version=current.version,
+        score_dimensions=({"name": "technical_fit", "value": 4},),
+        evidence_summary={"confidence": "low"},
+    )
+
+    saved = repo.save_correction_signal(signal)
+    loaded = repo.get_current(LOCAL_TENANT)
+    anchors_json = conn.execute(
+        """
+        SELECT anchors_json
+        FROM scoring_policies
+        WHERE tenant_id = ? AND version = 2
+        """,
+        (str(LOCAL_TENANT),),
+    ).fetchone()["anchors_json"]
+
+    assert saved.version == 2
+    assert loaded.version == 2
+    assert loaded.anchors[0].anchor_id == signal.anchor_id
+    assert loaded.anchors[0].corrected_fit_score == FitScore.create(7)
+    assert loaded.anchors[0].job_ref_hash.startswith("sha256:")
+    assert "https://example.com/job/sqlite-anchor" not in anchors_json
+    assert "Correction should become calibration evidence." not in anchors_json
+    assert loaded.resolve(ScoreBreakdown(reasoning="next")).anchor_ids == (
+        signal.anchor_id,
+    )
+
+
+def test_sqlite_policy_repository_loads_pr2_anchor_rows(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        INSERT INTO scoring_policies (
+            tenant_id, version, rubric_json, anchors_json, created_at,
+            created_from_event_id
+        ) VALUES (?, 7, ?, ?, ?, NULL)
+        """,
+        (
+            str(LOCAL_TENANT),
+            json.dumps(ScoringPolicy.default(LOCAL_TENANT).to_rubric_dict()),
+            json.dumps(
+                [
+                    {
+                        "anchor_id": "legacy-anchor",
+                        "job_id": "https://example.com/job/legacy",
+                        "fit_score": 6,
+                        "rationale": "Existing PR2 anchor shape.",
+                        "dimensions": ["technical_fit"],
+                        "created_at": "2024-01-04T00:00:00+00:00",
+                    }
+                ]
+            ),
+            "2024-01-04T00:00:00+00:00",
+        ),
+    )
+
+    policy = SqliteScoringPolicyRepository(conn).get_current(LOCAL_TENANT)
+
+    assert policy.version == 7
+    assert policy.anchors[0].anchor_id == "legacy-anchor"
+    assert policy.anchors[0].fit_score == FitScore.create(6)
+    assert policy.anchors[0].corrected_fit_score == FitScore.create(6)
+    serialized_anchor = policy.to_anchors_list()[0]
+    serialized_anchor_json = json.dumps(serialized_anchor)
+    assert serialized_anchor["job_ref_hash"].startswith("sha256:")
+    assert "https://example.com/job/legacy" not in serialized_anchor_json
+    assert "Existing PR2 anchor shape." not in serialized_anchor_json


### PR DESCRIPTION
## Summary
- Add `CorrectionSignal` and correction-derived `CalibrationAnchor` data to versioned scoring policies.
- Persist a new scoring policy version when Python score corrections are applied, while preserving current rubric weights and fit-band thresholds.
- Keep persisted policy anchors non-sensitive by serializing derived fields such as `job_ref_hash`, correction delta/direction, dimension summaries, evidence counts, and source policy metadata instead of raw job URLs or correction rationale.
- Mirror the policy update in the local TypeScript API `correctScore` path because that endpoint writes directly to SQLite.
- Document the correction-to-policy behavior in the scoring architecture, pipeline, and local API docs.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_policy.py workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_score_repository.py` -> 36 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/scoring/policy.py workers/automation/src/jobhunter/domain/scoring/use_cases.py workers/automation/src/jobhunter/domain/ports/scoring.py workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py workers/automation/src/jobhunter/domain/scoring/__init__.py workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_scoring_policy.py` -> All checks passed
- `corepack pnpm api:check` -> passed
- `corepack pnpm api:test` -> 6 files passed, 97 tests passed
- `git diff --check scoring/policy-model...HEAD` -> passed