### PR TITLE
docs: initialize salary range estimator milestone

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -21,18 +21,18 @@ v1.2 made the audit path inspectable across the two surfaces where users decide 
 - The Jobs drawer to Apply Review handoff preserves the selected job through the route search state.
 - The folded v1.1 cleanup removed obsolete `lucide-react` usage and normalized final Tailwind 4/shadcn token, icon, font, and QA expectations.
 
-v1.3 will make compensation facts inspectable in Jobs triage by combining posted salary extraction with externally sourced market salary estimates, including statistical confidence and source provenance for every displayed range.
+v1.3 will make compensation facts inspectable in Jobs triage by combining posted salary extraction with Europe-only public market salary baselines, including statistical confidence and source provenance for every displayed range.
 
 ## Current Milestone: v1.3 Salary Range Estimator
 
-**Goal:** Make salary facts in JobHunter inspectable and useful in Jobs triage by combining posted compensation extraction with externally sourced market-range estimates, while preserving an audit trail for every displayed range.
+**Goal:** Make salary facts in JobHunter inspectable and useful in Jobs triage by combining posted compensation extraction with Europe-only public market-range estimates, while preserving an audit trail for every displayed range.
 
 **Target features:**
 - Normalize compensation from raw job salary strings and compensation text in postings into a structured salary-range fact with source text, currency/period, statistical confidence, and parse warnings.
-- Add a market salary estimator that uses researched external compensation sources, explicitly including sources like Levels.fyi and Glassdoor where appropriate, to produce role/location/seniority/company-aware ranges when enough benchmark evidence exists.
+- Add a market salary estimator that uses Eurostat Structure of Earnings Survey, ESCO occupation mapping, and Spain INE Wage Structure Survey as v1.3 public baselines, with licensed sources such as Levels.fyi or Glassdoor represented only as disabled/unavailable seams unless permitted access is explicitly configured.
 - Maintain a salary-source registry/provenance model so every market estimate identifies source type, captured values, freshness, source agreement, sample/source count where available, assumptions, and whether the source supports the specific role/location/seniority claim.
-- Surface posted salary, market estimate, statistical confidence, source/freshness trail, and profile-floor comparison in the Jobs list/drawer audit triage.
-- Keep uncertain compensation audit-first: show confidence, source gaps, and unknowns clearly; do not silently rank, filter, or block jobs from opaque estimates.
+- Surface posted salary, Europe public baseline estimate, statistical confidence, source/freshness trail, and profile-floor comparison in the Jobs list/drawer audit triage.
+- Keep compensation audit-first and warning-only in v1.3: show confidence, source gaps, and unknowns clearly; do not silently rank, filter, or block jobs from posted salaries or market estimates.
 
 ## Requirements
 
@@ -58,8 +58,8 @@ v1.3 will make compensation facts inspectable in Jobs triage by combining posted
 ### Active
 
 - [ ] Normalize posted compensation into structured, source-backed salary facts.
-- [ ] Estimate market salary ranges from researched external compensation sources with statistical confidence and provenance.
-- [ ] Surface salary facts, market estimates, source trail, and profile-floor comparison in Jobs triage without opaque automatic gating.
+- [ ] Estimate Europe-only public market salary ranges with statistical confidence and provenance.
+- [ ] Surface salary facts, market estimates, source trail, and profile-floor comparison in Jobs triage as warnings without automatic gating.
 
 ### Out of Scope
 

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -11,6 +11,7 @@ A user can trust every line of a tailored resume because each bullet traces visi
 ## Current State
 
 **Shipped milestone:** v1.2 Apply Review Audit UX - Drawer + Resume Pins (2026-06-13)
+**Active milestone:** v1.3 Salary Range Estimator
 
 v1.2 made the audit path inspectable across the two surfaces where users decide whether a job and generated materials are ready:
 
@@ -20,7 +21,18 @@ v1.2 made the audit path inspectable across the two surfaces where users decide 
 - The Jobs drawer to Apply Review handoff preserves the selected job through the route search state.
 - The folded v1.1 cleanup removed obsolete `lucide-react` usage and normalized final Tailwind 4/shadcn token, icon, font, and QA expectations.
 
-No active milestone is currently defined. The next milestone should start with fresh requirements via `$gsd-new-milestone`.
+v1.3 will make compensation facts inspectable in Jobs triage by combining posted salary extraction with externally sourced market salary estimates, including statistical confidence and source provenance for every displayed range.
+
+## Current Milestone: v1.3 Salary Range Estimator
+
+**Goal:** Make salary facts in JobHunter inspectable and useful in Jobs triage by combining posted compensation extraction with externally sourced market-range estimates, while preserving an audit trail for every displayed range.
+
+**Target features:**
+- Normalize compensation from raw job salary strings and compensation text in postings into a structured salary-range fact with source text, currency/period, statistical confidence, and parse warnings.
+- Add a market salary estimator that uses researched external compensation sources, explicitly including sources like Levels.fyi and Glassdoor where appropriate, to produce role/location/seniority/company-aware ranges when enough benchmark evidence exists.
+- Maintain a salary-source registry/provenance model so every market estimate identifies source type, captured values, freshness, source agreement, sample/source count where available, assumptions, and whether the source supports the specific role/location/seniority claim.
+- Surface posted salary, market estimate, statistical confidence, source/freshness trail, and profile-floor comparison in the Jobs list/drawer audit triage.
+- Keep uncertain compensation audit-first: show confidence, source gaps, and unknowns clearly; do not silently rank, filter, or block jobs from opaque estimates.
 
 ## Requirements
 
@@ -45,7 +57,9 @@ No active milestone is currently defined. The next milestone should start with f
 
 ### Active
 
-None. New active requirements should be defined in the next milestone.
+- [ ] Normalize posted compensation into structured, source-backed salary facts.
+- [ ] Estimate market salary ranges from researched external compensation sources with statistical confidence and provenance.
+- [ ] Surface salary facts, market estimates, source trail, and profile-floor comparison in Jobs triage without opaque automatic gating.
 
 ### Out of Scope
 
@@ -132,4 +146,4 @@ This document evolves at phase transitions and milestone boundaries.
 4. Update Context with current state.
 
 ---
-*Last updated: 2026-06-13 after v1.2 milestone completion*
+*Last updated: 2026-06-19 after v1.3 milestone start*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -66,11 +66,10 @@
 - **SRC-F02**: User can connect Glassdoor only when explicit partner/API access or written permission exists for the intended use.
 - **SRC-F03**: User can add other licensed compensation providers through the salary-source registry and source-port model.
 
-### Geography Expansion
+### Europe Expansion
 
-- **GEO-F01**: User can add U.S. public baselines such as BLS/OEWS, O*NET, and OFLC in a later milestone.
-- **GEO-F02**: User can add non-European public baselines with region-specific source policies and confidence rules.
-- **GEO-F03**: User can compare spot-FX and purchasing-power converted salary ranges with source/date attribution.
+- **GEO-F01**: User can deepen European public baseline coverage with additional national statistical institutes and region-specific source policies.
+- **GEO-F02**: User can compare spot-FX and purchasing-power converted European salary ranges with source/date attribution.
 
 ### Product Expansion
 
@@ -85,7 +84,7 @@
 |---------|--------|
 | Glassdoor scraping | Glassdoor terms require express permission for automated scraping/mining; v1.3 only supports disabled/licensed seams. |
 | Unlicensed Levels.fyi scraping | Levels.fyi data/API access must be permitted and licensed before use; v1.3 only supports disabled/licensed seams. |
-| U.S. public baselines | The scoped milestone is Europe-only. BLS/O*NET/OFLC can be added later. |
+| Non-European public baselines | JobHunter is Europe-first; non-European salary baselines are not part of the active product direction. |
 | Automatic salary ranking/filtering/blockers | The user chose warning-only floor behavior for v1.3. |
 | Employer-side compensation screening | JobHunter is applicant-side local triage, not an employer-side selection system. |
 | Deep equity/RSU/bonus/OTE modeling | Public Europe baselines are wage/salary aggregates; total compensation modeling needs licensed structured data. |
@@ -94,51 +93,52 @@
 
 ## Traceability
 
-Which phases cover which requirements. Updated during roadmap creation.
+Which phases cover which requirements.
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| COMP-01 | TBD | Pending |
-| COMP-02 | TBD | Pending |
-| COMP-03 | TBD | Pending |
-| COMP-04 | TBD | Pending |
-| COMP-05 | TBD | Pending |
-| SRC-01 | TBD | Pending |
-| SRC-02 | TBD | Pending |
-| SRC-03 | TBD | Pending |
-| SRC-04 | TBD | Pending |
-| SRC-05 | TBD | Pending |
-| SRC-06 | TBD | Pending |
-| EST-01 | TBD | Pending |
-| EST-02 | TBD | Pending |
-| EST-03 | TBD | Pending |
-| EST-04 | TBD | Pending |
-| EST-05 | TBD | Pending |
-| EST-06 | TBD | Pending |
-| EST-07 | TBD | Pending |
-| API-01 | TBD | Pending |
-| API-02 | TBD | Pending |
-| API-03 | TBD | Pending |
-| API-04 | TBD | Pending |
-| API-05 | TBD | Pending |
-| UI-01 | TBD | Pending |
-| UI-02 | TBD | Pending |
-| UI-03 | TBD | Pending |
-| UI-04 | TBD | Pending |
-| UI-05 | TBD | Pending |
-| UI-06 | TBD | Pending |
-| QA-01 | TBD | Pending |
-| QA-02 | TBD | Pending |
-| QA-03 | TBD | Pending |
-| QA-04 | TBD | Pending |
-| QA-05 | TBD | Pending |
-| QA-06 | TBD | Pending |
+| COMP-01 | Phase 18 | Pending |
+| COMP-02 | Phase 18 | Pending |
+| COMP-03 | Phase 18 | Pending |
+| COMP-04 | Phase 18 | Pending |
+| COMP-05 | Phase 18 | Pending |
+| SRC-01 | Phase 17 | Pending |
+| SRC-02 | Phase 19 | Pending |
+| SRC-03 | Phase 19 | Pending |
+| SRC-04 | Phase 17 | Pending |
+| SRC-05 | Phase 17 | Pending |
+| SRC-06 | Phase 17 | Pending |
+| EST-01 | Phase 19 | Pending |
+| EST-02 | Phase 19 | Pending |
+| EST-03 | Phase 19 | Pending |
+| EST-04 | Phase 19 | Pending |
+| EST-05 | Phase 20 | Pending |
+| EST-06 | Phase 19 | Pending |
+| EST-07 | Phase 19 | Pending |
+| API-01 | Phase 20 | Pending |
+| API-02 | Phase 20 | Pending |
+| API-03 | Phase 20 | Pending |
+| API-04 | Phase 20 | Pending |
+| API-05 | Phase 20 | Pending |
+| UI-01 | Phase 21 | Pending |
+| UI-02 | Phase 21 | Pending |
+| UI-03 | Phase 21 | Pending |
+| UI-04 | Phase 21 | Pending |
+| UI-05 | Phase 21 | Pending |
+| UI-06 | Phase 21 | Pending |
+| QA-01 | Phase 22 | Pending |
+| QA-02 | Phase 22 | Pending |
+| QA-03 | Phase 22 | Pending |
+| QA-04 | Phase 22 | Pending |
+| QA-05 | Phase 22 | Pending |
+| QA-06 | Phase 22 | Pending |
 
 **Coverage:**
 - v1.3 requirements: 35 total
-- Mapped to phases: 0
-- Unmapped: 35
+- Mapped to phases: 35
+- Unmapped: 0
+- Duplicate mappings: 0
 
 ---
 *Requirements defined: 2026-06-19*
-*Last updated: 2026-06-19 after v1.3 requirements definition*
+*Last updated: 2026-06-19 after v1.3 roadmap creation*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,144 @@
+# Requirements: JobHunter v1.3 Salary Range Estimator
+
+**Defined:** 2026-06-19
+**Core Value:** A user can trust every line of a tailored resume because each bullet traces visibly to a real profile fact and a specific job requirement, with the reasoning and transform rule available for review.
+
+## v1.3 Requirements
+
+### Compensation Facts
+
+- [ ] **COMP-01**: User can see whether a job has no posted salary, an unparseable salary, an ambiguous salary, or a parsed posted range.
+- [ ] **COMP-02**: User can inspect the exact posting field or text excerpt that produced each parsed posted salary fact.
+- [ ] **COMP-03**: User can see normalized salary range fields for parsed posted compensation, including currency, period, component type, minimum, maximum, and annualized values only when annualization assumptions are explicit.
+- [ ] **COMP-04**: User can see parse confidence and parse warnings for ambiguous compensation text such as hourly pay, monthly pay, OTE, bonus, commission, equity, broad ranges, one-sided ranges, missing currency, or missing period.
+- [ ] **COMP-05**: User can still see the legacy raw salary string when no structured compensation fact exists, without treating that raw string as the normalized source of truth.
+
+### Europe Salary Sources
+
+- [ ] **SRC-01**: User can see a salary-source registry entry for every configured compensation source, including access mode, terms/source URL, license status, source type, freshness policy, attribution requirement, supported fields, and disabled reason when unavailable.
+- [ ] **SRC-02**: User can use Europe-only public baseline sources for v1.3: Eurostat Structure of Earnings Survey for Europe-wide wage baselines, ESCO for occupation mapping, and Spain INE Wage Structure Survey for Spain-specific wage baselines.
+- [ ] **SRC-03**: User can see when a public baseline is an occupation/location aggregate rather than a company-specific market range.
+- [ ] **SRC-04**: User can see Levels.fyi and Glassdoor represented only as disabled or unavailable licensed-source seams unless explicit permitted access is configured.
+- [ ] **SRC-05**: User is protected from unauthorized Glassdoor scraping because the product does not fetch, scrape, cache, or display Glassdoor-derived salary data without explicit partner/API access or written permission.
+- [ ] **SRC-06**: User is protected from unlicensed Levels.fyi use because the product does not fetch, scrape, cache, or display Levels.fyi-derived salary data without an explicitly configured permitted access mode and Europe coverage.
+
+### Market Estimates And Statistical Confidence
+
+- [ ] **EST-01**: User can see a market estimate state for each job: not requested, unsupported, insufficient evidence, estimated range, or source unavailable.
+- [ ] **EST-02**: User can see Europe-only market estimates only when the estimator has enough source support for role, occupation, geography, seniority, compensation component, and freshness.
+- [ ] **EST-03**: User can see statistical confidence for every market estimate, including confidence band, score or bucket, source count, sample count when available, freshness, source agreement or dispersion, and factor-level reasons.
+- [ ] **EST-04**: User can see an explicit insufficient-evidence explanation instead of a market range when source coverage, sample count, geography match, seniority match, or component compatibility is too weak.
+- [ ] **EST-05**: User can distinguish posted salary facts from benchmark-derived market estimates in every API and UI surface.
+- [ ] **EST-06**: User can see assumptions for remote-Europe, Spain-local, EU-wide, non-EU-Europe, and unknown-location mappings rather than having the system silently pick a market.
+- [ ] **EST-07**: User can see source conflict or broad aggregate warnings when public baselines and posted salary ranges diverge or when a range is too wide for precise triage.
+
+### Read Model And API
+
+- [ ] **API-01**: User-facing job list and job detail responses include compensation summary and compensation audit data from canonical persisted rows, not React or API read-time parsing.
+- [ ] **API-02**: User can trust compensation projections because Python and TypeScript projection builders produce matching compensation summary/detail JSON for the same canonical fixture.
+- [ ] **API-03**: User can see compensation facts update through the existing Operations/SSE invalidation path when a compensation assessment changes.
+- [ ] **API-04**: User can rely on existing raw `JobSummary.salary` compatibility while new consumers prefer the structured compensation audit contract.
+- [ ] **API-05**: User compensation preferences, local source payloads, credentials, raw benchmark pages, and local paths are not exposed in events, fixtures, logs, or API responses beyond safe comparison facts and allowed excerpts.
+
+### Jobs Triage UX
+
+- [ ] **UI-01**: User can scan posted salary, market estimate state, statistical confidence, and warning count from the Jobs list without opening the drawer.
+- [ ] **UI-02**: User can inspect a dedicated compensation audit section in the Jobs drawer showing posted range, market estimate, source trail, confidence factors, assumptions, warnings, and unavailable-source reasons.
+- [ ] **UI-03**: User can see profile-floor comparison as a warning-only audit concern, never as a hidden ranking, filtering, apply-readiness, or blocker decision in v1.3.
+- [ ] **UI-04**: User can tell whether profile-floor comparison used a posted salary, a market estimate, both, or neither.
+- [ ] **UI-05**: User can see missing salary and unsupported market-estimate states explicitly rather than seeing a blank salary cell or silent omission.
+- [ ] **UI-06**: User can review compensation source labels, freshness, confidence, and warnings on mobile and desktop without text overlap or layout crowding.
+
+### QA And Safety
+
+- [ ] **QA-01**: User-facing compensation behavior is covered by synthetic fixtures for below-floor posted salary, above-floor posted salary, missing posted salary, unparseable salary, broad posted range, OTE/equity ambiguity, Europe public baseline, Spain INE baseline, unsupported geography, stale source, source conflict, low-confidence estimate, and insufficient evidence.
+- [ ] **QA-02**: Product-path QA proves salary estimates do not change fit score, apply readiness, apply-review handoff, ranking, filtering, or auto-apply behavior in v1.3.
+- [ ] **QA-03**: Backend tests prove parser confidence and market confidence degrade when source quality, sample count, freshness, role match, seniority match, geography match, or component compatibility is weak.
+- [ ] **QA-04**: API and projection tests prove compensation audit data comes from canonical rows and remains parity-safe across Python and TypeScript projection refreshers.
+- [ ] **QA-05**: Frontend tests prove Jobs list and Jobs drawer render posted, estimated, unavailable, insufficient-evidence, warning-only floor comparison, and source-conflict states.
+- [ ] **QA-06**: QA uses synthetic or public aggregate data only and does not run auto-apply, browser submission, mailbox scanning, real generated-material regeneration, destructive profile/database actions, real external scraping, or worker-backed apply jobs.
+
+## Future Requirements
+
+### Licensed Source Expansion
+
+- **SRC-F01**: User can connect a licensed Levels.fyi data source when access, Europe coverage, retention, attribution, and redistribution terms are confirmed.
+- **SRC-F02**: User can connect Glassdoor only when explicit partner/API access or written permission exists for the intended use.
+- **SRC-F03**: User can add other licensed compensation providers through the salary-source registry and source-port model.
+
+### Geography Expansion
+
+- **GEO-F01**: User can add U.S. public baselines such as BLS/OEWS, O*NET, and OFLC in a later milestone.
+- **GEO-F02**: User can add non-European public baselines with region-specific source policies and confidence rules.
+- **GEO-F03**: User can compare spot-FX and purchasing-power converted salary ranges with source/date attribution.
+
+### Product Expansion
+
+- **UX-F01**: User can receive negotiation-anchor suggestions from compensation evidence.
+- **UX-F02**: User can opt into salary-based ranking, filtering, or hard blockers after confidence thresholds and source policy are validated.
+- **UX-F03**: User can correct parsed salary facts and market-source mappings, with corrections preserved as audit history.
+- **UX-F04**: User can model equity, bonus, OTE, and total compensation beyond base/gross wage baselines.
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Glassdoor scraping | Glassdoor terms require express permission for automated scraping/mining; v1.3 only supports disabled/licensed seams. |
+| Unlicensed Levels.fyi scraping | Levels.fyi data/API access must be permitted and licensed before use; v1.3 only supports disabled/licensed seams. |
+| U.S. public baselines | The scoped milestone is Europe-only. BLS/O*NET/OFLC can be added later. |
+| Automatic salary ranking/filtering/blockers | The user chose warning-only floor behavior for v1.3. |
+| Employer-side compensation screening | JobHunter is applicant-side local triage, not an employer-side selection system. |
+| Deep equity/RSU/bonus/OTE modeling | Public Europe baselines are wage/salary aggregates; total compensation modeling needs licensed structured data. |
+| Real external scraping in QA | QA must use synthetic/public aggregate fixtures and must not hit real salary pages or private account data. |
+| Frontend-only salary estimation | Every displayed compensation claim needs persisted provenance and an owning backend source of truth. |
+
+## Traceability
+
+Which phases cover which requirements. Updated during roadmap creation.
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| COMP-01 | TBD | Pending |
+| COMP-02 | TBD | Pending |
+| COMP-03 | TBD | Pending |
+| COMP-04 | TBD | Pending |
+| COMP-05 | TBD | Pending |
+| SRC-01 | TBD | Pending |
+| SRC-02 | TBD | Pending |
+| SRC-03 | TBD | Pending |
+| SRC-04 | TBD | Pending |
+| SRC-05 | TBD | Pending |
+| SRC-06 | TBD | Pending |
+| EST-01 | TBD | Pending |
+| EST-02 | TBD | Pending |
+| EST-03 | TBD | Pending |
+| EST-04 | TBD | Pending |
+| EST-05 | TBD | Pending |
+| EST-06 | TBD | Pending |
+| EST-07 | TBD | Pending |
+| API-01 | TBD | Pending |
+| API-02 | TBD | Pending |
+| API-03 | TBD | Pending |
+| API-04 | TBD | Pending |
+| API-05 | TBD | Pending |
+| UI-01 | TBD | Pending |
+| UI-02 | TBD | Pending |
+| UI-03 | TBD | Pending |
+| UI-04 | TBD | Pending |
+| UI-05 | TBD | Pending |
+| UI-06 | TBD | Pending |
+| QA-01 | TBD | Pending |
+| QA-02 | TBD | Pending |
+| QA-03 | TBD | Pending |
+| QA-04 | TBD | Pending |
+| QA-05 | TBD | Pending |
+| QA-06 | TBD | Pending |
+
+**Coverage:**
+- v1.3 requirements: 35 total
+- Mapped to phases: 0
+- Unmapped: 35
+
+---
+*Requirements defined: 2026-06-19*
+*Last updated: 2026-06-19 after v1.3 requirements definition*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,17 +2,116 @@
 
 ## Milestones
 
-- ✅ **v1.2 Apply Review Audit UX - Drawer + Resume Pins** — Phases 12-16, shipped 2026-06-13 ([roadmap archive](milestones/v1.2-ROADMAP.md), [requirements archive](milestones/v1.2-REQUIREMENTS.md), [audit](milestones/v1.2-MILESTONE-AUDIT.md))
+- 🚧 **v1.3 Salary Range Estimator** — Phases 17-22, active planning started 2026-06-19.
+- ✅ **v1.2 Apply Review Audit UX - Drawer + Resume Pins** — Phases 12-16, shipped 2026-06-13 ([roadmap archive](milestones/v1.2-ROADMAP.md), [requirements archive](milestones/v1.2-REQUIREMENTS.md), [audit](milestones/v1.2-MILESTONE-AUDIT.md)).
 - ✅ **v1.1 shadcn standard-token migration + preset b3F5kqmYd8** — Phases 6-10, shipped before v1.2; final cleanup folded into v1.2 Phase 12.
 - ✅ **v1.0 Grounded Resume Tailoring** — Phases 1-5, verified 2026-06-09.
 
-## Current Planning State
+## Overview
 
-No active milestone is defined. Start the next cycle with:
+v1.3 makes compensation facts inspectable in Jobs triage without turning uncertain salary evidence into hidden ranking, filtering, or apply gates. The milestone first locks source-access policy, then adds posted salary facts, Europe-only public market estimates, canonical read-model/API propagation, Jobs list/drawer UX, and product-path QA that proves the feature stays warning-only and audit-first.
 
-```bash
-$gsd-new-milestone
-```
+## Phases
+
+**Phase Numbering:**
+- Integer phases (17, 18, 19): Planned milestone work continuing after v1.2 Phase 16.
+- Decimal phases (17.1, 17.2): Urgent insertions only, if needed later.
+
+- [ ] **Phase 17: Source Registry & Access Policy** - Users can inspect which compensation sources are available, licensed, disabled, or blocked.
+- [ ] **Phase 18: Posted Compensation Facts** - Users can inspect structured posted salary facts with source text, confidence, warnings, and raw fallback.
+- [ ] **Phase 19: Europe Public Market Estimates** - Users can see Europe-only baseline estimates or explicit insufficient-evidence states with confidence factors.
+- [ ] **Phase 20: Canonical Read Model & Realtime API** - Users and API consumers receive compensation audit data from canonical persisted rows safely and consistently.
+- [ ] **Phase 21: Jobs Triage UX & Warning-Only Floor** - Users can scan and inspect compensation evidence in Jobs triage without salary data becoming an automatic gate.
+- [ ] **Phase 22: Product-Path QA & Safety Release** - Users can rely on v1.3 compensation behavior being verified with synthetic/public data and no prohibited actions.
+
+## Phase Details
+
+### Phase 17: Source Registry & Access Policy
+**Goal**: Users can trust which compensation sources are available, licensed, disabled, and safe to use before any estimate is generated.
+**Depends on**: Phase 16 (v1.2 shipped baseline)
+**Requirements**: SRC-01, SRC-04, SRC-05, SRC-06
+**Success Criteria** (what must be TRUE):
+  1. User can inspect each configured compensation source's access mode, terms/source URL, license status, source type, freshness policy, attribution requirement, supported fields, and disabled reason.
+  2. User can see Levels.fyi and Glassdoor only as disabled or unavailable licensed-source seams unless explicit permitted access is configured.
+  3. User is protected from unauthorized Glassdoor and Levels.fyi use because the product does not fetch, scrape, cache, or display either source without permitted access.
+  4. User can distinguish unavailable licensed-source seams from Europe public baseline sources in compensation source evidence.
+**Plans**: TBD
+
+### Phase 18: Posted Compensation Facts
+**Goal**: Users can inspect posted salary facts parsed from job postings, including source text, normalized values, confidence, warnings, and legacy raw fallback.
+**Depends on**: Phase 17
+**Requirements**: COMP-01, COMP-02, COMP-03, COMP-04, COMP-05
+**Success Criteria** (what must be TRUE):
+  1. User can see whether a job has no posted salary, an unparseable salary, an ambiguous salary, or a parsed posted range.
+  2. User can inspect the exact posting field or text excerpt that produced each parsed posted salary fact.
+  3. User can see normalized currency, period, component type, minimum, maximum, and annualized values only when annualization assumptions are explicit.
+  4. User can see parse confidence and warnings for hourly pay, monthly pay, OTE, bonus, commission, equity, broad ranges, one-sided ranges, missing currency, and missing period.
+  5. User can still see the legacy raw salary string when no structured compensation fact exists, without treating that raw string as the normalized source of truth.
+**Plans**: TBD
+
+### Phase 19: Europe Public Market Estimates
+**Goal**: Users can see Europe-only public market estimates when evidence is strong enough, or explicit explanations when support is weak or unavailable.
+**Depends on**: Phase 18
+**Requirements**: SRC-02, SRC-03, EST-01, EST-02, EST-03, EST-04, EST-06, EST-07
+**Success Criteria** (what must be TRUE):
+  1. User can see a market estimate state for each job: not requested, unsupported, insufficient evidence, estimated range, or source unavailable.
+  2. User can see Europe-only estimates from Eurostat Structure of Earnings Survey, ESCO occupation mapping, and Spain INE Wage Structure Survey only when role, occupation, geography, seniority, compensation component, and freshness are sufficiently supported.
+  3. User can see when a public baseline is an occupation/location aggregate rather than a company-specific market range.
+  4. User can see statistical confidence for every market estimate, including band or bucket, source count, sample count when available, freshness, source agreement or dispersion, and factor-level reasons.
+  5. User can see assumptions, source conflict warnings, broad aggregate warnings, or insufficient-evidence explanations instead of a precise market range when source support is too weak.
+**Plans**: TBD
+
+### Phase 20: Canonical Read Model & Realtime API
+**Goal**: Users and API consumers receive compensation summaries and audit details from canonical persisted rows, with parity-safe projections and safe event payloads.
+**Depends on**: Phase 19
+**Requirements**: EST-05, API-01, API-02, API-03, API-04, API-05
+**Success Criteria** (what must be TRUE):
+  1. User-facing job list and job detail responses include compensation summary and compensation audit data from canonical persisted rows, not client or read-time parsing.
+  2. Posted salary facts and benchmark-derived market estimates remain clearly separate in every compensation API/read-model contract.
+  3. Python and TypeScript projection builders produce matching compensation summary/detail JSON for the same canonical fixture.
+  4. User can see compensation facts update through the existing Operations/SSE invalidation path while existing raw `JobSummary.salary` compatibility remains intact.
+  5. User compensation preferences, local source payloads, credentials, raw benchmark pages, local paths, and unsafe source details are excluded from events, fixtures, logs, and API responses beyond safe comparison facts and allowed excerpts.
+**Plans**: TBD
+
+### Phase 21: Jobs Triage UX & Warning-Only Floor
+**Goal**: Users can scan and inspect compensation evidence in Jobs list and drawer triage without salary facts silently changing ranking, filtering, apply readiness, or blockers.
+**Depends on**: Phase 20
+**Requirements**: UI-01, UI-02, UI-03, UI-04, UI-05, UI-06
+**Success Criteria** (what must be TRUE):
+  1. User can scan posted salary, market estimate state, statistical confidence, and warning count from the Jobs list without opening the drawer.
+  2. User can inspect a dedicated compensation audit section in the Jobs drawer showing posted range, market estimate, source trail, confidence factors, assumptions, warnings, and unavailable-source reasons.
+  3. User can see profile-floor comparison as a warning-only audit concern and can tell whether it used posted salary, market estimate, both, or neither.
+  4. User can see missing salary and unsupported or insufficient-evidence market-estimate states explicitly instead of blank salary cells or silent omissions.
+  5. User can review compensation source labels, freshness, confidence, and warnings on mobile and desktop without text overlap or layout crowding.
+**Plans**: TBD
+**UI hint**: yes
+
+### Phase 22: Product-Path QA & Safety Release
+**Goal**: Users can rely on v1.3 compensation behavior because the full path is verified with synthetic/public data and the feature does not trigger prohibited actions.
+**Depends on**: Phase 21
+**Requirements**: QA-01, QA-02, QA-03, QA-04, QA-05, QA-06
+**Success Criteria** (what must be TRUE):
+  1. Human verifier can exercise synthetic fixtures for below-floor posted salary, above-floor posted salary, missing posted salary, unparseable salary, broad posted range, OTE/equity ambiguity, Europe public baseline, Spain INE baseline, unsupported geography, stale source, source conflict, low-confidence estimate, and insufficient evidence.
+  2. Product-path QA shows salary estimates do not change fit score, apply readiness, apply-review handoff, ranking, filtering, or auto-apply behavior in v1.3.
+  3. Backend, API, projection, and frontend tests prove parser confidence, market confidence, and canonical compensation data behave correctly across weak source quality and parity refresh paths.
+  4. Frontend checks prove the Jobs list and Jobs drawer render posted, estimated, unavailable, insufficient-evidence, warning-only floor comparison, and source-conflict states.
+  5. QA evidence confirms synthetic or public aggregate data only, with no auto-apply, browser submission, mailbox scanning, real generated-material regeneration, destructive profile/database actions, real external scraping, or worker-backed apply jobs.
+**Plans**: TBD
+**UI hint**: yes
+
+## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 17 -> 18 -> 19 -> 20 -> 21 -> 22
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 17. Source Registry & Access Policy | 0/TBD | Not started | - |
+| 18. Posted Compensation Facts | 0/TBD | Not started | - |
+| 19. Europe Public Market Estimates | 0/TBD | Not started | - |
+| 20. Canonical Read Model & Realtime API | 0/TBD | Not started | - |
+| 21. Jobs Triage UX & Warning-Only Floor | 0/TBD | Not started | - |
+| 22. Product-Path QA & Safety Release | 0/TBD | Not started | - |
 
 ## Completed Milestone Summary
 
@@ -34,11 +133,12 @@ Artifacts:
 
 </details>
 
-## Progress
+## Coverage
 
-| Milestone | Phases | Plans | Requirements | Status | Shipped |
-|-----------|--------|-------|--------------|--------|---------|
-| v1.2 Apply Review Audit UX - Drawer + Resume Pins | 5/5 | 10/10 | 30/30 | Complete | 2026-06-13 |
+- v1.3 requirements: 35 total
+- Mapped to phases: 35
+- Unmapped: 0
+- Duplicate mappings: 0
 
 ---
-*Last updated: 2026-06-13 after v1.2 milestone archive*
+*Last updated: 2026-06-19 for v1.3 roadmap creation*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,10 +3,10 @@ gsd_state_version: 1.0
 milestone: v1.3
 milestone_name: Salary Range Estimator
 status: planning
-last_updated: "2026-06-19T09:02:26.262Z"
+last_updated: "2026-06-19T09:39:10Z"
 last_activity: 2026-06-19
 progress:
-  total_phases: 0
+  total_phases: 6
   completed_phases: 0
   total_plans: 0
   completed_plans: 0
@@ -20,182 +20,78 @@ progress:
 See: .planning/PROJECT.md (updated 2026-06-19)
 
 **Core value:** A user can trust every line of a tailored resume because each bullet traces visibly to a real profile fact and a specific job requirement, with the reasoning and transform rule available for review.
-**Current focus:** Milestone v1.3 Salary Range Estimator is defining requirements.
+**Current focus:** Phase 17 - Source Registry & Access Policy is ready to plan.
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-06-19 — Milestone v1.3 started
+Phase: 17 of 22 (1 of 6 in v1.3)
+Plan: TBD
+Status: Ready to plan
+Last activity: 2026-06-19 - v1.3 roadmap created with 6 phases and 35/35 requirements mapped.
+Progress: [----------] 0%
 
 ## Active Milestone Summary
 
-Milestone v1.3 will make salary facts inspectable in Jobs triage by combining posted compensation extraction with externally sourced market salary estimates.
+Milestone v1.3 makes compensation facts inspectable in Jobs triage by combining posted salary extraction with Europe-only public market salary baselines. The milestone keeps salary evidence audit-first and warning-only: confidence, source gaps, unknowns, and profile-floor comparisons must be visible, but v1.3 must not silently rank, filter, block, or apply based on salary facts or market estimates.
 
-Target scope:
+Scoped source strategy:
 
-- Normalize posted compensation into structured salary facts with source text, currency/period, statistical confidence, and parse warnings.
-- Use researched external compensation sources, including sources like Levels.fyi and Glassdoor where appropriate, for role/location/seniority/company-aware market estimates.
-- Preserve salary-source provenance: source type, captured values, freshness, source agreement, sample/source count where available, assumptions, and applicability to the specific job.
-- Surface posted salary, market estimate, statistical confidence, source/freshness trail, and profile-floor comparison in Jobs list/drawer triage without opaque automatic gating.
-
-## Archived v1.2 Milestone Summary
-
-Milestone v1.2 implements Sketch 002 Option 1: Drawer + Resume Pins. The milestone updates two existing surfaces:
-
-| Surface | Owns |
-|---------|------|
-| Jobs row-click drawer (`JobDetailDrawer`) | Why ranked, readiness, hard blockers, eligibility concerns, and handoff to Apply Review |
-| Apply Review rendered resume/material surface | Source-to-artifact changes, grounding, claim risk, readiness agreement, and reviewer inspection before approval |
-
-Cross-surface invariant: readiness and eligibility/blocker facts must come from one shared API/read contract so the product cannot show contradictory facts for the same job.
-
-The leftover v1.1 cleanup is folded into v1.2 as a small early housekeeping slice. It covers stale verification command normalization, dependency/config audits, optional obsolete `lucide-react` cleanup only if import proof allows it, and narrow docs/config updates for final shadcn token, Tabler icon, font, and QA expectations.
-
-Explicitly not in scope:
-
-- Option 2 Evidence Ledger and Option 3 Gate Timeline.
-- Blind-auto-apply safety positioning in UI; README/docs positioning stays deferred.
-- Auto-apply, browser submission, mailbox scanning, real generated-material regeneration, destructive profile/database actions, or worker-backed jobs unless explicitly requested later.
-- Broad route redesign, scoring/tailoring policy redesign, worker automation expansion, marketing dashboard treatment, or landing-page work.
-- Hiding/suppressing missing audit data as a substitute for fixing the source of truth.
+- Public v1.3 baselines: Eurostat Structure of Earnings Survey, ESCO occupation mapping, and Spain INE Wage Structure Survey.
+- Levels.fyi and Glassdoor: disabled/unavailable seams only unless explicit permitted access exists.
+- Profile-floor comparison: warning-only in v1.3.
 
 ## Roadmap
 
 | Phase | Name | Status | Requirements |
 |-------|------|--------|--------------|
-| 12 | Folded Cleanup + Verification Baseline | Complete | CLEAN-01..CLEAN-04 |
-| 13 | Shared Apply Audit Contract | Complete | AUDIT-01..AUDIT-06 |
-| 14 | Jobs Drawer Audit Triage | Complete | DRAWER-01..DRAWER-06 |
-| 15 | Apply Review Resume Pins | Complete | REVIEW-01..REVIEW-08 |
-| 16 | Product-Path QA + Documentation | Complete | QA-01..QA-06 |
+| 17 | Source Registry & Access Policy | Not started | SRC-01, SRC-04, SRC-05, SRC-06 |
+| 18 | Posted Compensation Facts | Not started | COMP-01..COMP-05 |
+| 19 | Europe Public Market Estimates | Not started | SRC-02, SRC-03, EST-01..EST-04, EST-06, EST-07 |
+| 20 | Canonical Read Model & Realtime API | Not started | EST-05, API-01..API-05 |
+| 21 | Jobs Triage UX & Warning-Only Floor | Not started | UI-01..UI-06 |
+| 22 | Product-Path QA & Safety Release | Not started | QA-01..QA-06 |
 
-Next command: `/gsd-new-milestone`.
+Next command: `/gsd-plan-phase 17`.
 
-## Research Summary
+## Performance Metrics
 
-Research completed on 2026-06-11 in `.planning/research/`.
+**Velocity:**
+- Total plans completed: 0
+- Average duration: n/a
+- Total execution time: 0 hours
 
-Key findings:
-
-- Use the existing React/Vite/Tailwind/TanStack/shadcn stack; no new runtime dependency is recommended for the MVP.
-- A shared apply audit contract must precede UI work.
-- Resume pins should be derived from canonical artifact audit data, starting with `bulletProvenance` and `annotatedChanges`.
-- Jobs drawer and Apply Review have separate responsibilities; ranking belongs in Jobs, generated-material proof belongs in Apply Review.
-- QA must use synthetic/seeded data and must not trigger apply submission or worker-backed automation.
-
-## Completed Phase Evidence
-
-### Phase 12 - Folded Cleanup + Verification Baseline
-
-- Removed unused `lucide-react` dependency after source import audit proved zero `apps/web/src` imports.
-- Updated current-state codebase maps to describe Tailwind 4 CSS-first styling through `globals.css`, `tokens.css`, and `components.json`.
-- Updated `docs/frontend-target.md` icon guidance to use `@tabler/icons-react` and reject new `lucide-react` imports.
-- Verified with dependency/import audits, stale Tailwind config scans, strict legacy token scan, `corepack pnpm web:check`, `corepack pnpm web:build`, and `git diff --check`.
-
-### Phase 13 - Shared Apply Audit Contract
-
-- Added the shared `ApplyAudit` contract to `@jobhunter/contracts` and exposed it on both `ApplyReviewQueueItem` and `JobDetail`.
-- Added API/read-model derivation through `apps/api/src/apply-audit.ts`, sourced from application target, material availability, current stage state/error, latest apply run, score eligibility, and review evidence availability.
-- Updated Apply Review to consume `item.applyAudit` for queue tags, status counts, selected header status, summary copy, and compact missing/blocker/eligibility/source facts.
-- Verified with `corepack pnpm api:check`, targeted API tests, `corepack pnpm web:check`, targeted web tests, `corepack pnpm web:build`, `git diff --check`, and in-app browser QA on `/apply-review`.
-
-### Phase 14 - Jobs Drawer Audit Triage
-
-- Added a top-of-drawer audit triage section to `JobDetailDrawer` that answers why a job ranked where it did and whether it is ready for apply review.
-- Rendered rank evidence from existing score read-model fields and readiness/blocker/eligibility facts from the shared `applyAudit` contract only.
-- Added a non-mutating `/apply-review` handoff for generated-material proof instead of duplicating the full resume audit surface in the Jobs drawer.
-- Extended Jobs drawer regression tests and local QA docs for the new audit smoke path.
-- Verified with `corepack pnpm web:check`, targeted Jobs drawer tests, `corepack pnpm web:build`, `git diff --check`, and product-path browser QA from `/jobs` row activation.
-
-### Phase 15 - Apply Review Resume Pins
-
-- Added `ResumeAuditPins` as a context-owned material audit component backed by artifact detail read models.
-- Reworked Apply Review's Application Materials pane so the rendered resume appears first, with claim pins beside it on wider containers and below it on narrow containers.
-- Pin detail exposes source text, tailored text, transform, controls, evidence IDs, requirement IDs, matched signals, rationale, and grounding/risk/lifecycle facts.
-- Preserved the full tailoring inspector below the resume-centered pin surface.
-- Updated Apply Review tests and local QA docs for populated provenance and no-provenance states.
-- Verified with `corepack pnpm web:check`, targeted Apply Review tests, `corepack pnpm web:build`, `git diff --check`, and product-path browser QA on `/apply-review`.
-
-### Phase 16 - Product-Path QA + Documentation
-
-- Ran API and web verification commands for the changed surfaces.
-- Re-verified the Jobs drawer product path from `/jobs` row activation.
-- Re-verified the Apply Review product path from `/apply-review`.
-- Confirmed docs/checklists cover Jobs drawer audit triage and Apply Review resume pins.
-- Recorded final milestone acceptance evidence.
-- Follow-up correction: detached `pnpm dev:start` now reports observed API/web/Temporal bindings, including the actual Vite web URL when the requested port is occupied and Vite binds a higher port.
-- Follow-up correction: Jobs fit-score badges now use the numeric score as the color source of truth: 10 maps to visible green, 5 maps to neutral gray, and 0 maps to visible red, with intermediate scores moving toward the nearest endpoint.
-- Follow-up correction: Apply Review ready/ok badges and success facts now render in the success-green family instead of info/blue or weak neutral styling.
-- Follow-up correction: Apply Review no longer collapses to an empty provenance state when rendered resume text exists; the Application Materials pane now shows a line-by-line rendered-resume audit fallback and lays the audit inspector beside the PDF on wide screens.
-- Follow-up correction: Apply Review now keeps the audit rail and rendered-resume text selection synchronized so selecting a no-provenance audit row highlights the exact rendered text line, with the faithful PDF retained below for visual verification.
-- Follow-up correction: Apply Review rendered-resume fallback now uses a PDF-style page treatment with hidden debug labels, preserved blank lines, section/bullet styling, and selectable rendered text so the audit surface visually matches the generated resume instead of a line-debug table.
-- Follow-up correction: Apply Review now uses a separate tailored-resume text artifact id for source attribution, claim pins, and the tailoring inspector while keeping the resume PDF artifact id for faithful visual rendering, so PDF shell metadata no longer causes false missing-source states.
-- Follow-up correction: Apply Review audit rows now come from the rendered resume lines when rendered text exists, attach matching bullet/change provenance per line, keep audit metadata gaps separate from actual claim-risk findings, show source-backed/grounded status for backed lines, and scroll the right audit rail to the selected rendered line.
-- Follow-up correction: Apply Review now distinguishes canonical bullet provenance from coarse annotated-change fallback lineage; fallback rows show a source pointer and `source span` precision with the broader source span collapsed, instead of displaying a list of original bullets as if it were exact per-bullet lineage.
-- Follow-up correction: Apply Review right-rail audit cards now preview the source pointer for each rendered line, and the selected-line detail removes the duplicate tailored artifact text column because the selected tailored line is already highlighted in the rendered resume surface.
-- Follow-up correction: Apply Review right-rail audit cards now show inline source evidence from the recorded source span; selected cards expand the full span in place so reviewers do not need to look below the row to verify lineage.
-- Follow-up correction: Apply Review no longer renders a scrollable right-side audit-row list plus a separate lower detail box; it now renders one selected-line inspector driven by the highlighted resume line, with source evidence, source pointer, lineage precision, source id, transform, controls, requirement/evidence ids, matched keywords, rationale, and risk metadata in one box.
-- Follow-up correction: Apply Review selected-line audit now keeps only line-specific evidence in the dynamic inspector: unmatched rendered bullets inherit the nearest recorded source span in their resume section, source evidence and pointer appear directly in the selected-line box, artifact-level grounding/risk gates render once outside that box, and the older annotated resume changes ledger no longer duplicates the mapper.
-- Follow-up correction: Apply Review artifact-level grounding/risk now renders as a full-width Application Materials summary above the rendered resume audit surface, not inside the right-side line-by-line audit rail.
-- Follow-up correction: Apply Review artifact-level grounding/risk summary now uses inline gate chips and collapsed finding groups with counts/previews so the panel remains visible without pushing the resume far down the materials pane.
-- Follow-up correction: Shared success badges now use a visibly green background fill, border, and foreground using `oklab` color mixing so the `materials ready` header badge reads green in the browser.
-- Follow-up correction: Jobs table visible row content now opens the job overlay while checkbox hitboxes remain selection-only; verified by targeted grid/Jobs tests and live `/jobs` browser QA.
-- Follow-up correction: Jobs row-click overlay now opens as an almost full-screen audit workspace with a wide two-column detail grid so ranking, readiness, diagnostics, artifacts, outcomes, scoring, description, and audit history have usable room.
-- Follow-up correction: tailoring and cover lifecycle state now stays aligned with approved current-generation artifacts: rejected refreshes no longer hide accepted materials, orphaned stages recover from approved artifacts, re-tailor defaults preserve existing artifacts until replacement approval, new resume generations reset cover readiness to pending, and target-job-only technologies are explicitly context rather than candidate evidence in the generator prompt.
-- Follow-up correction: legacy profile bullets now act as deterministic achievement evidence when explicit `achievement_evidence` rows are absent, and the API read model backfills profile evidence IDs for accepted artifacts that have source-span annotations or bullet provenance but predate the newer evidence-id metadata. Live selected-artifact QA on `d44576c4042e4565a7babb856bef5660` showed populated `requiredIds` / `seniorityIds` and no `profile evidence mapping` quality error.
-- Live material-generation QA: after targeted repairs and reruns, all 49 score-qualified non-blocked jobs have complete approved current materials (`tailored_resume`, `resume_pdf`, `cover_letter`, `cover_letter_pdf`); the remaining 4 score-qualified incomplete jobs are blocked by score eligibility compensation blockers.
-- Live audit-metadata QA correction: the earlier landscape audit proved material presence, not evidence-mapping completeness. After the legacy evidence mapping fix, 9 review-queue artifacts still report incomplete audit metadata because they have no change annotations and no bullet provenance; those require forced re-tailor with the patched worker rather than read-model masking.
-- Verified safety boundaries: no auto-apply, browser submission, mailbox scanning, destructive profile/database action, or application submission. Worker-backed material regeneration was run only for the requested score-qualified landscape repair.
-- Live Apply Review QA: selecting rendered resume line 17 on `localhost:5173/apply-review` showed `source span`, 5 source evidence lines, 0 missing-source markers in the selected inspector, 1 artifact-level risk panel outside the selected inspector, and 0 legacy `Annotated resume changes` / `Tailoring rationale` duplicate sections.
-- Live Apply Review placement QA: the artifact-level grounding/risk region rendered before `Rendered resume audit`, outside both `Rendered resume audit` and `Line-by-line resume audit`, and occupied 97% of the Application Materials pane width on a 2763px desktop viewport.
-- Live Apply Review density QA: on a 2226px desktop viewport, the artifact-level grounding/risk panel measured 89.5px tall, remained above the rendered resume, had 4 inline metrics, 3 collapsed finding groups, and left only a 14px gap before the resume audit.
-
-## Prior Milestone Verification
-
-Milestone v1.0 was verified on 2026-06-09. All five phases plus cross-phase integration returned PASS. The durable summary is `.planning/MILESTONE-ACCEPTANCE.md`.
-
-Milestone v1.1 completed Phases 6-10 and landed semantic tokens, shared primitives, layout chrome, Tabler target, status semantics, and route visual QA via PRs #151-#155. The planned Phase 11 cleanup did not start and is now folded into v1.2 Phase 12.
+**By phase:** none yet.
 
 ## Accumulated Context
 
-### Current Decisions
+### Decisions
 
-- Choose Sketch 002 Option 1: Drawer + Resume Pins for implementation.
-- Define "job overlay" as the Jobs row-click drawer (`JobDetailDrawer`), not an Apply Review queue panel.
-- Keep Apply Review centered on the rendered resume/material, with row/claim pins for evidence inspection.
-- Share readiness and eligibility facts across Jobs drawer and Apply Review from one contract/source of truth.
-- Fold the leftover v1.1 cleanup into v1.2 as housekeeping, not as the core product outcome.
-- Defer blind-auto-apply safety positioning to README/docs rather than the v1.2 UI scope.
+- v1.3 starts at Phase 17 because v1.2 ended at Phase 16.
+- v1.3 uses Europe-only public baselines: Eurostat SES, ESCO, and Spain INE.
+- Levels.fyi and Glassdoor remain disabled unless permitted access exists; no unauthorized scraping, fetching, caching, or display.
+- Profile-floor comparison is warning-only and must not affect ranking, filtering, apply readiness, blockers, or auto-apply behavior.
 
-### Constraints And Concerns
+### Pending Todos
 
-- Auditability risk: the UI must not hide missing or embarrassing audit data; missing sources must be fixed at the owning layer.
-- Scope risk: ranking explanation belongs in the Jobs row-click drawer, while generated-material proof belongs in Apply Review.
-- Pin risk: PDF coordinates may be brittle; start from generated text/provenance anchors and validate visual placement during Phase 15.
-- QA risk: browser proof must use synthetic/seeded data and must not run auto-apply, browser submission, mailbox scanning, real material generation, destructive profile/database actions, or worker-backed jobs.
-- Cleanup risk: folded v1.1 cleanup should close stale dependency/config/docs items without re-opening broad visual-system migration.
+None yet.
+
+### Blockers/Concerns
+
+- Phase 19 planning must define public-data import/API strategy, statistical thresholds, remote-Europe assumptions, freshness windows, and confidence buckets.
+- Main risks to keep visible: source legality, false precision, lossy normalization, projection drift, and sensitive data leakage.
 
 ## Deferred Items
 
 | Category | Item | Status | Deferred At |
 |----------|------|--------|-------------|
-| Audit UX | Option 2 Evidence Ledger | Future milestone | 2026-06-11 |
-| Audit UX | Option 3 Gate Timeline | Future milestone | 2026-06-11 |
-| Audit UX | Deep PDF coordinate annotation beyond stable provenance/text anchors | Future milestone unless Phase 15 proves required | 2026-06-11 |
-| Product positioning | README/docs copy explaining why JobHunter is safer than blind auto-apply tools | Future docs update | 2026-06-11 |
-| Visual system | User-editable theme customization | Future milestone | 2026-06-09 |
-| Visual system | Dedicated visual regression service such as Chromatic/Loki/Percy | Future milestone | 2026-06-09 |
-| Motion | Motion and microinteraction system | Future milestone | 2026-06-09 |
+| Licensed sources | Levels.fyi and Glassdoor enabled integrations | Future milestone unless permitted access is confirmed | 2026-06-19 |
+| Geography | Non-European public baselines | Out of active product direction; JobHunter is Europe-first | 2026-06-19 |
+| Product behavior | Salary-based ranking, filtering, hard blockers, and negotiation anchors | Future milestone | 2026-06-19 |
+| Corrections | User correction and refresh loop for salary facts | Future milestone unless v1.3 planning reopens it | 2026-06-19 |
 
 ## Session Continuity
 
-Last session: 2026-06-11
-Stopped at: v1.2 complete
-Latest phase completed: Phase 16 - Product-Path QA + Documentation
+Last session: 2026-06-19
+Stopped at: v1.3 roadmap created
+Latest phase completed: Phase 16 - Product-Path QA + Documentation (v1.2)
 Resume file: None
-
-## Operator Next Steps
-
-- Start the next milestone with /gsd-new-milestone

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,38 +1,44 @@
 ---
 gsd_state_version: 1.0
-milestone: v1.2
-milestone_name: Apply Review Audit UX - Drawer + Resume Pins
-status: Awaiting next milestone
-stopped_at: v1.2 complete
-last_updated: "2026-06-13T08:37:07.825Z"
-last_activity: 2026-06-13 — Milestone v1.2 completed and archived
+milestone: v1.3
+milestone_name: Salary Range Estimator
+status: planning
+last_updated: "2026-06-19T09:02:26.262Z"
+last_activity: 2026-06-19
 progress:
-  total_phases: 5
-  completed_phases: 5
-  total_plans: 10
-  completed_plans: 10
-  percent: 100
+  total_phases: 0
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 0
 ---
 
 # Project State
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-06-13)
+See: .planning/PROJECT.md (updated 2026-06-19)
 
 **Core value:** A user can trust every line of a tailored resume because each bullet traces visibly to a real profile fact and a specific job requirement, with the reasoning and transform rule available for review.
-**Current focus:** Milestone v1.2 is archived; awaiting the next milestone definition.
+**Current focus:** Milestone v1.3 Salary Range Estimator is defining requirements.
 
 ## Current Position
 
-Phase: Milestone v1.2 complete
+Phase: Not started (defining requirements)
 Plan: —
-Status: Awaiting next milestone
-Last activity: 2026-06-13 — Milestone v1.2 completed and archived
+Status: Defining requirements
+Last activity: 2026-06-19 — Milestone v1.3 started
 
 ## Active Milestone Summary
 
-No active milestone is currently defined. Start the next cycle with `/gsd-new-milestone`.
+Milestone v1.3 will make salary facts inspectable in Jobs triage by combining posted compensation extraction with externally sourced market salary estimates.
+
+Target scope:
+
+- Normalize posted compensation into structured salary facts with source text, currency/period, statistical confidence, and parse warnings.
+- Use researched external compensation sources, including sources like Levels.fyi and Glassdoor where appropriate, for role/location/seniority/company-aware market estimates.
+- Preserve salary-source provenance: source type, captured values, freshness, source agreement, sample/source count where available, assumptions, and applicability to the specific job.
+- Surface posted salary, market estimate, statistical confidence, source/freshness trail, and profile-floor comparison in Jobs list/drawer triage without opaque automatic gating.
 
 ## Archived v1.2 Milestone Summary
 

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,215 +1,386 @@
-# Architecture Research
+# Architecture Patterns
 
-**Domain:** Local-first job-application audit UX
-**Researched:** 2026-06-11
-**Confidence:** HIGH for ownership boundaries, MEDIUM for final pin-rendering component shape
+**Domain:** JobHunter v1.3 Salary Range Estimator
+**Researched:** 2026-06-19
+**Scope:** Posted salary extraction, external-source market estimates, statistical confidence, provenance, and Jobs triage only.
 
-## Standard Architecture
+## Recommended Architecture
 
-### System Overview
+Treat salary as a typed compensation fact owned by the backend domain and projected into Jobs triage. Do not parse salary strings in React, do not overload the existing `jobs.salary` / `JobSummary.salary` field, and do not fold market estimates into the fit score.
 
-```text
-User clicks job row
-    -> Jobs view composer
-        -> JobDetailDrawer
-            -> useJobDetailQuery
-                -> GET job detail read model
-                    -> JobSummary + ScoreBreakdown + SharedApplyAudit + artifacts
-
-User opens Apply Review
-    -> ApplyReviewView
-        -> useApplyReviewQueueQuery
-            -> GET apply review queue read model
-                -> ApplyReviewQueueItem + SharedApplyAudit + material previews
-        -> Resume audit surface
-            -> ArtifactTailoringInspector / pin model
-                -> useArtifactDetailQuery
-                    -> ArtifactTailoringExplanation
-```
-
-### Component Responsibilities
-
-| Component | Responsibility | Current / Planned Implementation |
-|-----------|----------------|----------------------------------|
-| API read model | Own readiness, blockers, eligibility/readiness reasons, and DTO shape | Extend `@jobhunter/contracts`, `application-feedback.ts`, and `read-model.ts`; do not duplicate in views. |
-| Jobs drawer | Triage whether this job is worth/apply-ready and why it ranked this way | Refactor `JobDetailDrawer` sections around rank, readiness, blocker, and handoff panels. |
-| Apply Review | Inspect the generated artifact before approval | Rework `ApplyReviewView` so rendered resume is central and pins drive detail inspection. |
-| Materials context | Own artifact tailoring explanation rendering and reusable provenance widgets | Extend `ArtifactTailoringInspector`, `TailoringExplanationSection`, or new context-owned components for pin data. |
-| Operations hooks | Fetch read-side data | Continue `useJobDetailQuery`, `useApplyReviewQueueQuery`, and `useArtifactDetailQuery`; views do not call `apiClient` directly. |
-| Shared UI primitives | Visual controls and surfaces | Use existing shadcn/Radix primitives and Tabler icons. |
-
-## Recommended Project Structure
+The best architectural fit is:
 
 ```text
-packages/contracts/src/
-  schemas.ts                         # shared readiness/blocker and optional pin DTOs
-
-apps/api/src/
-  application-feedback.ts            # apply queue item mapping and shared audit derivation
-  read-model.ts                      # job detail mapping with same shared audit contract
-  *.test.ts                          # API/read-model contract tests
-
-apps/web/src/contexts/apply/
-  components/ApplyReadinessPanel.tsx # shared readiness/blocker display if owned by Apply
-  lib/apply-readiness.ts             # formatting only, no source-of-truth logic
-
-apps/web/src/contexts/materials/
-  components/ResumeAuditPins.tsx     # artifact provenance pins and selected-pin inspector
-  components/ResumePinInspector.tsx  # selected claim/source/risk detail
-  lib/resume-pin-model.ts            # maps artifact explanation to UI pin model
-
-apps/web/src/views/jobs/
-  JobDetailDrawer.tsx                # composer for ranking/readiness/blocker sections
-  JobRankAuditPanel.tsx              # view-local composition of scoring components
-
-apps/web/src/views/apply-review/
-  ApplyReviewView.tsx                # composer for queue, selected job, and rendered resume audit surface
-
-apps/web/e2e/tests/
-  apply-review-audit.spec.ts         # seeded product-path QA
+Discovery / Enrichment source text
+  -> Enrichment-owned compensation assessment use case
+  -> canonical compensation rows + provenance rows
+  -> JobCompensationAssessed domain event
+  -> Operations projections in Python and TypeScript
+  -> typed API contracts
+  -> Jobs view composes Enrichment-owned compensation components
 ```
 
-### Structure Rationale
+The estimator should be audit-first and non-gating. Compensation may inform user triage, but v1.3 should not silently rank, hide, block, auto-apply, or make tailoring/apply eligibility decisions from an opaque estimate.
 
-- **Contracts first:** The readiness/blocker facts are cross-surface data, so they belong in shared contracts and API mappers before UI work.
-- **Context-owned reusable audit pieces:** Materials provenance is not Apply Review-specific; resume-pin data should live near existing materials inspector logic.
-- **Views as composers:** Jobs and Apply Review views assemble panels but should not own server queries, API clients, or cross-context state.
-- **Small cleanup phase first:** Stale v1.1 cleanup reduces verification noise before feature work.
+## Proposed Bounded-Context Ownership
 
-## Architectural Patterns
+| Concern | Owner | Rationale |
+| --- | --- | --- |
+| Raw `jobs.salary` string from board/listing metadata | Job Discovery | This is discovery-time `JobMetadata.salary` and should remain the legacy raw source, not the new typed fact. |
+| Salary text found in full posting content | Job Enrichment | Full description/application URL already belong to Enrichment. Posted compensation spans extracted from the posting are an enrichment of the job posting. |
+| Posted salary normalization and parse warnings | Job Enrichment | Parsing source text into structured job facts is enrichment logic; keep it near source snapshots and extraction attempts. |
+| External market-source lookup and source registry | Job Enrichment | Market compensation is additional job intelligence gathered from external sources. It needs source adapters, freshness, and provenance, like enrichment. |
+| Market estimate aggregation and statistical confidence | Job Enrichment domain service | It transforms compensation evidence into a range and confidence. It is not candidate fit scoring. |
+| Candidate profile salary floor | Candidate Profile | The profile owns user expectations such as salary floor/currency. Other contexts receive a snapshot or projection, not mutable profile data. |
+| Profile-floor comparison for Jobs triage | Operations read model | It is a derived presentation fact from compensation + current profile snapshot. Persist only if requirements later demand historical comparison audit. |
+| Jobs list/detail salary display | Operations projections + frontend Jobs view composition | Operations owns read shapes; Jobs view composes read data and context components. |
+| Salary UI components | Frontend `contexts/enrichment/` | Frontend mirrors backend contexts. Since compensation assessment is Enrichment-owned, range/confidence/provenance components belong there. |
 
-### Pattern 1: Shared Read Contract
+Do not create a ninth top-level bounded context for v1.3. A future "Compensation Intelligence" context could be justified if compensation expands into negotiation tracking, offer comparison, longitudinal market analytics, or user-authenticated market-source accounts. The v1.3 scope fits inside Enrichment.
 
-**What:** A single DTO, for example `ApplyAuditReadiness`, describes readiness kind, label, blockers, eligibility concerns, missing prerequisites, and source/lifecycle metadata.
+## New/Changed Domain Concepts And Value Objects
 
-**When to use:** Any fact that appears in both Jobs drawer and Apply Review.
+Add explicit value objects in Python domain and TypeScript mirrors. Unknown, unparseable, posted, and estimated states should be distinct sum types, not nullable fields around primitive strings.
 
-**Trade-offs:** Adds API/contract work up front, but prevents UI disagreement and makes QA assert one source of truth.
+### CompensationRange
 
-```typescript
-interface ApplyAuditReadiness {
-  state: "ready" | "preparing" | "blocked" | "repair";
-  label: string;
-  summary: string;
-  missingPrerequisites: string[];
-  blockers: string[];
-  eligibilityConcerns: string[];
-  sources: Array<{ kind: string; id: string | null }>;
+```text
+CompensationRange
+  min: MoneyAmount | null
+  max: MoneyAmount | null
+  currency: CurrencyCode
+  period: CompensationPeriod
+  compensationKind: base | total | ote | hourly | contract | unknown
+```
+
+Invariants:
+
+- At least one of `min` or `max` must exist for a known range.
+- If both exist, `min <= max`.
+- `currency` must be explicit when an amount exists.
+- `period` must be explicit; if inferred, record an assumption.
+- Display strings are never the source of truth.
+
+### PostedCompensationFact
+
+Use a discriminated union:
+
+```text
+PostedCompensationFact =
+  | { kind: "not_found"; checkedSources; extractedAt }
+  | { kind: "unparseable"; rawText; source; warnings; extractedAt }
+  | { kind: "ambiguous"; candidates; source; warnings; extractedAt }
+  | { kind: "posted_range"; range; source; confidence; warnings; extractedAt }
+```
+
+`posted_range` must have a source span or source field. `not_found` must not have a range. `unparseable` must keep the raw text and warnings so the UI can explain why no normalized range exists.
+
+### MarketCompensationEstimate
+
+Use a discriminated union:
+
+```text
+MarketCompensationEstimate =
+  | { kind: "not_requested"; reason }
+  | { kind: "unsupported"; query; reasons; sourceAttempts }
+  | { kind: "insufficient_evidence"; query; sourceCount; sampleCount; gaps }
+  | { kind: "estimated_range"; query; range; confidence; sources; assumptions; computedAt }
+```
+
+`estimated_range` must have at least one supporting source and a confidence object. It should be impossible to represent a high-confidence estimate with zero source support.
+
+### SalarySourceEvidence
+
+```text
+SalarySourceEvidence
+  sourceId
+  sourceKind: posting_salary_field | posting_description_span | levels_fyi | glassdoor | other_market_source
+  label
+  url: string | null
+  capturedAt
+  observedAt: string | null
+  freshness
+  capturedRange: CompensationRange | null
+  sampleCount: number | null
+  supportsRole: supported | partial | unsupported | unknown
+  supportsLocation: supported | partial | unsupported | unknown
+  supportsSeniority: supported | partial | unsupported | unknown
+  warnings: string[]
+  snapshotHash: string | null
+```
+
+This is the provenance backbone. Every displayed posted or market range should point at one or more of these records.
+
+### CompensationConfidence
+
+```text
+CompensationConfidence
+  level: low | medium | high
+  score: number  // 0..1
+  method: posted_parse | source_agreement | fallback_prior
+  sourceCount: number
+  sampleCount: number | null
+  agreement: low | medium | high | unknown
+  freshness: fresh | aging | stale | unknown
+  warnings: string[]
+```
+
+Keep parser confidence and statistical market confidence separate in code, even if the UI renders both with the same badge component.
+
+### JobCompensationAssessment
+
+Persist a versioned Enrichment-owned record keyed by `(tenantId, jobId, version)`:
+
+```text
+JobCompensationAssessment
+  tenantId
+  jobId
+  version
+  posted: PostedCompensationFact
+  market: MarketCompensationEstimate
+  selectedDisplay: posted | market | none
+  assumptions: string[]
+  warnings: string[]
+  assessedAt
+```
+
+It should publish `JobCompensationAssessed` when a new version is saved.
+
+## Persistence, Projection, And Read-Model Flow
+
+### Canonical Tables
+
+Use canonical rows, not `metadata_json`, for compensation audit data.
+
+| Table | Purpose |
+| --- | --- |
+| `job_compensation_assessments` | One row per `(tenant_id, job_url, version)` with posted/market status, selected display kind, assessed timestamp, assumptions/warnings JSON. |
+| `job_posted_compensation_facts` | Posted extraction result for an assessment version, including raw text, source kind/path/span, normalized range fields, parser confidence, and warnings. |
+| `job_market_compensation_estimates` | Market estimate result for an assessment version, including query shape, normalized range fields, confidence fields, source/sample counts, agreement, and freshness. |
+| `job_compensation_sources` | One row per supporting/attempted source with source type, URL/hash, captured range, support flags, sample count, freshness, and warnings. |
+
+JSON columns are acceptable for arrays such as warnings, assumptions, and source gaps, but range, currency, period, status, confidence score, source count, sample count, and timestamps should be queryable columns.
+
+### Events
+
+Add a domain event:
+
+```text
+JobCompensationAssessed {
+  tenantId,
+  jobId,
+  assessmentVersion,
+  postedKind,
+  marketKind,
+  selectedDisplay,
+  assessedAt
 }
 ```
 
-The final shape should be planned in Phase 13; the important invariant is shared ownership, not this exact interface.
+Do not put the full source trail in the event payload. Projections should follow the existing derive-from-canonical pattern: the event marks the job dirty, and both projection builders re-read canonical compensation rows.
 
-### Pattern 2: Pin Model Derived From Artifact Explanation
+### Operations Projections
 
-**What:** Convert `ArtifactTailoringExplanation` into stable UI pins keyed by `bulletId`, `sourceId`, section, and generated text.
+Extend both projection builders:
 
-**When to use:** Apply Review resume claim inspection.
+- Python: `workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py`
+- TypeScript: `apps/api/src/projections.ts`
 
-**Trade-offs:** Text/bullet anchors are less visually exact than PDF coordinates, but they are safer and grounded in existing canonical provenance. Coordinate overlays can be added later if necessary.
-
-```typescript
-type ResumeAuditPin = {
-  id: string;
-  section: string;
-  generatedText: string;
-  sourceText: string[];
-  transformType: string;
-  evidenceIds: string[];
-  requirementIds: string[];
-  risk: "grounded" | "warning" | "unsupported" | "missing_source";
-};
-```
-
-### Pattern 3: Honest Missing States
-
-**What:** Components render explicit "not recorded" / "no source captured" states instead of blank panels.
-
-**When to use:** Any provenance, score, judge, prompt, or blocker data that may be absent.
-
-**Trade-offs:** The UI may show uncomfortable gaps, but this is core product value and aligns with the repository auditability discipline.
-
-## Data Flow
-
-### Readiness Flow
+Add matching columns:
 
 ```text
-Projection rows and latest apply/material state
-    -> API readiness/blocker derivation
-        -> Shared contract in JobDetail and ApplyReviewQueueItem
-            -> Jobs drawer readiness panel
-            -> Apply Review readiness panel and queue tags
-                -> Tests assert identical facts for the same job
+job_list_projections.compensation_summary_json TEXT
+job_detail_projections.compensation_audit_json TEXT
 ```
 
-### Resume-Pin Flow
+The list projection should contain compact triage facts:
 
 ```text
-Artifact detail
-    -> ArtifactTailoringExplanation
-        -> pin model derived from bulletProvenance + annotatedChanges + judge/quality/adversarial data
-            -> rendered resume preview with pin markers
-            -> selected pin inspector with source, generated text, transform, grounding, risk, action
+JobCompensationSummary
+  status: unknown | posted | estimated | insufficient_evidence | unparseable
+  displayRange: CompensationRange | null
+  displaySource: posted | market | none
+  confidenceLevel: low | medium | high | unknown
+  profileFloorComparison: below_floor | meets_floor | above_floor | unknown | no_profile_floor
+  freshness: fresh | aging | stale | unknown
+  warningCount
 ```
 
-### Ranking Flow
+The detail projection should contain the full audit shape:
 
 ```text
-Job detail
-    -> JobSummary score fields + ScoreBreakdown + ScoreTrace + EmployerAnalysis
-        -> Jobs drawer rank audit panel
-            -> requirements/matched/missing/transferable/eligibility display
-            -> handoff to Apply Review for material proof
+JobCompensationAudit
+  posted: PostedCompensationFact
+  market: MarketCompensationEstimate
+  sources: SalarySourceEvidence[]
+  profileFloorComparison
+  assumptions
+  warnings
+  assessedAt
 ```
 
-## Anti-Patterns
+Keep `JobSummary.salary` as the legacy raw string for compatibility during v1.3. New UI should prefer `JobSummary.compensation`; old raw salary can remain visible only as a fallback or in the provenance trail.
 
-### Anti-Pattern 1: UI-Only Readiness
+### Contracts And Domain Type Mirrors
 
-**What people do:** Derive status labels independently in `ApplyReviewView`, `JobDetailDrawer`, and queue cards.
+Update in lockstep:
 
-**Why it is wrong:** It creates contradictory "ready" and "not ready" labels and hides the actual blocker source.
+- `packages/contracts/src/schemas.ts`: add `CompensationRange`, `PostedCompensationFact`, `MarketCompensationEstimate`, `SalarySourceEvidence`, `JobCompensationSummary`, and `JobCompensationAudit`.
+- `packages/domain-types/src/operations/index.ts`: mirror projection fields.
+- `packages/domain-types/src/discovery/job.ts`: keep `JobMetadata.salary` as raw discovery metadata; do not replace it with the new fact.
+- Python value objects: add Enrichment/compensation value objects rather than placing parsed facts in `discovery/value_objects.py`.
 
-**Do this instead:** Compute/read the readiness contract once in the API/read model and use UI helpers only for formatting.
+The TypeScript API read model should deserialize projection JSON like employer analysis and requirement fit already do: parse projected JSON, do not recompute compensation in `apps/api/src/read-model.ts`.
 
-### Anti-Pattern 2: Resume Pins Without Canonical Anchors
+## Ports And Adapters
 
-**What people do:** Place visual markers by guessed PDF coordinates or line indexes without a canonical link to provenance.
+Add Enrichment-owned ports:
 
-**Why it is wrong:** Pins drift when rendering changes and can imply proof for the wrong claim.
+| Port | Local adapter | Hosted future | Notes |
+| --- | --- | --- | --- |
+| `PostedCompensationParser` | Pure parser over `jobs.salary`, description snippet, and full description | Same domain service | No network. Should return explicit unparseable/ambiguous states. |
+| `MarketCompensationSourcePort` | Source adapters for researched market sources | Managed source connectors or licensed data providers | Requirements must settle source legality and access. |
+| `CompensationRepository` | SQLite canonical tables | Postgres Enrichment repository tables | Tenant scoped, versioned. |
+| `EventPublisher` | In-process event bus | SQS event publisher | Existing pattern. |
 
-**Do this instead:** Anchor pins to generated text/provenance rows first; show "not located in preview" when an anchor cannot be matched.
+The external adapters must be anti-corruption layers. They translate source-specific concepts from Levels.fyi, Glassdoor, or other sources into `SalarySourceEvidence` and never leak scraped/provider-native payloads into the domain model.
 
-### Anti-Pattern 3: Evidence Suppression
+## Pipeline Integration
 
-**What people do:** Hide missing, unsupported, or risky sections to keep the UI clean.
+Do not add a new user-facing pipeline stage for v1.3. Keep Discover as the user-facing preparation stage.
 
-**Why it is wrong:** It directly undermines trust and violates the auditability rule.
+Recommended execution:
 
-**Do this instead:** Show explicit missing-source states and add source computation/persistence at the owning layer when the data should exist.
+1. Discovery stores raw listing salary in `JobMetadata.salary` as today.
+2. Enrichment captures full description/application URL.
+3. Discover preparation queues or invokes `assess_compensation` after enrichment, before or alongside scoring.
+4. Compensation assessment persists canonical rows and publishes `JobCompensationAssessed`.
+5. Operations marks the job dirty and refreshes list/detail projections.
 
-## Integration Points
+Compensation assessment failures should be non-blocking by default. A market-source outage should produce `market.kind = "unsupported"` or `"insufficient_evidence"` plus audit warnings, not fail scoring, tailoring, or apply readiness.
 
-| Boundary | Communication | Notes |
-|----------|---------------|-------|
-| API -> web contracts | `@jobhunter/contracts` DTOs | Shared readiness/blocker additions must be backward-compatible within the local app and covered by typecheck/tests. |
-| API read model -> Apply Review | `useApplyReviewQueueQuery` | Queue tags and selected view should consume shared readiness rather than local `materialStatus`. |
-| API read model -> Jobs drawer | `useJobDetailQuery` | Job detail should expose the same readiness/blocker facts when possible. |
-| Materials -> Apply Review | `useArtifactDetailQuery` | Resume pins can reuse artifact tailoring explanation data; no worker execution needed for QA. |
-| Browser QA -> seeded API data | Synthetic fixtures | Do not run auto-apply, browser submission, mailbox scanning, real generation, or destructive local data actions. |
+Requirements should decide whether compensation assessment is automatic for every enriched job, on-demand for the selected Jobs drawer job, or automatic only for jobs that pass an initial fit-score threshold. For MVP architecture, automatic posted extraction plus on-demand market estimation is the safest build: it gives immediate value from local source text while limiting external-source cost and brittleness.
+
+## Frontend Ownership And View Composition
+
+### Ownership
+
+| Frontend location | Responsibility |
+| --- | --- |
+| `contexts/operations/` | Read hooks and types for `JobSummary.compensation` and `JobDetail.compensationAudit`; query invalidation for compensation events. |
+| `contexts/enrichment/components/` | `CompensationRangeDisplay`, `CompensationConfidenceBadge`, `CompensationSourceTrail`, `CompensationTriagePanel`. |
+| `contexts/enrichment/hooks/` | Optional `useRefreshCompensationMutation` if requirements include manual refresh. |
+| `views/jobs/` | Compose compensation components in Jobs table, `JobOverview`, and `JobAuditTriage`; own layout only. |
+
+`JobAuditTriage.tsx` should not inspect source arrays or calculate confidence itself. It should receive `detail.compensationAudit` and render an Enrichment-owned component.
+
+`JobOverview.tsx` should stop showing only `{job.salary || "-"}` once the typed projection exists. Prefer the typed display range and expose raw salary as source detail.
+
+### Suggested UI Composition
+
+```text
+JobOverview
+  ScoreBadge
+  CompensationRangeDisplay(summary=detail.job.compensation)
+  Apply readiness
+
+JobAuditTriage
+  Ranking metrics
+  CompensationTriagePanel(audit=detail.compensationAudit)
+  Apply concerns
+```
+
+Jobs table can add a compact compensation column once the contract exists. The cell renderer should live in `contexts/enrichment/components/`, while the column definition remains in `views/jobs/columns.tsx`.
+
+## Suggested Build Order
+
+1. **Type model and canonical persistence**
+   - Add Python value objects and TypeScript contract/domain-type mirrors.
+   - Add SQLite tables and repository.
+   - Add invariants for range/currency/period/confidence states.
+
+2. **Posted salary extraction**
+   - Parse `jobs.salary`, discovery snippet, and full description.
+   - Persist posted fact versions and source spans.
+   - Publish `JobCompensationAssessed`.
+
+3. **Operations projection path**
+   - Extend Python and TypeScript projection builders together.
+   - Add `compensation_summary_json` and `compensation_audit_json`.
+   - Extend `JobSummary` and `JobDetail`.
+   - Add cross-runtime projection parity tests.
+
+4. **Profile-floor comparison**
+   - Read current profile salary floor from Candidate Profile data.
+   - Derive comparison in the read model with explicit `no_profile_floor` and `unknown` states.
+   - Do not persist a historical comparison unless requirements demand audit replay.
+
+5. **Market-source adapters and estimator**
+   - Add `MarketCompensationSourcePort`.
+   - Implement source registry and aggregation with explicit insufficient-evidence states.
+   - Start with one reliable source path plus fixture-backed adapter tests before adding multiple sources.
+
+6. **Jobs triage UI**
+   - Add Enrichment-owned salary display/provenance components.
+   - Compose them into `JobOverview`, `JobAuditTriage`, and optionally Jobs table columns.
+   - Add component tests/stories and a product-path QA fixture with posted, estimated, unknown, and unparseable jobs.
+
+7. **Refresh/on-demand workflow**
+   - Add manual refresh mutation only if requirements need it.
+   - If added, own it in `contexts/enrichment/` and invalidate Operations job list/detail keys through the event router.
+
+## Architecture Risks And Decisions To Settle In Requirements
+
+### External Source Access
+
+Levels.fyi and Glassdoor may not provide stable, permitted, or affordable APIs for this use case. Requirements must settle which sources are allowed, whether scraping is permitted, whether manual/user-provided data is acceptable, and how source failures appear in the UI.
+
+### Confidence Semantics
+
+"Confidence" can mean parser confidence, statistical confidence, source agreement, freshness, or role/location/seniority support. Requirements must define the displayed confidence rubric so the product does not imply precision it does not have.
+
+### Range Normalization
+
+Salary ranges can be annual, monthly, hourly, contract, OTE, base, total compensation, equity-inclusive, or currency-mixed. Requirements must define conversion rules, especially whether hourly/monthly values are normalized to annual equivalents or displayed in original period only.
+
+### Source Freshness
+
+Market data decays. Requirements must define freshness thresholds and whether stale-but-useful sources are displayed as low confidence, excluded from estimates, or shown only in provenance.
+
+### Profile Salary Floor
+
+The profile currently exposes salary expectation fields in API contracts. Requirements must decide the canonical profile field for "floor", whether blank means unknown or no floor, and whether profile-floor comparison uses annualized base pay only or total compensation.
+
+### Pipeline Cost And Latency
+
+Market lookups can make Discover slow and brittle. Requirements should decide whether market estimates run automatically, on demand, or behind a threshold. The architecture should treat external-source failure as salary audit degradation, not a pipeline blocker.
+
+### Projection Drift
+
+Both Python `ProjectionBuilder` and TypeScript `refreshProjections` write the same projection tables. Any compensation projection change must land in both runtimes with parity tests, or the API may erase/omit compensation data depending on which refresher last advanced the watermark.
+
+### Legacy Salary Field
+
+`JobMetadata.salary`, `job_list_projections.salary`, and `JobSummary.salary` are raw strings today. Requirements should explicitly name them legacy raw source fields and forbid UI logic from treating them as normalized compensation.
+
+### Sorting And Filtering
+
+Salary-based sorting/filtering is tempting but should be deferred unless requirements define how unknown, posted-only, estimated-only, currency-mixed, and low-confidence jobs compare. For v1.3, display and audit are safer than ranking policy.
 
 ## Sources
 
-- `docs/frontend-target.md` and `AGENTS.md` frontend conventions for view/context boundaries.
-- `apps/web/src/views/jobs/JobDetailDrawer.tsx`
-- `apps/web/src/views/apply-review/ApplyReviewView.tsx`
-- `apps/web/src/contexts/materials/components/ArtifactTailoringInspector.tsx`
-- `apps/web/src/contexts/materials/components/TailoringExplanationSection.tsx`
-- `apps/web/src/contexts/materials/components/BulletProvenanceList.tsx`
-- `apps/api/src/application-feedback.ts`
-- `apps/api/src/read-model.ts`
+- `.planning/PROJECT.md`
+- `docs/architecture.md`
+- `docs/ddd-target.md`
+- `docs/frontend-target.md`
+- `docs/job-pipeline-architecture.md`
+- `packages/domain-types/src/discovery/job.ts`
+- `packages/domain-types/src/operations/index.ts`
 - `packages/contracts/src/schemas.ts`
-
----
-*Architecture research for: v1.2 Apply Review Audit UX - Drawer + Resume Pins*
-*Researched: 2026-06-11*
+- `workers/automation/src/jobhunter/domain/discovery/value_objects.py`
+- `workers/automation/src/jobhunter/domain/scoring/services.py`
+- `workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py`
+- `apps/api/src/projections.ts`
+- `apps/api/src/read-model.ts`
+- `apps/web/src/views/jobs/JobAuditTriage.tsx`
+- `apps/web/src/views/jobs/JobOverview.tsx`

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,117 +1,182 @@
-# Feature Research
+# Feature Landscape
 
-**Domain:** Local-first job-application audit UX
-**Researched:** 2026-06-11
-**Confidence:** HIGH for milestone scope, MEDIUM for exact pin-anchor affordance until implementation spike
+**Domain:** Job-search salary range estimation and compensation audit triage
+**Project:** JobHunter v1.3 Salary Range Estimator
+**Researched:** 2026-06-19
+**Overall confidence:** HIGH for posted salary extraction and UX/provenance behavior; MEDIUM for exact external-source availability and licensing/API constraints.
 
-## Feature Landscape
+## Scope
 
-### Table Stakes
+This research covers only the v1.3 salary-range estimator surface:
+
+- posted salary extraction from job postings;
+- market salary estimation from external compensation sources such as Levels.fyi and Glassdoor where appropriate;
+- statistical confidence and uncertainty display;
+- compensation provenance;
+- Jobs list and drawer triage.
+
+It does not cover broad scoring redesign, auto-apply behavior, resume/material generation, new discovery sources, or public compliance/legal advice.
+
+## Table Stakes
+
+Features users expect. Missing = compensation triage feels incomplete or untrustworthy.
 
 | Feature | Why Expected | Complexity | Notes |
 |---------|--------------|------------|-------|
-| Job ranking explanation in the Jobs drawer | A technical job seeker needs to know why a job is ranked before investing review time. | MEDIUM | Use existing `ScoreBreakdown`, `scoreReasoning`, `scoreTrace`, and employer analysis data; present as triage, not a generic diagnostics dump. |
-| Readiness state with concrete missing prerequisites | The user must know whether a job can enter apply review and what blocks it. | MEDIUM | Must be a shared API/contract fact used by Jobs drawer and Apply Review. |
-| Hard blockers and eligibility concerns | Users need to distinguish "not a fit" from "system material missing" and "apply cannot proceed." | MEDIUM | Use scoring eligibility, stage/error blockers, application URL/material availability, and quality/judge blockers with clear lifecycle labels. |
-| Rendered resume remains central in Apply Review | The user wants to inspect the artifact they may approve, not an abstract summary. | HIGH | Rework layout around the resume preview and pin inspector rather than moving evidence into a detached ledger. |
-| Source-to-tailored change inspection | Users need to see what changed from profile/resume into generated material. | MEDIUM | Existing `annotatedChanges` and `bulletProvenance` provide a strong base. |
-| Grounding and claim-risk visibility | Users need to know whether generated claims are supported, adjacent, unsupported, or risky. | HIGH | Use `quality`, `judge`, `adversarialReview`, `reviewFeedback`, and per-bullet provenance data. |
-| Honest empty/missing states | Audit surfaces must not silently disappear when data is absent. | LOW | Existing inspector has this pattern; preserve it for pins/readiness. |
+| Posted salary extraction with source text | Salary is one of the first filters job seekers use, and pay-transparency norms increasingly make posted ranges a first-class job fact. | MEDIUM | Extract structured min/max, exact amount, period, currency, compensation type, and the original snippet. Treat the job posting as the primary source when present. |
+| Posted-vs-estimated separation | LinkedIn and Glassdoor distinguish employer-provided/expected salaries from platform-estimated salaries; users need the same separation to avoid over-trusting a model. | LOW | In Jobs list and drawer, label "Posted" and "Market estimate" separately. Never merge them into one unlabeled range. |
+| Normalized compensation model | Raw strings like "$150k-$180k + equity" are useful to preserve, but triage needs comparable annual/base fields. | MEDIUM | Store raw text plus normalized annual base range, currency, period, hourly/annual flag, bonus/equity/commission indicators, and parse warnings. |
+| Parse confidence and warnings | Salary text is often ambiguous: hourly vs annual, OTE vs base, "up to", "competitive", broad ranges, bonus-heavy roles, or location-dependent bands. | MEDIUM | Confidence must attach to the parse, not just the final displayed number. Warnings should name the ambiguity. |
+| Market estimate only when evidence matches the job | LinkedIn shows estimates only when enough matching role/company/location data exists. Levels.fyi and Glassdoor data are most useful when title, level/seniority, company, and location align. | HIGH | If evidence is thin or mismatched, show "not enough benchmark evidence" rather than a fabricated-looking estimate. |
+| Source provenance for every market range | Compensation benchmarks are crowdsourced, modelled, or employer-provided; the user needs to know which. | MEDIUM | Persist source name/type, URL or source key when allowed, captured range/median, compensation components, sample/source count where available, freshness, and applicability notes. |
+| Statistical confidence visible at point of decision | Estimates should carry confidence/range width where the user decides whether to inspect, defer, or apply. | MEDIUM | Jobs list can show compact confidence; drawer should explain what drives it: sample count, freshness, source agreement, role/location/company match, parse certainty. |
+| Profile-floor comparison | JobHunter already stores `compensation.salary_expectation`, `salary_range_min/max`, currency note, target locations, work models, and seniority floors. | MEDIUM | Show whether posted max and/or market estimate clears the user floor. If below floor, render as an audit concern, not an automatic hide/filter. |
+| Jobs list triage column | Salary facts must be visible before opening the drawer. | MEDIUM | Add a compact compensation cell: posted range first, market estimate second if present, below/near/above floor indicator, confidence badge, and warning marker. |
+| Jobs drawer compensation audit section | The drawer is the existing audit workspace for "why this job is here." Salary belongs there with rank/readiness context. | MEDIUM | Add a dedicated compensation group near ranking/eligibility: posted salary, market estimate, floor comparison, source trail, assumptions, and warnings. |
+| Honest empty states | Missing salary is common and can be caused by reposting or extraction loss. | LOW | Show "No posted salary found" and whether market estimation was skipped due to missing role/location/company/seniority evidence. |
 
-### Differentiators
+## Differentiators Worth Considering
+
+Features that set JobHunter apart. Not required for the first slice, but valuable if they stay audit-first.
 
 | Feature | Value Proposition | Complexity | Notes |
 |---------|-------------------|------------|-------|
-| Resume pins tied to provenance rows | Makes trust inspectable at the exact claim level. | HIGH | Start with generated bullet/change anchors and a side inspector. |
-| One shared readiness/blocker contract | Prevents contradictory UI labels and makes QA deterministic. | MEDIUM | Add contract/API field first, then consume in both surfaces. |
-| Lifecycle-aware warnings | Distinguishes repair-attempt warnings, residual accepted warnings, and post-acceptance audit findings. | MEDIUM | Existing `reviewFeedback` fields help; display labels must be clear. |
-| Drawer-to-review handoff | Lets ranking/readiness triage hand off to generated-material inspection without duplicating every detail. | LOW | Existing Apply Review can open `JobDetailDrawer`; Jobs drawer can link to Apply Review once the selected target is URL-addressable. |
+| Source agreement score | Helps the user see whether Glassdoor, Levels.fyi, posted range, and other benchmarks broadly agree or conflict. | HIGH | Useful only if multiple source families exist. Show "sources disagree" instead of averaging away conflict. |
+| Negotiation anchor range | Converts compensation evidence into a practical discussion range without pretending it is an offer. | MEDIUM | Use posted range, market p50/p75, profile floor, and uncertainty. Label as "negotiation prep", not "expected offer". |
+| Compensation component breakdown | Tech compensation often includes base, bonus, equity/RSU, commission, and OTE. Levels.fyi explicitly emphasizes total compensation and components. | HIGH | For v1.3, detect and label components; defer full equity vesting math unless source data is structured. |
+| Freshness decay indicator | A 2023 salary report may be less useful than a current posted range; freshness is a major trust signal. | MEDIUM | Show captured/updated date and down-rank stale source data in confidence. |
+| Comparable-role assumptions | Makes title/level mapping inspectable, especially for Staff/Principal/EM/Director roles. | MEDIUM | Store assumptions such as "mapped Staff Platform Engineer to Software Engineer L6 / Staff IC." Let the drawer reveal them. |
+| "Why not estimated?" explanation | Avoids a blank market estimate feeling like a bug. | LOW | Examples: no matching role, location mismatch, company too small, no recent source, source terms unavailable, variable-comp role. |
+| User correction loop | Lets the user correct parsed salary/floor comparison and improve future parsing. | MEDIUM | Could mirror scoring correction discipline later. Initial v1.3 can persist parse warnings and allow future correction. |
+| Compensation source quality registry | Reuses JobHunter's source-health mindset for compensation sources. | MEDIUM | Track source family, allowed use, freshness, sample visibility, component coverage, and reliability notes. |
 
-### Anti-Features
+## Anti-Features
 
-| Feature | Why Requested | Why Problematic | Alternative |
-|---------|---------------|-----------------|-------------|
-| Option 2 Evidence Ledger as milestone implementation | It makes evidence feel comprehensive. | It moves attention away from the rendered artifact the user approves. | Use Option 1 pins with a focused inspector; keep ledger as future comparison. |
-| Option 3 Gate Timeline as milestone implementation | It explains process sequence. | It does not solve source-to-claim review on the resume. | Use readiness summary plus pins; timeline remains future comparison. |
-| Blind auto-apply safety pitch in UI | It reinforces positioning. | User explicitly deferred this to README/docs positioning later. | Leave product copy/docs for a later milestone. |
-| Real material regeneration during QA | It proves realism. | It can touch sensitive data and worker-backed flows outside scope. | Use seeded API/browser fixtures and static generated-material samples. |
-| Cosmetic relabeling of "not ready" states | It may quiet a symptom. | It does not explain why or fix source-of-truth disagreement. | Compute readiness reasons and blockers at the owning layer. |
+Features to explicitly not build.
 
-## Feature Dependencies
+| Anti-Feature | Why Avoid | What to Do Instead |
+|--------------|-----------|-------------------|
+| A single unlabeled salary number | It hides whether the value came from the employer, a parser, a benchmark, or a model. | Always label posted salary, extracted salary, and market estimate separately. |
+| Automatic job blocking from opaque market estimates | The project brief explicitly says uncertain compensation should not silently rank, filter, or block jobs. | Render low-confidence or below-floor estimates as audit concerns and allow user judgment. |
+| Averaging incompatible sources | Posted base salary, total compensation, OTE, Glassdoor employee reports, and Levels.fyi total comp are not interchangeable. | Normalize components separately; show conflicts and assumptions. |
+| Scraping gated/prohibited data as a hidden dependency | External compensation products may restrict automated extraction, and access patterns may change. | Prefer public, official, allowed sources/APIs/export paths; record source availability and terms as provenance. |
+| Presenting Glassdoor or crowd data as verified truth | Crowdsourced salary data varies by sample size, freshness, company size, role specificity, and self-selection. | Display confidence, sample/source count when available, freshness, and cross-source agreement. |
+| Suppressing missing salary facts | Hiding the salary section when no posted pay exists makes the absence invisible. | Show an explicit missing state and the reason market estimation did or did not run. |
+| Recomputing audit facts only in the UI | JobHunter's audit discipline requires displayed claims to have a source of truth. | Persist posted salary facts, estimate inputs, source records, assumptions, confidence, and warnings in the owning projection/read model. |
+| Treating broad pay ranges as equally useful | Very wide ranges can be compliance theater or compensation ambiguity. | Flag broadness using range ratio/width and explain that wide ranges reduce decision usefulness. |
+| Currency conversion without audit | The profile has a currency note, and postings may use USD/EUR/GBP or local currencies. | Store original currency and any converted value with rate/date/source or mark conversion unavailable. |
+| Full compensation ranking redesign in v1.3 | Salary should enrich triage, not replace fit/readiness ranking. | Add compensation facts to existing Jobs list/drawer audit surfaces and keep scoring/readiness separate. |
 
-```text
-Shared readiness/blocker contract
-    -> Jobs drawer readiness and blocker panel
-    -> Apply Review readiness and blocker panel
-    -> Browser QA for agreement across surfaces
+## Specific UX Facts Jobs Triage Should Show
 
-Artifact tailoring explanation
-    -> Resume pin model
-        -> Pin inspector
-            -> Apply Review rendered-resume audit UX
+### Jobs List
 
-Score breakdown and employer analysis
-    -> Jobs drawer ranking explanation
-        -> Drawer-to-review handoff
+The list should support fast scan, not full explanation. Add a compact compensation cell or group with these facts:
 
-Folded cleanup
-    -> Clean verification commands and icon/config dependency state
-        -> Lower-noise implementation and QA
-```
+| UX Fact | Display Recommendation | Source of Truth |
+|---------|------------------------|-----------------|
+| Posted salary | Show the normalized range, e.g. `Posted $150k-$180k base`, preserving period/currency. | Structured posted salary fact from job posting/raw salary text. |
+| Posted parse state | Small warning marker when parse confidence is not high or warnings exist. | Salary parse confidence + warnings. |
+| Market estimate | Show only if supported: `Market ~$170k-$220k`, clearly labelled as estimate. | Persisted market estimate record. |
+| Estimate confidence | Compact badge: High, Medium, Low, or Insufficient. | Estimate confidence bucket derived from evidence. |
+| Floor comparison | Small status: `above floor`, `near floor`, `below floor`, or `floor unknown`. | Profile compensation fields + normalized salary/estimate. |
+| Source count/agreement | Compact secondary text when useful: `3 sources agree`, `sources conflict`, `1 source`. | Salary-source registry/provenance. |
+| Missing state | `No posted salary` or `No reliable estimate` rather than blank. | Extraction/estimation status. |
 
-### Dependency Notes
+### Jobs Drawer
 
-- **Shared contract must come before UI agreement checks:** If both surfaces compute readiness independently, tests can only assert two copies of logic.
-- **Resume pins require artifact explanation data:** Pins should be derived from `bulletProvenance` and `annotatedChanges`, not handcrafted from the job post.
-- **Jobs drawer ranking explanation is separate from material proof:** Jobs owns rank/readiness triage; Apply Review owns generated artifact inspection.
-- **Cleanup should be early and narrow:** It removes stale v1.1 friction without becoming the milestone's core feature.
+The drawer should make the compensation decision inspectable:
 
-## MVP Definition
+| UX Fact | Display Recommendation | Source of Truth |
+|---------|------------------------|-----------------|
+| Original source text | Show the exact excerpt or raw salary field that produced the posted salary fact. | Job posting salary string / compensation text snapshot. |
+| Normalized posted range | Show min/max, currency, period, compensation type, and component labels. | Salary normalization model. |
+| Parse warnings | List warnings such as "annualized hourly rate", "range is broad", "OTE/commission detected", "currency unspecified", "upper bound only". | Parser warnings. |
+| Market estimate | Show estimated low/median/high or p25/p50/p75 if available, plus whether it is base or total comp. | Market estimate record. |
+| Evidence basis | Show role, company, location, seniority/level, source families, captured dates, and sample/source count where available. | Source registry + estimate inputs. |
+| Source trail | One row per source: source name, source type, value captured, freshness, match quality, and caveats. | Salary-source provenance rows. |
+| Confidence explanation | Plain-language explanation of what makes confidence high/medium/low. | Confidence factor breakdown. |
+| Profile-floor result | Compare user min/expectation/range to posted and market ranges; call out whether only the estimate clears the floor or the posted range does. | Profile compensation + normalized salary facts. |
+| Decision caveat | Explain that estimates are for triage/negotiation prep and do not guarantee an offer. | Static product copy tied to estimate state. |
+| Estimation skipped reason | If skipped, show why: insufficient matching evidence, source terms unavailable, variable-heavy role, missing location/seniority, or external lookup failed. | Estimation status. |
 
-### Launch With (v1.2)
+## How Statistical Confidence Should Be Displayed
 
-- [ ] Narrow cleanup of stale v1.1 verification/config/dependency leftovers.
-- [ ] Shared readiness/blocker DTO served to both `JobDetail` and `ApplyReviewQueueItem`.
-- [ ] Jobs drawer audit triage: rank explanation, readiness, blockers, eligibility concerns.
-- [ ] Apply Review centered on rendered resume/material with pin affordances and selected-pin inspector.
-- [ ] Pin detail showing source evidence, tailored text, transform/change type, grounding status, claim risk, and reviewer action when available.
-- [ ] Synthetic product-path QA that proves both surfaces agree and no apply submission path runs.
+Use two layers: a scan-friendly badge and an inspectable explanation.
 
-### Add After Validation
+| Confidence Layer | User-Facing Display | Backing Factors |
+|------------------|---------------------|-----------------|
+| Parse confidence | `Parsed: high/medium/low` with warning chips. | Explicit salary field vs body text, clear min/max, known period/currency, component ambiguity, range width, and parsing pattern reliability. |
+| Estimate confidence | `Estimate confidence: high/medium/low/insufficient`. | Source count, sample count where available, data freshness, source agreement, company match, title/role match, seniority/level match, location match, compensation-component match, and source quality. |
+| Range uncertainty | Prefer a visible range over a point estimate. Use median only as supporting detail. | Low/high, p25/p75, or confidence interval where the estimator actually supports it. |
+| Confidence explanation | One sentence plus expandable factor list: e.g. "Medium: company and location match, but only one recent benchmark source and seniority mapping is inferred." | Factor breakdown persisted with the estimate. |
+| Insufficient evidence | Show no range. Explain why the system withheld the estimate. | Estimation status and missing evidence list. |
 
-- [ ] Dedicated evidence ledger if users need bulk comparison beyond pin inspection.
-- [ ] Gate timeline if users need lifecycle sequence debugging after the audit surfaces are usable.
-- [ ] Deep PDF coordinate annotation if text/change anchors are not sufficient.
-- [ ] README/docs positioning for why JobHunter is safer than blind auto-apply tools.
+Recommended behavior:
 
-### Future Consideration
+1. Display the range first, confidence second, source label third.
+2. Use "estimate" in the label whenever the value is modelled or benchmark-derived.
+3. Do not imply precision with unnecessary exact dollars; round estimates to sensible bands such as nearest `$1k`, `$5k`, or local equivalent.
+4. Use plain language for confidence: "High confidence" means enough recent, matching, agreeing evidence; "Low confidence" means the range is a weak signal only.
+5. Show confidence drivers in the drawer, not only a color badge. Users should know whether uncertainty comes from parsing, old data, one source, source conflict, or title/location mismatch.
+6. If confidence is low, do not use the estimate for hard blockers. Use the posted salary, if present, for below-floor blocker/warning logic, and show low-confidence estimates as advisory context.
+7. Treat wide posted ranges as a confidence issue. A range where max/min is unusually large should warn that the employer range may be too broad for precise triage.
 
-- [ ] Multi-artifact side-by-side diff for resume versions.
-- [ ] Reviewer annotations/comments attached to individual pins.
-- [ ] Exportable audit packet for a selected application.
+## Dependencies on Existing JobHunter Features
 
-## Feature Prioritization Matrix
+| Existing Feature | Dependency | v1.3 Implication |
+|------------------|------------|------------------|
+| Jobs projection/read model | Jobs list and drawer already read `JobSummary` / `JobDetail` from Operations. | Add salary facts and estimate summaries as additive read-model fields; keep views as composers. |
+| `JobOverview.tsx` | Currently displays raw `job.salary` beside location. | Replace or augment with structured posted salary and confidence while preserving raw/missing state access in the drawer. |
+| `JobAuditTriage.tsx` | Existing audit workspace shows ranking confidence, apply concerns, sources, and readiness. | Add a compensation triage section using the same audit tone: facts, warnings, sources, confidence, and floor comparison. |
+| Jobs table columns | Current columns include fit score, title, company, sources, location, stage, state, discovered, and apply. | Add salary/compensation as a scannable column or TitleStack-style secondary fact; avoid crowding ranking columns. |
+| Profile compensation fields | Structured profile already stores salary expectation, currency, min/max range, and currency note. | Use these as the profile floor. Do not invent separate salary preferences unless normalization requires explicit annual/base semantics later. |
+| Profile target search fields | Target locations, work models, tracks, and seniority floors already exist. | Use them to improve market-estimate matching and explain assumptions. |
+| Existing scoring eligibility | Scoring already has logic for posted compensation below profile minimum. | Make this source-backed and visible; avoid a second hidden compensation gate. |
+| Source provenance conventions | Jobs already expose discovery/posting source and apply audit sources. | Extend provenance patterns to salary sources rather than introducing an opaque estimator. |
+| SSE/invalidation router | JobHunter refreshes projection-backed UI through Operations. | Add salary extraction/estimation events to read-model invalidation if v1.3 includes async worker computation. |
+| Local-first safety | JobHunter treats profile, job, and generated artifacts as sensitive. | Keep salary-source snapshots bounded; do not expose local profile details or raw private source payloads in fixtures/stories. |
 
-| Feature | User Value | Implementation Cost | Priority |
-|---------|------------|---------------------|----------|
-| Shared readiness/blocker contract | HIGH | MEDIUM | P1 |
-| Jobs drawer ranking/readiness triage | HIGH | MEDIUM | P1 |
-| Apply Review resume pins | HIGH | HIGH | P1 |
-| Pin inspector with grounding/risk detail | HIGH | MEDIUM | P1 |
-| Folded cleanup | MEDIUM | LOW | P1 |
-| Evidence ledger | MEDIUM | MEDIUM | P3 |
-| Gate timeline | MEDIUM | MEDIUM | P3 |
-| Blind auto-apply safety docs | MEDIUM | LOW | P3 |
+## MVP Recommendation
+
+Prioritize:
+
+1. Structured posted salary extraction with raw source text, normalized annual/base range, currency/period, parse confidence, and parse warnings.
+2. Jobs list and drawer triage that shows posted salary, floor comparison, confidence, missing states, and source text.
+3. Market estimate record/provenance model that can render "estimate unavailable" honestly before full external coverage exists.
+4. One or two allowed external benchmark source adapters, only if they can produce provenance and confidence factors without violating access constraints.
+5. Regression fixtures proving below-floor, no-salary, low-confidence, broad-range, and posted-vs-market-conflict states.
+
+Defer:
+
+- Deep equity/RSU vesting math: useful for Levels.fyi-style total compensation, but not needed for the first audit slice.
+- Negotiation recommendation generation: depends on trustworthy source agreement and user correction loops.
+- Automatic salary-based filtering/ranking: violates the v1.3 audit-first constraint until confidence and user preferences are validated.
+- Broad compensation-source marketplace: start with a small source registry and explicit gaps.
 
 ## Sources
 
-- User-selected sketch: `.planning/sketches/002-layered-audit-surfaces/` Option 1.
-- User stories and scope split from QA comments on 2026-06-11.
-- `apps/web/src/views/jobs/JobDetailDrawer.tsx` for current Jobs overlay.
-- `apps/web/src/views/apply-review/ApplyReviewView.tsx` for current Apply Review material surface.
-- `apps/web/src/contexts/materials/components/TailoringExplanationSection.tsx` and `BulletProvenanceList.tsx` for existing material audit capabilities.
-- `packages/contracts/src/schemas.ts` for score, readiness, artifact, tailoring, and provenance DTO inventory.
+- JobHunter project brief and v1.3 scope: `.planning/PROJECT.md`
+- JobHunter local QA and Jobs drawer smoke expectations: `docs/local-reliability-qa.md`
+- JobHunter frontend architecture and Operations read-model conventions: `docs/frontend-target.md`
+- JobHunter local API/read-model behavior: `docs/local-ts-api.md`
+- Current Jobs drawer salary/ranking surfaces: `apps/web/src/views/jobs/JobOverview.tsx`, `apps/web/src/views/jobs/JobAuditTriage.tsx`
+- Current profile compensation fields: `apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx`
+- Glassdoor salary estimate behavior and user need for salary before applying: https://www.glassdoor.com/blog/salary-estimates-announcement/
+- Glassdoor salary-estimate inputs and distinction from personalized market value: https://www.glassdoor.com/blog/use-salary-estimates-determine-next-employees-salary/
+- Glassdoor pay-range accuracy research and caveats around broad/variable-comp ranges: https://www.glassdoor.com/blog/pay-range-accuracy/
+- Glassdoor Help Center salary confidence snippets from search result, including high/low confidence and estimate interpretation: https://help.glassdoor.com/s/article/What-Salary-Information-is-on-Glassdoor?language=en_US
+- Levels.fyi verified salary documentation: https://www.levels.fyi/verified/
+- Levels.fyi compensation benchmarking source description: https://www.levels.fyi/offerings/data/
+- Levels.fyi public company salary pages showing role, level, total compensation, freshness, and source attribution patterns: https://www.levels.fyi/companies/google/salaries
+- LinkedIn Salary Insights distinction between employer expected salary and LinkedIn estimated salary: https://www.linkedin.com/business/talent/blog/product-tips/introducing-linkedin-salary-insights
+- Indeed pay transparency/job posting salary guidance: https://www.indeed.com/hire/resources/howtohub/can-you-post-a-job-on-indeed-without-salary
+- Indeed Hiring Lab pay transparency trend data: https://www.hiringlab.org/2023/03/14/us-pay-transparency-march-2023/
+- NYC Council Data Team salary transparency analysis on missing salaries and range-width ratios: https://council.nyc.gov/data/salary-transparency/
+- Schema.org `JobPosting`, `estimatedSalary`, and `salaryCurrency` semantics: https://schema.org/JobPosting
+- Schema.org `baseSalary`: https://schema.org/baseSalary
+- Google Search Central JobPosting structured-data guidance and visible-content consistency requirement: https://developers.google.com/search/docs/appearance/structured-data/job-posting
+- Province of British Columbia pay-transparency posting guidance for examples of acceptable/unacceptable salary wording: https://www2.gov.bc.ca/gov/content/governments/about-the-bc-government/gender-equity/wage-or-salary-information-on-job-postings
+- UK Government Analysis Function guidance on communicating quality and uncertainty: https://analysisfunction.civilservice.gov.uk/policy-store/communicating-quality-uncertainty-and-change/
+- Nielsen Norman Group explanation of confidence intervals and why ranges need accompanying uncertainty: https://www.nngroup.com/articles/confidence-interval/
 
----
-*Feature research for: v1.2 Apply Review Audit UX - Drawer + Resume Pins*
-*Researched: 2026-06-11*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,187 +1,283 @@
-# Pitfalls Research
+# Domain Pitfalls
 
-**Domain:** Local-first job-application audit UX
-**Researched:** 2026-06-11
-**Confidence:** HIGH for auditability and scope pitfalls, MEDIUM for pin placement risks
+**Domain:** Salary range estimation for a local-first job-search automation app
+**Project:** JobHunter v1.3 Salary Range Estimator
+**Researched:** 2026-06-19
+**Overall confidence:** HIGH for source-access risks and audit architecture; MEDIUM for source-specific data-quality behavior because salary platforms expose limited methodology.
+
+## Research Bottom Line
+
+Build the salary estimator as an audit feature, not a ranking oracle. Posted salary extraction can be deterministic and high-confidence when the source span is visible. External market estimates must be optional, source-licensed, provenance-backed, and shown with explicit uncertainty. Do not scrape Glassdoor or Levels.fyi by default. Treat them as named source adapters that are disabled unless their current terms and access mode allow the specific use.
+
+For JobHunter, the safest design is: `posted compensation fact` first, `licensed/manual market benchmarks` second, `profile-floor comparison` third, and no automatic apply/ranking gate from an opaque market estimate. Persist canonical salary facts and benchmark observations in the owning backend layer, project them into the Jobs detail read model, and render missing/uncertain data explicitly in `JobAuditTriage`.
 
 ## Critical Pitfalls
 
-### Pitfall 1: Contradictory Readiness Labels
+### Pitfall 1: Scraping Salary Sources Without a Valid Access Basis
 
-**What goes wrong:**
-Jobs drawer, Apply Review queue, selected header, and decision controls show different readiness/blocker facts for the same job.
+**What goes wrong:** The estimator silently crawls Glassdoor, Levels.fyi, or a third-party scraper API and stores salary data as if it were freely reusable.
 
-**Why it happens:**
-Each UI surface derives its own status from a subset of fields. The current Apply Review view already has local `materialStatus` logic while the API queue exposes a simpler `materials.ready` field.
+**Why it happens:** Public salary pages feel like ordinary web data, but salary platforms impose source-specific terms, login gates, paywalls, anti-bot rules, attribution rules, and commercial-use restrictions.
 
-**How to avoid:**
-Create one shared readiness/blocker contract in the API/read model and consume it in both surfaces. UI helpers can format labels, but cannot decide source facts.
+**Consequences:** Legal/TOS exposure, brittle integrations, user account lockouts, blocked IPs, unusable roadmap work, and a product surface that cannot explain where a range came from or whether JobHunter was allowed to use it.
 
-**Warning signs:**
-- New helpers named `materialStatus` or `readinessStatus` inside views.
-- Tests assert labels without checking the API contract.
-- `materials.ready` and blocker labels are not derived from the same source.
+**Prevention:**
+- Ship a salary-source registry before any external fetcher. Each source must declare `access_mode`, `terms_url`, `license_status`, `attribution_required`, `supports_api`, `supports_manual_entry`, `supports_public_reference`, `allowed_fields`, `freshness_policy`, and `disabled_reason`.
+- Default external sources to `disabled` unless the adapter has a documented permitted mode: licensed API/MCP/CLI, official export, user-entered benchmark, or specifically allowed public structured data with attribution.
+- Do not use third-party Glassdoor/Levels scraper products as a compliance shortcut. A vendor API may solve transport, but it does not prove JobHunter has rights to use or redistribute the underlying data.
+- Store source references and captured values, not raw pages, unless the source terms and privacy posture explicitly allow retention.
+- Require an adapter-level test that unauthorized sources return `unavailable_due_to_access_policy` instead of fetching.
 
-**Phase to address:** Phase 13 shared audit contract.
+**Detection:**
+- Code contains raw `fetch`, browser automation, reverse-engineered endpoints, or scraper libraries targeting salary pages.
+- A benchmark row lacks `terms_url`, `source_url`, `captured_at`, and `access_mode`.
+- UI shows source names without the access status or attribution required by the source.
 
----
+**Research notes:**
+- Glassdoor terms say services are personal/non-commercial unless separately approved and prohibit automated agents or scraping/mining data without express written permission.
+- Glassdoor also has a developer registration page, but it requires login and ties keys to a Glassdoor account; do not assume broad public salary API availability without an approved key and current API terms.
+- Levels.fyi terms define Salary Data as proprietary, generalized-comparison data with no warranty, and prohibit manual or automated scraping/crawling/spidering pages as a harmful act.
+- Levels.fyi separately advertises API/MCP/CLI access through a request form and enterprise data products. That supports a licensed adapter path, not default scraping.
+- Some Levels.fyi pages advertise AI-readable structured `.md` resources with attribution and guidelines. Treat that as source-specific public-reference support only after checking the current `robots.txt`/`llms.txt` guidance and terms for the exact intended use.
 
-### Pitfall 2: Ranking Explanation Implemented in the Wrong Surface
+### Pitfall 2: Presenting Estimates as Truth Instead of Statistical Claims
 
-**What goes wrong:**
-The milestone explains ranking in Apply Review but leaves the Jobs row-click drawer vague.
+**What goes wrong:** The UI displays `$180K - $220K market range` as a confident fact when the estimate came from a handful of stale, mismatched, or broad-title observations.
 
-**Why it happens:**
-Apply Review currently shows requirement evidence and can open job details, so it is tempting to keep adding ranking content there.
+**Why it happens:** Salary products expose polished numbers, but compensation varies by title taxonomy, job family, seniority, company size, location, work arrangement, date, equity liquidity, bonus/commission mix, and source coverage.
 
-**How to avoid:**
-Keep the scope split explicit: Jobs drawer owns rank explanation, readiness, blockers, and eligibility concerns. Apply Review owns generated-material inspection.
+**Consequences:** Users over-trust weak estimates, reject good jobs, anchor negotiations incorrectly, or lose faith when a posted salary disagrees with the estimate.
 
-**Warning signs:**
-- Jobs drawer still starts with generic "Preparation diagnostics" before rank/readiness triage.
-- Apply Review becomes the only place a user can answer why the job ranked highly.
+**Prevention:**
+- Store confidence as an evidence computation, not a label from one source. Inputs should include sample/source count, recency, role-title match, seniority match, location match, company match, currency/period certainty, source agreement, dispersion, and access reliability.
+- Require `confidence_band` plus `confidence_reasons`, not just `high/medium/low`.
+- Use wide intervals for weak evidence and show `insufficient evidence` when minimum thresholds fail.
+- Never show one precise percentile unless the source provides that percentile and enough provenance to support it.
+- Display market estimates as "benchmark estimate", not "salary", "expected offer", "fair pay", or "what they will pay".
+- Keep posted salary and market benchmark separate. A posted employer range is a source-backed job fact; a benchmark is an external comparison.
 
-**Phase to address:** Phase 14 Jobs drawer audit triage.
+**Detection:**
+- UI renders a single market number without sample count/source count.
+- Tests can pass with `confidence=high` but zero sources.
+- Estimate confidence does not change when role/location/seniority match quality is degraded.
 
----
+### Pitfall 3: Normalizing Currency, Period, and Compensation Type Too Aggressively
 
-### Pitfall 3: Resume Pins That Are Decorative Instead of Auditable
+**What goes wrong:** A parser converts `€70k OTE`, `$80/hr`, `£90,000 + equity`, or `up to 120k gross` into a clean annual base salary range without preserving assumptions.
 
-**What goes wrong:**
-Pins appear on or near the resume but do not open concrete source evidence, transformed text, grounding status, or risk.
+**Why it happens:** Existing `ConstraintChecker` salary parsing already extracts numeric maxima for eligibility checks, but v1.3 needs a richer compensation model than "max annual number".
 
-**Why it happens:**
-The UI work focuses on layout before deriving a pin model from `bulletProvenance`, `annotatedChanges`, and judge/quality data.
+**Consequences:** Incorrect profile-floor blockers, misleading comparisons across countries, loss of bonus/equity semantics, and hard-to-debug user complaints.
 
-**How to avoid:**
-Define a pin model first. Every pin must point to a generated claim/bullet and show source profile/resume text, requirements/evidence IDs, transform/change type, grounding/risk, and reviewer action where available.
+**Prevention:**
+- Model compensation components explicitly: `base`, `total_comp`, `OTE`, `bonus`, `commission`, `equity`, `hourly`, `monthly`, `annual`, `gross`, `net`, `unknown`.
+- Preserve the original source span and parse warnings for every normalized fact.
+- Do not convert hourly/monthly/contract rates to annual unless hours, months, or working schedule assumptions are explicit and displayed.
+- Currency conversion must store `from_currency`, `to_currency`, `rate`, `rate_source`, `rate_date`, and whether the conversion is spot FX or PPP/cost-of-living adjusted.
+- Prefer ECB reference rates for EUR-based spot FX display and label them informational. Prefer OECD/World Bank PPP only for optional purchasing-power context, never as the canonical offered salary.
+- Keep gross/net unknown visible, especially for Europe.
 
-**Warning signs:**
-- Pins are keyed by array index only.
-- Pins do not survive sorting/filtering/re-rendering.
-- Pin detail cannot name source evidence or generated text.
+**Detection:**
+- A test fixture with hourly, monthly, OTE, equity, and ambiguous `k` values produces no parse warnings.
+- Converted values lack exchange-rate source/date.
+- Profile-floor comparison uses a converted estimate without showing the basis.
 
-**Phase to address:** Phase 15 Apply Review resume pins.
+### Pitfall 4: Reintroducing Opaque Gates Through Salary Data
 
----
+**What goes wrong:** Market estimates silently affect job ranking, apply readiness, or blockers, contradicting the v1.3 requirement to keep uncertain compensation audit-first.
 
-### Pitfall 4: Missing Audit Data Hidden for Polish
+**Why it happens:** The current scoring path already has deterministic compensation blocker logic against posted salary/profile minimums. It is tempting to extend that to external estimates.
 
-**What goes wrong:**
-Unsupported claims, missing evidence, missing prompt/judge details, absent source bullets, or incomplete material status are hidden or renamed to make the UI feel cleaner.
+**Consequences:** Jobs disappear or look blocked because of weak market data; users cannot tell whether a job failed due to the employer-posted range or a third-party benchmark.
 
-**Why it happens:**
-Audit gaps look embarrassing in review surfaces.
+**Prevention:**
+- Only a parsed posted salary with a visible source span should be eligible for deterministic `below profile floor` blocker behavior.
+- External benchmark estimates may produce warnings or comparison copy, not blockers, unless the user explicitly opts into salary-based filtering and the source confidence meets documented thresholds.
+- Render lifecycle labels: `posted salary parsed`, `market estimate computed`, `market estimate unavailable`, `below profile floor based on posted range`, `below profile floor based on user opt-in market estimate`.
+- Update scoring QA to prove market estimates do not change `fitScore`, `applyAudit.state`, or apply readiness by default.
 
-**How to avoid:**
-Preserve explicit missing states and fix missing audit sources in the owning layer when the source should exist.
+**Detection:**
+- A job with no posted salary but a low market estimate becomes blocked.
+- Changing a market source fixture changes fit-score color, apply readiness, or queue eligibility.
+- JobAuditTriage cannot tell whether floor comparison used posted salary or market data.
 
-**Warning signs:**
-- Empty arrays return `null` instead of an explicit empty state.
-- "not recorded" states disappear from inspector components.
-- PR text says a field was removed because it was confusing without source-of-truth remediation.
+### Pitfall 5: Missing Source-of-Truth Audit Rows
 
-**Phase to address:** All phases; especially Phases 13 and 15.
+**What goes wrong:** Salary facts are computed in the TypeScript read model or React component from raw job text and benchmark payloads instead of persisted canonical rows.
 
----
+**Why it happens:** The Jobs drawer is already a convenient composer and current salary parsing in scoring is utility-style. That path is too shallow for v1.3 auditability.
 
-### Pitfall 5: QA Accidentally Uses Sensitive or Live Application Flows
+**Consequences:** TS/Python drift, stale projections, UI-only facts with no event history, impossible regression fixtures, and a repeat of prior audit risks where read-time recomputation diverged from generated artifacts.
 
-**What goes wrong:**
-Browser proof exposes local resume/profile/application data or triggers apply/browser submission/worker-backed actions.
+**Prevention:**
+- Add canonical backend tables/records for salary facts and benchmark observations before UI work.
+- Projection builders in Python and TypeScript must produce the same read-model JSON from canonical rows.
+- Job detail should expose salary audit data through Operations read hooks; `JobAuditTriage` should only render the projected contract.
+- Every displayed range needs `source_kind`, `source_label`, `source_url_or_reference`, `captured_at`, `freshness`, `raw_value`, `normalized_value`, `warnings`, and `confidence`.
 
-**Why it happens:**
-The most realistic path is a running local app with real data, but this repo treats generated materials and local artifacts as sensitive.
+**Detection:**
+- `JobAuditTriage` imports parser functions or computes currency/seniority matching.
+- Salary UI tests seed only component props, not canonical salary projection fixtures.
+- API response contains salary display strings but no audit facts behind them.
 
-**How to avoid:**
-Use synthetic seeded fixtures or scrubbed static examples. QA must not run auto-apply, browser submission, mailbox scanning, real material generation, destructive profile/database actions, or worker-backed jobs unless explicitly requested.
+## Moderate Pitfalls
 
-**Warning signs:**
-- Screenshots show real company/candidate identifiers from the user environment.
-- QA command starts `jobhunter run`, a Temporal worker, apply automation, or browser submission without explicit approval.
+### Pitfall 1: Bias From Crowdsourced and Platform-Specific Data
 
-**Phase to address:** Phase 16 QA/docs.
+**What goes wrong:** The estimator treats self-reported compensation data as representative of the labor market.
 
----
+**Prevention:**
+- Track source type: employer-posted, user-reported, verified user-reported, government survey, licensed benchmark, manual user note.
+- Show representativeness warnings for narrow samples, self-selected crowdsourced data, tech-heavy sources, missing non-tech sectors, and small-company rows.
+- Cross-check multiple source types before showing medium/high confidence.
+- Do not use salary estimates for employer-side screening. JobHunter is applicant-side triage; README already warns against employer-side selection without governance.
 
-### Pitfall 6: Folded Cleanup Overtakes the Product Milestone
+### Pitfall 2: Geography and Work-Arrangement Mismatch
 
-**What goes wrong:**
-The leftover v1.1 cleanup expands into broad styling, route, or dependency refactors before the audit UX is delivered.
+**What goes wrong:** Remote-US, Spain-local, Europe-remote, city, metro, country, and global benchmarks are blended into one range.
 
-**Why it happens:**
-Cleanup items are easy to chase because they touch many files and have obvious grep targets.
+**Prevention:**
+- Normalize location at multiple levels: city, metro/region, country, remote scope, and source-specific market.
+- Confidence should drop when a benchmark is only country-level for a city-specific role or when remote scope is unknown.
+- For Spain/Europe target workflows, treat US-heavy Levels.fyi/software-engineering data as low confidence unless the source supports the exact country/region and role.
 
-**How to avoid:**
-Limit cleanup to stale verification command normalization, dependency/config audit, obsolete `lucide-react` removal only if imports are zero, and narrow docs/config updates.
+### Pitfall 3: Seniority and Level Taxonomy Drift
 
-**Warning signs:**
-- Cleanup phase changes product layout or route behavior.
-- Cleanup PR touches unrelated design tokens beyond stale references.
-- No audit UX phases are planned yet.
+**What goes wrong:** `Senior Software Engineer`, `Staff`, `Engineering Manager`, `Tech Lead`, and local title variants are mapped to the wrong benchmark level.
 
-**Phase to address:** Phase 12 folded cleanup.
+**Prevention:**
+- Store title match and seniority match separately.
+- Persist assumptions: `assumed_seniority`, `source_level`, `mapping_confidence`, `mapping_reason`.
+- Use "not enough level evidence" instead of falling back to a broad role average for senior roles.
+- QA should include fixtures where title and level disagree, such as `Lead Engineer` IC vs manager.
 
-## Technical Debt Patterns
+### Pitfall 4: Posted Range Compliance Overreach
 
-| Shortcut | Immediate Benefit | Long-term Cost | When Acceptable |
-|----------|-------------------|----------------|-----------------|
-| Formatting readiness in the UI from raw fields | Fast visible labels | Permanent cross-surface drift | Never for shared facts. |
-| Pins keyed by visual order | Quick prototype | Breaks proof when rendering changes | Only in throwaway sketches, not production. |
-| Missing keyword list inferred from job keywords | Easy to fill UI | False audit claims | Never; use coverage audit or rendered text with provenance. |
-| Adding new UI components inside views only | Fast local change | Reuse and testing suffer | Acceptable only for pure layout composers. |
-| Deferring API tests for read-model DTOs | Faster PR | Contract regressions slip to browser QA | Not acceptable for shared contract changes. |
+**What goes wrong:** The UI implies a missing or broad salary range is illegal.
 
-## Integration Gotchas
+**Prevention:**
+- Show "no posted range found" or "range is broad/ambiguous", not legal conclusions.
+- If jurisdictional context is added later, gate it behind a specific legal-source module. The EU pay transparency rules are taking effect across the EU and require employers to inform job seekers about starting salary or pay range in the vacancy notice or before interview, but implementation and enforcement remain jurisdiction-specific.
 
-| Integration | Common Mistake | Correct Approach |
-|-------------|----------------|------------------|
-| Contracts/API/web | Add fields to web types without API mapper tests | Add DTO fields in `@jobhunter/contracts`, map in API, and cover with tests/typecheck. |
-| Apply Review and Jobs drawer | Duplicate blocker formatting | Share source facts; localize only labels or compact display variants. |
-| PDF preview and pins | Assume PDF page coordinates are stable | Anchor to generated text/provenance first and show fallback when visual location cannot be established. |
-| Storybook/QA fixtures | Reuse local artifacts | Use synthetic data and scrubbed examples. |
-| Icon cleanup | Remove dependency before import proof | Run import/dependency audit before removing `lucide-react`. |
+### Pitfall 5: Freshness Decay Is Ignored
 
-## UX Pitfalls
+**What goes wrong:** A 2022 benchmark is shown beside a 2026 posting without warning.
 
-| Pitfall | User Impact | Better Approach |
-|---------|-------------|-----------------|
-| Dense audit panels disconnected from the resume | User cannot connect evidence to the artifact they approve. | Put pins/markers on or beside the rendered resume and show detail on selection. |
-| Generic "materials not ready" tag | User does not know why review is blocked. | Show concrete prerequisites and blocker source. |
-| Ranking mixed with material proof | User cannot tell whether a problem is job fit or generated artifact risk. | Jobs drawer owns fit/readiness; Apply Review owns artifact proof. |
-| Over-explaining process text in the app | Slows repeated review workflow. | Use compact labels, disclosure, pins, and inspector detail. |
-| Hero/marketing treatment | Misfits dense operational tool usage. | Keep a utilitarian, scannable, work-focused layout. |
+**Prevention:**
+- Store `observed_at`, `published_at`, `source_updated_at`, and `captured_at` separately when available.
+- Degrade confidence by age and show stale-source warnings.
+- For sources that update daily or expose "last updated", retain that in provenance.
 
-## Looks Done But Is Not Checklist
+## Minor Pitfalls
 
-- [ ] **Readiness:** Both surfaces show labels, but tests do not assert they come from the same contract.
-- [ ] **Jobs drawer:** It contains score details, but no clear answer to "why ranked this way."
-- [ ] **Apply Review:** It shows provenance cards, but selecting a resume line/claim does not reveal source and risk.
-- [ ] **Pins:** They exist visually, but cannot name source profile/resume text and generated text.
-- [ ] **Claim risk:** Judge/adversarial warnings are present somewhere, but not connected to specific generated claims or accepted lifecycle state.
-- [ ] **QA:** Browser screenshots look good, but data is real or the apply path was triggered.
-- [ ] **Cleanup:** `lucide-react` is removed without import/dependency proof, or stale Tailwind config references remain.
+### Pitfall 1: Overloaded "Salary" Vocabulary
 
-## Pitfall-to-Phase Mapping
+**What goes wrong:** Users cannot tell whether a range means base pay, total compensation, OTE, or posted employer range.
 
-| Pitfall | Prevention Phase | Verification |
-|---------|------------------|--------------|
-| Contradictory readiness labels | Phase 13 | API/read-model tests plus browser proof of same job in Jobs drawer and Apply Review. |
-| Ranking explanation in wrong surface | Phase 14 | Jobs drawer test/browser QA answers rank/readiness/blocker stories without opening Apply Review. |
-| Decorative pins | Phase 15 | Component tests assert pin detail includes source, generated text, transform, evidence, grounding, risk. |
-| Hidden missing audit data | Phases 13-15 | Empty/missing-state tests and review checklist. |
-| Sensitive/live QA | Phase 16 | QA evidence uses synthetic data and records no auto-apply/submission commands. |
-| Cleanup scope creep | Phase 12 | Diff scoped to stale config/dependency/docs proof. |
+**Prevention:** Use component-specific labels: `Posted base range`, `Posted total/OTE`, `Market total-comp estimate`, `Market base estimate`, `Profile floor comparison`.
+
+### Pitfall 2: False Precision in Display Formatting
+
+**What goes wrong:** Converted estimates render as `$183,247 - $219,812`, implying precision the data does not support.
+
+**Prevention:** Round benchmark estimates to sensible buckets, preserve exact raw values in the audit drawer, and show exactness only for parsed posted values when the source text is exact.
+
+### Pitfall 3: Sensitive Data in Fixtures, Logs, and Telemetry
+
+**What goes wrong:** Salary source payloads, user profile floor, raw job text, or benchmark rows leak into committed fixtures, logs, screenshots, or Langfuse traces.
+
+**Prevention:** Use synthetic salary fixtures only; redact raw source pages; log identifiers/counts/warnings rather than raw compensation payloads; never include user profile salary preferences in domain events beyond safe comparison facts.
+
+## Security And Privacy Risks
+
+| Risk | Impact | Prevention |
+| --- | --- | --- |
+| User credentials for salary platforms stored in JobHunter | Account compromise and TOS exposure | Do not collect Glassdoor/Levels credentials. Use official API keys/contracts only, stored like other secrets in local `.env`, never in SQLite events/projections. |
+| Raw benchmark pages retained locally | Copyright/privacy retention risk | Store normalized observations, source URL/reference, and small allowed excerpts only when permitted. |
+| Profile compensation floor exposed in UI events/logs | Sensitive personal preference leak | Keep floor comparison local, redact in event payloads, and avoid telemetry export of full profile compensation fields. |
+| External requests include job/profile context | Job search privacy leak to providers | Query only role/location/seniority/company fields needed for benchmark lookup; never send resume, generated materials, or application status. |
+| Third-party scraper dependencies | Supply-chain and legal ambiguity | Avoid scraper dependencies. If a licensed vendor is used later, isolate behind a port and record license/source provenance. |
+| Currency-rate or source API outages | Stale or missing estimates | Fail closed with `market estimate unavailable`, not cached stale values pretending to be current. |
+
+## Preventive Requirements
+
+1. **Salary source registry:** Every external source must have explicit access mode, terms URL, attribution requirement, license status, freshness policy, supported fields, and disabled reason.
+2. **Canonical salary facts:** Persist posted salary facts and market benchmark observations before projection/UI rendering.
+3. **Source provenance contract:** Every displayed range must identify source type, source label, source URL/reference, captured value, normalized value, captured date, freshness, confidence, sample/source count when available, warnings, and assumptions.
+4. **Confidence model:** Confidence must combine evidence volume, recency, source agreement, dispersion, role match, seniority match, location match, currency/period certainty, and source access reliability.
+5. **No opaque gating:** Market estimates must not block, hide, rank, or apply-filter jobs by default. Posted salary/profile-floor blockers must name the posted source span.
+6. **Currency/location normalization:** FX or PPP conversions must retain rate source/date and be labeled. Location scope and work arrangement must be explicit.
+7. **Component separation:** Base, total compensation, OTE, bonus, commission, and equity must remain distinct until a source explicitly supports total-comp comparison.
+8. **Privacy by design:** Do not store credentials for consumer salary sites, raw pages, raw profile salary preferences in events, or sensitive source payloads in fixtures/logs.
+9. **Adapter failure states:** Unsupported, paywalled, access-denied, rate-limited, stale, and insufficient-evidence outcomes must be first-class user-visible states.
+10. **Attribution:** If a source requires attribution, the UI and exported audit data must include it automatically.
+
+## QA Recommendations
+
+### Backend/domain tests
+
+- Posted salary parser fixtures for exact range, single value, `k` suffix, European decimals, hourly, monthly, OTE, equity, bonus, commission, gross/net unknown, multiple currencies, and no salary.
+- Market confidence fixtures where confidence degrades for low sample count, stale data, broad geography, wrong seniority, source disagreement, missing currency basis, and unauthorized source access.
+- Source registry tests proving Glassdoor/Levels-style sources are disabled without explicit allowed access mode.
+- Profile-floor tests proving only posted salary facts can create default blockers; market estimates create warnings unless a future user opt-in says otherwise.
+- Projection parity fixture for salary facts and benchmark observations across Python and TypeScript projection builders.
+
+### API/read-model tests
+
+- `JobDetail` exposes salary audit facts from canonical rows, not UI recomputation.
+- Missing benchmark data returns explicit `unavailable` reasons.
+- API responses redact raw pages, profile salary preferences, secrets, local paths, and source payloads beyond allowed excerpts.
+- SSE invalidation covers salary fact/benchmark updates so the Jobs drawer refreshes without manual reload.
+
+### Frontend tests
+
+- `JobAuditTriage` renders posted salary, market estimate, confidence, warnings, source trail, freshness, and profile-floor comparison from the Operations read hook contract.
+- Low-confidence benchmark renders as uncertain and does not change fit-score badge, apply readiness, or Apply Review handoff.
+- Missing salary and missing benchmark states are visible, not blank.
+- Long source labels, currency strings, and warning text fit in the drawer at mobile and desktop widths.
+- Accessibility test for expanded salary audit details.
+
+### Product-path QA
+
+- Seed synthetic jobs with: posted salary below floor, posted salary above floor, no posted salary plus low-confidence benchmark, high-confidence licensed benchmark, stale benchmark, currency conversion, OTE-only role, and Europe remote role.
+- Open `/jobs`, select each row, and verify the drawer explains which compensation facts are posted vs estimated and whether any floor comparison is based on posted data.
+- Confirm no apply/browser automation, mailbox scanning, real external scraping, or real generated-material workflow is triggered by salary QA.
+
+## Phase-Specific Warnings
+
+| Phase Topic | Likely Pitfall | Mitigation |
+| --- | --- | --- |
+| Posted salary extraction | Existing max-salary parser is too lossy for audit | Build structured compensation facts with source spans, components, periods, currencies, and warnings. |
+| External benchmark adapter | Scraping or unlicensed access sneaks in | Start with registry + disabled adapters + manual/licensed-source seams before any network fetcher. |
+| Confidence scoring | Confidence becomes a subjective label | Derive confidence from recorded evidence dimensions and test degradation cases. |
+| Read model | Salary facts recomputed in TS/UI | Persist canonical rows and add projection parity tests. |
+| Jobs drawer UI | Salary estimate looks like a hard truth | Label posted vs benchmark, show confidence/warnings/source trail, and avoid ranking/apply gates. |
+| Currency/location | Cross-country comparisons become misleading | Store FX/PPP source/date and render location/work-arrangement assumptions. |
+| Privacy/security | Sensitive salary preferences leak into logs/events | Use synthetic fixtures and redact profile floors/source payloads from events and telemetry. |
 
 ## Sources
 
-- `AGENTS.md` auditability and QA discipline.
-- `apps/web/src/views/apply-review/ApplyReviewView.tsx`
-- `apps/web/src/views/jobs/JobDetailDrawer.tsx`
-- `apps/api/src/application-feedback.ts`
-- `packages/contracts/src/schemas.ts`
-- `.planning/sketches/002-layered-audit-surfaces/README.md`
-
----
-*Pitfalls research for: v1.2 Apply Review Audit UX - Drawer + Resume Pins*
-*Researched: 2026-06-11*
+- Glassdoor Terms of Use, accessed 2026-06-19: https://www.glassdoor.com/about/terms/
+  - Confidence: HIGH. Official source. Key findings: non-commercial default use; automated scraping/mining requires express written permission.
+- Glassdoor developer registration/API pages, accessed 2026-06-19: https://www.glassdoor.com/developer/register_input.htm and https://www.glassdoor.com/developer/salariesApiActions.htm
+  - Confidence: MEDIUM. Official pages are sparse/currently login-gated; use only to justify treating Glassdoor API access as account/approval-based.
+- Glassdoor robots.txt, accessed 2026-06-19: https://www.glassdoor.com/robots.txt
+  - Confidence: HIGH for crawl-policy signal, not a complete legal license.
+- Levels.fyi Terms and Conditions, accessed 2026-06-19: https://www.levels.fyi/about/terms.html
+  - Confidence: HIGH. Official source. Key findings: Salary Data is proprietary, approximate, no-warranty, generalized-comparison data; scraping/crawling/spidering is prohibited.
+- Levels.fyi API/MCP/CLI access page, accessed 2026-06-19: https://www.levels.fyi/api-access/
+  - Confidence: HIGH. Official source. Key finding: API/MCP/CLI access is request-based.
+- Levels.fyi compensation data offering/pricing page, accessed 2026-06-19: https://www.levels.fyi/offerings/data/
+  - Confidence: HIGH. Official source. Key findings: paid tiers, enterprise API/MCP access, data granularity, validation claims, and freshness claims.
+- Levels.fyi public salary pages indexed with AI-readable `.md` and attribution notices, accessed 2026-06-19 via search results such as https://www.levels.fyi/t/software-engineer
+  - Confidence: MEDIUM. Official page snippets indicate structured AI resources and attribution requirements, but implementation should verify current robots/llms guidance before use.
+- U.S. Bureau of Labor Statistics OEWS research estimates, accessed 2026-06-19: https://www.bls.gov/oes/oes_research_2024.htm
+  - Confidence: HIGH. Official source. Key findings: salary estimates from sample surveys have sampling and nonsampling error; PRSE is used to communicate reliability.
+- European Central Bank euro foreign exchange reference rates, accessed 2026-06-19: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html
+  - Confidence: HIGH. Official source. Key findings: updated on working days; informational reference rates, discouraged for transaction use.
+- OECD Purchasing Power Parities dataset, accessed 2026-06-19: https://www.oecd.org/en/data/datasets/purchasing-power-parities.html
+  - Confidence: HIGH. Official source. Key finding: PPPs equalize purchasing power by eliminating price-level differences and are intended for real cross-country comparisons.
+- World Bank PPP indicator, accessed 2026-06-19: https://data.worldbank.org/indicator/PA.NUS.PPP
+  - Confidence: HIGH. Official/open-data source with CC BY-4.0 license; useful for PPP availability and attribution.
+- European Commission pay transparency explainer, published 2026-06-05, accessed 2026-06-19: https://commission.europa.eu/news-and-media/news/new-eu-rules-pay-transparency-explained-2026-06-05_en
+  - Confidence: HIGH. Official source. Key finding: EU rules require job seekers to be informed of starting salary/pay range in the vacancy notice or before interview and prohibit pay-history questions.

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -134,12 +134,12 @@ For JobHunter, the safest design is: `posted compensation fact` first, `licensed
 
 ### Pitfall 2: Geography and Work-Arrangement Mismatch
 
-**What goes wrong:** Remote-US, Spain-local, Europe-remote, city, metro, country, and global benchmarks are blended into one range.
+**What goes wrong:** Spain-local, Europe-remote, EU-wide, non-EU-Europe, unknown-location, company-HQ, city, metro, and country benchmarks are blended into one range.
 
 **Prevention:**
 - Normalize location at multiple levels: city, metro/region, country, remote scope, and source-specific market.
 - Confidence should drop when a benchmark is only country-level for a city-specific role or when remote scope is unknown.
-- For Spain/Europe target workflows, treat US-heavy Levels.fyi/software-engineering data as low confidence unless the source supports the exact country/region and role.
+- For Spain/Europe target workflows, treat broad or non-European Levels.fyi/software-engineering data as low confidence unless the source supports the exact country/region and role.
 
 ### Pitfall 3: Seniority and Level Taxonomy Drift
 
@@ -271,8 +271,6 @@ For JobHunter, the safest design is: `posted compensation fact` first, `licensed
   - Confidence: HIGH. Official source. Key findings: paid tiers, enterprise API/MCP access, data granularity, validation claims, and freshness claims.
 - Levels.fyi public salary pages indexed with AI-readable `.md` and attribution notices, accessed 2026-06-19 via search results such as https://www.levels.fyi/t/software-engineer
   - Confidence: MEDIUM. Official page snippets indicate structured AI resources and attribution requirements, but implementation should verify current robots/llms guidance before use.
-- U.S. Bureau of Labor Statistics OEWS research estimates, accessed 2026-06-19: https://www.bls.gov/oes/oes_research_2024.htm
-  - Confidence: HIGH. Official source. Key findings: salary estimates from sample surveys have sampling and nonsampling error; PRSE is used to communicate reliability.
 - European Central Bank euro foreign exchange reference rates, accessed 2026-06-19: https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html
   - Confidence: HIGH. Official source. Key findings: updated on working days; informational reference rates, discouraged for transaction use.
 - OECD Purchasing Power Parities dataset, accessed 2026-06-19: https://www.oecd.org/en/data/datasets/purchasing-power-parities.html

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,90 +1,187 @@
-# Stack Research
+# Technology Stack Research
 
-**Domain:** Local-first job-application audit UX
-**Researched:** 2026-06-11
-**Confidence:** HIGH for current repo stack, MEDIUM for exact resume-pin rendering mechanics
+**Project:** JobHunter v1.3 Salary Range Estimator  
+**Researched:** 2026-06-19  
+**Scope:** Posted salary extraction, market compensation sources, statistical confidence, source provenance, and Jobs triage surfacing.  
+**Overall confidence:** HIGH for repo integration approach and public/government source constraints; MEDIUM for licensed commercial data availability until the user chooses a provider/account.
 
-## Recommended Stack
+## Recommendation
 
-### Core Technologies
+Build v1.3 as a local-first compensation evidence feature on the existing Python worker, SQLite canonical tables, projection-backed TypeScript API, and Jobs drawer/list UI. Do not introduce a new service, queue, scraper platform, or separate analytics store.
 
-| Technology | Version | Purpose | Why Recommended |
-|------------|---------|---------|-----------------|
-| React | 19.2.x in `apps/web` | UI composition for Jobs drawer and Apply Review | Existing production stack; supports componentized audit panes without changing routing or state architecture. |
-| Vite | 7.x in `apps/web` | Web build and dev server | Existing fast local workflow; no new bundler needed for milestone UI work. |
-| TypeScript | 6.0.3 root dev dependency | Contracts, API, and web type safety | Shared `@jobhunter/contracts` DTOs can make readiness/blocker drift a compile-time problem. |
-| Tailwind CSS | 4.x in `apps/web` | CSS-first semantic token styling | v1.1 already migrated to shadcn semantic tokens; v1.2 should build on the current token system rather than add a second styling layer. |
-| TanStack Router/Query/Table/Form | Current repo packages | URL state, server state, tables, forms | Existing frontend target architecture requires Operations hooks for reads and context-owned mutations for writes. |
-| SQLite projection read model | Current API architecture | Local-first read DTOs for Jobs and Apply Review | The shared readiness/audit contract belongs in projection-backed API read models rather than duplicated UI derivation. |
+The practical stack is:
 
-### Supporting Libraries
+| Layer | Recommended approach | Why |
+| --- | --- | --- |
+| Posted salary extraction | Deterministic Python parser in the Discovery/Enrichment domain, backed by canonical salary-fact rows | `JobMetadata.salary` is currently a raw string and scoring has only a private `_salary_max` heuristic. v1.3 needs inspectable parse facts with source text, period, currency, warnings, and confidence. |
+| Market salary estimation | New Python compensation/market estimator use case, fed by pluggable source adapters | The Python worker already owns external I/O, source provenance, scoring, and local persistence. Keep source calls out of React and out of the TS read model. |
+| Public baseline data | BLS OEWS/O*NET as default public benchmark baseline; optional OFLC/H-1B disclosure import for company/location-specific U.S. tech signal | These are official/public sources with clear access paths and freshness metadata. They are weaker than Levels.fyi for tech leveling, but suitable as legally safe default evidence. |
+| Licensed commercial data | Optional Levels.fyi adapter behind an explicit user-provided access configuration | Levels.fyi advertises API/MCP/CLI and data-stream access, but API/data-stream access is gated behind commercial access. Treat it as optional, not table stakes. |
+| Glassdoor | Do not scrape. Use only if the user has explicit API-partner access or written permission | Glassdoor Terms prohibit automated agents/scraping/data mining without express written permission. Public developer docs indicate additional APIs are partner-only. |
+| Statistics | Pure Python aggregation and confidence scoring; use existing `pandas` only for bulk file imports | v1.3 needs medians/percentiles/source agreement, not a heavy statistics stack. Avoid `numpy`/`scipy` unless later requirements need inferential stats. |
+| API/read path | Add compensation DTOs to `packages/contracts`, project them through `job_list_projections` and `job_detail_projections`, and map in `apps/api/src/read-model.ts` | Jobs list/detail already read from projections. Salary facts should travel with the same projection and SSE invalidation model as score/audit facts. |
+| UI | Add context-owned salary components composed by Jobs views | `JobOverview.tsx` currently prints `job.salary`; `JobAuditTriage.tsx` owns the audit triage surface. Keep views as composers and avoid direct API calls. |
 
-| Library | Purpose | When to Use |
-|---------|---------|-------------|
-| `@jobhunter/contracts` | Shared DTO interfaces and schemas | Add the readiness/blocker contract and any resume-pin DTOs here before consuming them in web or API code. |
-| `@tabler/icons-react` | Current icon target | Use for any new icon buttons, pins, warnings, and drawer controls. Do not add lucide usage. |
-| Radix/shadcn copied primitives | Dialog/sheet/card/button/select primitives | Use existing shared primitives and sheet/drawer patterns rather than adding a new modal library. |
-| `PdfPreviewViewer` | Existing PDF preview surface | Keep PDF rendering in the current viewer; add pin affordances around/alongside it only if anchors are stable. |
-| Vitest + Testing Library + MSW | Unit/component/API hook tests | Cover shared contract mapping, readiness/blocker states, and component interaction states. |
-| Playwright | Browser QA and E2E | Required for product-path proof across `/jobs` drawer and `/apply-review`; use synthetic or seeded data only. |
-| Storybook + axe addon | Visual/a11y states | Use for new audit cards, pin inspector states, and drawer panel variants if components are extracted. |
+## Source Strategy
 
-### Development Tools
+Use a tiered estimator. The UI should show the best available salary evidence and the confidence/source gaps, not force every job through the same source path.
 
-| Tool | Purpose | Notes |
-|------|---------|-------|
-| `pnpm web:check` | Web TypeScript check | Required when contracts or UI components change. |
-| `pnpm web:build` | Production web build | Required before claiming user-facing route work is complete. |
-| `pnpm --filter @jobhunter/web test` | Web unit/component tests | Add targeted tests for new view/context components. |
-| `pnpm --filter @jobhunter/web e2e` | Browser E2E | Use targeted specs or documented Browser QA for the selected paths. |
-| `pnpm api:test` | API/read-model tests | Required when shared readiness/blocker contract is computed by the API. |
-| `rg` audits | Dependency/config/source checks | Use for folded cleanup: legacy tokens, stale Tailwind config references, lucide imports, and sensitive fixture text. |
+1. **Posted compensation first.** If the posting contains a usable employer-provided range, show it as the highest-provenance fact. Parse from both the existing `jobs.salary` field and compensation windows in `description` / `full_description`.
+2. **Licensed tech-market benchmark second.** If configured, query Levels.fyi for role/company/location/level data and store only allowed derived results plus provider provenance, according to the user's license.
+3. **Public occupation/location baseline third.** Map job title/seniority to SOC/O*NET, then use BLS OEWS/O*NET wage data as fallback or corroboration.
+4. **OFLC/H-1B disclosure as a niche corroborator.** Use for U.S. employer/location/title evidence when imported locally, but label it as visa/LCA-biased and not a general market range.
+5. **No opaque ranking/filtering.** Salary evidence can compare against the profile floor and produce warnings, but v1.3 should not auto-block, hide, or downrank jobs from market estimates.
 
-## Installation
+## Salary Data Sources Considered
 
-No new runtime stack is recommended for the milestone. The preferred implementation uses existing dependencies and components.
+| Source | Access method | Constraints | Freshness expectation | Recommendation |
+| --- | --- | --- | --- | --- |
+| Posted job salary text | Existing discovery/enrichment fields and full posting text | Raw board salary strings are inconsistent; descriptions can contain unrelated numbers, OTE, hourly rates, contract rates, equity, or benefits. | Fresh at discovery/enrichment time; refresh when posting snapshot changes. | **Use by default.** Store parse source text, source field, normalized range, period, currency, parse warnings, and confidence. |
+| Levels.fyi | Official paid data/API/MCP/CLI/data-stream access or approved embeds | API/data-stream access is commercial. Public page advertises request access, paid benchmark plans, data stream, API/MCP access, and restrictions on transferred data. Do not scrape or redistribute raw data unless license permits. | Levels.fyi markets data as real-time/live, daily-refreshing for paid data, with recent trailing-data products. | **Optional licensed adapter.** Best fit for tech roles, company/level granularity, and total compensation breakdowns. Gate behind config and requirements decision. |
+| Glassdoor | Partner API or express written permission only | Glassdoor Terms prohibit automated agents used to scrape/strip/mine data without express written permission. Jobs API docs say additional APIs are not public and are available to API partners. Public salary pages may show useful numbers, but scraping is not acceptable for this milestone. | Current visible pages can be fresh, but usable automated access is uncertain without a partner agreement. | **Do not integrate in v1.3 unless the user already has licensed access.** Record as a requirements decision, not an implementation default. |
+| BLS OEWS | Official BLS tables/downloads; BLS Public Data API for series where appropriate | OEWS is occupation/location aggregate data, not company or seniority specific. API series IDs can be awkward; tables/downloads may be easier for local cache. | Current OEWS documentation is May 2025, last modified May 15, 2026. Annual estimates for about 830 occupations across national, state, metro, and nonmetro areas. | **Use as default public baseline.** Good for floor/market sanity and public provenance. |
+| O*NET Web Services / O*NET OnLine | Registered developer REST API; O*NET OnLine displays wage/employment data sourced from BLS OEWS | Requires registration for API credentials. O*NET is best for occupation matching/crosswalk and readable occupation labels; wage data ultimately traces to BLS. | O*NET Web Services uses current O*NET database releases; O*NET OnLine wage data references BLS 2025 OEWS updated June 17, 2026. | **Use for title-to-SOC/O*NET mapping.** Use BLS as canonical wage source when possible. |
+| DOL OFLC/H-1B disclosure | Official quarterly/fiscal-year XLSX disclosure files imported locally | Biased toward visa-sponsored roles, certified/offered wage records, and employer-submitted fields. Files are large XLSX; not a simple live API. | OFLC released FY2026 Q2 disclosure data on May 15, 2026, covering Oct 1, 2025 through Mar 31, 2026. | **Optional local import/corroborator.** Useful for company/location/title evidence, but never sole market estimate. |
+| Salary.com DaaS / CompAnalyst APIs | Commercial APIs | Commercial model; likely requires customer relationship. More employer/HR-oriented than local job seeker MVP. | Vendor-managed. | **Defer.** Consider only if user wants commercial provider support beyond Levels.fyi. |
+| Scraper marketplaces / unofficial APIs | Apify, Bright Data, Piloterr, OpenWeb Ninja, similar | Legal/licensing ambiguity, provenance dilution, possible ToS conflict with source sites, and more infra than needed. | Vendor-dependent. | **Do not add for v1.3.** They undermine the audit-first trust model unless separately licensed and approved. |
 
-If a later plan proves that PDF coordinate annotations are required, evaluate that in a spike before adding a PDF annotation or text-extraction package. The MVP should first try stable generated-text anchors from `bulletProvenance` and `annotatedChanges`.
+## Stack Additions
 
-## Alternatives Considered
+### Add Python Domain Modules, Not New Infrastructure
 
-| Recommended | Alternative | When to Use Alternative |
-|-------------|-------------|-------------------------|
-| Shared DTO in `@jobhunter/contracts` | UI-only helpers in Jobs/Apply Review | Only for transient labels that do not affect readiness/blocker facts. |
-| Existing `PdfPreviewViewer` plus side rail/pin inspector | New PDF annotation library | Only if generated material text cannot be mapped to stable visible rows and a spike proves the library is worth the blast radius. |
-| Operations read hooks | Direct `apiClient` calls in views | Never for this milestone; repo frontend architecture forbids direct API calls from views. |
-| Existing shadcn/Radix primitives | New design system package | Not needed; v1.1 just established the visual foundation. |
-| Tabler icons | Lucide icons | Avoid; v1.1 made Tabler the icon target and lucide cleanup is folded into v1.2. |
+Recommended new worker-side modules:
 
-## What NOT to Use
+| Module | Responsibility |
+| --- | --- |
+| `domain/compensation/value_objects.py` | `MoneyAmount`, `SalaryPeriod`, `SalaryRangeFact`, `MarketSalaryEstimate`, `SalarySource`, `SalaryConfidence`, parse warning enums. |
+| `domain/compensation/services.py` | Deterministic parser, range normalization, annualization, source-agreement scoring, confidence formula. |
+| `domain/ports/compensation.py` | `SalaryBenchmarkSourcePort` and `OccupationMatcherPort` interfaces. |
+| `infrastructure/compensation/bls_oews.py` | Local BLS/OEWS table loader/cache and/or API client. |
+| `infrastructure/compensation/onet.py` | O*NET occupation search/crosswalk adapter if API credentials are configured. |
+| `infrastructure/compensation/levels_fyi.py` | Optional licensed adapter; disabled unless configured. |
+| `infrastructure/compensation/oflc.py` | Optional local XLSX disclosure importer using existing `pandas`. |
 
-| Avoid | Why | Use Instead |
-|-------|-----|-------------|
-| Separate readiness logic in each UI surface | This already caused visible disagreement risk between queue tags and API material fields. | A shared API/contract object consumed by both surfaces. |
-| PDF-only pin coordinates as the first implementation | Coordinates can be brittle across renderers, zoom, and pages. | Anchor by generated bullet/change text first; use PDF overlay only when anchors are stable. |
-| Recomputing missing keywords from job keywords alone | It violates the project auditability rule and can mislabel generated material. | Use generation-time coverage or actual rendered resume text with provenance-backed coverage. |
-| Hiding incomplete audit fields | It removes user value and masks source-of-truth gaps. | Show explicit missing-source states and fix the owning layer. |
-| Real profile/resume/application data in tests or screenshots | Sensitive local artifacts must not be exposed. | Synthetic seeded fixtures and scrubbed screenshots only. |
+Keep the estimator deterministic where possible. Use LLMs only if a later phase explicitly needs ambiguous seniority/role classification beyond existing title and employer-analysis signals.
 
-## Version Compatibility
+### Use Existing Dependencies
 
-| Package/Layer | Compatible With | Notes |
-|---------------|-----------------|-------|
-| React 19 + Vite 7 | Current web app | Continue colocated component tests and Vite build checks. |
-| Tailwind 4 CSS-first tokens | v1.1 shadcn token migration | Do not reintroduce `apps/web/tailwind.config.ts` assumptions. |
-| `@jobhunter/contracts` DTOs | API read model and web Operations hooks | Contract additions must be reflected in API mappers and consuming hooks/components. |
-| SQLite projections | Local-first API endpoints | Read model should deserialize/derive audit facts without requiring worker runs during QA. |
+| Existing dependency | Use |
+| --- | --- |
+| `httpx` | BLS/O*NET/Levels API calls with timeouts, retries, and source metadata. |
+| `pandas` | Bulk XLSX/CSV import for BLS/OEWS or OFLC files if table downloads are chosen. |
+| `pydantic` | DTO validation for external source payload adapters if useful. |
+| SQLite | Canonical compensation facts, source observations, cache metadata, and projection columns. |
+| TanStack Query/Table | Jobs list refresh and triage surfacing through existing Operations hooks. |
+
+No new runtime dependency is required for MVP salary parsing. If a parser later needs locale-aware currency formatting, prefer a small, isolated formatter or existing app formatting helpers before adding Babel or a money library.
+
+## Suggested Data Model
+
+Use canonical rows rather than `metadata_json` blobs, consistent with the v1.2 audit direction.
+
+| Table/shape | Purpose |
+| --- | --- |
+| `job_salary_facts` | One row per parsed posted compensation fact: `tenant_id`, `job_url`, `source_kind`, `source_field`, `source_text_excerpt`, `currency`, `period`, `min_amount`, `max_amount`, `annual_min`, `annual_max`, `confidence`, `warnings_json`, `parsed_at`, `snapshot_hash`. |
+| `salary_market_sources` | Registry/cache of external source captures: provider id, query parameters, freshness timestamp, license/access mode, source URL/API endpoint label, sample/source count, provider confidence metadata. |
+| `job_salary_estimates` | One latest estimate per job/version: normalized market range, source count, source agreement, confidence, assumptions, profile-floor comparison, stale/fresh status, and source refs. |
+| Projection columns | Add `posted_salary_fact_json` and `market_salary_estimate_json` to job list/detail projections, or a single `salary_audit_json` if the UI should consume one grouped contract. |
+
+Prefer a single contract field in `JobSummary`/`JobDetail`, for example:
+
+```typescript
+interface SalaryAudit {
+  posted: PostedSalaryFact | null;
+  market: MarketSalaryEstimate | null;
+  profileFloor: ProfileSalaryFloor | null;
+  comparison: "above_floor" | "below_floor" | "overlaps_floor" | "unknown";
+  summary: string;
+  confidence: "high" | "medium" | "low" | "unknown";
+  sources: SalarySourceSummary[];
+  warnings: SalaryWarning[];
+}
+```
+
+This keeps Jobs triage from reconstructing salary logic in React.
+
+## Confidence Model
+
+Use explainable confidence bands instead of pretending external salary data is precise.
+
+Recommended first-pass factors:
+
+| Factor | Raises confidence | Lowers confidence |
+| --- | --- | --- |
+| Posted salary extraction | Explicit salary field, two-sided range, currency/period present, exact source text | Description-only match, many unrelated numbers, OTE/equity ambiguity, missing period, one-sided range |
+| Role match | O*NET/SOC or Levels role matches title and inferred seniority | Generic title, mixed management/IC signal, no seniority match |
+| Location match | Same metro/country/remote market | State/national fallback, remote geography unclear |
+| Company match | Same company in licensed source or OFLC | Industry/occupation-only baseline |
+| Source freshness | Posted snapshot current; provider data has captured/updated date | Old imported file, unknown provider timestamp |
+| Source agreement | Posted and market ranges overlap; multiple sources agree | Wide divergence or only one weak source |
+| Sample count | Source exposes sample count/count bucket and it clears threshold | Missing count, tiny count, or source cannot support sample claim |
+
+Display `confidence`, `source_count`, `sample_count` where available, `freshness`, `assumptions`, and parse warnings. Never show a precise-looking single number without range/provenance.
+
+## Integration Points In JobHunter
+
+| Area | Current state | v1.3 integration |
+| --- | --- | --- |
+| Discovery value object | `JobMetadata.salary` is an optional raw string. | Preserve raw value; add parsed salary fact generation when job metadata or enriched description changes. |
+| Scoring constraints | `ConstraintChecker` has private regex helpers for `_salary_max` and profile minimum blocker. | Replace or delegate this heuristic to canonical posted salary facts. Scoring should consume salary audit facts, not re-parse ad hoc. |
+| Pipeline | Discover drains enrichment and preparation work. | Salary extraction should run after discovery/enrichment writes and before scoring uses compensation blockers. Market estimation can be a preparation work item or enrichment substep, depending on whether external access is configured. |
+| SQLite/projections | `job_list_projections.salary` stores raw string; `JobSummary.salary` exposes it. | Add canonical tables plus projection JSON for posted/market salary audit. Keep raw `salary` for compatibility. |
+| TypeScript contracts | `JobSummary` has `salary: string`; no salary audit DTO. | Add `SalaryAudit` DTOs in `packages/contracts/src/schemas.ts` and re-export through Operations types. |
+| API read model | `rowToJobSummary` maps raw salary only. | Parse projection JSON into `job.salaryAudit`; include on list and detail. |
+| Jobs overview | Displays `location · salary`. | Replace or augment raw salary with posted range label plus confidence/source indicator. Keep raw source text inspectable. |
+| Jobs audit triage | Shows ranking, fit confidence, eligibility, score metadata, apply concerns. | Add a compensation section with posted range, market estimate, profile-floor comparison, source trail, and warnings. |
+| UI invalidation | Existing SSE invalidation handles job updates by event type. | Add `SalaryFactsExtracted` / `MarketSalaryEstimated` events and register handlers in the operations invalidation router. |
+
+## What Not To Add For v1.3
+
+| Do not add | Reason |
+| --- | --- |
+| Glassdoor scraping | Violates/risks source terms without written permission and creates an auditability/legal problem. |
+| Unofficial Glassdoor/Levels scraper APIs | They add vendor dependency while inheriting source-access ambiguity. |
+| A new hosted backend or external database | JobHunter is local-first; SQLite/projections are enough for v1.3. |
+| A new ranking/filter gate from market salary | The milestone explicitly says uncertain compensation should stay audit-first, not opaque gating. |
+| Full currency conversion service | Useful later, but v1.3 can normalize only when currency/period is explicit and label unknowns honestly. |
+| Equity/bonus/TC modeling as required MVP | Posted salary and BLS are base/wage oriented; Levels.fyi total compensation can be optional source metadata if licensed. |
+| Broad AI extraction for all salary parsing | Deterministic parse plus warnings is more auditable. Use LLM only for explicit future ambiguous cases. |
+| A frontend-only estimator | Salary facts need canonical provenance and must be visible through the API/read model. |
+| New charting library | Jobs triage needs compact labels, ranges, source trail, and warning states; tables/cards/tags are enough. |
+
+## Risks And Requirements Decisions
+
+| Decision needed | Why it matters |
+| --- | --- |
+| Does the user have or want to buy Levels.fyi data/API access? | Determines whether v1.3 can support company/level-aware tech compensation beyond public baselines. |
+| Is Glassdoor explicitly licensed/partner-accessible for this project? | Without written permission or partner API access, Glassdoor should be excluded. |
+| What geography is in scope for public baselines? | BLS/O*NET/OFLC are U.S.-centric. Europe/Spain roles need a separate public source decision, or should be labeled unsupported/low-confidence. |
+| Is the estimate base salary only or total compensation? | Posted salary and BLS are base/wage oriented; Levels.fyi can include total compensation. Mixing them without labels will mislead users. |
+| How should remote jobs map to location? | Remote U.S., Europe remote, global remote, and company HQ produce different ranges. This needs explicit assumptions. |
+| What minimum sample/source count is required to show a market range? | Prevents false precision for sparse licensed or OFLC data. |
+| Should profile floor comparison use minimum acceptable salary, expectation, or range overlap? | Profile has `salary_expectation`, `salary_range_min`, and `salary_range_max`; UI wording depends on which is authoritative. |
+
+## Implementation Ordering
+
+1. Add compensation domain value objects and deterministic posted salary parser with fixtures.
+2. Persist `job_salary_facts` and project posted salary audit into list/detail read models.
+3. Replace scoring's ad hoc `_salary_max` path with canonical posted salary facts for profile-floor eligibility warnings/blockers.
+4. Add public baseline adapter: O*NET/SOC mapping plus BLS OEWS cache.
+5. Add optional provider registry and disabled-by-default Levels.fyi adapter shape.
+6. Surface `SalaryAudit` in Jobs overview and audit triage with source trail and unknown states.
 
 ## Sources
 
-- `package.json` - current scripts, package manager, TypeScript version, and verification commands.
-- `apps/web/package.json` - current React/Vite/Tailwind/TanStack/Storybook/Playwright stack.
-- `apps/web/src/views/jobs/JobDetailDrawer.tsx` - existing Jobs row-click drawer surface.
-- `apps/web/src/views/apply-review/ApplyReviewView.tsx` - existing Apply Review queue, status derivation, and material preview surface.
-- `packages/contracts/src/schemas.ts` - existing Apply Review, Job Detail, artifact, provenance, and tailoring explanation DTOs.
-- `apps/api/src/application-feedback.ts` and `apps/api/src/read-model.ts` - current queue/detail read-model construction.
-- `.planning/sketches/002-layered-audit-surfaces/` - chosen Option 1 sketch.
-
----
-*Stack research for: v1.2 Apply Review Audit UX - Drawer + Resume Pins*
-*Researched: 2026-06-11*
+- JobHunter repo context: `.planning/PROJECT.md`, `docs/architecture.md`, `docs/job-pipeline-architecture.md`, `docs/local-ts-api.md`, `workers/automation/src/jobhunter/domain/discovery/value_objects.py`, `workers/automation/src/jobhunter/domain/scoring/services.py`, `apps/api/src/read-model.ts`, `apps/web/src/views/jobs/JobOverview.tsx`, `apps/web/src/views/jobs/JobAuditTriage.tsx`.
+- Levels.fyi API access page: https://www.levels.fyi/api-access/
+- Levels.fyi data/benchmarking offering: https://www.levels.fyi/offerings/data/
+- Glassdoor Terms of Use: https://www.glassdoor.com/about/terms/
+- Glassdoor Jobs API documentation: https://www.glassdoor.com/developer/jobsApiActions.htm
+- BLS OEWS home: https://www.bls.gov/oes/
+- BLS OEWS documentation: https://www.bls.gov/oes/oes_doc.htm
+- BLS Public Data API getting started and FAQ: https://www.bls.gov/developers/home.htm and https://www.bls.gov/developers/api_faqs.htm
+- O*NET Web Services and reference manual: https://services.onetcenter.org/ and https://services.onetcenter.org/reference/
+- O*NET OnLine external data source freshness: https://www.onetonline.org/help/online/datasources
+- DOL OFLC disclosure/performance data: https://www.dol.gov/agencies/eta/foreign-labor/performance
+- FLAG prevailing wages: https://flag.dol.gov/programs/prevailingwages
+- Salary.com API overview: https://developers.salary.com/apis/welcome

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -3,7 +3,7 @@
 **Project:** JobHunter v1.3 Salary Range Estimator  
 **Researched:** 2026-06-19  
 **Scope:** Posted salary extraction, market compensation sources, statistical confidence, source provenance, and Jobs triage surfacing.  
-**Overall confidence:** HIGH for repo integration approach and public/government source constraints; MEDIUM for licensed commercial data availability until the user chooses a provider/account.
+**Overall confidence:** HIGH for repo integration approach and public/government source constraints; MEDIUM for licensed commercial data availability until the user chooses a provider/account. Post-research scoping selected Europe-only public baselines for v1.3.
 
 ## Recommendation
 
@@ -15,7 +15,7 @@ The practical stack is:
 | --- | --- | --- |
 | Posted salary extraction | Deterministic Python parser in the Discovery/Enrichment domain, backed by canonical salary-fact rows | `JobMetadata.salary` is currently a raw string and scoring has only a private `_salary_max` heuristic. v1.3 needs inspectable parse facts with source text, period, currency, warnings, and confidence. |
 | Market salary estimation | New Python compensation/market estimator use case, fed by pluggable source adapters | The Python worker already owns external I/O, source provenance, scoring, and local persistence. Keep source calls out of React and out of the TS read model. |
-| Public baseline data | BLS OEWS/O*NET as default public benchmark baseline; optional OFLC/H-1B disclosure import for company/location-specific U.S. tech signal | These are official/public sources with clear access paths and freshness metadata. They are weaker than Levels.fyi for tech leveling, but suitable as legally safe default evidence. |
+| Public baseline data | Eurostat Structure of Earnings Survey plus ESCO occupation mapping as the Europe-wide public baseline; Spain INE Wage Structure Survey as the Spain-specific corroborator | These are official/public European sources with clear access paths and freshness metadata. They are aggregated and survey-based, so they need confidence caveats and should not be framed as company-specific market truth. |
 | Licensed commercial data | Optional Levels.fyi adapter behind an explicit user-provided access configuration | Levels.fyi advertises API/MCP/CLI and data-stream access, but API/data-stream access is gated behind commercial access. Treat it as optional, not table stakes. |
 | Glassdoor | Do not scrape. Use only if the user has explicit API-partner access or written permission | Glassdoor Terms prohibit automated agents/scraping/data mining without express written permission. Public developer docs indicate additional APIs are partner-only. |
 | Statistics | Pure Python aggregation and confidence scoring; use existing `pandas` only for bulk file imports | v1.3 needs medians/percentiles/source agreement, not a heavy statistics stack. Avoid `numpy`/`scipy` unless later requirements need inferential stats. |
@@ -28,8 +28,8 @@ Use a tiered estimator. The UI should show the best available salary evidence an
 
 1. **Posted compensation first.** If the posting contains a usable employer-provided range, show it as the highest-provenance fact. Parse from both the existing `jobs.salary` field and compensation windows in `description` / `full_description`.
 2. **Licensed tech-market benchmark second.** If configured, query Levels.fyi for role/company/location/level data and store only allowed derived results plus provider provenance, according to the user's license.
-3. **Public occupation/location baseline third.** Map job title/seniority to SOC/O*NET, then use BLS OEWS/O*NET wage data as fallback or corroboration.
-4. **OFLC/H-1B disclosure as a niche corroborator.** Use for U.S. employer/location/title evidence when imported locally, but label it as visa/LCA-biased and not a general market range.
+3. **Public Europe occupation/location baseline third.** Map job title/seniority to ESCO/ISCO where possible, then use Eurostat Structure of Earnings Survey datasets as fallback or corroboration.
+4. **Spain INE corroborator for Spain jobs.** Use Spain INE Wage Structure Survey data for Spanish market baselines and label it as official statistical data, not employer-offer evidence.
 5. **No opaque ranking/filtering.** Salary evidence can compare against the profile floor and produce warnings, but v1.3 should not auto-block, hide, or downrank jobs from market estimates.
 
 ## Salary Data Sources Considered
@@ -39,9 +39,10 @@ Use a tiered estimator. The UI should show the best available salary evidence an
 | Posted job salary text | Existing discovery/enrichment fields and full posting text | Raw board salary strings are inconsistent; descriptions can contain unrelated numbers, OTE, hourly rates, contract rates, equity, or benefits. | Fresh at discovery/enrichment time; refresh when posting snapshot changes. | **Use by default.** Store parse source text, source field, normalized range, period, currency, parse warnings, and confidence. |
 | Levels.fyi | Official paid data/API/MCP/CLI/data-stream access or approved embeds | API/data-stream access is commercial. Public page advertises request access, paid benchmark plans, data stream, API/MCP access, and restrictions on transferred data. Do not scrape or redistribute raw data unless license permits. | Levels.fyi markets data as real-time/live, daily-refreshing for paid data, with recent trailing-data products. | **Optional licensed adapter.** Best fit for tech roles, company/level granularity, and total compensation breakdowns. Gate behind config and requirements decision. |
 | Glassdoor | Partner API or express written permission only | Glassdoor Terms prohibit automated agents used to scrape/strip/mine data without express written permission. Jobs API docs say additional APIs are not public and are available to API partners. Public salary pages may show useful numbers, but scraping is not acceptable for this milestone. | Current visible pages can be fresh, but usable automated access is uncertain without a partner agreement. | **Do not integrate in v1.3 unless the user already has licensed access.** Record as a requirements decision, not an implementation default. |
-| BLS OEWS | Official BLS tables/downloads; BLS Public Data API for series where appropriate | OEWS is occupation/location aggregate data, not company or seniority specific. API series IDs can be awkward; tables/downloads may be easier for local cache. | Current OEWS documentation is May 2025, last modified May 15, 2026. Annual estimates for about 830 occupations across national, state, metro, and nonmetro areas. | **Use as default public baseline.** Good for floor/market sanity and public provenance. |
-| O*NET Web Services / O*NET OnLine | Registered developer REST API; O*NET OnLine displays wage/employment data sourced from BLS OEWS | Requires registration for API credentials. O*NET is best for occupation matching/crosswalk and readable occupation labels; wage data ultimately traces to BLS. | O*NET Web Services uses current O*NET database releases; O*NET OnLine wage data references BLS 2025 OEWS updated June 17, 2026. | **Use for title-to-SOC/O*NET mapping.** Use BLS as canonical wage source when possible. |
-| DOL OFLC/H-1B disclosure | Official quarterly/fiscal-year XLSX disclosure files imported locally | Biased toward visa-sponsored roles, certified/offered wage records, and employer-submitted fields. Files are large XLSX; not a simple live API. | OFLC released FY2026 Q2 disclosure data on May 15, 2026, covering Oct 1, 2025 through Mar 31, 2026. | **Optional local import/corroborator.** Useful for company/location/title evidence, but never sole market estimate. |
+| Eurostat Structure of Earnings Survey (SES) | Eurostat public datasets/API; annual/monthly/hourly earnings datasets such as `earn_ses_annual`, `earn_ses_monthly`, `earn_ses_hourly` | Aggregate survey data by occupation/activity/geography/demographics. Not company-specific, not live, and some detailed microdata requires research access/safe-centre rules. | SES is 4-yearly at microdata level; public datasets expose harmonized earnings measures with publication/update timestamps. | **Use as default Europe-wide public baseline.** Label as occupation/location aggregate and degrade confidence for broad mappings. |
+| ESCO | European Commission ESCO web-service API or local API | Occupation taxonomy/mapping only; it does not itself provide salary amounts. Requires careful mapping from noisy job titles to ESCO/ISCO concepts. | ESCO API page lists current version ESCO v1.2.1, last update 2025-12-10. | **Use for Europe occupation mapping.** Pair with Eurostat/INE wage data. |
+| Spain INE Wage Structure Survey | INE public tables/downloads/API where available | Spain-specific official statistics; not company-specific and may use broad occupation/activity groupings. | INE published final 2024 Wage Structure Survey data on 2026-05-28. | **Use as Spain-specific public baseline/corroborator.** Best fit for the user's Europe-only scope when jobs are Spain-local or Spain-remote. |
+| BLS/O*NET/OFLC | U.S. public sources | Strong public U.S. wage data, but outside the selected v1.3 geography. | Current, but not relevant to Europe-only v1.3. | **Out of scope for v1.3.** Keep as future milestone option only. |
 | Salary.com DaaS / CompAnalyst APIs | Commercial APIs | Commercial model; likely requires customer relationship. More employer/HR-oriented than local job seeker MVP. | Vendor-managed. | **Defer.** Consider only if user wants commercial provider support beyond Levels.fyi. |
 | Scraper marketplaces / unofficial APIs | Apify, Bright Data, Piloterr, OpenWeb Ninja, similar | Legal/licensing ambiguity, provenance dilution, possible ToS conflict with source sites, and more infra than needed. | Vendor-dependent. | **Do not add for v1.3.** They undermine the audit-first trust model unless separately licensed and approved. |
 
@@ -56,10 +57,10 @@ Recommended new worker-side modules:
 | `domain/compensation/value_objects.py` | `MoneyAmount`, `SalaryPeriod`, `SalaryRangeFact`, `MarketSalaryEstimate`, `SalarySource`, `SalaryConfidence`, parse warning enums. |
 | `domain/compensation/services.py` | Deterministic parser, range normalization, annualization, source-agreement scoring, confidence formula. |
 | `domain/ports/compensation.py` | `SalaryBenchmarkSourcePort` and `OccupationMatcherPort` interfaces. |
-| `infrastructure/compensation/bls_oews.py` | Local BLS/OEWS table loader/cache and/or API client. |
-| `infrastructure/compensation/onet.py` | O*NET occupation search/crosswalk adapter if API credentials are configured. |
+| `infrastructure/compensation/eurostat_ses.py` | Local Eurostat SES table/API loader and cache for Europe-wide wage baselines. |
+| `infrastructure/compensation/esco.py` | ESCO occupation search/crosswalk adapter or local taxonomy loader for European occupation matching. |
+| `infrastructure/compensation/ine_spain.py` | Spain INE Wage Structure Survey table/API loader for Spain-specific public wage baselines. |
 | `infrastructure/compensation/levels_fyi.py` | Optional licensed adapter; disabled unless configured. |
-| `infrastructure/compensation/oflc.py` | Optional local XLSX disclosure importer using existing `pandas`. |
 
 Keep the estimator deterministic where possible. Use LLMs only if a later phase explicitly needs ambiguous seniority/role classification beyond existing title and employer-analysis signals.
 
@@ -67,8 +68,8 @@ Keep the estimator deterministic where possible. Use LLMs only if a later phase 
 
 | Existing dependency | Use |
 | --- | --- |
-| `httpx` | BLS/O*NET/Levels API calls with timeouts, retries, and source metadata. |
-| `pandas` | Bulk XLSX/CSV import for BLS/OEWS or OFLC files if table downloads are chosen. |
+| `httpx` | Eurostat/ESCO/INE/Levels API calls with timeouts, retries, and source metadata. |
+| `pandas` | Bulk XLSX/CSV import for Eurostat or INE files if table downloads are chosen. |
 | `pydantic` | DTO validation for external source payload adapters if useful. |
 | SQLite | Canonical compensation facts, source observations, cache metadata, and projection columns. |
 | TanStack Query/Table | Jobs list refresh and triage surfacing through existing Operations hooks. |
@@ -112,9 +113,9 @@ Recommended first-pass factors:
 | Factor | Raises confidence | Lowers confidence |
 | --- | --- | --- |
 | Posted salary extraction | Explicit salary field, two-sided range, currency/period present, exact source text | Description-only match, many unrelated numbers, OTE/equity ambiguity, missing period, one-sided range |
-| Role match | O*NET/SOC or Levels role matches title and inferred seniority | Generic title, mixed management/IC signal, no seniority match |
+| Role match | ESCO/ISCO or licensed Levels role matches title and inferred seniority | Generic title, mixed management/IC signal, no seniority match |
 | Location match | Same metro/country/remote market | State/national fallback, remote geography unclear |
-| Company match | Same company in licensed source or OFLC | Industry/occupation-only baseline |
+| Company match | Same company in licensed source | Industry/occupation-only baseline |
 | Source freshness | Posted snapshot current; provider data has captured/updated date | Old imported file, unknown provider timestamp |
 | Source agreement | Posted and market ranges overlap; multiple sources agree | Wide divergence or only one weak source |
 | Sample count | Source exposes sample count/count bucket and it clears threshold | Missing count, tiny count, or source cannot support sample claim |
@@ -144,7 +145,7 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 | A new hosted backend or external database | JobHunter is local-first; SQLite/projections are enough for v1.3. |
 | A new ranking/filter gate from market salary | The milestone explicitly says uncertain compensation should stay audit-first, not opaque gating. |
 | Full currency conversion service | Useful later, but v1.3 can normalize only when currency/period is explicit and label unknowns honestly. |
-| Equity/bonus/TC modeling as required MVP | Posted salary and BLS are base/wage oriented; Levels.fyi total compensation can be optional source metadata if licensed. |
+| Equity/bonus/TC modeling as required MVP | Posted salary and Eurostat/INE public baselines are base/wage oriented; Levels.fyi total compensation can be optional source metadata if licensed and Europe coverage is confirmed. |
 | Broad AI extraction for all salary parsing | Deterministic parse plus warnings is more auditable. Use LLM only for explicit future ambiguous cases. |
 | A frontend-only estimator | Salary facts need canonical provenance and must be visible through the API/read model. |
 | New charting library | Jobs triage needs compact labels, ranges, source trail, and warning states; tables/cards/tags are enough. |
@@ -155,10 +156,10 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 | --- | --- |
 | Does the user have or want to buy Levels.fyi data/API access? | Determines whether v1.3 can support company/level-aware tech compensation beyond public baselines. |
 | Is Glassdoor explicitly licensed/partner-accessible for this project? | Without written permission or partner API access, Glassdoor should be excluded. |
-| What geography is in scope for public baselines? | BLS/O*NET/OFLC are U.S.-centric. Europe/Spain roles need a separate public source decision, or should be labeled unsupported/low-confidence. |
-| Is the estimate base salary only or total compensation? | Posted salary and BLS are base/wage oriented; Levels.fyi can include total compensation. Mixing them without labels will mislead users. |
+| What Europe geography granularity is in scope for public baselines? | Eurostat/INE data can be country/region/occupation/activity aggregates. Requirements should define how Spain-local, Europe-remote, EU-wide, and non-EU-Europe jobs map to estimates or unsupported states. |
+| Is the estimate base salary only or total compensation? | Posted salary and Eurostat/INE public baselines are base/wage oriented; Levels.fyi can include total compensation when licensed. Mixing them without labels will mislead users. |
 | How should remote jobs map to location? | Remote U.S., Europe remote, global remote, and company HQ produce different ranges. This needs explicit assumptions. |
-| What minimum sample/source count is required to show a market range? | Prevents false precision for sparse licensed or OFLC data. |
+| What minimum sample/source count is required to show a market range? | Prevents false precision for sparse licensed data or broad public aggregate data. |
 | Should profile floor comparison use minimum acceptable salary, expectation, or range overlap? | Profile has `salary_expectation`, `salary_range_min`, and `salary_range_max`; UI wording depends on which is authoritative. |
 
 ## Implementation Ordering
@@ -166,7 +167,7 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 1. Add compensation domain value objects and deterministic posted salary parser with fixtures.
 2. Persist `job_salary_facts` and project posted salary audit into list/detail read models.
 3. Replace scoring's ad hoc `_salary_max` path with canonical posted salary facts for profile-floor eligibility warnings/blockers.
-4. Add public baseline adapter: O*NET/SOC mapping plus BLS OEWS cache.
+4. Add public Europe baseline adapters: ESCO/ISCO mapping plus Eurostat SES cache, with Spain INE as a Spain-specific source.
 5. Add optional provider registry and disabled-by-default Levels.fyi adapter shape.
 6. Surface `SalaryAudit` in Jobs overview and audit triage with source trail and unknown states.
 
@@ -185,3 +186,8 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 - DOL OFLC disclosure/performance data: https://www.dol.gov/agencies/eta/foreign-labor/performance
 - FLAG prevailing wages: https://flag.dol.gov/programs/prevailingwages
 - Salary.com API overview: https://developers.salary.com/apis/welcome
+- Eurostat Structure of Earnings Survey microdata overview: https://ec.europa.eu/eurostat/web/microdata/collections-research/structure-of-earnings-survey
+- Eurostat API introduction: https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-introduction
+- Eurostat Structure of earnings survey annual earnings dataset: https://ec.europa.eu/eurostat/databrowser/view/earn_ses_annual/default/table
+- ESCO API overview: https://esco.ec.europa.eu/en/about-esco/escopedia/escopedia/esco-api
+- Spain INE Wage Structure Survey latest data: https://www.ine.es/dyngs/INEbase/en/operacion.htm?c=Estadistica_C&cid=1254736177025&idp=1254735976596

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -42,7 +42,6 @@ Use a tiered estimator. The UI should show the best available salary evidence an
 | Eurostat Structure of Earnings Survey (SES) | Eurostat public datasets/API; annual/monthly/hourly earnings datasets such as `earn_ses_annual`, `earn_ses_monthly`, `earn_ses_hourly` | Aggregate survey data by occupation/activity/geography/demographics. Not company-specific, not live, and some detailed microdata requires research access/safe-centre rules. | SES is 4-yearly at microdata level; public datasets expose harmonized earnings measures with publication/update timestamps. | **Use as default Europe-wide public baseline.** Label as occupation/location aggregate and degrade confidence for broad mappings. |
 | ESCO | European Commission ESCO web-service API or local API | Occupation taxonomy/mapping only; it does not itself provide salary amounts. Requires careful mapping from noisy job titles to ESCO/ISCO concepts. | ESCO API page lists current version ESCO v1.2.1, last update 2025-12-10. | **Use for Europe occupation mapping.** Pair with Eurostat/INE wage data. |
 | Spain INE Wage Structure Survey | INE public tables/downloads/API where available | Spain-specific official statistics; not company-specific and may use broad occupation/activity groupings. | INE published final 2024 Wage Structure Survey data on 2026-05-28. | **Use as Spain-specific public baseline/corroborator.** Best fit for the user's Europe-only scope when jobs are Spain-local or Spain-remote. |
-| BLS/O*NET/OFLC | U.S. public sources | Strong public U.S. wage data, but outside the selected v1.3 geography. | Current, but not relevant to Europe-only v1.3. | **Out of scope for v1.3.** Keep as future milestone option only. |
 | Salary.com DaaS / CompAnalyst APIs | Commercial APIs | Commercial model; likely requires customer relationship. More employer/HR-oriented than local job seeker MVP. | Vendor-managed. | **Defer.** Consider only if user wants commercial provider support beyond Levels.fyi. |
 | Scraper marketplaces / unofficial APIs | Apify, Bright Data, Piloterr, OpenWeb Ninja, similar | Legal/licensing ambiguity, provenance dilution, possible ToS conflict with source sites, and more infra than needed. | Vendor-dependent. | **Do not add for v1.3.** They undermine the audit-first trust model unless separately licensed and approved. |
 
@@ -158,7 +157,7 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 | Is Glassdoor explicitly licensed/partner-accessible for this project? | Without written permission or partner API access, Glassdoor should be excluded. |
 | What Europe geography granularity is in scope for public baselines? | Eurostat/INE data can be country/region/occupation/activity aggregates. Requirements should define how Spain-local, Europe-remote, EU-wide, and non-EU-Europe jobs map to estimates or unsupported states. |
 | Is the estimate base salary only or total compensation? | Posted salary and Eurostat/INE public baselines are base/wage oriented; Levels.fyi can include total compensation when licensed. Mixing them without labels will mislead users. |
-| How should remote jobs map to location? | Remote U.S., Europe remote, global remote, and company HQ produce different ranges. This needs explicit assumptions. |
+| How should remote jobs map to location? | Spain-local, Europe-remote, EU-wide, non-EU-Europe, unknown-location, and company-HQ markets produce different ranges. This needs explicit assumptions. |
 | What minimum sample/source count is required to show a market range? | Prevents false precision for sparse licensed data or broad public aggregate data. |
 | Should profile floor comparison use minimum acceptable salary, expectation, or range overlap? | Profile has `salary_expectation`, `salary_range_min`, and `salary_range_max`; UI wording depends on which is authoritative. |
 
@@ -178,13 +177,6 @@ Display `confidence`, `source_count`, `sample_count` where available, `freshness
 - Levels.fyi data/benchmarking offering: https://www.levels.fyi/offerings/data/
 - Glassdoor Terms of Use: https://www.glassdoor.com/about/terms/
 - Glassdoor Jobs API documentation: https://www.glassdoor.com/developer/jobsApiActions.htm
-- BLS OEWS home: https://www.bls.gov/oes/
-- BLS OEWS documentation: https://www.bls.gov/oes/oes_doc.htm
-- BLS Public Data API getting started and FAQ: https://www.bls.gov/developers/home.htm and https://www.bls.gov/developers/api_faqs.htm
-- O*NET Web Services and reference manual: https://services.onetcenter.org/ and https://services.onetcenter.org/reference/
-- O*NET OnLine external data source freshness: https://www.onetonline.org/help/online/datasources
-- DOL OFLC disclosure/performance data: https://www.dol.gov/agencies/eta/foreign-labor/performance
-- FLAG prevailing wages: https://flag.dol.gov/programs/prevailingwages
 - Salary.com API overview: https://developers.salary.com/apis/welcome
 - Eurostat Structure of Earnings Survey microdata overview: https://ec.europa.eu/eurostat/web/microdata/collections-research/structure-of-earnings-survey
 - Eurostat API introduction: https://ec.europa.eu/eurostat/web/user-guides/data-browser/api-data-access/api-introduction

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -186,9 +186,9 @@ Phases with standard patterns (skip research-phase):
 
 - Levels.fyi access: confirm whether the user has or wants paid/API/MCP/CLI/data-stream access, whether it covers the relevant European markets, and what retention/redistribution is allowed.
 - Glassdoor access: confirm whether explicit partner/API access or written permission exists; otherwise exclude it from implementation.
-- Geography: v1.3 targets Europe-only public baselines. U.S. BLS/O*NET/OFLC support is out of scope unless a later milestone reopens it.
+- Geography: v1.3 targets Europe-only public baselines. Non-European public salary baselines are outside the active product direction.
 - Compensation scope: decide whether estimates are base salary only, total compensation, OTE, or component-separated display.
-- Remote mapping: define how remote U.S., Europe remote, global remote, and company-HQ markets should affect estimates.
+- Remote mapping: define how Spain-local, Europe-remote, EU-wide, non-EU-Europe, unknown-location, and company-HQ markets should affect estimates.
 - Profile floor: decide which profile field is canonical for "floor" and whether comparisons use annualized base pay only.
 - Confidence thresholds: define minimum source/sample counts, freshness cutoffs, role/location/seniority match requirements, and rounding bands.
 - Market workflow: decide whether market estimation is automatic for every enriched job, on-demand in the drawer, or automatic only after a fit-score threshold.

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,157 +1,218 @@
 # Project Research Summary
 
-**Project:** JobHunter - Grounded Resume Tailoring
-**Domain:** Local-first job-application audit UX
-**Researched:** 2026-06-11
-**Confidence:** HIGH for scope and repo architecture, MEDIUM for exact resume-pin rendering mechanics
+**Project:** JobHunter v1.3 Salary Range Estimator
+**Domain:** Local-first compensation evidence, salary estimation, and Jobs triage audit
+**Researched:** 2026-06-19
+**Confidence:** HIGH for repo integration, audit architecture, posted salary parsing, and source-access constraints; MEDIUM for commercial provider availability until access is confirmed
 
 ## Executive Summary
 
-Milestone v1.2 should implement Sketch 002 Option 1: Drawer + Resume Pins. The current code already has the right raw ingredients: Jobs has a row-click `JobDetailDrawer` with score, stage, artifact, employer-analysis, and audit history sections; Apply Review has queue state, material preview, PDF/text preview, and the shared `ArtifactTailoringInspector`; artifact details already carry `annotatedChanges`, `bulletProvenance`, keyword coverage, judge, quality, voice-pass, and adversarial audit data.
+JobHunter v1.3 should make compensation evidence inspectable in the same trust-first style as the existing job and materials audit surfaces. Experts build this kind of feature by separating employer-posted facts from benchmark estimates, preserving source provenance, modeling uncertainty explicitly, and refusing to turn weak compensation data into hidden ranking or apply gates.
 
-The main gap is ownership and shape. Jobs drawer needs to become a rank/readiness/blocker triage surface. Apply Review needs to make the rendered resume the center of inspection, with pins that reveal source-to-tailored changes and claim risk. Readiness and blocker facts must move out of duplicated UI derivation and into one shared API/contract object consumed by both surfaces.
+The recommended approach is to build an Enrichment-owned compensation assessment path on the existing local-first stack: deterministic posted salary extraction, canonical SQLite compensation/provenance rows, projection-backed Operations read models, typed contracts, and Jobs list/drawer components that render salary facts as audit evidence. The source strategy should be tiered: posted salary first, optional licensed Levels.fyi-style tech benchmarks second, public BLS/O*NET baselines third, optional OFLC corroboration for U.S. employer/location evidence, and no Glassdoor scraping.
 
-The milestone should start with the folded v1.1 cleanup, then build the shared contract, then implement Jobs drawer triage, then Apply Review resume pins, and finally run synthetic product-path QA. Do not broaden into auto-apply, worker execution, route redesign, Option 2/3 implementation, or blind-auto-apply positioning copy.
+The main risks are source legality, false precision, lossy normalization, and projection drift between Python and TypeScript. Mitigate them with a salary-source registry, disabled-by-default external adapters, first-class insufficient-evidence states, separate parse and market confidence, canonical rows before UI rendering, projection parity tests, and QA fixtures that prove market estimates do not silently alter fit score, apply readiness, or queue eligibility.
 
 ## Key Findings
 
 ### Recommended Stack
 
-Use the existing stack. No new runtime dependency is justified for the MVP.
+Use the current JobHunter architecture. Do not introduce a new service, scraper platform, analytics database, charting library, or frontend-only estimator. Salary facts need canonical provenance and must flow through the same worker/API/projection/UI path as other audit claims.
 
 **Core technologies:**
-- React 19 + Vite 7: existing UI/build stack for route and drawer changes.
-- TypeScript + `@jobhunter/contracts`: required to keep shared readiness/blocker DTOs consistent across API and web.
-- Tailwind 4 + shadcn/Radix primitives: v1.1 visual foundation; v1.2 should not add a parallel design layer.
-- TanStack Query through Operations hooks: existing read-side pattern; views must not call API clients directly.
-- SQLite projection-backed API read model: right owner for cross-surface readiness and blocker facts.
+- Python worker domain services: deterministic posted compensation parser, market estimator, source registry, confidence scoring, and repository orchestration.
+- SQLite canonical tables: persisted compensation assessments, posted salary facts, market estimates, and source evidence.
+- Existing projection builders: Python and TypeScript projection paths must both emit compensation summary/detail JSON.
+- `packages/contracts` and domain types: shared DTOs for compensation ranges, posted facts, market estimates, source evidence, and confidence.
+- TanStack Query through Operations hooks: Jobs views consume projected compensation data; views do not recompute salary logic.
+- Enrichment frontend context components: reusable salary range, confidence, source trail, and triage panel components composed by Jobs views.
+
+**Recommended source/integration strategy:**
+- Posted job salary text is the primary source and should always preserve raw/source text.
+- BLS OEWS plus O*NET title/SOC mapping is the safest public default baseline.
+- OFLC/H-1B disclosure can be an optional U.S. corroborator, labeled as visa/LCA-biased.
+- Levels.fyi is optional and licensed only. Build a disabled adapter seam unless the user has approved API/MCP/CLI/data access.
+- Glassdoor must not be scraped. Use only with explicit partner/API access or written permission.
+- Unofficial scraper marketplaces should be excluded from v1.3.
 
 ### Expected Features
 
-**Must have:**
-- Jobs drawer explains why the job ranked as it did.
-- Jobs drawer and Apply Review show the same readiness and blocker facts.
-- Hard blockers and eligibility concerns are explicit.
-- Apply Review keeps the rendered resume/material central.
-- Resume claims/rows have pins or markers that open source evidence, tailored text, transform/change type, grounding status, claim risk, and reviewer action when available.
-- Missing audit data stays visible as an explicit state.
-- QA uses synthetic data and avoids auto-apply/submission/worker-backed actions.
+**Must have (table stakes):**
+- Posted salary extraction with source text, normalized range, currency, period, compensation type, parse confidence, and warnings.
+- Clear separation between "Posted" compensation and "Market estimate".
+- Market estimate only when matching evidence supports role, location, seniority, company, and compensation component.
+- Source provenance for every market range: source type, captured value, freshness, sample/source count where available, match quality, caveats, and allowed access mode.
+- Visible statistical confidence at decision points, with an inspectable factor breakdown in the drawer.
+- Profile-floor comparison rendered as an audit concern, not an opaque automatic filter.
+- Jobs list triage cell or compact group for posted range, estimate, confidence, missing state, and below/near/above floor.
+- Jobs drawer compensation audit section with source trail, assumptions, warnings, and skipped/unavailable reasons.
+- Honest empty states for no posted salary, unsupported source access, stale data, insufficient evidence, and unparseable text.
 
-**Should have after validation:**
-- Evidence Ledger as an optional bulk-comparison view.
-- Gate Timeline as an optional lifecycle-debug view.
-- Deeper PDF coordinate annotation if text/provenance anchors are insufficient.
-- README/docs copy explaining why JobHunter is safer than blind auto-apply tools.
+**Should have (differentiators):**
+- Source agreement/conflict score when multiple source families exist.
+- Comparable-role and seniority mapping assumptions shown in the drawer.
+- Freshness decay indicator that lowers confidence and explains stale evidence.
+- Compensation component labeling for base, total compensation, OTE, bonus, commission, equity, hourly, monthly, and contract rates.
+- "Why not estimated?" explanation for skipped market estimates.
+- Source quality registry with access mode, terms URL, license status, attribution, freshness policy, and disabled reason.
+
+**Defer (v2+):**
+- Negotiation anchor recommendations.
+- Deep equity/RSU vesting math.
+- Automatic salary-based ranking, filtering, or blockers from market estimates.
+- Broad commercial source marketplace.
+- Full currency conversion/PPP system beyond explicit, audited conversions.
+- AI-based broad salary extraction unless a later phase proves deterministic parsing is insufficient.
 
 ### Architecture Approach
 
-The architecture should be contract-first: add a shared readiness/blocker DTO to `@jobhunter/contracts`, compute it in API read-model code, and surface it through both `JobDetail` and `ApplyReviewQueueItem`. Jobs and Apply Review remain view composers. Materials context owns reusable provenance/pin components derived from `ArtifactTailoringExplanation`.
+Salary should be a typed Enrichment-owned compensation assessment projected into Operations read models. Keep raw `JobMetadata.salary` as legacy discovery metadata, but do not overload it as the normalized source of truth. Persist canonical salary facts and benchmark observations before adding UI, and keep profile-floor comparison derived for presentation unless requirements demand historical replay.
 
 **Major components:**
-1. Shared readiness/blocker contract - one source of truth for readiness, missing prerequisites, eligibility concerns, and blockers.
-2. Jobs drawer audit triage - ranking explanation, readiness, blockers, eligibility, and handoff.
-3. Resume pin model and inspector - generated claim to source evidence, transform, grounding, risk, and action.
-4. Synthetic QA fixtures and browser proof - seeded validation without touching sensitive data or submit flows.
+1. Compensation value objects and contracts — `CompensationRange`, posted fact union, market estimate union, source evidence, confidence, and audit/summary DTOs.
+2. Posted compensation parser — deterministic parser over `jobs.salary`, description snippets, and full posting text with source spans and warnings.
+3. Source registry and market-source adapters — disabled-by-default external adapters behind explicit access modes and anti-corruption layers.
+4. Market estimator and confidence service — combines evidence volume, source agreement, recency, role/location/seniority/company match, dispersion, and component/currency certainty.
+5. Canonical persistence — assessments, posted facts, market estimates, and source evidence rows keyed by tenant/job/version.
+6. Projection/read model — `compensation_summary_json` on list projections and `compensation_audit_json` on detail projections, emitted by both Python and TypeScript builders.
+7. Jobs triage UI — Enrichment-owned compensation components composed into Jobs list, `JobOverview`, and `JobAuditTriage`.
+
+### Statistical Confidence Model Guidance
+
+Use two independent confidence tracks: posted parse confidence and market estimate confidence. Do not collapse them into one generic badge in the data model.
+
+Parse confidence should increase with explicit salary fields, clear two-sided ranges, known currency/period, exact source spans, and low component ambiguity. It should decrease for body-text-only matches, multiple unrelated numbers, OTE/equity/commission language, missing period/currency, one-sided ranges, broad ranges, hourly/monthly assumptions, and gross/net ambiguity.
+
+Market confidence should be computed from evidence, not provider branding. Inputs should include source count, sample count, data freshness, source agreement/dispersion, company match, role/title match, seniority/level match, location/remote-scope match, compensation component match, currency/period certainty, and source access reliability. Show `insufficient_evidence` rather than a range when minimum thresholds fail. When shown, estimates should be rounded to sensible bands and labeled as benchmark estimates, not offers or truth.
 
 ### Critical Pitfalls
 
-1. **Contradictory readiness labels** - prevent with one API/read-model contract, not local UI status functions.
-2. **Ranking explanation in the wrong surface** - keep ranking in the Jobs row-click drawer.
-3. **Decorative pins** - every pin must open concrete source/generated/risk details.
-4. **Hidden missing audit data** - preserve explicit missing-source states and fix owning layers.
-5. **Sensitive/live QA** - use synthetic seeded data and avoid auto-apply/submission paths.
-6. **Cleanup scope creep** - keep folded v1.1 cleanup narrow and early.
+1. **Scraping salary sources without a valid access basis** — prevent with a source registry, disabled-by-default adapters, documented terms/access mode, and tests proving unauthorized sources return access-policy unavailable states.
+2. **Presenting estimates as truth** — prevent with confidence factors, source/sample counts, wide ranges for weak evidence, and explicit insufficient-evidence states.
+3. **Aggressive normalization of currency, period, and compensation type** — preserve original source text, components, assumptions, warnings, and conversion source/date whenever conversion occurs.
+4. **Reintroducing opaque gates through market salary data** — only posted salary facts with visible source spans may drive default below-floor blockers; market estimates produce advisory warnings unless a future explicit opt-in changes policy.
+5. **Missing source-of-truth audit rows** — do not compute salary claims in React or API read-time helpers; persist canonical backend rows and project them.
+6. **Projection drift** — update Python and TypeScript projection builders together and add parity fixtures so either refresher preserves compensation data.
+7. **Sensitive data leakage** — keep profile floors, credentials, raw benchmark pages, local paths, source payloads, logs, and fixtures redacted or synthetic.
 
 ## Implications for Roadmap
 
-### Phase 12: Folded Cleanup + Verification Baseline
+Based on research, suggested phase structure:
 
-**Rationale:** Close v1.1 residue before introducing new audit UX code.
-**Delivers:** Stale command cleanup, dependency/config audit, optional lucide removal if import proof allows, docs/config normalization.
-**Addresses:** Cleanup requirements only.
-**Avoids:** Scope creep and verification noise.
+### Phase 1: Compensation Domain Model And Source Policy
+**Rationale:** The feature needs typed states, provenance, and access rules before parsing or external calls can be trusted.
+**Delivers:** Python value objects, TypeScript contract/domain-type mirrors, source registry shape, external source access-policy states, and initial invariants.
+**Addresses:** Posted-vs-estimated separation, source provenance, confidence semantics, Glassdoor/Levels handling.
+**Avoids:** Scraping by default, overloaded salary vocabulary, and high-confidence estimates with zero sources.
 
-### Phase 13: Shared Apply Audit Contract
+### Phase 2: Posted Salary Extraction And Canonical Persistence
+**Rationale:** Posted compensation is the highest-provenance source and provides immediate local value without external dependency.
+**Delivers:** Deterministic parser, source spans, raw text preservation, normalized posted facts, parser warnings, canonical SQLite rows, and parser fixtures.
+**Addresses:** Structured posted salary extraction, normalized compensation model, parse confidence, honest unparseable/not-found states.
+**Avoids:** Existing lossy `_salary_max` behavior becoming the v1.3 audit source.
 
-**Rationale:** Cross-surface facts must be owned before either UI changes.
-**Delivers:** Shared readiness/blocker/eligibility DTO, API read-model mapping, tests, and web consumption path.
-**Addresses:** Readiness agreement, blocker source of truth, eligibility concerns.
-**Avoids:** Contradictory labels and UI-only status derivation.
+### Phase 3: Projection Path And Profile-Floor Comparison
+**Rationale:** Jobs list/drawer must consume projected audit facts, not recompute compensation in UI or API read helpers.
+**Delivers:** `compensation_summary_json`, `compensation_audit_json`, read-model DTOs, Operations hook types, SSE invalidation for compensation assessment, projection parity tests, and profile-floor comparison states.
+**Addresses:** Jobs list triage, drawer audit source of truth, below/near/above floor display, legacy raw salary compatibility.
+**Avoids:** Projection drift, UI-only audit claims, and hidden compensation gates.
 
-### Phase 14: Jobs Drawer Audit Triage
+### Phase 4: Public Baseline And Optional Licensed Adapter Seams
+**Rationale:** Market estimates require provider constraints, source matching, and insufficient-evidence states before UI can make them useful.
+**Delivers:** Market source port, BLS/O*NET baseline path or cache strategy, optional OFLC import seam, disabled Levels.fyi adapter shape, explicit Glassdoor blocked/unavailable handling, source evidence rows, and estimator confidence scoring.
+**Addresses:** Market salary estimation, source trail, source count/sample count, freshness, agreement/conflict, "why not estimated" states.
+**Avoids:** Unlicensed Glassdoor/Levels usage, false precision, geography/seniority mismatch, and slow/brittle Discover failures.
 
-**Rationale:** User clarified that the job overlay is the Jobs row-click popup/drawer.
-**Delivers:** Drawer information architecture for why ranked, readiness, blockers, eligibility, and handoff.
-**Uses:** Existing `ScoreBreakdown`, score fields, employer analysis, stage state, artifacts, and shared contract.
-**Avoids:** Implementing ranking explanation only in Apply Review.
+### Phase 5: Jobs Triage UI And Product QA
+**Rationale:** UI should land after contracts/projections so every displayed claim has an owning source of truth.
+**Delivers:** Enrichment-owned compensation components, Jobs table/list salary cell, `JobOverview` structured display, `JobAuditTriage` compensation panel, stories/component tests/a11y checks, and product-path QA with synthetic seeded jobs.
+**Addresses:** User-facing table stakes, confidence at point of decision, source trail, missing states, mobile/desktop rendering, audit-first floor comparison.
+**Avoids:** Salary estimates looking like hard truth, layout crowding, and market estimates changing fit/apply readiness.
 
-### Phase 15: Apply Review Resume Pins
-
-**Rationale:** Apply Review owns generated-material proof and must center the rendered resume.
-**Delivers:** Resume pin model, pin affordances, selected-pin inspector, grounding/risk/action detail, and honest missing states.
-**Uses:** `ArtifactTailoringExplanation`, `annotatedChanges`, `bulletProvenance`, keyword coverage, quality, judge, adversarial review, and review feedback.
-**Avoids:** Decorative pins and detached evidence dumps.
-
-### Phase 16: Product-Path QA + Docs
-
-**Rationale:** User-facing UX work needs browser proof and test coverage, not just typecheck.
-**Delivers:** API/web tests, seeded browser QA, a11y checks where relevant, docs updates for changed QA/product behavior, final milestone audit readiness.
-**Avoids:** Sensitive data exposure and accidental apply/submission flows.
+### Phase 6: Refresh And User Correction Loop
+**Rationale:** Manual refresh and corrections are useful only after the base audit model is stable.
+**Delivers:** Optional refresh mutation, on-demand market estimation workflow, parse correction persistence or deferral decision, cache freshness behavior, and retry/failure UI.
+**Addresses:** Freshness decay, user correction loop, source outage handling, future provider expansion.
+**Avoids:** Making Discover slow or brittle and replacing accepted audit facts with failed refresh attempts.
 
 ### Phase Ordering Rationale
 
-- Cleanup first reduces noise but remains small.
-- Shared contract precedes UI work so both surfaces consume the same facts.
-- Jobs drawer precedes Apply Review pins because rank/readiness triage is separate from material proof.
-- Apply Review pins come after the artifact/source contract is understood.
-- QA/docs close the loop after both surfaces are implemented.
+- Model/source policy first because Levels.fyi, Glassdoor, public data, and manual/licensed sources have different legality, provenance, and display constraints.
+- Posted extraction before market estimation because it is local, auditable, and the only compensation signal appropriate for default below-floor blockers.
+- Projection/read-model work before UI because audit surfaces must render persisted source-of-truth data.
+- Market adapters after projection because unsupported/insufficient states need the same read-path as successful estimates.
+- UI and QA last because the product-path tests should exercise the real contracts and seeded projection states.
 
 ### Research Flags
 
-Phases likely needing deeper design/technical validation during planning:
-- **Phase 13:** Final DTO shape and exact blocker/eligibility source precedence.
-- **Phase 15:** Whether pin anchors can be attached directly to PDF preview, text preview, or a side rail without brittle coordinates.
-- **Phase 16:** Best seeded QA path for showing both surfaces without exposing local artifacts.
+Phases likely needing deeper research during planning:
+- **Phase 4:** External integration details. Confirm current BLS/OEWS table/API strategy, O*NET access credentials, Levels.fyi license/access mode, OFLC import scope, and whether Glassdoor is explicitly licensed.
+- **Phase 4:** Statistical thresholds. Define minimum source/sample counts, freshness decay windows, agreement/dispersion bands, remote-location assumptions, and confidence bucket boundaries.
+- **Phase 6:** Correction and refresh policy. Decide whether user corrections become canonical facts, annotations, or deferred backlog.
 
-Phases with standard patterns:
-- **Phase 12:** Mechanical cleanup and docs/config audit.
-- **Phase 14:** Existing drawer composition and score components provide most building blocks.
+Phases with standard patterns (skip research-phase):
+- **Phase 1:** Local value objects/contracts/source registry shape follows established JobHunter DDD and contract patterns.
+- **Phase 2:** Deterministic parser fixtures and SQLite persistence are standard local-first domain work.
+- **Phase 3:** Projection/read-model/SSE invalidation follows existing Operations architecture, though parity tests are required.
+- **Phase 5:** Jobs view composition and context-owned frontend components follow existing frontend target architecture.
+
+## Concrete Requirement Implications For v1.3
+
+- Every displayed salary range must identify whether it is employer-posted, parsed from posting text, benchmark-derived, public baseline, licensed commercial, manual, or unavailable.
+- Glassdoor is out of default scope unless explicit partner/API access or written permission exists. Requirements should state "do not scrape Glassdoor."
+- Levels.fyi support should be a disabled optional adapter unless a license/API/MCP/CLI/data-stream arrangement is confirmed. Do not store or redistribute raw data beyond license permissions.
+- Public baselines should be labeled as occupation/location aggregates, not company-specific market truth.
+- The MVP should support `not_found`, `unparseable`, `ambiguous`, `posted_range`, `not_requested`, `unsupported`, `insufficient_evidence`, and `estimated_range` states.
+- Profile-floor comparison must name whether it used posted salary or market estimate. Default blockers may use posted salary only; market estimates are advisory warnings.
+- Currency, period, base/total/OTE/equity/bonus/hourly/monthly/gross/net assumptions must be preserved and rendered as warnings when ambiguous.
+- The Jobs drawer must show source text or allowed excerpt for posted facts and source evidence rows for market estimates.
+- API events should mark compensation assessments dirty but should not include raw source payloads, secrets, or profile salary preferences.
+- QA must include synthetic fixtures for below-floor posted salary, above-floor posted salary, no posted salary, unparseable salary, broad range, OTE/equity ambiguity, low-confidence benchmark, high-confidence licensed benchmark, stale source, source conflict, currency/period ambiguity, and Europe/remote location mismatch.
 
 ## Confidence Assessment
 
 | Area | Confidence | Notes |
 |------|------------|-------|
-| Stack | HIGH | Current repo packages and scripts define the implementation stack. |
-| Features | HIGH | User stories and selected Option 1 scope are explicit. |
-| Architecture | HIGH | Repo frontend/API boundaries are documented and current code follows them. |
-| Pin mechanics | MEDIUM | Existing provenance supports pins, but exact visual anchoring needs phase-level validation. |
-| QA fixtures | MEDIUM | Synthetic QA is required; exact fixture path should be chosen during phase planning. |
+| Stack | HIGH | Strong repo fit: existing Python worker, SQLite, projections, contracts, Operations hooks, and Jobs audit surfaces support the feature without new infrastructure. |
+| Features | HIGH | Table stakes are consistent across posted salary UX, pay transparency expectations, benchmark-source behavior, and JobHunter's audit-first product direction. |
+| Architecture | HIGH | Recommended ownership aligns with current DDD/frontend target architecture and avoids a premature ninth bounded context. Projection parity remains a known implementation risk. |
+| Pitfalls | HIGH | Source-access, false precision, normalization, gating, audit-source, and privacy risks are well supported by official source terms and repo constraints. |
+| External providers | MEDIUM | Glassdoor restrictions are clear enough to exclude default scraping; Levels.fyi licensed access is plausible but requires a user/provider decision before implementation. |
+| Statistical thresholds | MEDIUM | Confidence factors are clear, but exact bucket boundaries and minimum source/sample thresholds need requirements-level decisions. |
 
-**Overall confidence:** HIGH for milestone plan, MEDIUM for the PDF/pin implementation details until Phase 15 planning.
+**Overall confidence:** HIGH for roadmap direction; MEDIUM for provider-specific implementation until access and licensing are confirmed.
 
-## Gaps to Address
+### Gaps to Address
 
-- **Shared DTO naming and fields:** Decide during Phase 13 planning, but preserve the invariant that both surfaces consume the same facts.
-- **Pin location model:** Validate whether pins attach to text rows, PDF preview side rail, or generated bullet list before coding.
-- **Risk severity mapping:** Define how quality/judge/adversarial signals collapse into pin-level `grounded`, `warning`, `unsupported`, or `missing_source` display states.
-- **Synthetic QA data:** Use or add fixtures that prove blockers, ready state, missing source, grounded claim, and risky claim states.
+- Levels.fyi access: confirm whether the user has or wants paid/API/MCP/CLI/data-stream access and what retention/redistribution is allowed.
+- Glassdoor access: confirm whether explicit partner/API access or written permission exists; otherwise exclude it from implementation.
+- Geography: define whether v1.3 targets U.S.-only public baselines or must support Spain/Europe roles with separate public sources or low-confidence unsupported states.
+- Compensation scope: decide whether estimates are base salary only, total compensation, OTE, or component-separated display.
+- Remote mapping: define how remote U.S., Europe remote, global remote, and company-HQ markets should affect estimates.
+- Profile floor: decide which profile field is canonical for "floor" and whether comparisons use annualized base pay only.
+- Confidence thresholds: define minimum source/sample counts, freshness cutoffs, role/location/seniority match requirements, and rounding bands.
+- Market workflow: decide whether market estimation is automatic for every enriched job, on-demand in the drawer, or automatic only after a fit-score threshold.
 
 ## Sources
 
-### Primary
+### Primary (HIGH confidence)
+- `.planning/PROJECT.md` — v1.3 goal, target features, active requirements, local-first/audit constraints.
+- `.planning/research/STACK.md` — recommended source strategy, stack additions, data model, confidence model, and integration points.
+- `.planning/research/FEATURES.md` — table stakes, differentiators, anti-features, UX facts, and MVP recommendation.
+- `.planning/research/ARCHITECTURE.md` — bounded-context ownership, domain model, persistence/projection/read-model flow, ports, pipeline integration, and build order.
+- `.planning/research/PITFALLS.md` — critical/moderate/minor pitfalls, source constraints, privacy/security risks, preventive requirements, and QA recommendations.
+- JobHunter architecture docs cited by researchers: `docs/architecture.md`, `docs/frontend-target.md`, `docs/job-pipeline-architecture.md`, `docs/local-ts-api.md`, `docs/local-reliability-qa.md`.
+- Official source constraints cited by researchers: Glassdoor Terms of Use, Levels.fyi Terms/API/data offering, BLS OEWS, O*NET Web Services, DOL OFLC disclosure data, ECB FX reference rates, OECD/World Bank PPP references, and European Commission pay-transparency explainer.
 
-- `AGENTS.md` - repo workflow, frontend boundaries, auditability, and QA safety rules.
-- `docs/frontend-target.md` - frontend architecture and view/context separation.
-- `apps/web/src/views/jobs/JobDetailDrawer.tsx` - Jobs row-click drawer implementation.
-- `apps/web/src/views/apply-review/ApplyReviewView.tsx` - Apply Review surface and current status derivation.
-- `apps/web/src/contexts/materials/components/ArtifactTailoringInspector.tsx`
-- `apps/web/src/contexts/materials/components/TailoringExplanationSection.tsx`
-- `apps/web/src/contexts/materials/components/BulletProvenanceList.tsx`
-- `packages/contracts/src/schemas.ts`
-- `apps/api/src/application-feedback.ts`
-- `apps/api/src/read-model.ts`
-- `.planning/sketches/002-layered-audit-surfaces/`
+### Secondary (MEDIUM confidence)
+- Glassdoor salary behavior/help/blog sources — useful for user-facing salary UX patterns, but not an implementation license.
+- Levels.fyi public salary/product pages — useful for role/level/TC/freshness patterns, but API/data use requires licensed access confirmation.
+- LinkedIn/Indeed/pay-transparency examples — useful for market UX expectations and missing/broad salary handling.
+- Nielsen Norman Group and UK Government uncertainty guidance — useful for communicating ranges and uncertainty.
+
+### Tertiary (LOW confidence)
+- Unofficial scraper marketplaces or reverse-engineered salary data APIs — excluded from v1.3 because they do not resolve underlying source rights and add brittle infrastructure.
 
 ---
-*Research completed: 2026-06-11*
+*Research completed: 2026-06-19*
 *Ready for roadmap: yes*

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -9,7 +9,7 @@
 
 JobHunter v1.3 should make compensation evidence inspectable in the same trust-first style as the existing job and materials audit surfaces. Experts build this kind of feature by separating employer-posted facts from benchmark estimates, preserving source provenance, modeling uncertainty explicitly, and refusing to turn weak compensation data into hidden ranking or apply gates.
 
-The recommended approach is to build an Enrichment-owned compensation assessment path on the existing local-first stack: deterministic posted salary extraction, canonical SQLite compensation/provenance rows, projection-backed Operations read models, typed contracts, and Jobs list/drawer components that render salary facts as audit evidence. The source strategy should be tiered: posted salary first, optional licensed Levels.fyi-style tech benchmarks second, public BLS/O*NET baselines third, optional OFLC corroboration for U.S. employer/location evidence, and no Glassdoor scraping.
+The recommended approach is to build an Enrichment-owned compensation assessment path on the existing local-first stack: deterministic posted salary extraction, canonical SQLite compensation/provenance rows, projection-backed Operations read models, typed contracts, and Jobs list/drawer components that render salary facts as audit evidence. After requirements scoping, v1.3 is Europe-only: the source strategy should be tiered as posted salary first, Eurostat Structure of Earnings Survey plus ESCO occupation mapping as the public European baseline, Spain INE Wage Structure Survey as the Spain-specific baseline, optional licensed Levels.fyi-style tech benchmarks only when access and European coverage are confirmed, and no Glassdoor scraping.
 
 The main risks are source legality, false precision, lossy normalization, and projection drift between Python and TypeScript. Mitigate them with a salary-source registry, disabled-by-default external adapters, first-class insufficient-evidence states, separate parse and market confidence, canonical rows before UI rendering, projection parity tests, and QA fixtures that prove market estimates do not silently alter fit score, apply readiness, or queue eligibility.
 
@@ -29,8 +29,8 @@ Use the current JobHunter architecture. Do not introduce a new service, scraper 
 
 **Recommended source/integration strategy:**
 - Posted job salary text is the primary source and should always preserve raw/source text.
-- BLS OEWS plus O*NET title/SOC mapping is the safest public default baseline.
-- OFLC/H-1B disclosure can be an optional U.S. corroborator, labeled as visa/LCA-biased.
+- Eurostat Structure of Earnings Survey datasets are the default Europe-wide public baseline, with ESCO used for occupation classification/mapping and clear caveats for aggregation and survey lag.
+- Spain INE Wage Structure Survey is the default Spain-specific corroborator when the job market is Spain.
 - Levels.fyi is optional and licensed only. Build a disabled adapter seam unless the user has approved API/MCP/CLI/data access.
 - Glassdoor must not be scraped. Use only with explicit partner/API access or written permission.
 - Unofficial scraper marketplaces should be excluded from v1.3.
@@ -117,9 +117,9 @@ Based on research, suggested phase structure:
 **Addresses:** Jobs list triage, drawer audit source of truth, below/near/above floor display, legacy raw salary compatibility.
 **Avoids:** Projection drift, UI-only audit claims, and hidden compensation gates.
 
-### Phase 4: Public Baseline And Optional Licensed Adapter Seams
+### Phase 4: Europe Public Baseline And Optional Licensed Adapter Seams
 **Rationale:** Market estimates require provider constraints, source matching, and insufficient-evidence states before UI can make them useful.
-**Delivers:** Market source port, BLS/O*NET baseline path or cache strategy, optional OFLC import seam, disabled Levels.fyi adapter shape, explicit Glassdoor blocked/unavailable handling, source evidence rows, and estimator confidence scoring.
+**Delivers:** Market source port, Eurostat SES baseline path or cache strategy, ESCO occupation mapping, Spain INE wage-source adapter/import seam, disabled Levels.fyi adapter shape, explicit Glassdoor blocked/unavailable handling, source evidence rows, and estimator confidence scoring.
 **Addresses:** Market salary estimation, source trail, source count/sample count, freshness, agreement/conflict, "why not estimated" states.
 **Avoids:** Unlicensed Glassdoor/Levels usage, false precision, geography/seniority mismatch, and slow/brittle Discover failures.
 
@@ -146,7 +146,7 @@ Based on research, suggested phase structure:
 ### Research Flags
 
 Phases likely needing deeper research during planning:
-- **Phase 4:** External integration details. Confirm current BLS/OEWS table/API strategy, O*NET access credentials, Levels.fyi license/access mode, OFLC import scope, and whether Glassdoor is explicitly licensed.
+- **Phase 4:** External integration details. Confirm current Eurostat API/dataset strategy, ESCO API/local taxonomy strategy, Spain INE data access/table strategy, Levels.fyi license/access mode and Europe coverage, and whether Glassdoor is explicitly licensed.
 - **Phase 4:** Statistical thresholds. Define minimum source/sample counts, freshness decay windows, agreement/dispersion bands, remote-location assumptions, and confidence bucket boundaries.
 - **Phase 6:** Correction and refresh policy. Decide whether user corrections become canonical facts, annotations, or deferred backlog.
 
@@ -161,7 +161,7 @@ Phases with standard patterns (skip research-phase):
 - Every displayed salary range must identify whether it is employer-posted, parsed from posting text, benchmark-derived, public baseline, licensed commercial, manual, or unavailable.
 - Glassdoor is out of default scope unless explicit partner/API access or written permission exists. Requirements should state "do not scrape Glassdoor."
 - Levels.fyi support should be a disabled optional adapter unless a license/API/MCP/CLI/data-stream arrangement is confirmed. Do not store or redistribute raw data beyond license permissions.
-- Public baselines should be labeled as occupation/location aggregates, not company-specific market truth.
+- Public European baselines should be labeled as occupation/location aggregates, not company-specific market truth. Spain-specific INE rows should be labeled as national statistical data, not employer offer data.
 - The MVP should support `not_found`, `unparseable`, `ambiguous`, `posted_range`, `not_requested`, `unsupported`, `insufficient_evidence`, and `estimated_range` states.
 - Profile-floor comparison must name whether it used posted salary or market estimate. Default blockers may use posted salary only; market estimates are advisory warnings.
 - Currency, period, base/total/OTE/equity/bonus/hourly/monthly/gross/net assumptions must be preserved and rendered as warnings when ambiguous.
@@ -184,9 +184,9 @@ Phases with standard patterns (skip research-phase):
 
 ### Gaps to Address
 
-- Levels.fyi access: confirm whether the user has or wants paid/API/MCP/CLI/data-stream access and what retention/redistribution is allowed.
+- Levels.fyi access: confirm whether the user has or wants paid/API/MCP/CLI/data-stream access, whether it covers the relevant European markets, and what retention/redistribution is allowed.
 - Glassdoor access: confirm whether explicit partner/API access or written permission exists; otherwise exclude it from implementation.
-- Geography: define whether v1.3 targets U.S.-only public baselines or must support Spain/Europe roles with separate public sources or low-confidence unsupported states.
+- Geography: v1.3 targets Europe-only public baselines. U.S. BLS/O*NET/OFLC support is out of scope unless a later milestone reopens it.
 - Compensation scope: decide whether estimates are base salary only, total compensation, OTE, or component-separated display.
 - Remote mapping: define how remote U.S., Europe remote, global remote, and company-HQ markets should affect estimates.
 - Profile floor: decide which profile field is canonical for "floor" and whether comparisons use annualized base pay only.
@@ -202,7 +202,8 @@ Phases with standard patterns (skip research-phase):
 - `.planning/research/ARCHITECTURE.md` — bounded-context ownership, domain model, persistence/projection/read-model flow, ports, pipeline integration, and build order.
 - `.planning/research/PITFALLS.md` — critical/moderate/minor pitfalls, source constraints, privacy/security risks, preventive requirements, and QA recommendations.
 - JobHunter architecture docs cited by researchers: `docs/architecture.md`, `docs/frontend-target.md`, `docs/job-pipeline-architecture.md`, `docs/local-ts-api.md`, `docs/local-reliability-qa.md`.
-- Official source constraints cited by researchers: Glassdoor Terms of Use, Levels.fyi Terms/API/data offering, BLS OEWS, O*NET Web Services, DOL OFLC disclosure data, ECB FX reference rates, OECD/World Bank PPP references, and European Commission pay-transparency explainer.
+- Official source constraints cited by researchers: Glassdoor Terms of Use, Levels.fyi Terms/API/data offering, Eurostat Structure of Earnings Survey and API documentation, ESCO API documentation, Spain INE Wage Structure Survey, ECB FX reference rates, OECD/World Bank PPP references, and European Commission pay-transparency explainer.
+- Europe-only scope addendum: Eurostat SES is conducted across EU/candidate/EFTA countries and provides comparable earnings data; ESCO provides web-service and local APIs for European occupation classification; Spain INE published final 2024 Wage Structure Survey data on 2026-05-28; Eurostat APIs provide JSON-stat/SDMX access for public datasets.
 
 ### Secondary (MEDIUM confidence)
 - Glassdoor salary behavior/help/blog sources — useful for user-facing salary UX patterns, but not an implementation license.


### PR DESCRIPTION
## Summary

- Initialize v1.3 Salary Range Estimator planning artifacts.
- Define a Europe-first six-phase roadmap covering source policy, posted compensation facts, Europe public market estimates, read-model/API propagation, Jobs triage UX, and QA release gates.
- Record compensation source strategy for posted salary extraction, Eurostat SES, ESCO, Spain INE, and disabled/licensed seams for Levels.fyi and Glassdoor.

## Validation

- `git diff --check`
- `node /Users/eloibarti/.codex/gsd-core/bin/gsd-tools.cjs query stats.json` — reports v1.3 with 6 phases and 35 requirements
- `node /Users/eloibarti/.codex/gsd-core/bin/gsd-tools.cjs query roadmap.analyze` — reports Phase 17 as the next phase

## Notes

- Planning/docs-only change; product tests were not run.