### PR TITLE
chore(governance): require DCO sign-offs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+-
+
+## Validation
+
+-
+
+## Checklist
+
+- [ ] Every commit in this PR includes a DCO `Signed-off-by:` trailer (`git commit -s`).

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,21 @@
+name: DCO
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check commit sign-offs
+        uses: KineticCafe/actions-dco@v3.1.0
+        with:
+          config: |
+            [bot]
+            policy = "none"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,10 +27,30 @@ JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
 
 - Keep changes scoped to one behavior or documentation concern.
 - Use Conventional Commits for commit messages and PR titles.
+- Sign off every commit with the Developer Certificate of Origin trailer.
 - Update documentation when public behavior, commands, runtime requirements,
   configuration, architecture, or QA expectations change.
 - Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
   profiles, SQLite databases, or generated application materials.
+
+## Developer Certificate of Origin Sign-Off
+
+Every pull request commit must include a `Signed-off-by:` trailer. This is a
+DCO sign-off that says you have the right to submit the contribution; it is
+separate from GPG or SSH commit signing.
+
+Use `git commit -s` for new commits:
+
+```bash
+git commit -s -m "fix: describe the change"
+```
+
+If you already made a commit, amend or rebase it before pushing:
+
+```bash
+git commit --amend -s --no-edit
+git rebase --signoff origin/main
+```
 
 ## Validation
 


### PR DESCRIPTION
## What

- Adds a DCO workflow for pull requests.
- Updates the pull request template with the sign-off expectation.
- Documents `git commit -s` contribution guidance in `CONTRIBUTING.md`.

## Why

W2.5 makes contributor sign-off explicit before the repository is made public, while avoiding bot exemptions that would hide missing human sign-offs.

## Validation

- `python3 scripts/release_check.py` (passes with the three expected W0 prompt warnings called out in the remediation prompt)
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dco.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dco.yml`
- `python3 -m pytest -q --noconftest workers/automation/tests/test_release_check.py` (6 passed, 1 pytest config warning)
- `corepack pnpm qa:test` (3 tests)
- `corepack pnpm check`
- `corepack pnpm test` (API 340 tests, web build, Python 1806 tests)
- `git diff --check origin/main...HEAD`
- QA: W2.5 QA Gate: PASS

## Deviations

None. W2.1 rename/publish work is explicitly out of scope, so this PR keeps all `JobHunter`/`jobhunter` names unchanged.

## Deferred

The DCO workflow must still be observed green on this PR after GitHub Actions runs.