### PR TITLE
feat: expand target search recall

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,14 +413,17 @@ working while sources are promoted or rejected.
 
 The Preferences tab's Target search fields are discovery inputs. Target roles
 replace the active discovery query list with exact role queries plus
-deterministic JobSpy-only recall queries. Recall queries keep the same search
-tier as exact queries because relevance is determined after discovery by
-scoring, not by query generation. Target locations replace the active location
-list, and if target locations are blank the worker falls back to the profile
-city/country. Target locations are validated as real places before they can be
-saved. Hybrid and on-site target work models search and filter only the target
-location. Remote target work models search and filter the target country, and
-European countries also add an Europe-remote search and accept pattern.
+deterministic recall queries. Recall queries keep the same search tier as exact
+queries because relevance is determined after discovery by scoring, not by query
+generation. Broad-board providers such as JobSpy use those queries as retrieval
+probes. Direct ATS and Workday sources enumerate their known board/source and
+apply the same exact-plus-recall title intent internally, avoiding repeated
+board fetches for each role variant. Target locations replace the active
+location list, and if target locations are blank the worker falls back to the
+profile city/country. Target locations are validated as real places before they
+can be saved. Hybrid and on-site target work models search and filter only the
+target location. Remote target work models search and filter the target country,
+and European countries also add an Europe-remote search and accept pattern.
 Profile-driven discovery searches at least the last 30 days unless local config
 sets a larger window. A Spain or Europe target sets JobSpy's Indeed country to
 Spain, rejects America-only non-remote locations, and hides packaged

--- a/README.md
+++ b/README.md
@@ -412,12 +412,15 @@ Smart Extract entries start as `experimental` with the
 working while sources are promoted or rejected.
 
 The Preferences tab's Target search fields are discovery inputs. Target roles
-replace the active discovery query list, target locations replace the active
-location list, and if target locations are blank the worker falls back to the
-profile city/country. Target locations are validated as real places before they
-can be saved. Hybrid and on-site target work models search and filter only the
-target location. Remote target work models search and filter the target country,
-and European countries also add an Europe-remote search and accept pattern.
+replace the active discovery query list with exact tier-1 role queries plus
+deterministic lower-tier recall queries for JobSpy broad-board discovery, while
+Workday and ATS sources stay on exact tier-1 queries by default. Target
+locations replace the active location list, and if target locations are blank
+the worker falls back to the profile city/country. Target locations are
+validated as real places before they can be saved. Hybrid and on-site target
+work models search and filter only the target location. Remote target work
+models search and filter the target country, and European countries also add an
+Europe-remote search and accept pattern.
 Profile-driven discovery searches at least the last 30 days unless local config
 sets a larger window. A Spain or Europe target sets JobSpy's Indeed country to
 Spain, rejects America-only non-remote locations, and hides packaged

--- a/README.md
+++ b/README.md
@@ -412,15 +412,15 @@ Smart Extract entries start as `experimental` with the
 working while sources are promoted or rejected.
 
 The Preferences tab's Target search fields are discovery inputs. Target roles
-replace the active discovery query list with exact tier-1 role queries plus
-deterministic lower-tier recall queries for JobSpy broad-board discovery, while
-Workday and ATS sources stay on exact tier-1 queries by default. Target
-locations replace the active location list, and if target locations are blank
-the worker falls back to the profile city/country. Target locations are
-validated as real places before they can be saved. Hybrid and on-site target
-work models search and filter only the target location. Remote target work
-models search and filter the target country, and European countries also add an
-Europe-remote search and accept pattern.
+replace the active discovery query list with exact role queries plus
+deterministic JobSpy-only recall queries. Recall queries keep the same search
+tier as exact queries because relevance is determined after discovery by
+scoring, not by query generation. Target locations replace the active location
+list, and if target locations are blank the worker falls back to the profile
+city/country. Target locations are validated as real places before they can be
+saved. Hybrid and on-site target work models search and filter only the target
+location. Remote target work models search and filter the target country, and
+European countries also add an Europe-remote search and accept pattern.
 Profile-driven discovery searches at least the last 30 days unless local config
 sets a larger window. A Spain or Europe target sets JobSpy's Indeed country to
 Spain, rejects America-only non-remote locations, and hides packaged

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -314,8 +314,10 @@ classDiagram
 - Reads source registry data from packaged YAML plus local
   `source_registry_entries`.
 - Reads source-quality snapshots to schedule and budget sources.
-- Reads target search from `candidate_profiles` and overlays it onto
-  discovery search config.
+- Reads target search from `candidate_profiles` and overlays it onto discovery
+  search config as exact tier-1 role queries plus deterministic lower-tier
+  JobSpy recall queries. Workday and ATS discovery remain exact-tier by
+  default.
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -230,6 +230,7 @@ sequenceDiagram
     participant Rpc as JSON-RPC run_stage
     participant Action as run_local_action
     participant Runner as _run_discover
+    participant QueryPlanner as Target query planner
     participant Scheduler as DiscoveryScheduler
     participant JobSpy
     participant ATS as Canonical ATS APIs
@@ -241,15 +242,18 @@ sequenceDiagram
     Api->>Rpc: run_stage(stage="discover", limit, workers)
     Rpc->>Action: LocalActionRequest(stage="discover")
     Action->>Runner: run_pipeline(stages=["discover"])
-    Runner->>DB: init_db(); refresh source-control rows idempotently
+    Runner->>DB: init_db
+    Runner->>DB: refresh source-control rows idempotently
+    Runner->>QueryPlanner: compile profile target roles and locations
+    QueryPlanner-->>Runner: exact queries plus scoped recall queries
     Runner->>Scheduler: plan(registry, source quality, global limit)
     Scheduler-->>Runner: DiscoverySchedule
 
-    Runner->>JobSpy: run_discovery(cfg, scheduled boards, limit, run_id)
+    Runner->>JobSpy: run_discovery(cfg with exact plus recall queries)
     JobSpy->>DB: insert jobs, broad-board observations, learned source candidates
-    Runner->>ATS: run_scheduled_ats_sources(...)
+    Runner->>ATS: run scheduled canonical sources with in-scope queries
     ATS->>DB: create canonical jobs and source observations
-    Runner->>Workday: run_workday_discovery(...)
+    Runner->>Workday: run configured employers with in-scope queries
     Workday->>DB: insert/update jobs and observations
     Runner->>Smart: run_smart_extract(...)
     Smart->>DB: insert jobs, quarantine, manual-capture queue
@@ -270,6 +274,10 @@ classDiagram
     }
     class DiscoveryScheduler {
       +plan(registry, quality, global_limit)
+    }
+    class TargetQueryPlanner {
+      +build_target_role_queries(roles)
+      +query_applies_to_source(query, source)
     }
     class DiscoverySchedule {
       +for_prefix(prefix)
@@ -300,6 +308,7 @@ classDiagram
     }
 
     RunDiscover --> DiscoveryScheduler
+    RunDiscover --> TargetQueryPlanner
     DiscoveryScheduler --> DiscoverySchedule
     DiscoverySchedule --> SourceRegistryEntry
     RunDiscover --> JobSpyAdapter
@@ -318,6 +327,20 @@ classDiagram
   search config as exact role queries plus deterministic JobSpy-only recall
   queries. Recall queries keep the same search tier as exact queries because
   scoring, not query generation, determines relevance.
+- Compiles target roles into two query kinds:
+  - exact queries, copied from the saved profile role text after note stripping;
+  - recall queries, generated from the same target-role intent and marked with
+    `match_mode=recall`, `generated_from=target_roles`, and
+    `source_scope=["jobspy"]`.
+- Treats `source_scope` as an execution guard, not a relevance score. JobSpy is
+  the breadth layer: one query fans out across broad boards and many employers,
+  so recall expansion increases candidate coverage before scoring. Workday and
+  canonical ATS adapters are the source-verification layer: they run against
+  known employer/ATS sources, so applying the same recall expansion there would
+  multiply `queries x sources` before source-specific evidence says that source
+  is worth a broader crawl. Direct sources still run exact profile queries and
+  can become broader later through explicit source configuration, learned
+  runnable-source promotion, or manual/source-locator review.
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.
@@ -339,7 +362,10 @@ classDiagram
 Each source family is isolated. A failed JobSpy, ATS, Workday, or Smart Extract
 step records failure information and lets the caller see a partial source
 result. With `limit > 0`, the stage uses sequential source execution and skips
-remaining source families once the observed-job cap is consumed.
+remaining source families once the new-job cap is consumed. JobSpy also applies
+that cap inside its query loop: existing rediscoveries record observations but
+do not consume the remaining new-job budget, so exact-query duplicates do not
+prevent later recall queries from running.
 
 ## Phase 2: Enrich
 

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -245,15 +245,15 @@ sequenceDiagram
     Runner->>DB: init_db
     Runner->>DB: refresh source-control rows idempotently
     Runner->>QueryPlanner: compile profile target roles and locations
-    QueryPlanner-->>Runner: exact queries plus scoped recall queries
+    QueryPlanner-->>Runner: exact queries plus recall query filters
     Runner->>Scheduler: plan(registry, source quality, global limit)
     Scheduler-->>Runner: DiscoverySchedule
 
     Runner->>JobSpy: run_discovery(cfg with exact plus recall queries)
     JobSpy->>DB: insert jobs, broad-board observations, learned source candidates
-    Runner->>ATS: run scheduled canonical sources with in-scope queries
+    Runner->>ATS: enumerate scheduled canonical sources and filter internally
     ATS->>DB: create canonical jobs and source observations
-    Runner->>Workday: run configured employers with in-scope queries
+    Runner->>Workday: enumerate configured employers and filter internally
     Workday->>DB: insert/update jobs and observations
     Runner->>Smart: run_smart_extract(...)
     Smart->>DB: insert jobs, quarantine, manual-capture queue
@@ -278,6 +278,7 @@ classDiagram
     class TargetQueryPlanner {
       +build_target_role_queries(roles)
       +query_applies_to_source(query, source)
+      +title_matches_any_query(title, queries)
     }
     class DiscoverySchedule {
       +for_prefix(prefix)
@@ -324,23 +325,19 @@ classDiagram
   `source_registry_entries`.
 - Reads source-quality snapshots to schedule and budget sources.
 - Reads target search from `candidate_profiles` and overlays it onto discovery
-  search config as exact role queries plus deterministic JobSpy-only recall
-  queries. Recall queries keep the same search tier as exact queries because
-  scoring, not query generation, determines relevance.
+  search config as exact role queries plus deterministic recall queries. Recall
+  queries keep the same search tier as exact queries because scoring, not query
+  generation, determines relevance.
 - Compiles target roles into two query kinds:
   - exact queries, copied from the saved profile role text after note stripping;
   - recall queries, generated from the same target-role intent and marked with
-    `match_mode=recall`, `generated_from=target_roles`, and
-    `source_scope=["jobspy"]`.
-- Treats `source_scope` as an execution guard, not a relevance score. JobSpy is
-  the breadth layer: one query fans out across broad boards and many employers,
-  so recall expansion increases candidate coverage before scoring. Workday and
-  canonical ATS adapters are the source-verification layer: they run against
-  known employer/ATS sources, so applying the same recall expansion there would
-  multiply `queries x sources` before source-specific evidence says that source
-  is worth a broader crawl. Direct sources still run exact profile queries and
-  can become broader later through explicit source configuration, learned
-  runnable-source promotion, or manual/source-locator review.
+    `match_mode=recall` and `generated_from=target_roles`.
+- Applies exact-plus-recall intent to every discovery source family, but the
+  execution shape differs by source type. JobSpy is a broad-board retrieval
+  provider, so exact and recall queries are sent as external search probes.
+  Direct ATS and Workday sources are known boards/employers, so they enumerate
+  the source once per location and run exact-plus-recall title matching
+  internally instead of multiplying `queries x sources`.
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -315,9 +315,9 @@ classDiagram
   `source_registry_entries`.
 - Reads source-quality snapshots to schedule and budget sources.
 - Reads target search from `candidate_profiles` and overlays it onto discovery
-  search config as exact tier-1 role queries plus deterministic lower-tier
-  JobSpy recall queries. Workday and ATS discovery remain exact-tier by
-  default.
+  search config as exact role queries plus deterministic JobSpy-only recall
+  queries. Recall queries keep the same search tier as exact queries because
+  scoring, not query generation, determines relevance.
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -158,16 +158,19 @@ field caps pending detail jobs instead of falling back to the enrichment default
 batch size.
 
 Discover honors the profile Target search saved from the Preferences tab.
-Target roles replace the active discovery query list, target locations replace
-the active location list, and the worker falls back to profile city/country when
-target locations are blank. The API validates target locations as real places
-before saving profile preferences. Hybrid and on-site target work models search
-and filter only the target location. Remote target work models search and filter
-the target country, and European countries also add an Europe-remote search and
-accept pattern. Profile-driven discovery searches at least the last 30 days
-unless local config sets a larger window. Spain or Europe targets set JobSpy's
-Indeed country to Spain, reject America-only non-remote locations, and filter
-API-visible America-only source rows from `GET /v1/discovery/sources`.
+Target roles replace the active discovery query list with exact tier-1 role
+queries plus deterministic lower-tier recall queries for JobSpy broad-board
+discovery. Workday and ATS sources stay on exact tier-1 queries by default.
+Target locations replace the active location list, and the worker falls back to
+profile city/country when target locations are blank. The API validates target
+locations as real places before saving profile preferences. Hybrid and on-site
+target work models search and filter only the target location. Remote target
+work models search and filter the target country, and European countries also
+add an Europe-remote search and accept pattern. Profile-driven discovery
+searches at least the last 30 days unless local config sets a larger window.
+Spain or Europe targets set JobSpy's Indeed country to Spain, reject
+America-only non-remote locations, and filter API-visible America-only source
+rows from `GET /v1/discovery/sources`.
 
 The JSON-RPC worker is launched with the API runtime `appDir` as
 `JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -158,19 +158,19 @@ field caps pending detail jobs instead of falling back to the enrichment default
 batch size.
 
 Discover honors the profile Target search saved from the Preferences tab.
-Target roles replace the active discovery query list with exact tier-1 role
-queries plus deterministic lower-tier recall queries for JobSpy broad-board
-discovery. Workday and ATS sources stay on exact tier-1 queries by default.
-Target locations replace the active location list, and the worker falls back to
-profile city/country when target locations are blank. The API validates target
-locations as real places before saving profile preferences. Hybrid and on-site
-target work models search and filter only the target location. Remote target
-work models search and filter the target country, and European countries also
-add an Europe-remote search and accept pattern. Profile-driven discovery
-searches at least the last 30 days unless local config sets a larger window.
-Spain or Europe targets set JobSpy's Indeed country to Spain, reject
-America-only non-remote locations, and filter API-visible America-only source
-rows from `GET /v1/discovery/sources`.
+Target roles replace the active discovery query list with exact role queries
+plus deterministic JobSpy-only recall queries. Recall queries keep the same
+search tier as exact queries because relevance is determined after discovery by
+scoring, not by query generation. Target locations replace the active location
+list, and the worker falls back to profile city/country when target locations
+are blank. The API validates target locations as real places before saving
+profile preferences. Hybrid and on-site target work models search and filter
+only the target location. Remote target work models search and filter the
+target country, and European countries also add an Europe-remote search and
+accept pattern. Profile-driven discovery searches at least the last 30 days
+unless local config sets a larger window. Spain or Europe targets set JobSpy's
+Indeed country to Spain, reject America-only non-remote locations, and filter
+API-visible America-only source rows from `GET /v1/discovery/sources`.
 
 The JSON-RPC worker is launched with the API runtime `appDir` as
 `JOBHUNTER_DIR`, so API reads, SSE, and Python automation all use the same

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -159,15 +159,18 @@ batch size.
 
 Discover honors the profile Target search saved from the Preferences tab.
 Target roles replace the active discovery query list with exact role queries
-plus deterministic JobSpy-only recall queries. Recall queries keep the same
-search tier as exact queries because relevance is determined after discovery by
-scoring, not by query generation. Target locations replace the active location
-list, and the worker falls back to profile city/country when target locations
-are blank. The API validates target locations as real places before saving
-profile preferences. Hybrid and on-site target work models search and filter
-only the target location. Remote target work models search and filter the
-target country, and European countries also add an Europe-remote search and
-accept pattern. Profile-driven discovery searches at least the last 30 days
+plus deterministic recall queries. Recall queries keep the same search tier as
+exact queries because relevance is determined after discovery by scoring, not by
+query generation. JobSpy uses exact-plus-recall queries as broad-board retrieval
+probes. Direct ATS and Workday sources enumerate their known board/source and
+apply that same title intent internally, avoiding repeated board fetches for
+each role variant. Target locations replace the active location list, and the
+worker falls back to profile city/country when target locations are blank. The
+API validates target locations as real places before saving profile preferences.
+Hybrid and on-site target work models search and filter only the target
+location. Remote target work models search and filter the target country, and
+European countries also add an Europe-remote search and accept pattern.
+Profile-driven discovery searches at least the last 30 days
 unless local config sets a larger window. Spain or Europe targets set JobSpy's
 Indeed country to Spain, reject America-only non-remote locations, and filter
 API-visible America-only source rows from `GET /v1/discovery/sources`.

--- a/docs/plans/proposed/2026-05-24-target-search-recall.md
+++ b/docs/plans/proposed/2026-05-24-target-search-recall.md
@@ -4,7 +4,7 @@
 
 **Goal:** Expand profile-driven discovery searches so strong non-verbatim matches are found without changing saved profile preferences or weakening location controls.
 
-**Architecture:** Keep exact target-role queries as tier 1. Add deterministic JobSpy-only recall queries derived from the same target-role intent, keep them in the same tier, and mark them with a recall title-match mode so broad-board candidates can pass when they match the domain plus seniority/leadership intent. Relevance remains a scoring concern after discovery; query generation should not downrank candidates before they are seen.
+**Architecture:** Keep exact target-role queries as tier 1. Add deterministic recall queries derived from the same target-role intent, keep them in the same tier, and mark them with a recall title-match mode so candidates can pass when they match the domain plus seniority/leadership intent. Broad-board providers use recall queries as retrieval probes; direct ATS and Workday sources enumerate known boards/employers and apply the same exact-plus-recall intent internally. Relevance remains a scoring concern after discovery; query generation should not downrank candidates before they are seen.
 
 **Tech Stack:** Python worker discovery config, JobSpy adapter, shared title filtering helpers, pytest.
 
@@ -19,15 +19,15 @@
 
 - [x] **Step 1: Define deterministic exact-plus-recall query planning**
 
-Add a helper that turns target roles into ordered query dictionaries. Exact profile roles stay tier 1 with strict matching. Recall queries also stay tier 1, are deduped against exact roles, and carry `match_mode: "recall"`, `generated_from: "target_roles"`, and `source_scope: ["jobspy"]`.
+Add a helper that turns target roles into ordered query dictionaries. Exact profile roles stay tier 1 with strict matching. Recall queries also stay tier 1, are deduped against exact roles, and carry `match_mode: "recall"` and `generated_from: "target_roles"`.
 
 - [x] **Step 2: Wire profile target roles through the planner**
 
-Replace the direct `next_cfg["queries"] = [{"query": role, "tier": 1} ...]` assignment with the planner output. Preserve `workday_max_tier = 1` and `ats_max_tier = 1`, and have Workday/ATS query selection respect query `source_scope` so recall expansion does not accidentally multiply direct ATS crawls.
+Replace the direct `next_cfg["queries"] = [{"query": role, "tier": 1} ...]` assignment with the planner output. Preserve `workday_max_tier = 1` and `ats_max_tier = 1`. For direct ATS and Workday, use the planner output as local title filters after source enumeration rather than multiplying board fetches by every role variant.
 
 - [x] **Step 3: Update target-search tests**
 
-Assert that exact roles remain first and tier 1, recall queries are present as tier 1 with JobSpy-only source scope, profile notes are still stripped, and Workday/ATS query selection can skip JobSpy-only recall queries.
+Assert that exact roles remain first and tier 1, recall queries are present as tier 1 without source-only scoping, profile notes are still stripped, and direct ATS query handling uses the recall set as internal filters.
 
 ### Task 2: Add Recall-Safe Title Matching
 
@@ -39,7 +39,7 @@ Assert that exact roles remain first and tier 1, recall queries are present as t
 
 - [x] **Step 1: Preserve strict matching for exact queries**
 
-Keep `title_matches_query(title, query)` behavior unchanged by default so existing exact target roles and direct ATS paths keep their current precision.
+Keep `title_matches_query(title, query)` behavior unchanged by default so exact target roles keep their current precision.
 
 - [x] **Step 2: Add recall match mode**
 
@@ -62,7 +62,7 @@ Cover strict-vs-recall differences in the title filter and a JobSpy adapter test
 
 - [x] **Step 1: Document search behavior**
 
-Update the target-search sections to state that profile roles generate exact queries plus same-tier JobSpy-only recall queries, and that scoring determines relevance after discovery.
+Update the target-search sections to state that profile roles generate exact queries plus same-tier recall queries, JobSpy uses them as broad-board retrieval probes, direct ATS/Workday use them as internal title filters after source enumeration, and scoring determines relevance after discovery.
 
 ### Task 4: Prevent Existing Jobs From Consuming Bounded Discovery
 

--- a/docs/plans/proposed/2026-05-24-target-search-recall.md
+++ b/docs/plans/proposed/2026-05-24-target-search-recall.md
@@ -1,0 +1,73 @@
+# Target Search Recall Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand profile-driven discovery searches so strong non-verbatim matches are found without changing saved profile preferences or weakening location controls.
+
+**Architecture:** Keep exact target-role queries as tier 1. Add deterministic lower-tier recall queries derived from the same target-role intent, and mark those queries with a recall title-match mode so broad-board candidates can pass when they match the domain plus seniority/leadership intent. Keep Workday and ATS searches on tier 1 for now, so the larger recall net applies first to JobSpy broad-board lead generation.
+
+**Tech Stack:** Python worker discovery config, JobSpy adapter, shared title filtering helpers, pytest.
+
+---
+
+### Task 1: Add Target Query Expansion
+
+**Files:**
+- Create: `workers/automation/src/jobhunter/discovery/target_queries.py`
+- Modify: `workers/automation/src/jobhunter/config.py`
+- Test: `workers/automation/tests/test_target_search_preferences.py`
+
+- [x] **Step 1: Define deterministic exact-plus-recall query planning**
+
+Add a helper that turns target roles into ordered query dictionaries. Exact profile roles stay tier 1 with strict matching. Recall queries are tier 2, deduped against exact roles, and carry `match_mode: "recall"` plus `generated_from: "target_roles"`.
+
+- [x] **Step 2: Wire profile target roles through the planner**
+
+Replace the direct `next_cfg["queries"] = [{"query": role, "tier": 1} ...]` assignment with the planner output. Preserve `workday_max_tier = 1` and `ats_max_tier = 1` so direct ATS crawlers do not broaden until source-level evidence supports it.
+
+- [x] **Step 3: Update target-search tests**
+
+Assert that exact roles remain first and tier 1, recall queries are present as tier 2, profile notes are still stripped, and Workday/ATS tier caps remain exact-only.
+
+### Task 2: Add Recall-Safe Title Matching
+
+**Files:**
+- Modify: `workers/automation/src/jobhunter/discovery/title_filter.py`
+- Modify: `workers/automation/src/jobhunter/discovery/jobspy.py`
+- Test: `workers/automation/tests/test_title_filter.py`
+- Test: `workers/automation/tests/test_discovery_limits.py`
+
+- [x] **Step 1: Preserve strict matching for exact queries**
+
+Keep `title_matches_query(title, query)` behavior unchanged by default so existing exact target roles and direct ATS paths keep their current precision.
+
+- [x] **Step 2: Add recall match mode**
+
+Allow `title_matches_query(title, query, match_mode="recall")` to pass when the title contains both a leadership/seniority signal and a domain signal inferred from the generated query. This catches examples like `Head of Technology`, `Director, Cybersecurity`, and `Platform Engineering Manager`, while rejecting plain IC titles like `Software Engineer`.
+
+- [x] **Step 3: Pass query match mode through JobSpy searches**
+
+Carry query metadata from `_full_crawl()` into `_run_one_search()` and use it when filtering returned JobSpy rows by title.
+
+- [x] **Step 4: Add unit coverage**
+
+Cover strict-vs-recall differences in the title filter and a JobSpy adapter test showing recall-mode candidates are stored while non-leadership rows are filtered.
+
+### Task 3: Document And Verify
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/local-ts-api.md`
+- Modify: `docs/job-pipeline-architecture.md`
+
+- [x] **Step 1: Document search behavior**
+
+Update the target-search sections to state that profile roles generate exact tier-1 queries plus deterministic lower-tier broad-board recall queries, while Workday/ATS remain exact-tier by default.
+
+- [x] **Step 2: Verify targeted Python behavior**
+
+Run `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_title_filter.py workers/automation/tests/test_discovery_limits.py`.
+
+- [x] **Step 3: Verify formatting and branch diff**
+
+Run `git diff --check` before committing.

--- a/docs/plans/proposed/2026-05-24-target-search-recall.md
+++ b/docs/plans/proposed/2026-05-24-target-search-recall.md
@@ -4,7 +4,7 @@
 
 **Goal:** Expand profile-driven discovery searches so strong non-verbatim matches are found without changing saved profile preferences or weakening location controls.
 
-**Architecture:** Keep exact target-role queries as tier 1. Add deterministic lower-tier recall queries derived from the same target-role intent, and mark those queries with a recall title-match mode so broad-board candidates can pass when they match the domain plus seniority/leadership intent. Keep Workday and ATS searches on tier 1 for now, so the larger recall net applies first to JobSpy broad-board lead generation.
+**Architecture:** Keep exact target-role queries as tier 1. Add deterministic JobSpy-only recall queries derived from the same target-role intent, keep them in the same tier, and mark them with a recall title-match mode so broad-board candidates can pass when they match the domain plus seniority/leadership intent. Relevance remains a scoring concern after discovery; query generation should not downrank candidates before they are seen.
 
 **Tech Stack:** Python worker discovery config, JobSpy adapter, shared title filtering helpers, pytest.
 
@@ -19,15 +19,15 @@
 
 - [x] **Step 1: Define deterministic exact-plus-recall query planning**
 
-Add a helper that turns target roles into ordered query dictionaries. Exact profile roles stay tier 1 with strict matching. Recall queries are tier 2, deduped against exact roles, and carry `match_mode: "recall"` plus `generated_from: "target_roles"`.
+Add a helper that turns target roles into ordered query dictionaries. Exact profile roles stay tier 1 with strict matching. Recall queries also stay tier 1, are deduped against exact roles, and carry `match_mode: "recall"`, `generated_from: "target_roles"`, and `source_scope: ["jobspy"]`.
 
 - [x] **Step 2: Wire profile target roles through the planner**
 
-Replace the direct `next_cfg["queries"] = [{"query": role, "tier": 1} ...]` assignment with the planner output. Preserve `workday_max_tier = 1` and `ats_max_tier = 1` so direct ATS crawlers do not broaden until source-level evidence supports it.
+Replace the direct `next_cfg["queries"] = [{"query": role, "tier": 1} ...]` assignment with the planner output. Preserve `workday_max_tier = 1` and `ats_max_tier = 1`, and have Workday/ATS query selection respect query `source_scope` so recall expansion does not accidentally multiply direct ATS crawls.
 
 - [x] **Step 3: Update target-search tests**
 
-Assert that exact roles remain first and tier 1, recall queries are present as tier 2, profile notes are still stripped, and Workday/ATS tier caps remain exact-only.
+Assert that exact roles remain first and tier 1, recall queries are present as tier 1 with JobSpy-only source scope, profile notes are still stripped, and Workday/ATS query selection can skip JobSpy-only recall queries.
 
 ### Task 2: Add Recall-Safe Title Matching
 
@@ -62,7 +62,21 @@ Cover strict-vs-recall differences in the title filter and a JobSpy adapter test
 
 - [x] **Step 1: Document search behavior**
 
-Update the target-search sections to state that profile roles generate exact tier-1 queries plus deterministic lower-tier broad-board recall queries, while Workday/ATS remain exact-tier by default.
+Update the target-search sections to state that profile roles generate exact queries plus same-tier JobSpy-only recall queries, and that scoring determines relevance after discovery.
+
+### Task 4: Prevent Existing Jobs From Consuming Bounded Discovery
+
+**Files:**
+- Modify: `workers/automation/src/jobhunter/discovery/jobspy.py`
+- Test: `workers/automation/tests/test_discovery_limits.py`
+
+- [x] **Step 1: Count only new jobs against JobSpy's bounded crawl limit**
+
+Update `_full_crawl()` and `store_jobspy_results()` so existing rediscoveries do not reduce the remaining new-job limit. Keep using the configured fetch size per query so an existing first result does not hide later new candidates in the same query response.
+
+- [x] **Step 2: Add regression coverage**
+
+Add tests proving an existing exact-query hit does not prevent a later recall query from running, and an existing row inside one JobSpy result set does not consume the one-new-job storage limit.
 
 - [x] **Step 2: Verify targeted Python behavior**
 

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -20,7 +20,7 @@ from jobhunter.domain.discovery.source_registry import (
     SourceRegistryEntry,
     SourceState,
 )
-from jobhunter.discovery.title_filter import normalize_query
+from jobhunter.discovery.target_queries import build_target_role_queries
 from jobhunter.infrastructure.observability import source_validation_span
 
 log = logging.getLogger(__name__)
@@ -249,8 +249,7 @@ def _apply_profile_target_search(search_cfg: dict, target: dict | None = None) -
 
     next_cfg = dict(search_cfg)
     if roles:
-        role_queries = _dedupe_strings(normalize_query(role) for role in roles)
-        next_cfg["queries"] = [{"query": role, "tier": 1} for role in role_queries]
+        next_cfg["queries"] = build_target_role_queries(roles)
         next_cfg["workday_max_tier"] = 1
         next_cfg["ats_max_tier"] = 1
 

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -159,7 +159,6 @@ _AMERICA_ONLY_SOURCE_MARKERS = (
     "eluta.ca",
     "smart_extract:dice",
     "dice.com",
-    "smart_extract:wellfound",
     "wellfound.com/role/l/software-engineer/canada",
 )
 
@@ -775,6 +774,12 @@ def _url_has_search_placeholder(url: str) -> bool:
     return "{query_encoded}" in url or "{query}" in url
 
 
+def _row_overrides_adapter_config(row: sqlite3.Row, existing: SourceRegistryEntry | None) -> bool:
+    if existing is None:
+        return True
+    return str(row["owner"] or "").strip().lower() != "system"
+
+
 def _merge_local_source_registry(
     base_registry: list[SourceRegistryEntry],
 ) -> list[SourceRegistryEntry]:
@@ -801,7 +806,8 @@ def _merge_local_source_registry(
             existing.state if existing else SourceState.EXPERIMENTAL,
         )
         adapter_config = dict(existing.adapter_config) if existing else {}
-        adapter_config.update(_adapter_config_from_row(row))
+        if _row_overrides_adapter_config(row, existing):
+            adapter_config.update(_adapter_config_from_row(row))
         display_name = str(row["display_name"] or (existing.display_name if existing else source_id))
         owner = str(row["owner"] or (existing.owner if existing else "user"))
         merged[source_id] = _validated_source(

--- a/workers/automation/src/jobhunter/config/sites.yaml
+++ b/workers/automation/src/jobhunter/config/sites.yaml
@@ -153,7 +153,7 @@ sites:
     type: static
 
   - name: "Wellfound"
-    url: "https://wellfound.com/role/l/software-engineer/canada"
+    url: "https://wellfound.com/location/spain"
     type: static
 
   - name: "Arc.dev"

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -162,7 +162,7 @@ def store_jobspy_results(
     existing = 0
 
     for _, row in df.iterrows():
-        if limit > 0 and new + existing >= limit:
+        if limit > 0 and new >= limit:
             break
         url = str(row.get("job_url", ""))
         if not url or url == "nan":
@@ -898,13 +898,13 @@ def _full_crawl(
     completed = 0
 
     for s in searches:
-        remaining = max(limit - (total_new + total_existing), 0) if limit > 0 else 0
+        remaining = max(limit - total_new, 0) if limit > 0 else 0
         if limit > 0 and remaining <= 0:
             break
         result = _run_one_search(
             s,
             sites,
-            min(results_per_site, remaining) if limit > 0 else results_per_site,
+            results_per_site,
             hours_old,
             proxy_config,
             defaults,

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -625,8 +625,8 @@ def _truthy_remote(value: object) -> bool:
     return text in {"1", "true", "yes", "remote"}
 
 
-def _title_ok(title: str | None, query: str | None) -> bool:
-    return title_matches_query(title, query)
+def _title_ok(title: str | None, query: str | None, *, match_mode: str = "strict") -> bool:
+    return title_matches_query(title, query, match_mode=match_mode)
 
 
 # -- Single search execution -------------------------------------------------
@@ -747,6 +747,7 @@ def _run_one_search(
             lambda row: _title_ok(
                 str(row.get("title", "")) if str(row.get("title", "")) != "nan" else None,
                 s["query"],
+                match_mode=str(s.get("match_mode") or "strict"),
             ),
             axis=1,
         )
@@ -877,6 +878,7 @@ def _full_crawl(
                     "location": loc["location"],
                     "remote": loc.get("remote", False),
                     "tier": q.get("tier", 0),
+                    "match_mode": q.get("match_mode", "strict"),
                 }
             )
 

--- a/workers/automation/src/jobhunter/discovery/target_queries.py
+++ b/workers/automation/src/jobhunter/discovery/target_queries.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping, Sequence
 
 from jobhunter.discovery.title_filter import normalize_query
 
 
 RECALL_MATCH_MODE = "recall"
+JOBSPY_SOURCE_SCOPE = "jobspy"
 
 _RECALL_QUERY_LIMIT = 14
 
@@ -100,9 +101,10 @@ def build_target_role_queries(roles: Iterable[str]) -> list[dict[str, object]]:
         queries.append(
             {
                 "query": query,
-                "tier": 2,
+                "tier": 1,
                 "match_mode": RECALL_MATCH_MODE,
                 "generated_from": "target_roles",
+                "source_scope": [JOBSPY_SOURCE_SCOPE],
             }
         )
         exact_keys.add(key)
@@ -111,6 +113,19 @@ def build_target_role_queries(roles: Iterable[str]) -> list[dict[str, object]]:
             break
 
     return queries
+
+
+def query_applies_to_source(query: Mapping[str, object], source: str) -> bool:
+    """Return whether a query should run for the given discovery source."""
+
+    scope = query.get("source_scope")
+    if not scope:
+        return True
+    if isinstance(scope, str):
+        return scope == source
+    if isinstance(scope, Sequence):
+        return source in {str(item) for item in scope}
+    return True
 
 
 def _recall_queries_for_roles(exact_queries: list[str]) -> list[str]:

--- a/workers/automation/src/jobhunter/discovery/target_queries.py
+++ b/workers/automation/src/jobhunter/discovery/target_queries.py
@@ -6,10 +6,10 @@ import re
 from collections.abc import Iterable, Mapping, Sequence
 
 from jobhunter.discovery.title_filter import normalize_query
+from jobhunter.discovery.title_filter import title_matches_query
 
 
 RECALL_MATCH_MODE = "recall"
-JOBSPY_SOURCE_SCOPE = "jobspy"
 
 _RECALL_QUERY_LIMIT = 14
 
@@ -104,7 +104,6 @@ def build_target_role_queries(roles: Iterable[str]) -> list[dict[str, object]]:
                 "tier": 1,
                 "match_mode": RECALL_MATCH_MODE,
                 "generated_from": "target_roles",
-                "source_scope": [JOBSPY_SOURCE_SCOPE],
             }
         )
         exact_keys.add(key)
@@ -126,6 +125,49 @@ def query_applies_to_source(query: Mapping[str, object], source: str) -> bool:
     if isinstance(scope, Sequence):
         return source in {str(item) for item in scope}
     return True
+
+
+def query_specs_for_source(
+    queries: Iterable[Mapping[str, object]],
+    source: str,
+    *,
+    max_tier: int | None = None,
+) -> list[dict[str, object]]:
+    """Return target query specs that should run or match for a source."""
+
+    result: list[dict[str, object]] = []
+    for item in queries:
+        if not isinstance(item, Mapping) or not query_applies_to_source(item, source):
+            continue
+        if max_tier is not None and int(item.get("tier") or 99) > max_tier:
+            continue
+        query = str(item.get("query") or "").strip()
+        if not query:
+            continue
+        result.append(
+            {
+                "query": query,
+                "match_mode": str(item.get("match_mode") or "strict"),
+                "tier": int(item.get("tier") or 99),
+            }
+        )
+    return result
+
+
+def title_matches_any_query(title: str | None, queries: Iterable[Mapping[str, object]]) -> bool:
+    """Return whether a title matches at least one exact or recall query spec."""
+
+    materialized = list(queries)
+    if not materialized:
+        return True
+    return any(
+        title_matches_query(
+            title,
+            str(item.get("query") or ""),
+            match_mode=str(item.get("match_mode") or "strict"),
+        )
+        for item in materialized
+    )
 
 
 def _recall_queries_for_roles(exact_queries: list[str]) -> list[str]:

--- a/workers/automation/src/jobhunter/discovery/target_queries.py
+++ b/workers/automation/src/jobhunter/discovery/target_queries.py
@@ -1,0 +1,209 @@
+"""Profile target-role query planning for discovery."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from jobhunter.discovery.title_filter import normalize_query
+
+
+RECALL_MATCH_MODE = "recall"
+
+_RECALL_QUERY_LIMIT = 14
+
+_QUERY_DEDUPE_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "for",
+    "in",
+    "of",
+    "on",
+    "the",
+    "to",
+}
+
+_LEADERSHIP_TOKENS = {
+    "chief",
+    "cio",
+    "ciso",
+    "cto",
+    "director",
+    "head",
+    "lead",
+    "leader",
+    "leadership",
+    "manager",
+    "principal",
+    "staff",
+    "vp",
+}
+
+_ENGINEERING_TOKENS = {
+    "devops",
+    "engineering",
+    "engineer",
+    "infrastructure",
+    "platform",
+    "reliability",
+    "sre",
+}
+
+_PLATFORM_TOKENS = {
+    "cloud",
+    "devops",
+    "infrastructure",
+    "platform",
+    "reliability",
+    "sre",
+}
+
+_SECURITY_TOKENS = {
+    "ciso",
+    "cybersecurity",
+    "devsecops",
+    "information",
+    "security",
+}
+
+_TECHNOLOGY_TOKENS = {
+    "cio",
+    "cto",
+    "digital",
+    "information",
+    "it",
+    "technology",
+}
+
+_ABBREVIATION_EXPANSIONS = {
+    "cio": ("chief", "information", "officer", "technology"),
+    "ciso": ("chief", "information", "security", "officer"),
+    "cto": ("chief", "technology", "officer"),
+    "sre": ("site", "reliability", "engineering"),
+    "vp": ("vice", "president"),
+}
+
+
+def build_target_role_queries(roles: Iterable[str]) -> list[dict[str, object]]:
+    """Build exact and recall-oriented discovery queries from target roles."""
+
+    exact_queries = _dedupe_exact_queries(normalize_query(role) for role in roles)
+    queries: list[dict[str, object]] = [{"query": query, "tier": 1} for query in exact_queries]
+    exact_keys = {_query_key(query) for query in exact_queries}
+
+    recall_count = 0
+    for query in _recall_queries_for_roles(exact_queries):
+        key = _query_key(query)
+        if key in exact_keys:
+            continue
+        queries.append(
+            {
+                "query": query,
+                "tier": 2,
+                "match_mode": RECALL_MATCH_MODE,
+                "generated_from": "target_roles",
+            }
+        )
+        exact_keys.add(key)
+        recall_count += 1
+        if recall_count >= _RECALL_QUERY_LIMIT:
+            break
+
+    return queries
+
+
+def _recall_queries_for_roles(exact_queries: list[str]) -> list[str]:
+    tokens = _expanded_tokens(exact_queries)
+    if not tokens.intersection(_LEADERSHIP_TOKENS):
+        return []
+
+    candidates: list[str] = []
+    if tokens.intersection(_ENGINEERING_TOKENS):
+        candidates.extend(
+            [
+                "engineering manager",
+                "engineering director",
+                "head of engineering",
+                "technical director",
+            ]
+        )
+    if tokens.intersection(_PLATFORM_TOKENS):
+        candidates.extend(
+            [
+                "platform director",
+                "platform engineering manager",
+                "infrastructure director",
+                "infrastructure manager",
+                "cloud engineering manager",
+            ]
+        )
+    if tokens.intersection(_SECURITY_TOKENS):
+        candidates.extend(
+            [
+                "security director",
+                "cybersecurity director",
+                "information security director",
+                "security engineering manager",
+            ]
+        )
+    if tokens.intersection(_TECHNOLOGY_TOKENS):
+        candidates.extend(
+            [
+                "technology director",
+                "head of technology",
+                "IT director",
+                "information technology director",
+            ]
+        )
+
+    if tokens.intersection(_ENGINEERING_TOKENS | _PLATFORM_TOKENS | _SECURITY_TOKENS | _TECHNOLOGY_TOKENS):
+        candidates.extend(["technology leadership", "technical leadership"])
+
+    return _dedupe_recall_queries(candidates)
+
+
+def _dedupe_exact_queries(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = str(value or "").strip()
+        if not normalized:
+            continue
+        key = normalized.casefold()
+        if key not in seen:
+            result.append(normalized)
+            seen.add(key)
+    return result
+
+
+def _dedupe_recall_queries(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = str(value or "").strip()
+        if not normalized:
+            continue
+        key = _query_key(normalized)
+        if key not in seen:
+            result.append(normalized)
+            seen.add(key)
+    return result
+
+
+def _query_key(query: str) -> str:
+    tokens = sorted(token for token in _tokens(query) if token not in _QUERY_DEDUPE_STOPWORDS)
+    return " ".join(tokens) if tokens else str(query or "").strip().casefold()
+
+
+def _expanded_tokens(queries: Iterable[str]) -> set[str]:
+    tokens: set[str] = set()
+    for query in queries:
+        for token in _tokens(query):
+            tokens.add(token)
+            tokens.update(_ABBREVIATION_EXPANSIONS.get(token, ()))
+    return tokens
+
+
+def _tokens(value: str | None) -> list[str]:
+    return re.findall(r"[a-z0-9]+", str(value or "").casefold())

--- a/workers/automation/src/jobhunter/discovery/title_filter.py
+++ b/workers/automation/src/jobhunter/discovery/title_filter.py
@@ -42,8 +42,75 @@ _QUERY_ALIASES: tuple[tuple[frozenset[str], tuple[tuple[str, ...], ...]], ...] =
     (frozenset(("director", "platform", "engineering")), (("platform", "director"),)),
 )
 
+_RECALL_MATCH_MODE = "recall"
 
-def title_matches_query(title: str | None, query: str | None) -> bool:
+_RECALL_LEADERSHIP_TOKENS = {
+    "chief",
+    "cio",
+    "ciso",
+    "cto",
+    "director",
+    "head",
+    "lead",
+    "leader",
+    "leadership",
+    "manager",
+    "principal",
+    "staff",
+    "vp",
+}
+
+_RECALL_DOMAIN_TOKENS = {
+    "engineering": {
+        "cloud",
+        "devops",
+        "engineering",
+        "engineer",
+        "infrastructure",
+        "platform",
+        "reliability",
+        "software",
+        "sre",
+        "technical",
+        "technology",
+    },
+    "platform": {
+        "cloud",
+        "devops",
+        "infrastructure",
+        "platform",
+        "reliability",
+        "sre",
+    },
+    "security": {
+        "cybersecurity",
+        "devsecops",
+        "information",
+        "infosec",
+        "security",
+    },
+    "technology": {
+        "digital",
+        "information",
+        "it",
+        "systems",
+        "technical",
+        "technology",
+    },
+}
+
+_RECALL_TOKEN_EXPANSIONS = {
+    "cio": ("chief", "information", "officer", "technology"),
+    "ciso": ("chief", "information", "security", "officer"),
+    "cto": ("chief", "technology", "officer"),
+    "infosec": ("information", "security"),
+    "it": ("information", "technology"),
+    "sre": ("site", "reliability", "engineering"),
+    "vp": ("vice", "president"),
+}
+
+
+def title_matches_query(title: str | None, query: str | None, *, match_mode: str = "strict") -> bool:
     """Return whether a posting title satisfies a target search query."""
     normalized_query = normalize_query(query)
     if not normalized_query:
@@ -54,6 +121,8 @@ def title_matches_query(title: str | None, query: str | None) -> bool:
     query_tokens = [token for token in _tokens(normalized_query) if token not in _STOPWORDS]
     if not query_tokens:
         return False
+    if match_mode == _RECALL_MATCH_MODE:
+        return _recall_title_matches_query(title_tokens, query_tokens)
     return all(_token_matches_title(token, title_tokens) for token in query_tokens) or _query_alias_matches(
         query_tokens,
         title_tokens,
@@ -82,6 +151,36 @@ def _query_alias_matches(query_tokens: Sequence[str], title_tokens: set[str]) ->
         ):
             return True
     return False
+
+
+def _recall_title_matches_query(title_tokens: set[str], query_tokens: Sequence[str]) -> bool:
+    expanded_title = _expanded_tokens(title_tokens)
+    expanded_query = _expanded_tokens(query_tokens)
+    domain_tokens = _recall_domain_tokens(expanded_query)
+    if not domain_tokens:
+        domain_tokens = {
+            token
+            for token in expanded_query
+            if token not in _RECALL_LEADERSHIP_TOKENS and token not in _STOPWORDS
+        }
+    return bool(expanded_title.intersection(_RECALL_LEADERSHIP_TOKENS)) and bool(
+        expanded_title.intersection(domain_tokens)
+    )
+
+
+def _recall_domain_tokens(query_tokens: set[str]) -> set[str]:
+    domains: set[str] = set()
+    for tokens in _RECALL_DOMAIN_TOKENS.values():
+        if query_tokens.intersection(tokens):
+            domains.update(tokens)
+    return domains
+
+
+def _expanded_tokens(tokens: Sequence[str] | set[str]) -> set[str]:
+    expanded = set(tokens)
+    for token in tuple(tokens):
+        expanded.update(_RECALL_TOKEN_EXPANSIONS.get(token, ()))
+    return expanded
 
 
 def _tokens(value: str | None) -> list[str]:

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -30,7 +30,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
-from jobhunter.discovery.target_queries import query_applies_to_source
+from jobhunter.discovery.target_queries import query_specs_for_source, title_matches_any_query
 from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobhunter.state import record_job_event
@@ -197,6 +197,7 @@ def search_employer(
     max_pages: int = 25,
     accept_locs: list[str] | None = None,
     reject_locs: list[str] | None = None,
+    query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
 ) -> list[dict]:
     """Search an employer, paginate through all results, optionally filter by location."""
     log.info('%s: searching "%s"...', employer["name"], search_text)
@@ -224,7 +225,10 @@ def search_employer(
 
         for j in postings:
             title = j.get("title", "")
-            if not title_matches_query(title, search_text):
+            if query_specs is not None:
+                if not title_matches_any_query(title, query_specs):
+                    continue
+            elif not title_matches_query(title, search_text):
                 continue
             loc = j.get("locationsText", "")
             if location_filter and accept_locs is not None and reject_locs is not None:
@@ -448,6 +452,7 @@ def _process_one(
     limit: int = 0,
     max_pages_per_employer: int = 25,
     run_id: str | None = None,
+    query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
 ) -> dict:
     """Search one employer, fetch details, store results."""
     result = _search_and_fetch_one(
@@ -459,6 +464,7 @@ def _process_one(
         reject_locs,
         limit=limit,
         max_pages_per_employer=max_pages_per_employer,
+        query_specs=query_specs,
     )
     jobs = result.pop("jobs", [])
     if not jobs:
@@ -480,6 +486,7 @@ def _search_and_fetch_one(
     reject_locs: list[str],
     limit: int = 0,
     max_pages_per_employer: int = 25,
+    query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
 ) -> dict:
     """Search one employer and fetch details without writing to storage."""
     emp = employers[employer_key]
@@ -494,6 +501,7 @@ def _search_and_fetch_one(
             max_pages=max_pages_per_employer,
             accept_locs=accept_locs,
             reject_locs=reject_locs,
+            query_specs=query_specs,
         )
     except Exception as e:
         log.error("%s: ERROR searching '%s': %s", emp["name"], search_text, e)
@@ -525,6 +533,7 @@ def scrape_employers(
     limit: int = 0,
     max_pages_per_employer: int = 25,
     run_id: str | None = None,
+    query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
 ) -> dict:
     """Run full scrape: search -> filter -> detail -> store.
 
@@ -549,6 +558,7 @@ def scrape_employers(
     t0 = time.time()
 
     valid_keys = [k for k in employer_keys if k in employers]
+    query_kwargs = {"query_specs": query_specs} if query_specs is not None else {}
 
     if workers > 1 and len(valid_keys) > 1:
         # Parallel mode
@@ -566,6 +576,7 @@ def scrape_employers(
                         reject_locs,
                         limit,
                         max_pages_per_employer,
+                        **query_kwargs,
                     ): key
                     for key in valid_keys
                 }
@@ -582,6 +593,7 @@ def scrape_employers(
                         0,
                         max_pages_per_employer,
                         run_id,
+                        **query_kwargs,
                     ): key
                     for key in valid_keys
                 }
@@ -641,6 +653,7 @@ def scrape_employers(
                 remaining if limit > 0 else 0,
                 max_pages_per_employer,
                 run_id,
+                **query_kwargs,
             )
             completed += 1
             total_new += result["new"]
@@ -703,19 +716,15 @@ def run_workday_discovery(
     queries_cfg = search_cfg.get("queries", [])
     accept_locs, reject_locs = _load_location_filter(search_cfg)
 
-    # Default to tier 1-2 queries for workday scraping
+    # Default to tier 1-2 queries for Workday title matching.
     max_tier = search_cfg.get("workday_max_tier", 2)
-    queries = [
-        q["query"]
-        for q in queries_cfg
-        if q.get("tier", 99) <= max_tier and query_applies_to_source(q, "workday")
-    ]
+    query_specs = query_specs_for_source(queries_cfg, "workday", max_tier=max_tier)
 
-    if not queries:
-        # Fallback: use all queries
-        queries = [q["query"] for q in queries_cfg if query_applies_to_source(q, "workday")]
+    if not query_specs:
+        # Fallback: use all source-eligible queries.
+        query_specs = query_specs_for_source(queries_cfg, "workday")
 
-    if not queries:
+    if not query_specs and queries_cfg:
         log.warning("No search queries configured in searches.yaml.")
         return {"found": 0, "new": 0, "existing": 0, "queries": 0}
 
@@ -726,38 +735,39 @@ def run_workday_discovery(
     location_filter = search_cfg.get("workday_location_filter", True)
     max_pages_per_employer = _workday_max_pages_per_employer(search_cfg, limit=limit)
 
-    log.info("Workday crawl: %d queries x %d employers (workers=%d)", len(queries), len(employers), workers)
+    log.info(
+        "Workday crawl: source-first enumeration across %d employers using %d target query filters (workers=%d)",
+        len(employers),
+        len(query_specs),
+        workers,
+    )
 
     grand_new = 0
     grand_existing = 0
     grand_found = 0
 
-    for i, query in enumerate(queries, 1):
-        remaining = max(limit - grand_found, 0) if limit > 0 else 0
-        if limit > 0 and remaining <= 0:
-            break
-        log.info('Query %d/%d: "%s"', i, len(queries), query)
-        result = scrape_employers(
-            search_text=query,
-            employers=employers,
-            location_filter=location_filter,
-            accept_locs=accept_locs,
-            reject_locs=reject_locs,
-            workers=workers,
-            limit=remaining if limit > 0 else 0,
-            max_pages_per_employer=max_pages_per_employer,
-            run_id=run_id,
-        )
-        grand_new += result["new"]
-        grand_existing += result["existing"]
-        grand_found += result["found"]
+    result = scrape_employers(
+        search_text="",
+        employers=employers,
+        location_filter=location_filter,
+        accept_locs=accept_locs,
+        reject_locs=reject_locs,
+        workers=workers,
+        limit=limit,
+        max_pages_per_employer=max_pages_per_employer,
+        run_id=run_id,
+        query_specs=query_specs,
+    )
+    grand_new += result["new"]
+    grand_existing += result["existing"]
+    grand_found += result["found"]
 
     log.info(
-        "Workday crawl done: %d found, %d new, %d existing across %d queries x %d employers",
+        "Workday crawl done: %d found, %d new, %d existing across %d query filters x %d employers",
         grand_found,
         grand_new,
         grand_existing,
-        len(queries),
+        len(query_specs),
         len(employers),
     )
 
@@ -765,7 +775,8 @@ def run_workday_discovery(
         "found": grand_found,
         "new": grand_new,
         "existing": grand_existing,
-        "queries": len(queries),
+        "queries": 1,
+        "query_filters": len(query_specs),
     }
 
 

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -30,6 +30,7 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.discovery.target_queries import query_applies_to_source
 from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobhunter.state import record_job_event
@@ -704,11 +705,15 @@ def run_workday_discovery(
 
     # Default to tier 1-2 queries for workday scraping
     max_tier = search_cfg.get("workday_max_tier", 2)
-    queries = [q["query"] for q in queries_cfg if q.get("tier", 99) <= max_tier]
+    queries = [
+        q["query"]
+        for q in queries_cfg
+        if q.get("tier", 99) <= max_tier and query_applies_to_source(q, "workday")
+    ]
 
     if not queries:
         # Fallback: use all queries
-        queries = [q["query"] for q in queries_cfg]
+        queries = [q["query"] for q in queries_cfg if query_applies_to_source(q, "workday")]
 
     if not queries:
         log.warning("No search queries configured in searches.yaml.")

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -55,7 +55,7 @@ from jobhunter.domain.events.base import DomainEvent
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.ports.discovery import ScrapedJobPosting
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
-from jobhunter.discovery.target_queries import query_applies_to_source
+from jobhunter.discovery.target_queries import query_specs_for_source, title_matches_any_query
 from jobhunter.infrastructure.discovery.ats_adapters import (
     AshbyBoardAdapter,
     GreenhouseBoardAdapter,
@@ -482,20 +482,28 @@ def run_scheduled_ats_sources(
     sources_run: list[str] = []
     failed_sources: list[str] = []
     remaining = limit if limit > 0 else None
-    pairs = tuple(_query_location_pairs(search_cfg))
+    query_specs = tuple(_ats_query_specs(search_cfg))
+    locations = tuple(_location_values(search_cfg))
     for adapter in adapters:
         if remaining is not None and remaining <= 0:
             break
         postings: list[ScrapedJobPosting] = []
+        seen_postings: set[tuple[str, str, str]] = set()
         try:
-            for query, location in pairs:
+            for location in locations:
                 if remaining is not None and remaining <= 0:
                     break
                 for posting in adapter.scrape(
                     tenant_id=LOCAL_TENANT,
-                    query=query,
+                    query="",
                     location=location,
                 ):
+                    if not title_matches_any_query(posting.metadata.title, query_specs):
+                        continue
+                    posting_key = _scraped_posting_key(posting)
+                    if posting_key in seen_postings:
+                        continue
+                    seen_postings.add(posting_key)
                     postings.append(posting)
                     if remaining is not None:
                         remaining -= 1
@@ -526,6 +534,14 @@ def run_scheduled_ats_sources(
         sources_run=tuple(sources_run),
         failed_sources=tuple(failed_sources),
     ).to_result_dict()
+
+
+def _scraped_posting_key(posting: ScrapedJobPosting) -> tuple[str, str, str]:
+    return (
+        str(posting.source_id or ""),
+        str(posting.source_native_id or ""),
+        str(posting.canonical_url or posting.posting_url.value),
+    )
 
 
 def import_manual_capture_item(
@@ -1380,24 +1396,22 @@ def _adapter_for_source(
     return None
 
 
-def _query_location_pairs(search_cfg: Mapping[str, Any]) -> Iterable[tuple[str, str]]:
+def _ats_query_specs(search_cfg: Mapping[str, Any]) -> tuple[dict[str, object], ...]:
     queries_cfg = search_cfg.get("queries", [])
-    queries = [
-        str(item.get("query") or "").strip()
-        for item in queries_cfg
-        if isinstance(item, Mapping)
-        and int(item.get("tier") or 99) <= int(search_cfg.get("ats_max_tier") or 2)
-        and query_applies_to_source(item, "ats_api")
-    ]
+    queries = query_specs_for_source(
+        (item for item in queries_cfg if isinstance(item, Mapping)),
+        "ats_api",
+        max_tier=int(search_cfg.get("ats_max_tier") or 2),
+    )
     if not queries:
-        queries = [
-            str(item.get("query") or "").strip()
-            for item in queries_cfg
-            if isinstance(item, Mapping) and query_applies_to_source(item, "ats_api")
-        ]
-    queries = [query for query in queries if query]
-    if not queries and not queries_cfg:
-        queries = [""]
+        queries = query_specs_for_source(
+            (item for item in queries_cfg if isinstance(item, Mapping)),
+            "ats_api",
+        )
+    return tuple(queries)
+
+
+def _location_values(search_cfg: Mapping[str, Any]) -> tuple[str, ...]:
     locations_cfg = search_cfg.get("locations", [])
     locations = [
         str(item.get("location") or item.get("label") or "").strip()
@@ -1405,9 +1419,7 @@ def _query_location_pairs(search_cfg: Mapping[str, Any]) -> Iterable[tuple[str, 
         if isinstance(item, Mapping)
     ]
     locations = [location for location in locations if location] or [""]
-    for query in queries:
-        for location in locations:
-            yield query, location
+    return tuple(locations)
 
 
 def _manual_capture_snapshot_use_case(

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -55,6 +55,7 @@ from jobhunter.domain.events.base import DomainEvent
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.ports.discovery import ScrapedJobPosting
 from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
+from jobhunter.discovery.target_queries import query_applies_to_source
 from jobhunter.infrastructure.discovery.ats_adapters import (
     AshbyBoardAdapter,
     GreenhouseBoardAdapter,
@@ -1384,11 +1385,19 @@ def _query_location_pairs(search_cfg: Mapping[str, Any]) -> Iterable[tuple[str, 
     queries = [
         str(item.get("query") or "").strip()
         for item in queries_cfg
-        if isinstance(item, Mapping) and int(item.get("tier") or 99) <= int(search_cfg.get("ats_max_tier") or 2)
+        if isinstance(item, Mapping)
+        and int(item.get("tier") or 99) <= int(search_cfg.get("ats_max_tier") or 2)
+        and query_applies_to_source(item, "ats_api")
     ]
     if not queries:
-        queries = [str(item.get("query") or "").strip() for item in queries_cfg if isinstance(item, Mapping)]
-    queries = [query for query in queries if query] or [""]
+        queries = [
+            str(item.get("query") or "").strip()
+            for item in queries_cfg
+            if isinstance(item, Mapping) and query_applies_to_source(item, "ats_api")
+        ]
+    queries = [query for query in queries if query]
+    if not queries and not queries_cfg:
+        queries = [""]
     locations_cfg = search_cfg.get("locations", [])
     locations = [
         str(item.get("location") or item.get("label") or "").strip()

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -9,7 +9,7 @@ from jobhunter.database import close_connection, init_db
 from jobhunter.discovery import jobspy
 
 
-def test_jobspy_limit_runs_one_query_against_scheduled_boards(monkeypatch):
+def test_jobspy_limit_stops_after_one_new_job(monkeypatch):
     calls: list[tuple[str, str, list[str], int, int]] = []
 
     def fake_run_one_search(
@@ -41,8 +41,48 @@ def test_jobspy_limit_runs_one_query_against_scheduled_boards(monkeypatch):
         limit=1,
     )
 
-    assert calls == [("platform engineer", "Remote", ["indeed", "linkedin"], 1, 1)]
+    assert calls == [("platform engineer", "Remote", ["indeed", "linkedin"], 100, 1)]
     assert result["queries"] == 1
+
+
+def test_jobspy_limit_does_not_let_existing_jobs_starve_later_queries(monkeypatch):
+    calls: list[tuple[str, int, int]] = []
+
+    def fake_run_one_search(
+        search: dict,
+        _sites: list[str],
+        results_per_site: int,
+        *_args,
+        limit: int = 0,
+        **_kwargs,
+    ) -> dict:
+        calls.append((search["query"], results_per_site, limit))
+        if search["query"] == "exact role":
+            return {"new": 0, "existing": 1, "errors": 0, "filtered": 0, "total": 1}
+        return {"new": 1, "existing": 0, "errors": 0, "filtered": 0, "total": 1}
+
+    monkeypatch.setattr(jobspy, "init_db", lambda: None)
+    monkeypatch.setattr(
+        jobspy,
+        "get_connection",
+        lambda: SimpleNamespace(execute=lambda *_args, **_kwargs: SimpleNamespace(fetchone=lambda: [2])),
+    )
+    monkeypatch.setattr(jobspy, "_run_one_search", fake_run_one_search)
+
+    result = jobspy._full_crawl(
+        {
+            "queries": [{"query": "exact role"}, {"query": "recall role", "match_mode": "recall"}],
+            "locations": [{"label": "remote", "location": "Remote"}],
+            "defaults": {"results_per_site": 100},
+        },
+        sites=["linkedin"],
+        limit=1,
+    )
+
+    assert calls == [("exact role", 100, 1), ("recall role", 100, 1)]
+    assert result["new"] == 1
+    assert result["existing"] == 1
+    assert result["queries"] == 2
 
 
 def test_jobspy_filters_results_by_target_title(monkeypatch):
@@ -280,6 +320,63 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
             ("https://www.linkedin.com/jobs/view/1",),
         ).fetchone()
         assert event["event_type"] == "JobMetadataUpdated"
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_store_limit_counts_new_jobs_not_existing_observations(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        existing = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/existing",
+                    "title": "Head of Engineering",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, existing, "Head of Engineering", limit=1) == (1, 0)
+
+        mixed = pd.DataFrame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/existing",
+                    "title": "Head of Engineering",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/new",
+                    "title": "Head of Technology",
+                    "company": "AstraZeneca",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/second-new",
+                    "title": "Technology Director",
+                    "company": "AstraZeneca",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, mixed, "technology director", limit=1) == (1, 1)
+        urls = {
+            row["url"]
+            for row in conn.execute(
+                "SELECT url FROM jobs WHERE url LIKE 'https://www.linkedin.com/jobs/view/%'"
+            ).fetchall()
+        }
+        assert "https://www.linkedin.com/jobs/view/existing" in urls
+        assert "https://www.linkedin.com/jobs/view/new" in urls
+        assert "https://www.linkedin.com/jobs/view/second-new" not in urls
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -95,6 +95,67 @@ def test_jobspy_filters_results_by_target_title(monkeypatch):
     assert result["filtered"] == 1
 
 
+def test_jobspy_recall_title_filter_accepts_leadership_variants(monkeypatch):
+    stored_titles: list[str] = []
+
+    def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
+        return pd.DataFrame(
+            [
+                {
+                    "job_url": "https://example.test/head-technology",
+                    "title": "Head of Technology",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+                {
+                    "job_url": "https://example.test/software-engineer",
+                    "title": "Software Engineer",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+                {
+                    "job_url": "https://example.test/product-marketing-director",
+                    "title": "Product Marketing Director",
+                    "location": "Barcelona, Spain",
+                    "site": "indeed",
+                },
+            ]
+        )
+
+    def fake_store(_conn, df, _source_label: str, limit: int = 0, run_id: str = "jobspy") -> tuple[int, int]:
+        assert run_id == "jobspy"
+        stored_titles.extend(df["title"].tolist())
+        return len(df), 0
+
+    monkeypatch.setattr(jobspy, "_scrape_with_retry", fake_scrape)
+    monkeypatch.setattr(jobspy, "get_connection", lambda: object())
+    monkeypatch.setattr(jobspy, "store_jobspy_results", fake_store)
+
+    result = jobspy._run_one_search(
+        {
+            "query": "technology director",
+            "location": "Barcelona, Spain",
+            "remote": False,
+            "match_mode": "recall",
+        },
+        ["indeed"],
+        10,
+        72,
+        None,
+        {"country_indeed": "spain"},
+        0,
+        ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+        ["United States", "Canada"],
+        ["Barcelona, Spain"],
+        {},
+        limit=10,
+    )
+
+    assert stored_titles == ["Head of Technology"]
+    assert result["new"] == 1
+    assert result["filtered"] == 2
+
+
 def test_jobspy_remote_search_rejects_non_remote_country_only_location(monkeypatch):
     stored_locations: list[str] = []
 

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -360,6 +360,42 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
     assert ats_kinds == {"greenhouse", "lever", "ashby"}
 
 
+def test_canonical_ats_scheduler_fetches_each_source_once_then_filters_queries(
+    conn: sqlite3.Connection,
+) -> None:
+    registry = _barcelona_registry()
+    schedule = DiscoveryScheduler().plan(registry=registry)
+    ats_sources = schedule.for_kinds(SourceKind.ATS_API)
+    calls: list[str] = []
+
+    def http(url: str, **kwargs: Any) -> Any:
+        calls.append(url)
+        return _fake_ats_http(url, **kwargs)
+
+    result = run_scheduled_ats_sources(
+        conn,
+        ats_sources,
+        search_cfg={
+            "queries": [
+                {"query": "Engineering", "tier": 1},
+                {
+                    "query": "platform director",
+                    "tier": 1,
+                    "match_mode": "recall",
+                    "generated_from": "target_roles",
+                },
+            ],
+            "locations": [{"location": "Spain"}],
+            "ats_max_tier": 1,
+        },
+        run_id="acceptance:ats",
+        http=http,
+    )
+
+    assert result["new_jobs"] == 3
+    assert len(calls) == 3
+
+
 def test_canonical_ats_scheduler_preserves_successes_when_one_source_fails(
     conn: sqlite3.Connection,
 ) -> None:

--- a/workers/automation/tests/test_source_registry.py
+++ b/workers/automation/tests/test_source_registry.py
@@ -297,3 +297,68 @@ def test_load_source_registry_applies_local_product_control_overrides(tmp_path, 
     assert by_id["smart_extract:remoteok"].adapter_config["url"] == "https://remoteok.example/jobs"
     assert by_id["custom-careers"].kind is SourceKind.EMPLOYER_CAREERS_PAGE
     assert by_id["custom-careers"].adapter_config["url"] == "https://example.com/careers"
+
+
+def test_system_source_registry_rows_keep_packaged_seed_url_updates(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE source_registry_entries (
+          tenant_id TEXT NOT NULL,
+          source_id TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          display_name TEXT NOT NULL,
+          owner TEXT NOT NULL,
+          priority TEXT NOT NULL,
+          state TEXT NOT NULL,
+          policy_id TEXT NOT NULL,
+          seed_url TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, source_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO source_registry_entries (
+          tenant_id, source_id, kind, display_name, owner, priority,
+          state, policy_id, seed_url, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            str(LOCAL_TENANT),
+            "smart_extract:wellfound",
+            "smart_extract",
+            "Wellfound",
+            "system",
+            "fallback",
+            "active",
+            "smart_extract_experimental",
+            "https://wellfound.com/role/l/software-engineer/canada",
+            "2026-05-13T00:00:00Z",
+            "2026-05-13T00:00:00Z",
+        ),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+
+    registry = config.load_source_registry(
+        search_cfg={"target_region": "europe", "boards": []},
+        sites_cfg={
+            "sites": [
+                {
+                    "name": "Wellfound",
+                    "url": "https://wellfound.com/location/spain",
+                    "type": "static",
+                }
+            ],
+        },
+        employers_cfg={"employers": {}},
+    )
+
+    by_id = {entry.source_id: entry for entry in registry}
+    assert by_id["smart_extract:wellfound"].state is SourceState.ACTIVE
+    assert by_id["smart_extract:wellfound"].adapter_config["url"] == "https://wellfound.com/location/spain"

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -8,6 +8,8 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
+from jobhunter.infrastructure.discovery.production_wiring import _query_location_pairs
+from jobhunter.discovery.target_queries import query_applies_to_source
 
 
 def test_profile_target_search_overrides_discovery_queries_and_locations() -> None:
@@ -32,10 +34,15 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
     ]
     assert {
         "query": "technical director",
-        "tier": 2,
+        "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
+        "source_scope": ["jobspy"],
     } in merged["queries"]
+    recall_query = next(item for item in merged["queries"] if item.get("query") == "technical director")
+    assert query_applies_to_source(recall_query, "jobspy")
+    assert not query_applies_to_source(recall_query, "workday")
+    assert not query_applies_to_source(recall_query, "ats_api")
     assert merged["workday_max_tier"] == 1
     assert merged["ats_max_tier"] == 1
     assert merged["locations"] == [
@@ -71,16 +78,33 @@ def test_profile_target_search_strips_role_notes_from_queries() -> None:
     ]
     assert {
         "query": "platform director",
-        "tier": 2,
+        "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
+        "source_scope": ["jobspy"],
     } in merged["queries"]
     assert {
         "query": "cybersecurity director",
-        "tier": 2,
+        "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
+        "source_scope": ["jobspy"],
     } in merged["queries"]
+
+
+def test_recall_queries_do_not_expand_ats_query_pairs() -> None:
+    merged = config._apply_profile_target_search(
+        {"queries": [{"query": "software engineer", "tier": 1}]},
+        {
+            "roles": ["Head of Platform"],
+            "locations": ["Barcelona, Spain"],
+            "work_models": ["Hybrid"],
+        },
+    )
+
+    pairs = list(_query_location_pairs(merged))
+    assert ("Head of Platform", "Barcelona, Spain") in pairs
+    assert ("platform director", "Barcelona, Spain") not in pairs
 
 
 def test_profile_target_locations_replace_legacy_location_accept_patterns() -> None:
@@ -299,7 +323,10 @@ defaults:
         "VP Engineering",
     ]
     assert any(
-        item.get("query") == "engineering manager" and item.get("match_mode") == "recall"
+        item.get("query") == "engineering manager"
+        and item.get("tier") == 1
+        and item.get("match_mode") == "recall"
+        and item.get("source_scope") == ["jobspy"]
         for item in loaded["queries"]
     )
     assert loaded["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -26,10 +26,18 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
         },
     )
 
-    assert merged["queries"] == [
+    assert merged["queries"][:2] == [
         {"query": "Engineering Manager", "tier": 1},
         {"query": "Head of Engineering", "tier": 1},
     ]
+    assert {
+        "query": "technical director",
+        "tier": 2,
+        "match_mode": "recall",
+        "generated_from": "target_roles",
+    } in merged["queries"]
+    assert merged["workday_max_tier"] == 1
+    assert merged["ats_max_tier"] == 1
     assert merged["locations"] == [
         {"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False},
         {"label": "spain", "location": "Spain", "remote": True},
@@ -57,10 +65,22 @@ def test_profile_target_search_strips_role_notes_from_queries() -> None:
         },
     )
 
-    assert merged["queries"] == [
+    assert merged["queries"][:2] == [
         {"query": "Head of Platform", "tier": 1},
         {"query": "CISO", "tier": 1},
     ]
+    assert {
+        "query": "platform director",
+        "tier": 2,
+        "match_mode": "recall",
+        "generated_from": "target_roles",
+    } in merged["queries"]
+    assert {
+        "query": "cybersecurity director",
+        "tier": 2,
+        "match_mode": "recall",
+        "generated_from": "target_roles",
+    } in merged["queries"]
 
 
 def test_profile_target_locations_replace_legacy_location_accept_patterns() -> None:
@@ -274,10 +294,14 @@ defaults:
 
     loaded = config.load_search_config()
 
-    assert [item["query"] for item in loaded["queries"]] == [
+    assert [item["query"] for item in loaded["queries"][:2]] == [
         "Director of Engineering",
         "VP Engineering",
     ]
+    assert any(
+        item.get("query") == "engineering manager" and item.get("match_mode") == "recall"
+        for item in loaded["queries"]
+    )
     assert loaded["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]
     assert loaded["target_region"] == "europe"
 

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -8,8 +8,8 @@ from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
 )
-from jobhunter.infrastructure.discovery.production_wiring import _query_location_pairs
-from jobhunter.discovery.target_queries import query_applies_to_source
+from jobhunter.infrastructure.discovery.production_wiring import _ats_query_specs, _location_values
+from jobhunter.discovery.target_queries import query_applies_to_source, title_matches_any_query
 
 
 def test_profile_target_search_overrides_discovery_queries_and_locations() -> None:
@@ -37,12 +37,11 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
         "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
-        "source_scope": ["jobspy"],
     } in merged["queries"]
     recall_query = next(item for item in merged["queries"] if item.get("query") == "technical director")
     assert query_applies_to_source(recall_query, "jobspy")
-    assert not query_applies_to_source(recall_query, "workday")
-    assert not query_applies_to_source(recall_query, "ats_api")
+    assert query_applies_to_source(recall_query, "workday")
+    assert query_applies_to_source(recall_query, "ats_api")
     assert merged["workday_max_tier"] == 1
     assert merged["ats_max_tier"] == 1
     assert merged["locations"] == [
@@ -81,18 +80,16 @@ def test_profile_target_search_strips_role_notes_from_queries() -> None:
         "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
-        "source_scope": ["jobspy"],
     } in merged["queries"]
     assert {
         "query": "cybersecurity director",
         "tier": 1,
         "match_mode": "recall",
         "generated_from": "target_roles",
-        "source_scope": ["jobspy"],
     } in merged["queries"]
 
 
-def test_recall_queries_do_not_expand_ats_query_pairs() -> None:
+def test_recall_queries_expand_ats_internal_title_filters_without_query_pairs() -> None:
     merged = config._apply_profile_target_search(
         {"queries": [{"query": "software engineer", "tier": 1}]},
         {
@@ -102,9 +99,11 @@ def test_recall_queries_do_not_expand_ats_query_pairs() -> None:
         },
     )
 
-    pairs = list(_query_location_pairs(merged))
-    assert ("Head of Platform", "Barcelona, Spain") in pairs
-    assert ("platform director", "Barcelona, Spain") not in pairs
+    query_specs = _ats_query_specs(merged)
+    assert _location_values(merged) == ("Barcelona, Spain",)
+    assert any(item["query"] == "Head of Platform" for item in query_specs)
+    assert any(item["query"] == "platform director" for item in query_specs)
+    assert title_matches_any_query("Platform Engineering Manager", query_specs)
 
 
 def test_profile_target_locations_replace_legacy_location_accept_patterns() -> None:
@@ -326,14 +325,19 @@ defaults:
         item.get("query") == "engineering manager"
         and item.get("tier") == 1
         and item.get("match_mode") == "recall"
-        and item.get("source_scope") == ["jobspy"]
+        and "source_scope" not in item
         for item in loaded["queries"]
     )
     assert loaded["locations"] == [{"label": "barcelona-spain", "location": "Barcelona, Spain", "remote": False}]
     assert loaded["target_region"] == "europe"
 
 
-def test_source_registry_filters_america_only_sources_for_europe_target() -> None:
+def test_source_registry_filters_america_only_sources_for_europe_target(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(config, "DB_PATH", tmp_path / "jobhunter.db")
+
     registry = config.load_source_registry(
         search_cfg={"target_region": "europe", "boards": ["linkedin"]},
         sites_cfg={
@@ -342,6 +346,16 @@ def test_source_registry_filters_america_only_sources_for_europe_target() -> Non
                     "name": "Job Bank Canada",
                     "url": "https://www.jobbank.gc.ca/jobsearch/jobsearch?searchstring={query_encoded}",
                     "type": "search",
+                },
+                {
+                    "name": "Wellfound",
+                    "url": "https://wellfound.com/location/spain",
+                    "type": "static",
+                },
+                {
+                    "name": "Wellfound Canada",
+                    "url": "https://wellfound.com/role/l/software-engineer/canada",
+                    "type": "static",
                 },
                 {
                     "name": "WelcomeToTheJungle",
@@ -355,6 +369,8 @@ def test_source_registry_filters_america_only_sources_for_europe_target() -> Non
 
     by_id = {entry.source_id for entry in registry}
     assert "smart_extract:job-bank-canada" not in by_id
+    assert "smart_extract:wellfound" in by_id
+    assert "smart_extract:wellfound-canada" not in by_id
     assert "smart_extract:welcometothejungle" in by_id
 
 

--- a/workers/automation/tests/test_title_filter.py
+++ b/workers/automation/tests/test_title_filter.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from jobhunter.discovery.title_filter import title_matches_query
+
+
+def test_strict_title_matching_preserves_exact_query_precision() -> None:
+    assert title_matches_query("Director of Engineering", "Director of Engineering")
+    assert not title_matches_query("Head of Technology", "Director of Engineering")
+
+
+def test_recall_title_matching_accepts_leadership_domain_variants() -> None:
+    assert title_matches_query("Head of Technology", "technology director", match_mode="recall")
+    assert title_matches_query("Director, Cybersecurity", "security director", match_mode="recall")
+    assert title_matches_query("Platform Engineering Manager", "platform director", match_mode="recall")
+
+
+def test_recall_title_matching_rejects_non_leadership_ic_titles() -> None:
+    assert not title_matches_query("Software Engineer", "engineering director", match_mode="recall")
+    assert not title_matches_query("Security Analyst", "security director", match_mode="recall")

--- a/workers/automation/tests/test_workday_discovery.py
+++ b/workers/automation/tests/test_workday_discovery.py
@@ -115,6 +115,56 @@ def test_workday_search_rejects_loose_title_matches(monkeypatch: pytest.MonkeyPa
     assert [job["title"] for job in jobs] == ["Director of Engineering"]
 
 
+def test_workday_source_first_search_filters_against_expanded_query_specs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_search(_employer: dict, search_text: str, *, limit: int, offset: int) -> dict:
+        assert search_text == ""
+        assert limit == 20
+        assert offset == 0
+        return {
+            "total": 3,
+            "jobPostings": [
+                {
+                    "title": "Software Engineer",
+                    "locationsText": "Remote EMEA",
+                    "externalPath": "/job/EMEA/Software-Engineer_R-1",
+                },
+                {
+                    "title": "Platform Engineering Manager",
+                    "locationsText": "Remote EMEA",
+                    "externalPath": "/job/EMEA/Platform-Engineering-Manager_R-2",
+                },
+                {
+                    "title": "Account Executive",
+                    "locationsText": "Barcelona, Spain",
+                    "externalPath": "/job/Spain/Account-Executive_R-3",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(workday, "workday_search", fake_search)
+
+    jobs = workday.search_employer(
+        "acme",
+        {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "tenant": "acme",
+            "site_id": "External",
+        },
+        "",
+        accept_locs=["Spain", "Europe", "EMEA"],
+        reject_locs=["United States", "Canada"],
+        query_specs=[
+            {"query": "Head of Platform", "match_mode": "strict"},
+            {"query": "platform director", "match_mode": "recall"},
+        ],
+    )
+
+    assert [job["title"] for job in jobs] == ["Platform Engineering Manager"]
+
+
 def test_limited_workday_search_respects_page_cap(monkeypatch: pytest.MonkeyPatch) -> None:
     offsets: list[int] = []
 


### PR DESCRIPTION
## Summary
- Add deterministic recall query expansion from saved profile target roles while keeping exact and recall queries in the same search tier.
- Apply recall intent across discovery sources: JobSpy uses expanded queries as broad-board retrieval probes, while direct ATS and Workday enumerate known sources and filter titles internally to avoid `queries x sources` board fetches.
- Add a recall title-match mode so leadership/domain variants like `Head of Technology` can pass without admitting plain IC titles.
- Fix bounded JobSpy discovery so existing rediscoveries do not consume the new-job limit or starve later recall queries.
- Replace the Canada-specific Wellfound seed with the Spain location page and preserve packaged seed URL updates over stale system-generated registry rows.
- Document the target-search behavior in the pipeline architecture and keep all Mermaid blocks rendering.

## Stack
- Stacked on #93 (`worktree/fee3`).

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_source_registry.py workers/automation/tests/test_discovery_production_wiring.py workers/automation/tests/test_workday_discovery.py workers/automation/tests/test_title_filter.py workers/automation/tests/test_discovery_limits.py` (56 passed)
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/discovery/target_queries.py workers/automation/src/jobhunter/discovery/workday.py workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py workers/automation/src/jobhunter/config.py workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_source_registry.py workers/automation/tests/test_discovery_production_wiring.py workers/automation/tests/test_workday_discovery.py`
- `npx -y @mermaid-js/mermaid-cli` over all 15 Mermaid blocks from `docs/job-pipeline-architecture.md`
- `git diff --check`
- verified local source registry now resolves `smart_extract:wellfound` to `https://wellfound.com/location/spain` even with a stale system row in the DB
