### PR TITLE
feat: standardize data grid tables

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -1450,7 +1450,7 @@ export function listWorkflowRuns(
 ): PaginatedResponse<WorkflowRunSummary> {
   refreshProjections(db, DEFAULT_TENANT);
   if (!tableExists(db, "apply_run_projections")) {
-    return paginate([], query.page, query.pageSize, "started_at", "desc", {
+    return paginate([], query.page, query.pageSize, query.sort, query.dir, {
       status: query.status,
     });
   }
@@ -1478,9 +1478,31 @@ export function listWorkflowRuns(
   const all = rows
     .map(rowToWorkflowRunSummary)
     .filter((run) => query.status === "all" || run.status === query.status);
-  return paginate(all, query.page, query.pageSize, "started_at", "desc", {
+  all.sort((left, right) => compareWorkflowRuns(left, right, query.sort, query.dir));
+  return paginate(all, query.page, query.pageSize, query.sort, query.dir, {
     status: query.status,
   });
+}
+
+function compareWorkflowRuns(
+  left: WorkflowRunSummary,
+  right: WorkflowRunSummary,
+  field: string,
+  direction: "asc" | "desc",
+): number {
+  const multiplier = direction === "asc" ? 1 : -1;
+  const values: Record<string, [unknown, unknown]> = {
+    started_at: [left.startedAt, right.startedAt],
+    finished_at: [left.finishedAt, right.finishedAt],
+    duration_ms: [left.durationMs ?? -1, right.durationMs ?? -1],
+    title: [left.title, right.title],
+    company: [left.company, right.company],
+    status: [left.status, right.status],
+    model: [left.model ?? "", right.model ?? ""],
+    dry_run: [left.dryRun ? 1 : 0, right.dryRun ? 1 : 0],
+  };
+  const [leftValue, rightValue] = values[field] ?? values.started_at!;
+  return compareValues(leftValue, rightValue) * multiplier;
 }
 
 function rowToWorkflowRunSummary(row: ApplyRunProjectionRow): WorkflowRunSummary {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1268,6 +1268,21 @@ describe("local TypeScript API", () => {
       });
       expect(body.pagination).toMatchObject({ page: 1, total: 1, pages: 1 });
       expect(body.filter).toMatchObject({ status: "all" });
+      expect(body.sort).toMatchObject({ field: "started_at", dir: "desc" });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("accepts workflow run sort fields", async () => {
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/workflow-runs?sort=title&dir=asc",
+      });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().sort).toMatchObject({ field: "title", dir: "asc" });
     } finally {
       await app.close();
     }

--- a/apps/web/src/contexts/apply/components/ApplyHistory.stories.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyHistory.stories.tsx
@@ -5,10 +5,9 @@ import { sampleDashboardSummary } from "../../../test/fixtures/projections.js";
 import { ApplyHistory } from "./ApplyHistory.js";
 
 // ApplyHistory rows wrap a TanStack Router <Link> around badge/icon
-// content and inherit the same DataTable / FilterBar tree when embedded
-// in JobDetailDrawer. The Link surface lacks discernible text in the
-// production component (a button-name violation). Deferred — production
-// code, out of Phase 7 scope.
+// content. The Link surface lacks discernible text in the production
+// component (a button-name violation). Deferred — production code, out
+// of Phase 7 scope.
 const meta = {
   title: "Contexts/Apply/ApplyHistory",
   component: ApplyHistory,

--- a/apps/web/src/contexts/discovery/components/DiscoveryProductControls.test.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryProductControls.test.tsx
@@ -177,21 +177,24 @@ describe("DiscoveryProductControls", () => {
 
     const user = userEvent.setup();
     await user.click(
-      screen.getByRole("button", { name: /open table filters/i }),
+      screen.getByRole("button", { name: /filter company column/i }),
     );
     await user.type(screen.getByLabelText("Company filter text"), "sales");
     expect(within(sourceTable).getByText("Salesforce")).toBeInTheDocument();
     expect(within(sourceTable).queryByText("Indeed")).not.toBeInTheDocument();
     await user.clear(screen.getByLabelText("Company filter text"));
+    await user.click(screen.getByRole("button", { name: /close/i }));
 
-    await user.click(screen.getByRole("button", { name: /observed/i }));
-    await user.click(screen.getByRole("button", { name: /observed/i }));
+    await user.click(screen.getByRole("button", { name: /sort by observed/i }));
+    await user.click(
+      screen.getByRole("button", { name: /sort by observed \(ascending\)/i }),
+    );
 
     const rows = within(sourceTable).getAllByRole("row");
     expect(within(rows[1]!).getByText("Indeed")).toBeInTheDocument();
 
     await user.click(
-      screen.getByRole("button", { name: /open table filters/i }),
+      screen.getByRole("button", { name: /filter state column/i }),
     );
     await user.click(screen.getByRole("checkbox", { name: "active" }));
     await waitFor(() => {

--- a/apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx
@@ -560,12 +560,14 @@ function SourceRegistryPanel({
         label: "Observed",
         render: (source) => source.observedJobs,
         getSortValue: (source) => source.observedJobs,
+        getFilterValue: (source) => String(source.observedJobs),
       },
       {
         id: "newJobs",
         label: "New",
         render: (source) => source.newJobs,
         getSortValue: (source) => source.newJobs,
+        getFilterValue: (source) => String(source.newJobs),
       },
       {
         id: "lastRunCompletedAt",
@@ -576,12 +578,17 @@ function SourceRegistryPanel({
             : "n/a",
         getSortValue: (source) =>
           source.lastRunCompletedAt ? Date.parse(source.lastRunCompletedAt) : 0,
+        getFilterValue: (source) =>
+          source.lastRunCompletedAt
+            ? new Date(source.lastRunCompletedAt).toLocaleDateString()
+            : "n/a",
       },
       {
         id: "consecutiveFailures",
         label: "Failures",
         render: (source) => source.consecutiveFailures,
         getSortValue: (source) => source.consecutiveFailures,
+        getFilterValue: (source) => String(source.consecutiveFailures),
       },
       {
         id: "activeVerificationRate",
@@ -597,6 +604,7 @@ function SourceRegistryPanel({
           );
         },
         getSortValue: (source) => source.activeVerificationRate ?? -1,
+        getFilterValue: (source) => sourceQualityMetric(source, 0).value,
       },
       {
         id: "fullDescriptionSuccessRate",
@@ -612,6 +620,7 @@ function SourceRegistryPanel({
           );
         },
         getSortValue: (source) => source.fullDescriptionSuccessRate ?? -1,
+        getFilterValue: (source) => sourceQualityMetric(source, 1).value,
       },
       {
         id: "applyUrlSuccessRate",
@@ -627,6 +636,7 @@ function SourceRegistryPanel({
           );
         },
         getSortValue: (source) => source.applyUrlSuccessRate ?? -1,
+        getFilterValue: (source) => sourceQualityMetric(source, 2).value,
       },
       {
         id: "duplicateRate",
@@ -642,6 +652,7 @@ function SourceRegistryPanel({
           );
         },
         getSortValue: (source) => source.duplicateRate ?? -1,
+        getFilterValue: (source) => sourceQualityMetric(source, 3).value,
       },
       {
         id: "actions",
@@ -755,6 +766,8 @@ function SourceRegistryPanel({
         emptyMessage="No sources registered."
         initialSort={{ columnId: "displayName", direction: "asc" }}
         initialFilters={initialFilters}
+        paginate
+        initialPageSize={25}
       />
       <form className="source-upsert-form" onSubmit={submit}>
         <label className="field">

--- a/apps/web/src/routes/-runs.search.ts
+++ b/apps/web/src/routes/-runs.search.ts
@@ -1,8 +1,13 @@
-import { WORKFLOW_RUN_STATUS_FILTERS } from "@jobhunter/contracts";
+import {
+  WORKFLOW_RUN_SORT_FIELDS,
+  WORKFLOW_RUN_STATUS_FILTERS,
+} from "@jobhunter/contracts";
 import { z } from "zod";
 
 export const runsSearchSchema = z.object({
   status: z.enum(WORKFLOW_RUN_STATUS_FILTERS).default("all"),
+  sort: z.enum(WORKFLOW_RUN_SORT_FIELDS).default("started_at"),
+  dir: z.enum(["asc", "desc"]).default("desc"),
   page: z.number().int().min(1).default(1),
   pageSize: z.number().int().min(1).max(200).default(50),
 });

--- a/apps/web/src/shared/ui/filterable-data-grid.test.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.test.tsx
@@ -60,16 +60,46 @@ function renderGrid() {
 }
 
 describe("FilterableDataGrid", () => {
+  it("paginates local rows after filtering and sorting", async () => {
+    render(
+      <FilterableDataGrid
+        title="Grid view"
+        data={rows}
+        columns={columns}
+        getRowId={(row) => row.id}
+        loading={false}
+        loadingMessage="Loading rows."
+        emptyMessage="No rows."
+        initialSort={{ columnId: "company", direction: "asc" }}
+        paginate
+        initialPageSize={2}
+        pageSizeOptions={[2, 3]}
+      />,
+    );
+    const user = userEvent.setup();
+
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("BoardCo")).toBeInTheDocument();
+    expect(screen.queryByText("Salesforce")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "next" }));
+    expect(screen.queryByText("Acme")).not.toBeInTheDocument();
+    expect(screen.getByText("Salesforce")).toBeInTheDocument();
+  });
+
   it("combines text predicates, multi-select values, and sortable columns", async () => {
     renderGrid();
     const user = userEvent.setup();
+    const table = screen.getByRole("table");
 
     await user.click(
-      screen.getByRole("button", { name: /open table filters/i }),
+      screen.getByRole("button", { name: /filter company column/i }),
     );
     await user.type(screen.getByLabelText("Company filter text"), "ac");
+    expect(
+      document.querySelector('[aria-label="Filter Company column (active)"]'),
+    ).not.toBeNull();
 
-    const table = screen.getByRole("table");
     expect(within(table).getByText("Acme")).toBeInTheDocument();
     expect(within(table).queryByText("BoardCo")).not.toBeInTheDocument();
 
@@ -85,6 +115,7 @@ describe("FilterableDataGrid", () => {
     expect(within(table).queryByText("Acme")).not.toBeInTheDocument();
     expect(within(table).getByText("BoardCo")).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: /close/i }));
     await user.click(
       within(screen.getByLabelText("Active table filters")).getByRole(
         "button",
@@ -92,7 +123,7 @@ describe("FilterableDataGrid", () => {
       ),
     );
     await user.click(
-      screen.getByRole("button", { name: /open table filters/i }),
+      screen.getByRole("button", { name: /filter provider column/i }),
     );
     await user.click(screen.getByRole("checkbox", { name: "Workday ATS" }));
 
@@ -100,14 +131,17 @@ describe("FilterableDataGrid", () => {
     expect(within(table).getByText("Salesforce")).toBeInTheDocument();
     expect(within(table).queryByText("BoardCo")).not.toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: /close/i }));
     await user.click(
       within(screen.getByLabelText("Active table filters")).getByRole(
         "button",
         { name: /Provider/i },
       ),
     );
-    await user.click(screen.getByRole("button", { name: /Observed/i }));
-    await user.click(screen.getByRole("button", { name: /Observed/i }));
+    await user.click(screen.getByRole("button", { name: /sort by observed/i }));
+    await user.click(
+      screen.getByRole("button", { name: /sort by observed \(ascending\)/i }),
+    );
 
     const tableRows = screen.getAllByRole("row");
     expect(within(tableRows[1]!).getByText("BoardCo")).toBeInTheDocument();

--- a/apps/web/src/shared/ui/filterable-data-grid.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.tsx
@@ -1,10 +1,17 @@
 import { Filter, SortAsc, SortDesc, TableProperties, X } from "lucide-react";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
-import { Button } from "./button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog.js";
 import { Empty } from "./empty.js";
 import { Input } from "./input.js";
-import { Popover, PopoverContent, PopoverTrigger } from "./popover.js";
+import { TablePager, type TablePagerProps } from "./table-pager.js";
 
 export type DataGridSortDirection = "asc" | "desc";
 export type DataGridTextOperator = "contains" | "does_not_contain";
@@ -23,7 +30,9 @@ export type DataGridFilterState = Record<
 export interface DataGridColumn<TData> {
   id: string;
   label: string;
-  render: (row: TData) => ReactNode;
+  header?: ReactNode | ((context: DataGridHeaderContext<TData>) => ReactNode);
+  render: (row: TData, context: DataGridCellContext<TData>) => ReactNode;
+  sortable?: boolean;
   getSortValue?: (row: TData) => string | number;
   getFilterValue?: (row: TData) => string;
   getFilterSearchValue?: (row: TData) => string;
@@ -38,6 +47,26 @@ export interface DataGridSortState {
   direction: DataGridSortDirection;
 }
 
+export interface DataGridHeaderContext<TData> {
+  pageRows: readonly TData[];
+  visibleRows: readonly TData[];
+  allRows: readonly TData[];
+}
+
+export interface DataGridCellContext<TData> {
+  rowId: string;
+}
+
+export interface DataGridPaginationState {
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  totalRows?: number;
+  pageSizeOptions?: TablePagerProps["pageSizeOptions"];
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+}
+
 export interface FilterableDataGridProps<TData> {
   title: string;
   data: readonly TData[];
@@ -47,9 +76,23 @@ export interface FilterableDataGridProps<TData> {
   loadingMessage: string;
   emptyMessage: string;
   initialSort: DataGridSortState;
+  sort?: DataGridSortState;
+  onSortChange?: (next: DataGridSortState) => void;
+  manualSorting?: boolean;
   initialFilters?: DataGridFilterState;
+  filters?: DataGridFilterState;
+  onFiltersChange?: (next: DataGridFilterState) => void;
+  manualFiltering?: boolean;
+  paginate?: boolean;
+  initialPageSize?: number;
+  pageSizeOptions?: TablePagerProps["pageSizeOptions"];
+  pagination?: DataGridPaginationState;
   summary?: ReactNode;
   toolbarActions?: ReactNode;
+  tableClassName?: string;
+  rowClassName?: (row: TData) => string | undefined;
+  rowAriaSelected?: (row: TData) => boolean;
+  onRowActivate?: (row: TData) => void;
 }
 
 function emptyFilter(): DataGridTextFilter {
@@ -68,6 +111,19 @@ function compareValues(left: string | number, right: string | number): number {
     numeric: true,
     sensitivity: "base",
   });
+}
+
+function sortButtonLabel(
+  columnLabel: string,
+  activeDirection: DataGridSortDirection | null,
+): string {
+  if (activeDirection === "asc") {
+    return `Sort by ${columnLabel} (ascending)`;
+  }
+  if (activeDirection === "desc") {
+    return `Sort by ${columnLabel} (descending)`;
+  }
+  return `Sort by ${columnLabel}`;
 }
 
 function isActiveFilter(
@@ -90,6 +146,130 @@ function sortedDistinctValues<TData>(
   ).sort((left, right) => compareValues(left, right));
 }
 
+interface ColumnFilterDialogProps<TData> {
+  column: DataGridColumn<TData>;
+  filter: DataGridTextFilter;
+  values: readonly string[];
+  valueQuery: string;
+  active: boolean;
+  onClear: () => void;
+  onOperatorChange: (operator: DataGridTextOperator) => void;
+  onTextChange: (text: string) => void;
+  onValueQueryChange: (text: string) => void;
+  onToggleValue: (value: string) => void;
+}
+
+function ColumnFilterDialog<TData>({
+  column,
+  filter,
+  values,
+  valueQuery,
+  active,
+  onClear,
+  onOperatorChange,
+  onTextChange,
+  onValueQueryChange,
+  onToggleValue,
+}: ColumnFilterDialogProps<TData>) {
+  const normalizedQuery = normalize(valueQuery);
+  const visibleValues = values
+    .filter(
+      (value) => !normalizedQuery || normalize(value).includes(normalizedQuery),
+    )
+    .slice(0, column.filterValueLimit ?? 80);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={
+            active
+              ? "data-grid-column-filter-button active"
+              : "data-grid-column-filter-button"
+          }
+          aria-label={`Filter ${column.label} column${active ? " (active)" : ""}`}
+        >
+          <Filter size={12} aria-hidden="true" />
+        </button>
+      </DialogTrigger>
+      <DialogContent className="data-grid-column-filter-dialog">
+        <DialogHeader>
+          <DialogTitle>{column.label} filter</DialogTitle>
+          <DialogDescription>
+            Show rows where this column matches the selected values and text
+            predicate.
+          </DialogDescription>
+        </DialogHeader>
+        <section className="data-grid-filter-condition">
+          <div className="data-grid-filter-condition-head">
+            <strong>{column.label}</strong>
+            <button type="button" onClick={onClear}>
+              Clear
+            </button>
+          </div>
+          <div
+            className="data-grid-filter-operator"
+            role="group"
+            aria-label={`${column.label} text operator`}
+          >
+            {(["contains", "does_not_contain"] as const).map((operator) => (
+              <button
+                key={operator}
+                type="button"
+                aria-pressed={filter.operator === operator}
+                className={filter.operator === operator ? "active" : undefined}
+                onClick={() => onOperatorChange(operator)}
+              >
+                {operatorLabel(operator)}
+              </button>
+            ))}
+          </div>
+          <label className="data-grid-filter-field">
+            <span>Text predicate</span>
+            <Input
+              aria-label={`${column.label} filter text`}
+              value={filter.text}
+              placeholder={`${column.label} text`}
+              onChange={(event) => onTextChange(event.target.value)}
+            />
+          </label>
+          <label className="data-grid-filter-field">
+            <span>Find values</span>
+            <Input
+              aria-label={`${column.label} value search`}
+              value={valueQuery}
+              placeholder="Search values"
+              onChange={(event) => onValueQueryChange(event.target.value)}
+            />
+          </label>
+          <div
+            className="data-grid-value-list"
+            aria-label={`${column.label} values`}
+          >
+            {visibleValues.map((value) => (
+              <label key={value} className="data-grid-value-option">
+                <input
+                  type="checkbox"
+                  checked={filter.selectedValues.includes(value)}
+                  onChange={() => onToggleValue(value)}
+                />
+                <span>{value}</span>
+              </label>
+            ))}
+            {values.length > visibleValues.length ? (
+              <span className="data-grid-value-overflow">
+                {values.length - visibleValues.length} more values. Use search
+                or text predicate.
+              </span>
+            ) : null}
+          </div>
+        </section>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function FilterableDataGrid<TData>({
   title,
   data,
@@ -99,13 +279,37 @@ export function FilterableDataGrid<TData>({
   loadingMessage,
   emptyMessage,
   initialSort,
+  sort: controlledSort,
+  onSortChange,
+  manualSorting = false,
   initialFilters = {},
+  filters: controlledFilters,
+  onFiltersChange,
+  manualFiltering = false,
+  paginate = false,
+  initialPageSize = 25,
+  pageSizeOptions,
+  pagination,
   summary,
   toolbarActions,
+  tableClassName,
+  rowClassName,
+  rowAriaSelected,
+  onRowActivate,
 }: FilterableDataGridProps<TData>) {
-  const [sort, setSort] = useState<DataGridSortState>(initialSort);
-  const [filters, setFilters] = useState<DataGridFilterState>(initialFilters);
+  const [localSort, setLocalSort] = useState<DataGridSortState>(initialSort);
+  const [localFilters, setLocalFilters] =
+    useState<DataGridFilterState>(initialFilters);
+  const [localPage, setLocalPage] = useState(1);
+  const [localPageSize, setLocalPageSize] = useState(initialPageSize);
   const [valueQueries, setValueQueries] = useState<Record<string, string>>({});
+  const sort = controlledSort ?? localSort;
+  const filters = controlledFilters ?? localFilters;
+  const paginationEnabled = paginate || Boolean(pagination);
+  const page = pagination?.page ?? localPage;
+  const pageSize = pagination?.pageSize ?? localPageSize;
+  const effectivePageSizeOptions =
+    pagination?.pageSizeOptions ?? pageSizeOptions;
 
   const filterableColumns = useMemo(
     () => columns.filter((column) => Boolean(column.getFilterValue)),
@@ -120,41 +324,89 @@ export function FilterableDataGrid<TData>({
   }, [data, filterableColumns]);
 
   const visibleRows = useMemo(() => {
-    const filtered = data.filter((row) =>
-      filterableColumns.every((column) => {
-        if (!column.getFilterValue) return true;
-        const filter = filters[column.id];
-        if (!isActiveFilter(filter)) return true;
-        const value = column.getFilterValue(row);
-        const searchValue = column.getFilterSearchValue?.(row) ?? value;
-        const normalizedValue = normalize(searchValue);
-        const text = normalize(filter?.text ?? "");
-        if (
-          filter?.selectedValues.length &&
-          !filter.selectedValues.includes(value)
-        ) {
-          return false;
-        }
-        if (!text) return true;
-        if (filter.operator === "does_not_contain") {
-          return !normalizedValue.includes(text);
-        }
-        return normalizedValue.includes(text);
-      }),
-    );
+    const filtered = manualFiltering
+      ? data
+      : data.filter((row) =>
+          filterableColumns.every((column) => {
+            if (!column.getFilterValue) return true;
+            const filter = filters[column.id];
+            if (!isActiveFilter(filter)) return true;
+            const value = column.getFilterValue(row);
+            const searchValue = column.getFilterSearchValue?.(row) ?? value;
+            const normalizedValue = normalize(searchValue);
+            const text = normalize(filter?.text ?? "");
+            if (
+              filter?.selectedValues.length &&
+              !filter.selectedValues.includes(value)
+            ) {
+              return false;
+            }
+            if (!text) return true;
+            if (filter.operator === "does_not_contain") {
+              return !normalizedValue.includes(text);
+            }
+            return normalizedValue.includes(text);
+          }),
+        );
 
     const sortColumn = columns.find((column) => column.id === sort.columnId);
-    if (!sortColumn?.getSortValue) return filtered;
+    if (manualSorting || !sortColumn?.getSortValue) return filtered;
     const getSortValue = sortColumn.getSortValue;
     return [...filtered].sort((left, right) => {
       const compared = compareValues(getSortValue(left), getSortValue(right));
       return sort.direction === "asc" ? compared : compared * -1;
     });
-  }, [columns, data, filterableColumns, filters, sort]);
+  }, [
+    columns,
+    data,
+    filterableColumns,
+    filters,
+    manualFiltering,
+    manualSorting,
+    sort,
+  ]);
+
+  useEffect(() => {
+    if (!pagination) {
+      setLocalPage(1);
+    }
+  }, [filters, localPageSize, pagination, sort]);
+
+  const totalRows = pagination?.totalRows ?? visibleRows.length;
+  const totalPages =
+    pagination?.totalPages ?? Math.max(1, Math.ceil(totalRows / pageSize));
+  const safePage = Math.min(Math.max(page, 1), totalPages);
+
+  useEffect(() => {
+    if (pagination || safePage === localPage) return;
+    setLocalPage(safePage);
+  }, [localPage, pagination, safePage]);
+
+  const pageRows = useMemo(() => {
+    if (!paginationEnabled || pagination) return visibleRows;
+    const offset = (safePage - 1) * pageSize;
+    return visibleRows.slice(offset, offset + pageSize);
+  }, [pageSize, pagination, paginationEnabled, safePage, visibleRows]);
+
+  const headerContext = useMemo<DataGridHeaderContext<TData>>(
+    () => ({ pageRows, visibleRows, allRows: data }),
+    [data, pageRows, visibleRows],
+  );
 
   const activeFilters = filterableColumns
     .map((column) => ({ column, filter: filters[column.id] }))
     .filter(({ filter }) => isActiveFilter(filter));
+
+  const setFilters = (
+    updater: (current: DataGridFilterState) => DataGridFilterState,
+  ) => {
+    const next = updater(filters);
+    if (onFiltersChange) {
+      onFiltersChange(next);
+    } else {
+      setLocalFilters(next);
+    }
+  };
 
   const updateFilter = (
     columnId: string,
@@ -170,20 +422,22 @@ export function FilterableDataGrid<TData>({
     setFilters((current) => ({ ...current, [columnId]: emptyFilter() }));
   };
 
-  const clearAllFilters = () => {
-    setFilters({});
-  };
-
   const toggleSort = (column: DataGridColumn<TData>) => {
-    if (!column.getSortValue) return;
-    setSort((current) =>
-      current.columnId === column.id
+    if (!(column.sortable ?? Boolean(column.getSortValue))) return;
+    const next =
+      sort.columnId === column.id
         ? {
             columnId: column.id,
-            direction: current.direction === "asc" ? "desc" : "asc",
+            direction: (sort.direction === "asc"
+              ? "desc"
+              : "asc") as DataGridSortDirection,
           }
-        : { columnId: column.id, direction: "asc" },
-    );
+        : { columnId: column.id, direction: "asc" as const };
+    if (onSortChange) {
+      onSortChange(next);
+    } else {
+      setLocalSort(next);
+    }
   };
 
   const toggleFilterValue = (columnId: string, value: string) => {
@@ -198,159 +452,39 @@ export function FilterableDataGrid<TData>({
     });
   };
 
+  const handlePageChange = (nextPage: number) => {
+    if (pagination) {
+      pagination.onPageChange(nextPage);
+    } else {
+      setLocalPage(nextPage);
+    }
+  };
+
+  const handlePageSizeChange = (nextPageSize: number) => {
+    if (pagination) {
+      pagination.onPageSizeChange(nextPageSize);
+    } else {
+      setLocalPageSize(nextPageSize);
+      setLocalPage(1);
+    }
+  };
+
+  const summaryText = pagination
+    ? `${data.length} shown / ${totalRows ?? data.length} total`
+    : paginationEnabled
+      ? `${pageRows.length} shown / ${visibleRows.length} filtered / ${data.length} loaded`
+      : `${visibleRows.length} shown / ${data.length} loaded`;
+
   return (
     <div className="filterable-data-grid">
       <div className="data-grid-toolbar">
         <div className="data-grid-view-title">
           <TableProperties size={15} aria-hidden="true" />
           <strong>{title}</strong>
-          <span className="meta">
-            {visibleRows.length} shown / {data.length} loaded
-          </span>
+          <span className="meta">{summaryText}</span>
         </div>
         <div className="data-grid-tools">
           {summary}
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                type="button"
-                size="sm"
-                variant={activeFilters.length ? "secondary" : "ghost"}
-                aria-label="Open table filters"
-              >
-                <Filter size={14} aria-hidden="true" />
-                Filter
-                {activeFilters.length ? (
-                  <span>{activeFilters.length}</span>
-                ) : null}
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="data-grid-filter-popover">
-              <div className="data-grid-filter-head">
-                <div>
-                  <strong>Filter records</strong>
-                  <span>Show rows where all active conditions match.</span>
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  disabled={!activeFilters.length}
-                  onClick={clearAllFilters}
-                >
-                  Clear all
-                </Button>
-              </div>
-              <div className="data-grid-filter-list">
-                {filterableColumns.map((column) => {
-                  const filter = filters[column.id] ?? emptyFilter();
-                  const values = distinctValues.get(column.id) ?? [];
-                  const valueQuery = normalize(valueQueries[column.id] ?? "");
-                  const visibleValues = values
-                    .filter(
-                      (value) =>
-                        !valueQuery || normalize(value).includes(valueQuery),
-                    )
-                    .slice(0, column.filterValueLimit ?? 80);
-                  return (
-                    <section
-                      className="data-grid-filter-condition"
-                      key={column.id}
-                    >
-                      <div className="data-grid-filter-condition-head">
-                        <strong>{column.label}</strong>
-                        <button
-                          type="button"
-                          onClick={() => clearFilter(column.id)}
-                        >
-                          Clear
-                        </button>
-                      </div>
-                      <div
-                        className="data-grid-filter-operator"
-                        role="group"
-                        aria-label={`${column.label} text operator`}
-                      >
-                        {(["contains", "does_not_contain"] as const).map(
-                          (operator) => (
-                            <button
-                              key={operator}
-                              type="button"
-                              aria-pressed={filter.operator === operator}
-                              className={
-                                filter.operator === operator
-                                  ? "active"
-                                  : undefined
-                              }
-                              onClick={() =>
-                                updateFilter(column.id, (current) => ({
-                                  ...current,
-                                  operator,
-                                }))
-                              }
-                            >
-                              {operatorLabel(operator)}
-                            </button>
-                          ),
-                        )}
-                      </div>
-                      <label className="data-grid-filter-field">
-                        <span>Text predicate</span>
-                        <Input
-                          aria-label={`${column.label} filter text`}
-                          value={filter.text}
-                          placeholder={`${column.label} text`}
-                          onChange={(event) =>
-                            updateFilter(column.id, (current) => ({
-                              ...current,
-                              text: event.target.value,
-                            }))
-                          }
-                        />
-                      </label>
-                      <label className="data-grid-filter-field">
-                        <span>Find values</span>
-                        <Input
-                          aria-label={`${column.label} value search`}
-                          value={valueQueries[column.id] ?? ""}
-                          placeholder="Search values"
-                          onChange={(event) =>
-                            setValueQueries((current) => ({
-                              ...current,
-                              [column.id]: event.target.value,
-                            }))
-                          }
-                        />
-                      </label>
-                      <div
-                        className="data-grid-value-list"
-                        aria-label={`${column.label} values`}
-                      >
-                        {visibleValues.map((value) => (
-                          <label key={value} className="data-grid-value-option">
-                            <input
-                              type="checkbox"
-                              checked={filter.selectedValues.includes(value)}
-                              onChange={() =>
-                                toggleFilterValue(column.id, value)
-                              }
-                            />
-                            <span>{value}</span>
-                          </label>
-                        ))}
-                        {values.length > visibleValues.length ? (
-                          <span className="data-grid-value-overflow">
-                            {values.length - visibleValues.length} more values.
-                            Use search or text predicate.
-                          </span>
-                        ) : null}
-                      </div>
-                    </section>
-                  );
-                })}
-              </div>
-            </PopoverContent>
-          </Popover>
           {toolbarActions}
         </div>
       </div>
@@ -377,12 +511,27 @@ export function FilterableDataGrid<TData>({
         </div>
       ) : null}
       <div className="filterable-data-grid-scroll">
-        <table className="filterable-data-grid-table">
+        <table
+          className={
+            tableClassName
+              ? `filterable-data-grid-table ${tableClassName}`
+              : "filterable-data-grid-table"
+          }
+        >
           <thead>
             <tr>
               {columns.map((column) => {
                 const active = sort.columnId === column.id;
                 const SortIcon = sort.direction === "desc" ? SortDesc : SortAsc;
+                const sortable =
+                  column.sortable ?? Boolean(column.getSortValue);
+                const filterable = Boolean(column.getFilterValue);
+                const filter = filters[column.id] ?? emptyFilter();
+                const filterActive = isActiveFilter(filter);
+                const header =
+                  typeof column.header === "function"
+                    ? column.header(headerContext)
+                    : (column.header ?? column.label);
                 return (
                   <th
                     key={column.id}
@@ -391,58 +540,111 @@ export function FilterableDataGrid<TData>({
                         ? sort.direction === "asc"
                           ? "ascending"
                           : "descending"
-                        : column.getSortValue
+                        : sortable
                           ? "none"
                           : undefined
                     }
                     className={column.headerClassName}
                     scope="col"
                   >
-                    {column.getSortValue ? (
-                      <button
-                        type="button"
-                        className="data-grid-sort-button"
-                        onClick={() => toggleSort(column)}
-                      >
-                        <span>{column.label}</span>
-                        {active ? (
-                          <SortIcon size={13} aria-hidden="true" />
-                        ) : (
-                          <span aria-hidden="true">↕</span>
-                        )}
-                      </button>
-                    ) : (
-                      column.label
-                    )}
+                    <div className="data-grid-column-head">
+                      {sortable ? (
+                        <button
+                          type="button"
+                          className="data-grid-sort-button"
+                          aria-label={sortButtonLabel(
+                            column.label,
+                            active ? sort.direction : null,
+                          )}
+                          onClick={() => toggleSort(column)}
+                        >
+                          <span>{header}</span>
+                          {active ? (
+                            <SortIcon size={13} aria-hidden="true" />
+                          ) : (
+                            <span aria-hidden="true">↕</span>
+                          )}
+                        </button>
+                      ) : (
+                        <span className="data-grid-column-title">{header}</span>
+                      )}
+                      {filterable ? (
+                        <ColumnFilterDialog
+                          column={column}
+                          filter={filter}
+                          values={distinctValues.get(column.id) ?? []}
+                          valueQuery={valueQueries[column.id] ?? ""}
+                          active={filterActive}
+                          onClear={() => clearFilter(column.id)}
+                          onOperatorChange={(operator) =>
+                            updateFilter(column.id, (current) => ({
+                              ...current,
+                              operator,
+                            }))
+                          }
+                          onTextChange={(text) =>
+                            updateFilter(column.id, (current) => ({
+                              ...current,
+                              text,
+                            }))
+                          }
+                          onValueQueryChange={(text) =>
+                            setValueQueries((current) => ({
+                              ...current,
+                              [column.id]: text,
+                            }))
+                          }
+                          onToggleValue={(value) =>
+                            toggleFilterValue(column.id, value)
+                          }
+                        />
+                      ) : null}
+                    </div>
                   </th>
                 );
               })}
             </tr>
           </thead>
           <tbody>
-            {visibleRows.map((row) => (
-              <tr key={getRowId(row)}>
-                {columns.map((column) =>
-                  column.rowHeader ? (
-                    <th
-                      key={column.id}
-                      className={column.className}
-                      scope="row"
-                    >
-                      {column.render(row)}
-                    </th>
-                  ) : (
-                    <td key={column.id} className={column.className}>
-                      {column.render(row)}
-                    </td>
-                  ),
-                )}
-              </tr>
-            ))}
+            {pageRows.map((row) => {
+              const rowId = getRowId(row);
+              return (
+                <tr
+                  key={rowId}
+                  className={rowClassName?.(row)}
+                  aria-selected={rowAriaSelected?.(row)}
+                  tabIndex={onRowActivate ? 0 : undefined}
+                  onClick={() => onRowActivate?.(row)}
+                  onKeyDown={(event) => {
+                    if (!onRowActivate) return;
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      onRowActivate(row);
+                    }
+                  }}
+                >
+                  {columns.map((column) =>
+                    column.rowHeader ? (
+                      <th
+                        key={column.id}
+                        className={column.className}
+                        scope="row"
+                      >
+                        {column.render(row, { rowId })}
+                      </th>
+                    ) : (
+                      <td key={column.id} className={column.className}>
+                        {column.render(row, { rowId })}
+                      </td>
+                    ),
+                  )}
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {loading && !data.length ? <Empty title={loadingMessage} /> : null}
-        {!loading && !visibleRows.length ? (
+        {!loading && !pageRows.length ? (
           <Empty
             title={
               data.length ? "No rows match the current filters." : emptyMessage
@@ -450,6 +652,19 @@ export function FilterableDataGrid<TData>({
           />
         ) : null}
       </div>
+      {paginationEnabled ? (
+        <TablePager
+          page={safePage}
+          pageSize={pageSize}
+          totalPages={totalPages}
+          totalRows={totalRows}
+          {...(effectivePageSizeOptions
+            ? { pageSizeOptions: effectivePageSizeOptions }
+            : {})}
+          onPageChange={handlePageChange}
+          onPageSizeChange={handlePageSizeChange}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -919,9 +919,92 @@ textarea {
   font-weight: 500;
 }
 
+.data-grid-column-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.data-grid-column-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.data-grid-column-filter-button {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  padding: 0;
+}
+
+.data-grid-column-filter-button:hover,
+.data-grid-column-filter-button:focus-visible,
+.data-grid-column-filter-button.active {
+  border-color: var(--rule);
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.data-grid-column-filter-button.active {
+  color: var(--info);
+}
+
+.data-grid-column-filter-dialog {
+  width: min(520px, calc(100vw - 32px));
+  max-width: min(520px, calc(100vw - 32px));
+  max-height: min(760px, calc(100vh - 80px));
+  overflow: auto;
+}
+
+.filterable-data-grid-table tbody tr[tabindex] {
+  cursor: pointer;
+}
+
+.filterable-data-grid-table tbody tr[tabindex]:hover,
+.filterable-data-grid-table tbody tr[tabindex]:focus-visible {
+  background: var(--soft);
+}
+
+.filterable-data-grid-table tbody tr[aria-selected="true"] {
+  background: var(--paper-2);
+}
+
+.filterable-data-grid-table .row-check {
+  width: 36px;
+  min-width: 36px;
+  text-align: center;
+}
+
+.filterable-data-grid-table .row-check input {
+  width: 16px;
+  height: 16px;
+}
+
+.jobs-data-grid-table {
+  min-width: 1320px;
+}
+
+.artifacts-data-grid-table {
+  min-width: 1120px;
+}
+
+.runs-data-grid-table {
+  min-width: 1280px;
+}
+
 .data-grid-sort-button {
   display: inline-flex;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   align-items: center;
   justify-content: space-between;
   gap: 6px;

--- a/apps/web/src/views/artifacts/ArtifactsTable.stories.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsTable.stories.tsx
@@ -2,19 +2,18 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useState } from "react";
 
-import { makeArtifactsPage, sampleArtifact } from "../../test/fixtures/projections.js";
+import {
+  makeArtifactsPage,
+  sampleArtifact,
+} from "../../test/fixtures/projections.js";
 import { ArtifactsTable } from "./ArtifactsTable.js";
 
-// Inherits the <DataTable> role-row / aria-sort defect (see
-// data-table.stories.tsx) — production-code issue, deferred.
 const meta = {
   title: "Views/Artifacts/ArtifactsTable",
   component: ArtifactsTable,
   parameters: {
     withRouter: true,
     initialPath: "/artifacts",
-    // a11y deferred — DataTable role="row" / aria-sort defect; see data-table.stories.tsx.
-    a11y: { test: "off" },
   },
   args: {
     data: makeArtifactsPage(),
@@ -43,7 +42,9 @@ function Stateful({
   empty: boolean;
   many: boolean;
 }) {
-  const [sorting, setSorting] = useState<SortingState>([{ id: "created_at", desc: true }]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "created_at", desc: true },
+  ]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);

--- a/apps/web/src/views/artifacts/ArtifactsTable.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsTable.tsx
@@ -1,8 +1,14 @@
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
+import { useMemo } from "react";
 
-import type { ArtifactSummary, PaginatedResponse } from "../../contexts/operations/types.js";
-import { DataTable } from "../../shared/ui/data-table.js";
-import { TablePager } from "../../shared/ui/table-pager.js";
+import type {
+  ArtifactSummary,
+  PaginatedResponse,
+} from "../../contexts/operations/types.js";
+import {
+  FilterableDataGrid,
+  type DataGridSortState,
+} from "../../shared/ui/filterable-data-grid.js";
 import { artifactColumns } from "./columns.js";
 
 export interface ArtifactsTableProps {
@@ -32,33 +38,51 @@ export function ArtifactsTable({
   onPageSizeChange,
   onOpenArtifact,
 }: ArtifactsTableProps) {
+  const columns = useMemo(
+    () =>
+      artifactColumns({
+        rowSelection,
+        onRowSelectionChange,
+      }),
+    [onRowSelectionChange, rowSelection],
+  );
+  const gridSort = useMemo<DataGridSortState>(() => {
+    const head = sorting[0];
+    return {
+      columnId: head?.id ?? "created_at",
+      direction: head?.desc ? "desc" : "asc",
+    };
+  }, [sorting]);
+  const handleSortChange = (next: DataGridSortState) => {
+    onSortingChange([{ id: next.columnId, desc: next.direction === "desc" }]);
+  };
+
   return (
-    <DataTable<ArtifactSummary>
+    <FilterableDataGrid<ArtifactSummary>
+      title="Artifacts table"
       data={data?.items ?? []}
-      columns={artifactColumns}
+      columns={columns}
       getRowId={(row) => row.artifactId}
       loading={loading}
-      loaded={data !== null}
       loadingMessage="Loading artifacts."
       emptyMessage="No artifacts match."
-      headerClassName="data-row artifact artifact-header"
-      rowClassName="data-row artifact"
-      sorting={sorting}
-      onSortingChange={onSortingChange}
-      rowSelection={rowSelection}
-      onRowSelectionChange={onRowSelectionChange}
+      initialSort={{ columnId: "created_at", direction: "desc" }}
+      sort={gridSort}
+      onSortChange={handleSortChange}
+      manualSorting
+      tableClassName="artifacts-data-grid-table"
+      rowAriaSelected={(row) => Boolean(rowSelection[row.artifactId])}
       onRowActivate={(row) => onOpenArtifact(row.artifactId)}
-      cellClassName={(columnId) => (columnId === "select" ? "row-check" : undefined)}
-      footer={
-        <TablePager
-          page={page}
-          pageSize={pageSize}
-          totalPages={data?.pagination.pages ?? 1}
-          totalRows={data?.pagination.total}
-          onPageChange={onPageChange}
-          onPageSizeChange={onPageSizeChange}
-        />
-      }
+      pagination={{
+        page,
+        pageSize,
+        totalPages: data?.pagination.pages ?? 1,
+        ...(typeof data?.pagination.total === "number"
+          ? { totalRows: data.pagination.total }
+          : {}),
+        onPageChange,
+        onPageSizeChange,
+      }}
     />
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactsView.stories.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.stories.tsx
@@ -11,18 +11,20 @@ import { http, HttpResponse } from "msw";
 import { useMemo } from "react";
 
 import { artifactsSearchSchema } from "../../routes/-artifacts.search.js";
-import { makeArtifactsPage, sampleArtifact } from "../../test/fixtures/projections.js";
+import {
+  makeArtifactsPage,
+  sampleArtifact,
+} from "../../test/fixtures/projections.js";
 import { ArtifactsView } from "./ArtifactsView.js";
 
-// ArtifactsView mounts ArtifactsTable (DataTable role-row, see
-// data-table.stories.tsx) + ArtifactFilterBar (bare <select>, see
-// ArtifactFilterBar.stories.tsx). Both production-code defects from
-// Phase 1/4 and out of Phase 7 scope.
+// ArtifactsView still mounts ArtifactFilterBar, whose bare <select> is
+// tracked in docs/backlog.md. The table itself now uses the shared native
+// data grid.
 const meta = {
   title: "Views/Artifacts/ArtifactsView",
   component: ArtifactsView,
   parameters: {
-    // a11y deferred — DataTable + ArtifactFilterBar select-name defects; see meta comment above.
+    // a11y deferred — ArtifactFilterBar select-name defect; see meta comment above.
     a11y: { test: "off" },
   },
 } satisfies Meta<typeof ArtifactsView>;
@@ -73,7 +75,11 @@ export const Loading: Story = {
 export const Empty: Story = {
   parameters: {
     msw: {
-      handlers: [http.get("*/v1/artifacts", () => HttpResponse.json(makeArtifactsPage([])))],
+      handlers: [
+        http.get("*/v1/artifacts", () =>
+          HttpResponse.json(makeArtifactsPage([])),
+        ),
+      ],
     },
   },
   render: () => <ArtifactsViewHost />,

--- a/apps/web/src/views/artifacts/columns.tsx
+++ b/apps/web/src/views/artifacts/columns.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { RowSelectionState } from "@tanstack/react-table";
 import { type ChangeEvent, type MouseEvent } from "react";
 
 import { ArtifactStatusBadge } from "../../contexts/materials/components/ArtifactStatusBadge.js";
@@ -7,111 +7,167 @@ import { ArtifactTypeBadge } from "../../contexts/materials/components/ArtifactT
 import { OpenArtifactButton } from "../../contexts/materials/components/OpenArtifactButton.js";
 import { formatBytes } from "../../contexts/materials/lib/artifact-type-format.js";
 import type { ArtifactSummary } from "../../contexts/operations/types.js";
+import type {
+  DataGridColumn,
+  DataGridHeaderContext,
+} from "../../shared/ui/filterable-data-grid.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
 import { TitleStack } from "../../shared/ui/title-stack.js";
 
-const selectColumn: ColumnDef<ArtifactSummary> = {
-  id: "select",
-  enableSorting: false,
-  header: ({ table }) => (
+interface ArtifactColumnsOptions {
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: (next: RowSelectionState) => void;
+}
+
+function updateSelectedRows(
+  rowSelection: RowSelectionState,
+  onRowSelectionChange: (next: RowSelectionState) => void,
+  rows: readonly ArtifactSummary[],
+  checked: boolean,
+) {
+  const next: RowSelectionState = { ...rowSelection };
+  for (const row of rows) {
+    if (checked) {
+      next[row.artifactId] = true;
+    } else {
+      delete next[row.artifactId];
+    }
+  }
+  onRowSelectionChange(next);
+}
+
+function selectHeader(
+  { rowSelection, onRowSelectionChange }: ArtifactColumnsOptions,
+  { pageRows }: DataGridHeaderContext<ArtifactSummary>,
+) {
+  const allSelected =
+    pageRows.length > 0 &&
+    pageRows.every((row) => Boolean(rowSelection[row.artifactId]));
+  const someSelected = pageRows.some((row) =>
+    Boolean(rowSelection[row.artifactId]),
+  );
+  return (
     <input
       type="checkbox"
       aria-label="Select all rows on this page"
-      checked={table.getIsAllPageRowsSelected()}
+      checked={allSelected}
       ref={(node) => {
         if (node) {
-          node.indeterminate =
-            table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected();
+          node.indeterminate = someSelected && !allSelected;
         }
       }}
       onChange={(event: ChangeEvent<HTMLInputElement>) =>
-        table.toggleAllPageRowsSelected(event.target.checked)
+        updateSelectedRows(
+          rowSelection,
+          onRowSelectionChange,
+          pageRows,
+          event.target.checked,
+        )
       }
       onClick={(event: MouseEvent) => event.stopPropagation()}
     />
-  ),
-  cell: ({ row }) => (
-    <input
-      type="checkbox"
-      aria-label={`Select ${row.original.title || row.original.type}`}
-      checked={row.getIsSelected()}
-      disabled={!row.getCanSelect()}
-      onChange={(event: ChangeEvent<HTMLInputElement>) =>
-        row.toggleSelected(event.target.checked)
-      }
-      onClick={(event: MouseEvent) => event.stopPropagation()}
-    />
-  ),
-};
+  );
+}
 
-export const artifactColumns: ColumnDef<ArtifactSummary>[] = [
-  selectColumn,
-  {
-    id: "title",
-    header: "Title",
-    enableSorting: true,
-    accessorFn: (row) => row.title,
-    cell: ({ row }) => (
-      <Link
-        to="/artifacts/$artifactId"
-        params={{ artifactId: row.original.artifactId }}
-        className="title-link"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <TitleStack
-          primary={row.original.title || row.original.type}
-          secondary={row.original.company}
+function updateSelectedRow(
+  rowSelection: RowSelectionState,
+  onRowSelectionChange: (next: RowSelectionState) => void,
+  row: ArtifactSummary,
+  checked: boolean,
+) {
+  updateSelectedRows(rowSelection, onRowSelectionChange, [row], checked);
+}
+
+export function artifactColumns(
+  options: ArtifactColumnsOptions,
+): Array<DataGridColumn<ArtifactSummary>> {
+  return [
+    {
+      id: "select",
+      label: "Select",
+      header: (context) => selectHeader(options, context),
+      className: "row-check",
+      headerClassName: "row-check",
+      render: (row) => (
+        <input
+          type="checkbox"
+          aria-label={`Select ${row.title || row.type}`}
+          checked={Boolean(options.rowSelection[row.artifactId])}
+          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+            updateSelectedRow(
+              options.rowSelection,
+              options.onRowSelectionChange,
+              row,
+              event.target.checked,
+            )
+          }
+          onClick={(event: MouseEvent) => event.stopPropagation()}
         />
-      </Link>
-    ),
-  },
-  {
-    id: "company",
-    header: "Company",
-    enableSorting: true,
-    accessorFn: (row) => row.company,
-    cell: ({ row }) => <span className="muted-cell">{row.original.company || "-"}</span>,
-  },
-  {
-    id: "type",
-    header: "Type",
-    enableSorting: true,
-    accessorFn: (row) => row.type,
-    cell: ({ row }) => <ArtifactTypeBadge artifactType={row.original.type} />,
-  },
-  {
-    id: "status",
-    header: "Status",
-    enableSorting: true,
-    accessorFn: (row) => row.status,
-    cell: ({ row }) => <ArtifactStatusBadge status={row.original.status} />,
-  },
-  {
-    id: "size_bytes",
-    header: "Size",
-    enableSorting: true,
-    accessorFn: (row) => row.sizeBytes,
-    cell: ({ row }) => (
-      <span className="mono">{row.original.size || formatBytes(row.original.sizeBytes)}</span>
-    ),
-  },
-  {
-    id: "created_at",
-    header: "Created",
-    enableSorting: true,
-    accessorFn: (row) => row.createdAt,
-    cell: ({ row }) => <RelativeTime value={row.original.createdAt} />,
-  },
-  {
-    id: "actions",
-    header: "Actions",
-    enableSorting: false,
-    cell: ({ row }) => (
-      <OpenArtifactButton
-        artifactId={row.original.artifactId}
-        disabled={row.original.status === "missing"}
-      />
-    ),
-  },
-];
-
+      ),
+    },
+    {
+      id: "title",
+      label: "Title",
+      sortable: true,
+      rowHeader: true,
+      getFilterValue: (row) => row.title || row.type,
+      render: (row) => (
+        <Link
+          to="/artifacts/$artifactId"
+          params={{ artifactId: row.artifactId }}
+          className="title-link"
+          onClick={(event) => event.stopPropagation()}
+        >
+          <TitleStack primary={row.title || row.type} secondary={row.company} />
+        </Link>
+      ),
+    },
+    {
+      id: "company",
+      label: "Company",
+      sortable: true,
+      getFilterValue: (row) => row.company || "-",
+      render: (row) => <span className="muted-cell">{row.company || "-"}</span>,
+    },
+    {
+      id: "type",
+      label: "Type",
+      sortable: true,
+      getFilterValue: (row) => row.type,
+      render: (row) => <ArtifactTypeBadge artifactType={row.type} />,
+    },
+    {
+      id: "status",
+      label: "Status",
+      sortable: true,
+      getFilterValue: (row) => row.status,
+      render: (row) => <ArtifactStatusBadge status={row.status} />,
+    },
+    {
+      id: "size_bytes",
+      label: "Size",
+      sortable: true,
+      getFilterValue: (row) => row.size || formatBytes(row.sizeBytes),
+      render: (row) => (
+        <span className="mono">{row.size || formatBytes(row.sizeBytes)}</span>
+      ),
+    },
+    {
+      id: "created_at",
+      label: "Created",
+      sortable: true,
+      getFilterValue: (row) => row.createdAt ?? "-",
+      render: (row) => <RelativeTime value={row.createdAt} />,
+    },
+    {
+      id: "actions",
+      label: "Actions",
+      render: (row) => (
+        <OpenArtifactButton
+          artifactId={row.artifactId}
+          disabled={row.status === "missing"}
+        />
+      ),
+    },
+  ];
+}

--- a/apps/web/src/views/dashboard/KpiGrid.test.tsx
+++ b/apps/web/src/views/dashboard/KpiGrid.test.tsx
@@ -34,6 +34,16 @@ function buildRouter() {
 }
 
 describe("kpiSearchFor", () => {
+  it("renders blocked KPI copy that describes the required operator action", async () => {
+    const router = buildRouter();
+
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /blocked/i })).toBeInTheDocument());
+    expect(screen.getByText("needs review")).toBeInTheDocument();
+    expect(screen.queryByText("upstream missing")).not.toBeInTheDocument();
+  });
+
   it("builds a complete failed-jobs search for the failures KPI", () => {
     expect(kpiSearchFor("failed")).toEqual({
       q: "",

--- a/apps/web/src/views/dashboard/KpiGrid.tsx
+++ b/apps/web/src/views/dashboard/KpiGrid.tsx
@@ -38,7 +38,7 @@ const ITEMS: ReadonlyArray<{
 }> = [
   { label: "Jobs", key: "jobs", caption: "+0 today", target: "all", tone: "" },
   { label: "Failures", key: "failures", caption: "needs retry", target: "failed", tone: "alert" },
-  { label: "Blocked", key: "blocked", caption: "upstream missing", target: "blocked", tone: "warn" },
+  { label: "Blocked", key: "blocked", caption: "needs review", target: "blocked", tone: "warn" },
   { label: "Ready", key: "ready", caption: "ready queue", target: "ready", tone: "ok" },
   { label: "Applied", key: "applied", caption: "+0 today", target: "all", tone: "" },
   { label: "Dry runs", key: "dryRuns", caption: "today excluded", target: "all", tone: "" },

--- a/apps/web/src/views/discovery/DiscoveryView.test.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.test.tsx
@@ -22,9 +22,13 @@ describe("DiscoveryView", () => {
     await screen.findByRole("table");
     const user = userEvent.setup();
     await user.click(
-      screen.getByRole("button", { name: /open table filters/i }),
+      screen.getByRole("button", { name: /filter company column/i }),
     );
     expect(screen.getByLabelText("Company filter text")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    await user.click(
+      screen.getByRole("button", { name: /filter state column/i }),
+    );
     expect(screen.getByLabelText("State filter text")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/JobsTable.stories.tsx
+++ b/apps/web/src/views/jobs/JobsTable.stories.tsx
@@ -2,20 +2,19 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useState } from "react";
 
-import { makeJobsPage, sampleJob, sampleSecondaryJob } from "../../test/fixtures/projections.js";
+import {
+  makeJobsPage,
+  sampleJob,
+  sampleSecondaryJob,
+} from "../../test/fixtures/projections.js";
 import { JobsTable } from "./JobsTable.js";
 
-// JobsTable composes <DataTable> whose role="row" / aria-sort layout
-// flunks axe (see data-table.stories.tsx). Deferred until the primitive
-// is fixed in production code.
 const meta = {
   title: "Views/Jobs/JobsTable",
   component: JobsTable,
   parameters: {
     withRouter: true,
     initialPath: "/jobs",
-    // a11y deferred — DataTable role="row" / aria-sort defect; see data-table.stories.tsx.
-    a11y: { test: "off" },
   },
   args: {
     data: makeJobsPage(),
@@ -45,7 +44,9 @@ function Stateful({
   empty: boolean;
   large: boolean;
 }) {
-  const [sorting, setSorting] = useState<SortingState>([{ id: "discovered_at", desc: true }]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "discovered_at", desc: true },
+  ]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(50);

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -1,9 +1,14 @@
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useMemo } from "react";
 
-import type { JobSummary, PaginatedResponse } from "../../contexts/operations/types.js";
-import { DataTable } from "../../shared/ui/data-table.js";
-import { TablePager } from "../../shared/ui/table-pager.js";
+import type {
+  JobSummary,
+  PaginatedResponse,
+} from "../../contexts/operations/types.js";
+import {
+  FilterableDataGrid,
+  type DataGridSortState,
+} from "../../shared/ui/filterable-data-grid.js";
 import { jobColumns } from "./columns.js";
 
 export interface JobsTableProps {
@@ -45,35 +50,53 @@ export function JobsTable({
     }
     return next;
   }, [allMatchingSelected, data?.items, rowSelection]);
+  const columns = useMemo(
+    () =>
+      jobColumns({
+        rowSelection: displayedRowSelection,
+        onRowSelectionChange,
+      }),
+    [displayedRowSelection, onRowSelectionChange],
+  );
+  const gridSort = useMemo<DataGridSortState>(() => {
+    const head = sorting[0];
+    return {
+      columnId: head?.id ?? "discovered_at",
+      direction: head?.desc ? "desc" : "asc",
+    };
+  }, [sorting]);
+  const handleSortChange = (next: DataGridSortState) => {
+    onSortingChange([{ id: next.columnId, desc: next.direction === "desc" }]);
+  };
 
   return (
-    <DataTable<JobSummary>
+    <FilterableDataGrid<JobSummary>
+      title="Jobs table"
       data={data?.items ?? []}
-      columns={jobColumns}
+      columns={columns}
       getRowId={(row) => row.jobKey}
       loading={loading}
-      loaded={data !== null}
       loadingMessage="Loading jobs."
       emptyMessage="No jobs match."
-      headerClassName="data-row job job-header"
-      rowClassName="data-row job"
-      sorting={sorting}
-      onSortingChange={onSortingChange}
-      rowSelection={displayedRowSelection}
-      onRowSelectionChange={onRowSelectionChange}
-      onRowActivate={(row) => onOpenJob(row.jobKey)}
-      rowAriaSelected={(row) => allMatchingSelected || Boolean(rowSelection[row.jobKey])}
-      cellClassName={(columnId) => (columnId === "select" ? "row-check" : undefined)}
-      footer={
-        <TablePager
-          page={page}
-          pageSize={pageSize}
-          totalPages={data?.pagination.pages ?? 1}
-          totalRows={data?.pagination.total}
-          onPageChange={onPageChange}
-          onPageSizeChange={onPageSizeChange}
-        />
+      initialSort={{ columnId: "discovered_at", direction: "desc" }}
+      sort={gridSort}
+      onSortChange={handleSortChange}
+      manualSorting
+      tableClassName="jobs-data-grid-table"
+      rowAriaSelected={(row) =>
+        allMatchingSelected || Boolean(rowSelection[row.jobKey])
       }
+      onRowActivate={(row) => onOpenJob(row.jobKey)}
+      pagination={{
+        page,
+        pageSize,
+        totalPages: data?.pagination.pages ?? 1,
+        ...(typeof data?.pagination.total === "number"
+          ? { totalRows: data.pagination.total }
+          : {}),
+        onPageChange,
+        onPageSizeChange,
+      }}
     />
   );
 }

--- a/apps/web/src/views/jobs/JobsView.stories.tsx
+++ b/apps/web/src/views/jobs/JobsView.stories.tsx
@@ -11,18 +11,21 @@ import { http, HttpResponse } from "msw";
 import { useMemo } from "react";
 
 import { jobsSearchSchema } from "../../routes/-jobs.search.js";
-import { makeJobsPage, sampleJob, sampleSecondaryJob } from "../../test/fixtures/projections.js";
+import {
+  makeJobsPage,
+  sampleJob,
+  sampleSecondaryJob,
+} from "../../test/fixtures/projections.js";
 import { JobsView } from "./JobsView.js";
 
-// JobsView mounts JobsTable (DataTable role-row issue, see
-// data-table.stories.tsx) + JobFilterBar (bare <select> without
-// aria-label, see JobFilterBar.stories.tsx). Both production-code
-// defects from Phase 1/4 and out of Phase 7 scope.
+// JobsView still mounts JobFilterBar, whose bare <select> controls are
+// tracked in docs/backlog.md. The table itself now uses the shared native
+// data grid.
 const meta = {
   title: "Views/Jobs/JobsView",
   component: JobsView,
   parameters: {
-    // a11y deferred — DataTable + JobFilterBar select-name defects; see meta comment above.
+    // a11y deferred — JobFilterBar select-name defects; see meta comment above.
     a11y: { test: "off" },
   },
 } satisfies Meta<typeof JobsView>;
@@ -73,7 +76,9 @@ export const Loading: Story = {
 export const Empty: Story = {
   parameters: {
     msw: {
-      handlers: [http.get("*/v1/jobs", () => HttpResponse.json(makeJobsPage([])))],
+      handlers: [
+        http.get("*/v1/jobs", () => HttpResponse.json(makeJobsPage([]))),
+      ],
     },
   },
   render: () => <JobsViewStoryHost />,

--- a/apps/web/src/views/jobs/columns.tsx
+++ b/apps/web/src/views/jobs/columns.tsx
@@ -1,5 +1,5 @@
-import type { ColumnDef } from "@tanstack/react-table";
 import { type ChangeEvent, type MouseEvent } from "react";
+import type { RowSelectionState } from "@tanstack/react-table";
 
 import { ApplyRunBadge } from "../../contexts/apply/components/ApplyRunBadge.js";
 import { isApplyRunStatus } from "../../contexts/apply/lib/apply-run-status.js";
@@ -7,122 +7,188 @@ import { ScoreBadge } from "../../contexts/scoring/components/ScoreBadge.js";
 import { ScoreStalenessBadge } from "../../contexts/scoring/components/ScoreStalenessBadge.js";
 import { StageBadge } from "../../contexts/pipeline/components/StageBadge.js";
 import type { JobSummary } from "../../contexts/operations/types.js";
+import type {
+  DataGridColumn,
+  DataGridHeaderContext,
+} from "../../shared/ui/filterable-data-grid.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
 import { TitleStack } from "../../shared/ui/title-stack.js";
 
-const selectColumn: ColumnDef<JobSummary> = {
-  id: "select",
-  enableSorting: false,
-  header: ({ table }) => (
+interface JobColumnsOptions {
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: (next: RowSelectionState) => void;
+}
+
+function updateSelectedRows(
+  rowSelection: RowSelectionState,
+  onRowSelectionChange: (next: RowSelectionState) => void,
+  rows: readonly JobSummary[],
+  checked: boolean,
+) {
+  const next: RowSelectionState = { ...rowSelection };
+  for (const row of rows) {
+    if (checked) {
+      next[row.jobKey] = true;
+    } else {
+      delete next[row.jobKey];
+    }
+  }
+  onRowSelectionChange(next);
+}
+
+function updateSelectedRow(
+  rowSelection: RowSelectionState,
+  onRowSelectionChange: (next: RowSelectionState) => void,
+  row: JobSummary,
+  checked: boolean,
+) {
+  updateSelectedRows(rowSelection, onRowSelectionChange, [row], checked);
+}
+
+function selectHeader(
+  { rowSelection, onRowSelectionChange }: JobColumnsOptions,
+  { pageRows }: DataGridHeaderContext<JobSummary>,
+) {
+  const allSelected =
+    pageRows.length > 0 &&
+    pageRows.every((row) => Boolean(rowSelection[row.jobKey]));
+  const someSelected = pageRows.some((row) =>
+    Boolean(rowSelection[row.jobKey]),
+  );
+  return (
     <input
       type="checkbox"
       aria-label="Select all rows on this page"
-      checked={table.getIsAllPageRowsSelected()}
+      checked={allSelected}
       ref={(node) => {
         if (node) {
-          node.indeterminate =
-            table.getIsSomePageRowsSelected() && !table.getIsAllPageRowsSelected();
+          node.indeterminate = someSelected && !allSelected;
         }
       }}
       onChange={(event: ChangeEvent<HTMLInputElement>) =>
-        table.toggleAllPageRowsSelected(event.target.checked)
+        updateSelectedRows(
+          rowSelection,
+          onRowSelectionChange,
+          pageRows,
+          event.target.checked,
+        )
       }
       onClick={(event: MouseEvent) => event.stopPropagation()}
     />
-  ),
-  cell: ({ row }) => (
-    <input
-      type="checkbox"
-      aria-label={`Select ${row.original.title}`}
-      checked={row.getIsSelected()}
-      disabled={!row.getCanSelect()}
-      onChange={(event: ChangeEvent<HTMLInputElement>) =>
-        row.toggleSelected(event.target.checked)
-      }
-      onClick={(event: MouseEvent) => event.stopPropagation()}
-    />
-  ),
-};
+  );
+}
 
-export const jobColumns: ColumnDef<JobSummary>[] = [
-  selectColumn,
-  {
-    id: "fit_score",
-    header: "Fit score",
-    enableSorting: true,
-    accessorFn: (row) => row.fitScore,
-    cell: ({ row }) => (
-      <div className="score-cell">
-        <ScoreBadge score={row.original.fitScore} />
-        <ScoreStalenessBadge staleness={row.original.scoreStaleness} />
-      </div>
-    ),
-  },
-  {
-    id: "title",
-    header: "Title",
-    enableSorting: true,
-    accessorFn: (row) => row.title,
-    cell: ({ row }) => <TitleStack primary={row.original.title} />,
-  },
-  {
-    id: "company",
-    header: "Company",
-    enableSorting: true,
-    accessorFn: (row) => row.company,
-    cell: ({ row }) => <span className="muted-cell">{row.original.company || "-"}</span>,
-  },
-  {
-    id: "source",
-    header: "Sources",
-    enableSorting: false,
-    accessorFn: (row) => row.postingSource || row.discoverySource || row.source,
-    cell: ({ row }) => (
-      <TitleStack
-        primary={row.original.postingSource ? `posting ${row.original.postingSource}` : "-"}
-        secondary={row.original.discoverySource ? `discovered via ${row.original.discoverySource}` : null}
-      />
-    ),
-  },
-  {
-    id: "location",
-    header: "Location",
-    enableSorting: true,
-    accessorFn: (row) => row.location,
-    cell: ({ row }) => <span>{row.original.location || "-"}</span>,
-  },
-  {
-    id: "current_stage",
-    header: "Stage",
-    enableSorting: true,
-    accessorFn: (row) => row.currentStage,
-    cell: ({ row }) => <StageBadge stage={row.original.currentStage} />,
-  },
-  {
-    id: "current_state",
-    header: "State",
-    enableSorting: true,
-    accessorFn: (row) => row.currentState,
-    cell: ({ row }) => <StageBadge state={row.original.currentState} />,
-  },
-  {
-    id: "discovered_at",
-    header: "Discovered",
-    enableSorting: true,
-    accessorFn: (row) => row.discoveredAt,
-    cell: ({ row }) => <RelativeTime value={row.original.discoveredAt} />,
-  },
-  {
-    id: "apply_status",
-    header: "Apply",
-    enableSorting: false,
-    accessorFn: (row) => row.applyStatus,
-    cell: ({ row }) => {
-      const status = row.original.applyStatus;
-      if (!status || !isApplyRunStatus(status)) {
-        return null;
-      }
-      return <ApplyRunBadge result={status} />;
+export function jobColumns(
+  options: JobColumnsOptions,
+): Array<DataGridColumn<JobSummary>> {
+  return [
+    {
+      id: "select",
+      label: "Select",
+      header: (context) => selectHeader(options, context),
+      className: "row-check",
+      headerClassName: "row-check",
+      render: (row) => (
+        <input
+          type="checkbox"
+          aria-label={`Select ${row.title}`}
+          checked={Boolean(options.rowSelection[row.jobKey])}
+          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+            updateSelectedRow(
+              options.rowSelection,
+              options.onRowSelectionChange,
+              row,
+              event.target.checked,
+            )
+          }
+          onClick={(event: MouseEvent) => event.stopPropagation()}
+        />
+      ),
     },
-  },
-];
+    {
+      id: "fit_score",
+      label: "Fit score",
+      sortable: true,
+      getFilterValue: (row) => String(row.fitScore ?? "unscored"),
+      render: (row) => (
+        <div className="score-cell">
+          <ScoreBadge score={row.fitScore} />
+          <ScoreStalenessBadge staleness={row.scoreStaleness} />
+        </div>
+      ),
+    },
+    {
+      id: "title",
+      label: "Title",
+      sortable: true,
+      rowHeader: true,
+      getFilterValue: (row) => row.title,
+      render: (row) => <TitleStack primary={row.title} />,
+    },
+    {
+      id: "company",
+      label: "Company",
+      sortable: true,
+      getFilterValue: (row) => row.company || "-",
+      render: (row) => <span className="muted-cell">{row.company || "-"}</span>,
+    },
+    {
+      id: "source",
+      label: "Sources",
+      getFilterValue: (row) =>
+        row.postingSource || row.discoverySource || row.source || "-",
+      getFilterSearchValue: (row) =>
+        [row.postingSource, row.discoverySource, row.source]
+          .filter(Boolean)
+          .join(" "),
+      render: (row) => (
+        <TitleStack
+          primary={row.postingSource ? `posting ${row.postingSource}` : "-"}
+          secondary={
+            row.discoverySource ? `discovered via ${row.discoverySource}` : null
+          }
+        />
+      ),
+    },
+    {
+      id: "location",
+      label: "Location",
+      sortable: true,
+      getFilterValue: (row) => row.location || "-",
+      render: (row) => <span>{row.location || "-"}</span>,
+    },
+    {
+      id: "current_stage",
+      label: "Stage",
+      sortable: true,
+      getFilterValue: (row) => row.currentStage,
+      render: (row) => <StageBadge stage={row.currentStage} />,
+    },
+    {
+      id: "current_state",
+      label: "State",
+      sortable: true,
+      getFilterValue: (row) => row.currentState,
+      render: (row) => <StageBadge state={row.currentState} />,
+    },
+    {
+      id: "discovered_at",
+      label: "Discovered",
+      sortable: true,
+      getFilterValue: (row) => row.discoveredAt || "-",
+      render: (row) => <RelativeTime value={row.discoveredAt} />,
+    },
+    {
+      id: "apply_status",
+      label: "Apply",
+      getFilterValue: (row) => row.applyStatus ?? "not applied",
+      render: (row) => {
+        const status = row.applyStatus;
+        if (!status || !isApplyRunStatus(status)) {
+          return null;
+        }
+        return <ApplyRunBadge result={status} />;
+      },
+    },
+  ];
+}

--- a/apps/web/src/views/runs/RunsTable.test.tsx
+++ b/apps/web/src/views/runs/RunsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -9,11 +10,15 @@ import {
 import { RunsTable } from "./RunsTable.js";
 
 describe("<RunsTable>", () => {
-  function renderTable(overrides: Partial<React.ComponentProps<typeof RunsTable>> = {}) {
+  function renderTable(
+    overrides: Partial<React.ComponentProps<typeof RunsTable>> = {},
+  ) {
     return render(
       <RunsTable
         data={makeWorkflowRunsPage()}
         loading={false}
+        sorting={[{ id: "started_at", desc: true }]}
+        onSortingChange={() => undefined}
         page={1}
         pageSize={50}
         onPageChange={() => undefined}
@@ -28,9 +33,13 @@ describe("<RunsTable>", () => {
     renderTable();
 
     expect(screen.getByText(sampleWorkflowRun.title)).toBeInTheDocument();
-    expect(screen.getByText(sampleWorkflowRunCompleted.title)).toBeInTheDocument();
+    expect(
+      screen.getByText(sampleWorkflowRunCompleted.title),
+    ).toBeInTheDocument();
 
-    const links = screen.getAllByRole("link", { name: /Open workflow .* in Temporal Web UI/i });
+    const links = screen.getAllByRole("link", {
+      name: /Open workflow .* in Temporal Web UI/i,
+    });
     expect(links).toHaveLength(2);
     expect(links[0]?.getAttribute("href")).toBe(
       `http://127.0.0.1:8233/namespaces/default/workflows/${encodeURIComponent(
@@ -45,17 +54,24 @@ describe("<RunsTable>", () => {
     const onOpenRun = vi.fn();
     renderTable({ onOpenRun });
 
-    // Activate the row by clicking the title cell (the link cell stops
-    // propagation so it only opens the deep-link, not the row).
     const titleCell = screen.getByText(sampleWorkflowRun.title);
-    titleCell.click();
-    // DataTable wires `onRowActivate` to the row container, so simulate
-    // the row click via the closest row element.
-    const row = titleCell.closest("tr") ?? titleCell.closest(".data-row");
+    const row = titleCell.closest("tr");
     if (row) {
       (row as HTMLElement).click();
     }
     expect(onOpenRun).toHaveBeenCalledWith(sampleWorkflowRun.workflowId);
+  });
+
+  it("reports sortable column changes", async () => {
+    const user = userEvent.setup();
+    const onSortingChange = vi.fn();
+    renderTable({ onSortingChange });
+
+    await user.click(screen.getByRole("button", { name: "Sort by Job" }));
+
+    expect(onSortingChange).toHaveBeenCalledWith([
+      { id: "title", desc: false },
+    ]);
   });
 
   it("renders the loading state when no data has been fetched yet", () => {

--- a/apps/web/src/views/runs/RunsTable.tsx
+++ b/apps/web/src/views/runs/RunsTable.tsx
@@ -1,13 +1,21 @@
 import type { SortingState } from "@tanstack/react-table";
+import { useMemo } from "react";
 
-import type { PaginatedResponse, WorkflowRunSummary } from "../../contexts/operations/types.js";
-import { DataTable } from "../../shared/ui/data-table.js";
-import { TablePager } from "../../shared/ui/table-pager.js";
+import type {
+  PaginatedResponse,
+  WorkflowRunSummary,
+} from "../../contexts/operations/types.js";
+import {
+  FilterableDataGrid,
+  type DataGridSortState,
+} from "../../shared/ui/filterable-data-grid.js";
 import { workflowRunColumns } from "./columns.js";
 
 export interface RunsTableProps {
   data: PaginatedResponse<WorkflowRunSummary> | null;
   loading: boolean;
+  sorting: SortingState;
+  onSortingChange: (next: SortingState) => void;
   page: number;
   pageSize: number;
   onPageChange: (page: number) => void;
@@ -15,44 +23,53 @@ export interface RunsTableProps {
   onOpenRun: (workflowId: string) => void;
 }
 
-const NO_SORTING: SortingState = [];
-
 export function RunsTable({
   data,
   loading,
+  sorting,
+  onSortingChange,
   page,
   pageSize,
   onPageChange,
   onPageSizeChange,
   onOpenRun,
 }: RunsTableProps) {
+  const gridSort = useMemo<DataGridSortState>(() => {
+    const head = sorting[0];
+    return {
+      columnId: head?.id ?? "started_at",
+      direction: head?.desc ? "desc" : "asc",
+    };
+  }, [sorting]);
+  const handleSortChange = (next: DataGridSortState) => {
+    onSortingChange([{ id: next.columnId, desc: next.direction === "desc" }]);
+  };
+
   return (
-    <DataTable<WorkflowRunSummary>
+    <FilterableDataGrid<WorkflowRunSummary>
+      title="Workflow runs table"
       data={data?.items ?? []}
       columns={workflowRunColumns}
       getRowId={(row) => row.workflowId}
       loading={loading}
-      loaded={data !== null}
       loadingMessage="Loading workflow runs."
       emptyMessage="No workflow runs."
-      headerClassName="data-row run run-header"
-      rowClassName="data-row run"
-      sorting={NO_SORTING}
-      onSortingChange={() => undefined}
-      enableRowSelection={false}
-      rowSelection={{}}
-      onRowSelectionChange={() => undefined}
+      initialSort={{ columnId: "started_at", direction: "desc" }}
+      sort={gridSort}
+      onSortChange={handleSortChange}
+      manualSorting
+      tableClassName="runs-data-grid-table"
       onRowActivate={(row) => onOpenRun(row.workflowId)}
-      footer={
-        <TablePager
-          page={page}
-          pageSize={pageSize}
-          totalPages={data?.pagination.pages ?? 1}
-          totalRows={data?.pagination.total}
-          onPageChange={onPageChange}
-          onPageSizeChange={onPageSizeChange}
-        />
-      }
+      pagination={{
+        page,
+        pageSize,
+        totalPages: data?.pagination.pages ?? 1,
+        ...(typeof data?.pagination.total === "number"
+          ? { totalRows: data.pagination.total }
+          : {}),
+        onPageChange,
+        onPageSizeChange,
+      }}
     />
   );
 }

--- a/apps/web/src/views/runs/RunsView.stories.tsx
+++ b/apps/web/src/views/runs/RunsView.stories.tsx
@@ -18,17 +18,9 @@ import {
 } from "../../test/fixtures/projections.js";
 import { RunsView } from "./RunsView.js";
 
-// RunsView mounts RunsTable (DataTable role-row issue, see
-// data-table.stories.tsx) + RunsFilterBar (bare <select> wrapped in a
-// <label> — the label provides the accessible name, but DataTable's
-// shared a11y defects still trip the addon when the table renders).
-// Both production-code defects predate Phase 7 and are out of scope.
 const meta = {
   title: "Views/Runs/RunsView",
   component: RunsView,
-  parameters: {
-    a11y: { test: "off" },
-  },
 } satisfies Meta<typeof RunsView>;
 
 export default meta;
@@ -77,7 +69,11 @@ export const Loading: Story = {
 export const Empty: Story = {
   parameters: {
     msw: {
-      handlers: [http.get("*/v1/workflow-runs", () => HttpResponse.json(makeWorkflowRunsPage([])))],
+      handlers: [
+        http.get("*/v1/workflow-runs", () =>
+          HttpResponse.json(makeWorkflowRunsPage([])),
+        ),
+      ],
     },
   },
   render: () => <RunsViewStoryHost />,
@@ -105,7 +101,11 @@ export const ManyResults: Story = {
             makeWorkflowRunsPage(
               Array.from({ length: 18 }, (_, index) =>
                 index % 2 === 0
-                  ? { ...sampleWorkflowRun, workflowId: `wf-${index + 10}`, runId: `wf-${index + 10}` }
+                  ? {
+                      ...sampleWorkflowRun,
+                      workflowId: `wf-${index + 10}`,
+                      runId: `wf-${index + 10}`,
+                    }
                   : {
                       ...sampleWorkflowRunCompleted,
                       workflowId: `wf-${index + 10}`,

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -1,4 +1,10 @@
+import {
+  WORKFLOW_RUN_SORT_FIELDS,
+  type WorkflowRunSortField,
+} from "@jobhunter/contracts";
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import type { SortingState } from "@tanstack/react-table";
+import { useMemo } from "react";
 
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
 import type { WorkflowRunsListInput } from "../../contexts/operations/types.js";
@@ -16,17 +22,44 @@ function workflowRunsInput(search: RunsSearch): WorkflowRunsListInput {
     page: search.page,
     pageSize: search.pageSize,
     status: search.status,
+    sort: search.sort,
+    dir: search.dir,
   };
+}
+
+const SORTABLE_WORKFLOW_RUN_FIELDS: ReadonlySet<WorkflowRunSortField> = new Set(
+  WORKFLOW_RUN_SORT_FIELDS,
+);
+
+function isWorkflowRunSortField(value: string): value is WorkflowRunSortField {
+  return SORTABLE_WORKFLOW_RUN_FIELDS.has(value as WorkflowRunSortField);
 }
 
 export function RunsView() {
   const search = useSearch({ from: "/runs" });
   const navigate = useNavigate({ from: "/runs" });
-  const { data, isFetching, error } = useWorkflowRunsListQuery(workflowRunsInput(search));
+  const { data, isFetching, error } = useWorkflowRunsListQuery(
+    workflowRunsInput(search),
+  );
   const message = error instanceof Error ? error.message : null;
 
   const setSearch = (next: Partial<RunsSearch>) => {
     void navigate({ search: (prev: RunsSearch) => ({ ...prev, ...next }) });
+  };
+  const sorting = useMemo<SortingState>(
+    () => [{ id: search.sort, desc: search.dir === "desc" }],
+    [search.dir, search.sort],
+  );
+  const handleSortingChange = (next: SortingState) => {
+    const head = next[0];
+    if (!head || !isWorkflowRunSortField(head.id)) {
+      return;
+    }
+    setSearch({
+      sort: head.id,
+      dir: head.desc ? "desc" : "asc",
+      page: 1,
+    });
   };
 
   // The detail drawer route is `/runs/$runId`; clicking a row navigates
@@ -51,6 +84,8 @@ export function RunsView() {
         <RunsTable
           data={data ?? null}
           loading={isFetching}
+          sorting={sorting}
+          onSortingChange={handleSortingChange}
           page={search.page}
           pageSize={search.pageSize}
           onPageChange={(page) => setSearch({ page })}

--- a/apps/web/src/views/runs/columns.tsx
+++ b/apps/web/src/views/runs/columns.tsx
@@ -1,8 +1,7 @@
-import type { ColumnDef } from "@tanstack/react-table";
-
 import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
 import type { WorkflowRunSummary } from "../../contexts/operations/types.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
+import type { DataGridColumn } from "../../shared/ui/filterable-data-grid.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
 import { TitleStack } from "../../shared/ui/title-stack.js";
 import { temporalWebUiWorkflowUrl } from "./temporal-web-ui.js";
@@ -14,92 +13,96 @@ function formatDurationMs(value: number | null): string {
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   const remainder = seconds % 60;
-  if (minutes < 60) return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
+  if (minutes < 60)
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`;
   const hours = Math.floor(minutes / 60);
   const minRemainder = minutes % 60;
   return minRemainder ? `${hours}h ${minRemainder}m` : `${hours}h`;
 }
 
-export const workflowRunColumns: ColumnDef<WorkflowRunSummary>[] = [
+export const workflowRunColumns: Array<DataGridColumn<WorkflowRunSummary>> = [
   {
     id: "status",
-    header: "Status",
-    enableSorting: false,
-    accessorFn: (row) => row.status,
-    cell: ({ row }) => <RunStatusBadge status={row.original.status} />,
+    label: "Status",
+    sortable: true,
+    getFilterValue: (row) => row.status,
+    render: (row) => <RunStatusBadge status={row.status} />,
   },
   {
     id: "title",
-    header: "Job",
-    enableSorting: false,
-    accessorFn: (row) => row.title,
-    cell: ({ row }) => (
-      <TitleStack primary={row.original.title} secondary={row.original.company} />
-    ),
+    label: "Job",
+    sortable: true,
+    rowHeader: true,
+    getFilterValue: (row) => row.title,
+    getFilterSearchValue: (row) => `${row.title} ${row.company}`,
+    render: (row) => <TitleStack primary={row.title} secondary={row.company} />,
   },
   {
     id: "workflow",
-    header: "Workflow",
-    enableSorting: false,
-    accessorFn: (row) => row.workflowId,
-    cell: ({ row }) => (
-      <span className="mono" title={`Workflow id: ${row.original.workflowId}`}>
-        {row.original.workflowId}
+    label: "Workflow",
+    getFilterValue: (row) => row.workflowId,
+    render: (row) => (
+      <span className="mono" title={`Workflow id: ${row.workflowId}`}>
+        {row.workflowId}
       </span>
     ),
   },
   {
     id: "model",
-    header: "Model",
-    enableSorting: false,
-    accessorFn: (row) => row.model,
-    cell: ({ row }) => <span>{row.original.model ?? "-"}</span>,
+    label: "Model",
+    sortable: true,
+    getFilterValue: (row) => row.model ?? "-",
+    render: (row) => <span>{row.model ?? "-"}</span>,
   },
   {
     id: "dry_run",
-    header: "Mode",
-    enableSorting: false,
-    accessorFn: (row) => (row.dryRun ? "dry-run" : "live"),
-    cell: ({ row }) =>
-      row.original.dryRun ? <span className="tag info">dry-run</span> : <span>live</span>,
+    label: "Mode",
+    sortable: true,
+    getFilterValue: (row) => (row.dryRun ? "dry-run" : "live"),
+    render: (row) =>
+      row.dryRun ? (
+        <span className="tag info">dry-run</span>
+      ) : (
+        <span>live</span>
+      ),
   },
   {
     id: "started_at",
-    header: "Started",
-    enableSorting: false,
-    accessorFn: (row) => row.startedAt,
-    cell: ({ row }) => <RelativeTime value={row.original.startedAt} />,
+    label: "Started",
+    sortable: true,
+    getFilterValue: (row) => row.startedAt ?? "-",
+    render: (row) => <RelativeTime value={row.startedAt} />,
   },
   {
     id: "duration",
-    header: "Duration",
-    enableSorting: false,
-    accessorFn: (row) => row.durationMs,
-    cell: ({ row }) => <span className="mono">{formatDurationMs(row.original.durationMs)}</span>,
+    label: "Duration",
+    sortable: true,
+    getFilterValue: (row) => formatDurationMs(row.durationMs),
+    render: (row) => (
+      <span className="mono">{formatDurationMs(row.durationMs)}</span>
+    ),
   },
   {
     id: "finished_at",
-    header: "Finished",
-    enableSorting: false,
-    accessorFn: (row) => row.finishedAt,
-    cell: ({ row }) => (
-      <span className="mono" title={formatDateTime(row.original.finishedAt)}>
-        {row.original.finishedAt ? formatDateTime(row.original.finishedAt) : "-"}
+    label: "Finished",
+    sortable: true,
+    getFilterValue: (row) => row.finishedAt ?? "-",
+    render: (row) => (
+      <span className="mono" title={formatDateTime(row.finishedAt)}>
+        {row.finishedAt ? formatDateTime(row.finishedAt) : "-"}
       </span>
     ),
   },
   {
     id: "temporal_link",
-    header: "Temporal Web UI",
-    enableSorting: false,
-    accessorFn: (row) => row.workflowId,
-    cell: ({ row }) => (
+    label: "Temporal Web UI",
+    render: (row) => (
       <a
         className="btn ghost"
-        href={temporalWebUiWorkflowUrl(row.original.workflowId)}
+        href={temporalWebUiWorkflowUrl(row.workflowId)}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={`Open workflow ${row.original.workflowId} in Temporal Web UI`}
+        aria-label={`Open workflow ${row.workflowId} in Temporal Web UI`}
         onClick={(event) => event.stopPropagation()}
       >
         Open in Temporal

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -173,8 +173,8 @@ Out of scope for the local stack (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)
   state. Filters, sort, and page already survive live updates by virtue
   of the TanStack Router URL-state architecture; selection lives in
   `useState` in `apps/web/src/views/jobs/JobsView.tsx:51-66`, survives
-  SSE invalidations (TanStack Table preserves `rowSelection` across query
-  updates), and is cleared only on filter / sort / page change. If
+  SSE invalidations through stable row ids in the shared data grid, and is
+  cleared only on filter / sort / page change. If
   shareable selections become a requirement, promote to URL state.
 - Add side-by-side artifact comparison in the app, including AI-assisted
   comparison for resume and cover-letter variants.
@@ -283,7 +283,7 @@ no dual-mount, no compatibility shim.
 
 ## Frontend Accessibility Backlog (Phase 7 Deferrals)
 
-18 Storybook stories defer the a11y bar (`a11y: { test: "off" }`) because
+15 Storybook stories defer the a11y bar (`a11y: { test: "off" }`) because
 they exercise pre-existing production accessibility defects that are scoped
 out of the Phase 7 baseline. Each defect needs a follow-up production fix;
 once fixed, the deferral is removed from the corresponding story
@@ -291,13 +291,12 @@ parameters.
 
 | Production file | Defect | Stories that defer |
 | --- | --- | --- |
-| `apps/web/src/shared/ui/data-table.tsx` | Missing `role="row"` on table rows; missing `aria-sort` on sortable column headers. | `data-table.stories.tsx`, `JobsTable.stories.tsx`, `ArtifactsTable.stories.tsx` |
+| `apps/web/src/shared/ui/data-table.tsx` | Missing `role="row"` on table rows; missing `aria-sort` on sortable column headers. | `data-table.stories.tsx` |
 | `apps/web/src/shared/ui/toast.tsx` | `ToastClose` icon-only button has no accessible name (`button-name` axe rule). | `toast.stories.tsx`, `toaster.stories.tsx` |
 | `apps/web/src/views/jobs/JobFilterBar.tsx` | Bare `<select>` element with no associated label (`select-name` axe rule). | `JobFilterBar.stories.tsx` |
 | `apps/web/src/views/artifacts/ArtifactFilterBar.tsx` | Bare `<select>` element with no associated label. | `ArtifactFilterBar.stories.tsx` |
-| `apps/web/src/views/jobs/JobsView.tsx` (composes the above) | Inherits `DataTable` + `JobFilterBar` defects. | `JobsView.stories.tsx` |
-| `apps/web/src/views/artifacts/ArtifactsView.tsx` (composes the above) | Inherits `DataTable` + `ArtifactFilterBar` defects. | `ArtifactsView.stories.tsx` |
-| `apps/web/src/views/runs/RunsView.tsx` (composes `DataTable`) | Inherits `DataTable` defects. | `RunsView.stories.tsx` |
+| `apps/web/src/views/jobs/JobsView.tsx` (composes the above) | Inherits `JobFilterBar` defects. | `JobsView.stories.tsx` |
+| `apps/web/src/views/artifacts/ArtifactsView.tsx` (composes the above) | Inherits `ArtifactFilterBar` defects. | `ArtifactsView.stories.tsx` |
 | `apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx` | Bare `<select>` elements with no labels; icon-only buttons missing accessible names. | `StructuredProfileEditor.stories.tsx`, `ProfileEditor.stories.tsx` (composes it) |
 | `apps/web/src/contexts/apply/components/ApplyHistory.tsx` | TanStack Router `<Link>` rendered as a button without an accessible name. | `ApplyHistory.stories.tsx` |
 | Radix `DropdownMenu` portal | `aria-hidden-focus` violation reported during the open animation (Radix transient internal state). | `dropdown-menu.stories.tsx` |
@@ -308,7 +307,7 @@ parameters.
 
 Production fixes for the in-repo files (`data-table.tsx`, `toast.tsx`,
 `JobFilterBar.tsx`, `ArtifactFilterBar.tsx`, `StructuredProfileEditor.tsx`,
-`ApplyHistory.tsx`) unblock 13 of the 18 deferrals immediately. The five
+`ApplyHistory.tsx`) unblock 10 of the 15 deferrals immediately. The five
 remaining deferrals (Radix transient internals + cmdk) need either upstream
 fixes or local wrappers with the missing ARIA plumbing.
 

--- a/docs/delivered.md
+++ b/docs/delivered.md
@@ -116,9 +116,10 @@ Delivered (Phases 1–8):
 - **Phase 4 — Forms + Tables + Drawers (PR #27):** TanStack Form + Zod
   `safeParse` for the profile editor, settings form, credential form,
   and the resume-import wizard (nested routes with a Zustand+persist
-  draft store). TanStack Table v8 powers `JobsTable` and `ArtifactsTable`
-  with column models in `views/<view>/columns.tsx` and cell renderers
-  composed from context-owned components.
+  draft store). Shared table/data-grid models power `JobsTable`,
+  `ArtifactsTable`, and `RunsTable` with column models in
+  `views/<view>/columns.tsx` and cell renderers composed from
+  context-owned components.
 - **Phase 5 — SSE Endpoint + Real EventStream Adapter + Populated Router
   (PR #28):** `GET /v1/events/stream` ships on `apps/api/` with the
   COALESCE tenant filter, `Last-Event-ID` resume, `retry: 5000`,

--- a/docs/frontend-target.md
+++ b/docs/frontend-target.md
@@ -2364,7 +2364,7 @@ apps/web/
 │   │   │   └── index.ts
 │   │   ├── jobs/
 │   │   │   ├── JobsView.tsx
-│   │   │   ├── JobsTable.tsx              # TanStack Table v8
+│   │   │   ├── JobsTable.tsx              # shared data grid
 │   │   │   ├── JobFilterBar.tsx           # binds to URL via useSearch
 │   │   │   ├── JobBulkActions.tsx
 │   │   │   ├── JobDetailDrawer.tsx
@@ -2400,7 +2400,7 @@ apps/web/
 │   │   │   ├── badge.tsx
 │   │   │   ├── card.tsx
 │   │   │   ├── form.tsx                    # TanStack Form bindings
-│   │   │   ├── table.tsx                   # primitives for TanStack Table
+│   │   │   ├── table.tsx                   # native table primitives
 │   │   │   └── copyable-command.tsx        # `<CopyableCommand command={...} />` — preserves the "copyable CLI commands" affordance per docs/decisions.md (2026-05-03)
 │   │   ├── layout/
 │   │   │   ├── AppShell.tsx
@@ -2722,8 +2722,8 @@ sees stale data for up to `staleTime` even with the
 ### R10. Bundle-size growth as features compound
 
 Per-route code splitting (§4.3) limits initial-load cost, but a single
-large route (e.g., the jobs view with the full TanStack Table machinery
-+ all column renderers from every context) can dwarf others.
+large route (e.g., the jobs view with the full data-grid machinery + all
+column renderers from every context) can dwarf others.
 
 **Mitigations:**
 - The CI step `pnpm web:build` reports bundle sizes per route; a
@@ -2831,7 +2831,7 @@ first's reconciliation.
 | **JobActions** | Frontend (Pipeline composer) | Toolbar component composing per-stage / per-action buttons (`<RetryStageButton />`, `<GenerateMaterialsButton />`, `<ApplyButton />`, `<MarkAppliedButton />`, etc.). |
 | **JobDetailDrawer** | Frontend (Jobs view) | The right-side sheet (in `views/jobs/`) that opens when a job is selected. Composes overview, score, stages, artifacts, apply history, and actions from the contexts that own each. |
 | **JobId** | Domain (shared) | The system-generated stable identifier for a job per `ddd-target.md` §3.1 / §4.1. Branded type (`string & { __brand: "JobId" }`) constructed via `createJobId(...)` from `@jobhunter/domain-types`. The frontend uses `JobId` as its domain term throughout; the API client's currently-named `jobKey: string` parameter is a transport detail mapped at the ACL boundary (§6.5). |
-| **JobsTable** | Frontend (Jobs view) | The TanStack Table v8 instance in `views/jobs/JobsTable.tsx` rendering the jobs list; receives data from `useJobsListQuery` (Operations) and column cell components from `contexts/scoring/`, `contexts/pipeline/`, etc. |
+| **JobsTable** | Frontend (Jobs view) | The shared data-grid instance in `views/jobs/JobsTable.tsx` rendering the jobs list; receives data from `useJobsListQuery` (Operations) and column cell components from `contexts/scoring/`, `contexts/pipeline/`, etc. |
 | **KPI** | Frontend (Dashboard) | A top-line metric tile on the dashboard. |
 | **LayerSeparation** | Frontend (Modeling) | The architectural rule that every datum lives in exactly one of three layers: server (Query), URL (Router), or client (Zustand/Context). See §2.1. |
 | **Loader (Route)** | Frontend (Routing) | A function on a TanStack Router route that prefetches data via `queryClient.ensureQueryData(...)` before the component renders. |
@@ -2857,7 +2857,7 @@ first's reconciliation.
 | **TanStack Query** | Frontend (Library) | The server-state cache. All projection reads, mutations, and SSE-driven invalidations route through it. |
 | **TanStack Router** | Frontend (Library) | The routing library. File-based routes via Vite plugin; typed search params via Zod schemas; per-route loaders for prefetching. |
 | **TanStack Start** | Frontend (Evolution) | The SSR/RSC framework built on TanStack Router and Query. Named as the SSR evolution path; not built today. |
-| **TanStack Table** | Frontend (Library) | Headless table primitive used by `JobsTable` and `ArtifactsTable`. Replaces hand-rolled sort/select/pagination logic. |
+| **Shared Data Grid** | Frontend (UI Primitive) | Table primitive used by registry, jobs, artifacts, and runs tables. Provides the common sort, per-column filter, pagination, row selection, and row activation behavior. |
 | **TelemetryPort** | Frontend (Hexagonal) | Port for emitting frontend telemetry. Local adapter is no-op + console; hosted adapter is `OpenTelemetryWebAdapter`. |
 | **TenantProvider** | Frontend (Provider) | Context that exposes `useTenantId()`. Today reads from `LocalSessionAdapter`; tomorrow from JWT. |
 | **TenantPrefix** | Frontend (Query keys) | The first segment of every query key: `["tenant", tenantId, ...]`. Ensures cache isolation across tenants from day one. |

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -92,8 +92,8 @@ messages.
 Discovery product-control endpoints are local-first and share DTOs from
 `packages/contracts`. The web Discovery page composes these endpoints into
 source-registry, source-locator, quarantine-review, and manual-capture tabs; the
-source registry renders as a filterable/sortable table so source type and policy
-metadata are visible as columns instead of compact badges:
+source registry renders as a paginated, filterable, sortable table so source
+type and policy metadata are visible as columns instead of compact badges:
 
 - `GET /v1/discovery/sources` lists source registry entries merged with
   `source_quality_stats`.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -454,17 +454,33 @@ export type WorkflowRunStatus = (typeof WORKFLOW_RUN_STATUSES)[number];
 export const WORKFLOW_RUN_STATUS_FILTERS = ["all", ...WORKFLOW_RUN_STATUSES] as const;
 export type WorkflowRunStatusFilter = (typeof WORKFLOW_RUN_STATUS_FILTERS)[number];
 
+export const WORKFLOW_RUN_SORT_FIELDS = [
+  "started_at",
+  "finished_at",
+  "duration_ms",
+  "title",
+  "company",
+  "status",
+  "model",
+  "dry_run",
+] as const;
+export type WorkflowRunSortField = (typeof WORKFLOW_RUN_SORT_FIELDS)[number];
+
 export const WorkflowRunsListQuerySchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1).catch(1),
     pageSize: z.coerce.number().int().min(1).max(200).optional().catch(undefined),
     page_size: z.coerce.number().int().min(1).max(200).optional().catch(undefined),
     status: z.enum(WORKFLOW_RUN_STATUS_FILTERS).default("all").catch("all"),
+    sort: z.enum(WORKFLOW_RUN_SORT_FIELDS).default("started_at").catch("started_at"),
+    dir: SortDirectionSchema,
   })
   .transform((value) => ({
     page: value.page,
     pageSize: value.pageSize ?? value.page_size ?? 50,
     status: value.status,
+    sort: value.sort,
+    dir: value.dir,
   }));
 export type WorkflowRunsListQuery = z.infer<typeof WorkflowRunsListQuerySchema>;
 


### PR DESCRIPTION
## Summary
- Standardize Jobs, Artifacts, Runs, and Discovery Source registry tables on the shared filterable data grid with per-column filter dialogs and pagination.
- Add workflow-run sort fields through the contracts/API/read-model path so Runs table sorting stays server-backed.
- Replace the dashboard blocked KPI caption with clearer copy and refresh related docs/stories.

## Validation
- `corepack pnpm --filter @jobhunter/web test -- filterable-data-grid DiscoveryProductControls DiscoveryView JobsTable RunsTable RunsView`
- `corepack pnpm --filter @jobhunter/api test -- test/server.test.ts`
- `corepack pnpm web:check`
- `corepack pnpm api:check`
- `corepack pnpm --filter @jobhunter/contracts check`
- `corepack pnpm --filter @jobhunter/api-client check`
- `corepack pnpm web:build`
- `git diff --check`
- Live Discovery table smoke check: 14 column filter buttons, active State filter, Company filter dialog, pagination visible
