### PR TITLE
fix: harden jobs table rendering and worker recovery

### DIFF
--- a/apps/api/src/location-normalization.ts
+++ b/apps/api/src/location-normalization.ts
@@ -1,0 +1,62 @@
+const SPAIN_REGION_LABELS: Record<string, string> = {
+  AN: "Andalusia",
+  CT: "Catalonia",
+  MD: "Community of Madrid",
+};
+
+const REMOTE_PATTERN = /\b(?:remote|en remoto|remoto|teletrabajo|work from home|wfh)\b/i;
+const REMOTE_MARKER_PATTERN = /\s*\((?:remote|en remoto|remoto)\)\s*/gi;
+
+export function normalizeJobLocation(location: string | null | undefined): string {
+  const raw = String(location ?? "").trim();
+  if (!raw) {
+    return "";
+  }
+
+  const isRemote = REMOTE_PATTERN.test(raw) || /\((?:remote|en remoto|remoto)\)/i.test(raw);
+  const cleaned = raw
+    .replace(REMOTE_MARKER_PATTERN, " ")
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part && !REMOTE_PATTERN.test(part));
+
+  const hasSpainCountry = cleaned.some(isSpainCountryToken);
+  const parts = cleaned
+    .map((part) => normalizeLocationPart(part, hasSpainCountry))
+    .filter(Boolean);
+  const deduped = dedupeAdjacent(parts);
+  const base = deduped.length ? deduped.join(", ") : isRemote ? "Remote" : raw;
+
+  return isRemote && !/\bremote\b/i.test(base) ? `${base} (Remote)` : base;
+}
+
+function normalizeLocationPart(part: string, hasSpainCountry: boolean): string {
+  const token = part.trim();
+  if (!token) {
+    return "";
+  }
+  if (isSpainCountryToken(token)) {
+    return "Spain";
+  }
+  if (hasSpainCountry) {
+    const region = SPAIN_REGION_LABELS[token.toUpperCase()];
+    if (region) {
+      return region;
+    }
+  }
+  return token;
+}
+
+function isSpainCountryToken(part: string): boolean {
+  return /^(?:ES|ESP|Spain|España)$/i.test(part.trim());
+}
+
+function dedupeAdjacent(parts: string[]): string[] {
+  const result: string[] = [];
+  for (const part of parts) {
+    if (result[result.length - 1]?.toLocaleLowerCase() !== part.toLocaleLowerCase()) {
+      result.push(part);
+    }
+  }
+  return result;
+}

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -22,6 +22,7 @@
  */
 import { PROJECTION_WATERMARK_NAME, STAGES } from "./contracts.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { normalizeJobLocation } from "./location-normalization.js";
 
 const STAGE_ORDER: readonly string[] = STAGES;
 const SOURCE_BOARD_NAMES = new Set(["greenhouse", "linkedin", "talent.com"]);
@@ -1089,7 +1090,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
     employer,
     site || "unknown",
     stringField(job.strategy),
-    stringField(job.location),
+    normalizeJobLocation(stringField(job.location)),
     stringField(job.salary),
     applicationUrl,
     nullableString(job.discovered_at),

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -40,6 +40,7 @@ import type {
 } from "./contracts.js";
 import { ProfileSchema, STAGES, WORKFLOW_RUN_STATUSES } from "./contracts.js";
 import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { normalizeJobLocation } from "./location-normalization.js";
 import { refreshProjections } from "./projections.js";
 
 const DEFAULT_TENANT = "local";
@@ -392,7 +393,7 @@ function rowToJobSummary(row: JobListProjectionRow): JobSummary {
     company: row.employer || "Unknown company",
     source: row.source || "unknown",
     strategy: row.strategy ?? "",
-    location: row.location ?? "",
+    location: normalizeJobLocation(row.location),
     salary: row.salary ?? "",
     discoveredAt: row.discovered_at,
     applicationUrl: row.application_url,

--- a/apps/api/test/location-normalization.test.ts
+++ b/apps/api/test/location-normalization.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeJobLocation } from "../src/location-normalization.js";
+
+describe("normalizeJobLocation", () => {
+  it.each([
+    ["ES (Remote)", "Spain (Remote)"],
+    ["En remoto, ES (Remote)", "Spain (Remote)"],
+    ["Barcelona, CT, ES (Remote)", "Barcelona, Catalonia, Spain (Remote)"],
+    ["Madrid, MD, ES", "Madrid, Community of Madrid, Spain"],
+  ])("normalizes source location %s", (input, expected) => {
+    expect(normalizeJobLocation(input)).toBe(expected);
+  });
+});

--- a/apps/web/src/views/jobs/JobDescription.test.tsx
+++ b/apps/web/src/views/jobs/JobDescription.test.tsx
@@ -29,4 +29,10 @@ describe("JobDescription", () => {
     expect(screen.getByText("<script>alert('xss')</script>")).toBeInTheDocument();
     expect(document.querySelector("script")).toBeNull();
   });
+
+  it("renders escaped markdown and html entities as plain text", () => {
+    render(<JobDescription text="- Lead BSS \\&amp; Platform Services" />);
+
+    expect(screen.getByText("Lead BSS & Platform Services")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/views/jobs/JobDescription.tsx
+++ b/apps/web/src/views/jobs/JobDescription.tsx
@@ -177,5 +177,30 @@ function trimMarkdownMarkers(text: string): string {
 }
 
 function unescapeMarkdown(text: string): string {
-  return text.replace(/\\([\\`*_{}\[\]()#+\-.!>])/g, "$1");
+  return decodeHtmlEntities(text)
+    .replace(/\\+&/g, "&")
+    .replace(/\\([\\`*_{}\[\]()#+\-.!>])/g, "$1");
+}
+
+function decodeHtmlEntities(text: string): string {
+  const namedEntities: Record<string, string> = {
+    amp: "&",
+    apos: "'",
+    gt: ">",
+    lt: "<",
+    nbsp: " ",
+    quot: "\"",
+  };
+  return text.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entity, name: string) => {
+    const normalized = name.toLowerCase();
+    if (normalized.startsWith("#x")) {
+      const codePoint = Number.parseInt(normalized.slice(2), 16);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
+    }
+    if (normalized.startsWith("#")) {
+      const codePoint = Number.parseInt(normalized.slice(1), 10);
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
+    }
+    return namedEntities[normalized] ?? entity;
+  });
 }

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -1,4 +1,5 @@
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 import type { JobSummary, PaginatedResponse } from "../../contexts/operations/types.js";
 import { DataTable } from "../../shared/ui/data-table.js";
@@ -34,6 +35,17 @@ export function JobsTable({
   onPageSizeChange,
   onOpenJob,
 }: JobsTableProps) {
+  const displayedRowSelection = useMemo<RowSelectionState>(() => {
+    if (!allMatchingSelected) {
+      return rowSelection;
+    }
+    const next: RowSelectionState = {};
+    for (const job of data?.items ?? []) {
+      next[job.jobKey] = true;
+    }
+    return next;
+  }, [allMatchingSelected, data?.items, rowSelection]);
+
   return (
     <DataTable<JobSummary>
       data={data?.items ?? []}
@@ -47,7 +59,7 @@ export function JobsTable({
       rowClassName="data-row job"
       sorting={sorting}
       onSortingChange={onSortingChange}
-      rowSelection={rowSelection}
+      rowSelection={displayedRowSelection}
       onRowSelectionChange={onRowSelectionChange}
       onRowActivate={(row) => onOpenJob(row.jobKey)}
       rowAriaSelected={(row) => allMatchingSelected || Boolean(rowSelection[row.jobKey])}

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -52,6 +52,35 @@ afterEach(() => {
 });
 
 describe("<JobsView> bulk delete integration", () => {
+  it("checks visible row checkboxes after selecting all matching jobs", async () => {
+    const user = userEvent.setup();
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness);
+    const { container } = render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(screen.getByText(/Acme Corp/i)).toBeInTheDocument(), {
+      timeout: 5_000,
+    });
+
+    await user.click(screen.getByRole("button", { name: /select all matching/i }));
+    await waitFor(() => expect(screen.getByText(/2 selected/i)).toBeInTheDocument());
+
+    const checkboxes = Array.from(
+      container.querySelectorAll<HTMLInputElement>("input[type='checkbox']"),
+    );
+    const rowCheckboxes = checkboxes.filter(
+      (input) =>
+        input.getAttribute("aria-label")?.startsWith("Select ") &&
+        input.getAttribute("aria-label") !== "Select all rows on this page",
+    );
+
+    expect(screen.getByRole("checkbox", { name: /select all rows on this page/i })).toBeChecked();
+    expect(rowCheckboxes.length).toBeGreaterThan(0);
+    for (const checkbox of rowCheckboxes) {
+      expect(checkbox).toBeChecked();
+    }
+  });
+
   it("selects rows via checkbox, clicks delete, confirms, and posts to /v1/jobs/bulk-delete", async () => {
     const user = userEvent.setup();
     const calls: Array<{ jobKeys?: string[] }> = [];

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1200,6 +1200,8 @@ def worker(
         current_runtime_identity,
         write_worker_heartbeat,
     )
+    from jobhunter.database import get_connection
+    from jobhunter.state import recover_orphaned_running_stages
 
     queue = task_queue or JOBHUNTER_TASK_QUEUE
 
@@ -1212,10 +1214,16 @@ def worker(
             task_queue=queue,
         )
         identity = current_runtime_identity()
+        recovered = recover_orphaned_running_stages(get_connection())
         heartbeat_worker_id = write_worker_heartbeat(task_queue=queue)
         heartbeat_task = asyncio.create_task(
             _worker_heartbeat_loop(queue, heartbeat_worker_id)
         )
+        if recovered:
+            console.print(
+                f"[yellow]Recovered {recovered} orphaned pipeline stage run(s) "
+                "from prior worker shutdown.[/yellow]"
+            )
         console.print(
             f"[bold blue]JobHunter worker[/bold blue] running on task queue "
             f"[bold]{queue}[/bold] with {len(WORKFLOWS)} workflow(s) and "

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -24,6 +24,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     configured_local_location_accepts,
     location_matches_target,
+    normalize_location_display,
 )
 from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.network.proxy import parse_proxy
@@ -177,10 +178,9 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
         description = str(row.get("description", "")) if str(row.get("description", "")) != "nan" else None
         site_name = str(row.get("site", source_label))
         is_remote = _truthy_remote(row.get("is_remote", False))
+        location_str = normalize_location_display(location_str, is_remote=is_remote)
 
         site_label = f"{site_name}"
-        if is_remote:
-            location_str = f"{location_str} (Remote)" if location_str else "Remote"
 
         strategy = "jobspy"
 

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 
 from jobhunter import config
 from jobhunter.database import get_connection, init_db, resurface_deleted_job
+from jobhunter.domain.discovery.identity import normalize_observed_url
+from jobhunter.domain.job_content_identity import job_content_fingerprint, normalize_identity_text
 
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobhunter.infrastructure.network`` so the Enrichment context's
@@ -194,6 +196,25 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
         # Extract apply URL if JobSpy provided it
         apply_url = str(row.get("job_url_direct", "")) if str(row.get("job_url_direct", "")) != "nan" else None
 
+        duplicate_url = _find_existing_content_duplicate(
+            conn,
+            url=url,
+            title=title,
+            company=company,
+            full_description=full_description,
+        )
+        if duplicate_url:
+            _record_content_duplicate_link(
+                conn,
+                surviving_url=duplicate_url,
+                duplicate_url=url,
+                source=site_label,
+                observed_at=now,
+            )
+            resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
+            existing += 1
+            continue
+
         try:
             conn.execute(
                 "INSERT INTO jobs (url, title, company, salary, description, location, site, strategy, discovered_at, "
@@ -245,6 +266,95 @@ def _nullable_str(value: object) -> str | None:
     if not text or text == "nan":
         return None
     return text
+
+
+def _find_existing_content_duplicate(
+    conn: sqlite3.Connection,
+    *,
+    url: str,
+    title: str | None,
+    company: str | None,
+    full_description: str | None,
+) -> str | None:
+    incoming_key = job_content_fingerprint(
+        title=title,
+        company=company,
+        description=full_description,
+    )
+    if incoming_key is None:
+        return None
+    rows = conn.execute(
+        """
+        SELECT j.url, j.title, j.company,
+               COALESCE(je.full_description, j.full_description) AS full_description
+        FROM jobs j
+        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        WHERE j.url != ?
+          AND lower(trim(COALESCE(j.title, ''))) = ?
+          AND lower(trim(COALESCE(j.company, ''))) = ?
+        ORDER BY j.discovered_at ASC NULLS LAST, j.url ASC
+        """,
+        (
+            url,
+            normalize_identity_text(title),
+            normalize_identity_text(company),
+        ),
+    ).fetchall()
+    for existing in rows:
+        existing_key = job_content_fingerprint(
+            title=existing["title"],
+            company=existing["company"],
+            description=existing["full_description"],
+        )
+        if existing_key == incoming_key:
+            return str(existing["url"])
+    return None
+
+
+def _record_content_duplicate_link(
+    conn: sqlite3.Connection,
+    *,
+    surviving_url: str,
+    duplicate_url: str,
+    source: str,
+    observed_at: str,
+) -> None:
+    link_key = job_content_fingerprint(
+        title=surviving_url,
+        company=source,
+        description=duplicate_url,
+    )
+    if link_key is None:
+        return
+    duplicate_link_id = "content:" + link_key[:32]
+    normalized_url = normalize_observed_url(duplicate_url)
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO job_duplicate_links (
+            tenant_id, duplicate_link_id, surviving_job_id,
+            superseded_job_or_observation_id, reason, confidence, linked_at
+        ) VALUES ('local', ?, ?, ?, 'content_fingerprint_match', 0.95, ?)
+        """,
+        (duplicate_link_id, surviving_url, duplicate_url, observed_at),
+    )
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO job_source_observations (
+            tenant_id, source_observation_id, job_url, source_id,
+            source_native_id, observed_url, normalized_observed_url,
+            run_id, observed_at
+        ) VALUES ('local', ?, ?, ?, ?, ?, ?, 'jobspy', ?)
+        """,
+        (
+            f"content-duplicate:{duplicate_link_id}",
+            surviving_url,
+            source,
+            duplicate_url,
+            duplicate_url,
+            normalized_url,
+            observed_at,
+        ),
+    )
 
 
 def _truthy_remote(value: object) -> bool:

--- a/workers/automation/src/jobhunter/domain/job_content_identity.py
+++ b/workers/automation/src/jobhunter/domain/job_content_identity.py
@@ -1,0 +1,35 @@
+"""Content-based job identity helpers shared by discovery and scoring."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize_identity_text(value: object) -> str:
+    """Return a case-insensitive, whitespace-stable identity component."""
+
+    return _WHITESPACE_RE.sub(" ", str(value or "").strip()).casefold()
+
+
+def job_content_fingerprint(
+    *,
+    title: object,
+    company: object,
+    description: object,
+    description_limit: int | None = None,
+) -> str | None:
+    """Hash title + company + description when all content signals exist."""
+
+    normalized_title = normalize_identity_text(title)
+    normalized_company = normalize_identity_text(company)
+    normalized_description = normalize_identity_text(description)
+    if description_limit is not None and description_limit > 0:
+        normalized_description = normalized_description[:description_limit]
+    if not normalized_title or not normalized_company or not normalized_description:
+        return None
+    payload = "\x1f".join((normalized_title, normalized_company, normalized_description))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/workers/automation/src/jobhunter/domain/scoring/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/scoring/use_cases.py
@@ -202,7 +202,7 @@ def _utc_now() -> str:
 def _build_job_blob(job: dict[str, Any]) -> str:
     return (
         f"TITLE: {job.get('title', '')}\n"
-        f"COMPANY: {job.get('site', '')}\n"
+        f"COMPANY: {job.get('company') or job.get('site', '')}\n"
         f"LOCATION: {job.get('location') or 'N/A'}\n\n"
         f"DESCRIPTION:\n{(job.get('full_description') or '')[:6000]}"
     )

--- a/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py
@@ -254,6 +254,11 @@ AMBIGUOUS_REJECT_ABBREVIATIONS = {
     "sk",
     "yt",
 }
+SPAIN_REGION_LABELS = {
+    "AN": "Andalusia",
+    "CT": "Catalonia",
+    "MD": "Community of Madrid",
+}
 
 
 def configured_location_filters(search_cfg: Mapping[str, Any]) -> tuple[list[str], list[str]]:
@@ -313,6 +318,34 @@ def location_matches_target(
         return True
 
     return not concrete_accept and _matches_any(normalized, REMOTE_MARKERS)
+
+
+def normalize_location_display(location: str | None, *, is_remote: bool | None = None) -> str:
+    """Return a human-readable location string for source-provided locations."""
+
+    raw = str(location or "").strip()
+    if not raw:
+        return "Remote" if is_remote else ""
+
+    remote = bool(is_remote) or bool(
+        re.search(r"\b(remote|en remoto|remoto|teletrabajo|work from home|wfh)\b", raw, re.I)
+    )
+    without_remote_markers = re.sub(r"\s*\((remote|en remoto|remoto)\)\s*", " ", raw, flags=re.I)
+    parts = [
+        part.strip()
+        for part in without_remote_markers.split(",")
+        if part.strip()
+        and not re.search(r"\b(remote|en remoto|remoto|teletrabajo|work from home|wfh)\b", part, re.I)
+    ]
+    has_spain = any(_is_spain_country_token(part) for part in parts)
+    normalized_parts = [
+        normalized
+        for normalized in (_normalize_location_part(part, has_spain=has_spain) for part in parts)
+        if normalized
+    ]
+    deduped = _dedupe_adjacent(normalized_parts)
+    base = ", ".join(deduped) if deduped else ("Remote" if remote else raw)
+    return f"{base} (Remote)" if remote and not re.search(r"\bremote\b", base, re.I) else base
 
 
 def _string_list(value: object) -> list[str]:
@@ -397,6 +430,29 @@ def _matches(location: str, pattern: str | None) -> bool:
     if normalized.isalnum() and len(normalized) <= 3:
         return re.search(rf"(?<![a-z0-9]){re.escape(normalized)}(?![a-z0-9])", location) is not None
     return normalized in location
+
+
+def _normalize_location_part(part: str, *, has_spain: bool) -> str:
+    token = part.strip()
+    if not token:
+        return ""
+    if _is_spain_country_token(token):
+        return "Spain"
+    if has_spain:
+        return SPAIN_REGION_LABELS.get(token.upper(), token)
+    return token
+
+
+def _is_spain_country_token(part: str) -> bool:
+    return bool(re.fullmatch(r"ES|ESP|Spain|España", part.strip(), re.I))
+
+
+def _dedupe_adjacent(parts: Sequence[str]) -> list[str]:
+    result: list[str] = []
+    for part in parts:
+        if not result or result[-1].casefold() != part.casefold():
+            result.append(part)
+    return result
 
 
 def _normalize(value: str | None) -> str:

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -21,14 +21,18 @@ from __future__ import annotations
 
 import logging
 import time
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
 from jobhunter.config import RESUME_PATH
 from jobhunter.database import get_connection, get_jobs_by_stage
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.job_content_identity import job_content_fingerprint
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.scoring import LlmPort, ScoreRepository, ScoringPolicyRepository
 from jobhunter.domain.profile.snapshot import ProfileSnapshot
+from jobhunter.domain.scoring.aggregate import JobScore
 from jobhunter.domain.scoring.retrieval import (
     HybridSearchIndex,
     preselect_jobs_for_scoring,
@@ -226,8 +230,54 @@ def run_scoring(
         )
         record_job_event(conn, job["url"], "score", "StageStarted", message="Scoring started")
 
+    reusable_scores = (
+        {}
+        if rescore
+        else _reusable_scores_by_content_key(
+            conn=conn,
+            jobs=jobs,
+            repository=repository,
+            tenant_id=tenant_id,
+            criteria=criteria,
+            profile_snapshot=profile_snapshot,
+        )
+    )
+    pending_by_key: dict[str, dict[str, Any]] = {}
+    duplicate_jobs_by_representative: dict[str, list[dict[str, Any]]] = {}
+    jobs_to_compute: list[dict[str, Any]] = []
+    reused_results: list[tuple[dict[str, Any], ScoreJobOutcome]] = []
+    for job in jobs:
+        content_key = _score_content_key(job)
+        if content_key is None:
+            jobs_to_compute.append(job)
+            continue
+        reusable_score = reusable_scores.get(content_key)
+        if reusable_score is not None:
+            try:
+                outcome = _persist_reused_score(
+                    repository=repository,
+                    tenant_id=tenant_id,
+                    job=job,
+                    source_score=reusable_score,
+                )
+            except Exception as exc:  # noqa: BLE001 — surface as a stage failure
+                log.error("Score reuse failed for %r: %s", job.get("title", "?"), exc)
+                outcome = ScoreJobOutcome(
+                    ok=False,
+                    score=None,
+                    error=f"Score reuse failed: {exc}",
+                )
+            reused_results.append((job, outcome))
+            continue
+        representative = pending_by_key.get(content_key)
+        if representative is None:
+            pending_by_key[content_key] = job
+            jobs_to_compute.append(job)
+            continue
+        duplicate_jobs_by_representative.setdefault(representative["url"], []).append(job)
+
     t0 = time.time()
-    results: list[tuple[dict[str, Any], ScoreJobOutcome]] = []
+    results: list[tuple[dict[str, Any], ScoreJobOutcome]] = list(reused_results)
     errors = 0
 
     # Worker threads run the LLM step only — the SQLite connection is not
@@ -242,7 +292,7 @@ def run_scoring(
                 resume_text=resume_text,
                 criteria=criteria,
             ): job
-            for job in jobs
+            for job in jobs_to_compute
         }
         for completed, future in enumerate(as_completed(future_to_job), start=1):
             job = future_to_job[future]
@@ -265,13 +315,40 @@ def run_scoring(
                     )
 
             results.append((job, outcome))
-            if not outcome.ok:
-                errors += 1
+            for duplicate_job in duplicate_jobs_by_representative.get(job["url"], ()):
+                if outcome.ok and outcome.score is not None:
+                    try:
+                        duplicate_outcome = _persist_reused_score(
+                            repository=repository,
+                            tenant_id=tenant_id,
+                            job=duplicate_job,
+                            source_score=outcome.score,
+                        )
+                    except Exception as exc:  # noqa: BLE001 — surface as a stage failure
+                        log.error(
+                            "Score reuse failed for duplicate %r: %s",
+                            duplicate_job.get("title", "?"),
+                            exc,
+                        )
+                        duplicate_outcome = ScoreJobOutcome(
+                            ok=False,
+                            score=None,
+                            error=f"Score reuse failed: {exc}",
+                        )
+                else:
+                    duplicate_outcome = ScoreJobOutcome(
+                        ok=False,
+                        score=None,
+                        error=outcome.error or "Scoring failed",
+                    )
+                results.append((duplicate_job, duplicate_outcome))
             score_value = outcome.score.fit_score.value if outcome.ok and outcome.score else 0
             log.info(
                 "[%d/%d] score=%d  %s",
-                completed, len(jobs), score_value, str(job.get("title", "?"))[:60],
+                completed, len(jobs_to_compute), score_value, str(job.get("title", "?"))[:60],
             )
+
+    errors = sum(1 for _, outcome in results if not outcome.ok)
 
     finished_at = utc_now()
     for job, outcome in results:
@@ -361,6 +438,112 @@ def _retrieval_source_limit(limit: int) -> int:
     if limit <= 0:
         return 0
     return max(limit * 5, 50)
+
+
+def _score_content_key(job: dict[str, Any]) -> str | None:
+    return job_content_fingerprint(
+        title=job.get("title"),
+        company=job.get("company"),
+        description=job.get("full_description"),
+        description_limit=6000,
+    )
+
+
+def _reusable_scores_by_content_key(
+    *,
+    conn: sqlite3.Connection,
+    jobs: list[dict[str, Any]],
+    repository: ScoreRepository,
+    tenant_id: TenantId,
+    criteria: ScoringCriteria,
+    profile_snapshot: ProfileSnapshot,
+) -> dict[str, JobScore]:
+    wanted_keys = {key for job in jobs if (key := _score_content_key(job)) is not None}
+    if not wanted_keys:
+        return {}
+    rows = conn.execute(
+        """
+        SELECT j.url, j.title, j.company,
+               COALESCE(je.full_description, j.full_description) AS full_description
+        FROM jobs j
+        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        INNER JOIN (
+            SELECT s.job_url, MAX(s.version) AS max_version
+            FROM job_scores s
+            WHERE s.tenant_id = ?
+            GROUP BY s.job_url
+        ) latest ON latest.job_url = j.url
+        INNER JOIN job_scores s
+            ON s.job_url = latest.job_url
+           AND s.version = latest.max_version
+           AND s.tenant_id = ?
+        ORDER BY s.scored_at DESC
+        """,
+        (str(tenant_id), str(tenant_id)),
+    ).fetchall()
+
+    reusable: dict[str, JobScore] = {}
+    for row in rows:
+        job = dict(row)
+        key = _score_content_key(job)
+        if key is None or key not in wanted_keys or key in reusable:
+            continue
+        score = repository.load(tenant_id, JobId(str(job["url"])))
+        if score is None or not _score_matches_context(
+            score=score,
+            criteria=criteria,
+            profile_snapshot=profile_snapshot,
+        ):
+            continue
+        reusable[key] = score
+    return reusable
+
+
+def _score_matches_context(
+    *,
+    score: JobScore,
+    criteria: ScoringCriteria,
+    profile_snapshot: ProfileSnapshot,
+) -> bool:
+    if score.trace.criteria_version != criteria.criteria_version:
+        return False
+    if score.trace.profile_snapshot_version != profile_snapshot.version:
+        return False
+    return True
+
+
+def _persist_reused_score(
+    *,
+    repository: ScoreRepository,
+    tenant_id: TenantId,
+    job: dict[str, Any],
+    source_score: JobScore,
+) -> ScoreJobOutcome:
+    job_id = JobId(str(job["url"]))
+    previous = repository.load(tenant_id, job_id)
+    scored_at = utc_now()
+    if previous is None:
+        copied = JobScore.initial(
+            tenant_id=tenant_id,
+            job_id=job_id,
+            fit_score=source_score.fit_score,
+            breakdown=source_score.breakdown,
+            matched_keywords=source_score.matched_keywords,
+            scored_at=scored_at,
+            criteria=source_score.criteria,
+            trace=source_score.trace,
+        )
+    else:
+        copied = previous.next_version(
+            fit_score=source_score.fit_score,
+            breakdown=source_score.breakdown,
+            matched_keywords=source_score.matched_keywords,
+            scored_at=scored_at,
+            criteria=source_score.criteria,
+            trace=source_score.trace,
+        )
+    repository.save(copied)
+    return ScoreJobOutcome(ok=True, score=copied)
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/state.py
+++ b/workers/automation/src/jobhunter/state.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +49,9 @@ MAX_ATTEMPTS: dict[str, int | None] = {
     "pdf": 3,
     "apply": config.DEFAULTS["max_apply_attempts"],
 }
+
+ORPHANED_RUNNING_STAGE_GRACE_SECONDS = 150
+ORPHAN_RECOVERY_STAGES: tuple[str, ...] = tuple(stage for stage in STAGE_ORDER if stage != "apply")
 
 
 def utc_now() -> str:
@@ -98,6 +101,18 @@ def _duration_ms(started_at: str | None, finished_at: str | None) -> int | None:
     except ValueError:
         return None
     return max(0, int((finish - start).total_seconds() * 1000))
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +298,97 @@ def set_stage_state(
             existing[0] if not isinstance(existing, dict) else existing["version"]
         )
         raise OptimisticLockError(job_url, expected_version, actual or 0)
+
+
+def recover_orphaned_running_stages(
+    conn,
+    *,
+    stages: tuple[str, ...] | None = None,
+    stale_after_seconds: int = ORPHANED_RUNNING_STAGE_GRACE_SECONDS,
+    now: datetime | None = None,
+) -> int:
+    """Fail stale non-apply stage rows left ``running`` by a dead worker.
+
+    Stage activities mark per-job rows ``running`` before doing blocking work.
+    If the process dies before final state writes, those rows otherwise stay
+    visually active forever. The next worker startup owns this reconciliation.
+    ``apply`` is intentionally excluded because it has its own run-lock rescue.
+    """
+
+    recovery_stages = tuple(stages or ORPHAN_RECOVERY_STAGES)
+    if not recovery_stages:
+        return 0
+    invalid = [stage for stage in recovery_stages if stage not in ORPHAN_RECOVERY_STAGES]
+    if invalid:
+        raise ValueError(f"unsupported orphan recovery stage(s): {', '.join(invalid)}")
+
+    recovered_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    cutoff = recovered_at - timedelta(seconds=max(0, stale_after_seconds))
+    placeholders = ", ".join("?" for _ in recovery_stages)
+    rows = conn.execute(
+        f"""
+        SELECT job_url, stage, attempt_count, started_at, updated_at
+        FROM job_stage_states
+        WHERE state = 'running'
+          AND stage IN ({placeholders})
+        """,
+        recovery_stages,
+    ).fetchall()
+
+    recovered = 0
+    recovered_at_iso = recovered_at.isoformat()
+    for row in rows:
+        updated_at = _parse_timestamp(row["updated_at"])
+        started_at = _parse_timestamp(row["started_at"])
+        last_seen = updated_at or started_at
+        if last_seen is not None and last_seen > cutoff:
+            continue
+
+        stage = str(row["stage"])
+        job_url = str(row["job_url"])
+        attempt_count = max(1, int(row["attempt_count"] or 0))
+        message = (
+            f"{stage} stage was left running by a prior worker and has been "
+            "marked failed for retry."
+        )
+        set_stage_state(
+            conn,
+            job_url,
+            stage,
+            "failed",
+            attempt_count=attempt_count,
+            started_at=row["started_at"],
+            finished_at=recovered_at_iso,
+            error_code="ORPHANED_STAGE_RUN",
+            error_message=message,
+            retryable=True,
+            next_action=f"jobhunter retry {stage} {job_url}",
+            metadata={
+                "recovered_at": recovered_at_iso,
+                "previous_updated_at": row["updated_at"],
+            },
+            validate_transition=False,
+        )
+        record_job_event(
+            conn,
+            job_url,
+            stage,
+            "StageFailed",
+            level="error",
+            message=message,
+            occurred_at=recovered_at_iso,
+            payload={
+                "errorCode": "ORPHANED_STAGE_RUN",
+                "retryable": True,
+                "recoveredAt": recovered_at_iso,
+                "previousUpdatedAt": row["updated_at"],
+            },
+        )
+        recovered += 1
+
+    if recovered:
+        conn.commit()
+    return recovered
 
 
 def record_job_event(

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -221,6 +221,34 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         close_connection(db_path)
 
 
+def test_jobspy_normalizes_source_locations_before_storage(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        results = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://es.indeed.com/viewjob?jk=remote-spain",
+                    "title": "Director, Product Management",
+                    "company": "Vonage",
+                    "location": "En remoto, ES",
+                    "is_remote": True,
+                    "site": "indeed",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, results, "Director", limit=10) == (1, 0)
+        row = conn.execute(
+            "SELECT location FROM jobs WHERE url = ?",
+            ("https://es.indeed.com/viewjob?jk=remote-spain",),
+        ).fetchone()
+
+        assert row["location"] == "Spain (Remote)"
+    finally:
+        close_connection(db_path)
+
+
 def test_jobspy_missing_dependency_is_not_reported_as_empty_success(monkeypatch):
     def missing_jobspy(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
         raise ImportError("python-jobspy is not installed")

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -221,6 +221,54 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         close_connection(db_path)
 
 
+def test_jobspy_rejects_same_content_location_variants(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    description = "Lead security engineering, compliance, identity, and platform risk. " * 8
+    try:
+        first = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/4416248661",
+                    "title": "Director, Security Engineering - Remote in Spain",
+                    "company": "Auctane",
+                    "location": "Madrid, Spain",
+                    "site": "linkedin",
+                    "description": description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, first, "Security Engineering", limit=10) == (1, 0)
+
+        duplicate = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/4416235850",
+                    "title": "Director, Security Engineering - Remote in Spain",
+                    "company": "Auctane",
+                    "location": "Seville, Spain",
+                    "site": "linkedin",
+                    "description": description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, duplicate, "Security Engineering", limit=10) == (0, 1)
+
+        job_count = conn.execute(
+            "SELECT COUNT(*) FROM jobs WHERE company = 'Auctane'"
+        ).fetchone()[0]
+        assert job_count == 1
+        link = conn.execute(
+            "SELECT surviving_job_id, superseded_job_or_observation_id, reason "
+            "FROM job_duplicate_links"
+        ).fetchone()
+        assert link["surviving_job_id"] == "https://www.linkedin.com/jobs/view/4416248661"
+        assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4416235850"
+        assert link["reason"] == "content_fingerprint_match"
+    finally:
+        close_connection(db_path)
+
+
 def test_jobspy_normalizes_source_locations_before_storage(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)

--- a/workers/automation/tests/test_discovery_location_filter.py
+++ b/workers/automation/tests/test_discovery_location_filter.py
@@ -4,6 +4,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_local_location_accepts,
     configured_location_filters,
     location_matches_target,
+    normalize_location_display,
 )
 
 
@@ -152,3 +153,10 @@ def test_configured_location_filters_reads_nested_and_legacy_shapes() -> None:
     )
 
     assert local_accept == ["Barcelona, Spain", "Madrid, Spain"]
+
+
+def test_normalize_location_display_expands_source_country_codes() -> None:
+    assert normalize_location_display("ES", is_remote=True) == "Spain (Remote)"
+    assert normalize_location_display("En remoto, ES (Remote)") == "Spain (Remote)"
+    assert normalize_location_display("Barcelona, CT, ES", is_remote=True) == "Barcelona, Catalonia, Spain (Remote)"
+    assert normalize_location_display("Madrid, MD, ES") == "Madrid, Community of Madrid, Spain"

--- a/workers/automation/tests/test_orphaned_stage_recovery.py
+++ b/workers/automation/tests/test_orphaned_stage_recovery.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jobhunter.database import close_connection, init_db
+from jobhunter.state import (
+    ensure_job_stage_rows,
+    recover_orphaned_running_stages,
+    set_stage_state,
+)
+
+
+def _insert_job(conn: sqlite3.Connection, url: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO jobs (url, title, site, full_description, discovered_at)
+        VALUES (?, 'Engineer', 'ExampleCo', 'Build reliable systems.', ?)
+        """,
+        (url, "2026-05-21T20:00:00+00:00"),
+    )
+    ensure_job_stage_rows(conn, url)
+    conn.commit()
+
+
+def _mark_running_at(conn: sqlite3.Connection, url: str, stage: str, timestamp: str) -> None:
+    set_stage_state(
+        conn,
+        url,
+        stage,
+        "running",
+        started_at=timestamp,
+        validate_transition=False,
+    )
+    conn.execute(
+        """
+        UPDATE job_stage_states
+        SET updated_at = ?
+        WHERE job_url = ? AND stage = ?
+        """,
+        (timestamp, url, stage),
+    )
+    conn.commit()
+
+
+def test_recover_orphaned_running_stages_marks_only_stale_non_apply_runs_failed(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = init_db(db_path)
+    old_score_url = "https://example.com/jobs/orphaned-score"
+    fresh_score_url = "https://example.com/jobs/fresh-score"
+    apply_url = "https://example.com/jobs/apply-run"
+
+    try:
+        _insert_job(conn, old_score_url)
+        _insert_job(conn, fresh_score_url)
+        _insert_job(conn, apply_url)
+        _mark_running_at(conn, old_score_url, "score", "2026-05-21T20:00:00+00:00")
+        _mark_running_at(conn, fresh_score_url, "score", "2026-05-21T20:09:00+00:00")
+        _mark_running_at(conn, apply_url, "apply", "2026-05-21T20:00:00+00:00")
+
+        recovered = recover_orphaned_running_stages(
+            conn,
+            now=datetime(2026, 5, 21, 20, 10, 0, tzinfo=timezone.utc),
+            stale_after_seconds=150,
+        )
+
+        assert recovered == 1
+        recovered_row = conn.execute(
+            """
+            SELECT state, attempt_count, error_code, error_message, retryable, next_action
+            FROM job_stage_states
+            WHERE job_url = ? AND stage = 'score'
+            """,
+            (old_score_url,),
+        ).fetchone()
+        assert recovered_row["state"] == "failed"
+        assert recovered_row["attempt_count"] == 1
+        assert recovered_row["error_code"] == "ORPHANED_STAGE_RUN"
+        assert recovered_row["retryable"] == 1
+        assert old_score_url in recovered_row["next_action"]
+        assert "left running by a prior worker" in recovered_row["error_message"]
+
+        fresh_row = conn.execute(
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
+            (fresh_score_url,),
+        ).fetchone()
+        assert fresh_row["state"] == "running"
+
+        apply_row = conn.execute(
+            "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'apply'",
+            (apply_url,),
+        ).fetchone()
+        assert apply_row["state"] == "running"
+
+        event = conn.execute(
+            """
+            SELECT event_type, level, message, payload_json
+            FROM job_events
+            WHERE job_url = ? AND stage = 'score'
+            ORDER BY event_id DESC LIMIT 1
+            """,
+            (old_score_url,),
+        ).fetchone()
+        assert event["event_type"] == "StageFailed"
+        assert event["level"] == "error"
+        assert "marked failed for retry" in event["message"]
+        assert "ORPHANED_STAGE_RUN" in event["payload_json"]
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -40,6 +40,8 @@ class _ScriptedLlm:
 
     def __init__(self, *responses: dict | str) -> None:
         self._queue = list(responses)
+        self.calls = 0
+        self.messages = []
 
     def chat(  # pragma: no cover — structured-output cutover routes through chat_json
         self,
@@ -63,6 +65,8 @@ class _ScriptedLlm:
         max_tokens=None,
         thinking_budget=None,
     ) -> dict:
+        self.calls += 1
+        self.messages.append(messages)
         if not self._queue:
             return self._DRAIN
         next_payload = self._queue.pop(0)
@@ -108,11 +112,13 @@ def _seed_pending_job_with_description(
     title: str,
     description: str,
     discovered_at: str,
+    company: str = "Acme",
+    location: str = "Remote",
 ) -> None:
     conn.execute(
-        "INSERT INTO jobs (url, title, site, full_description, discovered_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (url, title, "Acme", description, discovered_at),
+        "INSERT INTO jobs (url, title, company, site, location, full_description, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (url, title, company, "linkedin", location, description, discovered_at),
     )
     conn.commit()
 
@@ -228,6 +234,50 @@ def test_score_job_with_explicit_sqlite_repository_uses_persisted_policy(
     )
 
 
+def test_score_job_prompt_uses_company_not_source(
+    conn: sqlite3.Connection,
+    profile_snapshot,
+) -> None:
+    url = "https://example.com/job/company"
+    conn.execute(
+        "INSERT INTO jobs (url, title, company, site, full_description, discovered_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (
+            url,
+            "Director, Security Engineering",
+            "Auctane",
+            "linkedin",
+            "Lead security engineering teams.",
+            "2024-01-01T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    repo = SqliteScoreRepository(conn)
+    llm = _ScriptedLlm(
+        {
+            "score": 9,
+            "technical_fit": 9,
+            "experience_fit": 9,
+            "role_fit": 9,
+            "keywords": ["security"],
+            "reasoning": "ok",
+        }
+    )
+
+    job_dict = dict(conn.execute("SELECT * FROM jobs WHERE url=?", (url,)).fetchone())
+    outcome = scorer_module.score_job(
+        profile_snapshot,
+        job_dict,
+        repository=repo,
+        llm_port=llm,
+    )
+
+    assert outcome.ok is True
+    prompt = llm.messages[0][1].content
+    assert "COMPANY: Auctane" in prompt
+    assert "COMPANY: linkedin" not in prompt
+
+
 # ---------------------------------------------------------------------------
 # run_scoring (batch)
 # ---------------------------------------------------------------------------
@@ -330,6 +380,133 @@ def test_run_scoring_loads_and_persists_local_scoring_criteria(
     assert loaded.criteria.criteria_text == "Favor platform reliability leadership."
     assert loaded.criteria.target_criteria == "Remote infrastructure roles."
     assert loaded.trace.criteria_version == criteria.criteria_version
+
+
+def test_run_scoring_reuses_same_content_score_for_duplicate_jobs(
+    conn: sqlite3.Connection, profile_snapshot, monkeypatch
+) -> None:
+    description = "Lead security engineering, compliance, identity, and platform risk. " * 8
+    first_url = "https://www.linkedin.com/jobs/view/1"
+    duplicate_url = "https://www.linkedin.com/jobs/view/2"
+    _seed_pending_job_with_description(
+        conn,
+        url=first_url,
+        title="Director, Security Engineering - Remote in Spain",
+        company="Auctane",
+        location="Madrid, Community of Madrid, Spain (Remote)",
+        description=description,
+        discovered_at="2026-01-02T00:00:00+00:00",
+    )
+    _seed_pending_job_with_description(
+        conn,
+        url=duplicate_url,
+        title="Director, Security Engineering - Remote in Spain",
+        company="Auctane",
+        location="Seville, Andalusia, Spain (Remote)",
+        description=description,
+        discovered_at="2026-01-01T00:00:00+00:00",
+    )
+    repo = SqliteScoreRepository(conn)
+    llm = _ScriptedLlm(
+        {
+            "score": 9,
+            "technical_fit": 9,
+            "experience_fit": 9,
+            "role_fit": 9,
+            "keywords": ["security"],
+            "reasoning": "ok",
+        },
+        {
+            "score": 3,
+            "technical_fit": 3,
+            "experience_fit": 3,
+            "role_fit": 3,
+            "keywords": ["security"],
+            "reasoning": "would diverge if called",
+        },
+    )
+
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=repo,
+        llm_port=llm,
+        resume_text="Security engineering leadership.",
+    )
+
+    assert summary["scored"] == 2
+    assert summary["errors"] == 0
+    assert llm.calls == 1
+    first_score = repo.load(LOCAL_TENANT, JobId(first_url))
+    duplicate_score = repo.load(LOCAL_TENANT, JobId(duplicate_url))
+    assert first_score is not None and first_score.fit_score.value == 9
+    assert duplicate_score is not None and duplicate_score.fit_score.value == 9
+
+
+def test_run_scoring_reuses_existing_same_content_score_without_llm(
+    conn: sqlite3.Connection, profile_snapshot, monkeypatch
+) -> None:
+    description = "Lead security engineering, compliance, identity, and platform risk. " * 8
+    scored_url = "https://www.linkedin.com/jobs/view/scored"
+    pending_url = "https://www.linkedin.com/jobs/view/pending-duplicate"
+    _seed_pending_job_with_description(
+        conn,
+        url=scored_url,
+        title="Director, Security Engineering - Remote in Spain",
+        company="Auctane",
+        description=description,
+        discovered_at="2026-01-01T00:00:00+00:00",
+    )
+    repo = SqliteScoreRepository(conn)
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+    first_llm = _ScriptedLlm(
+        {
+            "score": 9,
+            "technical_fit": 9,
+            "experience_fit": 9,
+            "role_fit": 9,
+            "keywords": ["security"],
+            "reasoning": "ok",
+        }
+    )
+    scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=repo,
+        llm_port=first_llm,
+        resume_text="Security engineering leadership.",
+    )
+    _seed_pending_job_with_description(
+        conn,
+        url=pending_url,
+        title="Director, Security Engineering - Remote in Spain",
+        company="Auctane",
+        location="Seville, Andalusia, Spain (Remote)",
+        description=description,
+        discovered_at="2026-01-02T00:00:00+00:00",
+    )
+    second_llm = _ScriptedLlm(
+        {
+            "score": 3,
+            "technical_fit": 3,
+            "experience_fit": 3,
+            "role_fit": 3,
+            "keywords": ["security"],
+            "reasoning": "should not be called",
+        }
+    )
+
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=repo,
+        llm_port=second_llm,
+        resume_text="Security engineering leadership.",
+    )
+
+    assert summary["scored"] == 1
+    assert summary["errors"] == 0
+    assert second_llm.calls == 0
+    pending_score = repo.load(LOCAL_TENANT, JobId(pending_url))
+    assert pending_score is not None and pending_score.fit_score.value == 9
 
 
 def test_run_scoring_records_failure_state_when_llm_returns_garbage(


### PR DESCRIPTION
## Summary

- Derive the visible table row-selection state from `allMatchingSelected` so the header and visible row checkboxes render checked after selecting all matching jobs.
- Decode escaped markdown ampersands and common HTML entities in captured job descriptions without injecting raw HTML.
- Normalize source job locations for Spain abbreviations and remote markers at ingestion, projection rebuild, and read-model output so existing and future rows render clean display locations.
- Recover stale non-apply pipeline stage rows left `running` by a dead worker so score/enrich/tailor/etc. do not appear active forever after a vanished workflow/process.
- Prevent same-content JobSpy location variants from being inserted as separate active jobs, and reuse equivalent current-context scores instead of independently scoring duplicate sourced copies.
- Fix scoring prompts to pass the actual employer as `COMPANY` instead of the source board name.

## Root Cause

`select all matching` stored selection in `allMatchingSelected` and cleared TanStack `rowSelection`. The row wrapper used `allMatchingSelected` for `aria-selected`, but the checkbox column only read TanStack row selection, so the rows looked selected while the inputs stayed unchecked.

Captured descriptions can contain source markdown escapes and HTML entities such as `\&amp;`; the renderer only handled a narrower markdown escape set, so literal backslashes reached the detail view.

Source job locations are not geocoded one-by-one. Profile target locations are validated before saving through place validation, while scraped job locations are filtered by discovery location rules and then stored/displayed from the source payload. Raw source tokens like `ES`, `CT`, `MD`, and `En remoto` therefore reached the jobs table.

Scoring was not running in another database. The API and worker both reported `/Users/eloibarti/.jobhunter/jobhunter.db` and the same DB identity. The UI showed `score/running` because 55 `job_stage_states` rows had been marked running at `2026-05-21T20:22:08Z`, but `/v1/workflow-runs` returned zero runs and Temporal listed no workflows. Non-apply stage runners had no orphan reconciliation path, unlike apply, so a dead attempt could leave rows visually running forever.

The Auctane rows were five same-content LinkedIn location variants. JobSpy writes directly to `jobs`, bypassing the Discovery canonical identity boundary, so different LinkedIn URLs were treated as separate jobs. Scoring then made separate LLM calls for equivalent content; four current-policy rows produced 9/9/9/10, while the older Barcelona row still had an older score/context. The scoring prompt also used `site` for the `COMPANY` field, so sourced copies were evaluated with `COMPANY: linkedin` rather than the employer.

## Source Findings

The active jobs currently come from JobSpy only: 35 LinkedIn and 16 Indeed after duplicate cleanup. Recent JobSpy runs are producing/refreshing jobs; recent Workday runs completed with `total=0`; recent Smart Extract runs executed configured targets but stored `new_jobs=0`, `existing_jobs=0`, and `observed_jobs=0`. That means the registered non-JobSpy source families are present but not contributing active job rows in the current local DB.

## Validation

- `corepack pnpm --filter @jobhunter/web test -- JobDescription.test.tsx JobsView.test.tsx`
- `corepack pnpm --filter @jobhunter/api test -- location-normalization.test.ts`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_discovery_limits.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_orphaned_stage_recovery.py workers/automation/tests/test_state_dashboard.py workers/automation/tests/test_score_queue_selectors.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_scorer.py workers/automation/tests/test_discovery_limits.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/discovery/location_filter.py workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/tests/test_discovery_location_filter.py workers/automation/tests/test_discovery_limits.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/state.py workers/automation/src/jobhunter/cli.py workers/automation/tests/test_orphaned_stage_recovery.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/job_content_identity.py workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/src/jobhunter/domain/scoring/use_cases.py workers/automation/src/jobhunter/scoring/scorer.py workers/automation/tests/test_scorer.py workers/automation/tests/test_discovery_limits.py`
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `git diff --check`
- Restarted the local stack through `scripts/dev` stop/start and verified `/v1/health` reports the API database and worker heartbeat are healthy.
- Worker startup recovered 56 orphaned pipeline stage runs from the live DB; the 55 stale score rows now return `score/failed` with `ORPHANED_STAGE_RUN` instead of false `score/running`.
- Browser/API verification on `http://127.0.0.1:4173/jobs?...`: raw `ES (Remote)` no longer appears in the first visible rows and `Spain (Remote)` does; detail view for the Vonage job renders `BSS & Platform Services` with no escaped ampersand; affected score rows now show `score failed`.
- Live Auctane cleanup verification: `/v1/jobs?deleted=active&q=Auctane` returns one active Auctane row with score 9; the four superseded same-content location variants are linked and marked deleted in the local DB/read model.

## Known Pre-Existing Failure

- `uv --project workers/automation run --extra dev pytest -q` currently fails only `workers/automation/tests/test_domain_event_parity.py::test_python_domain_event_types_match_typescript_union`. The touched diff does not modify event type declarations, and `origin/main` already has the mismatch: TypeScript includes `ScoreRescoreRequested` where Python's `DOMAIN_EVENT_TYPES` does not.