### PR TITLE
feat(jobs): add job audit history

### DIFF
--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -27,6 +27,7 @@ import type {
   DashboardSettings,
   DashboardSummary,
   JobDeletedFilter,
+  JobAuditEntry,
   JobDetail,
   JobListQuery,
   JobSummary,
@@ -575,6 +576,7 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
   );
   const stages = parseStages(detailRow?.stages_json);
   const artifacts = artifactsForJob(db, listRow.job_id);
+  const auditHistory = buildJobAuditHistory(db, listRow.job_id);
   return {
     ok: true,
     job: {
@@ -584,7 +586,1017 @@ export function getJobDetail(db: SqliteDatabase, jobKey: string): JobDetail | nu
     },
     stages,
     artifacts,
+    auditHistory,
   };
+}
+
+interface JobAuditEventRow extends Record<string, unknown> {
+  event_id: number | string;
+  event_type: string | null;
+  job_url: string | null;
+  stage: string | null;
+  level: string | null;
+  message: string | null;
+  occurred_at: string | null;
+  payload_json: string | null;
+}
+
+interface ApplicationReviewDecisionAuditRow extends Record<string, unknown> {
+  decision_id: string;
+  decision: string;
+  reason: string | null;
+  decided_by: string | null;
+  decided_at: string | null;
+}
+
+interface ApplicationOutcomeAuditRow extends Record<string, unknown> {
+  outcome_id: string;
+  kind: string;
+  source: string;
+  note: string | null;
+  occurred_at: string | null;
+  recorded_at: string | null;
+  suggestion_id: string | null;
+  evidence_id: string | null;
+}
+
+interface OutcomeSuggestionAuditRow extends Record<string, unknown> {
+  suggestion_id: string;
+  suggested_kind: string;
+  confidence: number | null;
+  status: string;
+  created_at: string | null;
+  decided_at: string | null;
+  decision: string | null;
+  decision_reason: string | null;
+  decided_outcome_id: string | null;
+}
+
+function buildJobAuditHistory(db: SqliteDatabase, jobId: string): JobAuditEntry[] {
+  const entries: JobAuditEntry[] = [];
+  const seenReferences = new Set<string>();
+
+  if (tableExists(db, "job_events")) {
+    const rows = allRows<JobAuditEventRow>(
+      db,
+      `SELECT event_id, event_type, job_url, stage, level, message, occurred_at, payload_json
+         FROM job_events
+        WHERE job_url = ?
+           OR (
+             payload_json IS NOT NULL
+             AND json_valid(payload_json)
+             AND (
+               JSON_EXTRACT(payload_json, '$.jobId') = ?
+               OR JSON_EXTRACT(payload_json, '$.job_id') = ?
+               OR JSON_EXTRACT(payload_json, '$.jobKey') = ?
+               OR JSON_EXTRACT(payload_json, '$.job_key') = ?
+             )
+           )
+        ORDER BY occurred_at ASC, event_id ASC`,
+      [jobId, jobId, jobId, jobId, jobId],
+    );
+    for (const row of rows) {
+      const payload = parseJsonRecord(row.payload_json) ?? {};
+      rememberAuditReferences(seenReferences, payload);
+      const entry = jobEventToAuditEntry(row, payload);
+      if (entry) entries.push(entry);
+    }
+  }
+
+  appendReviewDecisionAuditEntries(db, jobId, entries, seenReferences);
+  appendApplicationOutcomeAuditEntries(db, jobId, entries, seenReferences);
+  appendOutcomeSuggestionAuditEntries(db, jobId, entries, seenReferences);
+
+  entries.sort((left, right) => {
+    const leftAt = left.occurredAt ?? "";
+    const rightAt = right.occurredAt ?? "";
+    if (leftAt !== rightAt) return leftAt.localeCompare(rightAt);
+    return left.id.localeCompare(right.id);
+  });
+  return entries;
+}
+
+function rememberAuditReferences(seenReferences: Set<string>, payload: Record<string, unknown>): void {
+  for (const [prefix, keys] of [
+    ["review", ["decisionId", "decision_id"]],
+    ["outcome", ["outcomeId", "outcome_id"]],
+    ["suggestion", ["suggestionId", "suggestion_id"]],
+  ] as const) {
+    const id = payloadText(payload, ...keys);
+    if (id) seenReferences.add(`${prefix}:${id}`);
+  }
+}
+
+function appendReviewDecisionAuditEntries(
+  db: SqliteDatabase,
+  jobId: string,
+  entries: JobAuditEntry[],
+  seenReferences: Set<string>,
+): void {
+  if (!tableExists(db, "application_review_decisions")) return;
+  const rows = allRows<ApplicationReviewDecisionAuditRow>(
+    db,
+    `SELECT decision_id, decision, reason, decided_by, decided_at
+       FROM application_review_decisions
+      WHERE tenant_id = ? AND job_key = ?
+      ORDER BY decided_at ASC, decision_id ASC`,
+    [DEFAULT_TENANT, jobId],
+  );
+  for (const row of rows) {
+    if (seenReferences.has(`review:${row.decision_id}`)) continue;
+    entries.push(
+      makeAuditEntry({
+        id: `review:${row.decision_id}`,
+        category: "apply",
+        tone: "info",
+        title: "Apply review decision recorded",
+        description: applyReviewDecisionDescription(row.decision),
+        occurredAt: row.decided_at,
+        actor: row.decided_by || "user",
+        details: auditDetails(
+          ["Decision", humanizeToken(row.decision)],
+          ["Reason", row.reason ? "Provided" : ""],
+        ),
+      }),
+    );
+  }
+}
+
+function appendApplicationOutcomeAuditEntries(
+  db: SqliteDatabase,
+  jobId: string,
+  entries: JobAuditEntry[],
+  seenReferences: Set<string>,
+): void {
+  if (!tableExists(db, "application_outcomes")) return;
+  const rows = allRows<ApplicationOutcomeAuditRow>(
+    db,
+    `SELECT outcome_id, kind, source, note, occurred_at, recorded_at, suggestion_id, evidence_id
+       FROM application_outcomes
+      WHERE tenant_id = ? AND job_key = ?
+      ORDER BY occurred_at ASC, recorded_at ASC, outcome_id ASC`,
+    [DEFAULT_TENANT, jobId],
+  );
+  for (const row of rows) {
+    if (seenReferences.has(`outcome:${row.outcome_id}`)) continue;
+    entries.push(
+      makeAuditEntry({
+        id: `outcome:${row.outcome_id}`,
+        category: "outcome",
+        tone: outcomeTone(row.kind),
+        title: "Application outcome recorded",
+        description: `Outcome: ${humanizeToken(row.kind)}.`,
+        occurredAt: row.occurred_at ?? row.recorded_at,
+        actor: row.source === "manual" ? "user" : row.source,
+        details: auditDetails(
+          ["Outcome", humanizeToken(row.kind)],
+          ["Source", humanizeToken(row.source)],
+          ["Suggestion", row.suggestion_id],
+          ["Evidence", row.evidence_id],
+          ["Note", row.note ? "Provided" : ""],
+        ),
+      }),
+    );
+  }
+}
+
+function appendOutcomeSuggestionAuditEntries(
+  db: SqliteDatabase,
+  jobId: string,
+  entries: JobAuditEntry[],
+  seenReferences: Set<string>,
+): void {
+  if (!tableExists(db, "application_outcome_suggestions")) return;
+  const rows = allRows<OutcomeSuggestionAuditRow>(
+    db,
+    `SELECT suggestion_id, suggested_kind, confidence, status, created_at, decided_at,
+            decision, decision_reason, decided_outcome_id
+       FROM application_outcome_suggestions
+      WHERE tenant_id = ? AND job_key = ?
+      ORDER BY created_at ASC, suggestion_id ASC`,
+    [DEFAULT_TENANT, jobId],
+  );
+  for (const row of rows) {
+    if (seenReferences.has(`suggestion:${row.suggestion_id}`)) continue;
+    entries.push(
+      makeAuditEntry({
+        id: `suggestion:${row.suggestion_id}`,
+        category: "outcome",
+        tone: row.status === "pending" ? "warning" : "info",
+        title: row.status === "pending" ? "Application outcome suggested" : "Outcome suggestion decided",
+        description:
+          row.status === "pending"
+            ? `Suggested outcome: ${humanizeToken(row.suggested_kind)}.`
+            : `Suggestion ${humanizeToken(row.status)}.`,
+        occurredAt: row.decided_at ?? row.created_at,
+        actor: "system",
+        details: auditDetails(
+          ["Suggested outcome", humanizeToken(row.suggested_kind)],
+          ["Confidence", formatPercent(row.confidence)],
+          ["Decision", humanizeToken(row.decision)],
+          ["Reason", row.decision_reason ? "Provided" : ""],
+          ["Outcome", row.decided_outcome_id],
+        ),
+      }),
+    );
+  }
+}
+
+function jobEventToAuditEntry(
+  row: JobAuditEventRow,
+  payload: Record<string, unknown>,
+): JobAuditEntry | null {
+  const eventId = stringField(row.event_id);
+  const stage = payloadText(payload, "stage") || stringField(row.stage);
+  const base = {
+    id: `event:${eventId}`,
+    occurredAt: stringField(row.occurred_at) || null,
+  };
+
+  switch (row.event_type) {
+    case "JobDiscovered":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "success",
+        title: "Job discovered",
+        description: `Found via ${payloadText(payload, "source") || "a configured source"}.`,
+        actor: "system",
+        details: auditDetails(
+          ["Source", payloadText(payload, "source")],
+          ["Employer", payloadText(payload, "employer")],
+          ["Posting URL", payloadText(payload, "postingUrl", "posting_url")],
+        ),
+      });
+    case "JobSourceObserved":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "info",
+        title: "Source observed the job",
+        description: `Seen in ${payloadText(payload, "sourceId", "source_id") || "a source run"}.`,
+        actor: "system",
+        details: auditDetails(
+          ["Source", payloadText(payload, "sourceId", "source_id")],
+          ["Observed URL", payloadText(payload, "observedUrl", "observed_url")],
+          ["Run", payloadText(payload, "runId", "run_id")],
+        ),
+      });
+    case "CanonicalJobIdentityResolved":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "info",
+        title: "Canonical posting resolved",
+        description: "The posting was linked to its canonical ATS identity.",
+        actor: "system",
+        details: auditDetails(
+          ["ATS", humanizeToken(payloadText(payload, "atsKind", "ats_kind"))],
+          ["Canonical URL", payloadText(payload, "canonicalUrl", "canonical_url")],
+          ["Confidence", formatPercent(payloadNumber(payload, "confidence"))],
+        ),
+      });
+    case "DuplicateJobLinked":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "muted",
+        title: "Duplicate linked",
+        description: "A duplicate observation was linked to this job.",
+        actor: "system",
+        details: auditDetails(
+          ["Reason", humanizeToken(payloadText(payload, "reason"))],
+          ["Confidence", formatPercent(payloadNumber(payload, "confidence"))],
+        ),
+      });
+    case "DuplicateJobLinkRejected":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "info",
+        title: "Duplicate link rejected",
+        description: "A possible duplicate was reviewed and kept separate.",
+        actor: "system",
+        details: auditDetails(
+          ["Reason", humanizeToken(payloadText(payload, "reason"))],
+          ["Confidence", formatPercent(payloadNumber(payload, "confidence"))],
+          ["Candidate", payloadText(payload, "candidateJobId", "candidate_job_id")],
+        ),
+      });
+    case "DiscoveryFeedbackRecorded":
+      return makeAuditEntry({
+        ...base,
+        category: "discovery",
+        tone: "info",
+        title: "Discovery feedback recorded",
+        description: `Feedback marked this job as ${humanizeToken(payloadText(payload, "kind"))}.`,
+        actor: "user",
+        details: auditDetails(
+          ["Feedback", humanizeToken(payloadText(payload, "kind"))],
+          ["Source", payloadText(payload, "sourceId", "source_id")],
+        ),
+      });
+    case "JobUpdated":
+    case "JobMetadataUpdated":
+      return makeAuditEntry({
+        ...base,
+        category: "job",
+        tone: "info",
+        title: row.event_type === "JobMetadataUpdated" ? "Job metadata refreshed" : "Job details updated",
+        description:
+          row.event_type === "JobMetadataUpdated"
+            ? "Stored job metadata was refreshed from its source."
+            : "Stored job metadata changed.",
+        actor: "system",
+        details: auditDetails(
+          ["Changed fields", changedFieldList(payload)],
+          ["Source", payloadText(payload, "source")],
+        ),
+      });
+    case "JobDeleted":
+      return makeAuditEntry({
+        ...base,
+        category: "job",
+        tone: "warning",
+        title: "Job deleted",
+        description: "The job was removed from active lists.",
+        actor: "user",
+        details: auditDetails(["Reason", humanizeToken(payloadText(payload, "reason"))]),
+      });
+    case "JobRestored":
+      return makeAuditEntry({
+        ...base,
+        category: "job",
+        tone: "success",
+        title: "Job restored",
+        description: "The job was restored to active lists.",
+        actor: "user",
+        details: [],
+      });
+    case "JobHidden":
+      return makeAuditEntry({
+        ...base,
+        category: "job",
+        tone: "muted",
+        title: "Job hidden",
+        description: "The job was hidden from active views.",
+        actor: "user",
+        details: auditDetails(["Reason", humanizeToken(payloadText(payload, "reason"))]),
+      });
+    case "JobUnhidden":
+      return makeAuditEntry({
+        ...base,
+        category: "job",
+        tone: "success",
+        title: "Job unhidden",
+        description: "The job was restored from hidden views.",
+        actor: "user",
+        details: [],
+      });
+    case "JobEnriched":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: "success",
+        title: "Posting enriched",
+        description: "Full posting details were captured.",
+        actor: "system",
+        details: auditDetails(
+          ["Extraction tier", humanizeToken(payloadText(payload, "extractionTier", "extraction_tier"))],
+          ["Application URL", payloadText(payload, "applicationUrl", "application_url")],
+        ),
+      });
+    case "EnrichmentFailed":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: "danger",
+        title: "Enrichment failed",
+        description: safeAuditText(payloadText(payload, "error")) || "Posting enrichment failed.",
+        actor: "system",
+        details: auditDetails(["Attempt", payloadText(payload, "attemptNumber", "attempt_number")]),
+      });
+    case "PostingContentSnapshotCaptured":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: "success",
+        title: "Content snapshot captured",
+        description: "A posting content snapshot was stored for future comparisons.",
+        actor: "system",
+        details: auditDetails(
+          ["Source", payloadText(payload, "sourceId", "source_id")],
+          ["Version", payloadText(payload, "snapshotVersion", "snapshot_version")],
+          ["Extraction tier", humanizeToken(payloadText(payload, "extractionTier", "extraction_tier"))],
+        ),
+      });
+    case "PostingContentSnapshotFailed":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: "warning",
+        title: "Content snapshot failed",
+        description: "The system could not capture a posting content snapshot.",
+        actor: "system",
+        details: auditDetails(
+          ["Source", payloadText(payload, "sourceId", "source_id")],
+          ["Failure", humanizeToken(payloadText(payload, "errorClass", "error_class"))],
+          ["Retryable", yesNo(payloadBoolean(payload, "retryable"))],
+        ),
+      });
+    case "JobActiveStateChanged":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: payloadText(payload, "activeState", "active_state") === "active" ? "success" : "warning",
+        title: "Posting availability changed",
+        description: `Availability is ${humanizeToken(payloadText(payload, "activeState", "active_state"))}.`,
+        actor: "system",
+        details: auditDetails(
+          ["Previous", humanizeToken(payloadText(payload, "previousState", "previous_state"))],
+          ["Current", humanizeToken(payloadText(payload, "activeState", "active_state"))],
+          ["Verification", humanizeToken(payloadText(payload, "verificationMethod", "verification_method"))],
+        ),
+      });
+    case "ContentDuplicateCandidateDetected":
+      return makeAuditEntry({
+        ...base,
+        category: "enrichment",
+        tone: "warning",
+        title: "Possible content duplicate detected",
+        description: "The posting content looked similar to another job.",
+        actor: "system",
+        details: auditDetails(
+          ["Candidate", payloadText(payload, "candidateJobId", "candidate_job_id")],
+          ["Confidence", formatPercent(payloadNumber(payload, "confidence"))],
+        ),
+      });
+    case "JobScored":
+      return makeAuditEntry({
+        ...base,
+        category: "scoring",
+        tone: scoreTone(payloadNumber(payload, "fitScore", "fit_score")),
+        title: "Job scored",
+        description: `Fit score ${payloadText(payload, "fitScore", "fit_score") || "recorded"}.`,
+        actor: "system",
+        details: auditDetails(
+          ["Fit score", payloadText(payload, "fitScore", "fit_score")],
+          ["Fit band", humanizeToken(payloadText(payload, "fitBand", "fit_band"))],
+          ["Confidence", humanizeToken(payloadText(payload, "confidence"))],
+          ["Eligibility", eligibilityStatus(payload)],
+          ["Keywords", payloadList(payload, "keywords").join(", ")],
+        ),
+      });
+    case "ScoreCorrected":
+      return makeAuditEntry({
+        ...base,
+        category: "scoring",
+        tone: "info",
+        title: "Score corrected",
+        description: `Fit score changed from ${payloadText(payload, "originalScore", "original_score")} to ${payloadText(payload, "correctedScore", "corrected_score")}.`,
+        actor: "user",
+        details: auditDetails(
+          ["Original", payloadText(payload, "originalScore", "original_score")],
+          ["Corrected", payloadText(payload, "correctedScore", "corrected_score")],
+          ["Reason", safeAuditText(payloadText(payload, "reason"))],
+        ),
+      });
+    case "ScoreMarkedStale":
+      return makeAuditEntry({
+        ...base,
+        category: "scoring",
+        tone: "warning",
+        title: "Score marked stale",
+        description: "The score needs review because the scoring policy changed.",
+        actor: "system",
+        details: auditDetails(
+          ["Reason", humanizeToken(payloadText(payload, "staleReason", "stale_reason"))],
+          ["Old policy", payloadText(payload, "oldPolicyVersion", "old_policy_version")],
+          ["New policy", payloadText(payload, "newPolicyVersion", "new_policy_version")],
+        ),
+      });
+    case "ScoreRescoreRequested":
+      return makeAuditEntry({
+        ...base,
+        category: "scoring",
+        tone: "warning",
+        title: "Rescore requested",
+        description: "The score was marked stale and queued for rescoring.",
+        actor: "system",
+        details: auditDetails(
+          ["Reason", humanizeToken(payloadText(payload, "staleReason", "stale_reason"))],
+          ["Old policy", payloadText(payload, "oldPolicyVersion", "old_policy_version")],
+          ["New policy", payloadText(payload, "newPolicyVersion", "new_policy_version")],
+        ),
+      });
+    case "ResumeApproved":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "success",
+        title: "Resume approved",
+        description: "A tailored resume became apply-ready.",
+        actor: "system",
+        details: auditDetails(
+          ["Artifact", payloadText(payload, "artifactId", "artifact_id")],
+          ["Generation", payloadText(payload, "generation")],
+        ),
+      });
+    case "ResumeFailed":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "danger",
+        title: "Resume generation failed",
+        description: "The tailored resume did not pass validation.",
+        actor: "system",
+        details: auditDetails(
+          ["Attempt", payloadText(payload, "attemptNumber", "attempt_number")],
+          ["Validation", payloadList(payload, "validationErrors", "validation_errors").join(", ")],
+        ),
+      });
+    case "CoverLetterGenerated":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "success",
+        title: "Cover letter generated",
+        description: "A tailored cover letter was created.",
+        actor: "system",
+        details: auditDetails(["Artifact", payloadText(payload, "artifactId", "artifact_id")]),
+      });
+    case "PdfRendered":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "success",
+        title: "PDF rendered",
+        description: `${humanizeToken(payloadText(payload, "artifactType", "artifact_type")) || "Material"} PDF was rendered.`,
+        actor: "system",
+        details: auditDetails(["Artifact", payloadText(payload, "artifactId", "artifact_id")]),
+      });
+    case "MaterialsExhausted":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "warning",
+        title: "Materials attempts exhausted",
+        description: "The material generation retry limit was reached.",
+        actor: "system",
+        details: auditDetails(
+          ["Stage", humanizeToken(payloadText(payload, "stage"))],
+          ["Attempts", `${payloadText(payload, "attemptCount", "attempt_count")}/${payloadText(payload, "maxAttempts", "max_attempts")}`],
+        ),
+      });
+    case "TailorRetailorRequested":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "info",
+        title: "Re-tailoring requested",
+        description: "Resume tailoring was requested for this job.",
+        actor: requestActor(payloadText(payload, "requestKind", "request_kind")),
+        details: auditDetails(
+          ["Request", humanizeToken(payloadText(payload, "requestKind", "request_kind"))],
+          ["Reason", safeAuditText(payloadText(payload, "reason"))],
+          ["Current policy", payloadText(payload, "currentPolicyVersion", "current_policy_version")],
+        ),
+      });
+    case "TailoredArtifactsSuppressed":
+      return makeAuditEntry({
+        ...base,
+        category: "materials",
+        tone: "warning",
+        title: "Artifacts retained for audit",
+        description: "Previously active materials were suppressed and kept as historical audit material.",
+        actor: "system",
+        details: auditDetails(
+          ["Reason", humanizeToken(payloadText(payload, "suppressionReason", "suppression_reason"))],
+          ["Artifacts", payloadList(payload, "artifactIds", "artifact_ids").join(", ")],
+          ["Fit score", payloadText(payload, "currentFitScore", "current_fit_score")],
+          ["Threshold", payloadText(payload, "scoreThreshold", "score_threshold")],
+        ),
+      });
+    case "StageStarted":
+      return stageAuditEntry(base, "info", stage, payload, "Stage started", "Work started for this stage.");
+    case "StageCompleted":
+      return stageAuditEntry(base, "success", stage, payload, "Stage completed", "Work completed for this stage.");
+    case "StageFailed":
+      return stageAuditEntry(
+        base,
+        "danger",
+        stage,
+        payload,
+        "Stage failed",
+        safeAuditText(payloadText(payload, "errorMessage", "error_message")) || "This stage failed.",
+      );
+    case "StageExhausted":
+      return stageAuditEntry(base, "warning", stage, payload, "Stage exhausted", "Retry attempts were exhausted.");
+    case "StageReset":
+      return stageAuditEntry(base, "info", stage, payload, "Stage reset", "This stage was reset for another run.");
+    case "StageBlocked":
+      return stageAuditEntry(base, "warning", stage, payload, "Stage blocked", "This stage is blocked by prerequisites.");
+    case "StageSkipped":
+      return stageAuditEntry(
+        base,
+        "muted",
+        stage,
+        payload,
+        "Stage skipped",
+        safeAuditText(payloadText(payload, "reason")) || "This stage was skipped.",
+      );
+    case "StageCanceled":
+      return stageAuditEntry(
+        base,
+        "warning",
+        stage,
+        payload,
+        "Stage canceled",
+        safeAuditText(payloadText(payload, "reason")) || "This stage was canceled.",
+      );
+    case "PreparationWorkItemQueued":
+    case "PreparationWorkItemStarted":
+    case "PreparationWorkItemCompleted":
+    case "PreparationWorkItemFailed":
+      return preparationWorkItemAuditEntry(base, row.event_type, payload);
+    case "ApplyRunStarted":
+      return makeAuditEntry({
+        ...base,
+        category: "apply",
+        tone: payloadBoolean(payload, "dryRun", "dry_run") ? "info" : "warning",
+        title: payloadBoolean(payload, "dryRun", "dry_run") ? "Dry-run apply started" : "Apply run started",
+        description: payloadBoolean(payload, "dryRun", "dry_run")
+          ? "A dry-run application attempt started."
+          : "An application submission attempt started.",
+        actor: "system",
+        details: auditDetails(
+          ["Run", payloadText(payload, "runId", "run_id")],
+          ["Model", payloadText(payload, "model")],
+          ["Dry run", yesNo(payloadBoolean(payload, "dryRun", "dry_run"))],
+        ),
+      });
+    case "ApplicationSubmitted":
+      return makeAuditEntry({
+        ...base,
+        category: "apply",
+        tone: "success",
+        title: "Application submitted",
+        description: "The application was marked submitted.",
+        actor: "system",
+        details: auditDetails(
+          ["Run", payloadText(payload, "runId", "run_id")],
+          ["Confidence", formatPercent(payloadNumber(payload, "verificationConfidence", "verification_confidence"))],
+        ),
+      });
+    case "ApplicationManuallyMarked":
+      return makeAuditEntry({
+        ...base,
+        category: "apply",
+        tone: "success",
+        title: "Application marked applied",
+        description: "The job was manually marked as applied.",
+        actor: "user",
+        details: auditDetails(["Reason", safeAuditText(payloadText(payload, "reason"))]),
+      });
+    case "ApplicationFailed":
+      return makeAuditEntry({
+        ...base,
+        category: "apply",
+        tone: "danger",
+        title: "Application attempt failed",
+        description: "The apply run did not complete successfully.",
+        actor: "system",
+        details: auditDetails(
+          ["Run", payloadText(payload, "runId", "run_id")],
+          ["Attempt", payloadText(payload, "attemptNumber", "attempt_number")],
+        ),
+      });
+    case "ApplicationEmailFeedbackIngested":
+      return makeAuditEntry({
+        ...base,
+        category: "outcome",
+        tone: "info",
+        title: "Application email feedback ingested",
+        description: `Suggested outcome: ${humanizeToken(payloadText(payload, "suggestedKind", "suggested_kind"))}.`,
+        actor: "system",
+        details: auditDetails(
+          ["Provider", humanizeToken(payloadText(payload, "provider"))],
+          ["Classification confidence", formatPercent(payloadNumber(payload, "classificationConfidence", "classification_confidence"))],
+          ["Link confidence", formatPercent(payloadNumber(payload, "linkConfidence", "link_confidence"))],
+        ),
+      });
+    case "ApplyReviewDecisionRecorded":
+      return makeAuditEntry({
+        ...base,
+        category: "apply",
+        tone: "info",
+        title: "Apply review decision recorded",
+        description: applyReviewDecisionDescription(payloadText(payload, "decision")),
+        actor: "user",
+        details: auditDetails(
+          ["Decision", humanizeToken(payloadText(payload, "decision"))],
+          ["Reason", payloadBoolean(payload, "reasonPresent", "reason_present") ? "Provided" : ""],
+        ),
+      });
+    case "ApplicationOutcomeRecorded":
+      return makeAuditEntry({
+        ...base,
+        category: "outcome",
+        tone: outcomeTone(payloadText(payload, "kind")),
+        title: "Application outcome recorded",
+        description: `Outcome: ${humanizeToken(payloadText(payload, "kind"))}.`,
+        actor: payloadText(payload, "source") === "manual" ? "user" : payloadText(payload, "source"),
+        details: auditDetails(
+          ["Outcome", humanizeToken(payloadText(payload, "kind"))],
+          ["Source", humanizeToken(payloadText(payload, "source"))],
+          ["Evidence", payloadText(payload, "evidenceId", "evidence_id")],
+          ["Note", payloadBoolean(payload, "notePresent", "note_present") ? "Provided" : ""],
+        ),
+      });
+    case "OutcomeSuggestionDecided":
+      return makeAuditEntry({
+        ...base,
+        category: "outcome",
+        tone: "info",
+        title: "Outcome suggestion decided",
+        description: `Suggestion ${humanizeToken(payloadText(payload, "decision"))}.`,
+        actor: "user",
+        details: auditDetails(
+          ["Decision", humanizeToken(payloadText(payload, "decision"))],
+          ["Outcome", payloadText(payload, "outcomeId", "outcome_id")],
+          ["Reason", payloadBoolean(payload, "reasonPresent", "reason_present") ? "Provided" : ""],
+        ),
+      });
+    case "ActionStarted":
+      return legacyActionAuditEntry(base, "info", stage, payload, "Action started", "A local job action started.");
+    case "ActionSucceeded":
+      return legacyActionAuditEntry(base, "success", stage, payload, "Action completed", "A local job action completed.");
+    case "ActionFailed":
+      return legacyActionAuditEntry(
+        base,
+        "danger",
+        stage,
+        payload,
+        "Action failed",
+        safeAuditText(payloadText(payload, "error")) || "A local job action failed.",
+      );
+    default:
+      return null;
+  }
+}
+
+function legacyActionAuditEntry(
+  base: Pick<JobAuditEntry, "id" | "occurredAt">,
+  tone: JobAuditEntry["tone"],
+  stage: string,
+  payload: Record<string, unknown>,
+  title: string,
+  description: string,
+): JobAuditEntry {
+  return makeAuditEntry({
+    ...base,
+    category: "pipeline",
+    tone,
+    title: `${title}: ${stageLabel(stage)}`,
+    description,
+    actor: "system",
+    details: auditDetails(
+      ["Stage", stageLabel(stage)],
+      ["Action", payloadText(payload, "action_id", "actionId")],
+      ["Duration", durationLabel(payloadNumber(payload, "duration_ms", "durationMs"))],
+      ["Dry run", yesNo(payloadBoolean(payload, "dry_run", "dryRun"))],
+    ),
+  });
+}
+
+function stageAuditEntry(
+  base: Pick<JobAuditEntry, "id" | "occurredAt">,
+  tone: JobAuditEntry["tone"],
+  stage: string,
+  payload: Record<string, unknown>,
+  title: string,
+  description: string,
+): JobAuditEntry {
+  return makeAuditEntry({
+    ...base,
+    category: "pipeline",
+    tone,
+    title: `${title}: ${stageLabel(stage)}`,
+    description,
+    actor: "system",
+    details: auditDetails(
+      ["Stage", stageLabel(stage)],
+      ["Attempt", payloadText(payload, "attemptNumber", "attempt_number")],
+      ["Duration", durationLabel(payloadNumber(payload, "durationMs", "duration_ms"))],
+      ["Blocked by", payloadList(payload, "blockedBy", "blocked_by").map(stageLabel).join(", ")],
+      ["Retryable", yesNo(payloadBoolean(payload, "retryable"))],
+    ),
+  });
+}
+
+function preparationWorkItemAuditEntry(
+  base: Pick<JobAuditEntry, "id" | "occurredAt">,
+  eventType: string,
+  payload: Record<string, unknown>,
+): JobAuditEntry {
+  const kind = payloadText(payload, "kind");
+  const status =
+    eventType === "PreparationWorkItemQueued"
+      ? "queued"
+      : eventType === "PreparationWorkItemStarted"
+        ? "started"
+        : eventType === "PreparationWorkItemCompleted"
+          ? "completed"
+          : "failed";
+  return makeAuditEntry({
+    ...base,
+    category: "pipeline",
+    tone: status === "failed" ? "danger" : status === "completed" ? "success" : "info",
+    title: `Preparation ${status}: ${preparationKindLabel(kind)}`,
+    description:
+      status === "failed"
+        ? safeAuditText(payloadText(payload, "error", "errorMessage", "error_message")) ||
+          "Preparation work failed."
+        : "Preparation work moved through the queue.",
+    actor: "system",
+    details: auditDetails(
+      ["Work item", preparationKindLabel(kind)],
+      ["Attempt", payloadText(payload, "attemptNumber", "attempt_number")],
+      ["Reason", humanizeToken(payloadText(payload, "reason"))],
+    ),
+  });
+}
+
+function makeAuditEntry(entry: JobAuditEntry): JobAuditEntry {
+  return {
+    ...entry,
+    title: safeAuditText(entry.title, 120) || "Activity recorded",
+    description: entry.description ? safeAuditText(entry.description, 220) : null,
+    actor: entry.actor ? safeAuditText(entry.actor, 80) : null,
+    details: entry.details.slice(0, 8),
+  };
+}
+
+function auditDetails(
+  ...items: Array<readonly [label: string, value: unknown]>
+): JobAuditEntry["details"] {
+  return items.flatMap(([label, value]) => {
+    const safeValue = safeAuditText(value);
+    return safeValue ? [{ label, value: safeValue }] : [];
+  });
+}
+
+function safeAuditText(value: unknown, maxLength = 180): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) {
+    return safeAuditText(value.map((item) => safeAuditText(item, 60)).filter(Boolean).join(", "), maxLength);
+  }
+  if (typeof value === "object") return "";
+  const normalized = String(value).replace(/\s+/g, " ").trim();
+  if (!normalized || normalized === "null" || normalized === "undefined") return "";
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 1)}…` : normalized;
+}
+
+function payloadText(payload: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = payload[key];
+    const text = safeAuditText(value);
+    if (text) return text;
+  }
+  return "";
+}
+
+function payloadNumber(payload: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = nullableNumber(payload[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function payloadBoolean(payload: Record<string, unknown>, ...keys: string[]): boolean | null {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "boolean") return value;
+    if (typeof value === "number") return value !== 0;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      if (["true", "1", "yes"].includes(normalized)) return true;
+      if (["false", "0", "no"].includes(normalized)) return false;
+    }
+  }
+  return null;
+}
+
+function payloadList(payload: Record<string, unknown>, ...keys: string[]): string[] {
+  for (const key of keys) {
+    const value = payload[key];
+    if (Array.isArray(value)) {
+      return value.map((item) => safeAuditText(item, 80)).filter(Boolean);
+    }
+  }
+  return [];
+}
+
+function changedFieldList(payload: Record<string, unknown>): string {
+  const changedFields = payload.changedFields ?? payload.changed_fields;
+  if (!isRecord(changedFields)) return "";
+  return Object.keys(changedFields).map(humanizeToken).join(", ");
+}
+
+function eligibilityStatus(payload: Record<string, unknown>): string {
+  const eligibility = payload.eligibility;
+  if (!isRecord(eligibility)) return "";
+  return humanizeToken(safeAuditText(eligibility.status));
+}
+
+function applyReviewDecisionDescription(decision: string): string {
+  switch (decision) {
+    case "approve_submit":
+      return "Human review approved a real application submission.";
+    case "approve_dry_run":
+      return "Human review approved a dry-run application.";
+    case "defer":
+      return "Human review deferred this application.";
+    case "decline":
+      return "Human review declined this application.";
+    case "reset":
+      return "Human review reset the application decision.";
+    default:
+      return "Human review recorded an application decision.";
+  }
+}
+
+function outcomeTone(kind: unknown): JobAuditEntry["tone"] {
+  const normalized = safeAuditText(kind).toLowerCase();
+  if (["offer", "interview", "assessment", "recruiter_reply", "applied_confirmation"].includes(normalized)) {
+    return "success";
+  }
+  if (["rejection", "bounced", "withdrawn"].includes(normalized)) return "warning";
+  return "info";
+}
+
+function scoreTone(score: number | null): JobAuditEntry["tone"] {
+  if (score === null) return "info";
+  if (score >= 8) return "success";
+  if (score >= 6) return "info";
+  return "warning";
+}
+
+function requestActor(kind: string): string {
+  return kind === "single_job" || kind === "repair" ? "user" : "system";
+}
+
+function stageLabel(stage: string): string {
+  const normalized = stage.trim().toLowerCase();
+  if (!normalized) return "";
+  if (normalized === "discover") return "Discover";
+  if (normalized === "enrich") return "Enrich";
+  if (normalized === "score") return "Score";
+  if (normalized === "tailor") return "Tailor resume";
+  if (normalized === "cover") return "Cover letter";
+  if (normalized === "apply") return "Apply";
+  return humanizeToken(stage);
+}
+
+function preparationKindLabel(kind: string): string {
+  switch (kind) {
+    case "score_job":
+      return "Score job";
+    case "tailor_resume":
+      return "Tailor resume";
+    case "suppress_tailored_artifacts":
+      return "Suppress old materials";
+    default:
+      return humanizeToken(kind) || "Preparation work";
+  }
+}
+
+function humanizeToken(value: unknown): string {
+  const text = safeAuditText(value);
+  if (!text) return "";
+  return text
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return "";
+  const percent = value <= 1 ? value * 100 : value;
+  return `${Math.round(percent)}%`;
+}
+
+function durationLabel(value: number | null): string {
+  if (value === null) return "";
+  if (value < 1000) return `${value} ms`;
+  return `${Math.round(value / 1000)} s`;
+}
+
+function yesNo(value: boolean | null): string {
+  if (value === null) return "";
+  return value ? "Yes" : "No";
 }
 
 function findJobListRow(db: SqliteDatabase, jobKey: string): JobListProjectionRow | null {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -724,6 +724,129 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("returns a curated per-job audit history without raw debug events", async () => {
+    const jobUrl = "https://example.com/jobs/ready";
+    const db = new Database(options.dbPath);
+    const insertAuditEvent = db.prepare(
+      "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at, payload_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    insertAuditEvent.run(
+      jobUrl,
+      "discover",
+      "JobDiscovered",
+      "info",
+      "raw discovery message",
+      "2026-04-29T10:00:00+00:00",
+      JSON.stringify({
+        tenantId: "local",
+        jobId: jobUrl,
+        postingUrl: jobUrl,
+        source: "workday:example",
+        employer: "ExampleCo",
+        discoveredAt: "2026-04-29T10:00:00+00:00",
+      }),
+    );
+    insertAuditEvent.run(
+      jobUrl,
+      "score",
+      "JobScored",
+      "info",
+      "raw score message",
+      "2026-04-29T10:02:00+00:00",
+      JSON.stringify({
+        tenantId: "local",
+        jobId: jobUrl,
+        fitScore: 9,
+        fitBand: "excellent",
+        confidence: "high",
+        eligibility: { status: "eligible" },
+        keywords: ["platform reliability"],
+      }),
+    );
+    insertAuditEvent.run(
+      jobUrl,
+      "apply",
+      "ApplyReviewDecisionRecorded",
+      "info",
+      "debug apply review event",
+      "2026-04-29T10:03:00+00:00",
+      JSON.stringify({
+        tenantId: "local",
+        jobKey: jobUrl,
+        decisionId: "decision-1",
+        decision: "approve_dry_run",
+        reasonPresent: true,
+      }),
+    );
+    insertAuditEvent.run(
+      jobUrl,
+      "apply",
+      "ApplicationOutcomeRecorded",
+      "info",
+      "debug outcome event",
+      "2026-04-29T10:04:00+00:00",
+      JSON.stringify({
+        tenantId: "local",
+        jobKey: jobUrl,
+        outcomeId: "outcome-1",
+        kind: "interview",
+        source: "manual",
+        notePresent: true,
+      }),
+    );
+    insertAuditEvent.run(
+      jobUrl,
+      "apply",
+      "RawDebugEvent",
+      "debug",
+      "raw debug statement that should not render",
+      "2026-04-29T10:05:00+00:00",
+      JSON.stringify({ tenantId: "local", jobKey: jobUrl, secret: "payload_json" }),
+    );
+    db.close();
+
+    const app = buildApp(options);
+    const response = await app.inject({
+      method: "GET",
+      url: `/v1/jobs/${encodeURIComponent(jobUrl)}`,
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const body = response.json();
+    expect(body.auditHistory.map((entry: { title: string }) => entry.title)).toEqual([
+      "Job discovered",
+      "Job scored",
+      "Apply review decision recorded",
+      "Application outcome recorded",
+    ]);
+    expect(body.auditHistory[0]).toMatchObject({
+      category: "discovery",
+      tone: "success",
+      description: "Found via workday:example.",
+      actor: "system",
+      details: expect.arrayContaining([
+        { label: "Source", value: "workday:example" },
+        { label: "Employer", value: "ExampleCo" },
+      ]),
+    });
+    expect(body.auditHistory[2]).toMatchObject({
+      category: "apply",
+      description: "Human review approved a dry-run application.",
+      actor: "user",
+    });
+    expect(body.auditHistory[3]).toMatchObject({
+      category: "outcome",
+      tone: "success",
+      description: "Outcome: Interview.",
+      actor: "user",
+    });
+    expect(JSON.stringify(body.auditHistory)).not.toContain("RawDebugEvent");
+    expect(JSON.stringify(body.auditHistory)).not.toContain("raw debug statement");
+    expect(JSON.stringify(body.auditHistory)).not.toContain("payload_json");
+
+    await app.close();
+  });
+
   it("soft-deletes jobs, hides them from active lists, and restores them", async () => {
     const app = buildApp(options);
     const readyKey = encodeURIComponent("https://example.com/jobs/ready");

--- a/apps/web/src/contexts/operations/components/JobAuditHistory.tsx
+++ b/apps/web/src/contexts/operations/components/JobAuditHistory.tsx
@@ -1,0 +1,62 @@
+import type { JobAuditEntry } from "@jobhunter/contracts";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Empty } from "../../../shared/ui/empty.js";
+
+export interface JobAuditHistoryProps {
+  readonly entries: readonly JobAuditEntry[];
+}
+
+const CATEGORY_LABELS: Record<JobAuditEntry["category"], string> = {
+  discovery: "Discovery",
+  enrichment: "Enrichment",
+  scoring: "Scoring",
+  materials: "Materials",
+  apply: "Apply",
+  outcome: "Outcome",
+  pipeline: "Pipeline",
+  job: "Job",
+};
+
+function categoryLabel(category: JobAuditEntry["category"]): string {
+  return CATEGORY_LABELS[category] ?? category;
+}
+
+export function JobAuditHistory({ entries }: JobAuditHistoryProps) {
+  if (entries.length === 0) {
+    return <Empty title="No audit history recorded for this job." />;
+  }
+
+  return (
+    <ol className="job-audit-timeline" aria-label="Job audit history">
+      {entries.map((entry) => (
+        <li className={`job-audit-entry tone-${entry.tone}`} key={entry.id}>
+          <span className="job-audit-marker" aria-hidden="true" />
+          <span className="job-audit-body">
+            <span className="job-audit-head">
+              <span className="tag muted">{categoryLabel(entry.category)}</span>
+              <strong>{entry.title}</strong>
+              {entry.occurredAt ? (
+                <time dateTime={entry.occurredAt}>{formatDateTime(entry.occurredAt)}</time>
+              ) : null}
+            </span>
+            {entry.description ? (
+              <span className="job-audit-description">{entry.description}</span>
+            ) : null}
+            {entry.actor ? <span className="job-audit-actor">Actor: {entry.actor}</span> : null}
+            {entry.details.length ? (
+              <dl className="job-audit-details">
+                {entry.details.map((detail) => (
+                  <div key={`${entry.id}-${detail.label}`}>
+                    <dt>{detail.label}</dt>
+                    <dd>{detail.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2353,6 +2353,97 @@ textarea {
   overflow-wrap: anywhere;
 }
 
+.job-audit-timeline {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.job-audit-entry {
+  display: grid;
+  grid-template-columns: 12px minmax(0, 1fr);
+  gap: 10px;
+  align-items: start;
+}
+
+.job-audit-marker {
+  width: 8px;
+  height: 8px;
+  margin-top: 6px;
+  border-radius: 999px;
+  background: var(--info);
+}
+
+.job-audit-entry.tone-success .job-audit-marker {
+  background: var(--ok);
+}
+
+.job-audit-entry.tone-warning .job-audit-marker {
+  background: var(--warn);
+}
+
+.job-audit-entry.tone-danger .job-audit-marker {
+  background: var(--danger);
+}
+
+.job-audit-entry.tone-muted .job-audit-marker {
+  background: var(--muted);
+}
+
+.job-audit-body {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.job-audit-head {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  align-items: baseline;
+}
+
+.job-audit-head strong {
+  overflow-wrap: anywhere;
+}
+
+.job-audit-head time,
+.job-audit-actor {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.job-audit-description {
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.job-audit-details {
+  display: grid;
+  gap: 4px 12px;
+  margin: 2px 0 0;
+}
+
+.job-audit-details div {
+  display: grid;
+  grid-template-columns: 112px minmax(0, 1fr);
+  gap: 10px;
+}
+
+.job-audit-details dt {
+  color: var(--muted);
+}
+
+.job-audit-details dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .preformatted {
   white-space: pre-wrap;
   overflow-wrap: anywhere;

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -6,6 +6,7 @@ import type {
   ApplyReviewQueueResponse,
   CredentialsResponse,
   DashboardSummary,
+  JobAuditEntry,
   JobDetail,
   JobSummary,
   PaginatedResponse,
@@ -270,6 +271,45 @@ export function makeJobsPage(items: readonly JobSummary[] = [sampleJob, sampleSe
   };
 }
 
+export const sampleJobAuditHistory: JobAuditEntry[] = [
+  {
+    id: "event-1",
+    category: "discovery",
+    tone: "success",
+    title: "Job discovered",
+    description: "Found via lever:acme.",
+    occurredAt: "2026-05-01T12:00:00Z",
+    actor: "system",
+    details: [
+      { label: "Source", value: "lever:acme" },
+      { label: "Employer", value: "Acme Corp" },
+    ],
+  },
+  {
+    id: "event-2",
+    category: "scoring",
+    tone: "success",
+    title: "Job scored",
+    description: "Fit score 8.",
+    occurredAt: "2026-05-05T09:30:00Z",
+    actor: "system",
+    details: [
+      { label: "Fit score", value: "8" },
+      { label: "Fit band", value: "Strong" },
+    ],
+  },
+  {
+    id: "event-3",
+    category: "apply",
+    tone: "info",
+    title: "Apply review decision recorded",
+    description: "Human review approved a dry-run application.",
+    occurredAt: "2026-05-06T06:20:00Z",
+    actor: "user",
+    details: [{ label: "Decision", value: "Approve Dry Run" }],
+  },
+];
+
 export function makeJobDetail(job: JobSummary = sampleJob): JobDetail {
   return {
     ok: true,
@@ -311,6 +351,7 @@ export function makeJobDetail(job: JobSummary = sampleJob): JobDetail {
       },
     ],
     artifacts: [],
+    auditHistory: sampleJobAuditHistory,
   };
 }
 

--- a/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
@@ -73,4 +73,16 @@ describe("<JobDetailDrawer>", () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/jobs"));
   });
+
+  it("renders user-facing audit history without raw debug event copy", async () => {
+    renderJobDetailDrawer("job-1");
+
+    const history = await screen.findByLabelText("Job audit history");
+    expect(history).toHaveTextContent("Job discovered");
+    expect(history).toHaveTextContent("Found via lever:acme.");
+    expect(history).toHaveTextContent("Job scored");
+    expect(history).toHaveTextContent("Apply review decision recorded");
+    expect(history).not.toHaveTextContent("payload_json");
+    expect(history).not.toHaveTextContent("ApplyReviewDecisionRecorded");
+  });
 });

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -7,6 +7,7 @@ import { ApplyHistory } from "../../contexts/apply/components/ApplyHistory.js";
 import { JobOutcomePanel } from "../../contexts/apply/components/ApplicationOutcomes.js";
 import { ArtifactStatusBadge } from "../../contexts/materials/components/ArtifactStatusBadge.js";
 import { OpenArtifactButton } from "../../contexts/materials/components/OpenArtifactButton.js";
+import { JobAuditHistory } from "../../contexts/operations/components/JobAuditHistory.js";
 import { useJobDetailQuery } from "../../contexts/operations/hooks/useJobDetailQuery.js";
 import { JobActions } from "../../contexts/pipeline/components/JobActions.js";
 import { StageTimeline } from "../../contexts/pipeline/components/StageTimeline.js";
@@ -68,6 +69,9 @@ export function JobDetailDrawer({ jobId }: JobDetailDrawerProps) {
               currentStage={detail.job.currentStage}
               nextAction={detail.job.nextAction}
             />
+            <Section title="Audit history">
+              <JobAuditHistory entries={detail.auditHistory} />
+            </Section>
             <Section title="Preparation diagnostics">
               <StageTimeline stages={preparationStages(detail.stages)} />
             </Section>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,7 +191,7 @@ tables that back every read-model endpoint:
 |------------------------------|-------------------------------------------------------------------|
 | `job_list_projections`       | One row per job — title, employer, current stage/state, fit score, materials presence, apply status. |
 | `dashboard_projections`      | Singleton aggregates: counts, funnel per stage, source breakdown, score distribution. |
-| `job_detail_projections`     | Per-job description preview, score reasoning, full stages array. |
+| `job_detail_projections`     | Per-job description preview, score reasoning, full stages array, and curated audit history assembled from job events plus append-only apply feedback records. |
 | `artifact_list_projections`  | All generated artifacts (resume txt/pdf, cover txt/pdf) with provenance. |
 | `apply_run_projections`      | Apply-run telemetry with denormalised job context and event timeline. |
 | `discovery_run_projections`  | Scheduled discovery-run status, source ids, counts, and retry metadata. |
@@ -205,6 +205,11 @@ projections from canonical aggregate state, and advance the watermark in the
 same transaction. Both processes write to the same tables; SQLite handles the
 concurrent advances. This kills the per-stage `LEFT JOIN ... COALESCE` soup
 that the read-model used to assemble at request time.
+
+Job detail audit history is assembled at read time from allow-listed lifecycle
+events and append-only apply review/outcome records. It is a user-facing audit
+timeline, not a debug log: raw event payloads, debug messages, local paths, raw
+outcome notes, and email body text stay out of the response.
 
 ## Runtime Boundaries
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -59,6 +59,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | Dashboard KPI drilldowns stop matching their Jobs list filters | `apps/api/test/server.test.ts`; `apps/web/src/views/dashboard/KpiGrid.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
 | Apply-run drawers show roadmap placeholder copy instead of persisted timeline events | `apps/api/test/server.test.ts`; `apps/web/src/contexts/apply/components/ApplyRunTimeline.test.tsx` |
 | Activity events overload Dashboard or stop being inspectable from the Debug tab | `apps/api/test/server.test.ts`; `apps/web/src/views/dashboard/DashboardView.test.tsx`; `apps/web/src/views/debug/DebugActivityTable.test.tsx`; `apps/web/src/views/debug/DebugView.test.tsx` |
+| Job detail audit history misses user-relevant lifecycle milestones, duplicates raw event payloads, or exposes debug messages, raw notes, email bodies, or local paths | `apps/api/test/server.test.ts`; `apps/web/src/views/jobs/JobDetailDrawer.test.tsx` |
 | Jobs delete/hide lifecycle regresses, causing temporary deletes not to resurface, hidden jobs to leak into active/deleted views, or permanent deletes to leave suppressing tombstones behind | `apps/api/test/server.test.ts`; `workers/automation/tests/test_discovery_identity.py`; `apps/web/src/views/jobs/JobBulkActions.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
 | Destructive UI workflows touch real user data | `apps/api/test/qa-workflow.test.ts` with `pnpm qa:seed` |
 | Source registry compatibility drops legacy discovery config | `workers/automation/tests/test_source_registry.py` covers packaged `sites.yaml` migration, `employers.yaml` migration, JobSpy `boards` selection, and the one-release legacy `sites` alias warning |
@@ -137,8 +138,9 @@ records `approve_submit`, dry-run approval, defer, decline, and reset decisions
 without starting apply/browser automation, and refreshes the queue after each
 decision. Open a job detail drawer and verify manual outcomes save with a
 canonical timestamp, local notes render only in the outcome timeline, pending
-outcome suggestions can be accepted, corrected, or ignored, and no raw email
-body text appears in event/activity payloads.
+outcome suggestions can be accepted, corrected, or ignored, and the job audit
+history shows review/outcome milestones without raw notes, email body text,
+debug statements, or raw event names.
 
 For Gmail feedback changes, use fake Gmail clients or seeded worker fixtures.
 Do not scan a real mailbox for QA automation. Verify that the scan is bounded

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -47,6 +47,12 @@ unresolved stale markers, including the stale reason, current and target policy
 versions, marked time, and whether the score is waiting for explicit rescore
 reset. `scoreReasoning` remains on the wire as a compatibility summary during
 the scoring evidence migration.
+`/v1/jobs/:key` also returns `auditHistory[]`, a user-facing timeline assembled
+from allow-listed `job_events` milestones plus append-only apply review and
+outcome feedback records. The timeline summarizes discovery, enrichment,
+scoring, materials, pipeline, apply, outcome, and job visibility changes without
+returning raw event payloads, debug messages, local paths, raw notes, or email
+body text.
 Job summaries also include source provenance. `discoverySource` is the observed
 source registry id where the job was found and falls back to the discovery
 strategy/source pair for legacy rows. `postingSource` and `postingSourceUrl`

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1096,6 +1096,37 @@ export interface ActivityEventSummary {
   at: string | null;
 }
 
+export const JOB_AUDIT_CATEGORIES = [
+  "discovery",
+  "enrichment",
+  "scoring",
+  "materials",
+  "apply",
+  "outcome",
+  "pipeline",
+  "job",
+] as const;
+export type JobAuditCategory = (typeof JOB_AUDIT_CATEGORIES)[number];
+
+export const JOB_AUDIT_TONES = ["info", "success", "warning", "danger", "muted"] as const;
+export type JobAuditTone = (typeof JOB_AUDIT_TONES)[number];
+
+export interface JobAuditDetail {
+  label: string;
+  value: string;
+}
+
+export interface JobAuditEntry {
+  id: string;
+  category: JobAuditCategory;
+  tone: JobAuditTone;
+  title: string;
+  description: string | null;
+  occurredAt: string | null;
+  actor: string | null;
+  details: JobAuditDetail[];
+}
+
 export interface ActivityEventResponse {
   ok: true;
   event: ActivityEventSummary;
@@ -1234,6 +1265,7 @@ export interface JobDetail {
   };
   stages: StageSummary[];
   artifacts: ArtifactSummary[];
+  auditHistory: JobAuditEntry[];
 }
 
 export interface ArtifactDetail {

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -496,6 +496,7 @@ async def test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs(
         }
 
     monkeypatch.setattr(workflow_mod.workflow, "execute_activity", fake_execute_activity)
+    monkeypatch.setattr(workflow_mod.workflow, "info", lambda: SimpleNamespace(workflow_id="unit-test-workflow"))
 
     await workflow_mod._execute_stage(
         "score",


### PR DESCRIPTION
## Summary
- Add `auditHistory` to job detail responses, assembled from allow-listed job lifecycle events plus append-only apply review/outcome records.
- Render a user-facing Audit history section in the job detail drawer without raw event payloads, debug messages, raw notes, email bodies, or local paths.
- Add API/web regression coverage and update local API, architecture, and QA docs.
- Repair a Python workflow unit-test harness stub so the full repository test command can run outside a Temporal workflow event loop.

## Validation
- `git diff --check`
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `corepack pnpm --filter @jobhunter/api test -- server.test.ts -t "curated per-job audit"`
- `corepack pnpm --filter @jobhunter/web test -- JobDetailDrawer.test.tsx`
- `corepack pnpm --filter @jobhunter/web test-d`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_jsonrpc_handlers.py::test_pipeline_workflow_preserves_selected_job_urls_in_activity_inputs`
- `corepack pnpm test`
- Live stack from `/Users/eloibarti/.codex/worktrees/job-audit-history-20260604/JobHunter`: `corepack pnpm dev:status`, API health check, and Playwright job-detail drawer smoke check against `http://127.0.0.1:5173/jobs/...`