### PR TITLE
docs: archive requirement fit ledger plan

### DIFF
--- a/docs/plans/implemented/2026-06-15-requirement-fit-ledger.md
+++ b/docs/plans/implemented/2026-06-15-requirement-fit-ledger.md
@@ -1,8 +1,8 @@
 # Requirement Fit Ledger Implementation Plan
 
-> **Status:** Proposed. This plan tracks the migration from separate score
-> signals, employer requirements, and artifact coverage into one requirement-led
-> audit chain.
+> **Status:** Implemented. Canonical current behavior is documented in
+> `README.md`, `docs/local-ts-api.md`, `docs/local-reliability-qa.md`, and
+> `docs/architecture.md`.
 
 > **For agentic workers:** Implement task-by-task. Keep the compatibility read
 > model until the requirement fit report is projected everywhere the old score


### PR DESCRIPTION
## Summary
- Move the requirement fit ledger plan from proposed to implemented.
- Update the plan status note to point at the canonical current-behavior docs.

## Why
The requirement-fit ledger work is implemented on main: contracts, Python scoring value objects, persistence, deterministic scoring, API/read-model projection, tailoring directive use, artifact coverage mapping, job drawer and Apply Review UI, and regression/visual coverage are all present.

## Validation
- `git diff --check`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_score_aggregate.py workers/automation/tests/test_requirement_fit_resolution.py workers/automation/tests/test_score_use_cases.py::test_score_parser_parses_requirement_assessments workers/automation/tests/test_score_use_cases.py::test_score_parser_does_not_accept_matched_requirement_without_evidence workers/automation/tests/test_score_use_cases.py::test_score_job_includes_requirement_fit_inputs_in_prompt workers/automation/tests/test_score_use_cases.py::test_score_job_persists_resolved_requirement_fit_report workers/automation/tests/test_score_use_cases.py::test_score_job_requirement_fit_missing_must_have_drives_low_score workers/automation/tests/test_employer_analysis_projection.py::test_projection_serves_latest_requirement_fit_report_read_model workers/automation/tests/test_employer_analysis_projection.py::test_projection_requirement_fit_report_is_null_when_no_report_exists workers/automation/tests/test_materials_quality.py::test_build_tailoring_plan_uses_requirement_fit_directives workers/automation/tests/test_materials_quality.py::test_quality_rejects_prohibited_missing_requirement_claim workers/automation/tests/test_tailor_provenance_integration.py::test_accepted_resume_updates_requirement_fit_artifact_coverage`
- `corepack pnpm --filter @jobhunter/api test -- test/projections.test.ts`
- `corepack pnpm --filter @jobhunter/web test -- src/contexts/materials/components/EmployerAnalysisPanel.test.tsx src/views/jobs/JobDetailDrawer.test.tsx src/views/apply-review/ApplyReviewView.test.tsx`
- PR review gate: PASS
- QA gate: PASS

## Notes
Product/browser QA was not rerun for this PR because the diff is docs-only and does not touch runtime behavior; the archived plan and existing QA docs already reference the seeded browser and visual coverage for the requirement-fit drawer and Apply Review cards.