### PR TITLE
fix(api): reject cross-site fetch metadata

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,17 @@ The current supported mode is local-only. The TypeScript API binds to loopback b
 default and refuses non-loopback hosts unless explicitly configured. Hosted auth,
 tenant isolation, billing, managed browsers, and production secret vaulting are
 roadmap items rather than current guarantees.
+
+The local API browser boundary is defense in depth, not authentication. Requests
+must target a loopback `Host` (`localhost`, `127.0.0.1`, or `[::1]`), CORS only
+reflects loopback origins, and unsafe mutation requests must either carry trusted
+loopback `Origin`/`Referer` metadata or no browser origin metadata at all. When a
+browser sends `Sec-Fetch-Site`, unsafe mutations accept `same-origin` or `none`;
+`same-site` is accepted only with trusted loopback `Origin`/`Referer` metadata,
+and `cross-site` is rejected. Headerless local clients such as curl, seed
+scripts, and other local automation remain allowed because local processes are
+trusted in the supported local-only mode.
+
+Setting `JOBHUNTER_API_ALLOW_REMOTE_BIND=1` allows a non-loopback API bind. That
+is an operator-owned risk for controlled environments only; do not expose that
+mode on untrusted networks or treat it as a hosted security boundary.

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -215,6 +215,8 @@ const APPLY_REVIEW_PRECONDITION_ERRORS = new Set([
   "approval_stale_url",
   "partial_override_evidence_invalid",
 ]);
+const TRUSTED_SEC_FETCH_SITE_VALUES = new Set(["same-origin", "none"]);
+const LOOPBACK_ORIGIN_SEC_FETCH_SITE_VALUES = new Set(["same-origin", "same-site", "none"]);
 const execFileAsync = promisify(execFile);
 
 export type ArtifactPdfPageRenderer = (pdfPath: string, pageNumber: number) => Promise<Buffer>;
@@ -269,14 +271,27 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
     if (!UNSAFE_METHODS.has(request.method)) {
       return;
     }
-    if (isTrustedMutationSource(request.headers.origin, request.headers.referer)) {
-      return;
+    const hasBrowserOriginMetadata =
+      hasRequestHeader(request.headers.origin) || hasRequestHeader(request.headers.referer);
+    if (!isTrustedMutationSource(request.headers.origin, request.headers.referer)) {
+      return reply.code(403).send({
+        ok: false,
+        error: "cross_site_request",
+        message: "Mutation requests require a loopback Origin or Referer.",
+      });
     }
-    return reply.code(403).send({
-      ok: false,
-      error: "cross_site_request",
-      message: "Mutation requests require a loopback Origin or Referer.",
-    });
+    if (
+      !isTrustedSecFetchSite(request.headers["sec-fetch-site"], {
+        allowLoopbackSameSite: hasBrowserOriginMetadata,
+      })
+    ) {
+      return reply.code(403).send({
+        ok: false,
+        error: "cross_site_request",
+        message: "Mutation requests require trusted Sec-Fetch-Site metadata.",
+      });
+    }
+    return;
   });
 
   app.get("/v1/health", async () => ({
@@ -2846,6 +2861,25 @@ function parseBody<T>(reply: { code: (statusCode: number) => unknown }, schema: 
   }
   void reply.code(400);
   return null;
+}
+
+function isTrustedSecFetchSite(
+  secFetchSiteHeader: string | string[] | undefined,
+  options: { allowLoopbackSameSite?: boolean } = {},
+): boolean {
+  const values = Array.isArray(secFetchSiteHeader)
+    ? secFetchSiteHeader
+    : secFetchSiteHeader
+      ? [secFetchSiteHeader]
+      : [];
+  const trustedValues = options.allowLoopbackSameSite
+    ? LOOPBACK_ORIGIN_SEC_FETCH_SITE_VALUES
+    : TRUSTED_SEC_FETCH_SITE_VALUES;
+  return values.length === 0 || values.every((value) => trustedValues.has(value.trim()));
+}
+
+function hasRequestHeader(header: string | string[] | undefined): boolean {
+  return Array.isArray(header) ? header.length > 0 : header !== undefined;
 }
 
 function stageRunStatus(actions: ActionRunResponse[]): string {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -578,6 +578,88 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it.each([
+    {
+      name: "cross-site browser metadata",
+      jobUrl: "https://example.com/jobs/ready",
+      action: "mark-applied",
+      payload: { reason: "cross-site metadata" },
+      headers: { "sec-fetch-site": "cross-site" },
+      expectedStatus: 403,
+      expectedBody: { ok: false, error: "cross_site_request" },
+    },
+    {
+      name: "same-site browser metadata without loopback origin",
+      jobUrl: "https://example.com/jobs/ready",
+      action: "mark-applied",
+      payload: { reason: "same-site metadata" },
+      headers: { "sec-fetch-site": "same-site" },
+      expectedStatus: 403,
+      expectedBody: { ok: false, error: "cross_site_request" },
+    },
+    {
+      name: "loopback same-site browser metadata",
+      jobUrl: "https://example.com/jobs/ready",
+      action: "mark-applied",
+      payload: { reason: "loopback same-site metadata" },
+      headers: { origin: "http://127.0.0.1:5173", "sec-fetch-site": "same-site" },
+      expectedStatus: 200,
+      expectedBody: { action: "mark_applied", stage: { state: "succeeded" } },
+    },
+    {
+      name: "same-origin browser metadata",
+      jobUrl: "https://example.com/jobs/ready",
+      action: "mark-applied",
+      payload: { reason: "same-origin browser" },
+      headers: { origin: "http://127.0.0.1:5173", "sec-fetch-site": "same-origin" },
+      expectedStatus: 200,
+      expectedBody: { action: "mark_applied", stage: { state: "succeeded" } },
+    },
+    {
+      name: "browser navigation metadata",
+      jobUrl: "https://example.com/jobs/blocked-tailor",
+      action: "mark-skipped",
+      payload: { reason: "browser navigation" },
+      headers: { "sec-fetch-site": "none" },
+      expectedStatus: 200,
+      expectedBody: { action: "mark_skipped", stage: { state: "skipped" } },
+    },
+    {
+      name: "headerless curl-style mutation",
+      jobUrl: "https://example.com/jobs/failed-score",
+      action: "mark-skipped",
+      payload: { reason: "CLI" },
+      headers: {},
+      expectedStatus: 200,
+      expectedBody: { action: "mark_skipped", stage: { state: "skipped" } },
+    },
+  ])("enforces the unsafe mutation CSRF matrix for $name", async (testCase) => {
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: `/v1/jobs/${encodeURIComponent(testCase.jobUrl)}/actions/${testCase.action}`,
+        headers: testCase.headers,
+        payload: testCase.payload,
+      });
+
+      expect(response.statusCode, response.body).toBe(testCase.expectedStatus);
+      expect(response.json()).toMatchObject(testCase.expectedBody);
+
+      if (testCase.expectedStatus === 403) {
+        const db = new Database(options.dbPath);
+        const row = db.prepare("SELECT apply_status, applied_at FROM jobs WHERE url = ?").get(testCase.jobUrl) as {
+          apply_status: string | null;
+          applied_at: string | null;
+        };
+        db.close();
+        expect(row).toMatchObject({ apply_status: null, applied_at: null });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
   it("allows loopback browser and no-origin mutation callers", async () => {
     const app = buildApp(options);
     const appliedKey = encodeURIComponent("https://example.com/jobs/ready");

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -15,7 +15,11 @@ any request whose `Host` header is not a loopback host (`127.0.0.1`,
 local browser and CLI callers always send a loopback `Host`, so legitimate
 access is unaffected. A second guard rejects cross-site mutations: `DELETE`,
 `PATCH`, `POST`, and `PUT` requests whose `Origin` or `Referer` is present but
-not loopback fail with `403` `cross_site_request` before any handler runs.
+not loopback fail with `403` `cross_site_request` before any handler runs. When
+browser fetch metadata is present, unsafe mutations also reject
+`Sec-Fetch-Site: cross-site`; `same-site` is accepted only after the loopback
+`Origin`/`Referer` check has passed, so the default Vite web app on another
+loopback port still works while foreign browser origins do not.
 Full bearer-token authentication and keychain-to-worker
 credential passing remain a deliberate follow-up that needs coordinated
 frontend and dev-launcher changes.


### PR DESCRIPTION
## What

- Adds a `Sec-Fetch-Site` unsafe-method gate after the existing local Host/Origin/Referer checks.
- Keeps non-browser local clients working when fetch metadata is absent.
- Documents the loopback trust boundary in `SECURITY.md` and `docs/local-ts-api.md`.
- Adds API regression coverage for cross-site, same-origin, none, same-site, and headerless local-client cases.

## Why

W2.3 closes the browser fetch-metadata gap without changing the local-first API model. Cross-site browser requests should fail even if they try to spoof other trusted-looking mutation metadata, while local scripts and seeds remain supported.

## Validation

- `corepack pnpm api:check`
- `corepack pnpm api:test` (20 files / 346 tests)
- `corepack pnpm qa:test` (3 tests)
- `corepack pnpm check`
- `corepack pnpm test` (API 346 tests, web build, Python 1806 tests)
- `corepack pnpm docs:build` (4545 references / 230 emitted files)
- `python3 scripts/release_check.py` (passes with the three expected W0 prompt warnings called out in the remediation prompt)
- `git diff --check`
- Review: W2.3 reviewer Gate: PASS
- QA: W2.3 QA Gate: PASS; one Low docs gap was addressed before this PR was opened

## Deviations

None. W2.1 rename/publish work is explicitly out of scope, so this PR keeps all `JobHunter`/`jobhunter` names unchanged.

## Deferred

None for W2.3.