### PR TITLE
feat: learn posting sources from broad discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,14 +343,15 @@ state, priority, recommendation, activity, run health, and quality-metric
 columns. Located parseable sources are automatically approved into the active
 source registry; manual review is reserved for blocked, ambiguous, or
 unparseable sources. JobSpy broad-board results can also learn durable sources:
-when a result exposes a known ATS direct URL, JobHunter records the board
-provenance, promotes the ATS source into the registry, and links the job to the
-canonical posting URL; unknown owner URLs stay in review. These controls can add
-an experimental source, preview recently observed leads for a source, enable or
-quarantine a source, approve or reject quarantined leads, record source
-feedback, open a blocked lead in the local browser, and import a user-provided
-URL, current-page URL, pasted text, saved HTML, or email content as
-manual-capture provenance. Manual capture
+when a result exposes a direct owner URL, JobHunter records the board
+provenance, links the job to the canonical posting URL, and promotes runnable
+ATS sources into the registry; unknown owner URLs and ATS URLs that still need
+adapter configuration stay in review. These controls can add an experimental
+source, preview recently observed leads for a source, enable or quarantine a
+source, approve or reject quarantined leads, record source feedback, open a
+blocked lead in the local browser, and import a user-provided URL, current-page
+URL, pasted text, saved HTML, or email content as manual-capture provenance.
+Manual capture
 stores local provenance metadata and content hashes, not raw captured posting
 text in domain events. The `limit`
 control is honored by every pipeline stage tab, including `discover` and `enrich`, so

--- a/README.md
+++ b/README.md
@@ -311,9 +311,8 @@ The Vite dev server proxies `/v1/*` to the local API by default. Set
 `VITE_JOBHUNTER_API_BASE_URL` when the API runs on a different local origin.
 
 The Jobs tab can filter by stage, state, and fit-score range. Its source column
-shows the posting board first and the discovery source underneath when
-available, so broad-board results can be distinguished from canonical employer
-or ATS sources.
+shows the posting owner and the discovery source separately when available, so
+broad-board results can be distinguished from canonical employer or ATS sources.
 
 The Jobs tab separates temporary removal from permanent suppression. Deleting a
 job moves it to the Deleted tab; a later discovery run can resurface that job if
@@ -343,11 +342,15 @@ sources as a filterable, sortable table with company, source id, source type,
 state, priority, recommendation, activity, run health, and quality-metric
 columns. Located parseable sources are automatically approved into the active
 source registry; manual review is reserved for blocked, ambiguous, or
-unparseable sources. These controls can add an experimental source, preview
-recently observed leads for a source, enable or quarantine a source, approve or
-reject quarantined leads, record source feedback, open a blocked lead in the
-local browser, and import a user-provided URL, current-page URL, pasted text,
-saved HTML, or email content as manual-capture provenance. Manual capture
+unparseable sources. JobSpy broad-board results can also learn durable sources:
+when a result exposes a known ATS direct URL, JobHunter records the board
+provenance, promotes the ATS source into the registry, and links the job to the
+canonical posting URL; unknown owner URLs stay in review. These controls can add
+an experimental source, preview recently observed leads for a source, enable or
+quarantine a source, approve or reject quarantined leads, record source
+feedback, open a blocked lead in the local browser, and import a user-provided
+URL, current-page URL, pasted text, saved HTML, or email content as
+manual-capture provenance. Manual capture
 stores local provenance metadata and content hashes, not raw captured posting
 text in domain events. The `limit`
 control is honored by every pipeline stage tab, including `discover` and `enrich`, so

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -84,6 +84,8 @@ interface JobListProjectionRow extends Record<string, unknown> {
   employer: string;
   source: string;
   discovery_source: string;
+  posting_source_url: string | null;
+  posting_source_ats_kind: string | null;
   strategy: string;
   location: string;
   salary: string;
@@ -434,6 +436,8 @@ function rowToJobSummary(row: JobListProjectionRow): JobSummary {
     company: row.employer || "Unknown company",
     source: row.source || "unknown",
     discoverySource: displayDiscoverySource(row.discovery_source, row.strategy, row.source),
+    postingSource: displayPostingSource(row.posting_source_ats_kind, row.posting_source_url),
+    postingSourceUrl: row.posting_source_url,
     strategy: row.strategy ?? "",
     location: normalizeJobLocation(row.location),
     salary: row.salary ?? "",
@@ -1044,9 +1048,29 @@ function jobSqlFilter(db: SqliteDatabase, query: JobListQuery): { where: string;
     params.push(query.state);
   }
   if (query.source) {
-    clauses.push(`(LOWER(source) LIKE ? OR LOWER(${discoverySourceSqlExpression(db)}) LIKE ?)`);
-    const normalizedSource = `%${query.source.toLowerCase()}%`;
-    params.push(normalizedSource, normalizedSource);
+    const postingSourceUrlSql = postingSourceUrlSqlExpression(db);
+    const postingSourceAtsKindSql = postingSourceAtsKindSqlExpression(db);
+    clauses.push(
+      `(LOWER(source) LIKE ?
+        OR LOWER(${discoverySourceSqlExpression(db)}) LIKE ?
+        OR LOWER(COALESCE(${postingSourceUrlSql}, '')) LIKE ?
+        OR LOWER(COALESCE(${postingSourceAtsKindSql}, '')) LIKE ?
+        OR (
+          LOWER(COALESCE(${postingSourceAtsKindSql}, '')) LIKE ?
+          AND LOWER(COALESCE(${postingSourceUrlSql}, '')) LIKE ?
+        ))`,
+    );
+    const normalizedSource = query.source.toLowerCase();
+    const [postingSourceKind, ...postingSourceOwnerParts] = normalizedSource.split(":");
+    const postingSourceOwner = postingSourceOwnerParts.join(":") || normalizedSource;
+    params.push(
+      `%${normalizedSource}%`,
+      `%${normalizedSource}%`,
+      `%${normalizedSource}%`,
+      `%${normalizedSource}%`,
+      `%${postingSourceKind}%`,
+      `%${postingSourceOwner}%`,
+    );
   }
   if (query.company) {
     clauses.push("LOWER(employer) LIKE ?");
@@ -1106,6 +1130,8 @@ function jobProjectionSelect(db: SqliteDatabase): string {
        NULL AS score_stale_marked_at`;
   return `job_list_projections.*,
           ${discoverySourceSqlExpression(db)} AS discovery_source,
+          ${postingSourceUrlSqlExpression(db)} AS posting_source_url,
+          ${postingSourceAtsKindSqlExpression(db)} AS posting_source_ats_kind,
           ${hiddenSelect},
           ${stalenessSelect}`;
 }
@@ -1155,6 +1181,24 @@ function latestSourceObservationSql(): string {
             LIMIT 1)`;
 }
 
+function postingSourceUrlSqlExpression(db: SqliteDatabase): string {
+  if (!tableExists(db, "job_canonical_identities")) return "NULL";
+  return `(SELECT c.canonical_url
+             FROM job_canonical_identities c
+            WHERE c.tenant_id = job_list_projections.tenant_id
+              AND c.job_url = job_list_projections.job_id
+            LIMIT 1)`;
+}
+
+function postingSourceAtsKindSqlExpression(db: SqliteDatabase): string {
+  if (!tableExists(db, "job_canonical_identities")) return "NULL";
+  return `(SELECT c.ats_kind
+             FROM job_canonical_identities c
+            WHERE c.tenant_id = job_list_projections.tenant_id
+              AND c.job_url = job_list_projections.job_id
+            LIMIT 1)`;
+}
+
 function jobFilterPayload(query: JobListQuery): Record<string, unknown> {
   return {
     q: query.q,
@@ -1185,7 +1229,9 @@ function filterJob(job: JobSummary, query: JobListQuery, normalizedQuery: string
   if (query.state && job.currentState !== query.state) return false;
   if (
     query.source &&
-    ![job.source, job.discoverySource].some((source) => source.toLowerCase().includes(query.source.toLowerCase()))
+    ![job.source, job.discoverySource, job.postingSource, job.postingSourceUrl ?? ""].some((source) =>
+      source.toLowerCase().includes(query.source.toLowerCase()),
+    )
   ) {
     return false;
   }
@@ -1200,10 +1246,60 @@ function filterJob(job: JobSummary, query: JobListQuery, normalizedQuery: string
     job.location,
     job.source,
     job.discoverySource,
+    job.postingSource,
+    job.postingSourceUrl ?? "",
     job.strategy,
     job.currentStage,
     job.currentState,
   ].some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
+function displayPostingSource(
+  atsKind: string | null | undefined,
+  canonicalUrl: string | null | undefined,
+): string {
+  const normalizedKind = String(atsKind ?? "").trim().toLowerCase();
+  const normalizedUrl = String(canonicalUrl ?? "").trim();
+  if (!normalizedUrl || !normalizedKind || normalizedKind === "other") return "";
+  return `${normalizedKind}:${postingSourceSlug(normalizedUrl, normalizedKind)}`;
+}
+
+function postingSourceSlug(rawUrl: string, atsKind: string): string {
+  let host = "";
+  let segments: string[] = [];
+  try {
+    const parsed = new URL(rawUrl);
+    host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+    segments = parsed.pathname.split("/").filter(Boolean);
+  } catch {
+    return slugText(rawUrl);
+  }
+  if (atsKind === "greenhouse") {
+    const boardsIndex = segments.indexOf("boards");
+    const board = boardsIndex >= 0 ? segments[boardsIndex + 1] : undefined;
+    if (board) return slugText(board);
+    const firstSegment = segments[0];
+    if (host.includes("greenhouse.io") && firstSegment) return slugText(firstSegment);
+  }
+  if (atsKind === "lever") {
+    const postingsIndex = segments.indexOf("postings");
+    const postingSite = postingsIndex >= 0 ? segments[postingsIndex + 1] : undefined;
+    if (postingSite) return slugText(postingSite);
+    const firstSegment = segments[0];
+    if (firstSegment) return slugText(firstSegment);
+  }
+  if (atsKind === "ashby") {
+    const boardIndex = segments.indexOf("job-board");
+    const board = boardIndex >= 0 ? segments[boardIndex + 1] : undefined;
+    if (board) return slugText(board);
+    const firstSegment = segments[0];
+    if (firstSegment) return slugText(firstSegment);
+  }
+  return slugText(host || rawUrl);
+}
+
+function slugText(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "source";
 }
 
 function compareJobs(left: JobSummary, right: JobSummary, field: string, direction: "asc" | "desc"): number {

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -455,6 +455,119 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it("jobs endpoints expose discovered source and posting owner separately", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE job_source_observations (
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          source_observation_id TEXT NOT NULL,
+          job_url TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          source_native_id TEXT NOT NULL,
+          observed_url TEXT NOT NULL,
+          normalized_observed_url TEXT NOT NULL,
+          run_id TEXT NOT NULL DEFAULT '',
+          observed_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, source_observation_id)
+        );
+        CREATE TABLE job_canonical_identities (
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          job_url TEXT NOT NULL,
+          canonical_url TEXT NOT NULL,
+          ats_kind TEXT NOT NULL,
+          source_native_id TEXT NOT NULL,
+          confidence REAL NOT NULL,
+          resolved_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, job_url)
+        );
+      `);
+      db.prepare(
+        `INSERT INTO job_source_observations (
+          tenant_id, source_observation_id, job_url, source_id,
+          source_native_id, observed_url, normalized_observed_url,
+          run_id, observed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "local",
+        "obs-linkedin",
+        "https://example.com/jobs/event-driven",
+        "jobspy:linkedin",
+        "https://www.linkedin.com/jobs/view/1",
+        "https://www.linkedin.com/jobs/view/1",
+        "https://www.linkedin.com/jobs/view/1",
+        "discovery:jobspy:test",
+        "2026-05-06T09:01:00+00:00",
+      );
+      db.prepare(
+        `INSERT INTO job_canonical_identities (
+          tenant_id, job_url, canonical_url, ats_kind, source_native_id,
+          confidence, resolved_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "local",
+        "https://example.com/jobs/event-driven",
+        "https://boards.greenhouse.io/acme/jobs/123456",
+        "greenhouse",
+        "123456",
+        0.82,
+        "2026-05-06T09:02:00+00:00",
+      );
+      db.close();
+
+      const app = buildApp({
+        dbPath,
+        profilePath: path.join(path.dirname(dbPath), "profile.json"),
+        resumeStylePath: path.join(path.dirname(dbPath), "resume_style.json"),
+        resumeTemplatePath: path.join(path.dirname(dbPath), "resume_template.tex"),
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        const listRes = await app.inject({ method: "GET", url: "/v1/jobs" });
+        expect(listRes.statusCode, listRes.body).toBe(200);
+        const item = listRes
+          .json()
+          .items.find((j: { jobKey: string }) => j.jobKey === "https://example.com/jobs/event-driven");
+        expect(item).toMatchObject({
+          discoverySource: "jobspy:linkedin",
+          postingSource: "greenhouse:acme",
+          postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123456",
+        });
+
+        const sourceFilteredRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs?source=greenhouse%3Aacme&q=event",
+        });
+        expect(sourceFilteredRes.statusCode, sourceFilteredRes.body).toBe(200);
+        expect(sourceFilteredRes.json().items).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              jobKey: "https://example.com/jobs/event-driven",
+              postingSource: "greenhouse:acme",
+            }),
+          ]),
+        );
+
+        const detailRes = await app.inject({
+          method: "GET",
+          url: "/v1/jobs/https%3A%2F%2Fexample.com%2Fjobs%2Fevent-driven",
+        });
+        expect(detailRes.statusCode, detailRes.body).toBe(200);
+        expect(detailRes.json().job).toMatchObject({
+          discoverySource: "jobspy:linkedin",
+          postingSource: "greenhouse:acme",
+          postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123456",
+        });
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("jobs endpoints expose latest score evidence from job_scores", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -46,6 +46,8 @@ export const sampleJob: JobSummary = {
   company: "Acme Corp",
   source: "Lever",
   discoverySource: "lever:acme",
+  postingSource: "lever:acme",
+  postingSourceUrl: "https://jobs.lever.co/acme/1",
   strategy: "ats:lever",
   location: "Remote (US)",
   salary: "$220k-$260k",

--- a/apps/web/src/views/jobs/JobOverview.test.tsx
+++ b/apps/web/src/views/jobs/JobOverview.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { makeJobDetail, sampleJob } from "../../test/fixtures/projections.js";
+import { JobOverview } from "./JobOverview.js";
+
+describe("<JobOverview>", () => {
+  it("shows separate discovery and posting owner provenance", () => {
+    render(
+      <JobOverview
+        detail={makeJobDetail({
+          ...sampleJob,
+          company: "Acme Corp",
+          discoverySource: "jobspy:linkedin",
+          postingSource: "greenhouse:acme",
+          postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123",
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText("Acme Corp · posting: greenhouse:acme · discovered via: jobspy:linkedin"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -13,7 +13,8 @@ export function JobOverview({ detail }: JobOverviewProps) {
       <span>
         <small>
           {job.company}
-          {job.source && job.source !== job.company ? ` · source: ${job.source}` : ""}
+          {job.postingSource ? ` · posting: ${job.postingSource}` : ""}
+          {job.discoverySource ? ` · discovered via: ${job.discoverySource}` : ""}
         </small>
         <h2>{job.title}</h2>
         <p>

--- a/apps/web/src/views/jobs/JobsTable.test.tsx
+++ b/apps/web/src/views/jobs/JobsTable.test.tsx
@@ -2,24 +2,25 @@ import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import type { JobSummary } from "../../contexts/operations/types.js";
 import { makeJobsPage, sampleJob } from "../../test/fixtures/projections.js";
 import { JobsTable } from "./JobsTable.js";
 
-function renderJobsTable() {
+function renderJobsTable(jobs: readonly JobSummary[] = [
+  {
+    ...sampleJob,
+    company: "Acme Corp",
+    source: "LinkedIn",
+    discoverySource: "jobspy:linkedin",
+    postingSource: "greenhouse:acme",
+    postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123",
+  },
+]) {
   const sorting: SortingState = [{ id: "discovered_at", desc: true }];
   const rowSelection: RowSelectionState = {};
   return render(
     <JobsTable
-      data={makeJobsPage([
-        {
-          ...sampleJob,
-          company: "Acme Corp",
-          source: "LinkedIn",
-          discoverySource: "jobspy:linkedin",
-          postingSource: "greenhouse:acme",
-          postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123",
-        },
-      ])}
+      data={makeJobsPage(jobs)}
       loading={false}
       sorting={sorting}
       onSortingChange={() => {}}
@@ -45,5 +46,20 @@ describe("<JobsTable>", () => {
     expect(screen.getByText("posting greenhouse:acme")).toBeInTheDocument();
     expect(screen.getByText("discovered via jobspy:linkedin")).toBeInTheDocument();
     expect(screen.queryByText(/Acme Corp.*LinkedIn/)).not.toBeInTheDocument();
+  });
+
+  it("does not label a broad discovery board as the posting owner", () => {
+    renderJobsTable([
+      {
+        ...sampleJob,
+        source: "LinkedIn",
+        discoverySource: "jobspy:linkedin",
+        postingSource: "",
+        postingSourceUrl: null,
+      },
+    ]);
+
+    expect(screen.queryByText("posting LinkedIn")).not.toBeInTheDocument();
+    expect(screen.getByText("discovered via jobspy:linkedin")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/JobsTable.test.tsx
+++ b/apps/web/src/views/jobs/JobsTable.test.tsx
@@ -11,7 +11,14 @@ function renderJobsTable() {
   return render(
     <JobsTable
       data={makeJobsPage([
-        { ...sampleJob, company: "Acme Corp", source: "LinkedIn", discoverySource: "jobspy:linkedin" },
+        {
+          ...sampleJob,
+          company: "Acme Corp",
+          source: "LinkedIn",
+          discoverySource: "jobspy:linkedin",
+          postingSource: "greenhouse:acme",
+          postingSourceUrl: "https://boards.greenhouse.io/acme/jobs/123",
+        },
       ])}
       loading={false}
       sorting={sorting}
@@ -33,10 +40,10 @@ describe("<JobsTable>", () => {
     renderJobsTable();
 
     expect(screen.getByText("Company")).toBeInTheDocument();
-    expect(screen.getByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Sources")).toBeInTheDocument();
     expect(screen.getByText("Acme Corp")).toBeInTheDocument();
-    expect(screen.getByText("LinkedIn")).toBeInTheDocument();
-    expect(screen.getByText("discovery jobspy:linkedin")).toBeInTheDocument();
+    expect(screen.getByText("posting greenhouse:acme")).toBeInTheDocument();
+    expect(screen.getByText("discovered via jobspy:linkedin")).toBeInTheDocument();
     expect(screen.queryByText(/Acme Corp.*LinkedIn/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/columns.tsx
+++ b/apps/web/src/views/jobs/columns.tsx
@@ -76,16 +76,10 @@ export const jobColumns: ColumnDef<JobSummary>[] = [
     id: "source",
     header: "Sources",
     enableSorting: false,
-    accessorFn: (row) => row.postingSource || row.source,
+    accessorFn: (row) => row.postingSource || row.discoverySource || row.source,
     cell: ({ row }) => (
       <TitleStack
-        primary={
-          row.original.postingSource
-            ? `posting ${row.original.postingSource}`
-            : row.original.source
-              ? `posting ${row.original.source}`
-              : "-"
-        }
+        primary={row.original.postingSource ? `posting ${row.original.postingSource}` : "-"}
         secondary={row.original.discoverySource ? `discovered via ${row.original.discoverySource}` : null}
       />
     ),

--- a/apps/web/src/views/jobs/columns.tsx
+++ b/apps/web/src/views/jobs/columns.tsx
@@ -74,13 +74,19 @@ export const jobColumns: ColumnDef<JobSummary>[] = [
   },
   {
     id: "source",
-    header: "Source",
+    header: "Sources",
     enableSorting: false,
-    accessorFn: (row) => row.source,
+    accessorFn: (row) => row.postingSource || row.source,
     cell: ({ row }) => (
       <TitleStack
-        primary={row.original.source || "-"}
-        secondary={row.original.discoverySource ? `discovery ${row.original.discoverySource}` : null}
+        primary={
+          row.original.postingSource
+            ? `posting ${row.original.postingSource}`
+            : row.original.source
+              ? `posting ${row.original.source}`
+              : "-"
+        }
+        secondary={row.original.discoverySource ? `discovered via ${row.original.discoverySource}` : null}
       />
     ),
   },

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -245,8 +245,8 @@ sequenceDiagram
     Runner->>Scheduler: plan(registry, source quality, global limit)
     Scheduler-->>Runner: DiscoverySchedule
 
-    Runner->>JobSpy: run_discovery(cfg, scheduled boards, limit)
-    JobSpy->>DB: insert jobs with strategy=jobspy
+    Runner->>JobSpy: run_discovery(cfg, scheduled boards, limit, run_id)
+    JobSpy->>DB: insert jobs, broad-board observations, learned source candidates
     Runner->>ATS: run_scheduled_ats_sources(...)
     ATS->>DB: create canonical jobs and source observations
     Runner->>Workday: run_workday_discovery(...)
@@ -284,7 +284,7 @@ classDiagram
       +adapter_config
     }
     class JobSpyAdapter {
-      +run_discovery(cfg, limit)
+      +run_discovery(cfg, limit, run_id)
     }
     class AtsApiScheduler {
       +run_scheduled_ats_sources()
@@ -319,10 +319,14 @@ classDiagram
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.
-- Writes `jobs`, source observations, canonical identity rows, quarantine
-  entries, discovery run rows, `job_events`, and source-level operational
-  attempt metrics.
+- Writes `jobs`, source observations, canonical identity rows, source-learning
+  registry updates, review queue entries, quarantine entries, discovery run
+  rows, `job_events`, and source-level operational attempt metrics.
 - Emits stage events and source-level discovery events.
+- Treats JobSpy result URLs as broad-board observations and JobSpy direct URLs
+  as owner-source evidence. Known ATS direct URLs are promoted into
+  `source_registry_entries`; ambiguous direct URLs are surfaced through source
+  locator/manual-capture review instead of being ignored.
 - Classifies JobSpy board observations as `source_role=lead_generator` and
   root employer/ATS/API sources as `source_role=canonical_source`, so board
   discovery metrics do not collapse into canonical employer source health.

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -324,9 +324,10 @@ classDiagram
   rows, `job_events`, and source-level operational attempt metrics.
 - Emits stage events and source-level discovery events.
 - Treats JobSpy result URLs as broad-board observations and JobSpy direct URLs
-  as owner-source evidence. Known ATS direct URLs are promoted into
-  `source_registry_entries`; ambiguous direct URLs are surfaced through source
-  locator/manual-capture review instead of being ignored.
+  as owner-source evidence. Runnable ATS direct URLs are promoted into
+  `source_registry_entries`; ambiguous direct URLs and ATS URLs that still need
+  adapter configuration are surfaced through source locator/manual-capture
+  review instead of being ignored.
 - Classifies JobSpy board observations as `source_role=lead_generator` and
   root employer/ATS/API sources as `source_role=canonical_source`, so board
   discovery metrics do not collapse into canonical employer source health.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -108,9 +108,9 @@ metadata are visible as columns instead of compact badges:
   `GET /v1/discovery/manual-capture` expose the local review queues. Located
   parseable source candidates are auto-promoted into the active source registry;
   these queues are for blocked, ambiguous, unparseable, or legacy pending work.
-  JobSpy direct URLs feed this same loop: known ATS URLs are promoted into the
-  source registry, while unknown or ambiguous owner URLs remain visible for
-  review.
+  JobSpy direct URLs feed this same loop: runnable ATS URLs are promoted into
+  the source registry, while unknown owner URLs or ATS URLs that still need
+  adapter configuration remain visible for review.
 - `POST /v1/discovery/locator-candidates/:candidateId/promote` promotes a
   legacy source locator candidate into an active source registry entry and emits
   `SourceLocationCandidatePromoted`.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -43,11 +43,13 @@ unresolved stale markers, including the stale reason, current and target policy
 versions, marked time, and whether the score is waiting for explicit rescore
 reset. `scoreReasoning` remains on the wire as a compatibility summary during
 the scoring evidence migration.
-Job summaries also include `discoverySource`, which is the observed source
-registry id when available and falls back to the discovery strategy/source pair
-for legacy rows. The jobs list accepts `minFitScore` and `maxFitScore` query
-parameters, and the same score bounds are accepted by all-matching bulk job
-mutations.
+Job summaries also include source provenance. `discoverySource` is the observed
+source registry id where the job was found and falls back to the discovery
+strategy/source pair for legacy rows. `postingSource` and `postingSourceUrl`
+come from canonical identity evidence when a broad-board result points at a
+known ATS or employer-owned posting. The jobs list accepts `minFitScore` and
+`maxFitScore` query parameters, and the same score bounds are accepted by
+all-matching bulk job mutations.
 `POST /v1/jobs/:key/score-correction` writes a new corrected `job_scores`
 version, records `ScoreCorrected`, and updates the versioned `scoring_policies`
 table with a correction-derived calibration anchor. It mirrors the Python
@@ -106,6 +108,9 @@ metadata are visible as columns instead of compact badges:
   `GET /v1/discovery/manual-capture` expose the local review queues. Located
   parseable source candidates are auto-promoted into the active source registry;
   these queues are for blocked, ambiguous, unparseable, or legacy pending work.
+  JobSpy direct URLs feed this same loop: known ATS URLs are promoted into the
+  source registry, while unknown or ambiguous owner URLs remain visible for
+  review.
 - `POST /v1/discovery/locator-candidates/:candidateId/promote` promotes a
   legacy source locator candidate into an active source registry entry and emits
   `SourceLocationCandidatePromoted`.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -574,6 +574,8 @@ export interface JobSummary {
   company: string;
   source: string;
   discoverySource: string;
+  postingSource: string;
+  postingSourceUrl: string | null;
   strategy: string;
   location: string;
   salary: string;

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -11,10 +11,11 @@ import logging
 import re
 import sqlite3
 import time
+import hashlib
 from datetime import datetime, timezone
 
 from jobhunter import config
-from jobhunter.database import get_connection, init_db, resurface_deleted_job
+from jobhunter.database import ensure_source_observation_tables, get_connection, init_db, resurface_deleted_job
 from jobhunter.domain.discovery.identity import normalize_observed_url
 from jobhunter.domain.job_content_identity import job_content_fingerprint, normalize_identity_text
 
@@ -148,7 +149,13 @@ def _location_ok(
 # -- DB storage (JobSpy DataFrame -> SQLite) ---------------------------------
 
 
-def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit: int = 0) -> tuple[int, int]:
+def store_jobspy_results(
+    conn: sqlite3.Connection,
+    df,
+    source_label: str,
+    limit: int = 0,
+    run_id: str = "jobspy",
+) -> tuple[int, int]:
     """Store JobSpy DataFrame results into the DB. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
     new = 0
@@ -195,8 +202,11 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
             full_description = description
             detail_scraped_at = now
 
-        # Extract apply URL if JobSpy provided it
-        apply_url = str(row.get("job_url_direct", "")) if str(row.get("job_url_direct", "")) != "nan" else None
+        # Extract apply URL if JobSpy provided it. JobSpy's board URL remains
+        # the discovery observation; this direct URL can identify who owns the
+        # posting for future direct discovery.
+        apply_url = _nullable_str(row.get("job_url_direct"))
+        source_id = _jobspy_source_id(site_label)
 
         duplicate_url = _find_existing_content_duplicate(
             conn,
@@ -210,7 +220,22 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
                 conn,
                 surviving_url=duplicate_url,
                 duplicate_url=url,
-                source=_jobspy_source_id(site_label),
+                source=source_id,
+                observed_at=now,
+            )
+            _record_jobspy_source_observation(
+                conn,
+                job_url=duplicate_url,
+                observed_url=url,
+                source_id=source_id,
+                run_id=run_id,
+                observed_at=now,
+            )
+            _learn_posting_source(
+                conn,
+                job_url=duplicate_url,
+                posting_url=apply_url,
+                discovered_via_source_id=source_id,
                 observed_at=now,
             )
             resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
@@ -237,6 +262,21 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
                     detail_scraped_at,
                 ),
             )
+            _record_jobspy_source_observation(
+                conn,
+                job_url=url,
+                observed_url=url,
+                source_id=source_id,
+                run_id=run_id,
+                observed_at=now,
+            )
+            _learn_posting_source(
+                conn,
+                job_url=url,
+                posting_url=apply_url,
+                discovered_via_source_id=source_id,
+                observed_at=now,
+            )
             new += 1
         except sqlite3.IntegrityError:
             duplicate_url = _find_stored_content_duplicate_survivor(conn, url=url)
@@ -245,7 +285,22 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
                     conn,
                     surviving_url=duplicate_url,
                     duplicate_url=url,
-                    source=_jobspy_source_id(site_label),
+                    source=source_id,
+                    observed_at=now,
+                )
+                _record_jobspy_source_observation(
+                    conn,
+                    job_url=duplicate_url,
+                    observed_url=url,
+                    source_id=source_id,
+                    run_id=run_id,
+                    observed_at=now,
+                )
+                _learn_posting_source(
+                    conn,
+                    job_url=duplicate_url,
+                    posting_url=apply_url,
+                    discovered_via_source_id=source_id,
                     observed_at=now,
                 )
                 resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
@@ -268,6 +323,21 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
                         payload={"company": company, "source": site_label},
                         occurred_at=now,
                     )
+            _record_jobspy_source_observation(
+                conn,
+                job_url=url,
+                observed_url=url,
+                source_id=source_id,
+                run_id=run_id,
+                observed_at=now,
+            )
+            _learn_posting_source(
+                conn,
+                job_url=url,
+                posting_url=apply_url,
+                discovered_via_source_id=source_id,
+                observed_at=now,
+            )
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
@@ -276,8 +346,10 @@ def store_jobspy_results(conn: sqlite3.Connection, df, source_label: str, limit:
 
 
 def _nullable_str(value: object) -> str | None:
+    if value is None:
+        return None
     text = str(value).strip()
-    if not text or text == "nan":
+    if not text or text.casefold() in {"nan", "none", "nat", "<na>"}:
         return None
     return text
 
@@ -285,6 +357,112 @@ def _nullable_str(value: object) -> str | None:
 def _jobspy_source_id(source_label: str) -> str:
     slug = _SOURCE_SLUG_RE.sub("-", source_label.strip().lower()).strip("-")
     return f"jobspy:{slug or 'source'}"
+
+
+def _record_jobspy_source_observation(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    observed_url: str,
+    source_id: str,
+    run_id: str,
+    observed_at: str,
+) -> None:
+    ensure_source_observation_tables(conn)
+    normalized = normalize_observed_url(observed_url)
+    source_native_id = normalized or observed_url
+    observation_id = "jobspy:" + hashlib.sha256(
+        f"{source_id}:{source_native_id}".encode("utf-8")
+    ).hexdigest()[:24]
+    updated = conn.execute(
+        """
+        UPDATE job_source_observations SET
+            source_observation_id = ?,
+            job_url = ?,
+            observed_url = ?,
+            normalized_observed_url = ?,
+            run_id = ?,
+            observed_at = ?
+        WHERE tenant_id = 'local' AND source_id = ? AND source_native_id = ?
+        """,
+        (observation_id, job_url, observed_url, normalized, run_id, observed_at, source_id, source_native_id),
+    )
+    if updated.rowcount == 0:
+        updated = conn.execute(
+            """
+            UPDATE job_source_observations SET
+                source_observation_id = ?,
+                job_url = ?,
+                source_id = ?,
+                source_native_id = ?,
+                observed_url = ?,
+                run_id = ?,
+                observed_at = ?
+            WHERE tenant_id = 'local' AND normalized_observed_url = ?
+            """,
+            (observation_id, job_url, source_id, source_native_id, observed_url, run_id, observed_at, normalized),
+        )
+    if updated.rowcount == 0:
+        conn.execute(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id,
+                source_native_id, observed_url, normalized_observed_url,
+                run_id, observed_at
+            ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (observation_id, job_url, source_id, source_native_id, observed_url, normalized, run_id, observed_at),
+        )
+    from jobhunter.state import record_job_event
+
+    record_job_event(
+        conn,
+        job_url,
+        "discover",
+        "JobSourceObserved",
+        message="Job source observed.",
+        payload={
+            "tenantId": "local",
+            "job_id": job_url,
+            "jobId": job_url,
+            "source_observation_id": observation_id,
+            "sourceObservationId": observation_id,
+            "source_id": source_id,
+            "sourceId": source_id,
+            "source_native_id": source_native_id,
+            "sourceNativeId": source_native_id,
+            "observed_url": observed_url,
+            "observedUrl": observed_url,
+            "run_id": run_id,
+            "runId": run_id,
+            "observed_at": observed_at,
+            "observedAt": observed_at,
+        },
+        occurred_at=observed_at,
+    )
+
+
+def _learn_posting_source(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    posting_url: str | None,
+    discovered_via_source_id: str,
+    observed_at: str,
+) -> None:
+    if not posting_url:
+        return
+    from jobhunter.infrastructure.discovery.production_wiring import (
+        learn_posting_source_from_url,
+    )
+
+    learn_posting_source_from_url(
+        conn,
+        job_url=job_url,
+        posting_url=posting_url,
+        discovered_via_source_id=discovered_via_source_id,
+        observed_at=observed_at,
+    )
 
 
 def _find_existing_content_duplicate(
@@ -467,6 +645,7 @@ def _run_one_search(
     local_accept_locs: list[str],
     glassdoor_map: dict,
     limit: int = 0,
+    run_id: str = "jobspy",
 ) -> dict:
     """Run a single search query and store results in DB."""
     s = search
@@ -576,7 +755,7 @@ def _run_one_search(
     filtered = location_filtered + title_filtered
 
     conn = get_connection()
-    new, existing = store_jobspy_results(conn, df, s["query"], limit=limit)
+    new, existing = store_jobspy_results(conn, df, s["query"], limit=limit, run_id=run_id)
 
     msg = f"[{label}] {before} results -> {new} new, {existing} dupes"
     if location_filtered:
@@ -670,6 +849,7 @@ def _full_crawl(
     proxy: str | None = None,
     max_retries: int = 2,
     limit: int = 0,
+    run_id: str = "jobspy",
 ) -> dict:
     """Run all search queries from search config across all locations."""
     if sites is None:
@@ -732,6 +912,7 @@ def _full_crawl(
             local_accept_locs,
             glassdoor_map,
             limit=remaining if limit > 0 else 0,
+            run_id=run_id,
         )
         completed += 1
         total_new += result["new"]
@@ -779,7 +960,7 @@ def _full_crawl(
 # -- Public entry point ------------------------------------------------------
 
 
-def run_discovery(cfg: dict | None = None, limit: int = 0) -> dict:
+def run_discovery(cfg: dict | None = None, limit: int = 0, run_id: str | None = None) -> dict:
     """Main entry point for JobSpy-based job discovery.
 
     Loads search queries and locations from the user's search config YAML,
@@ -815,4 +996,5 @@ def run_discovery(cfg: dict | None = None, limit: int = 0) -> dict:
         hours_old=hours_old,
         proxy=proxy,
         limit=limit,
+        run_id=run_id or "jobspy",
     )

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -25,7 +25,7 @@ from jobhunter.database import (
     ensure_posting_snapshot_tables,
     ensure_source_observation_tables,
 )
-from jobhunter.domain.discovery.identity import AtsKind
+from jobhunter.domain.discovery.identity import AtsKind, CanonicalJobIdentity
 from jobhunter.domain.discovery.source_registry import (
     LocatorPolicy,
     ManualActionReason,
@@ -79,6 +79,16 @@ class SourceControlSeedSummary:
     registry_rows: int = 0
     locator_candidates: int = 0
     manual_action_count: int = 0
+
+
+@dataclass(frozen=True)
+class LearnedPostingSource:
+    """Outcome of learning a durable posting source from a discovered job."""
+
+    source_id: str | None
+    canonical_url: str | None
+    candidate_id: str | None
+    action: str
 
 
 @dataclass(frozen=True)
@@ -281,6 +291,102 @@ def run_deterministic_source_locator(
             _delete_locator_candidate(conn, candidate.candidate_id)
     conn.commit()
     return persisted, manual_actions
+
+
+def learn_posting_source_from_url(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    posting_url: str | None,
+    discovered_via_source_id: str,
+    observed_at: str,
+) -> LearnedPostingSource:
+    """Learn a durable owner source from a broad-board posting URL.
+
+    JobSpy often discovers a posting on a broad board while also exposing a
+    direct apply/detail URL. When that direct URL is a known ATS, promote the
+    owning ATS source into the registry and attach canonical identity to the
+    broad-board job. Unknown direct URLs are kept in local review queues.
+    """
+
+    candidate_url = str(posting_url or "").strip()
+    if not candidate_url:
+        return LearnedPostingSource(
+            source_id=None,
+            canonical_url=None,
+            candidate_id=None,
+            action="skipped",
+        )
+
+    ensure_worker_discovery_tables(conn)
+    detected = _detect_ats_kind(candidate_url)
+    if detected is None:
+        candidate = _source_location_candidate(
+            candidate_url=candidate_url,
+            source_kind=SourceKind.EMPLOYER_CAREERS_PAGE,
+            confidence=0.55,
+            detected_ats_kind=None,
+            employer_domain_matched=False,
+            source_id=None,
+            manual_reason=ManualActionReason.AMBIGUOUS_CAREER_SYSTEM,
+            retry_context={
+                "source": "broad_board_posting_url",
+                "discovered_via_source_id": discovered_via_source_id,
+                "job_url": job_url,
+            },
+        )
+        if _locator_candidate_is_new(conn, candidate):
+            _record_locator_event(conn, candidate)
+        _upsert_locator_candidate(conn, candidate)
+        _enqueue_manual_action_from_candidate(conn, candidate)
+        conn.commit()
+        return LearnedPostingSource(
+            source_id=None,
+            canonical_url=candidate_url,
+            candidate_id=candidate.candidate_id,
+            action="manual_review",
+        )
+
+    candidate = _source_location_candidate(
+        candidate_url=candidate_url,
+        source_kind=SourceKind.ATS_API,
+        confidence=0.82,
+        detected_ats_kind=detected.value,
+        employer_domain_matched=False,
+        source_id=discovered_via_source_id,
+        manual_reason=None,
+        retry_context={
+            "source": "broad_board_posting_url",
+            "discovered_via_source_id": discovered_via_source_id,
+            "job_url": job_url,
+        },
+    )
+    source_id = _source_id_from_locator_candidate(conn, candidate)
+    _promote_locator_candidate(conn, candidate)
+    identity = CanonicalJobIdentity(
+        canonical_url=candidate_url,
+        ats_kind=detected,
+        source_native_id=_source_native_id_from_url(candidate_url),
+        confidence=0.82,
+    )
+    SqliteJobRepository(conn).set_canonical_identity(
+        candidate.tenant_id,
+        JobId(job_url),
+        identity,
+    )
+    _record_canonical_identity_resolved_event(
+        conn,
+        job_url=job_url,
+        identity=identity,
+        occurred_at=observed_at,
+    )
+    conn.commit()
+    return LearnedPostingSource(
+        source_id=source_id,
+        canonical_url=candidate_url,
+        candidate_id=candidate.candidate_id,
+        action="promoted",
+    )
 
 
 def enqueue_manual_action_for_sources(
@@ -969,6 +1075,35 @@ def _record_source_registry_updated_event(
     )
 
 
+def _record_canonical_identity_resolved_event(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    identity: CanonicalJobIdentity,
+    occurred_at: str,
+) -> None:
+    record_job_event(
+        conn,
+        job_url,
+        "discover",
+        "CanonicalJobIdentityResolved",
+        message="Canonical job identity resolved.",
+        payload={
+            "tenantId": str(LOCAL_TENANT),
+            "job_id": job_url,
+            "jobId": job_url,
+            "canonical_url": identity.canonical_url,
+            "canonicalUrl": identity.canonical_url,
+            "ats_kind": identity.ats_kind.value,
+            "atsKind": identity.ats_kind.value,
+            "source_native_id": identity.source_native_id,
+            "sourceNativeId": identity.source_native_id,
+            "confidence": identity.confidence,
+        },
+        occurred_at=occurred_at,
+    )
+
+
 def _enqueue_manual_action_from_candidate(
     conn: sqlite3.Connection,
     candidate: SourceLocationCandidate,
@@ -1118,6 +1253,22 @@ def _policy_id_for_promoted_source(
 
 def _slug_text(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-") or "source"
+
+
+def _source_native_id_from_url(url: str) -> str:
+    parsed = urlparse(url)
+    segments = [segment for segment in parsed.path.split("/") if segment]
+    if "jobs" in segments:
+        index = segments.index("jobs")
+        if len(segments) > index + 1:
+            return segments[index + 1]
+    if "postings" in segments:
+        index = segments.index("postings")
+        if len(segments) > index + 2:
+            return segments[index + 2]
+    if segments:
+        return segments[-1]
+    return url
 
 
 def _record_ats_source_failure(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -347,6 +347,53 @@ def learn_posting_source_from_url(
             action="manual_review",
         )
 
+    identity = CanonicalJobIdentity(
+        canonical_url=candidate_url,
+        ats_kind=detected,
+        source_native_id=_source_native_id_from_url(candidate_url),
+        confidence=0.82,
+    )
+    SqliteJobRepository(conn).set_canonical_identity(
+        LOCAL_TENANT,
+        JobId(job_url),
+        identity,
+    )
+    _record_canonical_identity_resolved_event(
+        conn,
+        job_url=job_url,
+        identity=identity,
+        occurred_at=observed_at,
+    )
+
+    if detected is AtsKind.WORKDAY:
+        candidate = _source_location_candidate(
+            candidate_url=candidate_url,
+            source_kind=SourceKind.ATS_API,
+            confidence=0.82,
+            detected_ats_kind=detected.value,
+            employer_domain_matched=False,
+            source_id=None,
+            manual_reason=ManualActionReason.AMBIGUOUS_CAREER_SYSTEM,
+            retry_context={
+                "source": "broad_board_posting_url",
+                "discovered_via_source_id": discovered_via_source_id,
+                "job_url": job_url,
+                "ats_kind": detected.value,
+                "reason": "workday_adapter_config_required",
+            },
+        )
+        if _locator_candidate_is_new(conn, candidate):
+            _record_locator_event(conn, candidate)
+        _upsert_locator_candidate(conn, candidate)
+        _enqueue_manual_action_from_candidate(conn, candidate)
+        conn.commit()
+        return LearnedPostingSource(
+            source_id=None,
+            canonical_url=candidate_url,
+            candidate_id=candidate.candidate_id,
+            action="manual_review",
+        )
+
     candidate = _source_location_candidate(
         candidate_url=candidate_url,
         source_kind=SourceKind.ATS_API,
@@ -363,23 +410,6 @@ def learn_posting_source_from_url(
     )
     source_id = _source_id_from_locator_candidate(conn, candidate)
     _promote_locator_candidate(conn, candidate)
-    identity = CanonicalJobIdentity(
-        canonical_url=candidate_url,
-        ats_kind=detected,
-        source_native_id=_source_native_id_from_url(candidate_url),
-        confidence=0.82,
-    )
-    SqliteJobRepository(conn).set_canonical_identity(
-        candidate.tenant_id,
-        JobId(job_url),
-        identity,
-    )
-    _record_canonical_identity_resolved_event(
-        conn,
-        job_url=job_url,
-        identity=identity,
-        occurred_at=observed_at,
-    )
     conn.commit()
     return LearnedPostingSource(
         source_id=source_id,

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -1093,7 +1093,7 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
     search_cfg = config.load_search_config() or {}
     jobspy_sources = schedule.for_prefix("jobspy")
 
-    def run_jobspy() -> dict:
+    def run_jobspy(run_id: str | None = None) -> dict:
         if search_cfg.get("disable_jobspy", False):
             console.print("  [dim]JobSpy disabled in searches.yaml[/dim]")
             result = {"new": 0, "existing": 0, "errors": 0, "db_total": 0, "queries": 0}
@@ -1113,10 +1113,27 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
             result = {"new": 0, "existing": 0, "errors": 0, "db_total": 0, "queries": 0}
             source_results["jobspy"] = result
             return result
-        source_results["jobspy"] = run_discovery(
-            cfg=jobspy_cfg,
-            limit=_scheduled_limit(schedule, "jobspy", limit),
-        )
+        jobspy_limit = _scheduled_limit(schedule, "jobspy", limit)
+        try:
+            signature = inspect.signature(run_discovery)
+        except (TypeError, ValueError):
+            accepts_run_id = False
+        else:
+            accepts_run_id = (
+                "run_id" in signature.parameters
+                or any(
+                    param.kind is inspect.Parameter.VAR_KEYWORD
+                    for param in signature.parameters.values()
+                )
+            )
+        if accepts_run_id:
+            source_results["jobspy"] = run_discovery(
+                cfg=jobspy_cfg,
+                limit=jobspy_limit,
+                run_id=run_id,
+            )
+        else:
+            source_results["jobspy"] = run_discovery(cfg=jobspy_cfg, limit=jobspy_limit)
         return source_results["jobspy"]
 
     stats["jobspy"] = _run_discovery_source(

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -66,7 +66,8 @@ def test_jobspy_filters_results_by_target_title(monkeypatch):
             ]
         )
 
-    def fake_store(_conn, df, _source_label: str, limit: int = 0) -> tuple[int, int]:
+    def fake_store(_conn, df, _source_label: str, limit: int = 0, run_id: str = "jobspy") -> tuple[int, int]:
+        assert run_id == "jobspy"
         stored_titles.extend(df["title"].tolist())
         return len(df), 0
 
@@ -124,7 +125,8 @@ def test_jobspy_remote_search_rejects_non_remote_country_only_location(monkeypat
             ]
         )
 
-    def fake_store(_conn, df, _source_label: str, limit: int = 0) -> tuple[int, int]:
+    def fake_store(_conn, df, _source_label: str, limit: int = 0, run_id: str = "jobspy") -> tuple[int, int]:
+        assert run_id == "jobspy"
         stored_locations.extend(df["location"].tolist())
         return len(df), 0
 
@@ -213,10 +215,200 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         ).fetchone()
         assert row["company"] == "Keyrock"
         event = conn.execute(
-            "SELECT event_type FROM job_events WHERE job_url = ? ORDER BY event_id DESC LIMIT 1",
+            "SELECT event_type FROM job_events WHERE job_url = ? AND event_type = 'JobMetadataUpdated' LIMIT 1",
             ("https://www.linkedin.com/jobs/view/1",),
         ).fetchone()
         assert event["event_type"] == "JobMetadataUpdated"
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        direct_url = "https://boards.greenhouse.io/acme/jobs/123456"
+        frame = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/4416248661",
+                    "job_url_direct": direct_url,
+                    "title": "Staff Platform Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
+
+        observation = conn.execute(
+            """
+            SELECT source_id, observed_url, run_id
+            FROM job_source_observations
+            WHERE job_url = ?
+            """,
+            ("https://www.linkedin.com/jobs/view/4416248661",),
+        ).fetchone()
+        assert observation["source_id"] == "jobspy:linkedin"
+        assert observation["observed_url"] == "https://www.linkedin.com/jobs/view/4416248661"
+        assert observation["run_id"] == "jobspy"
+
+        identity = conn.execute(
+            """
+            SELECT canonical_url, ats_kind, source_native_id, confidence
+            FROM job_canonical_identities
+            WHERE job_url = ?
+            """,
+            ("https://www.linkedin.com/jobs/view/4416248661",),
+        ).fetchone()
+        assert identity["canonical_url"] == direct_url
+        assert identity["ats_kind"] == "greenhouse"
+        assert identity["source_native_id"] == "123456"
+        assert identity["confidence"] == 0.82
+
+        source = conn.execute(
+            """
+            SELECT source_id, kind, priority, state, seed_url
+            FROM source_registry_entries
+            WHERE source_id = 'greenhouse:acme'
+            """
+        ).fetchone()
+        assert dict(source) == {
+            "source_id": "greenhouse:acme",
+            "kind": "ats_api",
+            "priority": "canonical",
+            "state": "active",
+            "seed_url": direct_url,
+        }
+
+        events = {
+            row["event_type"]
+            for row in conn.execute("SELECT event_type FROM job_events").fetchall()
+        }
+        assert {
+            "JobSourceObserved",
+            "SourceRegistryEntryCreated",
+            "SourceLocationCandidatePromoted",
+            "CanonicalJobIdentityResolved",
+        }.issubset(events)
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_deduplicates_learned_sources_for_same_owner(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        frame = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/1",
+                    "job_url_direct": "https://boards.greenhouse.io/acme/jobs/111",
+                    "title": "Staff Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.indeed.com/viewjob?jk=2",
+                    "job_url_direct": "https://boards.greenhouse.io/acme/jobs/222",
+                    "title": "Principal Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (2, 0)
+
+        source_count = conn.execute(
+            "SELECT COUNT(*) FROM source_registry_entries WHERE source_id = 'greenhouse:acme'"
+        ).fetchone()[0]
+        assert source_count == 1
+        identities = conn.execute(
+            "SELECT COUNT(*) FROM job_canonical_identities WHERE ats_kind = 'greenhouse'"
+        ).fetchone()[0]
+        assert identities == 2
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_surfaces_ambiguous_direct_urls_for_source_review(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        direct_url = "https://careers.example.com/platform-engineer"
+        frame = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/9",
+                    "job_url_direct": direct_url,
+                    "title": "Platform Engineer",
+                    "company": "Example",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
+
+        candidate = conn.execute(
+            """
+            SELECT candidate_url, source_kind, confidence, manual_action_reason
+            FROM source_locator_candidates
+            WHERE candidate_url = ?
+            """,
+            (direct_url,),
+        ).fetchone()
+        assert candidate["source_kind"] == "employer_careers_page"
+        assert candidate["confidence"] == 0.55
+        assert candidate["manual_action_reason"] == "ambiguous_career_system"
+
+        manual = conn.execute(
+            """
+            SELECT originating_url, reason, status
+            FROM manual_capture_queue
+            WHERE originating_url = ?
+            """,
+            (direct_url,),
+        ).fetchone()
+        assert manual["reason"] == "ambiguous_career_system"
+        assert manual["status"] == "pending"
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_ignores_missing_direct_url_for_source_learning(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        frame = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/10",
+                    "job_url_direct": None,
+                    "title": "Platform Engineer",
+                    "company": "Example",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
+
+        job = conn.execute(
+            "SELECT application_url FROM jobs WHERE url = ?",
+            ("https://www.linkedin.com/jobs/view/10",),
+        ).fetchone()
+        assert job["application_url"] is None
+        assert conn.execute("SELECT COUNT(*) FROM job_canonical_identities").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM source_locator_candidates").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM manual_capture_queue").fetchone()[0] == 0
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -382,6 +382,71 @@ def test_jobspy_surfaces_ambiguous_direct_urls_for_source_review(tmp_path):
         close_connection(db_path)
 
 
+def test_jobspy_keeps_learned_workday_sources_in_review_until_runnable(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        direct_url = "https://acme.wd1.myworkdayjobs.com/en-US/acme/job/Platform-Engineer_JR-123"
+        frame = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/12",
+                    "job_url_direct": direct_url,
+                    "title": "Platform Engineer",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, frame, "Platform", limit=10) == (1, 0)
+
+        identity = conn.execute(
+            """
+            SELECT canonical_url, ats_kind, source_native_id
+            FROM job_canonical_identities
+            WHERE job_url = ?
+            """,
+            ("https://www.linkedin.com/jobs/view/12",),
+        ).fetchone()
+        assert identity["canonical_url"] == direct_url
+        assert identity["ats_kind"] == "workday"
+        assert identity["source_native_id"] == "Platform-Engineer_JR-123"
+
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM source_registry_entries WHERE source_id LIKE 'workday:%'"
+            ).fetchone()[0]
+            == 0
+        )
+
+        candidate = conn.execute(
+            """
+            SELECT candidate_url, source_kind, detected_ats_kind, manual_action_reason
+            FROM source_locator_candidates
+            WHERE candidate_url = ?
+            """,
+            (direct_url,),
+        ).fetchone()
+        assert candidate["source_kind"] == "ats_api"
+        assert candidate["detected_ats_kind"] == "workday"
+        assert candidate["manual_action_reason"] == "ambiguous_career_system"
+
+        manual = conn.execute(
+            """
+            SELECT originating_url, reason, status
+            FROM manual_capture_queue
+            WHERE originating_url = ?
+            """,
+            (direct_url,),
+        ).fetchone()
+        assert manual["reason"] == "ambiguous_career_system"
+        assert manual["status"] == "pending"
+    finally:
+        close_connection(db_path)
+
+
 def test_jobspy_ignores_missing_direct_url_for_source_learning(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)


### PR DESCRIPTION
## Summary
- Record JobSpy broad-board source observations with run provenance and learn owner sources from direct posting URLs.
- Promote runnable ATS direct URLs into the source registry, attach canonical job identities, dedupe repeated owner sources, and queue ambiguous or not-yet-runnable owner URLs for review.
- Expose posting-owner provenance in the jobs API and Jobs UI alongside the source that discovered the job.

## Validation
- `git diff --check`
- `pnpm check`
- `pnpm test` -> API 118 passed, web build passed, Python 888 passed.
- `pnpm --filter @jobhunter/web test -- src/views/jobs/JobsTable.test.tsx src/views/jobs/JobOverview.test.tsx` -> 97 files, 479 tests passed.
- Review gate: PASS, no Blocker/High findings.
- QA gate: PASS, no Blocker/High findings.
- QA ingestion probe: 3 JobSpy jobs stored, 3 `JobSourceObserved` rows, 2 canonical Greenhouse identities, 1 deduped `greenhouse:acme` source, and 1 ambiguous owner URL queued for review.
- API QA: `GET /v1/jobs` and `GET /v1/jobs?source=greenhouse%3Aacme` returned split discovered-source/posting-owner provenance.
- Browser QA: Jobs table and detail drawer showed `posting greenhouse:acme` plus `discovered via jobspy:linkedin/indeed`, with no `posting LinkedIn` fallback and no console errors.

## Limitations
- Source learning currently depends on JobSpy providing `job_url_direct` or equivalent direct posting evidence.
- Unknown owner URLs are queued for review rather than automatically parsed.
- ATS URLs that need extra adapter configuration, such as learned Workday direct URLs, are canonicalized for the job and surfaced for review instead of being promoted into active registry rows.
- Newly learned sources are registered for future direct discovery; this change does not crawl a newly learned source inside the same JobSpy run.