### PR TITLE
fix(web): lift CardHeader meta text contrast to WCAG AA

### DIFF
--- a/apps/web/src/styles/token-contrast.test.ts
+++ b/apps/web/src/styles/token-contrast.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const styleDir = dirname(fileURLToPath(import.meta.url));
+const tokensCss = readFileSync(resolve(styleDir, "tokens.css"), "utf8");
+const globalsCss = readFileSync(resolve(styleDir, "globals.css"), "utf8");
+
+const AA_NORMAL = 4.5;
+
+type Oklch = { L: number; C: number; H: number };
+
+const lightBlock = tokensCss.match(/:root\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+const darkBlock = tokensCss.match(/:root\[data-theme="dark"\]\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+
+function readToken(block: string, token: string): Oklch {
+  const raw = block.match(new RegExp(`--${token}:\\s*oklch\\(([^)]+)\\)`))?.[1];
+  if (!raw) throw new Error(`token --${token} not found`);
+  const [L, C = 0, H = 0] = raw.trim().split(/\s+/).map(Number);
+  if (L === undefined) throw new Error(`token --${token} has no lightness`);
+  return { L, C, H };
+}
+
+// OKLCH -> linear sRGB (Björn Ottosson's matrices).
+function oklchToLinearSrgb({ L, C, H }: Oklch): [number, number, number] {
+  const h = (H * Math.PI) / 180;
+  const a = C * Math.cos(h);
+  const b = C * Math.sin(h);
+  const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+  const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+  const s = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+
+const clamp01 = (x: number) => Math.min(1, Math.max(0, x));
+const encodeSrgb = (c: number) => (c <= 0.0031308 ? 12.92 * c : 1.055 * c ** (1 / 2.4) - 0.055);
+
+// Round to the 8-bit sRGB a browser renders, which is what axe-core samples.
+function to8Bit(color: Oklch): [number, number, number] {
+  return oklchToLinearSrgb(color).map((c) => Math.round(encodeSrgb(clamp01(c)) * 255)) as [
+    number,
+    number,
+    number,
+  ];
+}
+
+// WCAG relative luminance from 8-bit sRGB channels.
+function relativeLuminance([r, g, b]: [number, number, number]): number {
+  const linear = (v: number) => {
+    const cs = v / 255;
+    return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+function contrastRatio(fg: Oklch, bg: Oklch): number {
+  const l1 = relativeLuminance(to8Bit(fg));
+  const l2 = relativeLuminance(to8Bit(bg));
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+function cardHeaderRule(): string {
+  return globalsCss.match(/\.card-hd\s*\{([^}]*)\}/)?.[1] ?? "";
+}
+
+describe("muted-foreground WCAG AA contrast", () => {
+  it("CardHeader `.meta` renders on the muted card-header band, not the card body", () => {
+    expect(cardHeaderRule(), "card header must fill its band with --muted").toContain(
+      "background: var(--muted)",
+    );
+    expect(globalsCss, "`.meta` must resolve its color to --muted-foreground").toMatch(
+      /\.meta,[\s\S]*?\{[\s\S]*?color:\s*var\(--muted-foreground\)/,
+    );
+  });
+
+  it("clears 4.5:1 for muted-foreground on the muted card-header band in both themes", () => {
+    const light = contrastRatio(readToken(lightBlock, "muted-foreground"), readToken(lightBlock, "muted"));
+    const dark = contrastRatio(readToken(darkBlock, "muted-foreground"), readToken(darkBlock, "muted"));
+
+    expect(light, `light muted-foreground on --muted was ${light.toFixed(3)}:1`).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+    expect(dark, `dark muted-foreground on --muted was ${dark.toFixed(3)}:1`).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+  });
+
+  it("clears 4.5:1 for muted-foreground on the card surface in both themes", () => {
+    const light = contrastRatio(readToken(lightBlock, "muted-foreground"), readToken(lightBlock, "card"));
+    const dark = contrastRatio(readToken(darkBlock, "muted-foreground"), readToken(darkBlock, "card"));
+
+    expect(light, `light muted-foreground on --card was ${light.toFixed(3)}:1`).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+    expect(dark, `dark muted-foreground on --card was ${dark.toFixed(3)}:1`).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+  });
+
+  it("computes the pre-fix regression value so the guard cannot silently drift", () => {
+    const regressed = contrastRatio({ L: 0.556, C: 0, H: 0 }, readToken(lightBlock, "muted"));
+    expect(regressed, "the old oklch(0.556 0 0) must still measure below AA on --muted").toBeLessThan(
+      AA_NORMAL,
+    );
+  });
+});

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -13,7 +13,7 @@
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.535 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -136,13 +136,18 @@ For changes to the shadcn token foundation, `apps/web/src/styles/tokens.css`,
 classes, theme behavior, or density behavior, run the token foundation proof gate:
 
 ```bash
-corepack pnpm --filter @jobhunter/web test src/styles/token-contract.test.ts
+corepack pnpm --filter @jobhunter/web test src/styles/token-contract.test.ts src/styles/token-contrast.test.ts
 corepack pnpm web:check
 corepack pnpm web:build
 corepack pnpm dlx shadcn@latest info -c apps/web
 corepack pnpm --filter @jobhunter/web e2e -- tests/token-foundation.spec.ts
 git diff --check
 ```
+
+`token-contrast.test.ts` resolves the semantic token pairs from `tokens.css`
+and asserts WCAG AA (>= 4.5:1) for muted-foreground text on both the muted
+card-header band and the card surface in light and dark themes, so a
+regression that pushes muted secondary text below the bar fails deterministically.
 
 Also prove generated CSS contains the standard semantic utilities and scan for
 retired token aliases before accepting the change. Browser proof must use the
@@ -341,6 +346,13 @@ The Storybook `addon-a11y` is configured so that **critical** and **serious**
 axe violations fail CI (`a11y: { test: "error" }`). The Storybook test runner
 (`pnpm web:storybook:test`) is the gate; `pnpm --filter @jobhunter/web test`
 also runs the colocated `*.a11y.test.tsx` suites for forms and dialogs.
+
+The `color-contrast` axe rule is disabled in the Storybook test runner
+(`.storybook/test-runner.ts`) because contrast shifts across themes, and the
+jsdom `*.a11y.test.tsx` suites cannot evaluate rendered colors either. Token
+contrast is therefore guarded deterministically by
+`src/styles/token-contrast.test.ts`, which computes the WCAG ratio from the
+resolved token values against each real surface.
 
 10 stories defer the a11y check (`a11y: { test: "off" }`) because they exercise
 production a11y defects that are tracked outside the story. Each deferral is


### PR DESCRIPTION
## What

Darken the light-mode `--muted-foreground` token from `oklch(0.556 0 0)` to
`oklch(0.535 0 0)` so the shared **CardHeader `.meta`** text clears WCAG AA on
every dashboard card, and add a deterministic contrast regression test.

## Why

Real-browser axe (during PR #225 verification) flagged the shared CardHeader
`.meta` text at **4.34:1** in light mode — below the AA 4.5:1 floor for normal
text — on every dashboard card (FunnelCard, ApplyRunsCard, ConversionPanel, ...).
The defect pre-dates #225 and exists on `main`.

Root cause traced end to end:

- `CardHeader` (`apps/web/src/shared/ui/card-header.tsx`) renders
  `<span class="meta">`.
- `.meta` gets `color: var(--muted-foreground)` (`globals.css:248`).
- The `.meta` sits **inside** `.card-hd`, whose `background: var(--muted)`
  (`globals.css:301`) — so the real rendered background is `--muted`
  (`oklch(0.97 0 0)` = `#f5f5f5`), **not** the white card body or page.
- Light `--muted-foreground` (`oklch(0.556 0 0)` = `#737373`) on `#f5f5f5`
  = **4.34:1** (fails). On white it is 4.74:1 (passes) — which is why it only
  fails on the muted header band.

## Fix decision: shared token vs. scoped class

**Chose: adjust the shared `--muted-foreground` token (light mode only).** The
finding's root cause is the token, and the disposition prescribed a
shared-primitive/global-token change. Audit of every `--muted-foreground` usage:

- **Text usages** (nav, `.kpi-delta`, `.muted`, `.meta`, `.legend`, card
  descriptions, dialog/sheet/drawer descriptions, table headers, ScoreBadge
  `--fit-score-fg`, tabs, ...): all sit on surfaces at least as light as
  `--muted`. Darkening the foreground **only ever increases** their contrast, so
  they "should darken equally." The same muted-fg-on-muted-bg failure also
  affects the **tabs** primitive (`bg-muted text-muted-foreground`) and the
  dialog/drawer muted panels — all fixed by this one token change.
- **Background usages** (`color-mix` ingredient): `.seg-pending`
  (`globals.css:700`, non-text progress bar) and `.tag.muted` /
  `.stage-pill.neutral` (`globals.css:3623`, only 8% mixed into the bg). A ~0.02
  drop in the token's L moves these backgrounds negligibly (<=0.002 L) and only
  in the harmless/helpful direction; no text-on-token-background contrast is
  reduced. No usage is a full `background: var(--muted-foreground)`.
- Dark mode `--muted-foreground` (`oklch(0.708 0 0)`) already passes (5.86:1 on
  `--muted`, 6.94:1 on `--card`) and is left unchanged.

`oklch(0.535 0 0)` is the smallest change that clears AA with margin while
staying visibly muted (rgb 115 -> 109; not full foreground).

## Before / after (WCAG, 8-bit sRGB — matches axe)

| Mode | Surface (real bg) | Before | After |
| --- | --- | --- | --- |
| Light | `--muted` `#f5f5f5` (card-header band) | **4.34:1 FAIL** | **4.75:1 PASS** |
| Light | `--card` / page `#ffffff` | 4.74:1 | 5.17:1 |
| Light | `--secondary` `oklch(0.967)` (darkest std surface) | 4.34:1* | 4.70:1 |
| Dark | `--muted` `oklch(0.269)` | 5.86:1 | 5.86:1 (unchanged) |
| Dark | `--card` `oklch(0.205)` | 6.94:1 | 6.94:1 (unchanged) |

\* borderline on the slightly-darker secondary surface as well; now cleared.

## Regression guard

`apps/web/src/styles/token-contrast.test.ts` resolves the token pairs from
`tokens.css` and asserts the computed WCAG ratio (OKLCH -> 8-bit sRGB ->
relative luminance) `>= 4.5:1` for muted-foreground on the card-header band and
the card surface in **both** themes. A fourth case pins that the old
`oklch(0.556 0 0)` still measures below AA, so the guard cannot silently drift.
Wired into the "Token Foundation QA Gate" in `docs/local-reliability-qa.md`.

Note: the Storybook axe runner (`.storybook/test-runner.ts`) **disables the
`color-contrast` rule**, and the jsdom `*.a11y.test.tsx` suites cannot evaluate
rendered colors — this is why the defect was invisible to the existing gates and
why the deterministic computed-ratio test is the authoritative guard. This is
now documented in the "Accessibility bar" section.

## Backlog

- `docs/backlog.md` "Frontend Accessibility Backlog" has **no** entry for this
  defect (it was found fresh during #225 verification), so nothing to remove.
- No Storybook story set `parameters.a11y.test = "off"` for this defect, so
  nothing to re-enable.

## Validation

- `pnpm --filter @jobhunter/web test src/styles/token-contract.test.ts src/styles/token-contrast.test.ts` -> 2 files, 11 tests pass. Reverting the token to `0.556` fails `token-contrast.test.ts` with `light muted-foreground on --muted was 4.349:1`.
- `pnpm web:check` -> pass.
- `pnpm --filter @jobhunter/web test` -> 144 files, 850 tests pass.
- `pnpm web:build` -> built (pre-existing chunk-size warning only).
- `pnpm --filter @jobhunter/web test-d` -> 10 files, 10 tests pass.
- **Real-browser axe cross-check** (Chromium, `color-contrast` enabled, built Storybook CardHeader `With Meta` story): shipped `0.535` -> **no violation**; forced-old `0.556` on the same DOM -> violation `ratio 4.34, required 4.5:1, fg #737373 on bg #f5f5f5` (reproduces the finding); reverted -> no violation.

## Residual / out of scope

`.tag.muted` / `.stage-pill.neutral` remain marginally below AA (~4.3:1) because
their background is a color-mix that is *darker* than plain `--muted`; that is a
separate compound defect of that pill's own background choice, not the
CardHeader finding. Not fixed here to avoid over-darkening all secondary text
app-wide; flagged for a follow-up backlog entry.