### PR TITLE
feat(profile): add resume evidence controls

### DIFF
--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -17,6 +17,7 @@ export interface ProfilePaths {
 
 const CHILD_TABLES = [
   "candidate_profile_experience_bullets",
+  "candidate_profile_achievement_evidence",
   "candidate_profile_experience_entries",
   "candidate_profile_education_entries",
   "candidate_profile_skill_items",
@@ -139,6 +140,9 @@ const ROOT_COLUMNS = [
   "tailoring_allow_skill_reordering",
   "tailoring_allow_summary_rewrite",
   "tailoring_allow_minor_inference",
+  "tailoring_claim_mode",
+  "tailoring_auto_approvable_claim_modes_json",
+  "tailoring_allow_adjacent_achievement_drafts",
   "writing_tone",
   "writing_bullet_style",
   "writing_verbosity",
@@ -214,6 +218,9 @@ export function ensureProfileTables(db: SqliteDatabase): void {
       tailoring_allow_skill_reordering INTEGER NOT NULL DEFAULT 1,
       tailoring_allow_summary_rewrite INTEGER NOT NULL DEFAULT 1,
       tailoring_allow_minor_inference INTEGER NOT NULL DEFAULT 0,
+      tailoring_claim_mode TEXT NOT NULL DEFAULT 'evidence_reframing',
+      tailoring_auto_approvable_claim_modes_json TEXT NOT NULL DEFAULT '["verified_only","evidence_reframing"]',
+      tailoring_allow_adjacent_achievement_drafts INTEGER NOT NULL DEFAULT 0,
       writing_tone TEXT NOT NULL DEFAULT 'direct',
       writing_bullet_style TEXT NOT NULL DEFAULT 'balanced',
       writing_verbosity TEXT NOT NULL DEFAULT 'balanced',
@@ -252,6 +259,25 @@ export function ensureProfileTables(db: SqliteDatabase): void {
       bullet_index INTEGER NOT NULL,
       bullet_text TEXT NOT NULL,
       PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+    );
+    CREATE TABLE IF NOT EXISTS candidate_profile_achievement_evidence (
+      tenant_id TEXT NOT NULL,
+      profile_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      evidence_index INTEGER NOT NULL,
+      evidence_id TEXT NOT NULL DEFAULT '',
+      source_text TEXT NOT NULL DEFAULT '',
+      scope TEXT NOT NULL DEFAULT '',
+      action TEXT NOT NULL DEFAULT '',
+      tools_json TEXT NOT NULL DEFAULT '[]',
+      metrics_json TEXT NOT NULL DEFAULT '[]',
+      outcome TEXT NOT NULL DEFAULT '',
+      seniority_signal TEXT NOT NULL DEFAULT '',
+      evidence_strength TEXT NOT NULL DEFAULT 'supported',
+      claim_confidence REAL NOT NULL DEFAULT 0,
+      user_confirmed INTEGER NOT NULL DEFAULT 0,
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      PRIMARY KEY (tenant_id, profile_id, entry_id, evidence_index)
     );
     CREATE TABLE IF NOT EXISTS candidate_profile_education_entries (
       tenant_id TEXT NOT NULL,
@@ -341,6 +367,9 @@ const CANDIDATE_PROFILE_COLUMN_MIGRATIONS: Record<string, string> = {
   experience_target_specializations: "TEXT NOT NULL DEFAULT ''",
   experience_target_locations: "TEXT NOT NULL DEFAULT ''",
   experience_target_work_models: "TEXT NOT NULL DEFAULT ''",
+  tailoring_claim_mode: "TEXT NOT NULL DEFAULT 'evidence_reframing'",
+  tailoring_auto_approvable_claim_modes_json: "TEXT NOT NULL DEFAULT '[\"verified_only\",\"evidence_reframing\"]'",
+  tailoring_allow_adjacent_achievement_drafts: "INTEGER NOT NULL DEFAULT 0",
 };
 
 function ensureCandidateProfileColumns(db: SqliteDatabase): void {
@@ -480,6 +509,14 @@ function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
       tenant_id, profile_id, entry_id, bullet_index, bullet_text
     ) VALUES (?, ?, ?, ?, ?)
   `);
+  const insertEvidence = db.prepare(`
+    INSERT INTO candidate_profile_achievement_evidence (
+      tenant_id, profile_id, entry_id, evidence_index,
+      evidence_id, source_text, scope, action, tools_json,
+      metrics_json, outcome, seniority_signal, evidence_strength,
+      claim_confidence, user_confirmed, tags_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
   experienceEntries.forEach((entry, index) => {
     const entryId = text(entry.id);
     insertExperience.run(
@@ -494,6 +531,26 @@ function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
     );
     asTextArray(entry.bullets).forEach((bullet, bulletIndex) => {
       insertBullet.run(TENANT_ID, PROFILE_ID, entryId, bulletIndex, bullet);
+    });
+    asRecordArray(entry.achievement_evidence).forEach((evidence, evidenceIndex) => {
+      insertEvidence.run(
+        TENANT_ID,
+        PROFILE_ID,
+        entryId,
+        evidenceIndex,
+        text(evidence.id),
+        text(evidence.source_text),
+        text(evidence.scope),
+        text(evidence.action),
+        jsonTextArray(evidence.tools),
+        jsonTextArray(evidence.metrics),
+        text(evidence.outcome),
+        text(evidence.seniority_signal),
+        text(evidence.evidence_strength, "supported"),
+        confidenceNumber(evidence.claim_confidence),
+        boolInt(evidence.user_confirmed, false),
+        jsonTextArray(evidence.tags),
+      );
     });
   });
 
@@ -656,6 +713,32 @@ function experienceRows(db: SqliteDatabase): Array<Record<string, unknown>> {
     company: text(row.company),
     location: text(row.location),
     bullets: orderedValues(db, "candidate_profile_experience_bullets", "bullet_text", "bullet_index", "entry_id = ?", [text(row.entry_id)]),
+    achievement_evidence: achievementEvidenceRows(db, text(row.entry_id)),
+  }));
+}
+
+function achievementEvidenceRows(db: SqliteDatabase, entryId: string): Array<Record<string, unknown>> {
+  const rows = db.prepare(`
+    SELECT evidence_id, source_text, scope, action, tools_json, metrics_json,
+           outcome, seniority_signal, evidence_strength, claim_confidence,
+           user_confirmed, tags_json
+    FROM candidate_profile_achievement_evidence
+    WHERE tenant_id = ? AND profile_id = ? AND entry_id = ?
+    ORDER BY evidence_index
+  `).all(TENANT_ID, PROFILE_ID, entryId) as Array<Record<string, unknown>>;
+  return rows.map((row) => ({
+    id: text(row.evidence_id),
+    source_text: text(row.source_text),
+    scope: text(row.scope),
+    action: text(row.action),
+    tools: parseTextArray(row.tools_json),
+    metrics: parseTextArray(row.metrics_json),
+    outcome: text(row.outcome),
+    seniority_signal: text(row.seniority_signal),
+    evidence_strength: text(row.evidence_strength, "supported"),
+    claim_confidence: confidenceNumber(row.claim_confidence),
+    user_confirmed: Boolean(Number(row.user_confirmed ?? 0)),
+    tags: parseTextArray(row.tags_json),
   }));
 }
 
@@ -704,6 +787,9 @@ function tailoringRules(db: SqliteDatabase, row: ProfileRow): Record<string, unk
       allow_skill_reordering: Boolean(Number(row.tailoring_allow_skill_reordering ?? 1)),
       allow_summary_rewrite: Boolean(Number(row.tailoring_allow_summary_rewrite ?? 1)),
       allow_minor_inference: Boolean(Number(row.tailoring_allow_minor_inference ?? 0)),
+      claim_mode: stringColumn(row.tailoring_claim_mode, "evidence_reframing"),
+      auto_approvable_claim_modes: parseTextArray(row.tailoring_auto_approvable_claim_modes_json),
+      allow_adjacent_achievement_drafts: Boolean(Number(row.tailoring_allow_adjacent_achievement_drafts ?? 0)),
     },
     writing_style: {
       tone: stringColumn(row.writing_tone, "direct"),
@@ -823,6 +909,9 @@ function rootValues(
     boolInt(policy.allow_skill_reordering, true),
     boolInt(policy.allow_summary_rewrite, true),
     boolInt(policy.allow_minor_inference, false),
+    text(policy.claim_mode, "evidence_reframing"),
+    jsonTextArray(policy.auto_approvable_claim_modes),
+    boolInt(policy.allow_adjacent_achievement_drafts, false),
     text(writing.tone, "direct"),
     text(writing.bullet_style, "balanced"),
     text(writing.verbosity, "balanced"),
@@ -948,8 +1037,32 @@ function asTextArray(value: unknown): string[] {
   return Array.isArray(value) ? value.map((item) => text(item)).filter(Boolean) : [];
 }
 
+function jsonTextArray(value: unknown): string {
+  return JSON.stringify(asTextArray(value));
+}
+
+function parseTextArray(value: unknown): string[] {
+  let candidate: unknown = value;
+  if (typeof value === "string") {
+    try {
+      candidate = JSON.parse(value);
+    } catch {
+      candidate = [];
+    }
+  }
+  return asTextArray(candidate);
+}
+
 function text(value: unknown, fallback = ""): string {
   return value === undefined || value === null ? fallback : String(value);
+}
+
+function confidenceNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  if (!Number.isFinite(parsed)) {
+    return 0;
+  }
+  return Math.max(0, Math.min(1, parsed));
 }
 
 function stringColumn(value: string | number | null, fallback = ""): string {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -2858,6 +2858,79 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("preserves profile achievement evidence and tailoring quality controls", async () => {
+    const app = buildApp(options);
+    const profile = validProfileFixture("Evidence Candidate");
+    const resume = profile.resume as Record<string, unknown>;
+    const entries = resume.experience_entries as Array<Record<string, unknown>>;
+    entries[0]!.achievement_evidence = [
+      {
+        id: "ev_role_1_latency",
+        source_text: "Reduced API latency 35% by replacing synchronous enrichment calls.",
+        scope: "owned service",
+        action: "replaced synchronous enrichment calls",
+        tools: ["Python", "PostgreSQL"],
+        metrics: ["35% latency reduction"],
+        outcome: "faster API responses",
+        seniority_signal: "technical ownership",
+        evidence_strength: "verified",
+        claim_confidence: 0.95,
+        user_confirmed: true,
+        tags: ["latency", "backend", "performance"],
+      },
+    ];
+    resume.tailoring_rules = {
+      tailoring_policy: {
+        mode: "aggressive",
+        claim_mode: "draft_requires_confirmation",
+        auto_approvable_claim_modes: ["verified_only", "draft_requires_confirmation"],
+        allow_adjacent_achievement_drafts: true,
+      },
+    };
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const body = response.json();
+    expect(body.profile.resume.experience_entries[0].achievement_evidence[0]).toMatchObject({
+      id: "ev_role_1_latency",
+      metrics: ["35% latency reduction"],
+      claim_confidence: 0.95,
+      user_confirmed: true,
+    });
+    expect(body.profile.resume.tailoring_rules.tailoring_policy).toMatchObject({
+      mode: "aggressive",
+      claim_mode: "draft_requires_confirmation",
+      auto_approvable_claim_modes: ["verified_only"],
+      allow_adjacent_achievement_drafts: true,
+    });
+
+    const db = new Database(options.dbPath);
+    try {
+      expect(db.prepare("SELECT COUNT(*) AS count FROM candidate_profile_achievement_evidence").get()).toMatchObject({
+        count: 1,
+      });
+      expect(
+        db.prepare(
+          "SELECT tailoring_claim_mode, tailoring_auto_approvable_claim_modes_json, "
+            + "tailoring_allow_adjacent_achievement_drafts FROM candidate_profiles",
+        ).get(),
+      ).toMatchObject({
+        tailoring_claim_mode: "draft_requires_confirmation",
+        tailoring_auto_approvable_claim_modes_json: '["verified_only"]',
+        tailoring_allow_adjacent_achievement_drafts: 1,
+      });
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
   it("validates target-search locations before saving profile preferences", async () => {
     const placeValidator = vi.fn(async (place: string) => place === "Barcelona, Spain");
     const app = buildApp({ ...options, placeValidator });

--- a/docs/plans/proposed/2026-06-03-resume-tailoring-quality.md
+++ b/docs/plans/proposed/2026-06-03-resume-tailoring-quality.md
@@ -1,0 +1,322 @@
+# Resume Tailoring Quality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make resume tailoring produce evidence-grounded, seniority-appropriate,
+ATS-readable resumes that sound human, avoid fabricated claims, and receive
+extra adversarial review for high-fit jobs before approval.
+
+**Architecture:** Extend the existing Materials bounded context without adding a
+new generation pipeline. The flow remains profile snapshot + job -> tailored
+JSON -> validator -> judge -> MaterialsSet artifact, but gains explicit profile
+evidence, deterministic planning/ATS checks, and a high-fit adversarial review
+gate. Profile storage remains the source of user-confirmed evidence and
+tailoring controls.
+
+**Tech Stack:** Python domain/application services in
+`workers/automation/src/jobhunter/domain/materials`, Python profile aggregate and
+SQLite repository, TypeScript domain schemas/contracts, Fastify local API,
+React/TanStack profile UI, Vitest/pytest regression coverage, and the existing
+LLM port for generation and judging.
+
+---
+
+## Research Conclusions
+
+Resume quality needs to be controlled as a product system, not only as prompt
+wording.
+
+1. **Achievement structure should scale with seniority.** Junior bullets can be
+   task/action/result. Mid-level bullets should show ownership, technical
+   judgment, constraints, and measurable improvement. Senior/staff bullets
+   should show scope, cross-team influence, strategic tradeoffs, durable systems,
+   risk reduction, and second-order impact. The common pattern is action +
+   context + result, but the expected scope changes by level.
+2. **Human-sounding resumes are specific and bounded.** AI-sounding resumes
+   overuse generic action verbs, symmetrical phrasing, broad claims, inflated
+   seniority, vague metrics, and unnatural keyword density. The generator should
+   prefer plain verbs, real constraints, concrete nouns, varied bullet rhythm,
+   and interview-defensible claims.
+3. **ATS quality is partly deterministic.** Standard headings, parseable text,
+   conventional sections, keyword coverage, and role-relevant skill alignment can
+   be checked before and after generation. Keyword stuffing should be penalized
+   because ATS relevance and recruiter trust are separate goals.
+4. **Creative tailoring must be typed.** "Creativity" cannot be a single
+   boolean. The system needs claim modes: verified facts, evidence reframing,
+   adjacent translation from supported expertise, and draft claims requiring user
+   confirmation. Only verified and evidence-reframed claims may be auto-approved.
+5. **High-fit jobs deserve more scrutiny.** For jobs with fit score >= 8, run
+   adversarial review personas after normal judging: ATS parser, skeptical
+   recruiter, hiring manager/domain expert, evidence auditor, anti-AI voice
+   critic, and interview defensibility critic. Any blocker finding keeps the
+   resume unapproved.
+6. **Evaluation needs golden failure cases.** Quality must be protected with
+   regression examples for unsupported claims, AI voice, weak seniority framing,
+   ATS-unfriendly output, keyword stuffing, missing required evidence, and
+   high-fit adversarial failures.
+7. **The feedback loop should improve the profile, not the artifact only.**
+   User corrections such as "sounds fake", "claim is true", "claim is false",
+   and "helped in interview" should eventually feed profile evidence and policy
+   settings.
+
+## Current Implementation Snapshot
+
+The existing Materials pipeline already has important foundations:
+
+- `TailorResumeUseCase` generates multiple candidates, validates them, judges
+  them, persists policy metadata, and approves only judge-passing artifacts.
+- `ContentValidator` rejects LLM self-talk, banned phrases, fabricated watchlist
+  skills, missing sections, removed companies, missing education, and missing
+  required skill categories.
+- Profile controls already support required experience entries, required
+  bullets, required skill categories, verified metrics, writing style, and a
+  coarse tailoring policy.
+- The prompt already forbids invented companies, roles, degrees, certifications,
+  tools, metrics, and unsupported achievements.
+
+The gaps are:
+
+- Achievement evidence is stored mostly as free-form bullets and global metrics;
+  there is no typed evidence object that says what can be safely reframed.
+- Tailoring controls are coarse. `allow_minor_inference` and
+  `allow_achievement_rewriting` do not distinguish verified claims from adjacent
+  expertise translations or user-confirmation drafts.
+- ATS and anti-AI checks are mostly prompt/judge based rather than deterministic.
+- Judge output has one review perspective and no high-fit escalation.
+- Seniority expectations are implicit in writing style, not encoded as reusable
+  rules.
+- There is no dedicated tailoring evaluation corpus for resume-quality failure
+  modes.
+
+## Target Tailoring Flow
+
+```text
+Profile evidence + job + fit score
+  -> TailoringPlanBuilder
+  -> generator prompt with seniority, evidence, and ATS plan
+  -> ContentValidator structural/fabrication checks
+  -> DeterministicTailoringQualityChecks
+  -> normal judge
+  -> high-fit adversarial review when fit score >= 8
+  -> approved MaterialsSet artifact or repairable failure
+```
+
+## Stacked PRs
+
+### PR 0: Plan PR
+
+- [ ] Add this plan under `docs/plans/proposed/`.
+- [ ] Open a draft PR titled `docs: plan resume tailoring quality work`.
+- [ ] Validate with `git diff --check`.
+
+### PR 1: Profile Evidence And Tailoring Controls
+
+Scope:
+
+- [ ] Add typed achievement evidence to the Python profile domain:
+  `workers/automation/src/jobhunter/domain/profile/value_objects.py`,
+  `aggregate.py`, `snapshot.py`, and repository serialization.
+- [ ] Add schema helpers in `workers/automation/src/jobhunter/resume_profile.py`
+  for:
+  - `get_achievement_evidence(profile)`
+  - `get_claim_mode(profile)`
+  - `get_auto_approvable_claim_modes(profile)`
+  - `get_tailoring_quality_controls(profile)`
+- [ ] Extend TypeScript schemas in `packages/domain-types/src/profile/profile.ts`
+  and `packages/contracts/src/schemas.ts`.
+- [ ] Extend API profile persistence in `apps/api/src/profile-store.ts` so the
+  controls and evidence survive round trips.
+- [ ] Add or update profile import defaults in
+  `workers/automation/src/jobhunter/profile_import.py` and
+  `workers/automation/src/jobhunter/wizard/init.py`.
+- [ ] Update focused tests:
+  `workers/automation/tests/test_profile_aggregate.py`,
+  `workers/automation/tests/test_profile_import.py`,
+  `workers/automation/tests/test_sqlite_profile_repository.py`,
+  `packages/domain-types/test/profile.test.ts`, and API profile-store tests if
+  touched.
+
+Data shape:
+
+```json
+{
+  "resume": {
+    "experience_entries": [
+      {
+        "id": "role_1",
+        "achievement_evidence": [
+          {
+            "id": "ev_role_1_latency",
+            "source_text": "Reduced API latency 35% by replacing synchronous enrichment calls.",
+            "scope": "owned service",
+            "action": "replaced synchronous enrichment calls",
+            "tools": ["Python", "PostgreSQL"],
+            "metrics": ["35% latency reduction"],
+            "outcome": "faster API responses",
+            "seniority_signal": "technical ownership",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.95,
+            "user_confirmed": true,
+            "tags": ["latency", "backend", "performance"]
+          }
+        ]
+      }
+    ],
+    "tailoring_rules": {
+      "tailoring_policy": {
+        "claim_mode": "evidence_reframing",
+        "auto_approvable_claim_modes": ["verified_only", "evidence_reframing"],
+        "allow_adjacent_achievement_drafts": false
+      }
+    }
+  }
+}
+```
+
+Acceptance criteria:
+
+- [ ] Existing profiles with no `achievement_evidence` remain valid.
+- [ ] Strict mode disables adjacent drafts and only auto-approves verified
+  claims.
+- [ ] Aggressive mode may allow adjacent drafts, but those drafts are not
+  auto-approvable without explicit user confirmation.
+- [ ] Profile round trips preserve evidence, controls, and existing required
+  bullets/metrics.
+
+### PR 2: Tailoring Plan, ATS Checks, And Seniority Rules
+
+Scope:
+
+- [ ] Add a pure planning service in
+  `workers/automation/src/jobhunter/domain/materials/quality.py`.
+- [ ] Build `TailoringPlan` from profile evidence, job description, scoring/fit
+  context when available, claim mode, writing style, and seniority signals.
+- [ ] Add deterministic checks for:
+  - standard section headings
+  - required evidence IDs present
+  - metrics sourced from profile evidence or verified metrics
+  - keyword coverage from job title, skills, responsibilities, and scoring
+    signals
+  - keyword stuffing / unnatural repetition
+  - seniority mismatch between job level and bullet scope
+  - banned AI voice markers beyond the existing phrase list
+- [ ] Inject the tailoring plan into `_build_tailored_resume_prompt` and judge
+  prompt context in `workers/automation/src/jobhunter/domain/materials/use_cases.py`.
+- [ ] Persist plan/check metadata on the tailored resume artifact so failures
+  are inspectable without storing sensitive logs.
+- [ ] Update `ContentValidator` only for deterministic validation that does not
+  require an LLM.
+- [ ] Add tests in `workers/automation/tests/test_materials_quality.py`,
+  `test_content_validator.py`, and `test_materials_use_cases.py`.
+
+Acceptance criteria:
+
+- [ ] A generated claim using an unknown metric fails deterministic checks before
+  approval.
+- [ ] A resume that repeats a keyword unnaturally receives a warning or failure
+  depending on severity.
+- [ ] Senior/staff jobs require at least one ownership/scope/influence signal
+  when such evidence exists.
+- [ ] Junior/mid-level jobs are not forced into executive-style bullets.
+- [ ] Validator failures feed repair instructions into the existing retry loop.
+
+### PR 3: High-Fit Adversarial Review Gate
+
+Scope:
+
+- [ ] Add adversarial review schemas and prompt builders in
+  `workers/automation/src/jobhunter/domain/materials/adversarial.py`.
+- [ ] Run this gate only when the job fit score is >= 8.0 or an equivalent 0-1
+  fit score normalizes to >= 0.8.
+- [ ] Use the existing `LlmPort` and separate structured response schema for:
+  ATS parser, skeptical recruiter, hiring manager/domain expert, evidence
+  auditor, anti-AI voice critic, and interview defensibility critic.
+- [ ] Add retry feedback into the current avoid-notes loop.
+- [ ] Persist a compact adversarial summary in artifact metadata:
+  `ran`, `threshold`, `personas`, `blockers`, `warnings`, `score`.
+- [ ] Add tests in `workers/automation/tests/test_materials_adversarial.py` and
+  `test_materials_use_cases.py`.
+
+Acceptance criteria:
+
+- [ ] Fit < 8 jobs do not call the adversarial reviewer.
+- [ ] Fit >= 8 jobs call the reviewer after normal judge pass.
+- [ ] Any blocker from evidence, fabrication, ATS parseability, or AI voice
+  keeps the resume unapproved.
+- [ ] Warnings without blockers are persisted and do not block approval.
+- [ ] Failed adversarial findings are included in retry/repair instructions.
+
+### PR 4: Profile UI Controls And Documentation
+
+Scope:
+
+- [ ] Use the existing profile context UI, not a new view, to expose claim mode,
+  adjacent draft permission, auto-approvable claim modes, and achievement
+  evidence editing.
+- [ ] Update `apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx`
+  and focused profile form tests/stories.
+- [ ] Preserve existing required bullets and verified metrics controls.
+- [ ] Update `README.md` for user-facing tailoring controls.
+- [ ] Update `docs/local-reliability-qa.md` with resume-tailoring regression
+  checks and high-fit adversarial review QA.
+- [ ] Update `docs/ddd-target.md` only if the bounded-context contract changes
+  after implementation.
+
+Acceptance criteria:
+
+- [ ] Users can add, edit, and remove achievement evidence without touching raw
+  JSON.
+- [ ] Users can see which claim modes are safe for auto-approval.
+- [ ] The UI does not imply JobHunter can invent unverifiable achievements.
+- [ ] API round-trip tests and web component tests cover the controls.
+
+### PR 5: Tailoring Evaluation Harness
+
+Scope:
+
+- [ ] Add a small deterministic evaluation corpus under a non-sensitive fixture
+  path such as `workers/automation/tests/fixtures/tailoring_quality/`.
+- [ ] Include golden cases for unsupported metric, keyword stuffing,
+  AI-sounding bullet, seniority mismatch, missing required evidence, adjacent
+  draft requiring confirmation, and high-fit adversarial blocker.
+- [ ] Add a pytest entry point that runs without live LLM credentials using fake
+  ports and structured fixture outputs.
+- [ ] Document the eval command in `docs/local-reliability-qa.md`.
+
+Acceptance criteria:
+
+- [ ] The eval catches all listed golden failure modes.
+- [ ] The eval can be run locally with:
+  `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_materials_quality.py workers/automation/tests/test_materials_adversarial.py`.
+- [ ] No fixture contains a real user's resume, profile, job application, or
+  generated artifact.
+
+## Verification Matrix
+
+Run the smallest relevant command set per PR, and the broader set before the
+final stack is marked done:
+
+- Python profile/materials unit tests:
+  `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_profile_aggregate.py workers/automation/tests/test_profile_import.py workers/automation/tests/test_sqlite_profile_repository.py workers/automation/tests/test_content_validator.py workers/automation/tests/test_materials_use_cases.py`
+- New quality/adversarial tests:
+  `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_materials_quality.py workers/automation/tests/test_materials_adversarial.py`
+- Python lint:
+  `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/materials workers/automation/src/jobhunter/domain/profile workers/automation/src/jobhunter/resume_profile.py workers/automation/tests/test_materials_quality.py workers/automation/tests/test_materials_adversarial.py`
+- TypeScript domain/API tests:
+  `pnpm --filter @jobhunter/domain-types test`
+  `pnpm api:test`
+- Web profile tests when UI changes:
+  `pnpm --filter @jobhunter/web test -- StructuredProfileEditor ProfileEditor`
+  `pnpm web:check`
+- Diff hygiene:
+  `git diff --check`
+
+## Non-Goals
+
+- Do not submit applications or run browser auto-apply flows.
+- Do not ingest or expose real generated resumes, cover letters, PDFs, browser
+  profiles, local databases, or job application data.
+- Do not replace the existing Materials aggregate or LLM port.
+- Do not make high-fit adversarial review mandatory for every job; the cost and
+  latency are reserved for high-fit opportunities.
+- Do not allow automatic approval of unverifiable invented achievements.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -508,6 +508,9 @@ export type BulkJobMutationRequest = z.infer<typeof BulkJobMutationRequestSchema
 // ---------------------------------------------------------------------------
 
 export const TAILORING_MODES = ["strict", "balanced", "aggressive"] as const;
+export const CLAIM_MODES = ["verified_only", "evidence_reframing", "adjacent_translation", "draft_requires_confirmation"] as const;
+export const AUTO_APPROVABLE_CLAIM_MODES = ["verified_only", "evidence_reframing"] as const;
+export const EVIDENCE_STRENGTHS = ["verified", "supported", "inferred", "draft"] as const;
 export const WRITING_TONES = ["direct", "executive", "technical", "confident", "warm"] as const;
 export const BULLET_STYLES = ["balanced", "impact", "technical_depth", "leadership"] as const;
 export const VERBOSITY_LEVELS = ["concise", "balanced", "detailed"] as const;
@@ -583,6 +586,21 @@ const ProfileEeoSchema = z
   })
   .partial();
 
+const ProfileAchievementEvidenceSchema = z.object({
+  id: z.string().default(""),
+  source_text: z.string().default(""),
+  scope: z.string().default(""),
+  action: z.string().default(""),
+  tools: z.array(z.string()).default([]),
+  metrics: z.array(z.string()).default([]),
+  outcome: z.string().default(""),
+  seniority_signal: z.string().default(""),
+  evidence_strength: z.enum(EVIDENCE_STRENGTHS).default("supported"),
+  claim_confidence: z.number().min(0).max(1).default(0),
+  user_confirmed: z.boolean().default(false),
+  tags: z.array(z.string()).default([]),
+});
+
 const ProfileExperienceEntrySchema = z.object({
   id: z.string().min(1),
   title: z.string().min(1),
@@ -590,6 +608,7 @@ const ProfileExperienceEntrySchema = z.object({
   date_range: z.string().default(""),
   location: z.string().default(""),
   bullets: z.array(z.string()).default([]),
+  achievement_evidence: z.array(ProfileAchievementEvidenceSchema).default([]),
 });
 
 const ProfileEducationEntrySchema = z.object({
@@ -614,8 +633,59 @@ const ProfileTailoringPolicySchema = z
     allow_skill_reordering: z.boolean().default(true),
     allow_summary_rewrite: z.boolean().default(true),
     allow_minor_inference: z.boolean().default(false),
+    claim_mode: z.enum(CLAIM_MODES).default("evidence_reframing"),
+    auto_approvable_claim_modes: z.array(z.enum(CLAIM_MODES)).default(["verified_only", "evidence_reframing"]),
+    allow_adjacent_achievement_drafts: z.boolean().default(false),
   })
-  .partial();
+  .partial()
+  .default({})
+  .transform((policy) => normalizeProfileTailoringPolicy(policy));
+
+function normalizeProfileTailoringPolicy(policy: {
+  mode?: (typeof TAILORING_MODES)[number] | undefined;
+  allow_title_reframing?: boolean | undefined;
+  allow_achievement_rewriting?: boolean | undefined;
+  allow_skill_reordering?: boolean | undefined;
+  allow_summary_rewrite?: boolean | undefined;
+  allow_minor_inference?: boolean | undefined;
+  claim_mode?: (typeof CLAIM_MODES)[number] | undefined;
+  auto_approvable_claim_modes?: Array<(typeof CLAIM_MODES)[number]> | undefined;
+  allow_adjacent_achievement_drafts?: boolean | undefined;
+}) {
+  const mode = policy.mode ?? "balanced";
+  const autoApprovable = (policy.auto_approvable_claim_modes ?? ["verified_only", "evidence_reframing"]).filter(
+    (claimMode): claimMode is (typeof AUTO_APPROVABLE_CLAIM_MODES)[number] =>
+      (AUTO_APPROVABLE_CLAIM_MODES as readonly string[]).includes(claimMode),
+  );
+  const normalized = {
+    mode,
+    allow_title_reframing: policy.allow_title_reframing ?? false,
+    allow_achievement_rewriting: policy.allow_achievement_rewriting ?? true,
+    allow_skill_reordering: policy.allow_skill_reordering ?? true,
+    allow_summary_rewrite: policy.allow_summary_rewrite ?? true,
+    allow_minor_inference: policy.allow_minor_inference ?? false,
+    claim_mode: policy.claim_mode ?? "evidence_reframing",
+    auto_approvable_claim_modes: autoApprovable.length
+      ? autoApprovable
+      : (["verified_only", "evidence_reframing"] as const),
+    allow_adjacent_achievement_drafts:
+      mode === "aggressive" && (policy.allow_adjacent_achievement_drafts ?? false),
+  };
+  if (mode !== "strict") {
+    return normalized;
+  }
+  return {
+    ...normalized,
+    allow_title_reframing: false,
+    allow_achievement_rewriting: false,
+    allow_skill_reordering: false,
+    allow_summary_rewrite: false,
+    allow_minor_inference: false,
+    claim_mode: "verified_only" as const,
+    auto_approvable_claim_modes: ["verified_only"] as const,
+    allow_adjacent_achievement_drafts: false,
+  };
+}
 
 const ProfileWritingStyleSchema = z
   .object({
@@ -636,7 +706,7 @@ const ProfileTailoringRulesSchema = z
     required_skills_by_category_id: z.record(z.string(), z.array(z.string())).default({}),
     max_experience_bullets: z.number().int().positive().default(4),
     custom_tailoring_prompt: z.string().default(""),
-    tailoring_policy: ProfileTailoringPolicySchema.default({}),
+    tailoring_policy: ProfileTailoringPolicySchema,
     writing_style: ProfileWritingStyleSchema.default({}),
   })
   .partial();

--- a/packages/domain-types/src/profile/profile.ts
+++ b/packages/domain-types/src/profile/profile.ts
@@ -17,6 +17,15 @@ import type { TenantId } from "../tenant.js";
 export const TAILORING_MODES = ["strict", "balanced", "aggressive"] as const;
 export type TailoringMode = (typeof TAILORING_MODES)[number];
 
+export const CLAIM_MODES = ["verified_only", "evidence_reframing", "adjacent_translation", "draft_requires_confirmation"] as const;
+export type ClaimMode = (typeof CLAIM_MODES)[number];
+
+export const AUTO_APPROVABLE_CLAIM_MODES = ["verified_only", "evidence_reframing"] as const;
+export type AutoApprovableClaimMode = (typeof AUTO_APPROVABLE_CLAIM_MODES)[number];
+
+export const EVIDENCE_STRENGTHS = ["verified", "supported", "inferred", "draft"] as const;
+export type EvidenceStrength = (typeof EVIDENCE_STRENGTHS)[number];
+
 export const WRITING_TONES = ["direct", "executive", "technical", "confident", "warm"] as const;
 export type WritingTone = (typeof WRITING_TONES)[number];
 
@@ -102,6 +111,21 @@ export interface ResumeBaseline {
   readonly baselineText: string;
 }
 
+export interface AchievementEvidence {
+  readonly id: string;
+  readonly sourceText: string;
+  readonly scope: string;
+  readonly action: string;
+  readonly tools: readonly string[];
+  readonly metrics: readonly string[];
+  readonly outcome: string;
+  readonly senioritySignal: string;
+  readonly evidenceStrength: EvidenceStrength;
+  readonly claimConfidence: number;
+  readonly userConfirmed: boolean;
+  readonly tags: readonly string[];
+}
+
 export interface ExperienceEntry {
   readonly id: string;
   readonly title: string;
@@ -109,6 +133,7 @@ export interface ExperienceEntry {
   readonly dateRange: string;
   readonly location: string;
   readonly bullets: readonly string[];
+  readonly achievementEvidence: readonly AchievementEvidence[];
 }
 
 export interface EducationEntry {
@@ -136,6 +161,9 @@ export interface TailoringPolicy {
   readonly allowSkillReordering: boolean;
   readonly allowSummaryRewrite: boolean;
   readonly allowMinorInference: boolean;
+  readonly claimMode: ClaimMode;
+  readonly autoApprovableClaimModes: readonly AutoApprovableClaimMode[];
+  readonly allowAdjacentAchievementDrafts: boolean;
 }
 
 export interface WritingStyle {

--- a/packages/domain-types/test/profile.test.ts
+++ b/packages/domain-types/test/profile.test.ts
@@ -11,6 +11,9 @@ import { describe, it, expect } from "vitest";
 import { LOCAL_TENANT } from "../src/tenant.js";
 import {
   TAILORING_MODES,
+  CLAIM_MODES,
+  AUTO_APPROVABLE_CLAIM_MODES,
+  EVIDENCE_STRENGTHS,
   WRITING_TONES,
   BULLET_STYLES,
   VERBOSITY_LEVELS,
@@ -24,6 +27,17 @@ import {
 describe("Profile types", () => {
   it("exposes the canonical TailoringMode enum", () => {
     expect(TAILORING_MODES).toEqual(["strict", "balanced", "aggressive"]);
+  });
+
+  it("exposes claim mode and evidence-strength enums", () => {
+    expect(CLAIM_MODES).toEqual([
+      "verified_only",
+      "evidence_reframing",
+      "adjacent_translation",
+      "draft_requires_confirmation",
+    ]);
+    expect(AUTO_APPROVABLE_CLAIM_MODES).toEqual(["verified_only", "evidence_reframing"]);
+    expect(EVIDENCE_STRENGTHS).toEqual(["verified", "supported", "inferred", "draft"]);
   });
 
   it("exposes the canonical WritingTone enum", () => {
@@ -48,6 +62,22 @@ describe("Profile types", () => {
       dateRange: "2022 -- Present",
       location: "Remote",
       bullets: ["Shipped APIs."],
+      achievementEvidence: [
+        {
+          id: "ev_role_1_latency",
+          sourceText: "Reduced API latency 35%.",
+          scope: "owned service",
+          action: "replaced synchronous calls",
+          tools: ["Python"],
+          metrics: ["35% latency reduction"],
+          outcome: "faster API responses",
+          senioritySignal: "technical ownership",
+          evidenceStrength: "verified",
+          claimConfidence: 0.95,
+          userConfirmed: true,
+          tags: ["latency"],
+        },
+      ],
     };
 
     const profile: Profile = {
@@ -123,6 +153,9 @@ describe("Profile types", () => {
           allowSkillReordering: true,
           allowSummaryRewrite: true,
           allowMinorInference: false,
+          claimMode: "evidence_reframing",
+          autoApprovableClaimModes: ["verified_only", "evidence_reframing"],
+          allowAdjacentAchievementDrafts: false,
         },
         writingStyle: {
           tone: "direct",
@@ -136,6 +169,7 @@ describe("Profile types", () => {
     };
 
     expect(profile.experienceEntries[0]?.id).toBe("role_1");
+    expect(profile.experienceEntries[0]?.achievementEvidence[0]?.id).toBe("ev_role_1_latency");
     expect(profile.tailoringRules.tailoringPolicy.mode).toBe("balanced");
   });
 
@@ -214,6 +248,9 @@ describe("Profile types", () => {
           allowSkillReordering: true,
           allowSummaryRewrite: true,
           allowMinorInference: false,
+          claimMode: "evidence_reframing",
+          autoApprovableClaimModes: ["verified_only", "evidence_reframing"],
+          allowAdjacentAchievementDrafts: false,
         },
         writingStyle: {
           tone: "direct",

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -528,6 +528,9 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             tailoring_allow_skill_reordering  INTEGER NOT NULL DEFAULT 1,
             tailoring_allow_summary_rewrite   INTEGER NOT NULL DEFAULT 1,
             tailoring_allow_minor_inference   INTEGER NOT NULL DEFAULT 0,
+            tailoring_claim_mode              TEXT NOT NULL DEFAULT 'evidence_reframing',
+            tailoring_auto_approvable_claim_modes_json TEXT NOT NULL DEFAULT '["verified_only","evidence_reframing"]',
+            tailoring_allow_adjacent_achievement_drafts INTEGER NOT NULL DEFAULT 0,
             writing_tone                      TEXT NOT NULL DEFAULT 'direct',
             writing_bullet_style              TEXT NOT NULL DEFAULT 'balanced',
             writing_verbosity                 TEXT NOT NULL DEFAULT 'balanced',
@@ -574,6 +577,29 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             bullet_index    INTEGER NOT NULL,
             bullet_text     TEXT NOT NULL,
             PRIMARY KEY (tenant_id, profile_id, entry_id, bullet_index)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS candidate_profile_achievement_evidence (
+            tenant_id       TEXT NOT NULL,
+            profile_id      TEXT NOT NULL,
+            entry_id        TEXT NOT NULL,
+            evidence_index  INTEGER NOT NULL,
+            evidence_id     TEXT NOT NULL DEFAULT '',
+            source_text     TEXT NOT NULL DEFAULT '',
+            scope           TEXT NOT NULL DEFAULT '',
+            action          TEXT NOT NULL DEFAULT '',
+            tools_json      TEXT NOT NULL DEFAULT '[]',
+            metrics_json    TEXT NOT NULL DEFAULT '[]',
+            outcome         TEXT NOT NULL DEFAULT '',
+            seniority_signal TEXT NOT NULL DEFAULT '',
+            evidence_strength TEXT NOT NULL DEFAULT 'supported',
+            claim_confidence REAL NOT NULL DEFAULT 0,
+            user_confirmed  INTEGER NOT NULL DEFAULT 0,
+            tags_json       TEXT NOT NULL DEFAULT '[]',
+            PRIMARY KEY (tenant_id, profile_id, entry_id, evidence_index)
         )
         """
     )
@@ -693,6 +719,7 @@ def ensure_profile_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         "candidate_profiles",
         "candidate_profile_experience_entries",
         "candidate_profile_experience_bullets",
+        "candidate_profile_achievement_evidence",
         "candidate_profile_education_entries",
         "candidate_profile_skill_categories",
         "candidate_profile_skill_items",
@@ -712,6 +739,9 @@ _PROFILE_COLUMN_MIGRATIONS: dict[str, str] = {
     "experience_target_specializations": "TEXT NOT NULL DEFAULT ''",
     "experience_target_locations": "TEXT NOT NULL DEFAULT ''",
     "experience_target_work_models": "TEXT NOT NULL DEFAULT ''",
+    "tailoring_claim_mode": "TEXT NOT NULL DEFAULT 'evidence_reframing'",
+    "tailoring_auto_approvable_claim_modes_json": "TEXT NOT NULL DEFAULT '[\"verified_only\",\"evidence_reframing\"]'",
+    "tailoring_allow_adjacent_achievement_drafts": "INTEGER NOT NULL DEFAULT 0",
 }
 
 

--- a/workers/automation/src/jobhunter/domain/profile/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/profile/value_objects.py
@@ -40,6 +40,14 @@ def _bool(value: Any, default: bool) -> bool:
     return bool(value)
 
 
+def _float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, parsed))
+
+
 def _str_tuple(values: Any) -> tuple[str, ...]:
     if not isinstance(values, (list, tuple)):
         return ()
@@ -216,6 +224,58 @@ class ResumeBaseline:
 
 
 @dataclass(frozen=True)
+class AchievementEvidence:
+    id: str = ""
+    source_text: str = ""
+    scope: str = ""
+    action: str = ""
+    tools: tuple[str, ...] = ()
+    metrics: tuple[str, ...] = ()
+    outcome: str = ""
+    seniority_signal: str = ""
+    evidence_strength: str = "supported"
+    claim_confidence: float = 0.0
+    user_confirmed: bool = False
+    tags: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AchievementEvidence":
+        strength = _str(data.get("evidence_strength"), "supported")
+        if strength not in EVIDENCE_STRENGTHS:
+            strength = "supported"
+        return cls(
+            id=_str(data.get("id"), ""),
+            source_text=_str(data.get("source_text"), ""),
+            scope=_str(data.get("scope"), ""),
+            action=_str(data.get("action"), ""),
+            tools=_str_tuple(data.get("tools")),
+            metrics=_str_tuple(data.get("metrics")),
+            outcome=_str(data.get("outcome"), ""),
+            seniority_signal=_str(data.get("seniority_signal"), ""),
+            evidence_strength=strength,
+            claim_confidence=_float(data.get("claim_confidence"), 0.0),
+            user_confirmed=_bool(data.get("user_confirmed"), False),
+            tags=_str_tuple(data.get("tags")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "source_text": self.source_text,
+            "scope": self.scope,
+            "action": self.action,
+            "tools": list(self.tools),
+            "metrics": list(self.metrics),
+            "outcome": self.outcome,
+            "seniority_signal": self.seniority_signal,
+            "evidence_strength": self.evidence_strength,
+            "claim_confidence": self.claim_confidence,
+            "user_confirmed": self.user_confirmed,
+            "tags": list(self.tags),
+        }
+
+
+@dataclass(frozen=True)
 class ExperienceEntry:
     id: str
     title: str = ""
@@ -223,9 +283,16 @@ class ExperienceEntry:
     date_range: str = ""
     location: str = ""
     bullets: tuple[str, ...] = ()
+    achievement_evidence: tuple[AchievementEvidence, ...] = ()
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ExperienceEntry":
+        raw_evidence = data.get("achievement_evidence")
+        evidence = (
+            tuple(AchievementEvidence.from_dict(item) for item in raw_evidence if isinstance(item, dict))
+            if isinstance(raw_evidence, list)
+            else ()
+        )
         return cls(
             id=_str(data.get("id"), ""),
             title=_str(data.get("title"), ""),
@@ -233,6 +300,7 @@ class ExperienceEntry:
             date_range=_str(data.get("date_range"), ""),
             location=_str(data.get("location"), ""),
             bullets=_str_tuple(data.get("bullets")),
+            achievement_evidence=evidence,
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -243,6 +311,7 @@ class ExperienceEntry:
             "company": self.company,
             "location": self.location,
             "bullets": list(self.bullets),
+            "achievement_evidence": [item.to_dict() for item in self.achievement_evidence],
         }
 
 
@@ -302,6 +371,9 @@ class SkillCategory:
 
 
 TAILORING_MODES = ("strict", "balanced", "aggressive")
+CLAIM_MODES = ("verified_only", "evidence_reframing", "adjacent_translation", "draft_requires_confirmation")
+AUTO_APPROVABLE_CLAIM_MODES = ("verified_only", "evidence_reframing")
+EVIDENCE_STRENGTHS = ("verified", "supported", "inferred", "draft")
 WRITING_TONES = ("direct", "executive", "technical", "confident", "warm")
 BULLET_STYLES = ("balanced", "impact", "technical_depth", "leadership")
 VERBOSITY_LEVELS = ("concise", "balanced", "detailed")
@@ -316,6 +388,9 @@ class TailoringPolicy:
     allow_skill_reordering: bool = True
     allow_summary_rewrite: bool = True
     allow_minor_inference: bool = False
+    claim_mode: str = "evidence_reframing"
+    auto_approvable_claim_modes: tuple[str, ...] = AUTO_APPROVABLE_CLAIM_MODES
+    allow_adjacent_achievement_drafts: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any] | None) -> "TailoringPolicy":
@@ -323,6 +398,17 @@ class TailoringPolicy:
         mode = _str(data.get("mode"), "balanced")
         if mode not in TAILORING_MODES:
             mode = "balanced"
+        claim_mode = _str(data.get("claim_mode"), "evidence_reframing")
+        if claim_mode not in CLAIM_MODES:
+            claim_mode = "evidence_reframing"
+        auto_approvable = tuple(
+            claim_mode
+            for claim_mode in _str_tuple(data.get("auto_approvable_claim_modes"))
+            if claim_mode in AUTO_APPROVABLE_CLAIM_MODES
+        ) or AUTO_APPROVABLE_CLAIM_MODES
+        allow_adjacent_drafts = mode == "aggressive" and _bool(
+            data.get("allow_adjacent_achievement_drafts"), False
+        )
 
         policy = cls(
             mode=mode,
@@ -331,6 +417,9 @@ class TailoringPolicy:
             allow_skill_reordering=_bool(data.get("allow_skill_reordering"), True),
             allow_summary_rewrite=_bool(data.get("allow_summary_rewrite"), True),
             allow_minor_inference=_bool(data.get("allow_minor_inference"), False),
+            claim_mode=claim_mode,
+            auto_approvable_claim_modes=auto_approvable,
+            allow_adjacent_achievement_drafts=allow_adjacent_drafts,
         )
         # Strict mode forces every flag to False — the policy makes the
         # forbidden options unrepresentable rather than relying on consumers
@@ -343,11 +432,24 @@ class TailoringPolicy:
                 allow_skill_reordering=False,
                 allow_summary_rewrite=False,
                 allow_minor_inference=False,
+                claim_mode="verified_only",
+                auto_approvable_claim_modes=("verified_only",),
+                allow_adjacent_achievement_drafts=False,
             )
         return policy
 
     def to_dict(self) -> dict[str, Any]:
-        return {f.name: getattr(self, f.name) for f in fields(self)}
+        return {
+            "mode": self.mode,
+            "allow_title_reframing": self.allow_title_reframing,
+            "allow_achievement_rewriting": self.allow_achievement_rewriting,
+            "allow_skill_reordering": self.allow_skill_reordering,
+            "allow_summary_rewrite": self.allow_summary_rewrite,
+            "allow_minor_inference": self.allow_minor_inference,
+            "claim_mode": self.claim_mode,
+            "auto_approvable_claim_modes": list(self.auto_approvable_claim_modes),
+            "allow_adjacent_achievement_drafts": self.allow_adjacent_achievement_drafts,
+        }
 
 
 @dataclass(frozen=True)

--- a/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/profile/sqlite_repository.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 _CHILD_TABLES = (
     "candidate_profile_experience_bullets",
+    "candidate_profile_achievement_evidence",
     "candidate_profile_experience_entries",
     "candidate_profile_education_entries",
     "candidate_profile_skill_items",
@@ -236,8 +237,9 @@ class SqliteProfileRepository:
                     (str(tenant_id), profile_id),
                 )
 
+            root_values = _root_values(str(tenant_id), profile_id, profile_dict, style, template_text, version, now)
             self._conn.execute(
-                """
+                f"""
                 INSERT INTO candidate_profiles (
                     tenant_id, profile_id,
                     personal_full_name, personal_preferred_name, personal_email,
@@ -265,6 +267,8 @@ class SqliteProfileRepository:
                     tailoring_allow_achievement_rewriting,
                     tailoring_allow_skill_reordering, tailoring_allow_summary_rewrite,
                     tailoring_allow_minor_inference,
+                    tailoring_claim_mode, tailoring_auto_approvable_claim_modes_json,
+                    tailoring_allow_adjacent_achievement_drafts,
                     writing_tone, writing_bullet_style, writing_verbosity,
                     writing_keyword_density, writing_avoid_first_person,
                     max_experience_bullets, custom_tailoring_prompt,
@@ -273,12 +277,7 @@ class SqliteProfileRepository:
                     resume_style_moderncv_color, resume_style_page_scale,
                     resume_style_hints_column_width_cm, resume_style_body_alignment,
                     resume_template_text, version, updated_at
-                ) VALUES (
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-                )
+                ) VALUES ({", ".join("?" for _ in root_values)})
                 ON CONFLICT(tenant_id, profile_id) DO UPDATE SET
                     personal_full_name = excluded.personal_full_name,
                     personal_preferred_name = excluded.personal_preferred_name,
@@ -327,6 +326,9 @@ class SqliteProfileRepository:
                     tailoring_allow_skill_reordering = excluded.tailoring_allow_skill_reordering,
                     tailoring_allow_summary_rewrite = excluded.tailoring_allow_summary_rewrite,
                     tailoring_allow_minor_inference = excluded.tailoring_allow_minor_inference,
+                    tailoring_claim_mode = excluded.tailoring_claim_mode,
+                    tailoring_auto_approvable_claim_modes_json = excluded.tailoring_auto_approvable_claim_modes_json,
+                    tailoring_allow_adjacent_achievement_drafts = excluded.tailoring_allow_adjacent_achievement_drafts,
                     writing_tone = excluded.writing_tone,
                     writing_bullet_style = excluded.writing_bullet_style,
                     writing_verbosity = excluded.writing_verbosity,
@@ -346,7 +348,7 @@ class SqliteProfileRepository:
                     version = excluded.version,
                     updated_at = excluded.updated_at
                 """,
-                _root_values(str(tenant_id), profile_id, profile_dict, style, template_text, version, now),
+                root_values,
             )
 
             self._insert_children(str(tenant_id), profile_id, profile)
@@ -370,6 +372,35 @@ class SqliteProfileRepository:
                     ) VALUES (?, ?, ?, ?, ?)
                     """,
                     (tenant_id, profile_id, entry.id, bullet_index, bullet),
+                )
+            for evidence_index, evidence in enumerate(entry.achievement_evidence):
+                self._conn.execute(
+                    """
+                    INSERT INTO candidate_profile_achievement_evidence (
+                        tenant_id, profile_id, entry_id, evidence_index,
+                        evidence_id, source_text, scope, action, tools_json,
+                        metrics_json, outcome, seniority_signal, evidence_strength,
+                        claim_confidence, user_confirmed, tags_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        tenant_id,
+                        profile_id,
+                        entry.id,
+                        evidence_index,
+                        evidence.id,
+                        evidence.source_text,
+                        evidence.scope,
+                        evidence.action,
+                        _json_array(evidence.tools),
+                        _json_array(evidence.metrics),
+                        evidence.outcome,
+                        evidence.seniority_signal,
+                        evidence.evidence_strength,
+                        evidence.claim_confidence,
+                        1 if evidence.user_confirmed else 0,
+                        _json_array(evidence.tags),
+                    ),
                 )
 
         for index, entry in enumerate(profile.education_entries):
@@ -573,6 +604,11 @@ class SqliteProfileRepository:
                         where="entry_id = ?",
                         params=(row["entry_id"],),
                     ),
+                    "achievement_evidence": self._achievement_evidence(
+                        tenant_id,
+                        profile_id,
+                        row["entry_id"],
+                    ),
                 }
             )
         return entries
@@ -673,6 +709,13 @@ class SqliteProfileRepository:
                 "allow_skill_reordering": _as_bool(row["tailoring_allow_skill_reordering"]),
                 "allow_summary_rewrite": _as_bool(row["tailoring_allow_summary_rewrite"]),
                 "allow_minor_inference": _as_bool(row["tailoring_allow_minor_inference"]),
+                "claim_mode": row["tailoring_claim_mode"],
+                "auto_approvable_claim_modes": _json_str_list(
+                    row["tailoring_auto_approvable_claim_modes_json"]
+                ),
+                "allow_adjacent_achievement_drafts": _as_bool(
+                    row["tailoring_allow_adjacent_achievement_drafts"]
+                ),
             },
             "writing_style": {
                 "tone": row["writing_tone"],
@@ -682,6 +725,41 @@ class SqliteProfileRepository:
                 "avoid_first_person": _as_bool(row["writing_avoid_first_person"]),
             },
         }
+
+    def _achievement_evidence(
+        self,
+        tenant_id: str,
+        profile_id: str,
+        entry_id: str,
+    ) -> list[dict[str, Any]]:
+        rows = self._conn.execute(
+            """
+            SELECT evidence_id, source_text, scope, action, tools_json, metrics_json,
+                   outcome, seniority_signal, evidence_strength, claim_confidence,
+                   user_confirmed, tags_json
+            FROM candidate_profile_achievement_evidence
+            WHERE tenant_id = ? AND profile_id = ? AND entry_id = ?
+            ORDER BY evidence_index
+            """,
+            (tenant_id, profile_id, entry_id),
+        ).fetchall()
+        return [
+            {
+                "id": row["evidence_id"],
+                "source_text": row["source_text"],
+                "scope": row["scope"],
+                "action": row["action"],
+                "tools": _json_str_list(row["tools_json"]),
+                "metrics": _json_str_list(row["metrics_json"]),
+                "outcome": row["outcome"],
+                "seniority_signal": row["seniority_signal"],
+                "evidence_strength": row["evidence_strength"],
+                "claim_confidence": float(row["claim_confidence"] or 0.0),
+                "user_confirmed": _as_bool(row["user_confirmed"]),
+                "tags": _json_str_list(row["tags_json"]),
+            }
+            for row in rows
+        ]
 
     def _ordered_values(
         self,
@@ -828,6 +906,9 @@ def _root_values(
         _bool_int(policy.get("allow_skill_reordering"), True),
         _bool_int(policy.get("allow_summary_rewrite"), True),
         _bool_int(policy.get("allow_minor_inference"), False),
+        _text(policy.get("claim_mode"), "evidence_reframing"),
+        _json_array(_claim_modes(policy.get("auto_approvable_claim_modes"))),
+        _bool_int(policy.get("allow_adjacent_achievement_drafts"), False),
         _text(writing.get("tone"), "direct"),
         _text(writing.get("bullet_style"), "balanced"),
         _text(writing.get("verbosity"), "balanced"),
@@ -898,6 +979,28 @@ def _bool_int(value: Any, default: bool) -> int:
 
 def _as_bool(value: Any) -> bool:
     return bool(int(value or 0))
+
+
+def _json_array(values: tuple[str, ...] | list[str]) -> str:
+    return json.dumps([str(value) for value in values if str(value)])
+
+
+def _json_str_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        raw = value
+    else:
+        try:
+            raw = json.loads(str(value or "[]"))
+        except json.JSONDecodeError:
+            raw = []
+    if not isinstance(raw, list):
+        return []
+    return [str(item).strip() for item in raw if str(item).strip()]
+
+
+def _claim_modes(value: Any) -> list[str]:
+    modes = _json_str_list(value)
+    return modes or ["verified_only", "evidence_reframing"]
 
 
 def _diff_top_level_sections(previous: dict[str, Any], current: dict[str, Any]) -> tuple[str, ...]:

--- a/workers/automation/src/jobhunter/profile_import.py
+++ b/workers/automation/src/jobhunter/profile_import.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from statistics import median
 from typing import Any
 
-from jobhunter.resume_profile import DEFAULT_TAILORING_POLICY, DEFAULT_WRITING_STYLE
+from jobhunter.resume_profile import DEFAULT_TAILORING_POLICY, DEFAULT_WRITING_STYLE, get_tailoring_policy
 from jobhunter.infrastructure.materials.latex_pdf import normalize_resume_style
 
 MAX_IMPORT_BYTES = 12 * 1024 * 1024
@@ -191,6 +191,7 @@ def profile_from_resume_text(text: str, *, base_profile: dict[str, Any] | None =
     rules["tailoring_policy"] = {**DEFAULT_TAILORING_POLICY, **_dict_or_empty(rules.get("tailoring_policy"))}
     rules["writing_style"] = {**DEFAULT_WRITING_STYLE, **_dict_or_empty(rules.get("writing_style"))}
     rules.setdefault("custom_tailoring_prompt", "")
+    rules["tailoring_policy"] = get_tailoring_policy(profile)
 
     exp_meta = profile.setdefault("experience", {})
     if experiences:

--- a/workers/automation/src/jobhunter/resume_profile.py
+++ b/workers/automation/src/jobhunter/resume_profile.py
@@ -122,6 +122,9 @@ DEFAULT_TAILORING_POLICY = {
     "allow_skill_reordering": True,
     "allow_summary_rewrite": True,
     "allow_minor_inference": False,
+    "claim_mode": "evidence_reframing",
+    "auto_approvable_claim_modes": ["verified_only", "evidence_reframing"],
+    "allow_adjacent_achievement_drafts": False,
 }
 
 DEFAULT_WRITING_STYLE = {
@@ -131,6 +134,10 @@ DEFAULT_WRITING_STYLE = {
     "keyword_density": "natural",
     "avoid_first_person": True,
 }
+
+CLAIM_MODES = {"verified_only", "evidence_reframing", "adjacent_translation", "draft_requires_confirmation"}
+AUTO_APPROVABLE_CLAIM_MODES = {"verified_only", "evidence_reframing"}
+EVIDENCE_STRENGTHS = {"verified", "supported", "inferred", "draft"}
 
 
 def get_tailoring_policy(profile: dict) -> dict:
@@ -145,6 +152,17 @@ def get_tailoring_policy(profile: dict) -> dict:
     for key, default in DEFAULT_TAILORING_POLICY.items():
         if isinstance(default, bool):
             policy[key] = bool(policy.get(key, default))
+    if policy.get("claim_mode") not in CLAIM_MODES:
+        policy["claim_mode"] = DEFAULT_TAILORING_POLICY["claim_mode"]
+    raw_auto = policy.get("auto_approvable_claim_modes")
+    if isinstance(raw_auto, list):
+        policy["auto_approvable_claim_modes"] = [
+            str(mode)
+            for mode in raw_auto
+            if str(mode) in AUTO_APPROVABLE_CLAIM_MODES
+        ] or list(DEFAULT_TAILORING_POLICY["auto_approvable_claim_modes"])
+    else:
+        policy["auto_approvable_claim_modes"] = list(DEFAULT_TAILORING_POLICY["auto_approvable_claim_modes"])
     if policy["mode"] == "strict":
         policy.update(
             {
@@ -153,13 +171,60 @@ def get_tailoring_policy(profile: dict) -> dict:
                 "allow_skill_reordering": False,
                 "allow_summary_rewrite": False,
                 "allow_minor_inference": False,
+                "claim_mode": "verified_only",
+                "auto_approvable_claim_modes": ["verified_only"],
+                "allow_adjacent_achievement_drafts": False,
             }
         )
     elif policy["mode"] == "aggressive":
         policy.setdefault("allow_achievement_rewriting", True)
         policy.setdefault("allow_skill_reordering", True)
         policy.setdefault("allow_summary_rewrite", True)
+        policy["allow_adjacent_achievement_drafts"] = bool(
+            policy.get("allow_adjacent_achievement_drafts", False)
+        )
+    else:
+        policy["allow_adjacent_achievement_drafts"] = False
     return policy
+
+
+def get_claim_mode(profile: dict) -> str:
+    """Return the normalized claim mode used for resume tailoring."""
+    return str(get_tailoring_policy(profile)["claim_mode"])
+
+
+def get_auto_approvable_claim_modes(profile: dict) -> list[str]:
+    """Return claim modes that can be approved without extra user confirmation."""
+    return list(get_tailoring_policy(profile)["auto_approvable_claim_modes"])
+
+
+def get_tailoring_quality_controls(profile: dict) -> dict:
+    """Return normalized evidence/claim controls used by quality checks."""
+    policy = get_tailoring_policy(profile)
+    return {
+        "claim_mode": policy["claim_mode"],
+        "auto_approvable_claim_modes": list(policy["auto_approvable_claim_modes"]),
+        "allow_adjacent_achievement_drafts": policy["allow_adjacent_achievement_drafts"],
+    }
+
+
+def get_achievement_evidence(profile: dict) -> list[dict]:
+    """Return normalized achievement evidence flattened across experience entries."""
+    evidence: list[dict] = []
+    for entry in get_experience_entries(profile):
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id", "")).strip()
+        raw_items = entry.get("achievement_evidence")
+        if not isinstance(raw_items, list):
+            continue
+        for item in raw_items:
+            if not isinstance(item, dict):
+                continue
+            normalized = _normalize_achievement_evidence(item)
+            normalized["experience_entry_id"] = entry_id
+            evidence.append(normalized)
+    return evidence
 
 
 def get_writing_style(profile: dict) -> dict:
@@ -200,6 +265,38 @@ def get_max_experience_bullets(profile: dict, default: int = 4) -> int:
 
 def _normalize_text(value: object) -> str:
     return " ".join(str(value or "").lower().split())
+
+
+def _normalize_achievement_evidence(item: dict) -> dict:
+    strength = str(item.get("evidence_strength") or "supported").strip()
+    if strength not in EVIDENCE_STRENGTHS:
+        strength = "supported"
+    try:
+        confidence = float(item.get("claim_confidence", 0.0))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    confidence = max(0.0, min(1.0, confidence))
+
+    return {
+        "id": str(item.get("id", "")).strip(),
+        "source_text": str(item.get("source_text", "")).strip(),
+        "scope": str(item.get("scope", "")).strip(),
+        "action": str(item.get("action", "")).strip(),
+        "tools": _text_list(item.get("tools")),
+        "metrics": _text_list(item.get("metrics")),
+        "outcome": str(item.get("outcome", "")).strip(),
+        "seniority_signal": str(item.get("seniority_signal", "")).strip(),
+        "evidence_strength": strength,
+        "claim_confidence": confidence,
+        "user_confirmed": bool(item.get("user_confirmed", False)),
+        "tags": _text_list(item.get("tags")),
+    }
+
+
+def _text_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
 
 
 def tailored_experience_title(entry: dict, update: dict, profile: dict) -> str:
@@ -252,4 +349,3 @@ def tailored_skill_items(category: dict, update: dict, profile: dict) -> list[st
             items.append(item)
             seen.add(normalized)
     return items
-

--- a/workers/automation/src/jobhunter/wizard/init.py
+++ b/workers/automation/src/jobhunter/wizard/init.py
@@ -198,6 +198,9 @@ def _setup_structured_resume(profile: dict) -> None:
                 "allow_skill_reordering": True,
                 "allow_summary_rewrite": True,
                 "allow_minor_inference": False,
+                "claim_mode": "evidence_reframing",
+                "auto_approvable_claim_modes": ["verified_only", "evidence_reframing"],
+                "allow_adjacent_achievement_drafts": False,
             },
             "writing_style": {
                 "tone": "direct",

--- a/workers/automation/tests/test_profile_aggregate.py
+++ b/workers/automation/tests/test_profile_aggregate.py
@@ -25,6 +25,12 @@ from jobhunter.domain.profile.value_objects import (
     WritingStyle,
 )
 from jobhunter.domain.tenant import LOCAL_TENANT
+from jobhunter.resume_profile import (
+    get_achievement_evidence,
+    get_auto_approvable_claim_modes,
+    get_claim_mode,
+    get_tailoring_quality_controls,
+)
 
 
 def _valid_profile_dict() -> dict:
@@ -81,6 +87,7 @@ def test_from_dict_parses_valid_profile():
     assert profile.experience_metadata.years_of_experience_total == "5"
     assert len(profile.experience_entries) == 1
     assert profile.experience_entries[0].bullets == ("Built APIs.", "Reduced incidents 40%.")
+    assert profile.experience_entries[0].achievement_evidence == ()
     assert profile.tailoring_rules.max_experience_bullets == 3
     assert profile.resume_constraints.real_metrics == ("40%",)
 
@@ -132,6 +139,45 @@ def test_to_dict_round_trips_canonical_fields():
     assert "resume_facts" not in out
 
 
+def test_to_dict_round_trips_achievement_evidence_and_claim_controls():
+    original = _valid_profile_dict()
+    original["resume"]["experience_entries"][0]["achievement_evidence"] = [
+        {
+            "id": "ev_role_1_latency",
+            "source_text": "Reduced API latency 35% by replacing synchronous enrichment calls.",
+            "scope": "owned service",
+            "action": "replaced synchronous enrichment calls",
+            "tools": ["Python", "PostgreSQL"],
+            "metrics": ["35% latency reduction"],
+            "outcome": "faster API responses",
+            "seniority_signal": "technical ownership",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.95,
+            "user_confirmed": True,
+            "tags": ["latency", "backend", "performance"],
+        }
+    ]
+    original["resume"]["tailoring_rules"]["tailoring_policy"] = {
+        "mode": "aggressive",
+        "claim_mode": "adjacent_translation",
+        "auto_approvable_claim_modes": [
+            "verified_only",
+            "evidence_reframing",
+            "draft_requires_confirmation",
+        ],
+        "allow_adjacent_achievement_drafts": True,
+    }
+
+    out = Profile.from_dict(LOCAL_TENANT, original).to_dict()
+
+    evidence = out["resume"]["experience_entries"][0]["achievement_evidence"][0]
+    assert evidence == original["resume"]["experience_entries"][0]["achievement_evidence"][0]
+    policy = out["resume"]["tailoring_rules"]["tailoring_policy"]
+    assert policy["claim_mode"] == "adjacent_translation"
+    assert policy["auto_approvable_claim_modes"] == ["verified_only", "evidence_reframing"]
+    assert policy["allow_adjacent_achievement_drafts"] is True
+
+
 def test_to_dict_preserves_unknown_top_level_keys_for_forward_compat():
     raw = _valid_profile_dict()
     raw["custom_section"] = {"future": "thing"}
@@ -152,6 +198,9 @@ def test_tailoring_policy_strict_mode_disables_every_flag():
             "allow_achievement_rewriting": True,
             "allow_skill_reordering": True,
             "allow_minor_inference": True,
+            "claim_mode": "draft_requires_confirmation",
+            "auto_approvable_claim_modes": ["verified_only", "draft_requires_confirmation"],
+            "allow_adjacent_achievement_drafts": True,
         }
     )
     assert policy.mode == "strict"
@@ -160,6 +209,68 @@ def test_tailoring_policy_strict_mode_disables_every_flag():
     assert not policy.allow_achievement_rewriting
     assert not policy.allow_skill_reordering
     assert not policy.allow_minor_inference
+    assert policy.claim_mode == "verified_only"
+    assert policy.auto_approvable_claim_modes == ("verified_only",)
+    assert policy.allow_adjacent_achievement_drafts is False
+
+
+def test_tailoring_policy_filters_draft_claims_from_auto_approval():
+    policy = TailoringPolicy.from_dict(
+        {
+            "mode": "aggressive",
+            "claim_mode": "draft_requires_confirmation",
+            "auto_approvable_claim_modes": ["draft_requires_confirmation"],
+            "allow_adjacent_achievement_drafts": True,
+        }
+    )
+
+    assert policy.claim_mode == "draft_requires_confirmation"
+    assert policy.auto_approvable_claim_modes == ("verified_only", "evidence_reframing")
+    assert policy.allow_adjacent_achievement_drafts is True
+
+
+def test_resume_profile_helpers_return_normalized_evidence_controls():
+    profile = _valid_profile_dict()
+    profile["resume"]["experience_entries"][0]["achievement_evidence"] = [
+        {
+            "id": "ev_role_1_latency",
+            "source_text": "Reduced latency.",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.9,
+            "user_confirmed": True,
+        }
+    ]
+    profile["resume"]["tailoring_rules"]["tailoring_policy"] = {
+        "mode": "strict",
+        "claim_mode": "draft_requires_confirmation",
+        "auto_approvable_claim_modes": ["verified_only", "draft_requires_confirmation"],
+        "allow_adjacent_achievement_drafts": True,
+    }
+
+    assert get_claim_mode(profile) == "verified_only"
+    assert get_auto_approvable_claim_modes(profile) == ["verified_only"]
+    assert get_tailoring_quality_controls(profile) == {
+        "claim_mode": "verified_only",
+        "auto_approvable_claim_modes": ["verified_only"],
+        "allow_adjacent_achievement_drafts": False,
+    }
+    assert get_achievement_evidence(profile) == [
+        {
+            "id": "ev_role_1_latency",
+            "source_text": "Reduced latency.",
+            "scope": "",
+            "action": "",
+            "tools": [],
+            "metrics": [],
+            "outcome": "",
+            "seniority_signal": "",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.9,
+            "user_confirmed": True,
+            "tags": [],
+            "experience_entry_id": "role_1",
+        }
+    ]
 
 
 def test_writing_style_clamps_unknown_enum_values():

--- a/workers/automation/tests/test_profile_import.py
+++ b/workers/automation/tests/test_profile_import.py
@@ -110,6 +110,9 @@ def test_profile_from_resume_text_builds_structured_profile_and_preserves_applic
     assert rules["required_education_entry_ids"] == ["state_university_master_of_science_in_computer_science_2018"]
     assert rules["required_bullets_by_experience_id"] == {}
     assert rules["tailoring_policy"]["mode"] == "strict"
+    assert rules["tailoring_policy"]["claim_mode"] == "verified_only"
+    assert rules["tailoring_policy"]["auto_approvable_claim_modes"] == ["verified_only"]
+    assert rules["tailoring_policy"]["allow_adjacent_achievement_drafts"] is False
     assert rules["writing_style"]["tone"] == "technical"
     assert rules["custom_tailoring_prompt"] == "Keep platform impact visible."
     assert profile["resume_constraints"]["real_metrics"] == ["2M events", "35%", "20 teams"]

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -93,6 +93,7 @@ def test_profile_schema_is_normalized_without_profile_json_escape_hatch(tmp_path
         "candidate_profiles",
         "candidate_profile_experience_entries",
         "candidate_profile_experience_bullets",
+        "candidate_profile_achievement_evidence",
         "candidate_profile_education_entries",
         "candidate_profile_skill_categories",
         "candidate_profile_skill_items",
@@ -131,6 +132,52 @@ def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
     assert loaded is not None
     assert loaded.to_dict() == Profile.from_dict(LOCAL_TENANT, _valid_profile()).to_dict()
     assert [event.event_type for event in events] == ["ProfileUpdated"]
+
+
+def test_save_and_load_preserves_achievement_evidence_and_tailoring_controls(tmp_path):
+    repo, conn, _ = _new_repo(tmp_path)
+    raw = _valid_profile()
+    raw["resume"]["experience_entries"][0]["achievement_evidence"] = [
+        {
+            "id": "ev_role_1_latency",
+            "source_text": "Reduced API latency 35% by replacing synchronous enrichment calls.",
+            "scope": "owned service",
+            "action": "replaced synchronous enrichment calls",
+            "tools": ["Python", "PostgreSQL"],
+            "metrics": ["35% latency reduction"],
+            "outcome": "faster API responses",
+            "seniority_signal": "technical ownership",
+            "evidence_strength": "verified",
+            "claim_confidence": 0.95,
+            "user_confirmed": True,
+            "tags": ["latency", "backend", "performance"],
+        }
+    ]
+    raw["resume"]["tailoring_rules"]["tailoring_policy"] = {
+        "mode": "aggressive",
+        "claim_mode": "draft_requires_confirmation",
+        "auto_approvable_claim_modes": ["verified_only", "draft_requires_confirmation"],
+        "allow_adjacent_achievement_drafts": True,
+    }
+
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, raw))
+
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_achievement_evidence").fetchone()[0] == 1
+    root = conn.execute(
+        "SELECT tailoring_claim_mode, tailoring_auto_approvable_claim_modes_json, "
+        "tailoring_allow_adjacent_achievement_drafts FROM candidate_profiles"
+    ).fetchone()
+    assert root["tailoring_claim_mode"] == "draft_requires_confirmation"
+    assert json.loads(root["tailoring_auto_approvable_claim_modes_json"]) == ["verified_only"]
+    assert root["tailoring_allow_adjacent_achievement_drafts"] == 1
+
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    loaded_entry = loaded.to_dict()["resume"]["experience_entries"][0]
+    assert loaded_entry["achievement_evidence"] == raw["resume"]["experience_entries"][0]["achievement_evidence"]
+    assert loaded.to_dict()["resume"]["tailoring_rules"]["tailoring_policy"][
+        "auto_approvable_claim_modes"
+    ] == ["verified_only"]
 
 
 def test_legacy_profile_json_seeds_sqlite_once_and_writes_stay_in_sqlite(tmp_path):


### PR DESCRIPTION
## Summary

- Add optional per-experience `achievement_evidence` value objects to the Python profile aggregate and TypeScript profile schemas.
- Add tailoring policy controls for `claim_mode`, `auto_approvable_claim_modes`, and `allow_adjacent_achievement_drafts`.
- Persist the new evidence rows and policy controls through Python SQLite storage and the local TypeScript API profile store.
- Add focused Python, domain-types, and API regression coverage for round trips and strict/aggressive policy normalization.

## Notes

- Strict mode normalizes to `claim_mode: verified_only`, disables adjacent drafts, and only auto-approves `verified_only`.
- `draft_requires_confirmation` is filtered out of auto-approvable modes.
- Documentation was not updated in this PR because this stack already has the plan PR and this layer adds internal schema/persistence only; user-facing documentation belongs with the PR 4 UI controls.

## Validation

- `git diff --check` -> passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_profile_aggregate.py workers/automation/tests/test_profile_import.py workers/automation/tests/test_sqlite_profile_repository.py` -> 26 passed
- `pnpm --filter @jobhunter/domain-types test` -> 12 files passed, 168 tests passed
- `pnpm --filter @jobhunter/api test -- test/server.test.ts -t profile` -> 9 files passed, 163 tests passed
- `pnpm --filter @jobhunter/contracts check` -> passed
- `pnpm --filter @jobhunter/api check` -> passed
- `pnpm --filter @jobhunter/domain-types check` -> passed