### PR TITLE
fix(analysis): isolate Codex SDK CODEX_HOME to stop polluting user's codex chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Important local files include:
   profile/rendering seed files imported into SQLite when no profile row exists.
 - `tailored_resumes/`, `cover_letters/`, `logs/`: generated artifacts.
 - `chrome-workers/`, `apply-workers/`: local browser/apply worker state.
+- `codex_home/`: isolated Codex SDK home (session rollouts plus a copied auth
+  token; sensitive, never commit).
 
 Do not commit profile data, keys, generated resumes, cover letters, PDFs,
 browser profiles, logs, or SQLite databases.

--- a/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
@@ -6,6 +6,13 @@ Node sidecar, no CLI-subprocess wrapper), forcing JSON-schema-constrained
 output via ``output_schema`` on ``thread.run`` and parsing the structured
 result off ``TurnResult.final_response``.
 
+CODEX_HOME isolation: the live factory redirects the Codex SDK's ``CODEX_HOME``
+to an isolated dir under the JobHunter runtime root (``~/.jobhunter/codex_home``)
+seeded with a copy of the user's ``~/.codex/auth.json``, so Codex session
+rollouts never land in — and pollute — the user's real ``~/.codex`` chat
+history. The SDK merges ``CodexConfig.env`` over the parent environment, so only
+``CODEX_HOME`` is overridden; PATH/HOME/etc. are preserved.
+
 Test-mockability (no live auth in tests — D-04): the ``AsyncCodex`` class is
 resolved through an injectable factory that defaults to a lazy import, so tests
 pass a fake context-manager whose thread returns a canned ``final_response``.
@@ -17,7 +24,9 @@ No timeout (D-19): ``thread.run`` is awaited to completion; effort is pinned to
 
 from __future__ import annotations
 
+import shutil
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from jobhunter.domain.materials.analysis import (
@@ -32,12 +41,78 @@ AsyncCodexFactory = Callable[[], Any]
 # impl time; model ids drift.
 CODEX_ANALYSIS_MODEL = "gpt-5.4"
 
+# Disable Codex plugins/apps so the isolated home only ever holds JobHunter's
+# analysis rollouts + the copied auth token (mirrors mestre's vendor lane).
+_CODEX_CONFIG_OVERRIDES = ("features.plugins=false", "features.apps=false")
+# Isolated Codex home lives under the JobHunter runtime root, NOT ``~/.codex``.
+_CODEX_HOME_DIRNAME = "codex_home"
+
+
+def _isolated_codex_home() -> Path:
+    """Return ``<JOBHUNTER_DIR>/codex_home`` (config imported lazily to avoid cycles)."""
+    from jobhunter.config import APP_DIR
+
+    return APP_DIR / _CODEX_HOME_DIRNAME
+
+
+def _copy_newer_file(source: Path, target: Path, *, mode: int | None = None) -> bool:
+    """Copy ``source`` to ``target`` when it is newer or ``target`` is missing.
+
+    Returns ``True`` when a copy happened, ``False`` otherwise. When ``source``
+    is missing but ``target`` exists, the target is still re-chmod'd (if ``mode``
+    is given) so a stale copy keeps its locked-down permissions.
+    """
+    if not source.exists():
+        if target.exists() and mode is not None:
+            target.chmod(mode)
+        return False
+    target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    target.parent.chmod(0o700)
+    if target.exists() and target.stat().st_mtime >= source.stat().st_mtime:
+        if mode is not None:
+            target.chmod(mode)
+        return False
+    shutil.copy2(source, target)
+    if mode is not None:
+        target.chmod(mode)
+    return True
+
+
+def _prepare_isolated_codex_home() -> Path:
+    """Create the isolated Codex home and refresh auth from the user's real login."""
+    home = _isolated_codex_home()
+    home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    home.chmod(0o700)
+    # The copied auth token is sensitive; lock it to 0600.
+    _copy_newer_file(Path.home() / ".codex" / "auth.json", home / "auth.json", mode=0o600)
+    return home
+
+
+def _isolated_codex_env(codex_home: Path) -> dict[str, str]:
+    """Return the minimal env override; the SDK merges this over ``os.environ``."""
+    return {"CODEX_HOME": str(codex_home)}
+
 
 def _load_async_codex_factory() -> AsyncCodexFactory:
-    """Lazy-import ``openai_codex.AsyncCodex`` so the package imports without it."""
-    from openai_codex import AsyncCodex  # type: ignore[import-untyped]
+    """Build an isolated ``AsyncCodex`` CM: redirect ``CODEX_HOME`` so Codex
+    session rollouts never land in the user's real ``~/.codex``.
 
-    return AsyncCodex
+    Lazy-imports ``openai_codex`` so the package imports without it installed.
+    """
+    from openai_codex import AsyncCodex, CodexConfig  # type: ignore[import-untyped]
+
+    def _make() -> Any:
+        codex_home = _prepare_isolated_codex_home()
+        config_kwargs: dict[str, Any] = {
+            "env": _isolated_codex_env(codex_home),
+            "config_overrides": _CODEX_CONFIG_OVERRIDES,
+        }
+        codex_bin = shutil.which("codex")
+        if codex_bin:
+            config_kwargs["codex_bin"] = codex_bin
+        return AsyncCodex(config=CodexConfig(**config_kwargs))
+
+    return _make
 
 
 def _load_sandbox_read_only() -> Any:

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -1,0 +1,164 @@
+"""Codex SDK ``CODEX_HOME`` isolation — pure-helper regression.
+
+These tests pin the invariant that the Codex analysis leg writes its session
+rollouts (and a copied auth token) into an isolated home under the JobHunter
+runtime root instead of the user's real ``~/.codex`` chat history. They exercise
+ONLY the pure helpers — no ``openai_codex`` import, no app-server, no network —
+by pointing both ``jobhunter.config.APP_DIR`` and ``Path.home()`` at tmp dirs.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import jobhunter.config
+from jobhunter.infrastructure.analysis import codex_analysis_adapter as adapter
+
+
+def _isolate_homes(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    """Redirect ``APP_DIR`` and ``Path.home()`` under ``tmp_path``.
+
+    ``APP_DIR`` is read lazily via ``from jobhunter.config import APP_DIR`` inside
+    the helper, so patching ``jobhunter.config.APP_DIR`` is what takes effect.
+    Returns ``(app_dir, user_home)``.
+    """
+    app_dir = tmp_path / "jobhunter"
+    user_home = tmp_path / "home"
+    user_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(jobhunter.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user_home))
+    return app_dir, user_home
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+def test_isolated_codex_home_is_under_app_dir(monkeypatch, tmp_path: Path) -> None:
+    app_dir, _ = _isolate_homes(monkeypatch, tmp_path)
+    home = adapter._isolated_codex_home()
+    assert home == app_dir / "codex_home"
+    # Patch actually took effect: the path is under our tmp app dir.
+    assert tmp_path in home.parents
+
+
+def test_prepare_creates_home_0700_and_copies_auth_0600(monkeypatch, tmp_path: Path) -> None:
+    app_dir, user_home = _isolate_homes(monkeypatch, tmp_path)
+    source_auth = user_home / ".codex" / "auth.json"
+    source_auth.parent.mkdir(parents=True, exist_ok=True)
+    payload = b'{"OPENAI_API_KEY":"sk-isolation-token"}'
+    source_auth.write_bytes(payload)
+
+    home = adapter._prepare_isolated_codex_home()
+
+    assert home == app_dir / "codex_home"
+    assert home.is_dir()
+    assert _mode(home) == 0o700
+    target_auth = home / "auth.json"
+    assert target_auth.is_file()
+    assert target_auth.read_bytes() == payload  # identical bytes
+    assert _mode(target_auth) == 0o600
+
+
+def test_prepare_without_source_auth_still_creates_home(monkeypatch, tmp_path: Path) -> None:
+    app_dir, user_home = _isolate_homes(monkeypatch, tmp_path)
+    # No ~/.codex/auth.json on disk.
+    assert not (user_home / ".codex" / "auth.json").exists()
+
+    home = adapter._prepare_isolated_codex_home()  # must not raise
+
+    assert home == app_dir / "codex_home"
+    assert home.is_dir()
+    assert _mode(home) == 0o700
+    assert not (home / "auth.json").exists()
+
+
+def test_isolated_codex_env_is_minimal(monkeypatch, tmp_path: Path) -> None:
+    _, _ = _isolate_homes(monkeypatch, tmp_path)
+    home = tmp_path / "codex_home"
+    env = adapter._isolated_codex_env(home)
+    # Minimal — the SDK merges this over os.environ, so only CODEX_HOME is set.
+    assert env == {"CODEX_HOME": str(home)}
+
+
+def test_copy_newer_file_copies_when_target_missing(tmp_path: Path) -> None:
+    source = tmp_path / "src.json"
+    target = tmp_path / "dst" / "auth.json"
+    source.write_bytes(b"first")
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is True
+    assert target.read_bytes() == b"first"
+    assert _mode(target) == 0o600
+    # Parent dir is locked down to 0700.
+    assert _mode(target.parent) == 0o700
+
+
+def test_copy_newer_file_skips_when_target_is_newer(tmp_path: Path) -> None:
+    source = tmp_path / "src.json"
+    target = tmp_path / "dst.json"
+    source.write_bytes(b"source")
+    target.write_bytes(b"existing-newer")
+    # Make the target strictly newer than the source.
+    os.utime(source, (1_000, 1_000))
+    os.utime(target, (2_000, 2_000))
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is False
+    assert target.read_bytes() == b"existing-newer"  # not overwritten
+    assert _mode(target) == 0o600  # still re-chmod'd
+
+
+def test_copy_newer_file_skips_when_mtimes_equal(tmp_path: Path) -> None:
+    source = tmp_path / "src.json"
+    target = tmp_path / "dst.json"
+    source.write_bytes(b"source")
+    target.write_bytes(b"existing-equal")
+    os.utime(source, (1_500, 1_500))
+    os.utime(target, (1_500, 1_500))  # equal mtime -> skip (>=)
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is False
+    assert target.read_bytes() == b"existing-equal"
+
+
+def test_copy_newer_file_overwrites_when_source_is_newer(tmp_path: Path) -> None:
+    source = tmp_path / "src.json"
+    target = tmp_path / "dst.json"
+    target.write_bytes(b"stale")
+    source.write_bytes(b"fresh")
+    os.utime(target, (1_000, 1_000))
+    os.utime(source, (2_000, 2_000))  # source newer -> copy
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is True
+    assert target.read_bytes() == b"fresh"
+    assert _mode(target) == 0o600
+
+
+def test_copy_newer_file_rechmods_when_source_missing_but_target_exists(tmp_path: Path) -> None:
+    source = tmp_path / "missing.json"  # does not exist
+    target = tmp_path / "dst.json"
+    target.write_bytes(b"existing")
+    target.chmod(0o644)
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is False
+    assert _mode(target) == 0o600  # re-chmod'd despite missing source
+
+
+def test_copy_newer_file_missing_source_and_target_is_noop(tmp_path: Path) -> None:
+    source = tmp_path / "missing-src.json"
+    target = tmp_path / "missing-dst.json"
+
+    copied = adapter._copy_newer_file(source, target, mode=0o600)
+
+    assert copied is False
+    assert not target.exists()


### PR DESCRIPTION
## What changed

The Codex analysis ensemble leg constructed `AsyncCodex()` with no config. The official `openai_codex` SDK then spawned the `codex app-server` subprocess against the default `CODEX_HOME` (`~/.codex`), which writes session rollouts there — so JobHunter's analysis turns were polluting the user's **real Codex chat/session history**.

This redirects the **live** factory's `CODEX_HOME` to an isolated dir under the JobHunter runtime root (`~/.jobhunter/codex_home`), seeded with a copy of the user's existing `~/.codex/auth.json` so Codex still authenticates. Adapted from mestre's `vendor_lane/backends/codex_sdk.py` (`_prepare_isolated_codex_home` / `_copy_newer_file`), **without** mestre's observability/streaming stack.

Only `workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py` changed (plus a new test and a one-line README entry).

### Design
- New module constants `_CODEX_CONFIG_OVERRIDES = ("features.plugins=false", "features.apps=false")` and `_CODEX_HOME_DIRNAME = "codex_home"`.
- New pure helpers: `_isolated_codex_home()` (lazily imports `APP_DIR`), `_copy_newer_file(...)` (faithful port — copy-if-newer, re-chmod on missing source), `_prepare_isolated_codex_home()` (mkdir 0700 + copy auth 0600), `_isolated_codex_env(home)` (minimal `{"CODEX_HOME": ...}`).
- `_load_async_codex_factory()` rewritten to return a **zero-arg** `Callable[[], Any]` that builds `AsyncCodex(config=CodexConfig(env=..., config_overrides=..., codex_bin=shutil.which("codex")))`. `draft()`, the `__init__` signature, and the `AsyncCodexFactory` type alias are unchanged, so injected test fakes never hit the live path.

## Why

Session-history pollution: the user's `~/.codex` chat history was accumulating JobHunter's employer-analysis turns. Isolating `CODEX_HOME` keeps those rollouts in a JobHunter-owned dir.

### Merge-semantics rationale for the minimal env
In the installed SDK (`openai_codex/client.py`, `CodexClient.start`): `env = os.environ.copy(); if self.config.env: env.update(self.config.env)`. `CodexConfig.env` is **merged over** the parent environment, not a replacement. So we pass **only** `{"CODEX_HOME": str(codex_home)}` — PATH/HOME/etc. are preserved and nothing is hand-copied from `os.environ`. Verified the source line directly (see validation).

### Security note (copied auth token)
`~/.jobhunter/codex_home/auth.json` is a **copy of the user's Codex auth token** (sensitive). The isolated home is created `0700` and the copied token is chmod'd `0600`. The copy is **copy-if-newer** so a refreshed `~/.codex` login propagates on the next run; if the source is missing but a stale copy exists, it is re-chmod'd (never left world-readable). It must never be committed.

## Validation

Lazy-import property preserved (package imports without `openai_codex`); injectable factory arity unchanged; no timeouts added; no live network call made by the suite.

### `ruff check` (adapter + new test)
```
$ uv --project workers/automation run --extra dev ruff check \
    workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py \
    workers/automation/tests/test_codex_home_isolation.py
All checks passed!
```

### `pytest` (existing status test + new isolation test)
```
$ uv --project workers/automation run --extra dev pytest -q \
    workers/automation/tests/test_codex_adapter_status.py \
    workers/automation/tests/test_codex_home_isolation.py
............                                                             [100%]
12 passed in 0.40s
```

The 2 existing `test_codex_adapter_status.py` tests pass unchanged (they inject a zero-arg fake factory → never touch the live path). The 10 new `test_codex_home_isolation.py` tests cover: isolated home under `APP_DIR`; `_prepare_isolated_codex_home()` creates `codex_home` (dir 0700) and copies `~/.codex/auth.json` → `auth.json` (file 0600, identical bytes); missing-source auth does not raise; `_isolated_codex_env` returns exactly `{"CODEX_HOME": ...}`; and full `_copy_newer_file` semantics (copy when target missing, skip when target newer/equal, overwrite when source newer, re-chmod when source missing but target exists, no-op when both missing) with deterministic `os.utime` mtimes.

Sanity (not in suite, run manually since `openai_codex` + a login exist here): the live factory returns a real `AsyncCodex` and creates `<APP_DIR>/codex_home` at mode `0700`; no app-server spawned (that happens on `__aenter__`, not construction).

## Docs

`README.md` enumerates `~/.jobhunter/` generated artifacts and ends that list with a "do not commit ... sensitive" note, so this new local dir belongs there. Added one line:
`codex_home/` — isolated Codex SDK home (session rollouts plus a copied auth token; sensitive, never commit).

No other doc update is warranted: this is internal infrastructure (where Codex writes its session files) and changes no CLI command, user-facing product behavior, or generated user artifact.

## Scope

Only `codex_analysis_adapter.py`, the new `test_codex_home_isolation.py`, and the one-line README entry. The injectable factory and its arity are unchanged; no timeouts added; the Antigravity/Claude legs, ensemble, and grounding are untouched.