### PR TITLE
docs(backlog): record the five known-failing web e2e baseline specs

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -186,6 +186,31 @@ Out of scope for the local stack (stays in [`TODO_FUTURE.md`](../TODO_FUTURE.md)
   wording, relevance to a target job, achievement framing, evidence strength,
   and whether the item deserves required placement in the final resume.
 
+### Known-Failing Web E2E Baseline (2026-07-03)
+
+Five Playwright specs fail identically on `main` and on every Temporal
+rearchitecture validation run (isolated stacks, 2026-07-02 → 2026-07-03,
+PR #233 / #235 / #237 gate runs). They pre-date that work and are not caused
+by it. QA gates treat them as the known baseline: "e2e passes" means **no NEW
+failures beyond these five**. Fixing any of them must remove it from this
+list so the baseline shrinks instead of masking regressions.
+
+- `apps/web/e2e/tests/dashboard.spec.ts:3` — dashboard KPIs render; clicking
+  the Jobs KPI navigates to `/jobs` with a matching row count.
+- `apps/web/e2e/tests/jobs-drawer.spec.ts:297` — compensation source-conflict
+  evidence stays product-visible on mobile viewport without unsafe requests.
+- `apps/web/e2e/tests/jobs-drawer.spec.ts:371` — job drawer opens with
+  requirement fit / stages / artifacts, survives reload, and close preserves
+  the URL filter.
+- `apps/web/e2e/tests/route-visual-qa.spec.ts:507` — requirement-fit drawer
+  and Apply Review cards visual regression coverage.
+- `apps/web/e2e/tests/token-foundation.spec.ts:349` — domain status surfaces
+  use painted semantic token classes (funnel segments, apply-run dots, tags).
+
+Root causes are untriaged; failure modes are assertion-level (seeded-fixture
+expectations and visual/painted-style assertions), not infrastructure. Triage
+each spec, fix or re-fixture it, and delete its bullet here.
+
 ## SaaS And Commercialization
 
 These items are intentionally deferred until local validation is solid.


### PR DESCRIPTION
## What
Adds a "Known-Failing Web E2E Baseline (2026-07-03)" subsection to docs/backlog.md listing the five Playwright specs that fail on main (dashboard.spec.ts:3, jobs-drawer.spec.ts:297 and :371, route-visual-qa.spec.ts:507, token-foundation.spec.ts:349), what each asserts, and the rule that QA gates count only NEW failures beyond these five.

## Why
Every Temporal-rearch validation run (PRs #233/#235/#237 and the current #238–#240 gate runs) reproduced these five failures identically on main and at feature heads. The baseline was previously documented only in the implementation spec on a plan branch; the backlog on main is the owning document, and each fix should shrink the list rather than let the baseline mask regressions.

## Validation
Docs-only change; no behavior touched. Verified the five spec paths and line anchors against origin/main.