### PR TITLE
ci(release): disable tag publishing until distribution rename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
+# W2.1 restores tag publishing after the PyPI distribution rename.
 name: Publish to PyPI
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## What
- Changed `.github/workflows/publish.yml` to run only via `workflow_dispatch`.
- Added a header comment pointing at W2.1 for restoring tag publishing after the PyPI distribution rename.

## Why
W0.5 in `docs/plans/2026-07-03-oss-release-remediation-spec.md` closes the accidental publish window before W0.3 adds the structural scanner check that prevents silently re-enabling tag publishing under the blocked distribution name.

## Validation
- `rg -n "(^|\\s)(push:|tags:)" .github/workflows/publish.yml || true`
  - no output
- `python3 scripts/release_check.py`
  - `Release check passed.`
- `uv --project workers/automation run --extra dev pytest -q`
  - `1710 passed in 43.85s`
- `uv --project workers/automation run --extra dev ruff check .`
  - `All checks passed!`
- `uv --project workers/automation run --extra dev python -m build workers/automation`
  - `Successfully built jobhunter-0.3.0.tar.gz and jobhunter-0.3.0-py3-none-any.whl`
- `pnpm api:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `pnpm api:test`
  - `Test Files  19 passed (19)`
  - `Tests  323 passed (323)`
- `pnpm qa:test`
  - `Test Files  1 passed (1)`
  - `Tests  3 passed (3)`
- `pnpm web:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-5-vitest/localStorage.json pnpm --filter @jobhunter/web test`
  - `Test Files  145 passed (145)`
  - `Tests  895 passed (895)`
- `pnpm --filter @jobhunter/web test-d`
  - `Test Files  9 passed (9)`
  - `Tests  9 passed (9)`
  - `Type Errors  no errors`
- `pnpm check`
  - `All checks passed!`
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-5-vitest/full-test-localStorage.json pnpm test`
  - `Test Files  19 passed (19)`
  - `Tests  323 passed (323)`
  - `1710 passed in 27.39s`
- `git diff --check`
  - no output

## Deviations
None.

## Deferred
- Restoring tag-triggered publishing is deferred to W2.1, after the distribution rename.