### PR TITLE
fix(projections): deterministic dashboard by_source tie-break

### DIFF
--- a/apps/api/src/projections.ts
+++ b/apps/api/src/projections.ts
@@ -2611,7 +2611,9 @@ function rebuildDashboardProjection(db: SqliteDatabase, tenantId: string): void 
     const key = row.source || "unknown";
     sourceCounts.set(key, (sourceCounts.get(key) ?? 0) + 1);
   }
-  const bySource = [...sourceCounts.entries()].sort((a, b) => b[1] - a[1]);
+  const bySource = [...sourceCounts.entries()].sort(
+    (a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0),
+  );
 
   const scoreCounts = new Map<number, number>();
   for (const row of active) {

--- a/apps/api/test/projections.test.ts
+++ b/apps/api/test/projections.test.ts
@@ -1596,6 +1596,62 @@ describe("apply_run_projections without legacy apply_runs table", () => {
     }
   });
 
+  it("orders dashboard by_source by count desc then source name ascending", async () => {
+    const { dbPath, cleanup } = withTempDb();
+    try {
+      seedSchema(dbPath);
+      const db = new Database(dbPath);
+      const insert = db.prepare(
+        "INSERT INTO jobs (url, title, site, strategy, location, discovered_at) VALUES (?, ?, ?, ?, ?, ?)",
+      );
+      // seedSchema pre-seeds one ExampleCo job (count 1). Netflix leads on
+      // count; Acme and Wayfair tie at 2, seeded reverse-alphabetically so a
+      // count-only sort would leak insertion order. The tiebreak re-orders the
+      // tie A->Z, byte-identical to the Python builder.
+      const seeded: Array<[string, string]> = [
+        ["https://example.com/jobs/w1", "Wayfair"],
+        ["https://example.com/jobs/w2", "Wayfair"],
+        ["https://example.com/jobs/n1", "Netflix"],
+        ["https://example.com/jobs/n2", "Netflix"],
+        ["https://example.com/jobs/n3", "Netflix"],
+        ["https://example.com/jobs/a1", "Acme"],
+        ["https://example.com/jobs/a2", "Acme"],
+      ];
+      for (const [url, site] of seeded) {
+        insert.run(url, "Engineer", site, "jobspy", "Remote", "2026-05-06T09:00:00+00:00");
+      }
+      db.close();
+
+      const app = buildApp({
+        dbPath,
+        settingsPath: path.join(path.dirname(dbPath), "dashboard.json"),
+      });
+      try {
+        const res = await app.inject({ method: "GET", url: "/v1/dashboard/summary" });
+        expect(res.statusCode, res.body).toBe(200);
+      } finally {
+        await app.close();
+      }
+
+      const readonlyDb = new Database(dbPath, { readonly: true });
+      try {
+        const row = readonlyDb
+          .prepare("SELECT by_source_json FROM dashboard_projections WHERE tenant_id = 'local'")
+          .get() as { by_source_json: string } | undefined;
+        expect(JSON.parse(row?.by_source_json ?? "[]")).toEqual([
+          ["Netflix", 3],
+          ["Acme", 2],
+          ["Wayfair", 2],
+          ["ExampleCo", 1],
+        ]);
+      } finally {
+        readonlyDb.close();
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
   it("uses explicit company from discovered jobs before source inference", async () => {
     const { dbPath, cleanup } = withTempDb();
     try {

--- a/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
+++ b/workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py
@@ -1548,7 +1548,7 @@ class ProjectionBuilder:
             source = _row_str(row, "source") or "unknown"
             source_counts[source] = source_counts.get(source, 0) + 1
         by_source = tuple(
-            sorted(source_counts.items(), key=lambda kv: kv[1], reverse=True)
+            sorted(source_counts.items(), key=lambda kv: (-kv[1], kv[0]))
         )
 
         # score_distribution — group by fit_score.

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -337,6 +337,30 @@ def test_by_source_counts(conn: sqlite3.Connection) -> None:
     assert counts["TwoCo"] == 1
 
 
+def test_by_source_orders_ties_by_source_name(conn: sqlite3.Connection) -> None:
+    # Netflix leads on count; Acme and Wayfair tie at 2, seeded reverse-
+    # alphabetically so a count-only sort would leak insertion order. The
+    # tiebreak re-orders the tie A->Z, byte-identical to the TS builder.
+    seeded = [
+        ("https://example.com/w1", "Wayfair"),
+        ("https://example.com/w2", "Wayfair"),
+        ("https://example.com/n1", "Netflix"),
+        ("https://example.com/n2", "Netflix"),
+        ("https://example.com/n3", "Netflix"),
+        ("https://example.com/a1", "Acme"),
+        ("https://example.com/a2", "Acme"),
+    ]
+    for url, site in seeded:
+        _seed_job(conn, url, site=site)
+        record_job_event(conn, url, "discover", "JobDiscovered")
+    conn.commit()
+    ProjectionBuilder(conn_factory=lambda: conn).refresh()
+
+    row = _dashboard(conn)
+    by_source = json.loads(_row_value(row, "by_source_json", "[]"))
+    assert by_source == [["Netflix", 3], ["Acme", 2], ["Wayfair", 2]]
+
+
 def _apply_job(conn: sqlite3.Connection, url: str, *, site: str, fit_score: int) -> None:
     _seed_job(conn, url, site=site)
     conn.execute(

--- a/workers/automation/tests/test_dashboard_projection.py
+++ b/workers/automation/tests/test_dashboard_projection.py
@@ -338,17 +338,21 @@ def test_by_source_counts(conn: sqlite3.Connection) -> None:
 
 
 def test_by_source_orders_ties_by_source_name(conn: sqlite3.Connection) -> None:
-    # Netflix leads on count; Acme and Wayfair tie at 2, seeded reverse-
-    # alphabetically so a count-only sort would leak insertion order. The
-    # tiebreak re-orders the tie A->Z, byte-identical to the TS builder.
+    # Netflix leads on count; Acme and Wayfair tie at 2. The builder seeds
+    # source_counts from fetch_job_list, which returns rows ORDER BY job_id —
+    # so the URL prefixes below deliberately put Wayfair FIRST in job_id order
+    # (a-wayfair < m-netflix < z-acme) while the tie must render Acme first
+    # A->Z. A count-only sort would leak insertion order ([..., Wayfair, Acme])
+    # and fail; only the count-desc-then-source-asc tiebreak passes,
+    # byte-identical to the TS builder.
     seeded = [
-        ("https://example.com/w1", "Wayfair"),
-        ("https://example.com/w2", "Wayfair"),
-        ("https://example.com/n1", "Netflix"),
-        ("https://example.com/n2", "Netflix"),
-        ("https://example.com/n3", "Netflix"),
-        ("https://example.com/a1", "Acme"),
-        ("https://example.com/a2", "Acme"),
+        ("https://example.com/a-wayfair-1", "Wayfair"),
+        ("https://example.com/a-wayfair-2", "Wayfair"),
+        ("https://example.com/m-netflix-1", "Netflix"),
+        ("https://example.com/m-netflix-2", "Netflix"),
+        ("https://example.com/m-netflix-3", "Netflix"),
+        ("https://example.com/z-acme-1", "Acme"),
+        ("https://example.com/z-acme-2", "Acme"),
     ]
     for url, site in seeded:
         _seed_job(conn, url, site=site)


### PR DESCRIPTION
## What

Dashboard `by_source` ordering is now count-descending **then source-name ascending** in BOTH projection builders:

- `apps/api/src/projections.ts` — `.sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))`
- `workers/automation/src/jobhunter/infrastructure/projections/projection_builder.py` — `sorted(source_counts.items(), key=lambda kv: (-kv[1], kv[0]))`

This mirrors the tie-break the outcome-conversion `bySource` rollup (#223) already uses in both runtimes.

## Why

On a count tie, both builders fell back to insertion order — the TS `Map` seeded by rowid scan order, the Python dict by job-id scan order — so `dashboard_projections.by_source_json` could diverge between runtimes for identical data (last-writer-wins flips the displayed order nondeterministically). Found while re-deriving the #223 parity fixture: an incidental tie broke parity differently per runtime. The fixture was de-tied there; this PR fixes the underlying nondeterminism.

## Validation

- New per-runtime tie regressions, each seeding a tied source pair reverse-alphabetically and asserting A→Z ordering: `apps/api/test/projections.test.ts` ("orders dashboard by_source by count desc then source name ascending") and `workers/automation/tests/test_dashboard_projection.py::test_by_source_orders_ties_by_source_name`. Unit tests rather than the shared parity fixture: a tie-ordering-only change would otherwise force re-deriving every unrelated column in `audit_projection_parity.json`.
- `pnpm api:check` clean; `pnpm api:test` 300 passed; `uv --project workers/automation run --extra dev pytest -q` 1515 passed; ruff clean.
- Verified inside the full 23-branch integration union: pytest 1653 / api:test 323, all green.

No doc update: determinism bug fix with no user-facing or public-behavior change (`by_source_json` consumers see identical content, now in a stable order).

Stacked on #223 (`feat/outcome-conversion-projection`); merge after it.