### PR TITLE
fix: recover stale apply review materials state

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1494,7 +1494,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: null,
         resumePdfLayoutBoxes: [],
-        requirementLedAudit: requirementLedAuditForCandidates(text.candidate),
+        requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate),
         resumeTemplate: resumeTemplateStateForJob(db, jobKey),
       };
     }
@@ -1511,7 +1511,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: pdf.artifactId,
         resumePdfLayoutBoxes: resumeLayoutBoxesForArtifact(db, pdf.artifactId),
-        requirementLedAudit: requirementLedAuditForCandidates(text.candidate, pdf),
+        requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate, pdf),
         resumeTemplate: resumeTemplateStateForJob(db, jobKey),
       };
     }
@@ -1524,7 +1524,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
       resumeTextArtifactId: null,
       resumePdfArtifactId: pdfOnly.artifactId,
       resumePdfLayoutBoxes: resumeLayoutBoxesForArtifact(db, pdfOnly.artifactId),
-      requirementLedAudit: requirementLedAuditForCandidates(pdfOnly),
+      requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, pdfOnly),
       resumeTemplate: resumeTemplateStateForJob(db, jobKey),
     };
   }
@@ -1536,7 +1536,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
       resumeTextArtifactId: text.candidate.artifactId,
       resumePdfArtifactId: null,
       resumePdfLayoutBoxes: [],
-      requirementLedAudit: requirementLedAuditForCandidates(text.candidate),
+      requirementLedAudit: requirementLedAuditForCandidates(db, jobKey, text.candidate),
       resumeTemplate: resumeTemplateStateForJob(db, jobKey),
     };
   }
@@ -1548,21 +1548,117 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
     resumePdfLayoutBoxes: pdfCandidates[0]?.artifactId
       ? resumeLayoutBoxesForArtifact(db, pdfCandidates[0].artifactId)
       : [],
-    requirementLedAudit: pdfCandidates[0] ? requirementLedAuditForCandidates(pdfCandidates[0]) : null,
+    requirementLedAudit: pdfCandidates[0] ? requirementLedAuditForCandidates(db, jobKey, pdfCandidates[0]) : null,
     resumeTemplate: resumeTemplateStateForJob(db, jobKey),
   };
 }
 
 function requirementLedAuditForCandidates(
+  db: SqliteDatabase,
+  jobKey: string,
   ...candidates: readonly MaterialArtifactCandidate[]
 ): ApplyReviewRequirementLedAudit | null {
   for (const candidate of candidates) {
     const audit = parseRequirementLedAuditMetadata(candidate.metadataJson);
     if (audit) {
-      return audit;
+      return reconcileRequirementLedAuditWithProvenance(db, jobKey, candidate, audit);
     }
   }
   return null;
+}
+
+function reconcileRequirementLedAuditWithProvenance(
+  db: SqliteDatabase,
+  jobKey: string,
+  candidate: MaterialArtifactCandidate,
+  audit: ApplyReviewRequirementLedAudit,
+): ApplyReviewRequirementLedAudit {
+  const requirementById = requirementSummariesFromAudit(audit);
+  if (!requirementById.size || !tableExists(db, "job_bullet_provenance")) {
+    return audit;
+  }
+
+  const rows = provenanceRowsForCandidate(db, jobKey, candidate);
+  if (!rows.length) {
+    return audit;
+  }
+
+  const coveredIds = new Set<string>();
+  for (const row of rows) {
+    for (const id of parseStringListJson(row.requirement_ids_json)) {
+      if (requirementById.has(id)) {
+        coveredIds.add(id);
+      }
+    }
+  }
+
+  const priorUncoveredReason = new Map(audit.uncoveredRequirements.map((requirement) => [requirement.id, requirement.reason]));
+  const coveredRequirements: ApplyReviewRequirementLedAudit["coveredRequirements"] = [];
+  const uncoveredRequirements: ApplyReviewRequirementLedAudit["uncoveredRequirements"] = [];
+  for (const id of requirementById.keys()) {
+    if (coveredIds.has(id)) {
+      coveredRequirements.push(requirementAuditRequirement(id, requirementById, null));
+    } else {
+      uncoveredRequirements.push(
+        requirementAuditRequirement(
+          id,
+          requirementById,
+          priorUncoveredReason.get(id) ?? "No provenance-linked bullet in the selected tailored resume.",
+        ),
+      );
+    }
+  }
+
+  return {
+    ...audit,
+    coveredRequirements,
+    uncoveredRequirements,
+  };
+}
+
+function requirementSummariesFromAudit(
+  audit: ApplyReviewRequirementLedAudit,
+): Map<string, { textExcerpt: string; tier: string | null }> {
+  const result = new Map<string, { textExcerpt: string; tier: string | null }>();
+  for (const requirement of [...audit.coveredRequirements, ...audit.uncoveredRequirements]) {
+    if (requirement.id && !result.has(requirement.id)) {
+      result.set(requirement.id, {
+        textExcerpt: requirement.textExcerpt,
+        tier: requirement.tier,
+      });
+    }
+  }
+  return result;
+}
+
+function provenanceRowsForCandidate(
+  db: SqliteDatabase,
+  jobKey: string,
+  candidate: MaterialArtifactCandidate,
+): Array<{ requirement_ids_json: string }> {
+  const rowsByArtifact = candidate.artifactId
+    ? allRows<{ requirement_ids_json: string }>(
+        db,
+        `SELECT requirement_ids_json
+           FROM job_bullet_provenance
+          WHERE tenant_id = ?
+            AND job_url = ?
+            AND artifact_id = ?`,
+        [DEFAULT_TENANT, jobKey, candidate.artifactId],
+      )
+    : [];
+  if (rowsByArtifact.length || candidate.generation === null) {
+    return rowsByArtifact;
+  }
+  return allRows<{ requirement_ids_json: string }>(
+    db,
+    `SELECT requirement_ids_json
+       FROM job_bullet_provenance
+      WHERE tenant_id = ?
+        AND job_url = ?
+        AND generation = ?`,
+    [DEFAULT_TENANT, jobKey, candidate.generation],
+  );
 }
 
 function parseRequirementLedAuditMetadata(value: string | null): ApplyReviewRequirementLedAudit | null {

--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -1060,7 +1060,7 @@ function requirementsWithTailoredResumeCoverage(
   for (const row of rows) {
     const ids = parseStringListJson(row.requirement_ids_json).filter((id) => requirementIds.has(id));
     if (!ids.length) continue;
-    const example = cleanLimitedText(row.generated_text, EVIDENCE_TEXT_LIMIT);
+    const example = cleanText(row.generated_text);
     for (const id of ids) {
       const current = covered.get(id) ?? { bulletCount: 0, examples: [] };
       current.bulletCount += 1;
@@ -1149,11 +1149,15 @@ function cleanRequirementWeight(value: unknown): number | null {
 }
 
 function cleanLimitedText(value: unknown, limit: number): string {
-  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  const text = cleanText(value);
   if (!text) {
     return "";
   }
   return text.length > limit ? `${text.slice(0, limit).trim()}...` : text;
+}
+
+function cleanText(value: unknown): string {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
 }
 
 function boundedEvidenceList(values: readonly unknown[]): string[] {

--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -312,6 +312,112 @@ function reconcileDependencyBlockers(db: SqliteDatabase): Set<string> {
   return repairedJobs;
 }
 
+function reconcileObsoleteCoverGenerationConflicts(db: SqliteDatabase): Set<string> {
+  const repairedJobs = new Set<string>();
+  if (!tableExists(db, "job_stage_states") || !tableExists(db, "job_materials_artifacts")) {
+    return repairedJobs;
+  }
+
+  const columns = new Set(
+    allRows<{ name: string }>(db, "PRAGMA table_info(job_stage_states)").map((row) => row.name),
+  );
+  const rows = allRows<{
+    job_url: string;
+    error_message: string | null;
+    has_cover_letter: number | string | null;
+  }>(
+    db,
+    `
+    SELECT s.job_url,
+           s.error_message,
+           EXISTS (
+             SELECT 1
+               FROM job_materials_artifacts tr
+               JOIN job_materials_artifacts pdf
+                 ON pdf.job_url = tr.job_url
+                AND pdf.generation = tr.generation
+                AND pdf.artifact_type = 'resume_pdf'
+                AND pdf.status = 'approved'
+                AND COALESCE(TRIM(pdf.path), '') != ''
+               JOIN job_materials_artifacts cover
+                 ON cover.job_url = tr.job_url
+                AND cover.generation = tr.generation
+                AND cover.artifact_type = 'cover_letter'
+                AND cover.status = 'approved'
+                AND COALESCE(TRIM(cover.path), '') != ''
+              WHERE tr.job_url = s.job_url
+                AND tr.artifact_type = 'tailored_resume'
+                AND tr.status = 'approved'
+                AND COALESCE(TRIM(tr.path), '') != ''
+           ) AS has_cover_letter
+      FROM job_stage_states s
+     WHERE s.stage = 'cover'
+       AND s.state = 'failed'
+       AND s.error_code = 'COVER_FAILED'
+       AND s.error_message LIKE 'MaterialsSet generation conflict%'
+       AND s.error_message LIKE '%(or current==%'
+       AND EXISTS (
+             SELECT 1
+               FROM job_materials_artifacts tr
+               JOIN job_materials_artifacts pdf
+                 ON pdf.job_url = tr.job_url
+                AND pdf.generation = tr.generation
+                AND pdf.artifact_type = 'resume_pdf'
+                AND pdf.status = 'approved'
+                AND COALESCE(TRIM(pdf.path), '') != ''
+              WHERE tr.job_url = s.job_url
+                AND tr.artifact_type = 'tailored_resume'
+                AND tr.status = 'approved'
+                AND COALESCE(TRIM(tr.path), '') != ''
+           )
+    `,
+  );
+  if (rows.length === 0) return repairedJobs;
+
+  const assignments = [
+    "state = ?",
+    columns.has("updated_at") ? "updated_at = ?" : null,
+    columns.has("finished_at") ? "finished_at = ?" : null,
+    columns.has("error_code") ? "error_code = NULL" : null,
+    columns.has("error_message") ? "error_message = NULL" : null,
+    columns.has("retryable") ? "retryable = ?" : null,
+    columns.has("blocked_by_json") ? "blocked_by_json = NULL" : null,
+    columns.has("next_action") ? "next_action = NULL" : null,
+    columns.has("metadata_json") ? "metadata_json = ?" : null,
+  ].filter((assignment): assignment is string => Boolean(assignment));
+  const update = db.prepare(
+    `UPDATE job_stage_states
+        SET ${assignments.join(", ")}
+      WHERE job_url = ?
+        AND stage = 'cover'
+        AND state = 'failed'
+        AND error_code = 'COVER_FAILED'`,
+  );
+  const now = new Date().toISOString();
+
+  for (const row of rows) {
+    const targetState = Number(row.has_cover_letter ?? 0) > 0 ? "succeeded" : "pending";
+    const values: SqliteValue[] = [targetState];
+    if (columns.has("updated_at")) values.push(now);
+    if (columns.has("finished_at")) values.push(targetState === "succeeded" ? now : null);
+    if (columns.has("retryable")) values.push(targetState === "pending" ? 1 : 0);
+    if (columns.has("metadata_json")) {
+      values.push(
+        JSON.stringify({
+          repaired_at: now,
+          repair_reason: "obsolete_cover_generation_conflict",
+          target_state: targetState,
+          previous_error_message: row.error_message,
+        }),
+      );
+    }
+    update.run(...values, row.job_url);
+    repairedJobs.add(row.job_url);
+  }
+
+  return repairedJobs;
+}
+
 /** Idempotently create the projection tables. Mirrors the Python schema. */
 export function ensureProjectionTables(db: SqliteDatabase): boolean {
   db.exec(`
@@ -588,10 +694,11 @@ export function refreshProjections(db: SqliteDatabase, tenantId = "local"): void
   const projectionSchemaChanged = ensureProjectionTables(db);
   backfillLegacyStageStates(db);
   const repairedDependencyJobs = reconcileDependencyBlockers(db);
+  const repairedCoverConflictJobs = reconcileObsoleteCoverGenerationConflicts(db);
 
   const watermark = readWatermark(db, PROJECTION_WATERMARK_NAME);
 
-  let dirtyJobs = new Set<string>(repairedDependencyJobs);
+  let dirtyJobs = new Set<string>([...repairedDependencyJobs, ...repairedCoverConflictJobs]);
   let sourceQualityDirty = false;
   let maxEventId = watermark;
   if (tableExists(db, "job_events")) {

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -14,6 +14,8 @@ const READY_JOB = "https://example.com/jobs/apply-ready";
 const DRY_RUN_JOB = "https://example.com/jobs/apply-dry-run";
 const APPLIED_JOB = "https://example.com/jobs/already-applied";
 const NOW = "2026-06-01T10:00:00.000Z";
+const LONG_TAILORED_REQUIREMENT_EVIDENCE =
+  "Owned platform reliability improvements for incident response across four production services, reduced high-severity repeat incidents through clearer ownership, and built review habits that kept customer-facing systems stable during launch pressure.";
 
 let tempDir = "";
 let options: BuildAppOptions;
@@ -139,7 +141,7 @@ describe("application feedback API", () => {
               state: "covered",
               source: "tailored_resume_bullet_provenance",
               bulletCount: 1,
-              examples: ["Owned platform reliability improvements for incident response."],
+              examples: [LONG_TAILORED_REQUIREMENT_EVIDENCE],
             },
           },
           {
@@ -1976,7 +1978,7 @@ function insertBulletProvenance(db: Database.Database): void {
     "rephrased",
     "rephrase_allowed",
     "Reframed the bullet toward platform reliability.",
-    "Owned platform reliability improvements for incident response.",
+    LONG_TAILORED_REQUIREMENT_EVIDENCE,
     1,
     NOW,
   );

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -360,6 +360,78 @@ describe("application feedback API", () => {
     });
   });
 
+  it("self-heals obsolete cover generation conflicts before listing the review queue", async () => {
+    const staleConflict =
+      "MaterialsSet generation conflict for job_id='https://example.com/jobs/apply-ready': got generation=1, expected 2 (or current==0)";
+    const db = new Database(options.dbPath);
+    db.prepare(
+      `
+      UPDATE job_stage_states
+         SET state = 'failed',
+             error_code = 'COVER_FAILED',
+             error_message = ?,
+             retryable = 1,
+             next_action = ?,
+             updated_at = '2026-06-01T11:30:00.000Z'
+       WHERE job_url = ?
+         AND stage = 'cover'
+      `,
+    ).run(staleConflict, `jobhunter retry cover ${READY_JOB}`, READY_JOB);
+    db.close();
+    const app = buildApp(options);
+
+    const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const item = queueItem(response.json(), READY_JOB);
+    expect(item).toMatchObject({
+      currentStage: "apply",
+      currentState: "pending",
+      blockers: [],
+      applyAudit: {
+        state: "preparing",
+        label: "materials preparing",
+        summary: "cover is pending. Review evidence is still available where recorded.",
+        hardBlockers: [],
+      },
+    });
+    expect(JSON.stringify(item)).not.toContain("MaterialsSet generation conflict");
+    await app.close();
+
+    const readDb = new Database(options.dbPath, { readonly: true });
+    const stage = readDb
+      .prepare(
+        `
+        SELECT state, error_code, error_message, retryable, next_action, metadata_json
+          FROM job_stage_states
+         WHERE job_url = ?
+           AND stage = 'cover'
+        `,
+      )
+      .get(READY_JOB) as {
+      state: string;
+      error_code: string | null;
+      error_message: string | null;
+      retryable: number;
+      next_action: string | null;
+      metadata_json: string | null;
+    };
+    readDb.close();
+
+    expect(stage).toMatchObject({
+      state: "pending",
+      error_code: null,
+      error_message: null,
+      retryable: 1,
+      next_action: null,
+    });
+    expect(JSON.parse(stage.metadata_json ?? "{}")).toMatchObject({
+      repair_reason: "obsolete_cover_generation_conflict",
+      target_state: "pending",
+      previous_error_message: staleConflict,
+    });
+  });
+
   it("uses the posting URL as the review apply target when direct application URL is missing", async () => {
     const db = new Database(options.dbPath);
     db.prepare("UPDATE jobs SET application_url = NULL WHERE url = ?").run(READY_JOB);
@@ -700,6 +772,40 @@ describe("application feedback API", () => {
     expect(JSON.stringify(audit)).not.toContain("RAW PROMPT SECRET");
     expect(JSON.stringify(audit)).not.toContain("FULL PROFILE SECRET");
     expect(JSON.stringify(audit)).not.toContain("/private/secret-resume.pdf");
+
+    await app.close();
+  });
+
+  it("derives requirement-led coverage from selected artifact provenance rows", async () => {
+    const metadata = requirementLedAuditMetadata();
+    const qualityPlan = metadata.quality_plan as Record<string, unknown>;
+    const coverageGraph = qualityPlan.coverage_graph as Record<string, unknown>;
+    coverageGraph.covered_requirement_ids = ["r1", "r2"];
+    coverageGraph.uncovered_requirements = [];
+
+    const db = new Database(options.dbPath);
+    db.prepare(
+      `UPDATE job_materials_artifacts
+          SET metadata_json = ?
+        WHERE job_url = ?
+          AND artifact_id = 'apply-ready-resume-text'`,
+    ).run(JSON.stringify(metadata), READY_JOB);
+    db.close();
+    const app = buildApp(options);
+
+    const response = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const audit = queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit;
+    expect(audit?.coveredRequirements.map((requirement) => requirement.id)).toEqual(["r1"]);
+    expect(audit?.uncoveredRequirements).toEqual([
+      {
+        id: "r2",
+        textExcerpt: "Improve developer experience and incident-response practices.",
+        tier: "nice_to_have",
+        reason: "No provenance-linked bullet in the selected tailored resume.",
+      },
+    ]);
 
     await app.close();
   });
@@ -1146,7 +1252,8 @@ function seedDatabase(dbPath: string): void {
       error_message TEXT,
       retryable INTEGER,
       blocked_by_json TEXT,
-      next_action TEXT
+      next_action TEXT,
+      metadata_json TEXT
     );
     CREATE TABLE job_events (
       event_id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2103,6 +2103,21 @@ textarea:focus-visible {
   padding-left: 2px;
 }
 
+.apply-review-requirement-evidence {
+  margin: 6px 0 0;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.apply-review-requirement-evidence > span {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
 .apply-review-ideal-requirement-head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) max-content;

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -848,11 +848,11 @@ describe("<ApplyReviewView>", () => {
     expect(requirementLedAudit.getByText("1/2 requirements covered")).toBeInTheDocument();
     expect(requirementLedAudit.getByText("2 coverage edges")).toBeInTheDocument();
     expect(requirementLedAudit.getByText("review blockers: 1")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("Covered requirements")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("Uncovered requirements")).toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("Covered requirements")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("Uncovered requirements")).not.toBeInTheDocument();
     expect(
-      requirementLedAudit.getByText("Improve incident-response practices and developer experience."),
-    ).toBeInTheDocument();
+      requirementLedAudit.queryByText("Improve incident-response practices and developer experience."),
+    ).not.toBeInTheDocument();
     expect(requirementLedAudit.getByText("Review-blocking or draft claims")).toBeInTheDocument();
     expect(requirementLedAudit.getByText("adjacent translation")).toBeInTheDocument();
     expect(requirementLedAudit.getByText("draft")).toBeInTheDocument();

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -840,26 +840,33 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByText("missing from tailored resume")).toBeInTheDocument();
     expect(screen.getByText("2 resume bullets")).toBeInTheDocument();
     expect(
-      screen.getByText(/Tailored resume evidence: Owned platform reliability improvements/i),
+      screen.getByText((_, element) =>
+        Boolean(
+          element?.classList.contains("apply-review-requirement-evidence") &&
+            element.textContent?.includes("Tailored resume evidence: Owned platform reliability improvements"),
+        ),
+      ),
     ).toBeInTheDocument();
     const requirementLedAudit = within(
       screen.getByRole("region", { name: "Requirement-led tailoring audit" }),
     );
     expect(requirementLedAudit.getByText("1/2 requirements covered")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("2 coverage edges")).toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("2 coverage edges")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("3 profile achievements")).not.toBeInTheDocument();
     expect(requirementLedAudit.getByText("review blockers: 1")).toBeInTheDocument();
     expect(requirementLedAudit.queryByText("Covered requirements")).not.toBeInTheDocument();
     expect(requirementLedAudit.queryByText("Uncovered requirements")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("Evidence-backed claims")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("Review-blocking or draft claims")).not.toBeInTheDocument();
     expect(
       requirementLedAudit.queryByText("Improve incident-response practices and developer experience."),
     ).not.toBeInTheDocument();
-    expect(requirementLedAudit.getByText("Review-blocking or draft claims")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("adjacent translation")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("draft")).toBeInTheDocument();
-    expect(requirementLedAudit.getByText("review required")).toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("ev_incident_leadership")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("edge-r2-ev-incident")).not.toBeInTheDocument();
+    expect(requirementLedAudit.queryByText("ev_platform_reliability")).not.toBeInTheDocument();
     expect(
-      requirementLedAudit.getByText("Bridges incident leadership into developer-experience practice improvements."),
-    ).toBeInTheDocument();
+      requirementLedAudit.queryByText("Bridges incident leadership into developer-experience practice improvements."),
+    ).not.toBeInTheDocument();
     expect(requirementLedAudit.getByText(/mandatory requirement coverage|requirement coverage/)).toBeInTheDocument();
     expect(requirementLedAudit.getByText(/Fit gate:\s*7\.6\/10/)).toBeInTheDocument();
     expect(requirementLedAudit.getByText(/Must-have coverage:\s*50%/)).toBeInTheDocument();

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -283,6 +283,27 @@ function formatBulletCount(count: number): string {
   return `${count} resume bullet${count === 1 ? "" : "s"}`;
 }
 
+function formatEvidenceReference(value: string, index: number): string {
+  const bullet = value.match(/(?:^|[_-])bullet[_-]?(\d+)(?:$|[_-])/i) ?? value.match(/(?:^|[_-])bullet[_-]?(\d+)$/i);
+  if (bullet?.[1]) {
+    return `bullet ${bullet[1]}`;
+  }
+  const evidence = value.match(/(?:^|[_-])ev(?:idence)?[_-]?([a-z0-9]+)$/i);
+  if (evidence?.[1]) {
+    return formatReadableToken(evidence[1]);
+  }
+  return `source ${index + 1}`;
+}
+
+function compactEvidenceReferences(values: readonly string[], limit = 4): string[] {
+  const references = values
+    .map((value, index) => formatEvidenceReference(value, index))
+    .filter((value, index, all) => all.indexOf(value) === index)
+    .slice(0, limit);
+  const hidden = values.length - references.length;
+  return hidden > 0 ? [...references, `+${hidden} more`] : references;
+}
+
 function formatScoreValue(value: number | null | undefined): string {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return "not scored";
@@ -490,11 +511,13 @@ function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) 
                         </div>
                       </div>
                       {requirement.evidence ? (
-                        <p className="meta">Job post evidence: {requirement.evidence}</p>
+                        <p className="apply-review-requirement-evidence">
+                          <span>Job post evidence:</span> {requirement.evidence}
+                        </p>
                       ) : null}
                       {requirement.coverage.examples.length ? (
-                        <p className="meta">
-                          Tailored resume evidence: {requirement.coverage.examples.join("; ")}
+                        <p className="apply-review-requirement-evidence">
+                          <span>Tailored resume evidence:</span> {requirement.coverage.examples.join("; ")}
                         </p>
                       ) : null}
                     </li>
@@ -607,68 +630,10 @@ function RequirementLedAuditPanel({
       <h3>Requirement-led tailoring audit</h3>
       <div className="apply-review-audit-summary" aria-label="Requirement-led audit summary">
         <span className={`tag ${audit.uncoveredRequirements.length ? "warn" : "ok"}`}>{coveredLabel}</span>
-        <span className="tag muted">{audit.coverageEdgeCount} coverage edges</span>
-        <span className="tag muted">{audit.achievementCount} profile achievements</span>
         {audit.reviewBlockers.length ? <span className="tag warn">{reviewBlockerLabel}</span> : null}
       </div>
-      <ClaimAuditList
-        title="Evidence-backed claims"
-        emptyTitle="No evidence-backed claim mappings were recorded."
-        claims={audit.evidenceBackedClaims}
-      />
-      <ClaimAuditList
-        title="Review-blocking or draft claims"
-        emptyTitle="No adjacent or draft claim mappings were recorded."
-        claims={audit.adjacentOrDraftClaims}
-      />
       <BulletOverflowAudit overflows={audit.bulletLimitOverflows} />
       <RevisionAudit revision={audit.revision} reviewBlockers={audit.reviewBlockers} />
-    </section>
-  );
-}
-
-function ClaimAuditList({
-  title,
-  emptyTitle,
-  claims,
-}: {
-  readonly title: string;
-  readonly emptyTitle: string;
-  readonly claims: readonly ApplyReviewRequirementLedAudit["evidenceBackedClaims"][number][];
-}) {
-  return (
-    <section className="apply-review-audit-section">
-      <h4>{title}</h4>
-      {claims.length ? (
-        <ol className="apply-review-audit-list">
-          {claims.map((claim, index) => (
-            <li key={`${title}:${claim.section}:${claim.label}:${index}`}>
-              <div className="apply-review-claim-head">
-                <b>{claim.label}</b>
-                <span className={`tag ${claim.reviewRequired ? "warn" : "ok"}`}>
-                  {claim.reviewRequired ? "review required" : "auto-approvable"}
-                </span>
-              </div>
-              <AuditTagGroup label="Claim labels" values={claim.claimLabels.map(formatReadableToken)} tone="muted" />
-              <AuditTagGroup label="Requirements" values={claim.requirementIds} tone="muted" />
-              <AuditTagGroup label="Evidence" values={claim.evidenceIds} tone="muted" />
-              <AuditTagGroup label="Coverage edges" values={claim.coverageEdgeIds} tone="muted" />
-              {claim.positioningReasons.length ? (
-                <p className="meta">{claim.positioningReasons.join("; ")}</p>
-              ) : null}
-              {claim.textExcerpts.length ? (
-                <ul className="apply-review-audit-excerpts">
-                  {claim.textExcerpts.map((excerpt) => (
-                    <li key={excerpt}>{excerpt}</li>
-                  ))}
-                </ul>
-              ) : null}
-            </li>
-          ))}
-        </ol>
-      ) : (
-        <p className="meta">{emptyTitle}</p>
-      )}
     </section>
   );
 }
@@ -713,12 +678,12 @@ function BulletOverflowAudit({
         <ol className="apply-review-audit-list">
           {overflows.map((overflow) => (
             <li key={`${overflow.experienceEntryId}:${overflow.actualBullets}`}>
-              <b>{overflow.experienceEntryId}</b>
+              <b>{formatReadableToken(overflow.experienceEntryId)}</b>
               <span className="meta">
                 {overflow.actualBullets}/{overflow.maxBullets} bullets retained:{" "}
                 {formatReadableToken(overflow.reason)}
               </span>
-              <AuditTagGroup label="Evidence" values={overflow.evidenceIds} tone="muted" />
+              <AuditTagGroup label="Evidence" values={compactEvidenceReferences(overflow.evidenceIds)} tone="muted" />
             </li>
           ))}
         </ol>

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -611,16 +611,6 @@ function RequirementLedAuditPanel({
         <span className="tag muted">{audit.achievementCount} profile achievements</span>
         {audit.reviewBlockers.length ? <span className="tag warn">{reviewBlockerLabel}</span> : null}
       </div>
-      <RequirementAuditList
-        title="Covered requirements"
-        emptyTitle="No covered requirements were recorded."
-        requirements={audit.coveredRequirements}
-      />
-      <RequirementAuditList
-        title="Uncovered requirements"
-        emptyTitle="No uncovered requirements were recorded."
-        requirements={audit.uncoveredRequirements}
-      />
       <ClaimAuditList
         title="Evidence-backed claims"
         emptyTitle="No evidence-backed claim mappings were recorded."
@@ -633,37 +623,6 @@ function RequirementLedAuditPanel({
       />
       <BulletOverflowAudit overflows={audit.bulletLimitOverflows} />
       <RevisionAudit revision={audit.revision} reviewBlockers={audit.reviewBlockers} />
-    </section>
-  );
-}
-
-function RequirementAuditList({
-  title,
-  emptyTitle,
-  requirements,
-}: {
-  readonly title: string;
-  readonly emptyTitle: string;
-  readonly requirements: readonly ApplyReviewRequirementLedAudit["coveredRequirements"][number][];
-}) {
-  return (
-    <section className="apply-review-audit-section">
-      <h4>{title}</h4>
-      {requirements.length ? (
-        <ol className="apply-review-audit-list">
-          {requirements.map((requirement) => (
-            <li key={`${title}:${requirement.id}`}>
-              <b>{requirement.textExcerpt}</b>
-              <span>
-                {requirement.tier ? <span className="tag muted">{formatReadableToken(requirement.tier)}</span> : null}
-                {requirement.reason ? <span className="meta">{requirement.reason}</span> : null}
-              </span>
-            </li>
-          ))}
-        </ol>
-      ) : (
-        <p className="meta">{emptyTitle}</p>
-      )}
     </section>
   );
 }

--- a/workers/automation/src/jobhunter/infrastructure/materials/sqlite_repository.py
+++ b/workers/automation/src/jobhunter/infrastructure/materials/sqlite_repository.py
@@ -57,7 +57,7 @@ class MaterialsGenerationConflict(ValueError):
         self.expected = expected
         super().__init__(
             f"MaterialsSet generation conflict for job_id={job_id!r}: "
-            f"got generation={attempted}, expected {expected} (or current=={attempted - 1})"
+            f"got generation={attempted}, expected existing generation or next generation={expected}"
         )
 
 
@@ -433,9 +433,14 @@ class SqliteMaterialsRepository:
             (str(materials.job_id), str(materials.tenant_id)),
         ).fetchone()
         current_max = int(latest[0] if latest else 0)
-        # Allow either: append to current generation (re-save) OR mint
-        # the next one. Anything else is a conflict.
-        if materials.generation not in (current_max, current_max + 1):
+        existing = self._conn.execute(
+            "SELECT 1 FROM job_materials WHERE job_url = ? AND tenant_id = ? AND generation = ?",
+            (str(materials.job_id), str(materials.tenant_id), materials.generation),
+        ).fetchone()
+        # Allow either: update an existing generation or mint exactly the next one.
+        # Failed re-tailors can leave newer rejected generations while the last
+        # approved generation remains the current downstream material for cover/PDF.
+        if existing is None and materials.generation != current_max + 1:
             raise MaterialsGenerationConflict(
                 job_id=materials.job_id,
                 attempted=materials.generation,

--- a/workers/automation/tests/test_materials_repository.py
+++ b/workers/automation/tests/test_materials_repository.py
@@ -232,6 +232,39 @@ def test_save_idempotent_within_same_generation(conn: sqlite3.Connection) -> Non
     assert loaded.cover_letter.status is ArtifactStatus.APPROVED
 
 
+def test_save_allows_cover_update_to_preserved_approved_generation(
+    conn: sqlite3.Connection,
+) -> None:
+    """Cover generation can update the current approved resume after failed re-tailors."""
+    url = _seed_job(conn)
+    repo = SqliteMaterialsRepository(conn)
+    approved = _approved_with_pdf(url)
+    repo.save(approved)
+    repo.save(_rejected(url, generation=2))
+    repo.save(_rejected(url, generation=3))
+
+    current = repo.load_current_approved(LOCAL_TENANT, JobId(url))
+    assert current is not None
+    assert current.generation == 1
+
+    with_cover = current.with_cover_letter(
+        _make_artifact(ArtifactType.COVER_LETTER, path="/tmp/cover.txt"),
+        validation=ValidationResult.success(),
+        updated_at="2024-01-04T00:00:00+00:00",
+    )
+    repo.save(with_cover)
+
+    loaded_current = repo.load_current_approved(LOCAL_TENANT, JobId(url))
+    assert loaded_current is not None
+    assert loaded_current.generation == 1
+    assert loaded_current.cover_letter is not None
+    assert loaded_current.cover_letter.status is ArtifactStatus.APPROVED
+
+    raw_latest = repo.load(LOCAL_TENANT, JobId(url))
+    assert raw_latest is not None
+    assert raw_latest.generation == 3
+
+
 def test_save_persists_resume_layout_boxes_outside_artifact_metadata(
     conn: sqlite3.Connection,
 ) -> None:


### PR DESCRIPTION
## What changed

- Allows materials repository saves to update an existing approved generation even when newer rejected generations exist.
- Self-heals old cover-stage generation-conflict failures during projection refresh when approved resume text and PDF artifacts already prove the state is recoverable.
- Reconciles Apply Review requirement coverage against selected artifact provenance rows so stale generation metadata cannot claim a requirement is covered when the selected resume lacks a provenance-linked bullet.
- Simplifies the Apply Review artifact audit panel: the right pane now keeps lifecycle/gate status only, while requirement-by-requirement coverage remains on the left.
- Removes primary UI exposure of internal claim mappings, coverage-edge counts, profile-achievement counts, raw evidence IDs, and numbered requirement/bullet references that had no visible anchors.
- Returns full cleaned tailored-resume evidence from selected artifact provenance and renders requirement evidence as multiline review text instead of truncating it.
- Adds regressions for preserved-generation cover saves, stale cover blocker repair, selected-artifact requirement coverage, non-duplicated audit UI, removed internal graph UI, and full tailored evidence examples.

## Why

Cover generation can validly continue from the last approved resume after later re-tailor attempts fail. The prior save guard rejected that write pattern, and already-failed stage rows stayed visible as manual retry blockers even after the repository behavior was corrected. Apply Review should repair machine-recoverable state from canonical materials data instead of asking users to perform useless retries.

The right-side claim/edge map used internal graph identifiers and numbered references that did not correspond to visible numbering in the review UI. That made the panel look precise while giving the reviewer no actionable path. The useful coverage proof is the left requirement card: job-post evidence, candidate fit, tailoring action, resume coverage, and the actual tailored resume evidence.

No documentation update: this is a bug fix and review-surface cleanup, not a new command, runtime requirement, or public workflow.

## Validation

- `corepack pnpm check`
- `corepack pnpm test`
- `corepack pnpm api:test -- application-feedback.test.ts`
- `corepack pnpm --filter @jobhunter/web test -- ApplyReviewView.test.tsx`
- `corepack pnpm api:check`
- `corepack pnpm web:check`
- `corepack pnpm web:build`
- `git diff --check`
- Live headless browser check against `/apply-review?jobKey=https%3A%2F%2Fwww.linkedin.com%2Fjobs%2Fview%2F4375576106`: no claim map, no evidence-backed/review-blocking claim headings, no coverage-edge/profile-achievement counters in the right audit panel, and tailored evidence paragraphs render without API ellipsis truncation.
- Earlier branch validation also covered the Python materials repository/use-case regressions for preserved-generation cover saves and stale blocker repair.
