### PR TITLE
test(scoring): harden policy eval governance

### DIFF
--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -499,6 +499,11 @@ classDiagram
   versions are excluded. Successful uncorrected rescores under the newer policy
   resolve the stale marker; the local API can also reset active stale markers
   for explicit `jobhunter run score --rescore` processing.
+- Supports a local, non-sensitive scoring governance report for QA. The report
+  summarizes current policy version, rubric version, anchor count, unresolved
+  and resolved stale-marker counts, correction count, and correction agreement
+  signal without emitting raw job URLs, correction rationales, anchor IDs,
+  resumes, generated artifacts, or local paths.
 - Updates legacy-compatible score fields where needed by queue selectors.
 - Publishes score events consumed by Pipeline and Operations.
 - Refreshes dashboard score distributions and job list score badges.
@@ -508,7 +513,10 @@ classDiagram
 `limit` applies after retrieval preselection. `rescore=true` allows jobs with
 existing scores back into the candidate pool. Parser warnings and failed LLM
 calls are recorded so score failures do not masquerade as successful low-fit
-results.
+results. Scoring prompt, model, schema, rubric, or policy changes must run the
+local scoring eval gate documented in `docs/local-reliability-qa.md`; the gate
+checks deterministic policy resolution separately from the raw LLM score and
+pins stale-score exclusion until explicit reset/rescore.
 
 ## Phase 4: Tailor
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -51,8 +51,23 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Preferences Target search stops driving discovery roles, location fallback, Spain/Europe source filtering, or API-visible source controls | `workers/automation/tests/test_target_search_preferences.py`; `apps/api/test/discovery-controls.test.ts` |
 | Discovery RFC production wiring stops auto-approving located parseable sources, feeding API-visible manual queues, canonical ATS ingestion, manual-capture imports, snapshot persistence, or acceptance evidence | `workers/automation/tests/test_discovery_production_wiring.py` uses a Barcelona/Spain tech-leadership fixture and report covering lead yield, candidate sources, manual-action count, canonical verification rate, duplicate/quarantine counts, source-quality updates, and scoring handoff count |
 | Hybrid retrieval picks stale or weak candidates before LLM scoring | `workers/automation/tests/test_hybrid_search_index.py`; `workers/automation/tests/test_scorer.py::test_run_scoring_preselects_retrieval_top_k_before_llm` |
-| Scoring prompt/schema/model changes silently regress parse validity, bands, blockers, ranking, or correction agreement | `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval*.py`; update the synthetic scoring fixtures or document why a scoring change does not affect them |
+| Scoring prompt/schema/model/policy changes silently regress parse validity, deterministic policy resolution, cross-job consistency, bands, blockers, ranking, correction agreement, or governance counters | `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval.py workers/automation/tests/test_scoring_eval_feedback.py workers/automation/tests/test_score_repository.py`; update the synthetic scoring fixtures or document why a scoring change does not affect them |
 | Score corrections change the policy but leave comparable uncorrected scores fresh, mark corrected versions stale, fail to expose stale policy metadata in jobs list/detail, or fail to clear selected/all stale markers for explicit rescore | `workers/automation/tests/test_score_repository.py`; `apps/api/test/server.test.ts`; `apps/web/src/contexts/scoring/hooks/useResetStaleScoresForRescoreMutation.test.ts`; `apps/web/src/views/jobs/JobsView.test.tsx` |
+
+### Scoring Policy Eval Gate
+
+For scoring prompt, schema, model, rubric, policy, correction-learning, or
+stale-score changes, run:
+
+```bash
+uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval.py workers/automation/tests/test_scoring_eval_feedback.py workers/automation/tests/test_score_repository.py
+```
+
+This gate keeps the local scoring harness focused on non-sensitive facts:
+synthetic dimensions, deterministic policy outputs, aggregate anchor/stale
+counts, and correction agreement. Do not add raw job URLs, correction
+rationales, anchors, resumes, or local paths to eval reports or committed
+fixtures.
 
 ## Frontend QA
 

--- a/docs/plans/proposed/2026-05-19-calibrated-scoring-policy-rfc.md
+++ b/docs/plans/proposed/2026-05-19-calibrated-scoring-policy-rfc.md
@@ -264,6 +264,8 @@ anchor with lower confidence.
 Scoring changes must expand the existing local harness. Required metrics:
 
 - Parse validity for structured evidence.
+- Deterministic policy-resolution accuracy independent from the raw LLM
+  overall score.
 - Dimension consistency against synthetic fixtures.
 - Band accuracy.
 - Hard-blocker precision and recall.
@@ -272,6 +274,9 @@ Scoring changes must expand the existing local harness. Required metrics:
 - Pairwise anchor consistency.
 - Stale-score detection precision on correction fixtures.
 - Reproducibility for same policy version and same extracted facts.
+- Governance counters: current policy version, rubric version, anchor count,
+  unresolved/resolved stale-marker counts, correction count, and correction
+  agreement signal.
 
 Evaluation sets should include:
 
@@ -283,6 +288,12 @@ Evaluation sets should include:
 
 Scoring prompt/schema/model changes must update eval fixtures or explain why
 the change cannot affect scoring behavior.
+
+Eval and governance outputs must stay non-sensitive. They may include
+synthetic dimensions, aggregate counts, policy/rubric versions, and correction
+agreement values. They must not include raw job URLs, correction rationales,
+anchor IDs, resumes, job descriptions, generated artifacts, API keys, browser
+profile data, local database paths, or application logs.
 
 ## Observability
 
@@ -351,10 +362,14 @@ This document plus a narrow backlog pointer.
 ### PR 6 - Evaluation And Governance Hardening
 
 - Extend `workers/automation/src/jobhunter/scoring/eval.py`.
-- Add pairwise anchor consistency and stale-score detection metrics.
-- Add correction fixtures.
+- Add deterministic policy-resolution checks independent from raw LLM overall
+  score, cross-job consistency checks, and stale-score detection checks.
+- Add correction-learning checks proving anchors/stale markers are created,
+  subsequent traces cite updated policy metadata, and stale scores stay out of
+  downstream queues until explicit reset/rescore.
 - Update `docs/local-reliability-qa.md` and architecture docs.
-- Add a local scoring policy report if useful for operator review.
+- Add a local scoring policy governance report for operator review without
+  exposing raw URLs, rationales, anchors, artifacts, or local paths.
 
 ## Done Criteria
 

--- a/workers/automation/src/jobhunter/scoring/eval.py
+++ b/workers/automation/src/jobhunter/scoring/eval.py
@@ -1,19 +1,25 @@
 """Local scoring evaluation harness.
 
-The harness is intentionally fixture-driven and pure Python: tests feed
+The core harness is intentionally fixture-driven and pure Python: tests feed
 synthetic/redacted labels and predicted score payloads, then compute metrics
-without opening the user's local database or profile files.
+without opening the user's local database or profile files. The governance
+report helper accepts an explicit SQLite connection and returns only aggregate
+counts/version metadata so operator review does not expose job URLs,
+rationales, anchors, or local paths.
 """
 
 from __future__ import annotations
 
 import json
 import math
+import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
+from jobhunter.domain.scoring import ScoreBreakdown, ScoringPolicy
 from jobhunter.domain.scoring.value_objects import fit_band_for_score
+from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 
 
 @dataclass(frozen=True)
@@ -49,6 +55,67 @@ class ScoringEvalReport:
             "blocker_precision": self.blocker_precision,
             "blocker_recall": self.blocker_recall,
             "ndcg_at_k": self.ndcg_at_k,
+            "correction_agreement": self.correction_agreement,
+        }
+
+
+@dataclass(frozen=True)
+class ScoringPolicyEvalCase:
+    job_id: str
+    dimensions: Mapping[str, int]
+    expected_fit_score: int
+    expected_fit_band: str
+    raw_llm_score: int | None = None
+    ideal_rank: int | None = None
+    consistency_group: str = ""
+
+
+@dataclass(frozen=True)
+class ScoringPolicyEvalPrediction:
+    job_id: str
+    raw_llm_score: int | None
+    policy_score: int
+    policy_fit_band: str
+    raw_weighted_score: float
+    consistency_group: str = ""
+
+
+@dataclass(frozen=True)
+class ScoringPolicyEvalReport:
+    policy_score_accuracy: float
+    policy_band_accuracy: float
+    raw_llm_band_accuracy: float | None
+    consistency_group_agreement: float | None
+    ndcg_at_k: float
+
+    def to_dict(self) -> dict[str, float | None]:
+        return {
+            "policy_score_accuracy": self.policy_score_accuracy,
+            "policy_band_accuracy": self.policy_band_accuracy,
+            "raw_llm_band_accuracy": self.raw_llm_band_accuracy,
+            "consistency_group_agreement": self.consistency_group_agreement,
+            "ndcg_at_k": self.ndcg_at_k,
+        }
+
+
+@dataclass(frozen=True)
+class ScoringGovernanceReport:
+    policy_version: int
+    rubric_version: str
+    anchor_count: int
+    stale_unresolved_count: int
+    stale_resolved_count: int
+    correction_signal_count: int
+    correction_agreement: float | None = None
+
+    def to_dict(self) -> dict[str, int | float | str | None]:
+        return {
+            "policy_version": self.policy_version,
+            "rubric_version": self.rubric_version,
+            "anchor_count": self.anchor_count,
+            "stale_unresolved_count": self.stale_unresolved_count,
+            "stale_resolved_count": self.stale_resolved_count,
+            "correction_signal_count": self.correction_signal_count,
             "correction_agreement": self.correction_agreement,
         }
 
@@ -119,6 +186,98 @@ def prediction_from_payload(job_id: str, payload: dict[str, Any] | None) -> Scor
     )
 
 
+def resolve_policy_predictions(
+    cases: Iterable[ScoringPolicyEvalCase],
+    policy: ScoringPolicy,
+) -> tuple[ScoringPolicyEvalPrediction, ...]:
+    predictions: list[ScoringPolicyEvalPrediction] = []
+    for case in cases:
+        resolved = policy.resolve(_breakdown_from_dimensions(case.dimensions))
+        predictions.append(
+            ScoringPolicyEvalPrediction(
+                job_id=case.job_id,
+                raw_llm_score=case.raw_llm_score,
+                policy_score=resolved.fit_score.value,
+                policy_fit_band=resolved.fit_band,
+                raw_weighted_score=resolved.raw_weighted_score,
+                consistency_group=case.consistency_group,
+            )
+        )
+    return tuple(predictions)
+
+
+def evaluate_policy_resolution(
+    cases: Iterable[ScoringPolicyEvalCase],
+    policy: ScoringPolicy,
+    *,
+    k: int = 10,
+) -> ScoringPolicyEvalReport:
+    case_list = list(cases)
+    predictions = resolve_policy_predictions(case_list, policy)
+    by_job = {prediction.job_id: prediction for prediction in predictions}
+
+    policy_score_accuracy = _ratio(
+        sum(
+            1
+            for case in case_list
+            if by_job[case.job_id].policy_score == case.expected_fit_score
+        ),
+        len(case_list),
+    )
+    policy_band_accuracy = _ratio(
+        sum(
+            1
+            for case in case_list
+            if by_job[case.job_id].policy_fit_band == case.expected_fit_band
+        ),
+        len(case_list),
+    )
+    raw_labeled = [case for case in case_list if case.raw_llm_score is not None]
+    raw_llm_band_accuracy = (
+        _ratio(
+            sum(
+                1
+                for case in raw_labeled
+                if policy.fit_band_for_score(int(case.raw_llm_score or 0))
+                == case.expected_fit_band
+            ),
+            len(raw_labeled),
+        )
+        if raw_labeled
+        else None
+    )
+    return ScoringPolicyEvalReport(
+        policy_score_accuracy=policy_score_accuracy,
+        policy_band_accuracy=policy_band_accuracy,
+        raw_llm_band_accuracy=raw_llm_band_accuracy,
+        consistency_group_agreement=_consistency_group_agreement(predictions),
+        ndcg_at_k=_policy_ndcg_at_k(case_list, by_job, k),
+    )
+
+
+def build_scoring_governance_report(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: TenantId = LOCAL_TENANT,
+    correction_agreement: float | None = None,
+) -> ScoringGovernanceReport:
+    """Return non-sensitive policy/eval governance counters for local QA."""
+    policy_version, rubric_version, anchor_count = _current_policy_report_fields(
+        conn,
+        tenant_id,
+    )
+    unresolved, resolved = _stale_marker_counts(conn, tenant_id)
+    return ScoringGovernanceReport(
+        policy_version=policy_version,
+        rubric_version=rubric_version,
+        anchor_count=anchor_count,
+        stale_unresolved_count=unresolved,
+        stale_resolved_count=resolved,
+        correction_signal_count=_correction_signal_count(conn, tenant_id),
+        correction_agreement=correction_agreement,
+    )
+
+
 def _prediction_band(prediction: ScoringEvalPrediction) -> str | None:
     if prediction.fit_band:
         return prediction.fit_band
@@ -171,6 +330,133 @@ def _dcg(cases: list[ScoringEvalCase]) -> float:
     return total
 
 
+def _breakdown_from_dimensions(dimensions: Mapping[str, int]) -> ScoreBreakdown:
+    return ScoreBreakdown(
+        technical_fit=int(dimensions.get("technical_fit", 0)),
+        experience_fit=int(dimensions.get("experience_fit", 0)),
+        role_fit=int(dimensions.get("role_fit", 0)),
+        reasoning="synthetic policy eval fixture",
+    )
+
+
+def _consistency_group_agreement(
+    predictions: tuple[ScoringPolicyEvalPrediction, ...],
+) -> float | None:
+    groups: dict[str, list[ScoringPolicyEvalPrediction]] = {}
+    for prediction in predictions:
+        if prediction.consistency_group:
+            groups.setdefault(prediction.consistency_group, []).append(prediction)
+    comparable_groups = [items for items in groups.values() if len(items) > 1]
+    if not comparable_groups:
+        return None
+    agreed = 0
+    for items in comparable_groups:
+        first = items[0]
+        if all(
+            item.policy_score == first.policy_score
+            and item.policy_fit_band == first.policy_fit_band
+            for item in items[1:]
+        ):
+            agreed += 1
+    return _ratio(agreed, len(comparable_groups))
+
+
+def _policy_ndcg_at_k(
+    cases: list[ScoringPolicyEvalCase],
+    by_job: dict[str, ScoringPolicyEvalPrediction],
+    k: int,
+) -> float:
+    rankable = [case for case in cases if case.ideal_rank is not None]
+    if not rankable:
+        return 0.0
+    predicted_order = sorted(
+        rankable,
+        key=lambda case: by_job[case.job_id].policy_score,
+        reverse=True,
+    )[:k]
+    ideal_order = sorted(rankable, key=lambda case: case.ideal_rank or 999)[:k]
+    return _policy_dcg(predicted_order) / max(_policy_dcg(ideal_order), 1e-9)
+
+
+def _policy_dcg(cases: list[ScoringPolicyEvalCase]) -> float:
+    total = 0.0
+    for index, case in enumerate(cases, start=1):
+        relevance = 1.0 / max(case.ideal_rank or index, 1)
+        total += relevance / math.log2(index + 1)
+    return total
+
+
+def _stale_marker_counts(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+) -> tuple[int, int]:
+    if not _table_exists(conn, "job_score_staleness"):
+        return 0, 0
+    rows = conn.execute(
+        """
+        SELECT resolved, COUNT(*) AS count
+        FROM job_score_staleness
+        WHERE tenant_id = ?
+        GROUP BY resolved
+        """,
+        (str(tenant_id),),
+    ).fetchall()
+    counts = {int(_row_value(row, "resolved", 0)): int(_row_value(row, "count", 1)) for row in rows}
+    return counts.get(0, 0), counts.get(1, 0)
+
+
+def _current_policy_report_fields(
+    conn: sqlite3.Connection,
+    tenant_id: TenantId,
+) -> tuple[int, str, int]:
+    default_policy = ScoringPolicy.default(tenant_id)
+    if not _table_exists(conn, "scoring_policies"):
+        return default_policy.version, default_policy.rubric_version, 0
+    row = conn.execute(
+        """
+        SELECT version, rubric_json, anchors_json
+        FROM scoring_policies
+        WHERE tenant_id = ?
+        ORDER BY version DESC
+        LIMIT 1
+        """,
+        (str(tenant_id),),
+    ).fetchone()
+    if row is None:
+        return default_policy.version, default_policy.rubric_version, 0
+    rubric = _json_object(_row_value(row, "rubric_json", 1))
+    anchors = _json_list(_row_value(row, "anchors_json", 2))
+    return (
+        int(_row_value(row, "version", 0)),
+        str(
+            rubric.get(
+                "rubric_version",
+                rubric.get("rubricVersion", default_policy.rubric_version),
+            )
+            or default_policy.rubric_version
+        ),
+        len(anchors),
+    )
+
+
+def _correction_signal_count(conn: sqlite3.Connection, tenant_id: TenantId) -> int:
+    if not _table_exists(conn, "job_scores"):
+        return 0
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS count
+        FROM job_scores
+        WHERE tenant_id = ?
+          AND correction_json IS NOT NULL
+          AND TRIM(correction_json) != ''
+        """,
+        (str(tenant_id),),
+    ).fetchone()
+    if row is None:
+        return 0
+    return int(_row_value(row, "count", 0))
+
+
 def _correction_agreement(
     cases: list[ScoringEvalCase],
     by_job: dict[str, ScoringEvalPrediction],
@@ -197,3 +483,33 @@ def _ratio(numerator: int, denominator: int) -> float:
     if denominator <= 0:
         return 0.0
     return numerator / denominator
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _row_value(row: Any, name: str, index: int) -> Any:
+    if isinstance(row, sqlite3.Row):
+        return row[name]
+    return row[index]
+
+
+def _json_object(raw: Any) -> dict[str, Any]:
+    try:
+        value = json.loads(str(raw or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _json_list(raw: Any) -> list[Any]:
+    try:
+        value = json.loads(str(raw or "[]"))
+    except json.JSONDecodeError:
+        return []
+    return value if isinstance(value, list) else []

--- a/workers/automation/tests/test_score_repository.py
+++ b/workers/automation/tests/test_score_repository.py
@@ -8,13 +8,14 @@ directly by these tests to seed the backfill path.
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from jobhunter.database import ensure_score_tables, init_db
+from jobhunter.database import ensure_score_tables, get_jobs_by_stage, init_db
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.scoring import (
     FitScore,
@@ -22,10 +23,11 @@ from jobhunter.domain.scoring import (
     MatchedKeywords,
     ScoreBreakdown,
     ScoreCorrection,
+    ScoreParseResult,
     ScoreTrace,
     ScoringCriteria,
 )
-from jobhunter.domain.scoring.use_cases import CorrectScoreUseCase
+from jobhunter.domain.scoring.use_cases import CorrectScoreUseCase, ScoreJobUseCase
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.scoring import (
     SqliteScoreRepository,
@@ -33,6 +35,8 @@ from jobhunter.infrastructure.scoring import (
     SqliteScoringPolicyRepository,
 )
 from jobhunter.infrastructure.scoring.sqlite_repository import ScoreVersionConflict
+from jobhunter.scoring.eval import build_scoring_governance_report
+from jobhunter.state import set_stage_state
 
 
 @pytest.fixture()
@@ -380,6 +384,168 @@ def test_score_correction_marks_comparable_uncorrected_scores_stale_and_resolve_
     ).fetchone()
     assert resolved["resolved"] == 1
     assert resolved["resolved_by_score_version"] == 2
+
+
+def test_score_correction_governance_report_and_downstream_staleness_gate(
+    conn: sqlite3.Connection,
+) -> None:
+    target_url = _seed_job(conn, url="https://example.com/job/eval-corrected")
+    comparable_url = _seed_job(conn, url="https://example.com/job/eval-comparable")
+    subsequent_url = _seed_job(conn, url="https://example.com/job/eval-subsequent")
+    repo = SqliteScoreRepository(conn)
+    policy_repo = SqliteScoringPolicyRepository(conn)
+    staleness_repo = SqliteScoreStalenessRepository(conn)
+    policy_v1 = policy_repo.get_current(LOCAL_TENANT)
+    target_resolution = policy_v1.resolve(
+        ScoreBreakdown(
+            technical_fit=5,
+            experience_fit=5,
+            role_fit=5,
+            reasoning="Initial score before correction.",
+        )
+    )
+    comparable_resolution = policy_v1.resolve(
+        ScoreBreakdown(
+            technical_fit=8,
+            experience_fit=7,
+            role_fit=8,
+            reasoning="Comparable score under the original policy.",
+        )
+    )
+
+    repo.save(
+        _build_score(
+            target_url,
+            fit=target_resolution.fit_score.value,
+            trace=ScoreTrace().with_policy_resolution(target_resolution),
+        )
+    )
+    repo.save(
+        _build_score(
+            comparable_url,
+            fit=comparable_resolution.fit_score.value,
+            trace=ScoreTrace().with_policy_resolution(comparable_resolution),
+        )
+    )
+    set_stage_state(
+        conn,
+        comparable_url,
+        "score",
+        "succeeded",
+        validate_transition=False,
+    )
+    pending_before = {
+        row["url"]
+        for row in get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=0)
+    }
+    assert comparable_url in pending_before
+
+    CorrectScoreUseCase(
+        repository=repo,
+        policy_repository=policy_repo,
+        staleness_repository=staleness_repo,
+    ).execute(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(target_url),
+        corrected_fit_score=FitScore.create(9),
+        rationale="Manual review found stronger platform evidence.",
+        corrected_at="2024-01-02T00:00:00+00:00",
+    )
+
+    policy_v2 = policy_repo.get_current(LOCAL_TENANT)
+    governance = build_scoring_governance_report(conn, correction_agreement=1.0)
+    governance_payload = json.dumps(governance.to_dict(), sort_keys=True)
+
+    assert policy_v2.version == 2
+    assert len(policy_v2.anchors) == 1
+    assert governance.to_dict() == {
+        "policy_version": 2,
+        "rubric_version": "default-scoring-rubric-v1",
+        "anchor_count": 1,
+        "stale_unresolved_count": 1,
+        "stale_resolved_count": 0,
+        "correction_signal_count": 1,
+        "correction_agreement": 1.0,
+    }
+    assert "https://example.com/job" not in governance_payload
+    assert "Manual review" not in governance_payload
+    assert policy_v2.anchors[0].anchor_id not in governance_payload
+
+    pending_after_correction = {
+        row["url"]
+        for row in get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=0)
+    }
+    assert comparable_url not in pending_after_correction
+
+    scorer = ScoreJobUseCase(
+        repository=repo,
+        llm=object(),
+        policy_repository=policy_repo,
+    )
+    subsequent = scorer.persist_outcome(
+        job={"url": subsequent_url},
+        parse=ScoreParseResult(
+            ok=True,
+            fit_score=FitScore.create(10),
+            breakdown=ScoreBreakdown(
+                technical_fit=7,
+                experience_fit=7,
+                role_fit=7,
+                reasoning="Subsequent score after correction.",
+            ),
+            keywords=MatchedKeywords.from_iterable(["python"]),
+        ),
+    )
+
+    assert subsequent.ok is True
+    assert subsequent.score is not None
+    assert subsequent.score.trace.scoring_policy_version == 2
+    assert subsequent.score.trace.rubric_version == "default-scoring-rubric-v1"
+    assert subsequent.score.trace.anchor_ids == (policy_v2.anchors[0].anchor_id,)
+
+    markers = staleness_repo.reset_for_rescore(
+        LOCAL_TENANT,
+        reset_at="2024-01-02T00:05:00+00:00",
+    )
+    pending_after_reset = {
+        row["url"]
+        for row in get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=0)
+    }
+    assert [str(marker.job_id) for marker in markers] == [comparable_url]
+    assert comparable_url not in pending_after_reset
+
+    refreshed_resolution = policy_v2.resolve(
+        ScoreBreakdown(
+            technical_fit=8,
+            experience_fit=7,
+            role_fit=8,
+            reasoning="Explicit rescore under updated policy.",
+        )
+    )
+    repo.save(
+        _build_score(
+            comparable_url,
+            version=2,
+            fit=refreshed_resolution.fit_score.value,
+            trace=ScoreTrace().with_policy_resolution(refreshed_resolution),
+        )
+    )
+    set_stage_state(
+        conn,
+        comparable_url,
+        "score",
+        "succeeded",
+        validate_transition=False,
+    )
+
+    final_governance = build_scoring_governance_report(conn, correction_agreement=1.0)
+    pending_after_rescore = {
+        row["url"]
+        for row in get_jobs_by_stage(conn, "pending_tailor", min_score=7, limit=0)
+    }
+    assert final_governance.stale_unresolved_count == 0
+    assert final_governance.stale_resolved_count == 1
+    assert comparable_url in pending_after_rescore
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_scoring_eval.py
+++ b/workers/automation/tests/test_scoring_eval.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from jobhunter.database import init_db
+from jobhunter.domain.scoring import ScoringPolicy
+from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.scoring.eval import (
     ScoringEvalPrediction,
+    ScoringPolicyEvalCase,
+    build_scoring_governance_report,
     evaluate_predictions,
+    evaluate_policy_resolution,
     load_cases,
     prediction_from_payload,
+    resolve_policy_predictions,
 )
 
 
@@ -52,3 +59,80 @@ def test_prediction_from_payload_marks_invalid_parse_without_user_data() -> None
     assert valid.score == 8
     assert valid.hard_blockers == ("below minimum salary",)
     assert invalid.score is None
+
+
+def test_policy_resolution_eval_is_independent_from_raw_llm_score() -> None:
+    policy = ScoringPolicy.default(LOCAL_TENANT)
+    cases = [
+        ScoringPolicyEvalCase(
+            job_id="similar-raw-low",
+            dimensions={"technical_fit": 8, "experience_fit": 7, "role_fit": 8},
+            expected_fit_score=8,
+            expected_fit_band="strong",
+            raw_llm_score=6,
+            ideal_rank=2,
+            consistency_group="platform-leadership",
+        ),
+        ScoringPolicyEvalCase(
+            job_id="similar-raw-high",
+            dimensions={"technical_fit": 8, "experience_fit": 7, "role_fit": 8},
+            expected_fit_score=8,
+            expected_fit_band="strong",
+            raw_llm_score=9,
+            ideal_rank=3,
+            consistency_group="platform-leadership",
+        ),
+        ScoringPolicyEvalCase(
+            job_id="materially-stronger",
+            dimensions={"technical_fit": 9, "experience_fit": 9, "role_fit": 8},
+            expected_fit_score=9,
+            expected_fit_band="excellent",
+            raw_llm_score=7,
+            ideal_rank=1,
+        ),
+        ScoringPolicyEvalCase(
+            job_id="materially-weaker",
+            dimensions={"technical_fit": 4, "experience_fit": 4, "role_fit": 4},
+            expected_fit_score=4,
+            expected_fit_band="stretch",
+            raw_llm_score=8,
+            ideal_rank=4,
+        ),
+    ]
+
+    predictions = resolve_policy_predictions(cases, policy)
+    report = evaluate_policy_resolution(cases, policy, k=4)
+
+    assert [(item.job_id, item.policy_score, item.policy_fit_band) for item in predictions] == [
+        ("similar-raw-low", 8, "strong"),
+        ("similar-raw-high", 8, "strong"),
+        ("materially-stronger", 9, "excellent"),
+        ("materially-weaker", 4, "stretch"),
+    ]
+    assert report.to_dict() == {
+        "policy_score_accuracy": 1.0,
+        "policy_band_accuracy": 1.0,
+        "raw_llm_band_accuracy": 0.0,
+        "consistency_group_agreement": 1.0,
+        "ndcg_at_k": 1.0,
+    }
+
+
+def test_governance_report_does_not_initialize_policy_rows(tmp_path: Path) -> None:
+    conn = init_db(tmp_path / "jobhunter.db")
+    before = conn.execute("SELECT COUNT(*) FROM scoring_policies").fetchone()[0]
+
+    report = build_scoring_governance_report(conn)
+    after = conn.execute("SELECT COUNT(*) FROM scoring_policies").fetchone()[0]
+
+    assert before == 0
+    assert after == 0
+    assert report.to_dict() == {
+        "policy_version": 1,
+        "rubric_version": "default-scoring-rubric-v1",
+        "anchor_count": 0,
+        "stale_unresolved_count": 0,
+        "stale_resolved_count": 0,
+        "correction_signal_count": 0,
+        "correction_agreement": None,
+    }


### PR DESCRIPTION
## Summary

- Extend the local scoring eval harness with deterministic policy-resolution cases that evaluate final policy scores separately from raw LLM overall scores.
- Add non-sensitive, read-only scoring governance reporting for policy/rubric version, anchor count, stale-marker counts, correction count, and correction agreement.
- Add regression coverage for correction-created anchors, stale-score exclusion, updated policy trace metadata on subsequent scores, explicit reset/rescore behavior, and governance report privacy/read-only constraints.
- Document the scoring policy eval gate in local QA, the Score phase architecture, and the PR6 RFC scope.

## Why

PR6 hardens the evaluation and governance layer around the calibrated scoring policy stack so prompt/model/policy changes cannot silently regress cross-job consistency, correction learning, or stale-score handling.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval.py::test_governance_report_does_not_initialize_policy_rows workers/automation/tests/test_score_repository.py::test_score_correction_governance_report_and_downstream_staleness_gate` -> `2 passed in 0.20s`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scoring_eval.py workers/automation/tests/test_scoring_eval_feedback.py workers/automation/tests/test_score_repository.py` -> `22 passed in 0.46s`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/scoring workers/automation/tests/test_scoring_eval.py workers/automation/tests/test_scoring_eval_feedback.py workers/automation/tests/test_score_repository.py` -> `All checks passed!`
- `git diff --check scoring/web-policy-feedback...HEAD` -> passed
- PR review gate -> PASS, no remaining findings
- QA gate -> PASS, no findings

## Notes

No API or UI contract changed in this slice, so no TS or browser checks were added. Documentation updates are limited to the existing scoring QA, pipeline architecture, and calibrated scoring RFC surfaces.