### PR TITLE
feat(materials): gate high-fit resumes with adversarial review

### DIFF
--- a/workers/automation/src/jobhunter/domain/materials/adversarial.py
+++ b/workers/automation/src/jobhunter/domain/materials/adversarial.py
@@ -1,0 +1,288 @@
+"""High-fit adversarial resume review helpers.
+
+The use case owns LLM I/O. This module owns deterministic fit-score gating,
+strict response schema, persona prompt context, and compact response parsing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from jobhunter.domain.profile.snapshot import ProfileSnapshot
+from jobhunter.domain.scoring.value_objects import FitScore
+from jobhunter.domain.materials.quality import TailoringPlan
+
+
+ADVERSARIAL_REVIEW_SCHEMA_VERSION = "tailor-adversarial.v1"
+ADVERSARIAL_REVIEW_THRESHOLD = 0.8
+ADVERSARIAL_REVIEW_PERSONAS: tuple[str, ...] = (
+    "ats_parser",
+    "skeptical_recruiter",
+    "hiring_manager_domain_expert",
+    "evidence_auditor",
+    "anti_ai_voice_critic",
+    "interview_defensibility_critic",
+)
+
+
+ADVERSARIAL_REVIEW_RESPONSE_SCHEMA: dict[str, Any] = {
+    "title": "TailoringAdversarialReview",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["verdict", "score", "personas", "blockers", "warnings", "repair_instructions"],
+    "properties": {
+        "verdict": {"type": "string", "enum": ["PASS", "FAIL"]},
+        "score": {"type": "number", "minimum": 0, "maximum": 1},
+        "personas": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "persona",
+                    "verdict",
+                    "score",
+                    "blockers",
+                    "warnings",
+                    "repair_instructions",
+                ],
+                "properties": {
+                    "persona": {"type": "string", "enum": list(ADVERSARIAL_REVIEW_PERSONAS)},
+                    "verdict": {"type": "string", "enum": ["PASS", "FAIL"]},
+                    "score": {"type": "number", "minimum": 0, "maximum": 1},
+                    "blockers": {"type": "array", "items": {"type": "string"}},
+                    "warnings": {"type": "array", "items": {"type": "string"}},
+                    "repair_instructions": {"type": "array", "items": {"type": "string"}},
+                },
+            },
+        },
+        "blockers": {"type": "array", "items": {"type": "string"}},
+        "warnings": {"type": "array", "items": {"type": "string"}},
+        "repair_instructions": {"type": "array", "items": {"type": "string"}},
+    },
+}
+
+
+@dataclass(frozen=True)
+class AdversarialPersonaFinding:
+    persona: str
+    verdict: str
+    score: float
+    blockers: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    repair_instructions: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "AdversarialPersonaFinding":
+        persona = str(data.get("persona") or "").strip()
+        if persona not in ADVERSARIAL_REVIEW_PERSONAS:
+            persona = "evidence_auditor"
+        verdict = str(data.get("verdict") or "FAIL").upper()
+        if verdict not in {"PASS", "FAIL"}:
+            verdict = "FAIL"
+        return cls(
+            persona=persona,
+            verdict=verdict,
+            score=_score(data.get("score")),
+            blockers=tuple(_string_list(data.get("blockers"))),
+            warnings=tuple(_string_list(data.get("warnings"))),
+            repair_instructions=tuple(_string_list(data.get("repair_instructions"))),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "persona": self.persona,
+            "verdict": self.verdict,
+            "score": self.score,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "repair_instructions": list(self.repair_instructions),
+        }
+
+
+@dataclass(frozen=True)
+class AdversarialReviewResult:
+    ran: bool
+    threshold: float
+    normalized_fit_score: float | None
+    passed: bool
+    score: float = 1.0
+    blockers: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    repair_instructions: tuple[str, ...] = ()
+    personas: tuple[AdversarialPersonaFinding, ...] = ()
+    skipped_reason: str = ""
+
+    @classmethod
+    def skipped(
+        cls,
+        *,
+        threshold: float,
+        normalized_fit_score: float | None,
+        reason: str,
+    ) -> "AdversarialReviewResult":
+        return cls(
+            ran=False,
+            threshold=threshold,
+            normalized_fit_score=normalized_fit_score,
+            passed=True,
+            skipped_reason=reason,
+        )
+
+    @classmethod
+    def failed_error(
+        cls,
+        *,
+        threshold: float,
+        normalized_fit_score: float | None,
+        error: str,
+    ) -> "AdversarialReviewResult":
+        return cls(
+            ran=True,
+            threshold=threshold,
+            normalized_fit_score=normalized_fit_score,
+            passed=False,
+            score=0.0,
+            blockers=(f"Adversarial review error: {error}",),
+            repair_instructions=("Retry adversarial review or remove risky unsupported claims.",),
+        )
+
+    @classmethod
+    def from_response(
+        cls,
+        response: Mapping[str, Any],
+        *,
+        threshold: float,
+        normalized_fit_score: float | None,
+    ) -> "AdversarialReviewResult":
+        personas = tuple(
+            AdversarialPersonaFinding.from_dict(item)
+            for item in response.get("personas", [])
+            if isinstance(item, Mapping)
+        )
+        blockers = [
+            *_string_list(response.get("blockers")),
+            *[blocker for persona in personas for blocker in persona.blockers],
+        ]
+        warnings = [
+            *_string_list(response.get("warnings")),
+            *[warning for persona in personas for warning in persona.warnings],
+        ]
+        repairs = [
+            *_string_list(response.get("repair_instructions")),
+            *[repair for persona in personas for repair in persona.repair_instructions],
+        ]
+        verdict = str(response.get("verdict") or "FAIL").upper()
+        score = _score(response.get("score"))
+        return cls(
+            ran=True,
+            threshold=threshold,
+            normalized_fit_score=normalized_fit_score,
+            passed=verdict == "PASS" and not blockers,
+            score=score,
+            blockers=tuple(dict.fromkeys(blockers)),
+            warnings=tuple(dict.fromkeys(warnings)),
+            repair_instructions=tuple(dict.fromkeys(repairs)),
+            personas=personas,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ran": self.ran,
+            "threshold": self.threshold,
+            "normalized_fit_score": self.normalized_fit_score,
+            "passed": self.passed,
+            "score": self.score,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "repair_instructions": list(self.repair_instructions),
+            "personas": [persona.to_dict() for persona in self.personas],
+            "skipped_reason": self.skipped_reason,
+            "schema_version": ADVERSARIAL_REVIEW_SCHEMA_VERSION,
+        }
+
+
+def normalized_job_fit_score(job: Mapping[str, Any]) -> float | None:
+    """Return a 0..1 fit score from current 1..10 or explicit normalized fields."""
+    fit_score = FitScore.from_optional(job.get("fit_score", job.get("fitScore")))
+    if fit_score is not None:
+        return fit_score.value / 10.0
+    for key in ("normalized_fit_score", "normalizedFitScore"):
+        raw = job.get(key)
+        try:
+            normalized = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if 0.0 <= normalized <= 1.0:
+            return normalized
+    return None
+
+
+def should_run_adversarial_review(
+    job: Mapping[str, Any],
+    *,
+    threshold: float = ADVERSARIAL_REVIEW_THRESHOLD,
+) -> bool:
+    normalized = normalized_job_fit_score(job)
+    return normalized is not None and normalized >= threshold
+
+
+def build_adversarial_review_prompt(
+    *,
+    profile_snapshot: ProfileSnapshot,
+    tailoring_plan: TailoringPlan,
+) -> str:
+    profile = profile_snapshot.as_dict()
+    resume = profile.get("resume", {})
+    return f"""You are running adversarial resume review for a high-fit JobHunter opportunity.
+
+Return ONLY JSON matching the provided schema. Do not include markdown.
+
+Evaluate the tailored resume from every persona below:
+- ats_parser: standard sections, parseable wording, no keyword stuffing.
+- skeptical_recruiter: no inflated language, vague claims, or resume-that-reads-like-job-description.
+- hiring_manager_domain_expert: role relevance, technical plausibility, seniority match.
+- evidence_auditor: every metric, tool, role, company, and achievement is supported by the profile.
+- anti_ai_voice_critic: no generic AI resume voice, repetitive phrasing, or stock verbs.
+- interview_defensibility_critic: every claim can survive interview follow-up questions.
+
+Blockers must include unsupported metrics, invented tools, inflated seniority,
+ATS parseability failures, AI-sounding voice that damages credibility, or
+claims the candidate could not defend in an interview. Warnings should be
+non-blocking improvements only.
+
+CANONICAL PROFILE RESUME:
+{json.dumps(resume, indent=2, ensure_ascii=False)}
+
+TAILORING QUALITY PLAN:
+{json.dumps(tailoring_plan.to_prompt_dict(), indent=2, ensure_ascii=False)}
+"""
+
+
+def _score(value: Any) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, parsed))
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+__all__ = [
+    "ADVERSARIAL_REVIEW_PERSONAS",
+    "ADVERSARIAL_REVIEW_RESPONSE_SCHEMA",
+    "ADVERSARIAL_REVIEW_SCHEMA_VERSION",
+    "ADVERSARIAL_REVIEW_THRESHOLD",
+    "AdversarialPersonaFinding",
+    "AdversarialReviewResult",
+    "build_adversarial_review_prompt",
+    "normalized_job_fit_score",
+    "should_run_adversarial_review",
+]

--- a/workers/automation/src/jobhunter/domain/materials/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/materials/use_cases.py
@@ -53,6 +53,14 @@ from jobhunter.domain.materials.aggregate import (
     MaterialsSet,
     MaterialsSetFactory,
 )
+from jobhunter.domain.materials.adversarial import (
+    ADVERSARIAL_REVIEW_RESPONSE_SCHEMA,
+    ADVERSARIAL_REVIEW_THRESHOLD,
+    AdversarialReviewResult,
+    build_adversarial_review_prompt,
+    normalized_job_fit_score,
+    should_run_adversarial_review,
+)
 from jobhunter.domain.materials.entities import Artifact
 from jobhunter.domain.materials.policy import TailoringPolicy
 from jobhunter.domain.materials.quality import (
@@ -850,6 +858,7 @@ class TailorResumeUseCase:
             "judge_min_score": report.get("judge_min_score"),
             "quality_plan": report.get("quality_plan") or {},
             "quality_checks": report.get("quality_checks") or {},
+            "adversarial_review": report.get("adversarial_review") or {},
             "candidate_summaries": report.get("candidate_summaries") or [],
             "judge": judge_record,
         }
@@ -963,6 +972,7 @@ class TailorResumeUseCase:
             "job_text": _build_job_blob(job),
             "quality_plan": tailoring_plan.to_metadata(),
             "quality_checks": None,
+            "adversarial_review": None,
             "attempt_history": [],
             "candidate_summaries": [],
         }
@@ -1031,6 +1041,7 @@ class TailorResumeUseCase:
                 report["validator"] = selected.validation.to_dict()
                 report["judge"] = selected.record.get("judge")
                 report["quality_checks"] = selected.record.get("quality_checks")
+                report["adversarial_review"] = selected.record.get("adversarial_review")
                 report["selected_candidate"] = selected.record.get("candidate_id")
                 report["selected_model"] = selected.model
                 attempt_record["status"] = "approved"
@@ -1048,16 +1059,26 @@ class TailorResumeUseCase:
                 elif status == "judge_rejected":
                     judge = candidate_record.get("judge") or {}
                     avoid_notes.append(f"Judge rejected: {judge.get('issues') or 'quality gate failed'}")
+                elif status == "adversarial_rejected":
+                    review = candidate_record.get("adversarial_review") or {}
+                    blockers = review.get("blockers") or []
+                    repairs = review.get("repair_instructions") or []
+                    avoid_notes.extend(str(item) for item in [*blockers, *repairs] if str(item))
 
             attempt_record["status"] = "failed_quality_gate"
             report["attempt_history"].append(attempt_record)
 
         report["status"] = "exhausted_retries"
         if best_rejected is not None:
-            report["status"] = "failed_judge"
+            report["status"] = (
+                "failed_adversarial_review"
+                if best_rejected.record.get("status") == "adversarial_rejected"
+                else "failed_judge"
+            )
             report["validator"] = best_rejected.validation.to_dict()
             report["judge"] = best_rejected.record.get("judge")
             report["quality_checks"] = best_rejected.record.get("quality_checks")
+            report["adversarial_review"] = best_rejected.record.get("adversarial_review")
             report["selected_candidate"] = best_rejected.record.get("candidate_id")
             report["selected_model"] = best_rejected.model
             return report, best_rejected.payload, best_rejected.validation, best_rejected.verdict
@@ -1200,9 +1221,23 @@ class TailorResumeUseCase:
             tailored_text=tailored_text,
             job=job,
         )
+        if verdict.approved:
+            adversarial_review = self._adversarial_review(
+                profile_snapshot=profile_snapshot,
+                tailoring_plan=tailoring_plan,
+                tailored_payload=payload,
+                tailored_text=tailored_text,
+                job=job,
+                validation_mode=validation_mode,
+            )
+            record["adversarial_review"] = adversarial_review.to_dict()
+            if not adversarial_review.passed:
+                verdict = self._adversarial_failed_verdict(verdict, adversarial_review)
         record["judge"] = self._judge_record(verdict)
         if verdict.approved:
             record["status"] = "approved"
+        elif record.get("adversarial_review", {}).get("ran"):
+            record["status"] = "adversarial_rejected"
         else:
             record["status"] = "judge_rejected"
         return _TailorCandidate(payload, validation, verdict, tailored_text, model, record)
@@ -1321,6 +1356,91 @@ class TailorResumeUseCase:
             issues=tuple(issues + blockers),
         )
 
+    def _adversarial_review(
+        self,
+        *,
+        profile_snapshot: ProfileSnapshot,
+        tailoring_plan: TailoringPlan,
+        tailored_payload: dict,
+        tailored_text: str,
+        job: dict,
+        validation_mode: str,
+    ) -> AdversarialReviewResult:
+        normalized_fit = normalized_job_fit_score(job)
+        if validation_mode == "lenient":
+            return AdversarialReviewResult.skipped(
+                threshold=ADVERSARIAL_REVIEW_THRESHOLD,
+                normalized_fit_score=normalized_fit,
+                reason="lenient_validation_mode",
+            )
+        if not should_run_adversarial_review(job):
+            return AdversarialReviewResult.skipped(
+                threshold=ADVERSARIAL_REVIEW_THRESHOLD,
+                normalized_fit_score=normalized_fit,
+                reason="below_high_fit_threshold",
+            )
+
+        messages = [
+            LlmMessage(
+                role="system",
+                content=build_adversarial_review_prompt(
+                    profile_snapshot=profile_snapshot,
+                    tailoring_plan=tailoring_plan,
+                ),
+            ),
+            LlmMessage(
+                role="user",
+                content=(
+                    f"TARGET JOB:\n{_build_job_blob(job)}\n\n"
+                    f"TAILORED JSON:\n{json.dumps(tailored_payload, indent=2, ensure_ascii=False)}\n\n"
+                    f"TAILORED RESUME:\n{tailored_text}\n\n"
+                    "Run the adversarial review and return JSON:"
+                ),
+            ),
+        ]
+        try:
+            response = self._chat_json_payload(
+                messages,
+                schema=ADVERSARIAL_REVIEW_RESPONSE_SCHEMA,
+                model=self._llm_policy.effective_judge_model,
+                temperature=self._llm_policy.judge_temperature,
+                max_tokens=self._llm_policy.judge_max_tokens,
+                thinking_budget=self._llm_policy.thinking_budget,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.error("Adversarial review LLM error: %s", exc)
+            return AdversarialReviewResult.failed_error(
+                threshold=ADVERSARIAL_REVIEW_THRESHOLD,
+                normalized_fit_score=normalized_fit,
+                error=str(exc),
+            )
+        return AdversarialReviewResult.from_response(
+            response,
+            threshold=ADVERSARIAL_REVIEW_THRESHOLD,
+            normalized_fit_score=normalized_fit,
+        )
+
+    def _adversarial_failed_verdict(
+        self,
+        base: JudgeVerdict,
+        review: AdversarialReviewResult,
+    ) -> JudgeVerdict:
+        try:
+            notes_payload = json.loads(base.notes) if base.notes else {}
+        except json.JSONDecodeError:
+            notes_payload = {"issues": [base.notes] if base.notes else []}
+        notes_payload["adversarial_review"] = review.to_dict()
+        criterion_scores = dict(base.criterion_scores)
+        criterion_scores["adversarial_review"] = review.score
+        issues = tuple(dict.fromkeys([*base.issues, *review.blockers]))
+        return JudgeVerdict(
+            approved=False,
+            score=min(base.score, review.score),
+            notes=json.dumps(notes_payload, ensure_ascii=False, sort_keys=True),
+            criterion_scores=criterion_scores,
+            issues=issues,
+        )
+
     def _judge_record(self, verdict: JudgeVerdict | None) -> dict[str, Any] | None:
         if verdict is None:
             return None
@@ -1350,6 +1470,8 @@ class TailorResumeUseCase:
     ) -> str:
         status = report.get("status", "pending")
         if status == "approved":
+            return status
+        if status == "failed_adversarial_review":
             return status
         if validation.passed and verdict is not None and not verdict.approved:
             return "failed_judge"

--- a/workers/automation/tests/test_materials_adversarial.py
+++ b/workers/automation/tests/test_materials_adversarial.py
@@ -1,0 +1,56 @@
+"""High-fit adversarial resume review helper tests."""
+
+from __future__ import annotations
+
+from jobhunter.domain.materials.adversarial import (
+    AdversarialReviewResult,
+    normalized_job_fit_score,
+    should_run_adversarial_review,
+)
+
+
+def test_normalized_job_fit_score_uses_current_ten_point_score() -> None:
+    assert normalized_job_fit_score({"fit_score": 8}) == 0.8
+    assert normalized_job_fit_score({"fitScore": "9"}) == 0.9
+    assert normalized_job_fit_score({"fit_score": 0}) is None
+
+
+def test_normalized_job_fit_score_accepts_explicit_normalized_fields() -> None:
+    assert normalized_job_fit_score({"normalized_fit_score": 0.83}) == 0.83
+    assert normalized_job_fit_score({"normalizedFitScore": "0.81"}) == 0.81
+    assert normalized_job_fit_score({"normalized_fit_score": 1.4}) is None
+
+
+def test_should_run_adversarial_review_threshold() -> None:
+    assert should_run_adversarial_review({"fit_score": 8}) is True
+    assert should_run_adversarial_review({"fit_score": 7}) is False
+    assert should_run_adversarial_review({"normalized_fit_score": 0.8}) is True
+
+
+def test_adversarial_review_result_merges_persona_blockers() -> None:
+    result = AdversarialReviewResult.from_response(
+        {
+            "verdict": "PASS",
+            "score": 0.9,
+            "blockers": [],
+            "warnings": ["General warning."],
+            "repair_instructions": [],
+            "personas": [
+                {
+                    "persona": "evidence_auditor",
+                    "verdict": "FAIL",
+                    "score": 0.2,
+                    "blockers": ["Metric is unsupported."],
+                    "warnings": ["Metric wording is vague."],
+                    "repair_instructions": ["Remove the metric."],
+                }
+            ],
+        },
+        threshold=0.8,
+        normalized_fit_score=0.9,
+    )
+
+    assert result.passed is False
+    assert result.blockers == ("Metric is unsupported.",)
+    assert result.warnings == ("General warning.", "Metric wording is vague.")
+    assert result.repair_instructions == ("Remove the metric.",)

--- a/workers/automation/tests/test_materials_use_cases.py
+++ b/workers/automation/tests/test_materials_use_cases.py
@@ -30,6 +30,7 @@ from jobhunter.domain.materials import (
     RenderFormat,
     ValidationResult,
 )
+from jobhunter.domain.materials.adversarial import ADVERSARIAL_REVIEW_RESPONSE_SCHEMA
 from jobhunter.domain.materials.aggregate import MaterialsLifecycle
 from jobhunter.domain.materials.services import ContentValidator, ResumeAssembler
 from jobhunter.domain.materials.use_cases import (
@@ -124,7 +125,7 @@ def job() -> dict:
         "title": "Backend Engineer",
         "site": "Acme",
         "full_description": "Build a Python service.",
-        "fit_score": 9,
+        "fit_score": 7,
     }
 
 
@@ -301,6 +302,50 @@ def _judge_with_score(score: float, verdict: str = "PASS") -> str:
     )
 
 
+def _adversarial_pass(*, warnings: list[str] | None = None) -> str:
+    return json.dumps(
+        {
+            "verdict": "PASS",
+            "score": 0.91,
+            "personas": [
+                {
+                    "persona": "evidence_auditor",
+                    "verdict": "PASS",
+                    "score": 0.92,
+                    "blockers": [],
+                    "warnings": warnings or [],
+                    "repair_instructions": [],
+                }
+            ],
+            "blockers": [],
+            "warnings": warnings or [],
+            "repair_instructions": [],
+        }
+    )
+
+
+def _adversarial_fail() -> str:
+    return json.dumps(
+        {
+            "verdict": "FAIL",
+            "score": 0.31,
+            "personas": [
+                {
+                    "persona": "interview_defensibility_critic",
+                    "verdict": "FAIL",
+                    "score": 0.25,
+                    "blockers": ["Claim cannot be defended in interview."],
+                    "warnings": [],
+                    "repair_instructions": ["Replace the unsupported claim with verified evidence."],
+                }
+            ],
+            "blockers": ["Unsupported high-fit resume claim."],
+            "warnings": [],
+            "repair_instructions": ["Use only verified evidence from ev_latency."],
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
 # TailorResumeUseCase
 # ---------------------------------------------------------------------------
@@ -340,7 +385,11 @@ def _assert_openai_strict_schema(schema: dict[str, Any], path: str = "$") -> Non
 
 @pytest.mark.parametrize(
     "schema",
-    [TAILORED_RESUME_RESPONSE_SCHEMA, TAILORING_JUDGE_RESPONSE_SCHEMA],
+    [
+        TAILORED_RESUME_RESPONSE_SCHEMA,
+        TAILORING_JUDGE_RESPONSE_SCHEMA,
+        ADVERSARIAL_REVIEW_RESPONSE_SCHEMA,
+    ],
 )
 def test_tailoring_structured_output_schemas_are_openai_strict_compatible(
     schema: dict[str, Any],
@@ -416,6 +465,135 @@ def test_tailor_use_case_injects_quality_plan_and_persists_metadata(
     assert metadata["quality_plan"]["required_evidence_ids"] == ["ev_latency"]
     assert metadata["quality_checks"]["passed"] is True
     assert outcome.report["tailoring_quality"]["quality_checks"]["passed"] is True
+
+
+def test_tailor_use_case_skips_adversarial_review_below_high_fit_threshold(
+    tmp_path: Path, snapshot: ProfileSnapshot, job: dict
+) -> None:
+    repo = _FakeRepository()
+    llm = _ScriptedLlm([_good_json_payload(), _judge_pass()])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+    )
+
+    outcome = use_case.execute(job=job, profile_snapshot=snapshot, tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    assert len(llm.calls) == 2
+    assert outcome.materials is not None
+    assert outcome.materials.tailored_resume is not None
+    review = outcome.materials.tailored_resume.metadata["adversarial_review"]
+    assert review["ran"] is False
+    assert review["skipped_reason"] == "below_high_fit_threshold"
+
+
+def test_tailor_use_case_runs_adversarial_review_for_high_fit_jobs(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    high_fit_job = {
+        **job,
+        "fit_score": 9,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "PostgreSQL", "API performance"],
+        "responsibilities": ["Own backend latency improvements"],
+        "full_description": "Own Python services and improve API latency.",
+    }
+    repo = _FakeRepository()
+    llm = _ScriptedLlm([_quality_json_payload(), _judge_pass(), _adversarial_pass()])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+    )
+
+    outcome = use_case.execute(job=high_fit_job, profile_snapshot=snapshot, tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    assert len(llm.calls) == 3
+    assert "adversarial resume review" in llm.calls[2][0].content
+    assert outcome.materials is not None
+    assert outcome.materials.tailored_resume is not None
+    review = outcome.materials.tailored_resume.metadata["adversarial_review"]
+    assert review["ran"] is True
+    assert review["passed"] is True
+    assert review["normalized_fit_score"] == 0.9
+
+
+def test_tailor_use_case_persists_adversarial_warnings_without_blocking(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    high_fit_job = {**job, "fit_score": 9, "title": "Senior Backend Engineer"}
+    repo = _FakeRepository()
+    llm = _ScriptedLlm([
+        _quality_json_payload(),
+        _judge_pass(),
+        _adversarial_pass(warnings=["Bullet could be more concise."]),
+    ])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+    )
+
+    outcome = use_case.execute(job=high_fit_job, profile_snapshot=snapshot, tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None
+    assert outcome.materials.tailored_resume is not None
+    review = outcome.materials.tailored_resume.metadata["adversarial_review"]
+    assert review["warnings"] == ["Bullet could be more concise."]
+
+
+def test_tailor_use_case_adversarial_blocker_fails_and_feeds_retry_notes(
+    tmp_path: Path, job: dict
+) -> None:
+    snapshot = ProfileSnapshot.from_profile(
+        Profile.from_dict(LOCAL_TENANT, _profile_with_evidence_dict())
+    )
+    high_fit_job = {
+        **job,
+        "fit_score": 9,
+        "title": "Senior Backend Engineer",
+        "skills": ["Python", "PostgreSQL", "API performance"],
+        "responsibilities": ["Own backend latency improvements"],
+        "full_description": "Own Python services and improve API latency.",
+    }
+    repo = _FakeRepository()
+    llm = _ScriptedLlm([
+        _quality_json_payload(),
+        _judge_pass(),
+        _adversarial_fail(),
+        _quality_json_payload(),
+        _judge_pass(),
+        _adversarial_pass(),
+    ])
+    use_case = TailorResumeUseCase(
+        repository=repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        max_retries=1,
+    )
+
+    outcome = use_case.execute(job=high_fit_job, profile_snapshot=snapshot, tailored_dir=tmp_path)
+
+    assert outcome.status == "approved"
+    assert len(llm.calls) == 6
+    assert "Unsupported high-fit resume claim" in llm.calls[3][0].content
+    first_candidate = outcome.report["attempt_history"][0]["candidates"][0]
+    assert first_candidate["status"] == "adversarial_rejected"
+    assert first_candidate["adversarial_review"]["passed"] is False
 
 
 def test_tailor_use_case_quality_failure_feeds_retry_notes(


### PR DESCRIPTION
## Summary

- adds high-fit adversarial review helpers, persona schema, fit-score normalization, and compact result parsing
- runs adversarial review only after a normal judge pass for high-fit jobs
- blocks approval on adversarial blockers, persists review metadata, and feeds blocker/repair notes into the existing retry loop

## Validation

- `git diff --check`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_materials_adversarial.py workers/automation/tests/test_materials_quality.py workers/automation/tests/test_materials_use_cases.py workers/automation/tests/test_content_validator.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/domain/materials workers/automation/tests/test_materials_adversarial.py workers/automation/tests/test_materials_quality.py workers/automation/tests/test_materials_use_cases.py`

## Notes

Stacked on PR #125. This does not add profile UI controls or eval fixtures; those remain follow-on stack layers.