### PR TITLE
feat(observability): trace ensemble legs, synthesizer, and voice pass as Langfuse generation spans

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -734,6 +734,9 @@ These sources emit spans:
 | Source | Span name | `langfuse.observation.type` |
 | --- | --- | --- |
 | Every LLM call (`jobhunter.llm.LLMClient.chat`) | `llm.<model>` | `generation` |
+| Each employer-analysis ensemble draft leg (scopes `jobhunter.analysis.claude` / `.codex` / `.antigravity`) | `llm.<model>` | `generation` |
+| The employer-analysis synthesizer (scope `jobhunter.analysis.synthesizer`) | `llm.<model>` | `generation` |
+| The resume voice pass (scope `jobhunter.materials.voice`) | `llm.<model>` | `generation` |
 | Every Temporal workflow + activity (via `temporalio.contrib.opentelemetry.TracingInterceptor`) | workflow / activity name | `span` (default) |
 | Every JSON-RPC dispatch (`jobhunter.infrastructure.rpc.server.JsonRpcServer.dispatch`) | `rpc.<method>` | `span` |
 | Every pipeline stage (`jobhunter.pipeline.runner`) | `pipeline.stage.<stage>` | `span` |
@@ -756,11 +759,22 @@ The employer-analysis ensemble is the first capability on the **agent-SDK**
 standard (Claude Agent SDK + Codex SDK + Google Antigravity/Gemini SDK). Those
 SDKs consume the existing local session credentials (Claude Code session, reused
 Codex login, and `GEMINI_API_KEY`/`GOOGLE_API_KEY` for the Antigravity leg) —
-they introduce no new key management. The analysis run is visible through its persisted
-`EmployerAnalyzed` `job_events` record and the read-model `ensemble_completeness`
-field today; folding the four ensemble legs (drafts + synthesizer) into the same
-Langfuse `generation`-span pipeline as the other LLM calls is the next
-observability step.
+they introduce no new key management. The analysis run is visible through its
+persisted `EmployerAnalyzed` `job_events` record and the read-model
+`ensemble_completeness` field. Each of the four ensemble legs (the three parallel
+drafts + the Claude synthesizer) and the post-selection resume voice pass wrap
+their SDK model call in the same `llm_generation_span` the `LLMClient` uses, so
+every frontier-model call reports its model, prompt/completion, latency, and —
+when the SDK surfaces usage — input/output token counts to Langfuse. Distinct
+instrumentation scopes keep the drafts, synthesizer, and voice pass separable
+even though they share the `llm.<model>` span name. Because the legs run inside
+the enclosing pipeline-stage / JSON-RPC span (OTel context propagates through the
+`asyncio.run` + `asyncio.gather` fan-out), Langfuse aggregates their token usage
+and cost onto the surrounding analysis trace — the per-analysis cost rollup —
+without extra plumbing. Instrumentation never changes control flow: an SDK error
+is recorded on the span and re-raised into the existing per-leg
+retry/partial-failure path, and missing SDK usage degrades to a span without
+token counts rather than fabricating them.
 
 The `TracingInterceptor` is registered both client-side
 (`infrastructure/temporal/client.py`) and worker-side

--- a/workers/automation/src/jobhunter/infrastructure/analysis/antigravity_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/antigravity_analysis_adapter.py
@@ -37,6 +37,7 @@ from jobhunter.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobhunter.infrastructure.analysis.gemini_schema import gemini_json_schema
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
 
 # An ``Agent`` factory: (config) -> async-context-manager agent.
 AgentFactory = Callable[[Any], Any]
@@ -48,6 +49,9 @@ ConfigFactory = Callable[..., Any]
 # 404s on the current key. Swappable via the ``model`` ctor arg if a newer id
 # becomes available — re-confirm against the SDK at impl time, model ids drift.
 ANTIGRAVITY_ANALYSIS_MODEL = "gemini-3.5-flash"
+
+# OTel instrumentation scope for the Antigravity draft leg's generation span.
+_ANTIGRAVITY_SCOPE = "jobhunter.analysis.antigravity"
 
 # Where the local Antigravity agent persists session + app state. Per-process,
 # 0700, under the OS temp dir so the suite and live runs never collide with a
@@ -155,25 +159,68 @@ class AntigravityAnalysisAdapter:
 
         config = self._build_config(config_factory, types_module, system_prompt=system_prompt)
 
-        async with agent_factory(config) as agent:
-            response = await agent.chat(jd_snapshot)
-            # The chunk stream MUST be drained before structured_output() resolves.
-            async for _chunk in response.chunks:
-                pass
-            structured = await response.structured_output()
+        span_input = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": jd_snapshot},
+        ]
+        with llm_generation_span(
+            model=self._model,
+            messages=span_input,
+            params={},
+            scope_name=_ANTIGRAVITY_SCOPE,
+        ) as record:
+            async with agent_factory(config) as agent:
+                response = await agent.chat(jd_snapshot)
+                # The chunk stream MUST be drained before structured_output() resolves.
+                async for _chunk in response.chunks:
+                    pass
+                structured = await response.structured_output()
+                usage_metadata = getattr(response, "usage_metadata", None)
 
-        if structured is None:
-            raise RuntimeError(
-                "Antigravity (Gemini) returned no structured output for response_schema"
+            if structured is None:
+                raise RuntimeError(
+                    "Antigravity (Gemini) returned no structured output for response_schema"
+                )
+            if not isinstance(structured, dict):
+                # Tolerate a JSON string shape; a non-object payload is a hard fail.
+                structured = json.loads(structured)
+            if not isinstance(structured, dict):
+                raise RuntimeError("Antigravity (Gemini) structured output was not a JSON object")
+
+            input_tokens, output_tokens = _usage_from_metadata(usage_metadata)
+            record(
+                json.dumps(structured, ensure_ascii=False),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
             )
-        if not isinstance(structured, dict):
-            # Tolerate a JSON string shape; a non-object payload is a hard fail.
-            structured = json.loads(structured)
-        if not isinstance(structured, dict):
-            raise RuntimeError("Antigravity (Gemini) structured output was not a JSON object")
+            analysis = JobAnalysis.model_validate(structured)
+            return JobAnalysisDraft(model_id=self._model, **analysis.model_dump())
 
-        analysis = JobAnalysis.model_validate(structured)
-        return JobAnalysisDraft(model_id=self._model, **analysis.model_dump())
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce an SDK usage field to ``int``, or ``None`` when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _usage_from_metadata(usage_metadata: Any) -> tuple[int | None, int | None]:
+    """Best-effort ``(input_tokens, output_tokens)`` from Gemini ``usage_metadata``.
+
+    ``prompt_token_count`` is the total input the model processed (cached tokens
+    included); output is the visible ``candidates_token_count`` plus the
+    ``thoughts_token_count`` reasoning tokens. Returns ``(None, None)`` when the
+    SDK surfaced no usage so the span omits token counts rather than fabricating.
+    """
+    if usage_metadata is None:
+        return None, None
+    prompt = _optional_int(getattr(usage_metadata, "prompt_token_count", None))
+    candidates = _optional_int(getattr(usage_metadata, "candidates_token_count", None)) or 0
+    thoughts = _optional_int(getattr(usage_metadata, "thoughts_token_count", None)) or 0
+    return prompt, ((candidates + thoughts) or None)
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/infrastructure/analysis/claude_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/claude_analysis_adapter.py
@@ -92,14 +92,25 @@ def _structured_output_from_messages(messages: list[Any]) -> dict[str, Any]:
     return structured
 
 
+def _optional_int(value: Any) -> int | None:
+    """Coerce an SDK usage field to ``int``, or ``None`` when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
     """Best-effort ``(input_tokens, output_tokens)`` from the final ResultMessage.
 
     The Claude Agent SDK reports authoritative cumulative usage on the terminal
     ``ResultMessage``; the true input is fresh + cache-creation + cache-read
     tokens (reading only ``input_tokens`` under-reports the cached system prompt).
-    Returns ``(None, None)`` when the SDK surfaced no usage so the span omits
-    token counts rather than fabricating them.
+    Every field is coerced defensively so a drifted/non-int usage shape yields
+    omitted counts rather than raising inside the span (telemetry must never fail
+    the leg). Returns ``(None, None)`` when the SDK surfaced no usage.
     """
     for message in reversed(messages):
         if type(message).__name__ != "ResultMessage":
@@ -108,11 +119,11 @@ def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
         if not isinstance(usage, Mapping):
             return None, None
         input_tokens = (
-            int(usage.get("input_tokens") or 0)
-            + int(usage.get("cache_creation_input_tokens") or 0)
-            + int(usage.get("cache_read_input_tokens") or 0)
+            (_optional_int(usage.get("input_tokens")) or 0)
+            + (_optional_int(usage.get("cache_creation_input_tokens")) or 0)
+            + (_optional_int(usage.get("cache_read_input_tokens")) or 0)
         )
-        output_tokens = int(usage.get("output_tokens") or 0)
+        output_tokens = _optional_int(usage.get("output_tokens")) or 0
         return (input_tokens or None, output_tokens or None)
     return None, None
 

--- a/workers/automation/src/jobhunter/infrastructure/analysis/claude_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/claude_analysis_adapter.py
@@ -18,7 +18,7 @@ cancellation of the wrapping asyncio task.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import Any
 
 from jobhunter.domain.materials.analysis import (
@@ -26,6 +26,7 @@ from jobhunter.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobhunter.infrastructure.analysis.prompts import build_synthesizer_user_prompt
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
 
 # A query callable: (prompt, options) -> async iterator of SDK messages.
 QueryFn = Callable[..., AsyncIterator[Any] | Awaitable[AsyncIterator[Any]]]
@@ -34,6 +35,11 @@ OptionsFactory = Callable[..., Any]
 # Top Claude model + default high effort (D-18). Re-confirm the id at impl time;
 # model ids drift. Mirrors the mestre Claude runtime default set.
 CLAUDE_ANALYSIS_MODEL = "claude-opus-4-8"
+
+# OTel instrumentation scopes so the draft leg and the synthesizer pass stay
+# distinguishable in Langfuse even though they share the Claude model + span name.
+_DRAFT_SCOPE = "jobhunter.analysis.claude"
+_SYNTHESIZER_SCOPE = "jobhunter.analysis.synthesizer"
 
 
 def _load_sdk_query() -> QueryFn:
@@ -86,6 +92,31 @@ def _structured_output_from_messages(messages: list[Any]) -> dict[str, Any]:
     return structured
 
 
+def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
+    """Best-effort ``(input_tokens, output_tokens)`` from the final ResultMessage.
+
+    The Claude Agent SDK reports authoritative cumulative usage on the terminal
+    ``ResultMessage``; the true input is fresh + cache-creation + cache-read
+    tokens (reading only ``input_tokens`` under-reports the cached system prompt).
+    Returns ``(None, None)`` when the SDK surfaced no usage so the span omits
+    token counts rather than fabricating them.
+    """
+    for message in reversed(messages):
+        if type(message).__name__ != "ResultMessage":
+            continue
+        usage = getattr(message, "usage", None)
+        if not isinstance(usage, Mapping):
+            return None, None
+        input_tokens = (
+            int(usage.get("input_tokens") or 0)
+            + int(usage.get("cache_creation_input_tokens") or 0)
+            + int(usage.get("cache_read_input_tokens") or 0)
+        )
+        output_tokens = int(usage.get("output_tokens") or 0)
+        return (input_tokens or None, output_tokens or None)
+    return None, None
+
+
 class _ClaudeStructuredCaller:
     """Shared call path for the draft adapter and the synthesizer."""
 
@@ -95,10 +126,12 @@ class _ClaudeStructuredCaller:
         model: str = CLAUDE_ANALYSIS_MODEL,
         query_fn: QueryFn | None = None,
         options_factory: OptionsFactory | None = None,
+        scope_name: str = _DRAFT_SCOPE,
     ) -> None:
         self._model = model
         self._query_fn = query_fn
         self._options_factory = options_factory
+        self._scope_name = scope_name
 
     async def call(self, *, system_prompt: str, user_prompt: str) -> dict[str, Any]:
         query_fn = self._query_fn or _load_sdk_query()
@@ -116,10 +149,27 @@ class _ClaudeStructuredCaller:
                 "schema": JobAnalysis.model_json_schema(),
             },
         )
-        raw = query_fn(prompt=user_prompt, options=options)
-        iterator = await _aiter(raw)
-        messages = [message async for message in iterator]
-        return _structured_output_from_messages(messages)
+        span_input = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        with llm_generation_span(
+            model=self._model,
+            messages=span_input,
+            params={},
+            scope_name=self._scope_name,
+        ) as record:
+            raw = query_fn(prompt=user_prompt, options=options)
+            iterator = await _aiter(raw)
+            messages = [message async for message in iterator]
+            structured = _structured_output_from_messages(messages)
+            input_tokens, output_tokens = _usage_from_messages(messages)
+            record(
+                json.dumps(structured, ensure_ascii=False),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+            return structured
 
 
 class ClaudeAnalysisAdapter:
@@ -134,7 +184,10 @@ class ClaudeAnalysisAdapter:
     ) -> None:
         self._model = model
         self._caller = _ClaudeStructuredCaller(
-            model=model, query_fn=query_fn, options_factory=options_factory
+            model=model,
+            query_fn=query_fn,
+            options_factory=options_factory,
+            scope_name=_DRAFT_SCOPE,
         )
 
     @property
@@ -159,7 +212,10 @@ class ClaudeAnalysisSynthesizer:
     ) -> None:
         self._model = model
         self._caller = _ClaudeStructuredCaller(
-            model=model, query_fn=query_fn, options_factory=options_factory
+            model=model,
+            query_fn=query_fn,
+            options_factory=options_factory,
+            scope_name=_SYNTHESIZER_SCOPE,
         )
 
     @property

--- a/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/analysis/codex_analysis_adapter.py
@@ -34,12 +34,16 @@ from jobhunter.domain.materials.analysis import (
     JobAnalysisDraft,
 )
 from jobhunter.infrastructure.analysis.strict_schema import strict_json_schema
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
 
 AsyncCodexFactory = Callable[[], Any]
 
 # Top current Codex model (gpt-5.5) + max reasoning effort (D-18). Matches
 # mestre's vendor-lane default for the Codex leg.
 CODEX_ANALYSIS_MODEL = "gpt-5.5"
+
+# OTel instrumentation scope for the Codex draft leg's generation span.
+_CODEX_SCOPE = "jobhunter.analysis.codex"
 
 # Disable Codex plugins/apps so the isolated home only ever holds JobHunter's
 # analysis rollouts + the copied auth token (mirrors mestre's vendor lane).
@@ -146,32 +150,70 @@ class CodexAnalysisAdapter:
     async def draft(self, system_prompt: str, jd_snapshot: str) -> JobAnalysisDraft:
         factory = self._async_codex_factory or _load_async_codex_factory()
         prompt = f"{system_prompt}\n\nJOB DESCRIPTION:\n{jd_snapshot}"
-        async with factory() as codex:  # reuses existing Codex login (D-04)
-            thread = await codex.thread_start(
-                model=self._model,
-                # Max reasoning effort (D-18); analysis reads the JD, no FS writes.
-                config={"model_reasoning_effort": "high"},
-                sandbox=_load_sandbox_read_only(),
-            )
-            result = await thread.run(
-                prompt,
-                # Codex/OpenAI strict structured output requires every object to
-                # set additionalProperties:false and list all props in required;
-                # Pydantic's model_json_schema() emits neither (live 400 otherwise).
-                output_schema=strict_json_schema(JobAnalysis.model_json_schema()),
-                effort="high",
-            )
-        # ``status`` is a ``TurnStatus`` enum whose ``str()`` is
-        # "TurnStatus.completed" — compare its ``.value`` ("completed"), not the
-        # enum repr, or a successful turn is wrongly rejected (live-caught bug).
-        status_obj = getattr(result, "status", None)
-        status = str(getattr(status_obj, "value", status_obj) or "")
-        final_response = getattr(result, "final_response", None)
-        if (status and status != "completed") or not final_response:
-            error = getattr(result, "error", None)
-            raise RuntimeError(f"Codex turn failed: status={status!r} err={error!r}")
-        analysis = JobAnalysis.model_validate_json(final_response)
-        return JobAnalysisDraft(model_id=self._model, **analysis.model_dump())
+        span_input = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": jd_snapshot},
+        ]
+        with llm_generation_span(
+            model=self._model,
+            messages=span_input,
+            params={},
+            scope_name=_CODEX_SCOPE,
+        ) as record:
+            async with factory() as codex:  # reuses existing Codex login (D-04)
+                thread = await codex.thread_start(
+                    model=self._model,
+                    # Max reasoning effort (D-18); analysis reads the JD, no FS writes.
+                    config={"model_reasoning_effort": "high"},
+                    sandbox=_load_sandbox_read_only(),
+                )
+                result = await thread.run(
+                    prompt,
+                    # Codex/OpenAI strict structured output requires every object to
+                    # set additionalProperties:false and list all props in required;
+                    # Pydantic's model_json_schema() emits neither (live 400 otherwise).
+                    output_schema=strict_json_schema(JobAnalysis.model_json_schema()),
+                    effort="high",
+                )
+            # ``status`` is a ``TurnStatus`` enum whose ``str()`` is
+            # "TurnStatus.completed" — compare its ``.value`` ("completed"), not the
+            # enum repr, or a successful turn is wrongly rejected (live-caught bug).
+            status_obj = getattr(result, "status", None)
+            status = str(getattr(status_obj, "value", status_obj) or "")
+            final_response = getattr(result, "final_response", None)
+            if (status and status != "completed") or not final_response:
+                error = getattr(result, "error", None)
+                raise RuntimeError(f"Codex turn failed: status={status!r} err={error!r}")
+            input_tokens, output_tokens = _usage_from_result(result)
+            record(final_response, input_tokens=input_tokens, output_tokens=output_tokens)
+            analysis = JobAnalysis.model_validate_json(final_response)
+            return JobAnalysisDraft(model_id=self._model, **analysis.model_dump())
+
+
+def _optional_int(value: Any) -> int | None:
+    """Coerce an SDK usage field to ``int``, or ``None`` when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _usage_from_result(result: Any) -> tuple[int | None, int | None]:
+    """Best-effort ``(input_tokens, output_tokens)`` from a Codex ``TurnResult``.
+
+    Codex reports cumulative token usage on ``result.usage.total``. Returns
+    ``(None, None)`` when the SDK surfaced no usage so the span omits token
+    counts rather than fabricating them.
+    """
+    total = getattr(getattr(result, "usage", None), "total", None)
+    if total is None:
+        return None, None
+    return (
+        _optional_int(getattr(total, "input_tokens", None)),
+        _optional_int(getattr(total, "output_tokens", None)),
+    )
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/infrastructure/materials/voice_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/materials/voice_adapter.py
@@ -21,11 +21,12 @@ wrapping asyncio task — matching the constraint "NO timeouts on the voice LLM 
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from typing import Any
 
 from jobhunter.domain.materials.voice import VoicePayload, VoiceRequest, VoiceResult
 from jobhunter.infrastructure.materials.voice_prompts import build_voice_user_prompt
+from jobhunter.infrastructure.observability.llm_spans import llm_generation_span
 
 # A query callable: (prompt, options) -> async iterator of SDK messages.
 QueryFn = Callable[..., AsyncIterator[Any] | Awaitable[AsyncIterator[Any]]]
@@ -34,6 +35,9 @@ OptionsFactory = Callable[..., Any]
 # Top Claude model + default high effort (mirrors the analysis adapter default).
 # Re-confirm the id at impl time; model ids drift.
 CLAUDE_VOICE_MODEL = "claude-opus-4-8"
+
+# OTel instrumentation scope for the voice pass's generation span.
+_VOICE_SCOPE = "jobhunter.materials.voice"
 
 
 def _load_sdk_query() -> QueryFn:
@@ -83,6 +87,30 @@ def _structured_output_from_messages(messages: list[Any]) -> dict[str, Any]:
     return structured
 
 
+def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
+    """Best-effort ``(input_tokens, output_tokens)`` from the final ResultMessage.
+
+    The Claude Agent SDK reports authoritative cumulative usage on the terminal
+    ``ResultMessage``; the true input is fresh + cache-creation + cache-read
+    tokens. Returns ``(None, None)`` when the SDK surfaced no usage so the span
+    omits token counts rather than fabricating them.
+    """
+    for message in reversed(messages):
+        if type(message).__name__ != "ResultMessage":
+            continue
+        usage = getattr(message, "usage", None)
+        if not isinstance(usage, Mapping):
+            return None, None
+        input_tokens = (
+            int(usage.get("input_tokens") or 0)
+            + int(usage.get("cache_creation_input_tokens") or 0)
+            + int(usage.get("cache_read_input_tokens") or 0)
+        )
+        output_tokens = int(usage.get("output_tokens") or 0)
+        return (input_tokens or None, output_tokens or None)
+    return None, None
+
+
 class ClaudeVoiceAdapter:
     """Claude Agent SDK voice pass (``VoicePort``)."""
 
@@ -117,12 +145,28 @@ class ClaudeVoiceAdapter:
             },
         )
         user_prompt = build_voice_user_prompt(request)
-        raw = query_fn(prompt=user_prompt, options=options)
-        iterator = await _aiter(raw)
-        messages = [message async for message in iterator]
-        structured = _structured_output_from_messages(messages)
-        payload = VoicePayload.model_validate(structured)
-        return VoiceResult.from_payload(payload)
+        span_input = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        with llm_generation_span(
+            model=self._model,
+            messages=span_input,
+            params={},
+            scope_name=_VOICE_SCOPE,
+        ) as record:
+            raw = query_fn(prompt=user_prompt, options=options)
+            iterator = await _aiter(raw)
+            messages = [message async for message in iterator]
+            structured = _structured_output_from_messages(messages)
+            input_tokens, output_tokens = _usage_from_messages(messages)
+            record(
+                json.dumps(structured, ensure_ascii=False),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+            payload = VoicePayload.model_validate(structured)
+            return VoiceResult.from_payload(payload)
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/infrastructure/materials/voice_adapter.py
+++ b/workers/automation/src/jobhunter/infrastructure/materials/voice_adapter.py
@@ -87,13 +87,24 @@ def _structured_output_from_messages(messages: list[Any]) -> dict[str, Any]:
     return structured
 
 
+def _optional_int(value: Any) -> int | None:
+    """Coerce an SDK usage field to ``int``, or ``None`` when absent/unparseable."""
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
     """Best-effort ``(input_tokens, output_tokens)`` from the final ResultMessage.
 
     The Claude Agent SDK reports authoritative cumulative usage on the terminal
     ``ResultMessage``; the true input is fresh + cache-creation + cache-read
-    tokens. Returns ``(None, None)`` when the SDK surfaced no usage so the span
-    omits token counts rather than fabricating them.
+    tokens. Every field is coerced defensively so a drifted/non-int usage shape
+    yields omitted counts rather than raising inside the span (telemetry must
+    never fail the leg). Returns ``(None, None)`` when the SDK surfaced no usage.
     """
     for message in reversed(messages):
         if type(message).__name__ != "ResultMessage":
@@ -102,11 +113,11 @@ def _usage_from_messages(messages: list[Any]) -> tuple[int | None, int | None]:
         if not isinstance(usage, Mapping):
             return None, None
         input_tokens = (
-            int(usage.get("input_tokens") or 0)
-            + int(usage.get("cache_creation_input_tokens") or 0)
-            + int(usage.get("cache_read_input_tokens") or 0)
+            (_optional_int(usage.get("input_tokens")) or 0)
+            + (_optional_int(usage.get("cache_creation_input_tokens")) or 0)
+            + (_optional_int(usage.get("cache_read_input_tokens")) or 0)
         )
-        output_tokens = int(usage.get("output_tokens") or 0)
+        output_tokens = _optional_int(usage.get("output_tokens")) or 0
         return (input_tokens or None, output_tokens or None)
     return None, None
 

--- a/workers/automation/tests/conftest.py
+++ b/workers/automation/tests/conftest.py
@@ -8,6 +8,10 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
 
 
 _TEST_APP_DIR = Path(tempfile.mkdtemp(prefix="jobhunter-pytest-"))
@@ -32,3 +36,24 @@ def disable_langfuse_network_export_by_default(monkeypatch: pytest.MonkeyPatch, 
     if test_file in {"test_otel_init.py", "test_doctor_langfuse.py"}:
         return
     monkeypatch.setenv("LANGFUSE_DISABLE", "1")
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """TracerProvider piped to an in-memory exporter for span assertions.
+
+    Resets the global provider guard so each requesting test gets a fresh,
+    isolated exporter; shared by the observability + generation-span tests.
+    """
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()

--- a/workers/automation/tests/test_antigravity_adapter.py
+++ b/workers/automation/tests/test_antigravity_adapter.py
@@ -17,10 +17,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.analysis import JobAnalysisDraft
 from jobhunter.infrastructure.analysis.antigravity_analysis_adapter import (
@@ -29,23 +25,6 @@ from jobhunter.infrastructure.analysis.antigravity_analysis_adapter import (
 )
 
 pytestmark = pytest.mark.asyncio
-
-
-@pytest.fixture
-def in_memory_exporter(monkeypatch):
-    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
-    from opentelemetry import trace as trace_api
-    from opentelemetry.util._once import Once
-
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    set_tracer_provider(provider)
-    yield exporter
-    exporter.clear()
 
 
 def _valid_analysis_dict() -> dict[str, Any]:

--- a/workers/automation/tests/test_antigravity_adapter.py
+++ b/workers/automation/tests/test_antigravity_adapter.py
@@ -13,9 +13,14 @@ Gemini-serialised (no ``additionalProperties``).
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.analysis import JobAnalysisDraft
 from jobhunter.infrastructure.analysis.antigravity_analysis_adapter import (
@@ -24,6 +29,23 @@ from jobhunter.infrastructure.analysis.antigravity_analysis_adapter import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
 
 
 def _valid_analysis_dict() -> dict[str, Any]:
@@ -56,10 +78,13 @@ def _valid_analysis_dict() -> dict[str, Any]:
 class _FakeResponse:
     """Mimics the SDK response: an async ``chunks`` iterator + structured_output()."""
 
-    def __init__(self, structured: Any, *, chunks: list[Any] | None = None) -> None:
+    def __init__(
+        self, structured: Any, *, chunks: list[Any] | None = None, usage_metadata: Any = None
+    ) -> None:
         self._structured = structured
         self._chunks = chunks if chunks is not None else ["chunk-a", "chunk-b"]
         self.drained = False
+        self.usage_metadata = usage_metadata
 
     @property
     async def chunks(self):  # noqa: D401 - async generator property mirroring the SDK
@@ -112,9 +137,10 @@ def _make_adapter(
     structured: Any,
     calls: dict[str, Any],
     chunks: list[Any] | None = None,
+    usage_metadata: Any = None,
 ) -> AntigravityAnalysisAdapter:
     """Build an adapter wired to fakes; ``calls`` captures the config kwargs."""
-    response = _FakeResponse(structured, chunks=chunks)
+    response = _FakeResponse(structured, chunks=chunks, usage_metadata=usage_metadata)
 
     def config_factory(**kwargs: Any) -> dict[str, Any]:
         calls["config_kwargs"] = kwargs
@@ -223,3 +249,51 @@ async def test_model_id_property() -> None:
 
     custom = AntigravityAnalysisAdapter(model="gemini-x")
     assert custom.model_id == "gemini-x"
+
+
+async def test_draft_opens_generation_span_with_model_and_tokens(
+    monkeypatch: pytest.MonkeyPatch, in_memory_exporter
+) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    usage = SimpleNamespace(
+        prompt_token_count=900,
+        candidates_token_count=150,
+        thoughts_token_count=40,
+        cached_content_token_count=0,
+        total_token_count=1090,
+    )
+    calls: dict[str, Any] = {}
+    adapter = _make_adapter(
+        structured=_valid_analysis_dict(), calls=calls, usage_metadata=usage
+    )
+
+    await adapter.draft("SYS", "6+ years of Python required.")
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "llm.gemini-3.5-flash"
+    assert span.instrumentation_scope.name == "jobhunter.analysis.antigravity"
+    attrs = dict(span.attributes or {})
+    assert attrs["langfuse.observation.type"] == "generation"
+    assert attrs["langfuse.observation.model.name"] == "gemini-3.5-flash"
+    assert attrs["gen_ai.usage.input_tokens"] == 900
+    # output = visible candidates (150) + reasoning thoughts (40).
+    assert attrs["gen_ai.usage.output_tokens"] == 190
+
+
+async def test_draft_span_omits_tokens_when_sdk_reports_no_usage(
+    monkeypatch: pytest.MonkeyPatch, in_memory_exporter
+) -> None:
+    # Instrumentation must never break a leg: no usage metadata -> the draft still
+    # succeeds and the span omits token counts rather than fabricating them.
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    calls: dict[str, Any] = {}
+    adapter = _make_adapter(structured=_valid_analysis_dict(), calls=calls)
+
+    draft = await adapter.draft("SYS", "6+ years of Python required.")
+    assert isinstance(draft, JobAnalysisDraft)
+
+    attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
+    assert attrs["langfuse.observation.model.name"] == "gemini-3.5-flash"
+    assert "gen_ai.usage.input_tokens" not in attrs

--- a/workers/automation/tests/test_employer_analysis_ensemble.py
+++ b/workers/automation/tests/test_employer_analysis_ensemble.py
@@ -19,17 +19,41 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.analysis import (
     EnsembleError,
     JobAnalysis,
     JobAnalysisDraft,
 )
-from jobhunter.infrastructure.analysis.claude_analysis_adapter import ClaudeAnalysisAdapter
+from jobhunter.infrastructure.analysis.claude_analysis_adapter import (
+    ClaudeAnalysisAdapter,
+    ClaudeAnalysisSynthesizer,
+)
 from jobhunter.infrastructure.analysis.codex_analysis_adapter import CodexAnalysisAdapter
 from jobhunter.infrastructure.analysis.ensemble import compute_agreement, run_ensemble
 
 pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
 
 JD = (
     "Staff Backend Engineer. Requires 8+ years building distributed systems in "
@@ -82,9 +106,15 @@ def _grounded_dict(model_tag: str | None = None) -> dict[str, Any]:
 class ResultMessage:
     """Named to match the real SDK class — the adapter keys on the class name."""
 
-    def __init__(self, structured_output: Any, subtype: str = "success") -> None:
+    def __init__(
+        self,
+        structured_output: Any,
+        subtype: str = "success",
+        usage: dict[str, int] | None = None,
+    ) -> None:
         self.structured_output = structured_output
         self.subtype = subtype
+        self.usage = usage
 
 
 class _FakeClaudeOptions:
@@ -92,7 +122,12 @@ class _FakeClaudeOptions:
         self.kwargs = kwargs
 
 
-def _fake_claude_query(structured: Any, *, captured: list[dict[str, Any]] | None = None):
+def _fake_claude_query(
+    structured: Any,
+    *,
+    captured: list[dict[str, Any]] | None = None,
+    usage: dict[str, int] | None = None,
+):
     """Return a fake ``query`` that yields one ResultMessage with ``structured``."""
 
     def query(*, prompt: str, options: Any):
@@ -100,7 +135,7 @@ def _fake_claude_query(structured: Any, *, captured: list[dict[str, Any]] | None
             captured.append({"prompt": prompt, "options": options})
 
         async def _gen():
-            yield ResultMessage(structured)
+            yield ResultMessage(structured, usage=usage)
 
         return _gen()
 
@@ -113,9 +148,10 @@ def _fake_claude_query(structured: Any, *, captured: list[dict[str, Any]] | None
 
 
 class _FakeCodexThread:
-    def __init__(self, final_response: str, status: str = "completed") -> None:
+    def __init__(self, final_response: str, status: str = "completed", usage: Any = None) -> None:
         self._final_response = final_response
         self._status = status
+        self._usage = usage
         self.runs: list[dict[str, Any]] = []
 
     async def run(self, prompt: str, **kwargs: Any) -> Any:
@@ -124,14 +160,15 @@ class _FakeCodexThread:
             status=self._status,
             final_response=self._final_response,
             error=None,
+            usage=self._usage,
         )
 
 
 class _FakeAsyncCodex:
-    def __init__(self, final_response: str, status: str = "completed") -> None:
+    def __init__(self, final_response: str, status: str = "completed", usage: Any = None) -> None:
         self._final_response = final_response
         self._status = status
-        self.thread = _FakeCodexThread(final_response, status)
+        self.thread = _FakeCodexThread(final_response, status, usage)
         self.thread_start_calls: list[dict[str, Any]] = []
 
     async def __aenter__(self) -> _FakeAsyncCodex:
@@ -185,6 +222,90 @@ class TestClaudeAdapter:
         with pytest.raises(RuntimeError, match="retries exhausted"):
             await adapter.draft("system", JD)
 
+    async def test_draft_opens_generation_span_with_model_and_tokens(self, in_memory_exporter) -> None:
+        adapter = ClaudeAnalysisAdapter(
+            model="claude-opus-4-8",
+            query_fn=_fake_claude_query(
+                _grounded_dict(),
+                usage={"input_tokens": 1200, "output_tokens": 340, "cache_read_input_tokens": 50},
+            ),
+            options_factory=_FakeClaudeOptions,
+        )
+        await adapter.draft("system", JD)
+
+        spans = in_memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "llm.claude-opus-4-8"
+        assert span.instrumentation_scope.name == "jobhunter.analysis.claude"
+        attrs = dict(span.attributes or {})
+        assert attrs["langfuse.observation.type"] == "generation"
+        assert attrs["langfuse.observation.model.name"] == "claude-opus-4-8"
+        # input = 1200 fresh + 50 cache_read; cache tokens count toward input processed.
+        assert attrs["gen_ai.usage.input_tokens"] == 1250
+        assert attrs["gen_ai.usage.output_tokens"] == 340
+        assert json.loads(attrs["langfuse.observation.usage_details"]) == {
+            "input_tokens": 1250,
+            "output_tokens": 340,
+            "total_tokens": 1590,
+        }
+
+    async def test_draft_span_omits_tokens_when_sdk_reports_no_usage(self, in_memory_exporter) -> None:
+        # Instrumentation must never break a leg: no SDK usage -> the draft still
+        # succeeds and the span omits token counts rather than fabricating them.
+        adapter = ClaudeAnalysisAdapter(
+            query_fn=_fake_claude_query(_grounded_dict()),
+            options_factory=_FakeClaudeOptions,
+        )
+        draft = await adapter.draft("system", JD)
+        assert draft.model_id == "claude-opus-4-8"
+
+        attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
+        assert attrs["langfuse.observation.model.name"] == "claude-opus-4-8"
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert "langfuse.observation.usage_details" not in attrs
+
+    async def test_draft_span_records_sdk_error_and_reraises(self, in_memory_exporter) -> None:
+        from opentelemetry.trace import StatusCode
+
+        def query(*, prompt: str, options: Any):
+            async def _gen():
+                yield ResultMessage(None, subtype="error_max_structured_output_retries")
+
+            return _gen()
+
+        adapter = ClaudeAnalysisAdapter(query_fn=query, options_factory=_FakeClaudeOptions)
+        with pytest.raises(RuntimeError, match="retries exhausted"):
+            await adapter.draft("system", JD)
+
+        spans = in_memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].status.status_code == StatusCode.ERROR
+
+
+class TestClaudeSynthesizer:
+    async def test_reconcile_opens_generation_span(self, in_memory_exporter) -> None:
+        synth = ClaudeAnalysisSynthesizer(
+            query_fn=_fake_claude_query(
+                _grounded_dict(),
+                usage={"input_tokens": 500, "output_tokens": 90},
+            ),
+            options_factory=_FakeClaudeOptions,
+        )
+        draft = JobAnalysisDraft(model_id="claude-opus-4-8", **_grounded_dict())
+        await synth.reconcile("synth-sys", drafts=(draft,), jd_snapshot=JD)
+
+        spans = in_memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "llm.claude-opus-4-8"
+        # A distinct scope keeps the synthesizer separable from the Claude draft leg.
+        assert span.instrumentation_scope.name == "jobhunter.analysis.synthesizer"
+        attrs = dict(span.attributes or {})
+        assert attrs["langfuse.observation.type"] == "generation"
+        assert attrs["gen_ai.usage.input_tokens"] == 500
+        assert attrs["gen_ai.usage.output_tokens"] == 90
+
 
 class TestCodexAdapter:
     async def test_parses_final_response_into_typed_draft(self) -> None:
@@ -211,6 +332,23 @@ class TestCodexAdapter:
         )
         with pytest.raises(RuntimeError, match="Codex turn failed"):
             await adapter.draft("system", JD)
+
+    async def test_draft_opens_generation_span_with_model_and_tokens(self, in_memory_exporter) -> None:
+        usage = SimpleNamespace(total=SimpleNamespace(input_tokens=800, output_tokens=210))
+        fake = _FakeAsyncCodex(json.dumps(_grounded_dict()), usage=usage)
+        adapter = CodexAnalysisAdapter(model="gpt-5.5", async_codex_factory=lambda: fake)
+        await adapter.draft("system", JD)
+
+        spans = in_memory_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "llm.gpt-5.5"
+        assert span.instrumentation_scope.name == "jobhunter.analysis.codex"
+        attrs = dict(span.attributes or {})
+        assert attrs["langfuse.observation.type"] == "generation"
+        assert attrs["langfuse.observation.model.name"] == "gpt-5.5"
+        assert attrs["gen_ai.usage.input_tokens"] == 800
+        assert attrs["gen_ai.usage.output_tokens"] == 210
 
 
 # --------------------------------------------------------------------------- #

--- a/workers/automation/tests/test_employer_analysis_ensemble.py
+++ b/workers/automation/tests/test_employer_analysis_ensemble.py
@@ -19,10 +19,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.analysis import (
     EnsembleError,
@@ -37,23 +33,6 @@ from jobhunter.infrastructure.analysis.codex_analysis_adapter import CodexAnalys
 from jobhunter.infrastructure.analysis.ensemble import compute_agreement, run_ensemble
 
 pytestmark = pytest.mark.asyncio
-
-
-@pytest.fixture
-def in_memory_exporter(monkeypatch):
-    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
-    from opentelemetry import trace as trace_api
-    from opentelemetry.util._once import Once
-
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    set_tracer_provider(provider)
-    yield exporter
-    exporter.clear()
 
 JD = (
     "Staff Backend Engineer. Requires 8+ years building distributed systems in "
@@ -281,6 +260,26 @@ class TestClaudeAdapter:
         spans = in_memory_exporter.get_finished_spans()
         assert len(spans) == 1
         assert spans[0].status.status_code == StatusCode.ERROR
+
+    async def test_draft_span_survives_malformed_sdk_usage(self, in_memory_exporter) -> None:
+        # A drifted / non-int usage field must NEVER fail the leg — token
+        # extraction runs inside the re-raising span block, so it degrades the
+        # unparseable count to omitted rather than raising.
+        adapter = ClaudeAnalysisAdapter(
+            query_fn=_fake_claude_query(
+                _grounded_dict(),
+                usage={"input_tokens": "n/a", "output_tokens": 10},
+            ),
+            options_factory=_FakeClaudeOptions,
+        )
+        draft = await adapter.draft("system", JD)  # must not raise
+        assert draft.model_id == "claude-opus-4-8"
+
+        attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
+        assert "gen_ai.usage.input_tokens" not in attrs
+        assert "langfuse.observation.usage_details" not in attrs
+        # A well-formed sibling field is still recorded.
+        assert attrs["gen_ai.usage.output_tokens"] == 10
 
 
 class TestClaudeSynthesizer:

--- a/workers/automation/tests/test_llm_spans.py
+++ b/workers/automation/tests/test_llm_spans.py
@@ -5,27 +5,6 @@ from __future__ import annotations
 import json
 
 import pytest
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import set_tracer_provider
-
-
-@pytest.fixture
-def in_memory_exporter(monkeypatch):
-    """Stand up a TracerProvider piped to an in-memory exporter for assertions."""
-    from opentelemetry import trace as trace_api
-    from opentelemetry.util._once import Once
-
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    set_tracer_provider(provider)
-    yield exporter
-    exporter.clear()
 
 
 def _attrs(span) -> dict:

--- a/workers/automation/tests/test_voice_adapter.py
+++ b/workers/automation/tests/test_voice_adapter.py
@@ -17,9 +17,30 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.voice import VoiceRequest
 from jobhunter.infrastructure.materials.voice_adapter import ClaudeVoiceAdapter
+
+
+@pytest.fixture
+def in_memory_exporter(monkeypatch):
+    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
+    from opentelemetry import trace as trace_api
+    from opentelemetry.util._once import Once
+
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
+    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    set_tracer_provider(provider)
+    yield exporter
+    exporter.clear()
 
 
 class ResultMessage:
@@ -29,9 +50,15 @@ class ResultMessage:
     double MUST be named ``ResultMessage`` (a leading underscore would hide it).
     """
 
-    def __init__(self, structured_output: Any, subtype: str = "success") -> None:
+    def __init__(
+        self,
+        structured_output: Any,
+        subtype: str = "success",
+        usage: dict[str, int] | None = None,
+    ) -> None:
         self.structured_output = structured_output
         self.subtype = subtype
+        self.usage = usage
 
 
 class _FakeClaudeOptions:
@@ -39,13 +66,18 @@ class _FakeClaudeOptions:
         self.kwargs = kwargs
 
 
-def _fake_query(structured: Any, *, captured: list[dict[str, Any]] | None = None):
+def _fake_query(
+    structured: Any,
+    *,
+    captured: list[dict[str, Any]] | None = None,
+    usage: dict[str, int] | None = None,
+):
     def _query(*, prompt: str, options: Any):
         if captured is not None:
             captured.append({"prompt": prompt, "options": options})
 
         async def _gen():
-            yield ResultMessage(structured)
+            yield ResultMessage(structured, usage=usage)
 
         return _gen()
 
@@ -108,3 +140,42 @@ async def test_raises_on_structured_output_retry_exhaustion() -> None:
     adapter = ClaudeVoiceAdapter(query_fn=_query, options_factory=_FakeClaudeOptions)
     with pytest.raises(RuntimeError):
         await adapter.rewrite("system", _request())
+
+
+@pytest.mark.asyncio
+async def test_rewrite_opens_generation_span_with_model_and_tokens(in_memory_exporter) -> None:
+    adapter = ClaudeVoiceAdapter(
+        query_fn=_fake_query(
+            _voiced_structured(),
+            usage={"input_tokens": 700, "output_tokens": 120},
+        ),
+        options_factory=_FakeClaudeOptions,
+    )
+    await adapter.rewrite("system", _request())
+
+    spans = in_memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "llm.claude-opus-4-8"
+    assert span.instrumentation_scope.name == "jobhunter.materials.voice"
+    attrs = dict(span.attributes or {})
+    assert attrs["langfuse.observation.type"] == "generation"
+    assert attrs["langfuse.observation.model.name"] == "claude-opus-4-8"
+    assert attrs["gen_ai.usage.input_tokens"] == 700
+    assert attrs["gen_ai.usage.output_tokens"] == 120
+
+
+@pytest.mark.asyncio
+async def test_rewrite_span_omits_tokens_when_sdk_reports_no_usage(in_memory_exporter) -> None:
+    # Instrumentation must never break the voice pass: no SDK usage -> the rewrite
+    # still succeeds and the span omits token counts rather than fabricating them.
+    adapter = ClaudeVoiceAdapter(
+        query_fn=_fake_query(_voiced_structured()),
+        options_factory=_FakeClaudeOptions,
+    )
+    result = await adapter.rewrite("system", _request())
+    assert result.executive_profile.startswith("Rebuilt the deploy pipeline")
+
+    attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
+    assert attrs["langfuse.observation.model.name"] == "claude-opus-4-8"
+    assert "gen_ai.usage.input_tokens" not in attrs

--- a/workers/automation/tests/test_voice_adapter.py
+++ b/workers/automation/tests/test_voice_adapter.py
@@ -17,30 +17,9 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
-from opentelemetry.trace import set_tracer_provider
 
 from jobhunter.domain.materials.voice import VoiceRequest
 from jobhunter.infrastructure.materials.voice_adapter import ClaudeVoiceAdapter
-
-
-@pytest.fixture
-def in_memory_exporter(monkeypatch):
-    """TracerProvider piped to an in-memory exporter for generation-span assertions."""
-    from opentelemetry import trace as trace_api
-    from opentelemetry.util._once import Once
-
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER_SET_ONCE", Once())
-    monkeypatch.setattr(trace_api, "_TRACER_PROVIDER", None)
-
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    set_tracer_provider(provider)
-    yield exporter
-    exporter.clear()
 
 
 class ResultMessage:
@@ -179,3 +158,24 @@ async def test_rewrite_span_omits_tokens_when_sdk_reports_no_usage(in_memory_exp
     attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
     assert attrs["langfuse.observation.model.name"] == "claude-opus-4-8"
     assert "gen_ai.usage.input_tokens" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_rewrite_span_survives_malformed_sdk_usage(in_memory_exporter) -> None:
+    # A drifted / non-int usage field must NEVER fail the voice pass — token
+    # extraction runs inside the re-raising span block, so it degrades the
+    # unparseable count to omitted rather than raising.
+    adapter = ClaudeVoiceAdapter(
+        query_fn=_fake_query(
+            _voiced_structured(),
+            usage={"input_tokens": "n/a", "output_tokens": 10},
+        ),
+        options_factory=_FakeClaudeOptions,
+    )
+    result = await adapter.rewrite("system", _request())  # must not raise
+    assert result.executive_profile.startswith("Rebuilt the deploy pipeline")
+
+    attrs = dict(in_memory_exporter.get_finished_spans()[0].attributes or {})
+    assert "gen_ai.usage.input_tokens" not in attrs
+    assert "langfuse.observation.usage_details" not in attrs
+    assert attrs["gen_ai.usage.output_tokens"] == 10


### PR DESCRIPTION
## What

Wraps the five previously-untraced frontier-model calls in the system in the existing `llm_generation_span` so they emit `langfuse.observation.type=generation` spans:

- **Employer-analysis ensemble** — the three parallel draft legs (Claude Agent SDK, Codex SDK, Antigravity/Gemini SDK) and the Claude synthesizer pass.
- **Resume voice pass** — the Claude voice adapter.

Each span carries the model name, prompt/completion, latency (span duration), and — when the SDK surfaces usage — input/output token counts, mirrored into both the Langfuse `langfuse.observation.*` and the GenAI-semconv `gen_ai.*` attributes.

## Why

Each employer-analysis run makes 4 frontier-model calls plus the voice pass makes a 5th. None of the agent-SDK adapters wrapped their calls in a span — only the legacy httpx `LLMClient.chat` was traced. So the single most expensive AI in the system reported **no** model, prompt, completion, token counts, cost, or latency to Langfuse, and there was no cost aggregation anywhere. `docs/architecture.md` admitted folding these legs into the span pipeline was still "next".

## How

- Token usage is read from each SDK's native shape and normalised: Claude `ResultMessage.usage` (fresh + cache-creation + cache-read = total input), Codex `TurnResult.usage.total`, Antigravity `response.usage_metadata` (`prompt_token_count` in, `candidates + thoughts` out). Extraction is best-effort: **absent usage → the span omits tokens rather than fabricating them.**
- Distinct instrumentation scopes (`jobhunter.analysis.{claude,codex,antigravity,synthesizer}`, `jobhunter.materials.voice`) keep the legs, synthesizer, and voice pass separable under the shared `llm.<model>` span name.
- **Control flow is unchanged.** An SDK error is recorded on the span (`StatusCode.ERROR`) and re-raised into the existing per-leg retry / partial-failure path; the ensemble's "no wall-clock timeout / partial-failure safe" behaviour is untouched.
- **Per-analysis rollup is free.** The legs run inside the enclosing pipeline-stage / JSON-RPC span (OTel context propagates through `asyncio.run` + `asyncio.gather`), so Langfuse aggregates their token usage and cost onto the surrounding analysis trace with no extra plumbing.
- No new key management, no new dependencies, no control-flow or product-behaviour change.

## Tests

New span assertions (in-memory OTLP exporter, SDK boundary mocked as the existing tests do) prove each leg + synthesizer + voice pass opens a generation span with the model attribute and token attributes when the mocked SDK returns usage:

- `test_employer_analysis_ensemble.py`: Claude draft, Codex draft, Claude synthesizer spans; graceful token omission when the SDK reports no usage; SDK error recorded on span + re-raised.
- `test_antigravity_adapter.py`: Antigravity draft span + graceful token omission.
- `test_voice_adapter.py`: voice-pass span + graceful token omission.

## Docs

`docs/architecture.md` observability section: added the ensemble legs / synthesizer / voice rows to the spans table and replaced the "next observability step" caveat with the implemented behaviour (generation spans, distinct scopes, trace-level cost rollup, non-fatal instrumentation).

## Validation

\`\`\`
$ uv --project workers/automation run --extra dev pytest -q \
    workers/automation/tests/test_llm_spans.py \
    workers/automation/tests/test_employer_analysis_ensemble.py \
    workers/automation/tests/test_voice_adapter.py \
    workers/automation/tests/test_otel_init.py \
    workers/automation/tests/test_antigravity_adapter.py
43 passed in 0.47s

$ uv --project workers/automation run --extra dev ruff check \
    workers/automation/src/jobhunter/infrastructure/analysis \
    workers/automation/src/jobhunter/infrastructure/materials/voice_adapter.py
All checks passed!

$ uv --project workers/automation run --extra dev pytest -q   # full worker suite
1495 passed in 38.50s
\`\`\`