### PR TITLE
feat: redesign apply review workspace

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import fs from "node:fs";
 
 import type {
   ApplicationOutcome,
@@ -18,6 +19,7 @@ import type {
   OutcomeSuggestionDecisionRequest,
   OutcomeSuggestionDecisionResponse,
   OutcomeSuggestionStatus,
+  ScoreBreakdown,
   Stage,
   StageState,
 } from "./contracts.js";
@@ -34,6 +36,11 @@ import { InputError, resolveJobUrl } from "./write-model.js";
 
 const DEFAULT_TENANT = "local";
 const CLOSED_ACTIVE_STATES = ["closed", "expired", "removed", "location_incompatible"];
+const POSITION_PREVIEW_CHAR_LIMIT = 6000;
+const MATERIAL_PREVIEW_CHAR_LIMIT = 4000;
+const MATERIAL_PREVIEW_BYTE_LIMIT = 24_000;
+const EVIDENCE_LIST_LIMIT = 12;
+const EVIDENCE_TEXT_LIMIT = 180;
 
 interface ReviewQueueRow extends Record<string, unknown> {
   job_id: string;
@@ -42,6 +49,10 @@ interface ReviewQueueRow extends Record<string, unknown> {
   source: string;
   application_url: string | null;
   fit_score: number | null;
+  description: string;
+  full_description: string;
+  score_breakdown_json: string | null;
+  score_keywords_json: string | null;
   current_stage: string;
   current_state: string;
   current_error_code: string | null;
@@ -213,7 +224,9 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
       WHERE row_num = 1
     )
     SELECT jlp.job_id, jlp.title, jlp.employer, jlp.source, jlp.application_url,
-           jlp.fit_score, jlp.current_stage, jlp.current_state,
+           jlp.fit_score, jlp.description, jlp.full_description,
+           jlp.score_breakdown_json, jlp.score_keywords_json,
+           jlp.current_stage, jlp.current_state,
            jlp.current_error_code, jlp.current_error_message,
            jlp.has_resume, jlp.has_cover_letter, jlp.has_pdf,
            latest_decision.decision_id, latest_decision.decision,
@@ -251,7 +264,7 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
 
   return {
     ok: true,
-    items: rows.map(reviewQueueItemFromRow),
+    items: rows.map((row) => reviewQueueItemFromRow(db, row)),
   };
 }
 
@@ -554,9 +567,10 @@ function getSuggestionRow(db: SqliteDatabase, suggestionId: string): SuggestionR
   );
 }
 
-function reviewQueueItemFromRow(row: ReviewQueueRow): ApplyReviewQueueItem {
+function reviewQueueItemFromRow(db: SqliteDatabase, row: ReviewQueueRow): ApplyReviewQueueItem {
   const currentState = stageState(row.current_state);
   const blockers = queueBlockers(row, currentState);
+  const scoreBreakdown = parseQueueScoreBreakdown(row.score_breakdown_json);
   return {
     jobKey: row.job_id,
     title: row.title || "Untitled",
@@ -572,6 +586,22 @@ function reviewQueueItemFromRow(row: ReviewQueueRow): ApplyReviewQueueItem {
       hasPdf: Boolean(row.has_pdf),
       ready: Boolean(row.has_resume),
     },
+    position: {
+      descriptionPreview: previewText(
+        row.full_description || row.description,
+        POSITION_PREVIEW_CHAR_LIMIT,
+      ),
+      requirements: boundedEvidenceList([
+        ...(scoreBreakdown?.matchedSignals ?? []),
+        ...(scoreBreakdown?.missingSignals ?? []),
+        ...(scoreBreakdown?.transferableSignals ?? []),
+      ]),
+      matched: boundedEvidenceList(scoreBreakdown?.matchedSignals ?? []),
+      missing: boundedEvidenceList(scoreBreakdown?.missingSignals ?? []),
+      transferable: boundedEvidenceList(scoreBreakdown?.transferableSignals ?? []),
+      keywords: boundedEvidenceList(parseStringListJson(row.score_keywords_json)),
+    },
+    materialsPreview: materialPreviewsForJob(db, row.job_id),
     latestApplyRun: row.run_id
       ? {
           runId: row.run_id,
@@ -599,6 +629,231 @@ function queueBlockers(row: ReviewQueueRow, currentState: StageState): string[] 
     blockers.push(row.current_error_code || row.current_error_message || `apply_${currentState}`);
   }
   return blockers;
+}
+
+function parseQueueScoreBreakdown(value: string | null): ScoreBreakdown | null {
+  if (!value) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(value) as Partial<ScoreBreakdown> | null;
+    if (!parsed || typeof parsed !== "object" || (parsed as Record<string, unknown>).legacy === true) {
+      return null;
+    }
+    return {
+      technicalFit: scoreDimension(parsed.technicalFit),
+      experienceFit: scoreDimension(parsed.experienceFit),
+      roleFit: scoreDimension(parsed.roleFit),
+      reasoning: typeof parsed.reasoning === "string" ? parsed.reasoning : "",
+      fitBand: parsed.fitBand ?? "plausible",
+      confidence: parsed.confidence ?? "medium",
+      eligibility: {
+        status: parsed.eligibility?.status ?? "unknown",
+        hardBlockers: boundedEvidenceList(parsed.eligibility?.hardBlockers ?? []),
+        warnings: boundedEvidenceList(parsed.eligibility?.warnings ?? []),
+      },
+      matchedSignals: boundedEvidenceList(parsed.matchedSignals ?? []),
+      missingSignals: boundedEvidenceList(parsed.missingSignals ?? []),
+      transferableSignals: boundedEvidenceList(parsed.transferableSignals ?? []),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function scoreDimension(value: unknown): number {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(0, Math.min(10, numeric)) : 0;
+}
+
+function parseStringListJson(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  try {
+    return parseStringList(JSON.parse(value));
+  } catch {
+    return [];
+  }
+}
+
+function parseStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return boundedEvidenceList(value);
+}
+
+function boundedEvidenceList(values: readonly unknown[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const value of values) {
+    const text = String(value ?? "").replace(/\s+/g, " ").trim();
+    if (!text) continue;
+    const bounded = text.length > EVIDENCE_TEXT_LIMIT ? `${text.slice(0, EVIDENCE_TEXT_LIMIT).trim()}...` : text;
+    const key = bounded.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(bounded);
+    if (out.length >= EVIDENCE_LIST_LIMIT) break;
+  }
+  return out;
+}
+
+function previewText(value: string | null | undefined, limit: number): string {
+  const text = String(value ?? "").replace(/\r\n/g, "\n").replace(/[ \t]+\n/g, "\n").trim();
+  if (!text) {
+    return "";
+  }
+  return text.length > limit ? `${text.slice(0, limit).trim()}...` : text;
+}
+
+function materialPreviewsForJob(
+  db: SqliteDatabase,
+  jobKey: string,
+): ApplyReviewQueueItem["materialsPreview"] {
+  return {
+    resumeText: firstReadableTextPreview(materialPreviewPaths(db, jobKey, "resume")),
+    resumePdfArtifactId: latestMaterialPdfArtifactId(db, jobKey, "resume"),
+    coverLetterText: firstReadableTextPreview(materialPreviewPaths(db, jobKey, "cover")),
+  };
+}
+
+function latestMaterialPdfArtifactId(db: SqliteDatabase, jobKey: string, kind: "resume" | "cover"): string | null {
+  const artifactTypes =
+    kind === "resume" ? ["tailored_resume_pdf", "resume_pdf"] : ["cover_letter_pdf"];
+  if (!tableExists(db, "artifact_list_projections")) {
+    return null;
+  }
+  const placeholders = artifactTypes.map(() => "?").join(", ");
+  const rows = allRows<{ artifact_id: string; local_path: string }>(
+    db,
+    `SELECT artifact_id, local_path
+     FROM artifact_list_projections
+     WHERE job_id = ?
+       AND artifact_type IN (${placeholders})
+       AND COALESCE(status, 'active') IN ('approved', 'active')
+       AND local_path IS NOT NULL
+       AND local_path != ''
+     ORDER BY COALESCE(generation, 0) DESC, COALESCE(created_at, '') DESC, artifact_id DESC
+     LIMIT 8`,
+    [jobKey, ...artifactTypes],
+  );
+  for (const row of rows) {
+    try {
+      if (fs.existsSync(row.local_path) && fs.statSync(row.local_path).isFile()) {
+        return row.artifact_id;
+      }
+    } catch {
+      // Artifact files can disappear while the local projection still exists.
+      // In that case the review UI should fall back to text evidence.
+    }
+  }
+  return null;
+}
+
+function materialPreviewPaths(db: SqliteDatabase, jobKey: string, kind: "resume" | "cover"): string[] {
+  const paths: string[] = [];
+  const artifactTypes =
+    kind === "resume"
+      ? ["tailored_resume", "tailored_resume_txt", "resume_txt"]
+      : ["cover_letter", "cover_letter_txt"];
+
+  if (tableExists(db, "job_materials_artifacts")) {
+    const placeholders = artifactTypes.map(() => "?").join(", ");
+    paths.push(
+      ...allRows<{ path: string }>(
+        db,
+        `SELECT path
+         FROM job_materials_artifacts
+         WHERE job_url = ?
+           AND artifact_type IN (${placeholders})
+           AND COALESCE(status, 'approved') IN ('approved', 'active')
+           AND path IS NOT NULL
+           AND path != ''
+         ORDER BY COALESCE(generation, 0) DESC, COALESCE(created_at, '') DESC`,
+        [jobKey, ...artifactTypes],
+      ).map((row) => row.path),
+    );
+  }
+
+  if (tableExists(db, "job_artifacts")) {
+    const placeholders = artifactTypes.map(() => "?").join(", ");
+    paths.push(
+      ...allRows<{ path: string }>(
+        db,
+        `SELECT path
+         FROM job_artifacts
+         WHERE job_url = ?
+           AND artifact_type IN (${placeholders})
+           AND COALESCE(status, 'active') NOT IN ('missing', 'failed', 'superseded', 'suppressed')
+           AND path IS NOT NULL
+           AND path != ''
+         ORDER BY COALESCE(created_at, '') DESC, rowid DESC`,
+        [jobKey, ...artifactTypes],
+      ).map((row) => row.path),
+    );
+  }
+
+  if (tableExists(db, "jobs")) {
+    const legacyColumn = kind === "resume" ? "tailored_resume_path" : "cover_letter_path";
+    const legacyRow = getRow<{ path: string | null }>(
+      db,
+      `SELECT ${legacyColumn} AS path FROM jobs WHERE url = ?`,
+      [jobKey],
+    );
+    if (legacyRow?.path) {
+      paths.push(legacyRow.path);
+    }
+  }
+
+  return paths;
+}
+
+function firstReadableTextPreview(paths: readonly string[]): string | null {
+  const seen = new Set<string>();
+  for (const artifactPath of paths) {
+    const path = artifactPath.trim();
+    if (!path || seen.has(path) || isBinaryPreviewPath(path)) continue;
+    seen.add(path);
+    const preview = readTextPreview(path);
+    if (preview) {
+      return preview;
+    }
+  }
+  return null;
+}
+
+function isBinaryPreviewPath(artifactPath: string): boolean {
+  return /\.(pdf|docx?|png|jpe?g|webp|gif|zip)$/i.test(artifactPath);
+}
+
+function readTextPreview(artifactPath: string): string | null {
+  let fd: number | null = null;
+  try {
+    const stats = fs.statSync(artifactPath);
+    if (!stats.isFile()) {
+      return null;
+    }
+    const byteCount = Math.min(stats.size, MATERIAL_PREVIEW_BYTE_LIMIT);
+    if (byteCount <= 0) {
+      return null;
+    }
+    const buffer = Buffer.alloc(byteCount);
+    fd = fs.openSync(artifactPath, "r");
+    const bytesRead = fs.readSync(fd, buffer, 0, byteCount, 0);
+    const text = buffer.subarray(0, bytesRead).toString("utf8");
+    if (!text.trim() || text.includes("\u0000")) {
+      return null;
+    }
+    return previewText(text, MATERIAL_PREVIEW_CHAR_LIMIT);
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      fs.closeSync(fd);
+    }
+  }
 }
 
 function outcomeFromRow(row: OutcomeRow): ApplicationOutcome {

--- a/apps/api/src/location-normalization.ts
+++ b/apps/api/src/location-normalization.ts
@@ -5,7 +5,9 @@ const SPAIN_REGION_LABELS: Record<string, string> = {
 };
 
 const REMOTE_PATTERN = /\b(?:remote|en remoto|remoto|teletrabajo|work from home|wfh)\b/i;
+const REMOTE_TOKEN_PATTERN = /\b(?:remote|en remoto|remoto|teletrabajo|work from home|wfh)\b/gi;
 const REMOTE_MARKER_PATTERN = /\s*\((?:remote|en remoto|remoto)\)\s*/gi;
+const REMOTE_SEPARATOR_PATTERN = /^\s*[-:|]+\s*|\s*[-:|]+\s*$/g;
 
 export function normalizeJobLocation(location: string | null | undefined): string {
   const raw = String(location ?? "").trim();
@@ -17,8 +19,8 @@ export function normalizeJobLocation(location: string | null | undefined): strin
   const cleaned = raw
     .replace(REMOTE_MARKER_PATTERN, " ")
     .split(",")
-    .map((part) => part.trim())
-    .filter((part) => part && !REMOTE_PATTERN.test(part));
+    .map(stripRemoteMarkers)
+    .filter(Boolean);
 
   const hasSpainCountry = cleaned.some(isSpainCountryToken);
   const parts = cleaned
@@ -28,6 +30,15 @@ export function normalizeJobLocation(location: string | null | undefined): strin
   const base = deduped.length ? deduped.join(", ") : isRemote ? "Remote" : raw;
 
   return isRemote && !/\bremote\b/i.test(base) ? `${base} (Remote)` : base;
+}
+
+function stripRemoteMarkers(part: string): string {
+  return part
+    .replace(REMOTE_MARKER_PATTERN, " ")
+    .replace(REMOTE_TOKEN_PATTERN, " ")
+    .replace(REMOTE_SEPARATOR_PATTERN, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
 }
 
 function normalizeLocationPart(part: string, hasSpainCountry: boolean): string {

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -60,6 +60,19 @@ describe("application feedback API", () => {
         hasResume: true,
         ready: true,
       },
+      position: {
+        descriptionPreview: "Full description",
+        requirements: ["platform leadership", "public company scale", "incident leadership"],
+        matched: ["platform leadership"],
+        missing: ["public company scale"],
+        transferable: ["incident leadership"],
+        keywords: ["platform", "leadership"],
+      },
+      materialsPreview: {
+        resumeText: "tailored resume",
+        resumePdfArtifactId: "apply-ready-resume-pdf",
+        coverLetterText: null,
+      },
       latestApplyRun: {
         runId: "dry-run-ready",
         dryRun: true,
@@ -412,7 +425,11 @@ function queueItem(body: unknown, jobKey: string): unknown {
 
 function seedDatabase(dbPath: string): void {
   const resumePath = path.join(path.dirname(dbPath), "resume.txt");
+  const resumePdfPath = path.join(path.dirname(dbPath), "resume.pdf");
+  const rejectedResumePdfPath = path.join(path.dirname(dbPath), "rejected-resume.pdf");
   fs.writeFileSync(resumePath, "tailored resume");
+  fs.writeFileSync(resumePdfPath, "%PDF-1.4\n% test\n");
+  fs.writeFileSync(rejectedResumePdfPath, "%PDF-1.4\n% rejected test\n");
   const db = new Database(dbPath);
   db.exec(`
     CREATE TABLE jobs (
@@ -483,6 +500,33 @@ function seedDatabase(dbPath: string): void {
       duration_ms INTEGER,
       events_json TEXT NOT NULL DEFAULT '[]'
     );
+    CREATE TABLE job_scores (
+      job_url TEXT NOT NULL,
+      version INTEGER NOT NULL,
+      tenant_id TEXT NOT NULL DEFAULT 'local',
+      fit_score INTEGER NOT NULL,
+      breakdown_json TEXT NOT NULL,
+      keywords_json TEXT NOT NULL,
+      scored_at TEXT,
+      correction_json TEXT NOT NULL DEFAULT '{}',
+      criteria_json TEXT NOT NULL DEFAULT '{}',
+      trace_json TEXT NOT NULL DEFAULT '{}',
+      PRIMARY KEY (job_url, version)
+    );
+    CREATE TABLE job_materials (
+      job_url TEXT NOT NULL,
+      generation INTEGER NOT NULL
+    );
+    CREATE TABLE job_materials_artifacts (
+      job_url TEXT NOT NULL,
+      generation INTEGER NOT NULL,
+      artifact_id TEXT,
+      artifact_type TEXT,
+      status TEXT,
+      path TEXT,
+      created_at TEXT,
+      size_bytes INTEGER
+    );
   `);
 
   insertJob(db, {
@@ -491,6 +535,8 @@ function seedDatabase(dbPath: string): void {
     site: "ExampleCo",
     fitScore: 9,
     resumePath,
+    resumePdfPath,
+    rejectedResumePdfPath,
     applyState: "pending",
   });
   insertJob(db, {
@@ -499,6 +545,8 @@ function seedDatabase(dbPath: string): void {
     site: "ExampleCo",
     fitScore: 8,
     resumePath,
+    resumePdfPath,
+    rejectedResumePdfPath,
     applyState: "pending",
   });
   insertJob(db, {
@@ -507,6 +555,8 @@ function seedDatabase(dbPath: string): void {
     site: "ExampleCo",
     fitScore: 8,
     resumePath,
+    resumePdfPath,
+    rejectedResumePdfPath,
     applyState: "succeeded",
     appliedAt: "2026-05-31T10:00:00.000Z",
   });
@@ -536,6 +586,8 @@ function insertJob(
     site: string;
     fitScore: number;
     resumePath: string;
+    resumePdfPath: string;
+    rejectedResumePdfPath: string;
     applyState: string;
     appliedAt?: string;
   },
@@ -570,6 +622,75 @@ function insertJob(
     insertStage(db, job.url, stage, "succeeded");
   }
   insertStage(db, job.url, "apply", job.applyState);
+  insertScore(db, job.url, job.fitScore);
+  insertMaterials(db, job.url, job.resumePath, job.resumePdfPath, job.rejectedResumePdfPath);
+}
+
+function insertMaterials(
+  db: Database.Database,
+  jobUrl: string,
+  resumePath: string,
+  resumePdfPath: string,
+  rejectedResumePdfPath: string,
+): void {
+  const artifactPrefix =
+    jobUrl === READY_JOB ? "apply-ready" : jobUrl === DRY_RUN_JOB ? "dry-run" : "already-applied";
+  db.prepare("INSERT INTO job_materials (job_url, generation) VALUES (?, ?)").run(jobUrl, 1);
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(jobUrl, 1, `${artifactPrefix}-resume-text`, "tailored_resume", "approved", resumePath, NOW, 15);
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(jobUrl, 1, `${artifactPrefix}-resume-pdf`, "resume_pdf", "approved", resumePdfPath, NOW, 15);
+  db.prepare(
+    `INSERT INTO job_materials_artifacts (
+       job_url, generation, artifact_id, artifact_type, status, path, created_at, size_bytes
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    jobUrl,
+    1,
+    `${artifactPrefix}-rejected-resume-pdf`,
+    "resume_pdf",
+    "rejected",
+    rejectedResumePdfPath,
+    "2026-06-01T11:00:00.000Z",
+    22,
+  );
+}
+
+function insertScore(db: Database.Database, jobUrl: string, fitScore: number): void {
+  db.prepare(
+    `INSERT INTO job_scores (
+       job_url, version, tenant_id, fit_score, breakdown_json, keywords_json,
+       scored_at, correction_json, criteria_json, trace_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    jobUrl,
+    1,
+    "local",
+    fitScore,
+    JSON.stringify({
+      reasoning: "Strong platform leadership fit.",
+      technical_fit: 9,
+      experience_fit: 8,
+      role_fit: 8,
+      fit_band: "strong",
+      confidence: "high",
+      eligibility: { status: "eligible", hard_blockers: [], warnings: [] },
+      matched_signals: ["platform leadership"],
+      missing_signals: ["public company scale"],
+      transferable_signals: ["incident leadership"],
+    }),
+    JSON.stringify(["platform", "leadership"]),
+    NOW,
+    "{}",
+    "{}",
+    "{}",
+  );
 }
 
 function insertStage(db: Database.Database, jobUrl: string, stage: string, state: string): void {

--- a/apps/api/test/location-normalization.test.ts
+++ b/apps/api/test/location-normalization.test.ts
@@ -8,6 +8,9 @@ describe("normalizeJobLocation", () => {
     ["En remoto, ES (Remote)", "Spain (Remote)"],
     ["Barcelona, CT, ES (Remote)", "Barcelona, Catalonia, Spain (Remote)"],
     ["Madrid, MD, ES", "Madrid, Community of Madrid, Spain"],
+    ["Work from Home - Poland", "Poland (Remote)"],
+    ["Work From Home - US", "US (Remote)"],
+    ["UK - Remote", "UK (Remote)"],
   ])("normalizes source location %s", (input, expected) => {
     expect(normalizeJobLocation(input)).toBe(expected);
   });

--- a/apps/web/src/contexts/apply/components/ApplyReviewDecisionControls.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyReviewDecisionControls.tsx
@@ -8,7 +8,7 @@ export interface ApplyReviewDecisionControlsProps {
 }
 
 const DECISION_LABELS: Record<ApplyReviewDecisionValue, string> = {
-  approve_submit: "Approve submit",
+  approve_submit: "Approve when ready",
   approve_dry_run: "Approve dry run",
   defer: "Defer",
   decline: "Decline",

--- a/apps/web/src/routes/apply-review.tsx
+++ b/apps/web/src/routes/apply-review.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { applyReviewKeys } from "../contexts/operations/applyReviewKeys.js";
-import { outcomesKeys } from "../contexts/operations/outcomesKeys.js";
 import { ApplyReviewView } from "../views/apply-review/ApplyReviewView.js";
 
 export const Route = createFileRoute("/apply-review")({
@@ -11,12 +10,6 @@ export const Route = createFileRoute("/apply-review")({
       queryFn: () => context.ports.api.applyReviewQueue(),
     });
 
-    await context.queryClient
-      .ensureQueryData({
-        queryKey: outcomesKeys.list(context.tenantId),
-        queryFn: () => context.ports.api.applicationOutcomes(),
-      })
-      .catch(() => undefined);
   },
   component: ApplyReviewView,
 });

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -1,13 +1,21 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { dashboardKeys } from "../contexts/operations/dashboardKeys.js";
+import { outcomesKeys } from "../contexts/operations/outcomesKeys.js";
 import { DashboardView } from "../views/dashboard/DashboardView.js";
 
 export const Route = createFileRoute("/dashboard")({
-  loader: ({ context }) =>
-    context.queryClient.ensureQueryData({
+  loader: async ({ context }) => {
+    await context.queryClient.ensureQueryData({
       queryKey: dashboardKeys.summary(context.tenantId),
       queryFn: () => context.ports.api.dashboardSummary(),
-    }),
+    });
+    await context.queryClient
+      .ensureQueryData({
+        queryKey: outcomesKeys.list(context.tenantId),
+        queryFn: () => context.ports.api.applicationOutcomes(),
+      })
+      .catch(() => undefined);
+  },
   component: DashboardView,
 });

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -603,57 +603,218 @@ textarea {
   gap: 18px;
 }
 
-.apply-review-table-wrap {
-  width: 100%;
-  overflow-x: auto;
+.apply-review-shell {
+  display: grid;
+  grid-template-columns: minmax(240px, 310px) minmax(0, 1fr);
+  min-height: min(76dvh, 760px);
 }
 
-.apply-review-table {
-  width: 100%;
-  min-width: 1160px;
-  border-collapse: collapse;
-  font-size: 12px;
-}
-
-.apply-review-table caption {
-  caption-side: top;
-  padding: 8px 10px;
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 11px;
-  text-align: right;
-}
-
-.apply-review-table th,
-.apply-review-table td {
-  border-bottom: 1px solid var(--rule);
-  padding: 10px 12px;
-  text-align: left;
-  vertical-align: top;
-}
-
-.apply-review-table thead th {
+.apply-review-queue {
+  min-width: 0;
+  border-right: 1px solid var(--rule);
   background: var(--paper-2);
+}
+
+.apply-review-queue-head {
+  display: grid;
+  gap: 4px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.apply-review-queue-list {
+  display: grid;
+  gap: 8px;
+  max-height: min(60dvh, 720px);
+  overflow: auto;
+  padding: 10px;
+  scrollbar-gutter: stable;
+}
+
+.apply-review-queue-item {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  gap: 7px;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper);
+  color: inherit;
+  cursor: pointer;
+  padding: 10px;
+  text-align: left;
+}
+
+.apply-review-queue-item:hover,
+.apply-review-queue-item.selected {
+  border-color: var(--info);
+  background: color-mix(in srgb, var(--info) 8%, var(--paper));
+}
+
+.apply-review-queue-item.selected {
+  box-shadow: inset 3px 0 0 var(--info);
+}
+
+.apply-review-queue-title {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+}
+
+.apply-review-queue-title b {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.apply-review-selected {
+  min-width: 0;
+}
+
+.apply-review-selected-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 16px;
+  align-items: start;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.apply-review-selected-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.apply-review-selected-actions .apply-review-actions {
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.apply-review-status-note {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--rule);
+  background: color-mix(in srgb, var(--info) 6%, var(--paper));
+  color: var(--muted);
+}
+
+.apply-review-status-note b {
+  color: var(--ink);
+}
+
+.apply-review-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 12px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.apply-review-pane {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: min(54dvh, 640px);
+  overflow: hidden;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper);
+}
+
+.apply-review-pane > header {
+  display: grid;
+  gap: 4px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.apply-review-pane > header h2,
+.apply-review-preview-block h3 {
+  margin: 0;
+  font-size: 13px;
+}
+
+.apply-review-pane-scroll {
+  display: grid;
+  align-content: start;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+  scrollbar-gutter: stable;
+}
+
+.apply-review-preview-block {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  padding-bottom: 14px;
+}
+
+.apply-review-preview-block + .apply-review-preview-block {
+  padding-top: 14px;
+  border-top: 1px solid var(--rule);
+}
+
+.apply-review-document {
+  max-height: 34dvh;
+  overflow: auto;
+  border: 1px solid var(--rule);
+  border-radius: 6px;
+  background: var(--paper-2);
+  padding: 12px;
+  scrollbar-gutter: stable;
+}
+
+.apply-review-pdf-preview {
+  container-type: inline-size;
+}
+
+.apply-review-pdf-preview .pdf-preview-viewer {
+  height: min(66dvh, 720px);
+  min-height: 520px;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
+@container (max-width: 520px) {
+  .apply-review-pdf-preview .pdf-preview-viewer {
+    min-height: 420px;
+  }
+}
+
+.apply-review-evidence-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.apply-review-evidence-list > div {
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+}
+
+.apply-review-evidence-list dt {
   color: var(--muted);
   font-family: var(--mono);
   font-size: 11px;
-  font-weight: 500;
 }
 
-.apply-review-table tbody th {
-  width: 32%;
-  min-width: 260px;
-  font-weight: 500;
-}
-
-.apply-review-table td {
-  min-width: 160px;
-}
-
-.apply-review-table td > span,
-.apply-review-table td > .muted-cell {
-  display: block;
-  margin-bottom: 4px;
+.apply-review-evidence-list dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+  margin: 0;
 }
 
 .apply-review-actions,
@@ -2806,10 +2967,23 @@ textarea {
   .outcome-form,
   .outcome-correction-form,
   .outcome-correction-fieldset,
+  .apply-review-shell,
+  .apply-review-selected-head,
+  .apply-review-workspace,
   .import-panel,
   .credential-row,
   .credential-row-form {
     grid-template-columns: 1fr;
+  }
+
+  .apply-review-queue {
+    border-right: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .apply-review-selected-actions,
+  .apply-review-selected-actions .apply-review-actions {
+    justify-content: flex-start;
   }
 
   .inline-list.compact {

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -150,6 +150,22 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         hasPdf: true,
         ready: true,
       },
+      position: {
+        descriptionPreview:
+          "Globex needs a principal engineer to lead platform reliability, incident response, and developer experience improvements.",
+        requirements: ["platform reliability", "SRE leadership", "incident response"],
+        matched: ["platform reliability", "SRE leadership"],
+        missing: ["public company scale"],
+        transferable: ["incident leadership"],
+        keywords: ["platform reliability", "sre"],
+      },
+      materialsPreview: {
+        resumeText:
+          "Principal Platform Engineer\n\nLed platform reliability programs and incident response improvements for distributed systems teams.",
+        resumePdfArtifactId: "resume-pdf-2",
+        coverLetterText:
+          "Dear Hiring Manager,\n\nI am excited to bring platform reliability leadership to Globex.",
+      },
       latestApplyRun: {
         runId: "apply-run-2",
         status: "succeeded",
@@ -179,6 +195,21 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         hasCoverLetter: false,
         hasPdf: true,
         ready: false,
+      },
+      position: {
+        descriptionPreview:
+          "Acme is hiring a staff software engineer to own platform reliability and product engineering workflows.",
+        requirements: ["platform reliability", "team leadership"],
+        matched: ["platform reliability"],
+        missing: ["team leadership"],
+        transferable: [],
+        keywords: ["platform", "typescript"],
+      },
+      materialsPreview: {
+        resumeText:
+          "Staff Software Engineer\n\nTailored resume draft focused on reliability, TypeScript, and product platform delivery.",
+        resumePdfArtifactId: "resume-pdf-1",
+        coverLetterText: null,
       },
       latestApplyRun: null,
       review: {

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -5,23 +5,64 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { routeTree } from "../../routeTree.gen.js";
-import {
-  sampleApplicationOutcomes,
-  sampleApplyReviewQueue,
-} from "../../test/fixtures/projections.js";
+import { sampleApplyReviewQueue } from "../../test/fixtures/projections.js";
 import { buildProviderHarness, renderWithProviders } from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
 import { ApplyReviewView } from "./ApplyReviewView.js";
 
+vi.mock("../../shared/ui/PdfPreviewViewer.js", () => ({
+  PdfPreviewViewer: ({ title, url }: { title: string; url: string }) => (
+    <div aria-label={title} data-url={url} role="img">
+      PDF preview
+    </div>
+  ),
+}));
+
 describe("<ApplyReviewView>", () => {
-  it("renders the review queue with readiness and latest apply context", async () => {
+  it("renders the review workspace with job evidence and tailored materials", async () => {
     renderWithProviders(<ApplyReviewView />);
 
-    expect(await screen.findByText("Principal Platform Engineer")).toBeInTheDocument();
-    expect(screen.getByText("ready")).toBeInTheDocument();
-    expect(screen.getByText(/dry run · succeeded · dry_run/i)).toBeInTheDocument();
-    expect(screen.getByText("cover letter missing")).toBeInTheDocument();
-    expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
+    expect(await screen.findAllByText("Principal Platform Engineer")).toHaveLength(2);
+    expect(screen.getByRole("heading", { name: "Requirements and original post" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Tailored resume and cover" })).toBeInTheDocument();
+    expect(screen.getAllByText("materials ready").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("platform reliability").length).toBeGreaterThan(0);
+    expect(screen.getByText("public company scale")).toBeInTheDocument();
+    expect(screen.getByText(/Dry run completed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/dry_run/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Globex needs a principal engineer/i)).toBeInTheDocument();
+    const resumePdf = screen.getByRole("img", { name: "Tailored resume PDF" });
+    expect(resumePdf.getAttribute("data-url")).toContain("/v1/artifacts/resume-pdf-2/preview.pdf");
+    expect(screen.queryByText("Recruiter reply indicates an interview request.")).not.toBeInTheDocument();
+  });
+
+  it("renders non-pending review decisions as user-facing copy", async () => {
+    const approvedQueue = {
+      ...sampleApplyReviewQueue,
+      items: sampleApplyReviewQueue.items.map((item, index) =>
+        index === 0
+          ? {
+              ...item,
+              review: {
+                state: "approved_submit" as const,
+                decision: "approve_submit" as const,
+                decidedAt: "2026-05-06T08:30:00Z",
+              },
+            }
+          : item,
+      ),
+    };
+
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({
+        api: {
+          applyReviewQueue: vi.fn(async () => approvedQueue),
+        },
+      }),
+    });
+
+    expect(await screen.findByText(/Current decision: Approved when ready/i)).toBeInTheDocument();
+    expect(screen.queryByText(/approved_submit/i)).not.toBeInTheDocument();
   });
 
   it("records approval without dispatching apply automation", async () => {
@@ -43,14 +84,13 @@ describe("<ApplyReviewView>", () => {
       ports: buildTestPorts({
         api: {
           applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
-          applicationOutcomes: vi.fn(async () => sampleApplicationOutcomes),
           decideApplyReview,
           applyJob,
         },
       }),
     });
 
-    await user.click(await screen.findByRole("button", { name: /approve submit for principal platform engineer/i }));
+    await user.click(await screen.findByRole("button", { name: /approve when ready for principal platform engineer/i }));
 
     await waitFor(() => expect(decideApplyReview).toHaveBeenCalledTimes(1));
     expect(decideApplyReview).toHaveBeenCalledWith(
@@ -60,13 +100,14 @@ describe("<ApplyReviewView>", () => {
     expect(applyJob).not.toHaveBeenCalled();
   });
 
-  it("renders the queue route when outcome prefetch fails", async () => {
+  it("does not depend on outcome suggestions to render the queue route", async () => {
+    const applicationOutcomes = vi.fn(async () => {
+      throw new Error("outcomes unavailable");
+    });
     const ports = buildTestPorts({
       api: {
         applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
-        applicationOutcomes: vi.fn(async () => {
-          throw new Error("outcomes unavailable");
-        }),
+        applicationOutcomes,
       },
     });
     const harness = buildProviderHarness({ ports, withEventStream: true });
@@ -78,7 +119,8 @@ describe("<ApplyReviewView>", () => {
 
     render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
 
-    expect(await screen.findByText("Principal Platform Engineer")).toBeInTheDocument();
-    expect(await screen.findByText("outcomes unavailable")).toBeInTheDocument();
+    expect(await screen.findAllByText("Principal Platform Engineer")).toHaveLength(2);
+    expect(screen.queryByText("outcomes unavailable")).not.toBeInTheDocument();
+    expect(applicationOutcomes).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1,141 +1,335 @@
 import type { ApplyReviewQueueItem } from "@jobhunter/contracts";
+import { useEffect, useState } from "react";
 
 import { ApplyReviewDecisionControls } from "../../contexts/apply/components/ApplyReviewDecisionControls.js";
-import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
-import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useApplyReviewQueueQuery } from "../../contexts/operations/hooks/useApplyReviewQueueQuery.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
+import { usePorts } from "../../shared/providers/PortsProvider.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { PdfPreviewViewer } from "../../shared/ui/PdfPreviewViewer.js";
 
-function readinessTone(item: ApplyReviewQueueItem): "ok" | "warn" {
-  return item.materials.ready && item.blockers.length === 0 ? "ok" : "warn";
-}
+type MaterialStatus = {
+  readonly kind: "ready" | "preparing" | "repair";
+  readonly label: string;
+  readonly tone: "ok" | "info" | "warn";
+  readonly summary: string;
+};
 
-function readinessLabel(item: ApplyReviewQueueItem): string {
-  if (item.materials.ready && item.blockers.length === 0) {
-    return "ready";
+function materialStatus(item: ApplyReviewQueueItem): MaterialStatus {
+  if (!item.applicationUrl) {
+    return {
+      kind: "repair",
+      label: "needs repair",
+      tone: "warn",
+      summary: "The application link is missing, so submission cannot run yet.",
+    };
   }
-  return item.blockers.length ? "blocked" : "materials incomplete";
+  if (!item.materials.hasResume) {
+    return {
+      kind: "preparing",
+      label: "materials preparing",
+      tone: "info",
+      summary: "The tailored resume is still being prepared automatically.",
+    };
+  }
+  if (!item.materials.hasPdf) {
+    return {
+      kind: "preparing",
+      label: "materials preparing",
+      tone: "info",
+      summary: "Submit-ready files are being prepared automatically; reviewable text is available now.",
+    };
+  }
+  if (item.currentState === "blocked" || item.currentState === "failed" || item.currentState === "stale") {
+    return {
+      kind: "repair",
+      label: "needs repair",
+      tone: "warn",
+      summary: "The apply workflow needs repair before submission; review evidence is still available.",
+    };
+  }
+  return {
+    kind: "ready",
+    label: "materials ready",
+    tone: "ok",
+    summary: "The tailored materials are ready to review before approval.",
+  };
 }
 
 function latestApplyContext(item: ApplyReviewQueueItem): string {
   const run = item.latestApplyRun;
   if (!run) {
-    return "no apply run";
+    return "No apply run yet.";
   }
-  const mode = run.dryRun ? "dry run" : "submit";
-  const result = run.result ? ` · ${run.result}` : "";
-  return `${mode} · ${run.status}${result}`;
-}
-
-function reviewLabel(item: ApplyReviewQueueItem): string {
-  if (item.review.decision && item.review.decidedAt) {
-    return `${item.review.state} · ${formatDateTime(item.review.decidedAt)}`;
+  const mode = run.dryRun ? "Dry run" : "Submit";
+  const timestamp = run.startedAt ? ` · ${formatDateTime(run.startedAt)}` : "";
+  const status = `${run.status} ${run.result ?? ""}`.toLowerCase();
+  if (status.includes("failed") || status.includes("skipped")) {
+    return `${mode} needs repair${timestamp}`;
   }
-  return item.review.state;
+  if (status.includes("running")) {
+    return `${mode} running${timestamp}`;
+  }
+  if (status.includes("queued") || status.includes("pending")) {
+    return `${mode} queued${timestamp}`;
+  }
+  if (status.includes("succeeded") || status.includes("complete")) {
+    return `${mode} completed${timestamp}`;
+  }
+  return `${mode} recorded${timestamp}`;
 }
 
-function materialsLabel(item: ApplyReviewQueueItem): string {
-  const parts = [
-    item.materials.hasResume ? "resume" : "no resume",
-    item.materials.hasCoverLetter ? "cover" : "no cover",
-    item.materials.hasPdf ? "pdf" : "no pdf",
-  ];
-  return parts.join(" · ");
+function selectedItem(items: readonly ApplyReviewQueueItem[], selectedJobKey: string | null) {
+  return items.find((item) => item.jobKey === selectedJobKey) ?? items[0] ?? null;
 }
 
-function ApplyReviewTable({ items }: { readonly items: readonly ApplyReviewQueueItem[] }) {
-  if (!items.length) {
-    return <Empty title="No application review items." />;
+function reviewStateLabel(item: ApplyReviewQueueItem): string | null {
+  if (item.review.state === "pending") {
+    return null;
+  }
+  const decidedAt = item.review.decidedAt ? ` · ${formatDateTime(item.review.decidedAt)}` : "";
+  switch (item.review.state) {
+    case "approved_submit":
+      return `Approved when ready${decidedAt}`;
+    case "approved_dry_run":
+      return `Approved for dry run${decidedAt}`;
+    case "deferred":
+      return `Deferred${decidedAt}`;
+    case "declined":
+      return `Declined${decidedAt}`;
+    default:
+      return null;
+  }
+}
+
+function evidenceValues(item: ApplyReviewQueueItem): Array<{ label: string; values: readonly string[] }> {
+  return [
+    { label: "Matched", values: item.position.matched },
+    { label: "Missing", values: item.position.missing },
+    { label: "Transferable", values: item.position.transferable },
+    { label: "Keywords", values: item.position.keywords },
+  ].filter((group) => group.values.length > 0);
+}
+
+function ApplyReviewQueue({
+  items,
+  selected,
+  onSelect,
+}: {
+  readonly items: readonly ApplyReviewQueueItem[];
+  readonly selected: ApplyReviewQueueItem;
+  readonly onSelect: (jobKey: string) => void;
+}) {
+  return (
+    <aside className="apply-review-queue" aria-label="Application review queue">
+      <div className="apply-review-queue-head">
+        <span className="eyebrow">Queue</span>
+        <b>{items.length} human decision{items.length === 1 ? "" : "s"}</b>
+      </div>
+      <div className="apply-review-queue-list">
+        {items.map((item) => {
+          const status = materialStatus(item);
+          return (
+            <button
+              key={item.jobKey}
+              type="button"
+              className={`apply-review-queue-item${item.jobKey === selected.jobKey ? " selected" : ""}`}
+              aria-pressed={item.jobKey === selected.jobKey}
+              onClick={() => onSelect(item.jobKey)}
+            >
+              <span className="apply-review-queue-title">
+                <span className="tag ok">{item.fitScore ?? "-"}</span>
+                <b>{item.title}</b>
+              </span>
+              <span className="meta">
+                {item.company} · {item.source}
+              </span>
+              <span className={`tag ${status.tone}`}>{status.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) {
+  const groups = evidenceValues(item);
+  if (!groups.length) {
+    return <Empty title="No scoring requirement evidence captured yet." />;
   }
   return (
-    <div className="apply-review-table-wrap">
-      <table className="apply-review-table">
-        <caption>{items.length} application review item{items.length === 1 ? "" : "s"}</caption>
-        <thead>
-          <tr>
-            <th scope="col">Job</th>
-            <th scope="col">Readiness</th>
-            <th scope="col">Latest apply context</th>
-            <th scope="col">Review</th>
-            <th scope="col">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr key={item.jobKey}>
-              <th scope="row">
-                <span className="title-stack">
-                  <b>{item.title}</b>
-                  <span>
-                    {item.company} · {item.source} · score {item.fitScore ?? "-"}
-                  </span>
-                  {item.applicationUrl ? <span>{item.applicationUrl}</span> : null}
-                </span>
-              </th>
-              <td>
-                <span className={`tag ${readinessTone(item)}`}>{readinessLabel(item)}</span>
-                <span className="muted-cell">{materialsLabel(item)}</span>
-                {item.blockers.length ? (
-                  <ul className="apply-review-blockers">
-                    {item.blockers.map((blocker) => (
-                      <li key={blocker}>{blocker}</li>
-                    ))}
-                  </ul>
-                ) : null}
-              </td>
-              <td>
-                <span>{latestApplyContext(item)}</span>
-                {item.latestApplyRun?.startedAt ? (
-                  <span className="muted-cell">{formatDateTime(item.latestApplyRun.startedAt)}</span>
-                ) : null}
-              </td>
-              <td>
-                <span>{reviewLabel(item)}</span>
-              </td>
-              <td>
-                <ApplyReviewDecisionControls item={item} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <dl className="apply-review-evidence-list">
+      {groups.map((group) => (
+        <div key={group.label}>
+          <dt>{group.label}</dt>
+          <dd>
+            {group.values.map((value) => (
+              <span className="tag muted" key={value}>
+                {value}
+              </span>
+            ))}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function TextPreview({
+  title,
+  text,
+  emptyTitle,
+}: {
+  readonly title: string;
+  readonly text: string | null;
+  readonly emptyTitle: string;
+}) {
+  return (
+    <section className="apply-review-preview-block">
+      <h3>{title}</h3>
+      {text ? <div className="apply-review-document preformatted">{text}</div> : <Empty title={emptyTitle} />}
+    </section>
+  );
+}
+
+function ResumePreview({ item }: { readonly item: ApplyReviewQueueItem }) {
+  const { api } = usePorts();
+  const artifactId = item.materialsPreview.resumePdfArtifactId;
+  if (!artifactId) {
+    return (
+      <TextPreview
+        title="Tailored resume"
+        text={item.materialsPreview.resumeText}
+        emptyTitle="Resume text is still being prepared."
+      />
+    );
+  }
+  return (
+    <section className="apply-review-preview-block apply-review-pdf-preview">
+      <h3>Tailored resume</h3>
+      <PdfPreviewViewer
+        cacheKey={`${artifactId}:${item.jobKey}`}
+        loadingMessage="The tailored resume PDF is loading into the in-app preview."
+        loadingTitle="Rendering tailored resume."
+        openLabel="open PDF"
+        pageAltPrefix={`${item.title} tailored resume`}
+        title="Tailored resume PDF"
+        url={api.artifactPreviewPdfUrl(artifactId, `${artifactId}:${item.jobKey}`)}
+      />
+    </section>
+  );
+}
+
+function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
+  const status = materialStatus(item);
+  const evidenceGroups = evidenceValues(item).length;
+  const reviewState = reviewStateLabel(item);
+  return (
+    <main className="apply-review-selected">
+      <header className="apply-review-selected-head">
+        <div className="title-stack">
+          <span className="eyebrow">Selected application</span>
+          <b>{item.title}</b>
+          <span>
+            {item.company} · score {item.fitScore ?? "-"} · {latestApplyContext(item)}
+          </span>
+        </div>
+        <div className="apply-review-selected-actions">
+          <span className={`tag ${status.tone}`}>{status.label}</span>
+          <ApplyReviewDecisionControls item={item} />
+        </div>
+      </header>
+
+      <div className="apply-review-status-note">
+        <b>{status.summary}</b>
+        {reviewState ? <span>Current decision: {reviewState}.</span> : null}
+      </div>
+
+      <section className="apply-review-workspace" aria-label={`Review evidence for ${item.title}`}>
+        <article className="apply-review-pane">
+          <header>
+            <span className="eyebrow">Job Position</span>
+            <h2>Requirements and original post</h2>
+          </header>
+          <div className="apply-review-pane-scroll">
+            <section className="apply-review-preview-block">
+              <h3>Requirement evidence</h3>
+              <p className="meta">
+                Derived from existing scoring evidence for this v1 review workspace.
+                {evidenceGroups ? ` ${evidenceGroups} evidence group${evidenceGroups === 1 ? "" : "s"} available.` : ""}
+              </p>
+              <RequirementEvidence item={item} />
+            </section>
+            <section className="apply-review-preview-block">
+              <h3>Verbatim job post</h3>
+              {item.position.descriptionPreview ? (
+                <div className="apply-review-document preformatted">{item.position.descriptionPreview}</div>
+              ) : (
+                <Empty title="No captured job post text." />
+              )}
+            </section>
+          </div>
+        </article>
+
+        <article className="apply-review-pane">
+          <header>
+            <span className="eyebrow">Application Materials</span>
+            <h2>Tailored resume and cover</h2>
+          </header>
+          <div className="apply-review-pane-scroll">
+            <ResumePreview item={item} />
+            <TextPreview
+              title="Cover letter"
+              text={item.materialsPreview.coverLetterText}
+              emptyTitle="No cover letter is required or available for this job."
+            />
+          </div>
+        </article>
+      </section>
+    </main>
   );
 }
 
 export function ApplyReviewView() {
   const queue = useApplyReviewQueueQuery();
-  const outcomes = useApplicationOutcomesQuery();
   const queueError = queue.error instanceof Error ? queue.error.message : null;
-  const outcomesError = outcomes.error instanceof Error ? outcomes.error.message : null;
   const items = queue.data?.items ?? [];
-  const pendingSuggestions = (outcomes.data?.suggestions ?? []).filter(
-    (suggestion) => suggestion.status === "pending",
-  );
-  const readyCount = items.filter((item) => readinessTone(item) === "ok").length;
-  const blockedCount = items.length - readyCount;
+  const [selectedJobKey, setSelectedJobKey] = useState<string | null>(null);
+  const selected = selectedItem(items, selectedJobKey);
+
+  useEffect(() => {
+    if (!items.length) {
+      setSelectedJobKey(null);
+      return;
+    }
+    if (!selectedJobKey || !items.some((item) => item.jobKey === selectedJobKey)) {
+      setSelectedJobKey(items[0]?.jobKey ?? null);
+    }
+  }, [items, selectedJobKey]);
+
+  const statuses = items.map(materialStatus);
+  const readyCount = statuses.filter((status) => status.kind === "ready").length;
+  const preparingCount = statuses.filter((status) => status.kind === "preparing").length;
+  const repairCount = statuses.filter((status) => status.kind === "repair").length;
 
   return (
     <div className="apply-review-layout">
       <section className="card full">
         <CardHeader
           title="Application review"
-          meta={`${readyCount} ready · ${blockedCount} blocked · ${pendingSuggestions.length} suggestions`}
+          meta={`${readyCount} ready · ${preparingCount} preparing · ${repairCount} need repair`}
         />
         {queueError ? <div className="banner inline">{queueError}</div> : null}
         {queue.isFetching && !queue.data ? <Empty title="Loading review queue." /> : null}
-        {queue.data ? <ApplyReviewTable items={items} /> : null}
-      </section>
-      <section className="card full">
-        <CardHeader
-          title="Outcome suggestions"
-          meta={outcomes.data ? `${pendingSuggestions.length} pending` : "loading"}
-        />
-        {outcomesError ? <div className="banner inline">{outcomesError}</div> : null}
-        {outcomes.isFetching && !outcomes.data ? <Empty title="Loading outcome suggestions." /> : null}
-        {outcomes.data ? <OutcomeSuggestionsPanel suggestions={pendingSuggestions} /> : null}
+        {queue.data && selected ? (
+          <div className="apply-review-shell">
+            <ApplyReviewQueue items={items} selected={selected} onSelect={setSelectedJobKey} />
+            <SelectedReview item={selected} />
+          </div>
+        ) : null}
+        {queue.data && !items.length ? <Empty title="No application review items." /> : null}
       </section>
     </div>
   );

--- a/apps/web/src/views/dashboard/DashboardView.test.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.test.tsx
@@ -16,5 +16,7 @@ describe("DashboardView", () => {
     expect(screen.queryByRole("heading", { name: "Pipeline actions" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Discovery controls" })).not.toBeInTheDocument();
     expect(screen.queryByText("Recent activity")).not.toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Outcome suggestions" })).toBeInTheDocument();
+    expect(screen.getByText("Recruiter reply indicates an interview request.")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -1,4 +1,7 @@
+import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
+import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
+import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { ApplyRunsCard } from "./ApplyRunsCard.js";
 import { Funnel } from "./Funnel.js";
@@ -7,16 +10,32 @@ import { SourceHealthCard } from "./SourceHealthCard.js";
 
 export function DashboardView() {
   const { data: summary, isLoading, error } = useDashboardSummaryQuery();
+  const outcomes = useApplicationOutcomesQuery();
   const message = error instanceof Error ? error.message : null;
+  const outcomesError = outcomes.error instanceof Error ? outcomes.error.message : null;
+  const pendingSuggestions = (outcomes.data?.suggestions ?? []).filter(
+    (suggestion) => suggestion.status === "pending",
+  );
   return (
     <>
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
       {message ? <div className="banner">{message}</div> : null}
+      {outcomesError ? <div className="banner">{outcomesError}</div> : null}
       {summary ? (
         <div className="dashboard-grid">
           <Funnel summary={summary} />
           <SourceHealthCard summary={summary} />
           <ApplyRunsCard summary={summary} />
+          <section className="card">
+            <CardHeader
+              title="Outcome suggestions"
+              meta={outcomes.data ? `${pendingSuggestions.length} pending` : "loading"}
+            />
+            {outcomes.isFetching && !outcomes.data ? (
+              <Empty title="Loading outcome suggestions." />
+            ) : null}
+            {outcomes.data ? <OutcomeSuggestionsPanel suggestions={pendingSuggestions} /> : null}
+          </section>
         </div>
       ) : (
         <Empty title={isLoading ? "Loading dashboard." : "No dashboard data."} />

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -219,6 +219,21 @@ export interface ApplyReviewDecisionResponse {
   decision: ApplyReviewDecision;
 }
 
+export interface ApplyReviewPositionEvidence {
+  descriptionPreview: string;
+  requirements: string[];
+  matched: string[];
+  missing: string[];
+  transferable: string[];
+  keywords: string[];
+}
+
+export interface ApplyReviewMaterialsPreview {
+  resumeText: string | null;
+  resumePdfArtifactId: string | null;
+  coverLetterText: string | null;
+}
+
 export interface ApplyReviewQueueItem {
   jobKey: string;
   title: string;
@@ -234,6 +249,8 @@ export interface ApplyReviewQueueItem {
     hasPdf: boolean;
     ready: boolean;
   };
+  position: ApplyReviewPositionEvidence;
+  materialsPreview: ApplyReviewMaterialsPreview;
   latestApplyRun: {
     runId: string;
     status: string;

--- a/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobhunter/infrastructure/discovery/production_wiring.py
@@ -36,14 +36,18 @@ from jobhunter.domain.discovery.source_registry import (
     SourceRegistryEntry,
     validate_locator_candidate,
 )
-from jobhunter.domain.discovery.use_cases import DiscoverJobsUseCase, PostingAcceptance
+from jobhunter.domain.discovery.use_cases import (
+    DiscoverJobsUseCase,
+    PostingAcceptance,
+    default_canonical_identity,
+)
 from jobhunter.domain.discovery.value_objects import (
     JobMetadata,
     PostingUrl,
     SearchStrategy,
     Source,
 )
-from jobhunter.domain.enrichment import DetailPage, ExtractionTier
+from jobhunter.domain.enrichment import DetailPage, ExtractionTier, FullDescription, JobEnrichment
 from jobhunter.domain.enrichment.services import CssSelectorExtractor, JsonLdExtractor
 from jobhunter.domain.enrichment.snapshot_services import (
     ContentAcquisitionService,
@@ -71,7 +75,7 @@ from jobhunter.infrastructure.enrichment import (
     SqliteEnrichmentRepository,
     SqlitePostingSnapshotSetRepository,
 )
-from jobhunter.state import record_job_event
+from jobhunter.state import ensure_job_stage_rows, record_job_event, set_stage_state
 
 
 def utc_now() -> str:
@@ -473,8 +477,10 @@ def run_scheduled_ats_sources(
     if not adapters:
         return ScheduledAtsSummary().to_result_dict()
 
+    job_repository = SqliteJobRepository(conn)
+    enrichment_repository = SqliteEnrichmentRepository(conn)
     use_case = DiscoverJobsUseCase(
-        repository=SqliteJobRepository(conn),
+        repository=job_repository,
         publisher=DurableJobEventPublisher(conn, stage="discover"),
         acceptance_policy=_posting_acceptance_policy(search_cfg),
     )
@@ -517,6 +523,14 @@ def run_scheduled_ats_sources(
                         postings=[posting],
                         run_id=run_id,
                     )
+                    if summary.new_jobs > 0 or summary.observed > 0:
+                        _promote_ats_source_description_to_enrichment(
+                            conn,
+                            job_repository=job_repository,
+                            enrichment_repository=enrichment_repository,
+                            posting=posting,
+                            observed_at=utc_now(),
+                        )
                     total += summary.total
                     new_jobs += summary.new_jobs
                     observed_jobs += summary.observed
@@ -539,6 +553,106 @@ def run_scheduled_ats_sources(
         sources_run=tuple(sources_run),
         failed_sources=tuple(failed_sources),
     ).to_result_dict()
+
+
+def _promote_ats_source_description_to_enrichment(
+    conn: sqlite3.Connection,
+    *,
+    job_repository: SqliteJobRepository,
+    enrichment_repository: SqliteEnrichmentRepository,
+    posting: ScrapedJobPosting,
+    observed_at: str,
+) -> bool:
+    description = str(posting.metadata.description or "").strip()
+    if not description:
+        return False
+
+    identity = default_canonical_identity(posting)
+    job_id = job_repository.find_canonical_owner(
+        LOCAL_TENANT,
+        source_id=posting.source_id,
+        source_native_id=identity.source_native_id,
+        canonical_url=identity.canonical_url,
+    ) or JobId(identity.canonical_url or posting.posting_url.value)
+    if job_repository.load(LOCAL_TENANT, job_id) is None:
+        return False
+
+    existing = enrichment_repository.load(LOCAL_TENANT, job_id)
+    if existing is not None and (existing.is_enriched or existing.is_running):
+        return False
+
+    base = existing or JobEnrichment.empty(
+        tenant_id=LOCAL_TENANT,
+        job_id=job_id,
+        updated_at=observed_at,
+    )
+    succeeded = base.start_attempt(
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        started_at=observed_at,
+    ).succeed_attempt(
+        full_description=FullDescription(text=description),
+        application_url=None,
+        extraction_tier=ExtractionTier.CSS_SELECTORS,
+        finished_at=observed_at,
+    )
+    enrichment_repository.save(succeeded)
+
+    job_url = str(job_id)
+    ensure_job_stage_rows(conn, job_url, discovered_at=observed_at)
+    stage_row = conn.execute(
+        "SELECT state FROM job_stage_states WHERE job_url = ? AND stage = 'enrich'",
+        (job_url,),
+    ).fetchone()
+    stage_state = str(stage_row["state"] or "") if stage_row is not None else ""
+    if stage_state != "succeeded":
+        if stage_state != "running":
+            try:
+                set_stage_state(
+                    conn,
+                    job_url,
+                    "enrich",
+                    "running",
+                    attempt_count=succeeded.attempt_count,
+                    started_at=observed_at,
+                )
+            except ValueError:
+                set_stage_state(
+                    conn,
+                    job_url,
+                    "enrich",
+                    "running",
+                    attempt_count=succeeded.attempt_count,
+                    started_at=observed_at,
+                    validate_transition=False,
+                )
+        set_stage_state(
+            conn,
+            job_url,
+            "enrich",
+            "succeeded",
+            attempt_count=succeeded.attempt_count,
+            started_at=observed_at,
+            finished_at=observed_at,
+        )
+        record_job_event(
+            conn,
+            job_url,
+            "enrich",
+            "StageCompleted",
+            message=(
+                "ATS source description promoted to enrichment: "
+                f"{len(description)} description chars"
+            ),
+            payload={
+                "source_id": posting.source_id,
+                "source_native_id": identity.source_native_id,
+                "extraction_tier": ExtractionTier.CSS_SELECTORS.value,
+                "description_length": len(description),
+            },
+            occurred_at=observed_at,
+        )
+    conn.commit()
+    return True
 
 
 def retire_invalid_source_jobs(

--- a/workers/automation/tests/fixtures/discovery_barcelona_acceptance.json
+++ b/workers/automation/tests/fixtures/discovery_barcelona_acceptance.json
@@ -11,6 +11,6 @@
     "manual_action_count": 1,
     "canonical_verification_rate": 1.0,
     "source_quality_updates": 4,
-    "scoring_handoff_count": 1
+    "scoring_handoff_count": 4
   }
 }

--- a/workers/automation/tests/test_discovery_production_wiring.py
+++ b/workers/automation/tests/test_discovery_production_wiring.py
@@ -11,7 +11,7 @@ import pytest
 
 from jobhunter import config
 from jobhunter.discovery import manual_capture_import as manual_capture_import_cli
-from jobhunter.database import close_connection, init_db
+from jobhunter.database import close_connection, get_jobs_by_stage, init_db
 from jobhunter.domain.discovery import (
     AtsKind,
     JobMetadata,
@@ -421,6 +421,33 @@ def test_canonical_ats_scheduler_routes_postings_through_discovery_use_case(
         ).fetchall()
     }
     assert ats_kinds == {"greenhouse", "lever", "ashby"}
+    expected_urls = {
+        "https://boards.greenhouse.io/barcelonatech/jobs/101",
+        "https://jobs.lever.co/leadershipco/202",
+        "https://jobs.ashbyhq.com/platformops/303",
+    }
+    enrichments = conn.execute(
+        """
+        SELECT job_url, current_status, full_description, extraction_tier
+        FROM job_enrichments
+        """
+    ).fetchall()
+    assert {row["job_url"] for row in enrichments} == expected_urls
+    assert {row["current_status"] for row in enrichments} == {"enriched"}
+    assert {row["extraction_tier"] for row in enrichments} == {"css_selectors"}
+    assert all(str(row["full_description"] or "").strip() for row in enrichments)
+    stage_rows = conn.execute(
+        """
+        SELECT job_url, state
+        FROM job_stage_states
+        WHERE stage = 'enrich'
+        """
+    ).fetchall()
+    assert {row["job_url"] for row in stage_rows} == expected_urls
+    assert {row["state"] for row in stage_rows} == {"succeeded"}
+    assert {
+        row["url"] for row in get_jobs_by_stage(conn, "pending_score", limit=0)
+    } == expected_urls
 
 
 def test_canonical_ats_scheduler_fetches_each_source_once_then_filters_queries(


### PR DESCRIPTION
## Summary
- Redesign the apply review page around a queue plus side-by-side job-position and tailored-materials evidence workspace.
- Add apply review API fields for bounded job description, scoring-derived requirement evidence, text previews, and the active tailored resume PDF artifact id.
- Render the tailored resume as the in-app PDF preview when a valid approved/active PDF artifact exists, falling back to text while materials are still being prepared.
- Move outcome suggestions out of apply review and into the dashboard, and replace raw material/review failure tags with user-facing review states.

## Validation
- `corepack pnpm api:test -- application-feedback`
- `corepack pnpm --filter @jobhunter/web test -- src/views/apply-review/ApplyReviewView.test.tsx src/views/dashboard/DashboardView.test.tsx`
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `corepack pnpm web:build`
- `git diff --check`
- Browser QA: verified `/apply-review` renders the tailored resume PDF preview with pages, does not show raw `pdf failed`, `SKIPPED`, or `approved_submit` copy, and verified outcome suggestions render on `/dashboard` instead.