### PR TITLE
ci(release): run release_check on every push and PR without path filters

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,29 @@
+name: Release Privacy Gate
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  release-check:
+    name: Release check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test runner
+        run: python -m pip install pytest
+
+      - name: Run release check
+        run: python3 scripts/release_check.py
+
+      - name: Run release check self-test
+        run: python3 -m pytest -q workers/automation/tests/test_release_check.py

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install test runner
-        run: python -m pip install pytest
+      - name: Install dependencies
+        run: python -m pip install -e "workers/automation[dev]"
 
       - name: Run release check
         run: python3 scripts/release_check.py

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: python -m pip install -e "workers/automation[dev]"
+      - name: Install test runner
+        run: python -m pip install pytest
 
       - name: Run release check
         run: python3 scripts/release_check.py
 
       - name: Run release check self-test
-        run: python3 -m pytest -q workers/automation/tests/test_release_check.py
+        run: python3 -m pytest -q --noconftest workers/automation/tests/test_release_check.py

--- a/release-check-scratch.toml
+++ b/release-check-scratch.toml
@@ -1,0 +1,1 @@
+W04_API_KEY = "sk-live-synthetic-release-check"

--- a/release-check-scratch.toml
+++ b/release-check-scratch.toml
@@ -1,1 +1,0 @@
-W04_API_KEY = "sk-live-synthetic-release-check"


### PR DESCRIPTION
## What
- Added `.github/workflows/release-check.yml` as an unfiltered privacy gate.
- The workflow runs on pushes to `main` and on all pull requests, with no `paths:` filter.
- The job runs `python3 scripts/release_check.py` and the W0.3 release-check self-test with pytest isolated from unrelated worker conftest setup.

## Why
W0.4 in `docs/plans/2026-07-03-oss-release-remediation-spec.md` requires the privacy scanner to run on every PR and on main pushes so no change can avoid the release scan through path filtering. This branch was rebased onto current `main` after temporal P2 landed.

## Validation
- `rg -n "paths:|workflow_dispatch|tags:|push:|pull_request:" .github/workflows/release-check.yml`
  - `4:  push:`
  - `6:  pull_request:`
- `python3 scripts/release_check.py`
  - `Release check warnings:`
  - `workers/automation/src/jobhunter/apply/prompt.py: CapSolver key is interpolated into prompt text`
  - `workers/automation/src/jobhunter/apply/prompt.py: hardcoded attestation defaults remain`
  - `workers/automation/src/jobhunter/apply/prompt.py: profile password is interpolated into prompt text`
  - `Release check passed.`
- `uv --project workers/automation run --extra dev pytest -q --noconftest workers/automation/tests/test_release_check.py`
  - `6 passed in 0.41s`
- `uv --project workers/automation run --extra dev pytest -q`
  - `1727 passed in 39.75s`
- `uv --project workers/automation run --extra dev ruff check .`
  - `All checks passed!`
- `uv --project workers/automation run --extra dev python -m build workers/automation`
  - `Successfully built jobhunter-0.3.0.tar.gz and jobhunter-0.3.0-py3-none-any.whl`
- `pnpm api:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `pnpm api:test`
  - `Test Files  19 passed (19)`
  - `Tests  324 passed (324)`
- `pnpm qa:test`
  - `Test Files  1 passed (1)`
  - `Tests  3 passed (3)`
- `pnpm web:check`
  - `tsc --noEmit --project tsconfig.json` completed successfully
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-4-vitest/rebased-localStorage.json pnpm --filter @jobhunter/web test`
  - `Test Files  145 passed (145)`
  - `Tests  903 passed (903)`
- `pnpm --filter @jobhunter/web test-d`
  - `Test Files  9 passed (9)`
  - `Tests  9 passed (9)`
  - `Type Errors  no errors`
- `pnpm check`
  - `All checks passed!`
- `NODE_OPTIONS=--localstorage-file=/tmp/jobhunter-w0-4-vitest/rebased-full-test-localStorage.json pnpm test`
  - `Test Files  19 passed (19)`
  - `Tests  324 passed (324)`
  - `1727 passed in 40.91s`
- `git diff --check`
  - no output

CI demonstration:
- Synthetic failing run: https://github.com/ebarti/JobHunter/actions/runs/28684234386 (`release-check-scratch.toml: contains non-placeholder W04_API_KEY assignment`).
- Reverted passing run on the rebased branch: https://github.com/ebarti/JobHunter/actions/runs/28684318161 (`Release check` job succeeded, including `Run release check` and `Run release check self-test`).

## Deviations
None.

## Deferred
None.