### PR TITLE
feat: preview artifacts and harden discovery runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,11 @@ pnpm dev:logs worker
 pnpm dev:stop
 ```
 
+The API health endpoint reports the API app/database identity and the latest
+Temporal worker heartbeat. The web topbar alerts when the worker is missing or
+stale, and pipeline stage buttons stay disabled until the worker is
+heartbeating against the same local database.
+
 For troubleshooting, run individual components in separate terminals:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -384,9 +384,14 @@ working while sources are promoted or rejected.
 The Preferences tab's Target search fields are discovery inputs. Target roles
 replace the active discovery query list, target locations replace the active
 location list, and if target locations are blank the worker falls back to the
-profile city/country. A Spain or Europe target sets JobSpy's Indeed country to
-Spain, broadens Europe/remote location accepts, rejects America-only non-remote
-locations, and hides packaged America-only source rows from discovery controls.
+profile city/country. Target locations are validated as real places before they
+can be saved. Hybrid and on-site target work models search and filter only the
+target location. Remote target work models search and filter the target country,
+and European countries also add an Europe-remote search and accept pattern.
+Profile-driven discovery searches at least the last 30 days unless local config
+sets a larger window. A Spain or Europe target sets JobSpy's Indeed country to
+Spain, rejects America-only non-remote locations, and hides packaged
+America-only source rows from discovery controls.
 
 Common environment variables:
 

--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -39,6 +39,7 @@ const AUTOMATION_PROJECT_DIR = path.resolve(API_SRC_DIR, "../../../workers/autom
 
 export interface ActionDispatchContext {
   appDir: string;
+  dbPath: string;
 }
 
 export interface ActionDispatchResult {
@@ -108,7 +109,7 @@ export function createActionDispatcher(
       return { status: "reset", message: "Stage reset for retry." };
     }
 
-    const rpcCall = mapCommandToRpc(command);
+    const rpcCall = mapCommandToRpc(command, context);
     if (!rpcCall) {
       return {
         status: "unsupported",
@@ -296,21 +297,21 @@ interface RpcCall {
   params: Record<string, unknown>;
 }
 
-function mapCommandToRpc(command: ActionCommandPayload): RpcCall | null {
+function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchContext): RpcCall | null {
   if (command.action === "run_stage") {
     if (!command.stage) return null;
-    return { method: "run_stage", params: runStageRpcParams(command) };
+    return { method: "run_stage", params: runStageRpcParams(command, context) };
   }
   if (command.action === "retry_stage") {
     if (!command.stage || !command.runAfter) return null;
     if (command.stage === "apply") {
-      return { method: "apply", params: applyRpcParams(command) };
+      return { method: "apply", params: applyRpcParams(command, context) };
     }
     return null;
   }
   if (command.action === "generate_materials") return null;
   if (command.action === "apply") {
-    return { method: "apply", params: applyRpcParams(command) };
+    return { method: "apply", params: applyRpcParams(command, context) };
   }
   if (command.action === "cancel") {
     // PR 3 added the cancel_run JSON-RPC method on the worker side; without
@@ -327,7 +328,7 @@ function mapCommandToRpc(command: ActionCommandPayload): RpcCall | null {
   return null;
 }
 
-function runStageRpcParams(command: ActionCommandPayload): Record<string, unknown> {
+function runStageRpcParams(command: ActionCommandPayload, context: ActionDispatchContext): Record<string, unknown> {
   const stages =
     command.stages && command.stages.length > 0
       ? command.stages
@@ -336,6 +337,8 @@ function runStageRpcParams(command: ActionCommandPayload): Record<string, unknow
         : [];
   const params: Record<string, unknown> = {
     tenantId: "local",
+    expectedAppDir: context.appDir,
+    expectedDbPath: context.dbPath,
     stage: command.stage,
     stages,
     limit: command.limit ?? 25,
@@ -355,9 +358,11 @@ function runStageRpcParams(command: ActionCommandPayload): Record<string, unknow
   return params;
 }
 
-function applyRpcParams(command: ActionCommandPayload): Record<string, unknown> {
+function applyRpcParams(command: ActionCommandPayload, context: ActionDispatchContext): Record<string, unknown> {
   const params: Record<string, unknown> = {
     tenantId: "local",
+    expectedAppDir: context.appDir,
+    expectedDbPath: context.dbPath,
     limit: command.limit ?? 1,
     workers: command.workers ?? 1,
     minScore: command.minScore ?? 7,

--- a/apps/api/src/place-validation.ts
+++ b/apps/api/src/place-validation.ts
@@ -1,0 +1,63 @@
+import type { ProfileShape } from "./contracts.js";
+import { ProfileInputError } from "./profile-store.js";
+
+export type PlaceValidator = (place: string) => Promise<boolean>;
+
+const NOMINATIM_SEARCH_URL = "https://nominatim.openstreetmap.org/search";
+const PLACE_VALIDATION_TIMEOUT_MS = 5_000;
+
+export async function validateProfileTargetPlaces(
+  profile: ProfileShape,
+  validator: PlaceValidator = validatePlaceExists,
+): Promise<void> {
+  const locations = splitTargetText(profile.experience?.target_locations);
+  const uniqueLocations = [...new Set(locations)];
+  for (const location of uniqueLocations) {
+    let exists = false;
+    try {
+      exists = await validator(location);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : "unknown error";
+      throw new ProfileInputError(`target location "${location}" could not be validated: ${detail}`);
+    }
+    if (!exists) {
+      throw new ProfileInputError(`target location "${location}" does not resolve to a real place.`);
+    }
+  }
+}
+
+export async function validatePlaceExists(place: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PLACE_VALIDATION_TIMEOUT_MS);
+  try {
+    const url = new URL(NOMINATIM_SEARCH_URL);
+    url.searchParams.set("format", "jsonv2");
+    url.searchParams.set("limit", "1");
+    url.searchParams.set("q", place);
+    const response = await fetch(url, {
+      headers: {
+        "Accept-Language": "en",
+        "User-Agent": "JobHunter local app place validation",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw new Error(`place lookup returned HTTP ${response.status}`);
+    }
+    const payload = await response.json();
+    return Array.isArray(payload) && payload.some((entry) => entry && typeof entry === "object");
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function splitTargetText(value: unknown): string[] {
+  if (value === null || value === undefined) {
+    return [];
+  }
+  return String(value)
+    .replace(/^\s*Target locations?:\s*/i, "")
+    .split(/[;\n]+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/apps/api/src/profile-events.ts
+++ b/apps/api/src/profile-events.ts
@@ -1,0 +1,148 @@
+import {
+  createProfileUpdated,
+  LOCAL_TENANT,
+  type ProfileUpdated,
+} from "@jobhunter/domain-types";
+
+import {
+  PIPELINE_ACTION_JOB_KEY,
+  type ActionCommandPayload,
+  type ProfileUpdateRequest,
+} from "./contracts.js";
+import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import type { ActionDispatchContext, ActionDispatcher } from "./local-actions.js";
+
+export function profileChangedSections(request: ProfileUpdateRequest): string[] {
+  const sections: string[] = [];
+  if (request.profile !== undefined || request.profileText !== undefined) {
+    sections.push("profile");
+  }
+  if (request.style !== undefined || request.styleText !== undefined) {
+    sections.push("style");
+  }
+  if (request.templateText !== undefined) {
+    sections.push("template");
+  }
+  return sections;
+}
+
+export function shouldRetailorForProfileUpdate(request: ProfileUpdateRequest): boolean {
+  return request.profile !== undefined || request.profileText !== undefined;
+}
+
+export function hasRetailorableResumes(db: SqliteDatabase): boolean {
+  if (tableExists(db, "job_materials_artifacts")) {
+    const row = getRow<{ count: number }>(
+      db,
+      `SELECT COUNT(*) AS count
+       FROM job_materials_artifacts
+       WHERE artifact_type = 'tailored_resume'
+         AND status = 'approved'`,
+    );
+    if (Number(row?.count ?? 0) > 0) {
+      return true;
+    }
+  }
+
+  if (tableExists(db, "jobs")) {
+    const row = getRow<{ count: number }>(
+      db,
+      `SELECT COUNT(*) AS count
+       FROM jobs
+       WHERE tailored_resume_path IS NOT NULL
+         AND tailored_resume_path != ''`,
+    );
+    if (Number(row?.count ?? 0) > 0) {
+      return true;
+    }
+  }
+
+  if (tableExists(db, "job_artifacts")) {
+    const row = getRow<{ count: number }>(
+      db,
+      `SELECT COUNT(*) AS count
+       FROM job_artifacts
+       WHERE artifact_type IN ('tailored_resume', 'tailored_resume_txt')
+         AND status IN ('active', 'approved')`,
+    );
+    if (Number(row?.count ?? 0) > 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function recordProfileUpdatedEvent(
+  db: SqliteDatabase,
+  changedSections: readonly string[],
+  occurredAt = new Date().toISOString(),
+): ProfileUpdated | null {
+  if (!tableExists(db, "job_events")) {
+    return null;
+  }
+  const event = {
+    ...createProfileUpdated(LOCAL_TENANT, {
+      changedSections,
+      updatedAt: occurredAt,
+    }),
+    occurredAt,
+  };
+  insertProfileEvent(db, event);
+  return event;
+}
+
+export async function handleProfileUpdatedEvent(
+  event: ProfileUpdated,
+  actionDispatcher: ActionDispatcher,
+  actionContext: ActionDispatchContext,
+): Promise<void> {
+  if (!event.payload.changedSections.includes("profile")) {
+    return;
+  }
+  const command: ActionCommandPayload = {
+    action: "run_stage",
+    jobKey: PIPELINE_ACTION_JOB_KEY,
+    stage: "tailor",
+    stages: ["tailor", "pdf"],
+    dryRun: false,
+    limit: 0,
+    workers: 1,
+    minScore: 0,
+    validationMode: "normal",
+    retailor: true,
+  };
+  await actionDispatcher(command, actionContext);
+}
+
+function insertProfileEvent(db: SqliteDatabase, event: ProfileUpdated): void {
+  const columns = columnNames(db, "job_events");
+  const values: Record<string, SqliteValue> = {
+    job_url: null,
+    stage: null,
+    event_type: event.eventType,
+    level: "info",
+    message: "Candidate profile updated.",
+    occurred_at: event.occurredAt,
+    payload_json: JSON.stringify({
+      tenantId: event.tenantId,
+      ...event.payload,
+    }),
+  };
+  const entries = Object.entries(values).filter(([name]) => columns.has(name));
+  if (entries.length === 0) {
+    return;
+  }
+  db.prepare(
+    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries
+      .map(() => "?")
+      .join(", ")})`,
+  ).run(...entries.map(([, value]) => value));
+}
+
+function columnNames(db: SqliteDatabase, tableName: string): Set<string> {
+  if (!tableExists(db, tableName)) {
+    return new Set();
+  }
+  return new Set(allRows<{ name: string }>(db, `PRAGMA table_info(${tableName})`).map((row) => row.name));
+}

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -408,6 +408,13 @@ export function writeProfileConfig(
   return readProfileConfig(db, paths);
 }
 
+export function parseProfileUpdateProfile(request: ProfileUpdateRequest): ProfileShape | undefined {
+  if (request.profile === undefined && request.profileText === undefined) {
+    return undefined;
+  }
+  return parseProfileInput(request.profile, request.profileText);
+}
+
 function importLegacyProfileIfNeeded(db: SqliteDatabase, paths: ProfilePaths): void {
   if (getProfileRow(db) || !fs.existsSync(paths.profilePath)) {
     return;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -94,6 +94,7 @@ import {
   recordProfileUpdatedEvent,
   shouldRetailorForProfileUpdate,
 } from "./profile-events.js";
+import { dbFileIdentity, readWorkerHealth } from "./worker-health.js";
 import {
   cancelJobAction,
   correctScore,
@@ -143,7 +144,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   const manualCaptureImporter = options.manualCaptureImporter ?? createWorkerManualCaptureImporter();
   const profileImporter = options.profileImporter ?? defaultProfileImporter;
   const profilePreviewRenderer = options.profilePreviewRenderer ?? defaultProfilePreviewRenderer;
-  const actionContext = { appDir };
+  const actionContext = { appDir, dbPath: options.dbPath };
 
   void app.register(cors, {
     origin: LOCAL_ORIGIN_PATTERNS,
@@ -167,7 +168,10 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   app.get("/v1/health", async () => ({
     ok: true,
     dbPath: options.dbPath,
+    appDir,
     dbExists: databaseExists(options.dbPath),
+    dbIdentity: dbFileIdentity(options.dbPath),
+    worker: readWorkerHealth(options.dbPath),
   }));
 
   registerEventStreamRoute(app, { dbPath: options.dbPath });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -84,9 +84,11 @@ import {
 import { isTrustedMutationSource, LOCAL_CORS_METHODS, LOCAL_ORIGIN_PATTERNS } from "./local-origin.js";
 import {
   ProfileInputError,
+  parseProfileUpdateProfile,
   readProfileConfig,
   writeProfileConfig,
 } from "./profile-store.js";
+import { validateProfileTargetPlaces, type PlaceValidator } from "./place-validation.js";
 import {
   handleProfileUpdatedEvent,
   hasRetailorableResumes,
@@ -130,6 +132,7 @@ export interface BuildAppOptions {
   artifactOpener?: ArtifactOpener;
   credentialStore?: CredentialStore;
   manualCaptureImporter?: ManualCaptureImporter;
+  placeValidator?: PlaceValidator;
   profileImporter?: ProfileImporter;
   profilePreviewRenderer?: ProfilePreviewRenderer;
   logger?: boolean;
@@ -781,6 +784,18 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!databaseExists(options.dbPath)) {
       void reply.code(503);
       return { ok: false, error: "db_not_found", message: `No JobHunter database found at ${options.dbPath}` };
+    }
+    try {
+      const nextProfile = parseProfileUpdateProfile(body);
+      if (nextProfile) {
+        await validateProfileTargetPlaces(nextProfile, options.placeValidator);
+      }
+    } catch (error) {
+      if (error instanceof ProfileInputError) {
+        void reply.code(400);
+        return { ok: false, error: "invalid_profile", message: error.message };
+      }
+      throw error;
     }
     const db = openDatabase(options.dbPath);
     let profileResponse: ProfileConfigResponse | undefined;

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -26,6 +26,7 @@ import {
   ManualCaptureDismissSchema,
   ManualCaptureImportSchema,
   ProfileImportRequestSchema,
+  type ProfileConfigResponse,
   ProfileUpdateRequestSchema,
   QuarantineDecisionSchema,
   ResetStaleScoresForRescoreRequestSchema,
@@ -86,6 +87,13 @@ import {
   readProfileConfig,
   writeProfileConfig,
 } from "./profile-store.js";
+import {
+  handleProfileUpdatedEvent,
+  hasRetailorableResumes,
+  profileChangedSections,
+  recordProfileUpdatedEvent,
+  shouldRetailorForProfileUpdate,
+} from "./profile-events.js";
 import {
   cancelJobAction,
   correctScore,
@@ -668,6 +676,34 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     }),
   );
 
+  app.get<{ Params: { artifactId: string } }>("/v1/artifacts/:artifactId/preview.pdf", async (request, reply) => {
+    const detail = withDb(reply, options.dbPath, (db) => getArtifactDetail(db, decodeRouteParam(request.params.artifactId)));
+    if (!detail) {
+      void reply.code(404);
+      return { ok: false, error: "artifact_not_found" };
+    }
+    if ("ok" in detail && detail.ok === false) {
+      return detail;
+    }
+    if (!isPdfArtifact(detail.artifact.type, detail.artifact.localPath)) {
+      void reply.code(415);
+      return { ok: false, error: "artifact_preview_unsupported" };
+    }
+    if (!fs.existsSync(detail.artifact.localPath) || !fs.statSync(detail.artifact.localPath).isFile()) {
+      void reply.code(404);
+      return { ok: false, error: "artifact_missing" };
+    }
+
+    return reply
+      .type("application/pdf")
+      .header("cache-control", "no-store")
+      .header(
+        "content-disposition",
+        `inline; filename="${path.basename(detail.artifact.localPath).replaceAll('"', "")}"`,
+      )
+      .send(fs.createReadStream(detail.artifact.localPath));
+  });
+
   app.post<{ Params: { artifactId: string } }>("/v1/artifacts/:artifactId/open", async (request, reply) => {
     const detail = withDb(reply, options.dbPath, (db) => getArtifactDetail(db, decodeRouteParam(request.params.artifactId)));
     if (!detail) {
@@ -743,8 +779,11 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       return { ok: false, error: "db_not_found", message: `No JobHunter database found at ${options.dbPath}` };
     }
     const db = openDatabase(options.dbPath);
+    let profileResponse: ProfileConfigResponse | undefined;
+    let profileUpdatedEvent: ReturnType<typeof recordProfileUpdatedEvent> = null;
+    let queueRetailor = false;
     try {
-      return writeProfileConfig(
+      profileResponse = writeProfileConfig(
         db,
         {
           profilePath: options.profilePath,
@@ -753,6 +792,8 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         },
         body,
       );
+      profileUpdatedEvent = recordProfileUpdatedEvent(db, profileChangedSections(body));
+      queueRetailor = shouldRetailorForProfileUpdate(body) && hasRetailorableResumes(db);
     } catch (error) {
       if (error instanceof InputError || error instanceof ProfileInputError) {
         void reply.code(400);
@@ -762,6 +803,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     } finally {
       db.close();
     }
+    if (profileUpdatedEvent && queueRetailor) {
+      try {
+        await handleProfileUpdatedEvent(profileUpdatedEvent, actionDispatcher, actionContext);
+      } catch (error) {
+        request.log.error({ err: error }, "Failed to dispatch profile-update re-tailoring run");
+      }
+    }
+    return profileResponse;
   });
 
   app.post("/v1/profile/import-resume", async (request, reply) => {
@@ -836,6 +885,10 @@ function decodeRouteParam(value: string): string {
   } catch {
     return value;
   }
+}
+
+function isPdfArtifact(artifactType: string, localPath: string): boolean {
+  return artifactType.toLowerCase().endsWith("_pdf") || localPath.toLowerCase().endsWith(".pdf");
 }
 
 function unsupportedPerJobMaterialAction(jobKey?: string): {

--- a/apps/api/src/worker-health.ts
+++ b/apps/api/src/worker-health.ts
@@ -1,0 +1,172 @@
+import { statSync } from "node:fs";
+import path from "node:path";
+import Database from "better-sqlite3";
+
+import { databaseExists, openReadOnlyDatabase } from "./db.js";
+
+const WORKER_HEARTBEAT_TABLE = "worker_runtime_heartbeats";
+const WORKER_STALE_AFTER_MS = 45_000;
+
+export type WorkerHealthStatus = "healthy" | "missing" | "stale" | "mismatched";
+
+export interface WorkerHeartbeatSnapshot {
+  workerId: string;
+  component: string;
+  pid: number | null;
+  hostname: string;
+  appDir: string;
+  dbPath: string;
+  taskQueue: string;
+  startedAt: string;
+  lastSeenAt: string;
+}
+
+export interface WorkerHealthSnapshot {
+  status: WorkerHealthStatus;
+  expectedDbPath: string;
+  expectedAppDir: string;
+  staleAfterSeconds: number;
+  message: string;
+  heartbeat: WorkerHeartbeatSnapshot | null;
+}
+
+interface HeartbeatRow {
+  worker_id: string;
+  component: string;
+  pid: number | null;
+  hostname: string;
+  app_dir: string;
+  db_path: string;
+  task_queue: string;
+  started_at: string;
+  last_seen_at: string;
+}
+
+export function readWorkerHealth(dbPath: string, now = new Date()): WorkerHealthSnapshot {
+  const expectedDbPath = normalizePath(dbPath);
+  const expectedAppDir = normalizePath(path.dirname(dbPath));
+  const staleAfterSeconds = Math.round(WORKER_STALE_AFTER_MS / 1000);
+
+  if (!databaseExists(dbPath)) {
+    return {
+      status: "missing",
+      expectedDbPath,
+      expectedAppDir,
+      staleAfterSeconds,
+      message: `No JobHunter database found at ${expectedDbPath}.`,
+      heartbeat: null,
+    };
+  }
+
+  let db: Database.Database | null = null;
+  try {
+    db = openReadOnlyDatabase(dbPath);
+    if (!tableExists(db, WORKER_HEARTBEAT_TABLE)) {
+      return {
+        status: "missing",
+        expectedDbPath,
+        expectedAppDir,
+        staleAfterSeconds,
+        message: "No Temporal worker heartbeat has been written to the API database.",
+        heartbeat: null,
+      };
+    }
+
+    const row = db
+      .prepare(
+        `SELECT worker_id, component, pid, hostname, app_dir, db_path, task_queue, started_at, last_seen_at
+         FROM ${WORKER_HEARTBEAT_TABLE}
+         ORDER BY last_seen_at DESC
+         LIMIT 1`,
+      )
+      .get() as HeartbeatRow | undefined;
+
+    if (!row) {
+      return {
+        status: "missing",
+        expectedDbPath,
+        expectedAppDir,
+        staleAfterSeconds,
+        message: "No Temporal worker heartbeat has been written to the API database.",
+        heartbeat: null,
+      };
+    }
+
+    const heartbeat = toHeartbeatSnapshot(row);
+    const mismatches = runtimeMismatches({ heartbeat, expectedAppDir, expectedDbPath });
+    if (mismatches.length > 0) {
+      return {
+        status: "mismatched",
+        expectedDbPath,
+        expectedAppDir,
+        staleAfterSeconds,
+        message: `Temporal worker runtime does not match the API runtime: ${mismatches.join("; ")}.`,
+        heartbeat,
+      };
+    }
+
+    const lastSeenMs = Date.parse(heartbeat.lastSeenAt);
+    const stale = Number.isNaN(lastSeenMs) || now.getTime() - lastSeenMs > WORKER_STALE_AFTER_MS;
+    return {
+      status: stale ? "stale" : "healthy",
+      expectedDbPath,
+      expectedAppDir,
+      staleAfterSeconds,
+      message: stale
+        ? `Temporal worker heartbeat is stale; last seen at ${heartbeat.lastSeenAt}.`
+        : "Temporal worker heartbeat is current and uses the API database.",
+      heartbeat,
+    };
+  } finally {
+    db?.close();
+  }
+}
+
+export function dbFileIdentity(dbPath: string): string | null {
+  try {
+    const stat = statSync(dbPath);
+    return `${stat.dev}:${stat.ino}`;
+  } catch {
+    return null;
+  }
+}
+
+function tableExists(db: Database.Database, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(tableName) as { name: string } | undefined;
+  return Boolean(row);
+}
+
+function toHeartbeatSnapshot(row: HeartbeatRow): WorkerHeartbeatSnapshot {
+  return {
+    workerId: row.worker_id,
+    component: row.component,
+    pid: row.pid === null ? null : Number(row.pid),
+    hostname: row.hostname,
+    appDir: normalizePath(row.app_dir),
+    dbPath: normalizePath(row.db_path),
+    taskQueue: row.task_queue,
+    startedAt: row.started_at,
+    lastSeenAt: row.last_seen_at,
+  };
+}
+
+function normalizePath(value: string): string {
+  return path.resolve(value);
+}
+
+function runtimeMismatches(input: {
+  heartbeat: WorkerHeartbeatSnapshot;
+  expectedAppDir: string;
+  expectedDbPath: string;
+}): string[] {
+  const mismatches: string[] = [];
+  if (input.heartbeat.appDir !== input.expectedAppDir) {
+    mismatches.push(`worker app dir ${input.heartbeat.appDir}, API app dir ${input.expectedAppDir}`);
+  }
+  if (input.heartbeat.dbPath !== input.expectedDbPath) {
+    mismatches.push(`worker DB ${input.heartbeat.dbPath}, API DB ${input.expectedDbPath}`);
+  }
+  return mismatches;
+}

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -53,13 +53,15 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         dryRun: true,
         model: "haiku",
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls).toHaveLength(1);
     expect(fake.calls[0]?.method).toBe("apply");
     expect(fake.calls[0]?.params).toMatchObject({
       tenantId: "local",
+      expectedAppDir: "/tmp",
+      expectedDbPath: "/tmp/jobhunter.db",
       jobUrl: "https://example.com/jobs/x",
       limit: 1,
       dryRun: true,
@@ -82,7 +84,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         dryRun: true,
         limit: 1,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls[0]?.method).toBe("apply");
@@ -115,7 +117,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         rescore: true,
         retailor: false,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls).toHaveLength(1);
@@ -123,6 +125,8 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       method: "run_stage",
       params: {
         tenantId: "local",
+        expectedAppDir: "/tmp",
+        expectedDbPath: "/tmp/jobhunter.db",
         stage: "score",
         stages: ["score"],
         limit: 20,
@@ -160,10 +164,13 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         stage: "discover",
         dryRun: false,
       },
-      { appDir: "/tmp/jobhunter-runtime" },
+      { appDir: "/tmp/jobhunter-runtime", dbPath: "/tmp/jobhunter-runtime/jobhunter.db" },
     );
 
-    expect(factory).toHaveBeenCalledWith({ appDir: "/tmp/jobhunter-runtime" });
+    expect(factory).toHaveBeenCalledWith({
+      appDir: "/tmp/jobhunter-runtime",
+      dbPath: "/tmp/jobhunter-runtime/jobhunter.db",
+    });
     expect(fake.calls[0]?.method).toBe("run_stage");
   });
 
@@ -193,7 +200,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       dryRun: true,
     };
 
-    const result = await dispatcher(command, { appDir: "/tmp" });
+    const result = await dispatcher(command, { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" });
     const response = buildActionResponse(command, result);
 
     expect(result).toMatchObject({
@@ -243,7 +250,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
       dryRun: false,
     };
 
-    const result = await dispatcher(command, { appDir: "/tmp" });
+    const result = await dispatcher(command, { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" });
     const response = buildActionResponse(command, result);
 
     expect(result).toMatchObject({
@@ -284,13 +291,15 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         headless: true,
         continuous: true,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls).toHaveLength(1);
     expect(fake.calls[0]?.method).toBe("apply");
     expect(fake.calls[0]?.params).toEqual({
       tenantId: "local",
+      expectedAppDir: "/tmp",
+      expectedDbPath: "/tmp/jobhunter.db",
       limit: 10,
       workers: 2,
       minScore: 9,
@@ -314,7 +323,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         dryRun: true,
         limit: 1,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls).toHaveLength(0);
@@ -333,7 +342,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         limit: 1,
         dryRun: true,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(fake.calls).toHaveLength(0);
@@ -359,7 +368,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         limit: 1,
         dryRun: true,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(result).toMatchObject({
@@ -384,7 +393,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         limit: 1,
         dryRun: true,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
 
     expect(result.status).toBe("queued");
@@ -401,7 +410,7 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         limit: 1,
         dryRun: true,
       },
-      { appDir: "/tmp" },
+      { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" },
     );
     expect(fake.calls[0]?.params).toHaveProperty("tenantId", "local");
   });

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -125,9 +125,105 @@ describe("local TypeScript API", () => {
     expect(response.headers["access-control-allow-origin"]).toBe("http://localhost:8765");
     expect(response.json()).toMatchObject({
       ok: true,
+      appDir: tempDir,
       dbPath: options.dbPath,
       dbExists: true,
+      worker: {
+        status: "missing",
+        expectedDbPath: options.dbPath,
+        expectedAppDir: tempDir,
+        heartbeat: null,
+      },
     });
+
+    await app.close();
+  });
+
+  it("reports a healthy Temporal worker heartbeat from the API database", async () => {
+    insertWorkerHeartbeat(options.dbPath, {
+      workerId: "worker-1",
+      appDir: tempDir,
+      dbPath: options.dbPath,
+      lastSeenAt: new Date().toISOString(),
+    });
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      worker: {
+        status: "healthy",
+        expectedDbPath: options.dbPath,
+        expectedAppDir: tempDir,
+        heartbeat: {
+          workerId: "worker-1",
+          appDir: tempDir,
+          dbPath: options.dbPath,
+          taskQueue: "jobhunter-default",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("reports a stale Temporal worker heartbeat", async () => {
+    insertWorkerHeartbeat(options.dbPath, {
+      workerId: "worker-stale",
+      appDir: tempDir,
+      dbPath: options.dbPath,
+      lastSeenAt: "2026-01-01T00:00:00.000Z",
+    });
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      worker: {
+        status: "stale",
+        heartbeat: {
+          workerId: "worker-stale",
+        },
+      },
+    });
+
+    await app.close();
+  });
+
+  it("reports a mismatched Temporal worker heartbeat", async () => {
+    insertWorkerHeartbeat(options.dbPath, {
+      workerId: "worker-wrong-db",
+      appDir: path.join(tempDir, "other-app"),
+      dbPath: path.join(tempDir, "other-app", "jobhunter.db"),
+      lastSeenAt: new Date().toISOString(),
+    });
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: "/v1/health",
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      worker: {
+        status: "mismatched",
+        expectedDbPath: options.dbPath,
+        expectedAppDir: tempDir,
+        heartbeat: {
+          workerId: "worker-wrong-db",
+          appDir: path.join(tempDir, "other-app"),
+          dbPath: path.join(tempDir, "other-app", "jobhunter.db"),
+        },
+      },
+    });
+    expect(response.json().worker.message).toContain("does not match");
 
     await app.close();
   });
@@ -1395,7 +1491,7 @@ describe("local TypeScript API", () => {
         runAfter: true,
         dryRun: true,
       }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -1452,7 +1548,7 @@ describe("local TypeScript API", () => {
           limit: 1,
           dryRun: true,
         },
-        { appDir: tempDir },
+        { appDir: tempDir, dbPath: options.dbPath },
       ),
     ).resolves.toMatchObject({
       status: "unsupported",
@@ -1468,7 +1564,7 @@ describe("local TypeScript API", () => {
           limit: 1,
           dryRun: true,
         },
-        { appDir: tempDir },
+        { appDir: tempDir, dbPath: options.dbPath },
       ),
     ).resolves.toMatchObject({
       status: "unsupported",
@@ -1515,7 +1611,7 @@ describe("local TypeScript API", () => {
     });
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ action: "apply", dryRun: true, jobKey: "https://example.com/jobs/ready" }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -1587,7 +1683,7 @@ describe("local TypeScript API", () => {
         continuous: true,
         jobKey: "pipeline",
       }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -1637,7 +1733,7 @@ describe("local TypeScript API", () => {
     });
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ action: "run_stage", stage: "score", jobKey: "pipeline" }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -1757,7 +1853,7 @@ describe("local TypeScript API", () => {
     await waitForExpectation(() => expect(dispatch).toHaveBeenCalled());
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ action: "run_stage", stage: "apply", stages: ["apply"], dryRun: true, jobKey: "pipeline" }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -1925,7 +2021,7 @@ describe("local TypeScript API", () => {
         minScore: 0,
         retailor: true,
       }),
-      { appDir: tempDir },
+      { appDir: tempDir, dbPath: options.dbPath },
     );
 
     const db = new Database(options.dbPath);
@@ -2088,7 +2184,7 @@ describe("local TypeScript API", () => {
         importStyle: true,
         pdfBytes: expect.any(Buffer),
       }),
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -2124,7 +2220,7 @@ describe("local TypeScript API", () => {
         profile: expect.objectContaining({ personal: expect.objectContaining({ full_name: "Jordan Candidate" }) }),
         templateText: "\\documentclass{article}",
       },
-      expect.objectContaining({ appDir: tempDir }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
     await app.close();
@@ -2525,6 +2621,47 @@ function seedDatabase(dbPath: string): void {
     "succeeded",
     1,
     "2026-04-29T10:15:00+00:00",
+  );
+  db.close();
+}
+
+function insertWorkerHeartbeat(
+  dbPath: string,
+  heartbeat: {
+    workerId: string;
+    appDir: string;
+    dbPath: string;
+    lastSeenAt: string;
+  },
+): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS worker_runtime_heartbeats (
+      worker_id TEXT PRIMARY KEY,
+      component TEXT NOT NULL,
+      pid INTEGER NOT NULL,
+      hostname TEXT NOT NULL,
+      app_dir TEXT NOT NULL,
+      db_path TEXT NOT NULL,
+      task_queue TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL
+    );
+  `);
+  db.prepare(
+    `INSERT INTO worker_runtime_heartbeats
+      (worker_id, component, pid, hostname, app_dir, db_path, task_queue, started_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    heartbeat.workerId,
+    "temporal-worker",
+    1234,
+    "localhost",
+    heartbeat.appDir,
+    heartbeat.dbPath,
+    "jobhunter-default",
+    "2026-05-20T10:00:00.000Z",
+    heartbeat.lastSeenAt,
   );
   db.close();
 }

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1626,7 +1626,7 @@ describe("local TypeScript API", () => {
       url: "/v1/pipeline/actions/run-stage",
       payload: {
         stages: ["score", "tailor", "apply"],
-        limit: 12,
+        limit: 1000,
         workers: 3,
         minScore: 8,
         validationMode: "strict",
@@ -1656,7 +1656,7 @@ describe("local TypeScript API", () => {
             jobKey: "pipeline",
             stage: "score",
             stages: ["score", "tailor", "apply"],
-            limit: 12,
+            limit: 1000,
             workers: 3,
             minScore: 8,
             validationMode: "strict",

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -67,6 +67,7 @@ beforeEach(() => {
     resumeStylePath: path.join(tempDir, "resume_style.json"),
     resumeTemplatePath: path.join(tempDir, "resume_template.tex"),
     settingsPath: path.join(tempDir, "dashboard.json"),
+    actionDispatcher: vi.fn(async (): Promise<ActionDispatchResult> => ({ status: "queued", runId: "run-profile-retailor" })),
   };
   seedDatabase(options.dbPath);
   fs.writeFileSync(options.profilePath, JSON.stringify(validProfileFixture("Jordan Candidate")));
@@ -1195,6 +1196,7 @@ describe("local TypeScript API", () => {
     const artifactId = encodeURIComponent(artifact.artifactId);
 
     const detailResponse = await app.inject({ method: "GET", url: `/v1/artifacts/${artifactId}` });
+    const previewResponse = await app.inject({ method: "GET", url: `/v1/artifacts/${artifactId}/preview.pdf` });
     const openResponse = await app.inject({ method: "POST", url: `/v1/artifacts/${artifactId}/open` });
 
     expect(detailResponse.statusCode, detailResponse.body).toBe(200);
@@ -1206,6 +1208,9 @@ describe("local TypeScript API", () => {
         type: "tailored_resume_pdf",
       },
     });
+    expect(previewResponse.statusCode, previewResponse.body).toBe(200);
+    expect(previewResponse.headers["content-type"]).toContain("application/pdf");
+    expect(previewResponse.body).toBe("%PDF test");
     expect(openResponse.statusCode, openResponse.body).toBe(200);
     expect(openResponse.json()).toMatchObject({
       ok: true,
@@ -1891,6 +1896,54 @@ describe("local TypeScript API", () => {
       });
       expect(db.prepare("SELECT COUNT(*) AS count FROM candidate_profile_experience_bullets").get()).toMatchObject({
         count: 1,
+      });
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
+  it("records profile updates and starts an event-driven re-tailoring run", async () => {
+    const dispatch = vi.fn(async (): Promise<ActionDispatchResult> => ({ status: "queued", runId: "run-retailor" }));
+    const app = buildApp({ ...options, actionDispatcher: dispatch });
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile: validProfileFixture("Event Driven Candidate") },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "run_stage",
+        jobKey: "pipeline",
+        stage: "tailor",
+        stages: ["tailor", "pdf"],
+        dryRun: false,
+        limit: 0,
+        minScore: 0,
+        retailor: true,
+      }),
+      { appDir: tempDir },
+    );
+
+    const db = new Database(options.dbPath);
+    try {
+      const event = db
+        .prepare(
+          "SELECT job_url, stage, event_type, payload_json FROM job_events WHERE event_type = 'ProfileUpdated' ORDER BY event_id DESC LIMIT 1",
+        )
+        .get() as { job_url: string | null; stage: string | null; event_type: string; payload_json: string };
+      expect(event).toMatchObject({
+        job_url: null,
+        stage: null,
+        event_type: "ProfileUpdated",
+      });
+      expect(JSON.parse(event.payload_json)).toMatchObject({
+        tenantId: "local",
+        changedSections: ["profile"],
+        updatedAt: expect.any(String),
       });
     } finally {
       db.close();

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -36,6 +36,16 @@ function validProfileFixture(fullName: string): Record<string, unknown> {
   };
 }
 
+function profileWithTargetSearch(fullName: string, location: string, workModel: string): Record<string, unknown> {
+  return {
+    ...validProfileFixture(fullName),
+    experience: {
+      target_locations: location,
+      target_work_models: workModel,
+    },
+  };
+}
+
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -1996,6 +2006,56 @@ describe("local TypeScript API", () => {
     } finally {
       db.close();
     }
+
+    await app.close();
+  });
+
+  it("validates target-search locations before saving profile preferences", async () => {
+    const placeValidator = vi.fn(async (place: string) => place === "Barcelona, Spain");
+    const app = buildApp({ ...options, placeValidator });
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: {
+        profile: profileWithTargetSearch("Location Target", "Barcelona, Spain", "Remote"),
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(placeValidator).toHaveBeenCalledWith("Barcelona, Spain");
+    const db = new Database(options.dbPath);
+    try {
+      expect(
+        db.prepare("SELECT experience_target_locations, experience_target_work_models FROM candidate_profiles").get(),
+      ).toMatchObject({
+        experience_target_locations: "Barcelona, Spain",
+        experience_target_work_models: "Remote",
+      });
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
+  it("rejects target-search locations that do not resolve to real places", async () => {
+    const dispatch = vi.fn(async (): Promise<ActionDispatchResult> => ({ status: "queued", runId: "run-retailor" }));
+    const app = buildApp({ ...options, actionDispatcher: dispatch, placeValidator: vi.fn(async () => false) });
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: {
+        profile: profileWithTargetSearch("Bad Location", "Atlantis", "Hybrid"),
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(400);
+    expect(response.json()).toMatchObject({
+      ok: false,
+      error: "invalid_profile",
+      message: 'target location "Atlantis" does not resolve to a real place.',
+    });
+    expect(dispatch).not.toHaveBeenCalled();
 
     await app.close();
   });

--- a/apps/web/src/contexts/materials/components/ArtifactStatusBadge.test.tsx
+++ b/apps/web/src/contexts/materials/components/ArtifactStatusBadge.test.tsx
@@ -8,13 +8,16 @@ describe("<ArtifactStatusBadge>", () => {
     const { container } = render(<ArtifactStatusBadge status={status} />);
     expect(screen.getByText(status)).toBeInTheDocument();
     expect(container.querySelector("span")?.className).toMatch(/tag /);
+    expect(container.querySelector("span")?.getAttribute("title")).toBeTruthy();
   });
 
   it("snapshots approved", () => {
     const { container } = render(<ArtifactStatusBadge status="approved" />);
     expect(container.firstChild).toMatchInlineSnapshot(`
       <span
+        aria-label="approved: Approved means this generated material passed validation and is the accepted version for this job."
         class="tag ok"
+        title="Approved means this generated material passed validation and is the accepted version for this job."
       >
         approved
       </span>

--- a/apps/web/src/contexts/materials/components/ArtifactStatusBadge.tsx
+++ b/apps/web/src/contexts/materials/components/ArtifactStatusBadge.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 
+import { artifactStatusDescription } from "../lib/artifact-status-copy.js";
 import { artifactStatusTone } from "../lib/artifact-status-tone.js";
 
 export interface ArtifactStatusBadgeProps {
@@ -7,5 +8,14 @@ export interface ArtifactStatusBadgeProps {
 }
 
 export function ArtifactStatusBadge({ status }: ArtifactStatusBadgeProps): JSX.Element {
-  return <span className={`tag ${artifactStatusTone(status)}`}>{status}</span>;
+  const description = artifactStatusDescription(status);
+  return (
+    <span
+      aria-label={`${status}: ${description}`}
+      className={`tag ${artifactStatusTone(status)}`}
+      title={description}
+    >
+      {status}
+    </span>
+  );
 }

--- a/apps/web/src/contexts/materials/lib/artifact-status-copy.ts
+++ b/apps/web/src/contexts/materials/lib/artifact-status-copy.ts
@@ -1,0 +1,13 @@
+const DESCRIPTIONS: Record<string, string> = {
+  active: "Active means this registered artifact is the current file exposed by the local read model.",
+  approved: "Approved means this generated material passed validation and is the accepted version for this job.",
+  candidate: "Candidate means the material was generated but has not been accepted yet.",
+  missing: "Missing means the metadata exists, but the local artifact file cannot be found.",
+  rejected: "Rejected means validation or review did not accept this generated material.",
+  stale: "Stale means the artifact may no longer match the latest job or profile state.",
+  superseded: "Superseded means a newer artifact replaced this version.",
+};
+
+export function artifactStatusDescription(status: string): string {
+  return DESCRIPTIONS[status] ?? `Artifact lifecycle status: ${status}.`;
+}

--- a/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/useHealthQuery.ts
@@ -4,21 +4,15 @@ import { useTenantId } from "../../../shared/providers/TenantProvider.js";
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
 import type { ApiHealthResponse } from "../../../shared/ports/ApiClientPort.js";
 import { healthKeys } from "../healthKeys.js";
-import { useEventStreamStatus } from "../providers/EventStreamProvider.js";
-
-const SSE_BACKSTOP_INTERVAL_MS = 30_000;
+const HEALTH_POLL_INTERVAL_MS = 30_000;
 
 export function useHealthQuery(): UseQueryResult<ApiHealthResponse> {
   const tenantId = useTenantId();
   const { api } = usePorts();
-  const streamStatus = useEventStreamStatus();
-  // SSE heartbeat covers liveness when the stream is open; HTTP polling
-  // only fires as a backstop while the stream is unhealthy (target §7.7).
-  const refetchInterval = streamStatus === "open" ? false : SSE_BACKSTOP_INTERVAL_MS;
   return useQuery({
     queryKey: healthKeys.live(tenantId),
     queryFn: () => api.health(),
-    refetchInterval,
+    refetchInterval: HEALTH_POLL_INTERVAL_MS,
     staleTime: 10_000,
   });
 }

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "../../../test/render.js";
-import { sampleDashboardSummary } from "../../../test/fixtures/projections.js";
+import { sampleDashboardSummary, sampleHealthResponse } from "../../../test/fixtures/projections.js";
 import { buildTestPorts } from "../../../test/testPorts.js";
 import { useStageTriggerStore } from "../stores/stage-trigger-store.js";
 import { StageTriggerPanel } from "./StageTriggerPanel.js";
@@ -20,6 +20,34 @@ describe("StageTriggerPanel", () => {
 
     expect(screen.getByLabelText("Dry run")).toBeChecked();
     expect(screen.getByRole("button", { name: "Run Discover" })).toBeEnabled();
+  });
+
+  it("blocks stage runs when the Temporal worker heartbeat is missing", async () => {
+    const user = userEvent.setup();
+    const runPipelineStages = vi.fn();
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({
+        api: {
+          health: vi.fn(async () => ({
+            ...sampleHealthResponse,
+            worker: {
+              ...sampleHealthResponse.worker,
+              status: "missing" as const,
+              message: "No Temporal worker heartbeat has been written to the API database.",
+              heartbeat: null,
+            },
+          })),
+          runPipelineStages,
+        },
+      }),
+    });
+
+    expect(await screen.findByRole("button", { name: "Worker unavailable" })).toBeDisabled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "No Temporal worker heartbeat has been written to the API database.",
+    );
+    await user.click(screen.getByRole("button", { name: "Worker unavailable" }));
+    expect(runPipelineStages).not.toHaveBeenCalled();
   });
 
   it("renders a matching tabpanel for every stage trigger", () => {

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -165,7 +165,7 @@ describe("StageTriggerPanel", () => {
       count: 1,
       command: {
         stages: ["discover"],
-        limit: 1,
+        limit: 1000,
         workers: 1,
         minScore: 7,
         validationMode: "normal" as const,
@@ -182,15 +182,17 @@ describe("StageTriggerPanel", () => {
       ports: buildTestPorts({ api: { runPipelineStages } }),
     });
 
-    await user.clear(screen.getByLabelText("Limit"));
-    await user.type(screen.getByLabelText("Limit"), "1");
+    const limitInput = screen.getByLabelText("Limit");
+    expect(limitInput).toHaveAttribute("max", "1000");
+    await user.clear(limitInput);
+    await user.type(limitInput, "1000");
     await user.click(screen.getByLabelText("Dry run"));
     await user.click(screen.getByRole("button", { name: "Run Discover" }));
 
     await waitFor(() => expect(runPipelineStages).toHaveBeenCalledTimes(1));
     expect(runPipelineStages).toHaveBeenCalledWith({
       stages: ["discover"],
-      limit: 1,
+      limit: 1000,
       workers: 1,
       minScore: 7,
       validationMode: "normal",

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -233,7 +233,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
             <span>Limit</span>
             <input
               min={1}
-              max={500}
+              max={1000}
               type="number"
               value={config.limit}
               onChange={(event) => patchConfig({ limit: event.target.value })}

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -13,6 +13,7 @@ import { Button } from "../../../shared/ui/button.js";
 import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../shared/ui/tabs.js";
 import { useDashboardSummaryQuery } from "../../operations/hooks/useDashboardSummaryQuery.js";
+import { useHealthQuery } from "../../operations/hooks/useHealthQuery.js";
 import type { DashboardSummary } from "../../operations/types.js";
 import { useRunPipelineStagesMutation } from "../hooks/useRunPipelineStagesMutation.js";
 import { useStageTriggerStore, type StageTriggerConfig } from "../stores/stage-trigger-store.js";
@@ -178,6 +179,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
   const [submittedStage, setSubmittedStage] = useState<Stage | null>(null);
   const [submittedAt, setSubmittedAt] = useState<number | null>(null);
   const dashboardSummary = useDashboardSummaryQuery();
+  const health = useHealthQuery();
   const activeStage = useStageTriggerStore((state) => state.activeStage);
   const config = useStageTriggerStore((state) => state.configs[state.activeStage]);
   const setActiveStage = useStageTriggerStore((state) => state.setActiveStage);
@@ -191,6 +193,8 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
   const visibleStageActivity = relevantPendingActivity ?? (!runStages.isPending ? stageActivity : null);
   const headerMeta = runStages.isPending ? "starting" : (runStages.data?.status ?? (runStages.error ? "failed" : "ready"));
   const activeStagePanel = stagePanels[activeStage] ?? null;
+  const workerUnhealthy = Boolean(health.data && health.data.worker.status !== "healthy");
+  const workerHealthMessage = health.data?.worker.message ?? "Temporal worker health is unavailable.";
 
   const patchConfig = (patch: Partial<StageTriggerConfig>) => {
     patchStageConfig(activeStage, patch);
@@ -198,6 +202,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
 
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (workerUnhealthy) return;
     setSubmittedStage(activeStage);
     setSubmittedAt(Date.now());
     runStages.mutate({
@@ -340,11 +345,19 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
       </div>
 
       <div className="stage-trigger-actions">
-        <Button disabled={runStages.isPending} type="submit">
+        <Button disabled={runStages.isPending || workerUnhealthy} type="submit">
           <Play aria-hidden="true" size={16} />
-          {runStages.isPending ? `Starting ${labelForStage(statusStage)}` : `Run ${labelForStage(activeStage)}`}
+          {workerUnhealthy
+            ? "Worker unavailable"
+            : runStages.isPending
+              ? `Starting ${labelForStage(statusStage)}`
+              : `Run ${labelForStage(activeStage)}`}
         </Button>
-        {runStages.isPending ? (
+        {workerUnhealthy ? (
+          <span className="status-line danger-action" role="alert">
+            {workerHealthMessage}
+          </span>
+        ) : runStages.isPending ? (
           <span className="status-line" role="status">
             {relevantPendingActivity
               ? stageActivityStatusLine(statusStage, relevantPendingActivity)

--- a/apps/web/src/contexts/profile/components/ResumePreviewIframe.tsx
+++ b/apps/web/src/contexts/profile/components/ResumePreviewIframe.tsx
@@ -1,131 +1,16 @@
-import pdfWorkerUrl from "pdfjs-dist/legacy/build/pdf.worker.mjs?url";
-import { useEffect, useState } from "react";
-
+import { PdfPreviewViewer } from "../../../shared/ui/PdfPreviewViewer.js";
 import { useProfilePdfPreviewUrl } from "../hooks/useProfilePdfPreviewUrl.js";
-
-type PdfJsModule = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
-type PdfLoadingTask = ReturnType<PdfJsModule["getDocument"]>;
-
-interface RenderedPage {
-  height: number;
-  pageNumber: number;
-  src: string;
-  width: number;
-}
-
-type PreviewState =
-  | { status: "loading"; pages: RenderedPage[]; message: string }
-  | { status: "ready"; pages: RenderedPage[]; message: string }
-  | { status: "error"; pages: RenderedPage[]; message: string };
-
-const PDF_RENDER_SCALE = 1.45;
 
 export function ResumePreviewIframe() {
   const { url, cacheKey } = useProfilePdfPreviewUrl();
-  const [state, setState] = useState<PreviewState>({
-    status: "loading",
-    pages: [],
-    message: "Rendering resume preview.",
-  });
-
-  useEffect(() => {
-    let cancelled = false;
-    let loadingTask: PdfLoadingTask | undefined;
-    setState({ status: "loading", pages: [], message: "Rendering resume preview." });
-
-    async function renderPreview() {
-      try {
-        const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
-        pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
-        loadingTask = pdfjs.getDocument({ url });
-        const document = await loadingTask.promise;
-        const pages: RenderedPage[] = [];
-        const outputScale = window.devicePixelRatio || 1;
-
-        for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
-          const page = await document.getPage(pageNumber);
-          const viewport = page.getViewport({ scale: PDF_RENDER_SCALE });
-          const renderViewport = page.getViewport({ scale: PDF_RENDER_SCALE * outputScale });
-          const canvas = window.document.createElement("canvas");
-          const context = canvas.getContext("2d");
-          if (!context) {
-            throw new Error("Canvas rendering is unavailable.");
-          }
-
-          canvas.width = Math.floor(renderViewport.width);
-          canvas.height = Math.floor(renderViewport.height);
-          await page.render({ canvas, canvasContext: context, viewport: renderViewport }).promise;
-          pages.push({
-            height: viewport.height,
-            pageNumber,
-            src: canvas.toDataURL("image/png"),
-            width: viewport.width,
-          });
-          page.cleanup();
-        }
-
-        if (!cancelled) {
-          setState({
-            status: "ready",
-            pages,
-            message: `${document.numPages} page${document.numPages === 1 ? "" : "s"}`,
-          });
-        }
-        await document.destroy();
-      } catch (error) {
-        if (!cancelled) {
-          setState({
-            status: "error",
-            pages: [],
-            message: error instanceof Error ? error.message : "Unable to render resume preview.",
-          });
-        }
-      }
-    }
-
-    void renderPreview();
-    return () => {
-      cancelled = true;
-      void loadingTask?.destroy();
-    };
-  }, [cacheKey, url]);
-
   return (
-    <div className="pdf-preview-viewer">
-      <div className="pdf-preview-toolbar">
-        <span>Resume preview</span>
-        <span className="mono">{state.message}</span>
-        <a href={url} rel="noreferrer" target="_blank">
-          open PDF
-        </a>
-      </div>
-      {state.status === "error" ? (
-        <div className="pdf-preview-state" role="status">
-          <b>Preview failed</b>
-          <span>{state.message}</span>
-        </div>
-      ) : null}
-      {state.status === "loading" ? (
-        <div className="pdf-preview-state" role="status">
-          <b>Rendering resume.</b>
-          <span>The PDF endpoint is loading into the in-app preview.</span>
-        </div>
-      ) : null}
-      {state.pages.length ? (
-        <div className="pdf-preview-pages" aria-label="Rendered resume pages">
-          {state.pages.map((page) => (
-            <figure className="pdf-preview-page" key={page.pageNumber}>
-              <img
-                alt={`Resume page ${page.pageNumber}`}
-                height={page.height}
-                src={page.src}
-                width={page.width}
-              />
-              <figcaption>Page {page.pageNumber}</figcaption>
-            </figure>
-          ))}
-        </div>
-      ) : null}
-    </div>
+    <PdfPreviewViewer
+      cacheKey={cacheKey}
+      loadingMessage="The PDF endpoint is loading into the in-app preview."
+      loadingTitle="Rendering resume."
+      pageAltPrefix="Resume"
+      title="Resume preview"
+      url={url}
+    />
   );
 }

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -119,6 +119,9 @@ export class FetchApiClientAdapter implements ApiClientPort {
   artifact(artifactId: string) {
     return this.client.artifact(artifactId);
   }
+  artifactPreviewPdfUrl(artifactId: string, cacheKey?: number | string): string {
+    return this.client.artifactPreviewPdfUrl(artifactId, cacheKey);
+  }
   openArtifact(artifactId: string) {
     return this.client.openArtifact(artifactId);
   }

--- a/apps/web/src/shared/layout/ConnectionStatusPill.tsx
+++ b/apps/web/src/shared/layout/ConnectionStatusPill.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { useHealthQuery } from "../../contexts/operations/hooks/useHealthQuery.js";
 import { useEventStreamStatus } from "../../contexts/operations/providers/EventStreamProvider.js";
 import type { EventStreamStatus } from "../ports/EventStreamPort.js";
 
@@ -13,18 +14,25 @@ const CONNECTION_LOST_THRESHOLD_MS = 30_000;
 
 export function ConnectionStatusPill() {
   const status = useEventStreamStatus();
+  const health = useHealthQuery();
+  const workerStatus = health.data?.worker.status ?? "healthy";
+  const workerUnhealthy = workerStatus !== "healthy";
   const lostForLong = useDisconnectedLongerThan(status, CONNECTION_LOST_THRESHOLD_MS);
-  const label = lostForLong ? "offline" : STATUS_LABEL[status];
+  const label = workerUnhealthy ? "worker" : lostForLong ? "offline" : STATUS_LABEL[status];
   return (
     <div className="connection-pill-group">
       <span
         className="connection-pill"
-        data-status={lostForLong ? "lost" : status}
+        data-status={workerUnhealthy ? "lost" : lostForLong ? "lost" : status}
         aria-live="polite"
       >
         {label}
       </span>
-      {lostForLong ? (
+      {workerUnhealthy ? (
+        <div className="connection-banner" role="alert" aria-live="assertive">
+          {health.data?.worker.message ?? "Temporal worker health is unavailable."}
+        </div>
+      ) : lostForLong ? (
         <div className="connection-banner" role="status" aria-live="polite">
           Connection lost — events paused; data will refresh when reconnected.
         </div>

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -116,6 +116,7 @@ export interface ApiClientPort {
 
   artifacts(query?: Partial<ArtifactListQuery>): Promise<PaginatedResponse<ArtifactSummary>>;
   artifact(artifactId: string): Promise<ArtifactDetail>;
+  artifactPreviewPdfUrl(artifactId: string, cacheKey?: number | string): string;
   openArtifact(artifactId: string): Promise<ArtifactOpenResponse>;
 
   profile(): Promise<ProfileConfigResponse>;

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -56,8 +56,28 @@ import type {
 
 export interface ApiHealthResponse {
   ok: true;
+  appDir: string;
   dbPath: string;
   dbExists: boolean;
+  dbIdentity: string | null;
+  worker: {
+    status: "healthy" | "missing" | "stale" | "mismatched";
+    expectedDbPath: string;
+    expectedAppDir: string;
+    staleAfterSeconds: number;
+    message: string;
+    heartbeat: {
+      workerId: string;
+      component: string;
+      pid: number | null;
+      hostname: string;
+      appDir: string;
+      dbPath: string;
+      taskQueue: string;
+      startedAt: string;
+      lastSeenAt: string;
+    } | null;
+  };
 }
 
 export interface ApiClientPort {

--- a/apps/web/src/shared/ui/PdfPreviewViewer.tsx
+++ b/apps/web/src/shared/ui/PdfPreviewViewer.tsx
@@ -1,0 +1,146 @@
+import pdfWorkerUrl from "pdfjs-dist/legacy/build/pdf.worker.mjs?url";
+import { useEffect, useState } from "react";
+
+type PdfJsModule = typeof import("pdfjs-dist/legacy/build/pdf.mjs");
+type PdfLoadingTask = ReturnType<PdfJsModule["getDocument"]>;
+
+interface RenderedPage {
+  height: number;
+  pageNumber: number;
+  src: string;
+  width: number;
+}
+
+type PreviewState =
+  | { status: "loading"; pages: RenderedPage[]; message: string }
+  | { status: "ready"; pages: RenderedPage[]; message: string }
+  | { status: "error"; pages: RenderedPage[]; message: string };
+
+export interface PdfPreviewViewerProps {
+  url: string;
+  cacheKey?: number | string;
+  title: string;
+  loadingTitle: string;
+  loadingMessage: string;
+  pageAltPrefix: string;
+  openLabel?: string;
+}
+
+const PDF_RENDER_SCALE = 1.45;
+
+export function PdfPreviewViewer({
+  url,
+  cacheKey,
+  title,
+  loadingTitle,
+  loadingMessage,
+  pageAltPrefix,
+  openLabel = "open PDF",
+}: PdfPreviewViewerProps) {
+  const [state, setState] = useState<PreviewState>({
+    status: "loading",
+    pages: [],
+    message: loadingMessage,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    let loadingTask: PdfLoadingTask | undefined;
+    setState({ status: "loading", pages: [], message: loadingMessage });
+
+    async function renderPreview() {
+      try {
+        const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+        pdfjs.GlobalWorkerOptions.workerSrc = pdfWorkerUrl;
+        loadingTask = pdfjs.getDocument({ url });
+        const document = await loadingTask.promise;
+        const pages: RenderedPage[] = [];
+        const outputScale = window.devicePixelRatio || 1;
+
+        for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+          const page = await document.getPage(pageNumber);
+          const viewport = page.getViewport({ scale: PDF_RENDER_SCALE });
+          const renderViewport = page.getViewport({ scale: PDF_RENDER_SCALE * outputScale });
+          const canvas = window.document.createElement("canvas");
+          const context = canvas.getContext("2d");
+          if (!context) {
+            throw new Error("Canvas rendering is unavailable.");
+          }
+
+          canvas.width = Math.floor(renderViewport.width);
+          canvas.height = Math.floor(renderViewport.height);
+          await page.render({ canvas, canvasContext: context, viewport: renderViewport }).promise;
+          pages.push({
+            height: viewport.height,
+            pageNumber,
+            src: canvas.toDataURL("image/png"),
+            width: viewport.width,
+          });
+          page.cleanup();
+        }
+
+        if (!cancelled) {
+          setState({
+            status: "ready",
+            pages,
+            message: `${document.numPages} page${document.numPages === 1 ? "" : "s"}`,
+          });
+        }
+        await document.destroy();
+      } catch (error) {
+        if (!cancelled) {
+          setState({
+            status: "error",
+            pages: [],
+            message: error instanceof Error ? error.message : "Unable to render PDF preview.",
+          });
+        }
+      }
+    }
+
+    void renderPreview();
+    return () => {
+      cancelled = true;
+      void loadingTask?.destroy();
+    };
+  }, [cacheKey, loadingMessage, url]);
+
+  return (
+    <div className="pdf-preview-viewer">
+      <div className="pdf-preview-toolbar">
+        <span>{title}</span>
+        <span className="mono">{state.message}</span>
+        <a href={url} rel="noreferrer" target="_blank">
+          {openLabel}
+        </a>
+      </div>
+      {state.status === "error" ? (
+        <div className="pdf-preview-state" role="status">
+          <b>Preview failed</b>
+          <span>{state.message}</span>
+        </div>
+      ) : null}
+      {state.status === "loading" ? (
+        <div className="pdf-preview-state" role="status">
+          <b>{loadingTitle}</b>
+          <span>{loadingMessage}</span>
+        </div>
+      ) : null}
+      {state.pages.length ? (
+        <div className="pdf-preview-pages" aria-label={`${title} pages`}>
+          {state.pages.map((page) => (
+            <figure className="pdf-preview-page" key={page.pageNumber}>
+              <img
+                alt={`${pageAltPrefix} page ${page.pageNumber}`}
+                height={page.height}
+                src={page.src}
+                width={page.width}
+              />
+              <figcaption>Page {page.pageNumber}</figcaption>
+            </figure>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2242,3 +2242,7 @@ textarea {
 .connection-pill[data-status="closed"]::before {
   background: var(--danger);
 }
+
+.connection-pill[data-status="lost"]::before {
+  background: var(--danger);
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1275,6 +1275,10 @@ textarea {
   box-shadow: -18px 0 42px rgba(0, 0, 0, 0.18);
 }
 
+.artifact-detail-drawer {
+  width: min(1180px, 88vw);
+}
+
 .drawer-close {
   position: sticky;
   top: 12px;
@@ -1298,6 +1302,23 @@ textarea {
 .drawer-head h2 {
   margin: 4px 0;
   font-size: 22px;
+}
+
+.artifact-detail-layout {
+  display: grid;
+  grid-template-columns: minmax(320px, 0.42fr) minmax(420px, 0.58fr);
+  min-height: calc(100vh - 116px);
+}
+
+.artifact-detail-layout > .section {
+  min-width: 0;
+  border-right: 1px solid var(--rule);
+}
+
+.artifact-preview-panel {
+  min-width: 0;
+  min-height: 0;
+  background: #242424;
 }
 
 .external-link {
@@ -2121,6 +2142,19 @@ textarea {
 
   .drawer {
     width: min(100vw, 760px);
+  }
+
+  .artifact-detail-drawer {
+    width: min(100vw, 760px);
+  }
+
+  .artifact-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .artifact-detail-layout > .section {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
   }
 
   .data-row.job,

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -15,8 +15,28 @@ import type { ApiHealthResponse } from "../../shared/ports/ApiClientPort.js";
 
 export const sampleHealthResponse: ApiHealthResponse = {
   ok: true,
+  appDir: "/tmp/jobhunter-test",
   dbPath: "/tmp/jobhunter-test/jobhunter.db",
   dbExists: true,
+  dbIdentity: "1:2",
+  worker: {
+    status: "healthy",
+    expectedDbPath: "/tmp/jobhunter-test/jobhunter.db",
+    expectedAppDir: "/tmp/jobhunter-test",
+    staleAfterSeconds: 45,
+    message: "Temporal worker heartbeat is current and uses the API database.",
+    heartbeat: {
+      workerId: "worker-test",
+      component: "temporal-worker",
+      pid: 123,
+      hostname: "localhost",
+      appDir: "/tmp/jobhunter-test",
+      dbPath: "/tmp/jobhunter-test/jobhunter.db",
+      taskQueue: "jobhunter-default",
+      startedAt: "2026-05-20T10:00:00.000Z",
+      lastSeenAt: "2026-05-20T10:00:10.000Z",
+    },
+  },
 };
 
 export const sampleJob: JobSummary = {

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
@@ -1,0 +1,89 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { artifactsSearchSchema } from "../../routes/-artifacts.search.js";
+import { buildProviderHarness } from "../../test/render.js";
+import { sampleArtifact } from "../../test/fixtures/projections.js";
+import { ArtifactDetailPanel } from "./ArtifactDetailPanel.js";
+
+vi.mock("../../shared/ui/PdfPreviewViewer.js", () => ({
+  PdfPreviewViewer: ({ title, url }: { title: string; url: string }) => (
+    <div>
+      <span>{title}</span>
+      <span>{url}</span>
+    </div>
+  ),
+}));
+
+function renderArtifactRoute(children: ReactNode) {
+  const artifact = {
+    ...sampleArtifact,
+    artifactId: "artifact-preview",
+    type: "resume_pdf",
+    status: "approved",
+    localPath: "/tmp/artifact-preview.pdf",
+    sizeBytes: 1234,
+  };
+  const ports = buildProviderHarness().ports;
+  const artifactPreviewPdfUrl = vi.fn(() => "/v1/artifacts/artifact-preview/preview.pdf?v=test");
+  const harness = buildProviderHarness({
+    ports: {
+      ...ports,
+      api: Object.assign(Object.create(Object.getPrototypeOf(ports.api)), ports.api, {
+        artifact: vi.fn(async () => ({ ok: true as const, artifact })),
+        artifactPreviewPdfUrl,
+      }),
+    },
+  });
+
+  const root = createRootRoute({ component: () => <Outlet /> });
+  const artifacts = createRoute({
+    getParentRoute: () => root,
+    path: "/artifacts",
+    validateSearch: (search) => artifactsSearchSchema.parse(search),
+    component: () => <Outlet />,
+  });
+  const artifactDetail = createRoute({
+    getParentRoute: () => artifacts,
+    path: "$artifactId",
+    component: () => <>{children}</>,
+  });
+  const router = createRouter({
+    routeTree: root.addChildren([artifacts.addChildren([artifactDetail])]),
+    history: createMemoryHistory({ initialEntries: ["/artifacts/artifact-preview"] }),
+  });
+
+  render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+  return { artifactPreviewPdfUrl };
+}
+
+describe("<ArtifactDetailPanel>", () => {
+  it("explains approved status and renders PDF artifacts in the detail drawer", async () => {
+    const { artifactPreviewPdfUrl } = renderArtifactRoute(
+      <ArtifactDetailPanel artifactId="artifact-preview" />,
+    );
+
+    expect(
+      await screen.findByText(
+        "Approved means this generated material passed validation and is the accepted version for this job.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Artifact PDF preview")).toHaveTextContent("Artifact preview");
+    expect(screen.getByLabelText("Artifact PDF preview")).toHaveTextContent(
+      "/v1/artifacts/artifact-preview/preview.pdf?v=test",
+    );
+    expect(artifactPreviewPdfUrl).toHaveBeenCalledWith(
+      "artifact-preview",
+      expect.stringContaining("1234"),
+    );
+  });
+});

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -2,20 +2,32 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { useOpenArtifactMutation } from "../../contexts/materials/hooks/useOpenArtifactMutation.js";
+import { artifactStatusDescription } from "../../contexts/materials/lib/artifact-status-copy.js";
 import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status-tone.js";
 import { useArtifactDetailQuery } from "../../contexts/operations/hooks/useArtifactDetailQuery.js";
 import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
+import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { PdfPreviewViewer } from "../../shared/ui/PdfPreviewViewer.js";
 import { Section } from "../../shared/ui/section.js";
 
 export interface ArtifactDetailPanelProps {
   artifactId: string;
 }
 
+function isPreviewablePdfArtifact(type: string, localPath: string): boolean {
+  return type.toLowerCase().endsWith("_pdf") || localPath.toLowerCase().endsWith(".pdf");
+}
+
+function artifactPreviewCacheKey(createdAt: string | null, sizeBytes: number | null): string {
+  return `${createdAt ?? "unknown"}:${sizeBytes ?? "unknown"}`;
+}
+
 export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   const navigate = useNavigate();
   const search = useSearch({ from: "/artifacts" });
+  const { api } = usePorts();
   const close = useCallback(() => {
     void navigate({ to: "/artifacts", search });
   }, [navigate, search]);
@@ -30,7 +42,7 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
 
   return (
     <div className="drawer-backdrop">
-      <aside className="drawer detail-drawer">
+      <aside className="drawer detail-drawer artifact-detail-drawer">
         <button
           aria-label="Close artifact details"
           className="drawer-close"
@@ -44,8 +56,13 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
         {detail ? (
           <>
             <div className="drawer-head">
-              <span className={`tag ${artifactStatusTone(detail.artifact.status)}`}>
-                {detail.artifact.status}
+              <span>
+                <span
+                  className={`tag ${artifactStatusTone(detail.artifact.status)}`}
+                  title={artifactStatusDescription(detail.artifact.status)}
+                >
+                  {detail.artifact.status}
+                </span>
               </span>
               <span>
                 <small>{detail.artifact.company}</small>
@@ -55,47 +72,72 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
                 </p>
               </span>
             </div>
-            <Section title="Artifact details">
-              <dl className="detail-list">
-                <div>
-                  <dt>Artifact id</dt>
-                  <dd className="mono">{detail.artifact.artifactId}</dd>
-                </div>
-                <div>
-                  <dt>Job</dt>
-                  <dd>{detail.artifact.jobKey || "-"}</dd>
-                </div>
-                <div>
-                  <dt>Local path</dt>
-                  <dd className="mono">{detail.artifact.localPath || "-"}</dd>
-                </div>
-                <div>
-                  <dt>Size</dt>
-                  <dd>{detail.artifact.size}</dd>
-                </div>
-              </dl>
-              <button
-                className="tab on"
-                type="button"
-                disabled={openArtifact.isPending || detail.artifact.status === "missing"}
-                onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
-              >
-                {openArtifact.isPending ? "opening" : "open"}
-              </button>
-              <button
-                className="tab"
-                type="button"
-                disabled={!detail.artifact.jobKey}
-                onClick={() =>
-                  void navigate({
-                    to: "/jobs/$jobId",
-                    params: { jobId: detail.artifact.jobKey },
-                  })
-                }
-              >
-                open related job
-              </button>
-            </Section>
+            <div className="artifact-detail-layout">
+              <Section title="Artifact details">
+                <dl className="detail-list">
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
+                  </div>
+                  <div>
+                    <dt>Artifact id</dt>
+                    <dd className="mono">{detail.artifact.artifactId}</dd>
+                  </div>
+                  <div>
+                    <dt>Job</dt>
+                    <dd>{detail.artifact.jobKey || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Local path</dt>
+                    <dd className="mono">{detail.artifact.localPath || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Size</dt>
+                    <dd>{detail.artifact.size}</dd>
+                  </div>
+                </dl>
+                <button
+                  className="tab on"
+                  type="button"
+                  disabled={openArtifact.isPending || detail.artifact.status === "missing"}
+                  onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
+                >
+                  {openArtifact.isPending ? "opening" : "open"}
+                </button>
+                <button
+                  className="tab"
+                  type="button"
+                  disabled={!detail.artifact.jobKey}
+                  onClick={() =>
+                    void navigate({
+                      to: "/jobs/$jobId",
+                      params: { jobId: detail.artifact.jobKey },
+                    })
+                  }
+                >
+                  open related job
+                </button>
+              </Section>
+              {isPreviewablePdfArtifact(detail.artifact.type, detail.artifact.localPath) ? (
+                <section className="artifact-preview-panel" aria-label="Artifact PDF preview">
+                  <PdfPreviewViewer
+                    cacheKey={artifactPreviewCacheKey(
+                      detail.artifact.createdAt,
+                      detail.artifact.sizeBytes,
+                    )}
+                    loadingMessage="The artifact PDF is loading into the in-app preview."
+                    loadingTitle="Rendering artifact PDF."
+                    openLabel="open PDF"
+                    pageAltPrefix={detail.artifact.title || detail.artifact.type}
+                    title="Artifact preview"
+                    url={api.artifactPreviewPdfUrl(
+                      detail.artifact.artifactId,
+                      artifactPreviewCacheKey(detail.artifact.createdAt, detail.artifact.sizeBytes),
+                    )}
+                  />
+                </section>
+              ) : null}
+            </div>
             {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
           </>
         ) : null}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -14,6 +14,8 @@
   `GET /v1/events/stream` SSE contract.
 - `local-reliability-qa.md`: local QA checklist, regression matrix, and the
   frontend test pyramid + a11y bar.
+- `requirements.md`: product requirements that must stay true as
+  implementation changes.
 - `decisions.md`: accepted architecture decisions.
 - `delivered.md`: delivery history by PR.
 - `backlog.md`: deferred local and hosted work.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -21,6 +21,13 @@ pnpm api:dev
 pnpm web:dev -- --port 5173
 ```
 
+For worker-backed pipeline smoke, run the full local stack and confirm
+`GET /v1/health` reports `worker.status: "healthy"` before starting stages:
+
+```bash
+pnpm dev
+```
+
 For destructive browser QA, seed a disposable workspace:
 
 ```bash
@@ -38,7 +45,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Targeted apply skips fresh jobs | `workers/automation/tests/test_apply_regressions.py` |
 | Stages cannot be retried individually | `workers/automation/tests/test_state_dashboard.py` |
 | Explicit stage state loses to legacy columns | `workers/automation/tests/test_state_dashboard.py` |
-| Pipeline actions write events to a different DB, hide running stages, or ignore bounded stage limits | `apps/api/test/json-rpc-adapter.test.ts`; `workers/automation/tests/test_pipeline_observability.py`; `apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
+| Pipeline actions write events to a different DB, hide running stages, or ignore bounded stage limits | `apps/api/test/server.test.ts`; `apps/api/test/json-rpc-adapter.test.ts`; `workers/automation/tests/test_runtime_identity.py`; `workers/automation/tests/test_jsonrpc_handlers.py`; `workers/automation/tests/test_rpc_handlers_apply_workflow.py`; `workers/automation/tests/test_pipeline_observability.py`; `apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
 | PDF conversion publishes stray files | `workers/automation/tests/test_pdf_targets.py` |
 | Cover letters use the wrong resume | `workers/automation/tests/test_cover_requirements.py` |
 | Profile PDF import corrupts defaults | `workers/automation/tests/test_profile_import.py` |

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -145,7 +145,15 @@ locations, and filter API-visible America-only source rows from
 
 The JSON-RPC worker is launched with the API runtime `appDir` as
 `JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same
-local SQLite database. Non-apply pipeline runs also emit pipeline-level
+local SQLite database. The API also passes `expectedAppDir` and
+`expectedDbPath` into worker-started workflows. Worker activities verify those
+runtime values before writing, and fail non-retryably if the Temporal worker is
+connected to a different local app directory or SQLite database. The worker
+writes `worker_runtime_heartbeats` into the same database; `GET /v1/health`
+returns the API app/database identity plus the latest worker heartbeat status.
+The web topbar surfaces missing or stale worker heartbeats, and the pipeline
+stage trigger blocks new worker-backed actions until the worker is healthy.
+Non-apply pipeline runs also emit pipeline-level
 `StageStarted` / `StageCompleted` / `StageFailed` rows, and Discover emits
 the same lifecycle rows plus `DiscoveryRunStarted`,
 `DiscoveryRunCompleted`, and `DiscoveryRunFailed` for its JobSpy, Workday, and

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -138,10 +138,14 @@ batch size.
 Discover honors the profile Target search saved from the Preferences tab.
 Target roles replace the active discovery query list, target locations replace
 the active location list, and the worker falls back to profile city/country when
-target locations are blank. Spain or Europe targets set JobSpy's Indeed country
-to Spain, add Europe/remote location accepts, reject America-only non-remote
-locations, and filter API-visible America-only source rows from
-`GET /v1/discovery/sources`.
+target locations are blank. The API validates target locations as real places
+before saving profile preferences. Hybrid and on-site target work models search
+and filter only the target location. Remote target work models search and filter
+the target country, and European countries also add an Europe-remote search and
+accept pattern. Profile-driven discovery searches at least the last 30 days
+unless local config sets a larger window. Spain or Europe targets set JobSpy's
+Indeed country to Spain, reject America-only non-remote locations, and filter
+API-visible America-only source rows from `GET /v1/discovery/sources`.
 
 The JSON-RPC worker is launched with the API runtime `appDir` as
 `JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -13,6 +13,12 @@ tables are empty, the API can seed them once from legacy `profile.json`,
 `resume_style.json`, and `resume_template.tex`; subsequent writes update only
 SQLite and reconstruct the existing response object shape for frontend/client
 compatibility.
+Profile-data writes also record `ProfileUpdated` in `job_events`. When existing
+tailored resumes are present, the API handles that event by dispatching a
+background `tailor -> pdf` pipeline run with `retailor=true`, `dryRun=false`,
+and no item limit. The Python materials generation path creates a new materials
+generation for each re-tailored job and preserves the prior generation as
+historical/superseded artifact data.
 
 Read-model endpoints (`/v1/dashboard/summary`, `/v1/jobs`, `/v1/jobs/:key`,
 `/v1/artifacts`, `/v1/workflow-runs`) read from the local `*_projections` tables
@@ -20,6 +26,12 @@ maintained by `apps/api/src/projections.ts` (TS-side mirror) and the Python
 `ProjectionBuilder` (`workers/automation/src/jobhunter/infrastructure/projections/`).
 Both processes refresh projections idempotently via the shared
 `event_watermarks.operations_projections` watermark.
+Artifact detail routes include `GET /v1/artifacts/:artifactId` for metadata and
+`GET /v1/artifacts/:artifactId/preview.pdf` for inline preview of registered
+PDF artifacts. The preview route serves only known PDF artifact files from the
+local artifact projection; it returns `404` for missing metadata/files and
+`415` for non-PDF artifacts. The separate `POST /v1/artifacts/:artifactId/open`
+route still delegates to the local OS opener.
 
 `/v1/jobs` and `/v1/jobs/:key` expose the latest persisted scoring evidence
 from `job_scores` as additive read-model fields: `scoreBreakdown`,

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,17 @@
+# Requirements
+
+This file records product requirements that must remain true as implementation
+details change.
+
+## Discovery Location Filtering
+
+- Target-search location inputs must be validated as real places before they
+  are saved.
+- For hybrid or on-site target work models, discovery filters exclusively for
+  the target location, for example `Barcelona, Spain`.
+- For remote target work models, discovery filters for the target country, for
+  example `Spain`.
+- For remote target work models in European countries, discovery must also
+  include jobs that are remote in Europe.
+- Profile-driven target discovery must search at least the last 30 days unless
+  the local search configuration explicitly sets a larger lookback window.

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -59,8 +59,28 @@ const DEFAULT_NODE_BASE_URL = "http://127.0.0.1:8766";
 
 export interface HealthResponse {
   ok: true;
+  appDir: string;
   dbPath: string;
   dbExists: boolean;
+  dbIdentity: string | null;
+  worker: {
+    status: "healthy" | "missing" | "stale" | "mismatched";
+    expectedDbPath: string;
+    expectedAppDir: string;
+    staleAfterSeconds: number;
+    message: string;
+    heartbeat: {
+      workerId: string;
+      component: string;
+      pid: number | null;
+      hostname: string;
+      appDir: string;
+      dbPath: string;
+      taskQueue: string;
+      startedAt: string;
+      lastSeenAt: string;
+    } | null;
+  };
 }
 
 export class JobHunterApiClient {

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -226,6 +226,15 @@ export class JobHunterApiClient {
     return this.get(`/v1/artifacts/${encodeURIComponent(artifactId)}`);
   }
 
+  artifactPreviewPdfUrl(artifactId: string, cacheKey?: QueryValue): string {
+    const path = `/v1/artifacts/${encodeURIComponent(artifactId)}/preview.pdf`;
+    const url = new URL(`${this.baseUrl}${path}`, this.baseUrl ? undefined : "http://jobhunter.local");
+    if (cacheKey !== undefined && cacheKey !== null && cacheKey !== "") {
+      url.searchParams.set("v", String(cacheKey));
+    }
+    return this.baseUrl ? url.href : `${url.pathname}${url.search}`;
+  }
+
   openArtifact(artifactId: string): Promise<ArtifactOpenResponse> {
     return this.post(`/v1/artifacts/${encodeURIComponent(artifactId)}/open`);
   }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -152,6 +152,8 @@ export type CancelStageResult = z.infer<typeof CancelStageResultSchema>;
 export const RunStageParamsSchema = z
   .object({
     tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
     stage: z.enum(STAGES),
     stages: z.array(z.enum(STAGES)).min(1).max(STAGES.length).optional(),
     jobUrl: z.string().optional(),
@@ -172,6 +174,8 @@ export type RunStageParams = z.infer<typeof RunStageParamsSchema>;
 export const ApplyParamsSchema = z
   .object({
     tenantId: TenantParam,
+    expectedAppDir: z.string().trim().min(1).optional(),
+    expectedDbPath: z.string().trim().min(1).optional(),
     jobUrl: z.string().optional(),
     limit: z.number().int().min(1).default(1),
     workers: z.number().int().min(1).default(1),

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -98,7 +98,7 @@ export type ApplyJobRequest = z.infer<typeof ApplyJobRequestSchema>;
 export const RunPipelineStagesRequestSchema = z
   .object({
     stages: z.array(z.enum(STAGES)).min(1).max(STAGES.length),
-    limit: z.coerce.number().int().min(1).max(500).default(25),
+    limit: z.coerce.number().int().min(1).max(1000).default(25),
     workers: z.coerce.number().int().min(1).max(16).default(1),
     minScore: z.coerce.number().int().min(0).max(10).default(7),
     validationMode: z.enum(PIPELINE_VALIDATION_MODES).default("normal"),

--- a/workers/automation/src/jobhunter/apply/activities.py
+++ b/workers/automation/src/jobhunter/apply/activities.py
@@ -21,6 +21,8 @@ class ApplyActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     job_url: str | None = None
     limit: int = 1
     min_score: int = 7
@@ -57,7 +59,13 @@ async def apply_activity(payload: ApplyActivityInput) -> ApplyActivityOutput:
 
     # ``apply.launcher`` installs process signal handlers at import time; import
     # it on the activity event-loop thread before handing work to the executor.
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.apply.launcher import main as apply_main
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _run_apply() -> tuple[int, int]:
         # ``continuous=True`` selects the launcher's run-forever poll mode,

--- a/workers/automation/src/jobhunter/apply/workflow.py
+++ b/workers/automation/src/jobhunter/apply/workflow.py
@@ -26,6 +26,8 @@ with workflow.unsafe.imports_passed_through():
 @dataclass(frozen=True)
 class ApplyWorkflowInput:
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     job_url: str | None = None
     dry_run: bool = False
     headless: bool = False
@@ -68,6 +70,8 @@ class ApplyWorkflow:
                 apply_activity,
                 ApplyActivityInput(
                     tenant_id=payload.tenant_id,
+                    expected_app_dir=payload.expected_app_dir,
+                    expected_db_path=payload.expected_db_path,
                     job_url=payload.job_url,
                     limit=payload.limit,
                     min_score=payload.min_score,

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import time
@@ -1195,6 +1196,10 @@ def worker(
         get_temporal_client,
     )
     from jobhunter.infrastructure.temporal.registry import ACTIVITIES, WORKFLOWS
+    from jobhunter.infrastructure.runtime_identity import (
+        current_runtime_identity,
+        write_worker_heartbeat,
+    )
 
     queue = task_queue or JOBHUNTER_TASK_QUEUE
 
@@ -1206,12 +1211,23 @@ def worker(
             activities=ACTIVITIES,
             task_queue=queue,
         )
+        identity = current_runtime_identity()
+        heartbeat_worker_id = write_worker_heartbeat(task_queue=queue)
+        heartbeat_task = asyncio.create_task(
+            _worker_heartbeat_loop(queue, heartbeat_worker_id)
+        )
         console.print(
             f"[bold blue]JobHunter worker[/bold blue] running on task queue "
             f"[bold]{queue}[/bold] with {len(WORKFLOWS)} workflow(s) and "
-            f"{len(ACTIVITIES)} activity(ies) — Ctrl-C to stop."
+            f"{len(ACTIVITIES)} activity(ies) against DB "
+            f"[bold]{identity.db_path}[/bold] — Ctrl-C to stop."
         )
-        await worker.run()
+        try:
+            await worker.run()
+        finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
 
     from jobhunter.infrastructure.observability import shutdown_otel
 
@@ -1221,6 +1237,14 @@ def worker(
         # Flush any in-flight spans so the BatchSpanProcessor doesn't drop
         # them on Ctrl-C.
         shutdown_otel()
+
+
+async def _worker_heartbeat_loop(task_queue: str, worker_id: str) -> None:
+    from jobhunter.infrastructure.runtime_identity import write_worker_heartbeat
+
+    while True:
+        await asyncio.sleep(15)
+        write_worker_heartbeat(task_queue=task_queue, worker_id=worker_id)
 
 
 @app.command()

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -52,29 +52,28 @@ PACKAGE_DIR = Path(__file__).parent
 CONFIG_DIR = PACKAGE_DIR / "config"
 
 DEFAULT_JOBSPY_BOARDS = ("indeed", "linkedin", "zip_recruiter")
+TARGET_SEARCH_MIN_HOURS_OLD = 24 * 30
 
 _EUROPE_TARGET_MARKERS = (
-    "barcelona",
     "spain",
     "españa",
-    "madrid",
-    "valencia",
     "europe",
     "european union",
     " eu",
     "eu ",
 )
 
-_EUROPE_LOCATION_ACCEPTS = (
-    "Barcelona",
-    "Spain",
-    "España",
-    "Madrid",
-    "Valencia",
+_REMOTE_EUROPE_LOCATION_ACCEPTS = (
     "Europe",
     "European Union",
     "EU",
     "EMEA",
+)
+
+_SPAIN_LOCATION_ACCEPTS = (
+    "Spain",
+    "España",
+    "ES",
 )
 
 _AMERICA_LOCATION_REJECTS = (
@@ -91,6 +90,58 @@ _AMERICA_LOCATION_REJECTS = (
     "LATAM",
     "Americas",
 )
+
+_EUROPEAN_COUNTRY_ALIASES = {
+    "albania": ("albania",),
+    "andorra": ("andorra",),
+    "austria": ("austria",),
+    "belarus": ("belarus",),
+    "belgium": ("belgium",),
+    "bosnia and herzegovina": ("bosnia and herzegovina", "bosnia"),
+    "bulgaria": ("bulgaria",),
+    "croatia": ("croatia",),
+    "cyprus": ("cyprus",),
+    "czech republic": ("czech republic", "czechia"),
+    "denmark": ("denmark",),
+    "estonia": ("estonia",),
+    "finland": ("finland",),
+    "france": ("france",),
+    "germany": ("germany",),
+    "greece": ("greece",),
+    "hungary": ("hungary",),
+    "iceland": ("iceland",),
+    "ireland": ("ireland",),
+    "italy": ("italy",),
+    "kosovo": ("kosovo",),
+    "latvia": ("latvia",),
+    "liechtenstein": ("liechtenstein",),
+    "lithuania": ("lithuania",),
+    "luxembourg": ("luxembourg",),
+    "malta": ("malta",),
+    "moldova": ("moldova",),
+    "monaco": ("monaco",),
+    "montenegro": ("montenegro",),
+    "netherlands": ("netherlands", "the netherlands"),
+    "north macedonia": ("north macedonia", "macedonia"),
+    "norway": ("norway",),
+    "poland": ("poland",),
+    "portugal": ("portugal",),
+    "romania": ("romania",),
+    "san marino": ("san marino",),
+    "serbia": ("serbia",),
+    "slovakia": ("slovakia",),
+    "slovenia": ("slovenia",),
+    "spain": ("spain", "españa", "es"),
+    "sweden": ("sweden",),
+    "switzerland": ("switzerland",),
+    "ukraine": ("ukraine",),
+    "united kingdom": ("united kingdom", "uk", "great britain", "england", "scotland", "wales"),
+    "vatican city": ("vatican city", "vatican"),
+}
+
+_INDEED_COUNTRY_BY_TARGET_COUNTRY = {
+    "spain": "spain",
+}
 
 _AMERICA_ONLY_SOURCE_MARKERS = (
     "canada",
@@ -127,7 +178,8 @@ def get_chrome_path() -> str:
     if system == "Windows":
         candidates = [
             Path(os.environ.get("PROGRAMFILES", r"C:\Program Files")) / "Google/Chrome/Application/chrome.exe",
-            Path(os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)")) / "Google/Chrome/Application/chrome.exe",
+            Path(os.environ.get("PROGRAMFILES(X86)", r"C:\Program Files (x86)"))
+            / "Google/Chrome/Application/chrome.exe",
             Path(os.environ.get("LOCALAPPDATA", "")) / "Google/Chrome/Application/chrome.exe",
         ]
     elif system == "Darwin":
@@ -152,9 +204,7 @@ def get_chrome_path() -> str:
         if found:
             return found
 
-    raise FileNotFoundError(
-        "Chrome/Chromium not found. Install Chrome or set CHROME_PATH environment variable."
-    )
+    raise FileNotFoundError("Chrome/Chromium not found. Install Chrome or set CHROME_PATH environment variable.")
 
 
 def get_chrome_user_data() -> Path:
@@ -177,6 +227,7 @@ def ensure_dirs():
 def load_search_config() -> dict:
     """Load search configuration, honoring the profile target-search fields."""
     import yaml
+
     if not SEARCH_CONFIG_PATH.exists():
         # Fall back to package-shipped example
         example = CONFIG_DIR / "searches.example.yaml"
@@ -204,39 +255,150 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
         next_cfg["ats_max_tier"] = 1
 
     if locations:
-        location_accept = _dedupe_strings([*locations])
-        next_cfg["locations"] = [
-            {
-                "label": _source_slug(location),
-                "location": location,
-                "remote": _target_location_is_remote(location, work_models[index] if index < len(work_models) else ""),
-            }
-            for index, location in enumerate(locations)
-        ]
-        next_cfg["location_labels"] = [_source_slug(location) for location in locations]
-        next_cfg["location_accept"] = location_accept
+        target_locations = _build_target_location_config(locations, work_models)
+        next_cfg["locations"] = target_locations["locations"]
+        next_cfg["location_labels"] = [item["label"] for item in target_locations["locations"]]
+        next_cfg["location_accept"] = target_locations["accept"]
         location_cfg = dict(next_cfg.get("location") or {})
-        location_cfg["accept_patterns"] = location_accept
+        location_cfg["accept_patterns"] = target_locations["accept"]
         next_cfg["location"] = location_cfg
 
-    if _target_prefers_europe_from_values(locations):
-        defaults = dict(next_cfg.get("defaults") or {})
-        defaults.setdefault("country_indeed", "spain")
-        next_cfg["defaults"] = defaults
-        next_cfg["country"] = "Spain"
-        next_cfg["target_region"] = "europe"
-        location_accept = _dedupe_strings([*locations, *_EUROPE_LOCATION_ACCEPTS])
-        next_cfg["location_accept"] = _dedupe_strings(
-            location_accept
-        )
-        location_cfg = dict(next_cfg.get("location") or {})
-        location_cfg["accept_patterns"] = location_accept
-        next_cfg["location"] = location_cfg
-        next_cfg["location_reject_non_remote"] = _dedupe_strings(
-            [*_string_list(next_cfg.get("location_reject_non_remote")), *_AMERICA_LOCATION_REJECTS]
-        )
+        if target_locations["europe"]:
+            defaults = dict(next_cfg.get("defaults") or {})
+            defaults["hours_old"] = max(_positive_int(defaults.get("hours_old")), TARGET_SEARCH_MIN_HOURS_OLD)
+            if target_locations["country_indeed"]:
+                defaults.setdefault("country_indeed", target_locations["country_indeed"])
+            next_cfg["defaults"] = defaults
+            if target_locations["country"]:
+                next_cfg["country"] = target_locations["country"]
+            next_cfg["target_region"] = "europe"
+            next_cfg["location_reject_non_remote"] = _dedupe_strings(
+                [*_string_list(next_cfg.get("location_reject_non_remote")), *_AMERICA_LOCATION_REJECTS]
+            )
 
     return next_cfg
+
+
+def _build_target_location_config(locations: list[str], work_models: list[str]) -> dict:
+    search_locations: list[dict] = []
+    accept: list[str] = []
+    first_country = ""
+    first_indeed_country = ""
+    europe = False
+
+    for index, raw_location in enumerate(locations):
+        location = str(raw_location or "").strip()
+        if not location:
+            continue
+        work_model = work_models[index] if index < len(work_models) else ""
+        wants_remote, wants_local = _target_work_model_flags(work_model)
+        country = _target_location_country(location)
+        country_key = _country_key(country)
+        is_european_country = _is_european_country(country_key)
+
+        if wants_local:
+            _append_search_location(search_locations, location=location, remote=False)
+            accept.append(location)
+
+        if wants_remote:
+            remote_country = _display_country(country) or location
+            _append_search_location(search_locations, location=remote_country, remote=True)
+            accept.extend(_country_location_accepts(country_key, remote_country))
+            if is_european_country:
+                _append_search_location(
+                    search_locations,
+                    location="European Union",
+                    remote=True,
+                    label="europe-remote",
+                )
+                accept.extend(_REMOTE_EUROPE_LOCATION_ACCEPTS)
+
+        if is_european_country:
+            europe = True
+            first_country = first_country or (_display_country(country) or location)
+            first_indeed_country = first_indeed_country or _INDEED_COUNTRY_BY_TARGET_COUNTRY.get(country_key, "")
+
+    return {
+        "locations": search_locations,
+        "accept": _dedupe_strings(accept),
+        "country": first_country,
+        "country_indeed": first_indeed_country,
+        "europe": europe,
+    }
+
+
+def _append_search_location(
+    search_locations: list[dict],
+    *,
+    location: str,
+    remote: bool,
+    label: str | None = None,
+) -> None:
+    entry = {
+        "label": label or _source_slug(location),
+        "location": location,
+        "remote": remote,
+    }
+    key = (entry["label"], entry["location"], entry["remote"])
+    if key not in {(item["label"], item["location"], item["remote"]) for item in search_locations}:
+        search_locations.append(entry)
+
+
+def _target_work_model_flags(work_model: str) -> tuple[bool, bool]:
+    target = str(work_model or "").lower()
+    wants_remote = any(marker in target for marker in ("remote", "anywhere", "distributed"))
+    wants_local = any(marker in target for marker in ("hybrid", "on-site", "onsite", "on site", "office"))
+    if not wants_remote and not wants_local:
+        wants_local = True
+    return wants_remote, wants_local
+
+
+def _target_location_country(location: str) -> str:
+    parts = [part.strip() for part in str(location or "").split(",") if part.strip()]
+    if not parts:
+        return ""
+    if len(parts) == 1:
+        return parts[0]
+    return parts[-1]
+
+
+def _display_country(country: str) -> str:
+    country_key = _country_key(country)
+    if country_key == "spain":
+        return "Spain"
+    for canonical, aliases in _EUROPEAN_COUNTRY_ALIASES.items():
+        if country_key == canonical or country_key in aliases:
+            return canonical.title()
+    return country.strip()
+
+
+def _country_key(country: str) -> str:
+    normalized = str(country or "").strip().lower()
+    for canonical, aliases in _EUROPEAN_COUNTRY_ALIASES.items():
+        if normalized == canonical or normalized in aliases:
+            return canonical
+    return normalized
+
+
+def _positive_int(value: object) -> int:
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return result if result > 0 else 0
+
+
+def _is_european_country(country_key: str) -> bool:
+    return country_key in _EUROPEAN_COUNTRY_ALIASES
+
+
+def _country_location_accepts(country_key: str, fallback: str) -> list[str]:
+    if country_key == "spain":
+        return list(_SPAIN_LOCATION_ACCEPTS)
+    aliases = _EUROPEAN_COUNTRY_ALIASES.get(country_key)
+    if aliases:
+        return [alias.title() if len(alias) > 3 else alias.upper() for alias in aliases]
+    return [fallback]
 
 
 def _load_profile_target_search() -> dict[str, list[str]]:
@@ -280,11 +442,7 @@ def _split_target_text(value: object) -> list[str]:
     if value is None:
         return []
     cleaned = re.sub(r"^\s*Target (?:roles?|locations?):\s*", "", str(value), flags=re.IGNORECASE)
-    return [
-        item.strip()
-        for item in re.split(r"[;\n]+", cleaned)
-        if item.strip()
-    ]
+    return [item.strip() for item in re.split(r"[;\n]+", cleaned) if item.strip()]
 
 
 def _profile_home_location(row: sqlite3.Row) -> list[str]:
@@ -341,6 +499,7 @@ def _dedupe_strings(values: list[str]) -> list[str]:
 def load_sites_config() -> dict:
     """Load sites.yaml configuration (sites list, manual_ats, blocked, etc.)."""
     import yaml
+
     path = CONFIG_DIR / "sites.yaml"
     if not path.exists():
         return {}
@@ -382,9 +541,7 @@ def resolve_jobspy_boards(search_cfg: dict | None = None, *, warn: bool = True) 
         return boards
     if legacy_sites:
         if warn:
-            log.warning(
-                "searches.yaml key 'sites' is deprecated for JobSpy board selection; use 'boards'."
-            )
+            log.warning("searches.yaml key 'sites' is deprecated for JobSpy board selection; use 'boards'.")
         return legacy_sites
     return list(DEFAULT_JOBSPY_BOARDS)
 
@@ -504,9 +661,7 @@ def _configured_sources(sites_cfg: dict) -> list[SourceRegistryEntry]:
         if not isinstance(item, dict):
             continue
         source_id = str(item.get("id") or item.get("source_id") or "").strip()
-        display_name = str(
-            item.get("display_name") or item.get("name") or source_id
-        ).strip()
+        display_name = str(item.get("display_name") or item.get("name") or source_id).strip()
         if not source_id or not display_name:
             continue
         kind = _enum_value(SourceKind, item.get("kind"), SourceKind.EMPLOYER_CAREERS_PAGE)
@@ -758,9 +913,11 @@ DEFAULTS = {
     "viewport": "1280x900",
 }
 
+
 def load_env():
     """Load environment variables from ~/.jobhunter/.env if it exists."""
     from dotenv import load_dotenv
+
     if ENV_PATH.exists():
         load_dotenv(ENV_PATH)
     # Also try CWD .env as fallback
@@ -822,6 +979,7 @@ def check_tier(required: int, feature: str) -> None:
         return
 
     from rich.console import Console
+
     _console = Console(stderr=True)
 
     missing: list[str] = []

--- a/workers/automation/src/jobhunter/discovery/activities.py
+++ b/workers/automation/src/jobhunter/discovery/activities.py
@@ -17,6 +17,8 @@ class DiscoverActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     limit: int = 0
     workers: int = 1
     dry_run: bool = False
@@ -36,7 +38,13 @@ async def discover_activity(payload: DiscoverActivityInput) -> DiscoverActivityO
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -44,6 +44,8 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
             "pip install pydantic tls-client requests markdownify regex"
         ) from exc
 
+    _patch_jobspy_linkedin_location_parser()
+
     for attempt in range(max_retries + 1):
         try:
             return scrape_jobs(**kwargs)
@@ -56,6 +58,47 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
                 time.sleep(wait)
             else:
                 raise
+
+
+def _patch_jobspy_linkedin_location_parser() -> None:
+    """Keep unsupported LinkedIn country names from aborting the whole scrape."""
+    try:
+        from jobspy.linkedin import LinkedIn
+        from jobspy.model import Country, Location
+    except ImportError:
+        return
+
+    if getattr(LinkedIn, "_jobhunter_tolerates_unknown_countries", False):
+        return
+
+    def _country_or_text(country: str):
+        try:
+            return Country.from_string(country)
+        except ValueError:
+            return country
+
+    def _get_location(self, metadata_card):
+        location = Location(country=_country_or_text(getattr(self, "country", "worldwide")))
+        if metadata_card is None:
+            return location
+
+        location_tag = metadata_card.find("span", class_="job-search-card__location")
+        location_string = location_tag.text.strip() if location_tag else "N/A"
+        parts = location_string.split(", ")
+        if len(parts) == 2:
+            city, state = parts
+            return Location(
+                city=city,
+                state=state,
+                country=_country_or_text(getattr(self, "country", "worldwide")),
+            )
+        if len(parts) == 3:
+            city, state, country = parts
+            return Location(city=city, state=state, country=_country_or_text(country))
+        return location
+
+    LinkedIn._get_location = _get_location
+    LinkedIn._jobhunter_tolerates_unknown_countries = True
 
 
 # -- Location filtering ------------------------------------------------------

--- a/workers/automation/src/jobhunter/discovery/title_filter.py
+++ b/workers/automation/src/jobhunter/discovery/title_filter.py
@@ -38,6 +38,10 @@ _TOKEN_ALIASES: dict[str, tuple[tuple[str, ...], ...]] = {
     "it": (("it",), ("information",), ("technology",)),
 }
 
+_QUERY_ALIASES: tuple[tuple[frozenset[str], tuple[tuple[str, ...], ...]], ...] = (
+    (frozenset(("director", "platform", "engineering")), (("platform", "director"),)),
+)
+
 
 def title_matches_query(title: str | None, query: str | None) -> bool:
     """Return whether a posting title satisfies a target search query."""
@@ -50,7 +54,10 @@ def title_matches_query(title: str | None, query: str | None) -> bool:
     query_tokens = [token for token in _tokens(normalized_query) if token not in _STOPWORDS]
     if not query_tokens:
         return False
-    return all(_token_matches_title(token, title_tokens) for token in query_tokens)
+    return all(_token_matches_title(token, title_tokens) for token in query_tokens) or _query_alias_matches(
+        query_tokens,
+        title_tokens,
+    )
 
 
 def normalize_query(query: str | None) -> str:
@@ -64,6 +71,17 @@ def normalize_query(query: str | None) -> str:
 def _token_matches_title(token: str, title_tokens: set[str]) -> bool:
     alternatives: Sequence[tuple[str, ...]] = _TOKEN_ALIASES.get(token, ((token,),))
     return any(all(part in title_tokens for part in alternative) for alternative in alternatives)
+
+
+def _query_alias_matches(query_tokens: Sequence[str], title_tokens: set[str]) -> bool:
+    query_token_set = frozenset(query_tokens)
+    for required_query_tokens, title_aliases in _QUERY_ALIASES:
+        if required_query_tokens.issubset(query_token_set) and any(
+            all(part in title_tokens for part in title_alias)
+            for title_alias in title_aliases
+        ):
+            return True
+    return False
 
 
 def _tokens(value: str | None) -> list[str]:

--- a/workers/automation/src/jobhunter/enrichment/activities.py
+++ b/workers/automation/src/jobhunter/enrichment/activities.py
@@ -13,6 +13,8 @@ class EnrichActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     limit: int = 0
     workers: int = 1
     dry_run: bool = False
@@ -32,7 +34,13 @@ async def enrich_activity(payload: EnrichActivityInput) -> EnrichActivityOutput:
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -340,19 +340,37 @@ def _matches_reject(location: str, patterns: Sequence[str], *, accept: Sequence[
 
 
 def _matches_pattern_or_alias(location: str, pattern: str | None) -> bool:
-    aliases = ACCEPT_ALIASES.get(_normalize(pattern), (pattern,))
+    normalized = _normalize(pattern)
+    if "," in normalized:
+        return all(
+            _matches_pattern_or_alias(location, part)
+            for part in (item.strip() for item in normalized.split(","))
+            if part
+        )
+    aliases = ACCEPT_ALIASES.get(normalized, (pattern,))
     return any(_matches(location, alias) for alias in aliases)
 
 
 def _has_accepted_country_context(location: str, accept: Sequence[str]) -> bool:
     for pattern in accept:
-        aliases = ACCEPT_ALIASES.get(_normalize(pattern), ())
+        aliases = _aliases_for_pattern(pattern)
         if any(
             alias in ACCEPTED_COUNTRY_CONTEXT_ALIASES and _matches(location, alias)
             for alias in aliases
         ):
             return True
     return False
+
+
+def _aliases_for_pattern(pattern: str | None) -> tuple[str | None, ...]:
+    normalized = _normalize(pattern)
+    if "," not in normalized:
+        return ACCEPT_ALIASES.get(normalized, (pattern,))
+    aliases: list[str | None] = []
+    for part in (item.strip() for item in normalized.split(",")):
+        if part:
+            aliases.extend(ACCEPT_ALIASES.get(part, (part,)))
+    return tuple(aliases)
 
 
 def _matches(location: str, pattern: str | None) -> bool:

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -151,6 +151,20 @@ CANADA_LOCATION_ALIASES = (
     "sk",
     "yt",
 )
+SPAIN_LOCATION_ALIASES = (
+    "spain",
+    "españa",
+    "es",
+)
+EUROPE_LOCATION_ALIASES = (
+    "europe",
+    "european union",
+    "eu",
+    "emea",
+    "spain",
+    "españa",
+    "es",
+)
 REJECT_ALIASES = {
     "usa": US_LOCATION_ALIASES,
     "us": US_LOCATION_ALIASES,
@@ -159,6 +173,86 @@ REJECT_ALIASES = {
     "united states": US_LOCATION_ALIASES,
     "canada": CANADA_LOCATION_ALIASES,
     "canada only": CANADA_LOCATION_ALIASES,
+}
+ACCEPT_ALIASES = {
+    "spain": SPAIN_LOCATION_ALIASES,
+    "españa": SPAIN_LOCATION_ALIASES,
+    "barcelona": ("barcelona",),
+    "madrid": ("madrid",),
+    "valencia": ("valencia",),
+    "europe": EUROPE_LOCATION_ALIASES,
+    "european union": EUROPE_LOCATION_ALIASES,
+    "eu": EUROPE_LOCATION_ALIASES,
+    "emea": EUROPE_LOCATION_ALIASES,
+}
+ACCEPTED_COUNTRY_CONTEXT_ALIASES = frozenset(
+    (*SPAIN_LOCATION_ALIASES, *EUROPE_LOCATION_ALIASES)
+)
+AMBIGUOUS_REJECT_ABBREVIATIONS = {
+    "al",
+    "ak",
+    "az",
+    "ar",
+    "ca",
+    "co",
+    "ct",
+    "de",
+    "fl",
+    "ga",
+    "hi",
+    "id",
+    "il",
+    "in",
+    "ia",
+    "ks",
+    "ky",
+    "la",
+    "me",
+    "md",
+    "ma",
+    "mi",
+    "mn",
+    "ms",
+    "mo",
+    "mt",
+    "ne",
+    "nv",
+    "nh",
+    "nj",
+    "nm",
+    "ny",
+    "nc",
+    "nd",
+    "oh",
+    "ok",
+    "or",
+    "pa",
+    "ri",
+    "sc",
+    "sd",
+    "tn",
+    "tx",
+    "ut",
+    "vt",
+    "va",
+    "wa",
+    "dc",
+    "wv",
+    "wi",
+    "wy",
+    "ab",
+    "bc",
+    "mb",
+    "nb",
+    "nl",
+    "nt",
+    "ns",
+    "nu",
+    "on",
+    "pe",
+    "qc",
+    "sk",
+    "yt",
 }
 
 
@@ -192,7 +286,7 @@ def location_matches_target(
         return not concrete_accept
 
     normalized = _normalize(location)
-    if _matches_reject(normalized, reject):
+    if _matches_reject(normalized, reject, accept=concrete_accept):
         return False
 
     if search_location and _matches(normalized, search_location) and not concrete_accept:
@@ -222,17 +316,41 @@ def _dedupe(values: Sequence[str]) -> list[str]:
 
 
 def _matches_any(location: str, patterns: Sequence[str]) -> bool:
-    return any(_matches(location, pattern) for pattern in patterns)
+    return any(_matches_pattern_or_alias(location, pattern) for pattern in patterns)
 
 
 def _concrete_accept_patterns(patterns: Sequence[str]) -> list[str]:
     return [pattern for pattern in patterns if _normalize(pattern) not in REMOTE_MARKERS]
 
 
-def _matches_reject(location: str, patterns: Sequence[str]) -> bool:
+def _matches_reject(location: str, patterns: Sequence[str], *, accept: Sequence[str]) -> bool:
+    accepted_country_context = _has_accepted_country_context(location, accept)
     for pattern in patterns:
         aliases = REJECT_ALIASES.get(_normalize(pattern), (pattern,))
-        if _matches_any(location, aliases):
+        for alias in aliases:
+            normalized_alias = _normalize(alias)
+            if (
+                accepted_country_context
+                and normalized_alias in AMBIGUOUS_REJECT_ABBREVIATIONS
+            ):
+                continue
+            if _matches(location, alias):
+                return True
+    return False
+
+
+def _matches_pattern_or_alias(location: str, pattern: str | None) -> bool:
+    aliases = ACCEPT_ALIASES.get(_normalize(pattern), (pattern,))
+    return any(_matches(location, alias) for alias in aliases)
+
+
+def _has_accepted_country_context(location: str, accept: Sequence[str]) -> bool:
+    for pattern in accept:
+        aliases = ACCEPT_ALIASES.get(_normalize(pattern), ())
+        if any(
+            alias in ACCEPTED_COUNTRY_CONTEXT_ALIASES and _matches(location, alias)
+            for alias in aliases
+        ):
             return True
     return False
 

--- a/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
@@ -172,6 +172,8 @@ def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
     stages = _stage_list(params)
     payload = JobPipelineWorkflowInput(
         tenant_id=tenant_id,
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
         stages=stages,
         min_score=int(params.get("minScore", 7)),
         workers=int(params.get("workers", 1)),
@@ -210,6 +212,8 @@ def apply_action(params: dict[str, Any]) -> WorkflowStartSpec:
     tenant_id = _tenant_id(params)
     payload = ApplyWorkflowInput(
         tenant_id=tenant_id,
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
         job_url=params.get("jobUrl"),
         dry_run=bool(params.get("dryRun", False)),
         headless=bool(params.get("headless", False)),

--- a/workers/automation/src/jobhunter/infrastructure/runtime_identity.py
+++ b/workers/automation/src/jobhunter/infrastructure/runtime_identity.py
@@ -1,0 +1,119 @@
+"""Runtime identity and heartbeat helpers for local worker processes."""
+
+from __future__ import annotations
+
+import os
+import socket
+import sqlite3
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from jobhunter import config
+
+WORKER_HEARTBEAT_TABLE = "worker_runtime_heartbeats"
+
+
+class RuntimeIdentityMismatch(RuntimeError):
+    """Raised when a worker is about to write to a DB different from the API DB."""
+
+
+@dataclass(frozen=True)
+class RuntimeIdentity:
+    app_dir: str
+    db_path: str
+
+
+def current_runtime_identity() -> RuntimeIdentity:
+    return RuntimeIdentity(
+        app_dir=_normalize(config.APP_DIR),
+        db_path=_normalize(config.DB_PATH),
+    )
+
+
+def assert_expected_runtime(
+    *,
+    expected_app_dir: str | None = None,
+    expected_db_path: str | None = None,
+) -> None:
+    current = current_runtime_identity()
+    mismatches: list[str] = []
+    if expected_app_dir and _normalize(expected_app_dir) != current.app_dir:
+        mismatches.append(
+            f"API expected app dir {_normalize(expected_app_dir)}, worker is using {current.app_dir}"
+        )
+    if expected_db_path and _normalize(expected_db_path) != current.db_path:
+        mismatches.append(
+            f"API expected DB {_normalize(expected_db_path)}, worker is using {current.db_path}"
+        )
+    if mismatches:
+        raise RuntimeIdentityMismatch("Worker runtime mismatch: " + "; ".join(mismatches))
+
+
+def write_worker_heartbeat(
+    *,
+    task_queue: str,
+    worker_id: str | None = None,
+    now: datetime | None = None,
+) -> str:
+    identity = current_runtime_identity()
+    resolved_worker_id = worker_id or _default_worker_id()
+    timestamp = (now or datetime.now(UTC)).isoformat()
+    db_path = Path(identity.db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA busy_timeout=10000")
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {WORKER_HEARTBEAT_TABLE} (
+              worker_id TEXT PRIMARY KEY,
+              component TEXT NOT NULL,
+              pid INTEGER NOT NULL,
+              hostname TEXT NOT NULL,
+              app_dir TEXT NOT NULL,
+              db_path TEXT NOT NULL,
+              task_queue TEXT NOT NULL,
+              started_at TEXT NOT NULL,
+              last_seen_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            f"""
+            INSERT INTO {WORKER_HEARTBEAT_TABLE}
+              (worker_id, component, pid, hostname, app_dir, db_path, task_queue, started_at, last_seen_at)
+            VALUES (?, 'temporal-worker', ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(worker_id) DO UPDATE SET
+              component = excluded.component,
+              pid = excluded.pid,
+              hostname = excluded.hostname,
+              app_dir = excluded.app_dir,
+              db_path = excluded.db_path,
+              task_queue = excluded.task_queue,
+              last_seen_at = excluded.last_seen_at
+            """,
+            (
+                resolved_worker_id,
+                os.getpid(),
+                socket.gethostname(),
+                identity.app_dir,
+                identity.db_path,
+                task_queue,
+                timestamp,
+                timestamp,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return resolved_worker_id
+
+
+def _default_worker_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4().hex[:8]}"
+
+
+def _normalize(value: str | Path) -> str:
+    return str(Path(value).expanduser().resolve())

--- a/workers/automation/src/jobhunter/infrastructure/temporal/runtime_guard.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/runtime_guard.py
@@ -1,0 +1,28 @@
+"""Temporal activity guard for API/worker runtime identity."""
+
+from __future__ import annotations
+
+from temporalio.exceptions import ApplicationError
+
+from jobhunter.infrastructure.runtime_identity import (
+    RuntimeIdentityMismatch,
+    assert_expected_runtime,
+)
+
+
+def assert_activity_runtime(
+    *,
+    expected_app_dir: str | None = None,
+    expected_db_path: str | None = None,
+) -> None:
+    try:
+        assert_expected_runtime(
+            expected_app_dir=expected_app_dir,
+            expected_db_path=expected_db_path,
+        )
+    except RuntimeIdentityMismatch as exc:
+        raise ApplicationError(
+            str(exc),
+            type="RuntimeIdentityMismatch",
+            non_retryable=True,
+        ) from exc

--- a/workers/automation/src/jobhunter/materials/activities.py
+++ b/workers/automation/src/jobhunter/materials/activities.py
@@ -18,6 +18,8 @@ class TailorActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     min_score: int = 7
     limit: int = 0
     workers: int = 1
@@ -40,7 +42,13 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(
@@ -79,6 +87,8 @@ class CoverActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     min_score: int = 7
     limit: int = 0
     validation_mode: str = "normal"
@@ -99,7 +109,13 @@ async def cover_activity(payload: CoverActivityInput) -> CoverActivityOutput:
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(
@@ -136,6 +152,8 @@ class PdfActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     limit: int = 0
     dry_run: bool = False
 
@@ -154,7 +172,13 @@ async def pdf_activity(payload: PdfActivityInput) -> PdfActivityOutput:
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(

--- a/workers/automation/src/jobhunter/pipeline/workflow.py
+++ b/workers/automation/src/jobhunter/pipeline/workflow.py
@@ -51,6 +51,8 @@ class JobPipelineWorkflowInput:
 
     tenant_id: str
     stages: list[str]
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     min_score: int = 7
     workers: int = 1
     limit: int = 0
@@ -126,6 +128,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             discover_activity,
             DiscoverActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 workers=payload.workers,
                 limit=payload.limit,
                 dry_run=payload.dry_run,
@@ -139,6 +143,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             enrich_activity,
             EnrichActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 workers=payload.workers,
                 limit=payload.limit,
                 dry_run=payload.dry_run,
@@ -152,6 +158,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             score_activity,
             ScoreActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 workers=payload.workers,
                 limit=payload.limit,
                 dry_run=payload.dry_run,
@@ -166,6 +174,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             tailor_activity,
             TailorActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 min_score=payload.min_score,
                 workers=payload.workers,
                 limit=payload.limit,
@@ -182,6 +192,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             cover_activity,
             CoverActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 min_score=payload.min_score,
                 limit=payload.limit,
                 validation_mode=payload.validation_mode,
@@ -196,6 +208,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             pdf_activity,
             PdfActivityInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 limit=payload.limit,
                 dry_run=payload.dry_run,
             ),
@@ -208,6 +222,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
             ApplyWorkflow.run,
             ApplyWorkflowInput(
                 tenant_id=payload.tenant_id,
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
                 job_url=payload.job_url,
                 dry_run=payload.dry_run,
                 headless=payload.headless,

--- a/workers/automation/src/jobhunter/scoring/activities.py
+++ b/workers/automation/src/jobhunter/scoring/activities.py
@@ -13,6 +13,8 @@ class ScoreActivityInput:
     # ``tenant_id`` is currently informational; runners read from
     # ``LOCAL_TENANT`` until tenant scoping lands.
     tenant_id: str
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
     limit: int = 0
     workers: int = 1
     dry_run: bool = False
@@ -33,7 +35,13 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
     from jobhunter.infrastructure.temporal.run_in_activity import (
         run_blocking_with_heartbeat,
     )
+    from jobhunter.infrastructure.temporal.runtime_guard import assert_activity_runtime
     from jobhunter.pipeline import run_pipeline
+
+    assert_activity_runtime(
+        expected_app_dir=payload.expected_app_dir,
+        expected_db_path=payload.expected_db_path,
+    )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -93,6 +93,26 @@ def test_jobspy_filters_results_by_target_title(monkeypatch):
     assert result["filtered"] == 1
 
 
+def test_jobspy_linkedin_location_parser_tolerates_unknown_country():
+    from bs4 import BeautifulSoup
+    from jobspy.linkedin import LinkedIn
+
+    jobspy._patch_jobspy_linkedin_location_parser()
+
+    metadata = BeautifulSoup(
+        """
+        <div class="base-search-card__metadata">
+          <span class="job-search-card__location">Sarajevo, Federation, Bosnia and Herzegovina</span>
+        </div>
+        """,
+        "html.parser",
+    )
+
+    location = LinkedIn()._get_location(metadata)
+
+    assert location.display_location() == "Sarajevo, Federation, Bosnia and Herzegovina"
+
+
 def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
@@ -109,7 +129,9 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
             ]
         )
         assert jobspy.store_jobspy_results(conn, first, "Head of Engineering", limit=10) == (1, 0)
-        row = conn.execute("SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)).fetchone()
+        row = conn.execute(
+            "SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)
+        ).fetchone()
         assert row["company"] == "Keyrock"
 
         conn.execute("UPDATE jobs SET company = '' WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",))
@@ -127,7 +149,9 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         )
 
         assert jobspy.store_jobspy_results(conn, duplicate, "Head of Engineering", limit=10) == (0, 1)
-        row = conn.execute("SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)).fetchone()
+        row = conn.execute(
+            "SELECT company FROM jobs WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",)
+        ).fetchone()
         assert row["company"] == "Keyrock"
         event = conn.execute(
             "SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -40,6 +40,8 @@ def test_remote_region_locations_pass_when_region_is_accepted() -> None:
         "Remote EMEA",
         "Europe Remote",
         "Barcelona, Spain (Remote)",
+        "Barcelona, CT, ES",
+        "Madrid, MD, ES",
     ):
         assert location_matches_target(
             location,
@@ -62,6 +64,22 @@ def test_generic_remote_does_not_match_when_specific_locations_are_configured() 
         reject=EUROPE_REJECT,
         search_location="Remote",
     )
+
+
+def test_america_abbreviations_still_reject_when_country_context_matches() -> None:
+    for location in (
+        "Hartford, CT, US",
+        "Remote US",
+        "Remote Canada",
+        "Toronto, ON, CA",
+        "Madrid, MD",
+    ):
+        assert not location_matches_target(
+            location,
+            accept=EUROPE_ACCEPT,
+            reject=EUROPE_REJECT,
+            search_location="Remote",
+        )
 
 
 def test_short_accept_patterns_match_tokens_not_substrings() -> None:

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -51,6 +51,17 @@ def test_remote_region_locations_pass_when_region_is_accepted() -> None:
         )
 
 
+def test_composite_target_locations_require_city_and_country_context() -> None:
+    accept = ["Barcelona, Spain"]
+    reject = EUROPE_REJECT
+
+    assert location_matches_target("Barcelona, CT, ES", accept=accept, reject=reject)
+    assert location_matches_target("Barcelona, Spain", accept=accept, reject=reject)
+    assert not location_matches_target("Barcelona, Venezuela", accept=accept, reject=reject)
+    assert not location_matches_target("Madrid, MD, ES", accept=accept, reject=reject)
+    assert not location_matches_target("Remote Spain", accept=accept, reject=reject)
+
+
 def test_generic_remote_does_not_match_when_specific_locations_are_configured() -> None:
     assert not location_matches_target(
         "Remote",

--- a/workers/automation/tests/test_discovery_title_filter.py
+++ b/workers/automation/tests/test_discovery_title_filter.py
@@ -7,6 +7,10 @@ def test_title_filter_matches_leadership_aliases() -> None:
     assert title_matches_query("Vice President, Engineering", "VP of Engineering")
     assert title_matches_query("Chief Information Security Officer", "CISO")
     assert title_matches_query("Director, Information Security", "Director of IT & Security")
+    assert title_matches_query(
+        "Platform Director (100% Remote within Spain)",
+        "Director of Platform Engineering",
+    )
 
 
 def test_title_filter_rejects_loose_workday_results() -> None:

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -250,6 +250,8 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
             method="run_stage",
             params={
                 "tenantId": "local",
+                "expectedAppDir": "/tmp/jobhunter",
+                "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
                 "stage": "score",
                 "stages": ["score", "tailor"],
                 "limit": 5,
@@ -276,6 +278,8 @@ def test_run_stage_starts_job_pipeline_workflow(tmp_db: Path) -> None:
     (payload,) = seen[0].args
     assert payload == JobPipelineWorkflowInput(
         tenant_id="local",
+        expected_app_dir="/tmp/jobhunter",
+        expected_db_path="/tmp/jobhunter/jobhunter.db",
         stages=["score", "tailor"],
         min_score=8,
         workers=2,

--- a/workers/automation/tests/test_rpc_handlers_apply_workflow.py
+++ b/workers/automation/tests/test_rpc_handlers_apply_workflow.py
@@ -22,6 +22,8 @@ def test_apply_handler_returns_workflow_start_spec() -> None:
     spec = apply_action(
         {
             "tenantId": "local",
+            "expectedAppDir": "/tmp/jobhunter",
+            "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
             "jobUrl": "https://example.com/job/1",
             "limit": 2,
             "model": "sonnet",
@@ -38,6 +40,8 @@ def test_apply_handler_returns_workflow_start_spec() -> None:
     assert isinstance(payload, ApplyWorkflowInput)
     assert payload == ApplyWorkflowInput(
         tenant_id="local",
+        expected_app_dir="/tmp/jobhunter",
+        expected_db_path="/tmp/jobhunter/jobhunter.db",
         job_url="https://example.com/job/1",
         dry_run=True,
         headless=True,

--- a/workers/automation/tests/test_runtime_identity.py
+++ b/workers/automation/tests/test_runtime_identity.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+
+import pytest
+
+from jobhunter.infrastructure import runtime_identity
+
+
+def test_worker_heartbeat_writes_runtime_identity(monkeypatch, tmp_path):
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(runtime_identity.config, "APP_DIR", tmp_path)
+    monkeypatch.setattr(runtime_identity.config, "DB_PATH", db_path)
+
+    worker_id = runtime_identity.write_worker_heartbeat(
+        task_queue="jobhunter-default",
+        worker_id="worker-test",
+        now=datetime(2026, 5, 20, 10, 0, tzinfo=UTC),
+    )
+
+    assert worker_id == "worker-test"
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT worker_id, component, app_dir, db_path, task_queue, last_seen_at "
+            "FROM worker_runtime_heartbeats"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == (
+        "worker-test",
+        "temporal-worker",
+        str(tmp_path.resolve()),
+        str(db_path.resolve()),
+        "jobhunter-default",
+        "2026-05-20T10:00:00+00:00",
+    )
+
+
+def test_runtime_identity_mismatch_fails_before_worker_writes(monkeypatch, tmp_path):
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(runtime_identity.config, "APP_DIR", tmp_path)
+    monkeypatch.setattr(runtime_identity.config, "DB_PATH", db_path)
+
+    with pytest.raises(runtime_identity.RuntimeIdentityMismatch, match="API expected DB"):
+        runtime_identity.assert_expected_runtime(
+            expected_app_dir=str(tmp_path),
+            expected_db_path=str(tmp_path / "other.db"),
+        )

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -30,10 +30,15 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
         {"query": "Head of Engineering", "tier": 1},
     ]
     assert merged["locations"] == [
-        {"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": True}
+        {"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False},
+        {"label": "spain", "location": "Spain", "remote": True},
+        {"label": "europe-remote", "location": "European Union", "remote": True},
     ]
+    assert merged["defaults"]["hours_old"] == 720
     assert merged["defaults"]["country_indeed"] == "spain"
     assert "Barcelona, Spain" in merged["location_accept"]
+    assert "Spain" in merged["location_accept"]
+    assert "Europe" in merged["location_accept"]
     assert "Canada" in merged["location_reject_non_remote"]
 
 
@@ -82,6 +87,73 @@ def test_profile_target_locations_replace_legacy_location_accept_patterns() -> N
     assert location_matches_target("Barcelona, Spain (Remote)", accept=accept, reject=reject)
     assert location_matches_target("Remote EMEA", accept=accept, reject=reject)
     assert not location_matches_target("Switzerland - Zurich", accept=accept, reject=reject)
+
+
+def test_hybrid_target_locations_filter_to_exact_target_location() -> None:
+    merged = config._apply_profile_target_search(
+        {
+            "queries": [{"query": "software engineer", "tier": 1}],
+            "locations": [{"label": "remote", "location": "Remote", "remote": True}],
+        },
+        {
+            "roles": ["Director of Engineering"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Hybrid"],
+        },
+    )
+
+    accept, reject = configured_location_filters(merged)
+
+    assert merged["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]
+    assert "Europe" not in accept
+    assert "EMEA" not in accept
+    assert location_matches_target("Barcelona, CT, ES", accept=accept, reject=reject)
+    assert location_matches_target("Barcelona, Spain", accept=accept, reject=reject)
+    assert not location_matches_target("Remote EMEA", accept=accept, reject=reject)
+    assert not location_matches_target("Remote Spain", accept=accept, reject=reject)
+    assert not location_matches_target("Madrid, MD, ES", accept=accept, reject=reject)
+
+
+def test_remote_european_target_locations_filter_country_and_europe_remote() -> None:
+    merged = config._apply_profile_target_search(
+        {"queries": [{"query": "software engineer", "tier": 1}]},
+        {
+            "roles": ["Director of Engineering"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Remote"],
+        },
+    )
+
+    accept, reject = configured_location_filters(merged)
+
+    assert merged["locations"] == [
+        {"label": "spain", "location": "Spain", "remote": True},
+        {"label": "europe-remote", "location": "European Union", "remote": True},
+    ]
+    assert "Barcelona, Spain" not in accept
+    assert "Spain" in accept
+    assert "Europe" in accept
+    assert location_matches_target("Remote Spain", accept=accept, reject=reject)
+    assert location_matches_target("Remote EMEA", accept=accept, reject=reject)
+    assert location_matches_target("Barcelona, CT, ES", accept=accept, reject=reject)
+    assert not location_matches_target("Remote United States", accept=accept, reject=reject)
+    assert not location_matches_target("Barcelona, Venezuela", accept=accept, reject=reject)
+
+
+def test_profile_target_search_preserves_larger_configured_lookback() -> None:
+    merged = config._apply_profile_target_search(
+        {
+            "queries": [{"query": "software engineer", "tier": 1}],
+            "defaults": {"hours_old": 1440},
+        },
+        {
+            "roles": ["Director of Engineering"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Remote"],
+        },
+    )
+
+    assert merged["defaults"]["hours_old"] == 1440
 
 
 def test_load_search_config_reads_profile_target_search_from_db(tmp_path, monkeypatch) -> None:
@@ -144,9 +216,7 @@ defaults:
         "Director of Engineering",
         "VP Engineering",
     ]
-    assert loaded["locations"] == [
-        {"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}
-    ]
+    assert loaded["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]
     assert loaded["target_region"] == "europe"
 
 


### PR DESCRIPTION
## Summary
- Add inline PDF preview support for artifact detail drawers using a shared PDF preview viewer.
- Add status copy for artifact badges so approved/stale/superseded states are explainable.
- Record ProfileUpdated events from local profile saves and dispatch an event-driven retailor + PDF pipeline run while preserving historical resume generations.
- Add API/Temporal worker runtime identity guardrails: worker heartbeats in the local DB, `/v1/health` worker status, expected app/DB path propagation into workflows, non-retryable worker mismatch failures, and UI alerts/disabled pipeline actions when the worker is missing, stale, or mismatched.
- Add target-search location requirements and validate profile target locations before saving them.
- Fix discovery location filtering so hybrid/on-site searches use the exact target location while remote searches use the target country plus European Union remote coverage for European targets.
- Harden LinkedIn JobSpy discovery against unsupported country names in returned locations and allow `Platform Director` results to satisfy Director of Platform Engineering searches.

## Validation
- `corepack pnpm --filter @jobhunter/api check`
- `corepack pnpm --filter @jobhunter/api test -- server.test.ts`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_discovery_title_filter.py workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_target_search_preferences.py`
- `uv --project workers/automation run --extra dev ruff check .`
- `git diff --check`
- Live place lookup: `validatePlaceExists("Barcelona, Spain")` returned `true`.
- Live stack smoke: `GET /v1/health` reports `worker.status: "healthy"` with API and worker both using `/Users/eloibarti/.jobhunter/jobhunter.db`.
- Live discovery: `jobhunter discover --limit 1000 --workers 4` completed JobSpy with `20 new | 84 dupes | 0 errors | 63 total in DB`; Workday completed with `0 found, 0 new, 0 dupes`; Jobs page in the in-app browser shows `63 total`.
- Expected sample evidence: LinkedIn jobs `4375576106` and `4399159201` are present in the local DB; `4406600493` did not appear in LinkedIn guest search results even with a 30-day lookback and European Union remote search.

## Notes
- The 1000-limit discovery run was stopped during Smart Extract after JobSpy and Workday completed because Talent.com, SimplyHired, and PowerToFly were returning non-target rows/timeouts while making repeated LLM calls; no auto-apply or browser submission flows were run.
- Live profile mutation was not run because it would intentionally trigger real re-tailoring against local data.
