### PR TITLE
fix: scope job bulk actions to visible table rows

### DIFF
--- a/apps/web/src/shared/ui/filterable-data-grid.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.tsx
@@ -95,6 +95,7 @@ export interface FilterableDataGridProps<TData> {
   rowClassName?: (row: TData) => string | undefined;
   rowAriaSelected?: (row: TData) => boolean;
   onRowActivate?: (row: TData) => void;
+  onPageRowsChange?: (rows: readonly TData[]) => void;
 }
 
 function emptyFilter(): DataGridTextFilter {
@@ -128,10 +129,14 @@ function sortButtonLabel(
   return `Sort by ${columnLabel}`;
 }
 
-function isActiveFilter(
+export function isActiveDataGridFilter(
   filter: DataGridTextFilter | undefined,
 ): filter is DataGridTextFilter {
   return Boolean(filter?.text.trim() || filter?.selectedValues.length);
+}
+
+export function hasActiveDataGridFilters(filters: DataGridFilterState): boolean {
+  return Object.values(filters).some(isActiveDataGridFilter);
 }
 
 function operatorLabel(operator: DataGridTextOperator): string {
@@ -298,6 +303,7 @@ export function FilterableDataGrid<TData>({
   rowClassName,
   rowAriaSelected,
   onRowActivate,
+  onPageRowsChange,
 }: FilterableDataGridProps<TData>) {
   const [localSort, setLocalSort] = useState<DataGridSortState>(initialSort);
   const [localFilters, setLocalFilters] =
@@ -332,7 +338,7 @@ export function FilterableDataGrid<TData>({
           filterableColumns.every((column) => {
             if (!column.getFilterValue) return true;
             const filter = filters[column.id];
-            if (!isActiveFilter(filter)) return true;
+            if (!isActiveDataGridFilter(filter)) return true;
             const value = column.getFilterValue(row);
             const searchValue = column.getFilterSearchValue?.(row) ?? value;
             const normalizedValue = normalize(searchValue);
@@ -397,7 +403,11 @@ export function FilterableDataGrid<TData>({
 
   const activeFilters = filterableColumns
     .map((column) => ({ column, filter: filters[column.id] }))
-    .filter(({ filter }) => isActiveFilter(filter));
+    .filter(({ filter }) => isActiveDataGridFilter(filter));
+
+  useEffect(() => {
+    onPageRowsChange?.(pageRows);
+  }, [onPageRowsChange, pageRows]);
 
   const setFilters = (
     updater: (current: DataGridFilterState) => DataGridFilterState,
@@ -529,7 +539,7 @@ export function FilterableDataGrid<TData>({
                   column.sortable ?? Boolean(column.getSortValue);
                 const filterable = Boolean(column.getFilterValue);
                 const filter = filters[column.id] ?? emptyFilter();
-                const filterActive = isActiveFilter(filter);
+                const filterActive = isActiveDataGridFilter(filter);
                 const header =
                   typeof column.header === "function"
                     ? column.header(headerContext)

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -11,6 +11,7 @@ export interface JobBulkActionsProps {
   selectedStaleKeys?: readonly string[];
   hasItems: boolean;
   hasAnyMatching: boolean;
+  hasLocalFilters?: boolean;
   loading: boolean;
   onSetDeleted: (deleted: JobsSearch["deleted"]) => void;
   onSelectPage: () => void;
@@ -33,6 +34,7 @@ export function JobBulkActions({
   selectedStaleKeys = [],
   hasItems,
   hasAnyMatching,
+  hasLocalFilters = false,
   loading,
   onSetDeleted,
   onSelectPage,
@@ -49,8 +51,13 @@ export function JobBulkActions({
   const restoring = search.deleted === "deleted";
   const hidden = search.deleted === "hidden";
   const closed = search.deleted === "closed";
-  const retryableFailures = search.deleted === "active" && search.state === "failed";
-  const primaryLabel = hidden ? "unhide selected" : restoring ? "restore selected" : "delete selected";
+  const retryableFailures =
+    search.deleted === "active" && search.state === "failed";
+  const primaryLabel = hidden
+    ? "unhide selected"
+    : restoring
+      ? "restore selected"
+      : "delete selected";
   return (
     <div className="bulk-bar">
       <div className="tabs">
@@ -86,20 +93,39 @@ export function JobBulkActions({
       <span className="meta">
         {selectedCount ? `${selectedCount} selected` : "select jobs to manage"}
       </span>
-      <button className="tab" type="button" disabled={!hasItems} onClick={onSelectPage}>
+      <button
+        className="tab"
+        type="button"
+        disabled={!hasItems}
+        onClick={onSelectPage}
+      >
         select page
       </button>
-      <button className="tab" type="button" disabled={!hasAnyMatching} onClick={onSelectAllMatching}>
+      <button
+        className="tab"
+        type="button"
+        disabled={!hasAnyMatching || hasLocalFilters}
+        onClick={onSelectAllMatching}
+      >
         select all matching
       </button>
-      <button className="tab" type="button" disabled={!selectedCount} onClick={onClearSelection}>
+      <button
+        className="tab"
+        type="button"
+        disabled={!selectedCount}
+        onClick={onClearSelection}
+      >
         clear selected
       </button>
       {staleCount || selectedStaleKeys.length ? (
         <ResetStaleScoresButton
           jobKeys={selectedStaleKeys}
           staleCount={selectedStaleKeys.length || staleCount}
-          label={selectedStaleKeys.length ? "reset stale selected" : "reset all stale scores"}
+          label={
+            selectedStaleKeys.length
+              ? "reset stale selected"
+              : "reset all stale scores"
+          }
           onSuccess={onResetStaleSuccess}
         />
       ) : null}
@@ -136,7 +162,7 @@ export function JobBulkActions({
           <button
             className="tab"
             type="button"
-            disabled={!hasAnyMatching || loading}
+            disabled={!hasAnyMatching || hasLocalFilters || loading}
             onClick={onRetryAllFailed}
           >
             retry all failed

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -7,9 +7,14 @@ import type {
 } from "../../contexts/operations/types.js";
 import {
   FilterableDataGrid,
+  type DataGridFilterState,
   type DataGridSortState,
 } from "../../shared/ui/filterable-data-grid.js";
 import { jobColumns } from "./columns.js";
+
+const EMPTY_FILTERS: DataGridFilterState = {};
+const noopFiltersChange = () => {};
+const noopVisiblePageRowsChange = () => {};
 
 export interface JobsTableProps {
   data: PaginatedResponse<JobSummary> | null;
@@ -24,6 +29,9 @@ export interface JobsTableProps {
   onPageChange: (page: number) => void;
   onPageSizeChange: (pageSize: number) => void;
   onOpenJob: (jobKey: string) => void;
+  filters?: DataGridFilterState;
+  onFiltersChange?: (next: DataGridFilterState) => void;
+  onVisiblePageRowsChange?: (rows: readonly JobSummary[]) => void;
 }
 
 export function JobsTable({
@@ -39,6 +47,9 @@ export function JobsTable({
   onPageChange,
   onPageSizeChange,
   onOpenJob,
+  filters = EMPTY_FILTERS,
+  onFiltersChange = noopFiltersChange,
+  onVisiblePageRowsChange = noopVisiblePageRowsChange,
 }: JobsTableProps) {
   const [selectionAnchorJobKey, setSelectionAnchorJobKey] = useState<
     string | null
@@ -92,11 +103,14 @@ export function JobsTable({
       sort={gridSort}
       onSortChange={handleSortChange}
       manualSorting
+      filters={filters}
+      onFiltersChange={onFiltersChange}
       tableClassName="jobs-data-grid-table"
       rowAriaSelected={(row) =>
         allMatchingSelected || Boolean(rowSelection[row.jobKey])
       }
       onRowActivate={(row) => onOpenJob(row.jobKey)}
+      onPageRowsChange={onVisiblePageRowsChange}
       pagination={{
         page,
         pageSize,

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -18,7 +18,11 @@ import { userEvent } from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { jobsSearchSchema } from "../../routes/-jobs.search.js";
-import { makeJobsPage, sampleJob } from "../../test/fixtures/projections.js";
+import {
+  makeJobsPage,
+  sampleJob,
+  sampleSecondaryJob,
+} from "../../test/fixtures/projections.js";
 import { server } from "../../test/msw/server.js";
 import { buildProviderHarness } from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
@@ -242,6 +246,70 @@ describe("<JobsView> bulk delete integration", () => {
     for (const checkbox of rowCheckboxes) {
       expect(checkbox).toBeChecked();
     }
+  });
+
+  it("does not let page-local table filters drive unbounded bulk deletes", async () => {
+    const user = userEvent.setup();
+    const vonageJob: JobSummary = {
+      ...sampleJob,
+      jobKey: "vonage-1",
+      title: "Engineering Manager",
+      company: "Vonage",
+      source: "Greenhouse",
+      discoverySource: "greenhouse:vonage",
+      postingSource: "greenhouse:vonage",
+    };
+    const acaiJob: JobSummary = {
+      ...sampleSecondaryJob,
+      jobKey: "acai-1",
+      title: "Software Engineer (India)",
+      company: "Acai",
+      source: "Ashby",
+      discoverySource: "ashby:acai",
+      postingSource: "ashby:acai",
+    };
+    const jobs = vi.fn(async () => makeJobsPage([vonageJob, acaiJob]));
+    const deleteJobs = vi.fn(async (body: BulkJobMutationRequest) => ({
+      ok: true as const,
+      count: body.jobKeys.length,
+      jobKeys: body.jobKeys,
+    }));
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { jobs, deleteJobs } }),
+    });
+    const { router, Wrapper } = buildRouter(harness);
+
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    expect(await screen.findByText("Engineering Manager")).toBeInTheDocument();
+    expect(screen.getByText("Software Engineer (India)")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /filter sources column/i }),
+    );
+    await user.type(screen.getByLabelText("Sources filter text"), "vonage");
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Software Engineer (India)"),
+      ).not.toBeInTheDocument(),
+    );
+    await user.keyboard("{Escape}");
+    expect(
+      screen.getByRole("button", { name: /select all matching/i }),
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /select page/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/1 selected/i)).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: /delete selected/i }));
+
+    await waitFor(() => expect(deleteJobs).toHaveBeenCalledTimes(1));
+    expect(deleteJobs.mock.calls[0]?.[0]).toMatchObject({
+      allMatching: false,
+      jobKeys: ["vonage-1"],
+    });
   });
 
   it("selects rows via checkbox, clicks delete, confirms, and posts to /v1/jobs/bulk-delete", async () => {

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -2,11 +2,12 @@ import {
   type BulkJobMutationRequest,
   type JobMutationResponse,
   type JobSortField,
+  type JobSummary,
 } from "@jobhunter/contracts";
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/useDeleteJobsBulkMutation.js";
 import { useHideJobsBulkMutation } from "../../contexts/discovery/hooks/useHideJobsBulkMutation.js";
@@ -17,6 +18,10 @@ import { useJobsListQuery } from "../../contexts/operations/hooks/useJobsListQue
 import { useRetryFailedJobsMutation } from "../../contexts/pipeline/hooks/useRetryFailedJobsMutation.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
+import {
+  hasActiveDataGridFilters,
+  type DataGridFilterState,
+} from "../../shared/ui/filterable-data-grid.js";
 import { JobBulkActions } from "./JobBulkActions.js";
 import { JobFilterBar } from "./JobFilterBar.js";
 import { JobsTable } from "./JobsTable.js";
@@ -42,6 +47,16 @@ function isJobSortField(value: string): value is JobSortField {
   return SORTABLE_JOB_FIELDS.has(value as JobSortField);
 }
 
+function sameKeys(
+  current: readonly string[],
+  next: readonly string[],
+): boolean {
+  return (
+    current.length === next.length &&
+    current.every((jobKey, index) => jobKey === next[index])
+  );
+}
+
 export function JobsView() {
   const search = useSearch({ from: "/jobs" });
   const navigate = useNavigate({ from: "/jobs" });
@@ -57,6 +72,9 @@ export function JobsView() {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [allMatchingSelected, setAllMatchingSelected] = useState(false);
+  const [tableFilters, setTableFilters] = useState<DataGridFilterState>({});
+  const [visiblePageKeys, setVisiblePageKeys] = useState<string[]>([]);
+  const hasLocalFilters = hasActiveDataGridFilters(tableFilters);
 
   useEffect(() => {
     setRowSelection({});
@@ -73,6 +91,10 @@ export function JobsView() {
     search.minFitScore,
     search.maxFitScore,
   ]);
+  useEffect(() => {
+    setRowSelection({});
+    setAllMatchingSelected(false);
+  }, [tableFilters]);
 
   const setSearch = (next: Partial<JobsSearch>) => {
     void navigate({ search: (prev: JobsSearch) => ({ ...prev, ...next }) });
@@ -134,13 +156,21 @@ export function JobsView() {
 
   const selectPage = () => {
     setAllMatchingSelected(false);
-    const items = data?.items ?? [];
     const next: RowSelectionState = {};
-    for (const job of items) {
-      next[job.jobKey] = true;
+    for (const jobKey of visiblePageKeys) {
+      next[jobKey] = true;
     }
     setRowSelection(next);
   };
+  const handleVisiblePageRowsChange = useCallback(
+    (rows: readonly JobSummary[]) => {
+      const next = rows.map((row) => row.jobKey);
+      setVisiblePageKeys((current) =>
+        sameKeys(current, next) ? current : next,
+      );
+    },
+    [],
+  );
 
   const restoring = search.deleted === "deleted";
   const hidden = search.deleted === "hidden";
@@ -266,8 +296,9 @@ export function JobsView() {
           selectedJobKeys={allMatchingSelected ? [] : selectedKeys}
           staleCount={staleKeysOnPage.length}
           selectedStaleKeys={selectedStaleKeys}
-          hasItems={Boolean(data?.items.length)}
+          hasItems={visiblePageKeys.length > 0}
           hasAnyMatching={Boolean(data?.pagination.total)}
+          hasLocalFilters={hasLocalFilters}
           loading={mutateBusy || isFetching}
           onSetDeleted={(deleted) => setSearch({ deleted, page: 1 })}
           onSelectPage={selectPage}
@@ -294,6 +325,9 @@ export function JobsView() {
           onPageChange={(page) => setSearch({ page })}
           onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
           onOpenJob={openJob}
+          filters={tableFilters}
+          onFiltersChange={setTableFilters}
+          onVisiblePageRowsChange={handleVisiblePageRowsChange}
         />
       </section>
       <Outlet />


### PR DESCRIPTION
## What changed
- Tracks the Jobs table's active page-local filters in `JobsView`.
- Disables unbounded all-matching bulk actions while those page-local filters are active.
- Makes `select page` operate on the table rows currently visible after local filtering.
- Adds a regression test for the source-column filter plus bulk-delete workflow.

## Root cause
Jobs column filters were local to `FilterableDataGrid`, while Jobs bulk actions built all-matching requests only from URL/server filters. Filtering the Sources column to values like `vonage` changed what the user saw, but `select all matching` still targeted the broader server result set. `select page` also used the unfiltered server page, so rows hidden by a local column filter could be selected.

## Validation
- `pnpm --filter @jobhunter/web test -- JobsView.test.tsx` - 108 files passed, 565 tests passed.
- `pnpm web:check` - passed.
- `pnpm web:build` - passed.
- `git diff --check` - passed.
- Browser QA on `http://localhost:5173/jobs?...deleted=deleted...`: with `Sources contains "vonage"`, `select all matching` was disabled and `select page` selected 5 visible rows out of 5 visible rows.