### PR TITLE
fix(projections): Python builder writes score criteria/trace/correction audit columns

### DIFF
--- a/workers/automation/src/jobhunter/domain/operations/projections.py
+++ b/workers/automation/src/jobhunter/domain/operations/projections.py
@@ -81,6 +81,9 @@ class JobListProjection:
     score_reasoning: str = ""
     score_version: int | None = None
     scored_at: str | None = None
+    score_criteria_json: str | None = None
+    score_trace_json: str | None = None
+    score_correction_json: str | None = None
     current_stage: str = "discover"
     current_substage: str = "discover"
     current_state: str = "pending"
@@ -144,6 +147,9 @@ class JobDetailProjection:
     score_reasoning: str = ""
     score_version: int | None = None
     scored_at: str | None = None
+    score_criteria_json: str | None = None
+    score_trace_json: str | None = None
+    score_correction_json: str | None = None
     stages: tuple[StageProjection, ...] = ()
     last_updated_at: str | None = None
     # Phase 1: the canonical employer-analysis read shape (JSON of the latest

--- a/workers/automation/src/jobhunter/domain/ports/watermark.py
+++ b/workers/automation/src/jobhunter/domain/ports/watermark.py
@@ -23,9 +23,16 @@ class EventWatermarkRepository(Protocol):
         """
         ...
 
-    def set(self, projection_name: str, last_event_id: int) -> None:
+    def set(
+        self, projection_name: str, last_event_id: int, *, commit: bool = True
+    ) -> None:
         """Upsert *projection_name* → *last_event_id*.
 
-        Implementations must be transactional.
+        Implementations must be transactional and monotonic: the watermark
+        never regresses, so a stale or out-of-order write with a lower
+        *last_event_id* is a no-op.
+
+        Pass ``commit=False`` to defer the flush to an enclosing transaction
+        (e.g. the projection builder rebuilding within the caller's write).
         """
         ...

--- a/workers/automation/src/jobhunter/infrastructure/events/watermark.py
+++ b/workers/automation/src/jobhunter/infrastructure/events/watermark.py
@@ -33,17 +33,31 @@ class SqliteEventWatermarkRepository:
         except (KeyError, TypeError, IndexError):
             return int(row[0])
 
-    def set(self, projection_name: str, last_event_id: int) -> None:
+    def set(
+        self, projection_name: str, last_event_id: int, *, commit: bool = True
+    ) -> None:
         if last_event_id < 0:
             raise ValueError(f"last_event_id must be >= 0 (got {last_event_id})")
+        # MAX() keeps the watermark monotonic: a stale or out-of-order writer
+        # can never rewind it. updated_at only moves when the value advances.
         self._conn.execute(
             """
             INSERT INTO event_watermarks (projection_name, last_event_id, updated_at)
             VALUES (?, ?, ?)
             ON CONFLICT(projection_name) DO UPDATE SET
-                last_event_id = excluded.last_event_id,
-                updated_at    = excluded.updated_at
+                last_event_id = MAX(
+                    event_watermarks.last_event_id, excluded.last_event_id
+                ),
+                updated_at    = CASE
+                    WHEN excluded.last_event_id > event_watermarks.last_event_id
+                        THEN excluded.updated_at
+                    ELSE event_watermarks.updated_at
+                END
             """,
             (projection_name, int(last_event_id), _utc_now()),
         )
-        self._conn.commit()
+        # commit=False lets an outer transaction (the ProjectionBuilder's
+        # deferred-commit path) own the flush so the watermark bump stays
+        # atomic with the projection rebuild and the caller's own writes.
+        if commit:
+            self._conn.commit()

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -89,6 +89,13 @@ log = logging.getLogger(__name__)
 
 
 PROJECTION_NAME = "operations_projections"
+# One-time backfill marker: existing DBs already had the score-audit projection
+# columns (the TS builder added them via ensureProjectionColumn), so the schema-
+# migration reset in ``ensure_projection_tables`` never fires for them and the
+# scored rows the Python builder wrote before it learned to project the audit
+# columns keep NULL criteria/trace/correction. This marker drives a single
+# targeted rebuild of those rows, independent of column creation.
+SCORE_AUDIT_BACKFILL = "score_audit_columns_v1"
 COMPENSATION_PROJECTION_VERSION = 1
 POSTED_COMPENSATION_WARNING_MESSAGES = {
     "ambiguous_multiple_amounts": "Multiple compensation amounts were present and the primary range is ambiguous.",
@@ -420,6 +427,14 @@ class ProjectionBuilder:
                 pass
         dirty_jobs.update(self._stale_deleted_projection_jobs())
 
+        # One-time score-audit backfill (see SCORE_AUDIT_BACKFILL): rebuild any
+        # already-projected scored job whose audit columns are still NULL. This
+        # is independent of schema migration — on existing DBs the columns were
+        # added long ago by the TS builder, so the migration reset never runs.
+        audit_backfill_pending = not self._score_audit_backfill_done()
+        if audit_backfill_pending:
+            dirty_jobs.update(self._jobs_missing_score_audit_projection())
+
         # L5 (round-1 review): if there's nothing dirty AND we've already
         # synced past the latest event, skip the O(jobs × stages)
         # dashboard / apply-run rebuilds.  Exception: first-run, when
@@ -446,6 +461,7 @@ class ProjectionBuilder:
             and dashboard_exists
             and (source_quality_exists or not source_quality_history)
             and max_event_id == watermark
+            and not audit_backfill_pending
         ):
             return 0
 
@@ -468,6 +484,8 @@ class ProjectionBuilder:
                 self._watermarks.set(PROJECTION_NAME, max_event_id)
             if not dashboard_exists:
                 self._rebuild_dashboard()
+            if audit_backfill_pending:
+                self._mark_score_audit_backfill_done()
             if not defer_commit:
                 self._conn.commit()
             return 0
@@ -483,6 +501,8 @@ class ProjectionBuilder:
         self._rebuild_dashboard()
         if max_event_id > watermark:
             self._watermarks.set(PROJECTION_NAME, max_event_id)
+        if audit_backfill_pending:
+            self._mark_score_audit_backfill_done()
         if not defer_commit:
             self._conn.commit()
         return len(dirty_jobs)
@@ -1158,6 +1178,48 @@ class ProjectionBuilder:
                 WHERE p.tenant_id = ?
                   AND (d.restored_at IS NULL OR julianday(d.restored_at) <= julianday(d.deleted_at))
                   AND (p.deleted_at IS NULL OR p.deleted_at != d.deleted_at)
+                """,
+                (str(self._tenant_id),),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return set()
+        return {
+            str(row["job_id"] if not isinstance(row, tuple) else row[0])
+            for row in rows
+            if (row["job_id"] if not isinstance(row, tuple) else row[0])
+        }
+
+    @property
+    def _score_audit_backfill_marker(self) -> str:
+        # Per-tenant marker so a shared multi-tenant DB backfills each tenant's
+        # scored rows exactly once, matching the per-tenant scan below.
+        return f"{SCORE_AUDIT_BACKFILL}:{self._tenant_id}"
+
+    def _score_audit_backfill_done(self) -> bool:
+        try:
+            row = self._conn.execute(
+                "SELECT 1 FROM projection_backfills WHERE name = ?",
+                (self._score_audit_backfill_marker,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return False
+        return row is not None
+
+    def _mark_score_audit_backfill_done(self) -> None:
+        self._conn.execute(
+            "INSERT OR IGNORE INTO projection_backfills (name, completed_at) VALUES (?, ?)",
+            (self._score_audit_backfill_marker, _utc_now()),
+        )
+
+    def _jobs_missing_score_audit_projection(self) -> set[str]:
+        try:
+            rows = self._conn.execute(
+                """
+                SELECT p.job_id
+                FROM job_list_projections p
+                JOIN job_scores s ON s.job_url = p.job_id
+                WHERE p.tenant_id = ?
+                  AND p.score_criteria_json IS NULL
                 """,
                 (str(self._tenant_id),),
             ).fetchall()

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -481,7 +481,9 @@ class ProjectionBuilder:
             if source_quality_dirty or (not source_quality_exists and source_quality_history):
                 self._rebuild_source_quality()
             if max_event_id > watermark:
-                self._watermarks.set(PROJECTION_NAME, max_event_id)
+                self._watermarks.set(
+                    PROJECTION_NAME, max_event_id, commit=not defer_commit
+                )
             if not dashboard_exists:
                 self._rebuild_dashboard()
             if audit_backfill_pending:
@@ -500,7 +502,9 @@ class ProjectionBuilder:
             self._rebuild_job(job_url)
         self._rebuild_dashboard()
         if max_event_id > watermark:
-            self._watermarks.set(PROJECTION_NAME, max_event_id)
+            self._watermarks.set(
+                PROJECTION_NAME, max_event_id, commit=not defer_commit
+            )
         if audit_backfill_pending:
             self._mark_score_audit_backfill_done()
         if not defer_commit:

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -549,6 +549,9 @@ class ProjectionBuilder:
         score_keywords_json = score.get("keywords_json") or "[]"
         score_version = score.get("version")
         scored_at = score.get("scored_at")
+        score_criteria_json = score.get("criteria_json")
+        score_trace_json = score.get("trace_json")
+        score_correction_json = score.get("correction_json")
 
         # Materials presence:
         tailor_path = materials.get("tailor_path") or _row_nullable_str(
@@ -611,6 +614,9 @@ class ProjectionBuilder:
             score_reasoning=score_reasoning,
             score_version=score_version,
             scored_at=scored_at,
+            score_criteria_json=score_criteria_json,
+            score_trace_json=score_trace_json,
+            score_correction_json=score_correction_json,
             current_stage=current_stage,
             current_substage=current_substage,
             current_state=current_state,
@@ -642,6 +648,9 @@ class ProjectionBuilder:
             score_reasoning=score_reasoning,
             score_version=score_version,
             scored_at=scored_at,
+            score_criteria_json=score_criteria_json,
+            score_trace_json=score_trace_json,
+            score_correction_json=score_correction_json,
             stages=tuple(stages),
             employer_analysis_json=employer_analysis_json,
             requirement_fit_report_json=requirement_fit_report_json,
@@ -896,7 +905,8 @@ class ProjectionBuilder:
             row = self._conn.execute(
                 """
                 SELECT s.version, s.fit_score, s.scored_at, s.breakdown_json,
-                       s.keywords_json
+                       s.keywords_json, s.criteria_json, s.trace_json,
+                       s.correction_json
                 FROM job_scores s
                 WHERE s.job_url = ?
                 ORDER BY s.version DESC
@@ -923,6 +933,9 @@ class ProjectionBuilder:
             "breakdown_json": None if legacy else json.dumps(_camel_score_breakdown(breakdown)),
             "keywords_json": json.dumps([] if legacy and keywords == ["legacy"] else keywords),
             "reasoning": reasoning,
+            "criteria_json": _row_nullable_str(row, "criteria_json"),
+            "trace_json": _row_nullable_str(row, "trace_json"),
+            "correction_json": _row_nullable_str(row, "correction_json"),
         }
 
     def _load_latest_materials(self, job_url: str) -> dict:

--- a/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
@@ -311,6 +311,14 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
         ON operational_attempt_metrics(tenant_id, source_id, occurred_at DESC, metric_id DESC)
         """
     )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS projection_backfills (
+            name         TEXT PRIMARY KEY,
+            completed_at TEXT NOT NULL
+        )
+        """
+    )
     score_evidence_schema_changed = False
     for table_name, column_name, definition in SCORE_EVIDENCE_COLUMNS:
         score_evidence_schema_changed = (

--- a/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py
@@ -55,6 +55,9 @@ SCORE_EVIDENCE_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("job_list_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'"),
     ("job_list_projections", "score_version", "INTEGER"),
     ("job_list_projections", "scored_at", "TEXT"),
+    ("job_list_projections", "score_criteria_json", "TEXT"),
+    ("job_list_projections", "score_trace_json", "TEXT"),
+    ("job_list_projections", "score_correction_json", "TEXT"),
     ("job_list_projections", "current_substage", "TEXT NOT NULL DEFAULT 'discover'"),
     ("job_detail_projections", "score_breakdown_json", "TEXT"),
     ("job_detail_projections", "compensation_summary_json", "TEXT"),
@@ -62,6 +65,9 @@ SCORE_EVIDENCE_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("job_detail_projections", "score_keywords_json", "TEXT NOT NULL DEFAULT '[]'"),
     ("job_detail_projections", "score_version", "INTEGER"),
     ("job_detail_projections", "scored_at", "TEXT"),
+    ("job_detail_projections", "score_criteria_json", "TEXT"),
+    ("job_detail_projections", "score_trace_json", "TEXT"),
+    ("job_detail_projections", "score_correction_json", "TEXT"),
     ("job_detail_projections", "employer_analysis_json", "TEXT"),
     ("job_detail_projections", "requirement_fit_report_json", "TEXT"),
     ("artifact_list_projections", "metadata_json", "TEXT"),
@@ -97,6 +103,9 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             score_reasoning        TEXT NOT NULL DEFAULT '',
             score_version          INTEGER,
             scored_at              TEXT,
+            score_criteria_json    TEXT,
+            score_trace_json       TEXT,
+            score_correction_json  TEXT,
             current_stage          TEXT NOT NULL DEFAULT 'discover',
             current_substage       TEXT NOT NULL DEFAULT 'discover',
             current_state          TEXT NOT NULL DEFAULT 'pending',
@@ -151,6 +160,9 @@ def ensure_projection_tables(conn: sqlite3.Connection) -> list[str]:
             score_reasoning        TEXT NOT NULL DEFAULT '',
             score_version          INTEGER,
             scored_at              TEXT,
+            score_criteria_json    TEXT,
+            score_trace_json       TEXT,
+            score_correction_json  TEXT,
             stages_json            TEXT NOT NULL DEFAULT '[]',
             employer_analysis_json TEXT,
             requirement_fit_report_json TEXT,
@@ -352,6 +364,7 @@ class SqliteProjectionStore:
                 full_description, fit_score, compensation_summary_json,
                 score_breakdown_json, score_keywords_json,
                 score_reasoning, score_version, scored_at,
+                score_criteria_json, score_trace_json, score_correction_json,
                 current_stage, current_substage, current_state, current_error_code,
                 current_error_message, current_next_action, has_resume,
                 has_cover_letter, has_pdf, apply_status, applied_at,
@@ -359,7 +372,7 @@ class SqliteProjectionStore:
                 last_updated_at
             ) VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )
             ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 title                 = excluded.title,
@@ -379,6 +392,9 @@ class SqliteProjectionStore:
                 score_reasoning       = excluded.score_reasoning,
                 score_version         = excluded.score_version,
                 scored_at             = excluded.scored_at,
+                score_criteria_json   = excluded.score_criteria_json,
+                score_trace_json      = excluded.score_trace_json,
+                score_correction_json = excluded.score_correction_json,
                 current_stage         = excluded.current_stage,
                 current_substage      = excluded.current_substage,
                 current_state         = excluded.current_state,
@@ -414,6 +430,9 @@ class SqliteProjectionStore:
                 projection.score_reasoning,
                 projection.score_version,
                 projection.scored_at,
+                projection.score_criteria_json,
+                projection.score_trace_json,
+                projection.score_correction_json,
                 projection.current_stage,
                 projection.current_substage,
                 projection.current_state,
@@ -492,9 +511,10 @@ class SqliteProjectionStore:
                 tenant_id, job_id, description_preview, compensation_summary_json,
                 compensation_audit_json, score_breakdown_json, score_keywords_json,
                 score_reasoning, score_version, scored_at,
+                score_criteria_json, score_trace_json, score_correction_json,
                 stages_json, employer_analysis_json, requirement_fit_report_json,
                 last_updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tenant_id, job_id) DO UPDATE SET
                 description_preview    = excluded.description_preview,
                 compensation_summary_json = excluded.compensation_summary_json,
@@ -504,6 +524,9 @@ class SqliteProjectionStore:
                 score_reasoning        = excluded.score_reasoning,
                 score_version          = excluded.score_version,
                 scored_at              = excluded.scored_at,
+                score_criteria_json    = excluded.score_criteria_json,
+                score_trace_json       = excluded.score_trace_json,
+                score_correction_json  = excluded.score_correction_json,
                 stages_json            = excluded.stages_json,
                 employer_analysis_json = excluded.employer_analysis_json,
                 requirement_fit_report_json = excluded.requirement_fit_report_json,
@@ -520,6 +543,9 @@ class SqliteProjectionStore:
                 projection.score_reasoning,
                 projection.score_version,
                 projection.scored_at,
+                projection.score_criteria_json,
+                projection.score_trace_json,
+                projection.score_correction_json,
                 json.dumps(
                     [
                         {

--- a/workers/automation/tests/test_event_watermark.py
+++ b/workers/automation/tests/test_event_watermark.py
@@ -64,3 +64,50 @@ def test_negative_event_id_rejected(tmp_path: Path) -> None:
             repo.set("bad", -1)
     finally:
         close_connection(db_path)
+
+
+def test_set_is_monotonic_never_regresses(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        repo = SqliteEventWatermarkRepository(conn)
+        repo.set("scoring_projection", 10)
+        # A backwards write must be ignored — the watermark never regresses.
+        repo.set("scoring_projection", 5)
+        assert repo.get("scoring_projection") == 10
+        # Equal is a no-op; a forward write advances.
+        repo.set("scoring_projection", 10)
+        assert repo.get("scoring_projection") == 10
+        repo.set("scoring_projection", 15)
+        assert repo.get("scoring_projection") == 15
+    finally:
+        close_connection(db_path)
+
+
+def test_deferred_set_does_not_autocommit(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        repo = SqliteEventWatermarkRepository(conn)
+        repo.set("scoring_projection", 5)
+        # A deferred write leaves the transaction open for the outer owner
+        # to flush; rolling back reverts it so the watermark is unchanged.
+        repo.set("scoring_projection", 9, commit=False)
+        assert conn.in_transaction
+        conn.rollback()
+        assert repo.get("scoring_projection") == 5
+    finally:
+        close_connection(db_path)
+
+
+def test_default_set_commits_immediately(tmp_path: Path) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    try:
+        repo = SqliteEventWatermarkRepository(conn)
+        repo.set("scoring_projection", 7)
+        # Default set() commits, so there is nothing pending to roll back.
+        conn.rollback()
+        assert repo.get("scoring_projection") == 7
+    finally:
+        close_connection(db_path)

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -225,6 +225,164 @@ def test_projects_compensation_summary_and_audit_json(conn: sqlite3.Connection) 
     assert "/Users/" not in json.dumps(audit)
 
 
+def _insert_score(
+    conn: sqlite3.Connection,
+    job_url: str,
+    *,
+    fit_score: int,
+    scored_at: str,
+    criteria_json: str,
+    trace_json: str,
+    correction_json: str | None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO job_scores (job_url, version, tenant_id, fit_score,
+                                breakdown_json, keywords_json, scored_at,
+                                correction_json, criteria_json, trace_json)
+        VALUES (?, 1, 'local', ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            job_url,
+            fit_score,
+            json.dumps(
+                {
+                    "technical_fit": 9,
+                    "experience_fit": 7,
+                    "role_fit": 8,
+                    "reasoning": "Strong fit",
+                }
+            ),
+            json.dumps(["python"]),
+            scored_at,
+            correction_json,
+            criteria_json,
+            trace_json,
+        ),
+    )
+
+
+def test_projects_score_audit_columns_from_job_scores(conn: sqlite3.Connection) -> None:
+    """Score audit columns (rubric criteria + prompt/model trace) are projected
+    verbatim from ``job_scores`` into both the list and detail projections.
+
+    Regression guard for the read-model NULL bug: the Python builder must write
+    the same three audit columns the TS builder does, sourced byte-for-byte from
+    the latest ``job_scores`` row, so the score-audit surface is never NULL for a
+    normally-scored job even when the Python event handler owns the refresh.
+    """
+    url = "https://example.com/jobs/score-audit"
+    _seed_job(conn, url)
+    criteria_json = json.dumps(
+        {
+            "formula_version": "score-v3",
+            "rubric": {"technical_fit": "Depth of required stack"},
+            "weights": {"experience_fit": 0.3, "role_fit": 0.2, "technical_fit": 0.5},
+        },
+        sort_keys=True,
+    )
+    trace_json = json.dumps(
+        {
+            "correction_history": [],
+            "model": "claude-opus",
+            "parser_warnings": [],
+            "prompt_version": "score-prompt-v7",
+            "schema_version": "score-schema-v2",
+            "scoring_policy_version": 3,
+        },
+        sort_keys=True,
+    )
+    _insert_score(
+        conn,
+        url,
+        fit_score=8,
+        scored_at="2026-06-20T10:00:00+00:00",
+        criteria_json=criteria_json,
+        trace_json=trace_json,
+        correction_json=None,
+    )
+    record_job_event(conn, url, "score", "JobScored")
+    conn.commit()
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    list_row = conn.execute(
+        """
+        SELECT score_criteria_json, score_trace_json, score_correction_json
+        FROM job_list_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert list_row is not None
+    assert list_row["score_criteria_json"] == criteria_json
+    assert list_row["score_trace_json"] == trace_json
+    assert list_row["score_correction_json"] is None
+    assert json.loads(list_row["score_criteria_json"])["formula_version"] == "score-v3"
+    assert json.loads(list_row["score_trace_json"])["scoring_policy_version"] == 3
+
+    detail_row = conn.execute(
+        """
+        SELECT score_criteria_json, score_trace_json, score_correction_json
+        FROM job_detail_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert detail_row is not None
+    assert detail_row["score_criteria_json"] == criteria_json
+    assert detail_row["score_trace_json"] == trace_json
+    assert detail_row["score_correction_json"] is None
+
+
+def test_projects_score_correction_json_when_correction_exists(
+    conn: sqlite3.Connection,
+) -> None:
+    """A self-correction on the latest score row is projected verbatim into
+    ``score_correction_json`` for both projections, preserving the correction
+    history the score-audit surface renders.
+    """
+    url = "https://example.com/jobs/score-correction"
+    _seed_job(conn, url)
+    correction_json = json.dumps(
+        {
+            "adjustments": [
+                {"dimension": "experience_fit", "from": 9, "note": "overstated tenure", "to": 6}
+            ],
+            "corrected_fit_score": 7,
+            "original_fit_score": 9,
+            "reason": "adversarial_self_correction",
+        },
+        sort_keys=True,
+    )
+    _insert_score(
+        conn,
+        url,
+        fit_score=7,
+        scored_at="2026-06-20T11:00:00+00:00",
+        criteria_json=json.dumps({"formula_version": "score-v3"}, sort_keys=True),
+        trace_json=json.dumps({"prompt_version": "score-prompt-v7"}, sort_keys=True),
+        correction_json=correction_json,
+    )
+    record_job_event(conn, url, "score", "JobScored")
+    conn.commit()
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    list_row = conn.execute(
+        "SELECT score_correction_json FROM job_list_projections WHERE job_id = ?",
+        (url,),
+    ).fetchone()
+    assert list_row is not None
+    assert list_row["score_correction_json"] == correction_json
+
+    detail_row = conn.execute(
+        "SELECT score_correction_json FROM job_detail_projections WHERE job_id = ?",
+        (url,),
+    ).fetchone()
+    assert detail_row is not None
+    assert detail_row["score_correction_json"] == correction_json
+    assert json.loads(detail_row["score_correction_json"])["corrected_fit_score"] == 7
+
+
 def test_feedback_only_history_rebuilds_source_quality(conn: sqlite3.Connection) -> None:
     record_job_event(
         conn,

--- a/workers/automation/tests/test_projection_builder.py
+++ b/workers/automation/tests/test_projection_builder.py
@@ -383,6 +383,135 @@ def test_projects_score_correction_json_when_correction_exists(
     assert json.loads(detail_row["score_correction_json"])["corrected_fit_score"] == 7
 
 
+def test_score_audit_backfill_repopulates_existing_null_rows(conn: sqlite3.Connection) -> None:
+    """One-time backfill repopulates audit columns for jobs scored before the
+    Python builder learned to project them.
+
+    Reproduces the production state on an existing DB: a projection row written
+    by the old Python builder (audit columns NULL), a canonical ``job_scores``
+    row, and a watermark already advanced past the ``JobScored`` event (the
+    Python-first consumption that blocks the TS refresher). ``refresh()`` must
+    rebuild the row and populate the three audit columns from ``job_scores``
+    with no new score event. Without the backfill the row stays NULL because the
+    columns already exist, so the schema-migration reset never fires.
+    """
+    url = "https://example.com/jobs/backfill-existing-null"
+    _seed_job(conn, url)
+    criteria_json = json.dumps({"formula_version": "score-v3"}, sort_keys=True)
+    trace_json = json.dumps({"prompt_version": "score-prompt-v7"}, sort_keys=True)
+    correction_json = json.dumps({"reason": "adversarial_self_correction"}, sort_keys=True)
+    _insert_score(
+        conn,
+        url,
+        fit_score=8,
+        scored_at="2026-06-20T10:00:00+00:00",
+        criteria_json=criteria_json,
+        trace_json=trace_json,
+        correction_json=correction_json,
+    )
+    record_job_event(conn, url, "score", "JobScored")
+    conn.commit()
+
+    # Pre-fix projection rows: the old Python upsert never wrote the audit
+    # columns, so they default to NULL.
+    conn.execute(
+        "INSERT INTO job_list_projections (tenant_id, job_id, title, fit_score) "
+        "VALUES ('local', ?, 'Engineer', 8)",
+        (url,),
+    )
+    conn.execute(
+        "INSERT INTO job_detail_projections (tenant_id, job_id, description_preview) "
+        "VALUES ('local', ?, 'Short job description')",
+        (url,),
+    )
+    # Watermark already advanced past the score event: no event-driven rebuild.
+    latest_event_id = conn.execute("SELECT MAX(event_id) FROM job_events").fetchone()[0]
+    SqliteEventWatermarkRepository(conn).set(PROJECTION_NAME, int(latest_event_id))
+    conn.commit()
+
+    pre = conn.execute(
+        "SELECT score_criteria_json FROM job_list_projections WHERE job_id = ?",
+        (url,),
+    ).fetchone()
+    assert pre["score_criteria_json"] is None
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    list_row = conn.execute(
+        """
+        SELECT score_criteria_json, score_trace_json, score_correction_json
+        FROM job_list_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert list_row is not None
+    assert list_row["score_criteria_json"] == criteria_json
+    assert list_row["score_trace_json"] == trace_json
+    assert list_row["score_correction_json"] == correction_json
+
+    detail_row = conn.execute(
+        """
+        SELECT score_criteria_json, score_trace_json, score_correction_json
+        FROM job_detail_projections WHERE job_id = ?
+        """,
+        (url,),
+    ).fetchone()
+    assert detail_row is not None
+    assert detail_row["score_criteria_json"] == criteria_json
+    assert detail_row["score_trace_json"] == trace_json
+    assert detail_row["score_correction_json"] == correction_json
+
+
+def test_score_audit_backfill_runs_at_most_once(conn: sqlite3.Connection) -> None:
+    """The backfill marker gates the scan so it runs once per DB. A NULL-audit
+    row that appears after the marker is set is not re-backfilled, keeping steady
+    state cheap (no per-refresh O(jobs) resync).
+    """
+    first = "https://example.com/jobs/backfill-marker-first"
+    _seed_job(conn, first)
+    conn.commit()
+
+    # First refresh materialises the projection and sets the backfill marker.
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+    marker = conn.execute(
+        "SELECT COUNT(*) FROM projection_backfills WHERE name LIKE 'score_audit_columns_v1%'"
+    ).fetchone()[0]
+    assert marker == 1
+
+    # A stray NULL-audit projection row with a canonical score appears AFTER the
+    # marker is set. With the watermark advanced, the next refresh must leave it
+    # untouched — the one-time scan does not run again.
+    later = "https://example.com/jobs/backfill-marker-later"
+    _seed_job(conn, later)
+    _insert_score(
+        conn,
+        later,
+        fit_score=6,
+        scored_at="2026-06-20T12:00:00+00:00",
+        criteria_json=json.dumps({"formula_version": "score-v3"}, sort_keys=True),
+        trace_json=json.dumps({"prompt_version": "score-prompt-v7"}, sort_keys=True),
+        correction_json=None,
+    )
+    conn.execute(
+        "INSERT INTO job_list_projections (tenant_id, job_id, title, fit_score) "
+        "VALUES ('local', ?, 'Engineer', 6)",
+        (later,),
+    )
+    record_job_event(conn, later, "score", "JobScored")
+    latest_event_id = conn.execute("SELECT MAX(event_id) FROM job_events").fetchone()[0]
+    SqliteEventWatermarkRepository(conn).set(PROJECTION_NAME, int(latest_event_id))
+    conn.commit()
+
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    row = conn.execute(
+        "SELECT score_criteria_json FROM job_list_projections WHERE job_id = ?",
+        (later,),
+    ).fetchone()
+    assert row is not None
+    assert row["score_criteria_json"] is None
+
+
 def test_feedback_only_history_rebuilds_source_quality(conn: sqlite3.Connection) -> None:
     record_job_event(
         conn,


### PR DESCRIPTION
## What

Make the Python `ProjectionBuilder` write the three score-audit columns
`score_criteria_json`, `score_trace_json`, and `score_correction_json` into the
`job_list_projections` and `job_detail_projections` tables, mirroring the TS
`refreshProjections` builder exactly, AND backfill those columns for jobs that
were scored before this fix. TS side is unchanged.

Changed:
- `SCORE_EVIDENCE_COLUMNS` registry + `CREATE TABLE` statements for both
  projection tables (`sqlite_projection_store.py`), plus a new tiny
  `projection_backfills` marker table.
- `JobListProjection` / `JobDetailProjection` dataclasses (`projections.py`).
- Both upserts in `SqliteProjectionStore` (column list, placeholders, `ON
  CONFLICT` set, params).
- `ProjectionBuilder._load_latest_score` now selects `criteria_json`,
  `trace_json`, `correction_json` from the latest `job_scores` version and
  `_rebuild_job` threads them into both projections.
- `ProjectionBuilder._refresh_impl` runs a one-time, marker-guarded backfill of
  already-projected scored jobs whose audit columns are still NULL.

## Why (auditability data-loss bug, high severity)

Two projection builders write the SAME projection tables: the TS
`refreshProjections` and the Python `ProjectionBuilder`. The TS builder writes
the three score-audit columns; the Python builder omitted them.

Because Python's in-process event handler consumes each worker score event
**first** and advances the shared `event_watermarks` row, the TS refresher
early-returns (watermark already advanced) and never rebuilds worker-scored
jobs. The read model serves `scoreCriteria` / `scoreTrace` / `scoreCorrection`
straight from the projection column with no canonical fallback
(`read-model.ts` ~:1953-1955), so the score-audit surface (rubric, prompt/model/
version trace, self-correction history) was **NULL for every normally-scored
job** even though the data exists in `job_scores`.

## Two parts to the fix

1. **Write path (fresh + future scores).** `_load_latest_score` reads
   `criteria_json` / `trace_json` / `correction_json` from the latest
   `job_scores` version and both upserts persist them verbatim into the two
   projections.

2. **Backfill path (existing backlog).** Simply adding the columns to
   `SCORE_EVIDENCE_COLUMNS` is NOT enough on real user DBs: those columns were
   already added months ago by the TS builder's `ensureProjectionColumn`, so
   `_ensure_column` returns False, the `_reset_score_evidence_projections`
   schema-migration reset never fires, and the pre-existing Python-first rows
   (NULL audit + already-advanced watermark) would stay NULL until a brand-new
   `JobScored` event arrived. A one-time, marker-guarded backfill in
   `_refresh_impl` fixes the backlog: it marks every already-projected scored
   job whose `score_criteria_json` is still NULL as dirty and rebuilds it from
   canonical `job_scores`, then records a per-tenant marker row in the new
   `projection_backfills` table so the O(jobs) scan runs **at most once per DB**
   and every later refresh costs a single marker lookup. The marker write and
   the rebuilds share the refresh transaction, honouring the existing
   `defer_commit` contract; it is intentionally NOT coupled to PR #206's
   `SCHEMA_VERSION`.

## Parity guarantees

- Same source and ordering as TS `loadLatestScore`: latest row by `version DESC`
  from `job_scores`.
- Same correction resolution as TS: the latest score row's own `correction_json`
  column verbatim (NULL when absent). No separate corrected-vs-latest query.
- Byte-for-byte values: both runtimes pass the raw column string through without
  re-serialising. The canonical writer stores `criteria_json`/`trace_json` as
  non-empty `json.dumps(..., sort_keys=True)` (`NOT NULL DEFAULT '{}'`) and
  `correction_json` as NULL or `json.dumps(..., sort_keys=True)`, so the
  empty-string coercion in `_row_nullable_str` never triggers for these columns.

## How validated

Regression tests in `tests/test_projection_builder.py` (4 new):
- `test_projects_score_audit_columns_from_job_scores` — write path, no
  correction: audit columns projected verbatim into both projections;
  `score_correction_json` NULL.
- `test_projects_score_correction_json_when_correction_exists` — write path with
  a self-correction projected verbatim.
- `test_score_audit_backfill_repopulates_existing_null_rows` — reproduces the
  existing-DB backlog state (NULL-audit projection row + canonical `job_scores`
  row + watermark advanced past the score event) and asserts `refresh()`
  repopulates all three columns in both projections with no new event.
  **Verified to FAIL without the backfill** (temporarily disabled the backfill:
  `assert None == '{"formula_version": "score-v3"}'`) and pass with it.
- `test_score_audit_backfill_runs_at_most_once` — a NULL-audit row appearing
  after the marker is set is not re-backfilled (steady state stays cheap).

Commands:

```
uv --project workers/automation run --extra dev pytest -q \
  workers/automation/tests/test_projection_builder.py \
  workers/automation/tests/test_audit_projection_parity.py \
  workers/automation/tests/test_job_list_projection.py
# 25 passed

uv --project workers/automation run --extra dev ruff check \
  workers/automation/src/jobhunter/infrastructure/projections/sqlite_projection_store.py \
  workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py \
  workers/automation/src/jobhunter/domain/operations/projections.py \
  workers/automation/tests/test_projection_builder.py
# All checks passed!

# Safety net (full worker suite)
uv --project workers/automation run --extra dev pytest -q
# 1490 passed
```