### PR TITLE
docs: propose requirement-led resume tailoring

### DIFF
--- a/openspec/changes/requirement-led-resume-tailoring/.openspec.yaml
+++ b/openspec/changes/requirement-led-resume-tailoring/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-28

--- a/openspec/changes/requirement-led-resume-tailoring/design.md
+++ b/openspec/changes/requirement-led-resume-tailoring/design.md
@@ -31,6 +31,8 @@ which profile achievements before writing the resume.
 - Link enhancement and auto-approval behavior to claim policy.
 - Preserve user-pinned required experiences and bullets even when they do not
   cover a target requirement.
+- Include every achievement that covers at least one target requirement, even
+  when that pushes an experience entry above the configured max bullet count.
 - Use post-generation scoring to decide whether revision/enhancement is needed.
 - Persist safe audit data that explains coverage, gaps, unused achievements,
   enhancement status, and revision decisions.
@@ -98,7 +100,32 @@ Alternative considered: ask the model to emit the full resume JSON. That would
 make assembly simpler superficially, but it expands the model's authority into
 fixed profile structure and makes accidental profile drift more likely.
 
-### 3. Define Controls By Behavioral Authority
+### 3. Mandatory Content Overrides Bullet Budgets
+
+The configured max bullet count is a normal layout budget, not permission to
+drop required evidence. Candidate assembly must include content in this order:
+
+1. User-pinned required bullets and required experience entries.
+2. All achievements with at least one valid coverage edge to a job requirement.
+3. Enhancement-produced achievements that cover previously unmet requirements,
+   if the enhancement pass is allowed by claim policy.
+4. Optional positioning achievements, only if space remains under the configured
+   max.
+
+If mandatory content exceeds the max bullet count for an experience entry, the
+entry is allowed to exceed the limit. The overflow must be recorded in audit
+metadata with the reason, such as `pinned_required_bullet`,
+`requirement_coverage`, or `enhancement_coverage`.
+
+Enhancement cannot replace already selected covered achievements just to make
+room. It may append new covered achievements and trigger a max-bullet overflow
+audit note.
+
+Alternative considered: treat max bullets as a hard validator. That would let a
+layout preference remove exactly the content the requirement-led flow is meant
+to preserve.
+
+### 4. Define Controls By Behavioral Authority
 
 The required controls are:
 
@@ -167,7 +194,7 @@ Alternative considered: preserve the current UI controls and bolt new behavior
 behind them. That would keep overlapping knobs whose authority is unclear,
 which is the problem this change is meant to fix.
 
-### 4. Run Evidence-First, Then Score-Gated Revision
+### 5. Run Evidence-First, Then Score-Gated Revision
 
 The generation loop should be:
 
@@ -187,14 +214,15 @@ The generation loop should be:
 Enhancement is not the default write strategy. It is a second-stage response to
 measured fit gaps.
 
-### 5. Treat Scoring As A Gate, Not A Substitute For Validators
+### 6. Treat Scoring As A Gate, Not A Substitute For Validators
 
 The scorer decides whether the resume is good enough relative to the job. It
 does not authorize unsupported facts. Deterministic validators still own:
 
 - schema shape,
 - known profile and requirement IDs,
-- max bullet counts,
+- max bullet counts for optional content, with mandatory-overflow reasons for
+  user pins and requirement-covered achievements,
 - required pins,
 - exact skill membership,
 - verified metrics,
@@ -205,7 +233,7 @@ does not authorize unsupported facts. Deterministic validators still own:
 The scorer output can trigger revision and explain gaps, but it cannot approve
 fabrication.
 
-### 6. Persist Audit Data Separately From Raw Sensitive Inputs
+### 7. Persist Audit Data Separately From Raw Sensitive Inputs
 
 Material metadata and read models should expose bounded, safe summaries:
 
@@ -213,6 +241,8 @@ Material metadata and read models should expose bounded, safe summaries:
 - covered and uncovered requirement IDs/text excerpts,
 - evidence IDs used per generated line,
 - unused but pinned achievements,
+- experience entries that exceed the configured bullet max because mandatory
+  covered or pinned achievements had to be included,
 - claim labels and review blockers,
 - scorer dimensions and prioritized fixes,
 - revision attempts and why they ran.
@@ -235,6 +265,10 @@ local file paths, generated PDFs, logs, browser profiles, or SQLite contents.
 - Must-include bullets can reduce fit when they do not match the target job.
   Mitigation: keep pins authoritative, label them as pinned/positioning rather
   than requirement coverage, and let the scorer report the trade-off.
+- Requirement coverage can force longer experience entries than the user's
+  configured max bullets. Mitigation: treat max bullets as a soft budget after
+  mandatory content, audit the overflow reason, and keep optional positioning
+  content subject to the max.
 - A fit scorer can become overly broad or subjective.
   Mitigation: require structured dimensions, must-have coverage, red flags, and
   prioritized fixes; deterministic validators remain the hard safety gate.

--- a/openspec/changes/requirement-led-resume-tailoring/design.md
+++ b/openspec/changes/requirement-led-resume-tailoring/design.md
@@ -1,0 +1,265 @@
+## Context
+
+JobHunter already has the raw ingredients for requirement-led tailoring:
+
+- `RequirementFitReport` records job requirements, fit kind, evidence IDs,
+  tailoring directives, prohibited claims, weights, and confidence.
+- Profile experience entries can carry `achievement_evidence` with IDs, source
+  text, scope, action, tools, metrics, outcomes, evidence strength, confidence,
+  user confirmation, and tags.
+- Profile tailoring rules carry required experience entries, required bullets,
+  required skills, max bullets, current claim controls, writing style, and
+  rewrite permissions.
+- The current generator returns profile-row edits, not a full canonical resume.
+  Code assembles fixed structure and validates the result.
+
+The missing concept is a first-class many-to-many coverage graph. Today,
+requirement directives are consumed as prompt guidance, but the generation
+contract does not force the system to decide which requirements are covered by
+which profile achievements before writing the resume.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make requirement coverage the first-class tailoring plan.
+- Preserve the code-owned assembly model: the writer returns mutable profile-row
+  edits plus claim/coverage mappings, not arbitrary full-resume structure.
+- Define the control model the new flow needs, then migrate existing Preferences
+  controls into that model.
+- Use an evidence-first pass before any enhancement pass.
+- Link enhancement and auto-approval behavior to claim policy.
+- Preserve user-pinned required experiences and bullets even when they do not
+  cover a target requirement.
+- Use post-generation scoring to decide whether revision/enhancement is needed.
+- Persist safe audit data that explains coverage, gaps, unused achievements,
+  enhancement status, and revision decisions.
+
+**Non-Goals:**
+
+- Do not train or fine-tune models.
+- Do not let generated content modify the canonical profile automatically.
+- Do not allow the writer to create new experience rows, education rows, contact
+  fields, or unsupported skills.
+- Do not treat keyword counts or stock phrase markers as hard fit authority.
+- Do not preserve current Preferences controls just because they exist. Controls
+  that do not map to a real behavior must be removed, remapped, or hidden behind
+  an explicit compatibility migration.
+
+## Decisions
+
+### 1. Add A Requirement-Achievement Coverage Graph
+
+Introduce a tailoring-time graph with:
+
+- `requirements[]`: requirement id, text, tier, weight, source span, keywords,
+  and blocker status.
+- `achievements[]`: profile achievement evidence id, experience entry id,
+  source text, metrics, tools, strength, confirmation state, and whether it is
+  user-pinned.
+- `coverage_edges[]`: requirement id, achievement evidence id, coverage kind,
+  strength, claim policy needed, target terms, and rationale.
+- `uncovered_requirements[]`: requirements with zero valid coverage edges.
+- `unused_achievements[]`: profile achievements with zero target coverage edges
+  that may still be included if pinned or valuable positioning evidence.
+
+The graph is built through deterministic assembly plus a constrained planner:
+
+- Deterministic assembly loads requirements from `RequirementFitReport` and
+  profile achievements from `ProfileSnapshot`.
+- Existing `RequirementFitAssessment.fit.evidence_ids` seed direct or
+  transferable edges.
+- A coverage planner may propose additional edges, but only by referencing
+  existing requirement IDs and existing achievement evidence IDs.
+- Validators reject unknown IDs, duplicate edges, invalid coverage kinds,
+  unsupported metrics, prohibited claims, and claim-policy violations.
+
+Alternative considered: ask the writer to infer mappings while writing. That is
+the current failure mode in another form; it makes coverage hard to audit and
+hard to repair.
+
+### 2. Keep Profile-Row Edits, Add Claim Mapping
+
+The final writer still emits mutable resume edits keyed by profile IDs:
+
+- `executive_profile`
+- `experience_updates[]`
+- `skill_category_updates[]`
+
+The schema should add a sidecar claim map rather than switch to a full-resume
+schema. Each generated bullet and summary claim should map to one or more
+coverage edges or to an explicit non-requirement reason such as `pinned`,
+`positioning`, or `structure`.
+
+Code remains responsible for contact info, education, section order, rendering,
+and final artifact assembly.
+
+Alternative considered: ask the model to emit the full resume JSON. That would
+make assembly simpler superficially, but it expands the model's authority into
+fixed profile structure and makes accidental profile drift more likely.
+
+### 3. Define Controls By Behavioral Authority
+
+The required controls are:
+
+1. Claim policy:
+   - `verified_only`: only verified or user-confirmed source claims.
+   - `evidence_reframing`: rewrite existing evidence without adding new factual
+     content.
+   - `adjacent_translation`: translate adjacent evidence into target vocabulary
+     while preserving source facts and requiring explicit audit labels.
+   - `draft_requires_confirmation`: allow draft adjacent claims, but block
+     auto-approval until user review confirms them.
+2. Auto-approval policy:
+   - derived from claim policy and claim label, not exposed as an independent
+     general-purpose checklist unless advanced configuration needs it.
+   - verified-only and evidence-reframed claims can be auto-approvable.
+   - adjacent claims are not auto-approvable by default, but an advanced policy
+     may explicitly make adjacent translation auto-approvable with stronger
+     audit warnings.
+   - draft claims always require confirmation.
+3. Generation permissions:
+   - rewrite summary,
+   - rewrite achievement bullets,
+   - select/order existing skills,
+   - preserve fixed titles unless a future output schema supports title changes.
+4. Required content pins:
+   - required experience entries,
+   - required bullets by experience entry,
+   - required skill categories or skills.
+5. Writing style:
+   - tone,
+   - bullet standards,
+   - verbosity,
+   - keyword emphasis as advisory style guidance, not a hard keyword-density
+     validator.
+6. Revision gates:
+   - minimum post-tailoring fit score,
+   - must-have coverage threshold,
+   - maximum revision/enhancement attempts.
+   - these start as versioned policy defaults visible in audit, not editable
+     Preferences controls.
+7. Additional guidance:
+   - user text injected as writing/positioning guidance only; it cannot override
+     evidence, claim policy, pins, or validators.
+
+Existing Preferences controls are migration inputs:
+
+| Existing control | Decision |
+| --- | --- |
+| Tailoring mode | Use only as a migration input, then remove from the active Preferences surface in favor of explicit controls. |
+| Claim mode | Keep concept, rename or group as claim policy. |
+| Writing tone | Keep as writing style. |
+| Bullet standards | Keep as writing style. |
+| Verbosity | Keep as writing style. |
+| Keyword density | Replace or relabel as keyword emphasis; advisory only. |
+| Avoid first-person language | Keep as writing style. |
+| AI may rewrite executive summary | Keep as generation permission. |
+| AI may rewrite achievement bullets | Keep as generation permission. |
+| AI may reorder or trim skill items | Keep as generation permission for existing skills only. |
+| AI may reframe experience titles | Remove or disable until title changes are actually supported by schema and validators. |
+| AI may make minor inferred phrasing | Remap into claim policy; do not keep as a separate factual-expansion checkbox. |
+| Allow adjacent achievement drafts | Remap into claim policy and review gate. |
+| Auto-approvable claim modes | Derive from claim policy; expose only if the implementation keeps an advanced policy editor. |
+| Additional tailoring prompt | Keep as constrained guidance, not a safety override. |
+
+Alternative considered: preserve the current UI controls and bolt new behavior
+behind them. That would keep overlapping knobs whose authority is unclear,
+which is the problem this change is meant to fix.
+
+### 4. Run Evidence-First, Then Score-Gated Revision
+
+The generation loop should be:
+
+1. Build target profile from employer analysis and requirement fit.
+2. Build and validate coverage graph.
+3. Generate evidence-first profile-row edits from direct and reframed coverage.
+4. Assemble and validate the resume.
+5. Score the assembled resume with a fit scorer using the same target profile.
+6. If fit score and must-have coverage pass thresholds, accept unless review
+   blockers exist.
+7. If thresholds fail and claim policy allows adjacent or draft claims, run a
+   minimal revision pass using scorer prioritized fixes and uncovered
+   requirements.
+8. Re-score and select the best candidate that satisfies validators and review
+   policy.
+
+Enhancement is not the default write strategy. It is a second-stage response to
+measured fit gaps.
+
+### 5. Treat Scoring As A Gate, Not A Substitute For Validators
+
+The scorer decides whether the resume is good enough relative to the job. It
+does not authorize unsupported facts. Deterministic validators still own:
+
+- schema shape,
+- known profile and requirement IDs,
+- max bullet counts,
+- required pins,
+- exact skill membership,
+- verified metrics,
+- prohibited claims,
+- title immutability,
+- review-blocking claim states.
+
+The scorer output can trigger revision and explain gaps, but it cannot approve
+fabrication.
+
+### 6. Persist Audit Data Separately From Raw Sensitive Inputs
+
+Material metadata and read models should expose bounded, safe summaries:
+
+- requirement coverage status,
+- covered and uncovered requirement IDs/text excerpts,
+- evidence IDs used per generated line,
+- unused but pinned achievements,
+- claim labels and review blockers,
+- scorer dimensions and prioritized fixes,
+- revision attempts and why they ran.
+
+They must not expose raw prompts, full profile payloads, full job descriptions,
+local file paths, generated PDFs, logs, browser profiles, or SQLite contents.
+
+## Risks / Trade-offs
+
+- More intermediate data can make tailoring slower and more expensive.
+  Mitigation: cache deterministic graph assembly and run revision only after a
+  failed score gate.
+- Coverage planner output can overstate a weak connection.
+  Mitigation: require existing IDs, classify edge strength, and route adjacent
+  or draft edges through review policy.
+- UI control migration can confuse users if labels change abruptly.
+  Mitigation: migrate values deterministically, document the mapping, and keep
+  old fields readable for compatibility until the profile schema migration is
+  complete.
+- Must-include bullets can reduce fit when they do not match the target job.
+  Mitigation: keep pins authoritative, label them as pinned/positioning rather
+  than requirement coverage, and let the scorer report the trade-off.
+- A fit scorer can become overly broad or subjective.
+  Mitigation: require structured dimensions, must-have coverage, red flags, and
+  prioritized fixes; deterministic validators remain the hard safety gate.
+
+## Migration Plan
+
+1. Add new data structures and validators while continuing to read existing
+   tailoring controls.
+2. Implement a compatibility adapter from current profile controls to the new
+   control model.
+3. Add coverage graph generation and audit metadata behind a new tailoring
+   policy version.
+4. Update prompts and structured schemas for planner, writer, and scorer calls.
+5. Update API/read models and UI to show safe coverage and review blockers.
+6. Replace or relabel Preferences controls after migration tests prove the new
+   control model round-trips.
+7. Keep existing accepted artifacts unchanged; new requirement-led behavior
+   applies to new tailoring runs or explicit re-tailor actions.
+
+Rollback strategy: keep the previous tailoring policy version available for
+existing artifacts and allow re-tailoring only when the user explicitly chooses
+the new policy version.
+
+## Open Questions
+
+- None for the initial proposal. Thresholds start as versioned policy defaults;
+  Tailoring mode migrates away; adjacent translation auto-approval is allowed
+  only through explicit advanced policy configuration.

--- a/openspec/changes/requirement-led-resume-tailoring/proposal.md
+++ b/openspec/changes/requirement-led-resume-tailoring/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Current resume tailoring is profile-row based: the generator rewrites existing
+profile rows while requirement directives only influence emphasis. That makes it
+hard to prove that a final resume covered the right job requirements, used the
+minimum necessary enhancement, and preserved user-pinned experience and bullet
+requirements.
+
+The new flow should make requirement coverage the first-class planning unit:
+each job requirement is covered by zero or more profile achievements, and each
+profile achievement may cover zero or more job requirements.
+
+## What Changes
+
+- Add a requirement-achievement coverage graph before resume generation.
+- Convert current `EmployerAnalysis` and `RequirementFitReport` data into a
+  target-profile-style input for the writing and scoring loop.
+- Generate an evidence-first tailored resume by using coverage decisions to
+  populate the current profile-row edit schema rather than asking the model to
+  infer coverage indirectly.
+- Preserve user-pinned constraints: required experience entries and required
+  bullets must remain in the final resume even when they do not cover any target
+  requirement.
+- Run a score-gated revision loop after the evidence-first draft. Revision is
+  triggered by configured fit and must-have coverage thresholds, not by loose
+  keyword counts.
+- Define the required control model for requirement-led tailoring first, then
+  migrate, remap, remove, or replace the current Preferences controls to match
+  that model.
+- Bind enhancement behavior to claim policy and review requirements rather than
+  letting scattered checkboxes independently authorize factual expansion.
+- Persist and expose audit metadata for requirement coverage, uncovered
+  requirements, unused profile achievements, enhancement/draft claim status, and
+  scorer-driven revision decisions.
+- Align generator and verifier prompts with the local resume-content-writer and
+  resume-fit-scorer skill contracts while keeping JobHunter's structured-output
+  schemas and deterministic validators as the runtime contract.
+
+## Capabilities
+
+### New Capabilities
+
+- `requirement-led-resume-tailoring`: Defines requirement-achievement coverage
+  planning, evidence-first generation, claim-policy-gated enhancement,
+  score-gated revision, the required tailoring controls, and audit metadata for
+  tailored resumes.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Python Materials domain:
+  `workers/automation/src/jobhunter/domain/materials/quality.py`,
+  `use_cases.py`, provenance/audit helpers, and related tests.
+- Python Scoring domain: requirement fit report consumption and post-tailoring
+  fit scorer output used for revision gates.
+- Profile model and Preferences UI: define the new control model, then migrate
+  current tailoring mode, claim mode, writing tone, bullet standards, verbosity,
+  keyword density, rewrite permissions, minor inference, adjacent drafts,
+  auto-approvable modes, and additional prompt into clear supported controls.
+- TypeScript API/read models and web UI: expose safe coverage and enhancement
+  audit summaries without leaking raw prompts, full profile payloads, or raw job
+  descriptions.
+- Documentation: update `docs/tailoring.md`, active requirements, and QA matrix
+  entries to describe the requirement-led flow after implementation.

--- a/openspec/changes/requirement-led-resume-tailoring/proposal.md
+++ b/openspec/changes/requirement-led-resume-tailoring/proposal.md
@@ -21,6 +21,10 @@ profile achievement may cover zero or more job requirements.
 - Preserve user-pinned constraints: required experience entries and required
   bullets must remain in the final resume even when they do not cover any target
   requirement.
+- Require every achievement that covers one or more job requirements to appear
+  in the final resume, including enhancement-produced achievements that cover
+  previously unmet requirements. This requirement can exceed the configured
+  maximum bullet count for an experience entry.
 - Run a score-gated revision loop after the evidence-first draft. Revision is
   triggered by configured fit and must-have coverage thresholds, not by loose
   keyword counts.
@@ -30,8 +34,9 @@ profile achievement may cover zero or more job requirements.
 - Bind enhancement behavior to claim policy and review requirements rather than
   letting scattered checkboxes independently authorize factual expansion.
 - Persist and expose audit metadata for requirement coverage, uncovered
-  requirements, unused profile achievements, enhancement/draft claim status, and
-  scorer-driven revision decisions.
+  requirements, unused profile achievements, max-bullet overflows caused by
+  mandatory content, enhancement/draft claim status, and scorer-driven revision
+  decisions.
 - Align generator and verifier prompts with the local resume-content-writer and
   resume-fit-scorer skill contracts while keeping JobHunter's structured-output
   schemas and deterministic validators as the runtime contract.

--- a/openspec/changes/requirement-led-resume-tailoring/specs/requirement-led-resume-tailoring/spec.md
+++ b/openspec/changes/requirement-led-resume-tailoring/specs/requirement-led-resume-tailoring/spec.md
@@ -92,6 +92,46 @@ coverage optimization MUST NOT silently remove pinned content.
 - **THEN** the scorer reports the trade-off without authorizing removal of the
   pinned content
 
+### Requirement: Covered achievements are mandatory
+The system SHALL include every achievement that covers one or more job
+requirements in the final tailored resume. The configured maximum bullet count
+per experience entry MUST NOT cause covered achievements or user-pinned
+achievements to be removed.
+
+#### Scenario: Covered achievements exceed max bullets
+- **WHEN** an experience entry has more requirement-covered achievements than
+  the configured maximum bullet count
+- **THEN** the final resume includes all requirement-covered achievements for
+  that entry
+- **AND** audit metadata records that the bullet limit was exceeded for
+  requirement coverage
+
+#### Scenario: Enhancement produces covered achievements
+- **WHEN** a profile enhancement pass produces one or more achievements that
+  cover previously unmet requirements
+- **THEN** the final resume includes those enhancement-produced covered
+  achievements
+- **AND** the system does not remove already selected covered achievements to
+  make room under the configured bullet limit
+- **AND** audit metadata labels the added achievements with their enhancement
+  claim status and coverage reason
+
+#### Scenario: User-pinned achievement competes with covered achievements
+- **WHEN** an experience entry contains user-pinned achievements and additional
+  achievements that cover job requirements
+- **THEN** the final resume includes the user-pinned achievements under all
+  circumstances
+- **AND** the final resume also includes all requirement-covered achievements
+  even if the entry exceeds the configured bullet maximum
+
+#### Scenario: Optional achievements exceed max bullets
+- **WHEN** optional positioning achievements remain after all user-pinned and
+  requirement-covered achievements have been selected
+- **THEN** the configured maximum bullet count applies only to those optional
+  achievements
+- **AND** optional achievements may be omitted before any user-pinned or
+  requirement-covered achievement is removed
+
 ### Requirement: Claim policy controls factual expansion
 The system SHALL use explicit claim policy controls to decide which claim types
 are allowed and which claim types block auto-approval.
@@ -200,6 +240,12 @@ override deterministic validation failures.
   profile metrics, achievement evidence, or baseline bullets
 - **THEN** deterministic validation rejects the candidate
 
+#### Scenario: Mandatory achievement is missing
+- **WHEN** the assembled tailored resume omits a user-pinned achievement or an
+  achievement with one or more valid requirement coverage edges
+- **THEN** deterministic validation rejects the candidate even if the omission
+  keeps the experience entry within the configured bullet maximum
+
 #### Scenario: Invalid claim map appears
 - **WHEN** generated claim mapping references a missing coverage edge,
   unsupported claim label, missing requirement, or missing evidence item
@@ -220,7 +266,7 @@ local artifact paths, generated PDFs, browser data, logs, or SQLite databases.
 - **WHEN** a tailored resume has requirement-led audit metadata
 - **THEN** Apply Review can show covered requirements, uncovered requirements,
   evidence-backed generated claims, pinned content, adjacent or draft labels,
-  and review blockers using bounded safe excerpts
+  bullet-limit overflow reasons, and review blockers using bounded safe excerpts
 
 #### Scenario: Revision history is inspectable
 - **WHEN** the tailoring loop runs scorer-gated revision

--- a/openspec/changes/requirement-led-resume-tailoring/specs/requirement-led-resume-tailoring/spec.md
+++ b/openspec/changes/requirement-led-resume-tailoring/specs/requirement-led-resume-tailoring/spec.md
@@ -1,0 +1,233 @@
+## ADDED Requirements
+
+### Requirement: Requirement-achievement coverage graph
+The system SHALL build a requirement-achievement coverage graph before
+generating tailored resume text. The graph MUST support zero-or-more
+achievement coverage per requirement and zero-or-more requirement coverage per
+achievement.
+
+#### Scenario: Requirement has multiple supporting achievements
+- **WHEN** a job requirement is supported by several profile achievements
+- **THEN** the coverage graph records one edge per requirement-achievement pair
+- **AND** each edge records the requirement id, achievement evidence id,
+  coverage kind, strength, required claim policy, target terms, and rationale
+
+#### Scenario: Requirement is uncovered
+- **WHEN** no valid profile achievement supports a job requirement
+- **THEN** the coverage graph records the requirement as uncovered
+- **AND** the writer is prohibited from claiming that requirement unless a later
+  enhancement pass is allowed by claim policy and records a reviewable claim
+
+#### Scenario: Achievement does not cover target requirements
+- **WHEN** a profile achievement has no valid edge to any target requirement
+- **THEN** the graph records it as unused for requirement coverage
+- **AND** the achievement may still appear in the final resume only when it is
+  pinned, valuable positioning evidence, or required by profile rules
+
+#### Scenario: Planner proposes unknown identifiers
+- **WHEN** a coverage planner output references an unknown requirement id or
+  unknown achievement evidence id
+- **THEN** deterministic validation rejects that edge before generation
+
+### Requirement: Target profile adapter for writing and scoring
+The system SHALL adapt JobHunter's employer analysis, requirement fit report,
+job text, and profile evidence into a target-profile-style contract consumed by
+the writer and scorer prompts.
+
+#### Scenario: Target profile is built from existing analysis
+- **WHEN** employer analysis and requirement fit data exist for a job
+- **THEN** the target profile includes target role, seniority, must-have
+  requirements, nice-to-have requirements, hard skills, ATS keywords,
+  requirement weights, and source spans where available
+
+#### Scenario: Requirement fit seeds coverage
+- **WHEN** a requirement fit assessment contains evidence IDs
+- **THEN** those evidence IDs seed direct or transferable coverage edges before
+  any model-planned edges are accepted
+
+#### Scenario: Missing target profile inputs
+- **WHEN** required target profile inputs are stale or unavailable
+- **THEN** the system regenerates or reports the missing prerequisite instead of
+  running tailoring against an incomplete target
+
+### Requirement: Evidence-first profile-row generation
+The system SHALL generate an evidence-first tailored resume by mapping the
+coverage graph into the existing mutable profile-row edit contract. The writer
+MUST NOT emit arbitrary full-resume structure.
+
+#### Scenario: Writer returns mutable profile edits
+- **WHEN** the writer generates the first tailored candidate
+- **THEN** the response contains executive profile text, experience updates
+  keyed by existing experience entry IDs, and skill category updates keyed by
+  existing skill category IDs
+- **AND** contact data, education, section order, rendering, and final artifact
+  assembly remain code-owned
+
+#### Scenario: Generated claim mapping is present
+- **WHEN** a generated summary sentence or experience bullet claims target fit
+- **THEN** the response maps that generated claim to one or more coverage graph
+  edges or to an explicit non-requirement reason such as pinned, positioning, or
+  structure
+
+#### Scenario: Writer attempts unsupported structure
+- **WHEN** the writer returns a new experience row, new education row, contact
+  field, unsupported skill, or unrecognized section
+- **THEN** deterministic validation rejects the candidate
+
+### Requirement: Required content pins are authoritative
+The system SHALL preserve user-pinned required experiences, required bullets,
+and required skills according to the profile tailoring rules. Requirement
+coverage optimization MUST NOT silently remove pinned content.
+
+#### Scenario: Pinned bullet does not match the job
+- **WHEN** a required profile bullet has no coverage edge to any target
+  requirement
+- **THEN** the final resume still includes the bullet unless the user changes
+  the pin
+- **AND** audit metadata labels the bullet as pinned rather than requirement
+  coverage
+
+#### Scenario: Pinned content competes with fit
+- **WHEN** preserving pinned content lowers the post-tailoring fit score
+- **THEN** the scorer reports the trade-off without authorizing removal of the
+  pinned content
+
+### Requirement: Claim policy controls factual expansion
+The system SHALL use explicit claim policy controls to decide which claim types
+are allowed and which claim types block auto-approval.
+
+#### Scenario: Verified-only policy
+- **WHEN** claim policy is verified-only
+- **THEN** generated claims must trace to verified or user-confirmed profile
+  evidence
+- **AND** adjacent translation and draft claims are rejected before acceptance
+
+#### Scenario: Evidence reframing policy
+- **WHEN** claim policy is evidence reframing
+- **THEN** the writer may rewrite source evidence in target-role language
+  without adding new factual content
+- **AND** generated claims remain auto-approvable only when their claim labels
+  are included in the auto-approval policy
+
+#### Scenario: Adjacent translation policy
+- **WHEN** claim policy allows adjacent translation
+- **THEN** the writer may bridge from adjacent profile evidence to target
+  vocabulary without inventing tools, metrics, titles, credentials, or direct
+  experience
+- **AND** adjacent claims are review-blocking unless an explicit advanced policy
+  marks adjacent translation auto-approvable
+
+#### Scenario: Draft confirmation policy
+- **WHEN** claim policy allows draft claims requiring confirmation
+- **THEN** generated draft claims must be labeled as requiring confirmation
+- **AND** the system blocks auto-approval until the user confirms or edits those
+  claims
+
+### Requirement: Required control model replaces overlapping Preferences controls
+The system SHALL define tailoring controls by behavioral authority and migrate
+existing Preferences controls into that model. Controls that do not map to real
+runtime behavior MUST be removed, remapped, disabled, or hidden behind explicit
+advanced configuration.
+
+#### Scenario: Tailoring mode migration
+- **WHEN** an existing profile stores the top-level Tailoring mode
+- **THEN** migration uses that value only to derive explicit claim, generation,
+  writing, and gate controls
+- **AND** Tailoring mode is not kept as an independent runtime authority after
+  migration
+
+#### Scenario: Minor inference and adjacent drafts migrate to claim policy
+- **WHEN** an existing profile stores minor inference or adjacent draft flags
+- **THEN** those values are remapped into claim policy and review-gate behavior
+  instead of remaining independent factual-expansion checkboxes
+
+#### Scenario: Title reframing has no runtime support
+- **WHEN** an existing profile stores permission to reframe experience titles
+- **THEN** the active control surface removes or disables that control unless
+  the output schema and validators support title changes
+- **AND** generated titles remain empty or exactly match the source title
+
+#### Scenario: Keyword density becomes advisory
+- **WHEN** an existing profile stores keyword density
+- **THEN** migration maps it to keyword emphasis or equivalent writing guidance
+- **AND** keyword emphasis does not create hard deterministic blockers based on
+  loose keyword counts
+
+### Requirement: Score-gated revision and enhancement
+The system SHALL run post-generation fit scoring on the assembled tailored
+resume and SHALL use versioned policy thresholds to decide whether revision or
+enhancement is required.
+
+#### Scenario: Evidence-first candidate passes thresholds
+- **WHEN** the evidence-first tailored resume meets the minimum fit score and
+  must-have coverage thresholds
+- **THEN** the system accepts the candidate if deterministic validators and
+  review-gate policy pass
+
+#### Scenario: Evidence-first candidate fails thresholds
+- **WHEN** the evidence-first tailored resume falls below the minimum fit score
+  or must-have coverage threshold
+- **THEN** the system uses scorer prioritized fixes and uncovered requirements
+  to decide whether a revision pass is useful
+
+#### Scenario: Enhancement is allowed
+- **WHEN** thresholds fail and claim policy allows adjacent or draft enhancement
+- **THEN** the system runs the minimum revision pass needed to address the
+  scorer's prioritized gaps
+- **AND** every adjacent or draft claim is labeled in the generated claim map and
+  audit metadata
+
+#### Scenario: Enhancement is not allowed
+- **WHEN** thresholds fail but claim policy forbids adjacent or draft
+  enhancement
+- **THEN** the system records the uncovered requirements and score-gate failure
+  instead of inventing unsupported claims
+
+#### Scenario: Thresholds are policy defaults
+- **WHEN** revision gates are evaluated
+- **THEN** minimum fit score, must-have coverage threshold, and max revision
+  attempts come from the versioned tailoring policy
+- **AND** those thresholds are visible in audit metadata without requiring
+  editable Preferences controls in the initial implementation
+
+### Requirement: Deterministic validators remain hard gates
+The system SHALL keep deterministic validators as hard safety gates before a
+tailored resume can become an accepted artifact. LLM scoring or judging MUST NOT
+override deterministic validation failures.
+
+#### Scenario: Unsupported metric appears
+- **WHEN** generated resume text contains a metric that is not in verified
+  profile metrics, achievement evidence, or baseline bullets
+- **THEN** deterministic validation rejects the candidate
+
+#### Scenario: Invalid claim map appears
+- **WHEN** generated claim mapping references a missing coverage edge,
+  unsupported claim label, missing requirement, or missing evidence item
+- **THEN** deterministic validation rejects the candidate
+
+#### Scenario: Low-quality phrase signal appears
+- **WHEN** stock phrase markers or keyword-emphasis warnings appear without
+  fabrication, invalid structure, or unsupported claims
+- **THEN** the system records a non-blocking low-quality signal instead of
+  failing the candidate solely on that signal
+
+### Requirement: Audit data explains coverage and revisions safely
+The system SHALL persist and expose safe audit metadata for requirement-led
+tailoring without exposing raw prompts, full profile payloads, full job text,
+local artifact paths, generated PDFs, browser data, logs, or SQLite databases.
+
+#### Scenario: Apply Review shows coverage summary
+- **WHEN** a tailored resume has requirement-led audit metadata
+- **THEN** Apply Review can show covered requirements, uncovered requirements,
+  evidence-backed generated claims, pinned content, adjacent or draft labels,
+  and review blockers using bounded safe excerpts
+
+#### Scenario: Revision history is inspectable
+- **WHEN** the tailoring loop runs scorer-gated revision
+- **THEN** audit metadata records the score before revision, the triggered
+  threshold, prioritized fixes used, revision attempt count, and final score
+
+#### Scenario: Unused achievements are visible
+- **WHEN** profile achievements are not used for target requirement coverage
+- **THEN** audit metadata can distinguish unused achievements from missing
+  evidence and from pinned content preserved for user reasons

--- a/openspec/changes/requirement-led-resume-tailoring/tasks.md
+++ b/openspec/changes/requirement-led-resume-tailoring/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Add requirement-led tailoring policy version constants and policy-default revision gates for minimum fit score, must-have coverage, and max revision attempts.
 - [ ] 1.2 Add value objects for requirement nodes, achievement nodes, coverage edges, uncovered requirements, unused achievements, and generated claim mappings.
-- [ ] 1.3 Add deterministic validators for coverage graph IDs, edge kinds, claim labels, claim-policy compatibility, metric support, prohibited claims, and pinned content preservation.
+- [ ] 1.3 Add deterministic validators for coverage graph IDs, edge kinds, claim labels, claim-policy compatibility, metric support, prohibited claims, pinned content preservation, mandatory covered-achievement inclusion, and bullet-limit overflow reasons.
 - [ ] 1.4 Add compatibility adapter from existing profile tailoring controls to the new claim, generation, writing, and revision-gate control model.
 - [ ] 1.5 Add migration tests proving Tailoring mode is used only as migration input and no longer acts as independent runtime authority.
 
@@ -21,14 +21,14 @@
 - [ ] 3.3 Add evidence-first candidate generation that excludes adjacent or draft claims unless policy allows them.
 - [ ] 3.4 Integrate post-generation fit scoring against the assembled resume and target profile.
 - [ ] 3.5 Add scorer-threshold revision routing using prioritized fixes and uncovered requirements.
-- [ ] 3.6 Add minimal enhancement revision pass that labels every adjacent or draft claim and respects auto-approval policy.
-- [ ] 3.7 Add candidate selection tests for pass-on-first-draft, revise-after-low-score, no-enhancement-allowed, and review-blocked draft claims.
+- [ ] 3.6 Add minimal enhancement revision pass that labels every adjacent or draft claim, appends enhancement-produced covered achievements without evicting selected covered or pinned achievements, and respects auto-approval policy.
+- [ ] 3.7 Add candidate selection tests for pass-on-first-draft, revise-after-low-score, no-enhancement-allowed, review-blocked draft claims, covered achievements exceeding max bullets, and enhancement-added covered achievements.
 
 ## 4. Assembly, Provenance, And Audit
 
 - [ ] 4.1 Extend provenance annotations to include requirement IDs, evidence IDs, coverage edge IDs, claim labels, and pinned/positioning reasons.
-- [ ] 4.2 Preserve required experience entries, required bullets, and required skills even when they do not cover target requirements.
-- [ ] 4.3 Expose safe audit summaries for covered requirements, uncovered requirements, unused achievements, revision decisions, and review blockers.
+- [ ] 4.2 Preserve required experience entries, required bullets, required skills, and every requirement-covered achievement even when mandatory content exceeds configured max bullets.
+- [ ] 4.3 Expose safe audit summaries for covered requirements, uncovered requirements, unused achievements, bullet-limit overflow reasons, revision decisions, and review blockers.
 - [ ] 4.4 Ensure audit projections omit raw prompts, full profile payloads, full job descriptions, local paths, PDFs, logs, browser data, and SQLite contents.
 - [ ] 4.5 Add API/read-model tests for requirement-led audit metadata and review-blocking adjacent or draft claims.
 
@@ -45,6 +45,6 @@
 
 - [ ] 6.1 Update `docs/tailoring.md` to describe requirement-led coverage, claim policy, score-gated revision, and control migration.
 - [ ] 6.2 Update active requirements and local reliability QA entries for requirement-led tailoring and safe audit display.
-- [ ] 6.3 Add Python unit and evaluation fixtures covering coverage graph validation, claim-policy gates, pins, scorer thresholds, and low-quality advisory signals.
+- [ ] 6.3 Add Python unit and evaluation fixtures covering coverage graph validation, claim-policy gates, pins, mandatory covered-achievement inclusion, max-bullet overflow, scorer thresholds, and low-quality advisory signals.
 - [ ] 6.4 Add API tests for safe read-model exposure and Apply Review readiness with review-blocking enhanced claims.
 - [ ] 6.5 Add product-path QA for Preferences control migration and Apply Review coverage audit display.

--- a/openspec/changes/requirement-led-resume-tailoring/tasks.md
+++ b/openspec/changes/requirement-led-resume-tailoring/tasks.md
@@ -1,0 +1,50 @@
+## 1. Domain Model And Policy
+
+- [ ] 1.1 Add requirement-led tailoring policy version constants and policy-default revision gates for minimum fit score, must-have coverage, and max revision attempts.
+- [ ] 1.2 Add value objects for requirement nodes, achievement nodes, coverage edges, uncovered requirements, unused achievements, and generated claim mappings.
+- [ ] 1.3 Add deterministic validators for coverage graph IDs, edge kinds, claim labels, claim-policy compatibility, metric support, prohibited claims, and pinned content preservation.
+- [ ] 1.4 Add compatibility adapter from existing profile tailoring controls to the new claim, generation, writing, and revision-gate control model.
+- [ ] 1.5 Add migration tests proving Tailoring mode is used only as migration input and no longer acts as independent runtime authority.
+
+## 2. Coverage Planning
+
+- [ ] 2.1 Build target-profile adapter from `EmployerAnalysis`, `RequirementFitReport`, job data, and profile evidence.
+- [ ] 2.2 Seed coverage graph edges from existing requirement-fit evidence IDs before invoking any planner prompt.
+- [ ] 2.3 Add constrained coverage planner schema and prompt that can only reference existing requirement IDs and profile achievement evidence IDs.
+- [ ] 2.4 Add planner parsing tests for direct, transferable, adjacent, missing, and invalid-edge cases.
+- [ ] 2.5 Persist safe coverage graph metadata on tailoring attempts and final materials metadata.
+
+## 3. Writer And Scorer Loop
+
+- [ ] 3.1 Update writer schema to keep profile-row edits while adding generated claim mapping for summary claims, bullets, and skill choices.
+- [ ] 3.2 Update writer prompt to consume target profile, coverage graph, required pins, claim policy, generation permissions, and writing style.
+- [ ] 3.3 Add evidence-first candidate generation that excludes adjacent or draft claims unless policy allows them.
+- [ ] 3.4 Integrate post-generation fit scoring against the assembled resume and target profile.
+- [ ] 3.5 Add scorer-threshold revision routing using prioritized fixes and uncovered requirements.
+- [ ] 3.6 Add minimal enhancement revision pass that labels every adjacent or draft claim and respects auto-approval policy.
+- [ ] 3.7 Add candidate selection tests for pass-on-first-draft, revise-after-low-score, no-enhancement-allowed, and review-blocked draft claims.
+
+## 4. Assembly, Provenance, And Audit
+
+- [ ] 4.1 Extend provenance annotations to include requirement IDs, evidence IDs, coverage edge IDs, claim labels, and pinned/positioning reasons.
+- [ ] 4.2 Preserve required experience entries, required bullets, and required skills even when they do not cover target requirements.
+- [ ] 4.3 Expose safe audit summaries for covered requirements, uncovered requirements, unused achievements, revision decisions, and review blockers.
+- [ ] 4.4 Ensure audit projections omit raw prompts, full profile payloads, full job descriptions, local paths, PDFs, logs, browser data, and SQLite contents.
+- [ ] 4.5 Add API/read-model tests for requirement-led audit metadata and review-blocking adjacent or draft claims.
+
+## 5. Preferences Controls
+
+- [ ] 5.1 Replace or regroup the Preferences Tailoring controls around claim policy, generation permissions, required content pins, writing style, revision policy display, and additional guidance.
+- [ ] 5.2 Remove or disable experience-title reframing unless the output schema and validators support title changes.
+- [ ] 5.3 Remap minor inference and adjacent drafts into claim policy and review-gate behavior.
+- [ ] 5.4 Replace keyword density with advisory keyword emphasis and ensure it cannot create loose keyword-count blockers.
+- [ ] 5.5 Hide or move auto-approvable claim modes behind explicit advanced policy configuration; support configurable adjacent auto-approval only through that advanced policy.
+- [ ] 5.6 Add frontend tests for migrated controls, removed Tailoring mode behavior, advanced adjacent auto-approval, and constrained additional guidance.
+
+## 6. Documentation And QA
+
+- [ ] 6.1 Update `docs/tailoring.md` to describe requirement-led coverage, claim policy, score-gated revision, and control migration.
+- [ ] 6.2 Update active requirements and local reliability QA entries for requirement-led tailoring and safe audit display.
+- [ ] 6.3 Add Python unit and evaluation fixtures covering coverage graph validation, claim-policy gates, pins, scorer thresholds, and low-quality advisory signals.
+- [ ] 6.4 Add API tests for safe read-model exposure and Apply Review readiness with review-blocking enhanced claims.
+- [ ] 6.5 Add product-path QA for Preferences control migration and Apply Review coverage audit display.


### PR DESCRIPTION
## Summary
- Adds an OpenSpec proposal for requirement-led resume tailoring.
- Defines a requirement-achievement coverage graph, evidence-first generation, claim-policy-gated enhancement, score-gated revision, and safe audit metadata.
- Specifies that the new control model is defined first, then existing Preferences controls are migrated, remapped, removed, or moved to advanced policy as appropriate.

## Validation
- openspec validate requirement-led-resume-tailoring
- openspec status --change requirement-led-resume-tailoring
- git diff --check