### PR TITLE
feat(release): broaden release_check needles, file-type checks, and add a self-test

### DIFF
--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -1,12 +1,19 @@
-"""Pre-publication checks for private data and stale provenance."""
+"""Pre-publication checks for private data and stale provenance.
+
+The prompt tripwires are warnings by default because their source fixes land in
+W1. Pass ``--strict-prompt`` after W1 completes to promote them to failures.
+"""
 
 from __future__ import annotations
 
+import argparse
 import re
 import subprocess
 import sys
 import tarfile
 import zipfile
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,44 +22,171 @@ EXCLUDED_FILES = {
     Path("scripts/release_check.py"),
 }
 
-FORBIDDEN_TEXT = {
-    "-".join(("Pickle", "Pixel")): "old repository owner",
-    "Resume_" + "El" + "oi": "private resume filename",
-    "el" + "oi" + "barti": "private username/domain",
-    "El" + "oi": "private first name",
-}
-
-FORBIDDEN_PATH_NAMES = {
-    ".env",
-    "resume.txt",
-    "resume.pdf",
-}
-
-SECRET_ASSIGNMENT_RE = re.compile(
-    r"(?im)^\s*(GEMINI_API_KEY|OPENAI_API_KEY|LLM_API_KEY|CAPSOLVER_API_KEY)\s*=\s*([^#\s]+)"
-)
-
 TEXT_SUFFIXES = {
     "",
     ".cfg",
     ".css",
+    ".csv",
     ".html",
     ".ini",
     ".json",
     ".md",
     ".py",
+    ".sql",
+    ".svg",
     ".toml",
     ".txt",
+    ".xml",
     ".yaml",
     ".yml",
 }
 
+ARCHIVE_DIRS = (
+    Path("dist"),
+    Path("workers/automation/dist"),
+)
 
-def candidate_files() -> list[Path]:
+FORBIDDEN_PATH_NAMES = {
+    ".env",
+    ".env.development",
+    ".env.local",
+    ".env.production",
+    "profile.json",
+    "resume.pdf",
+    "resume.txt",
+    "token.json",
+}
+
+FORBIDDEN_FILE_SUFFIXES = {
+    ".db",
+    ".db-shm",
+    ".db-wal",
+    ".docx",
+    ".har",
+    ".key",
+    ".log",
+    ".pdf",
+    ".pem",
+    ".sqlite",
+    ".sqlite3",
+}
+
+BROWSER_PROFILE_MARKERS = {
+    ".mozilla/firefox/profiles",
+    "bravesoftware/brave-browser",
+    "browser-profile",
+    "browser_profiles",
+    "chrome-user-data",
+    "chrome_profile",
+    "chrome-profile",
+    "chromium/default",
+    "firefox-profile",
+    "google/chrome/default",
+    "microsoft edge/default",
+    "user data/default",
+}
+
+SECRET_KEY_RE = re.compile(
+    r"(?i)(?:[A-Z0-9]+_)+(?:API_KEY|SECRET|TOKEN|PASSWORD)$"
+)
+ENV_SECRET_ASSIGNMENT_RE = re.compile(
+    r"""(?im)^\s*([A-Z0-9_]+)\s*(?:=|:)\s*(['"]?)([^#\n'"]+)\2\s*,?\s*$"""
+)
+JSON_SECRET_ASSIGNMENT_RE = re.compile(
+    r"""(?im)^\s*"([^"]+)"\s*:\s*"([^"\n]+)"\s*,?\s*$"""
+)
+PROJECT_NAME_RE = re.compile(
+    r"""(?ims)^\[project\]\s*(?:(?!^\[).)*?^name\s*=\s*["']([^"']+)["']"""
+)
+
+SECRET_FILE_SUFFIXES = {".json", ".toml", ".yaml", ".yml"}
+PLACEHOLDER_VALUES = {
+    "changeme",
+    "change-me",
+    "dummy",
+    "example",
+    "fake",
+    "false",
+    "none",
+    "null",
+    "placeholder",
+    "replace-me",
+    "test",
+    "todo",
+    "true",
+}
+PLACEHOLDER_PREFIXES = (
+    "$",
+    "<",
+    "change_",
+    "dummy_",
+    "example_",
+    "fake_",
+    "placeholder_",
+    "replace_",
+    "test_",
+    "your_",
+    "your-",
+)
+
+PROMPT_PATH = Path("workers/automation/src/jobhunter/apply/prompt.py")
+
+
+@dataclass(frozen=True)
+class ForbiddenNeedle:
+    value: str
+    reason: str
+    case_sensitive: bool = False
+
+
+@dataclass
+class ScanResult:
+    findings: list[str]
+    warnings: list[str]
+
+    def extend(self, other: ScanResult) -> None:
+        self.findings.extend(other.findings)
+        self.warnings.extend(other.warnings)
+
+
+FORBIDDEN_TEXT = (
+    ForbiddenNeedle("-".join(("Pickle", "Pixel")), "old repository owner"),
+    ForbiddenNeedle("Resume_" + "El" + "oi", "private resume filename"),
+    ForbiddenNeedle("el" + "oi" + "barti", "private username/domain"),
+    ForbiddenNeedle("El" + "oi", "private first name"),
+    ForbiddenNeedle("El" + "oi " + "Barti " + "Tremoleda", "private full name"),
+    ForbiddenNeedle("el" + "oi" + "barti" + ".com", "private personal domain"),
+    ForbiddenNeedle(
+        "linkedin.com/in/" + "e" + "barti",
+        "private LinkedIn profile slug",
+    ),
+    ForbiddenNeedle("Well" + "tech", "private employer evidence"),
+    ForbiddenNeedle("Tes" + "la", "private employer evidence"),
+    ForbiddenNeedle("user:" + "el" + "oi", "private seed marker"),
+    ForbiddenNeedle("/Users/" + "el" + "oi" + "barti", "private home path"),
+    ForbiddenNeedle(".codex/" + "gsd-core", "private toolchain path"),
+    ForbiddenNeedle(".agents/" + "skills", "private toolchain path"),
+    ForbiddenNeedle(
+        "REQUIRED SUB-SKILL: Use " + "superpowers:",
+        "private skill banner",
+    ),
+)
+
+
+def candidate_files(root: Path = ROOT) -> list[Path]:
     """Return files that Git would consider for commit."""
+    return _git_paths(root, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"])
+
+
+def tracked_files(root: Path = ROOT) -> list[Path]:
+    """Return tracked files only."""
+    return _git_paths(root, ["ls-files", "--cached", "-z"])
+
+
+def _git_paths(root: Path, args: Sequence[str]) -> list[Path]:
     result = subprocess.run(
-        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"],
-        cwd=ROOT,
+        ["git", *args],
+        cwd=root,
         check=True,
         capture_output=True,
     )
@@ -63,96 +197,281 @@ def candidate_files() -> list[Path]:
         rel = Path(raw.decode())
         if rel in EXCLUDED_FILES:
             continue
-        path = ROOT / rel
+        path = root / rel
         if path.is_file():
             paths.append(rel)
     return paths
 
 
-def main() -> int:
-    findings: list[str] = []
-    for rel in candidate_files():
-        name_findings = scan_name(str(rel), rel.name, rel.suffix)
-        findings.extend(name_findings)
-        if name_findings:
-            continue
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict-prompt",
+        action="store_true",
+        help="Promote apply prompt safety tripwire warnings to failures.",
+    )
+    args = parser.parse_args(argv)
 
-        try:
-            text = (ROOT / rel).read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            continue
-        findings.extend(scan_text(str(rel), text))
+    result = scan_tree(ROOT, needles=FORBIDDEN_TEXT, strict_prompt=args.strict_prompt)
 
-    findings.extend(scan_dist_archives())
-
-    if findings:
+    if result.findings:
         print("Release check failed:")
-        for finding in findings:
+        for finding in result.findings:
             print(f"  - {finding}")
+    if result.warnings:
+        print("Release check warnings:")
+        for warning in result.warnings:
+            print(f"  - {warning}")
+
+    if result.findings:
         return 1
 
     print("Release check passed.")
     return 0
 
 
-def scan_name(label: str, name: str, suffix: str) -> list[str]:
+def scan_tree(
+    root: Path,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+    paths: Iterable[Path] | None = None,
+    tracked_paths: Iterable[Path] | None = None,
+    strict_prompt: bool = False,
+) -> ScanResult:
+    """Scan a repository tree for release-blocking private data."""
+    result = ScanResult(findings=[], warnings=[])
+    file_paths = list(paths) if paths is not None else candidate_files(root)
+    tracked = list(tracked_paths) if tracked_paths is not None else tracked_files(root)
+
+    for rel in file_paths:
+        name_findings = scan_name(str(rel), rel, needles=needles)
+        result.findings.extend(name_findings)
+        if name_findings:
+            continue
+
+        try:
+            text = (root / rel).read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        result.findings.extend(scan_text(str(rel), text, rel, needles=needles))
+
+    result.findings.extend(scan_structural_checks(root, tracked))
+    result.extend(scan_prompt_tripwires(root, strict_prompt=strict_prompt))
+    result.findings.extend(scan_dist_archives(root, needles=needles))
+    return result
+
+
+def scan_name(
+    label: str,
+    rel: Path,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+) -> list[str]:
     """Scan a path/archive member name for private artifacts."""
     findings = []
-    if name in FORBIDDEN_PATH_NAMES or suffix == ".db":
+    name = rel.name
+    suffix = rel.suffix.lower()
+    if name in FORBIDDEN_PATH_NAMES or suffix in FORBIDDEN_FILE_SUFFIXES:
         findings.append(f"{label}: private/runtime file should not be committed")
-    for needle, reason in FORBIDDEN_TEXT.items():
-        if needle in label:
-            findings.append(f"{label}: contains {reason} ({needle})")
+
+    normalized = rel.as_posix().lower()
+    if any(marker in normalized for marker in BROWSER_PROFILE_MARKERS):
+        findings.append(f"{label}: browser profile artifact should not be committed")
+
+    for needle in needles:
+        if _contains_needle(label, needle):
+            findings.append(f"{label}: contains {needle.reason}")
     return findings
 
 
-def scan_text(label: str, text: str) -> list[str]:
+def scan_text(
+    label: str,
+    text: str,
+    rel: Path,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+) -> list[str]:
     """Scan text content for forbidden strings and non-empty secret assignments."""
     findings = []
-    for needle, reason in FORBIDDEN_TEXT.items():
-        if needle in text:
-            findings.append(f"{label}: contains {reason} ({needle})")
+    for needle in needles:
+        if _contains_needle(text, needle):
+            findings.append(f"{label}: contains {needle.reason}")
 
-    for match in SECRET_ASSIGNMENT_RE.finditer(text):
-        value = match.group(2).strip()
-        if value and not value.startswith(("YOUR_", "your_", "<", "$")):
-            findings.append(f"{label}: contains non-empty {match.group(1)} assignment")
+    if _is_secret_assignment_file(rel):
+        findings.extend(scan_secret_assignments(label, text))
     return findings
 
 
-def scan_dist_archives() -> list[str]:
+def _contains_needle(haystack: str, needle: ForbiddenNeedle) -> bool:
+    if needle.case_sensitive:
+        return needle.value in haystack
+    return needle.value.casefold() in haystack.casefold()
+
+
+def _is_secret_assignment_file(rel: Path) -> bool:
+    name = rel.name.lower()
+    return name.startswith(".env") or rel.suffix.lower() in SECRET_FILE_SUFFIXES
+
+
+def scan_secret_assignments(label: str, text: str) -> list[str]:
+    """Find concrete secret assignments in env-like, JSON, YAML, and TOML text."""
+    findings = []
+    for key, value in _secret_assignments(text):
+        if SECRET_KEY_RE.fullmatch(key) and not _is_placeholder_secret(value):
+            findings.append(f"{label}: contains non-placeholder {key} assignment")
+    return findings
+
+
+def _secret_assignments(text: str) -> Iterable[tuple[str, str]]:
+    for match in ENV_SECRET_ASSIGNMENT_RE.finditer(text):
+        yield match.group(1), match.group(3)
+    for match in JSON_SECRET_ASSIGNMENT_RE.finditer(text):
+        yield match.group(1), match.group(2)
+
+
+def _is_placeholder_secret(value: str) -> bool:
+    normalized = value.strip().strip("'\"").rstrip(",").casefold()
+    if not normalized:
+        return True
+    if normalized in PLACEHOLDER_VALUES:
+        return True
+    return normalized.startswith(PLACEHOLDER_PREFIXES)
+
+
+def scan_structural_checks(root: Path, tracked: Iterable[Path]) -> list[str]:
+    """Run repository-structure checks that cannot be caught by text needles."""
+    findings = []
+    for rel in tracked:
+        if rel.parts and rel.parts[0] == ".planning":
+            findings.append(f"{rel}: private planning corpus must not be tracked")
+
+    if _blocked_distribution_name(root) and _publish_has_tag_trigger(root):
+        findings.append(
+            ".github/workflows/publish.yml: tag publishing is enabled "
+            "before the blocked distribution name is renamed"
+        )
+    return findings
+
+
+def _blocked_distribution_name(root: Path) -> bool:
+    pyproject = root / "workers/automation/pyproject.toml"
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    match = PROJECT_NAME_RE.search(text)
+    return bool(match and match.group(1) == "jobhunter")
+
+
+def _publish_has_tag_trigger(root: Path) -> bool:
+    workflow = root / ".github/workflows/publish.yml"
+    try:
+        lines = workflow.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return False
+
+    in_on_block = False
+    in_push_block = False
+    push_indent = 0
+    for raw_line in lines:
+        content = raw_line.split("#", 1)[0].rstrip()
+        if not content.strip():
+            continue
+        indent = len(content) - len(content.lstrip())
+        stripped = content.strip()
+
+        if indent == 0 and stripped == "on:":
+            in_on_block = True
+            in_push_block = False
+            continue
+        if in_on_block and indent == 0:
+            break
+        if not in_on_block:
+            continue
+
+        if stripped == "push:":
+            in_push_block = True
+            push_indent = indent
+            continue
+        if in_push_block and indent <= push_indent:
+            in_push_block = False
+        if in_push_block and stripped.startswith("tags:"):
+            return True
+
+    return False
+
+
+def scan_prompt_tripwires(root: Path, *, strict_prompt: bool) -> ScanResult:
+    """Scan apply prompt safety issues that W1 items remove later."""
+    result = ScanResult(findings=[], warnings=[])
+    path = root / PROMPT_PATH
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return result
+
+    messages = []
+    if "API key: {capsolver_key" in text:
+        messages.append(f"{PROMPT_PATH}: CapSolver key is interpolated into prompt text")
+    if "Age 18+: Yes" in text and "Felony: No" in text:
+        messages.append(f"{PROMPT_PATH}: hardcoded attestation defaults remain")
+    if "{personal.get('password', '')}" in text:
+        messages.append(f"{PROMPT_PATH}: profile password is interpolated into prompt text")
+
+    if strict_prompt:
+        result.findings.extend(messages)
+    else:
+        result.warnings.extend(messages)
+    return result
+
+
+def scan_dist_archives(
+    root: Path = ROOT,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+) -> list[str]:
     """Scan built wheel and sdist archives when present."""
-    dist = ROOT / "dist"
     findings: list[str] = []
-    if not dist.exists():
-        return findings
-
-    for archive in sorted(dist.glob("*")):
-        if archive.suffix == ".whl":
-            findings.extend(scan_zip_archive(archive))
-        elif archive.name.endswith(".tar.gz"):
-            findings.extend(scan_tar_archive(archive))
+    for dist in ARCHIVE_DIRS:
+        dist_path = root / dist
+        if not dist_path.exists():
+            continue
+        for archive in sorted(dist_path.glob("*")):
+            if archive.suffix == ".whl":
+                findings.extend(scan_zip_archive(root, archive, needles=needles))
+            elif archive.name.endswith(".tar.gz"):
+                findings.extend(scan_tar_archive(root, archive, needles=needles))
     return findings
 
 
-def scan_zip_archive(path: Path) -> list[str]:
+def scan_zip_archive(
+    root: Path,
+    path: Path,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+) -> list[str]:
     """Scan a wheel archive."""
     findings: list[str] = []
     with zipfile.ZipFile(path) as archive:
         for info in archive.infolist():
             member = Path(info.filename)
-            label = f"{path.relative_to(ROOT)}!{info.filename}"
-            findings.extend(scan_name(label, member.name, member.suffix))
+            label = f"{path.relative_to(root)}!{info.filename}"
+            findings.extend(scan_name(label, member, needles=needles))
             if member.suffix in TEXT_SUFFIXES:
                 try:
                     text = archive.read(info).decode("utf-8")
                 except UnicodeDecodeError:
                     continue
-                findings.extend(scan_text(label, text))
+                findings.extend(scan_text(label, text, member, needles=needles))
     return findings
 
 
-def scan_tar_archive(path: Path) -> list[str]:
+def scan_tar_archive(
+    root: Path,
+    path: Path,
+    *,
+    needles: Iterable[ForbiddenNeedle] = FORBIDDEN_TEXT,
+) -> list[str]:
     """Scan an sdist archive."""
     findings: list[str] = []
     with tarfile.open(path) as archive:
@@ -160,8 +479,8 @@ def scan_tar_archive(path: Path) -> list[str]:
             if not info.isfile():
                 continue
             member = Path(info.name)
-            label = f"{path.relative_to(ROOT)}!{info.name}"
-            findings.extend(scan_name(label, member.name, member.suffix))
+            label = f"{path.relative_to(root)}!{info.name}"
+            findings.extend(scan_name(label, member, needles=needles))
             if member.suffix in TEXT_SUFFIXES:
                 extracted = archive.extractfile(info)
                 if extracted is None:
@@ -170,7 +489,7 @@ def scan_tar_archive(path: Path) -> list[str]:
                     text = extracted.read().decode("utf-8")
                 except UnicodeDecodeError:
                     continue
-                findings.extend(scan_text(label, text))
+                findings.extend(scan_text(label, text, member, needles=needles))
     return findings
 
 

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_RELEASE_CHECK_PATH = Path(__file__).resolve().parents[3] / "scripts/release_check.py"
+_SPEC = importlib.util.spec_from_file_location("release_check", _RELEASE_CHECK_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+release_check = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = release_check
+_SPEC.loader.exec_module(release_check)
+
+
+def test_public_byline_files_do_not_trigger_default_needles() -> None:
+    for rel in (
+        Path("package.json"),
+        Path("workers/automation/pyproject.toml"),
+        Path("README.md"),
+    ):
+        label = rel.as_posix()
+        text = (release_check.ROOT / rel).read_text(encoding="utf-8")
+
+        assert release_check.scan_name(label, rel) == []
+        assert release_check.scan_text(label, text, rel) == []
+
+
+def test_release_check_catches_synthetic_violation_per_class(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".github/workflows/publish.yml",
+        """
+        name: Publish
+        on:
+          push:
+            tags:
+              - "v*"
+        jobs: {}
+        """,
+    )
+    _write(
+        tmp_path / "workers/automation/pyproject.toml",
+        """
+        [project]
+        name = "jobhunter"
+        """,
+    )
+    _write(
+        tmp_path / "workers/automation/src/jobhunter/apply/prompt.py",
+        """
+        section = f"API key: {capsolver_key}"
+        defaults = ["Age 18+: Yes", "Felony: No"]
+        login = f"{personal.get('password', '')}"
+        """,
+    )
+    _write(tmp_path / "docs/private.md", "SyntheticSecret")
+    _write(tmp_path / "exports/dump.sql", "syntheticsecret")
+    _write(tmp_path / "config/app.toml", 'SERVICE_API_KEY = "live-secret"')
+    _write(tmp_path / ".planning/notes.md", "private planning")
+    _write(tmp_path / "runtime/state.sqlite", "")
+    _write(tmp_path / "chrome-user-data/Default/Preferences", "{}")
+    _track_all(tmp_path)
+
+    result = release_check.scan_tree(
+        tmp_path,
+        needles=(release_check.ForbiddenNeedle("SyntheticSecret", "synthetic identity"),),
+        strict_prompt=True,
+    )
+    findings = "\n".join(result.findings)
+
+    assert "contains synthetic identity" in findings
+    assert "runtime/state.sqlite: private/runtime file" in findings
+    assert "browser profile artifact" in findings
+    assert "non-placeholder SERVICE_API_KEY assignment" in findings
+    assert ".planning/notes.md: private planning corpus" in findings
+    assert "tag publishing is enabled" in findings
+    assert "CapSolver key is interpolated" in findings
+    assert "hardcoded attestation defaults remain" in findings
+    assert "profile password is interpolated" in findings
+
+
+def test_release_check_clean_temp_tree_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".github/workflows/publish.yml",
+        """
+        name: Publish
+        on:
+          workflow_dispatch:
+        jobs: {}
+        """,
+    )
+    _write(
+        tmp_path / "workers/automation/pyproject.toml",
+        """
+        [project]
+        name = "jobhunter"
+        """,
+    )
+    _write(tmp_path / "config/app.toml", 'SERVICE_API_KEY = "YOUR_SERVICE_API_KEY"')
+    _write(tmp_path / "docs/readme.md", "Synthetic public docs.")
+    _track_all(tmp_path)
+
+    result = release_check.scan_tree(
+        tmp_path,
+        needles=(release_check.ForbiddenNeedle("SyntheticSecret", "synthetic identity"),),
+    )
+
+    assert result.findings == []
+    assert result.warnings == []
+
+
+def test_publish_tag_trigger_fails_under_blocked_distribution_name(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".github/workflows/publish.yml",
+        """
+        name: Publish
+        on:
+          push:
+            tags:
+              - "v*"
+        jobs: {}
+        """,
+    )
+    _write(
+        tmp_path / "workers/automation/pyproject.toml",
+        """
+        [project]
+        name = "jobhunter"
+        """,
+    )
+    _track_all(tmp_path)
+
+    result = release_check.scan_tree(
+        tmp_path,
+        needles=(release_check.ForbiddenNeedle("SyntheticSecret", "synthetic identity"),),
+    )
+
+    assert any("tag publishing is enabled" in finding for finding in result.findings)
+
+
+def test_prompt_tripwires_warn_until_strict(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "workers/automation/src/jobhunter/apply/prompt.py",
+        """
+        section = f"API key: {capsolver_key}"
+        defaults = ["Age 18+: Yes", "Felony: No"]
+        login = f"{personal.get('password', '')}"
+        """,
+    )
+
+    warning_result = release_check.scan_prompt_tripwires(tmp_path, strict_prompt=False)
+    strict_result = release_check.scan_prompt_tripwires(tmp_path, strict_prompt=True)
+
+    assert warning_result.findings == []
+    assert len(warning_result.warnings) == 3
+    assert strict_result.warnings == []
+    assert len(strict_result.findings) == 3
+
+
+def test_cli_exit_code_is_nonzero_on_synthetic_violation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _write(
+        tmp_path / ".github/workflows/publish.yml",
+        """
+        name: Publish
+        on:
+          workflow_dispatch:
+        jobs: {}
+        """,
+    )
+    _write(
+        tmp_path / "workers/automation/pyproject.toml",
+        """
+        [project]
+        name = "jobhunter"
+        """,
+    )
+    _write(tmp_path / "leak.md", "SyntheticSecret")
+    _track_all(tmp_path)
+
+    monkeypatch.setattr(release_check, "ROOT", tmp_path)
+    monkeypatch.setattr(
+        release_check,
+        "FORBIDDEN_TEXT",
+        (release_check.ForbiddenNeedle("SyntheticSecret", "synthetic identity"),),
+    )
+
+    assert release_check.main(()) == 1
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dedent(text), encoding="utf-8")
+
+
+def _dedent(text: str) -> str:
+    lines = text.splitlines()
+    if lines and not lines[0].strip():
+        lines = lines[1:]
+    if lines and not lines[-1].strip():
+        lines = lines[:-1]
+    indents = [len(line) - len(line.lstrip()) for line in lines if line.strip()]
+    indent = min(indents, default=0)
+    return "\n".join(line[indent:] for line in lines) + "\n"
+
+
+def _track_all(root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+    subprocess.run(["git", "add", "."], cwd=root, check=True, capture_output=True)


### PR DESCRIPTION
## What
- Replaced the v1 release scanner with an injectable v2 scanner covering case-insensitive identity needles, private path/tooling fragments, file-type and browser-profile artifacts, broader text suffixes, generalized secret assignments, structural repository checks, and apply-prompt tripwires.
- Added W0.3 pytest coverage for byline collision, synthetic violation classes, clean temp trees, the publish tag trigger plus blocked distribution fixture, prompt strictness, and nonzero CLI behavior.
- Kept prompt tripwires as default warnings and `--strict-prompt` failures for the later W1 flip.

## Why
W0.3 in `docs/plans/2026-07-03-oss-release-remediation-spec.md` broadens `release_check.py` so the repository catches the leak classes that occurred, while W0.5 keeps the publish-trigger structural check green on the post-W0.5 tree.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_release_check.py`
  - `6 passed in 0.89s`
- `uv --project workers/automation run --extra dev ruff check scripts/release_check.py workers/automation/tests/test_release_check.py`
  - `All checks passed!`
- `python3 scripts/release_check.py --strict-prompt`
  - exited 1 as expected with three prompt tripwire findings
- `uv --project workers/automation run --extra dev pytest -q`
  - `1716 passed in 44.13s`
- `uv --project workers/automation run --extra dev ruff check .`
  - `All checks passed!`
- `uv --project workers/automation run --extra dev python -m build workers/automation`
  - `Successfully built jobhunter-0.3.0.tar.gz and jobhunter-0.3.0-py3-none-any.whl`
- `pnpm api:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `pnpm api:test`
  - `Test Files  19 passed (19)`
  - `Tests  323 passed (323)`
- `pnpm qa:test`
  - `Test Files  1 passed (1)`
  - `Tests  3 passed (3)`
- `pnpm web:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-3-vitest/localStorage.json pnpm --filter @jobhunter/web test`
  - `Test Files  145 passed (145)`
  - `Tests  895 passed (895)`
- `pnpm --filter @jobhunter/web test-d`
  - `Test Files  9 passed (9)`
  - `Tests  9 passed (9)`
  - `Type Errors  no errors`
- `pnpm check`
  - `All checks passed!`
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-3-vitest/full-test-localStorage.json pnpm test`
  - `Test Files  19 passed (19)`
  - `Tests  323 passed (323)`
  - `1716 passed in 26.93s`
- `python3 scripts/release_check.py`
  - `Release check warnings:`
  - `workers/automation/src/jobhunter/apply/prompt.py: CapSolver key is interpolated into prompt text`
  - `workers/automation/src/jobhunter/apply/prompt.py: hardcoded attestation defaults remain`
  - `workers/automation/src/jobhunter/apply/prompt.py: profile password is interpolated into prompt text`
  - `Release check passed.`
- `git diff --check`
  - no output

## Deviations
None.

## Deferred
- Prompt tripwire strict-green fixes remain deferred to W1.4/W1.5/W1.6 per W0.3 item 8.