### PR TITLE
docs: add open source documentation foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # JobHunter Environment Configuration
-# Copy to ~/.jobhunter/.env and fill in your values.
+# Copy to ~/.jobhunter/.env for personal use. Keep real values out of git.
 
 # LLM Provider (pick one)
 GEMINI_API_KEY=           # Gemini 3.5 Flash by default (gemini-3.5-flash)
@@ -7,21 +7,42 @@ GEMINI_API_KEY=           # Gemini 3.5 Flash by default (gemini-3.5-flash)
 # LLM_URL=http://127.0.0.1:8080/v1  # Local LLM (llama.cpp, Ollama)
 # LLM_MODEL=              # Override model name
 
+# Local runtime (optional)
+# JOBHUNTER_DIR=~/.jobhunter
+# JOBHUNTER_DB_PATH=~/.jobhunter/jobhunter.db
+# JOBHUNTER_API_HOST=127.0.0.1
+# JOBHUNTER_API_PORT=8766
+# JOBHUNTER_API_ALLOW_REMOTE_BIND=0
+# JOBHUNTER_WEB_PORT=5173
+# JOBHUNTER_TEMPORAL_DB=.dev/temporal/temporal.db
+
 # Resume tailoring quality controls (optional)
 # TAILORING_GENERATOR_MODELS=local:draft-a,gemini:gemini-3.5-flash
 # TAILORING_JUDGE_MODEL=gemini:gemini-3.5-flash
 # TAILORING_JUDGE_MIN_SCORE=0.82
+# JOBHUNTER_RESUME_RENDERER=html_pdf
 
-# Runtime paths (optional)
-# JOBHUNTER_DIR=~/.jobhunter
+# Browser and artifact tooling (optional)
 # PDFLATEX_PATH=/Library/TeX/texbin/pdflatex
 # CHROME_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 # Local web UI (optional)
 # VITE_GOOGLE_MAPS_API_KEY=  # Enables Google Maps address search in Profile.
 
-# Auto-Apply (optional)
+# Apply automation (optional, explicit user authorization still required)
+# JOBHUNTER_APPLY_TIMEOUT_SECONDS=900
 CAPSOLVER_API_KEY=        # For CAPTCHA solving during auto-apply
+
+# Gmail outcome connector (optional, read-only scope)
+# JOBHUNTER_GMAIL_DIR=~/.jobhunter/gmail
+# JOBHUNTER_GMAIL_OAUTH_CLIENT_PATH=~/.jobhunter/gmail/oauth-client.json
+# JOBHUNTER_GMAIL_TOKEN_PATH=~/.jobhunter/gmail/token.json
+
+# Observability (optional)
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+# LANGFUSE_BASE_URL=
+# LANGFUSE_DISABLE=1
 
 # Proxy (optional, for scraping)
 # PROXY=host:port:user:pass

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Code of Conduct
+
+JobHunter contributors are expected to keep collaboration professional,
+specific, and respectful.
+
+## Expected Behavior
+
+- Be direct about technical risks without personal attacks.
+- Assume good intent, but ask for evidence when a claim affects user data,
+  safety, architecture, or reliability.
+- Keep discussions focused on the code, documentation, tests, and product
+  behavior.
+- Respect privacy. Do not ask contributors to share real resumes, job-search
+  databases, credentials, logs, browser profiles, or generated materials.
+
+## Unacceptable Behavior
+
+- Harassment, threats, or discriminatory language.
+- Publishing private user data, secrets, local paths, credentials, or generated
+  application materials.
+- Pressuring users or contributors to run automation that submits applications,
+  bypasses site controls, or exposes local data without explicit consent.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments; close issues or PRs; and limit
+participation when behavior violates this code of conduct or puts user data at
+risk.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for helping improve JobHunter. This project handles job-search data,
+resumes, generated application materials, browser state, local logs, and
+credentials, so contributions need to preserve privacy and local safety first.
+
+## Development Setup
+
+```bash
+pnpm dev:setup
+uv --project workers/automation run jobhunter doctor
+pnpm dev
+```
+
+The full local stack runs in the foreground and starts Temporal, the TypeScript
+API, the Vite web app, and the Python worker. Keep that terminal open while
+using the app.
+
+Use a disposable workspace for destructive or screenshot-oriented testing:
+
+```bash
+pnpm qa:seed -- /tmp/jobhunter-qa
+JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
+```
+
+## Pull Requests
+
+- Keep changes scoped to one behavior or documentation concern.
+- Use Conventional Commits for commit messages and PR titles.
+- Update documentation when public behavior, commands, runtime requirements,
+  configuration, architecture, or QA expectations change.
+- Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
+  profiles, SQLite databases, or generated application materials.
+
+## Validation
+
+Run the narrowest useful checks while iterating. Before opening a PR, prefer:
+
+```bash
+pnpm check
+pnpm test
+uv --project workers/automation run --extra dev python -m build workers/automation
+git diff --check
+```
+
+For user-facing UI/API/product-flow changes, include a product-path QA step, not
+only unit tests. See [docs/local-reliability-qa.md](docs/local-reliability-qa.md)
+for the regression matrix.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -2,57 +2,80 @@
 
 JobHunter is a local-first job search automation system. It keeps your profile,
 job database, generated materials, browser state, and logs on your machine while
-helping you move jobs through the user-facing pipeline:
+helping you move jobs through a focused pipeline:
 
 ```text
 discover -> apply
 ```
 
-Discovery also drains the internal preparation work needed before applying,
-including enrichment, scoring, resume tailoring, and artifact suppression.
-Those lower-level stages remain available as maintenance and diagnostic
-commands.
-
-The automation engine is Python. The product surface is a local TypeScript API
-plus a React/Vite web app built on TanStack Router, TanStack Query, TanStack
-Table, and TanStack Form. SQLite and local files remain the source of truth
-while the project validates reliability before any hosted/SaaS hardening.
+Discovery finds and enriches jobs, scores them against your candidate profile,
+and prepares tailored materials when the job is eligible. Apply is separate
+because it can drive browser automation and submit applications.
 
 ## What It Does
 
-JobHunter can:
+- Discover jobs from configured searches and supported source registries.
+- Enrich postings with full descriptions, canonical posting URLs, and apply URLs.
+- Score jobs as an applicant-side triage aid with auditable evidence.
+- Generate tailored resumes, cover letters, PDFs, and review artifacts.
+- Review and edit generated resumes in Apply Review before approval.
+- Edit resume PDF style templates in Preferences, choose a default template, and
+  override the template per job without modifying candidate profile data.
+- Track pipeline state, failures, retries, workflow runs, artifacts, and apply
+  history in a local web UI.
+- Optionally run browser-based apply automation, starting with dry runs.
 
-- find jobs from configured searches and supported source registries, then
-  enrich matching jobs with full descriptions and application URLs;
-- score jobs against your candidate profile with an LLM;
-- tailor resumes from your structured resume baseline;
-- edit resume PDF style templates in Preferences, choose a default template,
-  and override the template per job without modifying candidate profile data;
-- generate cover letters;
-- convert generated text artifacts to PDFs;
-- show stage state, failures, retries, artifacts, and apply runs in a local UI;
-- show posted and reported company-role compensation ranges with statistical
-  confidence and selected source-row evidence, including source links when
-  available, in Jobs triage and Apply Review;
-- optionally drive local browser-based application submission.
+Auto-apply is powerful and must be treated as an explicit submission tool. Use
+dry-run paths and narrow targets before allowing it to submit anything.
 
-Auto-apply is powerful and should be treated as an explicit submission tool. Use
-dry-run paths and targeted commands before allowing it to submit anything.
+## Current System
 
-## Current System Shape
+JobHunter has three local runtime components:
 
-JobHunter is split by responsibility:
+- `apps/api`: local TypeScript/Fastify API for read models, profile/settings,
+  structured actions, artifacts, and worker dispatch.
+- `apps/web`: React/Vite app using TanStack Router, Query, Table, and Form with
+  SSE-backed cache invalidation.
+- `workers/automation`: Python automation engine, CLI, Temporal worker,
+  discovery, scoring, materials, PDF rendering, and apply automation.
 
-- `apps/api`: local TypeScript/Fastify API for typed read models, local
-  product actions, profile/settings, artifacts, and worker invocation.
-- `apps/web`: React/Vite local web app using TanStack Router, Query, Table,
-  and Form with SSE-backed cache invalidation.
-- `workers/automation/src/jobhunter`: Python automation engine, CLI, workers,
-  profile import, PDF creation, and apply automation.
+SQLite and local files are the source of truth. Hosted accounts, billing,
+managed browsers, object storage, and SaaS deployment are deferred; see
+[ROADMAP.md](ROADMAP.md).
 
-## Safety And Data
+## Quick Start
 
-By default, JobHunter writes user data under:
+Requirements:
+
+- Python 3.11+
+- Node.js 20.19+
+- pnpm through Corepack
+- uv
+- Temporal CLI with `temporal server start-dev`
+- Playwright Chromium for HTML/CSS PDF rendering
+- an LLM provider key or local LLM endpoint for scoring and materials
+
+Install and run:
+
+```bash
+git clone https://github.com/ebarti/JobHunter.git
+cd JobHunter
+pnpm dev:setup
+uv --project workers/automation run jobhunter init
+uv --project workers/automation run jobhunter doctor
+pnpm dev
+```
+
+`pnpm dev` starts the full local stack in the foreground: Temporal dev server,
+TypeScript API, Vite web app, and Python worker. Keep the terminal open while
+using the app and stop it with Ctrl-C.
+
+For the full first-run guide, see
+[docs/user/getting-started.md](docs/user/getting-started.md).
+
+## Local Data And Safety
+
+By default, JobHunter writes local data under:
 
 ```text
 ~/.jobhunter/
@@ -60,775 +83,96 @@ By default, JobHunter writes user data under:
 
 Important local files include:
 
-- `jobhunter.db`: local SQLite database, including normalized candidate profile,
-  jobs, discovery settings, events, projections, and artifact metadata.
-- `.env`: API keys and local runtime settings.
-- `tailored_resumes/`, `cover_letters/`, `logs/`: generated artifacts.
+- `jobhunter.db`: local SQLite database with profile, jobs, events,
+  projections, settings, and artifact metadata.
+- `.env`: provider keys and local runtime settings.
+- `tailored_resumes/`, `cover_letters/`, `logs/`: generated artifacts and logs.
 - `chrome-workers/`, `apply-workers/`: local browser/apply worker state.
-- `codex_home/`: isolated Codex SDK home (session rollouts plus a copied auth
-  token; sensitive, never commit).
-
-Do not commit profile data, keys, generated resumes, cover letters, PDFs,
-browser profiles, logs, or SQLite databases.
-
-Job scoring is an applicant-side triage aid. Scores, criteria snapshots,
-eligibility blockers, confidence, trace metadata, and user corrections are
-stored locally so you can inspect why a job was ranked or gated. Do not use
-JobHunter as an employer-side candidate screening or selection tool without a
-separate legal, bias-audit, validation, and notice process.
-
-The local TypeScript API binds to `127.0.0.1` by default. Binding it to a
-non-loopback interface requires an explicit opt-in because it exposes local job,
-profile, and artifact metadata.
-
-## Requirements
-
-Core pipeline:
-
-- Python 3.11 or newer.
-- A local LLM provider configuration for scoring, tailoring, and cover letters.
-  Gemini, OpenAI, and local HTTP-backed providers are supported through
-  environment variables. Gemini keys default to `gemini-3.5-flash` unless
-  `LLM_MODEL` overrides the model.
-- Playwright Chromium for HTML/CSS resume and cover-letter PDF output. The
-  Python worker dependency includes Playwright; if Chromium is missing, run
-  `uv --project workers/automation run playwright install chromium`.
-- Optional TeX distribution with `pdflatex` only for the legacy resume renderer
-  selected with `JOBHUNTER_RESUME_RENDERER=latex_pdf`.
-- Poppler with `pdftoppm` on `PATH` for local PDF page previews in the web UI.
-- Temporal CLI with dev server support (`temporal server start-dev`) for the
-  workflow engine the Python worker runs against. The local dev launcher starts
-  it for you with persistent local workflow history; see
-  `docs/local-development.md`.
-
-Local API and web UI:
-
-- Node.js 20.19 or newer.
-- pnpm through Corepack.
-- Optional `VITE_GOOGLE_MAPS_API_KEY` for Google Maps address search in the
-  Profile form.
-
-Auto-apply:
-
-- Chrome or Chromium.
-- Node.js and `npx` for the Playwright MCP runtime.
-- Claude Code CLI for browser-driven form completion.
-- Optional Gmail connector auth for read-only email verification codes.
-- Optional `CAPSOLVER_API_KEY` for CAPTCHA solving.
-
-Run the doctor command after setup. It is the fastest way to see which tier of
-functionality is available on your machine.
-
-## Install From Source
-
-```bash
-git clone https://github.com/ebarti/JobHunter.git
-cd JobHunter
-pnpm dev:setup
-uv --project workers/automation run jobhunter doctor
-```
-
-Start the full local dev stack for UI/API job runs:
-
-```bash
-pnpm dev
-```
-
-`pnpm dev:setup` installs the Node workspace dependencies and syncs the
-uv-managed Python automation environment, including `python-jobspy` and its
-locked transitive dependencies plus the Python dev extras used by local checks.
-`pnpm dev` runs the process supervisor in the foreground and also invokes the
-Python worker through `uv run`, which re-syncs the worker environment if needed.
-Keep that terminal open while using the app and stop it with Ctrl-C. First-time
-setup should use `pnpm dev:setup` so dependency failures are separated from
-process startup.
-
-For verification:
-
-```bash
-pnpm test
-```
-
-Discovery includes `python-jobspy` for broad-board scraping through JobSpy.
-If `jobhunter doctor` reports JobSpy is missing, rerun
-`uv --project workers/automation sync`.
-
-## First-Time Setup
-
-Create your local profile and configuration:
-
-```bash
-uv --project workers/automation run jobhunter init
-uv --project workers/automation run jobhunter doctor
-```
-
-The setup writes local files into `~/.jobhunter`. Review them before running a
-large pipeline:
-
-```bash
-ls ~/.jobhunter
-```
-
-At minimum, confirm:
-
-- your profile and resume facts are accurate;
-- your search configuration is narrow enough for a first run;
-- your LLM key or local model endpoint is configured;
-- optional frontend-only keys such as `VITE_GOOGLE_MAPS_API_KEY` are available
-  from repo `.env`, `~/.jobhunter/.env`, or `~/Jobhunter/.env` before starting
-  `pnpm dev`;
-- Playwright Chromium is available for resume and cover-letter PDFs;
-- `pdflatex` is available only if you explicitly use
-  `JOBHUNTER_RESUME_RENDERER=latex_pdf`;
-- `pdftoppm` is available if you need PDF page previews in the web UI;
-- Chrome and Claude Code are available only if you intend to use auto-apply.
-
-## Running The Pipeline
-
-Run the default preparation pipeline:
-
-```bash
-uv --project workers/automation run jobhunter run
-```
-
-Run specific low-level maintenance stages:
-
-```bash
-uv --project workers/automation run jobhunter discover
-uv --project workers/automation run jobhunter score --workers 4
-uv --project workers/automation run jobhunter tailor --workers 4 --min-score 7
-uv --project workers/automation run jobhunter cover --min-score 7
-```
-
-Run low-level stages by name through the orchestrator:
-
-```bash
-uv --project workers/automation run jobhunter run discover score
-uv --project workers/automation run jobhunter run tailor cover --validation normal
-uv --project workers/automation run jobhunter run --stream
-```
-
-`jobhunter enrich` remains available as a diagnostic queue-drain command, but
-normal discovery runs own detail enrichment.
-
-Refresh compensation facts for existing jobs without rerunning discovery,
-scoring, tailoring, cover-letter generation, or apply automation:
-
-```bash
-uv --project workers/automation run jobhunter compensation-refresh \
-  --observations-json /path/to/reported-compensation.json
-```
-
-The command reparses current `jobs.salary` values plus compensation text found
-in job descriptions into posted-compensation facts, imports local reported
-compensation rows from `--observations-json` when supplied, imports configured
-licensed Levels.fyi and Glassdoor feeds by default when their source-policy
-environment variables and feed path or URL are present, imports public Euro Top
-Tech community-reported rows by default, and refreshes local projections. Set
-`JOBHUNTER_LEVELS_FYI_OBSERVATIONS_PATH` or
-`JOBHUNTER_LEVELS_FYI_OBSERVATIONS_URL` for Levels.fyi feeds and
-`JOBHUNTER_GLASSDOOR_OBSERVATIONS_PATH` or
-`JOBHUNTER_GLASSDOOR_OBSERVATIONS_URL` for Glassdoor feeds; JSON and CSV feeds
-are accepted. When no external reported evidence matches,
-JobHunter derives low-confidence market ranges from employer-posted salary facts
-it already captured.
-It uses the best available grounded tier: same company and role first, then
-same-location role evidence, same-company adjacent roles, trimodal company-tier
-fallbacks, and finally a broad market baseline when that is all the local data
-supports. The market response stores both the best range and a wider confidence
-interval; weaker tiers get wider intervals. Employer-posted rows are attributed
-as job posting salary text, not Levels.fyi, Glassdoor, Euro Top Tech, or manual
-reported data. Use `--url <job-url>` or `--limit N` to narrow the refresh. Use
-`--no-eurotoptech` to disable only the public Euro Top Tech import, or
-`--eurotoptech-max-pages N` to cap its paginated data-entry fetch.
-The Jobs toolbar also exposes a `refresh compensation` maintenance action that
-uses the same source-loading path for every existing job without rerunning the
-application pipeline.
-
-Useful options:
-
-- `--dry-run`: preview a stage without executing it.
-- `--workers` / `-w`: parallelize supported stages.
-- `--limit`: cap eligible records for supported single-stage commands.
-- `--min-score`: control which scored jobs proceed to materials or apply.
-- `--validation strict|normal|lenient`: tune tailoring and cover-letter checks.
-- `--retailor`: regenerate tailored resumes for jobs that already have one.
-- `--tailor-models`: comma-separated tailoring generator model specs such as
-  `local:draft-a,gemini:gemini-3.5-flash`; omit it to use the existing
-  `LLM_MODEL`/provider default.
-- `--tailor-judge-model`: optional separate model spec for the structured
-  tailoring judge. This is independent of the apply `--model` option.
-- `--tailor-judge-min-score`: minimum structured judge score for approval
-  (`0.82` by default). `--validation lenient` skips the judge.
-
-For high-fit jobs (fit score `8+`), a resume that passes deterministic
-validation and the structured judge is also checked by adversarial reviewer
-personas. Blocker findings keep the resume unapproved and feed the retry loop
-instead of being hidden as a successful tailoring run. Non-blocking review
-warnings also feed a repair retry while retry budget remains; any warning still
-shown on the accepted artifact is residual feedback on the selected resume.
-Persona reviews persist their rubric, bounded LLM request excerpts, structured
-response fields, and score rationale so a `PASS (100%)` judgement remains
-auditable.
-
-The same tailoring controls can be provided through
-`TAILORING_GENERATOR_MODELS`, `TAILORING_JUDGE_MODEL`, and
-`TAILORING_JUDGE_MIN_SCORE`. The shorter aliases `TAILOR_LLM_MODELS`,
-`TAILOR_JUDGE_MODEL`, and `TAILOR_JUDGE_MIN_SCORE` are also accepted. Model
-specs name only a provider/model (`gemini:...`, `openai:...`, or `local:...`);
-credentials and local endpoint URLs still come only from environment variables
-and are not written to artifact metadata.
-
-## Single-Job And Retry Commands
-
-Process one URL:
-
-```bash
-uv --project workers/automation run jobhunter job https://example.com/job/123 --tailor --dry-run
-uv --project workers/automation run jobhunter job https://example.com/job/123 --tailor
-uv --project workers/automation run jobhunter job https://example.com/job/123 --apply --dry-run
-```
-
-Reset one stage for one job:
-
-```bash
-uv --project workers/automation run jobhunter retry score https://example.com/job/123
-uv --project workers/automation run jobhunter retry tailor https://example.com/job/123 --reset-attempts
-```
-
-`retry --run` can process other eligible pending work for some stages. Use it
-deliberately.
-
-In the local web UI, dashboard KPIs open matching Jobs filters. Failures opens
-failed jobs so you can retry selected failures or retry all currently matching
-failed jobs after confirmation. The active Jobs toolbar keeps `retry all failed`
-available outside the failed-state filter; it retries failed jobs matching the
-current non-state filters. Bulk failed retries reset the failed preparation
-substage and immediately queue grouped preparation workflows for `enrich`,
-`score`, `tailor`, or `cover` with the worker count from the saved pipeline
-controls. The same toolbar also exposes `continue pending prep`, which queues
-eligible active pending preparation work without resetting failures. Both bulk
-actions run only preparation substages (`enrich`, `score`, `tailor`, or
-`cover`) and do not auto-run `apply`. Viewing the Jobs page also picks up
-eligible visible pending preparation substages by starting the job-scoped
-pipeline at that substage. This pickup is paced and eligibility-gated, so a
-page of pending rows does not start skip-only worker runs for jobs that are not
-ready for the requested substage. A retry from a job detail drawer resumes
-the remaining preparation pipeline for that job (`enrich` -> `score` ->
-`tailor` -> `cover`, starting at the retried stage); application submission
-remains a separate explicit action. Cover remains retryable preparation work,
-but a pending or failed cover stage does not keep a job with a tailored resume
-out of Apply review. Applied opens the jobs with an actual applied outcome
-(`applied_at` present or apply status `applied`), not a synthetic pipeline
-state.
-
-## Auto-Apply
-
-Auto-apply launches local browser workers and can submit applications. Start
-with dry runs and narrow targets:
-
-```bash
-uv --project workers/automation run jobhunter apply --dry-run --limit 1
-uv --project workers/automation run jobhunter apply --url https://example.com/job/123 --dry-run
-```
-
-Run apply for prepared jobs:
-
-```bash
-uv --project workers/automation run jobhunter apply --limit 5
-uv --project workers/automation run jobhunter apply --workers 3 --min-score 8
-```
-
-Utility modes:
-
-```bash
-uv --project workers/automation run jobhunter apply --gen --url https://example.com/job/123
-uv --project workers/automation run jobhunter apply --mark-applied https://example.com/job/123
-uv --project workers/automation run jobhunter apply --mark-failed https://example.com/job/123 --fail-reason "manual review"
-uv --project workers/automation run jobhunter apply --reset-failed
-```
-
-Auto-apply requires a prepared profile, generated materials, Chrome/Chromium,
-Node.js, and Claude Code CLI. Jobs can start from a direct application URL
-when enrichment finds one, or from the original posting URL when the local
-agent needs to click through to the employer form. The default model is
-`default`, which lets Claude Code use its configured local model; pass
-`--model <name>` only when you want to override that local default.
-
-For LinkedIn postings, enrichment can use a dedicated authenticated Chrome
-profile to retry first-pass misses and capture the external company apply URL.
-The resolver only clicks far enough to capture the outbound target; it does not
-fill forms or submit applications.
-
-The local API and web app also record apply-review decisions and application
-outcomes. The web `/apply-review` queue shows active apply-stage jobs with
-materials readiness, latest apply-run context, blockers, review decisions, and
-pending outcome suggestions. Job details include a local outcome timeline and
-manual outcome form. `approve_submit` is an approval fact only; it does not
-start browser submission by itself, and the web UI only offers submit approval
-after a completed dry run. Manual outcomes can include local notes in SQLite,
-but event payloads contain only safe identifiers, outcome kinds, and
-presence flags.
-
-Gmail outcome feedback is a separate read-only scan from the verification-code
-MCP server. `POST /v1/outcomes/gmail/scan` asks the worker to search bounded
-post-application windows for known application anchors only, using the
-candidate recipient email plus employer, ATS, title/company, and application
-URL/domain hints. JobHunter reads and stores a full Gmail body only after the
-metadata is confidently linked to one known application. Linked evidence stays
-in local SQLite with body text and a body hash; API responses, event payloads,
-logs, and broad projections expose only safe evidence/suggestion identifiers,
-kinds, confidence values, and link signals.
-
-Applications that send verification codes by email use JobHunter's first-party,
-read-only Gmail connector. Put a Google OAuth Desktop client file at
-`~/.jobhunter/gmail/oauth-client.json`, then authenticate once:
-
-```bash
-uv --project workers/automation run jobhunter gmail-auth
-uv --project workers/automation run jobhunter doctor
-```
-
-The connector requests only the `gmail.readonly` OAuth scope and stores the
-token at `~/.jobhunter/gmail/token.json`. `jobhunter doctor` reports `Gmail
-connector auth`. Without authenticated Gmail,
-auto-apply stops with `RESULT:LOGIN_ISSUE` when an application requires an
-email verification code. Override long ATS timeouts with
-`JOBHUNTER_APPLY_TIMEOUT_SECONDS=<seconds>` in `~/.jobhunter/.env`.
-
-## Structured Local Actions
-
-The CLI also exposes a JSON-returning action surface used by local UI paths:
-
-```bash
-uv --project workers/automation run jobhunter action score --limit 5 --dry-run
-uv --project workers/automation run jobhunter action apply --url https://example.com/job/123 --dry-run
-uv --project workers/automation run jobhunter action profile_import --pdf ~/resume.pdf --dry-run
-```
-
-These actions record start and finish events where possible and return
-structured success or failure data.
-
-## Local UI
-
-Start the full local development stack:
-
-```bash
-pnpm dev
-```
-
-That launches the Temporal dev server, local TypeScript API, React/Vite web app,
-and JobHunter automation worker in the foreground. Before each component starts,
-the launcher stops the previous tracked JobHunter process tree for that
-component, so rerunning `pnpm dev` starts from a clean owned stack. Keep the
-terminal open and use Ctrl-C to stop the stack. The launcher defaults to
-`~/.jobhunter`,
-`127.0.0.1:8766` for the API, and `127.0.0.1:5173` for the web app. Inspect the
-stack from another terminal with:
-
-```bash
-pnpm dev:status
-pnpm dev:logs worker
-```
-
-`pnpm dev:status` reports process liveness for the local fleet and includes
-the API health classification for the worker heartbeat, so a live worker process
-whose heartbeat has gone stale is shown as `stale` instead of only `up`.
-
-For a detached background stack, use the explicit daemon mode:
-
-```bash
-pnpm dev:start
-pnpm dev:stop
-```
-
-`pnpm dev:start` prints the observed local bindings after launch. Use that
-output as the browser URL, especially when Vite moves the web app to a higher
-port because `5173` is already occupied.
-
-The API health endpoint reports the API app/database identity and the latest
-JobHunter automation worker heartbeat. The web topbar alerts when the worker is
-missing or stale, and pipeline stage buttons stay disabled until the worker is
-heartbeating against the same local database.
-
-Temporal workflow history is persisted under `.dev/temporal/temporal.db` by
-default so local debugging can survive launcher restarts. Override
-`JOBHUNTER_TEMPORAL_DB` when a separate Temporal dev store is needed.
-
-For troubleshooting, run individual components in separate terminals:
-
-```bash
-temporal server start-dev --db-filename .dev/temporal/temporal.db
-pnpm api:dev
-pnpm web:dev
-uv --project workers/automation run jobhunter worker
-```
-
-The Vite dev server proxies `/v1/*` to the local API by default. Set
-`VITE_JOBHUNTER_API_BASE_URL` when the API runs on a different local origin.
-
-The Jobs tab can filter by stage, state, and fit-score range. Its source column
-shows the posting owner and the discovery source separately when available, so
-broad-board results can be distinguished from canonical employer or ATS sources.
-Its compensation column shows the best available persisted range, whether it
-comes from posted salary text or reported company-role market data, plus
-statistical confidence, source/sample support, and warnings. The expanded job
-drawer keeps posted salary and reported market evidence separate with source
-trail, collapsed selected evidence rows, source links when available, and
-confidence factors. Compensation
-display is warning-only: it does not change fit score, sorting, filtering, apply
-readiness, Apply Review handoff, or apply mutation behavior.
-Apply Review renders current HTML/CSS resume artifacts as a live Plate editor.
-Human edits are saved as separate resume-review drafts, JobHunter line comments
-can be replied to in place, and approval controls stay blocked until a saved
-draft validates and renders into replacement resume artifacts. The previously
-accepted materials remain available until that replacement render succeeds.
-The Profile page renders the baseline resume through the same Plate HTML/CSS
-editor surface, backed by `GET /v1/profile/preview.html`, so the profile
-baseline matches the generated-materials layout without the old PDF iframe or
-Profile-specific LaTeX render path.
-Product data grids, including Jobs, Discovery sources, Runs, Artifacts, and
-Debug activity, expose resizable column handles in the headers so long local
-data can be inspected without changing code or global density settings.
-
-The Jobs tab separates posting lifecycle state from manual suppression. Closed
-jobs are postings the system verified as unavailable, expired, removed, or
-location-incompatible; they move to the Closed tab instead of staying in the
-active dashboard or worker queues. Deleting a job moves it to the Deleted tab; a
-later discovery run can resurface that job if the posting is found again. Hiding
-a job moves it to the Hidden tab and keeps it hidden across future discovery
-runs until you select it there and use **unhide selected**. Deleted and hidden
-rows can also be permanently deleted from the local database; discovery can add
-the same posting again later because that action clears the delete/hide
-tombstones instead of creating a new suppression record.
-
-The Pipelines tab exposes the product-stage starts for `discover` and `apply`.
-Discover owns preparation and Apply owns browser automation; lower-level
-`enrich`, `score`, `tailor`, and `cover` remain CLI/API maintenance and
-diagnostic surfaces rather than product tabs. The Jobs page can still start
-eligible internal stages for visible pending per-job work through the
-job-scoped API, and failed rows remain recoverable through retry. Each product
-tab keeps persisted local config and only shows
-controls that the selected stage actually consumes. Running a tab submits that
-stage through the local API. The panel reports when the request is waiting on
-the local worker, whether the start was queued, completed, dry-run, or failed,
-and the returned run/action id when one is
-available. Queued or running Discover and Apply workflows expose stop controls
-from the Pipelines and Workflow Runs views, and active per-job apply runs can be
-stopped from Apply review when a latest apply run is attached to the job.
-Jobs whose first-time tailoring is skipped by the default low-fit gate can still
-be tailored explicitly from the job detail tailor stage. The job detail panel
-also has a "generate materials" control that runs the canonical material stages
-(tailor → cover) for a single job on demand; it confirms before dispatching,
-shows a queued/in-flight state, and never discards the last accepted materials —
-the prior accepted artifact is superseded only after a replacement is approved, so
-a failed regeneration stays as inspectable audit history. Re-tailor controls are
-reserved for jobs that already have tailored artifacts and need current-policy
-regeneration.
-The job detail drawer surfaces the tailored resume artifact, and Apply review
-uses a Plate-backed HTML/CSS resume editor for line-level review. The editor is
-fed from the generated resume HTML used to create the final PDF, keeps an "open
-final file" link for the approved artifact, and renders JobHunter-authored
-comments directly beside resume lines instead of a separate side-by-side audit
-pane. Existing legacy LaTeX resume PDFs can be moved onto the same HTML/CSS
-source with `uv --project workers/automation run jobhunter migrate-resume-html`
-(`--dry-run`, `--force`, `--job-url`, and `--limit` are available for scoped
-migration or refresh).
-The employer-analysis panel shows the reasoned "ideal candidate"
-analysis — requirements classified must-have vs nice-to-have with a priority
-weight, and reasoned keywords each tied to a quoted job-description evidence span,
-plus the ensemble audit trail and a degraded-ensemble indicator. When the latest
-score has requirement-level evidence, each requirement shows the candidate fit,
-score contribution, and tailoring action that explain the fit score. Older scores
-that predate requirement-fit reports show an explicit "not assessed" state with a
-re-score action instead of inferring matches from broad score-signal text. The
-per-bullet provenance list shows, for each generated bullet, the original-profile-bullet →
-tailored-bullet diff and the evidence × requirement × transform × control ×
-rationale that produced it. The tailoring rationale also includes keyword
-coverage counts for actionable high-signal terms derived from the material audit
-and job scoring keywords, the voice-pass status (whether the de-buzzword pass ran,
-was accepted, and why), evidence support, quality gates, review outcome,
-warning-repair status,
-annotated source-vs-tailored resume changes, high-fit persona prompt/response
-audit, and model summary. Persona warnings include an expandable audit trail for
-the stored LLM request and structured response behind that judgment. Missing audit
-data is rendered explicitly: a job with no analysis shows a "not recorded" state,
-empty requirement/keyword/evidence sets show "none recorded", and the keyword
-section marks when a resume keyword match audit was not recorded, instead
-of treating target terms as missing from the resume.
-rationale does not expose raw generator prompts, raw profile payloads, or raw job
-text; annotated changes and persona prompts are bounded excerpts explaining what
-was reframed, what was asked, how the reviewer responded, and why the score was
-assigned.
-Longer-running progress appears in the dashboard pipeline and
-apply-runs cards, while the Debug tab owns the paginated Recent activity table
-for event-level inspection. Non-apply stages emit pipeline lifecycle events;
-Discover also emits source-step events and scheduled discovery-run events for
-JobSpy, Workday, and Smart Extract so a stuck or low-quality source is visible
-before the request finishes. Long JobSpy crawls also persist source-level
-progress, including completed search combinations, current query/location, new
-rows, duplicates, filtered rows, errors, and raw observed rows. Stopping a
-running Discover workflow marks the matching source run terminal so the
-dashboard does not keep reporting an old crawl as active. The dashboard
-source-health card summarizes the
-local source-quality projection used to budget and demote future crawls. The
-Discovery page owns the local source registry, source locator candidates,
-observed-source preview, quarantined leads, and manual-capture queue. Its source
-registry tab renders sources as a filterable, sortable table with company,
-source id, source type, state, priority, recommendation, activity, run health,
-and quality-metric columns. Located parseable sources are automatically approved
-into the active source registry; manual review is reserved for blocked,
-ambiguous, or unparseable sources. JobSpy broad-board results can also learn
-durable sources: when a result exposes a direct owner URL, JobHunter records the
-board provenance, links the job to the canonical posting URL, and promotes
-runnable ATS sources into the registry; unknown owner URLs and ATS URLs that
-still need adapter configuration stay in review. These controls can add an
-experimental source, preview recently observed leads for a source, enable or
-quarantine a source, approve or reject quarantined leads, record source
-feedback, review low-score role-match suggestions, approve or decline exact
-title-exclusion rules for future discovery, open a blocked lead in the local
-browser, and import a user-provided URL, current-page URL, pasted text, saved
-HTML, or email content as manual-capture provenance. Manual capture stores
-local provenance metadata and content hashes, not raw captured posting text in
-domain events. The `limit` control is honored by the Discover and Apply tabs; a
-bounded Discover run stops
-remaining sources once the cap is reached. Tabs default to dry-run mode so apply
-automation does not submit applications unless you explicitly clear dry run.
-
-## Inspecting Progress
-
-Show pipeline counts:
-
-```bash
-uv --project workers/automation run jobhunter status
-```
-
-Inspect recent apply runs:
-
-```bash
-uv --project workers/automation run jobhunter runs
-uv --project workers/automation run jobhunter runs --failed-only
-uv --project workers/automation run jobhunter runs --run-id <prefix>
-```
-
-The normalized stage states are stored in `job_stage_states`, and events are
-stored in `job_events`. Prefer the local UI/API and CLI over direct SQLite
-edits.
+- `codex_home/`: isolated Codex SDK home when apply/review agents need it.
+
+Never commit profiles, API keys, generated resumes, cover letters, PDFs, browser
+profiles, logs, SQLite databases, screenshots containing real data, or local
+worker state. See [docs/user/data-and-safety.md](docs/user/data-and-safety.md)
+and [SECURITY.md](SECURITY.md).
+
+## Normal Flow
+
+1. Create or import a candidate profile.
+2. Configure target roles, locations, work models, and application preferences.
+3. Run Discover from the UI or CLI.
+4. Review jobs, scores, blockers, compensation evidence, and audit history.
+5. Generate or inspect materials for promising jobs.
+6. Use Apply Review to edit/approve the resume and review comments.
+7. Run apply dry-runs before approving any real browser submission.
+8. Track progress in Dashboard, Jobs, Runs, Artifacts, Apply Review, and Debug.
+
+See [docs/user/normal-flows.md](docs/user/normal-flows.md) for commands and
+expected state transitions.
 
 ## Configuration
 
-JobHunter uses local user configuration plus package-shipped registries:
+Configuration comes from three places:
 
-- `~/.jobhunter/jobhunter.db`: candidate profile source of truth, application
-  defaults, discovery settings, resume baseline, tailoring controls, rendering
-  settings, jobs, events, and projections.
-- `~/.jobhunter/.env`: provider keys and runtime environment.
-- `workers/automation/src/jobhunter/config/employers.yaml`: packaged employer registry.
-- `workers/automation/src/jobhunter/config/sites.yaml`: packaged site and ATS
-  behavior settings.
+- the local SQLite profile/settings database;
+- environment variables in `~/.jobhunter/.env`, repo `.env`, or an explicit
+  shell environment;
+- package-shipped source registries under `workers/automation/src/jobhunter/config/`.
 
-Create or update the Candidate Profile through the local Profile page or the
-resume-import flow so profile data, rendering settings, and template text are
-stored in SQLite.
+Start with [.env.example](.env.example), then read the full reference in
+[docs/user/configuration.md](docs/user/configuration.md).
 
-Profile, Preferences, Discovery target search, Discovery automation settings,
-and Settings forms autosave five seconds after the last edit through the same
-local API mutations as the Save buttons. Checkbox, select, and other non-text
-setting controls keep an in-session undo history for Ctrl+Z / Cmd+Z.
-
-Preferences includes resume tailoring controls for claim mode, auto-approvable
-claim modes, adjacent achievement drafts, writing style, and custom tailoring
-instructions. Profile experience entries include achievement evidence fields
-for source text, scope, action, tools, metrics, outcome, seniority signal,
-evidence strength, claim confidence, and user confirmation. Only verified facts
-and evidence reframing can be auto-approved; adjacent translations and draft
-claims remain review material.
-
-Discovery runtime settings are edited on the Discovery page and stored in the
-SQLite `discovery_settings` table. JobSpy board selection uses the `boards`
-field in that row, and target roles/locations from the Discovery target-search
-form are overlaid by the worker before any source persists jobs. The Discovery
-page also owns the automation settings for minimum fit score and auto apply;
-the Settings page keeps execution controls such as apply concurrency.
-
-The legacy `sites` key is still accepted for the compatibility window and logs
-a warning instead of failing. When both keys are present, `boards` wins. The
-worker also builds a local source registry contract from packaged
-`sites.yaml`, `employers.yaml`, and the selected JobSpy boards; migrated
-Smart Extract entries start as `experimental` with the
-`smart_extract_experimental` policy so existing arbitrary-site discovery keeps
-working while sources are promoted or rejected.
-
-The Discovery page's Target search settings are discovery inputs. Target roles
-stay as explicit guidance and replace the active discovery query list with exact
-role queries. Target tracks are normalized to IC, management, and executive;
-seniority floors use the engineering ladder choices shown in Discovery
-settings. Target tracks, seniority floors, role areas, and specializations add
-structured intent; resume import can suggest these fields conservatively but
-does not overwrite existing user choices. The worker expands that intent into
-deterministic recall queries. Recall queries keep the same search tier as exact
-queries because relevance is determined after discovery by scoring, not by
-query generation.
-Recall title matching enforces candidate seniority and track: IC targets stay
-IC, management targets stay management, executive targets stay executive, and
-mixed profiles can opt into multiple tracks explicitly. Broad-board providers
-such as JobSpy use exact and recall queries as retrieval probes. Direct ATS,
-Workday, and source-first Smart Extract sources enumerate their known
-board/source and apply the same
-exact-plus-recall title intent internally, avoiding repeated board fetches for
-each role variant. Smart Extract search-only sources still fan out by query when
-the source has no useful browse/all-jobs page. Canonical ATS rows must include a
-usable description before insertion; Greenhouse reads the public board content
-payload instead of creating blank-description rows. Each discovery run also
-checks discovered postings for staleness: verified unavailable, expired,
-removed, or location-incompatible postings move to Closed, while active jobs
-that no longer satisfy the current title, location, or description contract are
-soft-deleted instead of remaining visible. Target locations replace the active
-location list, and if target locations are blank
-the worker falls back to the profile city/country. Target locations are
-validated as real places before they can be saved. Hybrid and on-site target
-work models search and filter only the target location. Remote target work
-models search and filter the target country, and European countries also add an
-Europe-remote search and accept pattern. Profile-driven discovery searches at
-least the last 30 days unless local config sets a larger window. A Spain or
-Europe target sets JobSpy's Indeed country to Spain, rejects America-only
-non-remote locations, and hides packaged America-only source rows from discovery
-controls. Discovery `limit` is a new-job budget: already-seen jobs record
-observations but do not consume the cap.
-Title matching uses deterministic exact/alias checks first. When a posting only
-matches a target role loosely and an LLM provider is configured, discovery asks
-the LLM to adjudicate the role family, primary function, seniority, and track
-before keeping the row. This prevents broad-board keyword overlap such as
-finance, vendor, construction, project, product, or sales manager titles from
-entering engineering, platform, security, IT, or technology leadership queues
-just because they contain one target keyword.
-
-Common environment variables:
+Common variables:
 
 - `JOBHUNTER_DIR`: override the local app directory.
 - `GEMINI_API_KEY`, `OPENAI_API_KEY`, or `LLM_URL`: configure LLM access.
-- `LLM_MODEL`: choose the model for the configured provider. Gemini defaults to
-  `gemini-3.5-flash`.
-- Pipeline scoring, resume tailoring, and cover-letter generation default to
-  the explicit model spec `gemini:gemini-3.5-flash`; stage-specific tailoring
-  model variables below override that pipeline default.
-- `JOBHUNTER_DISCOVERY_LLM_ROLE_FILTER`: controls LLM adjudication for loose
-  discovery title matches. Defaults to `auto`, which enables the check when an
-  LLM provider is configured. Set `0` to force deterministic title matching.
-- `JOBHUNTER_DISCOVERY_ROLE_FILTER_MODEL`: optional model spec for discovery
-  role adjudication; defaults to the configured LLM model.
-- `TAILORING_GENERATOR_MODELS`: optional comma-separated generator model specs
-  for resume tailoring.
-- `TAILORING_JUDGE_MODEL`: optional separate judge model spec for resume
-  tailoring.
-- `TAILORING_JUDGE_MIN_SCORE`: optional quality threshold for judge approval.
+- `LLM_MODEL`: choose the default model for the configured provider.
+- `VITE_GOOGLE_MAPS_API_KEY`: optional address search in the Profile form.
 - `CHROME_PATH`: override Chrome/Chromium detection.
-- `JOBHUNTER_LINKEDIN_APPLY_RESOLVER`: set to `0` to disable authenticated
-  LinkedIn apply URL resolution during enrichment.
-- `JOBHUNTER_LINKEDIN_APPLY_PROFILE_DIR`: Chrome profile directory used for
-  LinkedIn apply URL resolution. Defaults to
-  `~/.jobhunter/chrome-workers/linkedin-apply-url-resolver`.
-- `JOBHUNTER_LINKEDIN_APPLY_SOURCE_PROFILE_DIR`: optional Chrome profile to
-  copy into the dedicated LinkedIn resolver profile the first time it is
-  created. Defaults to the platform Chrome user-data directory.
-- `JOBHUNTER_LINKEDIN_APPLY_CHROME_PROFILE`: Chrome profile name inside the
-  resolver user-data directory, for example `Default` or `Profile 2`.
-- `JOBHUNTER_LINKEDIN_APPLY_HEADLESS`: set to `1` to run the LinkedIn resolver
-  profile headless. The default is visible Chrome so a throwaway LinkedIn
-  account can be logged in and kept fresh.
-- `JOBHUNTER_RESUME_RENDERER`: set to `latex_pdf` to use the legacy LaTeX
-  resume renderer for generated resume materials; defaults to `html_pdf`.
-- `PDFLATEX_PATH`: override LaTeX detection when the legacy renderer is enabled.
-- `CAPSOLVER_API_KEY`: enable CAPTCHA solving support.
-- `JOBHUNTER_APPLY_TIMEOUT_SECONDS`: per-job auto-apply agent timeout
-  (`900` seconds by default).
-- `JOBHUNTER_GMAIL_DIR`, `JOBHUNTER_GMAIL_OAUTH_CLIENT_PATH`,
-  `JOBHUNTER_GMAIL_TOKEN_PATH`: override the first-party Gmail connector auth
-  directory, OAuth client file, or token file.
-- `JOBHUNTER_API_HOST`, `JOBHUNTER_API_PORT`: local TypeScript API bind
-  settings.
-- `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`:
-  enable OpenTelemetry export of LLM, workflow, and JSON-RPC spans to a
-  Langfuse instance. When any of these is unset the worker runs normally
-  without exporting. Set `LANGFUSE_DISABLE=1` to opt out even when
-  credentials are present. Enabling this exports every LLM prompt and
-  completion to the configured Langfuse instance.
-- `LANGFUSE_OTEL_TIMEOUT_SECONDS`: optional OTLP/HTTP export timeout for
-  Langfuse; defaults to `5.0`.
+- `JOBHUNTER_RESUME_RENDERER=latex_pdf`: opt into the legacy LaTeX resume
+  renderer. The default is HTML/CSS printed by Playwright.
+- `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL`: optional
+  OpenTelemetry/Langfuse export. Set `LANGFUSE_DISABLE=1` to opt out.
 
 ## Development
 
-Install dependencies:
-
 ```bash
 pnpm dev:setup
-```
-
-Run the standard checks:
-
-```bash
 pnpm check
 pnpm test
 uv --project workers/automation run --extra dev python -m build workers/automation
 git diff --check
 ```
 
-Useful focused checks:
+Useful focused commands:
 
 ```bash
 pnpm api:check
 pnpm api:test
-pnpm qa:test
 pnpm web:check
 pnpm web:build
-uv --project workers/automation run --extra dev pytest workers/automation/tests/test_state_dashboard.py -q
+pnpm web:test
+pnpm web:e2e
+uv --project workers/automation run --extra dev pytest -q
 ```
 
-Seed a disposable local QA workspace when you need to exercise destructive UI
-flows without touching `~/.jobhunter`:
+For contributor workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-```bash
-pnpm qa:seed -- /tmp/jobhunter-qa
-JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
-```
+## Documentation
 
-Build the Python package:
-
-```bash
-uv --project workers/automation run --extra dev python -m build workers/automation
-```
-
-## Project Status
-
-The near-term priority is local reliability:
-
-- make per-stage state canonical;
-- keep retries targeted and observable;
-- keep generated artifacts registered before the UI opens them;
-- keep dry-run apply behavior safe;
-- keep product-facing behavior in the TypeScript API and current React/Vite
-  shell while steering frontend architecture toward TanStack Router and
-  TanStack Query.
-
-Hosted accounts, billing, object storage, Postgres migration, hosted workers,
-and SaaS deployment are intentionally deferred until the local workflow is
-reliable.
-
-## Documentation Map
-
-- `docs/INDEX.md`: documentation index.
-- `docs/architecture.md`: current architecture and runtime boundaries.
-- `docs/job-pipeline-architecture.md`: detailed phase-by-phase job pipeline
-  execution diagrams and call paths.
-- `docs/ddd-target.md`: canonical DDD target, domain language, and ownership rules.
-- `docs/local-development.md`: setup, run, build, test, and lint commands.
-- `docs/local-ts-api.md`: local API and web development notes.
-- `docs/local-reliability-qa.md`: local QA checklist and regression matrix.
-- `docs/decisions.md`: accepted architecture decisions.
-- `docs/delivered.md`: delivery history by PR.
-- `docs/backlog.md`: deferred local and hosted work.
-- `docs/plans/`: proposed and implemented feature plans.
+- [docs/user/](docs/user/): end-user setup, configuration, normal flows, and
+  safety.
+- [docs/developer/](docs/developer/): contributor onboarding and architecture
+  reading path.
+- [docs/architecture.md](docs/architecture.md): current runtime architecture.
+- [docs/job-pipeline-architecture.md](docs/job-pipeline-architecture.md):
+  phase-by-phase pipeline sequence and class diagrams.
+- [docs/local-reliability-qa.md](docs/local-reliability-qa.md): regression
+  matrix and QA gates.
+- [docs/decisions.md](docs/decisions.md): accepted architecture decisions.
+- [docs/delivered.md](docs/delivered.md): delivery history.
+- [docs/backlog.md](docs/backlog.md): detailed engineering backlog.
+- [docs/plans/](docs/plans/): historical proposal and implementation records.
 
 ## License
 
-JobHunter is licensed under AGPL-3.0-only.
+JobHunter is licensed under AGPL-3.0-only. See [LICENSE](LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,43 @@
+# Roadmap
+
+This roadmap is the public, contributor-facing view. The detailed engineering
+backlog lives in [docs/backlog.md](docs/backlog.md), and delivered work is
+archived in [docs/delivered.md](docs/delivered.md).
+
+## Now
+
+- Tighten public documentation for local-first setup, configuration, normal
+  flows, safety boundaries, and architecture onboarding.
+- Keep the local stack reliable: Temporal dev server, TypeScript API, Vite web
+  app, Python worker, SSE updates, and projection-backed read models.
+- Continue hardening high-risk workflows: discovery preparation, resume
+  tailoring evidence, Apply Review draft promotion, dry-run apply, retries,
+  cancellation, and generated artifact inspection.
+- Keep screenshot and QA fixtures synthetic so public docs can be refreshed
+  without exposing real job-search data.
+
+## Next
+
+- Improve workflow-run parity for non-apply pipeline stages so Discover,
+  preparation, and Apply have one consistent run history and cancellation model.
+- Reduce broad SSE invalidation with targeted cache patches for jobs, artifacts,
+  and dashboard projections.
+- Finish data-model cleanup around URL-shaped job identifiers, legacy projection
+  fallbacks, source/employer persistence, and searchable scoring keywords.
+- Strengthen frontend tooling: linting, dependency-boundary checks, type-level
+  tests, Playwright e2e in CI, and visual regression from Storybook or the docs
+  screenshot flow.
+- Add saved table views and column-visibility preferences for high-density job
+  and source-review workflows.
+
+## Later
+
+- Package the local app for easier desktop installation and updates.
+- Add export/import flows for local workspaces and generated artifacts.
+- Design hosted deployment only after the local product loop is reliable:
+  authentication, tenant isolation, Postgres, object storage, managed workflow
+  services, secret vaulting, hosted browser isolation, audit logs, retention, and
+  billing.
+- Revisit cloud frontend adapters such as TanStack Start, authenticated sessions,
+  hosted event streams, and CDN-cached projection reads when public deployment
+  becomes a concrete goal.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+JobHunter is local-first, but the local data is sensitive: resumes, profile
+facts, generated materials, job decisions, logs, browser profiles, credentials,
+and local SQLite databases can all reveal private career activity.
+
+## Reporting Vulnerabilities
+
+Do not include vulnerability details in a public issue. Prefer GitHub private
+vulnerability reporting if it is enabled for this repository. If private
+reporting is not available, open a minimal public issue asking for a private
+contact path and omit exploit details, secrets, logs, profile data, generated
+materials, and local paths.
+
+## Sensitive Data
+
+Never attach or commit:
+
+- `.env` files or API keys
+- `~/.jobhunter/jobhunter.db` or any copied SQLite database
+- resumes, cover letters, PDFs, screenshots with real profile data, or generated
+  application materials
+- browser profiles, session state, Gmail OAuth tokens, or apply-worker state
+- raw logs or traces containing prompts, completions, job text, or local paths
+
+Use synthetic fixtures or `pnpm qa:seed` for reproduction cases.
+
+## Supported Security Posture
+
+The current supported mode is local-only. The TypeScript API binds to loopback by
+default and refuses non-loopback hosts unless explicitly configured. Hosted auth,
+tenant isolation, billing, managed browsers, and production secret vaulting are
+roadmap items rather than current guarantees.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,22 +1,52 @@
 # Documentation Index
 
-- `architecture.md`: runtime boundaries and repository ownership.
-- `job-pipeline-architecture.md`: phase-by-phase pipeline execution, sequence
-  diagrams, component diagrams, call paths, persistence, events, and failure
-  behavior.
-- `ddd-target.md`: canonical DDD + hexagonal target architecture, domain
-  language, and ownership rules (backend).
-- `frontend-target.md`: canonical frontend architecture — three-layer state,
-  eight bounded contexts mirrored from the backend, hexagonal frontend ports,
-  SSE realtime + invalidation router, testing pyramid.
-- `local-development.md`: setup, run, build, test, and lint commands.
-- `local-ts-api.md`: local TypeScript API, web app development notes, and the
-  `GET /v1/events/stream` SSE contract.
-- `local-reliability-qa.md`: local QA checklist, regression matrix, and the
-  frontend test pyramid + a11y bar.
-- `requirements.md`: product requirements that must stay true as
-  implementation changes.
-- `decisions.md`: accepted architecture decisions.
-- `delivered.md`: delivery history by PR.
-- `backlog.md`: deferred local and hosted work.
-- `plans/`: proposal and implementation history.
+## Public Project Docs
+
+- [`../README.md`](../README.md): product overview, quick start, safety notes,
+  command summary, and top-level documentation map.
+- [`../ROADMAP.md`](../ROADMAP.md): public roadmap and open-source readiness
+  direction.
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md): contributor workflow, validation,
+  documentation expectations, and PR standards.
+- [`../SECURITY.md`](../SECURITY.md): supported security contact path and
+  sensitive-data handling rules.
+- [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md): community standards.
+
+## End-User Guides
+
+- [`user/getting-started.md`](user/getting-started.md): install, configure, run,
+  and seed a disposable workspace.
+- [`user/configuration.md`](user/configuration.md): runtime variables,
+  provider keys, local data paths, telemetry, browser automation, Gmail, and
+  screenshot/test workspaces.
+- [`user/normal-flows.md`](user/normal-flows.md): expected product flows from
+  setup through review and apply.
+- [`user/data-and-safety.md`](user/data-and-safety.md): local data boundaries,
+  generated artifacts, automation consent, and open-source sharing guidance.
+
+## Developer Docs
+
+- [`developer/README.md`](developer/README.md): contributor entry point and
+  architecture/QA reading path.
+- [`architecture.md`](architecture.md): runtime boundaries and repository
+  ownership.
+- [`job-pipeline-architecture.md`](job-pipeline-architecture.md): phase-by-phase
+  pipeline execution, sequence diagrams, component diagrams, call paths,
+  persistence, events, and failure behavior.
+- [`ddd-target.md`](ddd-target.md): canonical DDD + hexagonal architecture,
+  domain language, and backend ownership rules.
+- [`frontend-target.md`](frontend-target.md): canonical frontend architecture,
+  state layers, bounded contexts, ports, SSE realtime, invalidation, and test
+  pyramid.
+- [`local-development.md`](local-development.md): setup, run, build, test, and
+  lint commands.
+- [`local-ts-api.md`](local-ts-api.md): local TypeScript API, web app
+  development notes, and the `GET /v1/events/stream` SSE contract.
+- [`local-reliability-qa.md`](local-reliability-qa.md): local QA checklist,
+  regression matrix, frontend test pyramid, and a11y bar.
+- [`requirements.md`](requirements.md): product and technical requirements that
+  must stay true as implementation changes.
+- [`decisions.md`](decisions.md): accepted architecture decision records.
+- [`delivered.md`](delivered.md): delivery history by PR.
+- [`backlog.md`](backlog.md): detailed engineering backlog and deferred work.
+- [`plans/`](plans/): proposal and implementation history.

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,95 @@
+# Developer Guide
+
+This guide points contributors through the current architecture and QA surfaces.
+The top-level [README.md](../../README.md) is the public product overview; this
+directory is for contributors who need to change behavior safely.
+
+## Start Here
+
+1. [Getting started](../user/getting-started.md) for the local stack.
+2. [Configuration](../user/configuration.md) for runtime variables and local
+   data boundaries.
+3. [Architecture](../architecture.md) for the current runtime shape.
+4. [Job pipeline architecture](../job-pipeline-architecture.md) for phase-by-
+   phase sequence and class diagrams.
+5. [Local reliability QA](../local-reliability-qa.md) for regression ownership.
+
+## Current Runtime Shape
+
+```mermaid
+flowchart LR
+  Web["React/Vite web app"] --> Api["TypeScript Fastify API"]
+  Api --> Db["SQLite read/write model"]
+  Api --> Rpc["JSON-RPC subprocess"]
+  Rpc --> Worker["Python automation worker"]
+  Worker --> Db
+  Worker --> Files["Local artifacts"]
+  Worker --> Temporal["Temporal dev server"]
+  Worker --> Providers["LLMs / job sources / browser automation"]
+  Db --> Sse["SSE event stream"]
+  Sse --> Web
+```
+
+The domain is organized around eight bounded contexts:
+
+- Discovery
+- Enrichment
+- Profile
+- Scoring
+- Materials
+- Apply
+- Pipeline
+- Operations / Read-Side
+
+The React app mirrors those contexts under `apps/web/src/contexts/`. Views under
+`apps/web/src/views/` compose context-owned hooks and components.
+
+## Current Vs Historical Docs
+
+- `docs/architecture.md` and `docs/job-pipeline-architecture.md` describe the
+  implemented local architecture.
+- `docs/ddd-target.md` and `docs/frontend-target.md` are canonical architecture
+  references that now describe the landed target shape plus hosted-future seams.
+- `docs/plans/implemented/` contains historical plans and QA notes. Do not treat
+  old plan text as current product behavior without checking the canonical docs
+  and live code.
+- `openspec/` contains current and archived OpenSpec-style requirements. When a
+  feature ships, sync public docs and `docs/delivered.md` so the archive is not
+  the only discoverable source.
+
+## Validation
+
+Use focused checks while editing:
+
+```bash
+pnpm api:check
+pnpm api:test
+pnpm web:check
+pnpm web:test
+uv --project workers/automation run --extra dev pytest -q
+```
+
+Before publishing a broad change:
+
+```bash
+pnpm check
+pnpm test
+uv --project workers/automation run --extra dev python -m build workers/automation
+git diff --check
+```
+
+For UI/product behavior, add a product-path QA step. For screenshot or
+destructive QA, use a disposable seeded workspace.
+
+## Documentation Changes
+
+Update the owning doc when behavior changes:
+
+- public behavior, setup, commands, config, or safety: README and `docs/user/`;
+- API/SSE behavior: `docs/local-ts-api.md`;
+- architecture or runtime ownership: `docs/architecture.md`;
+- frontend architecture: `docs/frontend-target.md`;
+- QA expectations: `docs/local-reliability-qa.md`;
+- roadmap/backlog: `ROADMAP.md` for public direction, `docs/backlog.md` for
+  detailed engineering tasks;
+- shipped feature summaries: `docs/delivered.md`.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -1,0 +1,144 @@
+# Configuration
+
+JobHunter configuration is intentionally local. Some settings are stored in the
+local SQLite database through the web UI; secrets and runtime switches are read
+from environment variables.
+
+## Configuration Sources
+
+| Source | Purpose |
+| --- | --- |
+| `~/.jobhunter/jobhunter.db` | Candidate profile, discovery settings, preferences, tailoring controls, jobs, events, projections, and artifact metadata. |
+| `~/.jobhunter/.env` | Personal provider keys and runtime environment. |
+| repo `.env` | Development-only overrides for the current checkout. |
+| shell environment | One-off overrides for commands and CI. |
+| `workers/automation/src/jobhunter/config/*.yaml` | Packaged employer, source, ATS, and site behavior registries. |
+
+The development launcher loads `~/.jobhunter/.env`, repo `.env`, and the optional
+`JOBHUNTER_USER_ENV_PATH` file before starting local services.
+
+## Core Runtime
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `JOBHUNTER_DIR` | `~/.jobhunter` | Local app directory for database, settings, artifacts, logs, browser worker state, and `.env`. |
+| `JOBHUNTER_DB_PATH` | `$JOBHUNTER_DIR/jobhunter.db` | TypeScript API database path. Use only when API and worker must point at a specific copy. |
+| `JOBHUNTER_DASHBOARD_CONFIG_PATH` | `$JOBHUNTER_DIR/dashboard.json` | Legacy settings-path override still used by local runtime compatibility surfaces. |
+| `JOBHUNTER_API_HOST` | `127.0.0.1` | Local API bind host. Non-loopback hosts require explicit opt-in. |
+| `JOBHUNTER_API_PORT` / `PORT` | `8766` | Local API port. |
+| `JOBHUNTER_API_ALLOW_REMOTE_BIND` | unset | Set to `1`, `true`, or `yes` to allow non-loopback API binding. This can expose private local data. |
+| `JOBHUNTER_WEB_PORT` | `5173` | Requested Vite development port. |
+| `VITE_JOBHUNTER_API_BASE_URL` | proxied `/v1` | Browser API origin when not using the default Vite proxy. |
+| `JOBHUNTER_TEMPORAL_DB` | `.dev/temporal/temporal.db` | Temporal dev-server SQLite history store. |
+
+## LLM Providers
+
+| Variable | What it does |
+| --- | --- |
+| `GEMINI_API_KEY` | Enables Gemini-backed scoring/materials. |
+| `OPENAI_API_KEY` | Enables OpenAI-backed scoring/materials. |
+| `LLM_URL` | Enables a local OpenAI-compatible HTTP endpoint. |
+| `LLM_MODEL` | Overrides the provider default model. |
+
+The pipeline default model spec is currently `gemini:gemini-3.5-flash` unless a
+stage or UI control overrides it.
+
+## Discovery
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `JOBHUNTER_DISCOVERY_LLM_ROLE_FILTER` | `auto` | Uses an LLM to adjudicate loose role-title matches when an LLM provider is configured. Set `0` to force deterministic matching only. |
+| `JOBHUNTER_DISCOVERY_ROLE_FILTER_MODEL` | configured LLM model | Optional model spec for discovery role adjudication. |
+| `PROXY` | unset | Optional scraping proxy in `host:port:user:pass` form. |
+
+Discovery target roles, locations, seniority, work models, source controls, and
+automation preferences are normally edited in the Discovery page and stored in
+SQLite.
+
+## Materials And Resume Rendering
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `TAILORING_GENERATOR_MODELS` | provider default | Comma-separated generator model specs for resume tailoring. |
+| `TAILORING_JUDGE_MODEL` | provider default | Optional separate model spec for the structured tailoring judge. |
+| `TAILORING_JUDGE_MIN_SCORE` | `0.82` | Minimum judge score for auto-approval. |
+| `TAILOR_LLM_MODELS` | alias | Backward-compatible alias for `TAILORING_GENERATOR_MODELS`. |
+| `TAILOR_JUDGE_MODEL` | alias | Backward-compatible alias for `TAILORING_JUDGE_MODEL`. |
+| `TAILOR_JUDGE_MIN_SCORE` | alias | Backward-compatible alias for `TAILORING_JUDGE_MIN_SCORE`. |
+| `JOBHUNTER_RESUME_RENDERER` | `html_pdf` | Set to `latex_pdf` only for the legacy LaTeX resume renderer. |
+| `PDFLATEX_PATH` | auto-detected | Override `pdflatex` location when using the legacy renderer. |
+
+The default resume renderer is HTML/CSS printed through Playwright. Apply Review
+loads the generated HTML source so edits, comments, validation, final PDF
+rendering, and layout boxes stay tied to the same material generation.
+
+## Browser Apply Automation
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `CHROME_PATH` | auto-detected | Chrome/Chromium executable path. |
+| `JOBHUNTER_APPLY_TIMEOUT_SECONDS` | `900` | Per-job autonomous apply timeout. |
+| `CAPSOLVER_API_KEY` | unset | Optional CAPTCHA solving support for explicitly authorized apply runs. |
+| `JOBHUNTER_LINKEDIN_APPLY_RESOLVER` | enabled | Set to `0` to disable authenticated LinkedIn outbound apply URL resolution. |
+| `JOBHUNTER_LINKEDIN_APPLY_PROFILE_DIR` | `~/.jobhunter/chrome-workers/linkedin-apply-url-resolver` | Dedicated Chrome profile for LinkedIn apply URL resolution. |
+| `JOBHUNTER_LINKEDIN_APPLY_SOURCE_PROFILE_DIR` | platform Chrome profile dir | Optional source profile copied into the resolver profile on first use. |
+| `JOBHUNTER_LINKEDIN_APPLY_CHROME_PROFILE` | browser default | Chrome profile name inside the resolver user-data directory. |
+| `JOBHUNTER_LINKEDIN_APPLY_HEADLESS` | visible Chrome | Set to `1` to run the resolver headless. |
+
+Apply automation can submit applications. Use dry runs and narrow targets before
+approving real submission.
+
+## Gmail Connector
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `JOBHUNTER_GMAIL_DIR` | `~/.jobhunter/gmail` | First-party Gmail connector auth directory. |
+| `JOBHUNTER_GMAIL_OAUTH_CLIENT_PATH` | `$JOBHUNTER_GMAIL_DIR/oauth-client.json` | Google OAuth Desktop client file. |
+| `JOBHUNTER_GMAIL_TOKEN_PATH` | `$JOBHUNTER_GMAIL_DIR/token.json` | Token written by `jobhunter gmail-auth`. |
+
+Authenticate with:
+
+```bash
+uv --project workers/automation run jobhunter gmail-auth
+uv --project workers/automation run jobhunter doctor
+```
+
+The connector requests Gmail read-only scope. Raw Gmail bodies stay local and are
+not copied into events, telemetry, broad projections, or logs.
+
+## Compensation Sources
+
+| Variable | What it does |
+| --- | --- |
+| `JOBHUNTER_LEVELS_FYI_ACCESS_MODE` | Enables configured licensed Levels.fyi rows only when the mode permits the source. |
+| `JOBHUNTER_LEVELS_FYI_EUROPE_COVERAGE` | Marks configured Levels.fyi evidence as Europe-capable. |
+| `JOBHUNTER_LEVELS_FYI_OBSERVATIONS_PATH` / `JOBHUNTER_LEVELS_FYI_OBSERVATIONS_URL` | JSON or CSV observations feed. |
+| `JOBHUNTER_GLASSDOOR_ACCESS_MODE` | Enables configured Glassdoor rows only when access is permitted. |
+| `JOBHUNTER_GLASSDOOR_OBSERVATIONS_PATH` / `JOBHUNTER_GLASSDOOR_OBSERVATIONS_URL` | JSON or CSV observations feed. |
+
+Provider payloads and restricted datasets should never be committed.
+
+## Observability
+
+| Variable | What it does |
+| --- | --- |
+| `LANGFUSE_PUBLIC_KEY`, `LANGFUSE_SECRET_KEY`, `LANGFUSE_BASE_URL` | Enable OpenTelemetry export of LLM, workflow, and JSON-RPC spans to Langfuse. |
+| `LANGFUSE_DISABLE=1` | Disable export even when credentials are present. |
+| `LANGFUSE_OTEL_TIMEOUT_SECONDS` | OTLP/HTTP export timeout, default `5.0`. |
+
+When Langfuse export is enabled, LLM prompts and completions are exported to the
+configured Langfuse instance. Do not enable it for private runs unless that is
+intentional.
+
+## Test And Documentation Workspaces
+
+| Variable | What it does |
+| --- | --- |
+| `JOBHUNTER_E2E_APP_DIR` | Disposable app directory used by Playwright e2e. |
+| `JOBHUNTER_E2E_DB_PATH` | E2E database path. |
+| `JOBHUNTER_E2E_SETTINGS_PATH` | E2E settings path. |
+| `JOBHUNTER_E2E_API_PORT` | E2E API port. |
+| `JOBHUNTER_E2E_WEB_PORT` | E2E web port. |
+| `JOBHUNTER_E2E_STUB_DISPATCH` | Routes selected dispatches through deterministic test stubs. |
+
+Use these only for synthetic QA, screenshot generation, and CI.

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -1,0 +1,82 @@
+# Data And Safety
+
+JobHunter is designed for local-first use because job-search data is sensitive.
+This page summarizes what is stored, what can leave the machine, and which
+actions require extra care.
+
+## Local Data
+
+Default local directory:
+
+```text
+~/.jobhunter/
+```
+
+Common files and directories:
+
+| Path | Contents |
+| --- | --- |
+| `jobhunter.db` | SQLite database with profile, jobs, events, projections, settings, artifacts, review drafts, and workflow state. |
+| `.env` | Provider keys and runtime settings. |
+| `tailored_resumes/` | Generated resumes and related HTML/PDF outputs. |
+| `cover_letters/` | Generated cover letters. |
+| `logs/` | Local worker and apply logs. |
+| `chrome-workers/` | Browser profiles and state for local browser tasks. |
+| `apply-workers/` | Apply-run worker state. |
+| `codex_home/` | Isolated SDK state used by local agent integrations when configured. |
+
+Do not commit any of those files or copied variants of them.
+
+## External Services
+
+Depending on configuration, JobHunter can call:
+
+- LLM providers for scoring, employer analysis, tailoring, and cover letters;
+- job boards, ATS APIs, or public posting pages for discovery and enrichment;
+- Gmail read-only APIs for verification-code or outcome feedback flows;
+- Langfuse/OpenTelemetry endpoints for traces when explicitly enabled;
+- CAPTCHA solving services when explicitly configured for apply automation.
+
+Review configuration before running large pipelines.
+
+## Auto-Apply Safety
+
+Apply automation can submit applications. JobHunter separates dry-run review
+from real submission:
+
+- dry-run apply should be used first;
+- submit approval is an explicit action;
+- web approval facts do not submit by themselves;
+- manual outcomes can be recorded without browser automation;
+- failed refreshes or invalid edited drafts must not destroy current accepted
+  materials.
+
+Never run auto-apply against broad targets until you have verified profile data,
+materials, field mapping, account state, and site-specific behavior.
+
+## Scoring Safety
+
+Scores are applicant-side triage aids. They are not employer-side candidate
+screening or hiring decisions. Do not use JobHunter to rank people for hiring
+without separate legal, bias-audit, validation, notice, and human-review
+processes.
+
+## Telemetry
+
+Langfuse export is off unless configured. If enabled, LLM prompts and
+completions are exported to the configured Langfuse instance. Set
+`LANGFUSE_DISABLE=1` to opt out even when credentials are present.
+
+## Public Bug Reports
+
+Use synthetic data. Do not include:
+
+- real resumes or profile fields;
+- real job-search databases;
+- API keys or OAuth tokens;
+- generated PDFs or cover letters;
+- local filesystem paths;
+- raw logs or prompt/completion traces.
+
+`pnpm qa:seed` creates a disposable synthetic workspace that is safe for
+screenshots and bug reproduction.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -1,0 +1,116 @@
+# Getting Started
+
+This guide gets JobHunter running locally with a disposable or personal local
+workspace. JobHunter is local-first: your profile, jobs, artifacts, logs, and
+browser state stay on your machine unless you explicitly configure external
+providers.
+
+## 1. Install Requirements
+
+Install these tools first:
+
+- Python 3.11 or newer
+- Node.js 20.19 or newer
+- pnpm through Corepack
+- uv
+- Temporal CLI with `temporal server start-dev`
+- Chrome or Chromium
+- Playwright Chromium for HTML/CSS PDF rendering
+- Poppler with `pdftoppm` on `PATH` for PDF page previews
+
+Optional:
+
+- TeX / `pdflatex` only when using `JOBHUNTER_RESUME_RENDERER=latex_pdf`
+- Google Maps API key for address autocomplete in Profile
+- Gmail OAuth Desktop client for read-only verification-code and outcome scans
+- CAPTCHA solving key for auto-apply workflows that explicitly opt into it
+
+## 2. Install Dependencies
+
+```bash
+git clone https://github.com/ebarti/JobHunter.git
+cd JobHunter
+pnpm dev:setup
+```
+
+`pnpm dev:setup` installs the Node workspace dependencies and syncs the
+uv-managed Python worker environment.
+
+If Playwright Chromium is missing:
+
+```bash
+uv --project workers/automation run playwright install chromium
+```
+
+## 3. Create Local Configuration
+
+```bash
+uv --project workers/automation run jobhunter init
+uv --project workers/automation run jobhunter doctor
+```
+
+`jobhunter init` creates local configuration under `~/.jobhunter/`.
+`jobhunter doctor` reports which feature tiers are available: local database,
+LLM provider, Temporal, browser automation, Gmail connector, and telemetry.
+
+At minimum, configure one LLM access path:
+
+```bash
+cp .env.example ~/.jobhunter/.env
+```
+
+Then edit `~/.jobhunter/.env` and set one of:
+
+- `GEMINI_API_KEY`
+- `OPENAI_API_KEY`
+- `LLM_URL`
+
+## 4. Start The App
+
+```bash
+pnpm dev
+```
+
+The launcher starts:
+
+- Temporal dev server
+- local TypeScript API
+- React/Vite web app
+- JobHunter Python worker
+
+Keep the terminal open while using the app. The launcher prints the web URL; it
+normally uses `http://127.0.0.1:5173/`, but Vite can move to another port when
+5173 is busy.
+
+Inspect the stack from another terminal:
+
+```bash
+pnpm dev:status
+pnpm dev:logs worker
+```
+
+Stop the foreground stack with Ctrl-C.
+
+## 5. Use A Disposable Workspace For QA
+
+Use this when testing destructive flows, taking screenshots, or sharing bug
+reports:
+
+```bash
+pnpm qa:seed -- /tmp/jobhunter-qa
+JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
+```
+
+The seed uses synthetic profile, job, score, materials, and worker-heartbeat
+data. It must not be mixed with your real `~/.jobhunter` workspace.
+
+## 6. First Useful Checks
+
+```bash
+uv --project workers/automation run jobhunter status
+uv --project workers/automation run jobhunter runs
+curl http://127.0.0.1:8766/v1/health
+```
+
+If the UI shows the worker as missing or stale, check `pnpm dev:status` and the
+worker logs before starting pipeline stages.

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -1,0 +1,134 @@
+# Normal Flows
+
+This page describes the product flow a normal local user follows. Command-line
+paths remain available for maintenance and diagnostics, but the web app is the
+primary operating surface.
+
+```mermaid
+flowchart LR
+  Profile["Create profile"] --> Configure["Configure targets"]
+  Configure --> Discover["Discover jobs"]
+  Discover --> Review["Review jobs and scores"]
+  Review --> Materials["Generate materials"]
+  Materials --> ApplyReview["Edit and approve in Apply Review"]
+  ApplyReview --> DryRun["Run apply dry-run"]
+  DryRun --> Submit["Approve real submission when ready"]
+```
+
+## 1. Build The Candidate Profile
+
+Use the Profile page or resume import flow to create structured profile data.
+The profile includes personal details, work authorization, experience,
+education, skills, target search preferences, writing style, resume rendering
+settings, and tailoring controls.
+
+Profile and settings forms autosave after a short delay. Explicit Save buttons
+use the same API mutation path.
+
+## 2. Configure Discovery
+
+Use the Discovery page to set:
+
+- target roles and role tracks;
+- target locations and work models;
+- source registry controls;
+- minimum fit score and automation preferences;
+- manual capture and quarantined source decisions.
+
+Target locations are validated before they can drive discovery. Discovery uses
+exact and recall role queries, then filters and scores results downstream.
+
+## 3. Run Discover
+
+From the UI, use the Pipelines page and run `Discover`. From the CLI:
+
+```bash
+uv --project workers/automation run jobhunter run discover
+```
+
+Discover owns the preparation path:
+
+- source crawling or ATS/API fetches;
+- detail enrichment;
+- scoring;
+- tailoring eligibility;
+- material generation or suppression for eligible jobs.
+
+Internal stages such as `enrich`, `score`, `tailor`, and `cover` remain visible
+in job detail and diagnostics, but the user-facing preparation stage is
+Discover.
+
+## 4. Review Jobs
+
+The Jobs view supports filters, sorting, pagination, deep links, deleted/hidden
+views, fit-score ranges, stage state, source provenance, compensation evidence,
+and job detail drawers.
+
+Use the job detail drawer to inspect:
+
+- score, confidence, blockers, gaps, and score policy metadata;
+- requirement-fit report when present;
+- audit history;
+- source and enrichment evidence;
+- generated artifacts;
+- apply readiness and blockers.
+
+Failed preparation work can be retried per job or in bulk without automatically
+starting apply automation.
+
+## 5. Generate And Inspect Materials
+
+Eligible jobs receive tailored resumes and cover letters during Discover. You
+can also generate materials for a single job from the job detail drawer.
+
+Generated material records are preserved as audit history. Re-generation does
+not destroy the previously accepted material; replacement artifacts become
+active only after validation and approval.
+
+## 6. Review And Edit The Resume
+
+Apply Review loads the generated HTML/CSS resume into a Plate editor. The editor
+keeps the final PDF link, source pins, risk labels, JobHunter comments, line
+anchors, and draft state together.
+
+Typical review actions:
+
+- edit generated resume text or formatting;
+- reply to JobHunter line comments;
+- save or autosave a draft revision;
+- validate and render an edited draft into replacement artifacts;
+- approve only after the edited draft is saved, valid, and rendered.
+
+Failed validation remains audit history and does not hide the last accepted
+artifact.
+
+## 7. Dry-Run Apply Before Submission
+
+Apply automation can submit applications. Start with dry runs:
+
+```bash
+uv --project workers/automation run jobhunter apply --dry-run --limit 1
+uv --project workers/automation run jobhunter apply --url https://example.com/job/123 --dry-run
+```
+
+Only approve real submission after inspecting the dry run, final materials,
+field mapping, blockers, and apply-run history.
+
+## 8. Inspect Progress
+
+Useful CLI commands:
+
+```bash
+uv --project workers/automation run jobhunter status
+uv --project workers/automation run jobhunter runs
+uv --project workers/automation run jobhunter runs --failed-only
+```
+
+Useful UI views:
+
+- Dashboard for high-level counts and source health.
+- Jobs for triage and per-job actions.
+- Runs for workflow history.
+- Artifacts for generated files.
+- Apply Review for approval and resume edits.
+- Debug for event-level inspection.

--- a/profile.example.json
+++ b/profile.example.json
@@ -42,8 +42,8 @@
     "target_seniority_floor": "Senior",
     "target_functions": "Backend; Platform",
     "target_specializations": "SaaS",
-    "target_locations": "Barcelona, Spain; Europe",
-    "target_work_models": "Hybrid, Remote; Remote"
+    "target_locations": "Remote; Springfield, IL",
+    "target_work_models": "Remote; Hybrid"
   },
   "resume": {
     "executive_profile": {

--- a/workers/automation/README.md
+++ b/workers/automation/README.md
@@ -4,8 +4,26 @@ This package contains JobHunter's Python automation engine and CLI. It owns job
 discovery, enrichment, scoring, tailoring, cover letters, PDF generation,
 profile import, and local browser apply automation.
 
-Run commands from the repository root with:
+Use it from the repository root through `uv`:
 
 ```bash
 uv --project workers/automation run jobhunter doctor
+uv --project workers/automation run jobhunter run
+uv --project workers/automation run jobhunter worker
 ```
+
+The full local application is normally started from the repository root with
+`pnpm dev`, which runs Temporal, the TypeScript API, the React web app, and this
+worker together.
+
+Useful docs:
+
+- root `README.md` for the public overview and quick start;
+- `docs/user/getting-started.md` for setup and local stack commands;
+- `docs/user/configuration.md` for environment variables;
+- `docs/architecture.md` and `docs/job-pipeline-architecture.md` for internal
+  runtime ownership.
+
+Profile data, generated materials, browser state, logs, and SQLite databases
+are sensitive local artifacts. Do not commit them or include them in public bug
+reports.


### PR DESCRIPTION
## Summary
- Rewrite the README as a concise public entry point on top of the newly merged resume-template docs from PR #193.
- Add open-source project foundations: AGPL license, contributing guide, security policy, code of conduct, and public roadmap.
- Add end-user and contributor documentation for setup, configuration, normal flows, data safety, and repository navigation.
- Refresh public examples for environment and profile configuration.

## Stack
1. #194 - open-source documentation foundation
2. #195 - synthetic screenshot workflow
3. #196 - internal current-state references

## Validation
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `corepack pnpm api:test`
- `corepack pnpm docs:screenshots`
- `git diff --check origin/main...HEAD`