### PR TITLE
feat: add apply review outcome foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,12 @@ agent needs to click through to the employer form. The default model is
 `default`, which lets Claude Code use its configured local model; pass
 `--model <name>` only when you want to override that local default.
 
+The local API also records apply-review decisions and application outcomes.
+`approve_submit` is an approval fact only in this foundation slice; it does not
+start browser submission by itself. Manual outcomes can include local notes in
+SQLite, but event payloads contain only safe identifiers, outcome kinds, and
+presence flags.
+
 Applications that send verification codes by email use JobHunter's first-party,
 read-only Gmail connector. Put a Google OAuth Desktop client file at
 `~/.jobhunter/gmail/oauth-client.json`, then authenticate once:

--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -317,9 +317,12 @@ export function listApplicationOutcomes(
 export function listJobApplicationOutcomes(
   db: SqliteDatabase,
   jobKey: string,
-): JobApplicationOutcomeListResponse {
+): JobApplicationOutcomeListResponse | null {
   ensureApplicationFeedbackTables(db);
-  const jobUrl = existingJobUrl(db, jobKey);
+  const jobUrl = resolveJobUrl(db, jobKey);
+  if (!jobUrl) {
+    return null;
+  }
   return {
     ok: true,
     jobKey: jobUrl,
@@ -356,6 +359,13 @@ export function decideOutcomeSuggestion(
   const existing = getSuggestionRow(db, suggestionId);
   if (!existing) {
     throw new InputError("Outcome suggestion not found.");
+  }
+  if (existing.status !== "pending") {
+    return {
+      ok: true,
+      suggestion: suggestionFromRow(existing),
+      outcome: existing.decided_outcome_id ? readOutcome(db, existing.decided_outcome_id) : null,
+    };
   }
   const decidedAt = new Date().toISOString();
   let outcome: ApplicationOutcome | null = null;
@@ -503,6 +513,18 @@ function readOutcomes(db: SqliteDatabase, jobKey?: string): ApplicationOutcome[]
      ORDER BY occurred_at DESC, recorded_at DESC, outcome_id DESC`,
     params,
   ).map(outcomeFromRow);
+}
+
+function readOutcome(db: SqliteDatabase, outcomeId: string): ApplicationOutcome | null {
+  const row = getRow<OutcomeRow>(
+    db,
+    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
+            recorded_at, suggestion_id, evidence_id
+     FROM application_outcomes
+     WHERE tenant_id = ? AND outcome_id = ?`,
+    [DEFAULT_TENANT, outcomeId],
+  );
+  return row ? outcomeFromRow(row) : null;
 }
 
 function readSuggestions(db: SqliteDatabase, jobKey?: string): OutcomeSuggestion[] {

--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1,0 +1,709 @@
+import crypto from "node:crypto";
+
+import type {
+  ApplicationOutcome,
+  ApplicationOutcomeKind,
+  ApplicationOutcomeListResponse,
+  ApplicationOutcomeSource,
+  ApplicationOutcomeWriteResponse,
+  ApplyReviewDecision,
+  ApplyReviewDecisionRequest,
+  ApplyReviewDecisionResponse,
+  ApplyReviewDecisionValue,
+  ApplyReviewQueueItem,
+  ApplyReviewQueueResponse,
+  JobApplicationOutcomeListResponse,
+  ManualApplicationOutcomeRequest,
+  OutcomeSuggestion,
+  OutcomeSuggestionDecisionRequest,
+  OutcomeSuggestionDecisionResponse,
+  OutcomeSuggestionStatus,
+  Stage,
+  StageState,
+} from "./contracts.js";
+import {
+  APPLICATION_OUTCOME_KINDS,
+  APPLY_REVIEW_DECISION_VALUES,
+  OUTCOME_SUGGESTION_STATUSES,
+  STAGES,
+  STAGE_STATES,
+} from "./contracts.js";
+import { allRows, getRow, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import { refreshProjections } from "./projections.js";
+import { InputError, resolveJobUrl } from "./write-model.js";
+
+const DEFAULT_TENANT = "local";
+const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
+
+interface ReviewQueueRow extends Record<string, unknown> {
+  job_id: string;
+  title: string;
+  employer: string;
+  source: string;
+  application_url: string | null;
+  fit_score: number | null;
+  current_stage: string;
+  current_state: string;
+  current_error_code: string | null;
+  current_error_message: string | null;
+  has_resume: number;
+  has_cover_letter: number;
+  has_pdf: number;
+  decision_id: string | null;
+  decision: string | null;
+  decided_at: string | null;
+  run_id: string | null;
+  apply_run_status: string | null;
+  result: string | null;
+  dry_run: number | null;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+interface OutcomeRow extends Record<string, unknown> {
+  outcome_id: string;
+  job_key: string;
+  kind: string;
+  source: string;
+  note: string | null;
+  occurred_at: string;
+  recorded_at: string;
+  suggestion_id: string | null;
+  evidence_id: string | null;
+}
+
+interface SuggestionRow extends Record<string, unknown> {
+  suggestion_id: string;
+  job_key: string;
+  evidence_id: string | null;
+  suggested_kind: string;
+  confidence: number;
+  rationale: string;
+  status: string;
+  created_at: string;
+  decided_at: string | null;
+  decision_reason: string | null;
+  decided_outcome_id: string | null;
+}
+
+export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS application_review_decisions (
+      tenant_id    TEXT NOT NULL DEFAULT 'local',
+      decision_id  TEXT NOT NULL,
+      job_key      TEXT NOT NULL,
+      decision     TEXT NOT NULL,
+      reason       TEXT,
+      decided_by   TEXT NOT NULL DEFAULT 'user',
+      decided_at   TEXT NOT NULL,
+      PRIMARY KEY (tenant_id, decision_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+      ON application_review_decisions(tenant_id, job_key, decided_at DESC);
+
+    CREATE TABLE IF NOT EXISTS application_outcomes (
+      tenant_id     TEXT NOT NULL DEFAULT 'local',
+      outcome_id    TEXT NOT NULL,
+      job_key       TEXT NOT NULL,
+      kind          TEXT NOT NULL,
+      source        TEXT NOT NULL,
+      note          TEXT,
+      occurred_at   TEXT NOT NULL,
+      recorded_at   TEXT NOT NULL,
+      suggestion_id TEXT,
+      evidence_id   TEXT,
+      created_by    TEXT NOT NULL DEFAULT 'user',
+      PRIMARY KEY (tenant_id, outcome_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
+      ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
+
+    CREATE TABLE IF NOT EXISTS application_email_evidence (
+      tenant_id            TEXT NOT NULL DEFAULT 'local',
+      evidence_id          TEXT NOT NULL,
+      job_key              TEXT NOT NULL,
+      provider             TEXT NOT NULL DEFAULT 'gmail',
+      provider_message_id  TEXT NOT NULL,
+      provider_thread_id   TEXT,
+      from_address         TEXT,
+      to_addresses_json    TEXT NOT NULL DEFAULT '[]',
+      subject              TEXT,
+      snippet              TEXT,
+      received_at          TEXT,
+      linked_at            TEXT NOT NULL,
+      link_confidence      REAL NOT NULL DEFAULT 0,
+      link_signals_json    TEXT NOT NULL DEFAULT '[]',
+      body_text            TEXT,
+      body_sha256          TEXT,
+      body_stored_at       TEXT,
+      PRIMARY KEY (tenant_id, evidence_id),
+      UNIQUE (tenant_id, provider, provider_message_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
+      ON application_email_evidence(tenant_id, job_key, received_at DESC);
+
+    CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
+      tenant_id          TEXT NOT NULL DEFAULT 'local',
+      suggestion_id      TEXT NOT NULL,
+      job_key            TEXT NOT NULL,
+      evidence_id        TEXT,
+      suggested_kind     TEXT NOT NULL,
+      confidence         REAL NOT NULL DEFAULT 0,
+      rationale          TEXT NOT NULL DEFAULT '',
+      status             TEXT NOT NULL DEFAULT 'pending',
+      created_at         TEXT NOT NULL,
+      decided_at         TEXT,
+      decision           TEXT,
+      decision_reason    TEXT,
+      decided_outcome_id TEXT,
+      PRIMARY KEY (tenant_id, suggestion_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
+      ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
+      ON application_outcome_suggestions(tenant_id, status, created_at DESC);
+  `);
+}
+
+export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueResponse {
+  ensureApplicationFeedbackTables(db);
+  refreshProjections(db);
+
+  const hiddenWhere = tableExists(db, "jobhunter_hidden_jobs")
+    ? `AND NOT EXISTS (
+         SELECT 1 FROM jobhunter_hidden_jobs h
+         WHERE h.job_url = jlp.job_id AND h.unhidden_at IS NULL
+       )`
+    : "";
+  const closedWhere = tableExists(db, "posting_snapshot_sets")
+    ? `AND NOT EXISTS (
+         SELECT 1 FROM posting_snapshot_sets pss
+         WHERE pss.job_url = jlp.job_id
+           AND pss.latest_active_state IN (${CLOSED_ACTIVE_STATES.map(() => "?").join(", ")})
+       )`
+    : "";
+  const closedParams = tableExists(db, "posting_snapshot_sets") ? CLOSED_ACTIVE_STATES : [];
+  const rows = allRows<ReviewQueueRow>(
+    db,
+    `
+    WITH latest_decision AS (
+      SELECT decision_id, job_key, decision, decided_at
+      FROM (
+        SELECT decision_id, job_key, decision, decided_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY tenant_id, job_key
+                 ORDER BY decided_at DESC, decision_id DESC
+               ) AS row_num
+        FROM application_review_decisions
+        WHERE tenant_id = ?
+      )
+      WHERE row_num = 1
+    ),
+    latest_apply_run AS (
+      SELECT run_id, job_id, status, result, dry_run, started_at, finished_at
+      FROM (
+        SELECT run_id, job_id, status, result, dry_run, started_at, finished_at,
+               ROW_NUMBER() OVER (
+                 PARTITION BY tenant_id, job_id
+                 ORDER BY COALESCE(started_at, finished_at, '') DESC, run_id DESC
+               ) AS row_num
+        FROM apply_run_projections
+        WHERE tenant_id = ?
+      )
+      WHERE row_num = 1
+    )
+    SELECT jlp.job_id, jlp.title, jlp.employer, jlp.source, jlp.application_url,
+           jlp.fit_score, jlp.current_stage, jlp.current_state,
+           jlp.current_error_code, jlp.current_error_message,
+           jlp.has_resume, jlp.has_cover_letter, jlp.has_pdf,
+           latest_decision.decision_id, latest_decision.decision,
+           latest_decision.decided_at,
+           latest_apply_run.run_id, latest_apply_run.status AS apply_run_status,
+           latest_apply_run.result, latest_apply_run.dry_run,
+           latest_apply_run.started_at, latest_apply_run.finished_at
+    FROM job_list_projections jlp
+    LEFT JOIN latest_decision ON latest_decision.job_key = jlp.job_id
+    LEFT JOIN latest_apply_run ON latest_apply_run.job_id = jlp.job_id
+    WHERE jlp.tenant_id = ?
+      AND jlp.deleted_at IS NULL
+      ${hiddenWhere}
+      ${closedWhere}
+      AND COALESCE(jlp.apply_status, '') != 'applied'
+      AND jlp.current_stage = 'apply'
+      AND jlp.current_state IN ('pending', 'blocked', 'failed', 'stale')
+      AND (
+        jlp.has_resume = 1
+        OR jlp.application_url IS NOT NULL
+        OR jlp.fit_score IS NOT NULL
+      )
+      AND COALESCE(latest_decision.decision, '') NOT IN ('defer', 'decline')
+    ORDER BY
+      CASE COALESCE(latest_decision.decision, '')
+        WHEN 'approve_submit' THEN 0
+        WHEN 'approve_dry_run' THEN 1
+        ELSE 2
+      END,
+      jlp.fit_score DESC,
+      jlp.title ASC
+    `,
+    [DEFAULT_TENANT, DEFAULT_TENANT, DEFAULT_TENANT, ...closedParams],
+  );
+
+  return {
+    ok: true,
+    items: rows.map(reviewQueueItemFromRow),
+  };
+}
+
+export function recordApplyReviewDecision(
+  db: SqliteDatabase,
+  jobKey: string,
+  request: ApplyReviewDecisionRequest,
+): ApplyReviewDecisionResponse {
+  ensureApplicationFeedbackTables(db);
+  const jobUrl = existingJobUrl(db, jobKey);
+  const decidedAt = new Date().toISOString();
+  const decision: ApplyReviewDecision = {
+    decisionId: crypto.randomUUID(),
+    jobKey: jobUrl,
+    decision: request.decision,
+    reason: request.reason ?? null,
+    decidedBy: request.decidedBy,
+    decidedAt,
+  };
+
+  db.prepare(
+    `INSERT INTO application_review_decisions (
+       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    decision.decisionId,
+    decision.jobKey,
+    decision.decision,
+    decision.reason,
+    decision.decidedBy,
+    decision.decidedAt,
+  );
+
+  recordEvent(db, {
+    eventType: "ApplyReviewDecisionRecorded",
+    jobUrl,
+    stage: "apply",
+    message: "Apply review decision recorded.",
+    payload: {
+      tenantId: DEFAULT_TENANT,
+      jobKey: jobUrl,
+      decisionId: decision.decisionId,
+      decision: decision.decision,
+      reasonPresent: Boolean(decision.reason),
+    },
+  });
+
+  return { ok: true, decision };
+}
+
+export function listApplicationOutcomes(
+  db: SqliteDatabase,
+): ApplicationOutcomeListResponse {
+  ensureApplicationFeedbackTables(db);
+  return {
+    ok: true,
+    outcomes: readOutcomes(db),
+    suggestions: readSuggestions(db),
+  };
+}
+
+export function listJobApplicationOutcomes(
+  db: SqliteDatabase,
+  jobKey: string,
+): JobApplicationOutcomeListResponse {
+  ensureApplicationFeedbackTables(db);
+  const jobUrl = existingJobUrl(db, jobKey);
+  return {
+    ok: true,
+    jobKey: jobUrl,
+    outcomes: readOutcomes(db, jobUrl),
+    suggestions: readSuggestions(db, jobUrl),
+  };
+}
+
+export function recordManualApplicationOutcome(
+  db: SqliteDatabase,
+  jobKey: string,
+  request: ManualApplicationOutcomeRequest,
+): ApplicationOutcomeWriteResponse {
+  ensureApplicationFeedbackTables(db);
+  const jobUrl = existingJobUrl(db, jobKey);
+  const outcome = insertOutcome(db, {
+    jobKey: jobUrl,
+    kind: request.kind,
+    source: "manual",
+    note: request.note ?? null,
+    occurredAt: request.occurredAt ?? new Date().toISOString(),
+    suggestionId: null,
+    evidenceId: null,
+  });
+  return { ok: true, outcome };
+}
+
+export function decideOutcomeSuggestion(
+  db: SqliteDatabase,
+  suggestionId: string,
+  request: OutcomeSuggestionDecisionRequest,
+): OutcomeSuggestionDecisionResponse {
+  ensureApplicationFeedbackTables(db);
+  const existing = getSuggestionRow(db, suggestionId);
+  if (!existing) {
+    throw new InputError("Outcome suggestion not found.");
+  }
+  const decidedAt = new Date().toISOString();
+  let outcome: ApplicationOutcome | null = null;
+
+  const write = db.transaction(() => {
+    if (request.decision === "accept" || request.decision === "correct") {
+      const kind =
+        request.decision === "correct"
+          ? (request.outcomeKind as ApplicationOutcomeKind)
+          : outcomeKind(existing.suggested_kind);
+      outcome = insertOutcome(db, {
+        jobKey: existing.job_key,
+        kind,
+        source: "email_suggestion",
+        note: request.note ?? null,
+        occurredAt: request.occurredAt ?? decidedAt,
+        suggestionId: existing.suggestion_id,
+        evidenceId: existing.evidence_id,
+      });
+    }
+
+    db.prepare(
+      `UPDATE application_outcome_suggestions
+       SET status = ?,
+           decision = ?,
+           decided_at = ?,
+           decision_reason = ?,
+           decided_outcome_id = ?
+       WHERE tenant_id = ? AND suggestion_id = ?`,
+    ).run(
+      suggestionStatusForDecision(request.decision),
+      request.decision,
+      decidedAt,
+      request.reason ?? null,
+      outcome?.outcomeId ?? null,
+      DEFAULT_TENANT,
+      existing.suggestion_id,
+    );
+
+    recordEvent(db, {
+      eventType: "OutcomeSuggestionDecided",
+      jobUrl: existing.job_key,
+      stage: "apply",
+      message: "Application outcome suggestion decision recorded.",
+      payload: {
+        tenantId: DEFAULT_TENANT,
+        jobKey: existing.job_key,
+        suggestionId: existing.suggestion_id,
+        evidenceId: existing.evidence_id,
+        decision: request.decision,
+        outcomeId: outcome?.outcomeId ?? null,
+        outcomeKind: outcome?.kind ?? null,
+        notePresent: Boolean(request.note),
+        reasonPresent: Boolean(request.reason),
+      },
+    });
+  });
+  write();
+
+  const suggestion = getSuggestionRow(db, suggestionId);
+  if (!suggestion) {
+    throw new InputError("Outcome suggestion not found.");
+  }
+  return {
+    ok: true,
+    suggestion: suggestionFromRow(suggestion),
+    outcome,
+  };
+}
+
+function insertOutcome(
+  db: SqliteDatabase,
+  input: {
+    jobKey: string;
+    kind: ApplicationOutcomeKind;
+    source: ApplicationOutcomeSource;
+    note: string | null;
+    occurredAt: string;
+    suggestionId: string | null;
+    evidenceId: string | null;
+  },
+): ApplicationOutcome {
+  const recordedAt = new Date().toISOString();
+  const outcome: ApplicationOutcome = {
+    outcomeId: crypto.randomUUID(),
+    jobKey: input.jobKey,
+    kind: input.kind,
+    source: input.source,
+    note: input.note,
+    occurredAt: input.occurredAt,
+    recordedAt,
+    suggestionId: input.suggestionId,
+    evidenceId: input.evidenceId,
+  };
+
+  db.prepare(
+    `INSERT INTO application_outcomes (
+       tenant_id, outcome_id, job_key, kind, source, note, occurred_at,
+       recorded_at, suggestion_id, evidence_id, created_by
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    DEFAULT_TENANT,
+    outcome.outcomeId,
+    outcome.jobKey,
+    outcome.kind,
+    outcome.source,
+    outcome.note,
+    outcome.occurredAt,
+    outcome.recordedAt,
+    outcome.suggestionId,
+    outcome.evidenceId,
+    "user",
+  );
+
+  recordEvent(db, {
+    eventType: "ApplicationOutcomeRecorded",
+    jobUrl: outcome.jobKey,
+    stage: "apply",
+    message: "Application outcome recorded.",
+    payload: {
+      tenantId: DEFAULT_TENANT,
+      jobKey: outcome.jobKey,
+      outcomeId: outcome.outcomeId,
+      kind: outcome.kind,
+      source: outcome.source,
+      occurredAt: outcome.occurredAt,
+      suggestionId: outcome.suggestionId,
+      evidenceId: outcome.evidenceId,
+      notePresent: Boolean(outcome.note),
+    },
+  });
+
+  return outcome;
+}
+
+function readOutcomes(db: SqliteDatabase, jobKey?: string): ApplicationOutcome[] {
+  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
+  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+  return allRows<OutcomeRow>(
+    db,
+    `SELECT outcome_id, job_key, kind, source, note, occurred_at,
+            recorded_at, suggestion_id, evidence_id
+     FROM application_outcomes
+     ${where}
+     ORDER BY occurred_at DESC, recorded_at DESC, outcome_id DESC`,
+    params,
+  ).map(outcomeFromRow);
+}
+
+function readSuggestions(db: SqliteDatabase, jobKey?: string): OutcomeSuggestion[] {
+  const where = jobKey ? "WHERE tenant_id = ? AND job_key = ?" : "WHERE tenant_id = ?";
+  const params = jobKey ? [DEFAULT_TENANT, jobKey] : [DEFAULT_TENANT];
+  return allRows<SuggestionRow>(
+    db,
+    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
+            rationale, status, created_at, decided_at, decision_reason,
+            decided_outcome_id
+     FROM application_outcome_suggestions
+     ${where}
+     ORDER BY created_at DESC, suggestion_id DESC`,
+    params,
+  ).map(suggestionFromRow);
+}
+
+function getSuggestionRow(db: SqliteDatabase, suggestionId: string): SuggestionRow | undefined {
+  return getRow<SuggestionRow>(
+    db,
+    `SELECT suggestion_id, job_key, evidence_id, suggested_kind, confidence,
+            rationale, status, created_at, decided_at, decision_reason,
+            decided_outcome_id
+     FROM application_outcome_suggestions
+     WHERE tenant_id = ? AND suggestion_id = ?`,
+    [DEFAULT_TENANT, suggestionId],
+  );
+}
+
+function reviewQueueItemFromRow(row: ReviewQueueRow): ApplyReviewQueueItem {
+  const currentState = stageState(row.current_state);
+  const blockers = queueBlockers(row, currentState);
+  return {
+    jobKey: row.job_id,
+    title: row.title || "Untitled",
+    company: row.employer || "Unknown company",
+    source: row.source || "unknown",
+    fitScore: nullableNumber(row.fit_score),
+    applicationUrl: row.application_url,
+    currentStage: stage(row.current_stage),
+    currentState,
+    materials: {
+      hasResume: Boolean(row.has_resume),
+      hasCoverLetter: Boolean(row.has_cover_letter),
+      hasPdf: Boolean(row.has_pdf),
+      ready: Boolean(row.has_resume),
+    },
+    latestApplyRun: row.run_id
+      ? {
+          runId: row.run_id,
+          status: row.apply_run_status ?? "",
+          result: row.result,
+          dryRun: Boolean(row.dry_run),
+          startedAt: row.started_at,
+          finishedAt: row.finished_at,
+        }
+      : null,
+    review: {
+      state: reviewState(row.decision),
+      decision: reviewDecision(row.decision),
+      decidedAt: row.decided_at,
+    },
+    blockers,
+  };
+}
+
+function queueBlockers(row: ReviewQueueRow, currentState: StageState): string[] {
+  const blockers: string[] = [];
+  if (!row.has_resume) blockers.push("missing_resume");
+  if (!row.application_url) blockers.push("missing_application_url");
+  if (currentState !== "pending") {
+    blockers.push(row.current_error_code || row.current_error_message || `apply_${currentState}`);
+  }
+  return blockers;
+}
+
+function outcomeFromRow(row: OutcomeRow): ApplicationOutcome {
+  return {
+    outcomeId: row.outcome_id,
+    jobKey: row.job_key,
+    kind: outcomeKind(row.kind),
+    source: row.source === "email_suggestion" ? "email_suggestion" : "manual",
+    note: row.note,
+    occurredAt: row.occurred_at,
+    recordedAt: row.recorded_at,
+    suggestionId: row.suggestion_id,
+    evidenceId: row.evidence_id,
+  };
+}
+
+function suggestionFromRow(row: SuggestionRow): OutcomeSuggestion {
+  return {
+    suggestionId: row.suggestion_id,
+    jobKey: row.job_key,
+    evidenceId: row.evidence_id,
+    suggestedKind: outcomeKind(row.suggested_kind),
+    confidence: Number(row.confidence ?? 0),
+    rationale: row.rationale ?? "",
+    status: suggestionStatus(row.status),
+    createdAt: row.created_at,
+    decidedAt: row.decided_at,
+    decisionReason: row.decision_reason,
+    decidedOutcomeId: row.decided_outcome_id,
+  };
+}
+
+function existingJobUrl(db: SqliteDatabase, jobKey: string): string {
+  const jobUrl = resolveJobUrl(db, jobKey);
+  if (!jobUrl) {
+    throw new InputError("Job not found.");
+  }
+  return jobUrl;
+}
+
+function recordEvent(
+  db: SqliteDatabase,
+  event: {
+    eventType: string;
+    payload: Record<string, unknown>;
+    message: string;
+    jobUrl: string;
+    stage: Stage;
+  },
+): void {
+  if (!tableExists(db, "job_events")) {
+    return;
+  }
+  const columns = new Set(
+    allRows<{ name: string }>(db, "PRAGMA table_info(job_events)").map((row) => row.name),
+  );
+  const values: Record<string, SqliteValue> = {
+    job_url: event.jobUrl,
+    stage: event.stage,
+    event_type: event.eventType,
+    level: "info",
+    message: event.message,
+    occurred_at: new Date().toISOString(),
+    payload_json: JSON.stringify(event.payload),
+  };
+  const entries = Object.entries(values).filter(([name]) => columns.has(name));
+  if (!entries.length) {
+    return;
+  }
+  db.prepare(
+    `INSERT INTO job_events (${entries.map(([name]) => name).join(", ")}) VALUES (${entries.map(() => "?").join(", ")})`,
+  ).run(...entries.map(([, value]) => value));
+}
+
+function reviewState(
+  value: string | null,
+): ApplyReviewQueueItem["review"]["state"] {
+  switch (value) {
+    case "approve_submit":
+      return "approved_submit";
+    case "approve_dry_run":
+      return "approved_dry_run";
+    case "defer":
+      return "deferred";
+    case "decline":
+      return "declined";
+    default:
+      return "pending";
+  }
+}
+
+function reviewDecision(value: string | null): ApplyReviewDecisionValue | null {
+  return APPLY_REVIEW_DECISION_VALUES.includes(value as ApplyReviewDecisionValue)
+    ? (value as ApplyReviewDecisionValue)
+    : null;
+}
+
+function outcomeKind(value: string): ApplicationOutcomeKind {
+  return APPLICATION_OUTCOME_KINDS.includes(value as ApplicationOutcomeKind)
+    ? (value as ApplicationOutcomeKind)
+    : "unknown";
+}
+
+function suggestionStatus(value: string): OutcomeSuggestionStatus {
+  return OUTCOME_SUGGESTION_STATUSES.includes(value as OutcomeSuggestionStatus)
+    ? (value as OutcomeSuggestionStatus)
+    : "pending";
+}
+
+function suggestionStatusForDecision(
+  decision: OutcomeSuggestionDecisionRequest["decision"],
+): OutcomeSuggestionStatus {
+  if (decision === "accept") return "accepted";
+  if (decision === "correct") return "corrected";
+  return "ignored";
+}
+
+function stage(value: string): Stage {
+  return STAGES.includes(value as Stage) ? (value as Stage) : "apply";
+}
+
+function stageState(value: string): StageState {
+  return STAGE_STATES.includes(value as StageState) ? (value as StageState) : "pending";
+}
+
+function nullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,6 +8,7 @@ import {
   type ActionCommandPayload,
   type ActionRunResponse,
   ActivityListQuerySchema,
+  ApplyReviewDecisionRequestSchema,
   ApplyJobRequestSchema,
   ArtifactListQuerySchema,
   BulkJobMutationRequestSchema,
@@ -26,8 +27,10 @@ import {
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
   MarkJobActionRequestSchema,
+  ManualApplicationOutcomeRequestSchema,
   ManualCaptureDismissSchema,
   ManualCaptureImportSchema,
+  OutcomeSuggestionDecisionRequestSchema,
   ProfileImportRequestSchema,
   type ProfileConfigResponse,
   ProfileUpdateRequestSchema,
@@ -45,6 +48,14 @@ import {
   type Stage,
   WorkflowRunsListQuerySchema,
 } from "./contracts.js";
+import {
+  decideOutcomeSuggestion,
+  listApplicationOutcomes,
+  listApplyReviewQueue,
+  listJobApplicationOutcomes,
+  recordApplyReviewDecision,
+  recordManualApplicationOutcome,
+} from "./application-feedback.js";
 import { databaseExists, openDatabase } from "./db.js";
 import {
   decideQuarantineEntry,
@@ -430,6 +441,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     withDb(reply, options.dbPath, (db) => listJobs(db, JobListQuerySchema.parse(request.query))),
   );
 
+  app.get("/v1/apply/review-queue", async (_request, reply) =>
+    withDb(reply, options.dbPath, (db) => listApplyReviewQueue(db)),
+  );
+
+  app.get("/v1/outcomes", async (_request, reply) =>
+    withDb(reply, options.dbPath, (db) => listApplicationOutcomes(db)),
+  );
+
   app.post("/v1/jobs/bulk-delete", async (request, reply) => {
     const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});
     if (!body) {
@@ -487,6 +506,48 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
       }
       return detail;
     }),
+  );
+
+  app.post<{ Params: { jobKey: string } }>(
+    "/v1/jobs/:jobKey/apply-review/decision",
+    async (request, reply) => {
+      const body = parseBody(reply, ApplyReviewDecisionRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+      return withWritableDb(reply, options.dbPath, (db) =>
+        recordApplyReviewDecision(db, decodeRouteParam(request.params.jobKey), body),
+      );
+    },
+  );
+
+  app.get<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/outcomes", async (request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      listJobApplicationOutcomes(db, decodeRouteParam(request.params.jobKey)),
+    ),
+  );
+
+  app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/outcomes", async (request, reply) => {
+    const body = parseBody(reply, ManualApplicationOutcomeRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    return withWritableDb(reply, options.dbPath, (db) =>
+      recordManualApplicationOutcome(db, decodeRouteParam(request.params.jobKey), body),
+    );
+  });
+
+  app.post<{ Params: { suggestionId: string } }>(
+    "/v1/outcome-suggestions/:suggestionId/decision",
+    async (request, reply) => {
+      const body = parseBody(reply, OutcomeSuggestionDecisionRequestSchema, request.body ?? {});
+      if (!body) {
+        return undefined;
+      }
+      return withWritableDb(reply, options.dbPath, (db) =>
+        decideOutcomeSuggestion(db, decodeRouteParam(request.params.suggestionId), body),
+      );
+    },
   );
 
   app.post<{ Params: { jobKey: string } }>(

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -522,9 +522,14 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   );
 
   app.get<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/outcomes", async (request, reply) =>
-    withDb(reply, options.dbPath, (db) =>
-      listJobApplicationOutcomes(db, decodeRouteParam(request.params.jobKey)),
-    ),
+    withDb(reply, options.dbPath, (db) => {
+      const outcomes = listJobApplicationOutcomes(db, decodeRouteParam(request.params.jobKey));
+      if (!outcomes) {
+        void reply.code(404);
+        return { ok: false, error: "job_not_found" };
+      }
+      return outcomes;
+    }),
   );
 
   app.post<{ Params: { jobKey: string } }>("/v1/jobs/:jobKey/outcomes", async (request, reply) => {

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -180,6 +180,20 @@ describe("application feedback API", () => {
     await app.close();
   });
 
+  it("returns not found for outcome reads on missing jobs", async () => {
+    const app = buildApp(options);
+
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent("https://example.com/jobs/missing")}/outcomes`,
+    });
+
+    expect(response.statusCode, response.body).toBe(404);
+    expect(response.json()).toEqual({ ok: false, error: "job_not_found" });
+
+    await app.close();
+  });
+
   it("accepts outcome suggestions without copying raw note or email body text into events", async () => {
     seedOutcomeSuggestion(options.dbPath);
     const app = buildApp(options);
@@ -197,6 +211,7 @@ describe("application feedback API", () => {
     });
 
     expect(response.statusCode, response.body).toBe(200);
+    const acceptedOutcomeId = response.json().outcome.outcomeId;
     expect(response.json()).toMatchObject({
       ok: true,
       suggestion: {
@@ -212,10 +227,33 @@ describe("application feedback API", () => {
       },
     });
 
+    const repeated = await app.inject({
+      method: "POST",
+      url: "/v1/outcome-suggestions/suggestion-1/decision",
+      payload: {
+        decision: "accept",
+        note: "second private note must not create a second outcome",
+      },
+    });
+
+    expect(repeated.statusCode, repeated.body).toBe(200);
+    expect(repeated.json()).toMatchObject({
+      ok: true,
+      suggestion: {
+        suggestionId: "suggestion-1",
+        status: "accepted",
+        decidedOutcomeId: acceptedOutcomeId,
+      },
+      outcome: {
+        outcomeId: acceptedOutcomeId,
+      },
+    });
+
     const jobOutcomes = await app.inject({
       method: "GET",
       url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/outcomes`,
     });
+    expect(jobOutcomes.json().outcomes).toHaveLength(1);
     expect(jobOutcomes.json().suggestions).toEqual([
       expect.objectContaining({ suggestionId: "suggestion-1", status: "accepted" }),
     ]);

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -1,0 +1,465 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
+import { type ActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
+import { type BuildAppOptions, buildApp } from "../src/server.js";
+
+const READY_JOB = "https://example.com/jobs/apply-ready";
+const DRY_RUN_JOB = "https://example.com/jobs/apply-dry-run";
+const APPLIED_JOB = "https://example.com/jobs/already-applied";
+const NOW = "2026-06-01T10:00:00.000Z";
+
+let tempDir = "";
+let options: BuildAppOptions;
+let actionDispatcher: ReturnType<typeof vi.fn> & ActionDispatcher;
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-feedback-api-"));
+  actionDispatcher = vi.fn(async (): Promise<ActionDispatchResult> => ({
+    status: "queued",
+    runId: "unexpected-run",
+  })) as ReturnType<typeof vi.fn> & ActionDispatcher;
+  options = {
+    dbPath: path.join(tempDir, "jobhunter.db"),
+    profilePath: path.join(tempDir, "profile.json"),
+    resumeStylePath: path.join(tempDir, "resume_style.json"),
+    resumeTemplatePath: path.join(tempDir, "resume_template.tex"),
+    settingsPath: path.join(tempDir, "dashboard.json"),
+    actionDispatcher,
+  };
+  seedDatabase(options.dbPath);
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { force: true, recursive: true });
+});
+
+describe("application feedback API", () => {
+  it("lists only apply-review eligible jobs with readiness and latest run context", async () => {
+    const app = buildApp(options);
+
+    const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const body = response.json();
+    expect(body.items.map((item: { jobKey: string }) => item.jobKey)).toEqual([
+      READY_JOB,
+      DRY_RUN_JOB,
+    ]);
+    expect(body.items[0]).toMatchObject({
+      jobKey: READY_JOB,
+      title: "Principal Platform Engineer",
+      currentStage: "apply",
+      currentState: "pending",
+      materials: {
+        hasResume: true,
+        ready: true,
+      },
+      latestApplyRun: {
+        runId: "dry-run-ready",
+        dryRun: true,
+      },
+      review: {
+        state: "pending",
+      },
+      blockers: [],
+    });
+
+    await app.close();
+  });
+
+  it("records approve, defer, reset, and decline review decisions without dispatching apply", async () => {
+    const app = buildApp(options);
+    const readyKey = encodeURIComponent(READY_JOB);
+    const dryRunKey = encodeURIComponent(DRY_RUN_JOB);
+
+    const approve = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: { decision: "approve_submit", reason: "Looks complete." },
+    });
+    expect(approve.statusCode, approve.body).toBe(200);
+    expect(approve.json()).toMatchObject({
+      ok: true,
+      decision: {
+        jobKey: READY_JOB,
+        decision: "approve_submit",
+      },
+    });
+    expect(actionDispatcher).not.toHaveBeenCalled();
+
+    const afterApprove = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+    expect(queueItem(afterApprove.json(), READY_JOB)).toMatchObject({
+      review: { state: "approved_submit", decision: "approve_submit" },
+    });
+
+    const defer = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: { decision: "defer", reason: "Wait for salary details." },
+    });
+    expect(defer.statusCode, defer.body).toBe(200);
+    const afterDefer = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+    expect(queueItem(afterDefer.json(), READY_JOB)).toBeUndefined();
+
+    const reset = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: { decision: "reset" },
+    });
+    expect(reset.statusCode, reset.body).toBe(200);
+    const afterReset = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+    expect(queueItem(afterReset.json(), READY_JOB)).toMatchObject({
+      review: { state: "pending", decision: "reset" },
+    });
+
+    const approveDryRun = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${dryRunKey}/apply-review/decision`,
+      payload: { decision: "approve_dry_run" },
+    });
+    expect(approveDryRun.statusCode, approveDryRun.body).toBe(200);
+
+    const decline = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${dryRunKey}/apply-review/decision`,
+      payload: { decision: "decline" },
+    });
+    expect(decline.statusCode, decline.body).toBe(200);
+    const afterDecline = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+    expect(queueItem(afterDecline.json(), DRY_RUN_JOB)).toBeUndefined();
+
+    await app.close();
+  });
+
+  it("writes manual outcomes and reads job/global outcome timelines", async () => {
+    const app = buildApp(options);
+    const note = "private outcome note that should stay out of event payloads";
+
+    const write = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/outcomes`,
+      payload: {
+        kind: "interview",
+        occurredAt: "2026-06-01T11:00:00.000Z",
+        note,
+      },
+    });
+
+    expect(write.statusCode, write.body).toBe(200);
+    const outcome = write.json().outcome;
+    expect(outcome).toMatchObject({
+      jobKey: READY_JOB,
+      kind: "interview",
+      source: "manual",
+      note,
+    });
+
+    const jobOutcomes = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/outcomes`,
+    });
+    expect(jobOutcomes.statusCode, jobOutcomes.body).toBe(200);
+    expect(jobOutcomes.json()).toMatchObject({
+      ok: true,
+      jobKey: READY_JOB,
+      outcomes: [expect.objectContaining({ outcomeId: outcome.outcomeId, note })],
+    });
+
+    const allOutcomes = await app.inject({ method: "GET", url: "/v1/outcomes" });
+    expect(allOutcomes.statusCode, allOutcomes.body).toBe(200);
+    expect(allOutcomes.json().outcomes).toEqual([
+      expect.objectContaining({ outcomeId: outcome.outcomeId, jobKey: READY_JOB }),
+    ]);
+
+    expect(eventPayloadText(options.dbPath)).not.toContain(note);
+    await app.close();
+  });
+
+  it("accepts outcome suggestions without copying raw note or email body text into events", async () => {
+    seedOutcomeSuggestion(options.dbPath);
+    const app = buildApp(options);
+    const privateNote = "private accepted suggestion note";
+    const rawBody = "raw confidential email body";
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/outcome-suggestions/suggestion-1/decision",
+      payload: {
+        decision: "accept",
+        note: privateNote,
+        reason: "Confirmation looks linked.",
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(response.json()).toMatchObject({
+      ok: true,
+      suggestion: {
+        suggestionId: "suggestion-1",
+        status: "accepted",
+        decidedOutcomeId: expect.any(String),
+      },
+      outcome: {
+        jobKey: READY_JOB,
+        kind: "applied_confirmation",
+        source: "email_suggestion",
+        note: privateNote,
+      },
+    });
+
+    const jobOutcomes = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/outcomes`,
+    });
+    expect(jobOutcomes.json().suggestions).toEqual([
+      expect.objectContaining({ suggestionId: "suggestion-1", status: "accepted" }),
+    ]);
+
+    const payloads = eventPayloadText(options.dbPath);
+    expect(payloads).not.toContain(privateNote);
+    expect(payloads).not.toContain(rawBody);
+
+    await app.close();
+  });
+});
+
+function queueItem(body: unknown, jobKey: string): unknown {
+  const items = (body as { items?: Array<{ jobKey: string }> }).items ?? [];
+  return items.find((item) => item.jobKey === jobKey);
+}
+
+function seedDatabase(dbPath: string): void {
+  const resumePath = path.join(path.dirname(dbPath), "resume.txt");
+  fs.writeFileSync(resumePath, "tailored resume");
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE jobs (
+      url TEXT PRIMARY KEY,
+      title TEXT,
+      site TEXT,
+      strategy TEXT,
+      location TEXT,
+      salary TEXT,
+      discovered_at TEXT,
+      application_url TEXT,
+      description TEXT,
+      full_description TEXT,
+      detail_scraped_at TEXT,
+      detail_error TEXT,
+      fit_score INTEGER,
+      score_reasoning TEXT,
+      scored_at TEXT,
+      tailored_resume_path TEXT,
+      tailored_at TEXT,
+      tailor_attempts INTEGER,
+      cover_letter_path TEXT,
+      cover_letter_at TEXT,
+      cover_attempts INTEGER,
+      apply_status TEXT,
+      apply_error TEXT,
+      applied_at TEXT
+    );
+    CREATE TABLE job_stage_states (
+      job_url TEXT,
+      stage TEXT,
+      state TEXT,
+      attempt_count INTEGER,
+      max_attempts INTEGER,
+      started_at TEXT,
+      updated_at TEXT,
+      finished_at TEXT,
+      duration_ms INTEGER,
+      error_code TEXT,
+      error_message TEXT,
+      retryable INTEGER,
+      blocked_by_json TEXT,
+      next_action TEXT
+    );
+    CREATE TABLE job_events (
+      event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_url TEXT,
+      stage TEXT,
+      event_type TEXT NOT NULL DEFAULT '',
+      level TEXT NOT NULL DEFAULT 'info',
+      message TEXT,
+      occurred_at TEXT NOT NULL,
+      payload_json TEXT
+    );
+    CREATE TABLE apply_run_projections (
+      run_id TEXT PRIMARY KEY,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      job_id TEXT NOT NULL,
+      job_title TEXT NOT NULL DEFAULT '',
+      job_employer TEXT NOT NULL DEFAULT '',
+      status TEXT NOT NULL DEFAULT '',
+      result TEXT,
+      dry_run INTEGER NOT NULL DEFAULT 0,
+      worker_id INTEGER,
+      model TEXT,
+      started_at TEXT,
+      finished_at TEXT,
+      duration_ms INTEGER,
+      events_json TEXT NOT NULL DEFAULT '[]'
+    );
+  `);
+
+  insertJob(db, {
+    url: READY_JOB,
+    title: "Principal Platform Engineer",
+    site: "ExampleCo",
+    fitScore: 9,
+    resumePath,
+    applyState: "pending",
+  });
+  insertJob(db, {
+    url: DRY_RUN_JOB,
+    title: "Staff Backend Engineer",
+    site: "ExampleCo",
+    fitScore: 8,
+    resumePath,
+    applyState: "pending",
+  });
+  insertJob(db, {
+    url: APPLIED_JOB,
+    title: "Already Applied Engineer",
+    site: "ExampleCo",
+    fitScore: 8,
+    resumePath,
+    applyState: "succeeded",
+    appliedAt: "2026-05-31T10:00:00.000Z",
+  });
+  db.prepare(
+    `INSERT INTO apply_run_projections (
+       run_id, job_id, job_title, job_employer, status, result, dry_run, started_at, finished_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "dry-run-ready",
+    READY_JOB,
+    "Principal Platform Engineer",
+    "ExampleCo",
+    "dry_run_complete",
+    "dry_run_complete",
+    1,
+    "2026-05-31T09:00:00.000Z",
+    "2026-05-31T09:01:00.000Z",
+  );
+  db.close();
+}
+
+function insertJob(
+  db: Database.Database,
+  job: {
+    url: string;
+    title: string;
+    site: string;
+    fitScore: number;
+    resumePath: string;
+    applyState: string;
+    appliedAt?: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO jobs (
+       url, title, site, strategy, location, salary, discovered_at, application_url,
+       description, full_description, detail_scraped_at, fit_score, score_reasoning,
+       scored_at, tailored_resume_path, tailored_at, apply_status, applied_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    job.url,
+    job.title,
+    job.site,
+    "test",
+    "Remote",
+    "",
+    NOW,
+    job.url,
+    "Short description",
+    "Full description",
+    NOW,
+    job.fitScore,
+    "Strong fit.",
+    NOW,
+    job.resumePath,
+    NOW,
+    job.appliedAt ? "applied" : null,
+    job.appliedAt ?? null,
+  );
+  for (const stage of ["discover", "enrich", "score", "tailor", "cover"]) {
+    insertStage(db, job.url, stage, "succeeded");
+  }
+  insertStage(db, job.url, "apply", job.applyState);
+}
+
+function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string): void {
+  db.prepare(
+    `INSERT INTO job_stage_states (
+       job_url, stage, state, attempt_count, max_attempts, updated_at,
+       error_code, error_message, retryable, blocked_by_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(jobUrl, stage, state, 0, 3, NOW, null, null, 1, "[]");
+}
+
+function seedOutcomeSuggestion(dbPath: string): void {
+  const db = new Database(dbPath);
+  ensureApplicationFeedbackTables(db);
+  db.prepare(
+    `INSERT INTO application_email_evidence (
+       tenant_id, evidence_id, job_key, provider, provider_message_id,
+       provider_thread_id, from_address, to_addresses_json, subject, snippet,
+       received_at, linked_at, link_confidence, link_signals_json,
+       body_text, body_sha256, body_stored_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "local",
+    "evidence-1",
+    READY_JOB,
+    "gmail",
+    "gmail-message-1",
+    "gmail-thread-1",
+    "recruiting@example.com",
+    JSON.stringify(["candidate@example.com"]),
+    "Application received",
+    "Thanks for applying.",
+    "2026-06-01T09:00:00.000Z",
+    "2026-06-01T09:05:00.000Z",
+    0.94,
+    JSON.stringify(["company", "title", "time_window"]),
+    "raw confidential email body",
+    "body-sha",
+    "2026-06-01T09:05:00.000Z",
+  );
+  db.prepare(
+    `INSERT INTO application_outcome_suggestions (
+       tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+       confidence, rationale, status, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    "local",
+    "suggestion-1",
+    READY_JOB,
+    "evidence-1",
+    "applied_confirmation",
+    0.91,
+    "Gmail subject and snippet look like an application confirmation.",
+    "pending",
+    "2026-06-01T09:06:00.000Z",
+  );
+  db.close();
+}
+
+function eventPayloadText(dbPath: string): string {
+  const db = new Database(dbPath);
+  try {
+    const rows = db
+      .prepare("SELECT payload_json FROM job_events ORDER BY event_id ASC")
+      .all() as Array<{ payload_json: string | null }>;
+    return rows.map((row) => row.payload_json ?? "").join("\n");
+  } finally {
+    db.close();
+  }
+}

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -180,6 +180,38 @@ describe("application feedback API", () => {
     await app.close();
   });
 
+  it("rejects non-timestamp outcome dates before they reach event payloads", async () => {
+    seedOutcomeSuggestion(options.dbPath);
+    const app = buildApp(options);
+    const privateTimestampText = "confidential recruiter feedback in a timestamp field";
+
+    const manual = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/outcomes`,
+      payload: {
+        kind: "interview",
+        occurredAt: privateTimestampText,
+        note: "manual note",
+      },
+    });
+    expect(manual.statusCode, manual.body).toBe(400);
+
+    const suggestion = await app.inject({
+      method: "POST",
+      url: "/v1/outcome-suggestions/suggestion-1/decision",
+      payload: {
+        decision: "accept",
+        occurredAt: privateTimestampText,
+      },
+    });
+    expect(suggestion.statusCode, suggestion.body).toBe(400);
+
+    expect(eventPayloadText(options.dbPath)).not.toContain(privateTimestampText);
+    expect(eventPayloadText(options.dbPath)).not.toContain("manual note");
+
+    await app.close();
+  });
+
   it("returns not found for outcome reads on missing jobs", async () => {
     const app = buildApp(options);
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,6 +144,25 @@ used to rank people for hiring decisions, the architecture needs a separate
 governance layer for validation, bias audits, notices, adverse-impact review,
 and human-review procedures before production use.
 
+## Apply Review And Outcome Feedback
+
+The Apply Automation context now has a local feedback foundation in the
+TypeScript API. `apps/api/src/application-feedback.ts` owns idempotent SQLite
+table creation and read/write helpers for:
+
+- `application_review_decisions`: append-only user decisions for apply review.
+- `application_outcomes`: reviewed manual or suggestion-derived outcomes.
+- `application_email_evidence`: future linked Gmail evidence, including body
+  storage columns for the Gmail slice.
+- `application_outcome_suggestions`: pending and decided classifier
+  suggestions.
+
+Apply-review approval is modeled as a recorded decision, not as an automatic
+worker dispatch. Manual outcome notes are stored only in the local outcome
+table. `job_events.payload_json` receives safe summaries with identifiers,
+kinds, sources, timestamps, and presence flags; raw notes and future raw email
+bodies are not copied into domain events, projections, logs, or telemetry.
+
 ## Read-Model Projections (Phase 9)
 
 The Operations / Read-Side context maintains denormalised projection
@@ -510,9 +529,10 @@ distributed-trace propagation across the TS↔Python JSON-RPC boundary
 
 SQLite in `~/.jobhunter/jobhunter.db` is the local source of truth for jobs,
 stage states, events, artifacts, normalized Candidate Profile data, profile
-rendering settings/template text, and run visibility. The five projection
-tables (above) are also stored here. Dashboard settings remain file-backed
-until their own storage migration.
+rendering settings/template text, run visibility, apply-review decisions,
+application outcomes, linked email evidence, and outcome suggestions. The
+projection tables (above) are also stored here. Dashboard settings remain
+file-backed until their own storage migration.
 
 Generated resumes, cover letters, PDFs, logs, and imported PDFs stay on the
 local filesystem. They are registered in `job_artifacts` and

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -151,6 +151,31 @@ uses `info.workflow_id` as the timeline key). The web Workflow Runs view at
 `/runs` deep-links each row to the local Temporal Web UI
 (`http://127.0.0.1:8233`).
 
+Apply review and outcome feedback endpoints are local-first API foundations for
+later UI and Gmail ingestion work:
+
+- `GET /v1/apply/review-queue` returns active apply-stage jobs that are ready
+  or close enough for human review, plus materials readiness, latest apply-run
+  context, blockers, and latest review state.
+- `POST /v1/jobs/:jobKey/apply-review/decision` appends an
+  `approve_submit`, `approve_dry_run`, `defer`, `decline`, or `reset`
+  decision. Approval records intent only in this slice; it does not dispatch
+  the apply worker.
+- `GET /v1/outcomes` and `GET /v1/jobs/:jobKey/outcomes` return reviewed
+  outcomes and any outcome suggestions.
+- `POST /v1/jobs/:jobKey/outcomes` writes a manual reviewed outcome.
+- `POST /v1/outcome-suggestions/:suggestionId/decision` accepts, corrects, or
+  ignores a pending suggestion and writes a reviewed outcome for accepted or
+  corrected suggestions.
+
+These routes create `application_review_decisions`, `application_outcomes`,
+`application_email_evidence`, and `application_outcome_suggestions`
+idempotently in SQLite. Gmail scanning and body ingestion are not implemented
+by this API slice. Outcome notes may be stored in `application_outcomes`, and
+future linked email bodies may live in `application_email_evidence`, but
+`job_events.payload_json` stores only safe IDs, kinds, sources, timestamps, and
+note/body presence flags.
+
 `POST /v1/pipeline/actions/run-stage` starts global/batch pipeline stage runs
 from the UI. The product-facing stage order is `discover -> apply`: the stage
 trigger sends `discover` for preparation and `apply` for browser automation.

--- a/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback-design.md
+++ b/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback-design.md
@@ -1,0 +1,153 @@
+# Apply Review Queue And Outcome Feedback Design
+
+## Goal
+
+Build an end-to-end application control loop for JobHunter:
+
+```text
+ready to apply -> user review -> apply/dry-run -> email feedback -> reviewed outcome
+```
+
+The first version is local-first, Gmail-only for email feedback, and keeps user
+approval in the loop for risky actions and outcome changes.
+
+## Scope
+
+This feature adds two linked product surfaces:
+
+- **Apply review queue:** a pre-submit queue for jobs that appear ready to apply
+  but still require explicit user review before submission.
+- **Outcome tracking:** a post-apply timeline that records manual outcomes and
+  Gmail-derived outcome suggestions.
+
+Gmail feedback is read-only. Full message bodies may be ingested only after a
+message is confidently linked to a known application. Stored message bodies are
+sensitive local evidence and must not be copied into domain events, telemetry,
+logs, broad projections, or public PR content.
+
+## Domain Model
+
+### Terms
+
+**ApplyReviewItem**  
+Read-side queue item for a job whose apply prerequisites are ready or nearly
+ready. It summarizes materials readiness, score, source/apply URL confidence,
+latest dry-run result, blockers, and review state.
+
+**ApplyReviewDecision**  
+User decision on a review item: approve submit, approve dry-run, defer, decline,
+or reset review. Decisions are recorded as local events and projected back into
+the queue.
+
+**ApplicationOutcome**  
+Reviewed job-search outcome for a submitted or externally handled application:
+applied confirmation, recruiter reply, interview, assessment, rejection, offer,
+withdrawn, bounced, no response, or unknown.
+
+**ApplicationEmailEvidence**  
+Sensitive local evidence captured from Gmail after linking a message to a known
+application. It stores message identifiers, headers/snippet, received time,
+linking signals, confidence, body text, and body hash.
+
+**OutcomeSuggestion**  
+Unreviewed classifier result derived from email evidence. Suggestions never
+silently overwrite a reviewed outcome in v1.
+
+### Invariants
+
+- Auto-submit remains opt-in. A review decision can approve a submit action, but
+  the apply execution path still respects existing dry-run and explicit submit
+  controls.
+- Review decisions and outcome decisions are append-only facts. Current queue
+  state and current outcome are projections over those facts.
+- Full Gmail bodies are stored only for linked application messages.
+- Raw email bodies are never written to `job_events.payload_json`, traces, logs,
+  or dashboard summary JSON.
+- Outcome suggestions require user acceptance or correction before they become
+  application outcomes.
+- Gmail feedback uses a dedicated feedback connector surface, not the existing
+  verification-only Gmail MCP tool.
+
+## Product Flow
+
+### Apply Review Queue
+
+1. A job enters the queue when it is active, not deleted/hidden, has apply stage
+   pending/blocked/failed/stale, and has enough evidence to review.
+2. The queue row shows job, company, source, fit score, materials readiness,
+   application URL, latest apply/dry-run status, blockers, and review state.
+3. The user can approve dry-run, approve submit, defer, or decline.
+4. Approve dry-run triggers the existing apply action with `dryRun: true`.
+5. Approve submit records review approval and triggers the existing apply action
+   with `dryRun: false`.
+6. Defer and decline keep the job inspectable and remove it from active review
+   until reset.
+
+### Outcome Tracking
+
+1. Apply success, manual mark-applied, or accepted confirmation creates an
+   application anchor for email feedback.
+2. Gmail feedback scan searches bounded time windows after known application
+   anchors using recipient, employer, ATS, domain, job title/company, and apply
+   timing signals.
+3. Candidate Gmail metadata is scored for linking confidence.
+4. When confidence is high enough, JobHunter reads and stores the full body as
+   `ApplicationEmailEvidence`.
+5. A local classifier produces an `OutcomeSuggestion` with kind, confidence,
+   rationale, and evidence reference.
+6. The UI outcome review queue lets the user accept, correct, or ignore the
+   suggestion.
+7. Accepted or corrected outcomes update job detail, dashboard metrics, and the
+   outcome history.
+
+## Data Storage
+
+The local SQLite schema gains focused tables:
+
+- `application_review_decisions`: append-only review decisions by job.
+- `application_outcomes`: reviewed outcomes by job.
+- `application_email_evidence`: linked Gmail evidence with body text and hashes.
+- `application_outcome_suggestions`: unreviewed/reviewed classifier suggestions.
+
+Projection reads may be implemented directly from these tables in v1. The
+existing `job_events` stream records only safe summaries and identifiers.
+
+## API Surface
+
+- `GET /v1/apply/review-queue`
+- `POST /v1/jobs/:jobKey/apply-review/decision`
+- `GET /v1/outcomes`
+- `GET /v1/jobs/:jobKey/outcomes`
+- `POST /v1/jobs/:jobKey/outcomes`
+- `POST /v1/outcome-suggestions/:suggestionId/decision`
+- `POST /v1/outcomes/gmail/scan`
+
+All mutating routes use existing local mutation origin protections.
+
+## Frontend Surface
+
+- Add an Apply review tab/page that composes existing score, materials, pipeline,
+  and apply controls.
+- Add outcome timeline and outcome controls to job detail.
+- Add outcome suggestion review UI for Gmail-derived suggestions.
+- Add dashboard conversion metrics for reviewed outcomes and pending outcome
+  suggestions.
+
+Forms must use semantic form controls, visible labels, fieldsets for grouped
+choices, and submit buttons with concrete action labels.
+
+## Stacked PRs
+
+1. **Foundation:** contracts, schema helpers, read/write model functions, docs,
+   and API tests for review decisions and manual outcomes.
+2. **Product UI:** apply review queue UI, job detail outcome timeline, frontend
+   hooks, dashboard metrics, and component tests.
+3. **Gmail feedback:** Gmail feedback connector, message linking, body evidence
+   ingestion, outcome suggestions, worker/API integration, and focused Python +
+   API tests.
+
+## Validation
+
+Automated validation must cover API behavior, persistence, projection/read-model
+behavior, frontend hooks/components, typechecks, build, and Python Gmail feedback
+logic. Manual QA is reserved for the final human product pass.

--- a/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback-design.md
+++ b/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback-design.md
@@ -29,27 +29,27 @@ logs, broad projections, or public PR content.
 
 ### Terms
 
-**ApplyReviewItem**  
+**ApplyReviewItem**
 Read-side queue item for a job whose apply prerequisites are ready or nearly
 ready. It summarizes materials readiness, score, source/apply URL confidence,
 latest dry-run result, blockers, and review state.
 
-**ApplyReviewDecision**  
+**ApplyReviewDecision**
 User decision on a review item: approve submit, approve dry-run, defer, decline,
 or reset review. Decisions are recorded as local events and projected back into
 the queue.
 
-**ApplicationOutcome**  
+**ApplicationOutcome**
 Reviewed job-search outcome for a submitted or externally handled application:
 applied confirmation, recruiter reply, interview, assessment, rejection, offer,
 withdrawn, bounced, no response, or unknown.
 
-**ApplicationEmailEvidence**  
+**ApplicationEmailEvidence**
 Sensitive local evidence captured from Gmail after linking a message to a known
 application. It stores message identifiers, headers/snippet, received time,
 linking signals, confidence, body text, and body hash.
 
-**OutcomeSuggestion**  
+**OutcomeSuggestion**
 Unreviewed classifier result derived from email evidence. Suggestions never
 silently overwrite a reviewed outcome in v1.
 

--- a/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback.md
+++ b/docs/plans/proposed/2026-06-01-apply-review-outcome-feedback.md
@@ -1,0 +1,81 @@
+# Apply Review Queue And Outcome Feedback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a user-approved apply review queue and outcome tracking loop with Gmail-only email feedback.
+
+**Architecture:** Extend the existing Apply, Pipeline, Operations, and Profile/Gmail boundaries without introducing a new CRM context. Use local SQLite tables for review decisions, reviewed outcomes, linked email evidence, and outcome suggestions; expose typed API routes and React views over those read models. Keep raw Gmail bodies out of event payloads, telemetry, logs, and broad dashboard projections.
+
+**Tech Stack:** TypeScript contracts/API, Fastify routes, SQLite, React/TanStack Query, Vitest/RTL/MSW, Python Gmail infrastructure and pytest.
+
+---
+
+## File Map
+
+- `packages/contracts/src/schemas.ts`: add review/outcome DTOs and request schemas.
+- `packages/api-client/src/client.ts`: add client methods for review/outcome routes.
+- `apps/api/src/application-feedback.ts`: new focused persistence/read/write helpers for review decisions, outcomes, suggestions, and safe Gmail scan request handling.
+- `apps/api/src/server.ts`: register review/outcome API routes.
+- `apps/api/test/application-feedback.test.ts`: API persistence and route coverage.
+- `apps/web/src/contexts/apply/*`: review queue hooks/components.
+- `apps/web/src/contexts/pipeline/*`: approved submit/dry-run decision mutation wiring where needed.
+- `apps/web/src/contexts/operations/*`: query keys and hooks for review/outcome reads.
+- `apps/web/src/views/apply-review/*`: review queue view composer.
+- `apps/web/src/views/jobs/*`: compose outcome timeline in the job drawer.
+- `apps/web/src/routes/apply-review.tsx`: route for review queue view.
+- `workers/automation/src/jobhunter/infrastructure/gmail/feedback.py`: Gmail feedback scan, linking, body ingestion, and classification helpers.
+- `workers/automation/tests/test_gmail_feedback.py`: Gmail feedback classifier/linking tests.
+- `README.md`, `docs/local-ts-api.md`, `docs/local-reliability-qa.md`, `docs/architecture.md`, `docs/frontend-target.md`: narrow behavior/API/QA/docs updates.
+
+## Stack Strategy
+
+### PR 1: Foundation API And Manual Outcomes
+
+- [ ] Create `feat/apply-review-foundation` from `origin/main`.
+- [ ] Add schemas for `ApplicationOutcomeKind`, `ApplyReviewDecision`, `ApplicationOutcome`, `OutcomeSuggestion`, queue items, list responses, and mutation requests in `packages/contracts/src/schemas.ts`.
+- [ ] Add `apps/api/src/application-feedback.ts` with idempotent table creation, queue derivation, decision writes, manual outcome writes, outcome reads, and safe event summaries.
+- [ ] Add Fastify routes for review queue, review decision, manual outcome writes, job outcome reads, outcome list reads, and suggestion decisions.
+- [ ] Add API tests that seed jobs/materials/stage rows, verify queue eligibility, approve/defer/decline decisions, write manual outcomes, and confirm raw outcome notes are not copied into `job_events.payload_json`.
+- [ ] Update `README.md`, `docs/local-ts-api.md`, and `docs/architecture.md` with the new local review/outcome behavior.
+- [ ] Run `pnpm api:test`, `pnpm api:check`, and `git diff --check`.
+- [ ] Commit and open PR 1 as `feat: add apply review and outcome foundation`.
+
+### PR 2: Review Queue And Outcome UI
+
+- [ ] Create `feat/apply-review-ui` from PR 1.
+- [ ] Add API client methods and Operations query hooks for review queue, job outcomes, and outcome suggestions.
+- [ ] Add Apply context review queue components with semantic forms for approve dry-run, approve submit, defer, and decline.
+- [ ] Add an `apply-review` route/view and AppShell navigation entry.
+- [ ] Add job detail outcome timeline and manual outcome form.
+- [ ] Add dashboard conversion metrics and pending suggestion count using existing dashboard composition patterns.
+- [ ] Add MSW fixtures and component/hook tests for queue rendering, review decisions, manual outcome submit, and job drawer timeline.
+- [ ] Update `docs/frontend-target.md` and `docs/local-reliability-qa.md`.
+- [ ] Run `pnpm --filter @jobhunter/web test`, `pnpm web:check`, `pnpm web:build`, `pnpm api:test`, and `git diff --check`.
+- [ ] Commit and open PR 2 as `feat: surface apply review and outcome tracking`.
+
+### PR 3: Gmail Feedback Ingestion
+
+- [ ] Create `feat/gmail-outcome-feedback` from PR 2.
+- [ ] Add a Gmail feedback module separate from the verification-only MCP server. It may reuse OAuth/token loading but must expose bounded feedback-scan functions, not a general mailbox reader.
+- [ ] Implement Gmail candidate search over application anchors using recipient, sender domain, employer/ATS hints, job title/company, and post-application time windows.
+- [ ] Implement confidence scoring and only fetch full message bodies after the message is linked to a known application.
+- [ ] Store `ApplicationEmailEvidence` locally with body text and body hash; write only safe evidence identifiers into events.
+- [ ] Implement deterministic v1 classification for confirmations, recruiter replies, interviews, assessments, rejections, offers, bounces, and unknown.
+- [ ] Add API/worker route or action to run a bounded Gmail feedback scan and create outcome suggestions.
+- [ ] Add tests for no-body-before-link, linked-body-ingested, suggestion classification, duplicate Gmail message id dedupe, and no raw body in events/loggable summaries.
+- [ ] Update `README.md`, `docs/local-ts-api.md`, `docs/local-reliability-qa.md`, and `docs/architecture.md` with Gmail feedback behavior and privacy constraints.
+- [ ] Run focused Python Gmail tests, `uv --project workers/automation run --extra dev ruff check .`, `pnpm api:test`, `pnpm test`, and `git diff --check`.
+- [ ] Commit and open PR 3 as `feat: ingest Gmail feedback for application outcomes`.
+
+## Final Gate
+
+- [ ] Run the full automated validation set after PR 3: `pnpm test`, `pnpm api:check`, `pnpm web:check`, `pnpm --filter @jobhunter/web test`, `uv --project workers/automation run --extra dev ruff check .`, and `git diff --check`.
+- [ ] Run the PR review/fix loop for each stacked PR until Blocker/High findings are resolved.
+- [ ] Stop before autonomous QA execution because the user requested manual QA at the end.
+- [ ] Final report must include PR numbers, stack order, commands run with results, and any Medium/Low risks left for manual QA.
+
+## Plan Self-Review
+
+- Spec coverage: PR 1 covers durable review/outcome facts and API; PR 2 covers the user-facing review/outcome product surfaces; PR 3 covers Gmail-only linked body ingestion and suggestions.
+- Placeholder scan: no implementation step relies on an unspecified placeholder.
+- Type consistency: the plan uses `ApplyReviewDecision`, `ApplicationOutcome`, `ApplicationEmailEvidence`, and `OutcomeSuggestion` consistently with the design document.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -71,6 +71,28 @@ const optionalText = z
   .transform((value) => value ?? "");
 
 const optionalNumber = z.coerce.number().int().optional().catch(undefined);
+const IsoTimestampSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(80)
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/,
+    "Expected an ISO-8601 UTC timestamp.",
+  )
+  .refine((value) => isCanonicalizableUtcTimestamp(value), "Expected a valid UTC timestamp.")
+  .transform((value) => new Date(value).toISOString());
+
+function isCanonicalizableUtcTimestamp(value: string): boolean {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return false;
+  }
+  const normalized = value.replace(/(?:\.(\d{1,3}))?Z$/, (_match, millis: string | undefined) => {
+    return `.${(millis ?? "").padEnd(3, "0")}Z`;
+  });
+  return new Date(timestamp).toISOString() === normalized;
+}
 
 export const RetryStageRequestSchema = z
   .object({
@@ -251,7 +273,7 @@ export type ApplicationOutcomeSource = (typeof APPLICATION_OUTCOME_SOURCES)[numb
 export const ManualApplicationOutcomeRequestSchema = z
   .object({
     kind: z.enum(APPLICATION_OUTCOME_KINDS),
-    occurredAt: z.string().trim().min(1).max(80).optional(),
+    occurredAt: IsoTimestampSchema.optional(),
     note: z.string().trim().max(4000).optional(),
   })
   .strict();
@@ -317,7 +339,7 @@ export const OutcomeSuggestionDecisionRequestSchema = z
   .object({
     decision: z.enum(["accept", "correct", "ignore"]),
     outcomeKind: z.enum(APPLICATION_OUTCOME_KINDS).optional(),
-    occurredAt: z.string().trim().min(1).max(80).optional(),
+    occurredAt: IsoTimestampSchema.optional(),
     note: z.string().trim().max(4000).optional(),
     reason: z.string().trim().max(400).optional(),
   })

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -163,6 +163,189 @@ export const ApplyJobRequestSchema = z
   .strict();
 export type ApplyJobRequest = z.infer<typeof ApplyJobRequestSchema>;
 
+export const APPLY_REVIEW_DECISION_VALUES = [
+  "approve_submit",
+  "approve_dry_run",
+  "defer",
+  "decline",
+  "reset",
+] as const;
+export type ApplyReviewDecisionValue = (typeof APPLY_REVIEW_DECISION_VALUES)[number];
+
+export const ApplyReviewDecisionRequestSchema = z
+  .object({
+    decision: z.enum(APPLY_REVIEW_DECISION_VALUES),
+    reason: z.string().trim().max(400).optional(),
+    decidedBy: z.string().trim().min(1).max(120).default("user"),
+  })
+  .strict();
+export type ApplyReviewDecisionRequest = z.infer<typeof ApplyReviewDecisionRequestSchema>;
+
+export interface ApplyReviewDecision {
+  decisionId: string;
+  jobKey: string;
+  decision: ApplyReviewDecisionValue;
+  reason: string | null;
+  decidedBy: string;
+  decidedAt: string;
+}
+
+export interface ApplyReviewDecisionResponse {
+  ok: true;
+  decision: ApplyReviewDecision;
+}
+
+export interface ApplyReviewQueueItem {
+  jobKey: string;
+  title: string;
+  company: string;
+  source: string;
+  fitScore: number | null;
+  applicationUrl: string | null;
+  currentStage: Stage;
+  currentState: StageState;
+  materials: {
+    hasResume: boolean;
+    hasCoverLetter: boolean;
+    hasPdf: boolean;
+    ready: boolean;
+  };
+  latestApplyRun: {
+    runId: string;
+    status: string;
+    result: string | null;
+    dryRun: boolean;
+    startedAt: string | null;
+    finishedAt: string | null;
+  } | null;
+  review: {
+    state: "pending" | "approved_submit" | "approved_dry_run" | "deferred" | "declined";
+    decision: ApplyReviewDecisionValue | null;
+    decidedAt: string | null;
+  };
+  blockers: string[];
+}
+
+export interface ApplyReviewQueueResponse {
+  ok: true;
+  items: ApplyReviewQueueItem[];
+}
+
+export const APPLICATION_OUTCOME_KINDS = [
+  "applied_confirmation",
+  "recruiter_reply",
+  "interview",
+  "assessment",
+  "rejection",
+  "offer",
+  "withdrawn",
+  "bounced",
+  "no_response",
+  "unknown",
+] as const;
+export type ApplicationOutcomeKind = (typeof APPLICATION_OUTCOME_KINDS)[number];
+
+export const APPLICATION_OUTCOME_SOURCES = ["manual", "email_suggestion"] as const;
+export type ApplicationOutcomeSource = (typeof APPLICATION_OUTCOME_SOURCES)[number];
+
+export const ManualApplicationOutcomeRequestSchema = z
+  .object({
+    kind: z.enum(APPLICATION_OUTCOME_KINDS),
+    occurredAt: z.string().trim().min(1).max(80).optional(),
+    note: z.string().trim().max(4000).optional(),
+  })
+  .strict();
+export type ManualApplicationOutcomeRequest = z.infer<typeof ManualApplicationOutcomeRequestSchema>;
+
+export interface ApplicationOutcome {
+  outcomeId: string;
+  jobKey: string;
+  kind: ApplicationOutcomeKind;
+  source: ApplicationOutcomeSource;
+  note: string | null;
+  occurredAt: string;
+  recordedAt: string;
+  suggestionId: string | null;
+  evidenceId: string | null;
+}
+
+export interface ApplicationOutcomeWriteResponse {
+  ok: true;
+  outcome: ApplicationOutcome;
+}
+
+export const OUTCOME_SUGGESTION_STATUSES = [
+  "pending",
+  "accepted",
+  "corrected",
+  "ignored",
+] as const;
+export type OutcomeSuggestionStatus = (typeof OUTCOME_SUGGESTION_STATUSES)[number];
+
+export interface ApplicationEmailEvidence {
+  evidenceId: string;
+  jobKey: string;
+  provider: "gmail";
+  providerMessageId: string;
+  providerThreadId: string | null;
+  fromAddress: string | null;
+  toAddresses: string[];
+  subject: string | null;
+  snippet: string | null;
+  receivedAt: string | null;
+  linkedAt: string;
+  linkConfidence: number;
+  bodySha256: string | null;
+  bodyStoredAt: string | null;
+}
+
+export interface OutcomeSuggestion {
+  suggestionId: string;
+  jobKey: string;
+  evidenceId: string | null;
+  suggestedKind: ApplicationOutcomeKind;
+  confidence: number;
+  rationale: string;
+  status: OutcomeSuggestionStatus;
+  createdAt: string;
+  decidedAt: string | null;
+  decisionReason: string | null;
+  decidedOutcomeId: string | null;
+}
+
+export const OutcomeSuggestionDecisionRequestSchema = z
+  .object({
+    decision: z.enum(["accept", "correct", "ignore"]),
+    outcomeKind: z.enum(APPLICATION_OUTCOME_KINDS).optional(),
+    occurredAt: z.string().trim().min(1).max(80).optional(),
+    note: z.string().trim().max(4000).optional(),
+    reason: z.string().trim().max(400).optional(),
+  })
+  .strict()
+  .refine((value) => value.decision !== "correct" || value.outcomeKind !== undefined, {
+    message: "outcomeKind is required when correcting a suggestion.",
+    path: ["outcomeKind"],
+  });
+export type OutcomeSuggestionDecisionRequest = z.infer<
+  typeof OutcomeSuggestionDecisionRequestSchema
+>;
+
+export interface OutcomeSuggestionDecisionResponse {
+  ok: true;
+  suggestion: OutcomeSuggestion;
+  outcome: ApplicationOutcome | null;
+}
+
+export interface ApplicationOutcomeListResponse {
+  ok: true;
+  outcomes: ApplicationOutcome[];
+  suggestions: OutcomeSuggestion[];
+}
+
+export interface JobApplicationOutcomeListResponse extends ApplicationOutcomeListResponse {
+  jobKey: string;
+}
+
 export const RunPipelineStagesRequestSchema = z
   .object({
     stages: z.array(z.enum(PIPELINE_RUN_STAGES)).min(1).max(PIPELINE_RUN_STAGES.length),


### PR DESCRIPTION
## Summary
- Add shared contract DTOs/schemas for apply review decisions, application outcomes, email evidence, outcome suggestions, and mutation/list responses.
- Add a focused local SQLite application-feedback module for idempotent table creation, review queue reads, review decisions, manual outcomes, outcome reads, and suggestion decisions.
- Add Fastify routes for the PR1 foundation API surface without dispatching apply from review approval.
- Add API coverage for queue eligibility, approve/defer/decline/reset decisions, manual outcomes, suggestion decisions, and safe `job_events.payload_json` summaries.
- Update README, local TS API docs, and architecture docs for the new foundation and privacy boundary.

## Out of scope
- React UI wiring.
- Gmail scanning/body ingestion.
- Worker-triggered apply execution from `approve_submit`.

## Validation
- `pnpm api:test` exited 0: 9 test files passed, 153 tests passed.
- `pnpm api:check` exited 0: TypeScript API typecheck passed.
- `git diff --check` exited 0: no whitespace errors.