### PR TITLE
chore(release): replace owner-derived fixture data with synthetic equivalents

### DIFF
--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -515,7 +515,7 @@ describe("application feedback API", () => {
 
   it("returns full resume text for apply-review PDF audit targets", async () => {
     const longResumeText = [
-      "Eloi Example",
+      "Jordan Example",
       "",
       "Experience",
       ...Array.from({ length: 90 }, (_, index) =>
@@ -609,7 +609,7 @@ describe("application feedback API", () => {
        ) VALUES ('local', 'default', ?, ?, ?, ?)`,
     ).run(
       "Jordan Candidate",
-      "42 Profile Street, Barcelona",
+      "42 Example Avenue, Harbor City",
       "do-not-send-this-field",
       "Experienced platform leader with reliable operations depth.",
     );
@@ -631,7 +631,7 @@ describe("application feedback API", () => {
         {
           path: "personal.address",
           label: "Profile > Personal information > Address",
-          value: "42 Profile Street, Barcelona",
+          value: "42 Example Avenue, Harbor City",
           section: "profile_personal",
         },
         {

--- a/apps/api/test/resume-review-drafts.test.ts
+++ b/apps/api/test/resume-review-drafts.test.ts
@@ -526,13 +526,13 @@ describe("resume review draft API", () => {
       url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
       payload: {
         editedText: [
-          "Eloi Example",
+          "Jordan Example",
           "Experience",
           "- Led platform reliability work across 3 critical services.",
           "Skills",
           "- TypeScript, Python, Temporal",
         ].join("\n"),
-        plateDocument: [{ type: "p", children: [{ text: "Eloi Example" }] }],
+        plateDocument: [{ type: "p", children: [{ text: "Jordan Example" }] }],
         editDeltas: [
           {
             kind: "replace_text",
@@ -655,7 +655,7 @@ describe("resume review draft API", () => {
 
     const longBullet =
       "- Owned the end-to-end reliability roadmap across ingestion, streaming, storage, and serving tiers while mentoring a large distributed platform engineering organization.";
-    const editedLines = ["Eloi Example", "Experience"];
+    const editedLines = ["Jordan Example", "Experience"];
     for (let index = 1; index <= 70; index += 1) {
       editedLines.push(
         index === 30 ? longBullet : `- Delivered platform outcome number ${index} across critical services.`,
@@ -718,7 +718,7 @@ describe("resume review draft API", () => {
       method: "POST",
       url: `/v1/resume-review/drafts/${encodeURIComponent(draftId)}/revisions`,
       payload: {
-        editedText: ["Eloi Example", "Experience", "- Led reliability work across services.", "Skills", "- TypeScript"].join(
+        editedText: ["Jordan Example", "Experience", "- Led reliability work across services.", "Skills", "- TypeScript"].join(
           "\n",
         ),
         editDeltas: [],

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -657,7 +657,7 @@ describe("local TypeScript API", () => {
               total: 72,
               unit: "searches",
               currentQuery: "Head of Platform",
-              currentLocation: "Spain (remote)",
+              currentLocation: "Exampleland (remote)",
               newJobs: 13,
               existingJobs: 46,
               filteredJobs: 412,
@@ -691,7 +691,7 @@ describe("local TypeScript API", () => {
           total: 72,
           unit: "searches",
           currentQuery: "Head of Platform",
-          currentLocation: "Spain (remote)",
+          currentLocation: "Exampleland (remote)",
           newJobs: 13,
           existingJobs: 46,
           filteredJobs: 412,
@@ -3437,7 +3437,7 @@ describe("local TypeScript API", () => {
     seedDb.prepare(`
       INSERT INTO candidate_profile_achievement_evidence (
         tenant_id, profile_id, entry_id, evidence_index, evidence_id, source_text
-      ) VALUES ('local', 'default', 'rider_law', 0, 'ev_rider_law', 'Preserved the Spanish market under aggressive legal deadlines.')
+      ) VALUES ('local', 'default', 'fleet_safety', 0, 'ev_fleet_safety', 'Preserved the pilot market under aggressive compliance deadlines.')
     `).run();
     insertJob(seedDb, {
       url: "https://example.com/jobs/tailoring-skill-source",
@@ -3464,7 +3464,7 @@ describe("local TypeScript API", () => {
       bulletId: "skills:leadership#0",
       section: "skills",
       sourceId: "leadership",
-      evidenceIds: ["ev_rider_law"],
+      evidenceIds: ["ev_fleet_safety"],
       requirementIds: ["req_leadership"],
       matchedKeywords: ["global teams"],
       transformType: "rephrase",
@@ -6311,18 +6311,18 @@ describe("local TypeScript API", () => {
   });
 
   it("validates target-search locations before saving profile preferences", async () => {
-    const placeValidator = vi.fn(async (place: string) => place === "Barcelona, Spain");
+    const placeValidator = vi.fn(async (place: string) => place === "Austin, TX");
     const app = buildApp({ ...options, placeValidator });
     const response = await app.inject({
       method: "PATCH",
       url: "/v1/profile",
       payload: {
-        profile: profileWithTargetSearch("Location Target", "Barcelona, Spain", "Remote"),
+        profile: profileWithTargetSearch("Location Target", "Austin, TX", "Remote"),
       },
     });
 
     expect(response.statusCode, response.body).toBe(200);
-    expect(placeValidator).toHaveBeenCalledWith("Barcelona, Spain");
+    expect(placeValidator).toHaveBeenCalledWith("Austin, TX");
     const db = new Database(options.dbPath);
     try {
       expect(
@@ -6343,7 +6343,7 @@ describe("local TypeScript API", () => {
         experience_target_seniority_floor: "Principal",
         experience_target_functions: "Platform",
         experience_target_specializations: "SaaS",
-        experience_target_locations: "Barcelona, Spain",
+        experience_target_locations: "Austin, TX",
         experience_target_work_models: "Remote",
       });
     } finally {

--- a/apps/web/src/shared/ui/PdfPreviewViewer.test.ts
+++ b/apps/web/src/shared/ui/PdfPreviewViewer.test.ts
@@ -126,7 +126,7 @@ describe("PdfAuditPreviewViewer line geometry", () => {
     const targets: PdfAuditLineTarget[] = [
       {
         lineNumber: 2,
-        text: "candidate@example.com | (+34) 611-682-399 | https://example.com | https://linkedin.com/in/example",
+        text: "candidate@example.test | (+1) 555-0104 | https://portfolio.example.test | https://linkedin.com/in/example",
       },
       {
         lineNumber: 5,
@@ -137,7 +137,7 @@ describe("PdfAuditPreviewViewer line geometry", () => {
     const lines = pdfTextLines(
       pdfjs,
       [
-        textItem("candidate@example.com • (+34) 611-682-399 • example.com", 80, 120, 360),
+        textItem("candidate@example.test • (+1) 555-0104 • portfolio.example.test", 80, 120, 360),
         textItem("Director of Engineering with 12+ years of experience leading platform organizations.", 80, 136, 430),
       ],
       viewport,
@@ -149,15 +149,15 @@ describe("PdfAuditPreviewViewer line geometry", () => {
 
   it("does not let tiny date fragments claim compact metadata lines", () => {
     const targets: PdfAuditLineTarget[] = [
-      { lineNumber: 9, text: "Barcelona, Spain (Remote) | Mar 2024 -- Present" },
-      { lineNumber: 22, text: "Berlin, Germany | Jul 2023 -- Mar 2024" },
+      { lineNumber: 9, text: "Harbor City (Remote) | Mar 2024 -- Present" },
+      { lineNumber: 22, text: "Riverton, USA | Jul 2023 -- Mar 2024" },
     ];
 
     const lines = pdfTextLines(
       pdfjs,
       [
         textItem("Mar 2024", 520, 120, 70),
-        textItem("Berlin, Germany Jul 2023 Mar 2024", 80, 145, 310),
+        textItem("Riverton, USA Jul 2023 Mar 2024", 80, 145, 310),
       ],
       viewport,
       targets,
@@ -171,16 +171,16 @@ describe("PdfAuditPreviewViewer line geometry", () => {
       {
         lineNumber: 36,
         text:
-          "- Preserved the Spanish market under aggressive legal deadlines by leading the cross-functional task force for the Rider Law regulation, partnering with Product, Legal, and Operations.",
+          "- Preserved the pilot market under aggressive compliance deadlines by leading the cross-functional task force for the Fleet Safety regulation, partnering with Product, Legal, and Operations.",
       },
     ];
 
     const lines = pdfTextLines(
       pdfjs,
       [
-        textItem("Preserved the Spanish market under aggressive legal deadlines by leading the cross-functional task force", 80, 120, 560),
-        textItem("for the Rider Law regulation, partnering with Product, Legal, and Operations.", 80, 134, 460),
-        textItem("Security Customer Advisory Board Member Sep 2022 Aug 2023", 80, 148, 390),
+        textItem("Preserved the pilot market under aggressive compliance deadlines by leading the cross-functional task force", 80, 120, 560),
+        textItem("for the Fleet Safety regulation, partnering with Product, Legal, and Operations.", 80, 134, 460),
+        textItem("Reliability Advisory Board Member Sep 2022 Aug 2023", 80, 148, 390),
         textItem("Influenced the product roadmap for enterprise-grade observability and security tools.", 80, 162, 520),
       ],
       viewport,
@@ -189,40 +189,40 @@ describe("PdfAuditPreviewViewer line geometry", () => {
 
     expect(lines.map((line) => line.resumeLineNumber)).toEqual([36, null, null]);
     expect(lines[0]?.text).toContain("Operations");
-    expect(lines[0]?.text).not.toContain("Security Customer");
+    expect(lines[0]?.text).not.toContain("Reliability Advisory");
     expect(lines[0]?.heightPct).toBeLessThan(4);
   });
 
   it("keeps heading rows separate while grouping wrapped bullet blocks", () => {
     const targets: PdfAuditLineTarget[] = [
-      { lineNumber: 61, text: "Software Engineer | Tesla" },
-      { lineNumber: 62, text: "Fremont & Palo Alto, USA | Feb 2016 -- Nov 2018" },
+      { lineNumber: 61, text: "Software Engineer | Northstar Robotics" },
+      { lineNumber: 62, text: "Riverton & Lakeview, USA | Feb 2016 -- Nov 2018" },
       {
         lineNumber: 63,
         text:
-          "- Designed the conveyor control layers for Model 3 general assembly automation and led 15 engineers through testing and deployment to get it running at production scale.",
+          "- Designed the conveyor control layers for autonomous warehouse assembly automation and led 15 engineers through testing and deployment to get it running at production scale.",
       },
       {
         lineNumber: 64,
         text:
-          "- Wrote Python APIs for real-time factory floor communication, giving the Manufacturing Operating System (MOS) fast, high-volume links to the industrial control systems.",
+          "- Wrote Python APIs for real-time factory floor communication, giving the Factory Operating Platform (FOP) fast, high-volume links to the industrial control systems.",
       },
     ];
 
     const lines = pdfTextLines(
       pdfjs,
       [
-        textItem("Tesla Fremont & Palo Alto, USA", 80, 120, 330),
-        textItem("Software Engineer Feb 2016 – Nov 2018", 80, 134, 320),
+        textItem("Northstar Robotics Riverton & Lakeview, USA", 80, 120, 330),
+        textItem("Software Engineer Northstar Robotics Feb 2016 – Nov 2018", 80, 134, 420),
         textItem(
-          "○ Designed the conveyor control layers for Model 3 general assembly automation and led 15 engineers through testing and",
+          "○ Designed the conveyor control layers for autonomous warehouse assembly automation and led 15 engineers through testing and",
           80,
           158,
           610,
         ),
         textItem("deployment to get it running at production scale.", 100, 172, 330),
         textItem(
-          "○ Wrote Python APIs for real-time factory floor communication, giving the Manufacturing Operating System (MOS) fast,",
+          "○ Wrote Python APIs for real-time factory floor communication, giving the Factory Operating Platform (FOP) fast,",
           80,
           196,
           610,
@@ -245,7 +245,7 @@ describe("PdfAuditPreviewViewer line geometry", () => {
       {
         lineNumber: 36,
         text:
-          "- Preserved the Spanish market under aggressive legal deadlines by leading the cross-functional task force for the Rider Law regulation, partnering with Product, Legal, and Operations.",
+          "- Preserved the pilot market under aggressive compliance deadlines by leading the cross-functional task force for the Fleet Safety regulation, partnering with Product, Legal, and Operations.",
       },
     ];
 

--- a/apps/web/src/test/msw/handlers.ts
+++ b/apps/web/src/test/msw/handlers.ts
@@ -643,7 +643,7 @@ export const handlers = [
       `
         <main class="resume-page">
           <section class="resume-section">
-            <h1 data-resume-layout-target="profile-name">Eloi Barti Tremoleda</h1>
+            <h1 data-resume-layout-target="profile-name">Jordan Vale</h1>
             <p>Engineering leader with platform, security, and infrastructure experience.</p>
           </section>
         </main>

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -258,7 +258,7 @@ function savedDraftPlateDocumentWithEntryHeading() {
               className: "resume-entry-heading",
               lineNumber: 30,
               pageNumber: 1,
-              semanticId: "experience:entry:datadog:heading",
+              semanticId: "experience:entry:northstar:heading",
               children: [
                 { text: "" },
                 {
@@ -271,14 +271,14 @@ function savedDraftPlateDocumentWithEntryHeading() {
                       type: "resume_inline",
                       tagName: "span",
                       className: "resume-entry-company",
-                      children: [{ text: "Datadog" }],
+                      children: [{ text: "Northstar Labs" }],
                     },
                     { text: "" },
                     {
                       type: "resume_inline",
                       tagName: "span",
                       className: "resume-entry-location",
-                      children: [{ text: "Barcelona, Spain" }],
+                      children: [{ text: "Harbor City, Remote" }],
                     },
                     { text: "" },
                   ],
@@ -293,7 +293,7 @@ function savedDraftPlateDocumentWithEntryHeading() {
                       type: "resume_inline",
                       tagName: "span",
                       className: "resume-entry-title",
-                      children: [{ text: "Security Customer Advisory Board Member" }],
+                      children: [{ text: "Reliability Advisory Board Member" }],
                     },
                     {
                       type: "resume_inline",
@@ -1328,7 +1328,7 @@ describe("<ApplyReviewView>", () => {
   it("normalizes saved entry heading rows so editing does not add spacer grid tracks", async () => {
     const draft = makeResumeReviewDraft(sampleApplyReviewQueue.items[0]!.jobKey, {
       editedText:
-        "Datadog Barcelona, Spain\nSecurity Customer Advisory Board Member Sep 2022 | Aug 2023",
+        "Northstar Labs Harbor City, Remote\nReliability Advisory Board Member Sep 2022 | Aug 2023",
       plateDocument: savedDraftPlateDocumentWithEntryHeading(),
     });
 
@@ -1342,7 +1342,7 @@ describe("<ApplyReviewView>", () => {
     });
 
     const shadow = await findResumeShadowRoot();
-    const heading = shadowElementWithText(shadow, "Datadog");
+    const heading = shadowElementWithText(shadow, "Northstar Labs");
     const rows = Array.from(heading.querySelectorAll<HTMLElement>(".resume-entry-row"));
 
     expect(rows).toHaveLength(2);
@@ -2074,20 +2074,20 @@ describe("<ApplyReviewView>", () => {
               materialsPreview: {
                 ...item.materialsPreview,
                 resumeText: [
-                  "Eloi Barti Tremoleda",
-                  "eloibarti@gmail.com | (+34) 611-682-399 | https://eloibarti.com | https://linkedin.com/in/ebarti",
+                  "Jordan Vale",
+                  "jordan.vale@example.test | (+1) 555-0104 | https://portfolio.example.test | https://linkedin.com/in/jordan-vale",
                   "",
                   "EXECUTIVE PROFILE",
                   "Engineering Director with 12+ years of experience.",
                   "",
                   "EXPERIENCE",
-                  "Director of Engineering / Acting CISO | Welltech",
-                  "Barcelona, Spain (Remote) | Mar 2024 -- Present",
+                  "Director of Engineering / Acting CISO | Northstar Labs",
+                  "Harbor City (Remote) | Mar 2024 -- Present",
                   "- Rebuilt engineering and IT organizations to 30+ engineers.",
                   "",
                   "EDUCATION",
-                  "Master's Degree in Aerospace and Mechanical Engineering",
-                  "Illinois Institute of Technology (IIT) | Chicago, IL | Aug 2014",
+                  "Master's Degree in Systems Engineering",
+                  "Example Institute of Technology | Chicago, IL | Aug 2014",
                   "",
                   "SKILLS",
                   "Platform & Cloud: Kubernetes, Docker, GCP",
@@ -2108,9 +2108,9 @@ describe("<ApplyReviewView>", () => {
     });
 
     const shadow = await findResumeShadowRoot();
-    expect(shadowText(shadow)).toContain("Director of Engineering / Acting CISO | Welltech");
-    expect(shadowText(shadow)).toContain("Barcelona, Spain (Remote) | Mar 2024 -- Present");
-    expect(shadowText(shadow)).toContain("Master's Degree in Aerospace and Mechanical Engineering");
+    expect(shadowText(shadow)).toContain("Director of Engineering / Acting CISO | Northstar Labs");
+    expect(shadowText(shadow)).toContain("Harbor City (Remote) | Mar 2024 -- Present");
+    expect(shadowText(shadow)).toContain("Master's Degree in Systems Engineering");
     expect(shadowText(shadow)).toContain("Platform & Cloud: Kubernetes, Docker, GCP");
     expect(screen.queryByRole("region", { name: "Rendered resume line review" })).not.toBeInTheDocument();
     expect(screen.queryByRole("list", { name: "Rendered resume text lines" })).not.toBeInTheDocument();

--- a/workers/automation/src/jobhunter/domain/enrichment/filter_override.py
+++ b/workers/automation/src/jobhunter/domain/enrichment/filter_override.py
@@ -45,7 +45,7 @@ class FilterOverrideLogger:
             policy=source.policy.content_filter_override,
             overridden_filter="low_confidence_extraction",
             reason="user marked source trusted for discovery",
-            requested_by="user:eloi",
+            requested_by="user:example",
             overridden_at="2026-05-13T00:00:00+00:00",
         )
 

--- a/workers/automation/tests/test_content_validator.py
+++ b/workers/automation/tests/test_content_validator.py
@@ -286,7 +286,7 @@ def test_validate_cover_letter_passes_for_clean_letter() -> None:
 def test_validate_cover_letter_rejects_incomplete_mid_sentence_draft() -> None:
     text = (
         "Dear Hiring Manager,\n\n"
-        "At Welltech, I built an AI-assisted developer workflow that accelerated content production 3x "
+        "At Northstar Labs, I built an AI-assisted developer workflow that accelerated content production 3x "
         "and decreased code review turnaround by 40%. This platform integrated LLM-based"
     )
     result = _VALIDATOR.validate_cover_letter(text)

--- a/workers/automation/tests/test_enrichment_snapshot_pr3.py
+++ b/workers/automation/tests/test_enrichment_snapshot_pr3.py
@@ -447,7 +447,7 @@ def test_filter_override_audit_admits_low_confidence_snapshot(caplog) -> None:
         ),
         overridden_filter="low_confidence_extraction",
         reason="user approved trusted source",
-        requested_by="user:eloi",
+        requested_by="user:example",
         overridden_at=NOW,
     )
     assert audit.source_id == SOURCE_ID
@@ -484,7 +484,7 @@ def test_filter_override_audit_admits_low_confidence_snapshot(caplog) -> None:
         "source_id": SOURCE_ID,
         "overridden_filter": "low_confidence_extraction",
         "reason": "user approved trusted source",
-        "requested_by": "user:eloi",
+        "requested_by": "user:example",
         "overridden_at": NOW,
     }
 
@@ -518,7 +518,7 @@ def test_filter_override_rejects_disallowed_policy() -> None:
             ),
             overridden_filter="low_confidence_extraction",
             reason="user approved trusted source",
-            requested_by="user:eloi",
+            requested_by="user:example",
             overridden_at=NOW,
         )
 


### PR DESCRIPTION
## What
- Replaced owner-derived names, contact lines, employer references, location-specific résumé content, and seed markers in tracked tests/fixtures with synthetic equivalents.
- Preserved the existing test coverage shape: long resumes remain long, PDF line matching still exercises wrapped rows, and audit/profile-source assertions remain intact.
- Captured the required private W0.2 needle inventory in ignored local `.planning/release-remediation/w0-2-needle-inventory.md` for W0.3 follow-up.

## Why
W0.2 removes owner-derived fixture data from the tracked tree while keeping the behavioral tests and assertions intact for OSS release readiness.

## Validation
- `test -f .planning/release-remediation/w0-2-needle-inventory.md && git check-ignore -q .planning/release-remediation/w0-2-needle-inventory.md` -> `private inventory exists and is ignored`
- `git grep -n -i -E "<private W0.2 needle regex>" -- <W0.2 files> || true` -> no output
- `git grep -n -i -E "<core private needle regex>" -- ':!.planning/**' || true` -> no output
- `git diff --name-status --diff-filter=D` -> no output
- `python3 scripts/release_check.py` -> `Release check passed.`
- `uv --project workers/automation run --extra dev pytest -q` -> `1710 passed in 40.92s`
- `uv --project workers/automation run --extra dev ruff check .` -> `All checks passed!`
- `uv --project workers/automation run --extra dev python -m build workers/automation` -> `Successfully built jobhunter-0.3.0.tar.gz and jobhunter-0.3.0-py3-none-any.whl`
- `pnpm api:check` -> passed
- `pnpm api:test` -> `Test Files 19 passed (19)`, `Tests 323 passed (323)`
- `pnpm qa:test` -> `Test Files 1 passed (1)`, `Tests 3 passed (3)`
- `pnpm web:check` -> passed
- `pnpm --filter @jobhunter/web test` -> `Test Files 145 passed (145)`, `Tests 895 passed (895)`
- `pnpm --filter @jobhunter/web test-d` -> `Test Files 9 passed (9)`, `Tests 9 passed (9)`, `Type Errors no errors`
- `pnpm check` -> `All checks passed!`
- `pnpm test` -> `api:test` 19 files / 323 tests passed, `web:build` built successfully, `python:test` 1710 passed
- `git diff --check` -> no output
- `git diff --cached --check` -> no output

## Deviations
- A source docstring example contained the same private seed-marker value class as the W0.2 test fixture; it was replaced with a synthetic marker because W0.2's objective is tracked-file scrub, and the change is documentation-only in the source file.
- Verification environment note: local default Node was `v26.3.1`; the web Vitest command was run with an isolated temporary `NODE_OPTIONS=--localstorage-file=/tmp/.../localStorage.json` because Node 26 requires a storage file before exposing `localStorage` to the jsdom test process. No repository files or persistent user data were changed for this.

## Deferred
- W0.3 owns converting the private inventory into the expanded release scanner needles and self-test coverage.
