### PR TITLE
feat(db): add SQLite backup command and schema-version guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,18 @@ rm -f ~/.jobhunter/jobhunter.db-wal ~/.jobhunter/jobhunter.db-shm
 cp ~/.jobhunter/backups/jobhunter-<timestamp>.db ~/.jobhunter/jobhunter.db
 ```
 
+Always restore the whole file — never hand-import individual tables from a
+backup. The read-model's projection watermark only ever moves forward, so a
+partial reconstruction can leave it ahead of the restored `job_events` and stall
+projection refresh; if you ever rebuild the database piecemeal, delete the
+`operations_projections` watermark row afterwards so the projections rebuild from
+scratch:
+
+```bash
+sqlite3 ~/.jobhunter/jobhunter.db \
+  "DELETE FROM event_watermarks WHERE projection_name = 'operations_projections';"
+```
+
 ## Normal Flow
 
 1. Create or import a candidate profile.

--- a/README.md
+++ b/README.md
@@ -95,11 +95,33 @@ Important local files include:
 - `tailored_resumes/`, `cover_letters/`, `logs/`: generated artifacts and logs.
 - `chrome-workers/`, `apply-workers/`: local browser/apply worker state.
 - `codex_home/`: isolated Codex SDK home when apply/review agents need it.
+- `backups/`: timestamped database snapshots written by `jobhunter backup`.
 
 Never commit profiles, API keys, generated resumes, cover letters, PDFs, browser
 profiles, logs, SQLite databases, screenshots containing real data, or local
 worker state. See [docs/user/data-and-safety.md](docs/user/data-and-safety.md)
 and [SECURITY.md](SECURITY.md).
+
+### Back Up And Restore
+
+All product state lives in `jobhunter.db`. Take a consistent snapshot at any
+time — even while the app is running — with:
+
+```bash
+uv --project workers/automation run jobhunter backup
+```
+
+This writes `~/.jobhunter/backups/jobhunter-<timestamp>.db` using SQLite
+`VACUUM INTO`, prints the path, and never deletes anything. Pass `--output
+<path>` to choose a specific file or target directory.
+
+To restore, stop the app (Ctrl-C on `pnpm dev`), clear any stale WAL sidecars,
+then copy a backup over the live database:
+
+```bash
+rm -f ~/.jobhunter/jobhunter.db-wal ~/.jobhunter/jobhunter.db-shm
+cp ~/.jobhunter/backups/jobhunter-<timestamp>.db ~/.jobhunter/jobhunter.db
+```
 
 ## Normal Flow
 

--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -4,12 +4,45 @@ import Database from "better-sqlite3";
 export type SqliteDatabase = Database.Database;
 export type SqliteValue = string | number | bigint | null;
 
+// Mirror of the Python worker's ``SCHEMA_VERSION``
+// (workers/automation/src/jobhunter/database.py). The worker is the single
+// writer that stamps ``PRAGMA user_version``; the API only reads it to fail
+// closed on a database written by a newer build. Bump both constants together
+// whenever the schema shape changes.
+export const SUPPORTED_SCHEMA_VERSION = 1;
+
+export class IncompatibleSchemaVersionError extends Error {
+  constructor(current: number) {
+    super(
+      `JobHunter database schema version ${current} is newer than this API build `
+        + `supports (max ${SUPPORTED_SCHEMA_VERSION}); it was created by a newer `
+        + `JobHunter build. Upgrade JobHunter or restore a compatible backup `
+        + `('jobhunter backup').`,
+    );
+    this.name = "IncompatibleSchemaVersionError";
+  }
+}
+
+function assertSchemaVersionSupported(db: SqliteDatabase): void {
+  // The API never writes ``user_version`` — the Python worker owns stamping so
+  // the schema marker has a single writer. A pre-guard database (0) or one
+  // stamped at the supported version opens normally; a greater version fails
+  // closed so a stale API never additively writes a schema it cannot
+  // understand.
+  const current = db.pragma("user_version", { simple: true }) as number;
+  if (current > SUPPORTED_SCHEMA_VERSION) {
+    db.close();
+    throw new IncompatibleSchemaVersionError(current);
+  }
+}
+
 export function openReadOnlyDatabase(dbPath: string): SqliteDatabase {
   const db = new Database(dbPath, { readonly: true, fileMustExist: true });
   // Match the worker's PRAGMA so contended reads wait instead of failing
   // immediately with SQLITE_BUSY.  Worker writes hold the WAL briefly;
   // 5s gives the API process room to retry transparently.
   db.pragma("busy_timeout = 5000");
+  assertSchemaVersionSupported(db);
   return db;
 }
 
@@ -21,6 +54,7 @@ export function openDatabase(dbPath: string): SqliteDatabase {
   // likely.  Match the worker's ``PRAGMA busy_timeout=10000`` half-way
   // so the API doesn't fail with ``SQLITE_BUSY`` on a write conflict.
   db.pragma("busy_timeout = 5000");
+  assertSchemaVersionSupported(db);
   return db;
 }
 

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import Database from "better-sqlite3";
+
+import {
+  IncompatibleSchemaVersionError,
+  SUPPORTED_SCHEMA_VERSION,
+  openDatabase,
+  openReadOnlyDatabase,
+} from "../src/db.js";
+
+function makeDbWithUserVersion(userVersion: number): { dbPath: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "jobhunter-api-schema-version-"));
+  const dbPath = path.join(dir, "jobs.db");
+  const db = new Database(dbPath);
+  db.pragma(`user_version = ${userVersion}`);
+  db.close();
+  return { dbPath, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+describe("schema version guard at DB open", () => {
+  it("refuses a database whose user_version is newer than the API supports", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION + 1);
+    try {
+      expect(() => openDatabase(dbPath)).toThrow(IncompatibleSchemaVersionError);
+      expect(() => openReadOnlyDatabase(dbPath)).toThrow(IncompatibleSchemaVersionError);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("opens a pre-guard database (user_version 0), mirroring the worker", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(0);
+    try {
+      openDatabase(dbPath).close();
+      openReadOnlyDatabase(dbPath).close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("opens a database stamped at exactly the supported version", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    try {
+      openDatabase(dbPath).close();
+      openReadOnlyDatabase(dbPath).close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("never stamps user_version — stamping stays the worker's job", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(0);
+    try {
+      openDatabase(dbPath).close();
+      const probe = new Database(dbPath, { readonly: true });
+      const stamped = probe.pragma("user_version", { simple: true }) as number;
+      probe.close();
+      expect(stamped).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -43,7 +43,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 
 | Risk | Automated coverage |
 | --- | --- |
-| SQLite has no backup/restore path, or the schema drifts without a `user_version` guard: unstamped databases go unnoticed, a pre-guard DB is not adopted, or a DB written by a newer build is silently downgraded | `workers/automation/tests/test_database_backup.py` |
+| SQLite has no backup/restore path, or the schema drifts without a `user_version` guard: unstamped databases go unnoticed, a pre-guard DB is not adopted, or a DB written by a newer build is silently downgraded by the worker or additively written by a stale TypeScript API | `workers/automation/tests/test_database_backup.py`; `apps/api/test/schema-version-guard.test.ts` |
 | Dry run marks a job applied | `workers/automation/tests/test_apply_regressions.py` |
 | Apply process hangs while stdout stays open | `workers/automation/tests/test_apply_regressions.py` |
 | Targeted apply skips fresh jobs | `workers/automation/tests/test_apply_regressions.py` |

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -43,6 +43,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 
 | Risk | Automated coverage |
 | --- | --- |
+| SQLite has no backup/restore path, or the schema drifts without a `user_version` guard: unstamped databases go unnoticed, a pre-guard DB is not adopted, or a DB written by a newer build is silently downgraded | `workers/automation/tests/test_database_backup.py` |
 | Dry run marks a job applied | `workers/automation/tests/test_apply_regressions.py` |
 | Apply process hangs while stdout stays open | `workers/automation/tests/test_apply_regressions.py` |
 | Targeted apply skips fresh jobs | `workers/automation/tests/test_apply_regressions.py` |

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import sqlite3
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1477,6 +1478,36 @@ def _worker_heartbeat_iteration(
         started_before=worker_started_at,
     )
     return (recovered_stages, recovered_discovery_runs)
+
+
+@app.command()
+def backup(
+    output: Optional[Path] = typer.Option(
+        None,
+        "--output",
+        "-o",
+        help=(
+            "Destination file, or a directory to place a timestamped backup in. "
+            "Defaults to ~/.jobhunter/backups/jobhunter-<timestamp>.db."
+        ),
+    ),
+) -> None:
+    """Write a consistent snapshot of the local SQLite database.
+
+    Uses SQLite VACUUM INTO, so it is safe to run while the app is running.
+    Nothing is ever deleted. To restore, stop the app and copy a backup file
+    over ~/.jobhunter/jobhunter.db.
+    """
+    from jobhunter.database import backup_database
+
+    try:
+        destination = backup_database(output)
+    except (FileNotFoundError, FileExistsError, OSError, sqlite3.Error) as exc:
+        console.print(f"[red]Backup failed:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    size = destination.stat().st_size
+    console.print(f"[green]Database backup written:[/green] {destination} ({size:,} bytes)")
 
 
 @app.command()

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -9,7 +9,6 @@ persistent run and event telemetry.
 """
 
 import json
-import logging
 import sqlite3
 import threading
 from datetime import datetime, timezone
@@ -18,13 +17,16 @@ from typing import Any
 
 from jobhunter.config import DB_PATH, DEFAULTS
 
-log = logging.getLogger(__name__)
-
 # Schema version stamped into the SQLite ``user_version`` header. The ensure_*
 # helpers below are additive and idempotent, so this is a lightweight
-# forward-incompatibility guard (detect a DB written by a newer build), not a
+# forward-incompatibility guard (refuse a DB written by a newer build), not a
 # migration framework. Bump it only when the schema shape changes.
 SCHEMA_VERSION = 1
+
+
+class IncompatibleSchemaVersionError(RuntimeError):
+    """Raised when the database was written by a newer build than this code."""
+
 
 # Thread-local connection storage — each thread gets its own connection
 # (required for SQLite thread safety with parallel workers)
@@ -105,6 +107,9 @@ def backup_database(
 
     src = sqlite3.connect(source)
     try:
+        # Match the app's lock-wait budget so a backup taken during transient
+        # DDL waits briefly instead of failing on "database is locked".
+        src.execute("PRAGMA busy_timeout=10000")
         src.execute("VACUUM INTO ?", (str(destination),))
     finally:
         src.close()
@@ -119,7 +124,7 @@ def _resolve_backup_destination(source: Path, output: Path | str | None) -> Path
         target_dir = candidate
     else:
         target_dir = source.parent / "backups"
-    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
     return target_dir / f"jobhunter-{timestamp}.db"
 
 
@@ -127,20 +132,20 @@ def _ensure_schema_version(conn: sqlite3.Connection) -> int:
     """Stamp ``PRAGMA user_version`` as a lightweight schema guard.
 
     Databases created before this guard report ``user_version == 0`` and are
-    adopted by stamping ``SCHEMA_VERSION``. A database whose version is newer
-    than this build is left untouched -- never silently downgraded -- and a
-    warning is logged so a stale build does not corrupt a forward-migrated file.
+    adopted by stamping ``SCHEMA_VERSION``; an equal version is a no-op. A
+    database whose version is newer than this build fails closed with
+    ``IncompatibleSchemaVersionError`` -- the caller (``init_db``) invokes this
+    before any table creation or migration, so a stale build never runs its
+    potentially destructive ``ensure_*`` migrations against a forward-migrated
+    file, and is never silently downgraded.
     """
     current = int(conn.execute("PRAGMA user_version").fetchone()[0])
     if current > SCHEMA_VERSION:
-        log.warning(
-            "Database schema version %s is newer than this build's schema version %s; "
-            "the database was written by a newer JobHunter. Upgrade JobHunter before "
-            "writing to it, and keep a backup ('jobhunter backup').",
-            current,
-            SCHEMA_VERSION,
+        raise IncompatibleSchemaVersionError(
+            f"database was written by a newer JobHunter build "
+            f"(schema version {current} > code schema version {SCHEMA_VERSION}); "
+            f"upgrade JobHunter or restore a compatible backup ('jobhunter backup')."
         )
-        return current
     if current < SCHEMA_VERSION:
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         conn.commit()

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -9,6 +9,7 @@ persistent run and event telemetry.
 """
 
 import json
+import logging
 import sqlite3
 import threading
 from datetime import datetime, timezone
@@ -16,6 +17,14 @@ from pathlib import Path
 from typing import Any
 
 from jobhunter.config import DB_PATH, DEFAULTS
+
+log = logging.getLogger(__name__)
+
+# Schema version stamped into the SQLite ``user_version`` header. The ensure_*
+# helpers below are additive and idempotent, so this is a lightweight
+# forward-incompatibility guard (detect a DB written by a newer build), not a
+# migration framework. Bump it only when the schema shape changes.
+SCHEMA_VERSION = 1
 
 # Thread-local connection storage — each thread gets its own connection
 # (required for SQLite thread safety with parallel workers)
@@ -64,6 +73,80 @@ def close_connection(db_path: Path | str | None = None) -> None:
             conn.close()
 
 
+def backup_database(
+    output: Path | str | None = None,
+    *,
+    db_path: Path | str | None = None,
+) -> Path:
+    """Write a consistent snapshot of the live database with ``VACUUM INTO``.
+
+    ``VACUUM INTO`` copies a transactionally consistent view of the database
+    even while the app is running under WAL, and always emits a standalone
+    single-file database (no ``-wal`` / ``-shm`` sidecars) that can be copied
+    over ``jobhunter.db`` to restore. Nothing is ever deleted.
+
+    Args:
+        output: Destination file, or an existing directory to place a
+            timestamped file into. Defaults to a timestamped file under a
+            ``backups/`` directory next to the source database.
+        db_path: Override the source database path (defaults to ``DB_PATH``).
+
+    Returns:
+        The path the backup was written to.
+    """
+    source = Path(db_path or DB_PATH)
+    if not source.exists():
+        raise FileNotFoundError(f"No database to back up at {source}")
+
+    destination = _resolve_backup_destination(source, output)
+    if destination.exists():
+        raise FileExistsError(f"Backup destination already exists: {destination}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    src = sqlite3.connect(source)
+    try:
+        src.execute("VACUUM INTO ?", (str(destination),))
+    finally:
+        src.close()
+    return destination
+
+
+def _resolve_backup_destination(source: Path, output: Path | str | None) -> Path:
+    if output is not None:
+        candidate = Path(output).expanduser()
+        if not candidate.is_dir():
+            return candidate
+        target_dir = candidate
+    else:
+        target_dir = source.parent / "backups"
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    return target_dir / f"jobhunter-{timestamp}.db"
+
+
+def _ensure_schema_version(conn: sqlite3.Connection) -> int:
+    """Stamp ``PRAGMA user_version`` as a lightweight schema guard.
+
+    Databases created before this guard report ``user_version == 0`` and are
+    adopted by stamping ``SCHEMA_VERSION``. A database whose version is newer
+    than this build is left untouched -- never silently downgraded -- and a
+    warning is logged so a stale build does not corrupt a forward-migrated file.
+    """
+    current = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    if current > SCHEMA_VERSION:
+        log.warning(
+            "Database schema version %s is newer than this build's schema version %s; "
+            "the database was written by a newer JobHunter. Upgrade JobHunter before "
+            "writing to it, and keep a backup ('jobhunter backup').",
+            current,
+            SCHEMA_VERSION,
+        )
+        return current
+    if current < SCHEMA_VERSION:
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+    return SCHEMA_VERSION
+
+
 def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     """Create the full jobs table with all columns from every pipeline stage.
 
@@ -92,6 +175,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
 
     conn = get_connection(path)
+    _ensure_schema_version(conn)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS jobs (
             -- Discovery stage (smart_extract / job_search)

--- a/workers/automation/tests/test_database_backup.py
+++ b/workers/automation/tests/test_database_backup.py
@@ -1,0 +1,178 @@
+"""Schema-version guard + VACUUM INTO backup for the local SQLite database.
+
+These pin the two data-durability invariants added alongside ``jobhunter
+backup``: every database carries a stamped ``PRAGMA user_version`` (adopted
+cleanly for pre-guard files, never silently downgraded), and a backup is a
+readable standalone SQLite file holding the same tables and rows as the source.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+
+import pytest
+
+from jobhunter.database import (
+    SCHEMA_VERSION,
+    backup_database,
+    close_connection,
+    init_db,
+)
+
+
+def _user_version(db_path) -> int:
+    conn = sqlite3.connect(db_path)
+    try:
+        return int(conn.execute("PRAGMA user_version").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def test_fresh_db_is_stamped_with_schema_version(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+
+def test_schema_version_persists_across_reopen(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+    # Re-opening an already-stamped database must be a no-op, not a re-stamp.
+    init_db(db_path)
+    close_connection(db_path)
+    assert _user_version(db_path) == SCHEMA_VERSION
+
+
+def test_legacy_version_zero_db_is_adopted_without_data_loss(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = init_db(db_path)
+    conn.execute("INSERT INTO jobs (url, title) VALUES (?, ?)", ("https://ex/legacy", "Engineer"))
+    conn.commit()
+    close_connection(db_path)
+
+    # Simulate a database created before the guard existed: version 0.
+    raw = sqlite3.connect(db_path)
+    raw.execute("PRAGMA user_version = 0")
+    raw.commit()
+    raw.close()
+
+    init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == SCHEMA_VERSION
+    check = sqlite3.connect(db_path)
+    try:
+        row = check.execute("SELECT title FROM jobs WHERE url = ?", ("https://ex/legacy",)).fetchone()
+    finally:
+        check.close()
+    assert row is not None and row[0] == "Engineer"
+
+
+def test_newer_schema_version_is_not_downgraded_and_warns(tmp_path, caplog) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    close_connection(db_path)
+
+    future_version = SCHEMA_VERSION + 5
+    raw = sqlite3.connect(db_path)
+    raw.execute(f"PRAGMA user_version = {future_version}")
+    raw.commit()
+    raw.close()
+
+    with caplog.at_level(logging.WARNING, logger="jobhunter.database"):
+        init_db(db_path)
+    close_connection(db_path)
+
+    assert _user_version(db_path) == future_version
+    assert "newer" in caplog.text.lower()
+
+
+def test_backup_copies_tables_and_rows_into_readable_sqlite(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = init_db(db_path)
+    conn.execute(
+        "INSERT INTO jobs (url, title, company) VALUES (?, ?, ?)",
+        ("https://ex/backup-1", "Staff Engineer", "Acme"),
+    )
+    conn.execute(
+        "INSERT INTO job_events (job_url, stage, event_type, level, message, occurred_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("https://ex/backup-1", "discover", "StageCompleted", "info", "done", "2026-05-01T00:00:00+00:00"),
+    )
+    conn.commit()
+
+    destination = backup_database(tmp_path / "snapshot.db", db_path=db_path)
+
+    assert destination == tmp_path / "snapshot.db"
+    assert destination.exists()
+    # VACUUM INTO produces a standalone single-file database, no WAL sidecar.
+    assert not (tmp_path / "snapshot.db-wal").exists()
+
+    backup = sqlite3.connect(destination)
+    try:
+        assert int(backup.execute("PRAGMA user_version").fetchone()[0]) == SCHEMA_VERSION
+        tables = {row[0] for row in backup.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()}
+        for expected in ("jobs", "job_events", "job_stage_states", "candidate_profiles"):
+            assert expected in tables
+        job_row = backup.execute(
+            "SELECT title, company FROM jobs WHERE url = ?", ("https://ex/backup-1",)
+        ).fetchone()
+        assert job_row == ("Staff Engineer", "Acme")
+        event_count = backup.execute(
+            "SELECT COUNT(*) FROM job_events WHERE job_url = ?", ("https://ex/backup-1",)
+        ).fetchone()[0]
+        assert event_count == 1
+    finally:
+        backup.close()
+
+
+def test_backup_default_path_is_timestamped_under_source_backups_dir(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+
+    destination = backup_database(db_path=db_path)
+
+    assert destination.parent == tmp_path / "backups"
+    assert destination.name.startswith("jobhunter-")
+    assert destination.suffix == ".db"
+    assert destination.exists()
+    readback = sqlite3.connect(destination)
+    try:
+        assert readback.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 0
+    finally:
+        readback.close()
+
+
+def test_backup_into_existing_directory_generates_timestamped_file(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    out_dir = tmp_path / "manual-backups"
+    out_dir.mkdir()
+
+    destination = backup_database(out_dir, db_path=db_path)
+
+    assert destination.parent == out_dir
+    assert destination.name.startswith("jobhunter-")
+    assert destination.suffix == ".db"
+    assert destination.exists()
+
+
+def test_backup_missing_source_raises(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError):
+        backup_database(db_path=tmp_path / "does-not-exist.db")
+
+
+def test_backup_refuses_existing_destination(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    init_db(db_path)
+    destination = tmp_path / "already-there.db"
+    destination.write_bytes(b"")
+
+    with pytest.raises(FileExistsError):
+        backup_database(destination, db_path=db_path)

--- a/workers/automation/tests/test_database_backup.py
+++ b/workers/automation/tests/test_database_backup.py
@@ -8,12 +8,12 @@ readable standalone SQLite file holding the same tables and rows as the source.
 
 from __future__ import annotations
 
-import logging
 import sqlite3
 
 import pytest
 
 from jobhunter.database import (
+    IncompatibleSchemaVersionError,
     SCHEMA_VERSION,
     backup_database,
     close_connection,
@@ -74,23 +74,57 @@ def test_legacy_version_zero_db_is_adopted_without_data_loss(tmp_path) -> None:
     assert row is not None and row[0] == "Engineer"
 
 
-def test_newer_schema_version_is_not_downgraded_and_warns(tmp_path, caplog) -> None:
+def test_newer_schema_version_fails_closed_before_migrations(tmp_path) -> None:
     db_path = tmp_path / "jobhunter.db"
-    init_db(db_path)
+    # A database stamped newer than this build, before any schema exists.
+    raw = sqlite3.connect(db_path)
+    raw.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+    raw.commit()
+    raw.close()
+
+    with pytest.raises(IncompatibleSchemaVersionError):
+        init_db(db_path)
     close_connection(db_path)
 
-    future_version = SCHEMA_VERSION + 5
+    # The guard fired before any migration ran: the version is not downgraded
+    # and no tables were created (init_db never reached CREATE TABLE / ensure_*).
+    assert _user_version(db_path) == SCHEMA_VERSION + 1
+    check = sqlite3.connect(db_path)
+    try:
+        tables = {
+            row[0]
+            for row in check.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+        }
+    finally:
+        check.close()
+    assert tables == set()
+
+
+def test_newer_schema_version_on_populated_db_fails_closed_without_data_loss(tmp_path) -> None:
+    db_path = tmp_path / "jobhunter.db"
+    conn = init_db(db_path)
+    conn.execute("INSERT INTO jobs (url, title) VALUES (?, ?)", ("https://ex/keep", "Engineer"))
+    conn.commit()
+    close_connection(db_path)
+
+    future_version = SCHEMA_VERSION + 3
     raw = sqlite3.connect(db_path)
     raw.execute(f"PRAGMA user_version = {future_version}")
     raw.commit()
     raw.close()
 
-    with caplog.at_level(logging.WARNING, logger="jobhunter.database"):
+    with pytest.raises(IncompatibleSchemaVersionError):
         init_db(db_path)
     close_connection(db_path)
 
+    # Existing data is untouched and the version is not downgraded.
     assert _user_version(db_path) == future_version
-    assert "newer" in caplog.text.lower()
+    check = sqlite3.connect(db_path)
+    try:
+        row = check.execute("SELECT title FROM jobs WHERE url = ?", ("https://ex/keep",)).fetchone()
+    finally:
+        check.close()
+    assert row is not None and row[0] == "Engineer"
 
 
 def test_backup_copies_tables_and_rows_into_readable_sqlite(tmp_path) -> None:


### PR DESCRIPTION
## What

Adds two additive, non-destructive data-durability safety nets to the local SQLite store (`~/.jobhunter/jobhunter.db`). No schema rewrite, no behavior change to existing paths.

1. **Schema-version guard** — `database.py` now defines `SCHEMA_VERSION` and stamps `PRAGMA user_version` on `init_db`:
   - Pre-guard databases report `user_version == 0` and are **adopted cleanly** (stamped to `SCHEMA_VERSION`).
   - A DB whose version is **newer than the running build** is left untouched (never silently downgraded) and logs a clear warning.
   - The existing idempotent `ensure_*` migrations remain the schema source of truth — this is a lightweight forward-incompatibility guard, not a migration framework.
2. **`jobhunter backup` command** (+ `backup_database` helper) — writes a consistent snapshot with SQLite `VACUUM INTO` to a timestamped file under `~/.jobhunter/backups/jobhunter-<timestamp>.db`. Safe to run while the app is running (WAL-consistent), produces a standalone single-file DB (no `-wal`/`-shm` sidecars), supports `--output <file|dir>`, prints the path, and never deletes anything.

## Why

The entire product state — canonical event log, all job/profile data, artifact pointers — lives in one WAL-mode SQLite file with **no backup/restore/export path** and **no `user_version` marker**. A stale build or an interrupted schema change could touch the DB undetected, the highest-probability real-world data-loss vector for this local-first app. These changes make snapshots trivial and make a version mismatch loud instead of silent.

## Docs

- `README.md`: new "Back Up And Restore" section (backup command + WAL-safe restore steps), and `backups/` added to the local files list.
- `docs/local-reliability-qa.md`: regression row mapping the invariant to `test_database_backup.py`.

## How validated

Run from the worktree.

**New tests + existing DB regression (`test_job_repository.py`):**
```
$ uv --project workers/automation run --extra dev pytest -q \
    workers/automation/tests/test_database_backup.py \
    workers/automation/tests/test_job_repository.py
.....................                                                    [100%]
21 passed in 0.51s
```
Also ran `test_dashboard_projection.py` + `test_projection_builder.py` (init_db-heavy): 32 passed.

**Lint:**
```
$ uv --project workers/automation run --extra dev ruff check \
    workers/automation/src/jobhunter/database.py workers/automation/src/jobhunter/cli.py
All checks passed!
$ uv --project workers/automation run --extra dev ruff check .   # whole worker package
All checks passed!
$ git diff --check
clean
```

**CLI smoke** (throwaway `JOBHUNTER_DIR`, never touches real `~/.jobhunter`): created a DB with one job row, then:
- `jobhunter backup` → wrote `backups/jobhunter-<ts>.db` (749,568 bytes), printed the path.
- `jobhunter backup --output <file>` → wrote the explicit file.
- Both backups reopened with `user_version=1` and the seeded job row present.
- `backup` shows in `jobhunter --help` and `jobhunter backup --help`.

## Safety

No auto-apply/browser/destructive actions were run. Backup is read-only against the DB; the restore procedure is documented (manual, app stopped) and not automated.