### PR TITLE
fix(pipeline): clear apply materials blocker after tailoring

### DIFF
--- a/workers/automation/src/jobhunter/state.py
+++ b/workers/automation/src/jobhunter/state.py
@@ -64,6 +64,7 @@ _DEPENDENCY_BLOCKER_MESSAGES: dict[str, tuple[tuple[str, tuple[str, ...]], ...]]
     "score": (("tailor", ("score has not completed.",)),),
     "tailor": (
         ("cover", ("tailor has not completed.",)),
+        ("apply", ("Materials are not ready.",)),
     ),
 }
 SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE = "SCORE_ELIGIBILITY_BLOCKED"

--- a/workers/automation/tests/test_state_dashboard.py
+++ b/workers/automation/tests/test_state_dashboard.py
@@ -284,6 +284,38 @@ def test_tailor_success_unblocks_cover_waiting_on_tailor(tmp_path):
         close_connection(db_path)
 
 
+def test_tailor_success_unblocks_apply_waiting_on_materials(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(conn, job["url"], discovered_at=job["discovered_at"])
+        set_stage_state(
+            conn,
+            job["url"],
+            "apply",
+            "blocked",
+            error_code="BLOCKED",
+            error_message="Materials are not ready.",
+        )
+
+        set_stage_state(conn, job["url"], "tailor", "running", started_at="2026-04-29T10:03:00+00:00")
+        set_stage_state(conn, job["url"], "tailor", "succeeded", finished_at="2026-04-29T10:04:00+00:00")
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT state, error_code, error_message FROM job_stage_states "
+            "WHERE job_url = ? AND stage = 'apply'",
+            (job["url"],),
+        ).fetchone()
+        assert row["state"] == "pending"
+        assert row["error_code"] is None
+        assert row["error_message"] is None
+    finally:
+        close_connection(db_path)
+
+
 def test_dependency_reconciliation_preserves_unrelated_blockers(tmp_path):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)


### PR DESCRIPTION
## Summary

Fixes a stale Apply review blocker where `job_stage_states.apply` could remain blocked with `Materials are not ready.` after tailored materials were generated.

## Root Cause

The dependency repair map cleared `score -> tailor` and `tailor -> cover` blockers, but did not treat the apply-stage `Materials are not ready.` row as a downstream dependency of successful tailoring. The Apply review projection then showed the stale apply-stage error even though the current materials projection had a tailored resume and rendered PDF.

## Changes

- Add `tailor -> apply` dependency reconciliation for the `Materials are not ready.` blocker.
- Add a regression test proving a blocked apply stage is reset to pending when tailoring succeeds.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_state_dashboard.py::test_tailor_success_unblocks_apply_waiting_on_materials` failed before the fix and passed after it.
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_state_dashboard.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_score_eligibility_stage_state.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_state_dashboard.py workers/automation/tests/test_score_eligibility_stage_state.py workers/automation/tests/test_discovery_preparation_orchestration.py workers/automation/tests/test_job_list_projection.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/state.py workers/automation/tests/test_state_dashboard.py`
- `pnpm --filter @jobhunter/api exec vitest run test/application-feedback.test.ts`
- `git diff --check`

## Notes

Full `uv --project workers/automation run --extra dev pytest -q` currently has one unrelated local failure in `workers/automation/tests/test_materials_repository.py::test_suppress_backfilled_legacy_job_makes_selectors_treat_paths_inactive`, where `stats["tailored"]` remains `1` after legacy artifact suppression. That test also fails in isolation and is outside this PR's touched stage-state path.

No documentation update: this is a bug fix to existing pipeline readiness behavior, not a new public capability.