### PR TITLE
fix(materials): require word-boundary match in employer-analysis grounding gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,10 +170,13 @@ through the analysis draft/synthesizer ports, not the generic LLM client.
   folding formatting-insignificant variation (whitespace runs, Unicode
   hyphen/dash variants, smart quotes, case), then **snaps** the stored span to
   the JD's verbatim text at the match so persisted evidence is always
-  copy-paste-findable. A span whose WORDS are absent from the snapshot (a
-  paraphrase, synonym, or hallucination) is still rejected — the cardinal
-  correctness gate, run on every draft and on the synthesized canonical before
-  persistence. JSON Schema cannot express this, so it is a separate hard check.
+  copy-paste-findable. The match must align to whole-token boundaries (its outer
+  edges border a non-alphanumeric or the string edge), so a short span cannot
+  ground INSIDE a larger word (a fabricated `"Go"` against `"goals"`). A span
+  whose WORDS are absent from the snapshot (a paraphrase, synonym, or
+  hallucination) is still rejected — the cardinal correctness gate, run on every
+  draft and on the synthesized canonical before persistence. JSON Schema cannot
+  express this, so it is a separate hard check.
 - **Ports + adapters** (`domain/ports/materials.py`,
   `infrastructure/analysis/`): the use case depends on `AnalysisDraftPort` /
   `AnalysisSynthesizerPort`, never on a concrete SDK. The ensemble runs the legs

--- a/workers/automation/src/jobhunter/domain/materials/analysis_grounding.py
+++ b/workers/automation/src/jobhunter/domain/materials/analysis_grounding.py
@@ -20,9 +20,15 @@ content-exact** via normalize → locate → snap-to-source:
      can let a fabrication through.
   2. **Locate** the span by building a tolerant regex from it (escape it, then
      relax escaped whitespace to ``\\s+``, each hyphen/quote to a character
-     class, and Markdown-escaped punctuation to the same source character) and
-     searching the ORIGINAL JD case-insensitively. A hit means the span is
-     genuinely present, modulo formatting.
+     class, and Markdown-escaped punctuation to the same source character),
+     anchored on a token boundary at both outer edges (the character just before
+     and just after the whole match must be non-alphanumeric or the string
+     edge), and searching the ORIGINAL JD case-insensitively. The boundary
+     anchor stops a short span from grounding INSIDE a larger word (``"Go"`` in
+     ``"goals"``, ``"AI"`` in ``"email"``, ``"R"``/``"C"`` in almost anything):
+     such a sub-word hit would slip a fabricated keyword past this cardinal gate
+     and snap the stored evidence to a mid-word fragment. A hit means the span is
+     genuinely present as whole token(s), modulo formatting.
   3. **Snap-to-source**: the located match yields the JD's ACTUAL text at that
      position, so the stored ``evidence_span`` becomes verbatim-from-the-posting
      (satisfies D-15 and enables clean char-offset highlighting later).
@@ -70,6 +76,13 @@ _DOUBLE_QUOTE_RE = re.compile(f"[{_DOUBLE_QUOTE_CHARS}]")
 _HYPHEN_CLASS = f"[-{_DASH_CHARS}]"
 _SINGLE_QUOTE_CLASS = f"['{_SINGLE_QUOTE_CHARS}]"
 _DOUBLE_QUOTE_CLASS = f'["{_DOUBLE_QUOTE_CHARS}]'
+
+# One alphanumeric character, Unicode-aware. Used as a zero-width lookaround to
+# require the located match to sit on whole-token boundaries. NOT ``\b``: ``\b``
+# treats ``_`` as a word char, whereas the grounding invariant is "the match is
+# not glued to another alphanumeric". ``[^\W_]`` is exactly ``str.isalnum()`` —
+# every word char minus the underscore.
+_ALNUM_CHAR = r"[^\W_]"
 
 
 def _strip_markdown_escapes(text: str) -> str:
@@ -122,13 +135,21 @@ def _tolerant_pattern(span: str) -> re.Pattern[str] | None:
     quote becomes the matching quote char-class. Searched case-insensitively
     against the ORIGINAL JD, so ``match.group()`` is the verbatim source slice.
 
+    The whole match is bracketed by token-boundary lookaround so it can only land
+    on whole word(s), never inside a longer word. The assertions are zero-width
+    and sit at the OUTER edges only, so a multi-word span still matches across
+    its internal spaces while its first/last real character must border a
+    non-alphanumeric (or the string edge). ``re.search`` therefore skips a
+    sub-word occurrence and keeps scanning for a boundary-aligned one.
+
     Returns ``None`` for an empty/whitespace-only span (no real text to locate).
     """
     normalized = _normalize(span)
     if not normalized:
         return None
     pattern = "".join(_char_pattern(char) for char in normalized)
-    return re.compile(pattern, re.IGNORECASE)
+    bounded = f"(?<!{_ALNUM_CHAR}){pattern}(?!{_ALNUM_CHAR})"
+    return re.compile(bounded, re.IGNORECASE)
 
 
 def locate_grounded_span(span: str, jd_snapshot: str) -> str | None:

--- a/workers/automation/tests/test_employer_analysis_model.py
+++ b/workers/automation/tests/test_employer_analysis_model.py
@@ -420,6 +420,43 @@ class TestTokenBoundaryGrounding:
             ground_and_snap(bad, jd)
         assert [(v.kind, v.ref_id) for v in exc.value.violations] == [("keyword", "Go")]
 
+    # --- Hardening: lock in the exact boundary semantics the fix relies on so a
+    # future switch to ``\b`` (treats "_" as a word char) or adding ``re.ASCII``
+    # (would stop counting non-ASCII letters/digits as alphanumeric) cannot
+    # silently reopen the sub-word hole. All pass against the current code. --- #
+
+    def test_digit_span_does_not_ground_inside_a_larger_number(self) -> None:
+        # A number is a token too: "5" must not ground inside "15", nor "24"
+        # inside "2024". Digits are alphanumeric boundaries just like letters.
+        assert is_grounded("5", "We had 15 incidents last year.") is False
+        assert is_grounded("24", "Founded in 2024 by two engineers.") is False
+
+    def test_digit_span_grounds_as_standalone_token(self) -> None:
+        jd = "We need 5 years of experience."
+        assert is_grounded("5", jd) is True
+        assert locate_grounded_span("5", jd) == "5"
+
+    def test_span_grounds_at_absolute_start_and_end_of_snapshot(self) -> None:
+        # The lookaround must treat the string edge as a boundary: a span flush
+        # against position 0 or against the final character still grounds.
+        start_jd = "Go is our primary backend language."
+        end_jd = "Our primary language is Rust"  # no trailing punctuation
+        assert is_grounded("Go", start_jd) is True
+        assert locate_grounded_span("Go", start_jd) == "Go"
+        assert is_grounded("Rust", end_jd) is True
+        assert locate_grounded_span("Rust", end_jd) == "Rust"
+
+    def test_letter_glued_span_is_rejected_including_non_ascii_glue(self) -> None:
+        # Glued to another letter -> part of a larger word -> rejected; bordered
+        # by a hyphen (non-alphanumeric) -> a whole token -> grounds. The
+        # non-ASCII cases pin the Unicode-aware boundary (str.isalnum), so an
+        # ASCII-only class would treat the accented letter as a non-boundary and
+        # wrongly ground the sub-word here.
+        assert is_grounded("AI", "We prefer naiveAI approaches here.") is False
+        assert is_grounded("AI", "We invest in AI-native tooling.") is True
+        assert is_grounded("AI", "Legacy stack AIür module.") is False  # U+00FC glue
+        assert is_grounded("Go", "The Goéland project.") is False  # U+00E9 glue
+
 
 # --------------------------------------------------------------------------- #
 # Cache key (D-11/D-12)

--- a/workers/automation/tests/test_employer_analysis_model.py
+++ b/workers/automation/tests/test_employer_analysis_model.py
@@ -335,6 +335,93 @@ class TestNormalizedGroundingAndSnap:
 
 
 # --------------------------------------------------------------------------- #
+# Token-boundary grounding (Dimension 1 — the cardinal no-fabrication gate)
+#
+# Regression for the defect where the per-character locator had NO word/token
+# boundary, so a short fabricated keyword grounded INSIDE an unrelated word
+# ("Go" in "goals", "AI" in "email"/"detail", "R"/"C" in almost anything) and
+# snap-to-source then rewrote the stored evidence to a mid-word fragment ("go"),
+# slipping a hallucinated keyword past the one gate JSON Schema cannot enforce.
+# The fix requires the located match to border a non-alphanumeric (or the string
+# edge) at both OUTER edges of the whole (possibly multi-word) span.
+# --------------------------------------------------------------------------- #
+
+
+class TestTokenBoundaryGrounding:
+    def test_short_keyword_does_not_ground_inside_a_larger_word(self) -> None:
+        # "goals" must NOT ground the fabricated keyword "Go" (the exact bug).
+        jd = "Our goals are ambitious and the mission is clear."
+        assert is_grounded("Go", jd) is False
+        assert locate_grounded_span("Go", jd) is None
+
+    def test_short_keyword_grounds_on_standalone_token(self) -> None:
+        # The same keyword grounds when the JD carries it as a standalone token,
+        # and snap-to-source returns that verbatim token.
+        jd = "We build backend services in Go and Rust."
+        assert is_grounded("Go", jd) is True
+        assert locate_grounded_span("Go", jd) == "Go"
+
+    def test_standalone_token_still_snaps_to_jd_casing(self) -> None:
+        # Case-insensitive grounding is preserved: a "Go" quote grounds against a
+        # lowercase standalone "go" and snaps to the JD's actual casing.
+        jd = "We build backend services in go and rust."
+        assert is_grounded("Go", jd) is True
+        assert locate_grounded_span("Go", jd) == "go"
+
+    def test_ai_does_not_ground_inside_email_or_detail(self) -> None:
+        jd = "Send an email with every detail of the retention plan."
+        assert is_grounded("AI", jd) is False
+
+    def test_single_letter_keyword_does_not_ground_inside_words(self) -> None:
+        # "R" and "C" matched almost any word before the boundary anchor.
+        jd = "We care about reliability and craft in our services."
+        assert is_grounded("R", jd) is False
+        assert is_grounded("C", jd) is False
+
+    def test_single_letter_keyword_grounds_as_standalone_token(self) -> None:
+        jd = "Statistical modeling in R and low-level systems work in C."
+        assert is_grounded("R", jd) is True
+        assert is_grounded("C", jd) is True
+        assert locate_grounded_span("R", jd) == "R"
+        assert locate_grounded_span("C", jd) == "C"
+
+    def test_keyword_grounds_when_bordered_by_hyphen(self) -> None:
+        # A hyphen is a non-alphanumeric boundary, so "AI" is a whole token in the
+        # hyphenated compound "AI-native" and legitimately grounds.
+        jd = "We invest in AI-native tooling across the org."
+        assert is_grounded("AI", jd) is True
+        assert locate_grounded_span("AI", jd) == "AI"
+
+    def test_multi_word_span_grounds_across_internal_whitespace_and_snaps(self) -> None:
+        # The anchor constrains only the OUTER edges: a multi-word span still
+        # matches across its internal whitespace run and snaps to verbatim source.
+        jd = "You will operate production\n   Kubernetes clusters at scale."
+        assert is_grounded("production Kubernetes clusters", jd) is True
+        assert locate_grounded_span("production Kubernetes clusters", jd) == (
+            "production\n   Kubernetes clusters"
+        )
+
+    def test_sub_word_hit_before_standalone_token_snaps_to_the_real_token(self) -> None:
+        # "goals" precedes a standalone "Go"; the locator must skip the sub-word
+        # occurrence and snap to the real token, never the mid-word "go" fragment.
+        jd = "Our goals are ambitious and we ship Go services daily."
+        assert is_grounded("Go", jd) is True
+        assert locate_grounded_span("Go", jd) == "Go"
+
+    def test_ground_and_snap_rejects_keyword_grounded_only_by_a_sub_word(self) -> None:
+        # End-to-end hard gate: a hallucinated keyword whose only "evidence" is a
+        # sub-word fragment is rejected, not snapped to the fragment.
+        jd = "We set ambitious goals and value attention to detail."
+        bad = _analysis(
+            requirements=[_requirement(id="r1", text="mission", evidence_span="ambitious goals")],
+            keywords=[ReasonedKeyword(keyword="Go", evidence_span="Go", requirement_ref="r1")],
+        )
+        with pytest.raises(GroundingError) as exc:
+            ground_and_snap(bad, jd)
+        assert [(v.kind, v.ref_id) for v in exc.value.violations] == [("keyword", "Go")]
+
+
+# --------------------------------------------------------------------------- #
 # Cache key (D-11/D-12)
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
## What

Tighten the deterministic evidence-span **grounding gate** (`workers/automation/src/jobhunter/domain/materials/analysis_grounding.py`) so a located match must sit on **whole-token boundaries**. A hallucinated short keyword can no longer ground *inside* an unrelated word.

## Why (root cause)

The grounding validator is the cardinal no-fabrication gate — the one invariant JSON Schema cannot enforce: every `evidence_span` MUST be locatable in the persisted JD snapshot. The locator built a per-character tolerant regex and ran `re.search` with **no token boundary**, so a short span matched inside a longer word:

- `"Go"` grounded against `"goals"` (snapped to the mid-word fragment `"go"`)
- `"AI"` grounded against `"email"` / `"detail"`
- `"R"` / `"C"` grounded against almost anything

A fabricated keyword thus passed the gate, and snap-to-source then rewrote the stored `evidence_span` to a mid-word fragment — persisting/displaying it as "verbatim proof" and feeding the spurious keyword into tailoring's ATS targets. Correctly-absent tokens like `"ML"`/`"SRE"` were rejected, masking the hole.

## How

Bracket the tolerant locator pattern with zero-width **token-boundary lookaround** at the OUTER edges only:

```
(?<![^\W_]) <tolerant-pattern> (?![^\W_])
```

- `[^\W_]` is exactly `str.isalnum()` (Unicode-aware). Deliberately **not** `\b`, which treats `_` as a word char; the invariant is "the match is not glued to another alphanumeric".
- Zero-width + outer-edge only: **multi-word spans still match across internal whitespace**; only the first/last real character must border a non-alphanumeric (or the string edge).
- Applied against the ORIGINAL JD, so **all formatting tolerance** (whitespace runs, Unicode hyphen/dash, smart quotes, case, Markdown-escape) and **snap-to-source** are preserved.
- Because the assertions live in the pattern, `re.search` **skips a sub-word occurrence and keeps scanning** for a boundary-aligned one (e.g. `"goals … Go"` still grounds and snaps to the standalone `"Go"`, never `"go"`).

Hyphenated compounds still ground correctly (`"AI"` in `"AI-native"` — the hyphen is a non-alphanumeric boundary).

## Tests

New regression class `TestTokenBoundaryGrounding` in `workers/automation/tests/test_employer_analysis_model.py` (10 cases) pinning the exact invariant: sub-word rejection (`"Go"` vs `"goals"`, `"AI"` vs `"email"/"detail"`, single-letter `"R"`/`"C"`), standalone-token grounding + case-preserving snap, hyphen-boundary grounding, multi-word span snap across a whitespace run, sub-word-before-standalone snap-to-real-token, and an end-to-end `ground_and_snap` rejection of a keyword grounded only by a sub-word.

## Validation

- `pytest workers/automation/tests/test_employer_analysis_ensemble.py test_analyze_job_use_case.py test_employer_analysis_model.py` → **68 passed**
- `pytest` (full worker suite) → **1496 passed** (Temporal gRPC connection warnings are unrelated env noise; no test failed)
- `ruff check` on the changed source and test files → **All checks passed**

## Docs

Updated `docs/architecture.md` grounding-gate description to state the whole-token-boundary requirement — the doc explicitly claims spans whose WORDS are absent are rejected, which the sub-word hole silently violated. No other doc owns this behavior; no README/CLI/API surface changed.