### PR TITLE
fix: guard rediscovery restores with current policy

### DIFF
--- a/workers/automation/src/jobhunter/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/discovery/use_cases.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterable, Protocol
+from typing import Iterable, Literal, Protocol
 
 from jobhunter.domain.discovery.aggregate import Job
 from jobhunter.domain.discovery.identity import (
@@ -45,12 +45,16 @@ from jobhunter.domain.events import (
     CanonicalJobIdentityResolvedPayload,
     DuplicateJobLinkedPayload,
     DuplicateJobLinkRejectedPayload,
+    JobDeletedPayload,
     JobDiscoveredPayload,
+    JobRestoredPayload,
     JobSourceObservedPayload,
     create_canonical_job_identity_resolved,
     create_duplicate_job_link_rejected,
     create_duplicate_job_linked,
+    create_job_deleted,
     create_job_discovered,
+    create_job_restored,
     create_job_source_observed,
 )
 from jobhunter.domain.identifiers import JobId
@@ -116,6 +120,42 @@ class CanonicalIdentityResolver(Protocol):
 
 
 @dataclass(frozen=True)
+class PostingAcceptance:
+    """Current discovery-policy verdict for one scraped posting."""
+
+    accepted: bool
+    reason: str = ""
+    rejection_reasons: tuple[str, ...] = ()
+
+    @classmethod
+    def accept(cls) -> "PostingAcceptance":
+        return cls(accepted=True)
+
+    @classmethod
+    def reject(
+        cls,
+        *,
+        reason: str,
+        rejection_reasons: Iterable[str] = (),
+    ) -> "PostingAcceptance":
+        return cls(
+            accepted=False,
+            reason=reason,
+            rejection_reasons=tuple(str(item) for item in rejection_reasons),
+        )
+
+
+class PostingAcceptancePolicy(Protocol):
+    """Function signature for current discovery-policy acceptance."""
+
+    def __call__(self, posting: ScrapedJobPosting) -> PostingAcceptance: ...
+
+
+def accept_all_postings(_posting: ScrapedJobPosting) -> PostingAcceptance:
+    return PostingAcceptance.accept()
+
+
+@dataclass(frozen=True)
 class DiscoveryDecision:
     """Outcome of a single ``ScrapedJobPosting`` ingest."""
 
@@ -124,6 +164,7 @@ class DiscoveryDecision:
     observation_id: str
     duplicate_link_id: str | None
     rejected_reason: str | None
+    rejected_kind: Literal["duplicate", "policy"] | None
     confidence: float
 
 
@@ -160,12 +201,14 @@ class DiscoverJobsUseCase:
         repository: JobRepository,
         publisher: EventPublisher,
         resolver: CanonicalIdentityResolver | None = None,
+        acceptance_policy: PostingAcceptancePolicy | None = None,
         run_id_factory: object | None = None,
         clock: object | None = None,
     ) -> None:
         self._repository = repository
         self._publisher = publisher
         self._resolver = resolver or default_canonical_identity
+        self._acceptance_policy = acceptance_policy or accept_all_postings
         self._run_id_factory = run_id_factory or (lambda: f"run:{uuid.uuid4().hex}")
         self._clock = clock or (lambda: datetime.now(timezone.utc).isoformat())
 
@@ -192,7 +235,7 @@ class DiscoverJobsUseCase:
             new_jobs=sum(1 for d in decisions if d.is_new_job),
             observed=sum(1 for d in decisions if not d.is_new_job and d.rejected_reason is None),
             duplicates_linked=sum(1 for d in decisions if d.duplicate_link_id is not None),
-            duplicates_rejected=sum(1 for d in decisions if d.rejected_reason is not None),
+            duplicates_rejected=sum(1 for d in decisions if d.rejected_kind == "duplicate"),
         )
 
     # ------------------------------------------------------------------
@@ -228,6 +271,14 @@ class DiscoverJobsUseCase:
         observation_id = f"obs:{uuid.uuid4().hex}"
 
         if owner_id is None:
+            acceptance = self._acceptance_policy(posting)
+            if not acceptance.accepted:
+                return self._policy_rejected_decision(
+                    job_id=JobId(identity.canonical_url or posting.posting_url.value),
+                    observation_id=observation_id,
+                    confidence=identity.confidence,
+                    acceptance=acceptance,
+                )
             return self._create_new_job(
                 tenant_id=tenant_id,
                 posting=posting,
@@ -335,6 +386,7 @@ class DiscoverJobsUseCase:
             observation_id=observation_id,
             duplicate_link_id=None,
             rejected_reason=None,
+            rejected_kind=None,
             confidence=identity.confidence,
         )
 
@@ -380,18 +432,57 @@ class DiscoverJobsUseCase:
                 observation_id=observation_id,
                 duplicate_link_id=None,
                 rejected_reason="confidence_below_threshold",
+                rejected_kind="duplicate",
                 confidence=identity.confidence,
             )
 
+        acceptance = self._acceptance_policy(posting)
         with dedupe_span(
             tenant_id=str(tenant_id),
             job_id=str(owner_id),
             stage="listing_ingest",
-            result="observed",
+            result="observed" if acceptance.accepted else "policy_rejected",
             confidence=identity.confidence,
         ):
             existing = self._repository.load(tenant_id, owner_id)
             if existing is not None:
+                if not acceptance.accepted:
+                    reason = _policy_rejection_reason(acceptance)
+                    if not existing.is_deleted:
+                        self._soft_delete_policy_rejected_job(
+                            tenant_id=tenant_id,
+                            job_id=owner_id,
+                            reason=reason,
+                            deleted_at=observed_at,
+                        )
+                    self._repository.attach_source_observation(
+                        tenant_id,
+                        owner_id,
+                        JobSourceObservation(
+                            source_observation_id=observation_id,
+                            source_id=posting.source_id,
+                            source_native_id=identity.source_native_id,
+                            observed_url=observed_url,
+                            run_id=run_id,
+                            observed_at=observed_at,
+                        ),
+                    )
+                    self._publish_source_observed(
+                        tenant_id=tenant_id,
+                        job_id=owner_id,
+                        observation_id=observation_id,
+                        posting=posting,
+                        identity=identity,
+                        observed_url=observed_url,
+                        run_id=run_id,
+                        observed_at=observed_at,
+                    )
+                    return self._policy_rejected_decision(
+                        job_id=owner_id,
+                        observation_id=observation_id,
+                        confidence=identity.confidence,
+                        acceptance=acceptance,
+                    )
                 refreshed = existing.with_metadata(posting.metadata)
                 if refreshed.is_deleted:
                     restored = self._repository.restore(
@@ -401,6 +492,15 @@ class DiscoverJobsUseCase:
                     )
                     if restored is not None:
                         refreshed = restored.with_metadata(posting.metadata)
+                        self._publisher.publish(
+                            create_job_restored(
+                                tenant_id,
+                                JobRestoredPayload(
+                                    job_id=str(owner_id),
+                                    restored_at=observed_at,
+                                ),
+                            )
+                        )
                 if refreshed != existing:
                     self._repository.save(refreshed)
             self._repository.attach_source_observation(
@@ -415,19 +515,15 @@ class DiscoverJobsUseCase:
                     observed_at=observed_at,
                 ),
             )
-        self._publisher.publish(
-            create_job_source_observed(
-                tenant_id,
-                JobSourceObservedPayload(
-                    job_id=str(owner_id),
-                    source_observation_id=observation_id,
-                    source_id=posting.source_id,
-                    source_native_id=identity.source_native_id,
-                    observed_url=observed_url,
-                    run_id=run_id,
-                    observed_at=observed_at,
-                ),
-            )
+        self._publish_source_observed(
+            tenant_id=tenant_id,
+            job_id=owner_id,
+            observation_id=observation_id,
+            posting=posting,
+            identity=identity,
+            observed_url=observed_url,
+            run_id=run_id,
+            observed_at=observed_at,
         )
 
         duplicate_link_id: str | None = None
@@ -461,8 +557,87 @@ class DiscoverJobsUseCase:
             observation_id=observation_id,
             duplicate_link_id=duplicate_link_id,
             rejected_reason=None,
+            rejected_kind=None,
             confidence=identity.confidence,
         )
+
+    def _publish_source_observed(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+        observation_id: str,
+        posting: ScrapedJobPosting,
+        identity: CanonicalJobIdentity,
+        observed_url: str,
+        run_id: str,
+        observed_at: str,
+    ) -> None:
+        self._publisher.publish(
+            create_job_source_observed(
+                tenant_id,
+                JobSourceObservedPayload(
+                    job_id=str(job_id),
+                    source_observation_id=observation_id,
+                    source_id=posting.source_id,
+                    source_native_id=identity.source_native_id,
+                    observed_url=observed_url,
+                    run_id=run_id,
+                    observed_at=observed_at,
+                ),
+            )
+        )
+
+    def _soft_delete_policy_rejected_job(
+        self,
+        *,
+        tenant_id: TenantId,
+        job_id: JobId,
+        reason: str,
+        deleted_at: str,
+    ) -> None:
+        deleted = self._repository.soft_delete(
+            tenant_id,
+            job_id,
+            reason=reason,
+            deleted_at=deleted_at,
+        )
+        if deleted is None:
+            return
+        self._publisher.publish(
+            create_job_deleted(
+                tenant_id,
+                JobDeletedPayload(
+                    job_id=str(job_id),
+                    reason=reason,
+                    deleted_at=deleted_at,
+                ),
+            )
+        )
+
+    def _policy_rejected_decision(
+        self,
+        *,
+        job_id: JobId,
+        observation_id: str,
+        confidence: float,
+        acceptance: PostingAcceptance,
+    ) -> DiscoveryDecision:
+        return DiscoveryDecision(
+            job_id=job_id,
+            is_new_job=False,
+            observation_id=observation_id,
+            duplicate_link_id=None,
+            rejected_reason=_policy_rejection_reason(acceptance),
+            rejected_kind="policy",
+            confidence=confidence,
+        )
+
+
+def _policy_rejection_reason(acceptance: PostingAcceptance) -> str:
+    if acceptance.rejection_reasons:
+        return f"{acceptance.reason}: {', '.join(acceptance.rejection_reasons)}"
+    return acceptance.reason or "policy_rejected"
 
 
 __all__ = [
@@ -471,5 +646,8 @@ __all__ = [
     "DiscoveryDecision",
     "DiscoveryRunSummary",
     "MIN_AUTO_MERGE_CONFIDENCE",
+    "PostingAcceptance",
+    "PostingAcceptancePolicy",
+    "accept_all_postings",
     "default_canonical_identity",
 ]

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -36,7 +36,7 @@ from jobhunter.domain.discovery.source_registry import (
     SourceRegistryEntry,
     validate_locator_candidate,
 )
-from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase
+from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase, PostingAcceptance
 from jobhunter.domain.discovery.value_objects import (
     JobMetadata,
     PostingUrl,
@@ -476,6 +476,7 @@ def run_scheduled_ats_sources(
     use_case = DiscoverJobsUseCase(
         repository=SqliteJobRepository(conn),
         publisher=DurableJobEventPublisher(conn, stage="discover"),
+        acceptance_policy=_posting_acceptance_policy(search_cfg),
     )
     total = 0
     new_jobs = 0
@@ -551,24 +552,7 @@ def retire_invalid_source_jobs(
     ensure_source_observation_tables(conn)
     ensure_enrichment_tables(conn)
     _ensure_deleted_jobs_table(conn)
-    query_specs_by_family = {
-        "ats_api": tuple(_ats_query_specs(search_cfg)),
-        "jobspy": tuple(query_specs_for_source(search_cfg.get("queries", []), "jobspy")),
-        "smartextract": tuple(
-            query_specs_for_source(search_cfg.get("queries", []), "smartextract")
-        ),
-        "workday": tuple(
-            query_specs_for_source(
-                search_cfg.get("queries", []),
-                "workday",
-                max_tier=int(search_cfg.get("workday_max_tier") or 2),
-            )
-        ),
-    }
-    if not query_specs_by_family["workday"]:
-        query_specs_by_family["workday"] = tuple(
-            query_specs_for_source(search_cfg.get("queries", []), "workday")
-        )
+    query_specs_by_family = _query_specs_by_family(search_cfg)
     accept_locs, reject_locs = configured_location_filters(search_cfg)
     locations = tuple(_location_values(search_cfg))
     now = utc_now()
@@ -662,6 +646,63 @@ def retire_invalid_source_jobs(
     return {"retired_jobs": len(retired), "jobs": retired}
 
 
+def _query_specs_by_family(search_cfg: Mapping[str, Any]) -> dict[str, tuple[dict[str, object], ...]]:
+    query_specs_by_family = {
+        "ats_api": tuple(_ats_query_specs(search_cfg)),
+        "jobspy": tuple(query_specs_for_source(search_cfg.get("queries", []), "jobspy")),
+        "smartextract": tuple(
+            query_specs_for_source(search_cfg.get("queries", []), "smartextract")
+        ),
+        "workday": tuple(
+            query_specs_for_source(
+                search_cfg.get("queries", []),
+                "workday",
+                max_tier=int(search_cfg.get("workday_max_tier") or 2),
+            )
+        ),
+    }
+    if not query_specs_by_family["workday"]:
+        query_specs_by_family["workday"] = tuple(
+            query_specs_for_source(search_cfg.get("queries", []), "workday")
+        )
+    return query_specs_by_family
+
+
+def _posting_acceptance_policy(search_cfg: Mapping[str, Any]):
+    query_specs_by_family = _query_specs_by_family(search_cfg)
+    accept_locs, reject_locs = configured_location_filters(search_cfg)
+    locations = tuple(_location_values(search_cfg))
+
+    def policy(posting: ScrapedJobPosting) -> PostingAcceptance:
+        strategy = str(getattr(posting.strategy, "value", posting.strategy) or "")
+        ats_kind = str(getattr(posting.ats_kind, "value", posting.ats_kind) or "")
+        family = _source_family(
+            source_id=str(posting.source_id or ""),
+            strategy=strategy,
+            ats_kind=ats_kind,
+        )
+        if family is None:
+            return PostingAcceptance.accept()
+        reasons = _source_rejection_reasons(
+            title=str(posting.metadata.title or ""),
+            location=str(posting.metadata.location or ""),
+            description=str(posting.metadata.description or ""),
+            query_specs=query_specs_by_family.get(family, ()),
+            accept_locs=accept_locs,
+            reject_locs=reject_locs,
+            locations=locations,
+        )
+        if not reasons:
+            return PostingAcceptance.accept()
+        source_id = str(posting.source_id or ats_kind or family)
+        return PostingAcceptance.reject(
+            reason=f"discovery policy rejected {source_id}",
+            rejection_reasons=reasons,
+        )
+
+    return policy
+
+
 def retire_invalid_canonical_ats_jobs(
     conn: sqlite3.Connection,
     *,
@@ -725,13 +766,16 @@ def _source_rejection_reasons(
 ) -> list[str]:
     reasons: list[str] = []
     effective_accept_locs = accept_locs or [location for location in locations if location]
+    location_evidence = " ".join(
+        str(part).strip() for part in (location, title) if str(part or "").strip()
+    )
     if not _usable_description_text(description):
         reasons.append("missing_description")
     if query_specs and not title_matches_any_query(title, query_specs):
         reasons.append("title_mismatch")
     if not any(
         location_matches_target(
-            location,
+            location_evidence,
             accept=effective_accept_locs,
             reject=reject_locs,
             search_location=target_location,

--- a/workers/automation/tests/test_discovery_identity.py
+++ b/workers/automation/tests/test_discovery_identity.py
@@ -18,7 +18,7 @@ from jobhunter.domain.discovery import (
     SearchStrategy,
     Source,
 )
-from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase
+from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase, PostingAcceptance
 from jobhunter.domain.events.base import DomainEvent
 from jobhunter.domain.identifiers import JobId
 from jobhunter.domain.ports.discovery import ScrapedJobPosting
@@ -410,6 +410,7 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
         reason="not relevant right now",
         deleted_at="2026-05-13T00:00:00Z",
     )
+    publisher.events.clear()
     current_time = "2026-05-14T00:00:00Z"
 
     summary = use_case.execute(
@@ -441,6 +442,169 @@ def test_discover_jobs_use_case_resurfaces_soft_deleted_existing_job(
     ).fetchone()
     assert tombstone is not None
     assert tombstone["restored_at"] == "2026-05-14T00:00:00Z"
+    assert [event.event_type for event in publisher.events] == [
+        "JobRestored",
+        "JobSourceObserved",
+    ]
+
+
+def test_discover_jobs_use_case_rejects_new_policy_mismatches_without_creating_job(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        acceptance_policy=lambda _posting: PostingAcceptance.reject(
+            reason="current_policy_mismatch",
+            rejection_reasons=("location_mismatch",),
+        ),
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+
+    summary = use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                canonical_url="https://jobs.ashbyhq.com/acai/india",
+                source_native_id="india",
+                source_id="ashby:acai",
+                ats_kind=AtsKind.ASHBY,
+                metadata=JobMetadata(
+                    title="Senior Software Engineer (India)",
+                    description="Build distributed systems.",
+                    location="Remote",
+                ),
+            )
+        ],
+        run_id="run-1",
+    )
+
+    assert summary.total == 1
+    assert summary.new_jobs == 0
+    assert summary.observed == 0
+    assert summary.duplicates_rejected == 0
+    assert repo.load(LOCAL_TENANT, JobId("https://jobs.ashbyhq.com/acai/india")) is None
+    assert publisher.events == []
+
+
+def test_discover_jobs_use_case_soft_deletes_active_job_rejected_by_current_policy(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+    use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    publisher.events.clear()
+    policy_use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        acceptance_policy=lambda _posting: PostingAcceptance.reject(
+            reason="current_policy_mismatch",
+            rejection_reasons=("location_mismatch",),
+        ),
+        clock=lambda: "2026-05-15T00:00:00Z",
+    )
+
+    summary = policy_use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                metadata=JobMetadata(
+                    title="Senior Software Engineer (India)",
+                    description="Build distributed systems.",
+                    location="Remote",
+                ),
+            )
+        ],
+        run_id="run-2",
+    )
+
+    assert summary.total == 1
+    assert summary.new_jobs == 0
+    assert summary.observed == 0
+    assert summary.duplicates_rejected == 0
+    job = repo.load(LOCAL_TENANT, JobId("https://boards.greenhouse.io/acme/jobs/123"))
+    assert job is not None
+    assert job.is_deleted is True
+    assert "location_mismatch" in (job.delete_reason or "")
+    assert job.metadata.title == "Platform Engineer"
+    observations = repo.list_observations(
+        LOCAL_TENANT,
+        JobId("https://boards.greenhouse.io/acme/jobs/123"),
+    )
+    assert [observation.run_id for observation in observations] == ["run-2"]
+    assert [event.event_type for event in publisher.events] == [
+        "JobDeleted",
+        "JobSourceObserved",
+    ]
+
+
+def test_discover_jobs_use_case_keeps_policy_rejected_deleted_job_hidden(
+    conn: sqlite3.Connection,
+) -> None:
+    repo = SqliteJobRepository(conn)
+    publisher = RecordingPublisher()
+    use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        clock=lambda: "2026-05-12T00:00:00Z",
+    )
+    job_id = JobId("https://boards.greenhouse.io/acme/jobs/123")
+    use_case.execute(tenant_id=LOCAL_TENANT, postings=[_posting()], run_id="run-1")
+    repo.soft_delete(
+        LOCAL_TENANT,
+        job_id,
+        reason="discovery hygiene rejected ashby:acai: location_mismatch",
+        deleted_at="2026-05-13T00:00:00Z",
+    )
+    publisher.events.clear()
+    policy_use_case = DiscoverJobsUseCase(
+        repository=repo,
+        publisher=publisher,
+        acceptance_policy=lambda _posting: PostingAcceptance.reject(
+            reason="current_policy_mismatch",
+            rejection_reasons=("location_mismatch",),
+        ),
+        clock=lambda: "2026-05-15T00:00:00Z",
+    )
+
+    summary = policy_use_case.execute(
+        tenant_id=LOCAL_TENANT,
+        postings=[
+            _posting(
+                metadata=JobMetadata(
+                    title="Senior Software Engineer (India)",
+                    description="Build distributed systems.",
+                    location="Remote",
+                ),
+            )
+        ],
+        run_id="run-2",
+    )
+
+    assert summary.total == 1
+    assert summary.new_jobs == 0
+    assert summary.observed == 0
+    assert summary.duplicates_rejected == 0
+    hidden = repo.load(LOCAL_TENANT, job_id)
+    assert hidden is not None
+    assert hidden.is_deleted is True
+    assert hidden.metadata.title == "Platform Engineer"
+    tombstone = conn.execute(
+        "SELECT restored_at FROM jobhunter_deleted_jobs WHERE job_url = ?",
+        (str(job_id),),
+    ).fetchone()
+    assert tombstone is not None
+    assert tombstone["restored_at"] is None
+    observations = repo.list_observations(LOCAL_TENANT, job_id)
+    assert [observation.run_id for observation in observations] == ["run-2"]
+    assert [event.event_type for event in publisher.events] == ["JobSourceObserved"]
 
 
 def test_discover_jobs_use_case_preserves_existing_salary_when_rediscovery_is_blank(

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -12,11 +12,20 @@ import pytest
 from jobhunter import config
 from jobhunter.discovery import manual_capture_import as manual_capture_import_cli
 from jobhunter.database import close_connection, init_db
+from jobhunter.domain.discovery import (
+    AtsKind,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
 from jobhunter.domain.discovery.scheduler import DiscoveryScheduler
 from jobhunter.domain.discovery.source_registry import SourceKind
+from jobhunter.domain.ports.discovery import ScrapedJobPosting
 from jobhunter.enrichment.detail import _record_posting_snapshot_from_cascade
 from jobhunter.infrastructure.discovery.production_wiring import (
     ManualCaptureImport,
+    _posting_acceptance_policy,
     build_discovery_acceptance_report,
     import_manual_capture_item,
     retire_invalid_canonical_ats_jobs,
@@ -147,6 +156,55 @@ def _fake_ats_http_with_lever_failure(url: str, **kwargs: Any) -> Any:
     if "lever" in url:
         raise TimeoutError("lever unavailable")
     return _fake_ats_http(url, **kwargs)
+
+
+def test_posting_acceptance_policy_uses_title_location_evidence_for_remote_roles() -> None:
+    policy = _posting_acceptance_policy(
+        {
+            "queries": [{"query": "Software Engineer", "tier": 1}],
+            "locations": [{"location": "Remote"}],
+            "location_accept": ["Remote", "Spain", "European Union", "EU", "EMEA"],
+            "location_reject_non_remote": ["India", "Poland", "United States"],
+            "ats_max_tier": 1,
+        }
+    )
+
+    rejected = policy(
+        ScrapedJobPosting(
+            posting_url=PostingUrl(value="https://jobs.ashbyhq.com/acai/india"),
+            source=Source(board="ashby"),
+            metadata=JobMetadata(
+                title="Senior Software Engineer (India)",
+                description="Build distributed systems.",
+                location="Remote",
+            ),
+            strategy=SearchStrategy.WORKDAY_API,
+            source_id="ashby:acai",
+            source_native_id="india",
+            canonical_url="https://jobs.ashbyhq.com/acai/india",
+            ats_kind=AtsKind.ASHBY,
+        )
+    )
+    accepted = policy(
+        ScrapedJobPosting(
+            posting_url=PostingUrl(value="https://jobs.ashbyhq.com/acai/spain"),
+            source=Source(board="ashby"),
+            metadata=JobMetadata(
+                title="Senior Software Engineer",
+                description="Build distributed systems.",
+                location="Spain (Remote)",
+            ),
+            strategy=SearchStrategy.WORKDAY_API,
+            source_id="ashby:acai",
+            source_native_id="spain",
+            canonical_url="https://jobs.ashbyhq.com/acai/spain",
+            ats_kind=AtsKind.ASHBY,
+        )
+    )
+
+    assert rejected.accepted is False
+    assert "location_mismatch" in rejected.rejection_reasons
+    assert accepted.accepted is True
 
 
 def _manual_capture_html() -> str:


### PR DESCRIPTION
## Summary
- Add a discovery acceptance policy to the discovery write boundary so current policy is checked before creating, restoring, updating, or keeping active jobs.
- Wire scheduled ATS ingestion through the same query/location checks used by discovery hygiene.
- Include title-based location evidence so remote rows with rejected geographies in the title are rejected consistently.
- Add regressions for new policy mismatches, active-job tombstoning, deleted-job non-restoration, and remote title geography filtering.

## Root Cause
Source adapters and hygiene treated "observed" differently: a source could emit a listing that the central discovery use case interpreted as a valid rediscovery, while the later hygiene pass interpreted the same row as policy-invalid. The restore path in `DiscoverJobsUseCase` restored tombstoned jobs before rechecking today's query/location policy.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_identity.py workers/automation/tests/test_discovery_production_wiring.py` -> `34 passed`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/discovery/use_cases.py workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py workers/automation/tests/test_discovery_identity.py workers/automation/tests/test_discovery_production_wiring.py` -> `All checks passed!`
- `uv --project workers/automation run --extra dev pytest -q` -> `1070 passed`
- `git diff --check` -> passed

Docs not updated: this is a bug fix to existing discovery policy enforcement, not a new user-facing command or workflow.