### PR TITLE
fix: reject non-remote remote-search country hits

### DIFF
--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -259,8 +259,10 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
         next_cfg["locations"] = target_locations["locations"]
         next_cfg["location_labels"] = [item["label"] for item in target_locations["locations"]]
         next_cfg["location_accept"] = target_locations["accept"]
+        next_cfg["location_accept_local"] = target_locations["local_accept"]
         location_cfg = dict(next_cfg.get("location") or {})
         location_cfg["accept_patterns"] = target_locations["accept"]
+        location_cfg["local_accept_patterns"] = target_locations["local_accept"]
         next_cfg["location"] = location_cfg
 
         if target_locations["europe"]:
@@ -282,6 +284,7 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
 def _build_target_location_config(locations: list[str], work_models: list[str]) -> dict:
     search_locations: list[dict] = []
     accept: list[str] = []
+    local_accept: list[str] = []
     first_country = ""
     first_indeed_country = ""
     europe = False
@@ -299,6 +302,7 @@ def _build_target_location_config(locations: list[str], work_models: list[str]) 
         if wants_local:
             _append_search_location(search_locations, location=location, remote=False)
             accept.append(location)
+            local_accept.append(location)
 
         if wants_remote:
             remote_country = _display_country(country) or location
@@ -321,6 +325,7 @@ def _build_target_location_config(locations: list[str], work_models: list[str]) 
     return {
         "locations": search_locations,
         "accept": _dedupe_strings(accept),
+        "local_accept": _dedupe_strings(local_accept),
         "country": first_country,
         "country_indeed": first_indeed_country,
         "europe": europe,

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -22,6 +22,7 @@ from jobhunter.database import get_connection, init_db, resurface_deleted_job
 # / ``_full_crawl``.
 from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
+    configured_local_location_accepts,
     location_matches_target,
 )
 from jobhunter.discovery.title_filter import title_matches_query
@@ -104,21 +105,39 @@ def _patch_jobspy_linkedin_location_parser() -> None:
 # -- Location filtering ------------------------------------------------------
 
 
-def _load_location_config(search_cfg: dict) -> tuple[list[str], list[str]]:
+def _load_location_config(search_cfg: dict) -> tuple[list[str], list[str], list[str]]:
     """Extract accept/reject location lists from search config.
 
     Falls back to sensible defaults if not defined in the YAML.
     """
-    return configured_location_filters(search_cfg)
+    accept, reject = configured_location_filters(search_cfg)
+    return accept, reject, configured_local_location_accepts(search_cfg)
 
 
-def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> bool:
+def _location_ok(
+    location: str | None,
+    accept: list[str],
+    reject: list[str],
+    *,
+    search_location: str | None = None,
+    remote_required: bool = False,
+    is_remote: bool | None = None,
+    local_accept: list[str] | None = None,
+) -> bool:
     """Check if a job location passes the user's location filter.
 
     Remote jobs are accepted only after explicit reject geography is checked.
     Non-remote jobs must match an accept pattern and not match a reject pattern.
     """
-    return location_matches_target(location, accept=accept, reject=reject)
+    return location_matches_target(
+        location,
+        accept=accept,
+        reject=reject,
+        search_location=search_location,
+        remote_required=remote_required,
+        is_remote=is_remote,
+        local_accept=local_accept or (),
+    )
 
 
 # -- DB storage (JobSpy DataFrame -> SQLite) ---------------------------------
@@ -157,7 +176,7 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
 
         description = str(row.get("description", "")) if str(row.get("description", "")) != "nan" else None
         site_name = str(row.get("site", source_label))
-        is_remote = row.get("is_remote", False)
+        is_remote = _truthy_remote(row.get("is_remote", False))
 
         site_label = f"{site_name}"
         if is_remote:
@@ -228,6 +247,13 @@ def _nullable_str(value: object) -> str | None:
     return text
 
 
+def _truthy_remote(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    text = str(value or "").strip().casefold()
+    return text in {"1", "true", "yes", "remote"}
+
+
 def _title_ok(title: str | None, query: str | None) -> bool:
     return title_matches_query(title, query)
 
@@ -245,6 +271,7 @@ def _run_one_search(
     max_retries: int,
     accept_locs: list[str],
     reject_locs: list[str],
+    local_accept_locs: list[str],
     glassdoor_map: dict,
     limit: int = 0,
 ) -> dict:
@@ -333,6 +360,10 @@ def _run_one_search(
                 str(row.get("location", "")) if str(row.get("location", "")) != "nan" else None,
                 accept_locs,
                 reject_locs,
+                search_location=s.get("location"),
+                remote_required=bool(s.get("remote")),
+                is_remote=_truthy_remote(row.get("is_remote", False)),
+                local_accept=local_accept_locs,
             ),
             axis=1,
         )
@@ -457,7 +488,7 @@ def _full_crawl(
     defaults = dict(search_cfg.get("defaults", {}))
     defaults.setdefault("country_indeed", search_cfg.get("country", "usa"))
     glassdoor_map = search_cfg.get("glassdoor_location_map", {})
-    accept_locs, reject_locs = _load_location_config(search_cfg)
+    accept_locs, reject_locs, local_accept_locs = _load_location_config(search_cfg)
 
     if tiers:
         queries = [q for q in queries if q.get("tier") in tiers]
@@ -505,6 +536,7 @@ def _full_crawl(
             max_retries,
             accept_locs,
             reject_locs,
+            local_accept_locs,
             glassdoor_map,
             limit=remaining if limit > 0 else 0,
         )

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -268,12 +268,25 @@ def configured_location_filters(search_cfg: Mapping[str, Any]) -> tuple[list[str
     return _dedupe(accept), _dedupe(reject)
 
 
+def configured_local_location_accepts(search_cfg: Mapping[str, Any]) -> list[str]:
+    """Return location patterns that are valid for non-remote postings."""
+
+    accept = [*_string_list(search_cfg.get("location_accept_local"))]
+    nested = search_cfg.get("location")
+    if isinstance(nested, Mapping):
+        accept.extend(_string_list(nested.get("local_accept_patterns")))
+    return _dedupe(accept)
+
+
 def location_matches_target(
     location: str | None,
     *,
     accept: Sequence[str],
     reject: Sequence[str],
     search_location: str | None = None,
+    remote_required: bool = False,
+    is_remote: bool | None = None,
+    local_accept: Sequence[str] = (),
 ) -> bool:
     """Return whether a posting location fits the configured target.
 
@@ -288,6 +301,10 @@ def location_matches_target(
     normalized = _normalize(location)
     if _matches_reject(normalized, reject, accept=concrete_accept):
         return False
+
+    has_remote_signal = bool(is_remote) or _matches_any(normalized, REMOTE_MARKERS)
+    if remote_required and not has_remote_signal:
+        return _matches_any(normalized, _concrete_accept_patterns(local_accept))
 
     if search_location and _matches(normalized, search_location) and not concrete_accept:
         return True

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -84,12 +84,71 @@ def test_jobspy_filters_results_by_target_title(monkeypatch):
         0,
         ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
         ["United States", "Canada"],
+        ["Barcelona, Spain"],
         {},
         limit=10,
     )
 
     assert stored_titles == ["Director of Engineering"]
     assert result["new"] == 1
+    assert result["filtered"] == 1
+
+
+def test_jobspy_remote_search_rejects_non_remote_country_only_location(monkeypatch):
+    stored_locations: list[str] = []
+
+    def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
+        return pd.DataFrame(
+            [
+                {
+                    "job_url": "https://example.test/la-rinconada",
+                    "title": "Chief Information Officer",
+                    "location": "La Rinconada, AN, ES",
+                    "is_remote": False,
+                    "site": "indeed",
+                },
+                {
+                    "job_url": "https://example.test/barcelona",
+                    "title": "Chief Information Officer",
+                    "location": "Barcelona, CT, ES",
+                    "is_remote": False,
+                    "site": "indeed",
+                },
+                {
+                    "job_url": "https://example.test/remote-spain",
+                    "title": "Chief Information Officer",
+                    "location": "Spain",
+                    "is_remote": True,
+                    "site": "indeed",
+                },
+            ]
+        )
+
+    def fake_store(_conn, df, _source_label: str, limit: int = 0) -> tuple[int, int]:
+        stored_locations.extend(df["location"].tolist())
+        return len(df), 0
+
+    monkeypatch.setattr(jobspy, "_scrape_with_retry", fake_scrape)
+    monkeypatch.setattr(jobspy, "get_connection", lambda: object())
+    monkeypatch.setattr(jobspy, "store_jobspy_results", fake_store)
+
+    result = jobspy._run_one_search(
+        {"query": "Chief Information Officer", "location": "Spain", "remote": True},
+        ["indeed"],
+        10,
+        72,
+        None,
+        {"country_indeed": "spain"},
+        0,
+        ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+        ["United States", "Canada"],
+        ["Barcelona, Spain"],
+        {},
+        limit=10,
+    )
+
+    assert stored_locations == ["Barcelona, CT, ES", "Spain"]
+    assert result["new"] == 2
     assert result["filtered"] == 1
 
 
@@ -178,6 +237,7 @@ def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch)
             {"country_indeed": "spain"},
             0,
             ["Barcelona, Spain"],
+            [],
             [],
             {},
             limit=10,

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from jobhunter.infrastructure.discovery.location_filter import (
+    configured_local_location_accepts,
     configured_location_filters,
     location_matches_target,
 )
@@ -49,6 +50,36 @@ def test_remote_region_locations_pass_when_region_is_accepted() -> None:
             reject=EUROPE_REJECT,
             search_location="Remote",
         )
+
+
+def test_remote_search_rejects_non_remote_country_hits_outside_local_target() -> None:
+    assert not location_matches_target(
+        "La Rinconada, AN, ES",
+        accept=["Spain", "Europe", "EMEA"],
+        reject=EUROPE_REJECT,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=False,
+        local_accept=["Barcelona, Spain"],
+    )
+    assert location_matches_target(
+        "Barcelona, CT, ES",
+        accept=["Spain", "Europe", "EMEA"],
+        reject=EUROPE_REJECT,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=False,
+        local_accept=["Barcelona, Spain"],
+    )
+    assert location_matches_target(
+        "La Rinconada, AN, ES",
+        accept=["Spain", "Europe", "EMEA"],
+        reject=EUROPE_REJECT,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=True,
+        local_accept=["Barcelona, Spain"],
+    )
 
 
 def test_composite_target_locations_require_city_and_country_context() -> None:
@@ -112,3 +143,12 @@ def test_configured_location_filters_reads_nested_and_legacy_shapes() -> None:
 
     assert accept == ["Remote", "Spain", "EMEA"]
     assert reject == ["USA", "Brazil"]
+
+    local_accept = configured_local_location_accepts(
+        {
+            "location_accept_local": ["Barcelona, Spain"],
+            "location": {"local_accept_patterns": ["Madrid, Spain"]},
+        }
+    )
+
+    assert local_accept == ["Barcelona, Spain", "Madrid, Spain"]

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -4,6 +4,7 @@ import sqlite3
 
 from jobhunter import config
 from jobhunter.infrastructure.discovery.location_filter import (
+    configured_local_location_accepts,
     configured_location_filters,
     location_matches_target,
 )
@@ -39,6 +40,7 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
     assert "Barcelona, Spain" in merged["location_accept"]
     assert "Spain" in merged["location_accept"]
     assert "Europe" in merged["location_accept"]
+    assert merged["location_accept_local"] == ["Barcelona, Spain"]
     assert "Canada" in merged["location_reject_non_remote"]
 
 
@@ -80,8 +82,10 @@ def test_profile_target_locations_replace_legacy_location_accept_patterns() -> N
     )
 
     accept, reject = configured_location_filters(merged)
+    local_accept = configured_local_location_accepts(merged)
 
     assert "Barcelona, Spain" in accept
+    assert local_accept == ["Barcelona, Spain"]
     assert "Switzerland" not in accept
     assert "Zurich" not in accept
     assert location_matches_target("Barcelona, Spain (Remote)", accept=accept, reject=reject)
@@ -103,8 +107,10 @@ def test_hybrid_target_locations_filter_to_exact_target_location() -> None:
     )
 
     accept, reject = configured_location_filters(merged)
+    local_accept = configured_local_location_accepts(merged)
 
     assert merged["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]
+    assert local_accept == ["Barcelona, Spain"]
     assert "Europe" not in accept
     assert "EMEA" not in accept
     assert location_matches_target("Barcelona, CT, ES", accept=accept, reject=reject)
@@ -125,19 +131,75 @@ def test_remote_european_target_locations_filter_country_and_europe_remote() -> 
     )
 
     accept, reject = configured_location_filters(merged)
+    local_accept = configured_local_location_accepts(merged)
 
     assert merged["locations"] == [
         {"label": "spain", "location": "Spain", "remote": True},
         {"label": "europe-remote", "location": "European Union", "remote": True},
     ]
     assert "Barcelona, Spain" not in accept
+    assert local_accept == []
     assert "Spain" in accept
     assert "Europe" in accept
     assert location_matches_target("Remote Spain", accept=accept, reject=reject)
     assert location_matches_target("Remote EMEA", accept=accept, reject=reject)
     assert location_matches_target("Barcelona, CT, ES", accept=accept, reject=reject)
+    assert not location_matches_target(
+        "Barcelona, CT, ES",
+        accept=accept,
+        reject=reject,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=False,
+        local_accept=local_accept,
+    )
     assert not location_matches_target("Remote United States", accept=accept, reject=reject)
     assert not location_matches_target("Barcelona, Venezuela", accept=accept, reject=reject)
+
+
+def test_remote_plus_local_target_rejects_non_remote_country_only_hits() -> None:
+    merged = config._apply_profile_target_search(
+        {"queries": [{"query": "software engineer", "tier": 1}]},
+        {
+            "roles": ["Chief Information Officer"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Remote, Hybrid, On-site"],
+        },
+    )
+
+    accept, reject = configured_location_filters(merged)
+    local_accept = configured_local_location_accepts(merged)
+
+    assert "Spain" in accept
+    assert "Europe" in accept
+    assert local_accept == ["Barcelona, Spain"]
+    assert not location_matches_target(
+        "La Rinconada, AN, ES",
+        accept=accept,
+        reject=reject,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=False,
+        local_accept=local_accept,
+    )
+    assert location_matches_target(
+        "Barcelona, CT, ES",
+        accept=accept,
+        reject=reject,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=False,
+        local_accept=local_accept,
+    )
+    assert location_matches_target(
+        "La Rinconada, AN, ES",
+        accept=accept,
+        reject=reject,
+        search_location="Spain",
+        remote_required=True,
+        is_remote=True,
+        local_accept=local_accept,
+    )
 
 
 def test_profile_target_search_preserves_larger_configured_lookback() -> None:


### PR DESCRIPTION
## Summary

- Preserve explicit local target locations separately from broad remote country and region accepts.
- Require remote JobSpy searches to keep only rows with a remote signal, unless the non-remote row matches an explicit local target such as Barcelona.
- Add regression coverage for the La Rinconada-style non-remote Spain hit.

## Root Cause

The remote Spain/EU discovery filter treated broad country aliases like `ES` as sufficient for all search rows. That let a non-remote Spain posting outside the explicit local target pass during a remote search.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_discovery_limits.py` passed: 24 tests
- Live profile/config assertion rejects `La Rinconada, AN, ES` for a remote Spain search when `is_remote` is false
- `git diff --check`