### PR TITLE
fix: make smart extract source capability driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,9 +416,17 @@ replace the active discovery query list with exact role queries plus
 deterministic recall queries. Recall queries keep the same search tier as exact
 queries because relevance is determined after discovery by scoring, not by query
 generation. Broad-board providers such as JobSpy use those queries as retrieval
-probes. Direct ATS and Workday sources enumerate their known board/source and
-apply the same exact-plus-recall title intent internally, avoiding repeated
-board fetches for each role variant. Target locations replace the active
+probes. Direct ATS, Workday, and source-first Smart Extract sources enumerate
+their known board/source and apply the same exact-plus-recall title intent
+internally, avoiding repeated board fetches for each role variant. Smart
+Extract search-only sources still fan out by query when the source has no
+useful browse/all-jobs page. Canonical ATS rows must include a usable
+description before insertion; Greenhouse reads the public board content payload
+instead of creating blank-description rows. Each discovery run also performs a
+source hygiene pass across JobSpy, direct ATS, Workday, and Smart Extract rows
+so active jobs that no longer satisfy the current title, location, or
+description contract are soft-deleted instead of remaining visible. Target
+locations replace the active
 location list, and if target locations are blank the worker falls back to the
 profile city/country. Target locations are validated as real places before they
 can be saved. Hybrid and on-site target work models search and filter only the

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -255,7 +255,7 @@ sequenceDiagram
     ATS->>DB: create canonical jobs and source observations
     Runner->>Workday: enumerate configured employers and filter internally
     Workday->>DB: insert/update jobs and observations
-    Runner->>Smart: run_smart_extract(...)
+    Runner->>Smart: source-first scrape or search-only query fanout
     Smart->>DB: insert jobs, quarantine, manual-capture queue
 
     Runner->>DB: DiscoveryRun*, Stage*, and operational attempt metrics
@@ -335,9 +335,18 @@ classDiagram
 - Applies exact-plus-recall intent to every discovery source family, but the
   execution shape differs by source type. JobSpy is a broad-board retrieval
   provider, so exact and recall queries are sent as external search probes.
-  Direct ATS and Workday sources are known boards/employers, so they enumerate
-  the source once per location and run exact-plus-recall title matching
-  internally instead of multiplying `queries x sources`.
+  Direct ATS, Workday, and source-first Smart Extract sources are known
+  boards/employers/pages, so they enumerate the source once per location and run
+  exact-plus-recall title matching internally instead of multiplying
+  `queries x sources`. Smart Extract search-only sources still fan out by query
+  when the source has no useful browse/all-jobs page.
+- Canonical ATS adapters only emit usable postings: title, target location,
+  and a non-empty description must all be present before a posting reaches the
+  discovery write boundary. Greenhouse uses the public board API's content
+  payload so discovered rows are not created with blank descriptions.
+- Runs source hygiene before source execution: active rows from JobSpy, direct
+  ATS, Workday, and Smart Extract are rechecked against the current title,
+  location, and description contract and soft-deleted when they no longer pass.
 - Upserts source registry control rows, source locator candidates, and
   manual-capture queue entries for protected/manual sources. Existing
   `imported` or `dismissed` manual-capture entries keep their status.

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -162,9 +162,16 @@ Target roles replace the active discovery query list with exact role queries
 plus deterministic recall queries. Recall queries keep the same search tier as
 exact queries because relevance is determined after discovery by scoring, not by
 query generation. JobSpy uses exact-plus-recall queries as broad-board retrieval
-probes. Direct ATS and Workday sources enumerate their known board/source and
-apply that same title intent internally, avoiding repeated board fetches for
-each role variant. Target locations replace the active location list, and the
+probes. Direct ATS, Workday, and source-first Smart Extract sources enumerate
+their known board/source and apply that same title intent internally, avoiding
+repeated board fetches for each role variant. Smart Extract search-only sources
+still fan out by query when the source has no useful browse/all-jobs page.
+Canonical ATS rows must also include a usable description before they are
+inserted; Greenhouse reads the public board content payload for that text. Each
+discover run also applies the current title, location, and description contract
+to active JobSpy, direct ATS, Workday, and Smart Extract rows and soft-deletes
+rows that no longer pass those source-family filters.
+Target locations replace the active location list, and the
 worker falls back to profile city/country when target locations are blank. The
 API validates target locations as real places before saving profile preferences.
 Hybrid and on-site target work models search and filter only the target

--- a/workers/automation/src/jobhunter/config.py
+++ b/workers/automation/src/jobhunter/config.py
@@ -576,6 +576,15 @@ def _smart_extract_sources(sites_cfg: dict) -> list[SourceRegistryEntry]:
         url = str(item.get("url", "")).strip()
         if not name or not url:
             continue
+        adapter_config = {
+            "name": name,
+            "url": url,
+            "type": item.get("type", "static"),
+            "base_url": base_urls.get(name),
+        }
+        for optional_key in ("query_mode", "search_mode"):
+            if item.get(optional_key):
+                adapter_config[optional_key] = item[optional_key]
         entries.append(
             _validated_source(
                 SourceRegistryEntry(
@@ -587,12 +596,7 @@ def _smart_extract_sources(sites_cfg: dict) -> list[SourceRegistryEntry]:
                     priority=SourcePriority.FALLBACK,
                     state=SourceState.EXPERIMENTAL,
                     policy=SMART_EXTRACT_EXPERIMENTAL_POLICY,
-                    adapter_config={
-                        "name": name,
-                        "url": url,
-                        "type": item.get("type", "static"),
-                        "base_url": base_urls.get(name),
-                    },
+                    adapter_config=adapter_config,
                 )
             )
         )

--- a/workers/automation/src/jobhunter/config/sites.yaml
+++ b/workers/automation/src/jobhunter/config/sites.yaml
@@ -2,6 +2,8 @@
 # Users can add their own sites following this pattern.
 # Use {location_encoded} placeholder for location (URL-encoded).
 # Use {query_encoded} placeholder for search terms (URL-encoded).
+# Optional query_mode controls Smart Extract execution: search_only fans out one
+# URL per query, source_first scrapes once and filters exact+recall roles locally.
 
 # ── Manual-Only ATS Domains ──────────────────────────────────────────────
 # These ATS platforms have unsolvable CAPTCHAs. Jobs routing through them

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -186,7 +186,9 @@ def store_jobspy_results(
             if interval:
                 salary += f"/{interval}"
 
-        description = str(row.get("description", "")) if str(row.get("description", "")) != "nan" else None
+        description = _nullable_str(row.get("description"))
+        if not (description or "").strip():
+            continue
         site_name = str(row.get("site", source_label))
         is_remote = _truthy_remote(row.get("is_remote", False))
         location_str = normalize_location_display(location_str, is_remote=is_remote)
@@ -237,6 +239,21 @@ def store_jobspy_results(
                 posting_url=apply_url,
                 discovered_via_source_id=source_id,
                 observed_at=now,
+            )
+            _refresh_existing_jobspy_job(
+                conn,
+                job_url=duplicate_url,
+                title=title,
+                company=company,
+                salary=salary,
+                description=description,
+                location=location_str,
+                site=site_label,
+                strategy=strategy,
+                full_description=full_description,
+                application_url=apply_url,
+                detail_scraped_at=detail_scraped_at,
+                updated_at=now,
             )
             resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
             existing += 1
@@ -303,26 +320,39 @@ def store_jobspy_results(
                     discovered_via_source_id=source_id,
                     observed_at=now,
                 )
+                _refresh_existing_jobspy_job(
+                    conn,
+                    job_url=duplicate_url,
+                    title=title,
+                    company=company,
+                    salary=salary,
+                    description=description,
+                    location=location_str,
+                    site=site_label,
+                    strategy=strategy,
+                    full_description=full_description,
+                    application_url=apply_url,
+                    detail_scraped_at=detail_scraped_at,
+                    updated_at=now,
+                )
                 resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
                 existing += 1
                 continue
-            if company:
-                cursor = conn.execute(
-                    "UPDATE jobs SET company = ? WHERE url = ? AND (company IS NULL OR company = '')",
-                    (company, url),
-                )
-                if cursor.rowcount:
-                    from jobhunter.state import record_job_event
-
-                    record_job_event(
-                        conn,
-                        url,
-                        "discover",
-                        "JobMetadataUpdated",
-                        message="Job company backfilled from JobSpy",
-                        payload={"company": company, "source": site_label},
-                        occurred_at=now,
-                    )
+            _refresh_existing_jobspy_job(
+                conn,
+                job_url=url,
+                title=title,
+                company=company,
+                salary=salary,
+                description=description,
+                location=location_str,
+                site=site_label,
+                strategy=strategy,
+                full_description=full_description,
+                application_url=apply_url,
+                detail_scraped_at=detail_scraped_at,
+                updated_at=now,
+            )
             _record_jobspy_source_observation(
                 conn,
                 job_url=url,
@@ -343,6 +373,73 @@ def store_jobspy_results(
 
     conn.commit()
     return new, existing
+
+
+def _refresh_existing_jobspy_job(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    title: str | None,
+    company: str | None,
+    salary: str | None,
+    description: str | None,
+    location: str | None,
+    site: str,
+    strategy: str,
+    full_description: str | None,
+    application_url: str | None,
+    detail_scraped_at: str | None,
+    updated_at: str,
+) -> None:
+    cursor = conn.execute(
+        """
+        UPDATE jobs SET
+            title = COALESCE(NULLIF(?, ''), title),
+            company = CASE
+                WHEN COALESCE(company, '') = '' THEN COALESCE(NULLIF(?, ''), company)
+                ELSE company
+            END,
+            salary = COALESCE(NULLIF(?, ''), salary),
+            description = COALESCE(NULLIF(?, ''), description),
+            location = COALESCE(NULLIF(?, ''), location),
+            site = COALESCE(NULLIF(?, ''), site),
+            strategy = COALESCE(NULLIF(?, ''), strategy),
+            full_description = COALESCE(NULLIF(?, ''), full_description),
+            application_url = COALESCE(NULLIF(?, ''), application_url),
+            detail_scraped_at = COALESCE(?, detail_scraped_at)
+        WHERE url = ?
+        """,
+        (
+            title,
+            company,
+            salary,
+            description,
+            location,
+            site,
+            strategy,
+            full_description,
+            application_url,
+            detail_scraped_at,
+            job_url,
+        ),
+    )
+    if cursor.rowcount:
+        from jobhunter.state import record_job_event
+
+        record_job_event(
+            conn,
+            job_url,
+            "discover",
+            "JobMetadataUpdated",
+            message="Job metadata refreshed from JobSpy",
+            payload={
+                "company": company,
+                "description": bool((description or "").strip()),
+                "location": location,
+                "source": site,
+            },
+            occurred_at=updated_at,
+        )
 
 
 def _nullable_str(value: object) -> str | None:

--- a/workers/automation/src/jobhunter/discovery/smartextract.py
+++ b/workers/automation/src/jobhunter/discovery/smartextract.py
@@ -18,6 +18,7 @@ import re
 import sqlite3
 import sys
 import time
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from urllib.parse import quote_plus, urljoin
@@ -32,6 +33,10 @@ from jobhunter.database import get_stats, init_db, resurface_deleted_job
 from jobhunter.infrastructure.discovery.location_filter import (
     configured_location_filters,
     location_matches_target,
+)
+from jobhunter.discovery.target_queries import (
+    query_specs_for_source,
+    title_matches_any_query,
 )
 from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.llm import get_client
@@ -66,6 +71,12 @@ def _location_ok(location: str | None, accept: list[str], reject: list[str]) -> 
 
 # -- Site configuration from YAML --------------------------------------------
 
+_NULL_DESCRIPTION_SENTINELS = {"<na>", "nan", "nat", "none", "null"}
+_MISSING_DESCRIPTION_SQL = (
+    "(description IS NULL OR TRIM(description) = '' "
+    "OR LOWER(TRIM(description)) IN ('<na>', 'nan', 'nat', 'none', 'null'))"
+)
+
 
 def load_sites() -> list[dict]:
     """Load scraping target sites from config/sites.yaml."""
@@ -84,7 +95,7 @@ def _store_jobs_filtered(
     strategy: str,
     accept_locs: list[str],
     reject_locs: list[str],
-    query: str | list[str] | None = None,
+    query: object | None = None,
     limit: int = 0,
     source_url: str | None = None,
 ) -> tuple[int, int]:
@@ -130,26 +141,57 @@ def _store_jobs_filtered(
             new += 1
         except sqlite3.IntegrityError:
             company = str(job.get("company") or "").strip()
+            title = str(job.get("title") or "").strip()
+            location = str(job.get("location") or "").strip()
+            salary = str(job.get("salary") or "").strip()
             update_fields: list[str] = []
             update_values: list[str] = []
+            metadata_payload: dict[str, object] = {"source": site}
+            if title:
+                update_fields.append("title = CASE WHEN title IS NULL OR title = '' OR title != ? THEN ? ELSE title END")
+                update_values.extend([title, title])
+                metadata_payload["title"] = title
             if company:
                 update_fields.append("company = CASE WHEN company IS NULL OR company = '' THEN ? ELSE company END")
                 update_values.append(company)
+                metadata_payload["company"] = company
+            if salary:
+                update_fields.append("salary = CASE WHEN salary IS NULL OR salary = '' THEN ? ELSE salary END")
+                update_values.append(salary)
+                metadata_payload["salary"] = True
             if description:
                 update_fields.append(
-                    "description = CASE WHEN description IS NULL OR description = '' THEN ? ELSE description END"
+                    f"description = CASE WHEN {_MISSING_DESCRIPTION_SQL} THEN ? ELSE description END"
                 )
                 update_values.append(description)
+                metadata_payload["description"] = True
+            if location:
+                update_fields.append(
+                    "location = CASE WHEN location IS NULL OR location = '' OR location != ? THEN ? ELSE location END"
+                )
+                update_values.extend([location, location])
+                metadata_payload["location"] = location
             if update_fields:
                 update_predicates: list[str] = []
+                if title:
+                    update_predicates.append("(title IS NULL OR title = '' OR title != ?)")
                 if company:
                     update_predicates.append("(company IS NULL OR company = '')")
+                if salary:
+                    update_predicates.append("(salary IS NULL OR salary = '')")
                 if description:
-                    update_predicates.append("(description IS NULL OR description = '')")
+                    update_predicates.append(_MISSING_DESCRIPTION_SQL)
+                if location:
+                    update_predicates.append("(location IS NULL OR location = '' OR location != ?)")
+                predicate_values: list[str] = []
+                if title:
+                    predicate_values.append(title)
+                if location:
+                    predicate_values.append(location)
                 cursor = conn.execute(
                     f"UPDATE jobs SET {', '.join(update_fields)} WHERE url = ? "
                     f"AND ({' OR '.join(update_predicates)})",
-                    (*update_values, url),
+                    (*update_values, url, *predicate_values),
                 )
                 if cursor.rowcount:
                     from jobhunter.state import record_job_event
@@ -159,8 +201,8 @@ def _store_jobs_filtered(
                         url,
                         "discover",
                         "JobMetadataUpdated",
-                        message="Job metadata backfilled from SmartExtract",
-                        payload={"company": company or None, "description": bool(description), "source": site},
+                        message="Job metadata refreshed from SmartExtract",
+                        payload=metadata_payload,
                         occurred_at=now,
                     )
             resurface_deleted_job(conn, url, resurfaced_at=now)
@@ -174,21 +216,36 @@ def _store_jobs_filtered(
     return new, existing
 
 
-def _title_matches_target_query(title: str | None, query: str | list[str] | None) -> bool:
+def _title_matches_target_query(title: str | None, query: object | None) -> bool:
+    if isinstance(query, Mapping):
+        return title_matches_any_query(title, [query])
     if isinstance(query, list):
         if not query:
             return True
-        return any(title_matches_query(title, item) for item in query)
-    return title_matches_query(title, query)
+        if all(isinstance(item, Mapping) for item in query):
+            return title_matches_any_query(title, query)
+        return any(title_matches_query(title, str(item)) for item in query)
+    if query is None:
+        return title_matches_query(title, None)
+    return title_matches_query(title, str(query))
 
 
 def _job_description_text(job: dict) -> str | None:
     """Return the best usable discovered description for a job."""
     for key in ("description", "full_description"):
-        value = str(job.get(key) or "").strip()
+        value = _usable_description_text(job.get(key))
         if value:
             return value
     return None
+
+
+def _usable_description_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text.casefold() in _NULL_DESCRIPTION_SENTINELS:
+        return ""
+    return text
 
 
 def _normalize_job_url(url: object, source_url: str | None = None) -> str | None:
@@ -1070,15 +1127,49 @@ def _run_one_site(name: str, url: str) -> dict:
 
 # -- Target building --------------------------------------------------------
 
+_QUERY_PLACEHOLDERS = ("{query_encoded}", "{query}")
+_SEARCH_ONLY_QUERY_MODES = {"query", "search", "search_only", "fanout"}
+_SOURCE_FIRST_QUERY_MODES = {"browse", "internal_filter", "source_first", "static"}
+
+
+def _smart_extract_query_mode(site: Mapping[str, object], site_type: str, site_url: str) -> str:
+    configured = str(site.get("query_mode") or site.get("search_mode") or "").strip()
+    if configured:
+        normalized = configured.replace("-", "_").casefold()
+        if normalized in _SEARCH_ONLY_QUERY_MODES:
+            return "search_only"
+        if normalized in _SOURCE_FIRST_QUERY_MODES:
+            return "source_first"
+    if site_type == "search" and _has_query_placeholder(site_url):
+        return "search_only"
+    return "source_first"
+
+
+def _has_query_placeholder(url: str) -> bool:
+    return any(placeholder in url for placeholder in _QUERY_PLACEHOLDERS)
+
+
+def _replace_url_placeholders(url: str, *, query: str | None, location: str) -> str:
+    expanded_url = url.replace("{location_encoded}", quote_plus(location))
+    if query is not None:
+        expanded_url = expanded_url.replace("{query_encoded}", quote_plus(query))
+        expanded_url = expanded_url.replace("{query}", quote_plus(query))
+    else:
+        expanded_url = expanded_url.replace("{query_encoded}", "")
+        expanded_url = expanded_url.replace("{query}", "")
+    return expanded_url
+
 
 def build_scrape_targets(
     sites: list[dict] | None = None,
     search_cfg: dict | None = None,
 ) -> list[dict]:
-    """Build the full list of (name, url) targets from sites + search config queries.
+    """Build scrape targets from sites + search config query specs.
 
-    - "search" sites get expanded: 1 URL per query from search config
-    - "static" sites get scraped once as-is
+    - Search-only sites get one URL per query because the external page is the
+      only source enumeration mechanism.
+    - Source-first/static sites get scraped once and filtered internally against
+      the full exact-plus-recall query spec set.
 
     Placeholders in URLs:
       {query_encoded} -> URL-encoded search query
@@ -1090,41 +1181,41 @@ def build_scrape_targets(
     if search_cfg is None:
         search_cfg = config.load_search_config()
 
-    queries_cfg = search_cfg.get("queries", [])
-    queries = [q["query"] for q in queries_cfg]
+    query_specs = query_specs_for_source(search_cfg.get("queries", []), "smartextract")
     locs = search_cfg.get("locations", [])
     default_location = locs[0]["location"] if locs else ""
 
     targets: list[dict] = []
 
     for site in sites:
-        site_url = site.get("url", "")
-        site_name = site.get("name", "Unknown")
-        site_type = site.get("type", "static")
+        site_url = str(site.get("url") or "").strip()
+        site_name = str(site.get("name") or "Unknown")
+        site_type = str(site.get("type") or "static").strip().casefold()
+        query_mode = _smart_extract_query_mode(site, site_type, site_url)
 
-        if site_type == "search" and queries:
-            for query in queries:
-                expanded_url = site_url
-                expanded_url = expanded_url.replace("{query_encoded}", quote_plus(query))
-                expanded_url = expanded_url.replace("{query}", quote_plus(query))
-                expanded_url = expanded_url.replace("{location_encoded}", quote_plus(default_location))
+        if query_mode == "search_only" and query_specs:
+            for query_spec in query_specs:
+                query = str(query_spec.get("query") or "")
+                expanded_url = _replace_url_placeholders(site_url, query=query, location=default_location)
                 targets.append(
                     {
                         "name": site_name,
                         "url": expanded_url,
                         "query": query,
-                        "queries": [query],
+                        "query_spec": query_spec,
+                        "queries": [query_spec],
+                        "query_mode": query_mode,
                     }
                 )
         else:
-            expanded_url = site_url
-            expanded_url = expanded_url.replace("{location_encoded}", quote_plus(default_location))
+            expanded_url = _replace_url_placeholders(site_url, query=None, location=default_location)
             targets.append(
                 {
                     "name": site_name,
                     "url": expanded_url,
                     "query": None,
-                    "queries": queries,
+                    "queries": query_specs,
+                    "query_mode": query_mode,
                 }
             )
 
@@ -1173,7 +1264,7 @@ def _run_all(
                 r.get("strategy", "?"),
                 accept_locs,
                 reject_locs,
-                query=target.get("query") or target.get("queries"),
+                query=target.get("query_spec") or target.get("queries") or target.get("query"),
                 limit=remaining if limit > 0 else 0,
                 source_url=target.get("url"),
             )

--- a/workers/automation/src/jobhunter/discovery/target_queries.py
+++ b/workers/automation/src/jobhunter/discovery/target_queries.py
@@ -120,10 +120,14 @@ def query_applies_to_source(query: Mapping[str, object], source: str) -> bool:
     scope = query.get("source_scope")
     if not scope:
         return True
+    source_aliases = _source_aliases(source)
     if isinstance(scope, str):
-        return scope == source
+        return bool(_source_aliases(scope).intersection(source_aliases))
     if isinstance(scope, Sequence):
-        return source in {str(item) for item in scope}
+        scoped_aliases: set[str] = set()
+        for item in scope:
+            scoped_aliases.update(_source_aliases(str(item)))
+        return bool(scoped_aliases.intersection(source_aliases))
     return True
 
 
@@ -246,6 +250,16 @@ def _dedupe_recall_queries(values: Iterable[str]) -> list[str]:
             result.append(normalized)
             seen.add(key)
     return result
+
+
+def _source_aliases(source: str) -> set[str]:
+    normalized = str(source or "").strip()
+    aliases = {normalized}
+    collapsed = normalized.replace("_", "")
+    aliases.add(collapsed)
+    if collapsed == "smartextract":
+        aliases.update({"smart_extract", "smartextract"})
+    return {alias for alias in aliases if alias}
 
 
 def _query_key(query: str) -> str:

--- a/workers/automation/src/jobhunter/discovery/title_filter.py
+++ b/workers/automation/src/jobhunter/discovery/title_filter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from itertools import product
 
 
 _STOPWORDS = {
@@ -39,10 +40,40 @@ _TOKEN_ALIASES: dict[str, tuple[tuple[str, ...], ...]] = {
 }
 
 _QUERY_ALIASES: tuple[tuple[frozenset[str], tuple[tuple[str, ...], ...]], ...] = (
-    (frozenset(("director", "platform", "engineering")), (("platform", "director"),)),
+    (
+        frozenset(("director", "platform", "engineering")),
+        (("platform", "director"), ("director", "platform")),
+    ),
 )
 
 _RECALL_MATCH_MODE = "recall"
+_MAX_MATCH_EXTRA_TOKENS = 1
+_EXCLUDED_ENGINEERING_SPECIALTIES = {
+    "aerospace",
+    "automotive",
+    "biomedical",
+    "chemical",
+    "civil",
+    "electrical",
+    "industrial",
+    "manufacturing",
+    "mechanical",
+    "process",
+    "structural",
+}
+_EXCLUDED_BUSINESS_FALSE_POSITIVE_TOKENS = {
+    "account",
+    "accounts",
+    "commercial",
+    "pmo",
+    "pricing",
+    "sales",
+}
+_EXCLUDED_BUSINESS_FALSE_POSITIVE_PHRASES = (
+    frozenset(("business", "transformation")),
+    frozenset(("customer", "success")),
+    frozenset(("product", "management")),
+)
 
 _RECALL_LEADERSHIP_TOKENS = {
     "chief",
@@ -115,17 +146,22 @@ def title_matches_query(title: str | None, query: str | None, *, match_mode: str
     normalized_query = normalize_query(query)
     if not normalized_query:
         return True
-    title_tokens = set(_tokens(title))
+    title_sequence = _significant_tokens(title)
+    title_tokens = set(title_sequence)
     if not title_tokens:
         return False
     query_tokens = [token for token in _tokens(normalized_query) if token not in _STOPWORDS]
     if not query_tokens:
         return False
+    if _has_business_function_false_positive(title_sequence, query_tokens):
+        return False
+    if _has_excluded_engineering_specialty(title_sequence, query_tokens):
+        return False
     if match_mode == _RECALL_MATCH_MODE:
-        return _recall_title_matches_query(title_tokens, query_tokens)
-    return all(_token_matches_title(token, title_tokens) for token in query_tokens) or _query_alias_matches(
+        return _recall_title_matches_query(title_sequence, query_tokens)
+    return _query_tokens_match_compactly(query_tokens, title_sequence) or _query_alias_matches(
         query_tokens,
-        title_tokens,
+        title_sequence,
     )
 
 
@@ -142,19 +178,71 @@ def _token_matches_title(token: str, title_tokens: set[str]) -> bool:
     return any(all(part in title_tokens for part in alternative) for alternative in alternatives)
 
 
-def _query_alias_matches(query_tokens: Sequence[str], title_tokens: set[str]) -> bool:
+def _query_alias_matches(query_tokens: Sequence[str], title_sequence: Sequence[str]) -> bool:
     query_token_set = frozenset(query_tokens)
     for required_query_tokens, title_aliases in _QUERY_ALIASES:
         if required_query_tokens.issubset(query_token_set) and any(
-            all(part in title_tokens for part in title_alias)
+            _query_tokens_match_compactly(title_alias, title_sequence)
             for title_alias in title_aliases
         ):
             return True
     return False
 
 
-def _recall_title_matches_query(title_tokens: set[str], query_tokens: Sequence[str]) -> bool:
-    expanded_title = _expanded_tokens(title_tokens)
+def _has_excluded_engineering_specialty(
+    title_sequence: Sequence[str],
+    query_tokens: Sequence[str],
+) -> bool:
+    query_token_set = set(query_tokens)
+    for index, token in enumerate(title_sequence):
+        if token not in {"engineer", "engineering"} or index == 0:
+            continue
+        modifier = title_sequence[index - 1]
+        if modifier in _EXCLUDED_ENGINEERING_SPECIALTIES and modifier not in query_token_set:
+            return True
+    return False
+
+
+def _has_business_function_false_positive(
+    title_sequence: Sequence[str],
+    query_tokens: Sequence[str],
+) -> bool:
+    title_tokens = set(title_sequence)
+    query_token_set = set(query_tokens)
+    excluded_tokens = _EXCLUDED_BUSINESS_FALSE_POSITIVE_TOKENS.difference(query_token_set)
+    if title_tokens.intersection(excluded_tokens):
+        return True
+    return any(
+        phrase.issubset(title_tokens) and not phrase.intersection(query_token_set)
+        for phrase in _EXCLUDED_BUSINESS_FALSE_POSITIVE_PHRASES
+    )
+
+
+def _query_tokens_match_compactly(query_tokens: Sequence[str], title_sequence: Sequence[str]) -> bool:
+    token_spans = [_token_spans(token, title_sequence) for token in query_tokens]
+    if any(not spans for spans in token_spans):
+        return False
+
+    for candidate in product(*token_spans):
+        total_span_tokens = sum(end - start for start, end in candidate)
+        window_start = min(start for start, _ in candidate)
+        window_end = max(end for _, end in candidate)
+        if window_end - window_start <= total_span_tokens + _MAX_MATCH_EXTRA_TOKENS:
+            return True
+    return False
+
+
+def _token_spans(token: str, title_sequence: Sequence[str]) -> tuple[tuple[int, int], ...]:
+    alternatives: Sequence[tuple[str, ...]] = _TOKEN_ALIASES.get(token, ((token,),))
+    spans: list[tuple[int, int]] = []
+    for alternative in alternatives:
+        spans.extend(_matching_alternative_spans(alternative, title_sequence))
+    return tuple(spans)
+
+
+def _recall_title_matches_query(title_sequence: Sequence[str], query_tokens: Sequence[str]) -> bool:
+    title_tokens = set(title_sequence)
+    expanded_title = _expanded_title_tokens(title_tokens)
     expanded_query = _expanded_tokens(query_tokens)
     domain_tokens = _recall_domain_tokens(expanded_query)
     if not domain_tokens:
@@ -163,8 +251,12 @@ def _recall_title_matches_query(title_tokens: set[str], query_tokens: Sequence[s
             for token in expanded_query
             if token not in _RECALL_LEADERSHIP_TOKENS and token not in _STOPWORDS
         }
-    return bool(expanded_title.intersection(_RECALL_LEADERSHIP_TOKENS)) and bool(
-        expanded_title.intersection(domain_tokens)
+    title_leadership_tokens = expanded_title.intersection(_RECALL_LEADERSHIP_TOKENS)
+    title_domain_tokens = expanded_title.intersection(domain_tokens)
+    return bool(title_leadership_tokens) and bool(title_domain_tokens) and _has_compact_recall_signal(
+        title_sequence,
+        title_leadership_tokens,
+        title_domain_tokens,
     )
 
 
@@ -176,11 +268,67 @@ def _recall_domain_tokens(query_tokens: set[str]) -> set[str]:
     return domains
 
 
+def _has_compact_recall_signal(
+    title_sequence: Sequence[str],
+    leadership_tokens: set[str],
+    domain_tokens: set[str],
+) -> bool:
+    leadership_spans = _title_spans_for_tokens(leadership_tokens, title_sequence)
+    domain_spans = _title_spans_for_tokens(domain_tokens, title_sequence)
+    for leadership_span in leadership_spans:
+        for domain_span in domain_spans:
+            window_start = min(leadership_span[0], domain_span[0])
+            window_end = max(leadership_span[1], domain_span[1])
+            if window_end - window_start <= 2 + _MAX_MATCH_EXTRA_TOKENS:
+                return True
+    return False
+
+
+def _title_spans_for_tokens(tokens: set[str], title_sequence: Sequence[str]) -> tuple[tuple[int, int], ...]:
+    spans: list[tuple[int, int]] = []
+    title_tokens = set(title_sequence)
+    for token in tokens:
+        if token in title_tokens:
+            spans.extend(_token_spans(token, title_sequence))
+        for alias_token, alternatives in _TOKEN_ALIASES.items():
+            if token != alias_token:
+                continue
+            for alternative in alternatives:
+                spans.extend(_matching_alternative_spans(alternative, title_sequence))
+    return tuple(spans)
+
+
+def _matching_alternative_spans(
+    alternative: Sequence[str],
+    title_sequence: Sequence[str],
+) -> tuple[tuple[int, int], ...]:
+    width = len(alternative)
+    if not width or width > len(title_sequence):
+        return ()
+    return tuple(
+        (start, start + width)
+        for start in range(0, len(title_sequence) - width + 1)
+        if tuple(title_sequence[start : start + width]) == tuple(alternative)
+    )
+
+
 def _expanded_tokens(tokens: Sequence[str] | set[str]) -> set[str]:
     expanded = set(tokens)
     for token in tuple(tokens):
         expanded.update(_RECALL_TOKEN_EXPANSIONS.get(token, ()))
     return expanded
+
+
+def _expanded_title_tokens(tokens: set[str]) -> set[str]:
+    expanded = _expanded_tokens(tokens)
+    for alias_token, alternatives in _TOKEN_ALIASES.items():
+        if any(set(alternative).issubset(tokens) for alternative in alternatives):
+            expanded.add(alias_token)
+    return expanded
+
+
+def _significant_tokens(value: str | None) -> list[str]:
+    return [token for token in _tokens(value) if token not in _STOPWORDS]
 
 
 def _tokens(value: str | None) -> list[str]:

--- a/workers/automation/src/jobhunter/discovery/workday.py
+++ b/workers/automation/src/jobhunter/discovery/workday.py
@@ -37,6 +37,8 @@ from jobhunter.state import record_job_event
 
 log = logging.getLogger(__name__)
 
+_NULL_DESCRIPTION_SENTINELS = {"<na>", "nan", "nat", "none", "null"}
+
 
 # -- Employer registry from YAML --------------------------------------------
 
@@ -362,7 +364,9 @@ def _posting_from_job(job: dict, employers: dict) -> ScrapedJobPosting | None:
     url = _job_url(job, employers)
     if not url:
         return None
-    description = str(job.get("full_description") or "")
+    description = _usable_description_text(job.get("full_description"))
+    if not description:
+        return None
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=url),
         source=Source(board=str(job.get("employer_name") or "Workday")),
@@ -381,7 +385,7 @@ def _posting_from_job(job: dict, employers: dict) -> ScrapedJobPosting | None:
 
 
 def _update_detail_columns(conn: sqlite3.Connection, job: dict, url: str, now: str) -> None:
-    description = str(job.get("full_description") or "")
+    description = _usable_description_text(job.get("full_description"))
     full_description = description if len(description) > 200 else None
     conn.execute(
         """
@@ -400,6 +404,15 @@ def _update_detail_columns(conn: sqlite3.Connection, job: dict, url: str, now: s
             url,
         ),
     )
+
+
+def _usable_description_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text.casefold() in _NULL_DESCRIPTION_SENTINELS:
+        return ""
+    return text
 
 
 def store_results(

--- a/workers/automation/src/jobhunter/domain/discovery/aggregate.py
+++ b/workers/automation/src/jobhunter/domain/discovery/aggregate.py
@@ -113,7 +113,15 @@ class Job:
 
     def with_metadata(self, metadata: JobMetadata) -> "Job":
         """Return a new Job with updated metadata (re-discovery flow)."""
-        return replace(self, metadata=metadata)
+        return replace(
+            self,
+            metadata=JobMetadata(
+                title=metadata.title or self.metadata.title,
+                salary=metadata.salary or self.metadata.salary,
+                description=metadata.description or self.metadata.description,
+                location=metadata.location or self.metadata.location,
+            ),
+        )
 
     def with_employer(self, employer: Employer) -> "Job":
         """Return a new Job whose employer was upgraded from ``Unknown``.

--- a/workers/automation/src/jobhunter/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/discovery/use_cases.py
@@ -391,8 +391,12 @@ class DiscoverJobsUseCase:
             confidence=identity.confidence,
         ):
             existing = self._repository.load(tenant_id, owner_id)
-            if existing is not None and existing.is_deleted:
-                self._repository.save(existing.restore())
+            if existing is not None:
+                refreshed = existing.with_metadata(posting.metadata)
+                if refreshed.is_deleted:
+                    refreshed = refreshed.restore()
+                if refreshed != existing:
+                    self._repository.save(refreshed)
             self._repository.attach_source_observation(
                 tenant_id,
                 owner_id,

--- a/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py
@@ -28,10 +28,13 @@ from __future__ import annotations
 
 import json
 import logging
+import html
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Iterator
+
+from bs4 import BeautifulSoup
 
 from jobhunter.domain.discovery.identity import AtsKind
 from jobhunter.domain.discovery.value_objects import (
@@ -47,6 +50,8 @@ from jobhunter.discovery.title_filter import title_matches_query
 from jobhunter.infrastructure.observability.adapter_spans import adapter_fetch_span
 
 log = logging.getLogger(__name__)
+
+_NULL_DESCRIPTION_SENTINELS = {"<na>", "nan", "nat", "none", "null"}
 
 
 # ---------------------------------------------------------------------------
@@ -299,7 +304,7 @@ class GreenhouseBoardAdapter:
 
     @property
     def url(self) -> str:
-        return f"https://boards-api.greenhouse.io/v1/boards/{self._board_token}/jobs"
+        return f"https://boards-api.greenhouse.io/v1/boards/{self._board_token}/jobs?content=true"
 
     def scrape(
         self,
@@ -357,6 +362,9 @@ class GreenhouseBoardAdapter:
             search_location=location,
         ):
             return None
+        description = _html_to_text(raw.get("content"))
+        if not description:
+            return None
         company = str(raw.get("company_name") or self._company or "").strip()
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=canonical_url),
@@ -364,7 +372,7 @@ class GreenhouseBoardAdapter:
             metadata=JobMetadata(
                 title=title,
                 salary="",
-                description="",
+                description=description,
                 location=loc,
             ),
             strategy=SearchStrategy.WORKDAY_API,  # ATS family marker
@@ -461,6 +469,9 @@ class LeverBoardAdapter:
             search_location=location,
         ):
             return None
+        description = _lever_description(raw)
+        if not description:
+            return None
         company = self._company or f"lever:{self._site}"
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=hosted_url),
@@ -468,7 +479,7 @@ class LeverBoardAdapter:
             metadata=JobMetadata(
                 title=text,
                 salary="",
-                description="",
+                description=description,
                 location=loc,
             ),
             strategy=SearchStrategy.WORKDAY_API,
@@ -563,6 +574,9 @@ class AshbyBoardAdapter:
             search_location=location,
         ):
             return None
+        description = _ashby_description(raw)
+        if not description:
+            return None
         company = self._company or f"ashby:{self._board_name}"
         return ScrapedJobPosting(
             posting_url=PostingUrl(value=job_url),
@@ -570,7 +584,7 @@ class AshbyBoardAdapter:
             metadata=JobMetadata(
                 title=title,
                 salary="",
-                description="",
+                description=description,
                 location=loc,
             ),
             strategy=SearchStrategy.WORKDAY_API,
@@ -579,6 +593,43 @@ class AshbyBoardAdapter:
             canonical_url=job_url,
             ats_kind=AtsKind.ASHBY,
         )
+
+
+def _lever_description(raw: dict[str, Any]) -> str:
+    parts = [
+        _html_to_text(raw.get("descriptionPlain") or raw.get("description")),
+        _html_to_text(raw.get("additionalPlain") or raw.get("additional")),
+    ]
+    lists = raw.get("lists") or []
+    if isinstance(lists, list):
+        for item in lists:
+            if isinstance(item, dict):
+                parts.append(_html_to_text(item.get("content")))
+    return _collapse_text("\n\n".join(part for part in parts if part))
+
+
+def _ashby_description(raw: dict[str, Any]) -> str:
+    return _html_to_text(
+        raw.get("descriptionPlain")
+        or raw.get("descriptionHtml")
+        or raw.get("description")
+        or raw.get("jobDescription")
+    )
+
+
+def _html_to_text(value: object) -> str:
+    raw = str(value or "").strip()
+    if not raw or raw.casefold() in _NULL_DESCRIPTION_SENTINELS:
+        return ""
+    unescaped = html.unescape(raw)
+    text = BeautifulSoup(unescaped, "html.parser").get_text(" ")
+    if text.strip().casefold() in _NULL_DESCRIPTION_SENTINELS:
+        return ""
+    return _collapse_text(text)
+
+
+def _collapse_text(value: str) -> str:
+    return " ".join(str(value or "").split())
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -62,7 +62,10 @@ from jobhunter.infrastructure.discovery.ats_adapters import (
     HttpFetcher,
     LeverBoardAdapter,
 )
-from jobhunter.infrastructure.discovery.location_filter import configured_location_filters
+from jobhunter.infrastructure.discovery.location_filter import (
+    configured_location_filters,
+    location_matches_target,
+)
 from jobhunter.infrastructure.discovery.sqlite_repository import SqliteJobRepository
 from jobhunter.infrastructure.enrichment import (
     SqliteEnrichmentRepository,
@@ -500,6 +503,8 @@ def run_scheduled_ats_sources(
                 ):
                     if not title_matches_any_query(posting.metadata.title, query_specs):
                         continue
+                    if not str(posting.metadata.description or "").strip():
+                        continue
                     posting_key = _scraped_posting_key(posting)
                     if posting_key in seen_postings:
                         continue
@@ -534,6 +539,221 @@ def run_scheduled_ats_sources(
         sources_run=tuple(sources_run),
         failed_sources=tuple(failed_sources),
     ).to_result_dict()
+
+
+def retire_invalid_source_jobs(
+    conn: sqlite3.Connection,
+    *,
+    search_cfg: Mapping[str, Any],
+    run_id: str = "discovery:hygiene",
+) -> dict[str, Any]:
+    """Soft-delete active discovered jobs that fail today's discovery contract."""
+
+    ensure_source_observation_tables(conn)
+    ensure_enrichment_tables(conn)
+    _ensure_deleted_jobs_table(conn)
+    query_specs_by_family = {
+        "ats_api": tuple(_ats_query_specs(search_cfg)),
+        "jobspy": tuple(query_specs_for_source(search_cfg.get("queries", []), "jobspy")),
+        "smartextract": tuple(
+            query_specs_for_source(search_cfg.get("queries", []), "smartextract")
+        ),
+        "workday": tuple(
+            query_specs_for_source(
+                search_cfg.get("queries", []),
+                "workday",
+                max_tier=int(search_cfg.get("workday_max_tier") or 2),
+            )
+        ),
+    }
+    if not query_specs_by_family["workday"]:
+        query_specs_by_family["workday"] = tuple(
+            query_specs_for_source(search_cfg.get("queries", []), "workday")
+        )
+    accept_locs, reject_locs = configured_location_filters(search_cfg)
+    locations = tuple(_location_values(search_cfg))
+    now = utc_now()
+    retired: list[dict[str, str]] = []
+
+    rows = conn.execute(
+        """
+        SELECT
+            j.url,
+            COALESCE(j.title, '') AS title,
+            COALESCE(j.location, '') AS location,
+            COALESCE(e.full_description, '') AS enrichment_description,
+            COALESCE(j.full_description, '') AS job_full_description,
+            COALESCE(j.description, '') AS job_description,
+            COALESCE(j.strategy, '') AS strategy,
+            COALESCE(c.ats_kind, '') AS ats_kind,
+            COALESCE(MIN(o.source_id), '') AS source_id
+        FROM jobs j
+        LEFT JOIN job_enrichments e
+          ON e.tenant_id = ? AND e.job_url = j.url
+        LEFT JOIN job_canonical_identities c
+          ON c.tenant_id = ? AND c.job_url = j.url
+        LEFT JOIN job_source_observations o
+          ON o.tenant_id = ? AND o.job_url = j.url
+        LEFT JOIN jobhunter_deleted_jobs d
+          ON d.job_url = j.url AND d.restored_at IS NULL
+        WHERE d.job_url IS NULL
+        GROUP BY j.url
+        """,
+        (str(LOCAL_TENANT), str(LOCAL_TENANT), str(LOCAL_TENANT)),
+    ).fetchall()
+
+    for row in rows:
+        family = _source_family(
+            source_id=str(row["source_id"] or ""),
+            strategy=str(row["strategy"] or ""),
+            ats_kind=str(row["ats_kind"] or ""),
+        )
+        if family is None:
+            continue
+        reasons = _source_rejection_reasons(
+            title=str(row["title"] or ""),
+            location=str(row["location"] or ""),
+            description=_first_usable_description(
+                row["enrichment_description"],
+                row["job_full_description"],
+                row["job_description"],
+            ),
+            query_specs=query_specs_by_family.get(family, ()),
+            accept_locs=accept_locs,
+            reject_locs=reject_locs,
+            locations=locations,
+        )
+        if not reasons:
+            continue
+        source_id = str(row["source_id"] or row["ats_kind"] or family)
+        reason = f"discovery hygiene rejected {source_id}: {', '.join(reasons)}"
+        job_url = str(row["url"])
+        conn.execute(
+            """
+            INSERT INTO jobhunter_deleted_jobs (job_url, deleted_at, reason, restored_at)
+            VALUES (?, ?, ?, NULL)
+            ON CONFLICT(job_url) DO UPDATE SET
+                deleted_at = excluded.deleted_at,
+                reason = excluded.reason,
+                restored_at = NULL
+            """,
+            (job_url, now, reason),
+        )
+        record_job_event(
+            conn,
+            job_url,
+            "discover",
+            "JobDeleted",
+            message=reason,
+            payload={
+                "job_id": job_url,
+                "reason": reason,
+                "deleted_at": now,
+                "run_id": run_id,
+                "source_id": source_id,
+                "rejection_reasons": reasons,
+            },
+            occurred_at=now,
+        )
+        retired.append({"job_url": job_url, "reason": reason})
+
+    if retired:
+        conn.commit()
+    return {"retired_jobs": len(retired), "jobs": retired}
+
+
+def retire_invalid_canonical_ats_jobs(
+    conn: sqlite3.Connection,
+    *,
+    search_cfg: Mapping[str, Any],
+    run_id: str = "discovery:hygiene",
+) -> dict[str, Any]:
+    """Backward-compatible wrapper for the broader source hygiene pass."""
+
+    return retire_invalid_source_jobs(conn, search_cfg=search_cfg, run_id=run_id)
+
+
+def _source_family(*, source_id: str, strategy: str, ats_kind: str) -> str | None:
+    if ats_kind in {"greenhouse", "lever", "ashby"} or source_id.startswith(
+        ("greenhouse:", "lever:", "ashby:")
+    ):
+        return "ats_api"
+    if ats_kind == "workday" or source_id.startswith("workday:") or strategy == "workday_api":
+        return "workday"
+    if source_id.startswith("jobspy:") or strategy == "jobspy":
+        return "jobspy"
+    if source_id.startswith("smart_extract:") or strategy in {
+        "api_response",
+        "css_selectors",
+        "json_ld",
+        "smart_extract",
+        "static",
+    }:
+        return "smartextract"
+    return None
+
+
+_NULL_DESCRIPTION_SENTINELS = {"<na>", "nan", "nat", "none", "null"}
+
+
+def _first_usable_description(*values: object) -> str:
+    for value in values:
+        text = _usable_description_text(value)
+        if text:
+            return text
+    return ""
+
+
+def _usable_description_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if text.casefold() in _NULL_DESCRIPTION_SENTINELS:
+        return ""
+    return text
+
+
+def _source_rejection_reasons(
+    *,
+    title: str,
+    location: str,
+    description: str,
+    query_specs: tuple[dict[str, object], ...],
+    accept_locs: list[str],
+    reject_locs: list[str],
+    locations: tuple[str, ...],
+) -> list[str]:
+    reasons: list[str] = []
+    effective_accept_locs = accept_locs or [location for location in locations if location]
+    if not _usable_description_text(description):
+        reasons.append("missing_description")
+    if query_specs and not title_matches_any_query(title, query_specs):
+        reasons.append("title_mismatch")
+    if not any(
+        location_matches_target(
+            location,
+            accept=effective_accept_locs,
+            reject=reject_locs,
+            search_location=target_location,
+        )
+        for target_location in locations
+    ):
+        reasons.append("location_mismatch")
+    return reasons
+
+
+def _ensure_deleted_jobs_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS jobhunter_deleted_jobs (
+            job_url TEXT PRIMARY KEY,
+            deleted_at TEXT NOT NULL,
+            reason TEXT,
+            restored_at TEXT,
+            FOREIGN KEY(job_url) REFERENCES jobs(url)
+        )
+        """
+    )
 
 
 def _scraped_posting_key(posting: ScrapedJobPosting) -> tuple[str, str, str]:

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -46,6 +46,7 @@ from jobhunter.infrastructure.discovery.sqlite_run_repository import (
 )
 from jobhunter.infrastructure.discovery.production_wiring import (
     enqueue_manual_action_for_sources,
+    retire_invalid_source_jobs,
     run_scheduled_ats_sources,
     seed_discovery_control_queues,
 )
@@ -1043,6 +1044,7 @@ def _smart_extract_sites(sources: tuple[ScheduledSource, ...]) -> list[dict]:
                 "name": str(source.adapter_config.get("name") or source.display_name),
                 "url": url,
                 "type": _smart_extract_site_type(source.adapter_config, url),
+                "query_mode": _smart_extract_query_mode(source.adapter_config, url),
             }
         )
     return sites
@@ -1055,6 +1057,15 @@ def _smart_extract_site_type(adapter_config: dict[str, object], url: str) -> str
     if "{query_encoded}" in url or "{query}" in url:
         return "search"
     return "static"
+
+
+def _smart_extract_query_mode(adapter_config: dict[str, object], url: str) -> str:
+    configured_mode = str(adapter_config.get("query_mode") or adapter_config.get("search_mode") or "").strip()
+    if configured_mode:
+        return configured_mode
+    if "{query_encoded}" in url or "{query}" in url:
+        return "search_only"
+    return "source_first"
 
 
 def _optional_float(value: object) -> float | None:
@@ -1091,6 +1102,13 @@ def _run_discover(workers: int = 1, limit: int = 0) -> dict:
 
     # JobSpy — skip if disabled in config or module not installed
     search_cfg = config.load_search_config() or {}
+    try:
+        hygiene = retire_invalid_source_jobs(conn, search_cfg=search_cfg)
+        retired = int(hygiene.get("retired_jobs") or 0)
+        if retired:
+            console.print(f"  [yellow]Discovery hygiene retired {retired} invalid source jobs[/yellow]")
+    except Exception:
+        log.warning("Discovery hygiene failed", exc_info=True)
     jobspy_sources = schedule.for_prefix("jobspy")
 
     def run_jobspy(run_id: str | None = None) -> dict:

--- a/workers/automation/tests/test_ats_adapters.py
+++ b/workers/automation/tests/test_ats_adapters.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from jobhunter.domain.discovery import AtsKind
 from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.discovery import (
@@ -154,7 +156,7 @@ def test_workday_adapter_rejects_loose_title_matches() -> None:
 
 def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
     def http(url: str) -> dict[str, Any]:
-        assert url == "https://boards-api.greenhouse.io/v1/boards/acme/jobs"
+        assert url == "https://boards-api.greenhouse.io/v1/boards/acme/jobs?content=true"
         return {
             "jobs": [
                 {
@@ -163,6 +165,7 @@ def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
                     "absolute_url": "https://boards.greenhouse.io/acme/jobs/123456",
                     "location": {"name": "Remote"},
                     "company_name": "Acme Corp",
+                    "content": "&lt;p&gt;Build backend systems for the platform team.&lt;/p&gt;",
                 }
             ]
         }
@@ -179,11 +182,39 @@ def test_greenhouse_adapter_maps_job_board_payload_to_scraped_posting() -> None:
     posting = postings[0]
     assert posting.metadata.title == "Staff Backend Engineer"
     assert posting.metadata.location == "Remote"
+    assert posting.metadata.description == "Build backend systems for the platform team."
     assert posting.source.board == "Acme Corp"
     assert posting.source_id == "greenhouse:acme"
     assert posting.source_native_id == "123456"
     assert posting.canonical_url == "https://boards.greenhouse.io/acme/jobs/123456"
     assert posting.ats_kind is AtsKind.GREENHOUSE
+
+
+@pytest.mark.parametrize("description", ["None", "nan", "<NA>"])
+def test_greenhouse_adapter_rejects_serialized_null_descriptions(
+    description: str,
+) -> None:
+    def http(_url: str) -> dict[str, Any]:
+        return {
+            "jobs": [
+                {
+                    "id": 123456,
+                    "title": "Staff Backend Engineer",
+                    "absolute_url": "https://boards.greenhouse.io/acme/jobs/123456",
+                    "location": {"name": "Remote"},
+                    "company_name": "Acme Corp",
+                    "content": description,
+                }
+            ]
+        }
+
+    adapter = GreenhouseBoardAdapter(
+        source_id="greenhouse:acme",
+        board_token="acme",
+        http=http,
+    )
+
+    assert list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Backend", location="Remote")) == []
 
 
 def test_lever_adapter_maps_postings_payload_to_scraped_posting() -> None:
@@ -195,6 +226,8 @@ def test_lever_adapter_maps_postings_payload_to_scraped_posting() -> None:
                 "text": "Product Platform Engineer",
                 "hostedUrl": "https://jobs.lever.co/acme/lever-posting-1",
                 "categories": {"location": "Remote"},
+                "description": "<p>Own the product platform roadmap.</p>",
+                "lists": [{"content": "<p>Lead cross-functional delivery.</p>"}],
             }
         ]
 
@@ -211,11 +244,37 @@ def test_lever_adapter_maps_postings_payload_to_scraped_posting() -> None:
     posting = postings[0]
     assert posting.metadata.title == "Product Platform Engineer"
     assert posting.metadata.location == "Remote"
+    assert posting.metadata.description == "Own the product platform roadmap. Lead cross-functional delivery."
     assert posting.source.board == "Acme Corp"
     assert posting.source_id == "lever:acme"
     assert posting.source_native_id == "lever-posting-1"
     assert posting.canonical_url == "https://jobs.lever.co/acme/lever-posting-1"
     assert posting.ats_kind is AtsKind.LEVER
+
+
+@pytest.mark.parametrize("description", ["None", "nan", "<NA>"])
+def test_lever_adapter_rejects_serialized_null_descriptions(
+    description: str,
+) -> None:
+    def http(_url: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "lever-posting-1",
+                "text": "Product Platform Engineer",
+                "hostedUrl": "https://jobs.lever.co/acme/lever-posting-1",
+                "categories": {"location": "Remote"},
+                "description": description,
+            }
+        ]
+
+    adapter = LeverBoardAdapter(
+        source_id="lever:acme",
+        site="acme",
+        company="Acme Corp",
+        http=http,
+    )
+
+    assert list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Platform", location="Remote")) == []
 
 
 def test_ashby_adapter_maps_public_board_payload_to_scraped_posting() -> None:
@@ -228,6 +287,7 @@ def test_ashby_adapter_maps_public_board_payload_to_scraped_posting() -> None:
                     "title": "Infrastructure Engineer",
                     "jobUrl": "https://jobs.ashbyhq.com/acme/ashby-posting-1",
                     "location": "Remote",
+                    "descriptionHtml": "<p>Operate infrastructure systems.</p>",
                 }
             ]
         }
@@ -245,8 +305,36 @@ def test_ashby_adapter_maps_public_board_payload_to_scraped_posting() -> None:
     posting = postings[0]
     assert posting.metadata.title == "Infrastructure Engineer"
     assert posting.metadata.location == "Remote"
+    assert posting.metadata.description == "Operate infrastructure systems."
     assert posting.source.board == "Acme Corp"
     assert posting.source_id == "ashby:acme"
     assert posting.source_native_id == "ashby-posting-1"
     assert posting.canonical_url == "https://jobs.ashbyhq.com/acme/ashby-posting-1"
     assert posting.ats_kind is AtsKind.ASHBY
+
+
+@pytest.mark.parametrize("description", ["None", "nan", "<NA>"])
+def test_ashby_adapter_rejects_serialized_null_descriptions(
+    description: str,
+) -> None:
+    def http(_url: str) -> dict[str, Any]:
+        return {
+            "jobs": [
+                {
+                    "id": "ashby-posting-1",
+                    "title": "Infrastructure Engineer",
+                    "jobUrl": "https://jobs.ashbyhq.com/acme/ashby-posting-1",
+                    "location": "Remote",
+                    "descriptionHtml": description,
+                }
+            ]
+        }
+
+    adapter = AshbyBoardAdapter(
+        source_id="ashby:acme",
+        board_name="acme",
+        company="Acme Corp",
+        http=http,
+    )
+
+    assert list(adapter.scrape(tenant_id=LOCAL_TENANT, query="Infrastructure", location="Remote")) == []

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -63,11 +63,12 @@ def _posting(
     source_native_id: str = "123",
     source_id: str = "greenhouse:acme",
     ats_kind: AtsKind = AtsKind.GREENHOUSE,
+    metadata: JobMetadata | None = None,
 ) -> ScrapedJobPosting:
     return ScrapedJobPosting(
         posting_url=PostingUrl(value=canonical_url),
         source=Source(board="greenhouse"),
-        metadata=JobMetadata(title="Platform Engineer", location="Remote"),
+        metadata=metadata or JobMetadata(title="Platform Engineer", location="Remote"),
         strategy=SearchStrategy.WORKDAY_API,
         source_id=source_id,
         source_native_id=source_native_id,
@@ -407,7 +408,19 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
         deleted_at="2026-05-13T00:00:00Z",
     )
 
-    summary = use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-2")
+    summary = use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                metadata=JobMetadata(
+                    title="Platform Engineering Manager",
+                    description="Lead platform engineering teams in Spain.",
+                    location="Barcelona, Spain",
+                ),
+            )
+        ],
+        run_id="run-2",
+    )
 
     assert summary.total == 1
     assert summary.new_jobs == 0
@@ -415,12 +428,62 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
     resurfaced = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
     assert resurfaced is not None
     assert resurfaced.is_deleted is False
+    assert resurfaced.metadata.title == "Platform Engineering Manager"
+    assert resurfaced.metadata.description == "Lead platform engineering teams in Spain."
+    assert resurfaced.metadata.location == "Barcelona, Spain"
     tombstone = conn.execute(
         "SELECT restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
         ("https://boards.greenhouse.io/acme/jobs/123",),
     ).fetchone()
     assert tombstone is not None
     assert tombstone["restored_at"] == "2026-05-12T00:00:00Z"
+
+
+def test_discover_jobs_use_case_preserves_existing_salary_when_rediscovery_is_blank(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+    use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                metadata=JobMetadata(
+                    title="Director of Engineering",
+                    salary="$180,000",
+                    description="Lead engineering teams.",
+                    location="Barcelona, Spain",
+                )
+            )
+        ],
+        run_id="run-1",
+    )
+
+    summary = use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                metadata=JobMetadata(
+                    title="Director of Engineering",
+                    salary="",
+                    description="Lead engineering teams in Spain.",
+                    location="Barcelona, Spain",
+                )
+            )
+        ],
+        run_id="run-2",
+    )
+
+    assert summary.observed == 1
+    rediscovered = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    assert rediscovered is not None
+    assert rediscovered.metadata.salary == "$180,000"
+    assert rediscovered.metadata.description == "Lead engineering teams in Spain."
 
 
 def test_discover_jobs_use_case_rejects_low_confidence_duplicate(

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -9,6 +9,13 @@ from jobhunter.database import close_connection, init_db
 from jobhunter.discovery import jobspy
 
 
+_JOBSPY_DESCRIPTION = "Lead engineering, platform, security, and delivery teams in Spain. " * 8
+
+
+def _jobspy_frame(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame([{"description": _JOBSPY_DESCRIPTION, **row} for row in rows])
+
+
 def test_jobspy_limit_stops_after_one_new_job(monkeypatch):
     calls: list[tuple[str, str, list[str], int, int]] = []
 
@@ -89,7 +96,7 @@ def test_jobspy_filters_results_by_target_title(monkeypatch):
     stored_titles: list[str] = []
 
     def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
-        return pd.DataFrame(
+        return _jobspy_frame(
             [
                 {
                     "job_url": "https://example.test/marketing",
@@ -139,7 +146,7 @@ def test_jobspy_recall_title_filter_accepts_leadership_variants(monkeypatch):
     stored_titles: list[str] = []
 
     def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
-        return pd.DataFrame(
+        return _jobspy_frame(
             [
                 {
                     "job_url": "https://example.test/head-technology",
@@ -200,7 +207,7 @@ def test_jobspy_remote_search_rejects_non_remote_country_only_location(monkeypat
     stored_locations: list[str] = []
 
     def fake_scrape(_kwargs: dict, max_retries: int = 2, backoff: float = 5.0):
-        return pd.DataFrame(
+        return _jobspy_frame(
             [
                 {
                     "job_url": "https://example.test/la-rinconada",
@@ -279,7 +286,7 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
-        first = pd.DataFrame(
+        first = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/1",
@@ -298,7 +305,7 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
 
         conn.execute("UPDATE jobs SET company = '' WHERE url = ?", ("https://www.linkedin.com/jobs/view/1",))
         conn.commit()
-        duplicate = pd.DataFrame(
+        duplicate = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/1",
@@ -324,11 +331,147 @@ def test_jobspy_stores_company_and_backfills_existing_job(tmp_path):
         close_connection(db_path)
 
 
+def test_jobspy_store_filters_rows_without_descriptions_before_limit(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        results = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/no-description",
+                    "title": "Head of Engineering",
+                    "company": "Missing Description Co",
+                    "description": "",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/with-description",
+                    "title": "Head of Engineering",
+                    "company": "With Description Co",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, results, "Head of Engineering", limit=1) == (1, 0)
+        urls = {row["url"] for row in conn.execute("SELECT url FROM jobs").fetchall()}
+        assert urls == {"https://www.linkedin.com/jobs/view/with-description"}
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_store_filters_null_description_sentinels(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        results = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/none-description",
+                    "title": "Head of Engineering",
+                    "company": "None Description Co",
+                    "description": None,
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/na-description",
+                    "title": "Head of Engineering",
+                    "company": "NA Description Co",
+                    "description": pd.NA,
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/string-none-description",
+                    "title": "Head of Engineering",
+                    "company": "String None Description Co",
+                    "description": "None",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                },
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, results, "Head of Engineering", limit=10) == (0, 0)
+        assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 0
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_existing_row_refreshes_metadata_before_restore(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    url = "https://www.linkedin.com/jobs/view/stale"
+    try:
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                "Stale Support Role",
+                "",
+                "",
+                "United States (Remote)",
+                "linkedin",
+                "jobspy",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        jobspy._ensure_deleted_jobs_table(conn)
+        conn.execute(
+            """
+            INSERT INTO jobhunter_deleted_jobs (job_url, deleted_at, reason, restored_at)
+            VALUES (?, ?, ?, NULL)
+            """,
+            (url, "2026-05-21T00:00:00+00:00", "stale invalid row"),
+        )
+        conn.commit()
+
+        description = ("Lead engineering teams in Spain. " * 12).strip()
+        rediscovered = _jobspy_frame(
+            [
+                {
+                    "job_url": url,
+                    "title": "Head of Engineering",
+                    "company": "Keyrock",
+                    "location": "Barcelona, Spain",
+                    "site": "linkedin",
+                    "description": description,
+                }
+            ]
+        )
+
+        assert jobspy.store_jobspy_results(conn, rediscovered, "Head of Engineering", limit=1) == (0, 1)
+        row = conn.execute(
+            "SELECT title, company, description, full_description, location FROM jobs WHERE url = ?",
+            (url,),
+        ).fetchone()
+        assert dict(row) == {
+            "title": "Head of Engineering",
+            "company": "Keyrock",
+            "description": description,
+            "full_description": description,
+            "location": "Barcelona, Spain",
+        }
+        tombstone = conn.execute(
+            "SELECT restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
+            (url,),
+        ).fetchone()
+        assert tombstone["restored_at"] is not None
+    finally:
+        close_connection(db_path)
+
+
 def test_jobspy_store_limit_counts_new_jobs_not_existing_observations(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
-        existing = pd.DataFrame(
+        existing = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/existing",
@@ -341,7 +484,7 @@ def test_jobspy_store_limit_counts_new_jobs_not_existing_observations(tmp_path):
         )
         assert jobspy.store_jobspy_results(conn, existing, "Head of Engineering", limit=1) == (1, 0)
 
-        mixed = pd.DataFrame(
+        mixed = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/existing",
@@ -386,7 +529,7 @@ def test_jobspy_learns_posting_owner_source_from_direct_ats_url(tmp_path):
     conn = init_db(db_path)
     try:
         direct_url = "https://boards.greenhouse.io/acme/jobs/123456"
-        frame = pd.DataFrame(
+        frame = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/4416248661",
@@ -459,7 +602,7 @@ def test_jobspy_deduplicates_learned_sources_for_same_owner(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
-        frame = pd.DataFrame(
+        frame = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/1",
@@ -499,7 +642,7 @@ def test_jobspy_surfaces_ambiguous_direct_urls_for_source_review(tmp_path):
     conn = init_db(db_path)
     try:
         direct_url = "https://careers.example.com/platform-engineer"
-        frame = pd.DataFrame(
+        frame = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/9",
@@ -545,7 +688,7 @@ def test_jobspy_keeps_learned_workday_sources_in_review_until_runnable(tmp_path)
     conn = init_db(db_path)
     try:
         direct_url = "https://acme.wd1.myworkdayjobs.com/en-US/acme/job/Platform-Engineer_JR-123"
-        frame = pd.DataFrame(
+        frame = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/12",
@@ -609,7 +752,7 @@ def test_jobspy_ignores_missing_direct_url_for_source_learning(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
-        frame = pd.DataFrame(
+        frame = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/10",
@@ -641,7 +784,7 @@ def test_jobspy_rejects_same_content_location_variants(tmp_path):
     conn = init_db(db_path)
     description = "Lead security engineering, compliance, identity, and platform risk. " * 8
     try:
-        first = pd.DataFrame(
+        first = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/4416248661",
@@ -655,7 +798,7 @@ def test_jobspy_rejects_same_content_location_variants(tmp_path):
         )
         assert jobspy.store_jobspy_results(conn, first, "Security Engineering", limit=10) == (1, 0)
 
-        duplicate = pd.DataFrame(
+        duplicate = _jobspy_frame(
             [
                 {
                     "job_url": "https://www.linkedin.com/jobs/view/4416235850",
@@ -695,7 +838,7 @@ def test_jobspy_content_dedupe_normalizes_typographic_punctuation(tmp_path):
     curly_description = "Own Vonage\u2019s platform services and partner APIs. " * 8
     straight_description = "Own Vonage's platform services and partner APIs. " * 8
     try:
-        first = pd.DataFrame(
+        first = _jobspy_frame(
             [
                 {
                     "job_url": "https://es.indeed.com/viewjob?jk=curly",
@@ -709,7 +852,7 @@ def test_jobspy_content_dedupe_normalizes_typographic_punctuation(tmp_path):
         )
         assert jobspy.store_jobspy_results(conn, first, "Product", limit=10) == (1, 0)
 
-        duplicate = pd.DataFrame(
+        duplicate = _jobspy_frame(
             [
                 {
                     "job_url": "https://es.indeed.com/viewjob?jk=straight",
@@ -734,7 +877,7 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
     survivor_url = "https://es.indeed.com/viewjob?jk=canonical"
     duplicate_url = "https://es.indeed.com/viewjob?jk=duplicate"
     try:
-        first = pd.DataFrame(
+        first = _jobspy_frame(
             [
                 {
                     "job_url": survivor_url,
@@ -776,7 +919,7 @@ def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp
         )
         conn.commit()
 
-        rediscovered = pd.DataFrame(
+        rediscovered = _jobspy_frame(
             [
                 {
                     "job_url": duplicate_url,
@@ -808,7 +951,7 @@ def test_jobspy_normalizes_source_locations_before_storage(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)
     try:
-        results = pd.DataFrame(
+        results = _jobspy_frame(
             [
                 {
                     "job_url": "https://es.indeed.com/viewjob?jk=remote-spain",

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -19,6 +19,8 @@ from jobhunter.infrastructure.discovery.production_wiring import (
     ManualCaptureImport,
     build_discovery_acceptance_report,
     import_manual_capture_item,
+    retire_invalid_canonical_ats_jobs,
+    retire_invalid_source_jobs,
     run_scheduled_ats_sources,
     seed_discovery_control_queues,
 )
@@ -112,6 +114,7 @@ def _fake_ats_http(url: str, **_kwargs: Any) -> Any:
                     ),
                     "location": {"name": "Barcelona, Spain"},
                     "company_name": "Barcelona Tech",
+                    "content": "<p>Lead engineering delivery for Barcelona teams.</p>",
                 }
             ]
         }
@@ -122,6 +125,7 @@ def _fake_ats_http(url: str, **_kwargs: Any) -> Any:
                 "text": "Head of Platform",
                 "hostedUrl": "https://jobs.lever.co/leadershipco/202",
                 "categories": {"location": "Spain"},
+                "description": "<p>Own platform strategy for Spain.</p>",
             }
         ]
     if "ashby" in url:
@@ -132,6 +136,7 @@ def _fake_ats_http(url: str, **_kwargs: Any) -> Any:
                     "title": "Engineering Manager",
                     "jobUrl": "https://jobs.ashbyhq.com/platformops/303",
                     "location": "Barcelona, Spain",
+                    "descriptionHtml": "<p>Manage engineering teams in Barcelona.</p>",
                 }
             ]
         }
@@ -394,6 +399,457 @@ def test_canonical_ats_scheduler_fetches_each_source_once_then_filters_queries(
 
     assert result["new_jobs"] == 3
     assert len(calls) == 3
+    assert "https://boards-api.greenhouse.io/v1/boards/barcelonatech/jobs?content=true" in calls
+
+
+def test_canonical_ats_scheduler_rejects_empty_descriptions(
+    conn: sqlite3.Connection,
+) -> None:
+    registry = _barcelona_registry()
+    schedule = DiscoveryScheduler().plan(registry=registry)
+    ats_sources = schedule.for_kinds(SourceKind.ATS_API)
+
+    def http(url: str, **_kwargs: Any) -> Any:
+        if "greenhouse" in url:
+            return {
+                "jobs": [
+                    {
+                        "id": 101,
+                        "title": "Director of Engineering",
+                        "absolute_url": "https://boards.greenhouse.io/barcelonatech/jobs/101",
+                        "location": {"name": "Barcelona, Spain"},
+                        "company_name": "Barcelona Tech",
+                    }
+                ]
+            }
+        return _fake_ats_http(url)
+
+    result = run_scheduled_ats_sources(
+        conn,
+        ats_sources,
+        search_cfg=_search_cfg(),
+        run_id="acceptance:ats",
+        http=http,
+    )
+
+    assert result["new_jobs"] == 2
+    row = conn.execute(
+        "SELECT 1 FROM jobs WHERE url = ?",
+        ("https://boards.greenhouse.io/barcelonatech/jobs/101",),
+    ).fetchone()
+    assert row is None
+
+
+def test_discovery_hygiene_retires_existing_invalid_canonical_ats_rows(
+    conn: sqlite3.Connection,
+) -> None:
+    rows = [
+        (
+            "https://boards.greenhouse.io/acme/jobs/valid",
+            "Director of Engineering",
+            "Barcelona, Spain",
+            "Lead engineering teams in Barcelona.",
+        ),
+        (
+            "https://boards.greenhouse.io/acme/jobs/empty-description",
+            "Director of Engineering",
+            "Barcelona, Spain",
+            "",
+        ),
+        (
+            "https://boards.greenhouse.io/acme/jobs/sales",
+            "Sales Director",
+            "Work from Home - Spain",
+            "Lead enterprise sales teams.",
+        ),
+        (
+            "https://boards.greenhouse.io/acme/jobs/india",
+            "Engineering Manager",
+            "India, Remote",
+            "Lead engineering teams.",
+        ),
+    ]
+    for index, (url, title, location, description) in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (url, title, "Acme", description, location, "Acme", "workday_api", "2026-05-20T00:00:00+00:00"),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_canonical_identities (
+                tenant_id, job_url, canonical_url, ats_kind, source_native_id, confidence, resolved_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("local", url, url, "greenhouse", f"gh-{index}", 1.0, "2026-05-20T00:00:00+00:00"),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                observed_url, normalized_observed_url, run_id, observed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                f"obs-{index}",
+                url,
+                "greenhouse:acme",
+                f"gh-{index}",
+                url,
+                url,
+                "test",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+    conn.commit()
+
+    result = retire_invalid_canonical_ats_jobs(
+        conn,
+        search_cfg=_search_cfg(),
+        run_id="hygiene:test",
+    )
+
+    assert result["retired_jobs"] == 3
+    deleted = {
+        row["job_url"]: row["reason"]
+        for row in conn.execute("SELECT job_url, reason FROM jobhunter_deleted_jobs").fetchall()
+    }
+    assert "https://boards.greenhouse.io/acme/jobs/valid" not in deleted
+    assert "missing_description" in deleted["https://boards.greenhouse.io/acme/jobs/empty-description"]
+    assert "title_mismatch" in deleted["https://boards.greenhouse.io/acme/jobs/sales"]
+    assert "location_mismatch" in deleted["https://boards.greenhouse.io/acme/jobs/india"]
+    event_count = conn.execute(
+        "SELECT COUNT(*) FROM job_events WHERE event_type = 'JobDeleted'"
+    ).fetchone()[0]
+    assert event_count == 3
+
+
+def test_discovery_hygiene_retires_invalid_jobspy_rows(
+    conn: sqlite3.Connection,
+) -> None:
+    rows = [
+        (
+            "https://www.linkedin.com/jobs/view/valid-head-engineering",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "Lead engineering teams in Barcelona.",
+            "jobspy:linkedin",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/head-school-biomedical",
+            "Head of School - School of Biomedical Engineering",
+            "Barcelona, Spain",
+            "Lead an academic biomedical engineering school.",
+            "jobspy:linkedin",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/us-engineering-manager",
+            "Engineering Manager",
+            "United States (Remote)",
+            "Lead engineering teams.",
+            "jobspy:linkedin",
+        ),
+    ]
+    for index, (url, title, location, description, source_id) in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                title,
+                "LinkedInCo",
+                description,
+                location,
+                "linkedin",
+                "jobspy",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                observed_url, normalized_observed_url, run_id, observed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                f"jobspy-obs-{index}",
+                url,
+                source_id,
+                f"li-{index}",
+                url,
+                url,
+                "test",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+    conn.commit()
+
+    result = retire_invalid_source_jobs(
+        conn,
+        search_cfg={
+            "queries": [
+                {"query": "Head of Engineering", "tier": 1},
+                {
+                    "query": "engineering manager",
+                    "tier": 1,
+                    "match_mode": "recall",
+                    "generated_from": "target_roles",
+                },
+            ],
+            "locations": [{"location": "Spain"}],
+            "location_accept": ["Spain", "Barcelona, Spain"],
+            "location_reject_non_remote": ["United States", "USA", "US only"],
+        },
+        run_id="hygiene:jobspy",
+    )
+
+    assert result["retired_jobs"] == 2
+    deleted = {
+        row["job_url"]: row["reason"]
+        for row in conn.execute("SELECT job_url, reason FROM jobhunter_deleted_jobs").fetchall()
+    }
+    assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
+    assert "title_mismatch" in deleted["https://www.linkedin.com/jobs/view/head-school-biomedical"]
+    assert "location_mismatch" in deleted["https://www.linkedin.com/jobs/view/us-engineering-manager"]
+
+
+def test_discovery_hygiene_treats_serialized_null_descriptions_as_missing(
+    conn: sqlite3.Connection,
+) -> None:
+    rows = [
+        (
+            "https://www.linkedin.com/jobs/view/valid-head-engineering",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "Lead engineering teams in Barcelona.",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/none-description",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "None",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/pandas-na-description",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "<NA>",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/nan-description",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "nan",
+        ),
+        (
+            "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback",
+            "Head of Engineering",
+            "Barcelona, Spain",
+            "Lead engineering teams in Barcelona.",
+        ),
+    ]
+    for index, (url, title, location, description) in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                title,
+                "LinkedInCo",
+                description,
+                location,
+                "linkedin",
+                "jobspy",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                observed_url, normalized_observed_url, run_id, observed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                f"jobspy-sentinel-obs-{index}",
+                url,
+                "jobspy:linkedin",
+                f"li-sentinel-{index}",
+                url,
+                url,
+                "test",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+    conn.execute(
+        """
+        INSERT INTO job_enrichments (
+            job_url, tenant_id, current_status, full_description, updated_at
+        ) VALUES (?, ?, ?, ?, ?)
+        """,
+        (
+            "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback",
+            "local",
+            "success",
+            "<NA>",
+            "2026-05-20T00:00:00+00:00",
+        ),
+    )
+    conn.commit()
+
+    result = retire_invalid_source_jobs(
+        conn,
+        search_cfg={
+            "queries": [{"query": "Head of Engineering", "tier": 1}],
+            "locations": [{"location": "Spain"}],
+            "location_accept": ["Spain", "Barcelona, Spain"],
+        },
+        run_id="hygiene:serialized-null",
+    )
+
+    assert result["retired_jobs"] == 3
+    deleted = {
+        row["job_url"]: row["reason"]
+        for row in conn.execute("SELECT job_url, reason FROM jobhunter_deleted_jobs").fetchall()
+    }
+    assert "https://www.linkedin.com/jobs/view/valid-head-engineering" not in deleted
+    assert (
+        "https://www.linkedin.com/jobs/view/enrichment-sentinel-with-fallback"
+        not in deleted
+    )
+    assert "missing_description" in deleted[
+        "https://www.linkedin.com/jobs/view/none-description"
+    ]
+    assert "missing_description" in deleted[
+        "https://www.linkedin.com/jobs/view/pandas-na-description"
+    ]
+    assert "missing_description" in deleted[
+        "https://www.linkedin.com/jobs/view/nan-description"
+    ]
+
+
+def test_discovery_hygiene_applies_to_workday_and_smart_extract_rows(
+    conn: sqlite3.Connection,
+) -> None:
+    rows = [
+        (
+            "https://acme.wd1.myworkdayjobs.com/jobs/valid-engineering-manager",
+            "Engineering Manager",
+            "Madrid, Spain",
+            "Lead engineering teams in Spain.",
+            "Acme",
+            "workday_api",
+            "workday:acme",
+        ),
+        (
+            "https://acme.wd1.myworkdayjobs.com/jobs/customer-success",
+            "Customer Success Manager",
+            "Madrid, Spain",
+            "Lead customer success teams.",
+            "Acme",
+            "workday_api",
+            "workday:acme",
+        ),
+        (
+            "https://wellfound.com/jobs/valid-head-engineering",
+            "Head of Engineering",
+            "Spain",
+            "Lead engineering teams at a startup.",
+            "Wellfound",
+            "api_response",
+            "smart_extract:wellfound",
+        ),
+        (
+            "https://wellfound.com/jobs/us-head-engineering",
+            "Head of Engineering",
+            "United States (Remote)",
+            "Lead engineering teams at a startup.",
+            "Wellfound",
+            "smart_extract",
+            "smart_extract:wellfound",
+        ),
+        (
+            "https://wellfound.com/jobs/missing-description",
+            "Head of Engineering",
+            "Spain",
+            "",
+            "Wellfound",
+            "static",
+            "smart_extract:wellfound",
+        ),
+    ]
+    for index, (url, title, location, description, site, strategy, source_id) in enumerate(rows):
+        conn.execute(
+            """
+            INSERT INTO jobs (url, title, company, description, location, site, strategy, discovered_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                title,
+                site,
+                description,
+                location,
+                site,
+                strategy,
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO job_source_observations (
+                tenant_id, source_observation_id, job_url, source_id, source_native_id,
+                observed_url, normalized_observed_url, run_id, observed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "local",
+                f"source-family-obs-{index}",
+                url,
+                source_id,
+                f"native-{index}",
+                url,
+                url,
+                "test",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+    conn.commit()
+
+    result = retire_invalid_source_jobs(
+        conn,
+        search_cfg={
+            "queries": [
+                {"query": "Head of Engineering", "tier": 1},
+                {"query": "Engineering Manager", "tier": 1},
+            ],
+            "locations": [{"location": "Spain"}],
+            "location_accept": ["Spain", "Madrid, Spain"],
+            "location_reject_non_remote": ["United States", "USA", "US only"],
+        },
+        run_id="hygiene:families",
+    )
+
+    assert result["retired_jobs"] == 3
+    deleted = {
+        row["job_url"]: row["reason"]
+        for row in conn.execute("SELECT job_url, reason FROM jobhunter_deleted_jobs").fetchall()
+    }
+    assert "https://acme.wd1.myworkdayjobs.com/jobs/valid-engineering-manager" not in deleted
+    assert "https://wellfound.com/jobs/valid-head-engineering" not in deleted
+    assert "title_mismatch" in deleted["https://acme.wd1.myworkdayjobs.com/jobs/customer-success"]
+    assert "location_mismatch" in deleted["https://wellfound.com/jobs/us-head-engineering"]
+    assert "missing_description" in deleted["https://wellfound.com/jobs/missing-description"]
 
 
 def test_canonical_ats_scheduler_preserves_successes_when_one_source_fails(

--- a/workers/automation/tests/test_pipeline_observability.py
+++ b/workers/automation/tests/test_pipeline_observability.py
@@ -93,6 +93,8 @@ def test_discover_emits_source_events(monkeypatch):
     assert source_events == [
         ("StageStarted", "jobspy"),
         ("StageCompleted", "jobspy"),
+        ("StageStarted", "ats_api"),
+        ("StageCompleted", "ats_api"),
         ("StageStarted", "workday"),
         ("StageCompleted", "workday"),
         ("StageStarted", "smartextract"),
@@ -132,7 +134,7 @@ def test_discover_limit_propagates_to_sources(monkeypatch):
 
     result = runner._run_discover(workers=4, limit=1)
 
-    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
+    assert result == {"jobspy": "ok", "ats_api": "ok", "workday": "ok", "smartextract": "ok"}
     assert calls == [
         ("jobspy", 1, None),
         ("workday", 1, 4),
@@ -173,7 +175,7 @@ def test_discover_passes_remaining_limit_to_downstream_sources(monkeypatch):
 
     result = runner._run_discover(workers=4, limit=10)
 
-    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
+    assert result == {"jobspy": "ok", "ats_api": "ok", "workday": "ok", "smartextract": "ok"}
     assert calls == [("jobspy", 10), ("workday", 4), ("smartextract", 2)]
 
 
@@ -287,8 +289,31 @@ def test_smart_extract_sites_infer_search_type_from_query_placeholder() -> None:
             "name": "WelcomeToTheJungle",
             "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
             "type": "search",
+            "query_mode": "search_only",
         }
     ]
+
+
+def test_smart_extract_sites_preserve_configured_query_mode() -> None:
+    source = runner.ScheduledSource(
+        source_id="smart_extract:wellfound",
+        display_name="Wellfound",
+        source_kind=SourceKind.SMART_EXTRACT,
+        priority=SourcePriority.FALLBACK,
+        configured_state=SourceState.EXPERIMENTAL,
+        crawl_budget=1,
+        decision="run",
+        reason="test",
+        recommended_state="normal",
+        adapter_config={
+            "name": "Wellfound",
+            "url": "https://wellfound.com/location/spain",
+            "type": "search",
+            "query_mode": "source_first",
+        },
+    )
+
+    assert runner._smart_extract_sites((source,))[0]["query_mode"] == "source_first"
 
 
 def test_discover_limit_skips_remaining_sources_after_cap(monkeypatch):
@@ -349,7 +374,7 @@ def test_discover_limit_does_not_skip_remaining_sources_after_existing_candidate
     result = runner._run_discover(workers=4, limit=1)
 
     assert calls == ["jobspy", "workday", "smartextract"]
-    assert result == {"jobspy": "ok", "workday": "ok", "smartextract": "ok"}
+    assert result == {"jobspy": "ok", "ats_api": "ok", "workday": "ok", "smartextract": "ok"}
 
 
 def test_enrich_limit_propagates_to_runner(monkeypatch):

--- a/workers/automation/tests/test_smartextract_discovery.py
+++ b/workers/automation/tests/test_smartextract_discovery.py
@@ -91,6 +91,90 @@ def test_smart_extract_static_site_filters_against_all_target_queries(
         close_connection(db_path)
 
 
+def test_smart_extract_static_site_uses_recall_match_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        jobs = [
+            {
+                "url": "https://example.com/software-engineer",
+                "title": "Software Engineer",
+                "location": "Spain",
+                "description": "Build product features for a remote team.",
+            },
+            {
+                "url": "https://example.com/head-technology",
+                "title": "Head of Technology",
+                "location": "Spain",
+                "description": "Lead engineering and technology strategy in Spain.",
+            },
+        ]
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            jobs,
+            "Wellfound",
+            "static",
+            ["Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query=[{"query": "technology director", "match_mode": "recall", "tier": 1}],
+        ) == (1, 0)
+
+        stored = conn.execute("SELECT title FROM jobs").fetchall()
+        assert [row["title"] for row in stored] == ["Head of Technology"]
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_target_builder_uses_source_capability() -> None:
+    search_cfg = {
+        "queries": [
+            {"query": "Director of Engineering", "tier": 1},
+            {"query": "technology director", "tier": 1, "match_mode": "recall"},
+        ],
+        "locations": [{"location": "Spain"}],
+    }
+    sites = [
+        {"name": "Wellfound", "url": "https://wellfound.com/location/spain", "type": "static"},
+        {
+            "name": "WelcomeToTheJungle",
+            "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
+            "type": "search",
+        },
+        {
+            "name": "SourceFirstSearchUrl",
+            "url": "https://example.com/jobs?q={query_encoded}&l={location_encoded}",
+            "type": "search",
+            "query_mode": "source_first",
+        },
+    ]
+
+    targets = smartextract.build_scrape_targets(sites=sites, search_cfg=search_cfg)
+
+    assert [target["name"] for target in targets] == [
+        "Wellfound",
+        "WelcomeToTheJungle",
+        "WelcomeToTheJungle",
+        "SourceFirstSearchUrl",
+    ]
+    assert targets[0]["query_mode"] == "source_first"
+    assert targets[0]["query"] is None
+    assert targets[0]["queries"] == [
+        {"query": "Director of Engineering", "match_mode": "strict", "tier": 1},
+        {"query": "technology director", "match_mode": "recall", "tier": 1},
+    ]
+    assert targets[1]["query"] == "Director of Engineering"
+    assert targets[1]["query_spec"] == {"query": "Director of Engineering", "match_mode": "strict", "tier": 1}
+    assert targets[2]["query"] == "technology director"
+    assert targets[2]["query_spec"] == {"query": "technology director", "match_mode": "recall", "tier": 1}
+    assert targets[3]["url"] == "https://example.com/jobs?q=&l=Spain"
+    assert targets[3]["queries"] == targets[0]["queries"]
+
+
 def test_smart_extract_store_filters_jobs_without_descriptions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -105,6 +189,24 @@ def test_smart_extract_store_filters_jobs_without_descriptions(
                 "title": "Head of Engineering",
                 "location": "Barcelona, Spain",
                 "description": "",
+            },
+            {
+                "url": "https://example.com/head-engineering-none",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+                "description": "None",
+            },
+            {
+                "url": "https://example.com/head-engineering-nan",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+                "description": "nan",
+            },
+            {
+                "url": "https://example.com/head-engineering-pandas-na",
+                "title": "Head of Engineering",
+                "location": "Barcelona, Spain",
+                "description": "<NA>",
             },
             {
                 "url": "https://example.com/head-engineering",
@@ -128,6 +230,169 @@ def test_smart_extract_store_filters_jobs_without_descriptions(
         assert [(row["url"], row["description"]) for row in stored] == [
             ("https://example.com/head-engineering", "Lead engineering teams and own platform delivery.")
         ]
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_updates_existing_serialized_null_description(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        url = "https://example.com/head-engineering"
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                url, title, company, description, location, site, strategy, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                "Head of Engineering",
+                "Startup.jobs",
+                "None",
+                "Barcelona, Spain",
+                "Startup.jobs",
+                "api_response",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobhunter_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT,
+                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO jobhunter_deleted_jobs (job_url, deleted_at, reason, restored_at)
+            VALUES (?, ?, ?, NULL)
+            """,
+            (url, "2026-05-20T00:00:00+00:00", "missing_description"),
+        )
+        conn.commit()
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            [
+                {
+                    "url": url,
+                    "title": "Head of Engineering",
+                    "location": "Barcelona, Spain",
+                    "description": "Lead engineering teams and own platform delivery.",
+                }
+            ],
+            "Startup.jobs",
+            "api_response",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Head of Engineering",
+        ) == (0, 1)
+
+        stored = conn.execute(
+            """
+            SELECT j.description, d.restored_at
+            FROM jobs j
+            JOIN jobhunter_deleted_jobs d ON d.job_url = j.url
+            WHERE j.url = ?
+            """,
+            (url,),
+        ).fetchone()
+        assert stored["description"] == "Lead engineering teams and own platform delivery."
+        assert stored["restored_at"] is not None
+    finally:
+        close_connection(db_path)
+
+
+def test_smart_extract_refreshes_existing_title_location_before_restore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    conn = init_db(db_path)
+    try:
+        url = "https://example.com/shared-url"
+        conn.execute(
+            """
+            INSERT INTO jobs (
+                url, title, company, description, location, site, strategy, discovered_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                url,
+                "Sales Director, Platform Services",
+                "",
+                "None",
+                "United States",
+                "Startup.jobs",
+                "api_response",
+                "2026-05-20T00:00:00+00:00",
+            ),
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS jobhunter_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT,
+                FOREIGN KEY(job_url) REFERENCES jobs(url)
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO jobhunter_deleted_jobs (job_url, deleted_at, reason, restored_at)
+            VALUES (?, ?, ?, NULL)
+            """,
+            (url, "2026-05-20T00:00:00+00:00", "title/location mismatch"),
+        )
+        conn.commit()
+
+        assert smartextract._store_jobs_filtered(
+            conn,
+            [
+                {
+                    "url": url,
+                    "title": "Head of Engineering",
+                    "company": "Acme",
+                    "location": "Barcelona, Spain",
+                    "description": "Lead engineering teams and own platform delivery.",
+                }
+            ],
+            "Startup.jobs",
+            "api_response",
+            ["Barcelona, Spain", "Spain", "Europe", "EMEA"],
+            ["United States", "Canada"],
+            query="Head of Engineering",
+        ) == (0, 1)
+
+        stored = conn.execute(
+            """
+            SELECT j.title, j.company, j.description, j.location, d.restored_at
+            FROM jobs j
+            JOIN jobhunter_deleted_jobs d ON d.job_url = j.url
+            WHERE j.url = ?
+            """,
+            (url,),
+        ).fetchone()
+        assert dict(stored) == {
+            "title": "Head of Engineering",
+            "company": "Acme",
+            "description": "Lead engineering teams and own platform delivery.",
+            "location": "Barcelona, Spain",
+            "restored_at": stored["restored_at"],
+        }
+        assert stored["restored_at"] is not None
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_target_search_preferences.py
+++ b/workers/automation/tests/test_target_search_preferences.py
@@ -42,6 +42,8 @@ def test_profile_target_search_overrides_discovery_queries_and_locations() -> No
     assert query_applies_to_source(recall_query, "jobspy")
     assert query_applies_to_source(recall_query, "workday")
     assert query_applies_to_source(recall_query, "ats_api")
+    assert query_applies_to_source({"query": "Engineering", "source_scope": "smart_extract"}, "smartextract")
+    assert query_applies_to_source({"query": "Engineering", "source_scope": "smartextract"}, "smart_extract")
     assert merged["workday_max_tier"] == 1
     assert merged["ats_max_tier"] == 1
     assert merged["locations"] == [
@@ -428,6 +430,7 @@ def test_local_source_registry_row_preserves_search_site_type(tmp_path, monkeypa
                     "name": "WelcomeToTheJungle",
                     "url": "https://www.welcometothejungle.com/en/jobs?query={query_encoded}",
                     "type": "search",
+                    "query_mode": "source_first",
                 }
             ]
         },
@@ -436,3 +439,4 @@ def test_local_source_registry_row_preserves_search_site_type(tmp_path, monkeypa
 
     by_id = {entry.source_id: entry for entry in registry}
     assert by_id["smart_extract:welcometothejungle"].adapter_config["type"] == "search"
+    assert by_id["smart_extract:welcometothejungle"].adapter_config["query_mode"] == "source_first"

--- a/workers/automation/tests/test_title_filter.py
+++ b/workers/automation/tests/test_title_filter.py
@@ -5,7 +5,28 @@ from jobhunter.discovery.title_filter import title_matches_query
 
 def test_strict_title_matching_preserves_exact_query_precision() -> None:
     assert title_matches_query("Director of Engineering", "Director of Engineering")
+    assert title_matches_query("Head of Platform Engineering", "Head of Engineering")
+    assert title_matches_query("Director of Software Engineering", "Director of Engineering")
+    assert title_matches_query("Platform Director", "Director of Platform Engineering")
+    assert title_matches_query("Vice President, Engineering", "VP of Engineering")
     assert not title_matches_query("Head of Technology", "Director of Engineering")
+    assert not title_matches_query("Sales Director Platform", "Director of Platform Engineering")
+    assert not title_matches_query(
+        "Director, Product Management (BSS/Platform Services)",
+        "Director of Platform Engineering",
+    )
+    assert not title_matches_query(
+        "Director, Electrical Engineering - North America, Data Centers",
+        "Director of Engineering",
+    )
+    assert not title_matches_query(
+        "Head of School - School of Biomedical Engineering",
+        "Head of Engineering",
+    )
+    assert not title_matches_query(
+        "Director of Customer Success for Engineering Platforms",
+        "Director of Engineering",
+    )
 
 
 def test_recall_title_matching_accepts_leadership_domain_variants() -> None:
@@ -17,3 +38,21 @@ def test_recall_title_matching_accepts_leadership_domain_variants() -> None:
 def test_recall_title_matching_rejects_non_leadership_ic_titles() -> None:
     assert not title_matches_query("Software Engineer", "engineering director", match_mode="recall")
     assert not title_matches_query("Security Analyst", "security director", match_mode="recall")
+    assert not title_matches_query(
+        "Head of School - School of Biomedical Engineering",
+        "engineering manager",
+        match_mode="recall",
+    )
+    assert not title_matches_query(
+        "Director, Electrical Engineering - North America, Data Centers",
+        "technical director",
+        match_mode="recall",
+    )
+    assert not title_matches_query("Sales Director Platform", "platform director", match_mode="recall")
+    assert not title_matches_query("PMO Engineering Manager", "engineering manager", match_mode="recall")
+    assert not title_matches_query("Account Platform Director", "platform director", match_mode="recall")
+    assert not title_matches_query(
+        "Director, Product Management (BSS/Platform Services)",
+        "platform director",
+        match_mode="recall",
+    )

--- a/workers/automation/tests/test_workday_discovery.py
+++ b/workers/automation/tests/test_workday_discovery.py
@@ -72,6 +72,112 @@ def test_workday_store_results_publishes_discovery_events(
     assert json.loads(observed["payload_json"])["source_id"] == "workday:acme"
 
 
+def test_workday_store_results_rejects_blank_descriptions_before_limit(
+    conn: sqlite3.Connection,
+) -> None:
+    jobs = [
+        {
+            "title": "Director of Engineering",
+            "location": "Barcelona, Spain",
+            "external_path": "/External/job/Barcelona/Director-of-Engineering_JR-blank",
+            "apply_url": "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-blank",
+            "job_req_id": "JR-blank",
+            "employer_key": "acme",
+            "employer_name": "Acme",
+            "full_description": "",
+        },
+        {
+            "title": "Director of Engineering",
+            "location": "Barcelona, Spain",
+            "external_path": "/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "apply_url": "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "job_req_id": "JR-valid",
+            "employer_key": "acme",
+            "employer_name": "Acme",
+            "full_description": "Lead engineering teams building local-first products.",
+        },
+    ]
+    employers = {
+        "acme": {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "site_id": "External",
+            "_source_id": "workday:acme",
+        }
+    }
+
+    new, existing = store_results(
+        conn,
+        jobs,
+        employers,
+        limit=1,
+        run_id="discovery:workday:test",
+    )
+
+    assert (new, existing) == (1, 0)
+    rows = conn.execute("SELECT url, description FROM jobs").fetchall()
+    assert [(row["url"], row["description"]) for row in rows] == [
+        (
+            "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "Lead engineering teams building local-first products."[:500],
+        )
+    ]
+
+
+@pytest.mark.parametrize("description", ["None", "nan", "<NA>"])
+def test_workday_store_results_rejects_serialized_null_descriptions_before_limit(
+    conn: sqlite3.Connection,
+    description: str,
+) -> None:
+    jobs = [
+        {
+            "title": "Director of Engineering",
+            "location": "Barcelona, Spain",
+            "external_path": "/External/job/Barcelona/Director-of-Engineering_JR-sentinel",
+            "apply_url": "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-sentinel",
+            "job_req_id": "JR-sentinel",
+            "employer_key": "acme",
+            "employer_name": "Acme",
+            "full_description": description,
+        },
+        {
+            "title": "Director of Engineering",
+            "location": "Barcelona, Spain",
+            "external_path": "/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "apply_url": "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "job_req_id": "JR-valid",
+            "employer_key": "acme",
+            "employer_name": "Acme",
+            "full_description": "Lead engineering teams building local-first products.",
+        },
+    ]
+    employers = {
+        "acme": {
+            "name": "Acme",
+            "base_url": "https://acme.wd1.myworkdayjobs.com",
+            "site_id": "External",
+            "_source_id": "workday:acme",
+        }
+    }
+
+    new, existing = store_results(
+        conn,
+        jobs,
+        employers,
+        limit=1,
+        run_id="discovery:workday:test",
+    )
+
+    assert (new, existing) == (1, 0)
+    rows = conn.execute("SELECT url, description FROM jobs").fetchall()
+    assert [(row["url"], row["description"]) for row in rows] == [
+        (
+            "https://acme.wd1.myworkdayjobs.com/External/job/Barcelona/Director-of-Engineering_JR-valid",
+            "Lead engineering teams building local-first products."[:500],
+        )
+    ]
+
+
 def test_workday_search_rejects_loose_title_matches(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_search(_employer: dict, _search_text: str, *, limit: int, offset: int) -> dict:
         assert limit == 20


### PR DESCRIPTION
## Summary
- Carry exact-plus-recall query specs through Smart Extract target construction and title filtering.
- Split Smart Extract execution between source-first scraping and search-only query fanout via `query_mode`, and preserve configured Smart Extract query-mode/source-scope settings.
- Require canonical ATS, JobSpy, Workday, and Smart Extract postings to have non-empty usable descriptions before insertion; Greenhouse now uses the public board `content=true` payload and Greenhouse/Lever/Ashby descriptions are normalized from HTML.
- Tighten discovery title matching so unrelated token-bag matches such as academic `Head of School ... Engineering`, customer-success roles, Sales/PMO/account roles, physical-engineering specialties such as electrical engineering, and distant platform mentions in product-management titles do not pass software/platform/security leadership searches.
- Add a discovery hygiene pass across JobSpy, direct ATS, Workday, and Smart Extract rows so active jobs that no longer satisfy the current title/location/description contract are soft-deleted, including serialized null description sentinels such as `None`, `nan`, and `<NA>`.
- Refresh existing job metadata on rediscovery before restoring a previously soft-deleted row, including the direct JobSpy and Smart Extract write paths, so stale invalid rows cannot reappear with old title, location, blank/sentinel descriptions, or locations. Preserve existing non-empty optional metadata such as salary when rediscovery sends blanks.
- Document source-first Smart Extract, canonical ATS description behavior, and source-family hygiene in the pipeline docs.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_ats_adapters.py workers/automation/tests/test_title_filter.py workers/automation/tests/test_discovery_title_filter.py workers/automation/tests/test_discovery_identity.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_workday_discovery.py workers/automation/tests/test_discovery_production_wiring.py workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_smartextract_discovery.py workers/automation/tests/test_smartextract_resilience.py workers/automation/tests/test_pipeline_observability.py workers/automation/tests/test_pipeline_use_cases.py` (121 passed)
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_identity.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_discovery_production_wiring.py` (49 passed)
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_smartextract_discovery.py workers/automation/tests/test_smartextract_resilience.py workers/automation/tests/test_discovery_production_wiring.py` (28 passed)
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_ats_adapters.py workers/automation/tests/test_workday_discovery.py workers/automation/tests/test_title_filter.py` (28 passed)
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/src/jobhunter/discovery/workday.py workers/automation/src/jobhunter/discovery/smartextract.py workers/automation/src/jobhunter/domain/discovery/aggregate.py workers/automation/src/jobhunter/domain/discovery/use_cases.py workers/automation/src/jobhunter/discovery/title_filter.py workers/automation/src/jobhunter/discovery/target_queries.py workers/automation/src/jobhunter/config.py workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py workers/automation/src/jobhunter/pipeline/runner.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_workday_discovery.py workers/automation/tests/test_discovery_identity.py workers/automation/tests/test_ats_adapters.py workers/automation/tests/test_title_filter.py workers/automation/tests/test_discovery_production_wiring.py workers/automation/tests/test_target_search_preferences.py workers/automation/tests/test_smartextract_discovery.py workers/automation/tests/test_smartextract_resilience.py workers/automation/tests/test_pipeline_observability.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/discovery/smartextract.py workers/automation/tests/test_smartextract_discovery.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/discovery/ats_adapters.py workers/automation/src/jobhunter/discovery/workday.py workers/automation/src/jobhunter/discovery/title_filter.py workers/automation/tests/test_ats_adapters.py workers/automation/tests/test_workday_discovery.py workers/automation/tests/test_title_filter.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/discovery/aggregate.py workers/automation/tests/test_discovery_identity.py`
- `git diff --check`
- Ad-hoc title probe confirmed Sales Director Platform, PMO Engineering Manager, Account Platform Director, Product Management Platform Services, and Electrical Engineering false positives return `False`.
- Live hygiene pass on the local DB retired invalid active rows, then the updated title-filter pass retired additional Product Management / Electrical Engineering false positives. A final active-source classifier check reported no active rows failing title, location, or usable-description checks.
- Live API check for `/v1/jobs?deleted=active` no longer shows the bad Greenhouse/Vonage Sales, Account, PMO, India, Japan, or US-only rows at the top of the active jobs list; sampled top rows all had non-empty stored descriptions.
- Live dry-run check against Vonage Greenhouse board with current target filters: 39 location-filtered postings before title filtering, 1 unique title+description accepted posting, description length 4850 characters.