### PR TITLE
docs(plans): OSS release remediation implementation spec for Codex

### DIFF
--- a/docs/plans/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/2026-07-03-oss-release-remediation-spec.md
@@ -63,7 +63,7 @@ of one temporal-stack rebase — an owner call, not the default.
 Sequencing summary:
 
 ```
-now         ──► W0.1→W0.2→W0.3→W0.4→W0.5→W0.6   (first: privacy CI gates every later PR)
+now         ──► W0.1→W0.2→W0.5→W0.3→W0.4→W0.6   (first: privacy CI gates every later PR)
             ──► W2.1, W2.2(docs), W2.5            (fully parallel)
 #233 merged ──► W2.3
 P2 merged   ──► W1.1→W1.2→W1.3→W1.4→W1.5→W1.6→W1.7  (stacked; do NOT wait for P4/P5)
@@ -268,6 +268,11 @@ actually occurred, not just four exact-case tokens, and is itself tested.
 **Branch:** `feat/w0-3-release-check-v2` ·
 **PR title:** `feat(release): broaden release_check needles, file-type checks, and add a self-test`
 
+**Ordering:** stacks on W0.5, not W0.2 — item 7 fails on any tree where
+the tag trigger is live under the blocked distribution name, which
+includes the post-W0.2 tree. Section numbers are stable IDs, not
+sequence; see §0.1 and the W0.5 ordering note.
+
 Work items:
 1. **Case-insensitive identity matching.** All identity needles match
    case-insensitively.
@@ -302,7 +307,9 @@ Work items:
 7. **Structural checks:** fail if any tracked path starts with
    `.planning/`; fail if `.github/workflows/publish.yml` has an enabled
    tag trigger while `workers/automation/pyproject.toml` still declares the
-   PyPI-blocked distribution name (this check is retired by W2.1).
+   PyPI-blocked distribution name. W0.5 lands before this item, so the
+   check is green on arrival; it exists to prevent a silent re-enable and
+   is retired by W2.1. Do not soften it with a bypass flag.
 8. **Source tripwires** (pinned to specific files): fail if
    `workers/automation/src/jobhunter/apply/prompt.py` interpolates the
    CapSolver key env var into prompt text, contains the hardcoded
@@ -321,7 +328,7 @@ Work items:
 
 **Definition of Done**
 - [ ] `python3 scripts/release_check.py` exits 0 with zero findings on the
-      post-W0.2 tree, and non-zero when any self-test violation is
+      post-W0.5 tree, and non-zero when any self-test violation is
       introduced.
 - [ ] Byline collision test passes.
 - [ ] Self-test runs in the Python test suite.
@@ -353,13 +360,24 @@ Python/TS CI workflows keep their path scoping.
 **Branch:** `ci/w0-5-guard-publish` ·
 **PR title:** `ci(release): disable tag publishing until distribution rename`
 
+**Ordering:** lands immediately after W0.2 and BEFORE W0.3, out of
+numeric order. W0.3 item 7 fails whenever the tag trigger is live under
+the blocked distribution name — true of the tree today — so the trigger
+must be disabled first for W0.3's exit-0 DoD to be satisfiable; landing
+this first also closes the accidental-publish window sooner. Do not
+resolve the conflict the other way (a bypass flag on item 7): the item-8
+`--strict-prompt` pattern is reserved for tripwires whose fix is gated on
+W1, and this one's fix is the two-line edit right here.
+
 Work items: change `.github/workflows/publish.yml` trigger to
 `workflow_dispatch` only, with a header comment pointing at W2.1. The W0.3
-structural check enforces this cannot silently revert.
+structural check (landing next in the stack) enforces this cannot
+silently revert.
 
 **Definition of Done**
 - [ ] No `push`/tag trigger remains in `publish.yml`.
-- [ ] `python3 scripts/release_check.py` passes.
+- [ ] `python3 scripts/release_check.py` passes (v1 at this point in the
+      stack).
 
 ### W0.6 — CONCERNS disposition gate
 

--- a/docs/plans/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/2026-07-03-oss-release-remediation-spec.md
@@ -1,0 +1,924 @@
+# OSS Release Remediation — Implementation Spec for Codex
+
+> **Audience:** an external implementing agent (Codex). This document is
+> self-contained and prescriptive: follow it literally. Where it says STOP,
+> stop and report rather than improvising.
+> **Companions:** `docs/plans/2026-07-03-temporal-native-rearchitecture.md`
+> (PR #230, the architectural plan) and
+> `docs/plans/2026-07-03-temporal-rearch-implementation-spec.md` (PR #232,
+> the P1b–P5 implementation spec). Workstream W1 below **builds on top of
+> temporal phase P2** and must not re-implement anything P2 delivers.
+> **Goal:** make this repository safe to publish as open source while
+> preserving every existing capability: live application submission,
+> CapSolver-based CAPTCHA solving, email applications, LinkedIn/Indeed
+> discovery boards, AGPL-3.0-only licensing, and the existing git history.
+> Compliance posture is disclosure and hard operator gates, not capability
+> removal.
+
+---
+
+## 0. How to use this document
+
+1. Implement exactly ONE work item (W0.x / W1.x / W2.x) per pull request,
+   in the dependency order of §0.1. Never combine items.
+2. Before every edit, locate the anchor **by symbol name** (grep/ripgrep).
+   Line numbers in this doc are hints captured 2026-07-03 and WILL have
+   drifted. If a named symbol does not exist, STOP and report — do not
+   guess, do not create a lookalike.
+3. Each work item has: Objective, Preconditions, Branch/PR names, Files you
+   may touch, Work Items, Tests, and a binary **Definition of Done**
+   checklist. An item is complete only when every Definition of Done entry
+   is checked and every verification command passes with the stated result.
+4. Rip-and-replace is the standing rule: when an item replaces a legacy
+   path, delete the legacy path in the same PR. No compatibility shims, no
+   feature flags guarding old-vs-new, no "deprecated" wrappers.
+5. If a required change appears to force edits outside the item's scope,
+   STOP and report the conflict instead of expanding scope.
+6. **Owner decision checkpoints** (§0.5) are places where you must STOP,
+   present options, and wait for the owner's choice before proceeding.
+
+### 0.1 Workstream order and parallelism
+
+```
+W0 (privacy & hygiene)          — from main, FIRST, W0.1 → W0.2 → W0.3 → W0.4 → W0.5 → W0.6
+temporal stack P1b→P3→P2→P4→P5  — per PR #232 spec (separate run; rebase it once after W0 merges)
+W1 (apply & runtime safety)     — stacked AFTER temporal P5, W1.1 → W1.2 → … → W1.8
+W2 (public surface & governance)— from main, parallel to W1, except:
+                                    W2.3 requires PR #233 (P0) merged
+                                    W2.6 and the doctor parts of W2.2 require temporal P5 merged
+Release flip                    — §5 checklist, last
+```
+
+- W0 lands first because every later PR must pass the W0.4 privacy CI
+  gate, and because W0.2 touches test files that temporal P2 also touches
+  (one rebase of the temporal stack after W0 merges is expected and cheap).
+- W1 items are a stacked series continuing the temporal stack: cut
+  `W1.1`'s branch from the P5 branch tip (or from `main` once P5 has
+  merged); each subsequent W1 branch cuts from its predecessor.
+- W2.1 (naming) can start any time; its publish re-enable step is last.
+
+### 0.2 Non-negotiable ground rules
+
+- **Never edit code on `main`; never leave `main` dirty.** Each item on its
+  own branch in its own worktree, cut from up-to-date `main` (or from the
+  predecessor branch for stacked W1 items).
+- Conventional Commits for every commit and PR title.
+- Never commit: SQLite databases, `*.pdf`, resumes, cover letters, browser
+  profiles, logs, `worker/` runtime dirs, API keys, `profile.json`.
+- Never run: `jobhunter apply` against real sites, auto-apply, real browser
+  submission, real mailbox scans, destructive DB commands. All apply-path
+  testing uses the unit/integration harnesses described below.
+- **This document and every file you create are public.** Never write the
+  owner's personal identity strings (name, username, personal domain,
+  LinkedIn slug, résumé content, real employer names used as owner
+  evidence) into any file, commit message, or PR text. The ONLY permitted
+  location for those literals is the obfuscated needle list inside
+  `scripts/release_check.py` (which excludes itself from scanning). When
+  this spec needs to reference such a string it does so by file/line
+  pointer; read the value at the pointer, use it in the needle list, and
+  never echo it anywhere else.
+- Never weaken, skip, or delete a parity or exhaustiveness test
+  (`every-event-has-handler.test.ts`, `every-stage-state-has-badge.test.tsx`,
+  type-level enum tests). When one fails it is doing its job: fix the
+  registry/handler/badge, not the test.
+- Any new domain event type lands in BOTH registries
+  (`workers/automation/src/jobhunter/domain/events/__init__.py` and
+  `packages/domain-types/src/events/index.ts`) plus a web invalidation
+  handler plus web fixtures, in the same PR — copy the pattern the P0
+  `Workflow*` family used.
+
+### 0.3 Verification command matrix
+
+Run the commands for every surface you touched; the full sweep before
+opening the PR.
+
+| Surface | Commands | Required result |
+| --- | --- | --- |
+| Python worker | `uv --project workers/automation run --extra dev pytest -q` | 100% pass |
+| Python lint | `uv --project workers/automation run --extra dev ruff check .` | `All checks passed!` |
+| Python package | `uv --project workers/automation run --extra dev python -m build workers/automation` | builds clean |
+| TS API | `pnpm api:check` then `pnpm api:test` | zero errors / all pass |
+| API QA harness | `pnpm qa:test` | all pass |
+| Web | `pnpm web:check`, `pnpm --filter @jobhunter/web test`, `pnpm --filter @jobhunter/web test-d` | zero errors / all pass |
+| Full check | `pnpm check` | zero errors |
+| Full sweep (pre-PR, always) | `pnpm test` | all pass |
+| Privacy (always, from W0.3 onward) | `python3 scripts/release_check.py` | **zero findings** |
+| Hygiene | `git diff --check` | clean |
+
+### 0.4 PR / completion report template
+
+Every PR description must contain: **What** (bullet list of changes incl.
+deletions), **Why** (one paragraph referencing this spec's item), 
+**Validation** (every §0.3 command you ran, verbatim, with its exact
+result), **Deviations** (empty section if none), **Deferred** (anything
+explicitly left out, with the item it was routed to). PR text must be
+PII-clean per §0.2.
+
+### 0.5 Owner decision checkpoints (STOP and ask)
+
+1. **W2.1** — final PyPI distribution name (you propose candidates with
+   evidence; the owner picks).
+2. **W2.4** — default daily spend-ceiling values per lane (you propose
+   defaults; the owner confirms).
+3. **W0.6** — any CONCERNS item you propose to classify as
+   "accepted risk" (the owner must approve each acceptance).
+4. **§5** — the actual repository visibility flip and first release tag are
+   owner-only actions; you prepare, you never execute them.
+
+---
+
+## 1. Locked owner decisions (do not re-litigate)
+
+- **Preserve all capabilities.** Live submit, CapSolver solving (env-gated,
+  off by default), email applications (rebuilt as a controlled owned-send
+  path in W1.7), LinkedIn/Indeed in the default discovery boards.
+  Compliance is achieved via hard approval gates, disclosure documentation,
+  and operator-explicit opt-ins — not removal.
+- **License:** AGPL-3.0-only stays. **Contributor policy:** DCO (W2.5).
+- **Git history is kept.** The current tree is scrubbed (W0); the owner
+  accepts that historical blobs remain technically reachable. This
+  acceptance is recorded at the release gate (§5). The W0.6 disposition
+  gate exists because one historical artifact is security-relevant, not
+  merely private.
+- **Naming:** the GitHub repo and product name stay `JobHunter`. Only the
+  PyPI distribution name changes (W2.1) because `jobhunter` is taken on
+  PyPI. The import package `jobhunter` and the `jobhunter` console script
+  do not change.
+
+---
+
+## 2. Workstream W0 — Privacy and release hygiene (from `main`, first)
+
+### W0.1 — Untrack the private planning corpus
+
+**Objective:** the tracked `.planning/` tree (143 files of internal
+milestones, research, and codebase notes) leaves the public tree; private
+skill banners leave `docs/plans/implemented/`.
+
+**Branch:** `chore/w0-1-untrack-planning` ·
+**PR title:** `chore(release): untrack private planning corpus and strip private banners`
+
+Work items:
+1. `git rm -r --cached .planning/` (files stay on disk for the owner). Add
+   `.planning/` to `.gitignore`.
+2. Grep `docs/plans/implemented/` for the private skill-banner prefix
+   (search for lines containing `superpowers`); six files open with such
+   banner lines. Delete the banner lines only; keep the document bodies.
+3. Confirm no other tracked file references `.planning/` paths in a way
+   that breaks (docs links etc.); fix any dangling references.
+
+**Definition of Done**
+- [ ] `git ls-files | grep -c '^\.planning/'` prints `0`.
+- [ ] `.gitignore` contains `.planning/`.
+- [ ] `grep -rn "superpowers" docs/` prints nothing.
+- [ ] Full sweep (§0.3) passes.
+
+### W0.2 — Scrub owner PII from tracked fixtures and tests
+
+**Objective:** every tracked file is free of the owner's personal identity
+and résumé-derived content. Swap data only — never delete a test, never
+weaken an assertion.
+
+**Branch:** `chore/w0-2-scrub-fixtures` ·
+**PR title:** `chore(release): replace owner-derived fixture data with synthetic equivalents`
+
+Known leak sites (line numbers are hints; each file must be fully re-read
+and scrubbed, not just at the hinted line):
+1. `apps/web/src/shared/ui/PdfPreviewViewer.test.ts` — embeds an
+   effectively complete real résumé (identity, employer names, role
+   history, location-specific bullet content). Replace with a synthetic
+   résumé of comparable length/structure for a fictional person at
+   fictional employers so the rendering assertions keep exercising the same
+   shapes.
+2. `apps/web/src/views/apply-review/ApplyReviewView.test.tsx` (~:2077–2078
+   plus one additional real-employer block elsewhere in the file) — real
+   contact card and employer references → synthetic.
+3. `apps/api/test/application-feedback.test.ts` (~:518),
+   `apps/api/test/resume-review-drafts.test.ts` (~:529, :658, :721),
+   `apps/api/test/server.test.ts` — owner name used as fixture values →
+   synthetic names.
+4. `apps/web/src/test/msw/handlers.ts` (~:642) — résumé HTML mock contains
+   the owner name → synthetic.
+5. `workers/automation/tests/test_bullet_provenance.py`,
+   `workers/automation/tests/test_requirement_led_tailoring.py`,
+   `workers/automation/tests/test_content_validator.py` — owner-evidence
+   résumé strings → synthetic.
+6. `workers/automation/tests/test_enrichment_snapshot_pr3.py` — a lowercase
+   `user:` + owner-username seed marker → `user:example`.
+
+**Definition of Done**
+- [ ] Every file above (and any additional hit found by the W0.3 scanner
+      run locally against your branch) contains only synthetic data.
+- [ ] No test was deleted; no assertion was weakened; suite counts did not
+      decrease.
+- [ ] Full sweep (§0.3) passes.
+
+### W0.3 — `release_check.py` v2
+
+**Objective:** the release scanner catches the classes of leak that
+actually occurred, not just four exact-case tokens, and is itself tested.
+
+**Branch:** `feat/w0-3-release-check-v2` ·
+**PR title:** `feat(release): broaden release_check needles, file-type checks, and add a self-test`
+
+Work items:
+1. **Case-insensitive identity matching.** All identity needles match
+   case-insensitively.
+2. **Needle classes** (literal values live ONLY inside
+   `scripts/release_check.py`, using the existing string-concatenation
+   obfuscation): the existing FORBIDDEN_TEXT list, plus — reading values at
+   the W0.2 leak sites before scrubbing them — the owner first name, full
+   name, username, personal domain, LinkedIn profile slug, the two real
+   employer names that appear as owner evidence in the leaked fixtures, the
+   lowercase seed-marker token, private toolchain path fragments (the
+   owner's absolute home-directory prefix, `.codex/gsd-core`,
+   `.agents/skills`), and the private skill-banner prefix.
+3. **Collision rule:** the public maintainer byline (the GitHub handle in
+   `package.json` / `pyproject.toml` / README author fields) is intended
+   and allowed. Do NOT add the bare surname or the GitHub handle as
+   needles. Add a unit test asserting the scanner passes on
+   `package.json`, `pyproject.toml`, and `README.md` as they exist after
+   W0.2.
+4. **File-type flags:** extend the name scan to flag tracked `*.sqlite`,
+   `*.sqlite3`, `*.db-wal`, `*.db-shm`, `*.pdf`, `*.docx`, `*.log`,
+   `*.har`, `*.pem`, `*.key`, `token.json`, and known browser-profile
+   directory names.
+5. **Text coverage:** add `.sql`, `.csv`, `.xml`, `.svg` to
+   `TEXT_SUFFIXES`.
+6. **Secret patterns:** generalize the env-assignment check from the
+   current four keys to any `*_API_KEY` / `*_SECRET` / `*_TOKEN` /
+   `*_PASSWORD` assignment with a non-placeholder literal value in
+   env-like, JSON, YAML, and TOML files. Keep the existing placeholder
+   allowances. Do not flag code that merely *reads* such variables.
+7. **Structural checks:** fail if any tracked path starts with
+   `.planning/`; fail if `.github/workflows/publish.yml` has an enabled
+   tag trigger while `workers/automation/pyproject.toml` still declares the
+   PyPI-blocked distribution name (this check is retired by W2.1).
+8. **Source tripwires** (pinned to specific files): fail if
+   `workers/automation/src/jobhunter/apply/prompt.py` interpolates the
+   CapSolver key env var into prompt text, contains the hardcoded
+   attestation-default block (the literal `Felony:` / `Age 18+:` default
+   lines), or interpolates the profile password. These start red-on-main
+   and go green as W1.4/W1.5/W1.6 land — therefore gate them behind a
+   `--strict-prompt` flag that the CI workflow (W0.4) only enables once W1
+   completes; run findings as warnings until then. Document the flag in
+   the script header.
+9. **Self-test:** make the needle list injectable; add a test (pytest,
+   under `workers/automation/tests/` or a `scripts/` test wired into CI)
+   that builds a temp tree containing one synthetic violation per class
+   and asserts each is caught, and that a clean temp tree passes. The
+   self-test must not contain real needles.
+10. Non-zero exit code on findings (verify; keep).
+
+**Definition of Done**
+- [ ] `python3 scripts/release_check.py` exits 0 with zero findings on the
+      post-W0.2 tree, and non-zero when any self-test violation is
+      introduced.
+- [ ] Byline collision test passes.
+- [ ] Self-test runs in the Python test suite.
+- [ ] Full sweep (§0.3) passes.
+
+### W0.4 — Unfiltered privacy CI gate
+
+**Objective:** the privacy scan runs on every push and PR with no path
+filters, so no change can dodge it.
+
+**Branch:** `ci/w0-4-privacy-gate` ·
+**PR title:** `ci(release): run release_check on every push and PR without path filters`
+
+Work items: add `.github/workflows/release-check.yml`: triggers `push`
+(main) + `pull_request` (all), no `paths:` filters; sets up Python; runs
+`python3 scripts/release_check.py` and the W0.3 self-test. Existing
+Python/TS CI workflows keep their path scoping.
+
+**Definition of Done**
+- [ ] Workflow file present, green on the branch.
+- [ ] A deliberate scratch commit adding a synthetic violation (pushed to
+      the PR branch, then reverted within the same PR) shows the check
+      failing in CI — link both runs in the PR description.
+
+### W0.5 — Disable tag publishing until rename
+
+**Objective:** no accidental PyPI publish before W2.1.
+
+**Branch:** `ci/w0-5-guard-publish` ·
+**PR title:** `ci(release): disable tag publishing until distribution rename`
+
+Work items: change `.github/workflows/publish.yml` trigger to
+`workflow_dispatch` only, with a header comment pointing at W2.1. The W0.3
+structural check enforces this cannot silently revert.
+
+**Definition of Done**
+- [ ] No `push`/tag trigger remains in `publish.yml`.
+- [ ] `python3 scripts/release_check.py` passes.
+
+### W0.6 — CONCERNS disposition gate
+
+**Objective:** the internal codebase-concerns document (now untracked, on
+disk at `.planning/codebase/CONCERNS.md`) maps known weaknesses with file
+locations. Because history is being kept, that map remains reachable in
+old commits. Every item in it must be dispositioned before the repo goes
+public.
+
+**Branch:** none (this is an audit deliverable, delivered as a PR comment
+thread or issue, not a code change — unless dispositions add
+`docs/backlog.md` entries, then `docs/w0-6-concerns-dispositions`).
+
+Work items: for every numbered concern in the file, record exactly one
+disposition: **fixed** (link the commit/PR), **fixed-by** (link the W1/W2
+item that fixes it), **public-backlog** (add a sanitized entry to
+`docs/backlog.md` — no exploit detail, no file-located vulnerability
+descriptions), or **accepted** (owner approval required per §0.5.3). The
+disposition table itself is delivered in the PR/issue body, NOT committed
+to the tree, because it inherits the sensitivity of its source.
+
+**Definition of Done**
+- [ ] Every concern has exactly one disposition; none is silently dropped.
+- [ ] All "fixed-by" references point at real items in this spec.
+- [ ] Owner has approved every "accepted" entry.
+
+---
+
+## 3. Workstream W1 — Apply and runtime safety (stacked after temporal P5)
+
+### W1.0 Substrate check (run before W1.1; STOP if any is missing)
+
+Temporal P2 (see PR #232 spec §5) must already provide, on the branch you
+build from:
+- `applyApprovalRequired` setting plumbed end-to-end (default `true`),
+  enforced by an `approve_submit` SELECT inside `acquire_job`'s
+  `BEGIN IMMEDIATE` transaction.
+- `ApplySubmitIntended` event in both registries; intent-aware recovery
+  with the `needs_verification` state (reaper #3 deleted).
+- Browser-layer dry-run guard in `apply/chrome.py` (CDP `Fetch`
+  interception + `Page.addScriptToEvaluateOnNewDocument` form-submit
+  override, auto-attach to new targets).
+- Evidence artifacts (`apply_agent_output`, `apply_confirmation`) and
+  derived `verification_confidence`.
+
+W1 **extends** these. If you find yourself re-implementing one, STOP.
+
+### W1.1 — Approval freshness binding
+
+**Objective:** an `approve_submit` decision is only valid for exactly what
+the human reviewed: the materials generation, the profile version, the
+application URL — and only after dry-run evidence exists (or an explicit
+partial-evidence override).
+
+**Branch:** `feat/w1-1-approval-binding` ·
+**PR title:** `feat(apply): bind approvals to materials/profile/URL and dry-run evidence`
+
+Work items:
+1. **Capture bindings at decision time.** Extend the decision write path
+   (`recordApplyReviewDecision`, `apps/api/src/application-feedback.ts`
+   ~:357, route in `apps/api/src/server.ts` ~:983) so an `approve_submit`
+   row records: the materials generation identifier the review displayed,
+   the current profile version, and the job's application URL. If no
+   monotonic profile version exists yet, add one at the profile write
+   layer (single integer bumped on every profile mutation, persisted
+   beside the profile) — locate the owning writer, do not scatter bumps.
+   Migration: `ALTER TABLE application_review_decisions ADD COLUMN`s,
+   nullable; register DDL in `init_db`'s ensure-block.
+2. **Stale-by-default for legacy rows.** A live claim treats an
+   `approve_submit` row with NULL bindings as stale (re-approval
+   required). Single-user rip-and-replace: no grandfathering.
+3. **Claim-time predicate.** Extend the P2 gate SELECT (still inside
+   `BEGIN IMMEDIATE`): claim a LIVE run only when the latest decision is
+   `approve_submit` AND its bound materials generation equals the job's
+   current one AND bound profile version equals current AND bound URL
+   equals the job's current application URL AND (a dry-run completion
+   with `coverage = "full"` exists for that same materials generation OR
+   the decision row has `partial_override = 1`). Record distinct skip
+   reasons in the existing skip channel: `awaiting_approval`,
+   `awaiting_dry_run`, `approval_stale_materials`,
+   `approval_stale_profile`, `approval_stale_url`.
+4. **Partial override.** New nullable column `partial_override` on the
+   decision row, settable only through an explicit UI affordance on the
+   approve action ("Approve with partial dry-run evidence") that renders a
+   persistent `role="alert"` warning naming what was not verified. Never
+   set implicitly.
+5. **UI.** The apply-review approval card shows what is being bound
+   (materials generation, dry-run evidence status/coverage, URL) and the
+   skip reasons from item 3 when a claim was refused.
+
+Tests: one claim fixture per predicate arm (no approval / no dry-run /
+each staleness dimension / valid / valid-with-override); API test that the
+decision write captures bindings; component test for the override warning.
+
+**Definition of Done**
+- [ ] A live claim is impossible without a fresh, fully-bound approval —
+      proven by the per-arm pytest fixtures.
+- [ ] Regenerating materials or mutating the profile invalidates a prior
+      approval (fixtures prove both).
+- [ ] Skip reasons visible in apply-review.
+- [ ] Full sweep (§0.3) passes, including `pnpm qa:test`.
+
+### W1.2 — Dry-run guard hardening and honest outcomes
+
+**Objective:** the P2 guard becomes airtight and its evidence becomes
+first-class: blocked channels are recorded, coverage is classified,
+violations are never relabeled as success, and live mode gains
+per-request intent breadcrumbs.
+
+**Branch:** `feat/w1-2-dryrun-guard-hardening` ·
+**PR title:** `feat(apply): dry-run coverage classification, violation outcomes, live-mode breadcrumbs`
+
+Work items:
+1. **Method set.** Add `DELETE` to the blocked method set.
+2. **DOM layer.** Extend the injected script to also wrap
+   `navigator.sendBeacon` (return `false`) and
+   `WebSocket.prototype.send` (drop + report) during dry-run, reporting
+   through a `Runtime.addBinding` channel rather than a window flag.
+3. **Blocked-request evidence.** Persist every blocked request (method,
+   URL origin+path only — strip query strings, they can carry PII —
+   frame, timestamp, and whether it was same-site to the application
+   flow) into a `job_artifacts` row of kind `apply_dryrun_blocked` (JSON
+   list), one row per run.
+4. **Coverage classification.** `DryRunComplete` gains
+   `coverage: "full" | "partial"`. `partial` when any blocked mutating
+   request was **same-site** to the application flow (registrable domain
+   of the frame's document) or any DOM-submit interception fired before
+   the final page; third-party beacon/analytics blocks do NOT demote
+   coverage. Contracts + Python mirror + web ripple (the dry-run evidence
+   card shows coverage and the blocked-channel list).
+5. **Violation outcome.** Delete the coercion in
+   `apply/claude_code_cli.py` (~:354–361) that maps `RESULT:APPLIED`
+   during dry-run to `DryRunComplete`. Replace with a distinct
+   `dry_run_violation` outcome: apply stage → `failed` with reason
+   `dry_run_violation`, an event is recorded, and apply-review renders it
+   as a red violation (the network layer guarantees nothing was
+   transmitted; the violation records that the agent attempted it —
+   that's an injection/prompt-quality signal, not a success).
+6. **Live-mode breadcrumbs.** Run the interceptor in live mode too, in
+   observe mode: before `Fetch.continueRequest` of a same-site mutating
+   request, append a durable breadcrumb (run id, method, origin+path,
+   timestamp) — committed synchronously. The coarse P2
+   `ApplySubmitIntended` remains the recovery trigger; breadcrumbs refine
+   it: recovery MAY safe-rewind to `pending` (instead of
+   `needs_verification`) when intent exists but the breadcrumb log shows
+   zero same-site mutating requests were continued. Otherwise P2's rule
+   stands. Add this refinement to the recovery function with tests for
+   both branches.
+7. **Adversarial fixture.** Extend the P2 integration harness (local HTTP
+   server as the "employer"): a page whose text contains an injection
+   instruction to submit anyway plus an auto-POST and a form; under
+   dry-run assert the server receives ZERO mutating requests, the blocked
+   artifact exists, coverage classification is correct, and a synthetic
+   `RESULT:APPLIED` maps to `dry_run_violation`. Add a third-party-beacon
+   page asserting coverage stays `full`, and a same-site step-POST page
+   asserting `partial`.
+
+**Definition of Done**
+- [ ] Zero mutating requests reach the harness server under dry-run
+      (POST/PUT/PATCH/DELETE, sendBeacon, WebSocket payloads).
+- [ ] `dry_run_violation` replaces the coercion; no path can emit
+      `applied` or `DryRunComplete` from a dry-run violation.
+- [ ] Coverage classification fixtures pass (full / partial /
+      third-party-beacon cases).
+- [ ] Breadcrumb-refined recovery fixtures pass (rewind vs park).
+- [ ] Event/state ripple complete: both registries, handlers, fixtures,
+      badges; parity tests green.
+- [ ] Full sweep (§0.3) passes.
+
+### W1.3 — Agent sandbox hardening
+
+**Objective:** the apply agent runs with an explicit tool allowlist, a
+minimal environment, a per-run budget, and scoped Gmail access.
+
+**Branch:** `feat/w1-3-agent-sandbox` ·
+**PR title:** `feat(apply): explicit tool allowlist, minimal env, per-run budget, scoped Gmail`
+
+Work items (all in
+`workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py`,
+`workers/automation/src/jobhunter/domain/apply/services.py`
+(`_default_mcp_config` ~:190–214), and
+`workers/automation/src/jobhunter/infrastructure/gmail/mcp_server.py`
+unless noted):
+1. **Allowlist replaces bypass.** Drop
+   `--permission-mode bypassPermissions` (~:151). Pass `--allowedTools`
+   with the exact enumerated tool names: the Playwright MCP tools from the
+   pinned `@playwright/mcp` version MINUS `browser_evaluate` and any
+   code-execution/install tool, plus the two Gmail read tools
+   (`search_emails`, `read_email`). Later items append their owned tools
+   (W1.5 `type_credential`, W1.6 `solve_captcha`). Keep
+   `--disallowedTools` as a belt listing the built-ins: `Bash`, `Edit`,
+   `Write`, `NotebookEdit`, `WebFetch`, `WebSearch`. Delete the current
+   `_DISALLOWED_TOOLS` list of nonexistent Gmail write tools (~:47–56).
+2. **Allowlist parity test.** A test enumerates the tools actually
+   advertised by the configured MCP servers and asserts
+   `allowlist == advertised − explicit_exclusions`, so a
+   `@playwright/mcp` version bump that adds a tool fails loudly instead
+   of silently granting or missing it. Pin the `@playwright/mcp` version
+   in the MCP config (replace `@latest`) so the parity test is
+   deterministic.
+3. **Minimal env.** Replace `env = os.environ.copy()` (~:158) with an
+   explicit allowlist dict: `PATH`, `HOME`, `LANG`/`LC_ALL`, `TMPDIR`,
+   plus only what the Claude CLI needs for auth (it reads config under
+   `HOME`). No API keys. Secrets needed by owned MCP servers are injected
+   via that server's `env` block inside the generated
+   `.mcp-apply-{worker_id}.json` — write that file with mode `0600` and
+   delete it in a `finally` block.
+4. **Per-run budget.** Pass `--max-budget-usd` (verified present in the
+   installed CLI) from a new setting (default `5.00`), plumbed like the
+   existing model setting; `doctor` warns when the installed CLI lacks
+   the flag (probe `claude --help` output).
+5. **Scoped Gmail.** The Gmail MCP server accepts constraints at spawn
+   (argv from `_default_mcp_config`): earliest-timestamp = run start, and
+   an allowed-sender-domain set derived from the job's application URL
+   and company domain. Enforce in query construction AND post-filter on
+   read. Out-of-scope queries return empty with an explanatory string.
+6. **Prompt hard rule + fixture.** Add to the hard-rules section: email
+   tools are only for retrieving verification codes; never transcribe
+   email content into page fields. Unit tests prove the server-side scope
+   (out-of-scope sender/time rejected). Add a manual-QA checklist entry
+   in `docs/local-reliability-qa.md` for the full-agent exfiltration
+   probe (harness page instructing the agent to read and paste inbox
+   content), since it needs a live model.
+
+**Definition of Done**
+- [ ] Golden test on the exact argv: no `bypassPermissions`, allowlist
+      present, budget flag present.
+- [ ] Allowlist parity test green against pinned server versions.
+- [ ] Env-allowlist test: subprocess env contains exactly the allowlisted
+      keys.
+- [ ] Gmail scope tests green (time bound + sender bound + post-filter).
+- [ ] MCP config file is 0600 and removed after the run (test).
+- [ ] Full sweep (§0.3) passes.
+
+### W1.4 — Truthful screening and typed attestations
+
+**Objective:** the agent never fabricates legal or screening answers.
+Legal answers come from typed profile attestations; unknown required
+answers fail the run with an actionable reason instead of a lie.
+
+**Branch:** `feat/w1-4-attestations` ·
+**PR title:** `feat(apply): typed application attestations replace fabricated screening defaults`
+
+Work items:
+1. **Delete the fabricated block** in
+   `workers/automation/src/jobhunter/apply/prompt.py` (~:79–85: the
+   hardcoded age/background/felony/previously-worked/how-heard defaults).
+2. **Typed attestations.** Add `application_attestations` to the profile
+   contract (Python profile loader + validation, TS profile schema in
+   `packages/contracts`): `age_18_plus`, `background_check_consent`,
+   `felony_conviction`, `previously_worked_at_employer` — each
+   `true | false | null` (null = unknown) — plus an extensible
+   string-keyed map for additional attestations. `how_heard` stays a
+   plain preference field, not an attestation. Update
+   `profile.example.json` with nulls and comments.
+3. **Prompt rendering.** Render an attestation section ONLY from non-null
+   values. Instruct: if a required screening question maps to an unknown
+   attestation, do not guess — output
+   `RESULT:FAILED:missing_profile_data:<field>`. Parse that reason in the
+   adapter and surface it as an actionable blocker (which field to fill)
+   in apply-review/jobs UI.
+4. **Evidence-bounded skills.** Replace the "answer YES … don't sell
+   short" instruction (~:182) with: answer yes only when the tool or its
+   family appears in profile/résumé evidence; otherwise answer honestly
+   with adjacent experience. Never fabricate.
+5. **Warnings, not claim-blocks.** `doctor` and the apply-review surface
+   warn when the attestation set is incomplete ("live applies may fail on
+   screening questions") — do not block claims on it; the run-time
+   failure path is the enforcement.
+6. Flip the W0.3 attestation tripwire from warning to strict for this
+   file once merged (see W0.3 item 8 / W1.8 item 4).
+
+Tests: prompt builder with full/partial/empty attestations; adapter parses
+the new failure reason; UI blocker fixture; `doctor` warning unit test.
+
+**Definition of Done**
+- [ ] No fabricated default remains in `prompt.py` (release_check strict
+      tripwire green for this class).
+- [ ] Unknown-required → `missing_profile_data` failure with the field
+      name, visible in the UI fixture.
+- [ ] Full sweep (§0.3) passes.
+
+### W1.5 — Credential handling
+
+**Objective:** the account password never enters model context, argv, or
+any persisted artifact.
+
+**Branch:** `feat/w1-5-credentials` ·
+**PR title:** `feat(apply): out-of-band credential typing and global secret redaction`
+
+Work items:
+1. **Remove interpolation** of the profile password (and paired email
+   sign-in/sign-up lines) from `prompt.py` (~:614–615).
+2. **Owned secure-input tool.** New owned MCP server
+   (`workers/automation/src/jobhunter/infrastructure/secure_input/mcp_server.py`,
+   modeled on the Gmail server) exposing `type_credential(kind:
+   "email" | "password")`. The tool receives NO secret from the model: the
+   server loads the profile itself, opens its own CDP connection to the
+   run's Chrome, verifies `document.activeElement` is an
+   `<input type="password">` (or email/text for `kind="email"`), and
+   types via CDP `Input.insertText`. Refuse (with a clear error string)
+   when the focused element doesn't match or the profile has no password.
+   Prompt: click the field, then call the tool. Add the tool to the W1.3
+   allowlist.
+3. **Global redaction.** A `redact(text)` helper seeded at profile/config
+   load with all secret values (profile password, any configured API
+   keys) applied at every persistence sink: worker log writer, timeline/
+   event persistence, and the P2 evidence artifacts
+   (`apply_agent_output` etc.). Integration test: run the harness with a
+   fake profile containing a distinctive fake password; assert it appears
+   in NO persisted output.
+
+**Definition of Done**
+- [ ] Password string absent from prompt text, argv, env, MCP config main
+      body, logs, events, and artifacts (needle-based integration test).
+- [ ] `type_credential` refuses non-credential fields (test).
+- [ ] W0.3 password tripwire strict-green for `prompt.py`.
+- [ ] Full sweep (§0.3) passes.
+
+### W1.6 — CapSolver as an owned tool
+
+**Objective:** CAPTCHA solving is preserved, but the ~200-line REST script
+and the API key move out of the prompt into owned code.
+
+**Branch:** `feat/w1-6-owned-captcha` ·
+**PR title:** `feat(apply): move CapSolver solving into an owned MCP tool; key leaves model context`
+
+Work items:
+1. New owned MCP server
+   (`workers/automation/src/jobhunter/infrastructure/captcha/mcp_server.py`)
+   exposing `solve_captcha(kind, sitekey, page_url)`. Port the
+   createTask/poll flow and the token-injection JavaScript currently
+   embedded in `_build_captcha_section`
+   (`prompt.py` ~:217–424) into Python (`httpx` for REST — this is a REST
+   integration, not an LLM client) + CDP `Runtime.evaluate` injection.
+   Return `{solved, kind, elapsed_s, cost_usd?}`; record a usage event or
+   artifact per solve with observable cost.
+2. The key reaches ONLY this server via its per-server `env` block in the
+   generated MCP config (W1.3 item 3). The tool is registered only when
+   the key is configured; otherwise it is absent.
+3. Shrink the prompt's CAPTCHA section to: if a CAPTCHA blocks progress
+   and `solve_captcha` is available, call it once with the visible
+   sitekey; on failure or absence output `RESULT:CAPTCHA`. Delete the
+   embedded REST/JS block. Keep `doctor`/wizard behavior (key optional,
+   default off).
+4. Add `solve_captcha` to the W1.3 allowlist and parity test.
+
+Tests: server unit tests with a mocked CapSolver API (success, failure,
+timeout); needle test that the key env var name and value appear nowhere
+in generated prompt text or the main env; prompt no longer contains the
+REST flow (W0.3 tripwire strict-green).
+
+**Definition of Done**
+- [ ] Key absent from prompt/argv/model env (tests).
+- [ ] Solve flow works against the mocked API; failures return the
+      CAPTCHA manual state without looping.
+- [ ] Prompt CAPTCHA section reduced to the bounded instruction.
+- [ ] Full sweep (§0.3) passes.
+
+### W1.7 — Email applications as a controlled owned send
+
+**Objective:** email-only postings become a real, safe capability. Today
+the prompt references a `send_email` tool that does not exist (the wired
+Gmail server is read-only) — this item builds the capability properly:
+the agent only detects; owned code composes, the human approves, owned
+code sends.
+
+**Branch:** `feat/w1-7-email-applications` ·
+**PR title:** `feat(apply): controlled email-application flow with approval-bound recipient`
+
+Work items:
+1. **Detection outcome.** Replace the dead email-only instruction
+   (`prompt.py` ~:607–609) with: on an email-only posting, output
+   `RESULT:EMAIL_ONLY:<address>` and stop. Adapter parses and validates
+   the address syntactically.
+2. **Owned candidate.** The worker validates the address appears verbatim
+   in the stored posting record (enrichment snapshot / description). If
+   not present → park with reason `email_recipient_unverified` for manual
+   handling (injection defense: run-time page text cannot introduce a new
+   recipient; failure mode is manual, not send). If present → persist an
+   `email_application_candidate`: recipient, subject and body rendered by
+   an OWNED template (display name, job title, company — agent-supplied
+   prose is NOT used), attachment = the reviewed résumé artifact id.
+3. **Approval binding.** The candidate surfaces in apply-review as a
+   full preview (to / subject / body / attachment name). Approval writes
+   the recipient and artifact id into the decision row (extending the
+   W1.1 bindings). No send without it.
+4. **Owned send.** Gmail adapter gains a send method (Gmail API,
+   `gmail.send` scope added to the OAuth flow; `doctor` reports scope
+   status; document the re-consent step). The send executes in the worker
+   (no agent involved): write `ApplySubmitIntended` (reuse P2 machinery)
+   → call the API → record the result. Crash after intent →
+   `needs_verification`, same as browser submits. Dry-run: the adapter
+   hard-refuses to send and returns the preview as evidence.
+5. **Ripple.** New event(s) (e.g. `EmailApplicationCandidateRecorded`) in
+   both registries + handlers + fixtures; any new review-item state gets
+   its badge; parity tests must pass.
+6. **Docs.** README + `docs/user/data-and-safety.md`: the new scope, what
+   is sent, and that recipients are bound at approval time.
+
+Tests: recipient-not-in-posting parks (never sends); template ignores
+agent prose; dry-run never calls the send API (mock assert); intent is
+persisted before the send call (ordering test); missing scope → 
+actionable error; UI preview fixture.
+
+**Definition of Done**
+- [ ] No send path is reachable by the agent process (grep: send only in
+      the owned adapter; agent allowlist unchanged except detection).
+- [ ] All six test classes above pass.
+- [ ] Full sweep (§0.3) passes, including `pnpm qa:test`.
+
+### W1.8 — Fail-closed surface defaults
+
+**Objective:** every entry point defaults to dry-run; the only live
+switch is explicit, and the claim gate (P2 + W1.1) remains the real
+enforcement behind it.
+
+**Branch:** `feat/w1-8-fail-closed-defaults` ·
+**PR title:** `feat(apply): dry-run-by-default surfaces and legacy live-path deletion`
+
+Work items:
+1. `jobhunter apply` (`workers/automation/src/jobhunter/cli.py`, command
+   ~:892): `dry_run` currently defaults `False` — a bare `jobhunter
+   apply` is a LIVE run today. Flip: default dry-run; add `--submit`
+   (mutually exclusive with `--dry-run`) for live mode. Startup banner
+   states the mode and that live submission additionally requires the
+   recorded approval gate. (This item runs after temporal P5, which owns
+   `cli.py` — verify P5 is merged in your base.)
+2. RPC `apply_action`
+   (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`
+   ~:499–507): `params.get("dryRun", False)` fails open — flip the
+   default to `True` and log when the caller omitted the param. (The TS
+   mapper already defaults true; this makes the Python side match.)
+3. Delete the legacy synchronous action path that hardcodes
+   `dry_run=False` (`workers/automation/src/jobhunter/actions.py` ~:196)
+   after grep-verifying all callers route through RPC/Temporal. If a
+   caller still uses it, STOP and report instead of keeping both paths.
+4. Flip all remaining W0.3 `--strict-prompt` tripwires to strict in the
+   privacy CI workflow (W1.4/W1.5/W1.6 are merged by now).
+5. `README.md` + `docs/local-reliability-qa.md`: document the new CLI
+   semantics and add the dry-run/live QA checklist entries.
+
+**Definition of Done**
+- [ ] Bare `jobhunter apply` performs a dry run (CLI test).
+- [ ] RPC default fail-closed (test).
+- [ ] Legacy path deleted; grep clean.
+- [ ] Privacy CI runs strict tripwires and is green.
+- [ ] Full sweep (§0.3) passes.
+
+---
+
+## 4. Workstream W2 — Public surface, naming, governance (from `main`)
+
+### W2.1 — PyPI distribution rename (owner checkpoint)
+
+**Objective:** a publishable distribution name; product and repo names
+unchanged.
+
+Work items:
+1. Propose ≥5 candidate names with evidence per candidate: PyPI
+   availability (`https://pypi.org/pypi/<name>/json` → 404), GitHub
+   name-collision quick check, a note from a quick USPTO TESS search.
+   STOP: owner picks (§0.5.1).
+2. After the pick: `workers/automation/pyproject.toml` `[project] name`
+   → the new distribution name; import package `jobhunter` and console
+   script `jobhunter` unchanged; README install instructions updated
+   (`pip install <newname>` → `jobhunter` CLI).
+3. Re-enable the tag trigger in `publish.yml`; update the W0.3 structural
+   check to expect the new name (retire the block).
+
+**Definition of Done**
+- [ ] Owner-approved name in `pyproject.toml`; build produces the renamed
+      sdist/wheel; `python3 scripts/release_check.py` green.
+- [ ] `publish.yml` tag trigger restored, gated on the release-check
+      workflow passing (workflow-level dependency or job condition).
+
+### W2.2 — Responsible-use documentation and warnings
+
+**Objective:** every preserved capability is disclosed; the operator makes
+informed choices.
+
+Work items:
+1. `README.md` gains a "Responsible use" section and
+   `docs/user/data-and-safety.md` is extended to cover, explicitly: live
+   submissions to real employers; email applications (`gmail.send`
+   scope); CAPTCHA solving via a paid third-party service, disabled
+   unless a key is configured, with ToS/legal risk resting on the
+   operator; scraping-source ToS risk including LinkedIn/Indeed defaults;
+   the local API's unauthenticated-on-loopback boundary (per W2.3);
+   AI spend and the W2.4 ceilings; the list of sensitive local artifacts;
+   and synthetic-data-only expectations for bug reports.
+2. `doctor` prints notices when: LinkedIn/Indeed boards are active, a
+   CapSolver key is configured, the approval gate is off, attestations
+   are incomplete (W1.4). Also cover the hardcoded board fallbacks in
+   `workers/automation/src/jobhunter/discovery/jobspy.py` (~:998, ~:1071)
+   so the warning reflects the boards actually used, not just
+   `DEFAULT_JOBSPY_BOARDS` (`config.py` ~:53). *(The `doctor`/`cli.py`
+   edits require temporal P5 merged; split into a follow-up PR if docs
+   are ready first.)*
+
+**Definition of Done**
+- [ ] Both docs updated; no capability left undisclosed.
+- [ ] `doctor` warning unit tests green.
+
+### W2.3 — CSRF: `Sec-Fetch-Site` gate *(requires PR #233 merged)*
+
+**Objective:** close the null-Origin fail-open without breaking local
+non-browser clients (curl, seeds, scripts).
+
+Work items: in the global `onRequest` hook (`apps/api/src/server.ts`
+~:253–272), for unsafe methods, after the existing Origin/Referer logic:
+if the `sec-fetch-site` header is present and its value is not
+`same-origin` or `none` → 403 `cross_site_request`. Requests with no
+Origin, no Referer, and no `Sec-Fetch-Site` (non-browser clients) remain
+allowed, and this boundary is documented in `SECURITY.md` (loopback bind +
+Host check + Origin/Referer + Sec-Fetch-Site; local processes are trusted;
+also document the `JOBHUNTER_API_ALLOW_REMOTE_BIND=1` escape hatch as
+operator-owned risk).
+
+Tests (`apps/api/test/server.test.ts`): matrix — cross-site browser
+request (`sec-fetch-site: cross-site`) → 403; same-origin browser → 200;
+headerless curl-style → allowed; existing Origin/Referer cases unchanged.
+
+**Definition of Done**
+- [ ] Test matrix green; `SECURITY.md` updated.
+- [ ] Full sweep (§0.3) passes.
+
+### W2.4 — AI spend ledger and ceilings (owner checkpoint for defaults)
+
+**Objective:** all AI spend is recorded; lanes have enforceable daily
+ceilings. Tokens are the universal metric (USD is not observable on
+subscription-auth lanes); USD is recorded where available.
+
+Work items:
+1. New table `ai_spend` (ts, lane, model, input_tokens, output_tokens,
+   usd_estimate NULLABLE, run_ref), DDL in `init_db`'s ensure-block.
+   Write at the chokepoints: the ensemble runner
+   (`workers/automation/src/jobhunter/infrastructure/analysis/ensemble.py`
+   and the agent-SDK adapters), the legacy `llm.py` client, and the apply
+   adapter's result-stats parse (`claude_code_cli.py` reads usage from
+   the result message).
+2. Config: per-lane daily ceilings in tokens (USD optional where
+   observable), read from settings/env. At each lane entry point, a
+   pre-run check refuses new work over the ceiling with a typed error and
+   a recorded event; surfaced in logs and (where a surface exists)
+   operations UI. Mid-run kill is explicitly OUT of scope for non-apply
+   lanes (the apply lane already has `--max-budget-usd` from W1.3).
+3. Propose default ceiling values per lane; STOP for owner confirmation
+   (§0.5.2).
+4. `doctor` prints today's spend by lane *(post-P5, may be a follow-up
+   PR)*. Document in README + `docs/user/data-and-safety.md`.
+
+**Definition of Done**
+- [ ] Ledger rows written from every chokepoint (tests with fakes).
+- [ ] Ceiling refusal test green; over-ceiling refusal visible in the log
+      channel.
+- [ ] Owner-confirmed defaults in place.
+- [ ] Full sweep (§0.3) passes.
+
+### W2.5 — DCO enforcement
+
+Work items: add a DCO check workflow (a maintained DCO action verifying
+`Signed-off-by` on every PR commit); `CONTRIBUTING.md` gains a sign-off
+section (`git commit -s`) and the PR template mentions it.
+
+**Definition of Done**
+- [ ] DCO workflow present and green on its own signed PR.
+- [ ] `CONTRIBUTING.md` updated.
+
+### W2.6 — Contributor AI-auth truthfulness *(requires temporal P5)*
+
+**Objective:** onboarding stops claiming a single provider key suffices
+when the Tier-2 scoring/materials ensemble actually requires the
+Claude Code session + Codex login + Gemini chain.
+
+Work items: `doctor` Tier-2 readiness reflects the real auth chain (check
+each: Claude session, Codex login, Gemini/Antigravity key) with per-link
+status; `docs/user/getting-started.md` and `docs/user/configuration.md`
+describe the full chain and what degrades when a link is missing.
+
+**Definition of Done**
+- [ ] `doctor` output test covers all-present / one-missing cases.
+- [ ] No doc claims single-key sufficiency for Tier 2.
+
+---
+
+## 5. Release gate — flipping public (owner executes; you prepare)
+
+All boxes below must be checked before the repository visibility flip and
+first tag. Assemble this checklist, with links, as the final deliverable.
+
+- [ ] W0.1–W0.6 merged; `release-check` CI green on `main` on every commit
+      since W0.4 landed.
+- [ ] Temporal P1b–P5 merged (PR #232 program complete).
+- [ ] W1.1–W1.8 merged, each with review gate `Gate: PASS` and QA gate
+      `Gate: PASS` per repo process.
+- [ ] W2.1 name chosen and live; `publish.yml` re-enabled and gated on the
+      privacy workflow.
+- [ ] W2.2, W2.3, W2.5 merged; W2.4 and W2.6 merged or explicitly deferred
+      by the owner in writing.
+- [ ] W0.6 dispositions closed: every concern fixed, backlogged
+      (sanitized), or owner-accepted.
+- [ ] Owner has recorded, in the flip PR/issue: acceptance of historical
+      blobs remaining reachable (git history kept), and the capability
+      posture (live submit, CapSolver, email send, LinkedIn/Indeed) as
+      deliberate, disclosed choices.
+- [ ] Final manual QA (human): `jobhunter doctor` clean with expected
+      warnings; seeded `/apply-review` smoke showing approval → dry-run
+      evidence → gated submit controls; one harness dry-run showing the
+      blocked-channel evidence. No real applications.
+- [ ] Owner flips visibility and tags the first release.

--- a/docs/plans/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/2026-07-03-oss-release-remediation-spec.md
@@ -37,24 +37,58 @@
 6. **Owner decision checkpoints** (§0.5) are places where you must STOP,
    present options, and wait for the owner's choice before proceeding.
 
-### 0.1 Workstream order and parallelism
+### 0.1 Ordering: per-item gates against the PR #232 program
+
+The temporal program (single stacked run P1b → P3 → P2 → P4 → P5, per the
+PR #232 spec) is in flight with unknown per-phase delivery dates. Do NOT
+branch from its unmerged stack. Every item below carries a **Gate** — what
+must have MERGED TO `main` before you cut the item's branch. Gate `none`
+means: start now, from `main`, in parallel with the temporal run.
+
+| Item | Gate | Collision with #232 (type) |
+| --- | --- | --- |
+| W0.1–W0.6 | none | Only W0.2's fixture-data swaps touch files P2/P3/P4 also edit — data-only, trivial rebase. |
+| W1.1, W1.2, W1.3→W1.5→W1.6, W1.7 | temporal **P2** | Same files AND same semantics: they extend P2's gate/guard/intent/`needs_verification` substrate. |
+| W1.4 | temporal **P2** (soft — see note) | Semantically independent of P2; only file contention (`packages/contracts`, adapter result parse, apply-review UI). |
+| W1.8 | temporal **P5** | `cli.py` and `pipeline/actions.py` are P5-owned; P5 itself rewrites/deletes the legacy path W1.8 targets. |
+| W2.1, W2.2 (docs), W2.5 | none | Disjoint. (P5 also edits `README.md`/`docs/**` — different sections, trivial.) |
+| W2.3 | PR **#233** (P0) | Same `server.ts`; P2 later touches other regions of it (trivial contention). |
+| W2.4 | temporal **P5** | P5 SHIPS the base spend system (`llm_spend`, `dailyBudgetUsd`, `check_spend_budget` preflight, dual-client recording). W2.4 is a delta on it — see the rewritten §W2.4. |
+| W2.6 + doctor parts of W2.2 | temporal **P5** | `cli.py` is P5-owned; P4 rewrites `discovery/**` including the board-fallback seams the doctor warning must reflect. |
+
+W1.4 note: if P2 is badly delayed, W1.4's core (prompt attestation
+removal + profile contract) MAY be pulled forward from `main` at the cost
+of one temporal-stack rebase — an owner call, not the default.
+
+Sequencing summary:
 
 ```
-W0 (privacy & hygiene)          — from main, FIRST, W0.1 → W0.2 → W0.3 → W0.4 → W0.5 → W0.6
-temporal stack P1b→P3→P2→P4→P5  — per PR #232 spec (separate run; rebase it once after W0 merges)
-W1 (apply & runtime safety)     — stacked AFTER temporal P5, W1.1 → W1.2 → … → W1.8
-W2 (public surface & governance)— from main, parallel to W1, except:
-                                    W2.3 requires PR #233 (P0) merged
-                                    W2.6 and the doctor parts of W2.2 require temporal P5 merged
-Release flip                    — §5 checklist, last
+now         ──► W0.1→W0.2→W0.3→W0.4→W0.5→W0.6   (first: privacy CI gates every later PR)
+            ──► W2.1, W2.2(docs), W2.5            (fully parallel)
+#233 merged ──► W2.3
+P2 merged   ──► W1.1→W1.2→W1.3→W1.4→W1.5→W1.6→W1.7  (stacked; do NOT wait for P4/P5)
+P5 merged   ──► W1.8, W2.4, W2.6, W2.2(doctor)
+all merged  ──► §5 release flip
 ```
 
-- W0 lands first because every later PR must pass the W0.4 privacy CI
-  gate, and because W0.2 touches test files that temporal P2 also touches
-  (one rebase of the temporal stack after W0 merges is expected and cheap).
-- W1 items are a stacked series continuing the temporal stack: cut
-  `W1.1`'s branch from the P5 branch tip (or from `main` once P5 has
-  merged); each subsequent W1 branch cuts from its predecessor.
+- W0 lands first; the temporal stack rebases once after W0 merges.
+- **W1.1–W1.7 unblock at P2, not P5.** P4/P5 touch almost none of their
+  files; the residual contention (P5 adds `dailyBudgetUsd` to
+  `packages/contracts` and the settings form) is a trivial rebase for the
+  temporal stack as W1 items land on `main`.
+- The critical path to the release flip runs through P5 only via the
+  `cli.py`-owned items (W1.8, W2.6, doctor warnings) and W2.4. If P5
+  stalls, the owner may approve pulling W1.8's CLI default flip forward
+  at the cost of a P5 rebase — owner call (§0.5), not a default.
+- **If the entire PR #232 program is already delivered**, every gate is
+  satisfied and nothing else changes: W0 first (the privacy CI gate is
+  still wanted under every later PR), then W1.1→W1.8 as one stacked
+  series with W2 fully parallel, then §5. Optional intra-W1 parallelism
+  in that world: lane {W1.1→W1.2→W1.7} (claim/review/recovery) alongside
+  lane {W1.3→W1.4→W1.5→W1.6} (adapter/prompt/owned tools), converging on
+  W1.8 — but both lanes touch `launcher.py`/`claude_code_cli.py` in
+  different functions, so prefer the single stacked series unless two
+  implementers actively coordinate.
 - W2.1 (naming) can start any time; its publish re-enable step is last.
 
 ### 0.2 Non-negotiable ground rules
@@ -346,12 +380,12 @@ line stating dispositions are complete.
 
 ---
 
-## 3. Workstream W1 — Apply and runtime safety (stacked after temporal P5)
+## 3. Workstream W1 — Apply and runtime safety (gated on temporal P2; W1.8 alone on P5)
 
 ### W1.0 Substrate check (run before W1.1; STOP if any is missing)
 
-Temporal P2 (see PR #232 spec §5) must already provide, on the branch you
-build from:
+Temporal P2 (see PR #232 spec §5) must already be MERGED TO `main` and
+provide:
 - `applyApprovalRequired` setting plumbed end-to-end (default `true`),
   enforced by an `approve_submit` SELECT inside `acquire_job`'s
   `BEGIN IMMEDIATE` transaction.
@@ -836,6 +870,10 @@ Work items:
    `dry_run=False` (`workers/automation/src/jobhunter/actions.py` ~:196)
    after grep-verifying all callers route through RPC/Temporal. If a
    caller still uses it, STOP and report instead of keeping both paths.
+   Note: temporal P5 rewrites `run_local_action` to start workflows and
+   deletes the in-process execution branches — P5 may already have
+   removed this path. In that case this item reduces to the grep check;
+   verify rather than re-delete.
 4. Flip all remaining W0.3 `--strict-prompt` tripwires to strict in the
    privacy CI workflow (W1.4/W1.5/W1.6 are merged by now).
 5. `README.md` + `docs/local-reliability-qa.md`: document the new CLI
@@ -898,8 +936,10 @@ Work items:
    `workers/automation/src/jobhunter/discovery/jobspy.py` (~:998, ~:1071)
    so the warning reflects the boards actually used, not just
    `DEFAULT_JOBSPY_BOARDS` (`config.py` ~:53). *(The `doctor`/`cli.py`
-   edits require temporal P5 merged; split into a follow-up PR if docs
-   are ready first.)*
+   edits require temporal P5 merged — and P4 rewrites `discovery/**`, so
+   re-locate the board-default seams by symbol after P4 rather than
+   trusting these line hints. Split into a follow-up PR if the docs are
+   ready first.)*
 
 **Definition of Done**
 - [ ] Both docs updated; no capability left undisclosed.
@@ -928,35 +968,51 @@ headerless curl-style → allowed; existing Origin/Referer cases unchanged.
 - [ ] Test matrix green; `SECURITY.md` updated.
 - [ ] Full sweep (§0.3) passes.
 
-### W2.4 — AI spend ledger and ceilings (owner checkpoint for defaults)
+### W2.4 — Per-lane spend attribution and token ceilings *(requires temporal P5; delta on P5's spend system; owner checkpoint for defaults)*
 
-**Objective:** all AI spend is recorded; lanes have enforceable daily
-ceilings. Tokens are the universal metric (USD is not observable on
-subscription-auth lanes); USD is recorded where available.
+**Objective:** extend — do not duplicate — the spend system temporal P5
+ships. P5 delivers the base: the `llm_spend` day-aggregate table
+(init_db ensure-block), usage recording hooked at the existing capture
+points in BOTH the legacy `llm.py` client and the agent-SDK client seam,
+a `dailyBudgetUsd` setting (default 25, 0 = unlimited) plumbed through
+all layers, a `check_spend_budget` preflight activity at the top of
+every spending workflow raising non-retryable `BudgetExceededError`, and
+settings + health-surface UI. W2.4 adds what P5 lacks: per-lane
+attribution, token-denominated ceilings (USD estimates are unreliable on
+subscription-auth lanes), apply-lane capture, and doctor visibility.
+**If you find yourself creating a second spend table or a second
+preflight, STOP — extend P5's.**
 
 Work items:
-1. New table `ai_spend` (ts, lane, model, input_tokens, output_tokens,
-   usd_estimate NULLABLE, run_ref), DDL in `init_db`'s ensure-block.
-   Write at the chokepoints: the ensemble runner
-   (`workers/automation/src/jobhunter/infrastructure/analysis/ensemble.py`
-   and the agent-SDK adapters), the legacy `llm.py` client, and the apply
-   adapter's result-stats parse (`claude_code_cli.py` reads usage from
-   the result message).
-2. Config: per-lane daily ceilings in tokens (USD optional where
-   observable), read from settings/env. At each lane entry point, a
-   pre-run check refuses new work over the ceiling with a typed error and
-   a recorded event; surfaced in logs and (where a surface exists)
-   operations UI. Mid-run kill is explicitly OUT of scope for non-apply
-   lanes (the apply lane already has `--max-budget-usd` from W1.3).
-3. Propose default ceiling values per lane; STOP for owner confirmation
+1. **Lane attribution.** Extend P5's recording seam so every recorded
+   usage entry carries a lane (`apply`, `scoring`, `tailoring`,
+   `employer_analysis`, `enrichment`, `profile`, …): either lane
+   columns/rows on `llm_spend` or a companion per-lane table folded at
+   the same write points — ONE mechanism, no double-counting (P5's own
+   tests already forbid double-counting; keep them green).
+2. **Apply-lane capture.** P5 hooks `llm.py` and the agent-SDK client;
+   the apply lane spends through the `claude` CLI subprocess instead.
+   Record its usage from the result-message stats parse in
+   `claude_code_cli.py` into the same ledger, lane = `apply`. (W1.3's
+   per-run `--max-budget-usd` and P5's daily USD ceiling both remain —
+   this adds attribution, not another cap.)
+3. **Per-lane token ceilings.** Per-lane daily token ceilings
+   (settings/env), enforced INSIDE P5's existing `check_spend_budget`
+   preflight (extend its input with the calling workflow's lane),
+   raising the same `BudgetExceededError` taxonomy. The global
+   `dailyBudgetUsd` behavior is unchanged.
+4. Propose default per-lane token ceilings; STOP for owner confirmation
    (§0.5.2).
-4. `doctor` prints today's spend by lane *(post-P5, may be a follow-up
-   PR)*. Document in README + `docs/user/data-and-safety.md`.
+5. **Visibility.** `doctor` prints today's spend by lane; extend the
+   health surface P5 added with the per-lane breakdown. Document in
+   README + `docs/user/data-and-safety.md`.
 
 **Definition of Done**
-- [ ] Ledger rows written from every chokepoint (tests with fakes).
-- [ ] Ceiling refusal test green; over-ceiling refusal visible in the log
-      channel.
+- [ ] Every recorded usage entry is lane-attributed; apply-lane entries
+      appear from the adapter parse (tests with fakes).
+- [ ] Per-lane token ceiling blocks via P5's preflight (test); global
+      USD ceiling behavior unchanged (P5's tests still green).
+- [ ] No second spend table or preflight exists (grep-provable).
 - [ ] Owner-confirmed defaults in place.
 - [ ] Full sweep (§0.3) passes.
 

--- a/docs/plans/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/2026-07-03-oss-release-remediation-spec.md
@@ -320,22 +320,29 @@ locations. Because history is being kept, that map remains reachable in
 old commits. Every item in it must be dispositioned before the repo goes
 public.
 
-**Branch:** none (this is an audit deliverable, delivered as a PR comment
-thread or issue, not a code change — unless dispositions add
-`docs/backlog.md` entries, then `docs/w0-6-concerns-dispositions`).
+**Branch:** `docs/w0-6-concerns-dispositions` ONLY if dispositions add
+sanitized `docs/backlog.md` entries; otherwise no branch — the table is
+not a code change.
 
 Work items: for every numbered concern in the file, record exactly one
 disposition: **fixed** (link the commit/PR), **fixed-by** (link the W1/W2
 item that fixes it), **public-backlog** (add a sanitized entry to
 `docs/backlog.md` — no exploit detail, no file-located vulnerability
 descriptions), or **accepted** (owner approval required per §0.5.3). The
-disposition table itself is delivered in the PR/issue body, NOT committed
-to the tree, because it inherits the sensitivity of its source.
+disposition table is a PRIVATE, off-repo owner artifact: write it into
+the now-untracked local `.planning/` directory (or wherever the owner
+designates). It must NOT be committed, and it must NOT be posted in PR
+comments, PR descriptions, or issues — all of those become public
+surface when repository visibility flips. The only public traces are the
+sanitized backlog entries, links to fixing PRs, and the §5 checklist
+line stating dispositions are complete.
 
 **Definition of Done**
 - [ ] Every concern has exactly one disposition; none is silently dropped.
 - [ ] All "fixed-by" references point at real items in this spec.
 - [ ] Owner has approved every "accepted" entry.
+- [ ] No concern-derived content appears in any committed file, PR text,
+      or issue — the table lives only at the owner's private location.
 
 ---
 
@@ -386,30 +393,43 @@ Work items:
    `BEGIN IMMEDIATE`): claim a LIVE run only when the latest decision is
    `approve_submit` AND its bound materials generation equals the job's
    current one AND bound profile version equals current AND bound URL
-   equals the job's current application URL AND (a dry-run completion
-   with `coverage = "full"` exists for that same materials generation OR
-   the decision row has `partial_override = 1`). Record distinct skip
-   reasons in the existing skip channel: `awaiting_approval`,
+   equals the job's current application URL AND dry-run evidence holds:
+   EITHER a dry-run completion with `coverage = "full"` exists for that
+   same materials generation and URL, OR the decision row's
+   `partial_override_run_id` references a specific dry-run run that
+   exists with `coverage = "partial"` for that same materials generation
+   and URL. An override that references no run, a missing run, or a run
+   for stale materials/URL is INVALID — the override weakens "full" to
+   "partial"; it never waives dry-run evidence entirely. Record distinct
+   skip reasons in the existing skip channel: `awaiting_approval`,
    `awaiting_dry_run`, `approval_stale_materials`,
-   `approval_stale_profile`, `approval_stale_url`.
-4. **Partial override.** New nullable column `partial_override` on the
-   decision row, settable only through an explicit UI affordance on the
-   approve action ("Approve with partial dry-run evidence") that renders a
-   persistent `role="alert"` warning naming what was not verified. Never
-   set implicitly.
+   `approval_stale_profile`, `approval_stale_url`,
+   `override_evidence_invalid`.
+4. **Partial override.** New nullable column `partial_override_run_id` on
+   the decision row (the dry-run run id accepted as evidence — not a
+   boolean), settable only through an explicit UI affordance on the
+   approve action ("Approve with partial dry-run evidence"). The
+   affordance is offered ONLY when a partial-coverage dry-run exists for
+   the current materials generation; it displays that run's
+   blocked-channel evidence and renders a persistent `role="alert"`
+   warning naming what was not verified. Never set implicitly.
 5. **UI.** The apply-review approval card shows what is being bound
    (materials generation, dry-run evidence status/coverage, URL) and the
    skip reasons from item 3 when a claim was refused.
 
 Tests: one claim fixture per predicate arm (no approval / no dry-run /
-each staleness dimension / valid / valid-with-override); API test that the
-decision write captures bindings; component test for the override warning.
+each staleness dimension / valid / valid-with-override /
+override-referencing-no-run refused / override-bound-to-stale-run
+refused); API test that the decision write captures bindings; component
+test for the override affordance gating and its warning.
 
 **Definition of Done**
 - [ ] A live claim is impossible without a fresh, fully-bound approval —
       proven by the per-arm pytest fixtures.
 - [ ] Regenerating materials or mutating the profile invalidates a prior
       approval (fixtures prove both).
+- [ ] An approval whose override references no matching partial dry-run
+      run cannot claim (fixtures prove it).
 - [ ] Skip reasons visible in apply-review.
 - [ ] Full sweep (§0.3) passes, including `pnpm qa:test`.
 
@@ -424,23 +444,38 @@ per-request intent breadcrumbs.
 **PR title:** `feat(apply): dry-run coverage classification, violation outcomes, live-mode breadcrumbs`
 
 Work items:
-1. **Method set.** Add `DELETE` to the blocked method set.
-2. **DOM layer.** Extend the injected script to also wrap
-   `navigator.sendBeacon` (return `false`) and
-   `WebSocket.prototype.send` (drop + report) during dry-run, reporting
-   through a `Runtime.addBinding` channel rather than a window flag.
+1. **Interception policy — replace P2's wholesale.** The temporal plan
+   and spec texts differ on P2's scoping (application-origin vs any
+   non-localhost host); regardless of which shipped, W1.2 replaces the
+   policy: during dry-run, allow ONLY `GET` and `HEAD`; block every
+   other method (`POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, anything
+   nonstandard) to EVERY origin, from every frame and every
+   auto-attached target. ATS flows hop origins via redirects, iframes,
+   and vendor domains — origin scoping is bypassable by design. The
+   only exemption is localhost/127.0.0.1, solely so the test harness
+   can act as the employer.
+2. **DOM layer + WebSocket.** Extend the injected script to also wrap
+   `navigator.sendBeacon` (return `false`) and the `window.WebSocket`
+   constructor (throw + report — blocking creation beats wrapping
+   `send`) during dry-run, reporting through a `Runtime.addBinding`
+   channel rather than a window flag. Because document-injected scripts
+   do not reach dedicated workers, additionally listen for CDP
+   `Network.webSocketCreated` on every auto-attached target as a
+   backstop reporter: any WebSocket observed during dry-run is recorded
+   in the blocked-channel evidence and demotes coverage (item 4).
 3. **Blocked-request evidence.** Persist every blocked request (method,
    URL origin+path only — strip query strings, they can carry PII —
-   frame, timestamp, and whether it was same-site to the application
-   flow) into a `job_artifacts` row of kind `apply_dryrun_blocked` (JSON
-   list), one row per run.
+   frame, CDP resourceType, timestamp) into a `job_artifacts` row of
+   kind `apply_dryrun_blocked` (JSON list), one row per run.
 4. **Coverage classification.** `DryRunComplete` gains
-   `coverage: "full" | "partial"`. `partial` when any blocked mutating
-   request was **same-site** to the application flow (registrable domain
-   of the frame's document) or any DOM-submit interception fired before
-   the final page; third-party beacon/analytics blocks do NOT demote
-   coverage. Contracts + Python mirror + web ripple (the dry-run evidence
-   card shows coverage and the blocked-channel list).
+   `coverage: "full" | "partial"`. Classify by CDP `resourceType`, not
+   by origin (ATS steps legitimately cross origins): `partial` when any
+   blocked request had resourceType `Document`, `XHR`, or `Fetch` —
+   from ANY origin — or any DOM-submit/WebSocket interception fired
+   before the final page. Blocked `Ping`/`Beacon`/`Image`/analytics
+   resource types do NOT demote coverage. Contracts + Python mirror +
+   web ripple (the dry-run evidence card shows coverage and the
+   blocked-channel list).
 5. **Violation outcome.** Delete the coercion in
    `apply/claude_code_cli.py` (~:354–361) that maps `RESULT:APPLIED`
    during dry-run to `DryRunComplete`. Replace with a distinct
@@ -450,32 +485,42 @@ Work items:
    transmitted; the violation records that the agent attempted it —
    that's an injection/prompt-quality signal, not a success).
 6. **Live-mode breadcrumbs.** Run the interceptor in live mode too, in
-   observe mode: before `Fetch.continueRequest` of a same-site mutating
-   request, append a durable breadcrumb (run id, method, origin+path,
-   timestamp) — committed synchronously. The coarse P2
-   `ApplySubmitIntended` remains the recovery trigger; breadcrumbs refine
-   it: recovery MAY safe-rewind to `pending` (instead of
-   `needs_verification`) when intent exists but the breadcrumb log shows
-   zero same-site mutating requests were continued. Otherwise P2's rule
-   stands. Add this refinement to the recovery function with tests for
-   both branches.
+   observe mode: before `Fetch.continueRequest` of ANY mutating request
+   — every method except GET/HEAD, every origin, every frame/target —
+   append a durable breadcrumb (run id, method, origin+path,
+   resourceType, timestamp), committed synchronously. The coarse P2
+   `ApplySubmitIntended` remains the recovery trigger; breadcrumbs
+   refine it in ONE direction only: recovery MAY safe-rewind to
+   `pending` (instead of `needs_verification`) when intent exists but
+   the breadcrumb log shows ZERO mutating continuations of any kind for
+   the run. Any mutating continuation — including cross-origin and
+   beacon-type — means P2's park rule stands; never rewind based on
+   origin or resource-type filtering. Add this refinement to the
+   recovery function with tests for both branches.
 7. **Adversarial fixture.** Extend the P2 integration harness (local HTTP
    server as the "employer"): a page whose text contains an injection
    instruction to submit anyway plus an auto-POST and a form; under
    dry-run assert the server receives ZERO mutating requests, the blocked
    artifact exists, coverage classification is correct, and a synthetic
-   `RESULT:APPLIED` maps to `dry_run_violation`. Add a third-party-beacon
-   page asserting coverage stays `full`, and a same-site step-POST page
-   asserting `partial`.
+   `RESULT:APPLIED` maps to `dry_run_violation`. Add: a
+   third-party-beacon page asserting coverage stays `full`; a step-POST
+   page asserting `partial`; a cross-origin iframe form page (second
+   local server port acting as the "ATS vendor") asserting its POST is
+   blocked and demotes coverage; a redirect-then-POST page asserting the
+   post-redirect submit is blocked; and a WebSocket page asserting
+   construction is blocked and reported.
 
 **Definition of Done**
-- [ ] Zero mutating requests reach the harness server under dry-run
-      (POST/PUT/PATCH/DELETE, sendBeacon, WebSocket payloads).
+- [ ] Zero non-GET/HEAD requests reach either harness server
+      (same-origin AND cross-origin/iframe/redirect paths) under
+      dry-run, including sendBeacon and WebSocket traffic.
 - [ ] `dry_run_violation` replaces the coercion; no path can emit
       `applied` or `DryRunComplete` from a dry-run violation.
 - [ ] Coverage classification fixtures pass (full / partial /
       third-party-beacon cases).
-- [ ] Breadcrumb-refined recovery fixtures pass (rewind vs park).
+- [ ] Breadcrumb-refined recovery fixtures pass: rewind only on a
+      zero-continuation log; any mutating continuation (any origin or
+      resource type) parks as `needs_verification`.
 - [ ] Event/state ripple complete: both registries, handlers, fixtures,
       badges; parity tests green.
 - [ ] Full sweep (§0.3) passes.
@@ -497,10 +542,11 @@ unless noted):
 1. **Allowlist replaces bypass.** Drop
    `--permission-mode bypassPermissions` (~:151). Pass `--allowedTools`
    with the exact enumerated tool names: the Playwright MCP tools from the
-   pinned `@playwright/mcp` version MINUS `browser_evaluate` and any
-   code-execution/install tool, plus the two Gmail read tools
-   (`search_emails`, `read_email`). Later items append their owned tools
-   (W1.5 `type_credential`, W1.6 `solve_captcha`). Keep
+   pinned `@playwright/mcp` version MINUS `browser_evaluate`,
+   `browser_file_upload` (see item 7), and any code-execution/install
+   tool, plus the owned tools from items 5 and 7
+   (`get_verification_code`, `upload_artifact`). Later items append
+   their owned tools (W1.5 `type_credential`, W1.6 `solve_captcha`). Keep
    `--disallowedTools` as a belt listing the built-ins: `Bash`, `Edit`,
    `Write`, `NotebookEdit`, `WebFetch`, `WebSearch`. Delete the current
    `_DISALLOWED_TOOLS` list of nonexistent Gmail write tools (~:47–56).
@@ -522,26 +568,57 @@ unless noted):
    installed CLI) from a new setting (default `5.00`), plumbed like the
    existing model setting; `doctor` warns when the installed CLI lacks
    the flag (probe `claude --help` output).
-5. **Scoped Gmail.** The Gmail MCP server accepts constraints at spawn
-   (argv from `_default_mcp_config`): earliest-timestamp = run start, and
-   an allowed-sender-domain set derived from the job's application URL
-   and company domain. Enforce in query construction AND post-filter on
-   read. Out-of-scope queries return empty with an explanatory string.
-6. **Prompt hard rule + fixture.** Add to the hard-rules section: email
-   tools are only for retrieving verification codes; never transcribe
-   email content into page fields. Unit tests prove the server-side scope
-   (out-of-scope sender/time rejected). Add a manual-QA checklist entry
-   in `docs/local-reliability-qa.md` for the full-agent exfiltration
-   probe (harness page instructing the agent to read and paste inbox
-   content), since it needs a live model.
+5. **Purpose-built verification tool replaces raw Gmail reads.** The
+   apply agent no longer gets `search_emails`/`read_email` — raw
+   subjects and bodies are an exfiltration payload under prompt
+   injection (those tools remain available to the feedback scanner
+   elsewhere, unchanged). When spawned for an apply run, the Gmail MCP
+   server exposes ONE tool instead: `get_verification_code()`.
+   Server-side it searches within a scope fixed at spawn (argv from
+   `_default_mcp_config`: earliest-timestamp = run start;
+   allowed-sender-domain set derived from the job's application URL and
+   company domain), extracts only OTP codes and verification links from
+   matching messages, and returns those extracted values. Raw
+   subjects/bodies never enter model context. Out-of-scope: returns
+   empty with an explanatory string.
+6. **Automated exfiltration fixtures (tool layer).** (a) A fixture
+   mailbox message carrying a decoy secret in its body: assert no
+   exposed tool-call sequence can return the body or the secret —
+   `get_verification_code` yields only the extracted code/link. (b)
+   Out-of-scope sender/time queries return empty. (c) `upload_artifact`
+   (item 7) refuses any kind outside the run's reviewed artifacts. Also
+   update the prompt hard rule: email tooling returns verification
+   codes only; never transcribe email-derived content into page fields.
+   Keep a full-agent live-model probe (harness page instructing the
+   agent to fetch and paste inbox content) as a manual-QA checklist
+   entry in `docs/local-reliability-qa.md` — the tool-layer fixtures
+   are the enforced guarantee; the live probe is defense-in-depth.
+7. **Owned artifact upload replaces raw file upload.** The current
+   prompt instructs uploading the résumé by absolute path (`prompt.py`
+   ~:620) via the Playwright file-upload tool — under prompt injection
+   that is an arbitrary-file exfiltration channel (any readable path
+   could be attached to an attacker's form). Exclude
+   `browser_file_upload` from the allowlist (item 1) and add an owned
+   `upload_artifact(kind: "resume" | "cover_letter")` tool (owned MCP
+   server; may share the W1.5 secure-input server process): the server
+   resolves the CURRENT run's reviewed artifact of that kind to a path
+   itself — the model never supplies a path — locates the pending file
+   chooser / file input through its own CDP connection
+   (`DOM.setFileInputFiles`), and attaches it. Refuses when the run has
+   no such artifact. Update the prompt's upload instruction to: click
+   the upload control, then call `upload_artifact`.
 
 **Definition of Done**
 - [ ] Golden test on the exact argv: no `bypassPermissions`, allowlist
       present, budget flag present.
-- [ ] Allowlist parity test green against pinned server versions.
+- [ ] Allowlist parity test green against pinned server versions; none
+      of `browser_evaluate`, `browser_file_upload`, `search_emails`,
+      `read_email` appears in the apply agent's allowlist.
 - [ ] Env-allowlist test: subprocess env contains exactly the allowlisted
       keys.
-- [ ] Gmail scope tests green (time bound + sender bound + post-filter).
+- [ ] Tool-layer exfiltration fixtures green: decoy body secret
+      unreachable through any exposed tool; out-of-scope queries empty;
+      out-of-run-artifact upload refused.
 - [ ] MCP config file is 0600 and removed after the run (test).
 - [ ] Full sweep (§0.3) passes.
 
@@ -609,12 +686,17 @@ Work items:
    modeled on the Gmail server) exposing `type_credential(kind:
    "email" | "password")`. The tool receives NO secret from the model: the
    server loads the profile itself, opens its own CDP connection to the
-   run's Chrome, verifies `document.activeElement` is an
-   `<input type="password">` (or email/text for `kind="email"`), and
-   types via CDP `Input.insertText`. Refuse (with a clear error string)
-   when the focused element doesn't match or the profile has no password.
-   Prompt: click the field, then call the tool. Add the tool to the W1.3
-   allowlist.
+   run's Chrome, and types via CDP `Input.insertText` — but ONLY after
+   verifying, via its own CDP inspection (pages are untrusted; a hostile
+   page can stage a decoy field to harvest the credential), that the
+   focused element: is an `<input type="password">` (or email/text for
+   `kind="email"`); is visible (non-zero box, within the viewport, no
+   `display:none` / `visibility:hidden` / zero-opacity ancestor);
+   belongs to the top frame or a visible frame whose registrable domain
+   matches the top-level document's (no hidden or cross-origin iframes);
+   and that the document has focus. Refuse with a distinct error string
+   per failed check, and when the profile has no password. Prompt: click
+   the field, then call the tool. Add the tool to the W1.3 allowlist.
 3. **Global redaction.** A `redact(text)` helper seeded at profile/config
    load with all secret values (profile password, any configured API
    keys) applied at every persistence sink: worker log writer, timeline/
@@ -622,11 +704,17 @@ Work items:
    (`apply_agent_output` etc.). Integration test: run the harness with a
    fake profile containing a distinctive fake password; assert it appears
    in NO persisted output.
+4. **Unique-password guidance.** Because this tool types the credential
+   into third-party pages, W2.2's responsible-use docs must instruct
+   operators to use a unique, dedicated password for job-site accounts
+   (never a reused personal password). The content lands in W2.2; this
+   item adds the cross-reference.
 
 **Definition of Done**
 - [ ] Password string absent from prompt text, argv, env, MCP config main
       body, logs, events, and artifacts (needle-based integration test).
-- [ ] `type_credential` refuses non-credential fields (test).
+- [ ] `type_credential` refusal fixtures green: non-credential field,
+      hidden input, off-screen input, cross-origin iframe field.
 - [ ] W0.3 password tripwire strict-green for `prompt.py`.
 - [ ] Full sweep (§0.3) passes.
 
@@ -796,7 +884,9 @@ Work items:
 1. `README.md` gains a "Responsible use" section and
    `docs/user/data-and-safety.md` is extended to cover, explicitly: live
    submissions to real employers; email applications (`gmail.send`
-   scope); CAPTCHA solving via a paid third-party service, disabled
+   scope); automated credential typing and the recommendation to use a
+   unique, dedicated password for job-site accounts (W1.5); CAPTCHA
+   solving via a paid third-party service, disabled
    unless a key is configured, with ToS/legal risk resting on the
    operator; scraping-source ToS risk including LinkedIn/Indeed defaults;
    the local API's unauthenticated-on-loopback boundary (per W2.3);

--- a/docs/plans/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/2026-07-03-oss-release-remediation-spec.md
@@ -216,6 +216,17 @@ weaken an assertion.
 **Branch:** `chore/w0-2-scrub-fixtures` ·
 **PR title:** `chore(release): replace owner-derived fixture data with synthetic equivalents`
 
+**Work item 0 — capture the needle inventory FIRST.** Before replacing
+anything, record the exact forbidden values present at the leak sites
+below (owner identity strings, the two employer names used as owner
+evidence, the seed marker, private path fragments) into a private
+OFF-REPO needle inventory at the same owner-designated location as the
+W0.6 artifact (e.g., the untracked local `.planning/`). W0.3 consumes
+this inventory to build its needle list. Never commit it; never post it
+in PR/issue text (§0.2). Fallback if the inventory is ever lost: harvest
+from the pre-W0.2 parent commit via git history (`git show
+<pre-W0.2-commit>:<path>` — history is kept per §1).
+
 Known leak sites (line numbers are hints; each file must be fully re-read
 and scrubbed, not just at the hinted line):
 1. `apps/web/src/shared/ui/PdfPreviewViewer.test.ts` — embeds an
@@ -241,6 +252,8 @@ and scrubbed, not just at the hinted line):
    `user:` + owner-username seed marker → `user:example`.
 
 **Definition of Done**
+- [ ] The private needle inventory exists at the owner-designated
+      location and covers every value class scrubbed below.
 - [ ] Every file above (and any additional hit found by the W0.3 scanner
       run locally against your branch) contains only synthetic data.
 - [ ] No test was deleted; no assertion was weakened; suite counts did not
@@ -260,8 +273,10 @@ Work items:
    case-insensitively.
 2. **Needle classes** (literal values live ONLY inside
    `scripts/release_check.py`, using the existing string-concatenation
-   obfuscation): the existing FORBIDDEN_TEXT list, plus — reading values at
-   the W0.2 leak sites before scrubbing them — the owner first name, full
+   obfuscation): the existing FORBIDDEN_TEXT list, plus — sourced from
+   the private needle inventory W0.2 captured before scrubbing
+   (fallback: the pre-W0.2 parent commit via git history; the values are
+   no longer in the working tree) — the owner first name, full
    name, username, personal domain, LinkedIn profile slug, the two real
    employer names that appear as owner evidence in the leaked fixtures, the
    lowercase seed-marker token, private toolchain path fragments (the
@@ -485,9 +500,12 @@ Work items:
    other method (`POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`, anything
    nonstandard) to EVERY origin, from every frame and every
    auto-attached target. ATS flows hop origins via redirects, iframes,
-   and vendor domains — origin scoping is bypassable by design. The
-   only exemption is localhost/127.0.0.1, solely so the test harness
-   can act as the employer.
+   and vendor domains — origin scoping is bypassable by design. There
+   is NO exemption — not even localhost/127.0.0.1 (P2's carve-out is
+   removed): the test harness only needs to SERVE pages, which is GET;
+   mutating page-origin requests to localhost-bound services are
+   blocked and recorded like any other, and the harness asserts
+   non-receipt precisely because the guard blocks them.
 2. **DOM layer + WebSocket.** Extend the injected script to also wrap
    `navigator.sendBeacon` (return `false`) and the `window.WebSocket`
    constructor (throw + report — blocking creation beats wrapping
@@ -546,8 +564,9 @@ Work items:
 
 **Definition of Done**
 - [ ] Zero non-GET/HEAD requests reach either harness server
-      (same-origin AND cross-origin/iframe/redirect paths) under
-      dry-run, including sendBeacon and WebSocket traffic.
+      (page-origin localhost AND cross-origin/iframe/redirect paths)
+      under dry-run, including sendBeacon and WebSocket traffic — no
+      localhost carve-out exists.
 - [ ] `dry_run_violation` replaces the coercion; no path can emit
       `applied` or `DryRunComplete` from a dry-run violation.
 - [ ] Coverage classification fixtures pass (full / partial /
@@ -633,9 +652,14 @@ unless noted):
    that is an arbitrary-file exfiltration channel (any readable path
    could be attached to an attacker's form). Exclude
    `browser_file_upload` from the allowlist (item 1) and add an owned
-   `upload_artifact(kind: "resume" | "cover_letter")` tool (owned MCP
-   server; may share the W1.5 secure-input server process): the server
-   resolves the CURRENT run's reviewed artifact of that kind to a path
+   `upload_artifact(kind: "resume" | "cover_letter")` tool hosted on a
+   NEW dedicated owned apply-tools MCP server
+   (`workers/automation/src/jobhunter/infrastructure/apply_tools/mcp_server.py`,
+   modeled on the Gmail server). This server is THE home for owned
+   apply-run tools: W1.5 adds `type_credential` to it and W1.6 adds
+   `solve_captcha` to it — later items extend this server, never create
+   another. The server resolves the CURRENT run's reviewed artifact of
+   that kind to a path
    itself — the model never supplies a path — locates the pending file
    chooser / file input through its own CDP connection
    (`DOM.setFileInputFiles`), and attaches it. Refuses when the run has
@@ -715,10 +739,10 @@ any persisted artifact.
 Work items:
 1. **Remove interpolation** of the profile password (and paired email
    sign-in/sign-up lines) from `prompt.py` (~:614–615).
-2. **Owned secure-input tool.** New owned MCP server
-   (`workers/automation/src/jobhunter/infrastructure/secure_input/mcp_server.py`,
-   modeled on the Gmail server) exposing `type_credential(kind:
-   "email" | "password")`. The tool receives NO secret from the model: the
+2. **Owned secure-input tool.** Extend the W1.3 apply-tools MCP server
+   (`workers/automation/src/jobhunter/infrastructure/apply_tools/mcp_server.py`)
+   with `type_credential(kind: "email" | "password")` — do NOT create a
+   second owned server. The tool receives NO secret from the model: the
    server loads the profile itself, opens its own CDP connection to the
    run's Chrome, and types via CDP `Input.insertText` — but ONLY after
    verifying, via its own CDP inspection (pages are untrusted; a hostile
@@ -761,24 +785,28 @@ and the API key move out of the prompt into owned code.
 **PR title:** `feat(apply): move CapSolver solving into an owned MCP tool; key leaves model context`
 
 Work items:
-1. New owned MCP server
-   (`workers/automation/src/jobhunter/infrastructure/captcha/mcp_server.py`)
-   exposing `solve_captcha(kind, sitekey, page_url)`. Port the
+1. Add `solve_captcha(kind, sitekey, page_url)` to the W1.3 apply-tools
+   MCP server; the solver implementation lives in
+   `workers/automation/src/jobhunter/infrastructure/captcha/` (imported
+   by the server — no separate server process). Port the
    createTask/poll flow and the token-injection JavaScript currently
    embedded in `_build_captcha_section`
    (`prompt.py` ~:217–424) into Python (`httpx` for REST — this is a REST
    integration, not an LLM client) + CDP `Runtime.evaluate` injection.
    Return `{solved, kind, elapsed_s, cost_usd?}`; record a usage event or
    artifact per solve with observable cost.
-2. The key reaches ONLY this server via its per-server `env` block in the
-   generated MCP config (W1.3 item 3). The tool is registered only when
-   the key is configured; otherwise it is absent.
+2. The key reaches ONLY the apply-tools server via its per-server `env`
+   block in the generated MCP config (W1.3 item 3); it stays
+   server-side. The tool is registered only when the key is configured;
+   otherwise it is absent AND the W1.3 allowlist omits it.
 3. Shrink the prompt's CAPTCHA section to: if a CAPTCHA blocks progress
    and `solve_captcha` is available, call it once with the visible
    sitekey; on failure or absence output `RESULT:CAPTCHA`. Delete the
    embedded REST/JS block. Keep `doctor`/wizard behavior (key optional,
    default off).
-4. Add `solve_captcha` to the W1.3 allowlist and parity test.
+4. Add `solve_captcha` to the W1.3 allowlist and extend the parity test
+   to cover BOTH configurations (key present: tool advertised and
+   allowlisted; key absent: neither).
 
 Tests: server unit tests with a mocked CapSolver API (success, failure,
 timeout); needle test that the key env var name and value appear nowhere


### PR DESCRIPTION
## What

Adds `docs/plans/2026-07-03-oss-release-remediation-spec.md` — a self-contained, prescriptive implementation spec (same format as the temporal spec in #232) for making the repository safe to publish as open source while preserving every capability: live submit, CapSolver, email applications (rebuilt as a controlled owned-send path), LinkedIn/Indeed defaults, AGPL-3.0-only, DCO, and the existing git history.

Three workstreams, each item one PR with binary Definition of Done + verification commands:

- **W0 — Privacy & release hygiene** (from `main`, first): untrack the private planning corpus, scrub owner-derived fixture data, `release_check.py` v2 (case-insensitive needle classes, file-type checks, structural checks, source tripwires, self-test), an unfiltered privacy CI gate, publish-workflow guard, and a disposition gate for the internal concerns document.
- **W1 — Apply & runtime safety** (stacked after temporal P5; explicitly builds on P2's substrate — approval gate in the atomic claim, `ApplySubmitIntended`, `needs_verification`, CDP dry-run guard — and never re-implements it): approval freshness binding (materials/profile/URL + dry-run-evidence precondition with explicit partial override), dry-run guard hardening (coverage classification, `dry_run_violation` replacing the applied→dry-run coercion, live-mode intent breadcrumbs), agent sandbox (explicit `--allowedTools`, minimal env, `--max-budget-usd`, scoped Gmail), typed attestations replacing fabricated screening defaults, out-of-band credential typing, CapSolver moved into an owned MCP tool, the email-application flow built properly (agent detects; owner-approved recipient; owned send with intent), and fail-closed surface defaults (`jobhunter apply` dry-run by default + legacy live-path deletion).
- **W2 — Public surface & governance** (parallel where files allow): PyPI distribution rename (owner picks; repo/product name unchanged), responsible-use docs + doctor warnings, `Sec-Fetch-Site` CSRF gate, token-based AI spend ledger + ceilings, DCO enforcement, and truthful Tier-2 auth-chain reporting.

Sequencing against the in-flight temporal program is explicit: W0 first (one rebase of the temporal stack expected), W1 stacked after P5, W2.3 after #233, W2.6/doctor items after P5. Owner decision checkpoints are enumerated (dist name, spend defaults, risk acceptances, the visibility flip itself).

## Why

The going-public audit and plan reviews established that release safety requires both current-tree privacy hygiene and apply-path safety gates, and that the apply-safety slice must build on the temporal P2 work rather than collide with it. This spec encodes the owner's locked posture (preserve capabilities; comply via hard gates + disclosure) in a form Codex can implement literally, one gated PR at a time.

## Validation

- `python3 scripts/release_check.py` — the new spec file produces **zero** findings (verified by filtering the scanner output for the file path). Pre-existing findings in fixture files remain, as expected; they are exactly what W0.2 removes.
- Docs-only change: no code paths touched; no test/build impact.
- The spec itself contains no owner identity strings, per its own §0.2 ground rule.

## Deviations

None.

## Deferred

Implementation of every workstream item — this PR is the spec only.