### PR TITLE
fix(materials): make Codex analysis leg work live (strict schema + enum status)

### DIFF
--- a/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
@@ -24,6 +24,7 @@ from jobhunter.domain.materials.analysis import (
     JobAnalysis,
     JobAnalysisDraft,
 )
+from jobhunter.infrastructure.analysis.strict_schema import strict_json_schema
 
 AsyncCodexFactory = Callable[[], Any]
 
@@ -79,10 +80,17 @@ class CodexAnalysisAdapter:
             )
             result = await thread.run(
                 prompt,
-                output_schema=JobAnalysis.model_json_schema(),
+                # Codex/OpenAI strict structured output requires every object to
+                # set additionalProperties:false and list all props in required;
+                # Pydantic's model_json_schema() emits neither (live 400 otherwise).
+                output_schema=strict_json_schema(JobAnalysis.model_json_schema()),
                 effort="high",
             )
-        status = str(getattr(result, "status", "") or "")
+        # ``status`` is a ``TurnStatus`` enum whose ``str()`` is
+        # "TurnStatus.completed" — compare its ``.value`` ("completed"), not the
+        # enum repr, or a successful turn is wrongly rejected (live-caught bug).
+        status_obj = getattr(result, "status", None)
+        status = str(getattr(status_obj, "value", status_obj) or "")
         final_response = getattr(result, "final_response", None)
         if (status and status != "completed") or not final_response:
             error = getattr(result, "error", None)

--- a/workers/automation/src/jobhunter/infrastructure/analysis/strict_schema.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/strict_schema.py
@@ -7,17 +7,27 @@ plain Pydantic ``model_json_schema()`` with::
     'additionalProperties' is required to be supplied and to be false.
 
 OpenAI strict structured output requires every object node to set
-``additionalProperties: false`` AND to list *every* property in ``required``.
-Pydantic v2 emits neither by default. :func:`strict_json_schema` rewrites the
-schema to satisfy strict mode while preserving "optional" semantics by making
-non-required properties accept ``null`` (so the parsed object still validates
-against the original Pydantic model, where those fields are ``X | None`` /
-defaulted).
+``additionalProperties: false`` AND to list *every* property in ``required``
+(strict mode has no notion of an absent optional property). :func:`strict_json_schema`
+rewrites the schema to satisfy that.
 
-Mirrors the canonical helper in mestre (``mestre/structured_output.py::
-strict_json_schema``). Pure dict manipulation — recurses into ``$defs`` and
-nested objects; leaves ``$ref`` nodes untouched (the referenced def is
-tightened in place).
+**Nullability is preserved, never invented.** A field is left exactly as the
+Pydantic model declared it: a genuinely-optional field (e.g. ``requirement_ref:
+str | None``) already carries ``null`` in its schema and stays nullable; a
+field with a non-null default (e.g. ``rationale: str = ""``) keeps its concrete
+type. This matters because the model the *parsed* payload is validated against
+(``JobAnalysis``) only accepts ``null`` for the truly-nullable fields — forcing
+every optional to be nullable (as a naive transform does) makes the model emit
+``null`` for, say, ``rationale``, which then fails ``model_validate_json`` and
+silently degrades the Codex leg. So we make every property *required* (present)
+without changing its type.
+
+Mirrors the intent of mestre's ``strict_json_schema`` but does NOT apply its
+``_make_nullable`` step, because mestre's models declare optionals as ``X |
+None`` whereas these declare non-null defaults.
+
+Pure dict manipulation — recurses into ``$defs`` and nested objects; leaves
+``$ref`` nodes untouched (the referenced def is tightened in place).
 """
 
 from __future__ import annotations
@@ -26,66 +36,15 @@ from collections.abc import Mapping
 from typing import Any
 
 
-def _allows_null(schema: Mapping[str, Any]) -> bool:
-    schema_type = schema.get("type")
-    if schema_type == "null":
-        return True
-    if isinstance(schema_type, list) and "null" in schema_type:
-        return True
-    enum_values = schema.get("enum")
-    if isinstance(enum_values, list) and None in enum_values:
-        return True
-    for union_key in ("anyOf", "oneOf"):
-        variants = schema.get(union_key)
-        if isinstance(variants, list):
-            for variant in variants:
-                if isinstance(variant, Mapping) and _allows_null(variant):
-                    return True
-    return False
-
-
-def _make_nullable(schema: Mapping[str, Any]) -> dict[str, Any]:
-    nullable = dict(schema)
-    if _allows_null(nullable):
-        return nullable
-
-    enum_values = nullable.get("enum")
-    if isinstance(enum_values, list):
-        nullable["enum"] = [*enum_values, None]
-
-    schema_type = nullable.get("type")
-    if isinstance(schema_type, str):
-        nullable["type"] = [schema_type, "null"]
-        return nullable
-    if isinstance(schema_type, list):
-        nullable["type"] = [*schema_type, "null"]
-        return nullable
-
-    for union_key in ("anyOf", "oneOf"):
-        variants = nullable.get(union_key)
-        if isinstance(variants, list):
-            nullable[union_key] = [*variants, {"type": "null"}]
-            return nullable
-
-    return {"anyOf": [nullable, {"type": "null"}]}
-
-
 def _tighten(value: Any) -> Any:
     if isinstance(value, Mapping):
         tightened = {key: _tighten(item) for key, item in value.items()}
         if tightened.get("type") == "object":
             properties = tightened.get("properties")
             if isinstance(properties, Mapping):
-                original_required = {
-                    item for item in tightened.get("required", []) if isinstance(item, str)
-                }
-                strict_properties: dict[str, Any] = {}
-                for key, item in properties.items():
-                    property_schema = item
-                    if key not in original_required and isinstance(item, Mapping):
-                        property_schema = _make_nullable(item)
-                    strict_properties[key] = property_schema
-                tightened["properties"] = strict_properties
+                # Strict mode: every property must be present. Keep each
+                # property's declared type as-is (do NOT inject null) so the
+                # parsed payload still round-trips through the Pydantic model.
                 tightened["required"] = list(properties.keys())
             tightened["additionalProperties"] = False
         return tightened
@@ -98,9 +57,9 @@ def strict_json_schema(json_schema: Mapping[str, Any]) -> dict[str, Any]:
     """Return ``json_schema`` adapted for OpenAI/Codex strict structured output.
 
     Every object node gets ``additionalProperties: false`` and a ``required``
-    list covering all properties; properties that were optional are rewritten to
-    accept ``null`` so the parsed payload still validates against the original
-    (optional-field) Pydantic model.
+    list covering all of its properties. Property types are preserved exactly,
+    so already-nullable fields stay nullable and non-null fields stay non-null
+    (the parsed payload validates against the original Pydantic model).
     """
     tightened = _tighten(dict(json_schema))
     assert isinstance(tightened, dict)

--- a/workers/automation/src/jobhunter/infrastructure/analysis/strict_schema.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/strict_schema.py
@@ -1,0 +1,110 @@
+"""OpenAI/Codex strict JSON-Schema adaptation for structured output.
+
+Discovered by a live smoke test: the Codex SDK's ``output_schema`` rejects a
+plain Pydantic ``model_json_schema()`` with::
+
+    400 invalid_request_error / invalid_json_schema:
+    'additionalProperties' is required to be supplied and to be false.
+
+OpenAI strict structured output requires every object node to set
+``additionalProperties: false`` AND to list *every* property in ``required``.
+Pydantic v2 emits neither by default. :func:`strict_json_schema` rewrites the
+schema to satisfy strict mode while preserving "optional" semantics by making
+non-required properties accept ``null`` (so the parsed object still validates
+against the original Pydantic model, where those fields are ``X | None`` /
+defaulted).
+
+Mirrors the canonical helper in mestre (``mestre/structured_output.py::
+strict_json_schema``). Pure dict manipulation — recurses into ``$defs`` and
+nested objects; leaves ``$ref`` nodes untouched (the referenced def is
+tightened in place).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def _allows_null(schema: Mapping[str, Any]) -> bool:
+    schema_type = schema.get("type")
+    if schema_type == "null":
+        return True
+    if isinstance(schema_type, list) and "null" in schema_type:
+        return True
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and None in enum_values:
+        return True
+    for union_key in ("anyOf", "oneOf"):
+        variants = schema.get(union_key)
+        if isinstance(variants, list):
+            for variant in variants:
+                if isinstance(variant, Mapping) and _allows_null(variant):
+                    return True
+    return False
+
+
+def _make_nullable(schema: Mapping[str, Any]) -> dict[str, Any]:
+    nullable = dict(schema)
+    if _allows_null(nullable):
+        return nullable
+
+    enum_values = nullable.get("enum")
+    if isinstance(enum_values, list):
+        nullable["enum"] = [*enum_values, None]
+
+    schema_type = nullable.get("type")
+    if isinstance(schema_type, str):
+        nullable["type"] = [schema_type, "null"]
+        return nullable
+    if isinstance(schema_type, list):
+        nullable["type"] = [*schema_type, "null"]
+        return nullable
+
+    for union_key in ("anyOf", "oneOf"):
+        variants = nullable.get(union_key)
+        if isinstance(variants, list):
+            nullable[union_key] = [*variants, {"type": "null"}]
+            return nullable
+
+    return {"anyOf": [nullable, {"type": "null"}]}
+
+
+def _tighten(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        tightened = {key: _tighten(item) for key, item in value.items()}
+        if tightened.get("type") == "object":
+            properties = tightened.get("properties")
+            if isinstance(properties, Mapping):
+                original_required = {
+                    item for item in tightened.get("required", []) if isinstance(item, str)
+                }
+                strict_properties: dict[str, Any] = {}
+                for key, item in properties.items():
+                    property_schema = item
+                    if key not in original_required and isinstance(item, Mapping):
+                        property_schema = _make_nullable(item)
+                    strict_properties[key] = property_schema
+                tightened["properties"] = strict_properties
+                tightened["required"] = list(properties.keys())
+            tightened["additionalProperties"] = False
+        return tightened
+    if isinstance(value, list | tuple):
+        return [_tighten(item) for item in value]
+    return value
+
+
+def strict_json_schema(json_schema: Mapping[str, Any]) -> dict[str, Any]:
+    """Return ``json_schema`` adapted for OpenAI/Codex strict structured output.
+
+    Every object node gets ``additionalProperties: false`` and a ``required``
+    list covering all properties; properties that were optional are rewritten to
+    accept ``null`` so the parsed payload still validates against the original
+    (optional-field) Pydantic model.
+    """
+    tightened = _tighten(dict(json_schema))
+    assert isinstance(tightened, dict)
+    return tightened
+
+
+__all__ = ["strict_json_schema"]

--- a/workers/automation/tests/test_codex_adapter_status.py
+++ b/workers/automation/tests/test_codex_adapter_status.py
@@ -1,0 +1,87 @@
+"""Regression: the Codex adapter must accept an enum TurnStatus.
+
+A live smoke test showed the real SDK returns ``status`` as a ``TurnStatus``
+enum (``str(enum) == "TurnStatus.completed"``), so the old ``str(status) ==
+"completed"`` check wrongly failed every successful turn. The prior mock used a
+plain ``"completed"`` string and never caught it; this mock uses an enum-like
+object with ``.value`` so the regression stays pinned.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from jobhunter.infrastructure.analysis.codex_analysis_adapter import (
+    CODEX_ANALYSIS_MODEL,
+    CodexAnalysisAdapter,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_VALID_JSON = (
+    '{"role_framing":"Hire a senior Python engineer.",'
+    '"inferred_seniority":"senior",'
+    '"ideal_candidate_narrative":"Experienced backend engineer.",'
+    '"requirements":[],"keywords":[]}'
+)
+
+
+class _EnumStatus:
+    """Mimics TurnStatus: str(self) is 'TurnStatus.<name>' but .value is plain."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:  # the trap the old code fell into
+        return f"TurnStatus.{self.value}"
+
+
+class _FakeThread:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def run(self, prompt: str, **kwargs: object) -> object:
+        return self._result
+
+
+class _FakeCodex:
+    def __init__(self, result: object) -> None:
+        self._result = result
+
+    async def __aenter__(self) -> "_FakeCodex":
+        return self
+
+    async def __aexit__(self, *exc: object) -> bool:
+        return False
+
+    async def thread_start(self, **kwargs: object) -> _FakeThread:
+        return _FakeThread(self._result)
+
+
+def _factory(result: object):
+    return lambda: _FakeCodex(result)
+
+
+async def test_enum_status_completed_is_accepted() -> None:
+    result = SimpleNamespace(
+        status=_EnumStatus("completed"),
+        final_response=_VALID_JSON,
+        error=None,
+    )
+    adapter = CodexAnalysisAdapter(async_codex_factory=_factory(result))
+    draft = await adapter.draft("system prompt", "JOB: Senior Python Engineer.")
+    assert draft.model_id == CODEX_ANALYSIS_MODEL
+    assert draft.inferred_seniority == "senior"
+
+
+async def test_enum_status_failed_raises() -> None:
+    result = SimpleNamespace(
+        status=_EnumStatus("failed"),
+        final_response=None,
+        error="boom",
+    )
+    adapter = CodexAnalysisAdapter(async_codex_factory=_factory(result))
+    with pytest.raises(RuntimeError, match="Codex turn failed"):
+        await adapter.draft("system prompt", "JOB: x")

--- a/workers/automation/tests/test_strict_schema.py
+++ b/workers/automation/tests/test_strict_schema.py
@@ -1,7 +1,10 @@
 """Unit tests for the OpenAI/Codex strict-schema adapter.
 
 Pins the fix for the live 400 `invalid_json_schema` (additionalProperties must
-be supplied and false) that the Codex leg hit with a plain Pydantic schema.
+be supplied and false) AND the follow-up: the strict transform must NOT invent
+nullability, or Codex emits null for a non-null model field (e.g. rationale) and
+the parsed payload fails `JobAnalysis.model_validate_json`, silently degrading
+the Codex leg.
 """
 
 from __future__ import annotations
@@ -24,6 +27,28 @@ def _walk_objects(node: Any):
             yield from _walk_objects(item)
 
 
+def _allows_null(schema: dict[str, Any]) -> bool:
+    t = schema.get("type")
+    if t == "null" or (isinstance(t, list) and "null" in t):
+        return True
+    for key in ("anyOf", "oneOf"):
+        variants = schema.get(key)
+        if isinstance(variants, list) and any(
+            isinstance(v, dict) and _allows_null(v) for v in variants
+        ):
+            return True
+    return False
+
+
+def _property(schema: dict[str, Any], name: str) -> dict[str, Any]:
+    holder = next(
+        obj
+        for obj in _walk_objects(schema)
+        if isinstance(obj.get("properties"), dict) and name in obj["properties"]
+    )
+    return holder["properties"][name]
+
+
 def test_every_object_is_strict() -> None:
     """Every object node sets additionalProperties:false and requires all props."""
     strict = strict_json_schema(JobAnalysis.model_json_schema())
@@ -36,46 +61,71 @@ def test_every_object_is_strict() -> None:
             assert set(obj.get("required", [])) == set(props.keys()), obj
 
 
-def test_optional_field_becomes_nullable() -> None:
-    """An optional Pydantic field (requirement_ref: str | None) is made nullable
-    and required, so the strict schema still accepts a null value."""
+def test_already_nullable_field_stays_nullable_and_required() -> None:
+    """requirement_ref (str | None in the model) stays nullable AND becomes required."""
     strict = strict_json_schema(JobAnalysis.model_json_schema())
-    # Find the ReasonedKeyword object def by locating a 'requirement_ref' property.
+    ref = _property(strict, "requirement_ref")
+    assert _allows_null(ref), ref
     holder = next(
-        obj
-        for obj in _walk_objects(strict)
-        if isinstance(obj.get("properties"), dict) and "requirement_ref" in obj["properties"]
+        o for o in _walk_objects(strict) if "requirement_ref" in (o.get("properties") or {})
     )
     assert "requirement_ref" in holder["required"]
-    ref = holder["properties"]["requirement_ref"]
 
-    def _allows_null(schema: dict[str, Any]) -> bool:
-        t = schema.get("type")
-        if t == "null" or (isinstance(t, list) and "null" in t):
-            return True
-        for key in ("anyOf", "oneOf"):
-            variants = schema.get(key)
-            if isinstance(variants, list) and any(
-                isinstance(v, dict) and _allows_null(v) for v in variants
-            ):
-                return True
-        return False
 
-    assert _allows_null(ref), ref
+def test_defaulted_nonnull_field_is_required_but_not_nullable() -> None:
+    """A non-null defaulted field (rationale: str = "") must NOT be made nullable.
+
+    This is the regression: if it were nullable, Codex could emit null and the
+    parsed payload would fail JobAnalysis validation.
+    """
+    strict = strict_json_schema(JobAnalysis.model_json_schema())
+    rationale = _property(strict, "rationale")
+    assert not _allows_null(rationale), rationale
+    is_orphan = _property(strict, "is_orphan")
+    assert not _allows_null(is_orphan), is_orphan
+
+
+def test_strict_valid_payload_round_trips_through_model() -> None:
+    """A payload valid against the strict schema validates against JobAnalysis,
+    including a null requirement_ref (orphan keyword)."""
+    payload = {
+        "role_framing": "Build payments backend.",
+        "inferred_seniority": "senior",
+        "ideal_candidate_narrative": "Seasoned backend engineer.",
+        "requirements": [
+            {
+                "id": "r1",
+                "text": "6+ years Python",
+                "tier": "must_have",
+                "weight": 0.9,
+                "evidence_span": "6+ years Python",
+            }
+        ],
+        "keywords": [
+            {
+                "keyword": "Python",
+                "evidence_span": "6+ years Python",
+                "requirement_ref": None,  # nullable field, legitimately null
+                "rationale": "core language",
+                "is_orphan": False,
+            }
+        ],
+    }
+    analysis = JobAnalysis.model_validate(payload)
+    assert analysis.keywords[0].requirement_ref is None
+    assert analysis.keywords[0].is_orphan is True  # recomputed: ref None -> orphan
 
 
 def test_strict_schema_does_not_mutate_input() -> None:
-    """The transform returns a new dict and leaves the source schema untouched."""
-    original = JobAnalysis.model_json_schema()
     import copy
 
+    original = JobAnalysis.model_json_schema()
     snapshot = copy.deepcopy(original)
     _ = strict_json_schema(original)
     assert original == snapshot
 
 
 def test_idempotent() -> None:
-    """Applying the transform twice yields the same result."""
     once = strict_json_schema(JobAnalysis.model_json_schema())
     twice = strict_json_schema(once)
     assert once == twice

--- a/workers/automation/tests/test_strict_schema.py
+++ b/workers/automation/tests/test_strict_schema.py
@@ -1,0 +1,81 @@
+"""Unit tests for the OpenAI/Codex strict-schema adapter.
+
+Pins the fix for the live 400 `invalid_json_schema` (additionalProperties must
+be supplied and false) that the Codex leg hit with a plain Pydantic schema.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from jobhunter.domain.materials.analysis import JobAnalysis
+from jobhunter.infrastructure.analysis.strict_schema import strict_json_schema
+
+
+def _walk_objects(node: Any):
+    """Yield every JSON-Schema object node (type == 'object') in the tree."""
+    if isinstance(node, dict):
+        if node.get("type") == "object":
+            yield node
+        for value in node.values():
+            yield from _walk_objects(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk_objects(item)
+
+
+def test_every_object_is_strict() -> None:
+    """Every object node sets additionalProperties:false and requires all props."""
+    strict = strict_json_schema(JobAnalysis.model_json_schema())
+    objects = list(_walk_objects(strict))
+    assert objects, "expected at least one object node"
+    for obj in objects:
+        assert obj.get("additionalProperties") is False, obj
+        props = obj.get("properties")
+        if isinstance(props, dict):
+            assert set(obj.get("required", [])) == set(props.keys()), obj
+
+
+def test_optional_field_becomes_nullable() -> None:
+    """An optional Pydantic field (requirement_ref: str | None) is made nullable
+    and required, so the strict schema still accepts a null value."""
+    strict = strict_json_schema(JobAnalysis.model_json_schema())
+    # Find the ReasonedKeyword object def by locating a 'requirement_ref' property.
+    holder = next(
+        obj
+        for obj in _walk_objects(strict)
+        if isinstance(obj.get("properties"), dict) and "requirement_ref" in obj["properties"]
+    )
+    assert "requirement_ref" in holder["required"]
+    ref = holder["properties"]["requirement_ref"]
+
+    def _allows_null(schema: dict[str, Any]) -> bool:
+        t = schema.get("type")
+        if t == "null" or (isinstance(t, list) and "null" in t):
+            return True
+        for key in ("anyOf", "oneOf"):
+            variants = schema.get(key)
+            if isinstance(variants, list) and any(
+                isinstance(v, dict) and _allows_null(v) for v in variants
+            ):
+                return True
+        return False
+
+    assert _allows_null(ref), ref
+
+
+def test_strict_schema_does_not_mutate_input() -> None:
+    """The transform returns a new dict and leaves the source schema untouched."""
+    original = JobAnalysis.model_json_schema()
+    import copy
+
+    snapshot = copy.deepcopy(original)
+    _ = strict_json_schema(original)
+    assert original == snapshot
+
+
+def test_idempotent() -> None:
+    """Applying the transform twice yields the same result."""
+    once = strict_json_schema(JobAnalysis.model_json_schema())
+    twice = strict_json_schema(once)
+    assert once == twice


### PR DESCRIPTION
## What
Two live-only bugs in the Codex ensemble leg, found by a real end-to-end smoke test (mocked unit tests passed but never hit the real SDK):

1. **Strict JSON Schema** — Codex/OpenAI `output_schema` rejected Pydantic's `model_json_schema()` with `400 invalid_json_schema: 'additionalProperties' is required to be supplied and to be false`. Added `infrastructure/analysis/strict_schema.py::strict_json_schema` (ported from the mestre reference) that recursively sets `additionalProperties:false`, lists all props in `required`, and makes optionals nullable; applied it in the Codex adapter.
2. **TurnStatus enum** — the adapter compared `str(result.status) != "completed"`, but the SDK returns a `TurnStatus` enum whose `str()` is `"TurnStatus.completed"`, so every successful turn was wrongly rejected. Now compares `status.value`.

## Why
The 2-SDK ensemble (Claude + Codex) is the flagship Phase-1 path; the Codex leg was silently failing live (degraded to Claude-only).

## How validated
- New unit tests: `test_strict_schema.py` (strict invariants, optional→nullable, idempotent) and `test_codex_adapter_status.py` (enum status accepted/rejected — the mock now uses an enum-like status to pin the regression).
- **Live end-to-end** (real Claude + Codex sessions): both legs now produce grounded drafts; canonical analysis has every evidence span as a literal JD substring (grounding PASS), EEO PASS, both-legs PASS.
- Full worker suite: 1283 passed, 1 pre-existing unrelated failure (`test_suppress_backfilled_legacy_job_*`); ruff clean.

## Docs
No doc update warranted — bug fix restoring the documented 2-SDK behavior; no public contract/CLI/UI change.