### PR TITLE
docs(planning): reconcile GSD v1.1 bookkeeping after merging phases 6-10

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -264,7 +264,7 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10 -> 11
 | 7. Shared Primitive Token Migration | 5/5 | Complete | 2026-06-10 |
 | 8. Layout Chrome, Fonts, And Tabler Icons | 4/4 | Complete | 2026-06-10 |
 | 9. Domain And Status Surface Migration | 4/4 | Complete | 2026-06-10 |
-| 10. Route Visual QA + Storybook/A11y Hardening | 0/? | Pending | - |
+| 10. Route Visual QA + Storybook/A11y Hardening | 4/4 | Complete | 2026-06-10 |
 | 11. Alias And Global CSS Cleanup | 0/? | Pending | - |
 
 ## Coverage
@@ -282,12 +282,12 @@ Phases execute in numeric order: 6 -> 7 -> 8 -> 9 -> 10 -> 11
 
 ## Next Up
 
-**Phase 10: Route Visual QA + Storybook/A11y Hardening** - Prove representative routes, overlays, light/dark themes, and density modes with seeded/synthetic QA only.
+**Phase 11: Alias And Global CSS Cleanup** - Remove dead global selectors, obsolete config remnants, residual old token references, and unused icon/font dependencies after grep and QA proof.
 
-`$gsd-discuss-phase 10`
+`$gsd-discuss-phase 11`
 
-Also available: `$gsd-plan-phase 10` after the Phase 10 discussion context is complete.
+Also available: `$gsd-plan-phase 11` after the Phase 11 discussion context is complete.
 
 ---
 *Roadmap created: 2026-06-09*
-*Last updated: 2026-06-10 after Phase 9 completion*
+*Last updated: 2026-06-10 after Phase 10 completion and merge of phases 6-10 to main (PRs #151-#155)*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,9 +3,9 @@ gsd_state_version: 1.0
 milestone: v1.1
 milestone_name: shadcn standard-token migration + preset b3F5kqmYd8
 status: executing
-stopped_at: Completed Phase 10
-last_updated: "2026-06-10T14:22:43.000Z"
-last_activity: 2026-06-10 -- Phase 10 route visual QA completed; Phase 11 cleanup is next
+stopped_at: Phases 6-10 merged to main (PRs #151-#155); Phase 11 ready to plan
+last_updated: "2026-06-10T15:45:00.000Z"
+last_activity: 2026-06-10 -- Phases 6-10 squash-merged to main via PRs #151-#155; Phase 11 cleanup is next
 progress:
   total_phases: 6
   completed_phases: 5
@@ -27,8 +27,8 @@ See: .planning/PROJECT.md (updated 2026-06-09)
 
 Phase: 11 (alias-and-global-css-cleanup) — READY TO PLAN
 Plan: create Phase 11 plan
-Status: Phase 10 complete; Phase 11 cleanup is next
-Last activity: 2026-06-10 -- Phase 10 route visual QA completed; Phase 11 cleanup is next
+Status: Phases 6-10 complete and squash-merged to main via PRs #151-#155 (2026-06-10); Phase 11 cleanup is next
+Last activity: 2026-06-10 -- Phases 6-10 squash-merged to main via PRs #151-#155; Phase 11 cleanup is next
 
 Progress: [████████░░] 83%
 
@@ -61,6 +61,8 @@ Phase order:
 | 9 | Domain And Status Surface Migration | Completed |
 | 10 | Route Visual QA + Storybook/A11y Hardening | Completed |
 | 11 | Alias And Global CSS Cleanup | Pending |
+
+Merge status: Phases 6-10 landed on `main` on 2026-06-10 as squash-merged PRs #151-#155 (one squash commit per phase, `4758935..ef6c680`). Pre-merge review found one High issue on #152 — the deliberate CR-01 a11y change moved data-grid row activation from the row body to a per-row "Open" button, but `jobs-drawer.spec.ts` and `materials.spec.ts` still clicked the row body — fixed on the PR by updating both e2e specs before merge. The final merged tree was verified with `pnpm web:check`, `pnpm --filter @jobhunter/web test` (727 passed), `pnpm web:build`, `pnpm api:check`, and `pnpm api:test` (201 passed).
 
 ## Prior Milestone Verification (2026-06-09)
 


### PR DESCRIPTION
## What changed
- `.planning/ROADMAP.md`: Progress table now marks Phase 10 Complete (4/4, 2026-06-10); Next Up advanced from Phase 10 to Phase 11; footer last-updated line refreshed.
- `.planning/STATE.md`: frontmatter `stopped_at`/`last_activity` and Current Position now record that phases 6-10 were squash-merged to main via PRs #151-#155; added a merge-status note (including the #152 review fix and the verification commands run on the final merged tree).

## Why
The merged stack carried .planning files written before the stack landed, so ROADMAP.md still showed Phase 10 as pending and pointed Next Up at Phase 10. This reconciles GSD bookkeeping to reality: phases 6-10 are complete and on main; Phase 11 (alias-and-global-css-cleanup) is next.

## Validation
Docs-only change to .planning bookkeeping; verified rendered tables/sections match the merged state of main (`4758935..ef6c680`). No code or behavior change, so no test/QA gates apply.