### PR TITLE
fix: restart dev stack from clean owned processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,13 @@ Use these repository documents before making architectural, workflow, or QA deci
 
 ## How To Run The Project
 
-To be defined as a complete, single source of truth. Until this is finalized, infer the narrowest correct run command from the referenced docs and package metadata, then state the command before running it.
+Use `pnpm dev` for the full local development stack. It stops previously tracked JobHunter process trees for the selected components, then runs the Temporal dev server, TypeScript API, React/Vite web app, and JobHunter Temporal worker in the foreground so supervised terminals keep the child processes alive. Keep the terminal session open while using the app and stop it with Ctrl-C. Use `pnpm dev:start` only when an explicitly detached background stack is desired in a normal shell.
 
 Known local commands:
 
 - Python CLI: `uv --project workers/automation run jobhunter doctor`, `uv --project workers/automation run jobhunter run`, or targeted `uv --project workers/automation run jobhunter <command>` after dependencies are installed.
+- Full local stack: `pnpm dev` (attached foreground supervisor; preferred for agents and annotation).
+- Detached local stack: `pnpm dev:start`, then `pnpm dev:status`, `pnpm dev:logs <name>`, and `pnpm dev:stop`.
 - Temporal worker: `uv --project workers/automation run jobhunter worker` (long-lived workflow worker; needs `temporal server start-dev` running).
 - TypeScript API: `pnpm api:dev`.
 - Web app: `pnpm web:dev`.

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ pnpm dev
 `pnpm dev:setup` installs the Node workspace dependencies and syncs the
 uv-managed Python automation environment, including `python-jobspy` and its
 locked transitive dependencies plus the Python dev extras used by local checks.
-`pnpm dev` also invokes the Python worker through `uv run`, which re-syncs the
-worker environment if needed, but first-time setup should use `pnpm dev:setup`
-so dependency failures are separated from process startup.
+`pnpm dev` runs the process supervisor in the foreground and also invokes the
+Python worker through `uv run`, which re-syncs the worker environment if needed.
+Keep that terminal open while using the app and stop it with Ctrl-C. First-time
+setup should use `pnpm dev:setup` so dependency failures are separated from
+process startup.
 
 For verification:
 
@@ -264,13 +266,23 @@ pnpm dev
 ```
 
 That launches the Temporal dev server, local TypeScript API, React/Vite web app,
-and JobHunter Temporal worker. The launcher defaults to `~/.jobhunter`,
-`127.0.0.1:8766` for the API, and `127.0.0.1:5173` for the web app. Inspect or
-stop the stack with:
+and JobHunter Temporal worker in the foreground. Before each component starts,
+the launcher stops the previous tracked JobHunter process tree for that
+component, so rerunning `pnpm dev` starts from a clean owned stack. Keep the
+terminal open and use Ctrl-C to stop the stack. The launcher defaults to
+`~/.jobhunter`,
+`127.0.0.1:8766` for the API, and `127.0.0.1:5173` for the web app. Inspect the
+stack from another terminal with:
 
 ```bash
 pnpm dev:status
 pnpm dev:logs worker
+```
+
+For a detached background stack, use the explicit daemon mode:
+
+```bash
+pnpm dev:start
 pnpm dev:stop
 ```
 

--- a/apps/api/test/dev-launcher-contract.test.ts
+++ b/apps/api/test/dev-launcher-contract.test.ts
@@ -1,0 +1,292 @@
+import { execFileSync, spawn, type ChildProcessByStdio } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const devScript = join(repoRoot, "scripts/dev");
+type DevLauncherProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+function waitForOutput(child: DevLauncherProcess, text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Timed out waiting for ${text}`));
+    }, 5_000);
+
+    let output = "";
+    const onData = (chunk: Buffer) => {
+      output += chunk.toString("utf8");
+      if (output.includes(text)) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`Process exited before ${text}: code=${code} signal=${signal} output=${output}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off("data", onData);
+      child.stderr.off("data", onData);
+      child.off("exit", onExit);
+    };
+
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+    child.once("exit", onExit);
+  });
+}
+
+function waitForFileText(path: string, text: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error(`Timed out waiting for ${text} in ${path}`));
+    }, 5_000);
+
+    const interval = setInterval(() => {
+      try {
+        if (readFileSync(path, "utf8").includes(text)) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve();
+        }
+      } catch {
+        // File is created by the child process; keep polling until timeout.
+      }
+    }, 25);
+  });
+}
+
+function waitForFileMatchCount(path: string, pattern: RegExp, count: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error(`Timed out waiting for ${count} matches of ${pattern} in ${path}`));
+    }, 5_000);
+
+    const interval = setInterval(() => {
+      try {
+        const matches = readFileSync(path, "utf8").match(pattern);
+        if ((matches?.length ?? 0) >= count) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve();
+        }
+      } catch {
+        // File is created by the child process; keep polling until timeout.
+      }
+    }, 25);
+  });
+}
+
+function waitForPidFile(path: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error(`Timed out waiting for numeric PID in ${path}`));
+    }, 5_000);
+
+    const interval = setInterval(() => {
+      try {
+        const text = readFileSync(path, "utf8").trim();
+        if (/^[1-9][0-9]*$/.test(text)) {
+          clearTimeout(timeout);
+          clearInterval(interval);
+          resolve(Number(text));
+        }
+      } catch {
+        // File is created by the child process; keep polling until timeout.
+      }
+    }, 25);
+  });
+}
+
+function processExists(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function devScriptEnv(devDir: string, extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    JOBHUNTER_DEV_DIR: devDir,
+    ...extra,
+  };
+}
+
+describe("dev launcher contract", () => {
+  it("keeps the documented default dev command attached", () => {
+    const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts.dev).toBe("scripts/dev run");
+    expect(packageJson.scripts["dev:start"]).toBe("scripts/dev start");
+  });
+
+  it("advertises foreground run mode and a direct web port override", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "jobhunter-dev-launcher-"));
+    const env = devScriptEnv(join(tempDir, "dev-state"));
+
+    try {
+      execFileSync("bash", ["-n", devScript], { cwd: repoRoot });
+
+      const help = execFileSync(devScript, ["help"], { cwd: repoRoot, encoding: "utf8", env });
+      expect(help).toContain("scripts/dev run [name...]");
+
+      const list = execFileSync(devScript, ["list"], { cwd: repoRoot, encoding: "utf8", env });
+      expect(list).toContain(
+        'web        pnpm --filter @jobhunter/web exec vite --host 127.0.0.1 --port "$JOBHUNTER_WEB_PORT"',
+      );
+    } finally {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("replaces a tracked process before starting a fresh detached process", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "jobhunter-dev-launcher-"));
+    const devDir = join(tempDir, "dev-state");
+    const callsLog = join(tempDir, "calls.log");
+    const pidFile = join(devDir, "pids/api.pid");
+    let firstPid: number | undefined;
+    let secondPid: number | undefined;
+
+    try {
+      writeFileSync(
+        join(tempDir, "pnpm"),
+        `#!/usr/bin/env bash
+echo "fake pnpm $*" >> "${callsLog}"
+trap 'echo "fake pnpm terminated $$" >> "${callsLog}"; exit 0' TERM INT
+while true; do sleep 1; done
+`,
+      );
+      chmodSync(join(tempDir, "pnpm"), 0o755);
+      const env = devScriptEnv(devDir, {
+        PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+        JOBHUNTER_STOP_WAIT_TICKS: "10",
+        JOBHUNTER_STOP_WAIT_INTERVAL_SECONDS: "0.05",
+      });
+
+      execFileSync(devScript, ["start", "api"], { cwd: repoRoot, env });
+      firstPid = await waitForPidFile(pidFile);
+      await waitForFileText(callsLog, "fake pnpm --filter @jobhunter/api dev");
+      expect(processExists(firstPid)).toBe(true);
+
+      execFileSync(devScript, ["start", "api"], { cwd: repoRoot, env });
+      secondPid = await waitForPidFile(pidFile);
+      await waitForFileMatchCount(callsLog, /fake pnpm --filter @jobhunter\/api dev/g, 2);
+
+      expect(secondPid).not.toBe(firstPid);
+      expect(processExists(firstPid)).toBe(false);
+      expect(processExists(secondPid)).toBe(true);
+      expect(readFileSync(callsLog, "utf8").match(/fake pnpm --filter @jobhunter\/api dev/g)).toHaveLength(2);
+    } finally {
+      try {
+        execFileSync(devScript, ["stop", "api"], { cwd: repoRoot, env: devScriptEnv(devDir) });
+      } catch {
+        // The process may already be stopped if an assertion failed late.
+      }
+      if (firstPid !== undefined && processExists(firstPid)) {
+        process.kill(firstPid, "SIGKILL");
+      }
+      if (secondPid !== undefined && processExists(secondPid)) {
+        process.kill(secondPid, "SIGKILL");
+      }
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("runs attached processes and cleans PID files on termination", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "jobhunter-dev-launcher-"));
+    const devDir = join(tempDir, "dev-state");
+    const callsLog = join(tempDir, "calls.log");
+    const childPidFile = join(tempDir, "child.pid");
+    const grandchildPidFile = join(tempDir, "grandchild.pid");
+    const pidFile = join(devDir, "pids/api.pid");
+    let child: DevLauncherProcess | undefined;
+    let spawnedChildPid: number | undefined;
+    let spawnedGrandchildPid: number | undefined;
+
+    try {
+      rmSync(pidFile, { force: true });
+      writeFileSync(
+        join(tempDir, "pnpm"),
+        `#!/usr/bin/env bash
+echo "fake pnpm $*" >> "${callsLog}"
+(
+  trap '' TERM INT
+  sleep 300 &
+  echo "$!" > "${grandchildPidFile}"
+  while true; do sleep 1; done
+) &
+echo "$!" > "${childPidFile}"
+trap 'echo "fake pnpm terminated" >> "${callsLog}"; exit 0' TERM INT
+while true; do sleep 1; done
+`,
+      );
+      chmodSync(join(tempDir, "pnpm"), 0o755);
+
+      const runningChild: DevLauncherProcess = spawn(devScript, ["run", "--", "api"], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PATH: `${tempDir}:${process.env.PATH ?? ""}`,
+          JOBHUNTER_DEV_DIR: devDir,
+          JOBHUNTER_STOP_WAIT_TICKS: "2",
+          JOBHUNTER_STOP_WAIT_INTERVAL_SECONDS: "0.05",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      child = runningChild;
+
+      await waitForOutput(runningChild, "dev: foreground run active");
+      expect(existsSync(pidFile)).toBe(true);
+      await waitForFileText(callsLog, "fake pnpm --filter @jobhunter/api dev");
+      spawnedChildPid = await waitForPidFile(childPidFile);
+      spawnedGrandchildPid = await waitForPidFile(grandchildPidFile);
+      expect(processExists(spawnedChildPid)).toBe(true);
+      expect(processExists(spawnedGrandchildPid)).toBe(true);
+
+      runningChild.kill("SIGTERM");
+      const exitCode = await new Promise<number | null>((resolve) => {
+        runningChild.once("exit", (code) => resolve(code));
+      });
+
+      expect(exitCode).toBe(143);
+      expect(existsSync(pidFile)).toBe(false);
+      expect(processExists(spawnedChildPid)).toBe(false);
+      expect(processExists(spawnedGrandchildPid)).toBe(false);
+    } finally {
+      child?.kill("SIGTERM");
+      if (spawnedChildPid !== undefined && processExists(spawnedChildPid)) {
+        process.kill(spawnedChildPid, "SIGKILL");
+      }
+      if (spawnedGrandchildPid !== undefined && processExists(spawnedGrandchildPid)) {
+        process.kill(spawnedGrandchildPid, "SIGKILL");
+      }
+      rmSync(pidFile, { force: true });
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -21,8 +21,13 @@ pnpm dev
 ```
 
 `pnpm dev` starts the full local fleet in dependency order: Temporal dev server,
-TypeScript API, Vite web app, and the JobHunter Temporal worker. The launcher
-tracks PIDs under `.dev/pids/`, writes logs under `.dev/logs/`, and defaults to:
+TypeScript API, Vite web app, and the JobHunter Temporal worker. Before each
+component starts, the launcher stops the previous tracked JobHunter process
+tree for that component, so rerunning `pnpm dev` starts from a clean owned
+stack. It runs in the foreground so supervised terminals keep the child
+processes alive; keep the terminal open and stop the stack with Ctrl-C. The
+launcher tracks PIDs under `.dev/pids/`, writes logs under `.dev/logs/`, and
+defaults to:
 
 - API data dir: `JOBHUNTER_DIR=${HOME}/.jobhunter`
 - API bind: `JOBHUNTER_API_HOST=127.0.0.1`,
@@ -30,13 +35,19 @@ tracks PIDs under `.dev/pids/`, writes logs under `.dev/logs/`, and defaults to:
 - Web API base URL: `VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766`
 - Web port: `5173` (`JOBHUNTER_WEB_PORT` can override it)
 
-Use the launcher for day-to-day process management:
+Inspect the foreground stack from another terminal:
 
 ```bash
 pnpm dev:status
 pnpm dev:logs worker
-pnpm dev:stop
 scripts/dev list
+```
+
+For a detached background stack in a normal shell, use the explicit daemon mode:
+
+```bash
+pnpm dev:start
+pnpm dev:stop
 ```
 
 Run individual components only when troubleshooting a specific process:

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -28,6 +28,9 @@ For worker-backed pipeline smoke, run the full local stack and confirm
 pnpm dev
 ```
 
+`pnpm dev` is the attached full-stack launcher; keep it running while exercising
+the UI and stop it with Ctrl-C when the QA pass is finished.
+
 For destructive browser QA, seed a disposable workspace:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "node": ">=20.19.0"
   },
   "scripts": {
-    "dev": "scripts/dev start",
+    "dev": "scripts/dev run",
     "dev:setup": "scripts/dev setup",
+    "dev:start": "scripts/dev start",
     "dev:status": "scripts/dev status",
     "dev:stop": "scripts/dev stop",
     "dev:logs": "scripts/dev logs",

--- a/scripts/dev
+++ b/scripts/dev
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 # scripts/dev — JobHunter local dev fleet launcher.
 #
-# Daemonizes temporal / api / web / worker into background processes, tracks each by
-# PID file under .dev/pids/, captures stdout+stderr to .dev/logs/, and
-# exposes individual start/stop/restart/logs so you can bounce one
-# without nuking the others.
+# Runs or daemonizes temporal / api / web / worker, tracks each by PID file
+# under .dev/pids/, captures stdout+stderr to .dev/logs/, and starts from a
+# clean owned process tree so stale local stack processes do not survive
+# between launches.
 #
 # Usage:
+#   scripts/dev run [name...]      Run named processes in the foreground
 #   scripts/dev start [name...]    Start named processes (or all if none given)
 #   scripts/dev stop  [name...]    Stop named (or all)
 #   scripts/dev restart [name...]  Stop then start
@@ -19,7 +20,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DEV_DIR="$ROOT/.dev"
+DEV_DIR="${JOBHUNTER_DEV_DIR:-$ROOT/.dev}"
 PID_DIR="$DEV_DIR/pids"
 LOG_DIR="$DEV_DIR/logs"
 mkdir -p "$PID_DIR" "$LOG_DIR"
@@ -32,7 +33,7 @@ process_command() {
   case "$1" in
     temporal) echo "temporal server start-dev" ;;
     api)      echo "pnpm --filter @jobhunter/api dev" ;;
-    web)      echo 'pnpm --filter @jobhunter/web dev -- --port "$JOBHUNTER_WEB_PORT"' ;;
+    web)      echo 'pnpm --filter @jobhunter/web exec vite --host 127.0.0.1 --port "$JOBHUNTER_WEB_PORT"' ;;
     worker)   echo "uv --project workers/automation run jobhunter worker" ;;
     *)        return 1 ;;
   esac
@@ -69,6 +70,73 @@ kill_tree() {
   kill "-$sig" "$pid" 2>/dev/null || true
 }
 
+collect_tree_pids() {
+  local pid="$1"
+  echo "$pid"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    collect_tree_pids "$child"
+  done
+}
+
+is_alive_pid() {
+  local pid="$1" stat
+  kill -0 "$pid" 2>/dev/null || return 1
+  stat=$(ps -o stat= -p "$pid" 2>/dev/null | awk '{ print $1 }')
+  [[ "$stat" != *Z* ]]
+}
+
+wait_pids_gone() {
+  local pids="$1" ticks="$2" interval="$3"
+  local i target alive
+  for i in $(seq 1 "$ticks"); do
+    alive=0
+    for target in $pids; do
+      if is_alive_pid "$target"; then
+        alive=1
+        break
+      fi
+    done
+    [[ "$alive" -eq 0 ]] && return 0
+    sleep "$interval"
+  done
+  return 1
+}
+
+stop_pid_tree() {
+  local pid="$1"
+  local pids target
+  local wait_ticks="${JOBHUNTER_STOP_WAIT_TICKS:-50}"
+  local wait_interval="${JOBHUNTER_STOP_WAIT_INTERVAL_SECONDS:-0.1}"
+  local kill_wait_ticks="${JOBHUNTER_KILL_WAIT_TICKS:-20}"
+  pids=$(collect_tree_pids "$pid" | awk '/^[0-9]+$/ && $1 > 0 && !seen[$1]++')
+  for target in $pids; do
+    kill -TERM "$target" 2>/dev/null || true
+  done
+
+  # Wait for graceful shutdown before SIGKILL; tests can shorten this.
+  wait_pids_gone "$pids" "$wait_ticks" "$wait_interval" && return 0
+
+  for target in $pids; do
+    kill -KILL "$target" 2>/dev/null || true
+  done
+
+  if ! wait_pids_gone "$pids" "$kill_wait_ticks" "$wait_interval"; then
+    echo "dev: failed to stop process tree rooted at $pid" >&2
+    return 1
+  fi
+}
+
+ensure_not_running() {
+  local name="$1"
+  if is_running "$name"; then
+    echo "$name: stopping previous process tree (pid $(read_pid "$name"))"
+    stop_one "$name" >/dev/null
+  else
+    rm -f "$(pid_file "$name")"
+  fi
+}
+
 # Load $ROOT/.env into the current shell so spawned children inherit
 # secrets (Langfuse keys, Gemini keys, etc.). Node and Python do not
 # auto-source .env at startup — leaving this off would silently disable
@@ -95,22 +163,60 @@ start_one() {
     echo "dev: unknown process '$name' (try: $(process_names))" >&2
     return 1
   fi
-  if is_running "$name"; then
-    echo "$name: already running (pid $(read_pid "$name"))"
-    return 0
-  fi
-  rm -f "$(pid_file "$name")"
+  ensure_not_running "$name"
   local cmd log
   cmd=$(process_command "$name")
   log=$(log_file "$name")
   : > "$log"
   # Use `nohup` so the child survives the launching shell; `bash -c`
   # gives the command a single PID we can track and tree-kill later.
-  ( cd "$ROOT" && nohup bash -c "exec $cmd" >>"$log" 2>&1 ) &
+  ( cd "$ROOT" && exec nohup bash -c "exec $cmd" ) </dev/null >>"$log" 2>&1 &
   local pid=$!
-  disown "$pid" 2>/dev/null || true
+  disown 2>/dev/null || true
   echo "$pid" > "$(pid_file "$name")"
   echo "$name: started (pid $pid, logs $log)"
+}
+
+run_pids=()
+run_names=()
+run_cleaned=0
+
+run_cleanup() {
+  [[ "$run_cleaned" -eq 0 ]] || return 0
+  run_cleaned=1
+  local i name pid
+  for i in "${!run_pids[@]}"; do
+    name="${run_names[$i]}"
+    pid="${run_pids[$i]}"
+    if stop_pid_tree "$pid"; then
+      rm -f "$(pid_file "$name")"
+    fi
+  done
+}
+
+start_run_one() {
+  local name="$1"
+  if ! is_known "$name"; then
+    echo "dev: unknown process '$name' (try: $(process_names))" >&2
+    return 1
+  fi
+  ensure_not_running "$name"
+  local cmd log
+  cmd=$(process_command "$name")
+  log=$(log_file "$name")
+  : > "$log"
+  (
+    set -o pipefail
+    cd "$ROOT"
+    bash -c "exec $cmd" 2>&1 \
+      | tee -a "$log" \
+      | awk -v name="$name" '{ print "[" name "] " $0; fflush(); }'
+  ) &
+  local pid=$!
+  echo "$pid" > "$(pid_file "$name")"
+  run_names+=("$name")
+  run_pids+=("$pid")
+  echo "$name: running in foreground (pid $pid, logs $log)"
 }
 
 stop_one() {
@@ -126,16 +232,7 @@ stop_one() {
   fi
   local pid
   pid=$(read_pid "$name")
-  kill_tree "$pid" TERM
-  # Wait up to 5s for graceful shutdown before SIGKILL.
-  local i
-  for i in $(seq 1 50); do
-    kill -0 "$pid" 2>/dev/null || break
-    sleep 0.1
-  done
-  if kill -0 "$pid" 2>/dev/null; then
-    kill_tree "$pid" KILL
-  fi
+  stop_pid_tree "$pid" || return 1
   rm -f "$(pid_file "$name")"
   echo "$name: stopped"
 }
@@ -148,6 +245,40 @@ cmd_start() {
     for n in $(process_names); do targets+=("$n"); done
   fi
   for n in "${targets[@]}"; do start_one "$n"; done
+}
+
+cmd_run() {
+  load_env_file
+  set_default_env
+  local targets=("$@")
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    for n in $(process_names); do targets+=("$n"); done
+  fi
+
+  trap 'run_cleanup; exit 130' INT
+  trap 'run_cleanup; exit 143' TERM
+  trap 'run_cleanup' EXIT
+
+  local n
+  for n in "${targets[@]}"; do start_run_one "$n"; done
+
+  echo "dev: foreground run active; press Ctrl-C to stop ($(IFS=,; echo "${targets[*]}"))"
+
+  local i name pid status
+  while true; do
+    for i in "${!run_pids[@]}"; do
+      name="${run_names[$i]}"
+      pid="${run_pids[$i]}"
+      if ! kill -0 "$pid" 2>/dev/null; then
+        status=0
+        wait "$pid" || status=$?
+        echo "dev: $name exited (status $status); stopping foreground run" >&2
+        run_cleanup
+        exit "$status"
+      fi
+    done
+    sleep 1
+  done
 }
 
 cmd_stop() {
@@ -207,13 +338,15 @@ cmd_list() {
 }
 
 cmd_help() {
-  sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
 }
 
 main() {
   local sub="${1:-help}"
   shift || true
+  [[ "${1:-}" == "--" ]] && shift
   case "$sub" in
+    run)     cmd_run "$@" ;;
     start)   cmd_start "$@" ;;
     stop)    cmd_stop "$@" ;;
     restart) cmd_restart "$@" ;;


### PR DESCRIPTION
## Summary

- Make `pnpm dev` the attached foreground full-stack launcher and keep detached mode under `pnpm dev:start`.
- Stop previously tracked JobHunter process trees before starting each component, so rerunning the launcher starts from a clean owned stack.
- Document the canonical launcher behavior in the repo run docs and agent guidance.
- Add dev launcher contract coverage for attached cleanup and restart replacement behavior.

## Root Cause

The local launcher could leave child process trees alive across runs or refuse to start when a tracked process was already present. That made repeated app startup unreliable during supervised local work.

## Validation

- `bash -n scripts/dev`
- `corepack pnpm --filter @jobhunter/api test -- dev-launcher-contract.test.ts` passed: 110 tests
- `git diff --check`