### PR TITLE
fix: hand off ATS postings to scoring

### DIFF
--- a/apps/api/src/location-normalization.ts
+++ b/apps/api/src/location-normalization.ts
@@ -5,7 +5,9 @@ const SPAIN_REGION_LABELS: Record<string, string> = {
 };
 
 const REMOTE_PATTERN = /\b(?:remote|en remoto|remoto|teletrabajo|work from home|wfh)\b/i;
+const REMOTE_TOKEN_PATTERN = /\b(?:remote|en remoto|remoto|teletrabajo|work from home|wfh)\b/gi;
 const REMOTE_MARKER_PATTERN = /\s*\((?:remote|en remoto|remoto)\)\s*/gi;
+const REMOTE_SEPARATOR_PATTERN = /^\s*[-:|]+\s*|\s*[-:|]+\s*$/g;
 
 export function normalizeJobLocation(location: string | null | undefined): string {
   const raw = String(location ?? "").trim();
@@ -17,8 +19,8 @@ export function normalizeJobLocation(location: string | null | undefined): strin
   const cleaned = raw
     .replace(REMOTE_MARKER_PATTERN, " ")
     .split(",")
-    .map((part) => part.trim())
-    .filter((part) => part && !REMOTE_PATTERN.test(part));
+    .map(stripRemoteMarkers)
+    .filter(Boolean);
 
   const hasSpainCountry = cleaned.some(isSpainCountryToken);
   const parts = cleaned
@@ -28,6 +30,15 @@ export function normalizeJobLocation(location: string | null | undefined): strin
   const base = deduped.length ? deduped.join(", ") : isRemote ? "Remote" : raw;
 
   return isRemote && !/\bremote\b/i.test(base) ? `${base} (Remote)` : base;
+}
+
+function stripRemoteMarkers(part: string): string {
+  return part
+    .replace(REMOTE_MARKER_PATTERN, " ")
+    .replace(REMOTE_TOKEN_PATTERN, " ")
+    .replace(REMOTE_SEPARATOR_PATTERN, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
 }
 
 function normalizeLocationPart(part: string, hasSpainCountry: boolean): string {

--- a/apps/api/test/location-normalization.test.ts
+++ b/apps/api/test/location-normalization.test.ts
@@ -8,6 +8,9 @@ describe("normalizeJobLocation", () => {
     ["En remoto, ES (Remote)", "Spain (Remote)"],
     ["Barcelona, CT, ES (Remote)", "Barcelona, Catalonia, Spain (Remote)"],
     ["Madrid, MD, ES", "Madrid, Community of Madrid, Spain"],
+    ["Work from Home - Poland", "Poland (Remote)"],
+    ["Work From Home - US", "US (Remote)"],
+    ["UK - Remote", "UK (Remote)"],
   ])("normalizes source location %s", (input, expected) => {
     expect(normalizeJobLocation(input)).toBe(expected);
   });

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -36,14 +36,18 @@ from jobhunter.domain.discovery.source_registry import (
     SourceRegistryEntry,
     validate_locator_candidate,
 )
-from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase, PostingAcceptance
+from jobhunter.domain.discovery.use_cases import (
+    DiscoverJobsUseCase,
+    PostingAcceptance,
+    default_canonical_identity,
+)
 from jobhunter.domain.discovery.value_objects import (
     JobMetadata,
     PostingUrl,
     SearchStrategy,
     Source,
 )
-from jobhunter.domain.enrichment import DetailPage, ExtractionTier
+from jobhunter.domain.enrichment import DetailPage, ExtractionTier, FullDescription, JobEnrichment
 from jobhunter.domain.enrichment.services import CssSelectorExtractor, JsonLdExtractor
 from jobhunter.domain.enrichment.snapshot_services import (
     ContentAcquisitionService,
@@ -71,7 +75,7 @@ from jobhunter.infrastructure.enrichment import (
     SqliteEnrichmentRepository,
     SqlitePostingSnapshotSetRepository,
 )
-from jobhunter.state import record_job_event
+from jobhunter.state import ensure_job_stage_rows, record_job_event, set_stage_state
 
 
 def utc_now() -> str:
@@ -473,8 +477,10 @@ def run_scheduled_ats_sources(
     if not adapters:
         return ScheduledAtsSummary().to_result_dict()
 
+    job_repository = SqliteJobRepository(conn)
+    enrichment_repository = SqliteEnrichmentRepository(conn)
     use_case = DiscoverJobsUseCase(
-        repository=SqliteJobRepository(conn),
+        repository=job_repository,
         publisher=DurableJobEventPublisher(conn, stage="discover"),
         acceptance_policy=_posting_acceptance_policy(search_cfg),
     )
@@ -517,6 +523,14 @@ def run_scheduled_ats_sources(
                         postings=[posting],
                         run_id=run_id,
                     )
+                    if summary.new_jobs > 0 or summary.observed > 0:
+                        _promote_ats_source_description_to_enrichment(
+                            conn,
+                            job_repository=job_repository,
+                            enrichment_repository=enrichment_repository,
+                            posting=posting,
+                            observed_at=utc_now(),
+                        )
                     total += summary.total
                     new_jobs += summary.new_jobs
                     observed_jobs += summary.observed
@@ -539,6 +553,106 @@ def run_scheduled_ats_sources(
         sources_run=tuple(sources_run),
         failed_sources=tuple(failed_sources),
     ).to_result_dict()
+
+
+def _promote_ats_source_description_to_enrichment(
+    conn: sqlite3.Connection,
+    *,
+    job_repository: SqliteJobRepository,
+    enrichment_repository: SqliteEnrichmentRepository,
+    posting: ScrapedJobPosting,
+    observed_at: str,
+) -> bool:
+    description = str(posting.metadata.description or "").strip()
+    if not description:
+        return False
+
+    identity = default_canonical_identity(posting)
+    job_id = job_repository.find_canonical_owner(
+        LOCAL_TENANT,
+        source_id=posting.source_id,
+        source_native_id=identity.source_native_id,
+        canonical_url=identity.canonical_url,
+    ) or JobId(identity.canonical_url or posting.posting_url.value)
+    if job_repository.load(LOCAL_TENANT, job_id) is None:
+        return False
+
+    existing = enrichment_repository.load(LOCAL_TENANT, job_id)
+    if existing is not None and (existing.is_enriched or existing.is_running):
+        return False
+
+    base = existing or JobEnrichment.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        updated_at=observed_at,
+    )
+    succeeded = base.start_attempt(
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        started_at=observed_at,
+    ).succeed_attempt(
+        full_description=FullDescription(text=description),
+        application_url=None,
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        finished_at=observed_at,
+    )
+    enrichment_repository.save(succeeded)
+
+    job_url = str(job_id)
+    ensure_job_stage_rows(conn, job_url, discovered_at=observed_at)
+    stage_row = conn.execute(
+        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        (job_url,),
+    ).fetchone()
+    stage_state = str(stage_row["state"] or "") if stage_row is not None else ""
+    if stage_state != "succeeded":
+        if stage_state != "running":
+            try:
+                set_stage_state(
+                    conn,
+                    job_url,
+                    "enrich",
+                    "running",
+                    attempt_count=succeeded.attempt_count,
+                    started_at=observed_at,
+                )
+            except ValueError:
+                set_stage_state(
+                    conn,
+                    job_url,
+                    "enrich",
+                    "running",
+                    attempt_count=succeeded.attempt_count,
+                    started_at=observed_at,
+                    validate_transition=False,
+                )
+        set_stage_state(
+            conn,
+            job_url,
+            "enrich",
+            "succeeded",
+            attempt_count=succeeded.attempt_count,
+            started_at=observed_at,
+            finished_at=observed_at,
+        )
+        record_job_event(
+            conn,
+            job_url,
+            "enrich",
+            "StageCompleted",
+            message=(
+                "ATS source description promoted to enrichment: "
+                f"{len(description)} description chars"
+            ),
+            payload={
+                "source_id": posting.source_id,
+                "source_native_id": identity.source_native_id,
+                "extraction_tier": ExtractionTier.CSS_SELECTORS.value,
+                "description_length": len(description),
+            },
+            occurred_at=observed_at,
+        )
+    conn.commit()
+    return True
 
 
 def retire_invalid_source_jobs(

--- a/workers/automation/tests/fixtures/discovery_barcelona_acceptance.json
+++ b/workers/automation/tests/fixtures/discovery_barcelona_acceptance.json
@@ -11,6 +11,6 @@
     "manual_action_count": 1,
     "canonical_verification_rate": 1.0,
     "source_quality_updates": 4,
-    "scoring_handoff_count": 1
+    "scoring_handoff_count": 4
   }
 }

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -11,7 +11,7 @@ import pytest
 
 from jobhunter import config
 from jobhunter.discovery import manual_capture_import as manual_capture_import_cli
-from jobhunter.database import close_connection, init_db
+from jobhunter.database import close_connection, get_jobs_by_stage, init_db
 from jobhunter.domain.discovery import (
     AtsKind,
     JobMetadata,
@@ -421,6 +421,33 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
         ).fetchall()
     }
     assert ats_kinds == {"greenhouse", "lever", "ashby"}
+    expected_urls = {
+        "https://boards.greenhouse.io/barcelonatech/jobs/101",
+        "https://jobs.lever.co/leadershipco/202",
+        "https://jobs.ashbyhq.com/platformops/303",
+    }
+    enrichments = conn.execute(
+        """
+        SELECT job_url, current_status, full_description, extraction_tier
+        FROM job_enrichments
+        """
+    ).fetchall()
+    assert {row["job_url"] for row in enrichments} == expected_urls
+    assert {row["current_status"] for row in enrichments} == {"enriched"}
+    assert {row["extraction_tier"] for row in enrichments} == {"css_selectors"}
+    assert all(str(row["full_description"] or "").strip() for row in enrichments)
+    stage_rows = conn.execute(
+        """
+        SELECT job_url, state
+        FROM job_stage_states
+        WHERE stage = 'enrich'
+        """
+    ).fetchall()
+    assert {row["job_url"] for row in stage_rows} == expected_urls
+    assert {row["state"] for row in stage_rows} == {"succeeded"}
+    assert {
+        row["url"] for row in get_jobs_by_stage(conn, "pending_score", limit=0)
+    } == expected_urls
 
 
 def test_canonical_ats_scheduler_fetches_each_source_once_then_filters_queries(


### PR DESCRIPTION
## Summary
- preserve geographic locations when normalizing remote ATS labels such as `Work from Home - Poland`
- promote accepted ATS source descriptions into enrichment so scoring can pick them up without waiting for a separate detail fetch
- update discovery production-wiring regressions and the acceptance fixture for the expanded scoring handoff count

## Root cause
Accepted Greenhouse/Lever/Ashby postings already carried full source descriptions, but the production discovery wiring persisted them only on the discovery job row. The scoring selector reads the enrichment-backed full description, so those jobs could remain active with no score handoff. Separately, the API location normalizer removed entire remote-marker segments, collapsing `Work from Home - Poland` to `Remote`.

## Validation
- `corepack pnpm --filter @jobhunter/api test location-normalization`
- `corepack pnpm api:check`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_discovery_production_wiring.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py workers/automation/tests/test_discovery_production_wiring.py`