### PR TITLE
chore(analysis): pin Codex analysis leg to gpt-5.5

### DIFF
--- a/.planning/phases/01-canonical-employer-analysis/01-AI-SPEC.md
+++ b/.planning/phases/01-canonical-employer-analysis/01-AI-SPEC.md
@@ -234,7 +234,7 @@ from jobhunter.domain.materials.analysis import JobAnalysis
 async def run_codex_draft(system_prompt: str, jd_snapshot: str) -> JobAnalysis:
     async with AsyncCodex() as codex:                      # reuses existing Codex login (D-04)
         thread = await codex.thread_start(
-            model="gpt-5.4",                               # top current Codex model (verify id at impl)
+            model="gpt-5.5",                               # top current Codex model
             config={"model_reasoning_effort": "high"},     # max effort (D-18)
             sandbox=Sandbox.read_only,                     # analysis reads the JD; no FS writes
         )
@@ -373,7 +373,7 @@ workers/automation/src/jobhunter/
 | Leg | SDK | Model (verify id at impl) | Effort / reasoning | Turn / token / time cap |
 |-----|-----|---------------------------|--------------------|--------------------------|
 | Claude draft | `claude-agent-sdk` | `claude-opus-4-8` | `effort` defaults to `high` on Opus 4.8 (1M ctx, 128k max output, extended/adaptive thinking) | `max_turns=None`; no `max_budget_usd`; no wall-clock (D-19) |
-| Codex draft | `openai-codex` | `gpt-5.4` (top Codex model) | `config={"model_reasoning_effort":"high"}` + per-turn `effort="high"` | awaited to completion; no documented cap to disable |
+| Codex draft | `openai-codex` | `gpt-5.5` (top Codex model) | `config={"model_reasoning_effort":"high"}` + per-turn `effort="high"` | awaited to completion; no documented cap to disable |
 | Gemini/Google draft | `google-antigravity` (`LocalAgentConfig` + `Agent`) | `gemini-3.5-flash` (`types.DEFAULT_MODEL`) | `response_schema` (Gemini-adapted JSON; `additionalProperties` stripped) | `GEMINI_API_KEY` / `GOOGLE_API_KEY` |
 | Synthesizer (D-07) | `claude-agent-sdk` | `claude-opus-4-8` | `high` | `max_turns=None` |
 

--- a/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
@@ -37,9 +37,9 @@ from jobhunter.infrastructure.analysis.strict_schema import strict_json_schema
 
 AsyncCodexFactory = Callable[[], Any]
 
-# Top current Codex model + max reasoning effort (D-18). Re-confirm the id at
-# impl time; model ids drift.
-CODEX_ANALYSIS_MODEL = "gpt-5.4"
+# Top current Codex model (gpt-5.5) + max reasoning effort (D-18). Matches
+# mestre's vendor-lane default for the Codex leg.
+CODEX_ANALYSIS_MODEL = "gpt-5.5"
 
 # Disable Codex plugins/apps so the isolated home only ever holds JobHunter's
 # analysis rollouts + the copied auth token (mirrors mestre's vendor lane).


### PR DESCRIPTION
## What changed

Bumps the Codex analysis leg's model id from `gpt-5.4` to `gpt-5.5` across the implementation and the Phase 1 AI design contract:

- `workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py` — `CODEX_ANALYSIS_MODEL = "gpt-5.5"`, and the adjacent comment now names `gpt-5.5` as the top current Codex model and notes it matches mestre's vendor-lane default (replacing the old "re-confirm the id at impl time; model ids drift" placeholder note).
- `.planning/phases/01-canonical-employer-analysis/01-AI-SPEC.md` — the `run_codex_draft` code example (`model="gpt-5.5"`) and the ensemble leg table row (`` `gpt-5.5` (top Codex model) ``) now reference `gpt-5.5`. A full-file scan confirmed these were the only two `gpt-5.4` occurrences in the spec.

No other files changed. `draft()`, the factory, `__init__`, the strict-schema logic, and the `CODEX_HOME` isolation are untouched.

## Why

`gpt-5.4` was a conservative placeholder that carried an explicit "re-confirm the id at impl time" comment. `gpt-5.5` is the current top Codex model and aligns the JobHunter Codex leg with mestre's vendor-lane default. **`gpt-5.5` was live-verified by the parent (me) against the installed Codex app-server before this PR — it runs and returns valid structured output, so this is a known-good id.** No live Codex network call was made from this PR; unit verification only.

## Tests

No test changes needed. `tests/test_codex_adapter_status.py` asserts `draft.model_id == CODEX_ANALYSIS_MODEL` by reading the constant, so it stays correct against the new value.

## Validation (exact output)

`grep -rn "gpt-5\.4" workers/automation/src .planning README.md docs` (ignoring `.venv`) → **no matches** (grep exit code 1, empty output), proving no stale `gpt-5.4` remains. README does not pin the model id, so no README change was required.

ruff:
```
$ uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
All checks passed!
```

pytest (targeted):
```
$ uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_codex_adapter_status.py workers/automation/tests/test_codex_home_isolation.py
............                                                             [100%]
12 passed in 1.26s
```