### PR TITLE
feat: ingest Gmail feedback for application outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,16 @@ start browser submission by itself. Manual outcomes can include local notes in
 SQLite, but event payloads contain only safe identifiers, outcome kinds, and
 presence flags.
 
+Gmail outcome feedback is a separate read-only scan from the verification-code
+MCP server. `POST /v1/outcomes/gmail/scan` asks the worker to search bounded
+post-application windows for known application anchors only, using the
+candidate recipient email plus employer, ATS, title/company, and application
+URL/domain hints. JobHunter reads and stores a full Gmail body only after the
+metadata is confidently linked to one known application. Linked evidence stays
+in local SQLite with body text and a body hash; API responses, event payloads,
+logs, and broad projections expose only safe evidence/suggestion identifiers,
+kinds, confidence values, and link signals.
+
 Applications that send verification codes by email use JobHunter's first-party,
 read-only Gmail connector. Put a Google OAuth Desktop client file at
 `~/.jobhunter/gmail/oauth-client.json`, then authenticate once:

--- a/apps/api/src/gmail-feedback-worker.ts
+++ b/apps/api/src/gmail-feedback-worker.ts
@@ -1,0 +1,222 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type {
+  ApplicationOutcomeKind,
+  GmailOutcomeScanRequest,
+  GmailOutcomeScanResponse,
+} from "./contracts.js";
+import { APPLICATION_OUTCOME_KINDS } from "./contracts.js";
+
+const API_SRC_DIR = path.dirname(fileURLToPath(import.meta.url));
+const AUTOMATION_PROJECT_DIR = path.resolve(API_SRC_DIR, "../../../workers/automation");
+
+export interface GmailFeedbackScanContext {
+  appDir: string;
+  dbPath: string;
+}
+
+export type GmailFeedbackScanner = (
+  input: GmailOutcomeScanRequest,
+  context: GmailFeedbackScanContext,
+) => Promise<unknown>;
+
+export interface WorkerGmailFeedbackScannerOptions {
+  projectDir?: string;
+  uvBinary?: string;
+}
+
+export class GmailFeedbackScanError extends Error {
+  readonly statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = "GmailFeedbackScanError";
+    this.statusCode = statusCode;
+  }
+}
+
+export function createWorkerGmailFeedbackScanner(
+  options: WorkerGmailFeedbackScannerOptions = {},
+): GmailFeedbackScanner {
+  const projectDir = options.projectDir ?? AUTOMATION_PROJECT_DIR;
+  const uvBinary = options.uvBinary ?? "uv";
+
+  return async (input, context) =>
+    runWorkerScan(input, {
+      appDir: context.appDir,
+      dbPath: context.dbPath,
+      projectDir,
+      uvBinary,
+    });
+}
+
+export function sanitizeGmailFeedbackScanResponse(output: unknown): GmailOutcomeScanResponse {
+  const record = isRecord(output) ? output : {};
+  return {
+    ok: true,
+    scannedAnchorCount: numberValue(record.scannedAnchorCount),
+    searchedMessageCount: numberValue(record.searchedMessageCount),
+    linkedEvidenceCount: numberValue(record.linkedEvidenceCount),
+    suggestionsCreatedCount: numberValue(record.suggestionsCreatedCount),
+    duplicateMessageCount: numberValue(record.duplicateMessageCount),
+    unlinkedCandidateCount: numberValue(record.unlinkedCandidateCount),
+    evidence: arrayValue(record.evidence).map((item) => {
+      const evidence = isRecord(item) ? item : {};
+      return {
+        evidenceId: textValue(evidence.evidenceId, "evidenceId"),
+        jobKey: textValue(evidence.jobKey, "jobKey"),
+        providerMessageId: textValue(evidence.providerMessageId, "providerMessageId"),
+        linkConfidence: numberValue(evidence.linkConfidence),
+      };
+    }),
+    suggestions: arrayValue(record.suggestions).map((item) => {
+      const suggestion = isRecord(item) ? item : {};
+      return {
+        suggestionId: textValue(suggestion.suggestionId, "suggestionId"),
+        evidenceId: textValue(suggestion.evidenceId, "evidenceId"),
+        jobKey: textValue(suggestion.jobKey, "jobKey"),
+        kind: outcomeKind(suggestion.kind),
+        confidence: numberValue(suggestion.confidence),
+      };
+    }),
+  };
+}
+
+interface WorkerRunOptions extends GmailFeedbackScanContext {
+  projectDir: string;
+  uvBinary: string;
+}
+
+function runWorkerScan(
+  payload: GmailOutcomeScanRequest,
+  options: WorkerRunOptions,
+): Promise<GmailOutcomeScanResponse> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      options.uvBinary,
+      [
+        "--project",
+        options.projectDir,
+        "run",
+        "python",
+        "-m",
+        "jobhunter.infrastructure.gmail.feedback",
+        "--db-path",
+        options.dbPath,
+      ],
+      {
+        cwd: options.appDir,
+        env: {
+          ...process.env,
+          JOBHUNTER_DIR: options.appDir,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        const parsed = tryParseWorkerOutput(stdout);
+        const message =
+          (isRecord(parsed) && optionalText(parsed.message)) ||
+          stderr.trim() ||
+          stdout.trim() ||
+          `Worker exited with code ${code ?? "unknown"}.`;
+        reject(new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message)));
+        return;
+      }
+      try {
+        const parsed = parseWorkerOutput(stdout);
+        if (!isRecord(parsed)) {
+          throw new Error("Worker response was not a JSON object.");
+        }
+        if (parsed.ok === false) {
+          const message = optionalText(parsed.message) ?? "Gmail feedback scan failed.";
+          throw new GmailFeedbackScanError(message, gmailFeedbackErrorStatus(message));
+        }
+        resolve(sanitizeGmailFeedbackScanResponse(parsed));
+      } catch (error) {
+        reject(
+          error instanceof GmailFeedbackScanError
+            ? error
+            : new GmailFeedbackScanError(
+                error instanceof Error ? error.message : "Unable to parse worker response.",
+                500,
+              ),
+        );
+      }
+    });
+    child.stdin.end(`${JSON.stringify(payload)}\n`);
+  });
+}
+
+function parseWorkerOutput(stdout: string): unknown {
+  const line = stdout
+    .trim()
+    .split("\n")
+    .findLast((candidate) => candidate.trim().startsWith("{"));
+  if (!line) {
+    throw new Error("Worker did not return a JSON object.");
+  }
+  return JSON.parse(line) as unknown;
+}
+
+function tryParseWorkerOutput(stdout: string): unknown {
+  try {
+    return parseWorkerOutput(stdout);
+  } catch {
+    return null;
+  }
+}
+
+function gmailFeedbackErrorStatus(message: string): number {
+  if (/recipient email|input must be a JSON object|application hints/i.test(message)) {
+    return 400;
+  }
+  if (/gmail auth|oauth|token|credentials|unauth/i.test(message)) {
+    return 503;
+  }
+  return 500;
+}
+
+function numberValue(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function textValue(value: unknown, name: string): string {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new GmailFeedbackScanError(`Worker response missing ${name}.`, 500);
+}
+
+function optionalText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function outcomeKind(value: unknown): ApplicationOutcomeKind {
+  return APPLICATION_OUTCOME_KINDS.includes(value as ApplicationOutcomeKind)
+    ? (value as ApplicationOutcomeKind)
+    : "unknown";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -23,6 +23,7 @@ import {
   DeleteJobRequestSchema,
   DiscoveryFeedbackRequestSchema,
   GenerateMaterialsRequestSchema,
+  GmailOutcomeScanRequestSchema,
   JobListQuerySchema,
   JsonRpcErrorCodes,
   JsonRpcRequestSchema,
@@ -92,6 +93,12 @@ import {
   type ManualCaptureImporter,
 } from "./manual-capture-worker.js";
 import {
+  createWorkerGmailFeedbackScanner,
+  GmailFeedbackScanError,
+  sanitizeGmailFeedbackScanResponse,
+  type GmailFeedbackScanner,
+} from "./gmail-feedback-worker.js";
+import {
   buildDashboardSummary,
   getActivityEvent,
   getArtifactDetail,
@@ -154,6 +161,7 @@ export interface BuildAppOptions {
   artifactOpener?: ArtifactOpener;
   credentialStore?: CredentialStore;
   manualCaptureImporter?: ManualCaptureImporter;
+  gmailFeedbackScanner?: GmailFeedbackScanner;
   placeValidator?: PlaceValidator;
   profileImporter?: ProfileImporter;
   profilePreviewRenderer?: ProfilePreviewRenderer;
@@ -168,6 +176,7 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   const artifactOpener = options.artifactOpener ?? defaultArtifactOpener;
   const credentialStore = options.credentialStore ?? new KeychainCredentialStore();
   const manualCaptureImporter = options.manualCaptureImporter ?? createWorkerManualCaptureImporter();
+  const gmailFeedbackScanner = options.gmailFeedbackScanner ?? createWorkerGmailFeedbackScanner();
   const profileImporter = options.profileImporter ?? defaultProfileImporter;
   const profilePreviewRenderer = options.profilePreviewRenderer ?? defaultProfilePreviewRenderer;
   const actionContext = { appDir, dbPath: options.dbPath };
@@ -448,6 +457,34 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   app.get("/v1/outcomes", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => listApplicationOutcomes(db)),
   );
+
+  app.post("/v1/outcomes/gmail/scan", async (request, reply) => {
+    const body = parseBody(reply, GmailOutcomeScanRequestSchema, request.body ?? {});
+    if (!body) {
+      return undefined;
+    }
+    if (!databaseExists(options.dbPath)) {
+      void reply.code(503);
+      return { ok: false, error: "db_not_found", message: `No JobHunter database found at ${options.dbPath}` };
+    }
+    try {
+      const output = await gmailFeedbackScanner(body, { appDir, dbPath: options.dbPath });
+      return sanitizeGmailFeedbackScanResponse(output);
+    } catch (error) {
+      if (error instanceof GmailFeedbackScanError) {
+        void reply.code(error.statusCode);
+        return {
+          ok: false,
+          error:
+            error.statusCode === 400
+              ? "invalid_gmail_feedback_scan"
+              : "gmail_feedback_scan_failed",
+          message: error.message,
+        };
+      }
+      throw error;
+    }
+  });
 
   app.post("/v1/jobs/bulk-delete", async (request, reply) => {
     const body = parseBody(reply, BulkJobMutationRequestSchema, request.body ?? {});

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -5,6 +5,7 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ensureApplicationFeedbackTables } from "../src/application-feedback.js";
+import { GmailFeedbackScanError, type GmailFeedbackScanner } from "../src/gmail-feedback-worker.js";
 import { type ActionDispatcher, type ActionDispatchResult } from "../src/local-actions.js";
 import { type BuildAppOptions, buildApp } from "../src/server.js";
 
@@ -177,6 +178,112 @@ describe("application feedback API", () => {
     ]);
 
     expect(eventPayloadText(options.dbPath)).not.toContain(note);
+    await app.close();
+  });
+
+  it("runs Gmail outcome scan through the worker and returns only safe summary fields", async () => {
+    const rawBody = "raw private Gmail body must not leave the worker boundary";
+    const gmailFeedbackScanner = vi.fn(async () => ({
+      ok: true,
+      scannedAnchorCount: 1,
+      searchedMessageCount: 2,
+      linkedEvidenceCount: 1,
+      suggestionsCreatedCount: 1,
+      duplicateMessageCount: 0,
+      unlinkedCandidateCount: 1,
+      evidence: [
+        {
+          evidenceId: "evidence-1",
+          jobKey: READY_JOB,
+          providerMessageId: "gmail-message-1",
+          linkConfidence: 0.94,
+          bodyText: rawBody,
+        },
+      ],
+      suggestions: [
+        {
+          suggestionId: "suggestion-1",
+          evidenceId: "evidence-1",
+          jobKey: READY_JOB,
+          kind: "interview",
+          confidence: 0.9,
+          bodyText: rawBody,
+        },
+      ],
+    })) as ReturnType<typeof vi.fn> & GmailFeedbackScanner;
+    const app = buildApp({ ...options, gmailFeedbackScanner });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/outcomes/gmail/scan",
+      payload: {
+        recipientEmail: "candidate@example.com",
+        limit: 2,
+        maxResultsPerAnchor: 3,
+        windowDays: 14,
+      },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(gmailFeedbackScanner).toHaveBeenCalledWith(
+      {
+        recipientEmail: "candidate@example.com",
+        limit: 2,
+        maxResultsPerAnchor: 3,
+        windowDays: 14,
+      },
+      { appDir: tempDir, dbPath: options.dbPath },
+    );
+    expect(response.json()).toEqual({
+      ok: true,
+      scannedAnchorCount: 1,
+      searchedMessageCount: 2,
+      linkedEvidenceCount: 1,
+      suggestionsCreatedCount: 1,
+      duplicateMessageCount: 0,
+      unlinkedCandidateCount: 1,
+      evidence: [
+        {
+          evidenceId: "evidence-1",
+          jobKey: READY_JOB,
+          providerMessageId: "gmail-message-1",
+          linkConfidence: 0.94,
+        },
+      ],
+      suggestions: [
+        {
+          suggestionId: "suggestion-1",
+          evidenceId: "evidence-1",
+          jobKey: READY_JOB,
+          kind: "interview",
+          confidence: 0.9,
+        },
+      ],
+    });
+    expect(response.body).not.toContain(rawBody);
+
+    await app.close();
+  });
+
+  it("maps Gmail outcome worker errors without exposing raw body fields", async () => {
+    const gmailFeedbackScanner = vi.fn(async () => {
+      throw new GmailFeedbackScanError("missing Gmail token at local auth path", 503);
+    }) as ReturnType<typeof vi.fn> & GmailFeedbackScanner;
+    const app = buildApp({ ...options, gmailFeedbackScanner });
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/v1/outcomes/gmail/scan",
+      payload: { limit: 1 },
+    });
+
+    expect(response.statusCode, response.body).toBe(503);
+    expect(response.json()).toEqual({
+      ok: false,
+      error: "gmail_feedback_scan_failed",
+      message: "missing Gmail token at local auth path",
+    });
+
     await app.close();
   });
 

--- a/apps/web/src/contexts/apply/handlers.ts
+++ b/apps/web/src/contexts/apply/handlers.ts
@@ -1,4 +1,5 @@
 import type {
+  ApplicationEmailFeedbackIngested,
   ApplicationFailed,
   ApplicationSubmitted,
   ApplyRunEventRecorded,
@@ -6,6 +7,7 @@ import type {
 } from "@jobhunter/domain-types";
 
 import { applyRunsKeys } from "../operations/applyRunsKeys.js";
+import { applyReviewKeys } from "../operations/applyReviewKeys.js";
 import { dashboardKeys } from "../operations/dashboardKeys.js";
 import {
   invalidate,
@@ -13,6 +15,7 @@ import {
   type InvalidationItem,
 } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
+import { outcomesKeys } from "../operations/outcomesKeys.js";
 import { workflowRunsKeys } from "../operations/workflowRunsKeys.js";
 
 export const applyRunStartedHandler = (
@@ -33,6 +36,14 @@ export const applyRunEventRecordedHandler = (
   event: ApplyRunEventRecorded,
 ): readonly InvalidationItem[] => [
   patchApplyRunEvent(event.tenantId, event.payload.runId, event),
+];
+
+export const applicationEmailFeedbackIngestedHandler = (
+  event: ApplicationEmailFeedbackIngested,
+): readonly InvalidationItem[] => [
+  invalidate(outcomesKeys.lists(event.tenantId)),
+  invalidate(outcomesKeys.detail(event.tenantId, event.payload.jobKey)),
+  invalidate(applyReviewKeys.queue(event.tenantId)),
 ];
 
 export const applicationSubmittedHandler = (

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -4,11 +4,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { eventByType } from "../../test/fixtures/events.js";
 import { activityKeys } from "./activityKeys.js";
+import { applyReviewKeys } from "./applyReviewKeys.js";
 import { applyRunsKeys } from "./applyRunsKeys.js";
 import { artifactsKeys } from "./artifactsKeys.js";
 import { dashboardKeys } from "./dashboardKeys.js";
 import { invalidationRouter } from "./invalidation-router.js";
 import { jobsKeys } from "./jobsKeys.js";
+import { outcomesKeys } from "./outcomesKeys.js";
 import { workflowRunsKeys } from "./workflowRunsKeys.js";
 import { discoveryKeys } from "../discovery/queryKeys.js";
 import { profileKeys } from "../profile/queryKeys.js";
@@ -213,6 +215,11 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   ApplyRunEventRecorded: [],
+  ApplicationEmailFeedbackIngested: [
+    outcomesKeys.lists(LOCAL_TENANT),
+    outcomesKeys.detail(LOCAL_TENANT, JOB_ID),
+    applyReviewKeys.queue(LOCAL_TENANT),
+  ],
   ApplicationSubmitted: [
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     jobsKeys.lists(LOCAL_TENANT),

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -4,6 +4,7 @@ import type { ApplyRunEventRecorded, TenantId } from "@jobhunter/domain-types";
 
 import { appendApplyRunEvent } from "../apply/selectors/applyRunSelectors.js";
 import {
+  applicationEmailFeedbackIngestedHandler,
   applicationFailedHandler,
   applicationSubmittedHandler,
   applyRunEventRecordedHandler,
@@ -149,6 +150,7 @@ export const handlers: HandlerMap = {
   PreparationWorkItemFailed: preparationWorkItemFailedHandler,
   ApplyRunStarted: applyRunStartedHandler,
   ApplyRunEventRecorded: applyRunEventRecordedHandler,
+  ApplicationEmailFeedbackIngested: applicationEmailFeedbackIngestedHandler,
   ApplicationSubmitted: applicationSubmittedHandler,
   ApplicationFailed: applicationFailedHandler,
   StageStarted: stageStartedHandler,

--- a/apps/web/src/test/fixtures/events.ts
+++ b/apps/web/src/test/fixtures/events.ts
@@ -1,4 +1,5 @@
 import {
+  createApplicationEmailFeedbackIngested,
   createApplicationFailed,
   createApplicationSubmitted,
   createApplyRunEventRecorded,
@@ -340,6 +341,16 @@ export const eventByType = {
   ApplyRunEventRecorded: createApplyRunEventRecorded(LOCAL_TENANT, {
     runId: RUN_ID,
     event: { at: NOW, type: "navigation", url: "https://example.com/apply/1" },
+  }),
+  ApplicationEmailFeedbackIngested: createApplicationEmailFeedbackIngested(LOCAL_TENANT, {
+    jobKey: JOB_ID,
+    evidenceId: "evidence-1",
+    suggestionId: "suggestion-1",
+    provider: "gmail",
+    suggestedKind: "interview",
+    classificationConfidence: 0.9,
+    linkConfidence: 0.84,
+    linkSignals: ["recipient", "time_window", "company"],
   }),
   ApplicationSubmitted: createApplicationSubmitted(LOCAL_TENANT, {
     jobId: JOB_ID,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,16 +152,32 @@ table creation and read/write helpers for:
 
 - `application_review_decisions`: append-only user decisions for apply review.
 - `application_outcomes`: reviewed manual or suggestion-derived outcomes.
-- `application_email_evidence`: future linked Gmail evidence, including body
-  storage columns for the Gmail slice.
+- `application_email_evidence`: linked Gmail evidence, including body storage
+  and body hash columns for confidently linked messages.
 - `application_outcome_suggestions`: pending and decided classifier
   suggestions.
 
 Apply-review approval is modeled as a recorded decision, not as an automatic
 worker dispatch. Manual outcome notes are stored only in the local outcome
-table. `job_events.payload_json` receives safe summaries with identifiers,
-kinds, sources, timestamps, and presence flags; raw notes and future raw email
-bodies are not copied into domain events, projections, logs, or telemetry.
+table.
+
+Gmail outcome feedback is implemented in
+`workers/automation/src/jobhunter/infrastructure/gmail/feedback.py`, separate
+from the verification-only Gmail MCP server. The scanner reuses the readonly
+Gmail OAuth/client support but searches only bounded post-application windows
+for known SQLite application anchors. Candidate queries combine the recipient
+email with employer/ATS hints, job title/company terms, application URL/domain
+tokens, and application timing. The worker reads a full Gmail body only after
+metadata reaches the link-confidence threshold, then stores body text,
+`body_sha256`, `linked_at`, confidence, safe link signals, and a unique provider
+message ID in `application_email_evidence`. Deterministic v1 classification
+writes pending `application_outcome_suggestions` for confirmations, recruiter
+replies, interviews, assessments, rejections, offers, bounces, and unknowns.
+
+`job_events.payload_json` receives safe summaries with identifiers, kinds,
+sources, timestamps, confidence values, link signals, and presence flags; raw
+notes and raw email bodies are not copied into domain events, projections,
+logs, telemetry, or Gmail scan API responses.
 
 ## Read-Model Projections (Phase 9)
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -64,7 +64,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Source registry compatibility drops legacy discovery config | `workers/automation/tests/test_source_registry.py` covers packaged `sites.yaml` migration, `employers.yaml` migration, JobSpy `boards` selection, and the one-release legacy `sites` alias warning |
 | Source quality stops feeding discovery budgets or dashboard health | `workers/automation/tests/test_discovery_scheduler_pr4.py`; `workers/automation/tests/test_source_quality_projection_pr4.py`; `apps/web/src/views/dashboard/SourceHealthCard.test.tsx`; `apps/web/src/contexts/operations/invalidation-router.test.ts` |
 | Discovery product controls stop recording source/quarantine/manual-capture feedback safely, mislabel locator candidates, preview quarantine residue as source leads, or hide low-score role-match suggestions and approval state | `apps/api/test/discovery-controls.test.ts`; `apps/api/test/server.test.ts`; `apps/web/src/contexts/discovery/components/DiscoveryProductControls.test.tsx`; `workers/automation/tests/test_title_filter.py` |
-| Apply review queue or outcome tracking starts apply automation, loses local-only outcome notes, hides pending outcome suggestions, or stops invalidating job/outcome views after decisions | `apps/api/test/application-feedback.test.ts`; `apps/web/src/views/apply-review/ApplyReviewView.test.tsx`; `apps/web/src/contexts/apply/components/ApplicationOutcomes.test.tsx`; `apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts`; `apps/web/src/contexts/operations/hooks/useApplyReviewOutcomeQueries.test.ts` |
+| Apply review queue or outcome tracking starts apply automation, loses local-only outcome notes, hides pending outcome suggestions, exposes raw Gmail body text, or stops invalidating job/outcome views after decisions | `apps/api/test/application-feedback.test.ts`; `workers/automation/tests/test_gmail_feedback.py`; `apps/web/src/views/apply-review/ApplyReviewView.test.tsx`; `apps/web/src/contexts/apply/components/ApplicationOutcomes.test.tsx`; `apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts`; `apps/web/src/contexts/operations/hooks/useApplyReviewOutcomeQueries.test.ts` |
 | Discovery Target search stops driving role guidance, structured track/seniority/function recall, location fallback, Spain/Europe source filtering, new-job discovery limits, or API-visible source controls | `workers/automation/tests/test_target_search_preferences.py`; `workers/automation/tests/test_discovery_limits.py`; `workers/automation/tests/test_discovery_production_wiring.py`; `apps/api/test/discovery-controls.test.ts` |
 | Profile, Preferences, Discovery target search, or Settings form autosave/undo regresses and risks losing user edits | `apps/web/src/contexts/profile/forms/profile-form.test.tsx`; `apps/web/src/contexts/profile/forms/settings-form.test.tsx` |
 | Discovery RFC production wiring stops auto-approving located parseable sources, feeding API-visible manual queues, canonical ATS ingestion, manual-capture imports, snapshot persistence, or acceptance evidence | `workers/automation/tests/test_discovery_production_wiring.py` uses a Barcelona/Spain tech-leadership fixture and report covering lead yield, candidate sources, manual-action count, canonical verification rate, duplicate/quarantine counts, source-quality updates, and scoring handoff count |
@@ -126,6 +126,13 @@ decision. Open a job detail drawer and verify manual outcomes save with a
 canonical timestamp, local notes render only in the outcome timeline, pending
 outcome suggestions can be accepted, corrected, or ignored, and no raw email
 body text appears in event/activity payloads.
+
+For Gmail feedback changes, use fake Gmail clients or seeded worker fixtures.
+Do not scan a real mailbox for QA automation. Verify that the scan is bounded
+by application anchors, recipient, max result/window limits, and employer/ATS
+hints; that `read_email` is not called for unlinked metadata; and that the API
+scan response includes only counts plus evidence/suggestion identifiers, kinds,
+and confidence values.
 
 ### Parity tests
 

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -183,8 +183,9 @@ future linked email bodies may live in `application_email_evidence`, but
 note/body presence flags.
 
 Apply review and outcome feedback endpoints power the local web
-`/apply-review` queue and the job-detail outcome timeline. Gmail ingestion is
-not implemented in this slice:
+`/apply-review` queue and the job-detail outcome timeline. Gmail feedback
+ingestion is Gmail-only and runs through the Python worker, not through the
+verification-code MCP server:
 
 - `GET /v1/apply/review-queue` returns active apply-stage jobs that are ready
   or close enough for human review, plus materials readiness, latest apply-run
@@ -199,6 +200,11 @@ not implemented in this slice:
 - `POST /v1/outcome-suggestions/:suggestionId/decision` accepts, corrects, or
   ignores a pending suggestion and writes a reviewed outcome for accepted or
   corrected suggestions.
+- `POST /v1/outcomes/gmail/scan` runs a bounded Gmail feedback scan over known
+  application anchors. The request accepts optional `recipientEmail`, `limit`,
+  `maxResultsPerAnchor`, and `windowDays` values. The response returns counts
+  plus evidence/suggestion IDs, job keys, kinds, and confidence values only; it
+  never returns raw Gmail body text.
 
 The web review queue records approval facts only. `approve_submit` does not
 dispatch browser submission, and `approve_dry_run` does not start a dry run.
@@ -207,10 +213,13 @@ Manual outcomes and suggestion corrections require canonical ISO-8601 UTC
 
 These routes create `application_review_decisions`, `application_outcomes`,
 `application_email_evidence`, and `application_outcome_suggestions`
-idempotently in SQLite. Gmail scanning and body ingestion are not implemented
-by this API slice. Outcome notes may be stored in `application_outcomes`, and
-future linked email bodies may live in `application_email_evidence`, but
-`job_events.payload_json` stores only safe IDs, kinds, sources, timestamps, and
+idempotently in SQLite. Gmail scanning searches only bounded post-application
+windows for anchors already known locally, using recipient, employer/ATS,
+title/company, application URL/domain, and application timing signals. Full
+Gmail bodies are read and stored only after metadata confidently links to a
+known application, with provider message ID dedupe. Outcome notes and linked
+email bodies may be stored locally, but `job_events.payload_json` stores only
+safe IDs, kinds, sources, timestamps, confidence values, link signals, and
 note/body presence flags.
 
 `POST /v1/pipeline/actions/run-stage` starts global/batch pipeline stage runs

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -28,6 +28,8 @@ import type {
   DiscoveryFeedbackResponse,
   DiscoveryPreviewResponse,
   GenerateMaterialsRequest,
+  GmailOutcomeScanRequest,
+  GmailOutcomeScanResponse,
   JobDetail,
   JobApplicationOutcomeListResponse,
   JobListQuery,
@@ -258,6 +260,12 @@ export class JobHunterApiClient {
     body: OutcomeSuggestionDecisionRequest,
   ): Promise<OutcomeSuggestionDecisionResponse> {
     return this.post(`/v1/outcome-suggestions/${encodeURIComponent(suggestionId)}/decision`, body);
+  }
+
+  scanGmailApplicationOutcomes(
+    body: GmailOutcomeScanRequest = {},
+  ): Promise<GmailOutcomeScanResponse> {
+    return this.post("/v1/outcomes/gmail/scan", body);
   }
 
   jobs(query: Partial<JobListQuery> = {}): Promise<PaginatedResponse<JobSummary>> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -370,6 +370,43 @@ export interface JobApplicationOutcomeListResponse extends ApplicationOutcomeLis
   jobKey: string;
 }
 
+export const GmailOutcomeScanRequestSchema = z
+  .object({
+    recipientEmail: z.string().trim().email().optional(),
+    limit: z.coerce.number().int().min(1).max(100).default(25),
+    maxResultsPerAnchor: z.coerce.number().int().min(1).max(20).default(5),
+    windowDays: z.coerce.number().int().min(1).max(180).default(45),
+  })
+  .strict();
+export type GmailOutcomeScanRequest = z.input<typeof GmailOutcomeScanRequestSchema>;
+
+export interface GmailOutcomeScanEvidenceSummary {
+  evidenceId: string;
+  jobKey: string;
+  providerMessageId: string;
+  linkConfidence: number;
+}
+
+export interface GmailOutcomeScanSuggestionSummary {
+  suggestionId: string;
+  evidenceId: string;
+  jobKey: string;
+  kind: ApplicationOutcomeKind;
+  confidence: number;
+}
+
+export interface GmailOutcomeScanResponse {
+  ok: true;
+  scannedAnchorCount: number;
+  searchedMessageCount: number;
+  linkedEvidenceCount: number;
+  suggestionsCreatedCount: number;
+  duplicateMessageCount: number;
+  unlinkedCandidateCount: number;
+  evidence: GmailOutcomeScanEvidenceSummary[];
+  suggestions: GmailOutcomeScanSuggestionSummary[];
+}
+
 export const RunPipelineStagesRequestSchema = z
   .object({
     stages: z.array(z.enum(PIPELINE_RUN_STAGES)).min(1).max(PIPELINE_RUN_STAGES.length),

--- a/packages/domain-types/src/events/apply.ts
+++ b/packages/domain-types/src/events/apply.ts
@@ -78,3 +78,28 @@ export function createApplyRunEventRecorded(
 ): ApplyRunEventRecorded {
   return createDomainEvent("ApplyRunEventRecorded", tenantId, payload);
 }
+
+// -- ApplicationEmailFeedbackIngested ---------------------------------------
+
+export interface ApplicationEmailFeedbackIngestedPayload {
+  readonly jobKey: string;
+  readonly evidenceId: string;
+  readonly suggestionId: string;
+  readonly provider: "gmail";
+  readonly suggestedKind: string;
+  readonly classificationConfidence: number;
+  readonly linkConfidence: number;
+  readonly linkSignals: readonly string[];
+}
+
+export type ApplicationEmailFeedbackIngested = DomainEvent<
+  "ApplicationEmailFeedbackIngested",
+  ApplicationEmailFeedbackIngestedPayload
+>;
+
+export function createApplicationEmailFeedbackIngested(
+  tenantId: TenantId,
+  payload: ApplicationEmailFeedbackIngestedPayload,
+): ApplicationEmailFeedbackIngested {
+  return createDomainEvent("ApplicationEmailFeedbackIngested", tenantId, payload);
+}

--- a/packages/domain-types/src/events/index.ts
+++ b/packages/domain-types/src/events/index.ts
@@ -141,6 +141,9 @@ export {
 } from "./preparation.js";
 
 export {
+  type ApplicationEmailFeedbackIngestedPayload,
+  type ApplicationEmailFeedbackIngested,
+  createApplicationEmailFeedbackIngested,
   type ApplicationSubmittedPayload,
   type ApplicationSubmitted,
   createApplicationSubmitted,
@@ -237,7 +240,13 @@ import type {
   PreparationWorkItemQueued,
   PreparationWorkItemStarted,
 } from "./preparation.js";
-import type { ApplicationFailed, ApplicationSubmitted, ApplyRunEventRecorded, ApplyRunStarted } from "./apply.js";
+import type {
+  ApplicationEmailFeedbackIngested,
+  ApplicationFailed,
+  ApplicationSubmitted,
+  ApplyRunEventRecorded,
+  ApplyRunStarted,
+} from "./apply.js";
 import type {
   StageBlocked,
   StageCanceled,
@@ -290,6 +299,7 @@ export type DomainEventUnion =
   | PreparationWorkItemFailed
   | ApplyRunStarted
   | ApplyRunEventRecorded
+  | ApplicationEmailFeedbackIngested
   | ApplicationSubmitted
   | ApplicationFailed
   | StageStarted
@@ -346,6 +356,7 @@ export const DOMAIN_EVENT_TYPES = [
   "PreparationWorkItemFailed",
   "ApplyRunStarted",
   "ApplyRunEventRecorded",
+  "ApplicationEmailFeedbackIngested",
   "ApplicationSubmitted",
   "ApplicationFailed",
   "StageStarted",

--- a/packages/domain-types/test/events.test.ts
+++ b/packages/domain-types/test/events.test.ts
@@ -41,7 +41,11 @@ import {
   createPreparationWorkItemQueued,
   createPreparationWorkItemStarted,
 } from "../src/events/preparation.js";
-import { createApplicationSubmitted, createApplyRunStarted } from "../src/events/apply.js";
+import {
+  createApplicationEmailFeedbackIngested,
+  createApplicationSubmitted,
+  createApplyRunStarted,
+} from "../src/events/apply.js";
 import { createStageStarted, createStageCompleted } from "../src/events/orchestration.js";
 import { createProfileUpdated, createProfileImported, createTailoringPolicyUpdated } from "../src/events/profile.js";
 
@@ -629,6 +633,17 @@ describe("All events carry tenantId", () => {
         queuedAt: "t",
       }),
     () =>
+      createApplicationEmailFeedbackIngested(LOCAL_TENANT, {
+        jobKey: "j1",
+        evidenceId: "e1",
+        suggestionId: "s1",
+        provider: "gmail",
+        suggestedKind: "interview",
+        classificationConfidence: 0.9,
+        linkConfidence: 0.8,
+        linkSignals: ["recipient"],
+      }),
+    () =>
       createApplicationSubmitted(LOCAL_TENANT, {
         jobId: "j1",
         runId: "r1",
@@ -659,7 +674,7 @@ describe("All events carry tenantId", () => {
 
 describe("DOMAIN_EVENT_TYPES enumeration", () => {
   it("lists every variant of DomainEventUnion exactly once", () => {
-    expect(DOMAIN_EVENT_TYPES).toHaveLength(52);
+    expect(DOMAIN_EVENT_TYPES).toHaveLength(53);
     expect(new Set(DOMAIN_EVENT_TYPES).size).toBe(DOMAIN_EVENT_TYPES.length);
   });
 
@@ -901,6 +916,16 @@ describe("DOMAIN_EVENT_TYPES enumeration", () => {
         runId: "r",
         appliedAt: "t",
         verificationConfidence: 0.5,
+      }).eventType,
+      createApplicationEmailFeedbackIngested(LOCAL_TENANT, {
+        jobKey: "j",
+        evidenceId: "e",
+        suggestionId: "s",
+        provider: "gmail",
+        suggestedKind: "interview",
+        classificationConfidence: 0.9,
+        linkConfidence: 0.8,
+        linkSignals: ["recipient"],
       }).eventType,
       createApplyRunStarted(LOCAL_TENANT, {
         jobId: "j",

--- a/workers/automation/src/jobhunter/domain/events/__init__.py
+++ b/workers/automation/src/jobhunter/domain/events/__init__.py
@@ -73,6 +73,8 @@ from jobhunter.domain.events.materials import (
     create_materials_exhausted,
 )
 from jobhunter.domain.events.apply import (
+    ApplicationEmailFeedbackIngestedPayload,
+    create_application_email_feedback_ingested,
     ApplicationSubmittedPayload,
     create_application_submitted,
     ApplicationFailedPayload,
@@ -147,6 +149,7 @@ DOMAIN_EVENT_TYPES: tuple[str, ...] = (
     "PreparationWorkItemFailed",
     "ApplyRunStarted",
     "ApplyRunEventRecorded",
+    "ApplicationEmailFeedbackIngested",
     "ApplicationSubmitted",
     "ApplicationFailed",
     "StageStarted",
@@ -243,6 +246,8 @@ __all__ = [
     "create_apply_run_started",
     "ApplyRunEventRecordedPayload",
     "create_apply_run_event_recorded",
+    "ApplicationEmailFeedbackIngestedPayload",
+    "create_application_email_feedback_ingested",
     # Orchestration
     "StageStartedPayload",
     "create_stage_started",

--- a/workers/automation/src/jobhunter/domain/events/apply.py
+++ b/workers/automation/src/jobhunter/domain/events/apply.py
@@ -58,3 +58,22 @@ class ApplyRunEventRecordedPayload:
 
 def create_apply_run_event_recorded(tenant_id: TenantId, payload: ApplyRunEventRecordedPayload) -> DomainEvent:
     return create_domain_event("ApplyRunEventRecorded", tenant_id, asdict(payload))
+
+
+@dataclass(frozen=True)
+class ApplicationEmailFeedbackIngestedPayload:
+    job_key: str
+    evidence_id: str
+    suggestion_id: str
+    provider: str = "gmail"
+    suggested_kind: str = "unknown"
+    classification_confidence: float = 0.0
+    link_confidence: float = 0.0
+    link_signals: list[str] = field(default_factory=list)
+
+
+def create_application_email_feedback_ingested(
+    tenant_id: TenantId,
+    payload: ApplicationEmailFeedbackIngestedPayload,
+) -> DomainEvent:
+    return create_domain_event("ApplicationEmailFeedbackIngested", tenant_id, asdict(payload))

--- a/workers/automation/src/jobhunter/infrastructure/gmail/client.py
+++ b/workers/automation/src/jobhunter/infrastructure/gmail/client.py
@@ -113,7 +113,7 @@ class GmailClient:
             messages = response.json().get("messages") or []
             results: list[dict[str, Any]] = []
             for item in messages[:max_results]:
-                msg = self._get_message_metadata(http, str(item["id"]))
+                msg = self._get_message_metadata(http, str(item["id"]), include_snippet=False)
                 internal_ms = int(msg.get("internalDate") or 0)
                 if internal_ms < after_ms or internal_ms > before_ms:
                     continue
@@ -128,7 +128,13 @@ class GmailClient:
             return _NullContext(self._http)
         return httpx.Client(timeout=20)
 
-    def _get_message_metadata(self, http: httpx.Client, message_id: str) -> dict[str, Any]:
+    def _get_message_metadata(
+        self,
+        http: httpx.Client,
+        message_id: str,
+        *,
+        include_snippet: bool = True,
+    ) -> dict[str, Any]:
         response = http.get(
             f"{GMAIL_API_ROOT}/messages/{message_id}",
             headers=self._headers(),
@@ -137,16 +143,19 @@ class GmailClient:
         response.raise_for_status()
         payload = response.json()
         headers = _headers_to_dict(payload.get("payload", {}).get("headers") or [])
-        return {
+        metadata = {
             "id": payload.get("id", ""),
             "threadId": payload.get("threadId", ""),
             "subject": headers.get("subject", ""),
             "from": headers.get("from", ""),
             "to": headers.get("to", ""),
             "date": headers.get("date", ""),
-            "snippet": payload.get("snippet", ""),
+            "snippet": "",
             "internalDate": payload.get("internalDate", "0"),
         }
+        if include_snippet:
+            metadata["snippet"] = payload.get("snippet", "")
+        return metadata
 
 
 class _NullContext:

--- a/workers/automation/src/jobhunter/infrastructure/gmail/client.py
+++ b/workers/automation/src/jobhunter/infrastructure/gmail/client.py
@@ -1,10 +1,11 @@
-"""Read-only Gmail API client for application verification codes."""
+"""Read-only Gmail API client for application verification and feedback."""
 
 from __future__ import annotations
 
 import base64
 import re
 import time
+from datetime import datetime
 from html import unescape
 from typing import Any
 
@@ -19,6 +20,11 @@ _HINT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{1,48}")
 _VERIFICATION_TERMS = (
     '(verification OR "verification code" OR code OR confirm OR confirmation '
     'OR OTP OR "one-time" OR security OR login)'
+)
+_FEEDBACK_TERMS = (
+    '("application received" OR "thank you for applying" OR application OR applied '
+    'OR recruiter OR interview OR assessment OR "coding challenge" OR rejection '
+    'OR offer OR undeliverable OR bounced)'
 )
 
 
@@ -77,6 +83,43 @@ class GmailClient:
             "body_text": _extract_body_text(payload.get("payload", {}))[:12000],
         }
 
+    def search_feedback_emails(
+        self,
+        *,
+        query: str,
+        to_email: str,
+        after: datetime,
+        before: datetime,
+        max_results: int = 10,
+    ) -> list[dict[str, Any]]:
+        """Search bounded application-feedback candidates and return metadata only."""
+
+        max_results = max(1, min(int(max_results or 10), 20))
+        after_ms = int(after.timestamp() * 1000)
+        before_ms = int(before.timestamp() * 1000)
+        q = _build_feedback_query(
+            query=query,
+            to_email=to_email,
+            after=after,
+            before=before,
+        )
+        with self._client() as http:
+            response = http.get(
+                f"{GMAIL_API_ROOT}/messages",
+                headers=self._headers(),
+                params={"q": q, "maxResults": max_results},
+            )
+            response.raise_for_status()
+            messages = response.json().get("messages") or []
+            results: list[dict[str, Any]] = []
+            for item in messages[:max_results]:
+                msg = self._get_message_metadata(http, str(item["id"]))
+                internal_ms = int(msg.get("internalDate") or 0)
+                if internal_ms < after_ms or internal_ms > before_ms:
+                    continue
+                results.append(msg)
+            return results
+
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {get_access_token()}"}
 
@@ -126,6 +169,29 @@ def _build_query(*, query: str, to_email: str) -> str:
     if hints:
         terms.append("(" + " OR ".join(hints) + ")")
     terms.append("newer_than:1d")
+    return " ".join(terms)
+
+
+def _build_feedback_query(
+    *,
+    query: str,
+    to_email: str,
+    after: datetime,
+    before: datetime,
+) -> str:
+    recipient = to_email.strip()
+    if not recipient or not _EMAIL_RE.match(recipient):
+        raise ValueError("Gmail feedback search requires a recipient email")
+    hints = _safe_query_hints(query)
+    if not hints:
+        raise ValueError("Gmail feedback search requires application hints")
+    terms = [
+        _FEEDBACK_TERMS,
+        f"to:{recipient}",
+        "(" + " OR ".join(hints) + ")",
+        f"after:{after.strftime('%Y/%m/%d')}",
+        f"before:{before.strftime('%Y/%m/%d')}",
+    ]
     return " ".join(terms)
 
 

--- a/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
@@ -544,7 +544,6 @@ def _link_metadata(
     text = " ".join(
         [
             _text(metadata.get("subject")),
-            _text(metadata.get("snippet")),
             _text(metadata.get("from")),
             _text(metadata.get("to")),
         ]

--- a/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
@@ -1,0 +1,925 @@
+"""Bounded Gmail application-outcome feedback ingestion."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from email.utils import getaddresses, parsedate_to_datetime
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import urlparse
+
+from jobhunter.infrastructure.gmail.client import GmailClient
+
+TENANT_ID = "local"
+PROVIDER = "gmail"
+LINK_THRESHOLD = 0.7
+DEFAULT_LIMIT = 25
+DEFAULT_MAX_RESULTS_PER_ANCHOR = 5
+DEFAULT_WINDOW_DAYS = 45
+MAX_LIMIT = 100
+MAX_RESULTS_PER_ANCHOR = 20
+MAX_WINDOW_DAYS = 180
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._+-]{1,64}")
+_ATS_HINTS = {
+    "ashby",
+    "greenhouse",
+    "icims",
+    "lever",
+    "smartrecruiters",
+    "workable",
+    "workday",
+}
+_OUTCOME_TERMS = (
+    "application",
+    "applied",
+    "applying",
+    "assessment",
+    "bounced",
+    "challenge",
+    "interview",
+    "offer",
+    "received",
+    "recruiter",
+    "rejection",
+    "submitted",
+    "undeliverable",
+)
+
+
+class GmailFeedbackError(RuntimeError):
+    """Raised when a bounded feedback scan cannot run safely."""
+
+
+class GmailFeedbackClient(Protocol):
+    def search_feedback_emails(
+        self,
+        *,
+        query: str,
+        to_email: str,
+        after: datetime,
+        before: datetime,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        """Return Gmail metadata only for bounded application-feedback search."""
+
+    def read_email(self, *, message_id: str) -> dict[str, Any]:
+        """Read a full Gmail message after metadata has been linked."""
+
+
+@dataclass(frozen=True)
+class ApplicationAnchor:
+    job_key: str
+    title: str
+    company: str
+    application_url: str
+    anchor_at: datetime
+
+
+@dataclass(frozen=True)
+class LinkDecision:
+    linked: bool
+    confidence: float
+    signals: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Classification:
+    kind: str
+    confidence: float
+    rationale: str
+
+
+def scan_gmail_feedback(
+    *,
+    db_path: Path | str,
+    client: GmailFeedbackClient | None = None,
+    recipient_email: str | None = None,
+    limit: int = DEFAULT_LIMIT,
+    max_results_per_anchor: int = DEFAULT_MAX_RESULTS_PER_ANCHOR,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+) -> dict[str, Any]:
+    """Scan Gmail metadata for known application anchors and store linked evidence."""
+
+    bounded_limit = _bounded_int(limit, minimum=1, maximum=MAX_LIMIT, default=DEFAULT_LIMIT)
+    bounded_max_results = _bounded_int(
+        max_results_per_anchor,
+        minimum=1,
+        maximum=MAX_RESULTS_PER_ANCHOR,
+        default=DEFAULT_MAX_RESULTS_PER_ANCHOR,
+    )
+    bounded_window_days = _bounded_int(
+        window_days,
+        minimum=1,
+        maximum=MAX_WINDOW_DAYS,
+        default=DEFAULT_WINDOW_DAYS,
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=10000")
+    gmail = client or GmailClient()
+    try:
+        ensure_application_feedback_tables(conn)
+        recipient = (recipient_email or _profile_email(conn)).strip().lower()
+        if not recipient or not _EMAIL_RE.match(recipient):
+            raise GmailFeedbackError(
+                "Gmail feedback scan requires a recipient email or candidate profile email."
+            )
+
+        anchors = _load_application_anchors(conn, limit=bounded_limit)
+        summary = {
+            "ok": True,
+            "scannedAnchorCount": len(anchors),
+            "searchedMessageCount": 0,
+            "linkedEvidenceCount": 0,
+            "suggestionsCreatedCount": 0,
+            "duplicateMessageCount": 0,
+            "unlinkedCandidateCount": 0,
+            "evidence": [],
+            "suggestions": [],
+        }
+        now = _utc_now()
+
+        for anchor in anchors:
+            after = anchor.anchor_at
+            before = anchor.anchor_at + timedelta(days=bounded_window_days)
+            query = _anchor_query(anchor)
+            if not query:
+                continue
+            metadata_items = gmail.search_feedback_emails(
+                query=query,
+                to_email=recipient,
+                after=after,
+                before=before,
+                max_results=bounded_max_results,
+            )
+            summary["searchedMessageCount"] += len(metadata_items)
+
+            for metadata in metadata_items:
+                decision = _link_metadata(
+                    anchor=anchor,
+                    metadata=metadata,
+                    recipient_email=recipient,
+                    after=after,
+                    before=before,
+                )
+                if not decision.linked:
+                    summary["unlinkedCandidateCount"] += 1
+                    continue
+
+                message_id = _text(metadata.get("id"))
+                if not message_id:
+                    summary["unlinkedCandidateCount"] += 1
+                    continue
+                if _provider_message_exists(conn, message_id):
+                    summary["duplicateMessageCount"] += 1
+                    continue
+
+                full_message = gmail.read_email(message_id=message_id)
+                evidence = _store_linked_message(
+                    conn=conn,
+                    anchor=anchor,
+                    metadata=metadata,
+                    full_message=full_message,
+                    decision=decision,
+                    linked_at=now,
+                )
+                classification = classify_outcome(
+                    subject=evidence["subject"] or "",
+                    snippet=evidence["snippet"] or "",
+                    body_text=_text(full_message.get("body_text")),
+                )
+                suggestion = _store_suggestion(
+                    conn=conn,
+                    anchor=anchor,
+                    evidence_id=evidence["evidenceId"],
+                    provider_message_id=message_id,
+                    classification=classification,
+                    created_at=now,
+                )
+                _record_safe_event(
+                    conn,
+                    job_key=anchor.job_key,
+                    evidence_id=evidence["evidenceId"],
+                    suggestion_id=suggestion["suggestionId"],
+                    classification=classification,
+                    link_confidence=evidence["linkConfidence"],
+                    signals=decision.signals,
+                    occurred_at=now,
+                )
+                conn.commit()
+
+                summary["linkedEvidenceCount"] += 1
+                if suggestion["created"]:
+                    summary["suggestionsCreatedCount"] += 1
+                summary["evidence"].append(
+                    {
+                        "evidenceId": evidence["evidenceId"],
+                        "jobKey": anchor.job_key,
+                        "providerMessageId": message_id,
+                        "linkConfidence": evidence["linkConfidence"],
+                    }
+                )
+                summary["suggestions"].append(
+                    {
+                        "suggestionId": suggestion["suggestionId"],
+                        "evidenceId": evidence["evidenceId"],
+                        "jobKey": anchor.job_key,
+                        "kind": classification.kind,
+                        "confidence": classification.confidence,
+                    }
+                )
+
+        return summary
+    finally:
+        conn.close()
+
+
+def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
+    """Create the feedback tables with the TypeScript API's table shape."""
+
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS application_review_decisions (
+          tenant_id    TEXT NOT NULL DEFAULT 'local',
+          decision_id  TEXT NOT NULL,
+          job_key      TEXT NOT NULL,
+          decision     TEXT NOT NULL,
+          reason       TEXT,
+          decided_by   TEXT NOT NULL DEFAULT 'user',
+          decided_at   TEXT NOT NULL,
+          PRIMARY KEY (tenant_id, decision_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
+          ON application_review_decisions(tenant_id, job_key, decided_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_outcomes (
+          tenant_id     TEXT NOT NULL DEFAULT 'local',
+          outcome_id    TEXT NOT NULL,
+          job_key       TEXT NOT NULL,
+          kind          TEXT NOT NULL,
+          source        TEXT NOT NULL,
+          note          TEXT,
+          occurred_at   TEXT NOT NULL,
+          recorded_at   TEXT NOT NULL,
+          suggestion_id TEXT,
+          evidence_id   TEXT,
+          created_by    TEXT NOT NULL DEFAULT 'user',
+          PRIMARY KEY (tenant_id, outcome_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_outcomes_job
+          ON application_outcomes(tenant_id, job_key, occurred_at DESC, recorded_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_email_evidence (
+          tenant_id            TEXT NOT NULL DEFAULT 'local',
+          evidence_id          TEXT NOT NULL,
+          job_key              TEXT NOT NULL,
+          provider             TEXT NOT NULL DEFAULT 'gmail',
+          provider_message_id  TEXT NOT NULL,
+          provider_thread_id   TEXT,
+          from_address         TEXT,
+          to_addresses_json    TEXT NOT NULL DEFAULT '[]',
+          subject              TEXT,
+          snippet              TEXT,
+          received_at          TEXT,
+          linked_at            TEXT NOT NULL,
+          link_confidence      REAL NOT NULL DEFAULT 0,
+          link_signals_json    TEXT NOT NULL DEFAULT '[]',
+          body_text            TEXT,
+          body_sha256          TEXT,
+          body_stored_at       TEXT,
+          PRIMARY KEY (tenant_id, evidence_id),
+          UNIQUE (tenant_id, provider, provider_message_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_email_evidence_job
+          ON application_email_evidence(tenant_id, job_key, received_at DESC);
+
+        CREATE TABLE IF NOT EXISTS application_outcome_suggestions (
+          tenant_id          TEXT NOT NULL DEFAULT 'local',
+          suggestion_id      TEXT NOT NULL,
+          job_key            TEXT NOT NULL,
+          evidence_id        TEXT,
+          suggested_kind     TEXT NOT NULL,
+          confidence         REAL NOT NULL DEFAULT 0,
+          rationale          TEXT NOT NULL DEFAULT '',
+          status             TEXT NOT NULL DEFAULT 'pending',
+          created_at         TEXT NOT NULL,
+          decided_at         TEXT,
+          decision           TEXT,
+          decision_reason    TEXT,
+          decided_outcome_id TEXT,
+          PRIMARY KEY (tenant_id, suggestion_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_job
+          ON application_outcome_suggestions(tenant_id, job_key, status, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
+          ON application_outcome_suggestions(tenant_id, status, created_at DESC);
+        """
+    )
+
+
+def classify_outcome(*, subject: str, snippet: str, body_text: str) -> Classification:
+    """Classify linked application email evidence with deterministic v1 rules."""
+
+    haystack = " ".join([subject, snippet, body_text]).lower()
+    rules: tuple[tuple[str, float, str, tuple[str, ...]], ...] = (
+        (
+            "bounced",
+            0.95,
+            "Delivery failure language indicates the application email bounced.",
+            ("undeliverable", "delivery status notification", "address not found", "bounced"),
+        ),
+        (
+            "offer",
+            0.95,
+            "Offer language indicates a positive application outcome.",
+            ("pleased to offer", "offer letter", "employment offer", "congratulations"),
+        ),
+        (
+            "rejection",
+            0.9,
+            "Rejection language indicates the employer is not moving forward.",
+            (
+                "not moving forward",
+                "not selected",
+                "unfortunately",
+                "pursue other candidates",
+                "after careful consideration",
+            ),
+        ),
+        (
+            "interview",
+            0.9,
+            "Interview scheduling language indicates an interview outcome.",
+            ("interview", "schedule a call", "availability", "meet with", "technical screen"),
+        ),
+        (
+            "assessment",
+            0.88,
+            "Assessment language indicates a test or take-home step.",
+            ("assessment", "coding challenge", "take-home", "take home", "online test"),
+        ),
+        (
+            "applied_confirmation",
+            0.9,
+            "Application confirmation language indicates the submission was received.",
+            (
+                "application received",
+                "thank you for applying",
+                "thanks for applying",
+                "we received your application",
+                "application has been submitted",
+            ),
+        ),
+        (
+            "recruiter_reply",
+            0.82,
+            "Recruiter reply language indicates direct follow-up from recruiting.",
+            ("recruiter", "talent acquisition", "thanks for reaching out", "next steps"),
+        ),
+    )
+    for kind, confidence, rationale, terms in rules:
+        if any(term in haystack for term in terms):
+            return Classification(kind=kind, confidence=confidence, rationale=rationale)
+    return Classification(
+        kind="unknown",
+        confidence=0.25,
+        rationale="No deterministic outcome language matched this linked email.",
+    )
+
+
+def _store_linked_message(
+    *,
+    conn: sqlite3.Connection,
+    anchor: ApplicationAnchor,
+    metadata: dict[str, Any],
+    full_message: dict[str, Any],
+    decision: LinkDecision,
+    linked_at: datetime,
+) -> dict[str, Any]:
+    message_id = _text(metadata.get("id") or full_message.get("id"))
+    evidence_id = _stable_id("gmail-evidence", message_id)
+    body_text = _text(full_message.get("body_text"))[:12000]
+    body_sha256 = hashlib.sha256(body_text.encode("utf-8")).hexdigest()
+    received_at = _message_datetime(metadata) or _message_datetime(full_message)
+    subject = _nullable_text(full_message.get("subject") or metadata.get("subject"))
+    snippet = _nullable_text(full_message.get("snippet") or metadata.get("snippet"))
+    from_address = _nullable_text(full_message.get("from") or metadata.get("from"))
+    to_addresses = _email_addresses(_text(full_message.get("to") or metadata.get("to")))
+    thread_id = _nullable_text(full_message.get("threadId") or metadata.get("threadId"))
+    linked_at_text = _iso(linked_at)
+
+    conn.execute(
+        """
+        INSERT INTO application_email_evidence (
+            tenant_id, evidence_id, job_key, provider, provider_message_id,
+            provider_thread_id, from_address, to_addresses_json, subject, snippet,
+            received_at, linked_at, link_confidence, link_signals_json,
+            body_text, body_sha256, body_stored_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            TENANT_ID,
+            evidence_id,
+            anchor.job_key,
+            PROVIDER,
+            message_id,
+            thread_id,
+            from_address,
+            json.dumps(to_addresses),
+            subject,
+            snippet,
+            _iso(received_at) if received_at else None,
+            linked_at_text,
+            decision.confidence,
+            json.dumps(list(decision.signals), sort_keys=True),
+            body_text,
+            body_sha256,
+            linked_at_text,
+        ),
+    )
+    return {
+        "evidenceId": evidence_id,
+        "subject": subject,
+        "snippet": snippet,
+        "linkConfidence": decision.confidence,
+    }
+
+
+def _store_suggestion(
+    *,
+    conn: sqlite3.Connection,
+    anchor: ApplicationAnchor,
+    evidence_id: str,
+    provider_message_id: str,
+    classification: Classification,
+    created_at: datetime,
+) -> dict[str, Any]:
+    suggestion_id = _stable_id(
+        "gmail-suggestion",
+        f"{anchor.job_key}|{provider_message_id}|{classification.kind}",
+    )
+    cursor = conn.execute(
+        """
+        INSERT OR IGNORE INTO application_outcome_suggestions (
+            tenant_id, suggestion_id, job_key, evidence_id, suggested_kind,
+            confidence, rationale, status, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            TENANT_ID,
+            suggestion_id,
+            anchor.job_key,
+            evidence_id,
+            classification.kind,
+            classification.confidence,
+            classification.rationale,
+            "pending",
+            _iso(created_at),
+        ),
+    )
+    return {"suggestionId": suggestion_id, "created": cursor.rowcount > 0}
+
+
+def _record_safe_event(
+    conn: sqlite3.Connection,
+    *,
+    job_key: str,
+    evidence_id: str,
+    suggestion_id: str,
+    classification: Classification,
+    link_confidence: float,
+    signals: tuple[str, ...],
+    occurred_at: datetime,
+) -> None:
+    if not _table_exists(conn, "job_events"):
+        return
+    columns = _columns(conn, "job_events")
+    payload = {
+        "tenantId": TENANT_ID,
+        "jobKey": job_key,
+        "evidenceId": evidence_id,
+        "suggestionId": suggestion_id,
+        "provider": PROVIDER,
+        "suggestedKind": classification.kind,
+        "classificationConfidence": classification.confidence,
+        "linkConfidence": link_confidence,
+        "linkSignals": list(signals),
+    }
+    values: dict[str, Any] = {
+        "job_url": job_key,
+        "stage": "apply",
+        "event_type": "ApplicationEmailFeedbackIngested",
+        "level": "info",
+        "message": "Application email feedback ingested.",
+        "occurred_at": _iso(occurred_at),
+        "payload_json": json.dumps(payload, sort_keys=True),
+    }
+    names = [name for name in values if name in columns]
+    if not names:
+        return
+    conn.execute(
+        f"INSERT INTO job_events ({', '.join(names)}) VALUES ({', '.join('?' for _ in names)})",
+        tuple(values[name] for name in names),
+    )
+
+
+def _link_metadata(
+    *,
+    anchor: ApplicationAnchor,
+    metadata: dict[str, Any],
+    recipient_email: str,
+    after: datetime,
+    before: datetime,
+) -> LinkDecision:
+    text = " ".join(
+        [
+            _text(metadata.get("subject")),
+            _text(metadata.get("snippet")),
+            _text(metadata.get("from")),
+            _text(metadata.get("to")),
+        ]
+    ).lower()
+    signals: list[str] = []
+    score = 0.0
+
+    recipients = {address.lower() for address in _email_addresses(_text(metadata.get("to")))}
+    if recipient_email.lower() in recipients:
+        signals.append("recipient")
+        score += 0.2
+
+    message_at = _message_datetime(metadata)
+    if message_at and after <= message_at <= before:
+        signals.append("time_window")
+        score += 0.2
+
+    if _any_hint_match(_name_tokens(anchor.company), text):
+        signals.append("company")
+        score += 0.2
+
+    if _any_hint_match(_title_tokens(anchor.title), text):
+        signals.append("job_title")
+        score += 0.15
+
+    if _any_hint_match(_application_url_tokens(anchor.application_url), text):
+        signals.append("application_domain")
+        score += 0.15
+
+    if _any_hint_match(_ATS_HINTS, text):
+        signals.append("ats_hint")
+        score += 0.1
+
+    if any(term in text for term in _OUTCOME_TERMS):
+        signals.append("outcome_term")
+        score += 0.1
+
+    confidence = round(min(score, 1.0), 2)
+    return LinkDecision(
+        linked=confidence >= LINK_THRESHOLD,
+        confidence=confidence,
+        signals=tuple(signals),
+    )
+
+
+def _load_application_anchors(conn: sqlite3.Connection, *, limit: int) -> list[ApplicationAnchor]:
+    anchors: dict[str, ApplicationAnchor] = {}
+    for anchor in [*_job_anchors(conn), *_outcome_anchors(conn), *_apply_run_anchors(conn)]:
+        existing = anchors.get(anchor.job_key)
+        if existing is None or anchor.anchor_at < existing.anchor_at:
+            anchors[anchor.job_key] = anchor
+    return sorted(anchors.values(), key=lambda item: item.anchor_at, reverse=True)[:limit]
+
+
+def _job_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
+    if not _table_exists(conn, "jobs"):
+        return []
+    columns = _columns(conn, "jobs")
+    title_expr = _column_expr(columns, "title")
+    company_expr = _first_column_expr(columns, ["company", "site", "employer"])
+    application_url_expr = _column_expr(columns, "application_url")
+    applied_at_expr = _column_expr(columns, "applied_at")
+    discovered_at_expr = _column_expr(columns, "discovered_at")
+    apply_status_expr = _column_expr(columns, "apply_status")
+    rows = conn.execute(
+        f"""
+        SELECT url AS job_key, {title_expr} AS title, {company_expr} AS company,
+               {application_url_expr} AS application_url,
+               COALESCE(NULLIF({applied_at_expr}, ''), NULLIF({discovered_at_expr}, '')) AS anchor_at
+        FROM jobs
+        WHERE NULLIF({applied_at_expr}, '') IS NOT NULL
+           OR lower(COALESCE({apply_status_expr}, '')) = 'applied'
+        """
+    ).fetchall()
+    return [_anchor_from_row(row) for row in rows if _anchor_from_row(row) is not None]
+
+
+def _outcome_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
+    if not _table_exists(conn, "application_outcomes") or not _table_exists(conn, "jobs"):
+        return []
+    columns = _columns(conn, "jobs")
+    title_expr = _column_expr(columns, "title", prefix="j")
+    company_expr = _first_column_expr(columns, ["company", "site", "employer"], prefix="j")
+    application_url_expr = _column_expr(columns, "application_url", prefix="j")
+    rows = conn.execute(
+        f"""
+        SELECT o.job_key AS job_key, {title_expr} AS title, {company_expr} AS company,
+               {application_url_expr} AS application_url, o.occurred_at AS anchor_at
+        FROM application_outcomes o
+        LEFT JOIN jobs j ON j.url = o.job_key
+        WHERE o.tenant_id = ?
+          AND o.kind IN (
+            'applied_confirmation', 'recruiter_reply', 'interview',
+            'assessment', 'rejection', 'offer', 'bounced'
+          )
+        """,
+        (TENANT_ID,),
+    ).fetchall()
+    return [_anchor_from_row(row) for row in rows if _anchor_from_row(row) is not None]
+
+
+def _apply_run_anchors(conn: sqlite3.Connection) -> list[ApplicationAnchor]:
+    if not _table_exists(conn, "apply_run_projections") or not _table_exists(conn, "jobs"):
+        return []
+    columns = _columns(conn, "jobs")
+    title_expr = _column_expr(columns, "title", prefix="j")
+    company_expr = _first_column_expr(columns, ["company", "site", "employer"], prefix="j")
+    application_url_expr = _column_expr(columns, "application_url", prefix="j")
+    rows = conn.execute(
+        f"""
+        SELECT a.job_id AS job_key, {title_expr} AS title, {company_expr} AS company,
+               {application_url_expr} AS application_url,
+               COALESCE(NULLIF(a.finished_at, ''), NULLIF(a.started_at, '')) AS anchor_at
+        FROM apply_run_projections a
+        LEFT JOIN jobs j ON j.url = a.job_id
+        WHERE COALESCE(a.dry_run, 0) = 0
+          AND (
+            lower(COALESCE(a.status, '')) IN ('succeeded', 'success', 'complete', 'completed')
+            OR lower(COALESCE(a.result, '')) LIKE '%applied%'
+            OR lower(COALESCE(a.result, '')) LIKE '%submitted%'
+          )
+        """
+    ).fetchall()
+    return [_anchor_from_row(row) for row in rows if _anchor_from_row(row) is not None]
+
+
+def _anchor_from_row(row: sqlite3.Row) -> ApplicationAnchor | None:
+    anchor_at = _parse_datetime(_text(row["anchor_at"]))
+    job_key = _text(row["job_key"])
+    if not job_key or anchor_at is None:
+        return None
+    return ApplicationAnchor(
+        job_key=job_key,
+        title=_text(row["title"]),
+        company=_text(row["company"]),
+        application_url=_text(row["application_url"]),
+        anchor_at=anchor_at,
+    )
+
+
+def _anchor_query(anchor: ApplicationAnchor) -> str:
+    hints: list[str] = []
+    hints.extend(_name_tokens(anchor.company))
+    hints.extend(_title_tokens(anchor.title))
+    hints.extend(_application_url_tokens(anchor.application_url))
+    hints.extend(hint for hint in _ATS_HINTS if hint in anchor.application_url.lower())
+    return " ".join(_dedupe(hints))
+
+
+def _profile_email(conn: sqlite3.Connection) -> str:
+    if not _table_exists(conn, "candidate_profiles") or "personal_email" not in _columns(conn, "candidate_profiles"):
+        return ""
+    row = conn.execute(
+        """
+        SELECT personal_email
+        FROM candidate_profiles
+        WHERE tenant_id = ? AND profile_id = ?
+        LIMIT 1
+        """,
+        (TENANT_ID, "default"),
+    ).fetchone()
+    return _text(row["personal_email"] if row else "")
+
+
+def _provider_message_exists(conn: sqlite3.Connection, provider_message_id: str) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM application_email_evidence
+        WHERE tenant_id = ? AND provider = ? AND provider_message_id = ?
+        LIMIT 1
+        """,
+        (TENANT_ID, PROVIDER, provider_message_id),
+    ).fetchone()
+    return row is not None
+
+
+def _message_datetime(message: dict[str, Any]) -> datetime | None:
+    internal_date = _text(message.get("internalDate"))
+    if internal_date.isdigit():
+        return datetime.fromtimestamp(int(internal_date) / 1000, tz=timezone.utc)
+    date_header = _text(message.get("date"))
+    if date_header:
+        try:
+            parsed = parsedate_to_datetime(date_header)
+        except (TypeError, ValueError):
+            return None
+        if parsed.tzinfo is None:
+            return parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    return None
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stable_id(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}-{digest}"
+
+
+def _bounded_int(value: int, *, minimum: int, maximum: int, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(parsed, maximum))
+
+
+def _email_addresses(value: str) -> list[str]:
+    return [address for _name, address in getaddresses([value]) if address]
+
+
+def _name_tokens(value: str) -> list[str]:
+    return [
+        token
+        for token in _safe_tokens(value)
+        if len(token) >= 3 and token.lower() not in {"inc", "llc", "ltd", "the"}
+    ][:4]
+
+
+def _title_tokens(value: str) -> list[str]:
+    stop = {"and", "for", "the", "with", "engineer", "developer", "manager"}
+    return [
+        token
+        for token in _safe_tokens(value)
+        if len(token) >= 4 and token.lower() not in stop
+    ][:6]
+
+
+def _application_url_tokens(value: str) -> list[str]:
+    if not value:
+        return []
+    parsed = urlparse(value)
+    tokens = _safe_tokens(" ".join([parsed.netloc, parsed.path]))
+    return [
+        token
+        for token in tokens
+        if len(token) >= 3 and token.lower() not in {"www", "com", "jobs", "apply"}
+    ][:8]
+
+
+def _safe_tokens(value: str) -> list[str]:
+    return _dedupe(
+        token
+        for token in _TOKEN_RE.findall(value or "")
+        if token.lower() not in {"from", "to", "after", "before", "older_than", "newer_than"}
+    )
+
+
+def _dedupe(values: Any) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = str(value).strip()
+        key = text.lower()
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        result.append(text)
+    return result
+
+
+def _any_hint_match(hints: Any, text: str) -> bool:
+    lowered = text.lower()
+    return any(str(hint).lower() in lowered for hint in hints if str(hint).strip())
+
+
+def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def _column_expr(columns: set[str], column: str, *, prefix: str | None = None) -> str:
+    if column not in columns:
+        return "''"
+    qualified = f"{prefix}.{column}" if prefix else column
+    return f"COALESCE({qualified}, '')"
+
+
+def _first_column_expr(
+    columns: set[str],
+    names: list[str],
+    *,
+    prefix: str | None = None,
+) -> str:
+    available = [
+        f"{prefix}.{name}" if prefix else name
+        for name in names
+        if name in columns
+    ]
+    if not available:
+        return "''"
+    return "COALESCE(" + ", ".join(available + ["''"]) + ")"
+
+
+def _text(value: Any) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def _nullable_text(value: Any) -> str | None:
+    text = _text(value)
+    return text or None
+
+
+def _read_stdin_json() -> dict[str, Any]:
+    if sys.stdin.isatty():
+        return {}
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise GmailFeedbackError("Gmail feedback worker input must be a JSON object.")
+    return parsed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run a bounded Gmail feedback scan.")
+    parser.add_argument("--db-path", required=True)
+    parser.add_argument("--recipient-email")
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT)
+    parser.add_argument("--max-results-per-anchor", type=int, default=DEFAULT_MAX_RESULTS_PER_ANCHOR)
+    parser.add_argument("--window-days", type=int, default=DEFAULT_WINDOW_DAYS)
+    args = parser.parse_args(argv)
+    try:
+        payload = _read_stdin_json()
+        summary = scan_gmail_feedback(
+            db_path=args.db_path,
+            recipient_email=payload.get("recipientEmail") or args.recipient_email,
+            limit=int(payload.get("limit") or args.limit),
+            max_results_per_anchor=int(
+                payload.get("maxResultsPerAnchor") or args.max_results_per_anchor
+            ),
+            window_days=int(payload.get("windowDays") or args.window_days),
+        )
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": exc.__class__.__name__,
+                    "message": str(exc),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/workers/automation/tests/test_gmail_feedback.py
+++ b/workers/automation/tests/test_gmail_feedback.py
@@ -99,6 +99,43 @@ def test_unlinked_metadata_does_not_read_email_body(tmp_path: Path) -> None:
     assert summary["unlinkedCandidateCount"] == 1
 
 
+def test_body_snippet_does_not_contribute_to_pre_link_decision(tmp_path: Path) -> None:
+    db_path = seed_feedback_db(tmp_path)
+    client = FakeGmailClient(
+        [
+            {
+                "id": "snippet-only-match",
+                "threadId": "thread-snippet",
+                "subject": "Weekly engineering newsletter",
+                "from": "newsletter@other.example",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 11:00:00 +0000",
+                "snippet": "ExampleCo Platform Engineer application received via greenhouse.",
+                "internalDate": str(epoch_ms("2026-06-01T11:00:00+00:00")),
+            }
+        ],
+        {
+            "snippet-only-match": {
+                "id": "snippet-only-match",
+                "body_text": "This body must not be fetched from a snippet-only match.",
+            }
+        },
+    )
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=client,
+        recipient_email=RECIPIENT,
+        limit=1,
+        max_results_per_anchor=5,
+        window_days=7,
+    )
+
+    assert client.read_calls == []
+    assert summary["linkedEvidenceCount"] == 0
+    assert summary["unlinkedCandidateCount"] == 1
+
+
 def test_linked_body_is_ingested_and_suggested(tmp_path: Path) -> None:
     db_path = seed_feedback_db(tmp_path)
     body_text = "Private application confirmation body for the candidate."

--- a/workers/automation/tests/test_gmail_feedback.py
+++ b/workers/automation/tests/test_gmail_feedback.py
@@ -1,0 +1,456 @@
+"""Gmail application outcome feedback ingestion tests."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from jobhunter.infrastructure.gmail.feedback import (
+    classify_outcome,
+    ensure_application_feedback_tables,
+    scan_gmail_feedback,
+)
+
+
+RECIPIENT = "candidate@example.com"
+JOB_URL = "https://jobs.example.com/platform-engineer"
+APPLIED_AT = "2026-06-01T10:00:00+00:00"
+
+
+class FakeGmailClient:
+    def __init__(
+        self,
+        metadata: list[dict[str, Any]],
+        bodies: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self.metadata = metadata
+        self.bodies = bodies or {}
+        self.search_calls: list[dict[str, Any]] = []
+        self.read_calls: list[str] = []
+
+    def search_feedback_emails(
+        self,
+        *,
+        query: str,
+        to_email: str,
+        after: datetime,
+        before: datetime,
+        max_results: int,
+    ) -> list[dict[str, Any]]:
+        self.search_calls.append(
+            {
+                "query": query,
+                "to_email": to_email,
+                "after": after,
+                "before": before,
+                "max_results": max_results,
+            }
+        )
+        return self.metadata[:max_results]
+
+    def read_email(self, *, message_id: str) -> dict[str, Any]:
+        self.read_calls.append(message_id)
+        return self.bodies[message_id]
+
+
+def test_unlinked_metadata_does_not_read_email_body(tmp_path: Path) -> None:
+    db_path = seed_feedback_db(tmp_path)
+    client = FakeGmailClient(
+        [
+            {
+                "id": "low-confidence",
+                "threadId": "thread-1",
+                "subject": "Weekly engineering newsletter",
+                "from": "newsletter@other.example",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 11:00:00 +0000",
+                "snippet": "General career content with no application signal.",
+                "internalDate": str(epoch_ms("2026-06-01T11:00:00+00:00")),
+            }
+        ]
+    )
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=client,
+        recipient_email=RECIPIENT,
+        limit=1,
+        max_results_per_anchor=5,
+        window_days=7,
+    )
+
+    assert client.search_calls
+    search = client.search_calls[0]
+    query = search["query"]
+    assert search["to_email"] == RECIPIENT
+    assert search["after"] == datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc)
+    assert search["before"] == datetime(2026, 6, 8, 10, 0, tzinfo=timezone.utc)
+    assert "ExampleCo" in query
+    assert "Platform" in query
+    assert "greenhouse" in query
+    assert client.read_calls == []
+    assert summary["linkedEvidenceCount"] == 0
+    assert summary["unlinkedCandidateCount"] == 1
+
+
+def test_linked_body_is_ingested_and_suggested(tmp_path: Path) -> None:
+    db_path = seed_feedback_db(tmp_path)
+    body_text = "Private application confirmation body for the candidate."
+    client = FakeGmailClient(
+        [
+            {
+                "id": "linked-message",
+                "threadId": "thread-2",
+                "subject": "ExampleCo application received for Platform Engineer",
+                "from": "recruiting@exampleco.com",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 12:00:00 +0000",
+                "snippet": "Thank you for applying to ExampleCo.",
+                "internalDate": str(epoch_ms("2026-06-01T12:00:00+00:00")),
+            }
+        ],
+        {
+            "linked-message": {
+                "id": "linked-message",
+                "threadId": "thread-2",
+                "subject": "ExampleCo application received for Platform Engineer",
+                "from": "recruiting@exampleco.com",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 12:00:00 +0000",
+                "snippet": "Thank you for applying to ExampleCo.",
+                "body_text": body_text,
+            }
+        },
+    )
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=client,
+        recipient_email=RECIPIENT,
+        limit=1,
+        max_results_per_anchor=5,
+        window_days=7,
+    )
+
+    assert client.read_calls == ["linked-message"]
+    assert summary["linkedEvidenceCount"] == 1
+    assert summary["suggestions"] == [
+        {
+            "suggestionId": summary["suggestions"][0]["suggestionId"],
+            "evidenceId": summary["evidence"][0]["evidenceId"],
+            "jobKey": JOB_URL,
+            "kind": "applied_confirmation",
+            "confidence": pytest.approx(0.9),
+        }
+    ]
+
+    conn = sqlite3.connect(db_path)
+    try:
+        evidence = conn.execute(
+            """
+            SELECT provider_message_id, body_text, body_sha256, link_confidence,
+                   link_signals_json
+            FROM application_email_evidence
+            """
+        ).fetchone()
+        assert evidence == (
+            "linked-message",
+            body_text,
+            hashlib.sha256(body_text.encode("utf-8")).hexdigest(),
+            pytest.approx(1.0),
+            json.dumps(
+                [
+                    "recipient",
+                    "time_window",
+                    "company",
+                    "job_title",
+                    "application_domain",
+                    "outcome_term",
+                ],
+                sort_keys=True,
+            ),
+        )
+        suggestion = conn.execute(
+            "SELECT suggested_kind, confidence, rationale FROM application_outcome_suggestions"
+        ).fetchone()
+        assert suggestion[0] == "applied_confirmation"
+        assert suggestion[1] == pytest.approx(0.9)
+        assert "application confirmation" in suggestion[2].lower()
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("subject", "snippet", "body", "expected"),
+    [
+        (
+            "Application received",
+            "Thank you for applying",
+            "We received your application.",
+            "applied_confirmation",
+        ),
+        (
+            "Recruiter follow-up",
+            "Talent acquisition reply",
+            "Thanks for reaching out. I am the recruiter for this role.",
+            "recruiter_reply",
+        ),
+        (
+            "Interview availability",
+            "Schedule a call",
+            "Can you share times for a technical interview?",
+            "interview",
+        ),
+        (
+            "Assessment invitation",
+            "Coding challenge",
+            "Please complete this take-home assessment.",
+            "assessment",
+        ),
+        (
+            "Application update",
+            "Unfortunately",
+            "We are not moving forward with your application.",
+            "rejection",
+        ),
+        (
+            "Offer from ExampleCo",
+            "Congratulations",
+            "We are pleased to offer you the position.",
+            "offer",
+        ),
+        (
+            "Delivery Status Notification",
+            "Undeliverable",
+            "Address not found and message bounced.",
+            "bounced",
+        ),
+        ("Hello", "A general note", "No recognizable outcome.", "unknown"),
+    ],
+)
+def test_classification_kinds(
+    subject: str,
+    snippet: str,
+    body: str,
+    expected: str,
+) -> None:
+    result = classify_outcome(subject=subject, snippet=snippet, body_text=body)
+
+    assert result.kind == expected
+    assert 0 <= result.confidence <= 1
+    assert result.rationale
+
+
+def test_duplicate_gmail_message_id_is_deduped(tmp_path: Path) -> None:
+    db_path = seed_feedback_db(tmp_path)
+    seed_existing_evidence(db_path, provider_message_id="dupe-message")
+    client = FakeGmailClient(
+        [
+            {
+                "id": "dupe-message",
+                "threadId": "thread-dupe",
+                "subject": "ExampleCo application received for Platform Engineer",
+                "from": "recruiting@exampleco.com",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 12:00:00 +0000",
+                "snippet": "Thank you for applying to ExampleCo.",
+                "internalDate": str(epoch_ms("2026-06-01T12:00:00+00:00")),
+            }
+        ],
+        {
+            "dupe-message": {
+                "id": "dupe-message",
+                "body_text": "This duplicate body must not be fetched.",
+            }
+        },
+    )
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=client,
+        recipient_email=RECIPIENT,
+        limit=1,
+        max_results_per_anchor=5,
+        window_days=7,
+    )
+
+    assert client.read_calls == []
+    assert summary["duplicateMessageCount"] == 1
+    conn = sqlite3.connect(db_path)
+    try:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM application_email_evidence WHERE provider_message_id = ?",
+                ("dupe-message",),
+            ).fetchone()[0]
+            == 1
+        )
+        assert conn.execute("SELECT COUNT(*) FROM application_outcome_suggestions").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_raw_body_is_not_written_to_events_or_summary(tmp_path: Path) -> None:
+    db_path = seed_feedback_db(tmp_path)
+    body_text = "Sensitive private Gmail outcome body."
+    client = FakeGmailClient(
+        [
+            {
+                "id": "private-message",
+                "threadId": "thread-private",
+                "subject": "ExampleCo interview for Platform Engineer",
+                "from": "recruiting@exampleco.com",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 12:00:00 +0000",
+                "snippet": "Schedule a call with ExampleCo.",
+                "internalDate": str(epoch_ms("2026-06-01T12:00:00+00:00")),
+            }
+        ],
+        {
+            "private-message": {
+                "id": "private-message",
+                "threadId": "thread-private",
+                "subject": "ExampleCo interview for Platform Engineer",
+                "from": "recruiting@exampleco.com",
+                "to": RECIPIENT,
+                "date": "Mon, 01 Jun 2026 12:00:00 +0000",
+                "snippet": "Schedule a call with ExampleCo.",
+                "body_text": body_text,
+            }
+        },
+    )
+
+    summary = scan_gmail_feedback(
+        db_path=db_path,
+        client=client,
+        recipient_email=RECIPIENT,
+        limit=1,
+        max_results_per_anchor=5,
+        window_days=7,
+    )
+
+    assert body_text not in json.dumps(summary)
+    conn = sqlite3.connect(db_path)
+    try:
+        payloads = "\n".join(
+            row[0] or "" for row in conn.execute("SELECT payload_json FROM job_events").fetchall()
+        )
+        assert body_text not in payloads
+    finally:
+        conn.close()
+
+
+def seed_feedback_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "jobhunter.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute(
+        """
+        CREATE TABLE jobs (
+            url TEXT PRIMARY KEY,
+            title TEXT,
+            company TEXT,
+            site TEXT,
+            application_url TEXT,
+            applied_at TEXT,
+            apply_status TEXT,
+            discovered_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            url, title, company, site, application_url, applied_at,
+            apply_status, discovered_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            JOB_URL,
+            "Principal Platform Engineer",
+            "ExampleCo",
+            "ExampleCo",
+            "https://boards.greenhouse.io/exampleco/jobs/123",
+            APPLIED_AT,
+            "applied",
+            "2026-05-31T10:00:00+00:00",
+        ),
+    )
+    conn.execute(
+        """
+        CREATE TABLE candidate_profiles (
+            tenant_id TEXT NOT NULL DEFAULT 'local',
+            profile_id TEXT NOT NULL DEFAULT 'default',
+            personal_email TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (tenant_id, profile_id)
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO candidate_profiles (tenant_id, profile_id, personal_email) VALUES (?, ?, ?)",
+        ("local", "default", RECIPIENT),
+    )
+    conn.execute(
+        """
+        CREATE TABLE job_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_url TEXT,
+            stage TEXT,
+            event_type TEXT NOT NULL DEFAULT '',
+            level TEXT NOT NULL DEFAULT 'info',
+            message TEXT,
+            occurred_at TEXT NOT NULL,
+            payload_json TEXT
+        )
+        """
+    )
+    ensure_application_feedback_tables(conn)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def seed_existing_evidence(db_path: Path, *, provider_message_id: str) -> None:
+    conn = sqlite3.connect(db_path)
+    ensure_application_feedback_tables(conn)
+    conn.execute(
+        """
+        INSERT INTO application_email_evidence (
+            tenant_id, evidence_id, job_key, provider, provider_message_id,
+            provider_thread_id, from_address, to_addresses_json, subject, snippet,
+            received_at, linked_at, link_confidence, link_signals_json,
+            body_text, body_sha256, body_stored_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "local",
+            "existing-evidence",
+            JOB_URL,
+            "gmail",
+            provider_message_id,
+            "thread-dupe",
+            "recruiting@exampleco.com",
+            json.dumps([RECIPIENT]),
+            "Existing",
+            "Existing",
+            "2026-06-01T12:00:00+00:00",
+            "2026-06-01T12:01:00+00:00",
+            0.95,
+            json.dumps(["recipient", "time_window", "company"]),
+            "existing body",
+            hashlib.sha256(b"existing body").hexdigest(),
+            "2026-06-01T12:01:00+00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+def epoch_ms(value: str) -> int:
+    return int(datetime.fromisoformat(value).timestamp() * 1000)


### PR DESCRIPTION
## Summary
- add a Gmail-only feedback scanner separate from the verification-code MCP server
- bound scans to known local application anchors, recipient/time windows, and employer/title/ATS/application URL hints
- persist linked Gmail evidence and deterministic outcome suggestions while keeping raw bodies out of API responses and event payloads
- expose `POST /v1/outcomes/gmail/scan` through a sanitized worker wrapper and update the API client/contracts
- document Gmail feedback behavior, privacy constraints, and QA coverage

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_gmail_feedback.py` -> 12 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/gmail workers/automation/tests/test_gmail_feedback.py` -> All checks passed
- `corepack pnpm api:test` -> 9 files / 157 tests passed
- `corepack pnpm api:check` -> passed
- `corepack pnpm test` -> API tests passed, web build passed, Python tests 1078 passed
- `corepack pnpm --filter @jobhunter/contracts check && corepack pnpm --filter @jobhunter/api-client check` -> passed
- `git diff --check` and `git diff --cached --check` -> passed

## Notes
- This PR is stacked on `feat/apply-review-ui` and includes base commit `5f3f71e` in ancestry.
- Tests use fakes only; no real Gmail mailbox data was scanned or ingested.