### PR TITLE
docs: reconcile proposed plan status

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -7,8 +7,9 @@ This is the authoritative roadmap. Keep detailed historical proposals under
 
 Delivered work is archived in [`docs/delivered.md`](delivered.md) and the
 implemented plan directory. Discovery RFC production wiring and scoring
-intelligence are implemented via PR #61; the local Temporal stack, DDD /
-hexagonal migration, and frontend TanStack migration are also implemented.
+intelligence are implemented via PR #61; the calibrated scoring policy stack,
+local Temporal stack, DDD / hexagonal migration, and frontend TanStack
+migration are also implemented.
 
 The active local-product backlog is the remaining validation and hardening
 work below: realtime cache patching beyond apply-run timeline events,
@@ -65,13 +66,13 @@ deferred until the local product is solid.
 
 ### Scoring Calibration
 
-- Implement the calibrated scoring policy RFC in
-  [`docs/plans/proposed/2026-05-19-calibrated-scoring-policy-rfc.md`](plans/proposed/2026-05-19-calibrated-scoring-policy-rfc.md).
-  Current scoring stores rich evidence and corrections, but the LLM still
-  returns one absolute 1..10 score per job. Corrections should become
-  calibration anchors in a versioned scoring policy, future scoring should use
-  that policy immediately, comparable uncorrected scores should be marked
-  stale, and bulk rescoring should remain explicit/user-triggered.
+Delivered by
+[`docs/plans/implemented/2026-05-19-calibrated-scoring-policy-rfc.md`](plans/implemented/2026-05-19-calibrated-scoring-policy-rfc.md).
+The current scoring stack persists a versioned scoring policy, derives
+calibration anchors from user corrections, records policy metadata in score
+traces, marks comparable uncorrected scores stale, exposes explicit stale-score
+reset/rescore behavior, and reflects policy/staleness state in the local API
+and jobs UI.
 
 ### Workflow Orchestration (Local Temporal)
 
@@ -335,8 +336,8 @@ and are tracked here per the migration plan §"Deferred follow-ups":
   installed for the Storybook test runner). The Vitest unit / hook /
   component suite, the type-level tests, and the standalone Playwright e2e
   specs at `apps/web/e2e/` are developer-local only — a regression in any
-  of those does not fail CI today. Wire the three jobs into
-  `typescript.yml` once the root aliases land.
+  of those does not fail CI today. Wire the three root aliases into
+  `typescript.yml`.
 - **Frontend ACL `JobId` is unbranded** —
   `apps/web/src/contexts/operations/types.ts` exports
   `type JobId = string` rather than re-exporting the branded

--- a/docs/delivered.md
+++ b/docs/delivered.md
@@ -3,6 +3,24 @@
 This is the per-PR delivery archive. It records what changed and where to find
 the detailed implementation plan or QA notes.
 
+## 2026-05-22: Proposed Plan Status Reconciliation
+
+Plans:
+
+- `docs/plans/implemented/2026-05-17-jobhunter-backlog-item-add-root.md`
+- `docs/plans/implemented/2026-05-19-calibrated-scoring-policy-rfc.md`
+
+Delivered:
+
+- Root web test aliases now exist in `package.json` for unit, watch,
+  coverage, type-level, e2e, and headed e2e web test commands.
+- The calibrated scoring policy stack is implemented across the Python scoring
+  domain, SQLite adapters, TypeScript API write/read models, contracts, web
+  scoring components, invalidation handlers, and local eval/governance tests.
+- `docs/backlog.md` no longer lists the scoring policy RFC as active
+  implementation work, and its CI follow-up now assumes the root web aliases
+  already exist.
+
 ## 2026-05-14: Discovery RFC + Scoring Intelligence Completion
 
 Plans:

--- a/docs/plans/implemented/2026-05-17-jobhunter-backlog-item-add-root.md
+++ b/docs/plans/implemented/2026-05-17-jobhunter-backlog-item-add-root.md
@@ -1,5 +1,12 @@
 # Add Root-Level Web Test Aliases
 
+## Completion Status
+
+Implemented. The root `package.json` now exposes `web:test`,
+`web:test:watch`, `web:test:coverage`, `web:test-d`, `web:e2e`, and
+`web:e2e:headed`, each delegating to the matching `@jobhunter/web` script.
+The original plan text below is retained as delivery history.
+
 ## Goal
 
 Add the missing root `pnpm` aliases for the web test commands named in the

--- a/docs/plans/implemented/2026-05-19-calibrated-scoring-policy-rfc.md
+++ b/docs/plans/implemented/2026-05-19-calibrated-scoring-policy-rfc.md
@@ -1,8 +1,17 @@
 # Calibrated Scoring Policy RFC
 
-> **Status:** proposed.
+> **Status:** implemented.
 > **Date:** 2026-05-19.
 > **Scope:** Scoring consistency, user score-correction feedback, explicit rescoring, and the implementation stack needed to make corrections change future scoring behavior.
+
+## Completion Status
+
+Implemented. The current codebase has the versioned scoring policy model,
+correction-derived calibration anchors, policy trace metadata, stale-score
+marking, explicit stale-score reset/rescore flow, API/web reflection, and
+non-sensitive scoring evaluation/governance coverage described by this RFC.
+The remaining sections preserve the original RFC text; references to current
+gaps describe the pre-implementation state.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

- Moved the remaining proposed plans for root web test aliases and calibrated scoring policy into `docs/plans/implemented/`.
- Added implemented-status notes at the top of each moved plan while preserving the original plan/RFC text as historical context.
- Updated backlog and delivery notes so active backlog wording no longer treats those completed items as future work.

## Validation

- `git diff --check`
- Current implementation evidence reviewed for the root web aliases and calibrated scoring policy surfaces.

No additional product QA was run for this docs-only status reconciliation.