### PR TITLE
feat: mark stale scores after policy corrections

### DIFF
--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -28,6 +28,7 @@ import {
   ProfileImportRequestSchema,
   ProfileUpdateRequestSchema,
   QuarantineDecisionSchema,
+  ResetStaleScoresForRescoreRequestSchema,
   RetryStageRequestSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
@@ -98,6 +99,7 @@ import {
   resetJobStage,
   restoreJob,
   restoreJobs,
+  resetStaleScoresForRescore,
   resolveJobUrl,
   softDeleteJob,
   softDeleteJobs,
@@ -420,6 +422,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       });
     },
   );
+
+  app.post("/v1/scoring/stale-scores/actions/reset-for-rescore", async (request, reply) => {
+    const body = parseBody(reply, ResetStaleScoresForRescoreRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) => resetStaleScoresForRescore(db, body));
+  });
 
   app.delete<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) => {
     const body = parseBody(reply, DeleteJobRequestSchema, request.body ?? {});

--- a/apps/api/src/write-model.ts
+++ b/apps/api/src/write-model.ts
@@ -258,6 +258,7 @@ export function correctScore(
     throw new InputError("Job not found.");
   }
   ensureJobScoresTable(db);
+  ensureScoreStalenessTable(db);
   const latest = getRow<Record<string, unknown>>(
     db,
     `SELECT * FROM job_scores
@@ -299,11 +300,17 @@ export function correctScore(
     String(latest.criteria_json ?? "{}"),
     JSON.stringify(trace),
   );
-  persistScoringPolicyCorrection(db, {
+  const policyChange = persistScoringPolicyCorrection(db, {
     jobUrl,
     latest,
     correctedScore: request.correctedScore,
     correctedAt: now,
+  });
+  markComparableScoresStale(db, {
+    correctedJobUrl: jobUrl,
+    markedAt: now,
+    newPolicyId: `local:scoring-policy-v${policyChange.newPolicyVersion}`,
+    newPolicyVersion: policyChange.newPolicyVersion,
   });
   recordActionEvent(db, {
     jobUrl,
@@ -321,6 +328,72 @@ export function correctScore(
     },
   });
   return { jobUrl, version: nextVersion };
+}
+
+export function resetStaleScoresForRescore(
+  db: SqliteDatabase,
+  request: { limit?: number } = {},
+): { ok: true; count: number; jobKeys: string[]; nextAction: string } {
+  ensureScoreStalenessTable(db);
+  const limit = Math.max(0, Math.floor(request.limit ?? 0));
+  const rows = allRows<Record<string, unknown>>(
+    db,
+    `SELECT job_url, stale_reason, old_policy_version, new_policy_version
+     FROM job_score_staleness
+     WHERE tenant_id = 'local' AND resolved = 0
+     ORDER BY marked_at ASC${limit > 0 ? " LIMIT ?" : ""}`,
+    limit > 0 ? [limit] : [],
+  );
+  const now = new Date().toISOString();
+  const jobKeys = rows.map((row) => String(row.job_url ?? "")).filter(Boolean);
+  for (const row of rows) {
+    const jobUrl = String(row.job_url ?? "");
+    if (!jobUrl) {
+      continue;
+    }
+    upsertStageState(db, jobUrl, "score", "pending", {
+      attemptCount: 0,
+      clearTiming: true,
+      skipValidation: true,
+    });
+    db.prepare(
+      `UPDATE job_score_staleness
+          SET resolved = 1,
+              resolved_at = ?
+        WHERE tenant_id = 'local'
+          AND job_url = ?
+          AND stale_reason = ?
+          AND old_policy_version = ?
+          AND new_policy_version = ?`,
+    ).run(
+      now,
+      jobUrl,
+      String(row.stale_reason ?? ""),
+      Number(row.old_policy_version ?? 0),
+      Number(row.new_policy_version ?? 0),
+    );
+    recordActionEvent(db, {
+      jobUrl,
+      stage: "score",
+      eventType: "ScoreRescoreRequested",
+      level: "info",
+      message: "Stale score reset for explicit rescore.",
+      payload: {
+        tenantId: "local",
+        jobId: jobUrl,
+        staleReason: String(row.stale_reason ?? ""),
+        oldPolicyVersion: Number(row.old_policy_version ?? 0),
+        newPolicyVersion: Number(row.new_policy_version ?? 0),
+        nextAction: "jobhunter run score --rescore",
+      },
+    });
+  }
+  return {
+    ok: true,
+    count: jobKeys.length,
+    jobKeys,
+    nextAction: "jobhunter run score --rescore",
+  };
 }
 
 export function softDeleteJob(db: SqliteDatabase, jobKey: string, request: DeleteJobRequest = {}): JobMutationResponse {
@@ -616,6 +689,7 @@ function purgeJobRows(db: SqliteDatabase, jobUrl: string): void {
   deleteWhere(db, "job_events", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_scores", "job_url = ?", [jobUrl]);
+  deleteWhere(db, "job_score_staleness", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials_artifacts", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_materials", "job_url = ?", [jobUrl]);
   deleteWhere(db, "job_enrichments", "job_url = ?", [jobUrl]);
@@ -678,6 +752,36 @@ function ensureJobScoresTable(db: SqliteDatabase): void {
   }
 }
 
+function ensureScoreStalenessTable(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_score_staleness (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_url TEXT NOT NULL,
+      stale_reason TEXT NOT NULL,
+      old_policy_id TEXT NOT NULL DEFAULT '',
+      old_policy_version INTEGER NOT NULL,
+      new_policy_id TEXT NOT NULL DEFAULT '',
+      new_policy_version INTEGER NOT NULL,
+      marked_at TEXT NOT NULL,
+      resolved INTEGER NOT NULL DEFAULT 0,
+      resolved_at TEXT,
+      resolved_by_score_version INTEGER,
+      PRIMARY KEY (
+        tenant_id, job_url, stale_reason,
+        old_policy_version, new_policy_version
+      )
+    )
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_job_score_staleness_unresolved
+    ON job_score_staleness(tenant_id, resolved, marked_at DESC)
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
+    ON job_score_staleness(tenant_id, job_url, resolved)
+  `);
+}
+
 function ensureScoringPoliciesTable(db: SqliteDatabase): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS scoring_policies (
@@ -704,7 +808,7 @@ function persistScoringPolicyCorrection(
     correctedScore: number;
     correctedAt: string;
   },
-): void {
+): { previousPolicyVersion: number; newPolicyVersion: number } {
   ensureScoringPoliciesTable(db);
   const current = getCurrentScoringPolicyRow(db, input.correctedAt);
   const previousTrace = parseObjectOrDefault(String(input.latest.trace_json ?? "{}"));
@@ -744,6 +848,117 @@ function persistScoringPolicyCorrection(
     JSON.stringify(anchors),
     input.correctedAt,
   );
+  return {
+    previousPolicyVersion: Number(current.version),
+    newPolicyVersion: Number(current.version) + 1,
+  };
+}
+
+function markComparableScoresStale(
+  db: SqliteDatabase,
+  input: {
+    correctedJobUrl: string;
+    markedAt: string;
+    newPolicyId: string;
+    newPolicyVersion: number;
+  },
+): void {
+  ensureScoreStalenessTable(db);
+  const latestRows = allRows<Record<string, unknown>>(
+    db,
+    `SELECT s.job_url, s.trace_json
+     FROM job_scores s
+     INNER JOIN (
+       SELECT job_url, MAX(version) AS max_version
+       FROM job_scores
+       WHERE tenant_id = 'local'
+       GROUP BY job_url
+     ) latest
+       ON latest.job_url = s.job_url AND latest.max_version = s.version
+     WHERE s.tenant_id = 'local'
+       AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
+  );
+  for (const row of latestRows) {
+    const jobUrl = String(row.job_url ?? "");
+    if (!jobUrl || jobUrl === input.correctedJobUrl) {
+      continue;
+    }
+    const trace = parseObjectOrDefault(String(row.trace_json ?? "{}"));
+    const oldPolicyVersion = numberOrDefault(trace.scoring_policy_version, 0);
+    if (oldPolicyVersion >= input.newPolicyVersion) {
+      continue;
+    }
+    const staleReason = "scoring_policy_changed";
+    const oldPolicyId = String(trace.scoring_policy_id ?? "");
+    const result = db
+      .prepare(
+        `INSERT OR IGNORE INTO job_score_staleness (
+           tenant_id, job_url, stale_reason,
+           old_policy_id, old_policy_version,
+           new_policy_id, new_policy_version,
+           marked_at, resolved, resolved_at, resolved_by_score_version
+         ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL)`,
+      )
+      .run(
+        jobUrl,
+        staleReason,
+        oldPolicyId,
+        oldPolicyVersion,
+        input.newPolicyId,
+        input.newPolicyVersion,
+        input.markedAt,
+      );
+    if (result.changes <= 0) {
+      continue;
+    }
+    markScoreStageStale(db, jobUrl, {
+      staleReason,
+      oldPolicyId,
+      oldPolicyVersion,
+      newPolicyId: input.newPolicyId,
+      newPolicyVersion: input.newPolicyVersion,
+      markedAt: input.markedAt,
+    });
+  }
+}
+
+function markScoreStageStale(
+  db: SqliteDatabase,
+  jobUrl: string,
+  marker: {
+    staleReason: string;
+    oldPolicyId: string;
+    oldPolicyVersion: number;
+    newPolicyId: string;
+    newPolicyVersion: number;
+    markedAt: string;
+  },
+): void {
+  const current = getRow<{ state?: string }>(
+    db,
+    "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
+    [jobUrl],
+  );
+  if (!current || current.state === "succeeded") {
+    upsertStageState(db, jobUrl, "score", "stale");
+  }
+  recordActionEvent(db, {
+    jobUrl,
+    stage: "score",
+    eventType: "ScoreMarkedStale",
+    level: "info",
+    message: "Score marked stale after scoring policy changed.",
+    payload: {
+      tenantId: "local",
+      jobId: jobUrl,
+      staleReason: marker.staleReason,
+      oldPolicyId: marker.oldPolicyId,
+      oldPolicyVersion: marker.oldPolicyVersion,
+      newPolicyId: marker.newPolicyId,
+      newPolicyVersion: marker.newPolicyVersion,
+      markedAt: marker.markedAt,
+    },
+  });
 }
 
 function getCurrentScoringPolicyRow(
@@ -1032,6 +1247,10 @@ function numberOrNull(value: unknown): number | null {
   return number;
 }
 
+function numberOrDefault(value: unknown, fallback: number): number {
+  return numberOrNull(value) ?? fallback;
+}
+
 function cleanJsonRecord(value: Record<string, unknown>): Record<string, unknown> {
   return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
 }
@@ -1047,6 +1266,7 @@ function cleanJsonRecord(value: Record<string, unknown>): Record<string, unknown
  *   - `markJobApplied`       — user assertion "I applied externally"
  *   - `markJobSkipped`       — user assertion "skip this one"
  *   - `cancelJobAction`      — user-initiated cancel from any state
+ *   - `resetStaleScoresForRescore` — explicit stale-score rescore request
  *
  * **Automated pipeline writes (Phase 9 / S-34 onward) MUST NOT pass
  * `skipValidation`.**  If you're adding a new TS write path and you can't

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -836,6 +836,161 @@ describe("local TypeScript API", () => {
     }
   });
 
+  it("marks comparable uncorrected scores stale when API correction changes the scoring policy", async () => {
+    const seedDb = new Database(options.dbPath);
+    const comparableUrl = "https://example.com/jobs/comparable-old-policy";
+    const currentPolicyUrl = "https://example.com/jobs/current-policy";
+    const alreadyCorrectedUrl = "https://example.com/jobs/already-corrected";
+    insertJob(seedDb, {
+      url: comparableUrl,
+      title: "Comparable Engineer",
+      site: "ExampleCo",
+      fitScore: 7,
+    });
+    insertScore(seedDb, comparableUrl, 1, 7, { policyVersion: 1 });
+    insertStage(seedDb, comparableUrl, "score", "succeeded");
+    insertJob(seedDb, {
+      url: currentPolicyUrl,
+      title: "Already Current Engineer",
+      site: "ExampleCo",
+      fitScore: 8,
+    });
+    insertScore(seedDb, currentPolicyUrl, 1, 8, { policyVersion: 2 });
+    insertStage(seedDb, currentPolicyUrl, "score", "succeeded");
+    insertJob(seedDb, {
+      url: alreadyCorrectedUrl,
+      title: "Reviewed Engineer",
+      site: "ExampleCo",
+      fitScore: 6,
+    });
+    insertScore(seedDb, alreadyCorrectedUrl, 1, 6, { policyVersion: 1 });
+    insertScore(seedDb, alreadyCorrectedUrl, 2, 8, {
+      correction: {
+        corrected_fit_score: 8,
+        rationale: "Already corrected.",
+        corrected_by: "local",
+        corrected_at: "2026-04-29T10:06:00+00:00",
+      },
+      policyVersion: 1,
+    });
+    insertStage(seedDb, alreadyCorrectedUrl, "score", "succeeded");
+    seedDb.close();
+
+    const app = buildApp(options);
+    const jobKey = encodeURIComponent("https://example.com/jobs/ready");
+    const response = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${jobKey}/score-correction`,
+      payload: { correctedScore: 6, reason: "Manual review found a seniority mismatch." },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+
+    const db = new Database(options.dbPath);
+    try {
+      const comparable = db
+        .prepare(
+          `SELECT stale_reason, old_policy_version, new_policy_version, resolved
+           FROM job_score_staleness
+           WHERE job_url = ?`,
+        )
+        .get(comparableUrl) as {
+        stale_reason: string;
+        old_policy_version: number;
+        new_policy_version: number;
+        resolved: number;
+      };
+      expect(comparable).toMatchObject({
+        stale_reason: "scoring_policy_changed",
+        old_policy_version: 1,
+        new_policy_version: 2,
+        resolved: 0,
+      });
+      const excludedRows = db
+        .prepare(
+          `SELECT job_url
+           FROM job_score_staleness
+           WHERE job_url IN (?, ?, ?)`,
+        )
+        .all("https://example.com/jobs/ready", currentPolicyUrl, alreadyCorrectedUrl);
+      expect(excludedRows).toEqual([]);
+      const staleStage = db
+        .prepare("SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
+        .get(comparableUrl) as { state: string };
+      expect(staleStage.state).toBe("stale");
+      const event = db
+        .prepare("SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1")
+        .get(comparableUrl) as { event_type: string };
+      expect(event.event_type).toBe("ScoreMarkedStale");
+    } finally {
+      db.close();
+      await app.close();
+    }
+  });
+
+  it("resets stale score markers for explicit rescore through the API", async () => {
+    const staleUrl = "https://example.com/jobs/stale-score";
+    const seedDb = new Database(options.dbPath);
+    insertJob(seedDb, {
+      url: staleUrl,
+      title: "Stale Engineer",
+      site: "ExampleCo",
+      fitScore: 7,
+    });
+    insertScore(seedDb, staleUrl, 1, 7, { policyVersion: 1 });
+    insertStage(seedDb, staleUrl, "score", "stale");
+    createScoreStalenessTable(seedDb);
+    seedDb
+      .prepare(
+        `INSERT INTO job_score_staleness (
+           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           new_policy_id, new_policy_version, marked_at, resolved
+         ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+           'local:scoring-policy-v2', 2, '2026-04-29T10:07:00+00:00', 0)`,
+      )
+      .run(staleUrl);
+    seedDb.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/scoring/stale-scores/actions/reset-for-rescore",
+      payload: { limit: 1 },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      count: 1,
+      jobKeys: [staleUrl],
+      nextAction: "jobhunter run score --rescore",
+    });
+
+    const db = new Database(options.dbPath);
+    try {
+      const marker = db
+        .prepare("SELECT resolved, resolved_at FROM job_score_staleness WHERE job_url = ?")
+        .get(staleUrl) as { resolved: number; resolved_at: string | null };
+      expect(marker.resolved).toBe(1);
+      expect(marker.resolved_at).toBeTruthy();
+      const stage = db
+        .prepare("SELECT state, attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'score'")
+        .get(staleUrl) as { state: string; attempt_count: number };
+      expect(stage).toMatchObject({ state: "pending", attempt_count: 0 });
+      const event = db
+        .prepare("SELECT event_type, payload_json FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1")
+        .get(staleUrl) as { event_type: string; payload_json: string };
+      expect(event.event_type).toBe("ScoreRescoreRequested");
+      expect(JSON.parse(event.payload_json)).toMatchObject({
+        nextAction: "jobhunter run score --rescore",
+        newPolicyVersion: 2,
+      });
+    } finally {
+      db.close();
+      await app.close();
+    }
+  });
+
   it("returns artifact detail by artifact id", async () => {
     const app = buildApp(options);
     const listResponse = await app.inject({ method: "GET", url: "/v1/artifacts?type=tailored_resume_txt" });
@@ -2307,12 +2462,17 @@ function insertScore(
   jobUrl: string,
   version: number,
   fitScore: number,
+  options: {
+    correction?: Record<string, unknown> | null;
+    policyVersion?: number;
+    policyId?: string;
+  } = {},
 ): void {
   db.prepare(
     `INSERT INTO job_scores (
       job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
-      scored_at, correction_json, criteria_json, trace_json
-    ) VALUES (?, ?, 'local', ?, ?, ?, ?, NULL, ?, ?)`,
+    scored_at, correction_json, criteria_json, trace_json
+    ) VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     jobUrl,
     version,
@@ -2331,6 +2491,11 @@ function insertScore(
     }),
     JSON.stringify(["platform"]),
     "2026-04-29T10:02:00+00:00",
+    options.correction === undefined
+      ? null
+      : options.correction === null
+        ? null
+        : JSON.stringify(options.correction),
     JSON.stringify({
       min_fit_score: 7,
       criteria_text: "Seeded criteria.",
@@ -2344,10 +2509,38 @@ function insertScore(
       model: "seed",
       criteria_version: "seeded-criteria",
       profile_snapshot_version: 1,
+      ...(options.policyVersion === undefined
+        ? {}
+        : {
+            scoring_policy_id: options.policyId ?? `local:scoring-policy-v${options.policyVersion}`,
+            scoring_policy_version: options.policyVersion,
+          }),
       parser_warnings: [],
       correction_history: [],
     }),
   );
+}
+
+function createScoreStalenessTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_score_staleness (
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_url TEXT NOT NULL,
+      stale_reason TEXT NOT NULL,
+      old_policy_id TEXT NOT NULL DEFAULT '',
+      old_policy_version INTEGER NOT NULL,
+      new_policy_id TEXT NOT NULL DEFAULT '',
+      new_policy_version INTEGER NOT NULL,
+      marked_at TEXT NOT NULL,
+      resolved INTEGER NOT NULL DEFAULT 0,
+      resolved_at TEXT,
+      resolved_by_score_version INTEGER,
+      PRIMARY KEY (
+        tenant_id, job_url, stale_reason,
+        old_policy_version, new_policy_version
+      )
+    )
+  `);
 }
 
 function insertStage(

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -494,6 +494,11 @@ classDiagram
   correction-derived calibration anchors; current behavior preserves rubric
   weights and thresholds while making later score traces cite the new policy
   version and anchor IDs.
+- Marks comparable latest uncorrected scores stale in `job_score_staleness`
+  when a correction creates a newer scoring policy version. Corrected score
+  versions are excluded. Successful uncorrected rescores under the newer policy
+  resolve the stale marker; the local API can also reset active stale markers
+  for explicit `jobhunter run score --rescore` processing.
 - Updates legacy-compatible score fields where needed by queue selectors.
 - Publishes score events consumed by Pipeline and Operations.
 - Refreshes dashboard score distributions and job list score badges.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -52,6 +52,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Discovery RFC production wiring stops auto-approving located parseable sources, feeding API-visible manual queues, canonical ATS ingestion, manual-capture imports, snapshot persistence, or acceptance evidence | `workers/automation/tests/test_discovery_production_wiring.py` uses a Barcelona/Spain tech-leadership fixture and report covering lead yield, candidate sources, manual-action count, canonical verification rate, duplicate/quarantine counts, source-quality updates, and scoring handoff count |
 | Hybrid retrieval picks stale or weak candidates before LLM scoring | `workers/automation/tests/test_hybrid_search_index.py`; `workers/automation/tests/test_scorer.py::test_run_scoring_preselects_retrieval_top_k_before_llm` |
 | Scoring prompt/schema/model changes silently regress parse validity, bands, blockers, ranking, or correction agreement | `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval*.py`; update the synthetic scoring fixtures or document why a scoring change does not affect them |
+| Score corrections change the policy but leave comparable uncorrected scores fresh, mark corrected versions stale, or fail to clear stale markers for explicit rescore | `workers/automation/tests/test_score_repository.py`; `apps/api/test/server.test.ts` |
 
 ## Frontend QA
 

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -29,7 +29,13 @@ the wire as a compatibility summary during the scoring evidence migration.
 version, records `ScoreCorrected`, and updates the versioned `scoring_policies`
 table with a correction-derived calibration anchor. It mirrors the Python
 `CorrectScoreUseCase` policy update path because this local API mutation writes
-directly to SQLite instead of crossing the Python JSON-RPC boundary.
+directly to SQLite instead of crossing the Python JSON-RPC boundary. When the
+policy version changes, the API also marks comparable latest uncorrected scores
+stale in `job_score_staleness`; corrected score versions are not marked stale.
+`POST /v1/scoring/stale-scores/actions/reset-for-rescore` clears active stale
+markers and resets their score stage to `pending` for an explicit rescore. The
+backend command that consumes those reset jobs is `jobhunter run score --rescore`
+or the batch API action with `stage: "score"` and `rescore: true`.
 The jobs list `deleted` filter accepts `active`, `deleted`, `hidden`, or `all`.
 Deleted jobs are temporary removals: discovery clears the delete tombstone when
 the same posting is observed again. Hidden jobs use a separate

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -60,6 +60,15 @@ export const RetryStageRequestSchema = z
   .strict();
 export type RetryStageRequest = z.infer<typeof RetryStageRequestSchema>;
 
+export const ResetStaleScoresForRescoreRequestSchema = z
+  .object({
+    limit: z.coerce.number().int().min(0).max(500).default(0),
+  })
+  .strict();
+export type ResetStaleScoresForRescoreRequest = z.infer<
+  typeof ResetStaleScoresForRescoreRequestSchema
+>;
+
 export const GenerateMaterialsRequestSchema = z
   .object({
     stages: z.array(z.enum(MATERIAL_STAGES)).min(1).default(["tailor", "cover", "pdf"]),

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -1863,6 +1863,29 @@ _TAILOR_NOT_EXHAUSTED: str = "(jss_t.jss_t_state IS NULL OR jss_t.jss_t_state !=
 _COVER_NOT_EXHAUSTED: str = "(jss_c.jss_c_state IS NULL OR jss_c.jss_c_state != 'exhausted')"
 
 
+# Stale-score guard for downstream stages. Legacy rows can have a pending
+# score-stage row while their usable score still lives only in
+# ``jobs.fit_score``; those remain eligible unless explicitly stale or
+# carrying an unresolved marker. Once the usable score comes from
+# ``job_scores``, downstream work requires a succeeded score-stage row.
+_SCORE_DOWNSTREAM_STATE_JOIN: str = (
+    "LEFT JOIN ("
+    "SELECT job_url AS jss_s_job_url, state AS jss_s_state "
+    "FROM job_stage_states WHERE stage = 'score'"
+    ") jss_s ON jss_s.jss_s_job_url = jobs.url "
+    "LEFT JOIN ("
+    "SELECT DISTINCT job_url AS jss_stale_job_url "
+    "FROM job_score_staleness WHERE resolved = 0"
+    ") jss_stale ON jss_stale.jss_stale_job_url = jobs.url"
+)
+_SCORE_CURRENT_FOR_DOWNSTREAM: str = (
+    "(jss_stale.jss_stale_job_url IS NULL "
+    "AND (jss_s.jss_s_state IS NULL "
+    "OR jss_s.jss_s_state = 'succeeded' "
+    "OR (js.js_fit_score IS NULL AND jss_s.jss_s_state != 'stale')))"
+)
+
+
 # ---------------------------------------------------------------------------
 # job_scores read fragments — used by every selector / stat that previously
 # read bare ``jobs.fit_score``. After Phase 5 the canonical fit score lives
@@ -2076,9 +2099,10 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
 
     stats["untailored_eligible"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_SCORE_JOIN} {_LATEST_MATERIALS_JOIN} "
-        f"{_ENRICHMENT_JOIN} "
+        f"{_SCORE_DOWNSTREAM_STATE_JOIN} {_ENRICHMENT_JOIN} "
         f"WHERE {_EFFECTIVE_FIT_SCORE} >= 7 "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {_EFFECTIVE_TAILOR_PATH} IS NULL"
     ).fetchone()[0]
@@ -2114,10 +2138,11 @@ def get_stats(conn: sqlite3.Connection | None = None) -> dict:
 
     stats["ready_to_apply"] = conn.execute(
         f"SELECT COUNT(*) FROM jobs {_LATEST_SCORE_JOIN} {_LATEST_MATERIALS_JOIN} "
-        f"{_ENRICHMENT_JOIN} {_LATEST_APPLY_RUN_JOIN} "
+        f"{_SCORE_DOWNSTREAM_STATE_JOIN} {_ENRICHMENT_JOIN} {_LATEST_APPLY_RUN_JOIN} "
         f"WHERE {_EFFECTIVE_TAILOR_PATH} IS NOT NULL "
         f"AND {_EFFECTIVE_FIT_SCORE} >= 7 "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {_EFFECTIVE_APPLIED_AT} IS NULL "
         f"AND {_EFFECTIVE_APPLICATION_URL} IS NOT NULL "
         f"AND {_EFFECTIVE_APPLICATION_URL} != ''"
@@ -2365,11 +2390,13 @@ def get_jobs_by_stage(
     pending_tailor_where = (
         f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {_TAILOR_NOT_EXHAUSTED} "
         f"AND ({_EFFECTIVE_TAILOR_PATH} IS NOT NULL OR {_EFFECTIVE_TAILOR_ATTEMPTS} < 5)"
         if retailor
         else f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {_EFFECTIVE_TAILOR_PATH} IS NULL "
         f"AND {_TAILOR_NOT_EXHAUSTED} "
         f"AND {_EFFECTIVE_TAILOR_ATTEMPTS} < 5"
@@ -2385,6 +2412,7 @@ def get_jobs_by_stage(
         "pending_cover": (
             f"{_EFFECTIVE_FIT_SCORE} >= ? AND {_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
             f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+            f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
             f"AND {_EFFECTIVE_TAILOR_PATH} IS NOT NULL AND {_EFFECTIVE_TAILOR_PATH} != '' "
             f"AND ({_EFFECTIVE_COVER_PATH} IS NULL OR {_EFFECTIVE_COVER_PATH} = '') "
             f"AND {_COVER_NOT_EXHAUSTED} "
@@ -2402,6 +2430,7 @@ def get_jobs_by_stage(
             f"{_EFFECTIVE_TAILOR_PATH} IS NOT NULL "
             f"AND {_EFFECTIVE_FIT_SCORE} >= ? "
             f"AND {_SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+            f"AND {_SCORE_CURRENT_FOR_DOWNSTREAM} "
             f"AND {_EFFECTIVE_APPLIED_AT} IS NULL "
             f"AND {_EFFECTIVE_APPLICATION_URL} IS NOT NULL "
             f"AND {_EFFECTIVE_APPLICATION_URL} != '' "
@@ -2459,7 +2488,8 @@ def get_jobs_by_stage(
         f"{_EFFECTIVE_APPLIED_AT} AS effective_applied_at, "
         f"{_EFFECTIVE_APPLY_STATUS} AS effective_apply_status "
         f"FROM jobs {_LATEST_SCORE_JOIN} {_LATEST_MATERIALS_JOIN} "
-        f"{_LATEST_STAGE_ATTEMPTS_JOIN} {_ENRICHMENT_JOIN} {_LATEST_APPLY_RUN_JOIN} "
+        f"{_LATEST_STAGE_ATTEMPTS_JOIN} {_SCORE_DOWNSTREAM_STATE_JOIN} "
+        f"{_ENRICHMENT_JOIN} {_LATEST_APPLY_RUN_JOIN} "
         f"WHERE {where} "
         f"ORDER BY {_EFFECTIVE_FIT_SCORE} DESC NULLS LAST, discovered_at DESC"
     )

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -932,6 +932,7 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         ON job_scores(job_url, version DESC)
     """)
     ensure_scoring_policy_tables(conn)
+    ensure_score_staleness_tables(conn)
 
     # One-shot backfill from the legacy columns. Only fires when
     # job_scores has no rows AND there are jobs with a legacy fit_score.
@@ -995,7 +996,7 @@ def ensure_score_tables(conn: sqlite3.Connection | None = None) -> list[str]:
                 )
 
     conn.commit()
-    return ["job_scores", "scoring_policies"]
+    return ["job_scores", "scoring_policies", "job_score_staleness"]
 
 
 def ensure_scoring_policy_tables(conn: sqlite3.Connection | None = None) -> list[str]:
@@ -1028,6 +1029,49 @@ def ensure_scoring_policy_tables(conn: sqlite3.Connection | None = None) -> list
     )
     conn.commit()
     return ["scoring_policies"]
+
+
+def ensure_score_staleness_tables(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Create score-staleness markers used after scoring-policy changes."""
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS job_score_staleness (
+            tenant_id                 TEXT NOT NULL DEFAULT 'local',
+            job_url                   TEXT NOT NULL,
+            stale_reason              TEXT NOT NULL,
+            old_policy_id             TEXT NOT NULL DEFAULT '',
+            old_policy_version        INTEGER NOT NULL,
+            new_policy_id             TEXT NOT NULL DEFAULT '',
+            new_policy_version        INTEGER NOT NULL,
+            marked_at                 TEXT NOT NULL,
+            resolved                  INTEGER NOT NULL DEFAULT 0,
+            resolved_at               TEXT,
+            resolved_by_score_version INTEGER,
+            PRIMARY KEY (
+                tenant_id, job_url, stale_reason,
+                old_policy_version, new_policy_version
+            ),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_unresolved
+        ON job_score_staleness(tenant_id, resolved, marked_at DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_score_staleness_job
+        ON job_score_staleness(tenant_id, job_url, resolved)
+        """
+    )
+    conn.commit()
+    return ["job_score_staleness"]
 
 
 def ensure_materials_tables(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/src/jobhunter/domain/ports/scoring.py
+++ b/workers/automation/src/jobhunter/domain/ports/scoring.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from typing import Protocol
 
 from jobhunter.domain.identifiers import JobId
-from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.aggregate import JobScore, ScoreStaleMarker
 from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobhunter.domain.tenant import TenantId
 
@@ -22,6 +22,7 @@ from jobhunter.domain.ports.llm import LlmMessage, LlmPort, LlmRole
 
 __all__ = [
     "ScoreRepository",
+    "ScoreStalenessRepository",
     "ScoringPolicyRepository",
     "LlmPort",
     "LlmMessage",
@@ -98,4 +99,24 @@ class ScoringPolicyRepository(Protocol):
 
     def save_correction_signal(self, signal: CorrectionSignal) -> ScoringPolicy:
         """Persist the next policy version derived from a correction signal."""
+        ...
+
+
+class ScoreStalenessRepository(Protocol):
+    """Persistence port for score-staleness markers."""
+
+    def mark_comparable_scores_stale(
+        self,
+        *,
+        tenant_id: TenantId,
+        stale_reason: str,
+        new_policy_id: str,
+        new_policy_version: int,
+        marked_at: str,
+    ) -> list[ScoreStaleMarker]:
+        """Mark latest uncorrected scores with older policy traces stale."""
+        ...
+
+    def resolve_for_score(self, score: JobScore) -> int:
+        """Resolve active stale markers satisfied by a new persisted score."""
         ...

--- a/workers/automation/src/jobhunter/domain/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/domain/scoring/__init__.py
@@ -16,7 +16,7 @@ from jobhunter.domain.scoring.value_objects import (
     ScoreTrace,
     ScoringCriteria,
 )
-from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.aggregate import JobScore, ScoreStaleMarker
 from jobhunter.domain.scoring.policy import (
     CalibrationAnchor,
     CorrectionSignal,
@@ -51,6 +51,7 @@ __all__ = [
     "ScoreTrace",
     "ScoringCriteria",
     "JobScore",
+    "ScoreStaleMarker",
     "CalibrationAnchor",
     "CorrectionSignal",
     "FitBandThreshold",

--- a/workers/automation/src/jobhunter/domain/scoring/aggregate.py
+++ b/workers/automation/src/jobhunter/domain/scoring/aggregate.py
@@ -168,3 +168,30 @@ class JobScore:
             "trace": self.trace.to_dict(),
             "correction": self.correction.to_dict() if self.correction else None,
         }
+
+
+@dataclass(frozen=True)
+class ScoreStaleMarker:
+    """Persisted marker that a latest score was produced by an older policy."""
+
+    tenant_id: TenantId
+    job_id: JobId
+    stale_reason: str
+    old_policy_id: str
+    old_policy_version: int
+    new_policy_id: str
+    new_policy_version: int
+    marked_at: str
+    resolved: bool = False
+    resolved_at: str | None = None
+    resolved_by_score_version: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.old_policy_version < 0:
+            raise ValueError("old_policy_version must be >= 0")
+        if self.new_policy_version < 0:
+            raise ValueError("new_policy_version must be >= 0")
+        if not self.stale_reason.strip():
+            raise ValueError("stale_reason must be non-empty")
+        if not self.marked_at.strip():
+            raise ValueError("marked_at must be non-empty")

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -37,7 +37,12 @@ from jobhunter.domain.events import (
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.llm import LlmMessage
-from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository, ScoringPolicyRepository
+from jobhunter.domain.ports.scoring import (
+    LlmPort,
+    ScoreRepository,
+    ScoreStalenessRepository,
+    ScoringPolicyRepository,
+)
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
 from jobhunter.domain.scoring.aggregate import JobScore
 from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
@@ -572,10 +577,12 @@ class CorrectScoreUseCase:
         repository: ScoreRepository,
         publisher: EventPublisher | None = None,
         policy_repository: ScoringPolicyRepository | None = None,
+        staleness_repository: ScoreStalenessRepository | None = None,
     ) -> None:
         self._repository = repository
         self._publisher = publisher
         self._policy_repository = policy_repository
+        self._staleness_repository = staleness_repository
 
     def execute(
         self,
@@ -601,7 +608,11 @@ class CorrectScoreUseCase:
         )
         new_score = previous.with_correction(correction)
         self._repository.save(new_score)
-        self._persist_policy_correction_signal(previous=previous, correction=correction)
+        new_policy = self._persist_policy_correction_signal(
+            previous=previous,
+            correction=correction,
+        )
+        self._mark_stale_scores(previous=previous, new_policy=new_policy, marked_at=correction.corrected_at)
         self._publish_corrected(previous=previous, new=new_score)
         return new_score
 
@@ -610,9 +621,9 @@ class CorrectScoreUseCase:
         *,
         previous: JobScore,
         correction: ScoreCorrection,
-    ) -> None:
+    ) -> ScoringPolicy | None:
         if self._policy_repository is None:
-            return
+            return None
         signal = CorrectionSignal(
             tenant_id=previous.tenant_id,
             job_id=str(previous.job_id),
@@ -631,10 +642,28 @@ class CorrectScoreUseCase:
             None,
         )
         if callable(save_correction_signal):
-            save_correction_signal(signal)
-            return
+            return save_correction_signal(signal)
         current = self._policy_repository.get_current(previous.tenant_id)
-        self._policy_repository.save(current.with_correction_signal(signal))
+        next_policy = current.with_correction_signal(signal)
+        self._policy_repository.save(next_policy)
+        return next_policy
+
+    def _mark_stale_scores(
+        self,
+        *,
+        previous: JobScore,
+        new_policy: ScoringPolicy | None,
+        marked_at: str,
+    ) -> None:
+        if self._staleness_repository is None or new_policy is None:
+            return
+        self._staleness_repository.mark_comparable_scores_stale(
+            tenant_id=previous.tenant_id,
+            stale_reason="scoring_policy_changed",
+            new_policy_id=new_policy.policy_id,
+            new_policy_version=new_policy.version,
+            marked_at=marked_at,
+        )
 
     def _publish_corrected(self, *, previous: JobScore, new: JobScore) -> None:
         if self._publisher is None or new.correction is None:

--- a/workers/automation/src/jobhunter/infrastructure/scoring/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/__init__.py
@@ -9,6 +9,7 @@ from jobhunter.infrastructure.scoring.feedback import (
 )
 from jobhunter.infrastructure.scoring.sqlite_repository import (
     SqliteScoreRepository,
+    SqliteScoreStalenessRepository,
     SqliteScoringPolicyRepository,
 )
 
@@ -17,6 +18,7 @@ __all__ = [
     "LocalScoringCriteriaProvider",
     "ScoringFeedbackSignal",
     "SqliteScoreRepository",
+    "SqliteScoreStalenessRepository",
     "SqliteScoringPolicyRepository",
     "collect_feedback_signals",
     "rank_jobs_with_feedback",

--- a/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py
@@ -21,9 +21,9 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Any
 
-from jobhunter.database import ensure_scoring_policy_tables
+from jobhunter.database import ensure_score_staleness_tables, ensure_scoring_policy_tables
 from jobhunter.domain.identifiers import JobId
-from jobhunter.domain.scoring.aggregate import JobScore
+from jobhunter.domain.scoring.aggregate import JobScore, ScoreStaleMarker
 from jobhunter.domain.scoring.policy import CorrectionSignal, ScoringPolicy
 from jobhunter.domain.scoring.value_objects import (
     FitScore,
@@ -34,6 +34,7 @@ from jobhunter.domain.scoring.value_objects import (
     ScoringCriteria,
 )
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
+from jobhunter.state import record_job_event, set_stage_state
 
 
 class ScoreVersionConflict(ValueError):
@@ -53,6 +54,271 @@ class ScoreVersionConflict(ValueError):
         )
 
 
+class SqliteScoreStalenessRepository:
+    """SQLite-backed score-staleness marker adapter."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_score_staleness_tables(conn)
+
+    def mark_comparable_scores_stale(
+        self,
+        *,
+        tenant_id: TenantId,
+        stale_reason: str,
+        new_policy_id: str,
+        new_policy_version: int,
+        marked_at: str,
+    ) -> list[ScoreStaleMarker]:
+        """Mark latest uncorrected scores that were produced by older policies."""
+        if new_policy_version <= 0:
+            return []
+
+        marked: list[ScoreStaleMarker] = []
+        rows = self._conn.execute(
+            """
+            SELECT s.job_url, s.trace_json
+            FROM job_scores s
+            INNER JOIN (
+                SELECT job_url, MAX(version) AS max_version
+                FROM job_scores
+                WHERE tenant_id = ?
+                GROUP BY job_url
+            ) latest
+              ON latest.job_url = s.job_url AND latest.max_version = s.version
+            WHERE s.tenant_id = ?
+              AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')
+            """,
+            (str(tenant_id), str(tenant_id)),
+        ).fetchall()
+        for row in rows:
+            job_url = _row_value(row, "job_url", 0)
+            trace = _json_object(_row_value(row, "trace_json", 1))
+            old_policy_version = _int_or_default(trace.get("scoring_policy_version"), 0)
+            if old_policy_version >= new_policy_version:
+                continue
+
+            marker = ScoreStaleMarker(
+                tenant_id=tenant_id,
+                job_id=JobId(str(job_url)),
+                stale_reason=stale_reason,
+                old_policy_id=str(trace.get("scoring_policy_id") or ""),
+                old_policy_version=old_policy_version,
+                new_policy_id=new_policy_id,
+                new_policy_version=new_policy_version,
+                marked_at=marked_at,
+            )
+            inserted = self._conn.execute(
+                """
+                INSERT OR IGNORE INTO job_score_staleness (
+                    tenant_id, job_url, stale_reason,
+                    old_policy_id, old_policy_version,
+                    new_policy_id, new_policy_version,
+                    marked_at, resolved, resolved_at, resolved_by_score_version
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL)
+                """,
+                (
+                    str(marker.tenant_id),
+                    str(marker.job_id),
+                    marker.stale_reason,
+                    marker.old_policy_id,
+                    marker.old_policy_version,
+                    marker.new_policy_id,
+                    marker.new_policy_version,
+                    marker.marked_at,
+                ),
+            )
+            if inserted.rowcount <= 0:
+                continue
+            marked.append(marker)
+            self._mark_score_stage_stale(marker)
+
+        self._conn.commit()
+        return marked
+
+    def resolve_for_score(self, score: JobScore) -> int:
+        """Resolve markers satisfied by a fresh, non-corrected score version."""
+        if score.correction is not None or score.trace.scoring_policy_version <= 0:
+            return 0
+        now = _utc_now()
+        result = self._conn.execute(
+            """
+            UPDATE job_score_staleness
+               SET resolved = 1,
+                   resolved_at = ?,
+                   resolved_by_score_version = ?
+             WHERE tenant_id = ?
+               AND job_url = ?
+               AND resolved = 0
+               AND new_policy_version <= ?
+            """,
+            (
+                now,
+                score.version,
+                str(score.tenant_id),
+                str(score.job_id),
+                score.trace.scoring_policy_version,
+            ),
+        )
+        if result.rowcount > 0:
+            self._record_score_event(
+                str(score.job_id),
+                "ScoreStalenessResolved",
+                "Score stale marker resolved by a fresh score.",
+                {
+                    "tenantId": str(score.tenant_id),
+                    "jobId": str(score.job_id),
+                    "scoreVersion": score.version,
+                    "scoringPolicyVersion": score.trace.scoring_policy_version,
+                },
+            )
+        self._conn.commit()
+        return int(result.rowcount)
+
+    def reset_for_rescore(
+        self,
+        tenant_id: TenantId,
+        *,
+        limit: int = 0,
+        reset_at: str | None = None,
+    ) -> list[ScoreStaleMarker]:
+        """Clear active markers and reset their score stage for explicit rescore."""
+        now = reset_at or _utc_now()
+        sql = (
+            "SELECT tenant_id, job_url, stale_reason, old_policy_id, "
+            "old_policy_version, new_policy_id, new_policy_version, marked_at, "
+            "resolved, resolved_at, resolved_by_score_version "
+            "FROM job_score_staleness "
+            "WHERE tenant_id = ? AND resolved = 0 "
+            "ORDER BY marked_at ASC"
+        )
+        params: list[Any] = [str(tenant_id)]
+        if limit > 0:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = self._conn.execute(sql, params).fetchall()
+        markers = [self._row_to_marker(row) for row in rows]
+        for marker in markers:
+            job_url = str(marker.job_id)
+            set_stage_state(
+                self._conn,
+                job_url,
+                "score",
+                "pending",
+                attempt_count=0,
+                next_action="jobhunter run score --rescore",
+                metadata={
+                    "stale_reason": marker.stale_reason,
+                    "new_policy_version": marker.new_policy_version,
+                },
+                validate_transition=False,
+            )
+            self._conn.execute(
+                """
+                UPDATE job_score_staleness
+                   SET resolved = 1,
+                       resolved_at = ?
+                 WHERE tenant_id = ?
+                   AND job_url = ?
+                   AND stale_reason = ?
+                   AND old_policy_version = ?
+                   AND new_policy_version = ?
+                """,
+                (
+                    now,
+                    str(marker.tenant_id),
+                    job_url,
+                    marker.stale_reason,
+                    marker.old_policy_version,
+                    marker.new_policy_version,
+                ),
+            )
+            self._record_score_event(
+                job_url,
+                "ScoreRescoreRequested",
+                "Stale score reset for explicit rescore.",
+                {
+                    "tenantId": str(marker.tenant_id),
+                    "jobId": job_url,
+                    "staleReason": marker.stale_reason,
+                    "oldPolicyVersion": marker.old_policy_version,
+                    "newPolicyVersion": marker.new_policy_version,
+                    "nextAction": "jobhunter run score --rescore",
+                },
+            )
+        self._conn.commit()
+        return markers
+
+    def _mark_score_stage_stale(self, marker: ScoreStaleMarker) -> None:
+        job_url = str(marker.job_id)
+        row = self._conn.execute(
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
+            (job_url,),
+        ).fetchone()
+        state = _row_value(row, "state", 0) if row is not None else None
+        if state in (None, "succeeded"):
+            set_stage_state(
+                self._conn,
+                job_url,
+                "score",
+                "stale",
+                metadata={
+                    "stale_reason": marker.stale_reason,
+                    "old_policy_version": marker.old_policy_version,
+                    "new_policy_version": marker.new_policy_version,
+                },
+            )
+        self._record_score_event(
+            job_url,
+            "ScoreMarkedStale",
+            "Score marked stale after scoring policy changed.",
+            {
+                "tenantId": str(marker.tenant_id),
+                "jobId": job_url,
+                "staleReason": marker.stale_reason,
+                "oldPolicyId": marker.old_policy_id,
+                "oldPolicyVersion": marker.old_policy_version,
+                "newPolicyId": marker.new_policy_id,
+                "newPolicyVersion": marker.new_policy_version,
+                "markedAt": marker.marked_at,
+            },
+        )
+
+    def _record_score_event(
+        self,
+        job_url: str,
+        event_type: str,
+        message: str,
+        payload: dict[str, Any],
+    ) -> None:
+        if not _table_exists(self._conn, "job_events"):
+            return
+        record_job_event(
+            self._conn,
+            job_url,
+            "score",
+            event_type,
+            message=message,
+            payload=payload,
+        )
+
+    @staticmethod
+    def _row_to_marker(row: Any) -> ScoreStaleMarker:
+        return ScoreStaleMarker(
+            tenant_id=TenantId(str(_row_value(row, "tenant_id", 0))),
+            job_id=JobId(str(_row_value(row, "job_url", 1))),
+            stale_reason=str(_row_value(row, "stale_reason", 2)),
+            old_policy_id=str(_row_value(row, "old_policy_id", 3) or ""),
+            old_policy_version=int(_row_value(row, "old_policy_version", 4) or 0),
+            new_policy_id=str(_row_value(row, "new_policy_id", 5) or ""),
+            new_policy_version=int(_row_value(row, "new_policy_version", 6) or 0),
+            marked_at=str(_row_value(row, "marked_at", 7)),
+            resolved=bool(_row_value(row, "resolved", 8)),
+            resolved_at=_row_value(row, "resolved_at", 9),
+            resolved_by_score_version=_row_value(row, "resolved_by_score_version", 10),
+        )
+
+
 class SqliteScoreRepository:
     """SQLite-backed implementation of ``ScoreRepository``.
 
@@ -65,6 +331,7 @@ class SqliteScoreRepository:
 
     def __init__(self, conn: sqlite3.Connection) -> None:
         self._conn = conn
+        self._staleness = SqliteScoreStalenessRepository(conn)
 
     @property
     def connection(self) -> sqlite3.Connection:
@@ -184,6 +451,7 @@ class SqliteScoreRepository:
                 json.dumps(score.trace.to_dict(), sort_keys=True),
             ),
         )
+        self._staleness.resolve_for_score(score)
         self._conn.commit()
 
     # ------------------------------------------------------------------
@@ -321,3 +589,32 @@ class SqliteScoringPolicyRepository:
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _row_value(row: Any, name: str, index: int) -> Any:
+    if isinstance(row, sqlite3.Row):
+        return row[name]
+    return row[index]
+
+
+def _json_object(raw: Any) -> dict[str, Any]:
+    try:
+        value = json.loads(str(raw or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _int_or_default(raw: Any, default: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -1248,10 +1248,12 @@ _PENDING_SQL: dict[str, str] = {
     "tailor": (
         f"SELECT COUNT(*) FROM jobs {db_module._LATEST_SCORE_JOIN} "
         f"{db_module._LATEST_MATERIALS_JOIN} {db_module._LATEST_STAGE_ATTEMPTS_JOIN} "
+        f"{db_module._SCORE_DOWNSTREAM_STATE_JOIN} "
         f"{db_module._ENRICHMENT_JOIN} "
         f"WHERE {db_module._EFFECTIVE_FIT_SCORE} >= ? "
         f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {db_module._EFFECTIVE_TAILOR_PATH} IS NULL "
         f"AND {db_module._TAILOR_NOT_EXHAUSTED} "
         f"AND {db_module._EFFECTIVE_TAILOR_ATTEMPTS} < 5"
@@ -1259,10 +1261,12 @@ _PENDING_SQL: dict[str, str] = {
     "cover": (
         f"SELECT COUNT(*) FROM jobs {db_module._LATEST_SCORE_JOIN} "
         f"{db_module._LATEST_MATERIALS_JOIN} {db_module._LATEST_STAGE_ATTEMPTS_JOIN} "
+        f"{db_module._SCORE_DOWNSTREAM_STATE_JOIN} "
         f"{db_module._ENRICHMENT_JOIN} "
         f"WHERE {db_module._EFFECTIVE_FIT_SCORE} >= ? "
         f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
         f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+        f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
         f"AND {db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL AND {db_module._EFFECTIVE_TAILOR_PATH} != '' "
         f"AND ({db_module._EFFECTIVE_COVER_PATH} IS NULL OR {db_module._EFFECTIVE_COVER_PATH} = '') "
         f"AND {db_module._COVER_NOT_EXHAUSTED} "
@@ -1294,12 +1298,14 @@ def _count_pending(stage: str, min_score: int = 7, retailor: bool = False) -> in
             f"{db_module._EFFECTIVE_FIT_SCORE} >= ? "
             f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
             f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+            f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
             f"AND {db_module._TAILOR_NOT_EXHAUSTED} "
             f"AND ({db_module._EFFECTIVE_TAILOR_PATH} IS NOT NULL OR {db_module._EFFECTIVE_TAILOR_ATTEMPTS} < 5)"
             if retailor else
             f"{db_module._EFFECTIVE_FIT_SCORE} >= ? "
             f"AND {db_module._EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
             f"AND {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM} "
+            f"AND {db_module._SCORE_CURRENT_FOR_DOWNSTREAM} "
             f"AND {db_module._EFFECTIVE_TAILOR_PATH} IS NULL "
             f"AND {db_module._TAILOR_NOT_EXHAUSTED} "
             f"AND {db_module._EFFECTIVE_TAILOR_ATTEMPTS} < 5"
@@ -1307,7 +1313,7 @@ def _count_pending(stage: str, min_score: int = 7, retailor: bool = False) -> in
         return conn.execute(
             f"SELECT COUNT(*) FROM jobs {db_module._LATEST_SCORE_JOIN} "
             f"{db_module._LATEST_MATERIALS_JOIN} {db_module._LATEST_STAGE_ATTEMPTS_JOIN} "
-            f"{db_module._ENRICHMENT_JOIN} "
+            f"{db_module._SCORE_DOWNSTREAM_STATE_JOIN} {db_module._ENRICHMENT_JOIN} "
             f"WHERE {where}",
             (min_score,),
         ).fetchone()[0]

--- a/workers/automation/tests/test_apply_queue_selectors.py
+++ b/workers/automation/tests/test_apply_queue_selectors.py
@@ -18,6 +18,7 @@ from jobhunter.database import (
     get_stats,
     init_db,
 )
+from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobhunter.state import ensure_job_stage_rows, record_job_event, set_stage_state
 
@@ -79,6 +80,50 @@ def _insert_blocked_score(conn, url: str, *, fit_score: int = 9) -> None:
     conn.commit()
 
 
+def _insert_allowed_score(conn, url: str, *, fit_score: int = 9) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json,
+            keywords_json, scored_at, correction_json, criteria_json, trace_json
+        ) VALUES (?, 1, 'local', ?, ?, '["python"]', ?, NULL, '{}', '{}')
+        """,
+        (
+            url,
+            fit_score,
+            json.dumps(
+                {
+                    "reasoning": "Strong match.",
+                    "eligibility": {
+                        "status": "eligible",
+                        "hard_blockers": [],
+                        "warnings": [],
+                    },
+                },
+                sort_keys=True,
+            ),
+            "2026-05-14T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+
+
+def _insert_active_score_staleness_marker(conn, url: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_url, stale_reason,
+            old_policy_id, old_policy_version,
+            new_policy_id, new_policy_version,
+            marked_at, resolved, resolved_at, resolved_by_score_version
+        ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+                  'local:scoring-policy-v2', 2, '2026-05-19T00:00:00+00:00', 0, NULL, NULL)
+        """,
+        (str(LOCAL_TENANT), url),
+    )
+    conn.commit()
+
+
 def _emit_started(conn, url: str, run_id: str, *, when: str = "t0") -> None:
     record_job_event(
         conn,
@@ -125,6 +170,28 @@ def test_pending_apply_excludes_high_score_blocked_jobs(conn):
     urls = {row["url"] for row in rows}
     assert "https://example.com/allowed" in urls
     assert "https://example.com/blocked" not in urls
+
+
+@pytest.mark.parametrize(
+    ("score_state", "active_marker"),
+    [
+        ("stale", True),
+        ("pending", False),
+        ("succeeded", True),
+    ],
+)
+def test_pending_apply_excludes_non_current_scores(conn, score_state: str, active_marker: bool):
+    url = f"https://example.com/non-current-apply-{score_state}-{active_marker}"
+    _insert_apply_ready_job(conn, url=url)
+    _insert_allowed_score(conn, url)
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(conn, url, "score", score_state, validate_transition=False)
+    if active_marker:
+        _insert_active_score_staleness_marker(conn, url)
+
+    rows = get_jobs_by_stage(conn, "pending_apply", min_score=7)
+    urls = {row["url"] for row in rows}
+    assert url not in urls
 
 
 def test_pending_apply_excludes_jobs_with_succeeded_apply_run(conn):

--- a/workers/automation/tests/test_score_queue_selectors.py
+++ b/workers/automation/tests/test_score_queue_selectors.py
@@ -42,6 +42,7 @@ from jobhunter.domain.scoring import (
 )
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.scoring import SqliteScoreRepository
+from jobhunter.state import ensure_job_stage_rows, set_stage_state
 
 
 @pytest.fixture()
@@ -77,6 +78,22 @@ def _save_score(
             scored_at=datetime.now(timezone.utc).isoformat(),
         )
     )
+
+
+def _insert_active_score_staleness_marker(conn: sqlite3.Connection, url: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_score_staleness (
+            tenant_id, job_url, stale_reason,
+            old_policy_id, old_policy_version,
+            new_policy_id, new_policy_version,
+            marked_at, resolved, resolved_at, resolved_by_score_version
+        ) VALUES (?, ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+                  'local:scoring-policy-v2', 2, ?, 0, NULL, NULL)
+        """,
+        (str(LOCAL_TENANT), url, datetime.now(timezone.utc).isoformat()),
+    )
+    conn.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -190,6 +207,40 @@ def test_pending_cover_excludes_high_score_blocked_jobs(
     assert url_blocked not in urls
 
 
+@pytest.mark.parametrize("stage", ["pending_tailor", "pending_cover"])
+@pytest.mark.parametrize(
+    ("score_state", "active_marker"),
+    [
+        ("stale", True),
+        ("pending", False),
+        ("succeeded", True),
+    ],
+)
+def test_downstream_materials_selectors_exclude_non_current_scores(
+    conn: sqlite3.Connection,
+    stage: str,
+    score_state: str,
+    active_marker: bool,
+) -> None:
+    url = f"https://example.com/job/non-current-{stage}-{score_state}-{active_marker}"
+    _seed_enriched_job(conn, url)
+    _save_score(conn, url, fit=9)
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(conn, url, "score", score_state, validate_transition=False)
+    if active_marker:
+        _insert_active_score_staleness_marker(conn, url)
+    if stage == "pending_cover":
+        conn.execute(
+            "UPDATE jobs SET tailored_resume_path=?, tailored_at=? WHERE url=?",
+            ("/tmp/tailored.txt", "2024-01-02T00:00:00+00:00", url),
+        )
+        conn.commit()
+
+    pending = get_jobs_by_stage(conn=conn, stage=stage, min_score=7)
+    urls = {row["url"] for row in pending}
+    assert url not in urls
+
+
 def test_get_jobs_by_stage_returns_canonical_score_in_dict(
     conn: sqlite3.Connection,
 ) -> None:
@@ -285,3 +336,19 @@ def test_pipeline_count_pending_tailor_picks_repository_scores(
     monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
 
     assert pipeline._count_pending("tailor", min_score=7) == 1
+
+
+def test_pipeline_count_pending_tailor_excludes_pending_rescore(
+    conn: sqlite3.Connection, monkeypatch
+) -> None:
+    from jobhunter import pipeline
+    from jobhunter.pipeline import runner as pipeline_runner
+
+    url = "https://example.com/job/pipeline-tailor-pending-rescore"
+    _seed_enriched_job(conn, url)
+    _save_score(conn, url, fit=8)
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(conn, url, "score", "pending", validate_transition=False)
+    monkeypatch.setattr(pipeline_runner, "get_connection", lambda: conn)
+
+    assert pipeline._count_pending("tailor", min_score=7) == 0

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -21,11 +21,17 @@ from jobhunter.domain.scoring import (
     JobScore,
     MatchedKeywords,
     ScoreBreakdown,
+    ScoreCorrection,
     ScoreTrace,
     ScoringCriteria,
 )
+from jobhunter.domain.scoring.use_cases import CorrectScoreUseCase
 from jobhunter.domain.tenant import LOCAL_TENANT
-from jobhunter.infrastructure.scoring import SqliteScoreRepository
+from jobhunter.infrastructure.scoring import (
+    SqliteScoreRepository,
+    SqliteScoreStalenessRepository,
+    SqliteScoringPolicyRepository,
+)
 from jobhunter.infrastructure.scoring.sqlite_repository import ScoreVersionConflict
 
 
@@ -45,7 +51,14 @@ def _seed_job(conn: sqlite3.Connection, url: str = "https://example.com/job/1") 
     return url
 
 
-def _build_score(url: str, version: int = 1, fit: int = 7) -> JobScore:
+def _build_score(
+    url: str,
+    version: int = 1,
+    fit: int = 7,
+    *,
+    trace: ScoreTrace | None = None,
+    correction: ScoreCorrection | None = None,
+) -> JobScore:
     return JobScore(
         tenant_id=LOCAL_TENANT,
         job_id=JobId(url),
@@ -54,6 +67,8 @@ def _build_score(url: str, version: int = 1, fit: int = 7) -> JobScore:
         breakdown=ScoreBreakdown(technical_fit=8, experience_fit=6, role_fit=7, reasoning="ok"),
         matched_keywords=MatchedKeywords.from_iterable(["python", "fastapi"]),
         scored_at=datetime.now(timezone.utc).isoformat(),
+        trace=trace or ScoreTrace(),
+        correction=correction,
     )
 
 
@@ -279,6 +294,92 @@ def test_list_by_score_range_validates_inputs(conn: sqlite3.Connection) -> None:
         repo.list_by_score_range(LOCAL_TENANT, min_score=0)
     with pytest.raises(ValueError):
         repo.list_by_score_range(LOCAL_TENANT, min_score=8, max_score=4)
+
+
+# ---------------------------------------------------------------------------
+# Staleness markers
+# ---------------------------------------------------------------------------
+
+
+def test_score_correction_marks_comparable_uncorrected_scores_stale_and_resolve_on_rescore(
+    conn: sqlite3.Connection,
+) -> None:
+    target_url = _seed_job(conn, url="https://example.com/job/corrected")
+    comparable_url = _seed_job(conn, url="https://example.com/job/comparable")
+    current_url = _seed_job(conn, url="https://example.com/job/current-policy")
+    already_corrected_url = _seed_job(conn, url="https://example.com/job/already-corrected")
+    policy_v1 = ScoreTrace(
+        scoring_policy_id="local:scoring-policy-v1",
+        scoring_policy_version=1,
+    )
+    policy_v2 = ScoreTrace(
+        scoring_policy_id="local:scoring-policy-v2",
+        scoring_policy_version=2,
+    )
+    repo = SqliteScoreRepository(conn)
+    repo.save(_build_score(target_url, trace=policy_v1))
+    repo.save(_build_score(comparable_url, trace=policy_v1))
+    repo.save(_build_score(current_url, trace=policy_v2))
+    already_corrected = _build_score(already_corrected_url, trace=policy_v1)
+    repo.save(already_corrected)
+    repo.save(
+        already_corrected.with_correction(
+            ScoreCorrection(
+                corrected_fit_score=FitScore.create(8),
+                rationale="Already reviewed.",
+                corrected_by=LOCAL_TENANT,
+                corrected_at="2024-01-01T00:01:00+00:00",
+            )
+        )
+    )
+
+    CorrectScoreUseCase(
+        repository=repo,
+        policy_repository=SqliteScoringPolicyRepository(conn),
+        staleness_repository=SqliteScoreStalenessRepository(conn),
+    ).execute(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(target_url),
+        corrected_fit_score=FitScore.create(9),
+        rationale="Manual review found stronger fit.",
+        corrected_at="2024-01-02T00:00:00+00:00",
+    )
+
+    rows = conn.execute(
+        """
+        SELECT job_url, stale_reason, old_policy_version, new_policy_version, resolved
+        FROM job_score_staleness
+        ORDER BY job_url
+        """
+    ).fetchall()
+    assert [row["job_url"] for row in rows] == [comparable_url]
+    assert rows[0]["stale_reason"] == "scoring_policy_changed"
+    assert rows[0]["old_policy_version"] == 1
+    assert rows[0]["new_policy_version"] == 2
+    assert rows[0]["resolved"] == 0
+    stale_stage = conn.execute(
+        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
+        (comparable_url,),
+    ).fetchone()
+    assert stale_stage["state"] == "stale"
+    stale_event = conn.execute(
+        "SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",
+        (comparable_url,),
+    ).fetchone()
+    assert stale_event["event_type"] == "ScoreMarkedStale"
+
+    repo.save(_build_score(comparable_url, version=2, fit=8, trace=policy_v2))
+
+    resolved = conn.execute(
+        """
+        SELECT resolved, resolved_by_score_version
+        FROM job_score_staleness
+        WHERE job_url = ?
+        """,
+        (comparable_url,),
+    ).fetchone()
+    assert resolved["resolved"] == 1
+    assert resolved["resolved_by_score_version"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Added persisted `job_score_staleness` markers for scores made stale by scoring-policy corrections.
- Wired Python `CorrectScoreUseCase` to mark comparable latest uncorrected scores stale after a new policy version is saved.
- Mirrored stale marking in the TypeScript local API score-correction path.
- Added an explicit local API reset path: `POST /v1/scoring/stale-scores/actions/reset-for-rescore`.
- Resolved stale markers when a fresh uncorrected score is saved under the newer policy.
- Added focused Python and API tests plus narrow backend/API/QA docs.

## Why

PR4 needs backend/API support for policy-change fallout before PR5 adds polished frontend reflection. A user correction can now create a newer scoring policy without leaving comparable older uncorrected scores looking current.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_score_repository.py workers/automation/tests/test_score_use_cases.py workers/automation/tests/test_scoring_policy.py` -> 37 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scorer.py` -> 6 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/database.py workers/automation/src/jobhunter/domain/ports/scoring.py workers/automation/src/jobhunter/domain/scoring/__init__.py workers/automation/src/jobhunter/domain/scoring/aggregate.py workers/automation/src/jobhunter/domain/scoring/use_cases.py workers/automation/src/jobhunter/infrastructure/scoring/__init__.py workers/automation/src/jobhunter/infrastructure/scoring/sqlite_repository.py workers/automation/tests/test_score_repository.py` -> passed
- `corepack pnpm --filter @jobhunter/api exec vitest run test/server.test.ts -t "score"` -> 4 passed, 58 skipped
- `corepack pnpm api:check` -> passed
- `corepack pnpm api:test` -> 6 files passed, 99 tests passed
- `corepack pnpm --filter @jobhunter/contracts check` -> passed
- `git diff --check scoring/correction-policy-learning...HEAD` -> passed

## Frontend note

No frontend UI docs or polished stale-score reflection were added because this PR is scoped to PR4 backend/API behavior. PR5 should decide how the web app surfaces stale scores.