### PR TITLE
fix: show job source column

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -966,8 +966,9 @@ textarea {
 
 .data-row.job {
   grid-template-columns:
-    28px 70px minmax(180px, 1.25fr) minmax(160px, 0.85fr)
-    minmax(150px, 0.85fr) 90px 105px 110px;
+    28px 70px minmax(180px, 1.2fr) minmax(140px, 0.7fr)
+    minmax(90px, 0.4fr) minmax(150px, 0.85fr) 80px 95px
+    105px 76px;
   gap: 14px;
 }
 

--- a/apps/web/src/views/jobs/JobsTable.test.tsx
+++ b/apps/web/src/views/jobs/JobsTable.test.tsx
@@ -1,0 +1,39 @@
+import type { RowSelectionState, SortingState } from "@tanstack/react-table";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { makeJobsPage, sampleJob } from "../../test/fixtures/projections.js";
+import { JobsTable } from "./JobsTable.js";
+
+function renderJobsTable() {
+  const sorting: SortingState = [{ id: "discovered_at", desc: true }];
+  const rowSelection: RowSelectionState = {};
+  return render(
+    <JobsTable
+      data={makeJobsPage([{ ...sampleJob, company: "Acme Corp", source: "LinkedIn" }])}
+      loading={false}
+      sorting={sorting}
+      onSortingChange={() => {}}
+      rowSelection={rowSelection}
+      onRowSelectionChange={() => {}}
+      allMatchingSelected={false}
+      page={1}
+      pageSize={50}
+      onPageChange={() => {}}
+      onPageSizeChange={() => {}}
+      onOpenJob={() => {}}
+    />,
+  );
+}
+
+describe("<JobsTable>", () => {
+  it("renders source as its own column instead of folding it into company", () => {
+    renderJobsTable();
+
+    expect(screen.getByText("Company")).toBeInTheDocument();
+    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Acme Corp")).toBeInTheDocument();
+    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+    expect(screen.queryByText(/Acme Corp.*LinkedIn/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/jobs/columns.tsx
+++ b/apps/web/src/views/jobs/columns.tsx
@@ -7,7 +7,6 @@ import { ScoreBadge } from "../../contexts/scoring/components/ScoreBadge.js";
 import { ScoreStalenessBadge } from "../../contexts/scoring/components/ScoreStalenessBadge.js";
 import { StageBadge } from "../../contexts/pipeline/components/StageBadge.js";
 import type { JobSummary } from "../../contexts/operations/types.js";
-import { formatCompanySource } from "../../shared/lib/formatters.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
 import { TitleStack } from "../../shared/ui/title-stack.js";
 
@@ -71,11 +70,14 @@ export const jobColumns: ColumnDef<JobSummary>[] = [
     header: "Company",
     enableSorting: true,
     accessorFn: (row) => row.company,
-    cell: ({ row }) => (
-      <span className="muted-cell">
-        {formatCompanySource(row.original.company, row.original.source)}
-      </span>
-    ),
+    cell: ({ row }) => <span className="muted-cell">{row.original.company || "-"}</span>,
+  },
+  {
+    id: "source",
+    header: "Source",
+    enableSorting: false,
+    accessorFn: (row) => row.source,
+    cell: ({ row }) => <span className="muted-cell">{row.original.source || "-"}</span>,
   },
   {
     id: "location",

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -134,6 +134,10 @@ Out of scope for the local stack (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)
 
 ### UI Quality
 
+- Add configurable jobs-table columns. The default Jobs table should keep
+  critical operational columns such as Source visible, but users need a
+  first-class control for choosing which columns are shown and hidden, with
+  persisted preferences per local profile or workspace.
 - Spike the best long-term resume rendering path. Evaluate whether to keep
   LaTeX as the PDF source of truth, switch to Tectonic, replace LaTeX with a
   different document engine such as Typst, or move to an HTML/CSS paged-media


### PR DESCRIPTION
## Summary

- Show `Source` as its own column in the Jobs table instead of folding it into Company.
- Adjust the Jobs table grid tracks so the rendered column count matches the layout.
- Add a backlog item for configurable visible and hidden Jobs table columns.
- Add a focused Jobs table test for the separate Source column.

## Root Cause

The Jobs table hid source provenance inside the Company cell, which made it harder to inspect why a row appeared in the list. The table also had more rendered columns than explicit grid tracks.

## Validation

- `corepack pnpm --filter @jobhunter/web test -- JobsTable.test.tsx` passed: 467 tests
- `corepack pnpm web:check`
- `git diff --check`