### PR TITLE
feat: expose discovery preparation API projections

### DIFF
--- a/apps/api/src/local-actions.ts
+++ b/apps/api/src/local-actions.ts
@@ -126,9 +126,8 @@ export function createActionDispatcher(
         result: response.error.data,
       };
     }
-    if (rpcCall.method === "apply") {
-      // workflow start — server returns { runId } (the Temporal workflow id).
-      const workflowStart = extractWorkflowStart(response.result);
+    const workflowStart = extractWorkflowStart(response.result);
+    if (hasWorkflowStart(workflowStart)) {
       const result: ActionDispatchResult = {
         status: "queued",
         result: response.result,
@@ -140,20 +139,13 @@ export function createActionDispatcher(
       }
       return result;
     }
+    if (rpcCall.method === "apply") {
+      return {
+        status: "queued",
+        result: response.result,
+      };
+    }
     if (rpcCall.method === "run_stage") {
-      const workflowStart = extractWorkflowStart(response.result);
-      if (workflowStart.runId) {
-        const result: ActionDispatchResult = {
-          status: "queued",
-          runId: workflowStart.runId,
-          result: response.result,
-        };
-        if (workflowStart.workflowId) result.workflowId = workflowStart.workflowId;
-        if (workflowStart.firstExecutionRunId) {
-          result.firstExecutionRunId = workflowStart.firstExecutionRunId;
-        }
-        return result;
-      }
       const status = extractStatus(response.result) ?? "succeeded";
       const result: ActionDispatchResult = {
         status,
@@ -310,6 +302,45 @@ function mapCommandToRpc(command: ActionCommandPayload, context: ActionDispatchC
     }
     return null;
   }
+  if (command.action === "rescore_job") {
+    return {
+      method: "rescore_job",
+      params: {
+        tenantId: "local",
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+        jobUrl: command.jobKey,
+        dryRun: Boolean(command.dryRun),
+        ...(command.reason ? { reason: command.reason } : {}),
+      },
+    };
+  }
+  if (command.action === "rescore_jobs_not_on_current_scoring_policy") {
+    return {
+      method: "rescore_jobs_not_on_current_scoring_policy",
+      params: {
+        tenantId: "local",
+        expectedAppDir: context.appDir,
+        expectedDbPath: context.dbPath,
+        limit: command.limit ?? 100,
+        jobUrls: command.jobKeys ?? [],
+        dryRun: Boolean(command.dryRun),
+        ...(command.reason ? { reason: command.reason } : {}),
+      },
+    };
+  }
+  if (command.action === "retailor_job") {
+    return {
+      method: "retailor_job",
+      params: retailorRpcParams(command, context, command.jobKey),
+    };
+  }
+  if (command.action === "retailor_current_policy") {
+    return {
+      method: "retailor_current_policy",
+      params: retailorRpcParams(command, context),
+    };
+  }
   if (command.action === "generate_materials") return null;
   if (command.action === "apply") {
     return { method: "apply", params: applyRpcParams(command, context) };
@@ -369,6 +400,39 @@ function runStageRpcParams(command: ActionCommandPayload, context: ActionDispatc
   return params;
 }
 
+function retailorRpcParams(
+  command: ActionCommandPayload,
+  context: ActionDispatchContext,
+  jobUrl?: string,
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    tenantId: "local",
+    expectedAppDir: context.appDir,
+    expectedDbPath: context.dbPath,
+    dryRun: Boolean(command.dryRun),
+    suppressExistingArtifacts: command.suppressExistingArtifacts !== false,
+  };
+  if (jobUrl) {
+    params.jobUrl = jobUrl;
+  } else {
+    params.limit = command.limit ?? 100;
+    params.jobUrls = command.jobKeys ?? [];
+  }
+  if (command.reason) {
+    params.reason = command.reason;
+  }
+  if (command.tailorModels && command.tailorModels.length > 0) {
+    params.tailorModels = command.tailorModels;
+  }
+  if (command.tailorJudgeModel) {
+    params.tailorJudgeModel = command.tailorJudgeModel;
+  }
+  if (command.tailorJudgeMinScore !== undefined) {
+    params.tailorJudgeMinScore = command.tailorJudgeMinScore;
+  }
+  return params;
+}
+
 function applyRpcParams(command: ActionCommandPayload, context: ActionDispatchContext): Record<string, unknown> {
   const params: Record<string, unknown> = {
     tenantId: "local",
@@ -401,6 +465,10 @@ function extractWorkflowStart(result: unknown): {
   const firstExecutionRunId =
     typeof result.firstExecutionRunId === "string" ? result.firstExecutionRunId : null;
   return { runId, workflowId, firstExecutionRunId };
+}
+
+function hasWorkflowStart(workflowStart: ReturnType<typeof extractWorkflowStart>): boolean {
+  return Boolean(workflowStart.runId || workflowStart.workflowId || workflowStart.firstExecutionRunId);
 }
 
 function extractActionId(result: unknown): string | null {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -1063,8 +1063,9 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const scoreBreakdownJson = score.breakdown ? JSON.stringify(score.breakdown) : null;
   const scoreKeywordsJson = JSON.stringify(score.keywords);
 
-  const tailorPath = materials.tailorPath ?? nullableString(job.tailored_resume_path);
-  const coverPath = materials.coverPath ?? nullableString(job.cover_letter_path);
+  const hasCanonicalMaterials = materials.generation !== null && materials.generation !== undefined;
+  const tailorPath = hasCanonicalMaterials ? materials.tailorPath : nullableString(job.tailored_resume_path);
+  const coverPath = hasCanonicalMaterials ? materials.coverPath : nullableString(job.cover_letter_path);
   const hasResume = Boolean(tailorPath);
   const hasCoverLetter = Boolean(coverPath);
   const hasPdf = Boolean(materials.resumePdfPath ?? materials.coverPdfPath);
@@ -1078,6 +1079,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const lastUpdatedAt = new Date().toISOString();
 
   const artifacts = collectArtifacts(db, jobUrl, materials);
+  const activeArtifacts = artifacts.filter(isDefaultVisibleArtifact);
 
   db.prepare(
     `INSERT INTO job_list_projections (
@@ -1155,7 +1157,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
     hasPdf ? 1 : 0,
     applyStatus,
     appliedAt,
-    artifacts.length,
+    activeArtifacts.length,
     deletedAt,
     lastUpdatedAt,
   );
@@ -1306,7 +1308,7 @@ function collectArtifacts(
   // still see the matching ``*_pdf`` row.  When a real PDF artifact is
   // registered we never overwrite it (``seen`` guards against
   // duplicates).
-  const tailorTxt = out.find((a) => a.artifactType === "tailored_resume_txt");
+  const tailorTxt = out.find((a) => a.artifactType === "tailored_resume_txt" && isDefaultVisibleArtifact(a));
   const tailorPdfPath =
     materials.resumePdfPath ?? (tailorTxt ? pdfSibling(tailorTxt.localPath) : null);
   if (tailorPdfPath && !seen.has(`tailored_resume_pdf:${tailorPdfPath}`)) {
@@ -1321,7 +1323,7 @@ function collectArtifacts(
       generation: null,
     });
   }
-  const coverTxt = out.find((a) => a.artifactType === "cover_letter_txt");
+  const coverTxt = out.find((a) => a.artifactType === "cover_letter_txt" && isDefaultVisibleArtifact(a));
   const coverPdfPath =
     materials.coverPdfPath ?? (coverTxt ? pdfSibling(coverTxt.localPath) : null);
   if (coverPdfPath && !seen.has(`cover_letter_pdf:${coverPdfPath}`)) {
@@ -1337,6 +1339,10 @@ function collectArtifacts(
     });
   }
   return out;
+}
+
+function isDefaultVisibleArtifact(artifact: Pick<ArtifactRow, "status">): boolean {
+  return String(artifact.status ?? "").toLowerCase() !== "suppressed";
 }
 
 function pdfSibling(value: string | null | undefined): string | null {
@@ -1358,12 +1364,13 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
     apply_status: string | null;
     applied_at: string | null;
     deleted_at: string | null;
+    has_resume: number;
     fit_score: number | null;
     source: string;
   }>(
     db,
     `SELECT job_id, current_stage, current_state, apply_status, applied_at,
-            deleted_at, fit_score, source
+            deleted_at, has_resume, fit_score, source
      FROM job_list_projections jlp
      WHERE tenant_id = ?
        ${hiddenWhere}`,
@@ -1376,7 +1383,8 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
   ).length;
   const blocked = active.filter((row) => row.current_state === "blocked").length;
   const ready = active.filter(
-    (row) => row.current_stage === "apply" && row.current_state === "pending",
+    (row) =>
+      row.current_stage === "apply" && row.current_state === "pending" && Number(row.has_resume ?? 0) === 1,
   ).length;
   const applied = active.filter(
     (row) => row.applied_at || row.apply_status === "applied",

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -30,6 +30,7 @@ import type {
   JobListQuery,
   JobSummary,
   PaginatedResponse,
+  PreparationSummary,
   ProfileShape,
   ScoreBreakdown,
   SettingsResponse,
@@ -287,6 +288,7 @@ export function buildDashboardSummary(db: SqliteDatabase): DashboardSummary {
     sourceHealth: listSourceHealth(db),
     operationalMetrics,
     applyRuns: recentApplyRuns(db),
+    preparation: buildPreparationSummary(db, DEFAULT_TENANT),
   };
 }
 
@@ -322,6 +324,188 @@ function dashboardTodayMetrics(
     jobsToday: rows.filter((row) => localDateKey(row.discovered_at) === today).length,
     appliedToday: rows.filter((row) => localDateKey(row.applied_at) === today).length,
   };
+}
+
+function buildPreparationSummary(db: SqliteDatabase, tenantId: string): PreparationSummary {
+  const currentScoringPolicyVersion = latestPolicyVersion(db, "scoring_policies", tenantId);
+  const currentTailoringPolicyVersion = latestPolicyVersion(db, "tailoring_policies", tenantId);
+  return {
+    currentScoringPolicyVersion,
+    currentTailoringPolicyVersion,
+    outdatedScoreCount: countOutdatedScores(db, tenantId, currentScoringPolicyVersion),
+    outdatedTailoredArtifactCount: countOutdatedTailoredArtifacts(db, tenantId, currentTailoringPolicyVersion),
+    workItems: countPreparationWorkItems(db, tenantId),
+  };
+}
+
+function latestPolicyVersion(
+  db: SqliteDatabase,
+  tableName: "scoring_policies" | "tailoring_policies",
+  tenantId: string,
+): number | null {
+  if (!tableExists(db, tableName)) return null;
+  const row = getRow<{ version: number | null }>(
+    db,
+    `SELECT MAX(version) AS version FROM ${tableName} WHERE tenant_id = ?`,
+    [tenantId],
+  );
+  return nullableNumber(row?.version);
+}
+
+function countOutdatedScores(
+  db: SqliteDatabase,
+  tenantId: string,
+  currentPolicyVersion: number | null,
+): number {
+  const activeJobs = activeJobUrlSet(db);
+  if (activeJobs.size === 0) return 0;
+
+  if (tableExists(db, "job_score_staleness")) {
+    const rows = tableExists(db, "job_scores")
+      ? allRows<{ job_url: string }>(
+          db,
+          `SELECT DISTINCT stale.job_url
+             FROM job_score_staleness stale
+             JOIN (
+               SELECT job_url, MAX(version) AS max_version
+               FROM job_scores
+               WHERE tenant_id = ?
+               GROUP BY job_url
+             ) latest ON latest.job_url = stale.job_url
+             JOIN job_scores s
+               ON s.tenant_id = stale.tenant_id
+              AND s.job_url = stale.job_url
+              AND s.version = latest.max_version
+            WHERE stale.tenant_id = ?
+              AND stale.resolved = 0
+              AND (s.correction_json IS NULL OR TRIM(s.correction_json) = '')`,
+          [tenantId, tenantId],
+        )
+      : allRows<{ job_url: string }>(
+          db,
+          "SELECT DISTINCT job_url FROM job_score_staleness WHERE tenant_id = ? AND resolved = 0",
+          [tenantId],
+        );
+    return rows.filter((row) => activeJobs.has(row.job_url)).length;
+  }
+
+  if (currentPolicyVersion === null || !tableExists(db, "job_scores")) return 0;
+  const rows = allRows<{ job_url: string; trace_json: string | null; correction_json: string | null }>(
+    db,
+    `SELECT s.job_url, s.trace_json, s.correction_json
+       FROM job_scores s
+       JOIN (
+         SELECT job_url, MAX(version) AS max_version
+         FROM job_scores
+         WHERE tenant_id = ?
+         GROUP BY job_url
+       ) latest ON latest.job_url = s.job_url AND latest.max_version = s.version
+      WHERE s.tenant_id = ?`,
+    [tenantId, tenantId],
+  );
+  return rows.filter((row) => {
+    if (!activeJobs.has(row.job_url)) return false;
+    if (row.correction_json?.trim()) return false;
+    const policyVersion = policyVersionFromJson(row.trace_json, [
+      "scoring_policy_version",
+      "scoringPolicyVersion",
+    ]);
+    return policyVersion === null || policyVersion < currentPolicyVersion;
+  }).length;
+}
+
+function countOutdatedTailoredArtifacts(
+  db: SqliteDatabase,
+  tenantId: string,
+  currentPolicyVersion: number | null,
+): number {
+  if (
+    currentPolicyVersion === null ||
+    !tableExists(db, "job_materials") ||
+    !tableExists(db, "job_materials_artifacts")
+  ) {
+    return 0;
+  }
+  const activeJobs = activeJobUrlSet(db);
+  if (activeJobs.size === 0) return 0;
+  const rows = allRows<{ job_url: string; metadata_json: string | null }>(
+    db,
+    `WITH latest AS (
+       SELECT job_url, MAX(generation) AS max_generation
+       FROM job_materials
+       WHERE tenant_id = ?
+       GROUP BY job_url
+     )
+     SELECT a.job_url, a.metadata_json
+       FROM job_materials_artifacts a
+       JOIN latest ON latest.job_url = a.job_url AND latest.max_generation = a.generation
+      WHERE a.artifact_type = 'tailored_resume'
+        AND a.status = 'approved'`,
+    [tenantId],
+  );
+  return rows.filter((row) => {
+    if (!activeJobs.has(row.job_url)) return false;
+    const policyVersion = policyVersionFromJson(row.metadata_json, [
+      "tailoring_policy_version",
+      "tailoringPolicyVersion",
+    ]);
+    return policyVersion === null || policyVersion < currentPolicyVersion;
+  }).length;
+}
+
+function countPreparationWorkItems(
+  db: SqliteDatabase,
+  tenantId: string,
+): PreparationSummary["workItems"] {
+  const counts: PreparationSummary["workItems"] = { queued: 0, running: 0, failed: 0 };
+  if (!tableExists(db, "preparation_work_items")) return counts;
+  const activeJobs = activeJobUrlSet(db);
+  if (activeJobs.size === 0) return counts;
+  const rows = allRows<{ job_id: string; state: string }>(
+    db,
+    `SELECT job_id, state
+       FROM preparation_work_items
+      WHERE tenant_id = ?
+        AND state IN ('queued', 'running', 'failed')`,
+    [tenantId],
+  );
+  for (const row of rows) {
+    if (!activeJobs.has(row.job_id)) continue;
+    if (row.state === "queued" || row.state === "running" || row.state === "failed") {
+      counts[row.state] += 1;
+    }
+  }
+  return counts;
+}
+
+function activeJobUrlSet(db: SqliteDatabase): Set<string> {
+  if (!tableExists(db, "job_list_projections")) return new Set();
+  const filter = jobSqlFilter(db, {
+    page: 1,
+    pageSize: 1,
+    q: "",
+    sort: "discovered_at",
+    dir: "desc",
+    deleted: "active",
+    source: "",
+    company: "",
+  });
+  const rows = allRows<{ job_id: string }>(
+    db,
+    `SELECT job_id FROM job_list_projections${filter.where}`,
+    filter.params,
+  );
+  return new Set(rows.map((row) => row.job_id).filter(Boolean));
+}
+
+function policyVersionFromJson(value: string | null, fields: readonly string[]): number | null {
+  const parsed = parseJsonRecord(value);
+  if (!parsed) return null;
+  for (const field of fields) {
+    const version = nullableNumber(parsed[field]);
+    if (version !== null) return version;
+  }
+  return null;
 }
 
 export function listJobs(db: SqliteDatabase, query: JobListQuery): PaginatedResponse<JobSummary> {
@@ -432,6 +616,7 @@ export function listArtifacts(db: SqliteDatabase, query: ArtifactListQuery): Pag
     [DEFAULT_TENANT],
   );
   const artifacts = rows.map(rowToArtifactSummary).filter((artifact) => {
+    if (!query.status && isSuppressedArtifactStatus(artifact.status)) return false;
     if (query.status && artifact.status !== query.status) return false;
     if (query.type && artifact.type !== query.type) return false;
     if (!normalizedQuery) return true;
@@ -699,7 +884,7 @@ function rowToArtifactSummary(row: ArtifactProjectionRow): ArtifactSummary {
     sizeBytes = localFileSize(localPath);
   }
   let status = row.status || "active";
-  if (localPath && sizeBytes === null) {
+  if (localPath && sizeBytes === null && !isSuppressedArtifactStatus(status)) {
     status = "missing";
   }
   return {
@@ -1057,7 +1242,11 @@ function artifactsForJob(db: SqliteDatabase, jobId: string): ArtifactSummary[] {
     "SELECT * FROM artifact_list_projections WHERE tenant_id = ? AND job_id = ?",
     [DEFAULT_TENANT, jobId],
   );
-  return rows.map(rowToArtifactSummary);
+  return rows.map(rowToArtifactSummary).filter((artifact) => !isSuppressedArtifactStatus(artifact.status));
+}
+
+function isSuppressedArtifactStatus(status: string | null | undefined): boolean {
+  return String(status ?? "").toLowerCase() === "suppressed";
 }
 
 // ================================================================ filters

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -11,6 +11,8 @@ import {
   ApplyJobRequestSchema,
   ArtifactListQuerySchema,
   BulkJobMutationRequestSchema,
+  BulkRescoreJobsNotOnCurrentScoringPolicyRequestSchema,
+  BulkRetailorCurrentPolicyRequestSchema,
   CancelJobActionRequestSchema,
   CorrectScoreRequestSchema,
   PIPELINE_ACTION_JOB_KEY,
@@ -30,8 +32,10 @@ import {
   type ProfileConfigResponse,
   ProfileUpdateRequestSchema,
   QuarantineDecisionSchema,
+  RescoreJobRequestSchema,
   ResetStaleScoresForRescoreRequestSchema,
   RetryStageRequestSchema,
+  RetailorJobRequestSchema,
   RunPipelineStagesRequestSchema,
   SettingsUpdateRequestSchema,
   SourceLocatorDecisionSchema,
@@ -488,6 +492,58 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     return withWritableDb(reply, options.dbPath, (db) => resetStaleScoresForRescore(db, body));
   });
 
+  app.post<{ Params: { jobKey: string } }>(
+    "/v1/jobs/:jobKey/actions/rescore-current-policy",
+    async (request, reply) => {
+      const body = parseBody(reply, RescoreJobRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+      const outcome = await withWritableDb(reply, options.dbPath, async (db) => {
+        const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
+        if (!jobUrl) {
+          return { ok: false, error: "job_not_found" };
+        }
+        const command: ActionCommandPayload = {
+          action: "rescore_job",
+          jobKey: jobUrl,
+          dryRun: body.dryRun,
+        };
+        if (body.reason) command.reason = body.reason;
+        const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+        if (!workerReady) {
+          return undefined;
+        }
+        const dispatch = await actionDispatcher(command, actionContext);
+        void reply.code(202);
+        return buildActionResponse(command, dispatch);
+      });
+      return outcome;
+    },
+  );
+
+  app.post("/v1/scoring/actions/rescore-current-policy", async (request, reply) => {
+    const body = parseBody(reply, BulkRescoreJobsNotOnCurrentScoringPolicyRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    const command: ActionCommandPayload = {
+      action: "rescore_jobs_not_on_current_scoring_policy",
+      jobKey: PIPELINE_ACTION_JOB_KEY,
+      jobKeys: body.jobKeys,
+      limit: body.limit,
+      dryRun: body.dryRun,
+    };
+    if (body.reason) command.reason = body.reason;
+    const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+    if (!workerReady) {
+      return undefined;
+    }
+    const dispatch = await actionDispatcher(command, actionContext);
+    void reply.code(202);
+    return buildActionResponse(command, dispatch);
+  });
+
   app.delete<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey", async (request, reply) => {
     const body = parseBody(reply, DeleteJobRequestSchema, request.body ?? {});
     if (!body) {
@@ -564,6 +620,70 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       void reply.code(400);
       return unsupportedPerJobMaterialAction(jobUrl);
     });
+  });
+
+  app.post<{ Params: { jobKey: string } }>(
+    "/v1/jobs/:jobKey/actions/retailor-current-policy",
+    async (request, reply) => {
+      const body = parseBody(reply, RetailorJobRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+      const outcome = await withWritableDb(reply, options.dbPath, async (db) => {
+        const jobUrl = resolveExistingJob(reply, db, decodeRouteParam(request.params.jobKey));
+        if (!jobUrl) {
+          return { ok: false, error: "job_not_found" };
+        }
+        const command: ActionCommandPayload = {
+          action: "retailor_job",
+          jobKey: jobUrl,
+          dryRun: body.dryRun,
+          suppressExistingArtifacts: body.suppressExistingArtifacts,
+          tailorModels: body.tailorModels,
+        };
+        if (body.reason) command.reason = body.reason;
+        if (body.tailorJudgeModel) command.tailorJudgeModel = body.tailorJudgeModel;
+        if (body.tailorJudgeMinScore !== undefined) {
+          command.tailorJudgeMinScore = body.tailorJudgeMinScore;
+        }
+        const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+        if (!workerReady) {
+          return undefined;
+        }
+        const dispatch = await actionDispatcher(command, actionContext);
+        void reply.code(202);
+        return buildActionResponse(command, dispatch);
+      });
+      return outcome;
+    },
+  );
+
+  app.post("/v1/materials/actions/retailor-current-policy", async (request, reply) => {
+    const body = parseBody(reply, BulkRetailorCurrentPolicyRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    const command: ActionCommandPayload = {
+      action: "retailor_current_policy",
+      jobKey: PIPELINE_ACTION_JOB_KEY,
+      jobKeys: body.jobKeys,
+      limit: body.limit,
+      dryRun: body.dryRun,
+      suppressExistingArtifacts: body.suppressExistingArtifacts,
+      tailorModels: body.tailorModels,
+    };
+    if (body.reason) command.reason = body.reason;
+    if (body.tailorJudgeModel) command.tailorJudgeModel = body.tailorJudgeModel;
+    if (body.tailorJudgeMinScore !== undefined) {
+      command.tailorJudgeMinScore = body.tailorJudgeMinScore;
+    }
+    const workerReady = requireWorkerReady(reply, options.dbPath, requireHealthyWorkerForActions);
+    if (!workerReady) {
+      return undefined;
+    }
+    const dispatch = await actionDispatcher(command, actionContext);
+    void reply.code(202);
+    return buildActionResponse(command, dispatch);
   });
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/actions/apply", async (request, reply) => {

--- a/apps/api/test/json-rpc-adapter.test.ts
+++ b/apps/api/test/json-rpc-adapter.test.ts
@@ -5,9 +5,13 @@
  * factory using a fake in-memory ``JsonRpcDispatcher`` so we don't need
  * to spawn the Python worker subprocess in CI.
  */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it, vi } from "vitest";
 
-import { DEFAULT_PIPELINE_LLM_MODEL } from "../src/contracts.js";
+import { DEFAULT_PIPELINE_LLM_MODEL, type ActionCommandPayload } from "../src/contracts.js";
 import {
   buildActionResponse,
   createActionDispatcher,
@@ -18,6 +22,8 @@ import type {
   JsonRpcDispatcher,
 } from "../src/json-rpc-adapter.js";
 import type { JsonRpcResponse, RpcMethod } from "../src/contracts.js";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
 class FakeDispatcher implements JsonRpcDispatcher {
   public readonly calls: Array<{ method: RpcMethod; params: Record<string, unknown> }> = [];
@@ -152,6 +158,198 @@ describe("createActionDispatcher (JSON-RPC adapter)", () => {
         firstExecutionRunId: "first-exec-run-id",
       },
     });
+  });
+
+  it("maps preparation maintenance actions to current-policy RPC methods", async () => {
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+    const context = { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" };
+
+    await dispatcher(
+      {
+        action: "rescore_job",
+        jobKey: "https://example.com/jobs/current",
+        dryRun: true,
+        reason: "policy refresh",
+      },
+      context,
+    );
+    await dispatcher(
+      {
+        action: "rescore_jobs_not_on_current_scoring_policy",
+        jobKey: "pipeline",
+        jobKeys: ["https://example.com/jobs/stale"],
+        limit: 10,
+        dryRun: true,
+      },
+      context,
+    );
+    await dispatcher(
+      {
+        action: "retailor_job",
+        jobKey: "https://example.com/jobs/current",
+        dryRun: true,
+        suppressExistingArtifacts: false,
+        tailorModels: ["gemini:test"],
+        tailorJudgeModel: "judge:test",
+        tailorJudgeMinScore: 0.82,
+      },
+      context,
+    );
+    await dispatcher(
+      {
+        action: "retailor_current_policy",
+        jobKey: "pipeline",
+        jobKeys: ["https://example.com/jobs/current"],
+        limit: 5,
+        dryRun: false,
+      },
+      context,
+    );
+
+    expect(fake.calls).toEqual([
+      {
+        method: "rescore_job",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobhunter.db",
+          jobUrl: "https://example.com/jobs/current",
+          dryRun: true,
+          reason: "policy refresh",
+        },
+      },
+      {
+        method: "rescore_jobs_not_on_current_scoring_policy",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobhunter.db",
+          limit: 10,
+          jobUrls: ["https://example.com/jobs/stale"],
+          dryRun: true,
+        },
+      },
+      {
+        method: "retailor_job",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobhunter.db",
+          jobUrl: "https://example.com/jobs/current",
+          dryRun: true,
+          suppressExistingArtifacts: false,
+          tailorModels: ["gemini:test"],
+          tailorJudgeModel: "judge:test",
+          tailorJudgeMinScore: 0.82,
+        },
+      },
+      {
+        method: "retailor_current_policy",
+        params: {
+          tenantId: "local",
+          expectedAppDir: "/tmp",
+          expectedDbPath: "/tmp/jobhunter.db",
+          limit: 5,
+          jobUrls: ["https://example.com/jobs/current"],
+          dryRun: false,
+          suppressExistingArtifacts: true,
+        },
+      },
+    ]);
+  });
+
+  it("surfaces workflow start identifiers for preparation maintenance actions", async () => {
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+    const context = { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" };
+    const commands: ActionCommandPayload[] = [
+      {
+        action: "rescore_job",
+        jobKey: "https://example.com/jobs/current",
+      },
+      {
+        action: "rescore_jobs_not_on_current_scoring_policy",
+        jobKey: "pipeline",
+      },
+      {
+        action: "retailor_job",
+        jobKey: "https://example.com/jobs/current",
+      },
+      {
+        action: "retailor_current_policy",
+        jobKey: "pipeline",
+      },
+    ];
+
+    for (const command of commands) {
+      fake.setResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          runId: `${command.action}-run`,
+          workflowId: `${command.action}-workflow`,
+          firstExecutionRunId: `${command.action}-first-execution`,
+        },
+      } as JsonRpcResponse);
+
+      const result = await dispatcher(command, context);
+      const response = buildActionResponse(command, result);
+
+      expect(response).toMatchObject({
+        status: "queued",
+        runId: `${command.action}-run`,
+        actionId: `${command.action}-run`,
+        workflowId: `${command.action}-workflow`,
+        firstExecutionRunId: `${command.action}-first-execution`,
+      });
+    }
+  });
+
+  it("dispatches only RPC methods registered by the Python worker", async () => {
+    const registeredWorkerMethods = new Set(
+      [
+        ...fs
+          .readFileSync(
+            path.join(
+              REPO_ROOT,
+              "workers/automation/src/jobhunter/infrastructure/rpc/handlers.py",
+            ),
+            "utf8",
+          )
+          .matchAll(/server\.register\(\s*"([^"]+)"/g),
+      ].map((match) => match[1]),
+    );
+    const fake = new FakeDispatcher();
+    const dispatcher = createActionDispatcher(fake);
+    const context = { appDir: "/tmp", dbPath: "/tmp/jobhunter.db" };
+
+    await dispatcher({ action: "run_stage", jobKey: "pipeline", stage: "score" }, context);
+    await dispatcher(
+      {
+        action: "retry_stage",
+        jobKey: "https://example.com/jobs/current",
+        stage: "apply",
+        runAfter: true,
+      },
+      context,
+    );
+    await dispatcher({ action: "apply", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher({ action: "cancel", jobKey: "pipeline", runId: "run-1" }, context);
+    await dispatcher({ action: "rescore_job", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher(
+      {
+        action: "rescore_jobs_not_on_current_scoring_policy",
+        jobKey: "pipeline",
+      },
+      context,
+    );
+    await dispatcher({ action: "retailor_job", jobKey: "https://example.com/jobs/current" }, context);
+    await dispatcher({ action: "retailor_current_policy", jobKey: "pipeline" }, context);
+
+    const dispatchedMethods = [...new Set(fake.calls.map((call) => call.method))];
+    const unregisteredMethods = dispatchedMethods.filter((method) => !registeredWorkerMethods.has(method));
+    expect(unregisteredMethods).toEqual([]);
   });
 
   it("creates the production JSON-RPC dispatcher with the API runtime appDir", async () => {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1359,6 +1359,303 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("hides suppressed current tailored artifacts from active displays and apply readiness", async () => {
+    const suppressedUrl = "https://example.com/jobs/suppressed-artifact";
+    const suppressedPath = path.join(tempDir, "suppressed-resume.txt");
+    fs.writeFileSync(suppressedPath, "suppressed resume");
+    const seedDb = new Database(options.dbPath);
+    createMaterialsTables(seedDb);
+    insertJob(seedDb, {
+      url: suppressedUrl,
+      title: "Suppressed Materials Engineer",
+      site: "ExampleCo",
+      fitScore: 9,
+      tailoredPath: suppressedPath,
+    });
+    insertScore(seedDb, suppressedUrl, 1, 9);
+    for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
+      insertStage(seedDb, suppressedUrl, stage, "succeeded");
+    }
+    insertStage(seedDb, suppressedUrl, "apply", "pending");
+    insertMaterialsGeneration(seedDb, {
+      jobUrl: suppressedUrl,
+      artifactId: "artifact-suppressed-resume",
+      artifactType: "tailored_resume",
+      status: "suppressed",
+      path: suppressedPath,
+      metadata: { tailoring_policy_version: 1 },
+    });
+    seedDb.close();
+
+    const app = buildApp(options);
+    try {
+      const detailResponse = await app.inject({
+        method: "GET",
+        url: `/v1/jobs/${encodeURIComponent(suppressedUrl)}`,
+      });
+      const defaultArtifactsResponse = await app.inject({
+        method: "GET",
+        url: "/v1/artifacts?type=tailored_resume",
+      });
+      const suppressedArtifactsResponse = await app.inject({
+        method: "GET",
+        url: "/v1/artifacts?type=tailored_resume&status=suppressed",
+      });
+      const artifactDetailResponse = await app.inject({
+        method: "GET",
+        url: "/v1/artifacts/artifact-suppressed-resume",
+      });
+      const dashboardResponse = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+
+      expect(detailResponse.statusCode, detailResponse.body).toBe(200);
+      const detailBody = detailResponse.json();
+      expect(detailBody.job).toMatchObject({
+        jobKey: suppressedUrl,
+        artifactCount: 0,
+      });
+      expect(detailBody.artifacts).toEqual([]);
+
+      expect(defaultArtifactsResponse.statusCode, defaultArtifactsResponse.body).toBe(200);
+      expect(
+        defaultArtifactsResponse
+          .json()
+          .items.some((artifact: { artifactId: string }) => artifact.artifactId === "artifact-suppressed-resume"),
+      ).toBe(false);
+
+      expect(suppressedArtifactsResponse.statusCode, suppressedArtifactsResponse.body).toBe(200);
+      expect(suppressedArtifactsResponse.json().items).toEqual([
+        expect.objectContaining({
+          artifactId: "artifact-suppressed-resume",
+          jobKey: suppressedUrl,
+          status: "suppressed",
+          type: "tailored_resume",
+        }),
+      ]);
+
+      expect(artifactDetailResponse.statusCode, artifactDetailResponse.body).toBe(200);
+      expect(artifactDetailResponse.json().artifact).toMatchObject({
+        artifactId: "artifact-suppressed-resume",
+        status: "suppressed",
+      });
+
+      expect(dashboardResponse.statusCode, dashboardResponse.body).toBe(200);
+      expect(dashboardResponse.json().totals.ready).toBe(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("exposes preparation policy versions, distinct outdated counts, and work-item counts in the dashboard summary", async () => {
+    const seedDb = new Database(options.dbPath);
+    createScoreStalenessTable(seedDb);
+    createMaterialsTables(seedDb);
+    seedDb.exec(`
+      CREATE TABLE scoring_policies (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        version INTEGER NOT NULL,
+        rubric_json TEXT NOT NULL,
+        anchors_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        created_from_event_id INTEGER,
+        PRIMARY KEY (tenant_id, version)
+      );
+      CREATE TABLE tailoring_policies (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        version INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, version)
+      );
+      CREATE TABLE preparation_work_items (
+        item_id TEXT NOT NULL PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        job_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        target_version INTEGER NOT NULL,
+        source_event_id TEXT NOT NULL DEFAULT '',
+        state TEXT NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        attempts INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        available_at TEXT NOT NULL
+      );
+    `);
+    const insertScoringPolicy = seedDb.prepare(
+      "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    insertScoringPolicy.run("local", 2, "{}", "[]", "2026-05-26T10:00:00+00:00");
+    insertScoringPolicy.run("local", 3, "{}", "[]", "2026-05-26T10:05:00+00:00");
+    seedDb
+      .prepare("INSERT INTO tailoring_policies (tenant_id, version, created_at) VALUES (?, ?, ?)")
+      .run("local", 2, "2026-05-26T10:00:00+00:00");
+    seedDb
+      .prepare(
+        `INSERT INTO job_score_staleness (
+           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           new_policy_id, new_policy_version, marked_at, resolved
+         ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+           'local:scoring-policy-v2', 2, '2026-05-26T10:01:00+00:00', 0)`,
+      )
+      .run("https://example.com/jobs/failed-score");
+    seedDb
+      .prepare(
+        `INSERT INTO job_score_staleness (
+           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           new_policy_id, new_policy_version, marked_at, resolved
+         ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+           'local:scoring-policy-v3', 3, '2026-05-26T10:06:00+00:00', 0)`,
+      )
+      .run("https://example.com/jobs/failed-score");
+    insertMaterialsGeneration(seedDb, {
+      jobUrl: "https://example.com/jobs/ready",
+      artifactId: "artifact-ready-old-policy",
+      artifactType: "tailored_resume",
+      status: "approved",
+      path: path.join(tempDir, "ready-resume.txt"),
+      metadata: { tailoring_policy_version: 1 },
+    });
+    for (const [itemId, jobId, state] of [
+      ["prep-queued", "https://example.com/jobs/ready", "queued"],
+      ["prep-running", "https://example.com/jobs/failed-score", "running"],
+      ["prep-failed", "https://example.com/jobs/blocked-tailor", "failed"],
+    ] as const) {
+      seedDb
+        .prepare(
+          `INSERT INTO preparation_work_items (
+             item_id, tenant_id, job_id, kind, target_version, source_event_id, state,
+             idempotency_key, attempts, last_error, created_at, updated_at, available_at
+           ) VALUES (?, 'local', ?, 'rescore', 2, 'event-1', ?, ?, 0, '', ?, ?, ?)`,
+        )
+        .run(
+          itemId,
+          jobId,
+          state,
+          `${itemId}-key`,
+          "2026-05-26T10:02:00+00:00",
+          "2026-05-26T10:02:00+00:00",
+          "2026-05-26T10:02:00+00:00",
+        );
+    }
+    seedDb.close();
+
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().preparation).toEqual({
+        currentScoringPolicyVersion: 3,
+        currentTailoringPolicyVersion: 2,
+        outdatedScoreCount: 1,
+        outdatedTailoredArtifactCount: 1,
+        workItems: { queued: 1, running: 1, failed: 1 },
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("does not count corrected old-policy scores as outdated when staleness markers are absent", async () => {
+    const seedDb = new Database(options.dbPath);
+    seedDb.exec(`
+      CREATE TABLE scoring_policies (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        version INTEGER NOT NULL,
+        rubric_json TEXT NOT NULL,
+        anchors_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        created_from_event_id INTEGER,
+        PRIMARY KEY (tenant_id, version)
+      );
+    `);
+    seedDb
+      .prepare(
+        "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("local", 2, "{}", "[]", "2026-05-26T10:00:00+00:00");
+    seedDb
+      .prepare("UPDATE job_scores SET trace_json = ?")
+      .run(JSON.stringify({ scoring_policy_id: "local:scoring-policy-v2", scoring_policy_version: 2 }));
+    insertJob(seedDb, {
+      url: "https://example.com/jobs/outdated-policy-score",
+      title: "Outdated Score",
+      site: "ExampleCo",
+      fitScore: 8,
+    });
+    insertScore(seedDb, "https://example.com/jobs/outdated-policy-score", 1, 8, { policyVersion: 1 });
+    insertJob(seedDb, {
+      url: "https://example.com/jobs/corrected-policy-score",
+      title: "Corrected Score",
+      site: "ExampleCo",
+      fitScore: 9,
+    });
+    insertScore(seedDb, "https://example.com/jobs/corrected-policy-score", 1, 9, {
+      correction: { fit_score: 9, reason: "user corrected score" },
+      policyVersion: 1,
+    });
+    seedDb.close();
+
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().preparation.outdatedScoreCount).toBe(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("does not count corrected latest scores as outdated when stale markers remain unresolved", async () => {
+    const seedDb = new Database(options.dbPath);
+    createScoreStalenessTable(seedDb);
+    seedDb.exec(`
+      CREATE TABLE scoring_policies (
+        tenant_id TEXT NOT NULL DEFAULT 'local',
+        version INTEGER NOT NULL,
+        rubric_json TEXT NOT NULL,
+        anchors_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        created_from_event_id INTEGER,
+        PRIMARY KEY (tenant_id, version)
+      );
+    `);
+    seedDb
+      .prepare(
+        "INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run("local", 3, "{}", "[]", "2026-05-26T10:00:00+00:00");
+    insertJob(seedDb, {
+      url: "https://example.com/jobs/stale-but-corrected",
+      title: "Corrected Stale Score",
+      site: "ExampleCo",
+      fitScore: 9,
+    });
+    insertScore(seedDb, "https://example.com/jobs/stale-but-corrected", 1, 7, { policyVersion: 1 });
+    insertScore(seedDb, "https://example.com/jobs/stale-but-corrected", 2, 9, {
+      correction: { fit_score: 9, reason: "user corrected score" },
+      policyVersion: 1,
+    });
+    seedDb
+      .prepare(
+        `INSERT INTO job_score_staleness (
+           tenant_id, job_url, stale_reason, old_policy_id, old_policy_version,
+           new_policy_id, new_policy_version, marked_at, resolved
+         ) VALUES ('local', ?, 'scoring_policy_changed', 'local:scoring-policy-v1', 1,
+           'local:scoring-policy-v3', 3, '2026-05-26T10:06:00+00:00', 0)`,
+      )
+      .run("https://example.com/jobs/stale-but-corrected");
+    seedDb.close();
+
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+      expect(response.statusCode, response.body).toBe(200);
+      expect(response.json().preparation.outdatedScoreCount).toBe(0);
+    } finally {
+      await app.close();
+    }
+  });
+
   it("formats zero-byte artifacts as real files instead of missing files", async () => {
     const db = new Database(options.dbPath);
     db.prepare("UPDATE job_artifacts SET size_bytes = 0 WHERE artifact_type = ?").run("tailored_resume_txt");
@@ -1851,6 +2148,103 @@ describe("local TypeScript API", () => {
     });
     expect(dispatch).toHaveBeenCalledWith(
       expect.objectContaining({ action: "apply", dryRun: true, jobKey: "https://example.com/jobs/ready" }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
+    );
+
+    await app.close();
+  });
+
+  it("dispatches current-policy rescore and re-tailor maintenance actions", async () => {
+    const dispatch = vi.fn(async (command: ActionCommandPayload): Promise<ActionDispatchResult> => ({
+      status: "queued",
+      runId: `run-${command.action}`,
+      result: { ok: true, action: command.action },
+    }));
+    const app = buildApp({ ...options, actionDispatcher: dispatch });
+    const jobKey = encodeURIComponent("https://example.com/jobs/ready");
+
+    const rescoreJob = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${jobKey}/actions/rescore-current-policy`,
+      payload: { dryRun: true, reason: "policy refresh" },
+    });
+    const rescoreBulk = await app.inject({
+      method: "POST",
+      url: "/v1/scoring/actions/rescore-current-policy",
+      payload: { jobKeys: ["https://example.com/jobs/failed-score"], limit: 10, dryRun: true },
+    });
+    const retailorJob = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${jobKey}/actions/retailor-current-policy`,
+      payload: {
+        dryRun: true,
+        suppressExistingArtifacts: false,
+        tailorModels: ["gemini:test"],
+        tailorJudgeModel: "judge:test",
+        tailorJudgeMinScore: 0.82,
+        reason: "policy refresh",
+      },
+    });
+    const retailorBulk = await app.inject({
+      method: "POST",
+      url: "/v1/materials/actions/retailor-current-policy",
+      payload: {
+        jobKeys: ["https://example.com/jobs/ready"],
+        limit: 5,
+        dryRun: false,
+        suppressExistingArtifacts: true,
+      },
+    });
+
+    for (const response of [rescoreJob, rescoreBulk, retailorJob, retailorBulk]) {
+      expect(response.statusCode, response.body).toBe(202);
+      expect(response.json()).toMatchObject({ ok: true, status: "queued" });
+    }
+    expect(dispatch).toHaveBeenCalledTimes(4);
+    expect(dispatch).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: "rescore_job",
+        jobKey: "https://example.com/jobs/ready",
+        dryRun: true,
+        reason: "policy refresh",
+      }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        action: "rescore_jobs_not_on_current_scoring_policy",
+        jobKey: "pipeline",
+        jobKeys: ["https://example.com/jobs/failed-score"],
+        limit: 10,
+        dryRun: true,
+      }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        action: "retailor_job",
+        jobKey: "https://example.com/jobs/ready",
+        dryRun: true,
+        suppressExistingArtifacts: false,
+        tailorModels: ["gemini:test"],
+        tailorJudgeModel: "judge:test",
+        tailorJudgeMinScore: 0.82,
+      }),
+      expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
+    );
+    expect(dispatch).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        action: "retailor_current_policy",
+        jobKey: "pipeline",
+        jobKeys: ["https://example.com/jobs/ready"],
+        limit: 5,
+        dryRun: false,
+        suppressExistingArtifacts: true,
+      }),
       expect.objectContaining({ appDir: tempDir, dbPath: options.dbPath }),
     );
 
@@ -3119,6 +3513,76 @@ function createScoreStalenessTable(db: Database.Database): void {
       )
     )
   `);
+}
+
+function createMaterialsTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS job_materials (
+      job_url TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      status TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_validation_json TEXT,
+      last_verdict_json TEXT,
+      metadata_json TEXT,
+      PRIMARY KEY (job_url, generation)
+    );
+    CREATE TABLE IF NOT EXISTS job_materials_artifacts (
+      job_url TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      artifact_type TEXT NOT NULL,
+      artifact_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      path TEXT NOT NULL,
+      render_format TEXT NOT NULL,
+      size_bytes INTEGER,
+      metadata_json TEXT,
+      created_at TEXT NOT NULL,
+      superseded_at TEXT,
+      PRIMARY KEY (job_url, generation, artifact_type)
+    );
+  `);
+}
+
+function insertMaterialsGeneration(
+  db: Database.Database,
+  artifact: {
+    jobUrl: string;
+    artifactId: string;
+    artifactType: string;
+    status: string;
+    path: string;
+    metadata?: Record<string, unknown>;
+  },
+): void {
+  db.prepare(
+    `INSERT OR REPLACE INTO job_materials (
+       job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
+     ) VALUES (?, 1, 'local', ?, ?, ?, ?)`,
+  ).run(
+    artifact.jobUrl,
+    artifact.status === "suppressed" ? "suppressed" : "resume_approved",
+    "2026-05-26T10:00:00+00:00",
+    "2026-05-26T10:00:00+00:00",
+    "{}",
+  );
+  db.prepare(
+    `INSERT OR REPLACE INTO job_materials_artifacts (
+       job_url, generation, artifact_type, artifact_id, status, path,
+       render_format, size_bytes, metadata_json, created_at
+     ) VALUES (?, 1, ?, ?, ?, ?, 'text', ?, ?, ?)`,
+  ).run(
+    artifact.jobUrl,
+    artifact.artifactType,
+    artifact.artifactId,
+    artifact.status,
+    artifact.path,
+    fs.existsSync(artifact.path) ? fs.statSync(artifact.path).size : null,
+    JSON.stringify(artifact.metadata ?? {}),
+    "2026-05-26T10:00:00+00:00",
+  );
 }
 
 function insertStage(

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -197,6 +197,7 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
   PreparationWorkItemCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+    artifactsKeys.lists(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   PreparationWorkItemFailed: [

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -13,6 +13,7 @@ import type {
   PreparationWorkItemStarted,
 } from "@jobhunter/domain-types";
 
+import { artifactsKeys } from "../operations/artifactsKeys.js";
 import { dashboardKeys } from "../operations/dashboardKeys.js";
 import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
@@ -77,11 +78,20 @@ type PreparationWorkItemEvent =
 
 const preparationWorkItemHandler = (
   event: PreparationWorkItemEvent,
-): readonly InvalidationItem[] => [
-  invalidate(jobsKeys.lists(event.tenantId)),
-  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
-  invalidate(dashboardKeys.summary(event.tenantId)),
-];
+): readonly InvalidationItem[] => {
+  const invalidations = [
+    invalidate(jobsKeys.lists(event.tenantId)),
+    invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  ];
+  if (
+    event.eventType === "PreparationWorkItemCompleted" &&
+    event.payload.kind === "suppress_tailored_artifacts"
+  ) {
+    invalidations.push(invalidate(artifactsKeys.lists(event.tenantId)));
+  }
+  invalidations.push(invalidate(dashboardKeys.summary(event.tenantId)));
+  return invalidations;
+};
 
 export const preparationWorkItemQueuedHandler = preparationWorkItemHandler;
 export const preparationWorkItemStartedHandler = preparationWorkItemHandler;

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -119,6 +119,20 @@ export class FetchApiClientAdapter implements ApiClientPort {
   resetStaleScoresForRescore(body: Parameters<JobHunterApiClient["resetStaleScoresForRescore"]>[0]) {
     return this.client.resetStaleScoresForRescore(body);
   }
+  rescoreJob(jobKey: string, body: Parameters<JobHunterApiClient["rescoreJob"]>[1] = {}) {
+    return this.client.rescoreJob(jobKey, body);
+  }
+  rescoreJobsNotOnCurrentScoringPolicy(
+    body: Parameters<JobHunterApiClient["rescoreJobsNotOnCurrentScoringPolicy"]>[0],
+  ) {
+    return this.client.rescoreJobsNotOnCurrentScoringPolicy(body);
+  }
+  retailorJob(jobKey: string, body: Parameters<JobHunterApiClient["retailorJob"]>[1] = {}) {
+    return this.client.retailorJob(jobKey, body);
+  }
+  retailorCurrentPolicy(body: Parameters<JobHunterApiClient["retailorCurrentPolicy"]>[0]) {
+    return this.client.retailorCurrentPolicy(body);
+  }
   workflowRuns(query: Parameters<JobHunterApiClient["workflowRuns"]>[0] = {}) {
     return this.client.workflowRuns(query);
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -9,6 +9,8 @@ import type {
   ArtifactOpenResponse,
   ArtifactSummary,
   BulkJobMutationRequest,
+  BulkRescoreJobsNotOnCurrentScoringPolicyRequest,
+  BulkRetailorCurrentPolicyRequest,
   CancelJobActionRequest,
   CredentialKey,
   CorrectScoreRequest,
@@ -40,6 +42,8 @@ import type {
   QuarantineDecision,
   QuarantineDecisionResponse,
   QuarantineListResponse,
+  RescoreJobRequest,
+  RetailorJobRequest,
   RetryStageRequest,
   ResetStaleScoresForRescoreRequest,
   ResetStaleScoresForRescoreResponse,
@@ -137,6 +141,12 @@ export interface ApiClientPort {
   resetStaleScoresForRescore(
     body: ResetStaleScoresForRescoreRequest,
   ): Promise<ResetStaleScoresForRescoreResponse>;
+  rescoreJob(jobKey: string, body?: Partial<RescoreJobRequest>): Promise<ActionRunResponse>;
+  rescoreJobsNotOnCurrentScoringPolicy(
+    body: BulkRescoreJobsNotOnCurrentScoringPolicyRequest,
+  ): Promise<ActionRunResponse>;
+  retailorJob(jobKey: string, body?: Partial<RetailorJobRequest>): Promise<ActionRunResponse>;
+  retailorCurrentPolicy(body: BulkRetailorCurrentPolicyRequest): Promise<ActionRunResponse>;
 
   workflowRuns(query?: Partial<WorkflowRunsListQuery>): Promise<PaginatedResponse<WorkflowRunSummary>>;
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -9,6 +9,8 @@ import type {
   ArtifactOpenResponse,
   ArtifactSummary,
   BulkJobMutationRequest,
+  BulkRescoreJobsNotOnCurrentScoringPolicyRequest,
+  BulkRetailorCurrentPolicyRequest,
   CancelJobActionRequest,
   CredentialKey,
   CorrectScoreRequest,
@@ -40,6 +42,8 @@ import type {
   QuarantineDecision,
   QuarantineDecisionResponse,
   QuarantineListResponse,
+  RescoreJobRequest,
+  RetailorJobRequest,
   RetryStageRequest,
   ResetStaleScoresForRescoreRequest,
   ResetStaleScoresForRescoreResponse,
@@ -257,6 +261,24 @@ export class JobHunterApiClient {
     body: ResetStaleScoresForRescoreRequest = { limit: 0, jobKeys: [] },
   ): Promise<ResetStaleScoresForRescoreResponse> {
     return this.post("/v1/scoring/stale-scores/actions/reset-for-rescore", body);
+  }
+
+  rescoreJob(jobKey: string, body: Partial<RescoreJobRequest> = {}): Promise<ActionRunResponse> {
+    return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/actions/rescore-current-policy`, body);
+  }
+
+  rescoreJobsNotOnCurrentScoringPolicy(
+    body: BulkRescoreJobsNotOnCurrentScoringPolicyRequest,
+  ): Promise<ActionRunResponse> {
+    return this.post("/v1/scoring/actions/rescore-current-policy", body);
+  }
+
+  retailorJob(jobKey: string, body: Partial<RetailorJobRequest> = {}): Promise<ActionRunResponse> {
+    return this.post(`/v1/jobs/${encodeURIComponent(jobKey)}/actions/retailor-current-policy`, body);
+  }
+
+  retailorCurrentPolicy(body: BulkRetailorCurrentPolicyRequest): Promise<ActionRunResponse> {
+    return this.post("/v1/materials/actions/retailor-current-policy", body);
   }
 
   workflowRuns(

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -771,6 +771,7 @@ export interface DashboardSummary {
     appliedToday: number;
     dryRuns: number;
   };
+  preparation?: PreparationSummary;
   funnel: Array<{
     stage: Stage;
     total: number;
@@ -792,6 +793,18 @@ export interface DashboardSummary {
     dryRun: boolean;
     startedAt: string | null;
   }>;
+}
+
+export interface PreparationSummary {
+  currentScoringPolicyVersion: number | null;
+  currentTailoringPolicyVersion: number | null;
+  outdatedScoreCount: number;
+  outdatedTailoredArtifactCount: number;
+  workItems: {
+    queued: number;
+    running: number;
+    failed: number;
+  };
 }
 
 export interface SourceHealthSummary {
@@ -895,6 +908,10 @@ export interface ActionCommandPayload {
   action:
     | "run_stage"
     | "retry_stage"
+    | "rescore_job"
+    | "rescore_jobs_not_on_current_scoring_policy"
+    | "retailor_job"
+    | "retailor_current_policy"
     | "generate_materials"
     | "apply"
     | "cancel"
@@ -907,6 +924,7 @@ export interface ActionCommandPayload {
   resetAttempts?: boolean;
   runAfter?: boolean;
   dryRun?: boolean;
+  jobKeys?: string[];
   limit?: number;
   workers?: number;
   minScore?: number;
@@ -918,6 +936,7 @@ export interface ActionCommandPayload {
   tailorModels?: string[];
   tailorJudgeModel?: string;
   tailorJudgeMinScore?: number;
+  suppressExistingArtifacts?: boolean;
   headless?: boolean;
   continuous?: boolean;
   runId?: string;

--- a/workers/automation/src/jobhunter/domain/materials/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/materials/use_cases.py
@@ -719,34 +719,50 @@ class TailorResumeUseCase:
         validation_mode: str = "normal",
         tenant_id: TenantId = LOCAL_TENANT,
         retailor: bool = False,
+        suppress_existing_artifacts: bool = False,
     ) -> TailorOutcome:
         job_id = JobId(str(job["url"]))
         previous = self._repository.load(tenant_id, job_id)
+        created_at = _utc_now()
 
         # Decide which generation we're writing.
         if previous is None:
             materials = MaterialsSetFactory.initial(
                 tenant_id=tenant_id,
                 job_id=job_id,
-                created_at=_utc_now(),
+                created_at=created_at,
             )
-            superseded = None
+            prior_generation = None
         elif retailor:
-            superseded, materials = MaterialsSetFactory.next_generation(
-                previous,
-                created_at=_utc_now(),
-            )
+            if suppress_existing_artifacts:
+                prior_generation = previous.suppress_active_artifacts(
+                    at=created_at,
+                    reason="retailor_current_policy",
+                )
+                materials = MaterialsSet(
+                    tenant_id=previous.tenant_id,
+                    job_id=previous.job_id,
+                    generation=previous.generation + 1,
+                    status=MaterialsLifecycle.RESUME_IN_PROGRESS,
+                    created_at=created_at,
+                    updated_at=created_at,
+                )
+            else:
+                prior_generation, materials = MaterialsSetFactory.next_generation(
+                    previous,
+                    created_at=created_at,
+                )
         else:
             # Re-saving the same generation (typical when a previous run
             # crashed mid-flight and left the aggregate in
             # ``resume_in_progress``).
-            superseded = None
+            prior_generation = None
             materials = previous
 
-        # Persist the superseded predecessor first so its artifacts carry
-        # ``superseded_at`` and the queue selectors stop picking them.
-        if superseded is not None:
-            self._repository.save(superseded)
+        # Persist the predecessor first so existing artifacts stop being
+        # active before the new generation is written.
+        if prior_generation is not None:
+            self._repository.save(prior_generation)
 
         report, parsed_payload, validation, verdict = self._run_attempts(
             job=job,

--- a/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobhunter/infrastructure/rpc/handlers.py
@@ -9,9 +9,10 @@ Per S-11 the initial method set covers:
 * Existing local-action wrappers — ``profile_import`` delegates to
   ``actions.run_local_action``.
 * Workflow starters — ``apply`` returns a :class:`WorkflowStartSpec` for
-  :class:`ApplyWorkflow`; ``run_stage`` returns one for
-  :class:`JobPipelineWorkflow`. The server starts them on the Temporal task
-  queue and ships back ``{"runId", "workflowId", "firstExecutionRunId"}``.
+  :class:`ApplyWorkflow`; ``run_stage`` and the current-policy maintenance
+  methods return one for :class:`JobPipelineWorkflow`. The server starts them
+  on the Temporal task queue and ships back
+  ``{"runId", "workflowId", "firstExecutionRunId"}``.
 * Cooperative cancellation — ``cancel_run`` cancels an in-flight workflow
   via the injected canceler.
 
@@ -53,6 +54,26 @@ def _require(params: dict[str, Any], name: str) -> Any:
     if name not in params or params[name] in (None, ""):
         raise invalid_params(f"missing required param: {name}")
     return params[name]
+
+
+def _bool_param(params: dict[str, Any], name: str, *, default: bool = False) -> bool:
+    raw = params.get(name, default)
+    if isinstance(raw, bool):
+        return raw
+    if raw is None:
+        return default
+    if isinstance(raw, str):
+        return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+    return bool(raw)
+
+
+def _job_urls(params: dict[str, Any]) -> tuple[str, ...]:
+    raw = params.get("jobUrls") or ()
+    if not raw:
+        return ()
+    if not isinstance(raw, list):
+        raise invalid_params("jobUrls must be an array")
+    return tuple(str(item).strip() for item in raw if str(item).strip())
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +223,102 @@ def run_stage(params: dict[str, Any]) -> WorkflowStartSpec:
     return WorkflowStartSpec(workflow=JobPipelineWorkflow, args=(payload,))
 
 
+def rescore_job(params: dict[str, Any]) -> WorkflowStartSpec:
+    job_url = str(_require(params, "jobUrl"))
+    return _pipeline_workflow_spec(
+        params,
+        stages=["score"],
+        limit=1,
+        rescore=True,
+        job_url=job_url,
+    )
+
+
+def rescore_jobs_not_on_current_scoring_policy(params: dict[str, Any]) -> WorkflowStartSpec:
+    return _pipeline_workflow_spec(
+        params,
+        stages=["score"],
+        limit=int(params.get("limit", 100)),
+        rescore=True,
+        job_urls=_job_urls(params),
+        score_current_policy_only=True,
+    )
+
+
+def retailor_job(params: dict[str, Any]) -> WorkflowStartSpec:
+    job_url = str(_require(params, "jobUrl"))
+    return _pipeline_workflow_spec(
+        params,
+        stages=["tailor"],
+        limit=1,
+        retailor=True,
+        job_url=job_url,
+        suppress_existing_artifacts=_bool_param(
+            params, "suppressExistingArtifacts", default=True
+        ),
+    )
+
+
+def retailor_current_policy(params: dict[str, Any]) -> WorkflowStartSpec:
+    return _pipeline_workflow_spec(
+        params,
+        stages=["tailor"],
+        limit=int(params.get("limit", 100)),
+        retailor=True,
+        job_urls=_job_urls(params),
+        tailor_current_policy_only=True,
+        suppress_existing_artifacts=_bool_param(
+            params, "suppressExistingArtifacts", default=True
+        ),
+    )
+
+
+def _pipeline_workflow_spec(
+    params: dict[str, Any],
+    *,
+    stages: list[str],
+    limit: int,
+    rescore: bool = False,
+    retailor: bool = False,
+    job_url: str | None = None,
+    job_urls: tuple[str, ...] = (),
+    score_current_policy_only: bool = False,
+    tailor_current_policy_only: bool = False,
+    suppress_existing_artifacts: bool = False,
+) -> WorkflowStartSpec:
+    tenant_id = _tenant_id(params)
+    raw_judge_min_score = params.get("tailorJudgeMinScore")
+    payload = JobPipelineWorkflowInput(
+        tenant_id=tenant_id,
+        expected_app_dir=params.get("expectedAppDir"),
+        expected_db_path=params.get("expectedDbPath"),
+        stages=stages,
+        min_score=int(params.get("minScore", 7)),
+        workers=int(params.get("workers", 1)),
+        limit=limit,
+        validation_mode=str(params.get("validationMode", "normal")),
+        dry_run=bool(params.get("dryRun", False)),
+        rescore=rescore,
+        retailor=retailor,
+        tailor_models=tuple(str(item) for item in (params.get("tailorModels") or ())),
+        tailor_judge_model=(
+            str(params["tailorJudgeModel"])
+            if params.get("tailorJudgeModel")
+            else None
+        ),
+        tailor_judge_min_score=(
+            float(raw_judge_min_score) if raw_judge_min_score is not None else None
+        ),
+        job_url=job_url,
+        job_urls=job_urls,
+        score_current_policy_only=score_current_policy_only,
+        tailor_current_policy_only=tailor_current_policy_only,
+        suppress_existing_artifacts=suppress_existing_artifacts,
+        llm_model=str(params.get("llmModel") or DEFAULT_PIPELINE_LLM_MODEL_SPEC),
+    )
+    return WorkflowStartSpec(workflow=JobPipelineWorkflow, args=(payload,))
+
+
 def profile_import(params: dict[str, Any]) -> dict[str, Any]:
     _tenant_id(params)
     pdf_path = str(_require(params, "pdfPath"))
@@ -272,6 +389,14 @@ def register_default_handlers(server: JsonRpcServer, *, canceler: WorkflowCancel
     server.register("profile_import", profile_import, mode="sync")
     # Workflow starters.
     server.register("run_stage", run_stage, mode="workflow")
+    server.register("rescore_job", rescore_job, mode="workflow")
+    server.register(
+        "rescore_jobs_not_on_current_scoring_policy",
+        rescore_jobs_not_on_current_scoring_policy,
+        mode="workflow",
+    )
+    server.register("retailor_job", retailor_job, mode="workflow")
+    server.register("retailor_current_policy", retailor_current_policy, mode="workflow")
     server.register("apply", apply_action, mode="workflow")
     # Cooperative cancellation of in-flight workflows.
     server.register("cancel_run", make_cancel_run(canceler), mode="sync")

--- a/workers/automation/src/jobhunter/materials/activities.py
+++ b/workers/automation/src/jobhunter/materials/activities.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+import time
 from typing import Any
 
 from temporalio import activity
@@ -28,6 +29,9 @@ class TailorActivityInput:
     validation_mode: str = "normal"
     dry_run: bool = False
     retailor: bool = False
+    job_urls: tuple[str, ...] = ()
+    current_policy_only: bool = False
+    suppress_existing_artifacts: bool = False
     tailor_models: tuple[str, ...] = ()
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
@@ -55,6 +59,32 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
         expected_app_dir=payload.expected_app_dir,
         expected_db_path=payload.expected_db_path,
     )
+
+    if payload.current_policy_only:
+        result = await run_blocking_with_heartbeat(
+            lambda: _run_current_policy_tailoring(payload),
+            starting_message="current-policy tailor starting",
+            progress_message="current-policy tailor still running",
+        )
+        return TailorActivityOutput(
+            status=str(result["status"]),
+            elapsed=float(result["elapsed"]),
+            errors=dict(result["errors"]),
+            stages=list(result["stages"]),
+        )
+
+    if payload.job_urls:
+        result = await run_blocking_with_heartbeat(
+            lambda: _run_selected_tailoring(payload),
+            starting_message="selected tailor starting",
+            progress_message="selected tailor still running",
+        )
+        return TailorActivityOutput(
+            status=str(result["status"]),
+            elapsed=float(result["elapsed"]),
+            errors=dict(result["errors"]),
+            stages=list(result["stages"]),
+        )
 
     def _do() -> dict[str, Any]:
         return run_pipeline(
@@ -85,6 +115,96 @@ async def tailor_activity(payload: TailorActivityInput) -> TailorActivityOutput:
         errors=errors,
         stages=stages,
     )
+
+
+def _run_current_policy_tailoring(payload: TailorActivityInput) -> dict[str, Any]:
+    from jobhunter.database import get_connection
+    from jobhunter.pipeline.current_policy_selectors import tailoring_current_policy_job_urls
+
+    urls = tailoring_current_policy_job_urls(
+        get_connection(),
+        tenant_id=payload.tenant_id,
+        min_score=payload.min_score,
+        limit=payload.limit,
+        job_urls=payload.job_urls,
+    )
+    return _run_selected_tailoring(replace(payload, job_urls=urls, limit=0))
+
+
+def _run_selected_tailoring(payload: TailorActivityInput) -> dict[str, Any]:
+    from jobhunter.domain.tenant import TenantId
+    from jobhunter.scoring.tailor import tailor_job_by_url
+
+    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    if payload.dry_run:
+        return {
+            "status": "ok",
+            "elapsed": 0.0,
+            "errors": {},
+            "stages": [
+                {
+                    "stage": "tailor",
+                    "status": "ok",
+                    "elapsed": 0.0,
+                    "selected": len(urls),
+                    "dry_run": True,
+                }
+            ],
+        }
+
+    t0 = time.time()
+    approved = 0
+    skipped = 0
+    failed = 0
+    errors: dict[str, str] = {}
+    for url in urls:
+        result = tailor_job_by_url(
+            url,
+            min_score=payload.min_score,
+            validation_mode=payload.validation_mode,
+            workers=payload.workers,
+            retailor=payload.retailor,
+            tenant_id=TenantId(payload.tenant_id),
+            llm_model=payload.llm_model,
+            suppress_existing_artifacts=payload.suppress_existing_artifacts,
+            tailor_models=payload.tailor_models,
+            tailor_judge_model=payload.tailor_judge_model,
+            tailor_judge_min_score=payload.tailor_judge_min_score,
+        )
+        status = str(result.get("status") or "error")
+        if status == "approved":
+            approved += 1
+        elif status in {"skipped", "not_eligible"}:
+            skipped += 1
+        else:
+            failed += 1
+            errors[url] = str(result.get("error") or f"Tailoring ended with status {status}")
+
+    elapsed = time.time() - t0
+    status = "failed" if errors else "ok"
+    return {
+        "status": status,
+        "elapsed": elapsed,
+        "errors": errors,
+        "stages": [
+            {
+                "stage": "tailor",
+                "status": status,
+                "elapsed": elapsed,
+                "selected": len(urls),
+                "approved": approved,
+                "skipped": skipped,
+                "failed": failed,
+            }
+        ],
+    }
+
+
+def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
+    unique = tuple(dict.fromkeys(url for url in job_urls if url))
+    if limit > 0:
+        return unique[:limit]
+    return unique
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/pipeline/current_policy_selectors.py
+++ b/workers/automation/src/jobhunter/pipeline/current_policy_selectors.py
@@ -1,0 +1,273 @@
+"""Selectors for current-policy maintenance workflows."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from jobhunter.database import ensure_scoring_policy_tables, ensure_tailoring_policy_tables
+
+
+def scoring_current_policy_job_urls(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    limit: int = 0,
+    job_urls: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    """Return active enriched jobs missing a current-policy score."""
+
+    current_version = _current_scoring_policy_version(conn, tenant_id)
+    requested = _clean_job_urls(job_urls)
+    requested_sql, requested_params = _requested_filter("j.url", requested)
+    active_sql = _active_job_filter(conn, "j.url")
+    limit_sql, limit_params = _limit_filter(limit)
+
+    rows = conn.execute(
+        f"""
+        SELECT j.url
+        FROM jobs j
+        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN (
+            SELECT s.job_url, s.trace_json, s.correction_json
+            FROM job_scores s
+            INNER JOIN (
+                SELECT job_url, MAX(version) AS max_version
+                FROM job_scores
+                WHERE tenant_id = ?
+                GROUP BY job_url
+            ) latest
+              ON latest.job_url = s.job_url AND latest.max_version = s.version
+            WHERE s.tenant_id = ?
+        ) latest_score ON latest_score.job_url = j.url
+        WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
+          {active_sql}
+          {requested_sql}
+          AND (
+            latest_score.job_url IS NULL
+            OR (
+              (latest_score.correction_json IS NULL OR TRIM(latest_score.correction_json) = '')
+              AND {_score_policy_version_expr("latest_score.trace_json")} != ?
+            )
+          )
+        ORDER BY j.discovered_at DESC
+        {limit_sql}
+        """,
+        (tenant_id, tenant_id, *requested_params, current_version, *limit_params),
+    ).fetchall()
+    return tuple(str(row[0]) for row in rows if row[0])
+
+
+def tailoring_current_policy_job_urls(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    min_score: int = 7,
+    limit: int = 0,
+    job_urls: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    """Return active eligible jobs missing a current-policy tailored artifact."""
+
+    current_version = _current_tailoring_policy_version(conn, tenant_id)
+    requested = _clean_job_urls(job_urls)
+    requested_sql, requested_params = _requested_filter("j.url", requested)
+    active_sql = _active_job_filter(conn, "j.url")
+    limit_sql, limit_params = _limit_filter(limit)
+    effective_tailor_path = (
+        "((lm.materials_job_url IS NOT NULL AND lm.tailored_resume_path IS NOT NULL "
+        "AND lm.tailored_resume_path != '') "
+        "OR (lm.materials_job_url IS NULL AND j.tailored_resume_path IS NOT NULL "
+        "AND j.tailored_resume_path != ''))"
+    )
+
+    rows = conn.execute(
+        f"""
+        SELECT j.url
+        FROM jobs j
+        LEFT JOIN job_enrichments je ON je.job_url = j.url
+        LEFT JOIN (
+            SELECT s.job_url, s.fit_score, s.breakdown_json
+            FROM job_scores s
+            INNER JOIN (
+                SELECT job_url, MAX(version) AS max_version
+                FROM job_scores
+                WHERE tenant_id = ?
+                GROUP BY job_url
+            ) latest
+              ON latest.job_url = s.job_url AND latest.max_version = s.version
+            WHERE s.tenant_id = ?
+        ) latest_score ON latest_score.job_url = j.url
+        LEFT JOIN (
+            SELECT job_url AS stale_job_url
+            FROM job_score_staleness
+            WHERE tenant_id = ? AND resolved = 0
+            GROUP BY job_url
+        ) stale_score ON stale_score.stale_job_url = j.url
+        LEFT JOIN job_stage_states score_state
+          ON score_state.job_url = j.url AND score_state.stage = 'score'
+        LEFT JOIN job_stage_states tailor_state
+          ON tailor_state.job_url = j.url AND tailor_state.stage = 'tailor'
+        LEFT JOIN (
+            SELECT m.job_url AS materials_job_url, tr.path AS tailored_resume_path,
+                   tr.metadata_json AS tailored_resume_metadata
+            FROM job_materials m
+            INNER JOIN (
+                SELECT job_url, MAX(generation) AS max_generation
+                FROM job_materials
+                WHERE tenant_id = ?
+                GROUP BY job_url
+            ) latest
+              ON latest.job_url = m.job_url AND latest.max_generation = m.generation
+            LEFT JOIN job_materials_artifacts tr
+              ON tr.job_url = m.job_url
+             AND tr.generation = m.generation
+             AND tr.artifact_type = 'tailored_resume'
+             AND tr.status = 'approved'
+             AND tr.superseded_at IS NULL
+            WHERE m.tenant_id = ?
+        ) lm ON lm.materials_job_url = j.url
+        WHERE COALESCE(je.full_description, j.full_description) IS NOT NULL
+          {active_sql}
+          {requested_sql}
+          AND COALESCE(latest_score.fit_score, j.fit_score) >= ?
+          AND {_score_eligible_expr("latest_score.breakdown_json")}
+          AND stale_score.stale_job_url IS NULL
+          AND (
+            score_state.state IS NULL
+            OR score_state.state = 'succeeded'
+            OR (latest_score.fit_score IS NULL AND score_state.state != 'stale')
+          )
+          AND (tailor_state.state IS NULL OR tailor_state.state != 'exhausted')
+          AND (
+            {effective_tailor_path}
+            OR COALESCE(tailor_state.attempt_count, j.tailor_attempts, 0) < 5
+          )
+          AND (
+            NOT {effective_tailor_path}
+            OR {_tailoring_policy_version_expr("lm.tailored_resume_metadata")} != ?
+          )
+        ORDER BY COALESCE(latest_score.fit_score, j.fit_score) DESC, j.discovered_at DESC
+        {limit_sql}
+        """,
+        (
+            tenant_id,
+            tenant_id,
+            tenant_id,
+            tenant_id,
+            tenant_id,
+            *requested_params,
+            min_score,
+            current_version,
+            *limit_params,
+        ),
+    ).fetchall()
+    return tuple(str(row[0]) for row in rows if row[0])
+
+
+def _current_scoring_policy_version(conn: sqlite3.Connection, tenant_id: str) -> int:
+    ensure_scoring_policy_tables(conn)
+    row = conn.execute(
+        "SELECT MAX(version) FROM scoring_policies WHERE tenant_id = ?",
+        (tenant_id,),
+    ).fetchone()
+    return _positive_int(row[0] if row else None, default=1)
+
+
+def _current_tailoring_policy_version(conn: sqlite3.Connection, tenant_id: str) -> int:
+    ensure_tailoring_policy_tables(conn)
+    row = conn.execute(
+        "SELECT MAX(version) FROM tailoring_policies WHERE tenant_id = ?",
+        (tenant_id,),
+    ).fetchone()
+    return _positive_int(row[0] if row else None, default=1)
+
+
+def _active_job_filter(conn: sqlite3.Connection, job_url_expr: str) -> str:
+    clauses: list[str] = []
+    if _table_exists(conn, "jobhunter_deleted_jobs"):
+        clauses.append(
+            "NOT EXISTS ("
+            "SELECT 1 FROM jobhunter_deleted_jobs d "
+            f"WHERE d.job_url = {job_url_expr} "
+            "AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))"
+            ")"
+        )
+    if _table_exists(conn, "jobhunter_hidden_jobs"):
+        clauses.append(
+            "NOT EXISTS ("
+            "SELECT 1 FROM jobhunter_hidden_jobs h "
+            f"WHERE h.job_url = {job_url_expr} AND h.unhidden_at IS NULL"
+            ")"
+        )
+    return "".join(f" AND {clause}" for clause in clauses)
+
+
+def _requested_filter(column: str, job_urls: tuple[str, ...]) -> tuple[str, tuple[str, ...]]:
+    if not job_urls:
+        return "", ()
+    placeholders = ", ".join("?" for _ in job_urls)
+    return f" AND {column} IN ({placeholders})", job_urls
+
+
+def _limit_filter(limit: int) -> tuple[str, tuple[int, ...]]:
+    if limit > 0:
+        return "LIMIT ?", (limit,)
+    return "", ()
+
+
+def _clean_job_urls(job_urls: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(url.strip() for url in job_urls if url and url.strip()))
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _score_policy_version_expr(json_expr: str) -> str:
+    return (
+        f"CASE WHEN json_valid({json_expr}) THEN COALESCE("
+        f"CAST(json_extract({json_expr}, '$.scoring_policy_version') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.scoringPolicyVersion') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.policy_version') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.policyVersion') AS INTEGER), "
+        "0) ELSE 0 END"
+    )
+
+
+def _tailoring_policy_version_expr(json_expr: str) -> str:
+    return (
+        f"CASE WHEN json_valid({json_expr}) THEN COALESCE("
+        f"CAST(json_extract({json_expr}, '$.tailoring_policy_version') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.tailoringPolicyVersion') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.policy_version') AS INTEGER), "
+        f"CAST(json_extract({json_expr}, '$.policyVersion') AS INTEGER), "
+        "0) ELSE 0 END"
+    )
+
+
+def _score_eligible_expr(json_expr: str) -> str:
+    status_expr = (
+        f"CASE WHEN json_valid({json_expr}) "
+        f"THEN LOWER(COALESCE(CAST(json_extract({json_expr}, '$.eligibility.status') AS TEXT), '')) "
+        "ELSE '' END"
+    )
+    blockers_expr = (
+        f"CASE WHEN json_valid({json_expr}) THEN COALESCE("
+        f"json_array_length({json_expr}, '$.eligibility.hard_blockers'), "
+        f"json_array_length({json_expr}, '$.eligibility.hardBlockers'), "
+        f"json_array_length({json_expr}, '$.eligibility.blockers'), "
+        "0) ELSE 0 END"
+    )
+    return f"{status_expr} != 'blocked' AND {blockers_expr} = 0"
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default

--- a/workers/automation/src/jobhunter/pipeline/workflow.py
+++ b/workers/automation/src/jobhunter/pipeline/workflow.py
@@ -63,6 +63,10 @@ class JobPipelineWorkflowInput:
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
     job_url: str | None = None
+    job_urls: tuple[str, ...] = ()
+    score_current_policy_only: bool = False
+    tailor_current_policy_only: bool = False
+    suppress_existing_artifacts: bool = False
     headless: bool = False
     model: str = "default"
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
@@ -179,6 +183,8 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 limit=payload.limit,
                 dry_run=payload.dry_run,
                 rescore=payload.rescore,
+                job_urls=_selected_job_urls(payload),
+                current_policy_only=payload.score_current_policy_only,
                 llm_model=payload.llm_model,
             ),
             start_to_close_timeout=_DEFAULT_TIMEOUT,
@@ -198,6 +204,9 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
                 validation_mode=payload.validation_mode,
                 dry_run=payload.dry_run,
                 retailor=payload.retailor,
+                job_urls=_selected_job_urls(payload),
+                current_policy_only=payload.tailor_current_policy_only,
+                suppress_existing_artifacts=payload.suppress_existing_artifacts,
                 tailor_models=payload.tailor_models,
                 tailor_judge_model=payload.tailor_judge_model,
                 tailor_judge_min_score=payload.tailor_judge_min_score,
@@ -246,6 +255,14 @@ async def _execute_stage(stage: str, payload: JobPipelineWorkflowInput) -> Any:
         f"Unknown stage: {stage}",
         non_retryable=True,
     )
+
+
+def _selected_job_urls(payload: JobPipelineWorkflowInput) -> tuple[str, ...]:
+    if payload.job_urls:
+        return payload.job_urls
+    if payload.job_url:
+        return (payload.job_url,)
+    return ()
 
 
 _SUCCESS_STAGE_STATUSES = frozenset({"ok", "partial", "skipped"})

--- a/workers/automation/src/jobhunter/scoring/activities.py
+++ b/workers/automation/src/jobhunter/scoring/activities.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+import time
 from typing import Any
 
 from temporalio import activity
@@ -21,6 +22,8 @@ class ScoreActivityInput:
     workers: int = 1
     dry_run: bool = False
     rescore: bool = False
+    job_urls: tuple[str, ...] = ()
+    current_policy_only: bool = False
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
 
 
@@ -46,6 +49,32 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
         expected_db_path=payload.expected_db_path,
     )
 
+    if payload.current_policy_only:
+        result = await run_blocking_with_heartbeat(
+            lambda: _run_current_policy_scores(payload),
+            starting_message="current-policy score starting",
+            progress_message="current-policy score still running",
+        )
+        return ScoreActivityOutput(
+            status=str(result["status"]),
+            elapsed=float(result["elapsed"]),
+            errors=dict(result["errors"]),
+            stages=list(result["stages"]),
+        )
+
+    if payload.job_urls:
+        result = await run_blocking_with_heartbeat(
+            lambda: _run_selected_scores(payload),
+            starting_message="selected score starting",
+            progress_message="selected score still running",
+        )
+        return ScoreActivityOutput(
+            status=str(result["status"]),
+            elapsed=float(result["elapsed"]),
+            errors=dict(result["errors"]),
+            stages=list(result["stages"]),
+        )
+
     def _do() -> dict[str, Any]:
         return run_pipeline(
             stages=["score"],
@@ -70,3 +99,77 @@ async def score_activity(payload: ScoreActivityInput) -> ScoreActivityOutput:
         errors=errors,
         stages=stages,
     )
+
+
+def _run_current_policy_scores(payload: ScoreActivityInput) -> dict[str, Any]:
+    from jobhunter.database import get_connection
+    from jobhunter.pipeline.current_policy_selectors import scoring_current_policy_job_urls
+
+    urls = scoring_current_policy_job_urls(
+        get_connection(),
+        tenant_id=payload.tenant_id,
+        limit=payload.limit,
+        job_urls=payload.job_urls,
+    )
+    return _run_selected_scores(replace(payload, job_urls=urls, limit=0))
+
+
+def _run_selected_scores(payload: ScoreActivityInput) -> dict[str, Any]:
+    from jobhunter.domain.tenant import TenantId
+    from jobhunter.scoring.scorer import score_job_by_url
+
+    urls = _limited_job_urls(payload.job_urls, payload.limit)
+    if payload.dry_run:
+        return {
+            "status": "ok",
+            "elapsed": 0.0,
+            "errors": {},
+            "stages": [
+                {
+                    "stage": "score",
+                    "status": "ok",
+                    "elapsed": 0.0,
+                    "selected": len(urls),
+                    "dry_run": True,
+                }
+            ],
+        }
+
+    t0 = time.time()
+    errors: dict[str, str] = {}
+    scored = 0
+    for url in urls:
+        outcome = score_job_by_url(
+            url,
+            tenant_id=TenantId(payload.tenant_id),
+            rescore=payload.rescore,
+            llm_model=payload.llm_model,
+        )
+        if outcome.ok:
+            scored += 1
+        else:
+            errors[url] = outcome.error or "Scoring failed"
+
+    elapsed = time.time() - t0
+    status = "failed" if errors else "ok"
+    return {
+        "status": status,
+        "elapsed": elapsed,
+        "errors": errors,
+        "stages": [
+            {
+                "stage": "score",
+                "status": status,
+                "elapsed": elapsed,
+                "selected": len(urls),
+                "scored": scored,
+            }
+        ],
+    }
+
+
+def _limited_job_urls(job_urls: tuple[str, ...], limit: int) -> tuple[str, ...]:
+    unique = tuple(dict.fromkeys(url for url in job_urls if url))
+    if limit > 0:
+        return unique[:limit]
+    return unique

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -424,6 +424,7 @@ def score_job_by_url(
     job_url: str,
     *,
     tenant_id: TenantId = LOCAL_TENANT,
+    rescore: bool = False,
     llm_model: str | None = DEFAULT_PIPELINE_LLM_MODEL_SPEC,
     profile_snapshot: ProfileSnapshot | None = None,
     resume_text: str | None = None,
@@ -438,7 +439,8 @@ def score_job_by_url(
     Internal Discovery preparation uses durable work items keyed to one job,
     so it cannot safely call the batch selector-based ``run_scoring`` helper.
     This entrypoint preserves the same Scoring use case and stage-state writes
-    while targeting the claimed work item only.
+    while targeting the claimed work item only. ``rescore=True`` forces a new
+    score version even when the job already has a current score.
     """
     conn = get_connection()
     job = load_job_with_enrichment(conn, job_url)
@@ -461,7 +463,7 @@ def score_job_by_url(
     if policy_repository is None:
         policy_repository = SqliteScoringPolicyRepository(conn)
     existing = repository.load(tenant_id, JobId(job_url))
-    if existing is not None:
+    if existing is not None and not rescore:
         _ensure_existing_score_stage_succeeded(
             conn,
             job=job,

--- a/workers/automation/src/jobhunter/scoring/tailor.py
+++ b/workers/automation/src/jobhunter/scoring/tailor.py
@@ -208,6 +208,7 @@ def _tailor_one_job(
     use_case: TailorResumeUseCase | None = None,
     pdf_renderer: PdfRendererPort | None = None,
     retailor: bool = False,
+    suppress_existing_artifacts: bool = False,
     tenant_id: TenantId = LOCAL_TENANT,
     llm_policy: TailoringLlmPolicy | None = None,
 ) -> dict:
@@ -230,6 +231,7 @@ def _tailor_one_job(
         validation_mode=validation_mode,
         tenant_id=tenant_id,
         retailor=retailor,
+        suppress_existing_artifacts=suppress_existing_artifacts,
     )
 
     pdf_path: str | None = None
@@ -572,6 +574,7 @@ def tailor_job_by_url(
     tailor_judge_model: str | None = None,
     tailor_judge_min_score: float | None = None,
     pdf_renderer: PdfRendererPort | None = None,
+    suppress_existing_artifacts: bool = False,
 ) -> dict:
     """Tailor exactly one eligible job by URL.
 
@@ -627,6 +630,7 @@ def tailor_job_by_url(
         use_case=None,
         pdf_renderer=pdf_renderer,
         retailor=retailor,
+        suppress_existing_artifacts=suppress_existing_artifacts,
         tenant_id=tenant_id,
         llm_policy=llm_policy,
     )

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -17,8 +19,13 @@ from jobhunter.domain.rpc.messages import (
 from jobhunter.infrastructure.rpc import handlers as handlers_mod
 from jobhunter.infrastructure.rpc.handlers import register_default_handlers
 from jobhunter.infrastructure.rpc.server import JsonRpcServer
+from jobhunter.materials import activities as materials_activities_mod
+from jobhunter.materials.activities import TailorActivityInput, tailor_activity
 from jobhunter.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
+from jobhunter.pipeline import workflow as workflow_mod
 from jobhunter.pipeline.workflow import JobPipelineWorkflow, JobPipelineWorkflowInput
+from jobhunter.scoring import activities as scoring_activities_mod
+from jobhunter.scoring.activities import ScoreActivityInput, score_activity
 
 
 class _StubHandle:
@@ -73,6 +80,10 @@ def test_default_handlers_are_registered() -> None:
         "cancel_stage",
         "cancel_run",
         "run_stage",
+        "rescore_job",
+        "rescore_jobs_not_on_current_scoring_policy",
+        "retailor_job",
+        "retailor_current_policy",
         "apply",
         "profile_import",
     }
@@ -331,6 +342,416 @@ def test_run_stage_preserves_omitted_tailor_judge_threshold(tmp_db: Path) -> Non
     assert payload.tailor_judge_min_score is None
 
 
+@pytest.mark.parametrize(
+    ("method", "params", "expected_payload"),
+    [
+        (
+            "rescore_job",
+            {
+                "tenantId": "local",
+                "expectedAppDir": "/tmp/jobhunter",
+                "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
+                "jobUrl": "https://example.com/job/score",
+                "dryRun": True,
+            },
+            {
+                "stages": ["score"],
+                "limit": 1,
+                "rescore": True,
+                "retailor": False,
+                "job_url": "https://example.com/job/score",
+                "dry_run": True,
+            },
+        ),
+        (
+            "rescore_jobs_not_on_current_scoring_policy",
+            {
+                "tenantId": "local",
+                "expectedAppDir": "/tmp/jobhunter",
+                "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
+                "limit": 10,
+                "jobUrls": [
+                    "https://example.com/job/score-a",
+                    "https://example.com/job/score-b",
+                ],
+                "dryRun": False,
+            },
+            {
+                "stages": ["score"],
+                "limit": 10,
+                "rescore": True,
+                "retailor": False,
+                "job_url": None,
+                "job_urls": (
+                    "https://example.com/job/score-a",
+                    "https://example.com/job/score-b",
+                ),
+                "score_current_policy_only": True,
+                "dry_run": False,
+            },
+        ),
+        (
+            "retailor_job",
+            {
+                "tenantId": "local",
+                "expectedAppDir": "/tmp/jobhunter",
+                "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
+                "jobUrl": "https://example.com/job/tailor",
+                "dryRun": True,
+                "suppressExistingArtifacts": False,
+                "tailorModels": ["local:draft-a"],
+                "tailorJudgeModel": "gemini:judge-c",
+                "tailorJudgeMinScore": 0.9,
+            },
+            {
+                "stages": ["tailor"],
+                "limit": 1,
+                "rescore": False,
+                "retailor": True,
+                "job_url": "https://example.com/job/tailor",
+                "dry_run": True,
+                "suppress_existing_artifacts": False,
+                "tailor_models": ("local:draft-a",),
+                "tailor_judge_model": "gemini:judge-c",
+                "tailor_judge_min_score": 0.9,
+            },
+        ),
+        (
+            "retailor_current_policy",
+            {
+                "tenantId": "local",
+                "expectedAppDir": "/tmp/jobhunter",
+                "expectedDbPath": "/tmp/jobhunter/jobhunter.db",
+                "limit": 5,
+                "jobUrls": [
+                    "https://example.com/job/tailor-a",
+                    "https://example.com/job/tailor-b",
+                ],
+                "dryRun": False,
+                "suppressExistingArtifacts": True,
+            },
+            {
+                "stages": ["tailor"],
+                "limit": 5,
+                "rescore": False,
+                "retailor": True,
+                "job_url": None,
+                "job_urls": (
+                    "https://example.com/job/tailor-a",
+                    "https://example.com/job/tailor-b",
+                ),
+                "tailor_current_policy_only": True,
+                "dry_run": False,
+                "suppress_existing_artifacts": True,
+            },
+        ),
+    ],
+)
+def test_current_policy_maintenance_methods_start_pipeline_workflows(
+    tmp_db: Path,
+    method: str,
+    params: dict[str, object],
+    expected_payload: dict[str, object],
+) -> None:
+    seen: list[WorkflowStartSpec] = []
+
+    async def starter(spec: WorkflowStartSpec) -> _StubHandle:
+        seen.append(spec)
+        return _StubHandle("maintenance-wf", "maintenance-run")
+
+    server = JsonRpcServer(workflow_starter=starter)
+    register_default_handlers(server, canceler=_stub_canceler)
+
+    response = server.dispatch(JsonRpcRequest(method=method, params=params, id=1))
+
+    assert response is not None
+    body = response.to_dict()
+    assert body["result"] == {
+        "runId": "maintenance-wf",
+        "workflowId": "maintenance-wf",
+        "firstExecutionRunId": "maintenance-run",
+    }
+    assert len(seen) == 1
+    assert seen[0].workflow is JobPipelineWorkflow
+    (payload,) = seen[0].args
+    assert isinstance(payload, JobPipelineWorkflowInput)
+    for name, value in expected_payload.items():
+        assert getattr(payload, name) == value
+    assert payload.tenant_id == "local"
+    assert payload.expected_app_dir == "/tmp/jobhunter"
+    assert payload.expected_db_path == "/tmp/jobhunter/jobhunter.db"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(monkeypatch) -> None:
+    captured: list[tuple[object, object]] = []
+
+    async def fake_execute_activity(activity_fn, payload, **_kwargs):
+        captured.append((activity_fn, payload))
+        return {
+            "status": "ok",
+            "elapsed": 0.0,
+            "errors": {},
+            "stages": [{"stage": "_", "status": "ok", "elapsed": 0.0}],
+        }
+
+    monkeypatch.setattr(workflow_mod.workflow, "execute_activity", fake_execute_activity)
+
+    await workflow_mod._execute_stage(
+        "score",
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["score"],
+            job_url="https://example.com/job/score-one",
+            rescore=True,
+        ),
+    )
+    await workflow_mod._execute_stage(
+        "score",
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["score"],
+            job_urls=(
+                "https://example.com/job/score-a",
+                "https://example.com/job/score-b",
+            ),
+            rescore=True,
+        ),
+    )
+    await workflow_mod._execute_stage(
+        "tailor",
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["tailor"],
+            job_url="https://example.com/job/tailor-one",
+            retailor=True,
+            suppress_existing_artifacts=False,
+        ),
+    )
+    await workflow_mod._execute_stage(
+        "tailor",
+        JobPipelineWorkflowInput(
+            tenant_id="local",
+            stages=["tailor"],
+            job_urls=(
+                "https://example.com/job/tailor-a",
+                "https://example.com/job/tailor-b",
+            ),
+            retailor=True,
+            suppress_existing_artifacts=True,
+        ),
+    )
+
+    assert len(captured) == 4
+    assert captured[0][0] is score_activity
+    assert isinstance(captured[0][1], ScoreActivityInput)
+    assert captured[0][1].job_urls == ("https://example.com/job/score-one",)
+    assert captured[1][0] is score_activity
+    assert isinstance(captured[1][1], ScoreActivityInput)
+    assert captured[1][1].job_urls == (
+        "https://example.com/job/score-a",
+        "https://example.com/job/score-b",
+    )
+    assert captured[2][0] is tailor_activity
+    assert isinstance(captured[2][1], TailorActivityInput)
+    assert captured[2][1].job_urls == ("https://example.com/job/tailor-one",)
+    assert captured[2][1].suppress_existing_artifacts is False
+    assert captured[3][0] is tailor_activity
+    assert isinstance(captured[3][1], TailorActivityInput)
+    assert captured[3][1].job_urls == (
+        "https://example.com/job/tailor-a",
+        "https://example.com/job/tailor-b",
+    )
+    assert captured[3][1].suppress_existing_artifacts is True
+
+
+def test_selected_score_activity_runs_only_requested_urls(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_score_job_by_url(url: str, **kwargs: object) -> SimpleNamespace:
+        calls.append((url, kwargs))
+        return SimpleNamespace(ok=True, error=None)
+
+    monkeypatch.setattr("jobhunter.scoring.scorer.score_job_by_url", fake_score_job_by_url)
+
+    result = scoring_activities_mod._run_selected_scores(
+        ScoreActivityInput(
+            tenant_id="local",
+            job_urls=(
+                "https://example.com/job/score-a",
+                "https://example.com/job/score-b",
+                "https://example.com/job/score-a",
+            ),
+            limit=2,
+            rescore=True,
+            llm_model="local:score",
+        )
+    )
+
+    assert [url for url, _kwargs in calls] == [
+        "https://example.com/job/score-a",
+        "https://example.com/job/score-b",
+    ]
+    assert all(call_kwargs["rescore"] is True for _url, call_kwargs in calls)
+    assert all(call_kwargs["llm_model"] == "local:score" for _url, call_kwargs in calls)
+    assert result["errors"] == {}
+    assert result["stages"][0]["selected"] == 2
+    assert result["stages"][0]["scored"] == 2
+
+
+def test_current_policy_score_activity_skips_current_policy_scores(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    conn = get_connection(tmp_db)
+    _seed_scoring_policy(conn, version=2)
+    current_url = "https://example.com/job/current-score"
+    outdated_url = "https://example.com/job/outdated-score"
+    corrected_url = "https://example.com/job/corrected-score"
+    missing_url = "https://example.com/job/missing-score"
+    for url in (current_url, outdated_url, corrected_url, missing_url):
+        _seed_enriched_job(conn, url)
+    _seed_score(conn, current_url, policy_version=2)
+    _seed_score(conn, outdated_url, policy_version=1)
+    _seed_score(conn, corrected_url, policy_version=1, correction={"fit_score": 9})
+
+    calls: list[str] = []
+
+    def fake_score_job_by_url(url: str, **_kwargs: object) -> SimpleNamespace:
+        calls.append(url)
+        return SimpleNamespace(ok=True, error=None)
+
+    monkeypatch.setattr("jobhunter.database.get_connection", lambda: get_connection(tmp_db))
+    monkeypatch.setattr("jobhunter.scoring.scorer.score_job_by_url", fake_score_job_by_url)
+
+    result = scoring_activities_mod._run_current_policy_scores(
+        ScoreActivityInput(
+            tenant_id="local",
+            limit=10,
+            rescore=True,
+            current_policy_only=True,
+        )
+    )
+
+    assert set(calls) == {missing_url, outdated_url}
+    assert result["stages"][0]["selected"] == 2
+    assert result["stages"][0]["scored"] == 2
+
+    calls.clear()
+    result = scoring_activities_mod._run_current_policy_scores(
+        ScoreActivityInput(
+            tenant_id="local",
+            limit=10,
+            rescore=True,
+            job_urls=(current_url, outdated_url, corrected_url),
+            current_policy_only=True,
+        )
+    )
+
+    assert calls == [outdated_url]
+    assert result["stages"][0]["selected"] == 1
+
+
+def test_selected_tailor_activity_runs_only_requested_urls(monkeypatch) -> None:
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_tailor_job_by_url(url: str, **kwargs: object) -> dict[str, object]:
+        calls.append((url, kwargs))
+        return {"status": "approved"}
+
+    monkeypatch.setattr("jobhunter.scoring.tailor.tailor_job_by_url", fake_tailor_job_by_url)
+
+    result = materials_activities_mod._run_selected_tailoring(
+        TailorActivityInput(
+            tenant_id="local",
+            job_urls=(
+                "https://example.com/job/tailor-a",
+                "https://example.com/job/tailor-b",
+                "https://example.com/job/tailor-a",
+            ),
+            limit=2,
+            min_score=8,
+            validation_mode="strict",
+            retailor=True,
+            suppress_existing_artifacts=True,
+            tailor_models=("local:tailor",),
+            tailor_judge_model="local:judge",
+            tailor_judge_min_score=0.9,
+            llm_model="local:default",
+        )
+    )
+
+    assert [url for url, _kwargs in calls] == [
+        "https://example.com/job/tailor-a",
+        "https://example.com/job/tailor-b",
+    ]
+    assert all(call_kwargs["retailor"] is True for _url, call_kwargs in calls)
+    assert all(call_kwargs["suppress_existing_artifacts"] is True for _url, call_kwargs in calls)
+    assert all(call_kwargs["min_score"] == 8 for _url, call_kwargs in calls)
+    assert all(call_kwargs["tailor_models"] == ("local:tailor",) for _url, call_kwargs in calls)
+    assert result["errors"] == {}
+    assert result["stages"][0]["selected"] == 2
+    assert result["stages"][0]["approved"] == 2
+
+
+def test_current_policy_tailor_activity_skips_current_policy_artifacts(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    conn = get_connection(tmp_db)
+    _seed_tailoring_policy(conn, version=2)
+    current_url = "https://example.com/job/current-tailor"
+    outdated_url = "https://example.com/job/outdated-tailor"
+    missing_url = "https://example.com/job/missing-tailor"
+    for url in (current_url, outdated_url, missing_url):
+        _seed_enriched_job(conn, url)
+        _seed_score(conn, url, policy_version=2, fit_score=9)
+    _seed_tailored_artifact(conn, current_url, policy_version=2)
+    _seed_tailored_artifact(conn, outdated_url, policy_version=1)
+
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    def fake_tailor_job_by_url(url: str, **kwargs: object) -> dict[str, object]:
+        calls.append((url, kwargs))
+        return {"status": "approved"}
+
+    monkeypatch.setattr("jobhunter.database.get_connection", lambda: get_connection(tmp_db))
+    monkeypatch.setattr("jobhunter.scoring.tailor.tailor_job_by_url", fake_tailor_job_by_url)
+
+    result = materials_activities_mod._run_current_policy_tailoring(
+        TailorActivityInput(
+            tenant_id="local",
+            min_score=7,
+            limit=10,
+            retailor=True,
+            current_policy_only=True,
+            suppress_existing_artifacts=True,
+        )
+    )
+
+    assert {url for url, _kwargs in calls} == {missing_url, outdated_url}
+    assert all(kwargs["suppress_existing_artifacts"] is True for _url, kwargs in calls)
+    assert result["stages"][0]["selected"] == 2
+    assert result["stages"][0]["approved"] == 2
+
+    calls.clear()
+    result = materials_activities_mod._run_current_policy_tailoring(
+        TailorActivityInput(
+            tenant_id="local",
+            min_score=7,
+            limit=10,
+            retailor=True,
+            job_urls=(current_url, outdated_url),
+            current_policy_only=True,
+            suppress_existing_artifacts=False,
+        )
+    )
+
+    assert [url for url, _kwargs in calls] == [outdated_url]
+    assert calls[0][1]["suppress_existing_artifacts"] is False
+    assert result["stages"][0]["selected"] == 1
+
+
 def test_profile_import_remains_sync_local_action(tmp_db: Path, monkeypatch) -> None:
     captured: list[LocalActionRequest] = []
     started_workflows: list[WorkflowStartSpec] = []
@@ -376,3 +797,95 @@ def test_profile_import_requires_pdf_path(tmp_db: Path) -> None:
     response = server.dispatch(JsonRpcRequest(method="profile_import", params={"tenantId": "local"}, id=1))
     assert response is not None
     assert response.to_dict()["error"]["code"] == INVALID_PARAMS
+
+
+def _seed_enriched_job(conn, url: str) -> None:
+    conn.execute(
+        "INSERT INTO jobs (url, title, full_description, discovered_at) VALUES (?, ?, ?, ?)",
+        (url, "Test job", "Full description", "2026-05-26T10:00:00+00:00"),
+    )
+    conn.commit()
+
+
+def _seed_scoring_policy(conn, *, version: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO scoring_policies (tenant_id, version, rubric_json, anchors_json, created_at)
+        VALUES ('local', ?, '{}', '[]', '2026-05-26T10:00:00+00:00')
+        """,
+        (version,),
+    )
+    conn.commit()
+
+
+def _seed_tailoring_policy(conn, *, version: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO tailoring_policies (
+            tenant_id, version, prompt_version, schema_version, judge_schema_version,
+            prompt_fingerprint, config_fingerprint, profile_policy_fingerprint,
+            custom_prompt_fingerprint, generator_settings_json, judge_settings_json,
+            runtime_settings_json, rollback_of_version, rollback_reason, created_at,
+            created_from_event_id
+        ) VALUES ('local', ?, 'prompt-v1', 'schema-v1', 'judge-v1',
+            'prompt-fp', 'config-fp', 'profile-fp', 'custom-fp',
+            '{}', '{}', '{}', NULL, '', '2026-05-26T10:00:00+00:00', NULL)
+        """,
+        (version,),
+    )
+    conn.commit()
+
+
+def _seed_score(
+    conn,
+    url: str,
+    *,
+    policy_version: int,
+    fit_score: int = 8,
+    correction: dict[str, object] | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (
+            job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+            scored_at, correction_json, criteria_json, trace_json
+        ) VALUES (?, 1, 'local', ?, ?, '[]', '2026-05-26T10:00:00+00:00',
+            ?, '{}', ?)
+        """,
+        (
+            url,
+            fit_score,
+            json.dumps({"reasoning": "ok", "eligibility": {"status": "eligible", "hard_blockers": []}}),
+            json.dumps(correction) if correction is not None else None,
+            json.dumps({"scoring_policy_version": policy_version}),
+        ),
+    )
+    conn.commit()
+
+
+def _seed_tailored_artifact(conn, url: str, *, policy_version: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_materials (
+            job_url, generation, tenant_id, status, created_at, updated_at, metadata_json
+        ) VALUES (?, 1, 'local', 'resume_approved',
+            '2026-05-26T10:00:00+00:00', '2026-05-26T10:00:00+00:00', '{}')
+        """,
+        (url,),
+    )
+    conn.execute(
+        """
+        INSERT INTO job_materials_artifacts (
+            job_url, generation, artifact_type, artifact_id, status, path,
+            render_format, size_bytes, metadata_json, created_at, superseded_at
+        ) VALUES (?, 1, 'tailored_resume', ?, 'approved', ?, 'text', 12, ?,
+            '2026-05-26T10:00:00+00:00', NULL)
+        """,
+        (
+            url,
+            f"artifact-{policy_version}-{url.rsplit('/', 1)[-1]}",
+            f"/tmp/{url.rsplit('/', 1)[-1]}.txt",
+            json.dumps({"tailoring_policy_version": policy_version}),
+        ),
+    )
+    conn.commit()

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -593,6 +593,61 @@ def test_tailor_use_case_retailor_supersedes_previous_generation(
     assert superseded_save is not None
 
 
+def test_tailor_use_case_retailor_suppresses_previous_generation_when_requested(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    repo = _FakeRepository()
+    initial = MaterialsSetFactory.initial(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(job["url"]),
+        created_at="2024-01-01T00:00:00+00:00",
+    ).with_resume_attempt(
+        Artifact.create(
+            type=ArtifactType.TAILORED_RESUME,
+            path="/tmp/old.txt",
+            created_at="2024-01-01T00:00:00+00:00",
+            render_format=RenderFormat.TEXT,
+        ),
+        validation=ValidationResult.success(),
+        verdict=JudgeVerdict.passed(),
+        updated_at="2024-01-02T00:00:00+00:00",
+    )
+    repo.save(initial)
+
+    llm = _ScriptedLlm([_good_json_payload(), _judge_pass()])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+    )
+    outcome = use_case.execute(
+        job=job,
+        profile_snapshot=snapshot,
+        tailored_dir=tmp_path,
+        retailor=True,
+        suppress_existing_artifacts=True,
+    )
+
+    assert outcome.materials is not None
+    assert outcome.materials.generation == 2
+    suppressed_save = next(
+        (
+            m
+            for m in repo.saved
+            if m.generation == 1
+            and m.tailored_resume is not None
+            and m.tailored_resume.status is ArtifactStatus.SUPPRESSED
+        ),
+        None,
+    )
+    assert suppressed_save is not None
+    assert suppressed_save.tailored_resume is not None
+    assert suppressed_save.tailored_resume.metadata["suppression"]["reason"] == (
+        "retailor_current_policy"
+    )
+
+
 # ---------------------------------------------------------------------------
 # GenerateCoverLetterUseCase
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add API routes and client/port contracts for current-policy rescore and re-tailor maintenance actions.
- Add dashboard preparation metadata for current policy versions, outdated score/material counts, and preparation work-item counts.
- Suppress active tailored artifacts from default artifact lists, job details, artifact counts, and apply-readiness while preserving explicit suppressed artifact lookup.

## Why
PR 5 needs the single Discovery preparation stack to expose API/read-model/SSE-adjacent contracts without adding user-facing controls. Score/tailor remain internal contexts, while maintenance actions and read-side freshness are available through the API and existing invalidation paths.

## Validation
- `pnpm api:test`
- `pnpm api:check`
- `pnpm --filter @jobhunter/web test -- src/contexts/operations/invalidation-router.test.ts src/contexts/operations/every-event-has-handler.test.ts src/contexts/operations/sse-integration.test.ts`
- `pnpm --filter @jobhunter/web test-d`
- `corepack pnpm --filter @jobhunter/contracts check`
- `corepack pnpm --filter @jobhunter/api-client check`
- `git diff --check feat/discovery-preparation-orchestration...HEAD`

## Documentation
No documentation update: this PR exposes internal API/read-model/projection contracts for the existing Discovery preparation plan and intentionally does not add user-facing controls. User-facing docs remain owned by the follow-up docs/UI surfaces.