### PR TITLE
feat(materials): per-bullet provenance + granular controls

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -783,22 +783,31 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | 
  * TS API and Python builder materialise the SAME read shape — the cross-runtime
  * parity test asserts both agree. Returns an empty map when no provenance exists.
  */
-function loadBulletProvenanceByArtifact(db: SqliteDatabase, jobUrl: string): Map<string, string> {
+function loadBulletProvenanceByArtifact(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobUrl: string,
+): Map<string, string> {
   const result = new Map<string, string>();
   if (!tableExists(db, "job_bullet_provenance")) return result;
+  // Tenant-scope BOTH the MAX(generation) probe and the row fetch so this matches
+  // the Python repo (``bullet_provenance_repository.py`` filters job_url AND
+  // tenant_id AND generation). Benign today under LOCAL_TENANT, but keeps the
+  // cross-runtime read path symmetric before any multi-tenant work.
   const genRow = getRow<{ generation: number | null }>(
     db,
-    `SELECT MAX(generation) AS generation FROM job_bullet_provenance WHERE job_url = ?`,
-    [jobUrl],
+    `SELECT MAX(generation) AS generation FROM job_bullet_provenance
+      WHERE job_url = ? AND tenant_id = ?`,
+    [jobUrl, tenantId],
   );
   const generation = genRow?.generation;
   if (generation === null || generation === undefined) return result;
   const rows = allRows<BulletProvenanceRow>(
     db,
     `SELECT * FROM job_bullet_provenance
-      WHERE job_url = ? AND generation = ?
+      WHERE job_url = ? AND tenant_id = ? AND generation = ?
       ORDER BY position, bullet_id`,
-    [jobUrl, Number(generation)],
+    [jobUrl, tenantId, Number(generation)],
   );
   if (rows.length === 0) return result;
   // All rows of one generation share the artifact they explain (the writer binds
@@ -1349,7 +1358,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const lastUpdatedAt = new Date().toISOString();
 
   const artifacts = collectArtifacts(db, jobUrl, materials);
-  const provenanceByArtifact = loadBulletProvenanceByArtifact(db, jobUrl);
+  const provenanceByArtifact = loadBulletProvenanceByArtifact(db, tenantId, jobUrl);
   const activeArtifacts = artifacts.filter(isDefaultVisibleArtifact);
 
   db.prepare(

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -338,7 +338,8 @@ export function ensureProjectionTables(db: SqliteDatabase): boolean {
       size_bytes             INTEGER,
       created_at             TEXT,
       generation             INTEGER,
-      metadata_json          TEXT
+      metadata_json          TEXT,
+      bullet_provenance_json TEXT
     );
     CREATE TABLE IF NOT EXISTS apply_run_projections (
       run_id                 TEXT PRIMARY KEY,
@@ -455,6 +456,8 @@ export function ensureProjectionTables(db: SqliteDatabase): boolean {
   schemaChanged =
     ensureProjectionColumn(db, "job_detail_projections", "employer_analysis_json", "TEXT") || schemaChanged;
   schemaChanged = ensureProjectionColumn(db, "artifact_list_projections", "metadata_json", "TEXT") || schemaChanged;
+  schemaChanged =
+    ensureProjectionColumn(db, "artifact_list_projections", "bullet_provenance_json", "TEXT") || schemaChanged;
   return schemaChanged;
 }
 
@@ -695,6 +698,21 @@ interface EmployerAnalysisRow extends Record<string, unknown> {
   created_at: string;
 }
 
+interface BulletProvenanceRow extends Record<string, unknown> {
+  artifact_id: string;
+  bullet_id: string;
+  section: string;
+  source_id: string | null;
+  evidence_ids_json: string;
+  requirement_ids_json: string;
+  matched_keywords_json: string;
+  transform_type: string;
+  control: string;
+  rationale: string | null;
+  generated_text: string;
+  position: number;
+}
+
 /**
  * Phase 1: rebuild the canonical employer-analysis read shape from canonical
  * rows. This MUST stay byte-equivalent to the Python
@@ -756,6 +774,57 @@ function loadEmployerAnalysisJson(db: SqliteDatabase, jobUrl: string): string | 
     })),
   };
   return JSON.stringify(readModel);
+}
+
+/**
+ * Phase 2 — load the latest per-bullet provenance read shape keyed by artifact.
+ *
+ * Mirrors the Python ``BulletProvenanceSet.to_read_model()`` projection so the
+ * TS API and Python builder materialise the SAME read shape — the cross-runtime
+ * parity test asserts both agree. Returns an empty map when no provenance exists.
+ */
+function loadBulletProvenanceByArtifact(db: SqliteDatabase, jobUrl: string): Map<string, string> {
+  const result = new Map<string, string>();
+  if (!tableExists(db, "job_bullet_provenance")) return result;
+  const genRow = getRow<{ generation: number | null }>(
+    db,
+    `SELECT MAX(generation) AS generation FROM job_bullet_provenance WHERE job_url = ?`,
+    [jobUrl],
+  );
+  const generation = genRow?.generation;
+  if (generation === null || generation === undefined) return result;
+  const rows = allRows<BulletProvenanceRow>(
+    db,
+    `SELECT * FROM job_bullet_provenance
+      WHERE job_url = ? AND generation = ?
+      ORDER BY position, bullet_id`,
+    [jobUrl, Number(generation)],
+  );
+  if (rows.length === 0) return result;
+  // All rows of one generation share the artifact they explain (the writer binds
+  // the whole set to one artifact_id). Group defensively by artifact_id anyway.
+  const byArtifact = new Map<string, Record<string, unknown>[]>();
+  for (const row of rows) {
+    const entry = {
+      bullet_id: row.bullet_id,
+      section: row.section,
+      source_id: row.source_id ?? null,
+      evidence_ids: parseJsonArray(row.evidence_ids_json),
+      requirement_ids: parseJsonArray(row.requirement_ids_json),
+      matched_keywords: parseJsonArray(row.matched_keywords_json),
+      transform_type: row.transform_type,
+      control: row.control,
+      rationale: row.rationale ?? "",
+      generated_text: row.generated_text,
+    };
+    const list = byArtifact.get(row.artifact_id) ?? [];
+    list.push(entry);
+    byArtifact.set(row.artifact_id, list);
+  }
+  for (const [artifactId, entries] of byArtifact) {
+    result.set(artifactId, JSON.stringify(entries));
+  }
+  return result;
 }
 
 function parseAnalysisAgreement(value: string | null): {
@@ -1280,6 +1349,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const lastUpdatedAt = new Date().toISOString();
 
   const artifacts = collectArtifacts(db, jobUrl, materials);
+  const provenanceByArtifact = loadBulletProvenanceByArtifact(db, jobUrl);
   const activeArtifacts = artifacts.filter(isDefaultVisibleArtifact);
 
   db.prepare(
@@ -1409,8 +1479,9 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
   const insertArtifact = db.prepare(
     `INSERT INTO artifact_list_projections (
        artifact_id, tenant_id, job_id, job_title, job_employer, artifact_type,
-       status, local_path, size_bytes, created_at, generation, metadata_json
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       status, local_path, size_bytes, created_at, generation, metadata_json,
+       bullet_provenance_json
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   for (const a of artifacts) {
     insertArtifact.run(
@@ -1426,6 +1497,7 @@ function rebuildJobProjections(db: SqliteDatabase, tenantId: string, jobUrl: str
       a.createdAt,
       a.generation,
       a.metadataJson,
+      provenanceByArtifact.get(a.artifactId) ?? null,
     );
   }
 }

--- a/apps/api/src/read-model.ts
+++ b/apps/api/src/read-model.ts
@@ -24,6 +24,7 @@ import type {
   ArtifactListQuery,
   ArtifactSummary,
   ArtifactTailoringExplanation,
+  BulletProvenanceEntry,
   BulkJobMutationFilter,
   DashboardSettings,
   DashboardSummary,
@@ -169,6 +170,7 @@ interface ArtifactProjectionRow extends Record<string, unknown> {
   created_at: string | null;
   generation: number | null;
   metadata_json: string | null;
+  bullet_provenance_json: string | null;
 }
 
 interface DashboardProjectionRow extends Record<string, unknown> {
@@ -2074,6 +2076,19 @@ function tailoringExplanationForArtifact(
 ): ArtifactTailoringExplanation | null {
   if (!TAILORING_ARTIFACT_TYPES.has(row.artifact_type)) return null;
 
+  const explanation = tailoringExplanationBaseForArtifact(db, row);
+  if (explanation === null) return null;
+  // Phase 2: attach canonical per-bullet provenance from the ``job_bullet_provenance``
+  // projection column (this row for a text resume; the sibling tailored-resume row
+  // for a PDF). Served exclusively from canonical rows — never derived from metadata.
+  explanation.bulletProvenance = bulletProvenanceForArtifact(db, row);
+  return explanation;
+}
+
+function tailoringExplanationBaseForArtifact(
+  db: SqliteDatabase,
+  row: ArtifactProjectionRow,
+): ArtifactTailoringExplanation | null {
   const jobKeywords = tailoringJobKeywordsForArtifact(db, row);
   const resumeText = tailoringResumeTextForArtifact(db, row);
   const direct = parseTailoringExplanation(row.metadata_json, { jobKeywords, resumeText });
@@ -2105,6 +2120,73 @@ function tailoringExplanationForArtifact(
   return missingTailoringAuditFields(siblingExplanation).length < missingTailoringAuditFields(direct).length
     ? siblingExplanation
     : direct;
+}
+
+/**
+ * Phase 2 — read canonical per-bullet provenance for an artifact from the
+ * ``bullet_provenance_json`` projection column. For a text resume the rows live
+ * on the row itself; for a PDF they live on the sibling tailored-resume row of
+ * the same generation. Returns [] when no provenance was recorded.
+ */
+function bulletProvenanceForArtifact(
+  db: SqliteDatabase,
+  row: ArtifactProjectionRow,
+): BulletProvenanceEntry[] {
+  let provenanceJson = row.bullet_provenance_json;
+  if (!provenanceJson && TAILORING_PDF_ARTIFACT_TYPES.has(row.artifact_type)) {
+    const sibling = getRow<{ bullet_provenance_json: string | null }>(
+      db,
+      `SELECT bullet_provenance_json
+         FROM artifact_list_projections
+        WHERE tenant_id = ?
+          AND job_id = ?
+          AND artifact_type IN ('tailored_resume', 'tailored_resume_txt')
+          AND bullet_provenance_json IS NOT NULL
+          AND TRIM(bullet_provenance_json) != ''
+          AND (? IS NULL OR generation = ? OR generation IS NULL)
+        ORDER BY CASE WHEN generation = ? THEN 0 ELSE 1 END, created_at DESC
+        LIMIT 1`,
+      [row.tenant_id, row.job_id, row.generation, row.generation, row.generation],
+    );
+    provenanceJson = sibling?.bullet_provenance_json ?? null;
+  }
+  return parseBulletProvenance(provenanceJson);
+}
+
+function parseBulletProvenance(value: string | null): BulletProvenanceEntry[] {
+  if (!value || !value.trim()) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const entries: BulletProvenanceEntry[] = [];
+  for (const raw of parsed) {
+    const record = metadataRecord(raw);
+    const bulletId = metadataText(record.bullet_id, 160);
+    const section = metadataText(record.section, 80);
+    const generatedText = metadataText(record.generated_text, 2000);
+    const transformType = metadataText(record.transform_type, 80);
+    const control = metadataText(record.control, 80);
+    // Drop structurally-invalid rows rather than emit a half-populated entry: the
+    // canonical writer always supplies these fields, so a missing one means junk.
+    if (!bulletId || !section || !generatedText || !transformType || !control) continue;
+    entries.push({
+      bulletId,
+      section,
+      sourceId: metadataText(record.source_id, 160),
+      evidenceIds: metadataTextList(record.evidence_ids, 32, 160),
+      requirementIds: metadataTextList(record.requirement_ids, 32, 160),
+      matchedKeywords: metadataTextList(record.matched_keywords, 32, 160),
+      transformType,
+      control,
+      rationale: metadataText(record.rationale, 600) ?? "",
+      generatedText,
+    });
+  }
+  return entries;
 }
 
 function tailoringJobKeywordsForArtifact(db: SqliteDatabase, row: ArtifactProjectionRow): string[] {
@@ -2277,6 +2359,9 @@ function parseTailoringExplanation(
       acceptedWarnings: metadataTextList(reviewFeedback.accepted_warning_notes, 8, 220),
     },
     annotatedChanges: parseTailoringChangeAnnotations(metadata.change_annotations),
+    // Phase 2: populated from canonical ``bullet_provenance_json`` projection rows
+    // by ``tailoringExplanationForArtifact`` — never derived from ``metadata_json``.
+    bulletProvenance: [],
     models: {
       candidateModels: metadataTextList(metadata.candidate_models, 6, 120),
       selectedModel: metadataText(metadata.selected_model, 120),

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -1231,6 +1231,189 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it("serves canonical per-bullet provenance from projection rows (TS↔Python parity)", async () => {
+    // AUDIT-02-style cross-runtime parity for Phase 2: seed the canonical
+    // ``job_bullet_provenance`` rows exactly as the Python repository writes
+    // them, then assert the TS projection builder + read model reconstruct the
+    // same ``bulletProvenance`` shape the Python ``BulletProvenanceSet
+    // .to_read_model()`` produces — served on the artifact's tailoring
+    // explanation, exclusively from canonical rows.
+    const { dbPath, cleanup } = withTempDb();
+    // Reuse the job ``seedSchema`` already inserts, so the artifact projection
+    // builds (the builder drops projections for jobs with no ``jobs`` row).
+    const jobUrl = "https://example.com/jobs/event-driven";
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE job_materials (
+          job_url TEXT NOT NULL,
+          generation INTEGER NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          status TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          last_validation_json TEXT,
+          last_verdict_json TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY (job_url, generation)
+        );
+        CREATE TABLE job_materials_artifacts (
+          job_url TEXT NOT NULL,
+          generation INTEGER NOT NULL,
+          artifact_type TEXT NOT NULL,
+          artifact_id TEXT NOT NULL,
+          status TEXT NOT NULL,
+          path TEXT NOT NULL,
+          render_format TEXT NOT NULL,
+          size_bytes INTEGER,
+          metadata_json TEXT,
+          created_at TEXT NOT NULL,
+          superseded_at TEXT,
+          PRIMARY KEY (job_url, generation, artifact_type)
+        );
+        CREATE TABLE job_bullet_provenance (
+          job_url TEXT NOT NULL,
+          generation INTEGER NOT NULL,
+          bullet_id TEXT NOT NULL,
+          tenant_id TEXT NOT NULL DEFAULT 'local',
+          artifact_id TEXT NOT NULL,
+          section TEXT NOT NULL,
+          source_id TEXT,
+          evidence_ids_json TEXT NOT NULL DEFAULT '[]',
+          requirement_ids_json TEXT NOT NULL DEFAULT '[]',
+          matched_keywords_json TEXT NOT NULL DEFAULT '[]',
+          transform_type TEXT NOT NULL,
+          control TEXT NOT NULL,
+          rationale TEXT NOT NULL DEFAULT '',
+          generated_text TEXT NOT NULL,
+          position INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          PRIMARY KEY (job_url, generation, bullet_id)
+        );
+      `);
+      // A complete metadata blob so the tailoring explanation has its audit fields
+      // (the explanation must exist for bulletProvenance to attach to it).
+      const completeMetadata = JSON.stringify({
+        validation_mode: "normal",
+        attempts: 1,
+        quality_plan: {
+          target_seniority: "senior",
+          claim_mode: "evidence_reframing",
+          auto_approvable_claim_modes: ["evidence_reframing"],
+          allow_adjacent_achievement_drafts: false,
+          required_evidence_ids: ["ev_latency"],
+          seniority_evidence_ids: ["ev_latency"],
+          verified_metric_count: 1,
+          job_keywords: ["latency"],
+        },
+        quality_checks: { passed: true, keyword_coverage: { covered: ["latency"], missing: [] } },
+        judge: { passed: true, verdict: "PASS", score: 0.9 },
+        judge_min_score: 0.7,
+        selected_model: "generator-a",
+        selected_candidate: "candidate-1",
+        judge_model: "judge-a",
+        candidate_models: ["generator-a"],
+        adversarial_review: { ran: false, skipped_reason: "below_threshold" },
+        change_annotations: [
+          {
+            section: "experience",
+            label: "Senior SWE at Acme Corp",
+            change_type: "achievement_reframed",
+            source_id: "acme_swe",
+            source_text: ["Built distributed systems."],
+            tailored_text: ["Owned the API and cut latency 40%."],
+            rationale: "Reframed for the target.",
+            job_signals: ["latency"],
+            controls: ["claim mode: evidence_reframing"],
+            evidence_ids: ["ev_latency"],
+            evidence_notes: [],
+          },
+        ],
+      });
+      db.prepare(
+        `INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at)
+         VALUES (?, 1, 'local', 'complete', '2026-06-08T12:00:00+00:00', '2026-06-08T12:10:00+00:00')`,
+      ).run(jobUrl);
+      const insertArtifact = db.prepare(
+        `INSERT INTO job_materials_artifacts (
+          job_url, generation, artifact_type, artifact_id, status, path,
+          render_format, size_bytes, metadata_json, created_at
+        ) VALUES (?, 1, ?, ?, 'approved', ?, ?, ?, ?, '2026-06-08T12:05:00+00:00')`,
+      );
+      insertArtifact.run(jobUrl, "tailored_resume", "resume-1", "/tmp/resume.txt", "text", 10, completeMetadata);
+      insertArtifact.run(jobUrl, "resume_pdf", "resume-pdf-1", "/tmp/resume.pdf", "pdf", 20, "{}");
+
+      // Provenance rows (as the Python repo writes them): bound to the text
+      // resume artifact, ordered by position.
+      const insertProvenance = db.prepare(
+        `INSERT INTO job_bullet_provenance (
+          job_url, generation, bullet_id, tenant_id, artifact_id, section, source_id,
+          evidence_ids_json, requirement_ids_json, matched_keywords_json,
+          transform_type, control, rationale, generated_text, position, created_at
+        ) VALUES (?, 1, ?, 'local', 'resume-1', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '2026-06-08T12:10:00+00:00')`,
+      );
+      insertProvenance.run(
+        jobUrl, "executive_profile#0", "executive_profile", "executive_profile",
+        "[]", "[]", "[]", "reframe", "rephrase_allowed", "Reframed summary.",
+        "Senior backend engineer focused on Python.", 0,
+      );
+      insertProvenance.run(
+        jobUrl, "experience:acme_swe#0", "experience", "acme_swe",
+        JSON.stringify(["ev_latency"]), JSON.stringify(["req_latency"]), JSON.stringify(["latency"]),
+        "quantify_from_evidence", "never_fabricate_metrics", "Surfaced a recorded metric.",
+        "Owned the API and cut latency 40%.", 1,
+      );
+      db.close();
+
+      const app = buildApp({
+        dbPath,
+        profilePath: path.join(path.dirname(dbPath), "profile.json"),
+        resumeStylePath: path.join(path.dirname(dbPath), "resume_style.json"),
+        resumeTemplatePath: path.join(path.dirname(dbPath), "resume_template.tex"),
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        // The text resume serves provenance directly from its own row.
+        const resumeRes = await app.inject({ method: "GET", url: "/v1/artifacts/resume-1" });
+        expect(resumeRes.statusCode, resumeRes.body).toBe(200);
+        const explanation = resumeRes.json().tailoringExplanation;
+        expect(explanation).not.toBeNull();
+        expect(explanation.bulletProvenance).toHaveLength(2);
+        // Ordered by position; FK bindings + transform/control round-trip exactly.
+        expect(explanation.bulletProvenance[0]).toMatchObject({
+          bulletId: "executive_profile#0",
+          section: "executive_profile",
+          transformType: "reframe",
+          control: "rephrase_allowed",
+        });
+        expect(explanation.bulletProvenance[1]).toMatchObject({
+          bulletId: "experience:acme_swe#0",
+          section: "experience",
+          sourceId: "acme_swe",
+          evidenceIds: ["ev_latency"],
+          requirementIds: ["req_latency"],
+          matchedKeywords: ["latency"],
+          transformType: "quantify_from_evidence",
+          control: "never_fabricate_metrics",
+          generatedText: "Owned the API and cut latency 40%.",
+        });
+
+        // The PDF artifact resolves provenance from the sibling text resume row.
+        const pdfRes = await app.inject({ method: "GET", url: "/v1/artifacts/resume-pdf-1" });
+        expect(pdfRes.statusCode, pdfRes.body).toBe(200);
+        const pdfExplanation = pdfRes.json().tailoringExplanation;
+        expect(pdfExplanation).not.toBeNull();
+        expect(pdfExplanation.bulletProvenance).toHaveLength(2);
+        expect(pdfExplanation.bulletProvenance[1].requirementIds).toEqual(["req_latency"]);
+      } finally {
+        await app.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("rebuilds source health from discovery, enrichment, and content events", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {

--- a/apps/web/src/contexts/materials/components/TailoringExplanationSection.test.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringExplanationSection.test.tsx
@@ -68,6 +68,7 @@ const keywordOnlyExplanation: ArtifactTailoringExplanation = {
     acceptedWarnings: [],
   },
   annotatedChanges: [],
+  bulletProvenance: [],
   models: {
     candidateModels: [],
     selectedModel: null,

--- a/apps/web/src/contexts/materials/handlers.ts
+++ b/apps/web/src/contexts/materials/handlers.ts
@@ -1,4 +1,5 @@
 import type {
+  BulletProvenanceRecorded,
   CoverLetterGenerated,
   EmployerAnalyzed,
   MaterialsExhausted,
@@ -58,6 +59,17 @@ export const employerAnalyzedHandler = (
 ): readonly InvalidationItem[] => [
   // The canonical employer analysis is served on the job detail; refresh it so
   // the inspector (Phase 5) shows the latest generation.
+  invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+];
+
+export const bulletProvenanceRecordedHandler = (
+  event: BulletProvenanceRecorded,
+): readonly InvalidationItem[] => [
+  // Per-bullet provenance is served on the artifact's tailoring explanation
+  // (Phase 2) and surfaces in the job detail; refresh both so the inspector
+  // (Phase 5) shows the latest generation's provenance.
+  invalidate(artifactsKeys.detail(event.tenantId, event.payload.artifactId)),
+  invalidate(artifactsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
 ];
 

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -19,6 +19,7 @@ type ExpectedKeys = readonly QueryKey[];
 
 const JOB_ID = "job-1";
 const RUN_ID = "run-1";
+const ARTIFACT_ID = "artifact-1";
 
 const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys> = {
   JobDiscovered: [jobsKeys.lists(LOCAL_TENANT), dashboardKeys.summary(LOCAL_TENANT)],
@@ -170,6 +171,11 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     dashboardKeys.summary(LOCAL_TENANT),
   ],
   EmployerAnalyzed: [jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
+  BulletProvenanceRecorded: [
+    artifactsKeys.detail(LOCAL_TENANT, ARTIFACT_ID),
+    artifactsKeys.lists(LOCAL_TENANT),
+    jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+  ],
   TailoringPolicyUpdated: [
     profileKeys.profile(LOCAL_TENANT),
     jobsKeys.all(LOCAL_TENANT),

--- a/apps/web/src/contexts/operations/invalidation-router.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.ts
@@ -38,6 +38,7 @@ import {
   postingContentSnapshotFailedHandler,
 } from "../enrichment/handlers.js";
 import {
+  bulletProvenanceRecordedHandler,
   coverLetterGeneratedHandler,
   employerAnalyzedHandler,
   materialsExhaustedHandler,
@@ -143,6 +144,7 @@ export const handlers: HandlerMap = {
   PdfRendered: pdfRenderedHandler,
   MaterialsExhausted: materialsExhaustedHandler,
   EmployerAnalyzed: employerAnalyzedHandler,
+  BulletProvenanceRecorded: bulletProvenanceRecordedHandler,
   TailoringPolicyUpdated: tailoringPolicyUpdatedHandler,
   TailorRetailorRequested: tailorRetailorRequestedHandler,
   TailoredArtifactsSuppressed: tailoredArtifactsSuppressedHandler,

--- a/apps/web/src/test/fixtures/events.ts
+++ b/apps/web/src/test/fixtures/events.ts
@@ -24,6 +24,7 @@ import {
   createJobScored,
   createJobSourceObserved,
   createJobUpdated,
+  createBulletProvenanceRecorded,
   createEmployerAnalyzed,
   createMaterialsExhausted,
   createPdfRendered,
@@ -285,6 +286,13 @@ export const eventByType = {
     legsSucceeded: 2,
     analyzedAt: NOW,
     cached: false,
+  }),
+  BulletProvenanceRecorded: createBulletProvenanceRecorded(LOCAL_TENANT, {
+    jobId: JOB_ID,
+    artifactId: ARTIFACT_ID,
+    generation: 1,
+    bulletCount: 7,
+    recordedAt: NOW,
   }),
   TailoringPolicyUpdated: createTailoringPolicyUpdated(LOCAL_TENANT, {
     policyId: "tailoring:default",

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -176,6 +176,7 @@ const sampleTailoringExplanation: ArtifactTailoringExplanation = {
       evidenceNotes: ["ev_platform_reliability: platform ownership"],
     },
   ],
+  bulletProvenance: [],
   models: {
     candidateModels: ["generator-a"],
     selectedModel: "generator-a",

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
@@ -244,6 +244,7 @@ describe("<ArtifactDetailPanel>", () => {
           evidenceNotes: ["ev_scope: technical ownership"],
         },
       ],
+      bulletProvenance: [],
       models: {
         candidateModels: ["generator-a"],
         selectedModel: "generator-a",
@@ -361,6 +362,7 @@ describe("<ArtifactDetailPanel>", () => {
         acceptedWarnings: [],
       },
       annotatedChanges: [],
+      bulletProvenance: [],
       models: {
         candidateModels: [],
         selectedModel: null,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,6 +200,60 @@ httpx `jobhunter.llm.LLMClient`.
   analysis is deferred to a later milestone; this milestone lands the backend,
   contracts, and read path only.
 
+## Per-Bullet Provenance + Granular Controls (Materials sub-step)
+
+Building on the persisted employer analysis, every generated resume bullet (and
+the executive-profile / skills lines) carries a canonical provenance record so
+the user can trust each line — what real profile fact it derives from, which job
+requirement it serves, the transform that produced it, and the granular rule that
+governed it. Like the analysis, this is canonical rows, not `metadata_json`.
+
+- **Domain model** (`domain/materials/provenance.py`): `BulletProvenance` is one
+  record per rendered line — `bullet_id` (stable within job/generation/section/
+  index), `section`, `source_id`, `evidence_ids` (canonical profile evidence),
+  `requirement_ids` (FK into `EmployerAnalysis` requirements), `matched_keywords`
+  (verified against the generated text), `transform_type`, `control`, a human
+  `rationale`, and `generated_text` (the rendered line — the coverage anchor).
+  `BulletProvenanceSet` is generation-versioned and bound to the artifact it
+  explains; a forced/failed re-tailor writes a higher generation and never
+  destroys the prior one. `transform_type` and `control` are closed enums in
+  `value_objects.py`: `TransformType` (verbatim / rephrase / reframe /
+  synthesize_from_related / quantify_from_evidence) and `ControlRule` (rephrase
+  always allowed; invent only for closely-related experience; never fabricate
+  metrics/titles/dates/employers).
+- **Provenance builder** (`domain/materials/provenance_builder.py`): computes one
+  `BulletProvenance` per bullet **against the selected candidate's rendered text**
+  (using the same `resume_profile` rendering helpers the assembler uses, so the
+  text is identical), maps the existing change-type vocabulary to the closed
+  `TransformType`, and binds `requirement_ids` as real foreign keys by matching
+  the bullet against the analysis keywords. A fabricated evidence/requirement id
+  is rejected before any row is built — provenance is FK bindings, not
+  model-authored free text.
+- **Deterministic never-fabricate detector** (`domain/materials/fabrication_detector.py`):
+  a pure check that runs **independently of the prompt** (the Phase-2 analogue of
+  the analysis grounding gate). Every numeric, date, percentage, money, title, and
+  company-suffixed employer token in a generated bullet must trace to recorded
+  profile evidence; a token that does not is a fabrication and is **hard-rejected
+  at generation time**. A metrics-hungry job paired with a numberless profile
+  yields zero unsourced numerics in the output.
+- **Lifecycle**: `TailorResumeUseCase` computes provenance + runs the detector
+  after assembling the selected candidate's text. A fabrication downgrades
+  validation so the resume is **not approved** (the last accepted generation's
+  artifact + provenance are preserved); an accepted generation persists its rows
+  through `BulletProvenanceRepository` transactionally with the artifact and
+  publishes `BulletProvenanceRecorded` (a `job_events` row → projection rebuild →
+  SSE invalidation). Persistence is canonical rows (`job_bullet_provenance`),
+  never `metadata_json`.
+- **Read path**: the single projection owner serves provenance on the artifact's
+  tailoring explanation (`artifact_list_projections.bullet_provenance_json`),
+  built identically by the Python projection builder and
+  `apps/api/src/projections.ts` and served by `read-model.ts` as
+  `ArtifactTailoringExplanation.bulletProvenance` (a PDF artifact resolves it from
+  the sibling tailored-resume row). A cross-runtime projection parity test covers
+  the table on both runtimes. This milestone lands the backend, contracts, and
+  read path; the divergent legacy read paths are retired and the inspector UI is
+  built in later milestones.
+
 ## Apply Review And Outcome Feedback
 
 The Apply Automation context now has a local feedback foundation in the

--- a/docs/job-pipeline-architecture.md
+++ b/docs/job-pipeline-architecture.md
@@ -595,8 +595,10 @@ sequenceDiagram
     alt eligible and no current active artifact
         Discover->>Queue: enqueue tailor_resume(target=tailoring policy version)
         Queue->>Materials: tailor_job_by_url(job, current policy)
+        Note over Materials: _run_analyze (canonical employer analysis, EmployerAnalyzed)<br/>then candidates -> validate -> judge -> adversarial<br/>then per-bullet provenance vs generated text + never-fabricate detector
         Materials-->>Ops: ResumeApproved / ResumeFailed
         opt resume approved
+            Materials-->>Ops: BulletProvenanceRecorded
             Queue->>Materials: run_cover_letters(job)
             Materials-->>Ops: CoverLetterGenerated / CoverLetterFailed
         end

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -1381,6 +1381,31 @@ export interface ArtifactDetail {
   tailoringExplanation: ArtifactTailoringExplanation | null;
 }
 
+/**
+ * Phase 2 — one canonical per-bullet provenance record served on the artifact's
+ * tailoring explanation.
+ *
+ * Mirrors the Python ``BulletProvenance.to_dict()`` projection: the profile
+ * evidence the bullet derives from (``evidenceIds``), the job requirement it
+ * serves (``requirementIds``, FK into the employer analysis), the transform that
+ * produced it (``transformType``), the granular control that governed it
+ * (``control``), a human rationale, and the actual rendered bullet text
+ * (``generatedText``) — the coverage anchor. Served exclusively from canonical
+ * ``job_bullet_provenance`` projection rows, never derived from ``metadata_json``.
+ */
+export interface BulletProvenanceEntry {
+  bulletId: string;
+  section: string;
+  sourceId: string | null;
+  evidenceIds: string[];
+  requirementIds: string[];
+  matchedKeywords: string[];
+  transformType: string;
+  control: string;
+  rationale: string;
+  generatedText: string;
+}
+
 export interface ArtifactTailoringExplanation {
   targetSeniority: string | null;
   claimMode: string | null;
@@ -1507,6 +1532,10 @@ export interface ArtifactTailoringExplanation {
     evidenceIds: string[];
     evidenceNotes: string[];
   }>;
+  // Phase 2: canonical per-bullet provenance served from ``job_bullet_provenance``
+  // projection rows (evidence × requirement × transform × control × rationale),
+  // or [] when no provenance was recorded for this artifact's generation.
+  bulletProvenance: BulletProvenanceEntry[];
   models: {
     candidateModels: string[];
     selectedModel: string | null;

--- a/packages/domain-types/src/events/index.ts
+++ b/packages/domain-types/src/events/index.ts
@@ -116,6 +116,9 @@ export {
   type EmployerAnalyzedPayload,
   type EmployerAnalyzed,
   createEmployerAnalyzed,
+  type BulletProvenanceRecordedPayload,
+  type BulletProvenanceRecorded,
+  createBulletProvenanceRecorded,
   RETAILOR_REQUEST_KINDS,
   type RetailorRequestKind,
   type TailorRetailorRequestedPayload,
@@ -229,6 +232,7 @@ import type {
 } from "./enrichment.js";
 import type { JobScored, ScoreCorrected, ScoreRescoreRequested } from "./scoring.js";
 import type {
+  BulletProvenanceRecorded,
   CoverLetterGenerated,
   EmployerAnalyzed,
   MaterialsExhausted,
@@ -296,6 +300,7 @@ export type DomainEventUnion =
   | PdfRendered
   | MaterialsExhausted
   | EmployerAnalyzed
+  | BulletProvenanceRecorded
   | TailorRetailorRequested
   | TailoredArtifactsSuppressed
   | PreparationWorkItemQueued
@@ -354,6 +359,7 @@ export const DOMAIN_EVENT_TYPES = [
   "PdfRendered",
   "MaterialsExhausted",
   "EmployerAnalyzed",
+  "BulletProvenanceRecorded",
   "TailorRetailorRequested",
   "TailoredArtifactsSuppressed",
   "PreparationWorkItemQueued",

--- a/packages/domain-types/src/events/materials.ts
+++ b/packages/domain-types/src/events/materials.ts
@@ -109,6 +109,32 @@ export function createEmployerAnalyzed(tenantId: TenantId, payload: EmployerAnal
   return createDomainEvent("EmployerAnalyzed", tenantId, payload);
 }
 
+// -- BulletProvenanceRecorded ----------------------------------------------
+
+/**
+ * Phase 2 — canonical per-bullet provenance was recorded for an artifact.
+ *
+ * Emitted when an accepted tailored resume's provenance rows are persisted
+ * (generation-versioned, bound to the `artifactId` they explain). Carries the
+ * bullet count so the read-side projection rebuilds and the inspector refreshes.
+ */
+export interface BulletProvenanceRecordedPayload {
+  readonly jobId: string;
+  readonly artifactId: string;
+  readonly generation: number;
+  readonly bulletCount: number;
+  readonly recordedAt: string;
+}
+
+export type BulletProvenanceRecorded = DomainEvent<"BulletProvenanceRecorded", BulletProvenanceRecordedPayload>;
+
+export function createBulletProvenanceRecorded(
+  tenantId: TenantId,
+  payload: BulletProvenanceRecordedPayload,
+): BulletProvenanceRecorded {
+  return createDomainEvent("BulletProvenanceRecorded", tenantId, payload);
+}
+
 // -- TailorRetailorRequested -----------------------------------------------
 
 export const RETAILOR_REQUEST_KINDS = ["single_job", "bulk_current_policy", "policy_update", "repair"] as const;

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -148,6 +148,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_tailoring_policy_tables(conn)
     ensure_materials_tables(conn)
     ensure_employer_analysis_tables(conn)
+    ensure_bullet_provenance_tables(conn)
     ensure_preparation_work_item_tables(conn)
     ensure_enrichment_tables(conn)
     ensure_posting_snapshot_tables(conn)
@@ -1532,6 +1533,74 @@ def ensure_employer_analysis_tables(conn: sqlite3.Connection | None = None) -> l
         "job_employer_analysis_sub_analyses",
         "job_employer_analysis_failures",
     ]
+
+
+def ensure_bullet_provenance_tables(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Create the canonical per-bullet provenance table (Phase 2).
+
+    Every generated resume bullet records one canonical row binding it to the
+    profile evidence it derives from, the job requirement it serves (FK into the
+    persisted employer analysis), the transform that produced it, and the granular
+    control that governed it. Per the auditability discipline (Anti-Pattern 1) the
+    audit data is stored as CANONICAL ROWS — never inside an artifact
+    ``metadata_json`` blob:
+
+      * ``job_bullet_provenance`` — one row per ``(job_url, generation, bullet_id)``.
+        Bound to the ``job_materials`` generation it explains and to the specific
+        ``artifact_id`` (the tailored resume) it was computed against. FK ids
+        (``evidence_ids_json`` / ``requirement_ids_json``) reference real profile
+        evidence + ``job_employer_analysis`` requirements — the builder rejects
+        fabricated ids before a row is ever written (GROUND-05). ``generated_text``
+        is the actual rendered line, the anchor for coverage (Anti-Pattern 2).
+
+    Generation-versioned like ``job_materials`` (Anti-Pattern 4 / success
+    criterion 5): a forced/failed re-tailor writes a higher generation; prior
+    generations are retained as audit history (never deleted), so a failed refresh
+    never destroys the last accepted generation's provenance.
+    """
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS job_bullet_provenance (
+            job_url             TEXT NOT NULL,
+            generation          INTEGER NOT NULL,
+            bullet_id           TEXT NOT NULL,
+            tenant_id           TEXT NOT NULL DEFAULT 'local',
+            artifact_id         TEXT NOT NULL,
+            section             TEXT NOT NULL,
+            source_id           TEXT,
+            evidence_ids_json   TEXT NOT NULL DEFAULT '[]',
+            requirement_ids_json TEXT NOT NULL DEFAULT '[]',
+            matched_keywords_json TEXT NOT NULL DEFAULT '[]',
+            transform_type      TEXT NOT NULL,
+            control             TEXT NOT NULL,
+            rationale           TEXT NOT NULL DEFAULT '',
+            generated_text      TEXT NOT NULL,
+            position            INTEGER NOT NULL DEFAULT 0,
+            created_at          TEXT NOT NULL,
+            PRIMARY KEY (job_url, generation, bullet_id),
+            FOREIGN KEY (job_url, generation)
+                REFERENCES job_materials(job_url, generation) ON DELETE CASCADE
+        )
+        """
+    )
+    # Selector for the read path: latest generation's rows for a job/artifact.
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_bullet_provenance_tenant_job_gen
+        ON job_bullet_provenance(tenant_id, job_url, generation DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_job_bullet_provenance_artifact
+        ON job_bullet_provenance(tenant_id, artifact_id)
+        """
+    )
+    conn.commit()
+    return ["job_bullet_provenance"]
 
 
 def ensure_enrichment_tables(conn: sqlite3.Connection | None = None) -> list[str]:

--- a/workers/automation/src/jobhunter/domain/events/__init__.py
+++ b/workers/automation/src/jobhunter/domain/events/__init__.py
@@ -73,6 +73,8 @@ from jobhunter.domain.events.materials import (
     create_materials_exhausted,
     EmployerAnalyzedPayload,
     create_employer_analyzed,
+    BulletProvenanceRecordedPayload,
+    create_bullet_provenance_recorded,
 )
 from jobhunter.domain.events.apply import (
     ApplicationEmailFeedbackIngestedPayload,
@@ -144,6 +146,7 @@ DOMAIN_EVENT_TYPES: tuple[str, ...] = (
     "PdfRendered",
     "MaterialsExhausted",
     "EmployerAnalyzed",
+    "BulletProvenanceRecorded",
     "TailorRetailorRequested",
     "TailoredArtifactsSuppressed",
     "PreparationWorkItemQueued",
@@ -242,6 +245,8 @@ __all__ = [
     "create_materials_exhausted",
     "EmployerAnalyzedPayload",
     "create_employer_analyzed",
+    "BulletProvenanceRecordedPayload",
+    "create_bullet_provenance_recorded",
     # Apply
     "ApplicationSubmittedPayload",
     "create_application_submitted",

--- a/workers/automation/src/jobhunter/domain/events/materials.py
+++ b/workers/automation/src/jobhunter/domain/events/materials.py
@@ -90,3 +90,26 @@ class EmployerAnalyzedPayload:
 
 def create_employer_analyzed(tenant_id: TenantId, payload: EmployerAnalyzedPayload) -> DomainEvent:
     return create_domain_event("EmployerAnalyzed", tenant_id, asdict(payload))
+
+
+@dataclass(frozen=True)
+class BulletProvenanceRecordedPayload:
+    """Phase 2 — canonical per-bullet provenance was recorded for an artifact.
+
+    Emitted when an accepted tailored resume's provenance rows are persisted
+    (generation-versioned, bound to the ``artifact_id`` they explain). Carries
+    the bullet count so the read-side projection rebuilds and the SSE invalidation
+    router refreshes the inspector immediately.
+    """
+
+    job_id: str
+    artifact_id: str
+    generation: int
+    bullet_count: int
+    recorded_at: str
+
+
+def create_bullet_provenance_recorded(
+    tenant_id: TenantId, payload: BulletProvenanceRecordedPayload
+) -> DomainEvent:
+    return create_domain_event("BulletProvenanceRecorded", tenant_id, asdict(payload))

--- a/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
+++ b/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
@@ -1,0 +1,364 @@
+"""Deterministic never-fabricate detector — the cardinal grounding gate (CONTROL-03).
+
+The Phase-2 analogue of Phase 1's ``analysis_grounding.py``: a pure, deterministic
+check that runs **independently of the tailoring prompt**. Every numeric, date,
+percentage, money, title, and employer token that appears in a generated resume
+bullet MUST trace to recorded profile evidence. A token that does not is a
+fabrication (the category's cardinal failure — invented metrics/titles/dates/
+employers) and is HARD-REJECTED at generation time — never trusted from the model,
+and never expressible in a JSON schema or a prompt instruction.
+
+Why a separate deterministic detector at all (CONTROL-03 / GROUND-05):
+
+  * The prompt can ask the model not to fabricate; the model can ignore it. The
+    detector is the *real* gate — it does not ask, it checks.
+  * It runs against the **actual generated bullet text** (the rendered line the
+    user sees), not the model's self-reported provenance, so a model that lies
+    about its own grounding still fails here.
+
+The "evidence corpus" is assembled once from canonical profile data (experience
+bullets, evidence items, verified metrics, titles, companies, date ranges,
+education) — the source of truth a real fact must appear in. Membership is decided
+by literal containment after normalising only insignificant whitespace and case,
+so trivial formatting differences do not produce false rejections while genuine
+fabrications still fail.
+
+This module has NO LLM call and NO I/O. It is unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from jobhunter.domain.materials.value_objects import ControlRule
+from jobhunter.resume_profile import (
+    get_achievement_evidence,
+    get_education_entries,
+    get_experience_entries,
+    get_resume_constraints,
+)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+# Numeric/metric tokens: money, percentages, multipliers, and bare numbers with a
+# unit or magnitude. Mirrors the metric grammar used by the quality evaluator so
+# the detector and the validator agree on what counts as a "number" in a bullet.
+_NUMERIC_RE = re.compile(
+    r"(?ix)"
+    r"(?:\$\s?\d+(?:[,.]\d+)*(?:\.\d+)?\s?(?:k|m|b|million|billion)?)"  # money
+    r"|(?:\b\d+(?:\.\d+)?\s?%)"  # percentage
+    r"|(?:\b\d+(?:\.\d+)?\s?x\b)"  # multiplier
+    r"|(?:\b\d[\d,]*(?:\.\d+)?\+?\b)"  # bare integer/decimal (incl. "10k", "5+")
+)
+
+# Four-digit years and explicit month/day-month-year date spans. Standalone small
+# integers are handled by ``_NUMERIC_RE``; this catches calendar dates that a
+# bullet might invent (e.g. "since 2019", "Jan 2020 - Mar 2021").
+_DATE_RE = re.compile(
+    r"(?ix)"
+    r"\b(?:19|20)\d{2}\b"  # a four-digit year
+    r"|\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\.?\s+(?:19|20)\d{2}\b"
+)
+
+# Leadership/seniority title tokens whose presence in a bullet implies a claimed
+# level. They are only a fabrication when the same signal is absent from the
+# profile evidence corpus (CONTROL never_fabricate_titles).
+_TITLE_TOKEN_RE = re.compile(
+    r"(?ix)\b("
+    r"chief|cto|ceo|cio|vp|vice\s+president|director|head\s+of|principal|staff|"
+    r"senior|sr\.?|lead|architect|founder|co-?founder|manager|executive"
+    r")\b"
+)
+
+# A company-like proper noun anchored by an explicit company suffix. Anchoring on
+# the suffix keeps the employer check PRECISE: it fires on "Globex Corporation" /
+# "Initech Inc." but never on ordinary prose like "with Python" or "for Docker",
+# which a bare "<preposition> <Capitalized word>" heuristic would wrongly flag.
+_EMPLOYER_RE = re.compile(
+    r"\b([A-Z][A-Za-z0-9&.\-]*(?:\s+[A-Z][A-Za-z0-9&.\-]*)*"
+    r"\s+(?:Inc|Incorporated|LLC|Ltd|Limited|Corp|Corporation|Co|Company|GmbH|PLC|AG|SA|NV|LLP)\.?)\b"
+)
+
+# Tokens that, while numeric, never imply a fabricated claim on their own — they
+# are structural/sequence numbers, not metrics. Kept tiny and explicit.
+_BENIGN_NUMERIC_TOKENS = frozenset({"0", "1", "2", "3", "4", "5", "24", "365", "24/7"})
+
+
+def _normalize(text: str) -> str:
+    """Lowercase + collapse insignificant whitespace; preserve word content.
+
+    Case and whitespace are normalised so a quote that differs only in spacing or
+    capitalisation still matches; punctuation and digits are preserved so the
+    check stays a genuine literal-containment test.
+    """
+    return _WHITESPACE_RE.sub(" ", text).strip().lower()
+
+
+def _digits_only(token: str) -> str:
+    """Return only the digit/decimal characters of a token for numeric matching.
+
+    A bullet may render ``$1.2M`` while the evidence records ``1,200,000`` or
+    ``1.2 million``; matching on the run of significant digits avoids false
+    fabrication flags on equivalent renderings while still catching invented
+    numbers (whose digits appear nowhere in the corpus).
+    """
+    return re.sub(r"[^\d.]", "", token).strip(".")
+
+
+@dataclass(frozen=True)
+class EvidenceCorpus:
+    """The canonical profile text + token sets a real bullet fact must trace to.
+
+    Assembled once from profile data via :func:`build_evidence_corpus`. ``text``
+    is the normalised concatenation of every grounded source; the token sets are
+    pre-extracted so per-bullet checks are cheap and deterministic.
+    """
+
+    text: str
+    numeric_digits: frozenset[str]
+    title_tokens: frozenset[str]
+    date_tokens: frozenset[str]
+
+    def contains_phrase(self, phrase: str) -> bool:
+        normalized = _normalize(phrase)
+        return bool(normalized) and normalized in self.text
+
+    def has_numeric(self, token: str) -> bool:
+        digits = _digits_only(token)
+        if not digits:
+            return True  # nothing numeric to ground
+        return digits in self.numeric_digits
+
+    def has_title(self, token: str) -> bool:
+        return _normalize(token) in self.title_tokens
+
+    def has_date(self, token: str) -> bool:
+        return _digits_only(token) in self.date_tokens or _normalize(token) in self.text
+
+
+def _collect(value: Any, into: list[str]) -> None:
+    """Flatten arbitrary nested profile values into a list of non-empty strings."""
+    if value is None:
+        return
+    if isinstance(value, str):
+        if value.strip():
+            into.append(value)
+    elif isinstance(value, dict):
+        for child in value.values():
+            _collect(child, into)
+    elif isinstance(value, (list, tuple, set)):
+        for child in value:
+            _collect(child, into)
+    else:
+        text = str(value).strip()
+        if text:
+            into.append(text)
+
+
+def build_evidence_corpus(profile: dict) -> EvidenceCorpus:
+    """Assemble the grounded-fact corpus from canonical profile data.
+
+    Sources (the explicit source of truth for every claim a bullet may make):
+      * experience entries — titles, companies, date ranges, locations, bullets;
+      * achievement evidence items — source text, metrics, tools, outcomes,
+        scope, seniority signals;
+      * resume constraints — the user's declared ``real_metrics``;
+      * education entries — degrees, institutions, dates.
+
+    Returns an :class:`EvidenceCorpus` whose token sets the detector checks each
+    generated bullet against.
+    """
+    fragments: list[str] = []
+
+    for entry in get_experience_entries(profile):
+        if isinstance(entry, dict):
+            _collect(
+                {
+                    "title": entry.get("title"),
+                    "company": entry.get("company"),
+                    "location": entry.get("location"),
+                    "date_range": entry.get("date_range"),
+                    "bullets": entry.get("bullets"),
+                },
+                fragments,
+            )
+
+    for item in get_achievement_evidence(profile):
+        if isinstance(item, dict):
+            _collect(
+                {
+                    "source_text": item.get("source_text"),
+                    "scope": item.get("scope"),
+                    "action": item.get("action"),
+                    "outcome": item.get("outcome"),
+                    "metrics": item.get("metrics"),
+                    "tools": item.get("tools"),
+                    "seniority_signal": item.get("seniority_signal"),
+                },
+                fragments,
+            )
+
+    _collect(get_resume_constraints(profile).get("real_metrics"), fragments)
+
+    for entry in get_education_entries(profile):
+        if isinstance(entry, dict):
+            _collect(
+                {
+                    "degree": entry.get("degree"),
+                    "institution": entry.get("institution"),
+                    "date": entry.get("date"),
+                    "details": entry.get("details"),
+                },
+                fragments,
+            )
+
+    text = _normalize("\n".join(fragments))
+    numeric_digits = frozenset(
+        digits for token in _NUMERIC_RE.findall(text) if (digits := _digits_only(token))
+    )
+    date_tokens = frozenset(
+        digits for token in _DATE_RE.findall(text) if (digits := _digits_only(token))
+    )
+    title_tokens = frozenset(_normalize(token) for token in _TITLE_TOKEN_RE.findall(text))
+    return EvidenceCorpus(
+        text=text,
+        numeric_digits=numeric_digits,
+        title_tokens=title_tokens,
+        date_tokens=date_tokens,
+    )
+
+
+@dataclass(frozen=True)
+class FabricationFinding:
+    """One token in a generated bullet that does not trace to profile evidence."""
+
+    bullet_id: str
+    kind: str  # "numeric" | "date" | "title" | "employer"
+    token: str
+    control: ControlRule
+    generated_text: str = field(default="")
+
+    def describe(self) -> str:
+        preview = self.generated_text if len(self.generated_text) <= 80 else self.generated_text[:77] + "..."
+        return (
+            f"bullet {self.bullet_id!r} fabricated {self.kind} {self.token!r} "
+            f"(violates {self.control.value}): {preview!r}"
+        )
+
+
+def find_fabricated_tokens(
+    bullet_id: str,
+    generated_text: str,
+    corpus: EvidenceCorpus,
+    *,
+    employers: frozenset[str] = frozenset(),
+) -> list[FabricationFinding]:
+    """Return every fabricated numeric/date/title/employer token in one bullet.
+
+    An empty list means the bullet is fully grounded. ``employers`` is the set of
+    normalised company names the user actually worked at (so an employer claim is
+    flagged only when it names a company absent from both the corpus and that
+    set).
+    """
+    findings: list[FabricationFinding] = []
+    seen: set[tuple[str, str]] = set()
+
+    def record(kind: str, token: str, control: ControlRule) -> None:
+        key = (kind, _normalize(token))
+        if key in seen:
+            return
+        seen.add(key)
+        findings.append(
+            FabricationFinding(
+                bullet_id=bullet_id,
+                kind=kind,
+                token=token.strip(),
+                control=control,
+                generated_text=generated_text,
+            )
+        )
+
+    # Dates first so a year is reported as a date, not a bare numeric.
+    date_tokens = {_normalize(token) for token in _DATE_RE.findall(generated_text)}
+    for token in _DATE_RE.findall(generated_text):
+        if not corpus.has_date(token):
+            record("date", token, ControlRule.NEVER_FABRICATE_DATES)
+
+    for token in _NUMERIC_RE.findall(generated_text):
+        normalized_token = _normalize(token)
+        if normalized_token in _BENIGN_NUMERIC_TOKENS or normalized_token in date_tokens:
+            continue
+        if not corpus.has_numeric(token):
+            record("numeric", token, ControlRule.NEVER_FABRICATE_METRICS)
+
+    for token in _TITLE_TOKEN_RE.findall(generated_text):
+        if not corpus.has_title(token):
+            record("title", token, ControlRule.NEVER_FABRICATE_TITLES)
+
+    # Employer claims: a company-suffixed proper noun ("Globex Corporation") that
+    # is neither one of the user's real employers nor present in the evidence
+    # corpus is a fabricated employer. Suffix-anchoring avoids false positives on
+    # ordinary prose ("with Python") that a bare preposition heuristic would hit.
+    for match in _EMPLOYER_RE.finditer(generated_text):
+        candidate = _normalize(match.group(1))
+        if candidate and candidate not in corpus.text and candidate not in employers:
+            record("employer", match.group(1).strip(), ControlRule.NEVER_FABRICATE_EMPLOYERS)
+
+    return findings
+
+
+class FabricationError(ValueError):
+    """Raised when a generated resume carries one or more fabricated tokens.
+
+    Carries the structured findings so the tailor use case can record them as the
+    rejection reason and block persistence — a candidate that fabricates a
+    metric/title/date/employer is never accepted (GROUND-05 hard reject).
+    """
+
+    def __init__(self, findings: list[FabricationFinding]) -> None:
+        self.findings = findings
+        detail = "; ".join(f.describe() for f in findings)
+        super().__init__(f"never-fabricate detector rejected {len(findings)} token(s): {detail}")
+
+
+def scan_resume_bullets(
+    bullets: list[tuple[str, str]],
+    corpus: EvidenceCorpus,
+    *,
+    employers: frozenset[str] = frozenset(),
+) -> list[FabricationFinding]:
+    """Scan ``(bullet_id, generated_text)`` pairs; return every fabrication finding.
+
+    The deterministic whole-resume gate. An empty result means every numeric/date/
+    title/employer token in every bullet traces to profile evidence.
+    """
+    findings: list[FabricationFinding] = []
+    for bullet_id, generated_text in bullets:
+        findings.extend(
+            find_fabricated_tokens(bullet_id, generated_text, corpus, employers=employers)
+        )
+    return findings
+
+
+def employer_name_set(profile: dict) -> frozenset[str]:
+    """Return the normalised set of companies the user actually worked at."""
+    names: list[str] = []
+    for entry in get_experience_entries(profile):
+        if isinstance(entry, dict):
+            company = str(entry.get("company") or "").strip()
+            if company:
+                names.append(_normalize(company))
+    return frozenset(name for name in names if name)
+
+
+__all__ = [
+    "EvidenceCorpus",
+    "FabricationError",
+    "FabricationFinding",
+    "build_evidence_corpus",
+    "employer_name_set",
+    "find_fabricated_tokens",
+    "scan_resume_bullets",
+]

--- a/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
+++ b/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
@@ -45,12 +45,24 @@ _WHITESPACE_RE = re.compile(r"\s+")
 # Numeric/metric tokens: money, percentages, multipliers, and bare numbers with a
 # unit or magnitude. Mirrors the metric grammar used by the quality evaluator so
 # the detector and the validator agree on what counts as a "number" in a bullet.
+#
+# Magnitude-suffix adjacency is deliberate (CONTROL-03 precision):
+#   * a SINGLE-LETTER suffix (k/m/b) is consumed ONLY when it directly abuts the
+#     digits — ``$5K`` / ``10M`` — never across a space, so a grounded ``$1,200,000
+#     budget`` does NOT have the "b" of "budget" eaten into the token (which would
+#     mint a phantom ``money:1.2e15`` and hard-reject a real figure);
+#   * the SPELLED-OUT words (million/billion) may take one optional space —
+#     ``$1.2 million`` / ``35 million`` — because a whole magnitude word cannot be
+#     the accidental first letter of an ordinary following word.
+# The bare-magnitude branch comes BEFORE the plain bare-number branch so the
+# suffix is consumed with its digits (``10M`` keys ``bare:10000000``, not ``10``).
 _NUMERIC_RE = re.compile(
     r"(?ix)"
-    r"(?:\$\s?\d+(?:[,.]\d+)*(?:\.\d+)?\s?(?:k|m|b|million|billion)?)"  # money
+    r"(?:\$\s?\d+(?:[,.]\d+)*(?:\.\d+)?(?:k|m|b|\s?million|\s?billion)?)"  # money (suffix adjacent unless spelled out)
     r"|(?:\b\d+(?:\.\d+)?\s?%)"  # percentage
     r"|(?:\b\d+(?:\.\d+)?\s?x\b)"  # multiplier
-    r"|(?:\b\d[\d,]*(?:\.\d+)?\+?\b)"  # bare integer/decimal (incl. "10k", "5+")
+    r"|(?:\b\d[\d,]*(?:\.\d+)?(?:k|m|b|\s?million|\s?billion)\b)"  # bare magnitude (no $): "10M", "5K", "35 million"
+    r"|(?:\b\d[\d,]*(?:\.\d+)?\+?\b)"  # bare integer/decimal (incl. "5+")
 )
 
 # Four-digit years and explicit month/day-month-year date spans. Standalone small

--- a/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
+++ b/workers/automation/src/jobhunter/domain/materials/fabrication_detector.py
@@ -76,6 +76,24 @@ _TITLE_TOKEN_RE = re.compile(
 # the suffix keeps the employer check PRECISE: it fires on "Globex Corporation" /
 # "Initech Inc." but never on ordinary prose like "with Python" or "for Docker",
 # which a bare "<preposition> <Capitalized word>" heuristic would wrongly flag.
+#
+# KNOWN, INTENTIONAL LIMITATION (precision-over-recall, by design): a *bare-name*
+# fabricated employer with no corporate suffix — e.g. "Owned the API at Netflix."
+# — is deliberately NOT flagged at this deterministic layer, and that gap is
+# acceptable for three concrete reasons:
+#   1. The resume's per-entry employer is CODE-INJECTED from the master resume in
+#      the assembler (``services.py`` ``entry.get("company")``), never authored by
+#      the model, so the structured employer field cannot be fabricated through
+#      this path. The model only authors bullet / summary / title prose.
+#   2. A bare capitalised token is genuinely ambiguous with tools, products, and
+#      methodologies ("Python", "Docker", "Kafka"); a non-suffix heuristic would
+#      over-flag ordinary prose and falsely reject clean resumes.
+#   3. The LLM judge is a second, prose-aware gate that explicitly fails
+#      "unsupported ... employers" (see ``use_cases.py`` judge prompt), so a model
+#      inventing a bare-name employer inside prose is caught there, not silently.
+# The residual risk is therefore deferred to the judge by design — do NOT try to
+# flag all bare names here. ``test_detector_defers_bare_name_employer_to_judge``
+# pins this contract.
 _EMPLOYER_RE = re.compile(
     r"\b([A-Z][A-Za-z0-9&.\-]*(?:\s+[A-Z][A-Za-z0-9&.\-]*)*"
     r"\s+(?:Inc|Incorporated|LLC|Ltd|Limited|Corp|Corporation|Co|Company|GmbH|PLC|AG|SA|NV|LLP)\.?)\b"
@@ -97,14 +115,70 @@ def _normalize(text: str) -> str:
 
 
 def _digits_only(token: str) -> str:
-    """Return only the digit/decimal characters of a token for numeric matching.
+    """Return only the digit/decimal characters of a token for date matching.
 
-    A bullet may render ``$1.2M`` while the evidence records ``1,200,000`` or
-    ``1.2 million``; matching on the run of significant digits avoids false
-    fabrication flags on equivalent renderings while still catching invented
-    numbers (whose digits appear nowhere in the corpus).
+    A four-digit year renders identically everywhere, so dates ground on the bare
+    digit run (numbers use the stricter :func:`_normalize_numeric` instead).
     """
     return re.sub(r"[^\d.]", "", token).strip(".")
+
+
+# Magnitude words/suffixes a money token may carry, resolved to a multiplier so a
+# bullet's ``$1.2M`` and the evidence's ``1.2 million`` collapse to the same value.
+_MAGNITUDE_FACTORS: dict[str, int] = {
+    "k": 1_000,
+    "m": 1_000_000,
+    "b": 1_000_000_000,
+    "million": 1_000_000,
+    "billion": 1_000_000_000,
+}
+_MAGNITUDE_RE = re.compile(r"(?i)(k|m|b|million|billion)\b\.?$")
+
+
+def _normalize_numeric(token: str) -> str | None:
+    """Canonicalise a numeric token to a ``kind:value`` key for grounding.
+
+    Grounding on the bare digit run is unsafe: a fabricated ``$35M`` or
+    ``35 million`` would "match" an unrelated profile ``35%`` because all three
+    share the digit run ``35`` (the reviewer's digit-collision case). Instead we
+    key on the token's KIND (percentage / currency / multiplier / bare number)
+    *and* its magnitude-resolved value, so a number with a different unit or
+    magnitude than any profile number is no longer silently grounded.
+
+    Equivalent renderings of the SAME quantity still collapse: ``$1.2M`` /
+    ``$1.2 million`` / ``$1,200,000`` all key to ``money:1200000``, so genuine
+    formatting differences do not produce false fabrication flags.
+
+    Returns ``None`` when the token carries no significant digits.
+    """
+    lowered = token.strip().lower()
+    # Commas are thousands separators (US format); drop them so ``1,200,000``
+    # parses as a number while ``1.2`` keeps its decimal point.
+    number_text = re.sub(r"[^\d.]", "", lowered.replace(",", "")).strip(".")
+    if not number_text:
+        return None
+
+    if lowered.startswith("$"):
+        kind = "money"
+    elif "%" in lowered:
+        kind = "pct"
+    elif re.search(r"\dx\b", lowered) or lowered.endswith("x"):
+        kind = "mult"
+    else:
+        kind = "bare"
+
+    try:
+        value = float(number_text)
+    except ValueError:
+        return None
+    magnitude = _MAGNITUDE_RE.search(lowered)
+    if magnitude:
+        value *= _MAGNITUDE_FACTORS[magnitude.group(1).lower()]
+
+    # Render the value canonically: integers without a trailing ``.0`` so the
+    # corpus key for ``5`` and the bullet key for ``5`` are byte-equal.
+    canonical = format(value, ".4f").rstrip("0").rstrip(".") if value % 1 else str(int(value))
+    return f"{kind}:{canonical}"
 
 
 @dataclass(frozen=True)
@@ -117,7 +191,7 @@ class EvidenceCorpus:
     """
 
     text: str
-    numeric_digits: frozenset[str]
+    numeric_keys: frozenset[str]
     title_tokens: frozenset[str]
     date_tokens: frozenset[str]
 
@@ -126,10 +200,13 @@ class EvidenceCorpus:
         return bool(normalized) and normalized in self.text
 
     def has_numeric(self, token: str) -> bool:
-        digits = _digits_only(token)
-        if not digits:
+        key = _normalize_numeric(token)
+        if key is None:
             return True  # nothing numeric to ground
-        return digits in self.numeric_digits
+        # Grounded only when a profile number of the SAME kind + magnitude exists
+        # — a different-unit/different-magnitude number sharing the digit run
+        # (``$35M`` vs a profile ``35%``) is no longer silently grounded.
+        return key in self.numeric_keys
 
     def has_title(self, token: str) -> bool:
         return _normalize(token) in self.title_tokens
@@ -215,8 +292,8 @@ def build_evidence_corpus(profile: dict) -> EvidenceCorpus:
             )
 
     text = _normalize("\n".join(fragments))
-    numeric_digits = frozenset(
-        digits for token in _NUMERIC_RE.findall(text) if (digits := _digits_only(token))
+    numeric_keys = frozenset(
+        key for token in _NUMERIC_RE.findall(text) if (key := _normalize_numeric(token))
     )
     date_tokens = frozenset(
         digits for token in _DATE_RE.findall(text) if (digits := _digits_only(token))
@@ -224,7 +301,7 @@ def build_evidence_corpus(profile: dict) -> EvidenceCorpus:
     title_tokens = frozenset(_normalize(token) for token in _TITLE_TOKEN_RE.findall(text))
     return EvidenceCorpus(
         text=text,
-        numeric_digits=numeric_digits,
+        numeric_keys=numeric_keys,
         title_tokens=title_tokens,
         date_tokens=date_tokens,
     )
@@ -301,6 +378,8 @@ def find_fabricated_tokens(
     # is neither one of the user's real employers nor present in the evidence
     # corpus is a fabricated employer. Suffix-anchoring avoids false positives on
     # ordinary prose ("with Python") that a bare preposition heuristic would hit.
+    # Bare-name fabricated employers ("at Netflix") are deliberately deferred to
+    # the LLM judge — see the ``_EMPLOYER_RE`` limitation note above.
     for match in _EMPLOYER_RE.finditer(generated_text):
         candidate = _normalize(match.group(1))
         if candidate and candidate not in corpus.text and candidate not in employers:

--- a/workers/automation/src/jobhunter/domain/materials/provenance.py
+++ b/workers/automation/src/jobhunter/domain/materials/provenance.py
@@ -1,0 +1,173 @@
+"""Canonical per-bullet provenance domain model (Phase 2).
+
+Every generated resume bullet (and executive-profile / skills line) carries one
+:class:`BulletProvenance` record: the canonical profile evidence it derives from
+(``evidence_ids``), the job requirement it serves (``requirement_ids``, FK into
+the persisted :class:`EmployerAnalysis` requirements), the transform that produced
+it (``transform_type``, a closed taxonomy — GROUND-04), the granular policy rule
+that governed the decision (``control`` — CONTROL-01/02), a human-readable
+rationale, and the actual rendered bullet text (``generated_text``) — the anchor
+against which coverage and fabrication are computed (never inferred from the job
+description — the auditability rule).
+
+This module is **pure data** (frozen dataclasses, no I/O). The computation that
+turns a selected tailored payload + the persisted analysis into these rows lives
+in ``provenance_builder.py``; the deterministic never-fabricate gate lives in
+``fabrication_detector.py``; persistence lives in the infrastructure layer.
+
+Locked decisions realised here:
+
+  * **GROUND-05 / canonical-rows** — provenance is foreign-key bindings, not
+    model-authored free text. ``evidence_ids`` and ``requirement_ids`` are
+    validated against the real profile + analysis at build time; a fabricated id
+    is rejected before a row is ever constructed.
+  * **GROUND-04** — ``transform_type`` is a member of the closed
+    :class:`TransformType` enum.
+  * **CONTROL-02** — ``control`` records the governing :class:`ControlRule`.
+  * **Anti-Pattern 4 / success criterion 5** — provenance is generation-versioned
+    via :class:`BulletProvenanceSet` and superseded with its artifact; a failed
+    re-tailor writes a fresh generation and never destroys the prior one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.materials.value_objects import ControlRule, TransformType
+from jobhunter.domain.tenant import TenantId
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True)
+class BulletProvenance:
+    """One canonical provenance record for a single generated resume line.
+
+    ``bullet_id`` is stable within ``(job, generation, section, index)`` so the
+    same line keeps its identity across re-saves of a generation while a new
+    generation mints fresh ids. Invariants are enforced up front so an instance
+    carries its validity (mirrors :class:`Artifact`).
+    """
+
+    bullet_id: str
+    section: str
+    source_id: str | None
+    evidence_ids: tuple[str, ...]
+    requirement_ids: tuple[str, ...]
+    matched_keywords: tuple[str, ...]
+    transform_type: TransformType
+    control: ControlRule
+    rationale: str
+    generated_text: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.bullet_id, str) or not self.bullet_id.strip():
+            raise ValueError("BulletProvenance.bullet_id must be a non-empty string")
+        if not isinstance(self.section, str) or not self.section.strip():
+            raise ValueError("BulletProvenance.section must be a non-empty string")
+        if not isinstance(self.transform_type, TransformType):
+            raise TypeError(
+                "BulletProvenance.transform_type must be a TransformType, "
+                f"got {type(self.transform_type).__name__}"
+            )
+        if not isinstance(self.control, ControlRule):
+            raise TypeError(
+                f"BulletProvenance.control must be a ControlRule, got {type(self.control).__name__}"
+            )
+        for label, value in (
+            ("evidence_ids", self.evidence_ids),
+            ("requirement_ids", self.requirement_ids),
+            ("matched_keywords", self.matched_keywords),
+        ):
+            if not isinstance(value, tuple):
+                raise TypeError(f"BulletProvenance.{label} must be a tuple")
+            for item in value:
+                if not isinstance(item, str):
+                    raise TypeError(f"BulletProvenance.{label} entries must be str")
+        if not isinstance(self.generated_text, str) or not self.generated_text.strip():
+            raise ValueError("BulletProvenance.generated_text must be non-empty (the coverage anchor)")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bullet_id": self.bullet_id,
+            "section": self.section,
+            "source_id": self.source_id,
+            "evidence_ids": list(self.evidence_ids),
+            "requirement_ids": list(self.requirement_ids),
+            "matched_keywords": list(self.matched_keywords),
+            "transform_type": self.transform_type.value,
+            "control": self.control.value,
+            "rationale": self.rationale,
+            "generated_text": self.generated_text,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> BulletProvenance:
+        return cls(
+            bullet_id=str(data["bullet_id"]),
+            section=str(data["section"]),
+            source_id=(str(data["source_id"]) if data.get("source_id") is not None else None),
+            evidence_ids=tuple(str(item) for item in (data.get("evidence_ids") or ())),
+            requirement_ids=tuple(str(item) for item in (data.get("requirement_ids") or ())),
+            matched_keywords=tuple(str(item) for item in (data.get("matched_keywords") or ())),
+            transform_type=TransformType(str(data["transform_type"])),
+            control=ControlRule(str(data["control"])),
+            rationale=str(data.get("rationale") or ""),
+            generated_text=str(data["generated_text"]),
+        )
+
+
+@dataclass(frozen=True)
+class BulletProvenanceSet:
+    """All provenance rows for one ``(tenant, job, generation)`` tailoring run.
+
+    Generation-versioned exactly like :class:`MaterialsSet` /
+    :class:`EmployerAnalysis` (Anti-Pattern 4 / success criterion 5): a forced or
+    failed re-tailor writes a higher generation and the prior generation's rows
+    are retained as audit history — never deleted. The set is bound to the
+    artifact it explains via ``artifact_id`` so the read model can join an
+    artifact to its exact provenance.
+    """
+
+    tenant_id: TenantId
+    job_id: JobId
+    generation: int
+    artifact_id: str
+    bullets: tuple[BulletProvenance, ...]
+    created_at: str = field(default_factory=_utc_now)
+
+    def __post_init__(self) -> None:
+        if self.generation < 1:
+            raise ValueError(f"BulletProvenanceSet.generation must be >= 1, got {self.generation}")
+        if not isinstance(self.artifact_id, str) or not self.artifact_id.strip():
+            raise ValueError("BulletProvenanceSet.artifact_id must be a non-empty string")
+        if not isinstance(self.bullets, tuple):
+            raise TypeError("BulletProvenanceSet.bullets must be a tuple")
+        for bullet in self.bullets:
+            if not isinstance(bullet, BulletProvenance):
+                raise TypeError("BulletProvenanceSet.bullets entries must be BulletProvenance")
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.bullets
+
+    def to_read_model(self) -> list[dict[str, Any]]:
+        """Serialise the inspectable read shape (the projection/DTO source).
+
+        The single owner of the provenance read shape: the Python projection
+        builder and (mirrored) the TS projection builder both materialise this
+        exact list so the read model is parity-checked. Ordered as produced so the
+        inspector renders bullets section-by-section in document order.
+        """
+        return [bullet.to_dict() for bullet in self.bullets]
+
+
+__all__ = [
+    "BulletProvenance",
+    "BulletProvenanceSet",
+]

--- a/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
+++ b/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
@@ -47,6 +47,7 @@ from jobhunter.resume_profile import (
     get_experience_entries,
     get_resume_master,
     get_skill_categories,
+    get_tailoring_policy,
     tailored_experience_bullets,
     tailored_experience_title,
     tailored_skill_items,
@@ -237,18 +238,27 @@ def build_bullet_provenance(
     rows: list[BulletProvenance] = []
 
     # ---- Executive profile (single line) --------------------------------
+    # The shipped summary is policy-gated EXACTLY as the assembler renders it
+    # (``services.py`` ``assemble_resume_text``): when ``allow_summary_rewrite``
+    # is off the resume ships the profile baseline, not the model's proposed
+    # rewrite. Provenance must anchor to the SHIPPED line — computing it against
+    # the never-rendered rewrite would break the "generated_text is byte-identical
+    # to what ResumeAssembler renders" invariant (Pattern 2 / GROUND-06) and feed
+    # the deterministic detector text that never reaches the user.
     baseline_summary = _normalize_space(
         str(resume.get("executive_profile", {}).get("baseline_text", ""))
     )
-    tailored_summary = _normalize_space(str(tailored_payload.get("executive_profile") or ""))
-    if tailored_summary:
+    allow_summary_rewrite = bool(get_tailoring_policy(profile)["allow_summary_rewrite"])
+    proposed_summary = _normalize_space(str(tailored_payload.get("executive_profile") or ""))
+    shipped_summary = proposed_summary if allow_summary_rewrite else baseline_summary
+    if shipped_summary:
         base = (
             TransformType.REFRAME
-            if _normalize_phrase(baseline_summary) != _normalize_phrase(tailored_summary)
+            if _normalize_phrase(baseline_summary) != _normalize_phrase(shipped_summary)
             else TransformType.VERBATIM
         )
-        transform = _bullet_transform(baseline_summary, tailored_summary, base=base, plan=plan)
-        served, matched = _served_requirements(tailored_summary.lower(), analysis)
+        transform = _bullet_transform(baseline_summary, shipped_summary, base=base, plan=plan)
+        served, matched = _served_requirements(shipped_summary.lower(), analysis)
         evidence_ids = _validated_evidence_ids(
             tuple(plan.seniority_evidence_ids[:6]), sources
         )
@@ -263,7 +273,7 @@ def build_bullet_provenance(
                 transform_type=transform,
                 control=_resolve_control(transform, claim_mode=claim_mode),
                 rationale=_summary_rationale(plan, transform, matched),
-                generated_text=tailored_summary,
+                generated_text=shipped_summary,
             )
         )
 

--- a/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
+++ b/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
@@ -1,0 +1,406 @@
+"""Compute canonical per-bullet provenance against the GENERATED resume text (Phase 2).
+
+The Phase-2 write-side computation: given the SELECTED tailored payload, the
+profile, the deterministic :class:`TailoringPlan`, and the persisted
+:class:`EmployerAnalysis`, emit one :class:`BulletProvenance` row per rendered
+bullet — computed against the **actual generated bullet text** the assembler
+produces, never inferred from the job description (the auditability rule /
+Anti-Pattern 2).
+
+Design (Patterns 2 + 3 from the architecture research):
+
+  * Reuse the existing ``resume_profile`` rendering helpers
+    (``tailored_experience_*`` / ``tailored_skill_items``) so a row's
+    ``generated_text`` is byte-identical to what ``ResumeAssembler`` renders —
+    the row is a true coverage anchor.
+  * Map the existing annotation ``change_type`` vocabulary to the closed
+    :class:`TransformType` taxonomy (GROUND-04).
+  * Bind ``requirement_ids`` as real foreign keys into the persisted analysis
+    requirements by matching the bullet text against each requirement's keywords
+    (verified against generated text, GROUND-02). ``matched_keywords`` are the
+    analysis keywords actually present in the line.
+  * Resolve the governing :class:`ControlRule` per bullet from the transform +
+    the active claim mode (Pattern 3 / CONTROL-02).
+  * Validate every ``evidence_id`` / ``requirement_id`` against the real profile
+    + analysis BEFORE constructing a row — a fabricated id raises
+    :class:`ProvenanceBindingError` (GROUND-05: FK bindings, not free text).
+
+This module is pure (no I/O, no LLM). Persistence + the deterministic
+never-fabricate token gate live in their own modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from jobhunter.domain.materials.analysis import EmployerAnalysis
+from jobhunter.domain.materials.provenance import BulletProvenance
+from jobhunter.domain.materials.quality import (
+    TailoringPlan,
+    _contains_term,
+    _normalize_phrase,
+    _normalize_space,
+)
+from jobhunter.domain.materials.value_objects import ControlRule, TransformType
+from jobhunter.resume_profile import (
+    get_claim_mode,
+    get_experience_entries,
+    get_resume_master,
+    get_skill_categories,
+    tailored_experience_bullets,
+    tailored_experience_title,
+    tailored_skill_items,
+)
+
+# Map the annotation/profile ``change_type`` vocabulary to the closed taxonomy.
+# Anything reframed-for-the-job is a REFRAME; a pure reword is a REPHRASE; an
+# unchanged line is VERBATIM. SYNTHESIZE_FROM_RELATED and QUANTIFY_FROM_EVIDENCE
+# are decided contextually below (adjacent drafts / metric introduction).
+_CHANGE_TYPE_TO_TRANSFORM: dict[str, TransformType] = {
+    "summary_reframed": TransformType.REFRAME,
+    "summary_preserved": TransformType.VERBATIM,
+    "title_and_achievement_reframed": TransformType.REFRAME,
+    "title_reframed": TransformType.REFRAME,
+    "achievement_reframed": TransformType.REFRAME,
+    "experience_preserved": TransformType.VERBATIM,
+    "skills_reordered": TransformType.REPHRASE,
+    "skills_preserved": TransformType.VERBATIM,
+}
+
+
+class ProvenanceBindingError(ValueError):
+    """Raised when a provenance row would reference a non-existent id (GROUND-05).
+
+    Provenance is canonical FK bindings, not model-authored free text: an
+    ``evidence_id`` that is not a real profile evidence item, or a
+    ``requirement_id`` that is not in the persisted analysis, is rejected before
+    any row is constructed — proving the binding could only ever name real data.
+    """
+
+    def __init__(self, kind: str, bad_ids: tuple[str, ...]) -> None:
+        self.kind = kind
+        self.bad_ids = bad_ids
+        super().__init__(
+            f"provenance referenced {len(bad_ids)} fabricated {kind} id(s): {', '.join(bad_ids)}"
+        )
+
+
+@dataclass(frozen=True)
+class _Sources:
+    """Pre-extracted lookup sets the builder validates bindings against."""
+
+    valid_evidence_ids: frozenset[str]
+    valid_requirement_ids: frozenset[str]
+
+
+def _sources(plan: TailoringPlan, analysis: EmployerAnalysis) -> _Sources:
+    return _Sources(
+        valid_evidence_ids=frozenset(item.evidence_id for item in plan.evidence_items if item.evidence_id),
+        valid_requirement_ids=frozenset(req.id for req in analysis.canonical.requirements if req.id),
+    )
+
+
+def _validated_evidence_ids(candidate: tuple[str, ...], sources: _Sources) -> tuple[str, ...]:
+    bad = tuple(eid for eid in candidate if eid not in sources.valid_evidence_ids)
+    if bad:
+        raise ProvenanceBindingError("evidence", bad)
+    return candidate
+
+
+def _validated_requirement_ids(candidate: tuple[str, ...], sources: _Sources) -> tuple[str, ...]:
+    bad = tuple(rid for rid in candidate if rid not in sources.valid_requirement_ids)
+    if bad:
+        raise ProvenanceBindingError("requirement", bad)
+    return candidate
+
+
+def _served_requirements(
+    generated_lower: str,
+    analysis: EmployerAnalysis,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return (requirement_ids, matched_keywords) the generated line actually serves.
+
+    A requirement is served when one of its analysis keywords (or its own text
+    terms) appears verbatim in the rendered bullet — verified against generated
+    text (GROUND-02), never assumed from the job description. ``matched_keywords``
+    are the reasoned analysis keywords present in the line.
+    """
+    keywords_by_requirement: dict[str, list[str]] = {}
+    for keyword in analysis.canonical.keywords:
+        ref = keyword.requirement_ref
+        if ref:
+            keywords_by_requirement.setdefault(ref, []).append(keyword.keyword)
+
+    served: list[str] = []
+    matched: list[str] = []
+    for requirement in analysis.canonical.requirements:
+        req_keywords = keywords_by_requirement.get(requirement.id, [])
+        hit_keywords = [kw for kw in req_keywords if _contains_term(generated_lower, kw)]
+        text_hit = _contains_term(generated_lower, requirement.text) if not hit_keywords else False
+        if hit_keywords or text_hit:
+            served.append(requirement.id)
+            matched.extend(hit_keywords)
+
+    # Also surface keywords whose requirement_ref is unset/orphan but appear in
+    # the line — useful audit signal even without a requirement to bind.
+    for keyword in analysis.canonical.keywords:
+        if not keyword.requirement_ref and _contains_term(generated_lower, keyword.keyword):
+            matched.append(keyword.keyword)
+
+    return (
+        tuple(dict.fromkeys(served)),
+        tuple(dict.fromkeys(_normalize_phrase(kw) for kw in matched if _normalize_phrase(kw))),
+    )
+
+
+def _resolve_control(transform: TransformType, *, claim_mode: str) -> ControlRule:
+    """Resolve the governing control rule for a bullet (Pattern 3 / CONTROL-02).
+
+    The control answers "which rule produced THIS line":
+      * a metric surfaced from evidence is governed by never-fabricate-metrics;
+      * a draft from closely-related experience is governed by
+        invent-closely-related;
+      * everything else (verbatim/rephrase/reframe of a real fact) is governed by
+        the always-allowed rephrase rule.
+    """
+    if transform is TransformType.QUANTIFY_FROM_EVIDENCE:
+        return ControlRule.NEVER_FABRICATE_METRICS
+    if transform is TransformType.SYNTHESIZE_FROM_RELATED:
+        return ControlRule.INVENT_CLOSELY_RELATED
+    return ControlRule.REPHRASE_ALLOWED
+
+
+def _bullet_transform(
+    source_text: str,
+    generated_text: str,
+    *,
+    base: TransformType,
+    plan: TailoringPlan,
+) -> TransformType:
+    """Refine the section-level transform for one concrete bullet.
+
+    A bullet that introduces a metric (a metric appears in the generated line but
+    not the source line) is a QUANTIFY_FROM_EVIDENCE; a brand-new bullet with no
+    source counterpart, permitted only under adjacent-draft policy, is a
+    SYNTHESIZE_FROM_RELATED; otherwise the section-level base transform stands.
+    """
+    generated_lower = _normalize_space(generated_text).lower()
+    source_lower = _normalize_space(source_text).lower()
+
+    if not source_lower and plan.allow_adjacent_achievement_drafts:
+        return TransformType.SYNTHESIZE_FROM_RELATED
+
+    introduced_metrics = [
+        metric
+        for metric in plan.verified_metrics
+        if metric and metric.lower() in generated_lower and metric.lower() not in source_lower
+    ]
+    if introduced_metrics:
+        return TransformType.QUANTIFY_FROM_EVIDENCE
+    return base
+
+
+def _evidence_ids_for_entry(plan: TailoringPlan, entry_id: str, generated_lower: str) -> tuple[str, ...]:
+    """Profile evidence ids that belong to an experience entry and are represented."""
+    ids: list[str] = []
+    for item in plan.evidence_items:
+        if item.experience_entry_id != entry_id:
+            continue
+        represented = (
+            item.evidence_id in plan.required_evidence_ids
+            or item.evidence_id in plan.seniority_evidence_ids
+            or (item.evidence_id and item.evidence_id.lower() in generated_lower)
+        )
+        if represented:
+            ids.append(item.evidence_id)
+    return tuple(dict.fromkeys(eid for eid in ids if eid))
+
+
+def build_bullet_provenance(
+    profile: dict,
+    job: dict,
+    tailored_payload: dict,
+    plan: TailoringPlan,
+    analysis: EmployerAnalysis,
+) -> tuple[BulletProvenance, ...]:
+    """Compute one :class:`BulletProvenance` per rendered resume line.
+
+    The bullets are rendered with the same helpers ``ResumeAssembler`` uses, so
+    each ``generated_text`` is exactly the line the user sees. ``bullet_id`` is
+    stable within ``(section, source, index)``. All evidence/requirement bindings
+    are validated against the real profile + analysis (GROUND-05) before a row is
+    built.
+    """
+    sources = _sources(plan, analysis)
+    claim_mode = get_claim_mode(profile)
+    resume = get_resume_master(profile)
+    rows: list[BulletProvenance] = []
+
+    # ---- Executive profile (single line) --------------------------------
+    baseline_summary = _normalize_space(
+        str(resume.get("executive_profile", {}).get("baseline_text", ""))
+    )
+    tailored_summary = _normalize_space(str(tailored_payload.get("executive_profile") or ""))
+    if tailored_summary:
+        base = (
+            TransformType.REFRAME
+            if _normalize_phrase(baseline_summary) != _normalize_phrase(tailored_summary)
+            else TransformType.VERBATIM
+        )
+        transform = _bullet_transform(baseline_summary, tailored_summary, base=base, plan=plan)
+        served, matched = _served_requirements(tailored_summary.lower(), analysis)
+        evidence_ids = _validated_evidence_ids(
+            tuple(plan.seniority_evidence_ids[:6]), sources
+        )
+        rows.append(
+            BulletProvenance(
+                bullet_id="executive_profile#0",
+                section="executive_profile",
+                source_id="executive_profile",
+                evidence_ids=evidence_ids,
+                requirement_ids=_validated_requirement_ids(served, sources),
+                matched_keywords=matched,
+                transform_type=transform,
+                control=_resolve_control(transform, claim_mode=claim_mode),
+                rationale=_summary_rationale(plan, transform, matched),
+                generated_text=tailored_summary,
+            )
+        )
+
+    # ---- Experience bullets (one row per rendered bullet) ----------------
+    experience_updates = {
+        str(update.get("id")): update
+        for update in tailored_payload.get("experience_updates") or []
+        if isinstance(update, dict) and update.get("id")
+    }
+    for entry in get_experience_entries(profile):
+        if not isinstance(entry, dict):
+            continue
+        entry_id = str(entry.get("id") or "")
+        update = experience_updates.get(entry_id, {})
+        source_bullets = [str(b).strip() for b in (entry.get("bullets") or []) if str(b).strip()]
+        tailored_bullets = tailored_experience_bullets(entry, update, profile)
+        for index, bullet in enumerate(tailored_bullets):
+            generated_text = _normalize_space(str(bullet))
+            if not generated_text:
+                continue
+            source_text = source_bullets[index] if index < len(source_bullets) else ""
+            base = (
+                TransformType.VERBATIM
+                if _normalize_phrase(source_text) == _normalize_phrase(generated_text)
+                else TransformType.REPHRASE
+                if source_text
+                else TransformType.SYNTHESIZE_FROM_RELATED
+            )
+            # If the entry title was reframed for the job, mark a job-reframe.
+            if base is TransformType.REPHRASE and _entry_title_reframed(entry, update, profile):
+                base = TransformType.REFRAME
+            transform = _bullet_transform(source_text, generated_text, base=base, plan=plan)
+            generated_lower = generated_text.lower()
+            served, matched = _served_requirements(generated_lower, analysis)
+            evidence_ids = _validated_evidence_ids(
+                _evidence_ids_for_entry(plan, entry_id, generated_lower), sources
+            )
+            rows.append(
+                BulletProvenance(
+                    bullet_id=f"experience:{entry_id}#{index}",
+                    section="experience",
+                    source_id=entry_id,
+                    evidence_ids=evidence_ids,
+                    requirement_ids=_validated_requirement_ids(served, sources),
+                    matched_keywords=matched,
+                    transform_type=transform,
+                    control=_resolve_control(transform, claim_mode=claim_mode),
+                    rationale=_experience_rationale(entry, transform, matched),
+                    generated_text=generated_text,
+                )
+            )
+
+    # ---- Skills (one row per rendered category line) ---------------------
+    skill_updates = {
+        str(update.get("id")): update
+        for update in tailored_payload.get("skill_category_updates") or []
+        if isinstance(update, dict) and update.get("id")
+    }
+    for category in get_skill_categories(profile):
+        if not isinstance(category, dict):
+            continue
+        category_id = str(category.get("id") or "")
+        update = skill_updates.get(category_id, {})
+        source_items = [str(i).strip() for i in (category.get("items") or []) if str(i).strip()]
+        tailored_items = tailored_skill_items(category, update, profile)
+        if not tailored_items:
+            continue
+        generated_text = f"{category.get('label', 'Skills')}: {', '.join(tailored_items)}"
+        reordered = [_normalize_phrase(i) for i in tailored_items] != [
+            _normalize_phrase(i) for i in source_items
+        ]
+        transform = TransformType.REPHRASE if reordered else TransformType.VERBATIM
+        served, matched = _served_requirements(_normalize_space(generated_text).lower(), analysis)
+        rows.append(
+            BulletProvenance(
+                bullet_id=f"skills:{category_id}#0",
+                section="skills",
+                source_id=category_id,
+                evidence_ids=(),
+                requirement_ids=_validated_requirement_ids(served, sources),
+                matched_keywords=matched,
+                transform_type=transform,
+                control=_resolve_control(transform, claim_mode=claim_mode),
+                rationale=_skills_rationale(transform, matched),
+                generated_text=_normalize_space(generated_text),
+            )
+        )
+
+    return tuple(rows)
+
+
+def _entry_title_reframed(entry: dict, update: dict, profile: dict) -> bool:
+    source_title = _normalize_phrase(str(entry.get("title") or ""))
+    tailored_title = _normalize_phrase(tailored_experience_title(entry, update, profile))
+    return bool(tailored_title) and tailored_title != source_title
+
+
+def _matched_phrase(matched: tuple[str, ...]) -> str:
+    return ", ".join(matched[:5])
+
+
+def _summary_rationale(plan: TailoringPlan, transform: TransformType, matched: tuple[str, ...]) -> str:
+    signals = _matched_phrase(matched)
+    if transform is TransformType.VERBATIM:
+        return "Executive profile is the profile baseline, unchanged under the selected controls."
+    base = (
+        f"Executive profile was {transform.value.replace('_', ' ')} for a "
+        f"{plan.target_seniority} target using {plan.claim_mode}"
+    )
+    return f"{base}; it serves the job signals {signals}." if signals else f"{base}."
+
+
+def _experience_rationale(entry: dict, transform: TransformType, matched: tuple[str, ...]) -> str:
+    company = str(entry.get("company") or "this experience").strip()
+    signals = _matched_phrase(matched)
+    verb = {
+        TransformType.VERBATIM: "carried in verbatim from the profile",
+        TransformType.REPHRASE: "reworded from a real profile bullet",
+        TransformType.REFRAME: "re-angled toward the target role",
+        TransformType.SYNTHESIZE_FROM_RELATED: "drafted from closely-related profile evidence",
+        TransformType.QUANTIFY_FROM_EVIDENCE: "surfaced a metric recorded in profile evidence",
+    }[transform]
+    if signals:
+        return f"{company} bullet was {verb}; it serves the job signals {signals}."
+    return f"{company} bullet was {verb}."
+
+
+def _skills_rationale(transform: TransformType, matched: tuple[str, ...]) -> str:
+    signals = _matched_phrase(matched)
+    if transform is TransformType.VERBATIM:
+        return "Skill category is preserved from the profile under the selected controls."
+    if signals:
+        return f"Skill ordering highlights job-matching signals ({signals}) while preserving profile skills."
+    return "Skill ordering was adjusted while preserving the profile skill category."
+
+
+__all__ = [
+    "ProvenanceBindingError",
+    "build_bullet_provenance",
+]

--- a/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
+++ b/workers/automation/src/jobhunter/domain/materials/provenance_builder.py
@@ -41,6 +41,7 @@ from jobhunter.domain.materials.quality import (
     _normalize_phrase,
     _normalize_space,
 )
+from jobhunter.domain.materials.services import sanitize_text
 from jobhunter.domain.materials.value_objects import ControlRule, TransformType
 from jobhunter.resume_profile import (
     get_claim_mode,
@@ -67,6 +68,24 @@ _CHANGE_TYPE_TO_TRANSFORM: dict[str, TransformType] = {
     "skills_reordered": TransformType.REPHRASE,
     "skills_preserved": TransformType.VERBATIM,
 }
+
+
+def _rendered_line(text: str) -> str:
+    """Render one line EXACTLY as ``ResumeAssembler`` ships it (Pattern 2 / GROUND-06).
+
+    The assembler applies :func:`sanitize_text` to every summary/bullet/skill line
+    it renders (``services.py`` ``_assemble_resume_text``), which rewrites smart
+    punctuation — curly quotes ``’“”`` to ASCII and em/en dashes to commas/hyphens.
+    Provenance is a coverage anchor only when its ``generated_text`` is
+    byte-identical to that shipped line, so the row — and the deterministic
+    never-fabricate detector that scans it — sees the text the user actually
+    received, not the model's pre-sanitised draft.
+
+    Keyword/FK matching is unaffected: every match path runs through
+    :func:`_normalize_phrase` (``_WORD_RE``), which already strips quote forms, so
+    ``team’s`` and ``team's`` normalise identically.
+    """
+    return _normalize_space(sanitize_text(text))
 
 
 class ProvenanceBindingError(ValueError):
@@ -245,11 +264,11 @@ def build_bullet_provenance(
     # the never-rendered rewrite would break the "generated_text is byte-identical
     # to what ResumeAssembler renders" invariant (Pattern 2 / GROUND-06) and feed
     # the deterministic detector text that never reaches the user.
-    baseline_summary = _normalize_space(
+    baseline_summary = _rendered_line(
         str(resume.get("executive_profile", {}).get("baseline_text", ""))
     )
     allow_summary_rewrite = bool(get_tailoring_policy(profile)["allow_summary_rewrite"])
-    proposed_summary = _normalize_space(str(tailored_payload.get("executive_profile") or ""))
+    proposed_summary = _rendered_line(str(tailored_payload.get("executive_profile") or ""))
     shipped_summary = proposed_summary if allow_summary_rewrite else baseline_summary
     if shipped_summary:
         base = (
@@ -291,7 +310,7 @@ def build_bullet_provenance(
         source_bullets = [str(b).strip() for b in (entry.get("bullets") or []) if str(b).strip()]
         tailored_bullets = tailored_experience_bullets(entry, update, profile)
         for index, bullet in enumerate(tailored_bullets):
-            generated_text = _normalize_space(str(bullet))
+            generated_text = _rendered_line(str(bullet))
             if not generated_text:
                 continue
             source_text = source_bullets[index] if index < len(source_bullets) else ""
@@ -341,12 +360,18 @@ def build_bullet_provenance(
         tailored_items = tailored_skill_items(category, update, profile)
         if not tailored_items:
             continue
-        generated_text = f"{category.get('label', 'Skills')}: {', '.join(tailored_items)}"
+        # Mirror the assembler's per-item ``sanitize_text`` + filter so the skills
+        # line is byte-identical to what ``ResumeAssembler`` ships (the label is
+        # code-injected profile data and is rendered raw there, so it stays raw).
+        sanitized_items = [sanitize_text(str(i)) for i in tailored_items if str(i).strip()]
+        generated_text = _normalize_space(
+            f"{category.get('label', 'Skills')}: {', '.join(sanitized_items)}"
+        )
         reordered = [_normalize_phrase(i) for i in tailored_items] != [
             _normalize_phrase(i) for i in source_items
         ]
         transform = TransformType.REPHRASE if reordered else TransformType.VERBATIM
-        served, matched = _served_requirements(_normalize_space(generated_text).lower(), analysis)
+        served, matched = _served_requirements(generated_text.lower(), analysis)
         rows.append(
             BulletProvenance(
                 bullet_id=f"skills:{category_id}#0",
@@ -358,7 +383,7 @@ def build_bullet_provenance(
                 transform_type=transform,
                 control=_resolve_control(transform, claim_mode=claim_mode),
                 rationale=_skills_rationale(transform, matched),
-                generated_text=_normalize_space(generated_text),
+                generated_text=generated_text,
             )
         )
 

--- a/workers/automation/src/jobhunter/domain/materials/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/materials/use_cases.py
@@ -41,10 +41,12 @@ if TYPE_CHECKING:  # pragma: no cover — type-only import, avoids any import cy
     from jobhunter.domain.materials.analyze_use_case import AnalyzeJobUseCase
 
 from jobhunter.domain.events import (
+    BulletProvenanceRecordedPayload,
     CoverLetterGeneratedPayload,
     PdfRenderedPayload,
     ResumeApprovedPayload,
     ResumeFailedPayload,
+    create_bullet_provenance_recorded,
     create_cover_letter_generated,
     create_pdf_rendered,
     create_resume_approved,
@@ -66,7 +68,18 @@ from jobhunter.domain.materials.adversarial import (
     should_run_adversarial_review,
 )
 from jobhunter.domain.materials.entities import Artifact
+from jobhunter.domain.materials.fabrication_detector import (
+    FabricationError,
+    build_evidence_corpus,
+    employer_name_set,
+    scan_resume_bullets,
+)
 from jobhunter.domain.materials.policy import TailoringPolicy
+from jobhunter.domain.materials.provenance import BulletProvenanceSet
+from jobhunter.domain.materials.provenance_builder import (
+    ProvenanceBindingError,
+    build_bullet_provenance,
+)
 from jobhunter.domain.materials.quality import (
     TailoringPlan,
     build_tailoring_change_annotations,
@@ -92,6 +105,7 @@ from jobhunter.domain.materials.value_objects import (
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.llm import LlmMessage, LlmPort
 from jobhunter.domain.ports.materials import (
+    BulletProvenanceRepository,
     MaterialsRepository,
     PdfRendererPort,
     TailoringPolicyRepository,
@@ -778,6 +792,7 @@ class TailorResumeUseCase:
         max_retries: int = 3,
         llm_policy: TailoringLlmPolicy | None = None,
         policy_repository: TailoringPolicyRepository | None = None,
+        provenance_repository: BulletProvenanceRepository | None = None,
         analyze_use_case: "AnalyzeJobUseCase | None" = None,
     ) -> None:
         self._repository = repository
@@ -788,6 +803,11 @@ class TailorResumeUseCase:
         self._max_retries = max_retries
         self._llm_policy = llm_policy or TailoringLlmPolicy.from_env()
         self._policy_repository = policy_repository
+        # Phase 2: the canonical per-bullet provenance repository. When injected,
+        # an accepted generation emits one ``BulletProvenance`` row per rendered
+        # bullet (computed vs the generated text), gated by the deterministic
+        # never-fabricate detector, and publishes ``BulletProvenanceRecorded``.
+        self._provenance_repository = provenance_repository
         # D-20: the canonical employer analysis is the front-half sub-step of
         # tailor. When an ``analyze_use_case`` is injected, ``execute`` runs
         # ``_run_analyze`` to produce/reuse it before tailoring; otherwise the
@@ -892,6 +912,24 @@ class TailorResumeUseCase:
         except OSError:
             size_bytes = None
 
+        # Phase 2: compute canonical per-bullet provenance against the GENERATED
+        # text and run the deterministic never-fabricate detector independently of
+        # the prompt. A fabricated metric/title/date/employer token — or a
+        # fabricated evidence/requirement FK — is a HARD reject at generation time:
+        # ``validation`` is downgraded to a failure so the resume is NOT approved
+        # and the last accepted generation's artifact + provenance are preserved.
+        provenance_rows, fabrication_error = self._compute_provenance(
+            profile_snapshot=profile_snapshot,
+            job=job,
+            tailored_payload=parsed_payload,
+            employer_analysis=employer_analysis,
+        )
+        if fabrication_error is not None:
+            validation = ValidationResult.failure(
+                (*validation.errors, fabrication_error),
+                warnings=validation.warnings,
+            )
+
         judge_record = self._judge_record(verdict)
         tailoring_policy = self._resolve_tailoring_policy(
             profile_snapshot=profile_snapshot,
@@ -949,6 +987,18 @@ class TailorResumeUseCase:
         if materials.is_resume_approved and prior_generation is not None:
             self._repository.save(prior_generation)
         self._repository.save(materials)
+
+        # Persist the canonical provenance rows only for an ACCEPTED generation,
+        # transactionally after the artifact is saved (so they share the
+        # generation). A failed re-tailor writes no provenance rows — the prior
+        # accepted generation's rows survive untouched (Anti-Pattern 4 / success
+        # criterion 5).
+        if materials.is_resume_approved and provenance_rows:
+            self._record_provenance(
+                materials=materials,
+                artifact_id=artifact.artifact_id,
+                bullets=provenance_rows,
+            )
 
         status = self._derive_status(report, validation, verdict)
         if materials.is_resume_approved:
@@ -1695,6 +1745,110 @@ class TailorResumeUseCase:
             self._publisher.publish(event)
         except Exception:  # noqa: BLE001
             log.exception("Failed to publish ResumeFailed for %s", materials.job_id)
+
+    # ------------------------------------------------------------------
+    # Phase 2 — per-bullet provenance + deterministic never-fabricate gate
+    # ------------------------------------------------------------------
+
+    def _compute_provenance(
+        self,
+        *,
+        profile_snapshot: ProfileSnapshot,
+        job: dict,
+        tailored_payload: dict,
+        employer_analysis: EmployerAnalysis,
+    ) -> tuple[tuple[Any, ...], str | None]:
+        """Compute per-bullet provenance + run the deterministic fabrication gate.
+
+        Returns ``(provenance_rows, fabrication_error)``. ``fabrication_error`` is
+        a non-empty message when the candidate must be HARD-REJECTED — either it
+        fabricated a numeric/date/title/employer token (CONTROL-03 / GROUND-05) or
+        a provenance binding referenced a non-existent evidence/requirement id
+        (GROUND-05: FK bindings, not free text). On reject the rows are dropped so
+        no provenance is persisted for an unaccepted candidate.
+
+        The detector runs INDEPENDENTLY of the tailoring prompt — it checks the
+        actual generated bullet text against the canonical profile evidence corpus,
+        never the model's self-reported provenance.
+        """
+        profile = profile_snapshot.as_dict()
+        plan = build_tailoring_plan(profile, job, employer_analysis=employer_analysis)
+        try:
+            rows = build_bullet_provenance(
+                profile, job, tailored_payload, plan, employer_analysis
+            )
+        except ProvenanceBindingError as exc:
+            log.warning("Provenance binding rejected for %s: %s", job.get("url"), exc)
+            return (), f"Provenance grounding failed: {exc}"
+
+        corpus = build_evidence_corpus(profile)
+        employers = employer_name_set(profile)
+        findings = scan_resume_bullets(
+            [(row.bullet_id, row.generated_text) for row in rows],
+            corpus,
+            employers=employers,
+        )
+        if findings:
+            try:
+                raise FabricationError(findings)
+            except FabricationError as exc:
+                log.warning("Never-fabricate detector rejected %s: %s", job.get("url"), exc)
+                return (), f"Never-fabricate detector failed: {exc}"
+        return rows, None
+
+    def _record_provenance(
+        self,
+        *,
+        materials: MaterialsSet,
+        artifact_id: str,
+        bullets: tuple[Any, ...],
+    ) -> None:
+        """Persist the accepted generation's provenance rows + publish the event.
+
+        Generation-versioned and bound to the artifact it explains. Persistence
+        and event publication never raise into the tailor flow — a provenance
+        write failure must not undo an accepted resume.
+        """
+        if self._provenance_repository is None:
+            return
+        try:
+            provenance_set = BulletProvenanceSet(
+                tenant_id=materials.tenant_id,
+                job_id=materials.job_id,
+                generation=materials.generation,
+                artifact_id=artifact_id,
+                bullets=tuple(bullets),
+                created_at=materials.updated_at,
+            )
+            self._provenance_repository.save(provenance_set)
+        except Exception:  # noqa: BLE001 — persistence must not break the use case
+            log.exception("Failed to persist bullet provenance for %s", materials.job_id)
+            return
+        self._publish_provenance(materials, artifact_id=artifact_id, bullet_count=len(bullets))
+
+    def _publish_provenance(
+        self,
+        materials: MaterialsSet,
+        *,
+        artifact_id: str,
+        bullet_count: int,
+    ) -> None:
+        if self._publisher is None:
+            return
+        try:
+            event = create_bullet_provenance_recorded(
+                materials.tenant_id,
+                BulletProvenanceRecordedPayload(
+                    job_id=str(materials.job_id),
+                    artifact_id=artifact_id,
+                    generation=materials.generation,
+                    bullet_count=bullet_count,
+                    recorded_at=materials.updated_at,
+                ),
+            )
+            self._publisher.publish(event)
+        except Exception:  # noqa: BLE001 — publishing must not break the use case
+            log.exception("Failed to publish BulletProvenanceRecorded for %s", materials.job_id)
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/src/jobhunter/domain/materials/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/materials/value_objects.py
@@ -84,6 +84,61 @@ class RenderFormat(str, Enum):
     TEXT = "text"
 
 
+class TransformType(str, Enum):
+    """The closed taxonomy of how a tailored bullet relates to its source (GROUND-04).
+
+    Every :class:`~jobhunter.domain.materials.provenance.BulletProvenance` row
+    records exactly one of these. The taxonomy is the user-facing contract — the
+    inspector shows it per bullet — so it is a closed enumeration the read model,
+    projection, and detector all read as the source of truth.
+
+    ``VERBATIM``               — the line is the profile fact unchanged (preserved).
+    ``REPHRASE``               — same fact, reworded for the target (always allowed).
+    ``REFRAME``                — same fact, re-angled to emphasise a job requirement.
+    ``SYNTHESIZE_FROM_RELATED`` — drafted from closely-related profile evidence
+                                  (permitted only under the invent-closely-related
+                                  control; never invents facts wholesale).
+    ``QUANTIFY_FROM_EVIDENCE`` — surfaces a metric that is already recorded in
+                                  profile evidence (NEVER an invented number — the
+                                  deterministic detector enforces this).
+    """
+
+    VERBATIM = "verbatim"
+    REPHRASE = "rephrase"
+    REFRAME = "reframe"
+    SYNTHESIZE_FROM_RELATED = "synthesize_from_related"
+    QUANTIFY_FROM_EVIDENCE = "quantify_from_evidence"
+
+
+class ControlRule(str, Enum):
+    """The granular tailoring rule that GOVERNED one bullet decision (CONTROL-01/02).
+
+    Recorded per bullet so the user can see what policy produced each line. The
+    rules encode the never-fabricate trust floor:
+
+    ``REPHRASE_ALLOWED``        — rewording a real profile fact is always permitted.
+    ``INVENT_CLOSELY_RELATED``  — drafting from closely-related experience is
+                                  permitted (governs ``SYNTHESIZE_FROM_RELATED``);
+                                  only reachable when the active policy allows
+                                  adjacent achievement drafts.
+    ``NEVER_FABRICATE_METRICS`` — metrics must trace to recorded evidence
+                                  (governs ``QUANTIFY_FROM_EVIDENCE``).
+    ``NEVER_FABRICATE_TITLES``  — titles/seniority must trace to the profile.
+    ``NEVER_FABRICATE_DATES``   — dates/durations must trace to the profile.
+    ``NEVER_FABRICATE_EMPLOYERS`` — employers/companies must trace to the profile.
+
+    The ``NEVER_FABRICATE_*`` rules are the ones the deterministic
+    ``fabrication_detector`` enforces independently of the prompt (CONTROL-03).
+    """
+
+    REPHRASE_ALLOWED = "rephrase_allowed"
+    INVENT_CLOSELY_RELATED = "invent_closely_related"
+    NEVER_FABRICATE_METRICS = "never_fabricate_metrics"
+    NEVER_FABRICATE_TITLES = "never_fabricate_titles"
+    NEVER_FABRICATE_DATES = "never_fabricate_dates"
+    NEVER_FABRICATE_EMPLOYERS = "never_fabricate_employers"
+
+
 # ---------------------------------------------------------------------------
 # ValidationResult
 # ---------------------------------------------------------------------------
@@ -400,9 +455,11 @@ class LlmModelSpec:
 __all__ = [
     "ArtifactStatus",
     "ArtifactType",
+    "ControlRule",
     "JudgeVerdict",
     "LlmModelSpec",
     "RenderFormat",
+    "TransformType",
     "ValidationResult",
 ]
 

--- a/workers/automation/src/jobhunter/domain/operations/projections.py
+++ b/workers/automation/src/jobhunter/domain/operations/projections.py
@@ -166,6 +166,13 @@ class ArtifactListProjection:
     created_at: str | None = None
     generation: int | None = None
     metadata_json: str | None = None
+    # Phase 2: the canonical per-bullet provenance read shape (JSON of the
+    # generation's ``BulletProvenanceSet.to_read_model()``), or None when no
+    # provenance was recorded (e.g. PDF artifacts, or a legacy generation tailored
+    # before Phase 2). Built by the single projection owner from canonical rows so
+    # the inspector read path has one source of truth — never derived from
+    # ``metadata_json``.
+    bullet_provenance_json: str | None = None
 
 
 @dataclass(frozen=True)

--- a/workers/automation/src/jobhunter/domain/ports/materials.py
+++ b/workers/automation/src/jobhunter/domain/ports/materials.py
@@ -26,6 +26,7 @@ from jobhunter.domain.materials.analysis import (
 )
 from jobhunter.domain.materials.entities import Artifact
 from jobhunter.domain.materials.policy import TailoringPolicy
+from jobhunter.domain.materials.provenance import BulletProvenanceSet
 from jobhunter.domain.materials.value_objects import (
     ArtifactStatus,
     ArtifactType,
@@ -240,6 +241,31 @@ class EmployerAnalysisRepository(Protocol):
         ...
 
 
+class BulletProvenanceRepository(Protocol):
+    """Persistence port for the :class:`BulletProvenanceSet` (Phase 2).
+
+    Generation-versioned exactly like :class:`MaterialsRepository`: :meth:`save`
+    writes the rows for the set's generation; prior generations are NEVER deleted
+    (Anti-Pattern 4 / success criterion 5), so a failed re-tailor that writes a
+    fresh generation leaves the last accepted generation's provenance intact.
+    :meth:`load` returns the latest generation's rows by default.
+    """
+
+    def load(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+        *,
+        generation: int | None = None,
+    ) -> BulletProvenanceSet | None:
+        """Return the requested provenance set (latest generation by default)."""
+        ...
+
+    def save(self, provenance: BulletProvenanceSet) -> None:
+        """Persist the rows for ``provenance.generation`` (idempotent re-save)."""
+        ...
+
+
 # ---------------------------------------------------------------------------
 # PdfRendererPort
 # ---------------------------------------------------------------------------
@@ -295,6 +321,7 @@ __all__ = [
     "AnalysisSynthesizerPort",
     "ArtifactStatus",
     "ArtifactType",
+    "BulletProvenanceRepository",
     "EmployerAnalysisRepository",
     "MaterialsRepository",
     "PdfRendererPort",
@@ -305,4 +332,4 @@ __all__ = [
 
 # Re-export to silence unused-import warnings for the schema types referenced
 # only in port signatures above.
-_ = (EmployerAnalysis, JobAnalysis, JobAnalysisDraft)
+_ = (EmployerAnalysis, JobAnalysis, JobAnalysisDraft, BulletProvenanceSet)

--- a/workers/automation/src/jobhunter/infrastructure/materials/__init__.py
+++ b/workers/automation/src/jobhunter/infrastructure/materials/__init__.py
@@ -12,6 +12,9 @@ See ddd-target.md §5.5. This package wires the domain ports defined in
 
 from __future__ import annotations
 
+from jobhunter.infrastructure.materials.bullet_provenance_repository import (
+    SqliteBulletProvenanceRepository,
+)
 from jobhunter.infrastructure.materials.employer_analysis_repository import (
     SqliteEmployerAnalysisRepository,
 )
@@ -29,6 +32,7 @@ __all__ = [
     "LatexPdfAdapter",
     "MaterialsGenerationConflict",
     "PlaywrightHtmlPdfAdapter",
+    "SqliteBulletProvenanceRepository",
     "SqliteEmployerAnalysisRepository",
     "SqliteMaterialsRepository",
     "SqliteTailoringPolicyRepository",

--- a/workers/automation/src/jobhunter/infrastructure/materials/bullet_provenance_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/materials/bullet_provenance_repository.py
@@ -1,0 +1,150 @@
+"""SqliteBulletProvenanceRepository — local-mode adapter (Phase 2).
+
+Persists :class:`BulletProvenanceSet` to the canonical ``job_bullet_provenance``
+table created by :func:`database.ensure_bullet_provenance_tables`. Mirrors
+:class:`SqliteEmployerAnalysisRepository`: one connection per adapter, eager
+commit, generation-versioned, supersede-not-destroy semantics (Anti-Pattern 4 /
+success criterion 5).
+
+A re-save of the SAME generation replaces that generation's rows (idempotent
+mid-flow re-save); writing a HIGHER generation leaves prior generations intact as
+audit history — a failed re-tailor never destroys the last accepted generation's
+provenance.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from jobhunter.database import ensure_bullet_provenance_tables
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
+from jobhunter.domain.tenant import TenantId
+
+
+class SqliteBulletProvenanceRepository:
+    """SQLite-backed implementation of ``BulletProvenanceRepository``."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        # Idempotent — safe if init_db already ran; keeps test setup minimal.
+        ensure_bullet_provenance_tables(conn)
+
+    # ------------------------------------------------------------------ read
+
+    def load(
+        self,
+        tenant_id: TenantId,
+        job_id: JobId,
+        *,
+        generation: int | None = None,
+    ) -> BulletProvenanceSet | None:
+        if generation is None:
+            gen_row = self._conn.execute(
+                """
+                SELECT MAX(generation) FROM job_bullet_provenance
+                WHERE job_url = ? AND tenant_id = ?
+                """,
+                (str(job_id), str(tenant_id)),
+            ).fetchone()
+            current = gen_row[0] if gen_row is not None else None
+            if current is None:
+                return None
+            generation = int(current)
+
+        rows = self._conn.execute(
+            """
+            SELECT * FROM job_bullet_provenance
+            WHERE job_url = ? AND tenant_id = ? AND generation = ?
+            ORDER BY position, bullet_id
+            """,
+            (str(job_id), str(tenant_id), int(generation)),
+        ).fetchall()
+        if not rows:
+            return None
+
+        bullets = tuple(self._row_to_bullet(row) for row in rows)
+        first = rows[0]
+        return BulletProvenanceSet(
+            tenant_id=tenant_id,
+            job_id=job_id,
+            generation=int(generation),
+            artifact_id=str(first["artifact_id"]),
+            bullets=bullets,
+            created_at=str(first["created_at"]),
+        )
+
+    # ----------------------------------------------------------------- write
+
+    def save(self, provenance: BulletProvenanceSet) -> None:
+        """Persist the rows for ``provenance.generation`` (idempotent re-save).
+
+        Replaces only THIS generation's rows; prior generations are untouched
+        (supersede-not-destroy). Saving an empty set is a no-op — a failed
+        re-tailor that produced no accepted candidate writes no rows and leaves
+        the last accepted generation intact.
+        """
+        if provenance.is_empty:
+            return
+
+        job_url = str(provenance.job_id)
+        tenant = str(provenance.tenant_id)
+        generation = provenance.generation
+
+        self._conn.execute(
+            "DELETE FROM job_bullet_provenance WHERE job_url = ? AND tenant_id = ? AND generation = ?",
+            (job_url, tenant, generation),
+        )
+        for position, bullet in enumerate(provenance.bullets):
+            self._conn.execute(
+                """
+                INSERT INTO job_bullet_provenance (
+                    job_url, generation, bullet_id, tenant_id, artifact_id,
+                    section, source_id, evidence_ids_json, requirement_ids_json,
+                    matched_keywords_json, transform_type, control, rationale,
+                    generated_text, position, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job_url,
+                    generation,
+                    bullet.bullet_id,
+                    tenant,
+                    provenance.artifact_id,
+                    bullet.section,
+                    bullet.source_id,
+                    json.dumps(list(bullet.evidence_ids), ensure_ascii=False),
+                    json.dumps(list(bullet.requirement_ids), ensure_ascii=False),
+                    json.dumps(list(bullet.matched_keywords), ensure_ascii=False),
+                    bullet.transform_type.value,
+                    bullet.control.value,
+                    bullet.rationale,
+                    bullet.generated_text,
+                    position,
+                    provenance.created_at,
+                ),
+            )
+        self._conn.commit()
+
+    # --------------------------------------------------------------- mapping
+
+    @staticmethod
+    def _row_to_bullet(row: sqlite3.Row) -> BulletProvenance:
+        return BulletProvenance.from_dict(
+            {
+                "bullet_id": row["bullet_id"],
+                "section": row["section"],
+                "source_id": row["source_id"],
+                "evidence_ids": json.loads(row["evidence_ids_json"]),
+                "requirement_ids": json.loads(row["requirement_ids_json"]),
+                "matched_keywords": json.loads(row["matched_keywords_json"]),
+                "transform_type": row["transform_type"],
+                "control": row["control"],
+                "rationale": row["rationale"],
+                "generated_text": row["generated_text"],
+            }
+        )
+
+
+__all__ = ["SqliteBulletProvenanceRepository"]

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -371,6 +371,7 @@ class ProjectionBuilder:
         score = self._load_latest_score(job_url)
         materials = self._load_latest_materials(job_url)
         employer_analysis_json = self._load_employer_analysis(job_url)
+        provenance_by_artifact = self._load_bullet_provenance_by_artifact(job_url)
         enrichment = self._load_enrichment(job_url)
         apply_run = self._load_latest_apply_run(job_url)
         deleted_at = self._load_deleted_at(job_url)
@@ -522,6 +523,7 @@ class ProjectionBuilder:
                 created_at=a.get("created_at"),
                 generation=a.get("generation"),
                 metadata_json=a.get("metadata_json"),
+                bullet_provenance_json=provenance_by_artifact.get(a["artifact_id"]),
             )
             for a in artifacts
         ]
@@ -677,6 +679,30 @@ class ProjectionBuilder:
         if record is None:
             return None
         return json.dumps(record.to_read_model(), ensure_ascii=False)
+
+    def _load_bullet_provenance_by_artifact(self, job_url: str) -> dict[str, str]:
+        """Project the latest per-bullet provenance read shape, keyed by artifact (Phase 2).
+
+        The single owner of the provenance read shape: it loads the latest
+        ``BulletProvenanceSet`` generation from canonical rows and serialises
+        ``to_read_model()`` to JSON, mapped to the ``artifact_id`` it explains so
+        the artifact projection can carry it directly. Returns an empty mapping
+        when no provenance exists (the common case before Phase 2 tailoring, or
+        for PDF artifacts).
+        """
+        from jobhunter.infrastructure.materials.bullet_provenance_repository import (
+            SqliteBulletProvenanceRepository,
+        )
+
+        try:
+            record = SqliteBulletProvenanceRepository(self._conn).load(
+                self._tenant_id, JobId(job_url)
+            )
+        except sqlite3.OperationalError:
+            return {}
+        if record is None or record.is_empty:
+            return {}
+        return {record.artifact_id: json.dumps(record.to_read_model(), ensure_ascii=False)}
 
     def _load_enrichment(self, job_url: str) -> dict:
         try:

--- a/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
@@ -61,6 +61,7 @@ SCORE_EVIDENCE_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("job_detail_projections", "scored_at", "TEXT"),
     ("job_detail_projections", "employer_analysis_json", "TEXT"),
     ("artifact_list_projections", "metadata_json", "TEXT"),
+    ("artifact_list_projections", "bullet_provenance_json", "TEXT"),
 )
 
 
@@ -161,7 +162,8 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             size_bytes             INTEGER,
             created_at             TEXT,
             generation             INTEGER,
-            metadata_json          TEXT
+            metadata_json          TEXT,
+            bullet_provenance_json TEXT
         )
         """
     )
@@ -525,8 +527,8 @@ class SqliteProjectionStore:
             INSERT INTO artifact_list_projections (
                 artifact_id, tenant_id, job_id, job_title, job_employer,
                 artifact_type, status, local_path, size_bytes, created_at,
-                generation, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                generation, metadata_json, bullet_provenance_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(artifact_id) DO UPDATE SET
                 job_id        = excluded.job_id,
                 job_title     = excluded.job_title,
@@ -537,7 +539,8 @@ class SqliteProjectionStore:
                 size_bytes    = excluded.size_bytes,
                 created_at    = excluded.created_at,
                 generation    = excluded.generation,
-                metadata_json = excluded.metadata_json
+                metadata_json = excluded.metadata_json,
+                bullet_provenance_json = excluded.bullet_provenance_json
             """,
             (
                 projection.artifact_id,
@@ -552,6 +555,7 @@ class SqliteProjectionStore:
                 projection.created_at,
                 projection.generation,
                 projection.metadata_json,
+                projection.bullet_provenance_json,
             ),
         )
 

--- a/workers/automation/src/jobhunter/scoring/tailor.py
+++ b/workers/automation/src/jobhunter/scoring/tailor.py
@@ -46,6 +46,7 @@ from jobhunter.domain.materials.use_cases import (
 from jobhunter.domain.ports.events import EventPublisher
 from jobhunter.domain.ports.llm import LlmPort
 from jobhunter.domain.ports.materials import (
+    BulletProvenanceRepository,
     MaterialsRepository,
     PdfRendererPort,
     TailoringPolicyRepository,
@@ -55,6 +56,7 @@ from jobhunter.domain.tenant import LOCAL_TENANT, TenantId
 from jobhunter.infrastructure.llm import get_llm_adapter
 from jobhunter.infrastructure.materials import (
     LatexPdfAdapter,
+    SqliteBulletProvenanceRepository,
     SqliteMaterialsRepository,
     SqliteTailoringPolicyRepository,
 )
@@ -191,6 +193,7 @@ def _build_use_case(
     assembler: ResumeAssembler | None = None,
     llm_policy: TailoringLlmPolicy | None = None,
     policy_repository: TailoringPolicyRepository | None = None,
+    provenance_repository: BulletProvenanceRepository | None = None,
     analyze_use_case=None,
 ) -> TailorResumeUseCase:
     """Construct a :class:`TailorResumeUseCase` using local-mode defaults."""
@@ -199,6 +202,8 @@ def _build_use_case(
         repository = SqliteMaterialsRepository(conn)
     if policy_repository is None:
         policy_repository = SqliteTailoringPolicyRepository(conn)
+    if provenance_repository is None:
+        provenance_repository = SqliteBulletProvenanceRepository(conn)
     if llm_port is None:
         llm_port = get_llm_adapter()
     if validator is None:
@@ -217,6 +222,7 @@ def _build_use_case(
         publisher=publisher,
         llm_policy=llm_policy,
         policy_repository=policy_repository,
+        provenance_repository=provenance_repository,
         analyze_use_case=analyze_use_case,
     )
 

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -39,6 +39,7 @@ from jobhunter.domain.materials.provenance_builder import (
     build_bullet_provenance,
 )
 from jobhunter.domain.materials.quality import build_tailoring_plan
+from jobhunter.domain.materials.services import ResumeAssembler
 from jobhunter.domain.materials.value_objects import ControlRule, TransformType
 from jobhunter.infrastructure.materials.bullet_provenance_repository import (
     SqliteBulletProvenanceRepository,
@@ -247,6 +248,73 @@ def test_provenance_has_one_row_per_rendered_bullet_with_closed_taxonomy() -> No
     assert experience.bullet_id == "experience:acme_swe#0"
 
 
+def _assembled_summary_line(profile: dict, payload: dict) -> str:
+    """The exact summary line the assembler ships (line after EXECUTIVE PROFILE)."""
+    text = ResumeAssembler().assemble_resume_text(payload, profile)
+    lines = text.splitlines()
+    idx = lines.index("EXECUTIVE PROFILE")
+    return lines[idx + 1].strip()
+
+
+def test_executive_provenance_anchors_to_shipped_summary_when_rewrite_disabled() -> None:
+    """Regression (Pattern 2 / GROUND-06): with ``allow_summary_rewrite`` off the
+    resume ships the profile baseline, so the executive-profile provenance
+    ``generated_text`` MUST equal the assembled summary line — not the model's
+    proposed (never-rendered) rewrite. Without the policy gate the provenance
+    anchor and the deterministic detector scan text the user never received."""
+    profile = _profile()
+    profile["resume"]["tailoring_rules"]["tailoring_policy"]["allow_summary_rewrite"] = False
+    # The model proposes a rewrite the resume will NOT ship under this policy.
+    proposed = "Backend engineer who delivered 99.99% uptime."
+    payload = _payload(
+        bullets=["Reduced API latency 35% by replacing synchronous calls."],
+        summary=proposed,
+    )
+
+    shipped_summary = _assembled_summary_line(profile, payload)
+    # Sanity: the assembler ships the baseline, not the proposed rewrite.
+    assert shipped_summary == "Senior backend engineer."
+    assert shipped_summary != proposed
+
+    rows = _build(profile, payload, _analysis())
+    executive = next(row for row in rows if row.section == "executive_profile")
+    # Provenance is anchored to the SHIPPED line (byte-identical), never the rewrite.
+    assert executive.generated_text == shipped_summary
+    assert executive.generated_text != proposed
+    # Baseline == shipped -> the transform is VERBATIM, not a phantom REFRAME.
+    assert executive.transform_type is TransformType.VERBATIM
+
+    # And the deterministic detector now scans the SHIPPED text: the rewrite's
+    # "99.99%" (absent from the profile) must NOT appear in any scanned bullet,
+    # so a clean baseline resume is not falsely rejected for the dropped rewrite.
+    corpus = build_evidence_corpus(profile)
+    findings = scan_resume_bullets(
+        [(row.bullet_id, row.generated_text) for row in rows],
+        corpus,
+        employers=employer_name_set(profile),
+    )
+    assert all("99.99" not in f.generated_text for f in findings)
+
+
+def test_executive_provenance_anchors_to_rewrite_when_rewrite_enabled() -> None:
+    """The complementary arm: with rewrite ON the shipped summary is the model's
+    summary, and provenance anchors to it (still equal to the assembled line)."""
+    profile = _profile()
+    profile["resume"]["tailoring_rules"]["tailoring_policy"]["allow_summary_rewrite"] = True
+    proposed = "Senior backend engineer who owns Python latency."
+    payload = _payload(
+        bullets=["Reduced API latency 35% by replacing synchronous calls."],
+        summary=proposed,
+    )
+
+    shipped_summary = _assembled_summary_line(profile, payload)
+    assert shipped_summary == proposed
+
+    rows = _build(profile, payload, _analysis())
+    executive = next(row for row in rows if row.section == "executive_profile")
+    assert executive.generated_text == shipped_summary
+
+
 def test_matched_keywords_and_requirement_ids_bind_to_analysis() -> None:
     rows = _build(
         _profile(),
@@ -361,6 +429,61 @@ def test_detector_flags_invented_metric() -> None:
     assert all(f.control is ControlRule.NEVER_FABRICATE_METRICS for f in findings if f.kind == "numeric")
 
 
+def test_detector_flags_digit_colliding_fabrication_with_different_unit() -> None:
+    """Regression (Pitfall 3 / criterion 4): a fabricated number that merely shares
+    a digit run with an unrelated profile number — but has a different unit or
+    magnitude — must be flagged. The profile's only number is ``35%``; a bullet
+    claiming ``$35M`` or ``35 million`` reuses the digits ``35`` yet states a
+    different KIND/magnitude, so digit-run membership would wrongly ground it."""
+    profile = _profile()  # only number anywhere is "35% latency reduction"
+    corpus = build_evidence_corpus(profile)
+    employers = employer_name_set(profile)
+
+    # Currency fabrication: $35M is money, the profile's 35 is a percentage.
+    money = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Drove $35M in revenue.",
+        corpus,
+        employers=employers,
+    )
+    assert any(f.kind == "numeric" and "$35" in f.token.lower() for f in money), money
+
+    # Magnitude fabrication: "35 million" is a bare magnitude, not 35%.
+    magnitude = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Scaled to 35 million users.",
+        corpus,
+        employers=employers,
+    )
+    assert any(f.kind == "numeric" for f in magnitude), magnitude
+
+    # Control: the real, same-kind number (35%) still grounds cleanly.
+    clean = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Reduced API latency 35% by replacing synchronous calls.",
+        corpus,
+        employers=employers,
+    )
+    assert [f for f in clean if f.kind == "numeric"] == []
+
+
+def test_detector_grounds_equivalent_money_renderings() -> None:
+    """The tightened numeric key must NOT over-flag: equivalent renderings of the
+    same recorded quantity (``$1.2M`` / ``$1.2 million`` / ``$1,200,000``) collapse
+    to one key, so a bullet rendering differs only in format is still grounded."""
+    profile = _profile()
+    profile["resume_constraints"] = {"real_metrics": ["$1.2M ARR"]}
+    corpus = build_evidence_corpus(profile)
+    for rendering in ("$1.2M", "$1.2 million", "$1,200,000"):
+        findings = find_fabricated_tokens(
+            "experience:acme_swe#0",
+            f"Grew the book of business to {rendering}.",
+            corpus,
+            employers=employer_name_set(profile),
+        )
+        assert [f for f in findings if f.kind == "numeric"] == [], (rendering, findings)
+
+
 def test_metrics_hungry_job_with_numberless_profile_yields_zero_unsourced_numerics() -> None:
     """Success criterion 4: a metrics-hungry job + a numberless profile must not
     let any unsourced numeric survive into the resume."""
@@ -404,6 +527,40 @@ def test_detector_flags_fabricated_title_and_employer() -> None:
     kinds = {f.kind for f in findings}
     assert "title" in kinds  # "Chief"/"CTO"-class token absent from profile
     assert "employer" in kinds  # "Globex Corporation" is not a real employer
+
+
+def test_detector_defers_bare_name_employer_to_judge() -> None:
+    """Pins the INTENTIONAL suffix-anchored employer limitation (precision-over-
+    recall by design): a suffixed fabricated employer ("Globex Corporation") is
+    flagged deterministically, but a bare-name fabricated employer ("at Netflix")
+    is deliberately NOT flagged at this layer — it is deferred to the prose-aware
+    LLM judge. The structured employer field is code-injected from the master
+    resume, so it cannot be fabricated through this path; flagging every bare
+    capitalised token would over-flag tools/products ("Python", "Docker")."""
+    profile = _profile()  # real employer: Acme Corp
+    corpus = build_evidence_corpus(profile)
+    employers = employer_name_set(profile)
+
+    # Suffixed fabricated employer: flagged here.
+    suffixed = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Led platform work at Globex Corporation.",
+        corpus,
+        employers=employers,
+    )
+    assert any(f.kind == "employer" for f in suffixed)
+
+    # Bare-name fabricated employer: deliberately NOT flagged at this layer
+    # (covered by the judge). "netflix" is also absent from the title/numeric/date
+    # arms, so the whole bullet passes the deterministic detector.
+    bare = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Owned the API at Netflix.",
+        corpus,
+        employers=employers,
+    )
+    assert [f for f in bare if f.kind == "employer"] == []
+    assert bare == []
 
 
 def test_detector_flags_fabricated_date() -> None:

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -1,0 +1,513 @@
+"""Phase 2: per-bullet provenance + the deterministic never-fabricate detector.
+
+Covers the Phase-2 success criteria as pure domain tests (no LLM/SDK calls):
+
+  * fabricated evidence/requirement-ID reject (GROUND-05, success criterion 2)
+  * never-fabricate detector — a metrics-hungry job + a numberless profile yields
+    zero unsourced numerics (CONTROL-03 / success criterion 4)
+  * per-bullet provenance shape + closed transform taxonomy (GROUND-03/04)
+  * the governing control rule is recorded per bullet (CONTROL-02 / criterion 3)
+  * generation-versioning round-trip + supersede-not-destroy (criterion 5)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+
+import pytest
+
+from jobhunter.database import close_connection, init_db
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.materials.analysis import (
+    AnalysisAgreement,
+    EmployerAnalysis,
+    JobAnalysis,
+    ReasonedKeyword,
+    Requirement,
+    compute_snapshot_hash,
+)
+from jobhunter.domain.materials.fabrication_detector import (
+    build_evidence_corpus,
+    employer_name_set,
+    find_fabricated_tokens,
+    scan_resume_bullets,
+)
+from jobhunter.domain.materials.provenance import BulletProvenance, BulletProvenanceSet
+from jobhunter.domain.materials.provenance_builder import (
+    ProvenanceBindingError,
+    build_bullet_provenance,
+)
+from jobhunter.domain.materials.quality import build_tailoring_plan
+from jobhunter.domain.materials.value_objects import ControlRule, TransformType
+from jobhunter.infrastructure.materials.bullet_provenance_repository import (
+    SqliteBulletProvenanceRepository,
+)
+from jobhunter.domain.tenant import LOCAL_TENANT
+
+JOB_URL = "https://example.com/senior-backend"
+
+
+# --------------------------------------------------------------------------
+# Fixtures (mirror test_materials_quality conventions)
+# --------------------------------------------------------------------------
+
+
+def _analysis(
+    *,
+    requirements: list[Requirement] | None = None,
+    keywords: list[ReasonedKeyword] | None = None,
+) -> EmployerAnalysis:
+    canonical = JobAnalysis(
+        role_framing="Own backend latency.",
+        inferred_seniority="senior",
+        ideal_candidate_narrative="A hands-on backend owner.",
+        requirements=requirements
+        or [
+            Requirement(
+                id="req_python",
+                text="5+ years of Python",
+                tier="must_have",
+                weight=0.9,
+                evidence_span="5+ years of Python",
+            ),
+            Requirement(
+                id="req_latency",
+                text="improve API latency",
+                tier="nice_to_have",
+                weight=0.5,
+                evidence_span="improve API latency",
+            ),
+        ],
+        keywords=keywords
+        or [
+            ReasonedKeyword(
+                keyword="Python",
+                evidence_span="5+ years of Python",
+                requirement_ref="req_python",
+            ),
+            ReasonedKeyword(
+                keyword="latency",
+                evidence_span="improve API latency",
+                requirement_ref="req_latency",
+            ),
+        ],
+    )
+    return EmployerAnalysis.build(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(JOB_URL),
+        generation=1,
+        snapshot_hash=compute_snapshot_hash("jd"),
+        canonical=canonical,
+        sub_analyses=(),
+        failures=(),
+        agreement=AnalysisAgreement(score=1.0),
+        legs_attempted=1,
+    )
+
+
+def _profile() -> dict:
+    return {
+        "personal": {"full_name": "Jane Doe", "email": "jane@example.com"},
+        "resume_constraints": {"real_metrics": ["35% latency reduction"]},
+        "resume": {
+            "executive_profile": {"baseline_text": "Senior backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "acme_swe",
+                    "date_range": "2020-Present",
+                    "title": "Senior SWE",
+                    "company": "Acme Corp",
+                    "location": "Remote",
+                    "bullets": ["Reduced API latency 35% by replacing synchronous calls."],
+                    "achievement_evidence": [
+                        {
+                            "id": "ev_latency",
+                            "source_text": (
+                                "Reduced API latency 35% by replacing synchronous "
+                                "enrichment calls."
+                            ),
+                            "scope": "owned service",
+                            "action": "replaced synchronous enrichment calls",
+                            "tools": ["Python", "PostgreSQL"],
+                            "metrics": ["35% latency reduction"],
+                            "outcome": "faster API responses",
+                            "seniority_signal": "technical ownership",
+                            "evidence_strength": "verified",
+                            "claim_confidence": 0.95,
+                            "user_confirmed": True,
+                            "tags": ["latency", "backend", "performance"],
+                        }
+                    ],
+                }
+            ],
+            "education_entries": [
+                {"id": "edu_state", "degree": "BSc CS", "institution": "State University", "date": "2015"}
+            ],
+            "skill_categories": [{"id": "languages", "label": "Languages", "items": ["Python", "Go"]}],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["acme_swe"],
+                "required_skill_category_ids": ["languages"],
+                "max_experience_bullets": 4,
+                "tailoring_policy": {
+                    "claim_mode": "evidence_reframing",
+                    "auto_approvable_claim_modes": ["verified_only", "evidence_reframing"],
+                },
+                "writing_style": {"tone": "direct", "bullet_style": "leadership"},
+            },
+        },
+    }
+
+
+def _numberless_profile() -> dict:
+    """A profile whose experience carries NO numerics/metrics at all."""
+    return {
+        "personal": {"full_name": "Sam Lee", "email": "sam@example.com"},
+        "resume_constraints": {"real_metrics": []},
+        "resume": {
+            "executive_profile": {"baseline_text": "Backend engineer."},
+            "experience_entries": [
+                {
+                    "id": "acme_swe",
+                    "date_range": "recent",
+                    "title": "Engineer",
+                    "company": "Acme Corp",
+                    "location": "Remote",
+                    "bullets": ["Improved API responsiveness by removing synchronous calls."],
+                    "achievement_evidence": [
+                        {
+                            "id": "ev_api",
+                            "source_text": "Improved API responsiveness by removing synchronous calls.",
+                            "scope": "owned service",
+                            "action": "removed synchronous calls",
+                            "tools": ["Python"],
+                            "metrics": [],
+                            "outcome": "faster responses",
+                            "tags": ["latency", "backend"],
+                        }
+                    ],
+                }
+            ],
+            "education_entries": [],
+            "skill_categories": [{"id": "languages", "label": "Languages", "items": ["Python"]}],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["acme_swe"],
+                "required_skill_category_ids": ["languages"],
+                "max_experience_bullets": 4,
+                "tailoring_policy": {"claim_mode": "verified_only"},
+            },
+        },
+    }
+
+
+def _job() -> dict:
+    return {
+        "url": JOB_URL,
+        "title": "Senior Backend Engineer",
+        "full_description": "Own Python backend services and improve API latency.",
+    }
+
+
+def _payload(*, bullets: list[str], summary: str = "Senior backend engineer.") -> dict:
+    return {
+        "executive_profile": summary,
+        "experience_updates": [{"id": "acme_swe", "title": "", "bullets": bullets}],
+        "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
+    }
+
+
+def _build(profile: dict, payload: dict, analysis: EmployerAnalysis) -> tuple[BulletProvenance, ...]:
+    plan = build_tailoring_plan(profile, _job(), employer_analysis=analysis)
+    return build_bullet_provenance(profile, _job(), payload, plan, analysis)
+
+
+# --------------------------------------------------------------------------
+# Per-bullet shape + transform taxonomy (GROUND-03/04)
+# --------------------------------------------------------------------------
+
+
+def test_provenance_has_one_row_per_rendered_bullet_with_closed_taxonomy() -> None:
+    rows = _build(
+        _profile(),
+        _payload(bullets=["Reduced API latency 35% by replacing synchronous calls."]),
+        _analysis(),
+    )
+    sections = {row.section for row in rows}
+    assert sections == {"executive_profile", "experience", "skills"}
+    # Every transform_type is a member of the closed taxonomy (GROUND-04).
+    for row in rows:
+        assert isinstance(row.transform_type, TransformType)
+        assert isinstance(row.control, ControlRule)
+        assert row.generated_text.strip()  # coverage anchor is the rendered text
+
+    experience = next(row for row in rows if row.section == "experience")
+    # Bullet equals the source profile bullet verbatim -> VERBATIM transform.
+    assert experience.transform_type is TransformType.VERBATIM
+    assert experience.source_id == "acme_swe"
+    assert experience.bullet_id == "experience:acme_swe#0"
+
+
+def test_matched_keywords_and_requirement_ids_bind_to_analysis() -> None:
+    rows = _build(
+        _profile(),
+        _payload(bullets=["Reduced API latency 35% by replacing synchronous Python calls."]),
+        _analysis(),
+    )
+    experience = next(row for row in rows if row.section == "experience")
+    # "latency" + "python" appear in the generated bullet -> their requirements served.
+    assert "latency" in experience.matched_keywords
+    assert "req_latency" in experience.requirement_ids
+    # requirement_ids are real FK ids from the analysis.
+    valid_ids = {req.id for req in _analysis().canonical.requirements}
+    assert set(experience.requirement_ids).issubset(valid_ids)
+
+
+def test_quantify_from_evidence_transform_when_metric_introduced() -> None:
+    # Source bullet has no metric; tailored bullet surfaces a verified metric.
+    profile = _profile()
+    profile["resume"]["experience_entries"][0]["bullets"] = [
+        "Replaced synchronous enrichment calls."
+    ]
+    rows = _build(
+        profile,
+        _payload(bullets=["Replaced synchronous calls, cutting 35% latency reduction."]),
+        _analysis(),
+    )
+    experience = next(row for row in rows if row.section == "experience")
+    assert experience.transform_type is TransformType.QUANTIFY_FROM_EVIDENCE
+    assert experience.control is ControlRule.NEVER_FABRICATE_METRICS
+
+
+def test_control_recorded_per_bullet_reflects_governing_rule() -> None:
+    rows = _build(
+        _profile(),
+        _payload(bullets=["Reduced API latency 35% by replacing synchronous calls."]),
+        _analysis(),
+    )
+    # A rephrase/verbatim of a real fact is governed by the always-allowed rule.
+    experience = next(row for row in rows if row.section == "experience")
+    assert experience.control is ControlRule.REPHRASE_ALLOWED
+
+
+# --------------------------------------------------------------------------
+# Fabricated FK reject (GROUND-05, success criterion 2)
+# --------------------------------------------------------------------------
+
+
+def test_fabricated_requirement_id_is_rejected_before_any_row_is_built() -> None:
+    # A BulletProvenance constructed with a requirement id NOT in the analysis
+    # must be rejected by the builder's FK validation. We simulate by validating
+    # directly: the builder only ever emits ids it resolved, so we assert the
+    # guard rejects an injected fabricated id.
+    from jobhunter.domain.materials.provenance_builder import (
+        _sources,
+        _validated_requirement_ids,
+    )
+
+    analysis = _analysis()
+    plan = build_tailoring_plan(_profile(), _job(), employer_analysis=analysis)
+    sources = _sources(plan, analysis)
+    with pytest.raises(ProvenanceBindingError) as excinfo:
+        _validated_requirement_ids(("req_python", "req_FABRICATED"), sources)
+    assert "req_FABRICATED" in str(excinfo.value)
+    assert excinfo.value.kind == "requirement"
+
+
+def test_fabricated_evidence_id_is_rejected() -> None:
+    from jobhunter.domain.materials.provenance_builder import (
+        _sources,
+        _validated_evidence_ids,
+    )
+
+    analysis = _analysis()
+    plan = build_tailoring_plan(_profile(), _job(), employer_analysis=analysis)
+    sources = _sources(plan, analysis)
+    with pytest.raises(ProvenanceBindingError) as excinfo:
+        _validated_evidence_ids(("ev_latency", "ev_FAKE"), sources)
+    assert "ev_FAKE" in str(excinfo.value)
+    assert excinfo.value.kind == "evidence"
+
+
+# --------------------------------------------------------------------------
+# Deterministic never-fabricate detector (CONTROL-03 / success criterion 4)
+# --------------------------------------------------------------------------
+
+
+def test_detector_passes_when_every_numeric_traces_to_evidence() -> None:
+    profile = _profile()
+    corpus = build_evidence_corpus(profile)
+    # "35%" is recorded in the profile evidence -> grounded.
+    findings = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Reduced API latency 35% by replacing synchronous calls.",
+        corpus,
+        employers=employer_name_set(profile),
+    )
+    assert findings == []
+
+
+def test_detector_flags_invented_metric() -> None:
+    profile = _profile()
+    corpus = build_evidence_corpus(profile)
+    # "10x" and "$2M" appear nowhere in the profile evidence -> fabricated.
+    findings = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Drove a 10x throughput gain and $2M in savings.",
+        corpus,
+        employers=employer_name_set(profile),
+    )
+    kinds = {f.kind for f in findings}
+    assert "numeric" in kinds
+    assert all(f.control is ControlRule.NEVER_FABRICATE_METRICS for f in findings if f.kind == "numeric")
+
+
+def test_metrics_hungry_job_with_numberless_profile_yields_zero_unsourced_numerics() -> None:
+    """Success criterion 4: a metrics-hungry job + a numberless profile must not
+    let any unsourced numeric survive into the resume."""
+    profile = _numberless_profile()
+    analysis = _analysis()
+    corpus = build_evidence_corpus(profile)
+    employers = employer_name_set(profile)
+
+    # The model (under a metrics-hungry job) tries to inject metrics the profile
+    # never stated. The detector must flag every one.
+    greedy_payload = _payload(
+        bullets=[
+            "Improved API responsiveness by removing synchronous calls, cutting latency 40%.",
+            "Scaled the platform to 5 million requests per day across 12 services.",
+        ],
+        summary="Backend engineer who delivered 99.99% uptime.",
+    )
+    plan = build_tailoring_plan(profile, _job(), employer_analysis=analysis)
+    rows = build_bullet_provenance(profile, _job(), greedy_payload, plan, analysis)
+    findings = scan_resume_bullets(
+        [(row.bullet_id, row.generated_text) for row in rows], corpus, employers=employers
+    )
+    fabricated_numerics = [f.token for f in findings if f.kind == "numeric"]
+    # Every injected number (40%, 5 million, 12, 99.99%) is unsourced and flagged.
+    assert fabricated_numerics, "detector must flag the injected numerics"
+    # And NONE of them trace to the (numberless) profile evidence corpus.
+    for token in fabricated_numerics:
+        assert token.lower() not in corpus.text
+
+
+def test_detector_flags_fabricated_title_and_employer() -> None:
+    profile = _profile()  # real title: Senior SWE; real employer: Acme Corp
+    corpus = build_evidence_corpus(profile)
+    employers = employer_name_set(profile)
+    findings = find_fabricated_tokens(
+        "executive_profile#0",
+        "Chief Technology Officer at Globex Corporation.",
+        corpus,
+        employers=employers,
+    )
+    kinds = {f.kind for f in findings}
+    assert "title" in kinds  # "Chief"/"CTO"-class token absent from profile
+    assert "employer" in kinds  # "Globex Corporation" is not a real employer
+
+
+def test_detector_flags_fabricated_date() -> None:
+    profile = _profile()  # profile dates: 2020-Present, 2015
+    corpus = build_evidence_corpus(profile)
+    findings = find_fabricated_tokens(
+        "experience:acme_swe#0",
+        "Led the platform rebuild in 1998.",
+        corpus,
+    )
+    assert any(f.kind == "date" and f.control is ControlRule.NEVER_FABRICATE_DATES for f in findings)
+
+
+# --------------------------------------------------------------------------
+# Persistence: generation-versioning + supersede-not-destroy (criterion 5)
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def conn(tmp_path) -> Iterator[sqlite3.Connection]:
+    """A real tmp-file DB with the canonical schema (avoids the shared
+    ``:memory:`` singleton that ``get_connection`` returns)."""
+    connection = init_db(tmp_path / "jobs.db")
+    connection.execute(
+        "INSERT INTO jobs (url, title, site) VALUES (?, ?, ?)",
+        (JOB_URL, "Senior Backend Engineer", "example"),
+    )
+    connection.commit()
+    yield connection
+    close_connection()
+
+
+def _seed_materials_generation(connection: sqlite3.Connection, generation: int, *, ts: str) -> None:
+    """Insert the ``job_materials`` FK parent row for a generation."""
+    connection.execute(
+        "INSERT INTO job_materials (job_url, generation, tenant_id, status, created_at, updated_at) "
+        "VALUES (?, ?, 'local', 'complete', ?, ?)",
+        (JOB_URL, generation, ts, ts),
+    )
+    connection.commit()
+
+
+def _provenance_set(generation: int, *, artifact_id: str, text: str) -> BulletProvenanceSet:
+    return BulletProvenanceSet(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(JOB_URL),
+        generation=generation,
+        artifact_id=artifact_id,
+        bullets=(
+            BulletProvenance(
+                bullet_id="experience:acme_swe#0",
+                section="experience",
+                source_id="acme_swe",
+                evidence_ids=("ev_latency",),
+                requirement_ids=("req_latency",),
+                matched_keywords=("latency",),
+                transform_type=TransformType.REPHRASE,
+                control=ControlRule.REPHRASE_ALLOWED,
+                rationale="reworded a real profile bullet",
+                generated_text=text,
+            ),
+        ),
+    )
+
+
+def test_repository_round_trip_preserves_canonical_fields(conn: sqlite3.Connection) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    repo = SqliteBulletProvenanceRepository(conn)
+    repo.save(_provenance_set(1, artifact_id="art-1", text="Reduced API latency 35%."))
+
+    loaded = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    assert loaded is not None
+    assert loaded.generation == 1
+    assert loaded.artifact_id == "art-1"
+    assert loaded.bullets[0].transform_type is TransformType.REPHRASE
+    assert loaded.bullets[0].requirement_ids == ("req_latency",)
+    assert loaded.to_read_model()[0]["matched_keywords"] == ["latency"]
+
+
+def test_failed_retailor_never_destroys_last_accepted_generation(conn: sqlite3.Connection) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    _seed_materials_generation(conn, 2, ts="2026-06-08T13:00:00Z")
+    repo = SqliteBulletProvenanceRepository(conn)
+    repo.save(_provenance_set(1, artifact_id="art-gen1", text="Gen 1 bullet."))
+    repo.save(_provenance_set(2, artifact_id="art-gen2", text="Gen 2 bullet."))
+
+    # The latest generation is served by default...
+    latest = repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    assert latest is not None and latest.generation == 2 and latest.artifact_id == "art-gen2"
+    # ...and generation 1's provenance is retained as audit history (not destroyed).
+    historical = repo.load(LOCAL_TENANT, JobId(JOB_URL), generation=1)
+    assert historical is not None
+    assert historical.bullets[0].generated_text == "Gen 1 bullet."
+
+
+def test_saving_empty_provenance_set_is_a_noop(conn: sqlite3.Connection) -> None:
+    _seed_materials_generation(conn, 1, ts="2026-06-08T12:00:00Z")
+    repo = SqliteBulletProvenanceRepository(conn)
+    empty = BulletProvenanceSet(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId(JOB_URL),
+        generation=1,
+        artifact_id="art-empty",
+        bullets=(),
+    )
+    repo.save(empty)
+    assert repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None

--- a/workers/automation/tests/test_bullet_provenance.py
+++ b/workers/automation/tests/test_bullet_provenance.py
@@ -315,6 +315,56 @@ def test_executive_provenance_anchors_to_rewrite_when_rewrite_enabled() -> None:
     assert executive.generated_text == shipped_summary
 
 
+def _assembled_section_line(profile: dict, payload: dict, *, prefix: str) -> str:
+    """Return the first assembled line beginning with ``prefix`` (e.g. ``"- "``)."""
+    text = ResumeAssembler().assemble_resume_text(payload, profile)
+    line = next(line for line in text.splitlines() if line.startswith(prefix))
+    return line.removeprefix(prefix).strip()
+
+
+def test_provenance_generated_text_is_byte_identical_to_sanitized_shipped_line() -> None:
+    """Regression (Finding 3 / Pattern 2 / GROUND-06): the assembler runs
+    ``sanitize_text`` on every rendered line — rewriting curly quotes and smart
+    punctuation to ASCII — but the provenance builder previously normalised only
+    whitespace, so a bullet with a curly apostrophe shipped as ``team's`` while its
+    provenance ``generated_text`` kept the curly ``team’s``. The coverage anchor (and
+    the deterministic detector that scans it) then saw text the user never received.
+    Provenance ``generated_text`` MUST now byte-match the assembled shipped line."""
+    profile = _profile()
+    profile["resume"]["tailoring_rules"]["tailoring_policy"]["allow_summary_rewrite"] = True
+    # Curly apostrophe + curly double quotes in the summary; curly apostrophe +
+    # em dash in the bullet; curly apostrophe in a skill item.
+    curly_summary = "Senior engineer who led the company’s “core” platform."
+    curly_bullet = "Owned the team’s API roadmap — reduced API latency 35%."
+    payload = _payload(bullets=[curly_bullet], summary=curly_summary)
+    payload["skill_category_updates"] = [{"id": "languages", "items": ["C’s", "Python"]}]
+
+    rows = _build(profile, payload, _analysis())
+
+    summary_row = next(r for r in rows if r.section == "executive_profile")
+    assert summary_row.generated_text == _assembled_summary_line(profile, payload)
+    # The smart punctuation was rewritten exactly as the assembler ships it.
+    assert summary_row.generated_text == 'Senior engineer who led the company\'s "core" platform.'
+
+    experience_row = next(r for r in rows if r.section == "experience")
+    assert experience_row.generated_text == _assembled_section_line(profile, payload, prefix="- ")
+    assert experience_row.generated_text == "Owned the team's API roadmap, reduced API latency 35%."
+
+    # Skills: the provenance row holds the whole "Label: items" line; compare to the
+    # full assembled SKILLS line (no prefix stripped).
+    assembled = ResumeAssembler().assemble_resume_text(payload, profile).splitlines()
+    shipped_skills = next(line for line in assembled if line.startswith("Languages:"))
+    skills_row = next(r for r in rows if r.section == "skills")
+    assert skills_row.generated_text == shipped_skills
+    assert skills_row.generated_text == "Languages: C's, Python"
+
+    # And no smart punctuation survives into ANY provenance row (the detector now
+    # scans the sanitised shipped text, never the model's pre-sanitised draft).
+    import re as _re
+
+    assert all(not _re.search(r"[‘’“”—–]", r.generated_text) for r in rows)
+
+
 def test_matched_keywords_and_requirement_ids_bind_to_analysis() -> None:
     rows = _build(
         _profile(),
@@ -482,6 +532,58 @@ def test_detector_grounds_equivalent_money_renderings() -> None:
             employers=employer_name_set(profile),
         )
         assert [f for f in findings if f.kind == "numeric"] == [], (rendering, findings)
+
+
+@pytest.mark.parametrize(
+    ("bullet", "needle"),
+    [
+        ("Scaled the platform to 10M users.", "10m"),
+        ("Cut infra cost by 5K monthly.", "5k"),
+        ("Grew the user base to 2B accounts.", "2b"),
+        ("Onboarded 100K accounts in a quarter.", "100k"),
+        ("Drove 3.5M ARR in new revenue.", "3.5m"),
+        ("Scaled to 35 million users.", "35 million"),
+    ],
+)
+def test_detector_flags_suffixed_bare_magnitude_against_numberless_profile(
+    bullet: str, needle: str
+) -> None:
+    """Regression (criterion 4 / CONTROL-03): a bare magnitude with a suffix and NO
+    leading ``$`` (``10M`` / ``5K`` / ``2B`` / ``100K`` / ``3.5M`` / ``35 million``)
+    is a numeric the model invented. Before the fix the trailing ``\\b`` of the
+    bare-number branch failed between the digit and the suffix letter, so these were
+    NOT extracted at all and an unsourced metric sailed past the deterministic gate
+    against a numberless profile. Each must now be flagged."""
+    profile = _numberless_profile()  # the profile carries NO numerics at all
+    corpus = build_evidence_corpus(profile)
+    findings = find_fabricated_tokens(
+        "experience:acme_swe#0", bullet, corpus, employers=employer_name_set(profile)
+    )
+    numeric = [f for f in findings if f.kind == "numeric"]
+    assert numeric, (bullet, findings)
+    assert all(f.control is ControlRule.NEVER_FABRICATE_METRICS for f in numeric)
+    # The flagged token carries the magnitude suffix (proves the suffix was
+    # consumed WITH the digits, not dropped as a bare integer).
+    assert any(needle in f.token.lower() for f in numeric), (needle, [f.token for f in numeric])
+
+
+def test_detector_does_not_eat_kmb_initial_word_after_grounded_money() -> None:
+    """Regression (Finding 2): a grounded money figure followed by a word that
+    starts with k/m/b (``$1,200,000 budget``) must stay grounded. Before the fix
+    the money branch's optional space + single-letter suffix ate the ``b`` of
+    ``budget`` into the token, minting a phantom ``money:1.2e15`` and hard-rejecting
+    a real figure. The single-letter magnitude suffix is now adjacency-only."""
+    profile = _profile()
+    profile["resume_constraints"] = {"real_metrics": ["$1.2M budget", "$5K monthly"]}
+    corpus = build_evidence_corpus(profile)
+    employers = employer_name_set(profile)
+    for bullet in (
+        "Managed a $1,200,000 budget across three teams.",
+        "Owned a $1.2 million budget.",
+        "Trimmed a $5K monthly spend.",
+    ):
+        findings = find_fabricated_tokens("experience:acme_swe#0", bullet, corpus, employers=employers)
+        assert [f for f in findings if f.kind == "numeric"] == [], (bullet, findings)
 
 
 def test_metrics_hungry_job_with_numberless_profile_yields_zero_unsourced_numerics() -> None:

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -325,6 +325,43 @@ def test_accepted_resume_records_provenance_and_publishes_event(tmp_path: Path) 
     assert provenance_events[0].payload["artifact_id"] == saved.artifact_id
 
 
+def test_suffixed_bare_magnitude_is_hard_rejected_by_detector_and_writes_no_provenance(
+    tmp_path: Path,
+) -> None:
+    """Regression for the High finding (criterion 4 / CONTROL-03): a metrics-hungry
+    job tempts the model to invent a bare magnitude with no leading ``$`` (``10M``).
+    The profile carries no such number, the base quality gate accepts the line
+    (it also has the grounded ``40%`` + a seniority signal) and the scripted judge
+    passes — so ONLY the deterministic never-fabricate detector can catch it. Before
+    the regex fix ``10M`` was not even extracted, so the unsourced metric was
+    approved and persisted with zero findings. It must now HARD-REJECT the resume
+    and persist no provenance."""
+    materials_repo = _FakeMaterialsRepo()
+    provenance_repo = _FakeProvenanceRepo()
+    publisher = _RecordingPublisher()
+    # "40%" is grounded; "10M users" is the invented bare magnitude.
+    fabricated = _payload(
+        "Owned the API, cut latency 40% with Python, and scaled it to 10M users."
+    )
+    llm = _ScriptedLlm([fabricated, _judge_pass()] * 4)  # responses for every retry
+    outcome = _use_case(materials_repo, provenance_repo, llm, publisher).execute(
+        job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
+    )
+
+    # The resume is NOT approved despite the judge pass — the detector gated it.
+    assert outcome.materials is not None
+    assert not outcome.materials.is_resume_approved
+    # No provenance was persisted for the rejected candidate.
+    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert not any(
+        getattr(e, "event_type", "") == "BulletProvenanceRecorded" for e in publisher.events
+    )
+    # The fabrication is surfaced as the rejection reason, naming the bare magnitude.
+    errors = " ".join(outcome.materials.last_validation.errors)
+    assert "fabricate" in errors.lower() or "fabrication" in errors.lower()
+    assert "10m" in errors.lower()
+
+
 def test_fabricated_employer_is_hard_rejected_by_detector_and_writes_no_provenance(
     tmp_path: Path,
 ) -> None:

--- a/workers/automation/tests/test_tailor_provenance_integration.py
+++ b/workers/automation/tests/test_tailor_provenance_integration.py
@@ -1,0 +1,355 @@
+"""Phase 2: TailorResumeUseCase emits provenance + enforces never-fabricate.
+
+Integration-level tests over the real ``TailorResumeUseCase`` with scripted LLM
+responses and in-memory fakes (mirrors ``test_materials_use_cases`` doubles):
+
+  * an accepted generation records one ``BulletProvenance`` per rendered bullet
+    and publishes ``BulletProvenanceRecorded`` (GROUND-03 wired end-to-end);
+  * the deterministic never-fabricate detector HARD-REJECTS a candidate whose
+    bullet invents a metric — the resume is not approved and NO provenance is
+    saved, so the last accepted generation is preserved (CONTROL-03 /
+    success criterion 2 + 5).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.materials.aggregate import MaterialsSet
+from jobhunter.domain.materials.analysis import (
+    AnalysisAgreement,
+    EmployerAnalysis,
+    JobAnalysis,
+    ReasonedKeyword,
+    Requirement,
+    compute_snapshot_hash,
+)
+from jobhunter.domain.materials.analyze_use_case import AnalyzeJobOutcome
+from jobhunter.domain.materials.provenance import BulletProvenanceSet
+from jobhunter.domain.materials.services import ContentValidator, ResumeAssembler
+from jobhunter.domain.materials.use_cases import TailorResumeUseCase
+from jobhunter.domain.profile.aggregate import Profile
+from jobhunter.domain.profile.snapshot import ProfileSnapshot
+from jobhunter.domain.ports.llm import LlmMessage
+from jobhunter.domain.tenant import LOCAL_TENANT
+
+JOB_URL = "https://example.com/job/provenance"
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+
+
+class _FakeAnalyze:
+    """Returns an analysis with real requirements so provenance can bind FKs."""
+
+    def execute(self, *, job: dict, tenant_id=LOCAL_TENANT, force: bool = False) -> AnalyzeJobOutcome:
+        canonical = JobAnalysis(
+            role_framing="Backend ownership.",
+            inferred_seniority="senior",
+            ideal_candidate_narrative="A hands-on backend owner.",
+            requirements=[
+                Requirement(
+                    id="req_latency",
+                    text="improve API latency",
+                    tier="must_have",
+                    weight=0.9,
+                    evidence_span="improve API latency",
+                ),
+            ],
+            keywords=[
+                ReasonedKeyword(
+                    keyword="latency",
+                    evidence_span="improve API latency",
+                    requirement_ref="req_latency",
+                ),
+                ReasonedKeyword(keyword="python", evidence_span="Python", requirement_ref="req_latency"),
+            ],
+        )
+        analysis = EmployerAnalysis.build(
+            tenant_id=tenant_id,
+            job_id=JobId(str(job["url"])),
+            generation=1,
+            snapshot_hash=compute_snapshot_hash(str(job.get("full_description") or "jd")),
+            canonical=canonical,
+            sub_analyses=(),
+            failures=(),
+            agreement=AnalysisAgreement(score=1.0),
+            legs_attempted=1,
+        )
+        return AnalyzeJobOutcome(analysis=analysis, cached=False)
+
+
+class _FakeMaterialsRepo:
+    def __init__(self) -> None:
+        self.saved: list[MaterialsSet] = []
+
+    def load(self, tenant_id, job_id, *, generation=None) -> MaterialsSet | None:
+        candidates = [
+            m
+            for m in reversed(self.saved)
+            if str(m.tenant_id) == str(tenant_id)
+            and str(m.job_id) == str(job_id)
+            and (generation is None or m.generation == generation)
+        ]
+        return candidates[0] if candidates else None
+
+    def save(self, materials: MaterialsSet) -> None:
+        self.saved.append(materials)
+
+    def list_pending_tailor(self, *a, **k):
+        return []
+
+    def list_pending_cover(self, *a, **k):
+        return []
+
+    def list_pending_pdf(self, *a, **k):
+        return []
+
+    def list_by_status(self, *a, **k):
+        return []
+
+    def suppress_active_artifacts(self, *a, **k):
+        return None
+
+
+class _FakeProvenanceRepo:
+    def __init__(self) -> None:
+        self.saved: list[BulletProvenanceSet] = []
+
+    def load(self, tenant_id, job_id, *, generation=None) -> BulletProvenanceSet | None:
+        candidates = [
+            s
+            for s in reversed(self.saved)
+            if str(s.tenant_id) == str(tenant_id)
+            and str(s.job_id) == str(job_id)
+            and (generation is None or s.generation == generation)
+        ]
+        return candidates[0] if candidates else None
+
+    def save(self, provenance: BulletProvenanceSet) -> None:
+        if provenance.is_empty:
+            return
+        self.saved.append(provenance)
+
+
+class _ScriptedLlm:
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+
+    def chat(self, messages: list[LlmMessage], **kwargs) -> str:
+        if not self._responses:
+            raise RuntimeError("no scripted response left")
+        return self._responses.pop(0)
+
+    def chat_json(self, messages: list[LlmMessage], **kwargs) -> dict:
+        return json.loads(self.chat(messages, **kwargs))
+
+    def ask(self, prompt: str, **kwargs) -> str:
+        return self.chat([LlmMessage(role="user", content=prompt)], **kwargs)
+
+
+class _RecordingPublisher:
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def publish(self, event) -> None:
+        self.events.append(event)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+
+def _profile_dict() -> dict:
+    """A profile that passes the base ``ContentValidator`` (mirrors the
+    happy-path fixture in ``test_materials_use_cases``) with real evidence so
+    provenance can bind FK ids. ``real_metrics`` includes 40% so the grounded
+    payload's "40%" traces to evidence, while an invented "200%" does not."""
+    return {
+        "personal": {"full_name": "Jane Doe", "email": "jane@example.com"},
+        "resume_constraints": {"real_metrics": ["40%"]},
+        "resume": {
+            "executive_profile": {"baseline_text": "Senior engineer."},
+            "experience_entries": [
+                {
+                    "id": "acme_swe",
+                    "date_range": "2020-Present",
+                    "title": "Senior SWE",
+                    "company": "Acme Corp",
+                    "location": "Remote",
+                    "bullets": ["Built distributed systems."],
+                    "achievement_evidence": [
+                        {
+                            "id": "ev_latency",
+                            "source_text": "Cut latency 40% by replacing synchronous calls.",
+                            "scope": "owned backend service",
+                            "action": "replaced synchronous enrichment calls",
+                            "tools": ["Python", "PostgreSQL"],
+                            "metrics": ["40%"],
+                            "outcome": "faster API responses",
+                            "seniority_signal": "technical ownership",
+                            "evidence_strength": "verified",
+                            "claim_confidence": 0.95,
+                            "user_confirmed": True,
+                            "tags": ["latency", "backend"],
+                        }
+                    ],
+                }
+            ],
+            "education_entries": [
+                {"id": "edu", "degree": "BSc CS", "institution": "State University", "date": "2015"}
+            ],
+            "skill_categories": [{"id": "languages", "label": "Languages", "items": ["Python", "Go"]}],
+            "tailoring_rules": {
+                "required_experience_entry_ids": ["acme_swe"],
+                "required_skill_category_ids": ["languages"],
+                "max_experience_bullets": 4,
+                "tailoring_policy": {
+                    "claim_mode": "evidence_reframing",
+                    "auto_approvable_claim_modes": ["verified_only", "evidence_reframing"],
+                },
+            },
+        },
+    }
+
+
+def _snapshot() -> ProfileSnapshot:
+    return ProfileSnapshot.from_profile(Profile.from_dict(LOCAL_TENANT, _profile_dict()))
+
+
+def _job() -> dict:
+    return {
+        "url": JOB_URL,
+        "title": "Senior Backend Engineer",
+        "site": "Acme",
+        "full_description": "Own Python services and improve API latency.",
+        "fit_score": 7,
+    }
+
+
+def _payload(bullet: str) -> str:
+    return json.dumps(
+        {
+            "executive_profile": "Senior backend engineer focused on Python API reliability.",
+            "experience_updates": [{"id": "acme_swe", "title": "", "bullets": [bullet]}],
+            "skill_category_updates": [{"id": "languages", "items": ["Python", "Go"]}],
+        }
+    )
+
+
+def _judge_pass() -> str:
+    return json.dumps(
+        {
+            "verdict": "PASS",
+            "score": 0.94,
+            "criterion_scores": {
+                "relevance_to_job": 0.95,
+                "evidence_support": 0.95,
+                "fabrication_safety": 1.0,
+                "required_content_preserved": 1.0,
+                "ats_readability": 0.9,
+                "specificity_and_metrics": 0.85,
+            },
+            "issues": [],
+            "unsupported_claims": [],
+            "fabrications": [],
+            "missing_required_evidence": [],
+            "repair_instructions": [],
+        }
+    )
+
+
+def _use_case(
+    materials_repo: _FakeMaterialsRepo,
+    provenance_repo: _FakeProvenanceRepo,
+    llm: _ScriptedLlm,
+    publisher: _RecordingPublisher,
+) -> TailorResumeUseCase:
+    return TailorResumeUseCase(
+        repository=materials_repo,
+        llm=llm,
+        validator=ContentValidator(),
+        assembler=ResumeAssembler(),
+        analyze_use_case=_FakeAnalyze(),
+        provenance_repository=provenance_repo,
+        publisher=publisher,
+    )
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_accepted_resume_records_provenance_and_publishes_event(tmp_path: Path) -> None:
+    materials_repo = _FakeMaterialsRepo()
+    provenance_repo = _FakeProvenanceRepo()
+    publisher = _RecordingPublisher()
+    # A grounded bullet: "40%" is recorded in the profile evidence + real_metrics.
+    # "Owned" carries the seniority signal the senior-role quality gate requires.
+    llm = _ScriptedLlm(
+        [
+            _payload("Owned the API and cut latency 40% with Python by replacing synchronous calls."),
+            _judge_pass(),
+        ]
+    )
+    outcome = _use_case(materials_repo, provenance_repo, llm, publisher).execute(
+        job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
+    )
+
+    assert outcome.status == "approved"
+    assert outcome.materials is not None and outcome.materials.is_resume_approved
+
+    # Provenance was saved for the accepted generation, bound to the artifact.
+    saved = provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL))
+    assert saved is not None
+    assert saved.artifact_id == outcome.materials.tailored_resume.artifact_id
+    assert saved.generation == outcome.materials.generation
+    sections = {row.section for row in saved.bullets}
+    assert {"executive_profile", "experience", "skills"}.issubset(sections)
+    experience = next(row for row in saved.bullets if row.section == "experience")
+    assert "req_latency" in experience.requirement_ids  # FK bound to the analysis
+    assert "latency" in experience.matched_keywords
+
+    # The BulletProvenanceRecorded event was published with the bullet count.
+    provenance_events = [
+        e for e in publisher.events if getattr(e, "event_type", "") == "BulletProvenanceRecorded"
+    ]
+    assert len(provenance_events) == 1
+    assert provenance_events[0].payload["bullet_count"] == len(saved.bullets)
+    assert provenance_events[0].payload["artifact_id"] == saved.artifact_id
+
+
+def test_fabricated_employer_is_hard_rejected_by_detector_and_writes_no_provenance(
+    tmp_path: Path,
+) -> None:
+    materials_repo = _FakeMaterialsRepo()
+    provenance_repo = _FakeProvenanceRepo()
+    publisher = _RecordingPublisher()
+    # The candidate invents an employer ("Globex Corporation") the user never
+    # worked at. The base quality gate does NOT check employers and the scripted
+    # judge "passes" — so ONLY the deterministic never-fabricate detector
+    # (independent of the prompt) can catch this. It must HARD-REJECT the resume.
+    fabricated = _payload("Owned the API and cut latency 40% at Globex Corporation.")
+    llm = _ScriptedLlm([fabricated, _judge_pass()] * 4)  # responses for every retry
+    outcome = _use_case(materials_repo, provenance_repo, llm, publisher).execute(
+        job=_job(), profile_snapshot=_snapshot(), tailored_dir=tmp_path
+    )
+
+    # The resume is NOT approved despite the judge pass — the detector gated it.
+    assert outcome.materials is not None
+    assert not outcome.materials.is_resume_approved
+    # No provenance was persisted for a rejected candidate (last accepted
+    # generation, if any, is preserved — here there is none).
+    assert provenance_repo.load(LOCAL_TENANT, JobId(JOB_URL)) is None
+    assert not any(
+        getattr(e, "event_type", "") == "BulletProvenanceRecorded" for e in publisher.events
+    )
+    # The fabrication is surfaced as the rejection reason on the validation errors.
+    errors = " ".join(outcome.materials.last_validation.errors)
+    assert "fabricate" in errors.lower() or "fabrication" in errors.lower()


### PR DESCRIPTION
## What

Phase 2 of grounded resume tailoring: **every generated resume bullet now carries a canonical, FK-bound `BulletProvenance` record** (evidence × requirement × transform × control × rationale) consuming Phase 1's persisted `EmployerAnalysis`, with **never-fabricate enforced by a deterministic detector independent of the prompt**. Backend + contracts + read-path only (no UI — that is Phase 5).

## Why

The category's cardinal failure is fabrication (invented metrics/titles/dates/employers) and "opaque tailoring". Phase 2 makes every displayed bullet claim have an explicit source of truth in canonical rows, and adds a deterministic gate so a model that ignores the prompt still cannot ship an unsourced number/title/date/employer.

## How

**Domain**
- `BulletProvenance` entity + generation-versioned `BulletProvenanceSet` (`domain/materials/provenance.py`).
- Closed enums `TransformType` (verbatim / rephrase / reframe / synthesize_from_related / quantify_from_evidence) and `ControlRule` (rephrase always allowed; invent only for closely-related; never fabricate metrics/titles/dates/employers) in `value_objects.py`.
- `provenance_builder.py` computes one row per **rendered** bullet (same `resume_profile` helpers the assembler uses, so `generated_text` is the exact rendered line — the coverage anchor), maps change-type → `TransformType`, and binds `requirement_ids` as real FKs into the analysis. A fabricated evidence/requirement id raises `ProvenanceBindingError` before any row is built (GROUND-05).

**Deterministic never-fabricate detector** (`domain/materials/fabrication_detector.py`)
- Pure, prompt-independent (the Phase-2 analogue of Phase 1's grounding gate). Every numeric/date/percentage/money/title/company-suffixed-employer token in a generated bullet must trace to recorded profile evidence; a token that does not is hard-rejected at generation time.

**Use case + persistence**
- `TailorResumeUseCase` computes provenance + runs the detector after assembling the selected candidate's text. A fabrication downgrades validation so the resume is **not approved** and the last accepted generation's artifact + provenance are preserved (Anti-Pattern 4). An accepted generation persists rows via `BulletProvenanceRepository` transactionally with the artifact and publishes `BulletProvenanceRecorded`.
- Canonical `job_bullet_provenance` table (NOT `metadata_json`), generation-versioned + supersede-not-destroy.

**Event** `BulletProvenanceRecorded`: Python factory + `DOMAIN_EVENT_TYPES`; `packages/domain-types` mirror + union + `DOMAIN_EVENT_TYPES`; web `materials/handlers.ts` + invalidation-router registration + fixture; `every-event-has-handler` parity passes.

**Read path**
- Projected onto `artifact_list_projections.bullet_provenance_json` by **both** the Python builder and `apps/api/projections.ts` (parity), served on `ArtifactTailoringExplanation.bulletProvenance` by `read-model.ts` (a PDF artifact resolves it from the sibling tailored-resume row); DTO added to `schemas.ts`.
- The divergent legacy sibling-file / TS-recompute read paths are intentionally left untouched — that is Phase 4.

## ROADMAP Phase-2 success criteria

1. ✅ Each bullet has a `job_bullet_provenance` row linking profile evidence + job requirement, recording a transform from the closed taxonomy + a rationale.
2. ✅ Provenance is FK bindings, not free text — a fabricated evidence/requirement id is hard-rejected at generation time (fixture proves the reject).
3. ✅ The governing control rule is recorded per bullet.
4. ✅ A deterministic numeric/date/title detector runs independently of the prompt — metrics-hungry job + numberless profile ⇒ zero unsourced numerics (fixture proves it).
5. ✅ Provenance is generation-versioned and superseded with its artifact — a failed re-tailor never destroys the last accepted generation's provenance (fixture proves it).

## How validated

- `uv --project workers/automation run --extra dev ruff check .` → **pass**
- `uv --project workers/automation run --extra dev pytest -q` → **1230 passed, 1 failed** (only the pre-existing unrelated `test_suppress_backfilled_legacy_job_makes_selectors_treat_paths_inactive`)
- `pnpm api:check` → pass · `pnpm api:test` → **196 passed** (incl. new cross-runtime provenance parity test)
- `pnpm web:check` → pass · `pnpm --filter @jobhunter/web test --run` → **637 passed** (incl. `every-event-has-handler` + router parity) · `pnpm --filter @jobhunter/web test-d` → **10 passed**

Docs: `docs/architecture.md` + `docs/job-pipeline-architecture.md` updated for the new canonical audit data, event, and read path.