### PR TITLE
feat: surface discovery progress and dedupe cross-board jobs

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -285,6 +285,7 @@ export function buildDashboardSummary(db: SqliteDatabase): DashboardSummary {
     },
     funnel: parseFunnel(dashboard.funnel_json),
     activity: recentActivity(db),
+    progress: listPipelineProgress(db),
     sourceHealth: listSourceHealth(db),
     operationalMetrics,
     applyRuns: recentApplyRuns(db),
@@ -1643,6 +1644,189 @@ function recentActivity(db: SqliteDatabase): DashboardSummary["activity"] {
     stage: "",
     eventType: "",
   }).items;
+}
+
+function listPipelineProgress(db: SqliteDatabase): DashboardSummary["progress"] {
+  if (!tableExists(db, "job_events")) {
+    return [];
+  }
+  const rows = allRows<{
+    stage: string | null;
+    event_type: string | null;
+    message: string | null;
+    occurred_at: string | null;
+    payload_json: string | null;
+  }>(
+    db,
+    `SELECT stage, event_type, message, occurred_at, payload_json
+       FROM job_events
+      WHERE COALESCE(job_url, '') IN ('', 'pipeline')
+        AND (
+          event_type IN ('StageStarted', 'StageCompleted', 'StageFailed')
+          OR (
+            payload_json IS NOT NULL
+            AND json_valid(payload_json)
+            AND (
+              JSON_EXTRACT(payload_json, '$.progress') IS NOT NULL
+              OR JSON_EXTRACT(payload_json, '$.progressTotal') IS NOT NULL
+            )
+          )
+        )
+        AND (
+          stage IN ('discover', 'enrich', 'score', 'tailor', 'cover', 'apply')
+          OR (
+            payload_json IS NOT NULL
+            AND json_valid(payload_json)
+            AND JSON_EXTRACT(payload_json, '$.stage') IN ('discover', 'enrich', 'score', 'tailor', 'cover', 'apply')
+          )
+        )
+      ORDER BY event_id DESC
+      LIMIT 100`,
+  );
+  const byStage = new Map<Stage, DashboardSummary["progress"][number]>();
+  for (const row of rows) {
+    const payload = parseJsonRecord(row.payload_json);
+    const stage = isStage(row.stage)
+      ? row.stage
+      : isStage(payload?.stage)
+        ? payload.stage
+        : null;
+    if (!stage || byStage.has(stage)) {
+      continue;
+    }
+    const progress = parseProgressPayload(payload, { ...row, stage });
+    if (progress) {
+      byStage.set(stage, progress);
+    }
+  }
+  return [...byStage.values()];
+}
+
+const COMPLETE_STAGE_MESSAGES = new Set(["stage ok", "stage partial", "stage skipped"]);
+const DISCOVERY_SOURCE_PROGRESS = [
+  ["jobspy", "JobSpy"],
+  ["ats_api", "Canonical ATS APIs"],
+  ["workday", "Workday scraper"],
+  ["smartextract", "Smart extract"],
+] as const;
+
+function parseProgressPayload(
+  payload: Record<string, unknown> | null,
+  row: {
+    stage: string | null;
+    event_type: string | null;
+    message: string | null;
+    occurred_at: string | null;
+  },
+): DashboardSummary["progress"][number] | null {
+  if (!payload || !isStage(row.stage)) {
+    return parseFallbackProgressPayload(row);
+  }
+  const source = isRecord(payload.progress) ? payload.progress : payload;
+  const completed = nullableNumber(source.completed ?? source.progressCompleted);
+  const total = nullableNumber(source.total ?? source.progressTotal);
+  if (completed === null || total === null || total <= 0) {
+    return parseFallbackProgressPayload(row);
+  }
+  const rawPercent = nullableNumber(source.percent ?? source.progressPercent);
+  const percent = rawPercent === null
+    ? Math.max(0, Math.min(100, Math.round((completed / total) * 100)))
+    : Math.max(0, Math.min(100, Math.round(rawPercent)));
+  return {
+    stage: row.stage,
+    status: progressStatus(source.status ?? source.progressStatus, row.event_type),
+    percent,
+    completed,
+    total,
+    currentStep: nullableString(source.currentStep ?? source.current_step),
+    message: stringField(source.message) || stringField(row.message),
+    updatedAt: nullableString(row.occurred_at),
+  };
+}
+
+function parseFallbackProgressPayload(row: {
+  stage: string | null;
+  event_type: string | null;
+  message: string | null;
+  occurred_at: string | null;
+}): DashboardSummary["progress"][number] | null {
+  if (!isStage(row.stage)) {
+    return null;
+  }
+  const status = progressStatus(null, row.event_type);
+  const message = stringField(row.message);
+  const discoverySourceProgress = row.stage === "discover"
+    ? parseDiscoverySourceProgress(row, status, message)
+    : null;
+  if (discoverySourceProgress) {
+    return discoverySourceProgress;
+  }
+  const normalizedMessage = message.replace(row.stage, "").trim().toLowerCase();
+  const isWholeStageCompletion =
+    row.event_type === "StageCompleted" && COMPLETE_STAGE_MESSAGES.has(normalizedMessage);
+  if (row.event_type === "StageCompleted" && !isWholeStageCompletion) {
+    return null;
+  }
+  const percent = status === "succeeded" ? 100 : status === "failed" ? 0 : 0;
+  return {
+    stage: row.stage,
+    status,
+    percent,
+    completed: status === "succeeded" ? 1 : 0,
+    total: 1,
+    currentStep: null,
+    message: message || (status === "succeeded" ? "Stage complete" : "Stage started"),
+    updatedAt: nullableString(row.occurred_at),
+  };
+}
+
+function parseDiscoverySourceProgress(
+  row: {
+    stage: string | null;
+    event_type: string | null;
+    message: string | null;
+    occurred_at: string | null;
+  },
+  status: DashboardSummary["progress"][number]["status"],
+  message: string,
+): DashboardSummary["progress"][number] | null {
+  const lowerMessage = message.toLowerCase();
+  const sourceIndex = DISCOVERY_SOURCE_PROGRESS.findIndex(([source]) =>
+    lowerMessage.includes(`discovery source ${source}`),
+  );
+  if (sourceIndex < 0) {
+    return null;
+  }
+  const sourceProgress = DISCOVERY_SOURCE_PROGRESS[sourceIndex];
+  if (!sourceProgress) {
+    return null;
+  }
+  const started = row.event_type === "StageStarted";
+  const completed = Math.max(0, sourceIndex + (started ? 0 : 1));
+  const total = DISCOVERY_SOURCE_PROGRESS.length + 1;
+  return {
+    stage: "discover",
+    status: status === "failed" ? "failed" : "running",
+    percent: Math.max(0, Math.min(100, Math.round((completed / total) * 100))),
+    completed,
+    total,
+    currentStep: sourceProgress[1],
+    message,
+    updatedAt: nullableString(row.occurred_at),
+  };
+}
+
+function progressStatus(value: unknown, eventType: string | null): DashboardSummary["progress"][number]["status"] {
+  if (value === "succeeded" || value === "failed" || value === "running" || value === "partial") {
+    return value;
+  }
+  if (eventType === "StageFailed") {
+    return "failed";
+  }
+  if (eventType === "StageCompleted") {
+    return "succeeded";
+  }
+  return "running";
 }
 
 function listActivityFromEvents(

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -474,6 +474,56 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("returns the latest pipeline progress snapshot from durable events", async () => {
+    const db = new Database(options.dbPath);
+    try {
+      db.prepare(
+        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+      ).run(
+        null,
+        "discover",
+        "StageCompleted",
+        "info",
+        "Discovery source workday ok",
+        "2026-04-29T10:20:00+00:00",
+        JSON.stringify({
+          tenantId: "local",
+          jobId: "pipeline",
+          stage: "discover",
+          progress: {
+            completed: 3,
+            total: 5,
+            percent: 60,
+            currentStep: "Workday scraper",
+            status: "running",
+            message: "Workday scraper complete",
+          },
+        }),
+      );
+    } finally {
+      db.close();
+    }
+
+    const app = buildApp(options);
+    const response = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json().progress).toEqual([
+      {
+        stage: "discover",
+        status: "running",
+        percent: 60,
+        completed: 3,
+        total: 5,
+        currentStep: "Workday scraper",
+        message: "Workday scraper complete",
+        updatedAt: "2026-04-29T10:20:00+00:00",
+      },
+    ]);
+
+    await app.close();
+  });
+
   it("returns local-day dashboard deltas for active jobs and applications", async () => {
     const now = new Date().toISOString();
     const db = new Database(options.dbPath);

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -374,6 +374,35 @@ describe("StageTriggerPanel", () => {
     );
   });
 
+  it("shows backend discovery percent progress when available", async () => {
+    renderWithProviders(<StageTriggerPanel />, {
+      ports: buildTestPorts({
+        api: {
+          dashboardSummary: vi.fn(async () => ({
+            ...sampleDashboardSummary,
+            progress: [
+              {
+                stage: "discover" as const,
+                status: "running" as const,
+                percent: 60,
+                completed: 3,
+                total: 5,
+                currentStep: "Workday scraper",
+                message: "Workday scraper complete",
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          })),
+        },
+      }),
+    });
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Discover 60% complete (3/5): Workday scraper complete.",
+    );
+    expect(screen.getByRole("progressbar", { name: "Discover progress" })).toHaveAttribute("value", "60");
+  });
+
   it("surfaces failed worker action responses", async () => {
     const user = userEvent.setup();
     const runPipelineStages = vi.fn(async (): Promise<PipelineStageRunResponse> => ({

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -21,6 +21,7 @@ import { useRunPipelineStagesMutation } from "../hooks/useRunPipelineStagesMutat
 import { useStageTriggerStore, type StageTriggerConfig } from "../stores/stage-trigger-store.js";
 
 type StageActivity = DashboardSummary["activity"][number];
+type StageProgress = DashboardSummary["progress"][number];
 
 function labelForStage(stage: Stage): string {
   return `${stage.charAt(0).toUpperCase()}${stage.slice(1)}`;
@@ -102,10 +103,20 @@ function latestStageActivity(summary: DashboardSummary | undefined, stage: Stage
   return summary?.activity.find((activity) => activity.stage === stage) ?? null;
 }
 
+function latestStageProgress(summary: DashboardSummary | undefined, stage: Stage): StageProgress | null {
+  return summary?.progress.find((progress) => progress.stage === stage) ?? null;
+}
+
 function isActivityAfter(activity: StageActivity, timestamp: number | null): boolean {
   if (timestamp === null || activity.at === null) return true;
   const occurredAt = Date.parse(activity.at);
   return Number.isNaN(occurredAt) || occurredAt >= timestamp - 5000;
+}
+
+function isProgressAfter(progress: StageProgress, timestamp: number | null): boolean {
+  if (timestamp === null || progress.updatedAt === null) return true;
+  const updatedAt = Date.parse(progress.updatedAt);
+  return Number.isNaN(updatedAt) || updatedAt >= timestamp - 5000;
 }
 
 function isRunningActivity(activity: StageActivity): boolean {
@@ -127,6 +138,48 @@ function stageActivityStatusLine(stage: Stage, activity: StageActivity): string 
     return `${stageLabel} latest failure: ${activity.message}${eventReference}.`;
   }
   return `${stageLabel} latest event: ${activity.message}${eventReference}.`;
+}
+
+function stageProgressStatusLine(stage: Stage, progress: StageProgress): string {
+  const stageLabel = labelForStage(stage);
+  const percent = progress.percent === null ? null : `${progress.percent}%`;
+  const count = `${progress.completed}/${progress.total}`;
+  const detail = progress.message || progress.currentStep || "stage progress updated";
+
+  if (progress.status === "failed") {
+    return percent
+      ? `${stageLabel} ${percent} complete (${count}): ${detail}.`
+      : `${stageLabel} progress (${count}): ${detail}.`;
+  }
+  if (progress.status === "succeeded" || progress.percent === 100) {
+    return `${stageLabel} 100% complete (${count}): ${detail}.`;
+  }
+  if (progress.status === "partial") {
+    return percent
+      ? `${stageLabel} ${percent} complete with warnings (${count}): ${detail}.`
+      : `${stageLabel} progress with warnings (${count}): ${detail}.`;
+  }
+  return percent
+    ? `${stageLabel} ${percent} complete (${count}): ${detail}.`
+    : `${stageLabel} progress (${count}): ${detail}.`;
+}
+
+function StageProgressLine({ stage, progress }: { readonly stage: Stage; readonly progress: StageProgress }) {
+  const progressValue = progress.percent ?? undefined;
+  return (
+    <span
+      className={progress.status === "failed" ? "status-line stage-progress-line danger-action" : "status-line stage-progress-line"}
+      role="status"
+    >
+      <span>{stageProgressStatusLine(stage, progress)}</span>
+      <progress
+        aria-label={`${labelForStage(stage)} progress`}
+        className="stage-progress-meter"
+        max={100}
+        value={progressValue}
+      />
+    </span>
+  );
 }
 
 const APPLY_MODEL_OPTIONS = ["default", "opus", "sonnet"] as const;
@@ -211,9 +264,12 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
   const selectedApplyModel = applyModelValue(config.model);
   const statusStage = submittedStage ?? activeStage;
   const stageActivity = latestStageActivity(dashboardSummary.data, statusStage);
+  const stageProgress = latestStageProgress(dashboardSummary.data, statusStage);
   const relevantPendingActivity =
     runStages.isPending && stageActivity && isActivityAfter(stageActivity, submittedAt) ? stageActivity : null;
   const visibleStageActivity = relevantPendingActivity ?? (!runStages.isPending ? stageActivity : null);
+  const visibleStageProgress =
+    stageProgress && isProgressAfter(stageProgress, submittedAt) ? stageProgress : null;
   const headerMeta = runStages.isPending ? "starting" : (runStages.data?.status ?? (runStages.error ? "failed" : "ready"));
   const activeStagePanel = stagePanels[activeStage] ?? null;
   const workerUnhealthy =
@@ -429,11 +485,17 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
             {workerHealthMessage}
           </span>
         ) : runStages.isPending ? (
-          <span className="status-line" role="status">
-            {relevantPendingActivity
-              ? stageActivityStatusLine(statusStage, relevantPendingActivity)
-              : pendingStageStatusLine(statusStage)}
-          </span>
+          visibleStageProgress ? (
+            <StageProgressLine stage={statusStage} progress={visibleStageProgress} />
+          ) : (
+            <span className="status-line" role="status">
+              {relevantPendingActivity
+                ? stageActivityStatusLine(statusStage, relevantPendingActivity)
+                : pendingStageStatusLine(statusStage)}
+            </span>
+          )
+        ) : visibleStageProgress ? (
+          <StageProgressLine stage={statusStage} progress={visibleStageProgress} />
         ) : runStages.data ? (
           <span className={runStages.data.status === "failed" ? "status-line danger-action" : "status-line"} role="status">
             {pipelineRunStatusLine(statusStage, runStages.data)}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1278,6 +1278,45 @@ textarea {
   gap: 10px 14px;
 }
 
+.stage-progress-line {
+  display: inline-flex;
+  flex: 0 1 620px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  min-width: min(100%, 260px);
+  max-width: 100%;
+}
+
+.stage-progress-line > span {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.stage-progress-meter {
+  flex: 0 1 180px;
+  width: min(180px, 100%);
+  height: 8px;
+  border: 0;
+  border-radius: 999px;
+  accent-color: var(--ok);
+}
+
+.stage-progress-meter::-webkit-progress-bar {
+  border-radius: 999px;
+  background: var(--rule);
+}
+
+.stage-progress-meter::-webkit-progress-value {
+  border-radius: 999px;
+  background: var(--ok);
+}
+
+.stage-progress-meter::-moz-progress-bar {
+  border-radius: 999px;
+  background: var(--ok);
+}
+
 .rows,
 .table {
   display: flex;

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -285,6 +285,7 @@ export const sampleDashboardSummary: DashboardSummary = {
       at: "2026-05-06T07:30:00Z",
     },
   ],
+  progress: [],
   sourceHealth: [
     {
       sourceId: "greenhouse:acme",

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -758,6 +758,17 @@ export interface ActivityEventResponse {
   event: ActivityEventSummary;
 }
 
+export interface PipelineProgressSummary {
+  stage: Stage;
+  status: "running" | "succeeded" | "failed" | "partial";
+  percent: number | null;
+  completed: number;
+  total: number;
+  currentStep: string | null;
+  message: string;
+  updatedAt: string | null;
+}
+
 export interface DashboardSummary {
   ok: true;
   generatedAt: string;
@@ -782,6 +793,7 @@ export interface DashboardSummary {
     failed: number;
   }>;
   activity: ActivityEventSummary[];
+  progress: PipelineProgressSummary[];
   sourceHealth: SourceHealthSummary[];
   operationalMetrics: OperationalMetricsSummary;
   applyRuns: Array<{

--- a/workers/automation/src/jobhunter/discovery/jobspy.py
+++ b/workers/automation/src/jobhunter/discovery/jobspy.py
@@ -17,7 +17,11 @@ from datetime import datetime, timezone
 from jobhunter import config
 from jobhunter.database import ensure_source_observation_tables, get_connection, init_db, resurface_deleted_job
 from jobhunter.domain.discovery.identity import normalize_observed_url
-from jobhunter.domain.job_content_identity import job_content_fingerprint, normalize_identity_text
+from jobhunter.domain.job_content_identity import (
+    descriptions_substantially_match,
+    job_content_fingerprint,
+    normalize_identity_text,
+)
 
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobhunter.infrastructure.network`` so the Enrichment context's
@@ -652,6 +656,8 @@ def _find_content_duplicate_survivor(
             description=existing["description"],
         )
         if existing_key == incoming_key:
+            return str(existing["url"])
+        if descriptions_substantially_match(description, existing["description"]):
             return str(existing["url"])
     return None
 

--- a/workers/automation/src/jobhunter/domain/job_content_identity.py
+++ b/workers/automation/src/jobhunter/domain/job_content_identity.py
@@ -8,6 +8,12 @@ import unicodedata
 
 
 _WHITESPACE_RE = re.compile(r"\s+")
+_MARKDOWN_ESCAPE_RE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|>])")
+_MARKDOWN_MARKER_RE = re.compile(r'[*_`>"]+')
+_CONTENT_TOKEN_RE = re.compile(r"[\w+]+")
+_DESCRIPTION_SHINGLE_SIZE = 5
+_MIN_DESCRIPTION_TOKENS_FOR_SIMILARITY = 80
+_DESCRIPTION_SHINGLE_JACCARD_THRESHOLD = 0.83
 _PUNCT_TRANSLATION = str.maketrans(
     {
         "\u2018": "'",
@@ -32,6 +38,15 @@ def normalize_identity_text(value: object) -> str:
     return _WHITESPACE_RE.sub(" ", text).casefold()
 
 
+def normalize_description_text(value: object) -> str:
+    """Return a board-format-stable description identity component."""
+
+    text = normalize_identity_text(value)
+    text = _MARKDOWN_ESCAPE_RE.sub(r"\1", text)
+    text = _MARKDOWN_MARKER_RE.sub("", text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
 def job_content_fingerprint(
     *,
     title: object,
@@ -43,10 +58,40 @@ def job_content_fingerprint(
 
     normalized_title = normalize_identity_text(title)
     normalized_company = normalize_identity_text(company)
-    normalized_description = normalize_identity_text(description)
+    normalized_description = normalize_description_text(description)
     if description_limit is not None and description_limit > 0:
         normalized_description = normalized_description[:description_limit]
     if not normalized_title or not normalized_company or not normalized_description:
         return None
     payload = "\x1f".join((normalized_title, normalized_company, normalized_description))
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def descriptions_substantially_match(left: object, right: object) -> bool:
+    """Return true when two board descriptions represent the same posting."""
+
+    left_text = normalize_description_text(left)
+    right_text = normalize_description_text(right)
+    if not left_text or not right_text:
+        return False
+    if left_text == right_text:
+        return True
+
+    left_shingles = _description_shingles(left_text)
+    right_shingles = _description_shingles(right_text)
+    if not left_shingles or not right_shingles:
+        return False
+
+    intersection = len(left_shingles & right_shingles)
+    union = len(left_shingles | right_shingles)
+    return union > 0 and intersection / union >= _DESCRIPTION_SHINGLE_JACCARD_THRESHOLD
+
+
+def _description_shingles(text: str) -> set[tuple[str, ...]]:
+    tokens = _CONTENT_TOKEN_RE.findall(text)
+    if len(tokens) < _MIN_DESCRIPTION_TOKENS_FOR_SIMILARITY:
+        return set()
+    return {
+        tuple(tokens[index : index + _DESCRIPTION_SHINGLE_SIZE])
+        for index in range(len(tokens) - _DESCRIPTION_SHINGLE_SIZE + 1)
+    }

--- a/workers/automation/src/jobhunter/pipeline/runner.py
+++ b/workers/automation/src/jobhunter/pipeline/runner.py
@@ -195,6 +195,28 @@ def _pipeline_event_payload(
     return enriched
 
 
+def _discovery_progress_payload(
+    *,
+    completed: int,
+    total: int,
+    current_step: str,
+    status: str = "running",
+    message: str | None = None,
+) -> dict[str, Any]:
+    bounded_total = max(1, total)
+    bounded_completed = min(max(0, completed), bounded_total)
+    progress: dict[str, Any] = {
+        "completed": bounded_completed,
+        "total": bounded_total,
+        "percent": round((bounded_completed / bounded_total) * 100),
+        "currentStep": current_step,
+        "status": status,
+    }
+    if message:
+        progress["message"] = message
+    return {"progress": progress}
+
+
 def _record_pipeline_observation_event(
     stage: str,
     event_type: str,
@@ -385,11 +407,21 @@ def _run_discovery_source(
     label: str,
     scheduled_sources: tuple[ScheduledSource, ...],
     run: Callable[[], Any],
+    *,
+    progress_completed: int | None = None,
+    progress_total: int | None = None,
 ) -> str:
     runnable = tuple(item for item in scheduled_sources if item.should_run)
     if not runnable:
         reason = scheduled_sources[0].reason if scheduled_sources else "not scheduled"
-        return _record_skipped_discovery_run(source, label, scheduled_sources, reason)
+        return _record_skipped_discovery_run(
+            source,
+            label,
+            scheduled_sources,
+            reason,
+            progress_completed=progress_completed,
+            progress_total=progress_total,
+        )
 
     source_ids = tuple(item.source_id for item in runnable)
     run_id = f"discovery:{source}:{uuid.uuid4().hex}"
@@ -427,7 +459,22 @@ def _run_discovery_source(
         "StageStarted",
         "info",
         f"Discovery source {source} started",
-        {"source": source, "sourceLabel": label, "runId": run_id, "sourceIds": list(source_ids)},
+        {
+            "source": source,
+            "sourceLabel": label,
+            "runId": run_id,
+            "sourceIds": list(source_ids),
+            **(
+                _discovery_progress_payload(
+                    completed=progress_completed,
+                    total=progress_total,
+                    current_step=label,
+                    message=f"{label} started",
+                )
+                if progress_completed is not None and progress_total is not None
+                else {}
+            ),
+        },
     )
     _record_discovery_source_attempts(
         source,
@@ -506,6 +553,17 @@ def _run_discovery_source(
                     "error": str(exc),
                     "errorCode": type(exc).__name__,
                     "errorMessage": str(exc),
+                    **(
+                        _discovery_progress_payload(
+                            completed=progress_completed + 1,
+                            total=progress_total,
+                            current_step=label,
+                            status="failed",
+                            message=f"{label} failed",
+                        )
+                        if progress_completed is not None and progress_total is not None
+                        else {}
+                    ),
                 },
             )
             return f"error: {exc}"
@@ -572,6 +630,16 @@ def _run_discovery_source(
                 "sourceIds": list(source_ids),
                 "durationMs": duration_ms,
                 "status": status,
+                **(
+                    _discovery_progress_payload(
+                        completed=progress_completed + 1,
+                        total=progress_total,
+                        current_step=label,
+                        message=f"{label} complete",
+                    )
+                    if progress_completed is not None and progress_total is not None
+                    else {}
+                ),
             },
         )
         return status
@@ -669,6 +737,9 @@ def _record_skipped_discovery_run(
     label: str,
     scheduled_sources: tuple[ScheduledSource, ...],
     reason: str,
+    *,
+    progress_completed: int | None = None,
+    progress_total: int | None = None,
 ) -> str:
     source_ids = tuple(item.source_id for item in scheduled_sources) or (source,)
     run_id = f"discovery:{source}:{uuid.uuid4().hex}"
@@ -751,6 +822,8 @@ def _record_skipped_discovery_run(
         run_id=run_id,
         source_ids=source_ids,
         record_metric=False,
+        progress_completed=progress_completed,
+        progress_total=progress_total,
     )
 
 
@@ -762,6 +835,8 @@ def _skip_discovery_source(
     run_id: str | None = None,
     source_ids: tuple[str, ...] = (),
     record_metric: bool = True,
+    progress_completed: int | None = None,
+    progress_total: int | None = None,
 ) -> str:
     status = _skip_status(reason)
     payload: dict[str, Any] = {
@@ -774,6 +849,15 @@ def _skip_discovery_source(
         payload["runId"] = run_id
     if source_ids:
         payload["sourceIds"] = list(source_ids)
+    if progress_completed is not None and progress_total is not None:
+        payload.update(
+            _discovery_progress_payload(
+                completed=progress_completed + 1,
+                total=progress_total,
+                current_step=label,
+                message=f"{label} skipped: {reason}",
+            )
+        )
     _record_pipeline_event(
         "discover",
         "StageCompleted",
@@ -1117,6 +1201,16 @@ def _run_discover(
     schedule = _plan_discovery_schedule(limit)
     bounded_workers = max(1, workers)
     start_count = _pipeline_job_count() if limit > 0 else 0
+    jobspy_sources = schedule.for_prefix("jobspy")
+    ats_sources = tuple(
+        source
+        for source in schedule.for_kinds(SourceKind.ATS_API)
+        if not source.source_id.startswith("workday:")
+    )
+    workday_sources = schedule.for_prefix("workday")
+    smart_extract_sources = _smart_extract_sources(schedule)
+    progress_total = 3 + (1 if ats_sources else 0) + 2
+    progress_completed = 0
 
     # JobSpy — skip if disabled in config or module not installed
     search_cfg = config.load_search_config() or {}
@@ -1141,16 +1235,54 @@ def _run_discover(
     )
 
     def finish_discovery() -> dict:
+        nonlocal progress_completed
+        _record_pipeline_event(
+            "discover",
+            "StageStarted",
+            "info",
+            "Discovery detail enrichment finishing",
+            _discovery_progress_payload(
+                completed=progress_completed,
+                total=progress_total,
+                current_step="Detail enrichment",
+                message="Detail enrichment finishing",
+            ),
+        )
         enrichment_stats = _finish_discovery_enrichment_worker(
             enrichment_done,
             enrichment_thread,
             enrichment_result,
         )
         stats["enrichment"] = str(enrichment_stats.get("status", "ok"))
+        progress_completed += 1
+        _record_pipeline_event(
+            "discover",
+            "StageCompleted",
+            "info",
+            "Discovery detail enrichment complete",
+            _discovery_progress_payload(
+                completed=progress_completed,
+                total=progress_total,
+                current_step="Detail enrichment",
+                message="Detail enrichment complete",
+            ),
+        )
         try:
             run_hygiene("after")
         except Exception:
             log.warning("Post-discovery hygiene failed", exc_info=True)
+        _record_pipeline_event(
+            "discover",
+            "StageStarted",
+            "info",
+            "Discovery preparation started",
+            _discovery_progress_payload(
+                completed=progress_completed,
+                total=progress_total,
+                current_step="Preparation",
+                message="Preparation started",
+            ),
+        )
         try:
             from jobhunter.pipeline.preparation import drain_discovery_preparation
 
@@ -1169,13 +1301,40 @@ def _run_discover(
                 stats["preparation_counts"] = preparation_stats
                 if preparation_stats.get("status") != "ok":
                     stats["status"] = "partial"
+            preparation_status = "partial" if preparation_stats.get("status") not in (None, "ok") else "succeeded"
+            progress_completed += 1
+            _record_pipeline_event(
+                "discover",
+                "StageCompleted",
+                "warn" if preparation_status == "partial" else "info",
+                "Discovery preparation complete",
+                _discovery_progress_payload(
+                    completed=progress_completed,
+                    total=progress_total,
+                    current_step="Preparation",
+                    status=preparation_status,
+                    message="Preparation complete",
+                ),
+            )
         except Exception as exc:
             log.exception("Discovery preparation orchestration failed")
             stats["preparation"] = f"error: {exc}"
             stats["status"] = "partial"
+            progress_completed += 1
+            _record_pipeline_event(
+                "discover",
+                "StageFailed",
+                "error",
+                f"Discovery preparation failed: {exc}",
+                _discovery_progress_payload(
+                    completed=progress_completed,
+                    total=progress_total,
+                    current_step="Preparation",
+                    status="failed",
+                    message="Preparation failed",
+                ),
+            )
         return stats
-
-    jobspy_sources = schedule.for_prefix("jobspy")
 
     def run_jobspy(run_id: str | None = None) -> dict:
         if search_cfg.get("disable_jobspy", False):
@@ -1225,19 +1384,40 @@ def _run_discover(
         "JobSpy",
         jobspy_sources,
         run_jobspy,
+        progress_completed=progress_completed,
+        progress_total=progress_total,
     )
+    progress_completed += 1
     if isinstance(stats["jobspy"], str) and stats["jobspy"].startswith("error"):
         console.print(f"  [red]JobSpy error:[/red] {stats['jobspy'][7:]}")
     if _discover_limit_consumed(start_count, limit, source_results.get("jobspy")):
-        stats["workday"] = _skip_discovery_source("workday", "Workday scraper", "limit reached")
-        stats["smartextract"] = _skip_discovery_source("smartextract", "Smart extract", "limit reached")
+        if ats_sources:
+            stats["ats_api"] = _skip_discovery_source(
+                "ats_api",
+                "Canonical ATS APIs",
+                "limit reached",
+                progress_completed=progress_completed,
+                progress_total=progress_total,
+            )
+            progress_completed += 1
+        stats["workday"] = _skip_discovery_source(
+            "workday",
+            "Workday scraper",
+            "limit reached",
+            progress_completed=progress_completed,
+            progress_total=progress_total,
+        )
+        progress_completed += 1
+        stats["smartextract"] = _skip_discovery_source(
+            "smartextract",
+            "Smart extract",
+            "limit reached",
+            progress_completed=progress_completed,
+            progress_total=progress_total,
+        )
+        progress_completed += 1
         return finish_discovery()
 
-    ats_sources = tuple(
-        source
-        for source in schedule.for_kinds(SourceKind.ATS_API)
-        if not source.source_id.startswith("workday:")
-    )
     if ats_sources:
         def run_ats(run_id: str | None = None) -> dict:
             console.print("  [cyan]Canonical ATS APIs...[/cyan]")
@@ -1255,17 +1435,32 @@ def _run_discover(
             "Canonical ATS APIs",
             ats_sources,
             run_ats,
+            progress_completed=progress_completed,
+            progress_total=progress_total,
         )
+        progress_completed += 1
         if isinstance(stats["ats_api"], str) and stats["ats_api"].startswith("error"):
             console.print(f"  [red]Canonical ATS API error:[/red] {stats['ats_api'][7:]}")
         if _discover_limit_consumed(start_count, limit, source_results.get("ats_api")):
-            stats["workday"] = _skip_discovery_source("workday", "Workday scraper", "limit reached")
-            stats["smartextract"] = _skip_discovery_source("smartextract", "Smart extract", "limit reached")
+            stats["workday"] = _skip_discovery_source(
+                "workday",
+                "Workday scraper",
+                "limit reached",
+                progress_completed=progress_completed,
+                progress_total=progress_total,
+            )
+            progress_completed += 1
+            stats["smartextract"] = _skip_discovery_source(
+                "smartextract",
+                "Smart extract",
+                "limit reached",
+                progress_completed=progress_completed,
+                progress_total=progress_total,
+            )
+            progress_completed += 1
             return finish_discovery()
 
     # Workday corporate scraper
-    workday_sources = schedule.for_prefix("workday")
-
     def run_workday(run_id: str | None = None) -> dict:
         console.print("  [cyan]Workday corporate scraper...[/cyan]")
         from jobhunter.discovery.workday import run_workday_discovery
@@ -1282,16 +1477,24 @@ def _run_discover(
         "Workday scraper",
         workday_sources,
         run_workday,
+        progress_completed=progress_completed,
+        progress_total=progress_total,
     )
+    progress_completed += 1
     if isinstance(stats["workday"], str) and stats["workday"].startswith("error"):
         console.print(f"  [red]Workday error:[/red] {stats['workday'][7:]}")
     if _discover_limit_consumed(start_count, limit, source_results.get("workday")):
-        stats["smartextract"] = _skip_discovery_source("smartextract", "Smart extract", "limit reached")
+        stats["smartextract"] = _skip_discovery_source(
+            "smartextract",
+            "Smart extract",
+            "limit reached",
+            progress_completed=progress_completed,
+            progress_total=progress_total,
+        )
+        progress_completed += 1
         return finish_discovery()
 
     # Smart extract
-    smart_extract_sources = _smart_extract_sources(schedule)
-
     def run_smart_extract_source() -> dict:
         console.print("  [cyan]Smart extract (AI-powered scraping)...[/cyan]")
         enqueue_manual_action_for_sources(conn, smart_extract_sources)
@@ -1311,7 +1514,10 @@ def _run_discover(
         "Smart extract",
         smart_extract_sources,
         run_smart_extract_source,
+        progress_completed=progress_completed,
+        progress_total=progress_total,
     )
+    progress_completed += 1
     if isinstance(stats["smartextract"], str) and stats["smartextract"].startswith("error"):
         console.print(f"  [red]Smart extract error:[/red] {stats['smartextract'][7:]}")
 

--- a/workers/automation/tests/test_discovery_limits.py
+++ b/workers/automation/tests/test_discovery_limits.py
@@ -972,6 +972,113 @@ def test_jobspy_content_dedupe_normalizes_typographic_punctuation(tmp_path):
         close_connection(db_path)
 
 
+def test_jobspy_rejects_cross_board_markdown_description_variants(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    shared_body = (
+        "G\\+D makes the lives of billions of people around the world more secure. "
+        "We shape trust in the digital age with built-in security technology. "
+        "The Head of Technology owns platform delivery, engineering standards, "
+        "vendor coordination, security governance, architecture roadmaps, "
+        "cloud reliability, compliance, and stakeholder communication. "
+    ) * 5
+    indeed_description = f"**{shared_body}**\n\nEqual opportunity footer and Indeed metadata."
+    linkedin_description = f"{shared_body}\n\nLinkedIn workplace summary."
+    try:
+        first = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://es.indeed.com/viewjob?jk=6b34cd5504dac130",
+                    "job_url_direct": "https://www.gi-de.com/en/careers/jobs/jobs-detail-view/27069-en-US",
+                    "title": "Head of Technology",
+                    "company": "Giesecke+Devrient",
+                    "location": "Catalonia, Spain (Remote)",
+                    "site": "indeed",
+                    "description": indeed_description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, first, "Head of Technology", limit=10) == (1, 0)
+
+        duplicate = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://www.linkedin.com/jobs/view/4409381449",
+                    "title": "Head of Technology",
+                    "company": "Giesecke+Devrient",
+                    "location": "Sant Joan Despí, Catalonia, Spain (Remote)",
+                    "site": "linkedin",
+                    "description": linkedin_description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, duplicate, "Head of Technology", limit=10) == (0, 1)
+
+        assert conn.execute("SELECT COUNT(*) FROM jobs WHERE company = 'Giesecke+Devrient'").fetchone()[0] == 1
+        link = conn.execute(
+            "SELECT surviving_job_id, superseded_job_or_observation_id, reason FROM job_duplicate_links"
+        ).fetchone()
+        assert link["surviving_job_id"] == "https://es.indeed.com/viewjob?jk=6b34cd5504dac130"
+        assert link["superseded_job_or_observation_id"] == "https://www.linkedin.com/jobs/view/4409381449"
+        assert link["reason"] == "content_fingerprint_match"
+        observations = conn.execute(
+            "SELECT source_id FROM job_source_observations WHERE job_url = ? ORDER BY source_id",
+            ("https://es.indeed.com/viewjob?jk=6b34cd5504dac130",),
+        ).fetchall()
+        assert [row["source_id"] for row in observations] == ["jobspy:indeed", "jobspy:linkedin"]
+    finally:
+        close_connection(db_path)
+
+
+def test_jobspy_keeps_same_title_company_when_descriptions_diverge(tmp_path):
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    shared_intro = (
+        "G\\+D makes the lives of billions of people around the world more secure. "
+        "We shape trust in the digital age with built-in security technology. "
+    ) * 2
+    platform_description = shared_intro + (
+        "This Head of Technology role owns platform reliability, incident response, "
+        "cloud architecture, developer tooling, service ownership, and infrastructure roadmaps. "
+    ) * 6
+    payments_description = shared_intro + (
+        "This Head of Technology role owns card personalization, payment terminals, "
+        "manufacturing systems, embedded firmware, supply-chain delivery, and factory operations. "
+    ) * 6
+    try:
+        first = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://example.test/jobs/platform",
+                    "title": "Head of Technology",
+                    "company": "Giesecke+Devrient",
+                    "location": "Catalonia, Spain",
+                    "site": "indeed",
+                    "description": platform_description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, first, "Head of Technology", limit=10) == (1, 0)
+
+        second = _jobspy_frame(
+            [
+                {
+                    "job_url": "https://example.test/jobs/payments",
+                    "title": "Head of Technology",
+                    "company": "Giesecke+Devrient",
+                    "location": "Madrid, Spain",
+                    "site": "linkedin",
+                    "description": payments_description,
+                }
+            ]
+        )
+        assert jobspy.store_jobspy_results(conn, second, "Head of Technology", limit=10) == (1, 0)
+        assert conn.execute("SELECT COUNT(*) FROM jobs WHERE company = 'Giesecke+Devrient'").fetchone()[0] == 2
+        assert conn.execute("SELECT COUNT(*) FROM job_duplicate_links").fetchone()[0] == 0
+    finally:
+        close_connection(db_path)
+
+
 def test_jobspy_exact_rediscovery_keeps_deleted_content_duplicate_suppressed(tmp_path):
     db_path = tmp_path / "jobs.db"
     conn = init_db(db_path)

--- a/workers/automation/tests/test_discovery_preparation_orchestration.py
+++ b/workers/automation/tests/test_discovery_preparation_orchestration.py
@@ -343,6 +343,61 @@ def test_discover_stage_kwargs_include_preparation_controls() -> None:
     }
 
 
+def test_discovery_source_failure_records_failed_progress(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, str, str, dict]] = []
+    scheduled = runner.ScheduledSource(
+        source_id="jobspy:linkedin",
+        display_name="LinkedIn",
+        source_kind=runner.SourceKind.BROAD_BOARD,
+        priority=runner.SourcePriority.STANDARD,
+        configured_state=runner.SourceState.ACTIVE,
+        crawl_budget=1,
+        decision="run",
+        reason="scheduled",
+        recommended_state="normal",
+    )
+
+    monkeypatch.setattr(runner, "get_connection", lambda: conn)
+    monkeypatch.setattr(runner, "_record_source_state_changes", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runner, "_record_discovery_run_event", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(runner, "_record_operational_attempt", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        runner,
+        "_record_pipeline_event",
+        lambda stage, event_type, _level, message, payload=None: events.append(
+            (stage, event_type, message, payload or {})
+        ),
+    )
+
+    def fail_source() -> None:
+        raise RuntimeError("source outage")
+
+    result = runner._run_discovery_source(
+        "jobspy",
+        "JobSpy",
+        (scheduled,),
+        fail_source,
+        progress_completed=1,
+        progress_total=5,
+    )
+
+    assert result == "error: source outage"
+    failed_event = [event for event in events if event[1] == "StageFailed"][0]
+    assert failed_event[0] == "discover"
+    assert failed_event[2] == "Discovery source jobspy failed: source outage"
+    assert failed_event[3]["progress"] == {
+        "completed": 2,
+        "total": 5,
+        "percent": 40,
+        "currentStep": "JobSpy",
+        "status": "failed",
+        "message": "JobSpy failed",
+    }
+
+
 def test_discover_runs_internal_preparation_after_enrichment(
     conn: sqlite3.Connection,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Add durable pipeline progress snapshots to the dashboard summary contract and render discovery percent complete in the Pipelines action row.
- Emit discovery progress from worker phases and derive fallback progress from existing stage events so currently running discovery work is visible.
- Strengthen JobSpy duplicate detection for same-title, same-company postings whose descriptions vary by board formatting.

## Validation
- `pnpm --filter @jobhunter/web test -- StageTriggerPanel`
- `pnpm api:test -- server.test.ts`
- `pnpm api:check`
- `pnpm web:check`
- `pnpm --filter @jobhunter/domain-types test`
- `pnpm --filter @jobhunter/contracts test`
- `pnpm web:build`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_preparation_orchestration.py workers/automation/tests/test_discovery_limits.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/pipeline/runner.py workers/automation/src/jobhunter/domain/job_content_identity.py workers/automation/src/jobhunter/discovery/jobspy.py workers/automation/tests/test_discovery_limits.py workers/automation/tests/test_discovery_preparation_orchestration.py`
- `git diff --check`
- Browser check: `/pipelines` shows `Discover 0% complete (0/5): Discovery source jobspy started.` with a native progressbar reporting `value=0` and `max=100`.