### PR TITLE
fix: clear stale apply material blockers

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -49,6 +49,14 @@ const DEFAULT_MAX_ATTEMPTS: Record<string, number> = {
   cover: 5,
   apply: 3,
 };
+const DEPENDENCY_BLOCKER_MESSAGES: Record<string, Array<{ downstream: string; messages: readonly string[] }>> = {
+  enrich: [{ downstream: "score", messages: ["Enrichment has not completed."] }],
+  score: [{ downstream: "tailor", messages: ["score has not completed."] }],
+  tailor: [
+    { downstream: "cover", messages: ["tailor has not completed."] },
+    { downstream: "apply", messages: ["Materials are not ready."] },
+  ],
+};
 
 interface BackfillOpts {
   jobUrl: string;
@@ -248,6 +256,57 @@ function backfillLegacyStageStates(db: SqliteDatabase): void {
       insertStage(row.url, "apply", "pending");
     }
   }
+}
+
+function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
+  const repairedJobs = new Set<string>();
+  if (!tableExists(db, "job_stage_states")) return repairedJobs;
+
+  const columns = new Set(
+    allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((row) => row.name),
+  );
+  const assignments = [
+    "state = 'pending'",
+    columns.has("updated_at") ? "updated_at = ?" : null,
+    columns.has("error_code") ? "error_code = NULL" : null,
+    columns.has("error_message") ? "error_message = NULL" : null,
+    columns.has("retryable") ? "retryable = 1" : null,
+    columns.has("blocked_by_json") ? "blocked_by_json = NULL" : null,
+    columns.has("next_action") ? "next_action = NULL" : null,
+    columns.has("metadata_json") ? "metadata_json = NULL" : null,
+  ].filter((assignment): assignment is string => Boolean(assignment));
+  const updateSql = `UPDATE job_stage_states SET ${assignments.join(", ")} WHERE job_url = ? AND stage = ?`;
+  const update = db.prepare(updateSql);
+  const now = new Date().toISOString();
+
+  for (const [upstream, downstreams] of Object.entries(DEPENDENCY_BLOCKER_MESSAGES)) {
+    for (const { downstream, messages } of downstreams) {
+      const placeholders = messages.map(() => "?").join(", ");
+      const rows = allRows<{ job_url: string; stage: string }>(
+        db,
+        `SELECT downstream.job_url, downstream.stage
+           FROM job_stage_states AS downstream
+          WHERE downstream.stage = ?
+            AND downstream.state = 'blocked'
+            AND downstream.error_code = 'BLOCKED'
+            AND downstream.error_message IN (${placeholders})
+            AND EXISTS (
+              SELECT 1
+                FROM job_stage_states AS upstream
+               WHERE upstream.job_url = downstream.job_url
+                 AND upstream.stage = ?
+                 AND upstream.state = 'succeeded'
+            )`,
+        [downstream, ...messages, upstream],
+      );
+      for (const row of rows) {
+        update.run(...(columns.has("updated_at") ? [now] : []), row.job_url, row.stage);
+        repairedJobs.add(row.job_url);
+      }
+    }
+  }
+
+  return repairedJobs;
 }
 
 /** Idempotently create the projection tables. Mirrors the Python schema. */
@@ -513,10 +572,11 @@ function setWatermark(db: SqliteDatabase, projection: string, eventId: number): 
 export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void {
   const projectionSchemaChanged = ensureProjectionTables(db);
   backfillLegacyStageStates(db);
+  const repairedDependencyJobs = reconcileDependencyBlockers(db);
 
   const watermark = readWatermark(db, PROJECTION_WATERMARK_NAME);
 
-  let dirtyJobs = new Set<string>();
+  let dirtyJobs = new Set<string>(repairedDependencyJobs);
   let sourceQualityDirty = false;
   let maxEventId = watermark;
   if (tableExists(db, "job_events")) {

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -113,6 +113,52 @@ describe("application feedback API", () => {
     await app.close();
   });
 
+  it("repairs stale apply material blockers before listing the review queue", async () => {
+    const db = new Database(options.dbPath);
+    db.prepare(
+      `
+      UPDATE job_stage_states
+         SET state = 'blocked',
+             error_code = 'BLOCKED',
+             error_message = 'Materials are not ready.',
+             retryable = 0
+       WHERE job_url = ?
+         AND stage = 'apply'
+      `,
+    ).run(READY_JOB);
+    db.close();
+    const app = buildApp(options);
+
+    const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    expect(queueItem(response.json(), READY_JOB)).toMatchObject({
+      currentStage: "apply",
+      currentState: "pending",
+      blockers: [],
+    });
+    await app.close();
+
+    const readDb = new Database(options.dbPath, { readonly: true });
+    const stage = readDb
+      .prepare(
+        `
+        SELECT state, error_code, error_message
+          FROM job_stage_states
+         WHERE job_url = ?
+           AND stage = 'apply'
+        `,
+      )
+      .get(READY_JOB) as { state: string; error_code: string | null; error_message: string | null };
+    readDb.close();
+
+    expect(stage).toEqual({
+      state: "pending",
+      error_code: null,
+      error_message: null,
+    });
+  });
+
   it("uses the posting URL as the review apply target when direct application URL is missing", async () => {
     const db = new Database(options.dbPath);
     db.prepare("UPDATE jobs SET application_url = NULL WHERE url = ?").run(READY_JOB);

--- a/workers/automation/src/jobhunter/state.py
+++ b/workers/automation/src/jobhunter/state.py
@@ -64,6 +64,7 @@ _DEPENDENCY_BLOCKER_MESSAGES: dict[str, tuple[tuple[str, tuple[str, ...]], ...]]
     "score": (("tailor", ("score has not completed.",)),),
     "tailor": (
         ("cover", ("tailor has not completed.",)),
+        ("apply", ("Materials are not ready.",)),
     ),
 }
 SCORE_ELIGIBILITY_BLOCKED_ERROR_CODE = "SCORE_ELIGIBILITY_BLOCKED"

--- a/workers/automation/tests/test_state_dashboard.py
+++ b/workers/automation/tests/test_state_dashboard.py
@@ -284,6 +284,38 @@ def test_tailor_success_unblocks_cover_waiting_on_tailor(tmp_path):
         close_connection(db_path)
 
 
+def test_tailor_success_unblocks_apply_waiting_on_materials(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(conn, job["url"], discovered_at=job["discovered_at"])
+        set_stage_state(
+            conn,
+            job["url"],
+            "apply",
+            "blocked",
+            error_code="BLOCKED",
+            error_message="Materials are not ready.",
+        )
+
+        set_stage_state(conn, job["url"], "tailor", "running", started_at="2026-04-29T10:03:00+00:00")
+        set_stage_state(conn, job["url"], "tailor", "succeeded", finished_at="2026-04-29T10:04:00+00:00")
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT state, error_code, error_message FROM job_stage_states "
+            "WHERE job_url = ? AND stage = 'apply'",
+            (job["url"],),
+        ).fetchone()
+        assert row["state"] == "pending"
+        assert row["error_code"] is None
+        assert row["error_message"] is None
+    finally:
+        close_connection(db_path)
+
+
 def test_dependency_reconciliation_preserves_unrelated_blockers(tmp_path):
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
@@ -346,6 +378,45 @@ def test_dependency_reconciliation_repairs_existing_stale_rows(tmp_path):
         row = conn.execute(
             "SELECT state, error_message FROM job_stage_states "
             "WHERE job_url = ? AND stage = 'tailor'",
+            (job["url"],),
+        ).fetchone()
+        assert repaired == 1
+        assert row["state"] == "pending"
+        assert row["error_message"] is None
+    finally:
+        close_connection(db_path)
+
+
+def test_dependency_reconciliation_repairs_existing_apply_material_blocker(tmp_path):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+
+    try:
+        job = _insert_job(conn)
+        ensure_job_stage_rows(conn, job["url"], discovered_at=job["discovered_at"])
+        set_stage_state(
+            conn,
+            job["url"],
+            "tailor",
+            "succeeded",
+            finished_at="2026-04-29T10:04:00+00:00",
+            validate_transition=False,
+        )
+        set_stage_state(
+            conn,
+            job["url"],
+            "apply",
+            "blocked",
+            error_code="BLOCKED",
+            error_message="Materials are not ready.",
+        )
+
+        repaired = reconcile_dependency_blockers(conn)
+        conn.commit()
+
+        row = conn.execute(
+            "SELECT state, error_message FROM job_stage_states "
+            "WHERE job_url = ? AND stage = 'apply'",
             (job["url"],),
         ).fetchone()
         assert repaired == 1


### PR DESCRIPTION
## Summary

- Clear stale apply-stage material blockers after the tailor stage succeeds in worker state reconciliation.
- Repair stale dependency blockers during TypeScript API projection refresh so `/v1/apply/review-queue` does not keep serving stale blocked rows.
- Add regression coverage for live tailor success, existing stale worker rows, and the apply-review API endpoint.

## Root Cause

Apply review rendered `materials not ready` because the canonical `job_stage_states` row for `apply` could remain blocked with `Materials are not ready.` even after tailoring later succeeded and material artifacts existed. Dependency reconciliation already cleared stale `tailor -> cover` blockers, but did not clear the equivalent `tailor -> apply` blocker. The TypeScript API projection path also needed the same repair because the visible review queue is served through that read path.

## Validation

- `pnpm api:test -- application-feedback.test.ts`
- `pnpm api:check`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_state_dashboard.py workers/automation/tests/test_score_eligibility_stage_state.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/state.py workers/automation/tests/test_state_dashboard.py`
- `git diff --check`
