### PR TITLE
fix(worker): bound LLM retries and cap score attempts (P1a)

### DIFF
--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -2881,7 +2881,8 @@ _COVER_NOT_EXHAUSTED: str = "(jss_c.jss_c_state IS NULL OR jss_c.jss_c_state != 
 # ``job_scores``, downstream work requires a succeeded score-stage row.
 _SCORE_DOWNSTREAM_STATE_JOIN: str = (
     "LEFT JOIN ("
-    "SELECT job_url AS jss_s_job_url, state AS jss_s_state "
+    "SELECT job_url AS jss_s_job_url, state AS jss_s_state, "
+    "attempt_count AS jss_s_attempts "
     "FROM job_stage_states WHERE stage = 'score'"
     ") jss_s ON jss_s.jss_s_job_url = jobs.url "
     "LEFT JOIN ("
@@ -2895,6 +2896,12 @@ _SCORE_CURRENT_FOR_DOWNSTREAM: str = (
     "OR jss_s.jss_s_state = 'succeeded' "
     "OR (js.js_fit_score IS NULL AND jss_s.jss_s_state != 'stale')))"
 )
+# Score has no legacy ``jobs.score_attempts`` column, so the canonical
+# ``job_stage_states.attempt_count`` counter is the only source (default 0
+# for un-scored rows). ``pending_score`` uses this to mirror the tailor /
+# cover ``< 5`` cap so a permanently-failing job stops re-billing the LLM
+# on every batch. Requires ``_SCORE_DOWNSTREAM_STATE_JOIN`` in the FROM.
+_EFFECTIVE_SCORE_ATTEMPTS: str = "COALESCE(jss_s.jss_s_attempts, 0)"
 
 
 # ---------------------------------------------------------------------------
@@ -3505,6 +3512,7 @@ def get_jobs_by_stage(
         "pending_score": (
             f"{_EFFECTIVE_FULL_DESCRIPTION} IS NOT NULL "
             f"AND {_EFFECTIVE_FIT_SCORE} IS NULL "
+            f"AND {_EFFECTIVE_SCORE_ATTEMPTS} < 5 "
             f"AND {_NOT_CLOSED_ACTIVE_STATE}"
         ),
         "scored": f"{_EFFECTIVE_FIT_SCORE} IS NOT NULL AND {_NOT_CLOSED_ACTIVE_STATE}",

--- a/workers/automation/src/jobhunter/llm.py
+++ b/workers/automation/src/jobhunter/llm.py
@@ -11,6 +11,7 @@ LLM_MODEL env var overrides the model name for any provider.
 
 import json
 import logging
+import math
 import os
 import random
 import re
@@ -136,18 +137,26 @@ def _retry_wait(attempt: int, retry_after: str | None = None) -> float:
     """Seconds to sleep before the next transient-failure retry.
 
     Uses exponential backoff from ``_RATE_LIMIT_BASE_WAIT``, honoring a
-    server ``Retry-After`` (seconds) when present. The result is jittered to
-    break retry lockstep and hard-capped at ``_MAX_RETRY_WAIT`` so a hostile
-    or buggy ``Retry-After`` cannot sleep for hours inside an activity.
+    server ``Retry-After`` (seconds) when present and finite. The result is
+    jittered to break retry lockstep and clamped to ``[0, _MAX_RETRY_WAIT]``
+    before it is returned, so a hostile or buggy ``Retry-After`` (huge,
+    negative, NaN, or infinite) can neither park an activity for hours nor
+    reach ``time.sleep()`` with a value it rejects.
     """
     wait = _RATE_LIMIT_BASE_WAIT * (2 ** attempt)
     if retry_after is not None:
         try:
-            wait = float(retry_after)
+            parsed = float(retry_after)
         except (ValueError, TypeError):
-            pass
+            parsed = None
+        # Only honor a finite Retry-After; NaN/inf are meaningless, so fall
+        # back to the exponential backoff above.
+        if parsed is not None and math.isfinite(parsed):
+            wait = parsed
     wait += random.uniform(0, _RETRY_JITTER)
-    return min(wait, _MAX_RETRY_WAIT)
+    # Floor at 0 (a negative Retry-After would make time.sleep raise
+    # ValueError) then cap at the ceiling.
+    return max(0.0, min(wait, _MAX_RETRY_WAIT))
 
 
 _GEMINI_COMPAT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"

--- a/workers/automation/src/jobhunter/llm.py
+++ b/workers/automation/src/jobhunter/llm.py
@@ -12,6 +12,7 @@ LLM_MODEL env var overrides the model name for any provider.
 import json
 import logging
 import os
+import random
 import re
 import time
 
@@ -119,9 +120,34 @@ _MAX_RETRIES = 5
 _TIMEOUT = 180  # seconds — Gemini thinking models can take >120s on a single call.
 _JSON_PARSE_RETRIES = 2
 
-# Base wait on first 429/503 (doubles each retry, caps at 60s).
+# Base wait on first transient failure (doubles each retry, caps at _MAX_RETRY_WAIT).
 # Gemini free tier is 15 RPM = 4s minimum between requests; 10s gives headroom.
 _RATE_LIMIT_BASE_WAIT = 10
+# Ceiling (seconds) for any single retry sleep, including a server-supplied
+# Retry-After. A hostile or buggy Retry-After must never park an activity for
+# hours, so the honored wait is hard-capped here.
+_MAX_RETRY_WAIT = 60
+# Max random jitter (seconds) added to each retry sleep so concurrent workers
+# don't retry in lockstep.
+_RETRY_JITTER = 5
+
+
+def _retry_wait(attempt: int, retry_after: str | None = None) -> float:
+    """Seconds to sleep before the next transient-failure retry.
+
+    Uses exponential backoff from ``_RATE_LIMIT_BASE_WAIT``, honoring a
+    server ``Retry-After`` (seconds) when present. The result is jittered to
+    break retry lockstep and hard-capped at ``_MAX_RETRY_WAIT`` so a hostile
+    or buggy ``Retry-After`` cannot sleep for hours inside an activity.
+    """
+    wait = _RATE_LIMIT_BASE_WAIT * (2 ** attempt)
+    if retry_after is not None:
+        try:
+            wait = float(retry_after)
+        except (ValueError, TypeError):
+            pass
+    wait += random.uniform(0, _RETRY_JITTER)
+    return min(wait, _MAX_RETRY_WAIT)
 
 
 _GEMINI_COMPAT_BASE = "https://generativelanguage.googleapis.com/v1beta/openai"
@@ -383,36 +409,36 @@ class LLMClient:
 
             except httpx.HTTPStatusError as exc:
                 resp = exc.response
-                if resp.status_code in (429, 503) and attempt < _MAX_RETRIES - 1:
-                    # Respect Retry-After header if provided (Gemini sends this).
+                status = resp.status_code
+                # Retry rate limits (429) and any server-side error (5xx);
+                # other 4xx client errors are not transient and fail fast.
+                retryable = status == 429 or 500 <= status < 600
+                if retryable and attempt < _MAX_RETRIES - 1:
+                    # Respect Retry-After header if provided (Gemini sends this),
+                    # but capped — see _retry_wait.
                     retry_after = (
                         resp.headers.get("Retry-After")
                         or resp.headers.get("X-RateLimit-Reset-Requests")
                     )
-                    if retry_after:
-                        try:
-                            wait = float(retry_after)
-                        except (ValueError, TypeError):
-                            wait = _RATE_LIMIT_BASE_WAIT * (2 ** attempt)
-                    else:
-                        wait = min(_RATE_LIMIT_BASE_WAIT * (2 ** attempt), 60)
-
+                    wait = _retry_wait(attempt, retry_after)
                     log.warning(
-                        "LLM rate limited (HTTP %s). Waiting %ds before retry %d/%d. "
+                        "LLM request failed (HTTP %s). Waiting %.1fs before retry %d/%d. "
                         "Tip: Gemini free tier = 15 RPM. Consider a paid account "
                         "or switching to a local model.",
-                        resp.status_code, wait, attempt + 1, _MAX_RETRIES,
+                        status, wait, attempt + 1, _MAX_RETRIES,
                     )
                     time.sleep(wait)
                     continue
                 raise
 
-            except httpx.TimeoutException:
+            except httpx.TransportError as exc:
+                # Connection-level failures — connect/read timeouts, network
+                # resets, protocol errors — are transient; retry with backoff.
                 if attempt < _MAX_RETRIES - 1:
-                    wait = min(_RATE_LIMIT_BASE_WAIT * (2 ** attempt), 60)
+                    wait = _retry_wait(attempt)
                     log.warning(
-                        "LLM request timed out, retrying in %ds (attempt %d/%d)",
-                        wait, attempt + 1, _MAX_RETRIES,
+                        "LLM request failed (%s: %s), retrying in %.1fs (attempt %d/%d)",
+                        type(exc).__name__, exc, wait, attempt + 1, _MAX_RETRIES,
                     )
                     time.sleep(wait)
                     continue

--- a/workers/automation/src/jobhunter/scoring/scorer.py
+++ b/workers/automation/src/jobhunter/scoring/scorer.py
@@ -308,6 +308,9 @@ def run_scoring(
             job["url"],
             "score",
             "running",
+            # Preserve the attempt counter across re-selection — see
+            # _score_attempt_count; a bare running write would reset it to 0.
+            attempt_count=_score_attempt_count(conn, job["url"]),
             started_at=started_at,
             validate_transition=False,
         )
@@ -516,7 +519,7 @@ def run_scoring(
                 url,
                 "score",
                 "failed",
-                attempt_count=1,
+                attempt_count=_score_attempt_count(conn, url) + 1,
                 started_at=started_ats.get(url),
                 finished_at=finished_at,
                 error_code="SCORE_FAILED",
@@ -653,6 +656,9 @@ def score_job_by_url(
         job_url,
         "score",
         "running",
+        # Preserve the attempt counter across re-selection — see
+        # _score_attempt_count; a bare running write would reset it to 0.
+        attempt_count=_score_attempt_count(conn, job_url),
         started_at=started_at,
         validate_transition=False,
     )
@@ -702,7 +708,7 @@ def score_job_by_url(
             job_url,
             "score",
             "failed",
-            attempt_count=1,
+            attempt_count=_score_attempt_count(conn, job_url) + 1,
             started_at=started_at,
             finished_at=finished_at,
             error_code="SCORE_FAILED",
@@ -849,6 +855,23 @@ def _row_value(row: Any, key: str, index: int) -> Any:
     if isinstance(row, sqlite3.Row):
         return row[key]
     return row[index]
+
+
+def _score_attempt_count(conn: sqlite3.Connection, job_url: str) -> int:
+    """Current score-stage attempt count (0 if unrecorded).
+
+    ``set_stage_state`` resets ``attempt_count`` to 0 whenever it is
+    omitted, so a bare ``running`` write would wipe the counter between
+    batch re-selections. The score stage therefore threads the current
+    count through the ``running`` write and increments it on failure, so
+    the ``pending_score`` ``< 5`` cap can engage and stop a permanently-
+    failing job from re-billing the LLM on every batch.
+    """
+    row = conn.execute(
+        "SELECT attempt_count FROM job_stage_states WHERE job_url = ? AND stage = 'score'",
+        (job_url,),
+    ).fetchone()
+    return int(_row_value(row, "attempt_count", 0) or 0)
 
 
 def _analysis_connection_for_repository(repository: ScoreRepository | None) -> sqlite3.Connection:

--- a/workers/automation/tests/test_llm_client.py
+++ b/workers/automation/tests/test_llm_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 
 import httpx
+import pytest
 
 from jobhunter import llm
 from jobhunter.domain.materials.use_cases import TAILORED_RESUME_RESPONSE_SCHEMA
@@ -175,3 +176,143 @@ def test_chat_json_retries_malformed_structured_output_without_token_cap() -> No
     assert response == {"score": 8}
     assert len(requests) == 2
     assert all("max_tokens" not in request for request in requests)
+
+
+# ---------------------------------------------------------------------------
+# Retry hardening (P1a): transient failures retry with bounded, jittered,
+# capped backoff; non-retryable client errors fail fast.
+# ---------------------------------------------------------------------------
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(
+        status_code=200,
+        json={
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        },
+    )
+
+
+def _client_with_handler(handler) -> LLMClient:
+    client = LLMClient(
+        base_url="https://api.openai.com/v1",
+        model="gpt-test",
+        api_key="test-key",
+    )
+    client._client.close()
+    client._client = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def test_chat_retries_5xx_then_succeeds(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(status_code=500, json={"error": "server"})
+        return _ok_response()
+
+    client = _client_with_handler(handler)
+    try:
+        result = client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert len(sleeps) == 1
+
+
+def test_chat_retries_connection_error_then_succeeds(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("connection refused", request=request)
+        return _ok_response()
+
+    client = _client_with_handler(handler)
+    try:
+        result = client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert len(sleeps) == 1
+
+
+def test_chat_caps_hostile_retry_after_header(monkeypatch) -> None:
+    """A 429 with an absurd ``Retry-After`` must not park the call for
+    hours — the honored wait is capped at the ceiling."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                status_code=429,
+                headers={"Retry-After": "86400"},
+                json={"error": "rate limited"},
+            )
+        return _ok_response()
+
+    client = _client_with_handler(handler)
+    try:
+        result = client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert result == "ok"
+    assert len(sleeps) == 1
+    assert sleeps[0] <= llm._MAX_RETRY_WAIT
+
+
+def test_chat_does_not_retry_client_error(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(status_code=400, json={"error": "bad request"})
+
+    client = _client_with_handler(handler)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert calls["n"] == 1
+    assert sleeps == []
+
+
+def test_chat_bounds_retries_on_persistent_transient_failure(monkeypatch) -> None:
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(status_code=503, json={"error": "unavailable"})
+
+    client = _client_with_handler(handler)
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert calls["n"] == llm._MAX_RETRIES
+    assert len(sleeps) == llm._MAX_RETRIES - 1
+    assert all(wait <= llm._MAX_RETRY_WAIT for wait in sleeps)

--- a/workers/automation/tests/test_llm_client.py
+++ b/workers/automation/tests/test_llm_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 
 import httpx
 import pytest
@@ -275,6 +276,68 @@ def test_chat_caps_hostile_retry_after_header(monkeypatch) -> None:
     assert result == "ok"
     assert len(sleeps) == 1
     assert sleeps[0] <= llm._MAX_RETRY_WAIT
+
+
+def test_chat_retries_on_negative_retry_after(monkeypatch) -> None:
+    """A negative ``Retry-After`` must not reach ``time.sleep`` (which rejects
+    it with ValueError). The honored wait is floored to a finite, non-negative
+    value and the request is retried."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                status_code=429,
+                headers={"Retry-After": "-100"},
+                json={"error": "rate limited"},
+            )
+        return _ok_response()
+
+    client = _client_with_handler(handler)
+    try:
+        result = client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert len(sleeps) == 1
+    assert math.isfinite(sleeps[0])
+    assert 0 <= sleeps[0] <= llm._MAX_RETRY_WAIT
+
+
+def test_chat_retries_on_nan_retry_after(monkeypatch) -> None:
+    """A NaN ``Retry-After`` must not reach ``time.sleep`` (which rejects it
+    with ValueError). It is treated as an absent header, so the call falls back
+    to bounded backoff and retries."""
+    sleeps: list[float] = []
+    monkeypatch.setattr(llm.time, "sleep", lambda seconds: sleeps.append(seconds))
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(
+                status_code=429,
+                headers={"Retry-After": "nan"},
+                json={"error": "rate limited"},
+            )
+        return _ok_response()
+
+    client = _client_with_handler(handler)
+    try:
+        result = client.chat([{"role": "user", "content": "hi"}])
+    finally:
+        client.close()
+
+    assert result == "ok"
+    assert calls["n"] == 2
+    assert len(sleeps) == 1
+    assert math.isfinite(sleeps[0])
+    assert 0 <= sleeps[0] <= llm._MAX_RETRY_WAIT
 
 
 def test_chat_does_not_retry_client_error(monkeypatch) -> None:

--- a/workers/automation/tests/test_score_queue_selectors.py
+++ b/workers/automation/tests/test_score_queue_selectors.py
@@ -140,6 +140,45 @@ def test_pending_score_excludes_jobs_already_in_job_scores(
     assert legacy["fit_score"] is None
 
 
+def test_pending_score_excludes_jobs_at_attempt_cap(
+    conn: sqlite3.Connection,
+) -> None:
+    """A job whose score stage has failed 5 times must drop out of
+    pending_score — otherwise a permanently-failing job re-bills the LLM
+    on every batch forever. Mirrors the tailor / cover ``< 5`` cap."""
+    url = "https://example.com/job/score-capped"
+    _seed_enriched_job(conn, url)
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(
+        conn, url, "score", "running",
+        started_at="2024-01-02T00:00:00+00:00", validate_transition=False,
+    )
+    set_stage_state(
+        conn, url, "score", "failed", attempt_count=5, validate_transition=False,
+    )
+
+    assert get_jobs_by_stage(conn=conn, stage="pending_score") == []
+
+
+def test_pending_score_includes_jobs_under_attempt_cap(
+    conn: sqlite3.Connection,
+) -> None:
+    """A job with fewer than 5 score attempts is still eligible."""
+    url = "https://example.com/job/score-under-cap"
+    _seed_enriched_job(conn, url)
+    ensure_job_stage_rows(conn, url)
+    set_stage_state(
+        conn, url, "score", "running",
+        started_at="2024-01-02T00:00:00+00:00", validate_transition=False,
+    )
+    set_stage_state(
+        conn, url, "score", "failed", attempt_count=4, validate_transition=False,
+    )
+
+    urls = {row["url"] for row in get_jobs_by_stage(conn=conn, stage="pending_score")}
+    assert url in urls
+
+
 def test_closed_postings_are_excluded_from_score_and_tailor_queues(
     conn: sqlite3.Connection, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/workers/automation/tests/test_scorer.py
+++ b/workers/automation/tests/test_scorer.py
@@ -1128,3 +1128,86 @@ def test_run_scoring_preselects_retrieval_top_k_before_llm(
     assert summary["errors"] == 0
     assert repo.load(LOCAL_TENANT, JobId(relevant_url)) is not None
     assert repo.load(LOCAL_TENANT, JobId(stale_irrelevant_url)) is None
+
+
+# ---------------------------------------------------------------------------
+# Score attempt cap (P1a): failures must advance
+# ``job_stage_states.attempt_count`` so the pending_score ``< 5`` cap can
+# engage and stop re-billing the LLM for a permanently-failing job.
+# ---------------------------------------------------------------------------
+
+
+def _score_attempt_count(conn: sqlite3.Connection, url: str) -> int:
+    row = conn.execute(
+        "SELECT attempt_count FROM job_stage_states WHERE job_url=? AND stage='score'",
+        (url,),
+    ).fetchone()
+    return int(row["attempt_count"]) if row is not None else 0
+
+
+def _failing_llm() -> _ScriptedLlm:
+    # score=99 is outside [1, 10] → the parser flags ok=False, exercising
+    # the failure path without a network round-trip.
+    return _ScriptedLlm(
+        {
+            "score": 99,
+            "technical_fit": 0,
+            "experience_fit": 0,
+            "role_fit": 0,
+            "keywords": [],
+            "reasoning": "invalid",
+        }
+    )
+
+
+def test_run_scoring_increments_score_attempts_until_cap(
+    conn: sqlite3.Connection, profile_snapshot, monkeypatch
+) -> None:
+    url = "https://example.com/job/score-permafail"
+    _seed_pending_job(conn, url)
+    repo = SqliteScoreRepository(conn)
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    for expected in range(1, 6):
+        summary = scorer_module.run_scoring(
+            profile_snapshot=profile_snapshot,
+            repository=repo,
+            llm_port=_failing_llm(),
+            resume_text="anything",
+        )
+        assert summary["errors"] == 1
+        assert _score_attempt_count(conn, url) == expected
+
+    # 6th batch: the job is now capped out of pending_score, so run_scoring
+    # finds nothing and the LLM is never called again.
+    drained = _failing_llm()
+    summary = scorer_module.run_scoring(
+        profile_snapshot=profile_snapshot,
+        repository=repo,
+        llm_port=drained,
+        resume_text="anything",
+    )
+    assert summary == {"scored": 0, "errors": 0, "elapsed": 0.0, "distribution": []}
+    assert drained.calls == 0
+    assert _score_attempt_count(conn, url) == 5
+
+
+def test_score_job_by_url_increments_score_attempts_on_failure(
+    conn: sqlite3.Connection, profile_snapshot, monkeypatch
+) -> None:
+    url = "https://example.com/job/score-single-fail"
+    _seed_pending_job(conn, url)
+    repo = SqliteScoreRepository(conn)
+    monkeypatch.setattr(scorer_module, "get_connection", lambda: conn)
+
+    for expected in (1, 2):
+        outcome = scorer_module.score_job_by_url(
+            url,
+            profile_snapshot=profile_snapshot,
+            resume_text="anything",
+            criteria=ScoringCriteria(),
+            repository=repo,
+            llm_port=_failing_llm(),
+        )
+        assert outcome.ok is False
+        assert _score_attempt_count(conn, url) == expected


### PR DESCRIPTION
## What

Two file-disjoint hardening slices called out in the Temporal-native rearchitecture plan (#230, P1 "Parallelization note" → P1a). Both stop a single stuck/hostile job from imposing unbounded LLM cost or latency. Python-only; runs in parallel with P0 and does not touch any file P0/P1b owns.

### 1. LLM retry hardening — `workers/automation/src/jobhunter/llm.py`
- **Broader transient retry.** Retry `429`, **all `5xx`**, and connection-level errors (`httpx.TransportError`: connect/read timeouts, network resets, protocol errors) with bounded exponential backoff. Previously only `429`/`503` and bare `TimeoutException` were retried, so a `500`/`502`/`504` or a connection reset failed the activity immediately.
- **Capped, jittered backoff.** A server `Retry-After` is now honored **up to a 60s ceiling** and every backoff sleep gets jitter. Previously `Retry-After` was slept verbatim (`float(retry_after)`), so a hostile or buggy value (e.g. `86400`) could park an activity for hours.
- **Fail-fast preserved.** Non-retryable `4xx` (other than `429`) still raise immediately. The public surface and return types of `chat()` / `chat_json()` are unchanged — retry *policy* only. No migration to the agent-SDK path.

### 2. Score attempt cap — `workers/automation/src/jobhunter/database.py` + `scoring/scorer.py`
- **Selector cap.** `pending_score` now excludes jobs whose score stage has failed 5+ times, mirroring the tailor/cover `< 5` selector cap (`_EFFECTIVE_SCORE_ATTEMPTS < 5`, read from `job_stage_states` via the existing `_SCORE_DOWNSTREAM_STATE_JOIN`, extended to expose `attempt_count`). Previously `pending_score` had **no cap**, so a permanently-failing job was re-selected and re-billed on every batch forever.
- **Increment on failure.** Score failures now advance `job_stage_states.attempt_count` (batch `run_scoring` and single `score_job_by_url`). The count is threaded through the `running`-state write because `set_stage_state` resets `attempt_count` to `0` when it is omitted — a bare `running` write would otherwise wipe the counter between batch re-selections (confirmed empirically). A succeeded job is excluded by its non-null fit score, so the success path is untouched.

## Why
Both were flagged in the plan as unbounded re-billing / unbounded sleep risks (`llm.py:392-406` uncapped `Retry-After`; `database.py:3505` uncapped `pending_score`).

## Validation
- `uv --project workers/automation run --extra dev pytest -q` → **1676 passed**
- `uv --project workers/automation run --extra dev ruff check .` → **All checks passed!**

New tests: `test_llm_client.py` (5xx retried→succeeds; connection error retried→succeeds; hostile `Retry-After: 86400` sleeps ≤ cap; `400` fails fast without retry; persistent transient bounded to `_MAX_RETRIES`). `test_score_queue_selectors.py` (`pending_score` excludes at cap, includes under cap). `test_scorer.py` (failure increments attempts across batches until the cap engages and the LLM is no longer called; single-job path increments too).

## Docs
Internal hardening with no change to public/CLI/API behavior → no doc update warranted per CLAUDE.md.

## Known follow-up (out of scope — `runner.py` is P0/P1b territory)
The streaming runner's `_count_pending("score")` uses a separate query (`_PENDING_SQL["score"]` in `pipeline/runner.py`) that does **not** include the new attempt cap, so it can over-count a capped-out job. Impact is **bounded and non-billing**: `run_scoring` selects via the (now capped) `get_jobs_by_stage`, returns empty, and the loop's no-progress guard bails after 3 no-op passes (marking the stage "stuck" rather than "done") — no extra LLM calls. The clean parity fix is to add `_SCORE_DOWNSTREAM_STATE_JOIN` + `_EFFECTIVE_SCORE_ATTEMPTS < 5` to `_PENDING_SQL["score"]`, which lives in the P1b-owned `runner.py`; leaving it for that slice to avoid a conflicting edit.