### PR TITLE
feat(apply): bind approvals to materials/profile/URL and dry-run evidence

### DIFF
--- a/apps/api/src/application-feedback.ts
+++ b/apps/api/src/application-feedback.ts
@@ -11,6 +11,8 @@ import type {
   ApplyReviewDecisionRequest,
   ApplyReviewDecisionResponse,
   ApplyReviewDecisionValue,
+  ApplyReviewApprovalGateReason,
+  ApplyReviewDryRunEvidence,
   ApplyReviewIdealRequirement,
   ApplyReviewProfileSourceField,
   ApplyReviewCoverageBasis,
@@ -91,6 +93,10 @@ interface ReviewQueueRow extends Record<string, unknown> {
   decision_id: string | null;
   decision: string | null;
   decided_at: string | null;
+  decision_materials_generation: number | null;
+  decision_profile_version: number | null;
+  decision_application_url: string | null;
+  partial_override_run_id: string | null;
   run_id: string | null;
   apply_run_status: string | null;
   result: string | null;
@@ -138,6 +144,10 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
       reason       TEXT,
       decided_by   TEXT NOT NULL DEFAULT 'user',
       decided_at   TEXT NOT NULL,
+      materials_generation INTEGER,
+      profile_version INTEGER,
+      application_url TEXT,
+      partial_override_run_id TEXT,
       PRIMARY KEY (tenant_id, decision_id)
     );
     CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
@@ -205,6 +215,22 @@ export function ensureApplicationFeedbackTables(db: SqliteDatabase): void {
     CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
       ON application_outcome_suggestions(tenant_id, status, created_at DESC);
   `);
+  ensureApplicationReviewDecisionColumns(db);
+}
+
+function ensureApplicationReviewDecisionColumns(db: SqliteDatabase): void {
+  const columns = tableColumnSet(db, "application_review_decisions");
+  const additions: Record<string, string> = {
+    materials_generation: "INTEGER",
+    profile_version: "INTEGER",
+    application_url: "TEXT",
+    partial_override_run_id: "TEXT",
+  };
+  for (const [column, definition] of Object.entries(additions)) {
+    if (!columns.has(column)) {
+      db.exec(`ALTER TABLE application_review_decisions ADD COLUMN ${column} ${definition}`);
+    }
+  }
 }
 
 export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueResponse {
@@ -256,9 +282,13 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
     db,
     `
     WITH latest_decision AS (
-      SELECT decision_id, job_key, decision, decided_at
+      SELECT decision_id, job_key, decision, decided_at,
+             materials_generation, profile_version, application_url,
+             partial_override_run_id
       FROM (
         SELECT decision_id, job_key, decision, decided_at,
+               materials_generation, profile_version, application_url,
+               partial_override_run_id,
                ROW_NUMBER() OVER (
                  PARTITION BY tenant_id, job_key
                  ORDER BY decided_at DESC, decision_id DESC
@@ -306,6 +336,10 @@ export function listApplyReviewQueue(db: SqliteDatabase): ApplyReviewQueueRespon
            jlp.has_resume, jlp.has_cover_letter, jlp.has_pdf,
            latest_decision.decision_id, latest_decision.decision,
            latest_decision.decided_at,
+           latest_decision.materials_generation AS decision_materials_generation,
+           latest_decision.profile_version AS decision_profile_version,
+           latest_decision.application_url AS decision_application_url,
+           latest_decision.partial_override_run_id,
            latest_apply_run.run_id, latest_apply_run.status AS apply_run_status,
            latest_apply_run.result, latest_apply_run.dry_run,
            latest_apply_run.started_at, latest_apply_run.finished_at,
@@ -361,6 +395,49 @@ export function recordApplyReviewDecision(
 ): ApplyReviewDecisionResponse {
   ensureApplicationFeedbackTables(db);
   const jobUrl = existingJobUrl(db, jobKey);
+  const applicationUrl = currentApplicationUrl(db, jobUrl);
+  const materialsGeneration = currentReviewMaterialsGeneration(db, jobUrl);
+  const profileVersion = currentProfileVersion(db);
+  const partialOverrideRunId =
+    request.decision === "approve_submit" ? request.partialOverrideRunId ?? null : null;
+  if (request.decision === "approve_submit") {
+    if (
+      request.materialsGeneration === undefined ||
+      request.materialsGeneration !== materialsGeneration
+    ) {
+      throw new InputError("approval_stale_materials");
+    }
+    if (request.profileVersion === undefined || request.profileVersion !== profileVersion) {
+      throw new InputError("approval_stale_profile");
+    }
+    if (request.applicationUrl === undefined || request.applicationUrl !== applicationUrl) {
+      throw new InputError("approval_stale_url");
+    }
+  }
+  const fullDryRunEvidence =
+    request.decision === "approve_submit"
+      ? latestDryRunEvidence(db, {
+          jobKey: jobUrl,
+          materialsGeneration,
+          profileVersion,
+          applicationUrl,
+          coverage: "full",
+        })
+      : null;
+  if (partialOverrideRunId) {
+    const partialEvidence = latestDryRunEvidence(db, {
+      jobKey: jobUrl,
+      materialsGeneration,
+      profileVersion,
+      applicationUrl,
+      coverage: "partial",
+    });
+    if (partialEvidence?.runId !== partialOverrideRunId) {
+      throw new InputError("partial_override_evidence_invalid");
+    }
+  } else if (request.decision === "approve_submit" && !fullDryRunEvidence) {
+    throw new InputError("awaiting_dry_run");
+  }
   const decidedAt = new Date().toISOString();
   const decision: ApplyReviewDecision = {
     decisionId: crypto.randomUUID(),
@@ -369,12 +446,17 @@ export function recordApplyReviewDecision(
     reason: request.reason ?? null,
     decidedBy: request.decidedBy,
     decidedAt,
+    materialsGeneration,
+    profileVersion,
+    applicationUrl,
+    partialOverrideRunId,
   };
 
   db.prepare(
     `INSERT INTO application_review_decisions (
-       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+       tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+       materials_generation, profile_version, application_url, partial_override_run_id
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
   ).run(
     DEFAULT_TENANT,
     decision.decisionId,
@@ -383,6 +465,10 @@ export function recordApplyReviewDecision(
     decision.reason,
     decision.decidedBy,
     decision.decidedAt,
+    decision.materialsGeneration,
+    decision.profileVersion,
+    decision.applicationUrl,
+    decision.partialOverrideRunId,
   );
 
   recordEvent(db, {
@@ -396,6 +482,10 @@ export function recordApplyReviewDecision(
       decisionId: decision.decisionId,
       decision: decision.decision,
       reasonPresent: Boolean(decision.reason),
+      materialsGeneration: decision.materialsGeneration,
+      profileVersion: decision.profileVersion,
+      applicationUrl: decision.applicationUrl,
+      partialOverrideRunId: decision.partialOverrideRunId,
     },
   });
 
@@ -665,6 +755,29 @@ function reviewQueueItemFromRow(
   const scoreKeywords = boundedEvidenceList(parseStringListJson(row.score_keywords_json));
   const applicationUrl = applyTargetUrl(row);
   const materialsPreview = materialPreviewsForJob(db, row.job_id, profileSourceFields);
+  const materialsGeneration = materialsPreview.materialsGeneration;
+  const profileVersion = currentProfileVersion(db);
+  const dryRunEvidence = latestDryRunEvidence(db, {
+    jobKey: row.job_id,
+    materialsGeneration,
+    profileVersion,
+    applicationUrl,
+    coverage: "full",
+  });
+  const partialDryRunEvidence = latestDryRunEvidence(db, {
+    jobKey: row.job_id,
+    materialsGeneration,
+    profileVersion,
+    applicationUrl,
+    coverage: "partial",
+  });
+  const approvalReasons = approvalGateReasons(row, {
+    materialsGeneration,
+    profileVersion,
+    applicationUrl,
+    dryRunEvidence,
+    partialDryRunEvidence,
+  });
   const idealCandidate = cleanLimitedText(
     row.employer_ideal_candidate_narrative,
     IDEAL_CANDIDATE_TEXT_LIMIT,
@@ -758,9 +871,62 @@ function reviewQueueItemFromRow(
       state: reviewState(row.decision),
       decision: reviewDecision(row.decision),
       decidedAt: row.decided_at,
+      materialsGeneration: nullableNumber(row.decision_materials_generation),
+      profileVersion: nullableNumber(row.decision_profile_version),
+      applicationUrl: row.decision_application_url,
+      partialOverrideRunId: row.partial_override_run_id,
+    },
+    approvalGate: {
+      materialsGeneration,
+      profileVersion,
+      applicationUrl,
+      dryRunEvidence,
+      partialDryRunEvidence,
+      reasons: approvalReasons,
     },
     blockers,
   };
+}
+
+function approvalGateReasons(
+  row: ReviewQueueRow,
+  current: {
+    readonly materialsGeneration: number | null;
+    readonly profileVersion: number | null;
+    readonly applicationUrl: string | null;
+    readonly dryRunEvidence: ApplyReviewDryRunEvidence | null;
+    readonly partialDryRunEvidence: ApplyReviewDryRunEvidence | null;
+  },
+): ApplyReviewApprovalGateReason[] {
+  if (row.decision !== "approve_submit") {
+    return ["awaiting_approval"];
+  }
+  if (
+    row.decision_materials_generation === null ||
+    current.materialsGeneration === null ||
+    Number(row.decision_materials_generation) !== current.materialsGeneration
+  ) {
+    return ["approval_stale_materials"];
+  }
+  if (
+    row.decision_profile_version === null ||
+    current.profileVersion === null ||
+    Number(row.decision_profile_version) !== current.profileVersion
+  ) {
+    return ["approval_stale_profile"];
+  }
+  if (!row.decision_application_url || row.decision_application_url !== current.applicationUrl) {
+    return ["approval_stale_url"];
+  }
+  if (current.dryRunEvidence) {
+    return [];
+  }
+  if (row.partial_override_run_id) {
+    return current.partialDryRunEvidence?.runId === row.partial_override_run_id
+      ? []
+      : ["override_evidence_invalid"];
+  }
+  return ["awaiting_dry_run"];
 }
 
 function queueBlockers(row: ReviewQueueRow, currentState: StageState): string[] {
@@ -780,6 +946,160 @@ function applyTargetUrl(row: ReviewQueueRow): string | null {
   }
   const postingUrl = cleanBlockerText(row.job_id);
   return postingUrl || null;
+}
+
+function currentApplicationUrl(db: SqliteDatabase, jobKey: string): string | null {
+  if (tableExists(db, "job_list_projections")) {
+    const row = getRow<{ application_url: string | null; job_id: string }>(
+      db,
+      `SELECT application_url, job_id
+       FROM job_list_projections
+       WHERE tenant_id = ? AND job_id = ?`,
+      [DEFAULT_TENANT, jobKey],
+    );
+    if (row) {
+      return cleanBlockerText(row.application_url) || cleanBlockerText(row.job_id) || null;
+    }
+  }
+  if (tableExists(db, "jobs")) {
+    const row = getRow<{ application_url: string | null; url: string }>(
+      db,
+      "SELECT application_url, url FROM jobs WHERE url = ?",
+      [jobKey],
+    );
+    if (row) {
+      return cleanBlockerText(row.application_url) || cleanBlockerText(row.url) || null;
+    }
+  }
+  return jobKey || null;
+}
+
+function latestMaterialsGeneration(db: SqliteDatabase, jobKey: string): number | null {
+  if (!tableExists(db, "job_materials")) return null;
+  const row = getRow<{ generation: number | null }>(
+    db,
+    "SELECT MAX(generation) AS generation FROM job_materials WHERE job_url = ?",
+    [jobKey],
+  );
+  return nullableNumber(row?.generation);
+}
+
+function currentReviewMaterialsGeneration(db: SqliteDatabase, jobKey: string): number | null {
+  return resumeMaterialPreviewForJob(db, jobKey).materialsGeneration ?? latestMaterialsGeneration(db, jobKey);
+}
+
+function currentProfileVersion(db: SqliteDatabase): number | null {
+  if (!tableExists(db, "candidate_profiles")) return null;
+  const columns = tableColumnSet(db, "candidate_profiles");
+  if (!columns.has("version")) return null;
+  const row = getRow<{ version: number | null }>(
+    db,
+    "SELECT version FROM candidate_profiles WHERE tenant_id = ? AND profile_id = ?",
+    [DEFAULT_TENANT, DEFAULT_PROFILE_ID],
+  );
+  return nullableNumber(row?.version);
+}
+
+function latestDryRunEvidence(
+  db: SqliteDatabase,
+  expected: {
+    readonly jobKey: string;
+    readonly materialsGeneration: number | null;
+    readonly profileVersion: number | null;
+    readonly applicationUrl: string | null;
+    readonly coverage: "full" | "partial";
+  },
+): ApplyReviewDryRunEvidence | null {
+  if (
+    expected.materialsGeneration === null ||
+    expected.profileVersion === null ||
+    !expected.applicationUrl ||
+    !tableExists(db, "job_events")
+  ) {
+    return null;
+  }
+  const rows = allRows<{ payload_json: string | null; occurred_at: string | null }>(
+    db,
+    `SELECT payload_json, occurred_at
+     FROM job_events
+     WHERE job_url = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
+     ORDER BY event_id DESC
+     LIMIT 24`,
+    [expected.jobKey],
+  );
+  for (const row of rows) {
+    const payload = parseJsonRecord(row.payload_json);
+    const runId = stringValue(recordValue(payload, "runId", "run_id"));
+    if (!runId) continue;
+    const coverage = stringValue(recordValue(payload, "coverage", "dry_run_coverage"));
+    if (coverage !== expected.coverage) continue;
+    if (
+      !dryRunCompletionMatches(
+        db,
+        {
+          jobKey: expected.jobKey,
+          materialsGeneration: expected.materialsGeneration,
+          profileVersion: expected.profileVersion,
+          applicationUrl: expected.applicationUrl,
+        },
+        runId,
+        payload,
+      )
+    ) {
+      continue;
+    }
+    return {
+      runId,
+      coverage,
+      finishedAt: stringValue(recordValue(payload, "finishedAt", "finished_at")) || row.occurred_at,
+      blockedChannels: parseStringList(recordValue(payload, "blockedChannels", "blocked_channels")),
+    };
+  }
+  return null;
+}
+
+function dryRunCompletionMatches(
+  db: SqliteDatabase,
+  expected: {
+    readonly jobKey: string;
+    readonly materialsGeneration: number;
+    readonly profileVersion: number;
+    readonly applicationUrl: string;
+  },
+  runId: string,
+  completionPayload: Record<string, unknown> | null,
+): boolean {
+  const completionGeneration = nullableNumber(
+    recordValue(completionPayload, "materialsGeneration", "materials_generation"),
+  );
+  const completionProfileVersion = nullableNumber(
+    recordValue(completionPayload, "profileVersion", "profile_version"),
+  );
+  const completionUrl = stringValue(recordValue(completionPayload, "applicationUrl", "application_url"));
+  const started = getRow<{ payload_json: string | null }>(
+    db,
+    `SELECT payload_json
+     FROM job_events
+     WHERE job_url = ?
+       AND stage = 'apply'
+       AND event_type = 'ApplyRunStarted'
+       AND payload_json LIKE ?
+     ORDER BY event_id DESC
+     LIMIT 1`,
+    [expected.jobKey, `%${runId}%`],
+  );
+  const startedPayload = parseJsonRecord(started?.payload_json ?? null);
+  const matchedGeneration =
+    completionGeneration ?? nullableNumber(recordValue(startedPayload, "materialsGeneration", "materials_generation"));
+  const matchedProfileVersion =
+    completionProfileVersion ?? nullableNumber(recordValue(startedPayload, "profileVersion", "profile_version"));
+  const matchedUrl =
+    completionUrl || stringValue(recordValue(startedPayload, "applicationUrl", "application_url"));
+  return (
+    matchedGeneration === expected.materialsGeneration &&
+    matchedProfileVersion === expected.profileVersion &&
+    matchedUrl === expected.applicationUrl
+  );
 }
 
 function stageBlockerReason(row: ReviewQueueRow, currentState: StageState): string {
@@ -1440,6 +1760,7 @@ function uniqueProfileSourceFields(fields: readonly ApplyReviewProfileSourceFiel
 
 type ResumeMaterialPreview = Pick<
   ApplyReviewQueueItem["materialsPreview"],
+  | "materialsGeneration"
   | "resumeText"
   | "resumeTextArtifactId"
   | "resumePdfArtifactId"
@@ -1496,6 +1817,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
     });
     if (text) {
       return {
+        materialsGeneration: text.candidate.generation,
         resumeText: text.preview,
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: null,
@@ -1513,6 +1835,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
     );
     if (text) {
       return {
+        materialsGeneration: text.candidate.generation,
         resumeText: text.preview,
         resumeTextArtifactId: text.candidate.artifactId,
         resumePdfArtifactId: pdf.artifactId,
@@ -1526,6 +1849,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
   const pdfOnly = pdfCandidates[0];
   if (pdfOnly) {
     return {
+      materialsGeneration: pdfOnly.generation,
       resumeText: null,
       resumeTextArtifactId: null,
       resumePdfArtifactId: pdfOnly.artifactId,
@@ -1538,6 +1862,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
   const text = firstReadableTextCandidate(textCandidates, { byteLimit: RESUME_AUDIT_TEXT_BYTE_LIMIT, charLimit: null });
   if (text) {
     return {
+      materialsGeneration: text.candidate.generation,
       resumeText: text.preview,
       resumeTextArtifactId: text.candidate.artifactId,
       resumePdfArtifactId: null,
@@ -1548,6 +1873,7 @@ function resumeMaterialPreviewForJob(db: SqliteDatabase, jobKey: string): Resume
   }
 
   return {
+    materialsGeneration: pdfCandidates[0]?.generation ?? null,
     resumeText: null,
     resumeTextArtifactId: null,
     resumePdfArtifactId: pdfCandidates[0]?.artifactId ?? null,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -208,6 +208,13 @@ import {
 } from "./write-model.js";
 
 const UNSAFE_METHODS = new Set(["DELETE", "PATCH", "POST", "PUT"]);
+const APPLY_REVIEW_PRECONDITION_ERRORS = new Set([
+  "awaiting_dry_run",
+  "approval_stale_materials",
+  "approval_stale_profile",
+  "approval_stale_url",
+  "partial_override_evidence_invalid",
+]);
 const execFileAsync = promisify(execFile);
 
 export type ArtifactPdfPageRenderer = (pdfPath: string, pageNumber: number) => Promise<Buffer>;
@@ -2521,6 +2528,14 @@ async function withWritableDb<T>(
       return { ok: false, error: "invalid_resume_template", message: error.message };
     }
     if (error instanceof InputError) {
+      if (APPLY_REVIEW_PRECONDITION_ERRORS.has(error.message)) {
+        void reply.code(409);
+        return {
+          ok: false,
+          error: error.message,
+          message: applyReviewPreconditionMessage(error.message),
+        };
+      }
       void reply.code(404);
       return { ok: false, error: "not_found", message: error.message };
     }
@@ -2533,6 +2548,22 @@ async function withWritableDb<T>(
   } finally {
     db?.close();
   }
+}
+
+function applyReviewPreconditionMessage(error: string): string {
+  if (error === "approval_stale_materials") {
+    return "The reviewed materials changed before submit approval. Refresh apply review and approve again.";
+  }
+  if (error === "approval_stale_profile") {
+    return "The reviewed profile changed before submit approval. Refresh apply review and approve again.";
+  }
+  if (error === "approval_stale_url") {
+    return "The reviewed application URL changed before submit approval. Refresh apply review and approve again.";
+  }
+  if (error === "partial_override_evidence_invalid") {
+    return "The selected partial dry-run evidence no longer matches this job's current materials, profile, and URL.";
+  }
+  return "Submit approval requires matching full dry-run evidence or an explicit matching partial dry-run override.";
 }
 
 type ApiDb = ReturnType<typeof openDatabase>;

--- a/apps/api/test/application-feedback.test.ts
+++ b/apps/api/test/application-feedback.test.ts
@@ -1007,18 +1007,95 @@ describe("application feedback API", () => {
 
     expect(response.statusCode, response.body).toBe(200);
     expect(queueItem(response.json(), READY_JOB)?.materialsPreview).toMatchObject({
+      materialsGeneration: 2,
       resumeText: "review required candidate resume",
       resumeTextArtifactId: "review-candidate-resume",
       resumePdfArtifactId: null,
+    });
+    expect(queueItem(response.json(), READY_JOB)?.approvalGate).toMatchObject({
+      materialsGeneration: 2,
     });
     expect(queueItem(response.json(), READY_JOB)?.materialsPreview.requirementLedAudit?.revision?.reason).toBe(
       "review_blocked_claims",
     );
 
+    const decisionDb = new Database(options.dbPath);
+    decisionDb.exec(`
+      CREATE TABLE IF NOT EXISTS candidate_profiles (
+        tenant_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, profile_id)
+      );
+    `);
+    decisionDb
+      .prepare(
+        "INSERT OR REPLACE INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
+      )
+      .run(7, NOW);
+    insertVersionedDryRunEvidence(decisionDb, {
+      applicationUrl: READY_JOB,
+      materialsGeneration: 2,
+      profileVersion: 7,
+      runId: "dry-run-review-candidate",
+    });
+    decisionDb.close();
+
+    const approve = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${encodeURIComponent(READY_JOB)}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        reason: "Reviewed candidate generation.",
+        materialsGeneration: 2,
+        profileVersion: 7,
+        applicationUrl: READY_JOB,
+      },
+    });
+    expect(approve.statusCode, approve.body).toBe(200);
+    const boundDb = new Database(options.dbPath);
+    try {
+      const row = boundDb
+        .prepare(
+          `SELECT materials_generation
+             FROM application_review_decisions
+            WHERE job_key = ?
+            ORDER BY decided_at DESC, decision_id DESC
+            LIMIT 1`,
+        )
+        .get(READY_JOB) as { materials_generation?: number } | undefined;
+      expect(row?.materials_generation).toBe(2);
+    } finally {
+      boundDb.close();
+    }
+
     await app.close();
   });
 
   it("records approve, defer, reset, and decline review decisions without dispatching apply", async () => {
+    const profileDb = new Database(options.dbPath);
+    profileDb.exec(`
+      CREATE TABLE candidate_profiles (
+        tenant_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, profile_id)
+      );
+    `);
+    profileDb
+      .prepare(
+        "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
+      )
+      .run(7, NOW);
+    insertVersionedDryRunEvidence(profileDb, {
+      applicationUrl: READY_JOB,
+      materialsGeneration: 1,
+      profileVersion: 7,
+      runId: "dry-run-profile-v7",
+    });
+    profileDb.close();
     const app = buildApp(options);
     const readyKey = encodeURIComponent(READY_JOB);
     const dryRunKey = encodeURIComponent(DRY_RUN_JOB);
@@ -1026,7 +1103,13 @@ describe("application feedback API", () => {
     const approve = await app.inject({
       method: "POST",
       url: `/v1/jobs/${readyKey}/apply-review/decision`,
-      payload: { decision: "approve_submit", reason: "Looks complete." },
+      payload: {
+        decision: "approve_submit",
+        reason: "Looks complete.",
+        materialsGeneration: 1,
+        profileVersion: 7,
+        applicationUrl: READY_JOB,
+      },
     });
     expect(approve.statusCode, approve.body).toBe(200);
     expect(approve.json()).toMatchObject({
@@ -1041,10 +1124,21 @@ describe("application feedback API", () => {
     try {
       const row = db
         .prepare(
-          "SELECT decision FROM application_review_decisions WHERE job_key = ? ORDER BY decided_at DESC LIMIT 1",
+          `SELECT decision, materials_generation, profile_version, application_url
+           FROM application_review_decisions
+           WHERE job_key = ?
+           ORDER BY decided_at DESC LIMIT 1`,
         )
-        .get(READY_JOB) as { decision?: string } | undefined;
+        .get(READY_JOB) as {
+          decision?: string;
+          materials_generation?: number;
+          profile_version?: number;
+          application_url?: string;
+        } | undefined;
       expect(row?.decision).toBe("approve_submit");
+      expect(row?.materials_generation).toBe(1);
+      expect(row?.profile_version).toBe(7);
+      expect(row?.application_url).toBe(READY_JOB);
     } finally {
       db.close();
     }
@@ -1089,6 +1183,236 @@ describe("application feedback API", () => {
     expect(decline.statusCode, decline.body).toBe(200);
     const afterDecline = await app.inject({ method: "GET", url: "/v1/apply/review-queue" });
     expect(queueItem(afterDecline.json(), DRY_RUN_JOB)).toBeUndefined();
+
+    await app.close();
+  });
+
+  it("returns approval precondition errors with stable conflict codes", async () => {
+    const db = new Database(options.dbPath);
+    db.exec(`
+      CREATE TABLE candidate_profiles (
+        tenant_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, profile_id)
+      );
+    `);
+    db.prepare(
+      "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
+    ).run(7, NOW);
+    db.prepare("DELETE FROM job_events WHERE event_type = 'DryRunCompleted'").run();
+    db.close();
+    const app = buildApp(options);
+    const readyKey = encodeURIComponent(READY_JOB);
+
+    const awaitingDryRun = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 7,
+        applicationUrl: READY_JOB,
+      },
+    });
+    expect(awaitingDryRun.statusCode, awaitingDryRun.body).toBe(409);
+    expect(awaitingDryRun.json()).toMatchObject({
+      ok: false,
+      error: "awaiting_dry_run",
+    });
+
+    const invalidPartialOverride = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 7,
+        applicationUrl: READY_JOB,
+        partialOverrideRunId: "missing-partial-run",
+      },
+    });
+    expect(invalidPartialOverride.statusCode, invalidPartialOverride.body).toBe(409);
+    expect(invalidPartialOverride.json()).toMatchObject({
+      ok: false,
+      error: "partial_override_evidence_invalid",
+    });
+
+    await app.close();
+  });
+
+  it("rejects submit approval when the displayed review binding is stale", async () => {
+    const db = new Database(options.dbPath);
+    db.exec(`
+      CREATE TABLE candidate_profiles (
+        tenant_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, profile_id)
+      );
+    `);
+    db.prepare(
+      "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
+    ).run(7, NOW);
+    insertVersionedDryRunEvidence(db, {
+      applicationUrl: READY_JOB,
+      materialsGeneration: 1,
+      profileVersion: 7,
+      runId: "dry-run-profile-v7",
+    });
+    db.close();
+    const app = buildApp(options);
+    const readyKey = encodeURIComponent(READY_JOB);
+
+    const staleMaterials = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 0,
+        profileVersion: 7,
+        applicationUrl: READY_JOB,
+      },
+    });
+    expect(staleMaterials.statusCode, staleMaterials.body).toBe(409);
+    expect(staleMaterials.json()).toMatchObject({ ok: false, error: "approval_stale_materials" });
+
+    const staleProfile = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 6,
+        applicationUrl: READY_JOB,
+      },
+    });
+    expect(staleProfile.statusCode, staleProfile.body).toBe(409);
+    expect(staleProfile.json()).toMatchObject({ ok: false, error: "approval_stale_profile" });
+
+    const staleUrl = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 7,
+        applicationUrl: "https://example.com/old-apply",
+      },
+    });
+    expect(staleUrl.statusCode, staleUrl.body).toBe(409);
+    expect(staleUrl.json()).toMatchObject({ ok: false, error: "approval_stale_url" });
+
+    await app.close();
+  });
+
+  it("rejects submit approval when dry-run evidence belongs to an older profile version", async () => {
+    const db = new Database(options.dbPath);
+    db.exec(`
+      CREATE TABLE candidate_profiles (
+        tenant_id TEXT NOT NULL,
+        profile_id TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (tenant_id, profile_id)
+      );
+    `);
+    db.prepare(
+      "INSERT INTO candidate_profiles (tenant_id, profile_id, version, updated_at) VALUES ('local', 'default', ?, ?)",
+    ).run(2, NOW);
+    db.prepare("DELETE FROM job_events WHERE event_type IN ('ApplyRunStarted', 'DryRunCompleted')").run();
+    db.prepare(
+      `INSERT INTO job_events (
+         job_url, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+    ).run(
+      READY_JOB,
+      "Stale-profile dry run started",
+      "2026-06-01T12:00:00.000Z",
+      JSON.stringify({
+        run_id: "dry-run-profile-v1",
+        dry_run: true,
+        materials_generation: 1,
+        profile_version: 1,
+        application_url: READY_JOB,
+      }),
+    );
+    db.prepare(
+      `INSERT INTO job_events (
+         job_url, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+    ).run(
+      READY_JOB,
+      "Stale-profile dry run completed",
+      "2026-06-01T12:01:00.000Z",
+      JSON.stringify({
+        run_id: "dry-run-profile-v1",
+        result: "dry_run_complete",
+        dry_run: true,
+        coverage: "full",
+        materials_generation: 1,
+        profile_version: 1,
+        application_url: READY_JOB,
+        finished_at: "2026-06-01T12:01:00.000Z",
+      }),
+    );
+    db.prepare(
+      `INSERT INTO job_events (
+         job_url, stage, event_type, level, message, occurred_at, payload_json
+       ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+    ).run(
+      READY_JOB,
+      "Stale-profile partial dry run completed",
+      "2026-06-01T12:02:00.000Z",
+      JSON.stringify({
+        run_id: "dry-run-profile-v1-partial",
+        result: "dry_run_complete",
+        dry_run: true,
+        coverage: "partial",
+        materials_generation: 1,
+        profile_version: 1,
+        application_url: READY_JOB,
+        finished_at: "2026-06-01T12:02:00.000Z",
+      }),
+    );
+    db.close();
+    const app = buildApp(options);
+    const readyKey = encodeURIComponent(READY_JOB);
+
+    const approveSubmit = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 2,
+        applicationUrl: READY_JOB,
+      },
+    });
+    expect(approveSubmit.statusCode, approveSubmit.body).toBe(409);
+    expect(approveSubmit.json()).toMatchObject({
+      ok: false,
+      error: "awaiting_dry_run",
+    });
+
+    const approvePartial = await app.inject({
+      method: "POST",
+      url: `/v1/jobs/${readyKey}/apply-review/decision`,
+      payload: {
+        decision: "approve_submit",
+        materialsGeneration: 1,
+        profileVersion: 2,
+        applicationUrl: READY_JOB,
+        partialOverrideRunId: "dry-run-profile-v1-partial",
+      },
+    });
+    expect(approvePartial.statusCode, approvePartial.body).toBe(409);
+    expect(approvePartial.json()).toMatchObject({
+      ok: false,
+      error: "partial_override_evidence_invalid",
+    });
 
     await app.close();
   });
@@ -1663,9 +1987,90 @@ function seedDatabase(dbPath: string): void {
     "2026-05-31T09:00:00.000Z",
     "2026-05-31T09:01:00.000Z",
   );
+  db.prepare(
+    `INSERT INTO job_events (
+       job_url, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+  ).run(
+    READY_JOB,
+    "Apply dry-run started",
+    "2026-05-31T09:00:00.000Z",
+    JSON.stringify({
+      run_id: "dry-run-ready",
+      dry_run: true,
+      materials_generation: 1,
+      application_url: READY_JOB,
+    }),
+  );
+  db.prepare(
+    `INSERT INTO job_events (
+       job_url, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+  ).run(
+    READY_JOB,
+    "Dry run completed",
+    "2026-05-31T09:01:00.000Z",
+    JSON.stringify({
+      run_id: "dry-run-ready",
+      result: "dry_run_complete",
+      dry_run: true,
+      coverage: "full",
+      materials_generation: 1,
+      application_url: READY_JOB,
+      finished_at: "2026-05-31T09:01:00.000Z",
+    }),
+  );
   insertBulletProvenance(db);
   insertCompensationRows(db, READY_JOB);
   db.close();
+}
+
+function insertVersionedDryRunEvidence(
+  db: Database.Database,
+  options: {
+    readonly applicationUrl: string;
+    readonly coverage?: "full" | "partial";
+    readonly materialsGeneration: number;
+    readonly profileVersion: number;
+    readonly runId: string;
+  },
+): void {
+  const coverage = options.coverage ?? "full";
+  db.prepare(
+    `INSERT INTO job_events (
+       job_url, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES (?, 'apply', 'ApplyRunStarted', 'info', ?, ?, ?)`,
+  ).run(
+    READY_JOB,
+    "Versioned dry run started",
+    "2026-06-01T12:00:00.000Z",
+    JSON.stringify({
+      run_id: options.runId,
+      dry_run: true,
+      materials_generation: options.materialsGeneration,
+      profile_version: options.profileVersion,
+      application_url: options.applicationUrl,
+    }),
+  );
+  db.prepare(
+    `INSERT INTO job_events (
+       job_url, stage, event_type, level, message, occurred_at, payload_json
+     ) VALUES (?, 'apply', 'DryRunCompleted', 'info', ?, ?, ?)`,
+  ).run(
+    READY_JOB,
+    "Versioned dry run completed",
+    "2026-06-01T12:01:00.000Z",
+    JSON.stringify({
+      run_id: options.runId,
+      result: "dry_run_complete",
+      dry_run: true,
+      coverage,
+      materials_generation: options.materialsGeneration,
+      profile_version: options.profileVersion,
+      application_url: options.applicationUrl,
+      finished_at: "2026-06-01T12:01:00.000Z",
+    }),
+  );
 }
 
 function insertCompensationRows(db: Database.Database, jobUrl: string): void {

--- a/apps/web/src/contexts/apply/components/ApplyReviewDecisionControls.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyReviewDecisionControls.tsx
@@ -35,6 +35,31 @@ const PRIMARY_DECISIONS: readonly ApplyReviewDecisionValue[] = [
   "decline",
 ];
 
+const GATE_REASON_LABELS: Record<string, string> = {
+  awaiting_approval: "approval not recorded",
+  awaiting_dry_run: "full dry-run evidence missing",
+  approval_stale_materials: "materials changed since approval",
+  approval_stale_profile: "profile changed since approval",
+  approval_stale_url: "application URL changed since approval",
+  override_evidence_invalid: "partial dry-run override no longer matches",
+};
+
+function formatBindingValue(value: number | string | null): string {
+  return value === null || value === "" ? "not recorded" : String(value);
+}
+
+function dryRunEvidenceLabel(item: ApplyReviewQueueItem): string {
+  const full = item.approvalGate.dryRunEvidence;
+  if (full) {
+    return `full dry-run evidence from ${full.runId}`;
+  }
+  const partial = item.approvalGate.partialDryRunEvidence;
+  if (partial) {
+    return `partial dry-run evidence from ${partial.runId}`;
+  }
+  return "no matching dry-run evidence";
+}
+
 export function ApplyReviewDecisionControls({
   approvalDisabledReason = null,
   approvalNotice = null,
@@ -46,9 +71,17 @@ export function ApplyReviewDecisionControls({
   const [preparingDecision, setPreparingDecision] = useState<ApplyReviewDecisionValue | null>(null);
   const pending = decision.isPending || preparingDecision !== null || approvalPreparing;
   const primaryDecisions = PRIMARY_DECISIONS;
-  const approvalMessage = approvalDisabledReason ?? approvalNotice;
+  const fullDryRunEvidence = item.approvalGate.dryRunEvidence;
+  const partialDryRunEvidence = item.approvalGate.partialDryRunEvidence;
+  const gateMessage = item.approvalGate.reasons
+    .map((reason) => GATE_REASON_LABELS[reason] ?? reason)
+    .join(", ");
+  const approvalMessage =
+    approvalDisabledReason ??
+    approvalNotice ??
+    (gateMessage ? `Submit gate: ${gateMessage}.` : null);
 
-  const submitDecision = async (value: ApplyReviewDecisionValue) => {
+  const submitDecision = async (value: ApplyReviewDecisionValue, partialOverrideRunId?: string) => {
     if (pending) return;
     if (value.startsWith("approve_") && onPrepareApproval) {
       setPreparingDecision(value);
@@ -67,21 +100,45 @@ export function ApplyReviewDecisionControls({
         decision: value,
         reason: DECISION_REASONS[value],
         decidedBy: "user",
+        ...(value === "approve_submit"
+          ? {
+              materialsGeneration: item.approvalGate.materialsGeneration,
+              profileVersion: item.approvalGate.profileVersion,
+              applicationUrl: item.approvalGate.applicationUrl,
+            }
+          : {}),
+        ...(partialOverrideRunId ? { partialOverrideRunId } : {}),
       },
     });
   };
 
   return (
     <div className="apply-review-actions">
+      <div className="apply-review-approval-binding" aria-label={`Submit approval binding for ${item.title}`}>
+        <span>Materials generation: {formatBindingValue(item.approvalGate.materialsGeneration)}</span>
+        <span>Profile version: {formatBindingValue(item.approvalGate.profileVersion)}</span>
+        <span>Application URL: {formatBindingValue(item.approvalGate.applicationUrl)}</span>
+        <span>Dry-run evidence: {dryRunEvidenceLabel(item)}</span>
+      </div>
       {primaryDecisions.map((value) => (
         <Button
           key={value}
           size="sm"
           type="button"
           variant={value === "decline" ? "outline" : value === "defer" ? "secondary" : "default"}
-          disabled={pending || (approvalDisabledReason !== null && value.startsWith("approve_"))}
+          disabled={
+            pending ||
+            (approvalDisabledReason !== null && value.startsWith("approve_")) ||
+            (value === "approve_submit" && !fullDryRunEvidence)
+          }
           aria-label={`${DECISION_LABELS[value]} for ${item.title}`}
-          title={value.startsWith("approve_") ? approvalMessage ?? undefined : undefined}
+          title={
+            value === "approve_submit" && !fullDryRunEvidence
+              ? "Full dry-run evidence is required before submit approval."
+              : value.startsWith("approve_")
+                ? approvalMessage ?? undefined
+                : undefined
+          }
           onClick={() => {
             void submitDecision(value);
           }}
@@ -89,6 +146,29 @@ export function ApplyReviewDecisionControls({
           {preparingDecision === value ? "Rendering" : decision.isPending ? "Saving" : DECISION_LABELS[value]}
         </Button>
       ))}
+      {!fullDryRunEvidence && partialDryRunEvidence ? (
+        <>
+          <span className="apply-review-approval-block" role="alert">
+            Partial dry-run evidence only. Blocked channels:{" "}
+            {partialDryRunEvidence.blockedChannels.length
+              ? partialDryRunEvidence.blockedChannels.join(", ")
+              : "not recorded"}
+            .
+          </span>
+          <Button
+            size="sm"
+            type="button"
+            variant="secondary"
+            disabled={pending || approvalDisabledReason !== null}
+            aria-label={`Approve with partial dry-run evidence for ${item.title}`}
+            onClick={() => {
+              void submitDecision("approve_submit", partialDryRunEvidence.runId);
+            }}
+          >
+            Approve with partial dry-run evidence
+          </Button>
+        </>
+      ) : null}
       {approvalMessage ? (
         <span className="apply-review-approval-block" role="status">
           {approvalMessage}

--- a/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts
+++ b/apps/web/src/contexts/apply/hooks/useApplyReviewMutations.test.ts
@@ -26,7 +26,14 @@ describe("apply review mutations", () => {
     await act(async () => {
       result.current.mutate({
         jobId: "job-2",
-        body: { decision: "approve_submit", reason: "approved", decidedBy: "user" },
+        body: {
+          decision: "approve_submit",
+          reason: "approved",
+          decidedBy: "user",
+          materialsGeneration: 1,
+          profileVersion: 3,
+          applicationUrl: "https://example.com/apply",
+        },
       });
     });
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1011,6 +1011,17 @@ textarea:focus-visible {
   text-align: end;
 }
 
+.apply-review-approval-binding {
+  display: flex;
+  flex-basis: 100%;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px 10px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  text-align: end;
+}
+
 .apply-review-audit-facts {
   display: grid;
   flex-basis: 100%;

--- a/apps/web/src/test/fixtures/projections.ts
+++ b/apps/web/src/test/fixtures/projections.ts
@@ -502,6 +502,7 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         keywords: ["platform reliability", "sre"],
       },
       materialsPreview: {
+        materialsGeneration: 2,
         resumeText:
           "Principal Platform Engineer\n\nOwned platform reliability improvements for incident response.",
         resumeTextArtifactId: "resume-text-2",
@@ -611,6 +612,23 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         state: "pending",
         decision: null,
         decidedAt: null,
+        materialsGeneration: null,
+        profileVersion: null,
+        applicationUrl: null,
+        partialOverrideRunId: null,
+      },
+      approvalGate: {
+        materialsGeneration: 1,
+        profileVersion: 3,
+        applicationUrl: sampleSecondaryJob.applicationUrl,
+        dryRunEvidence: {
+          runId: "apply-run-2",
+          coverage: "full",
+          finishedAt: "2026-05-06T06:35:00Z",
+          blockedChannels: [],
+        },
+        partialDryRunEvidence: null,
+        reasons: ["awaiting_approval"],
       },
       blockers: [],
     },
@@ -650,6 +668,7 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         keywords: ["platform", "typescript"],
       },
       materialsPreview: {
+        materialsGeneration: 1,
         resumeText:
           "Staff Software Engineer\n\nTailored resume draft focused on reliability, TypeScript, and product platform delivery.",
         resumeTextArtifactId: "resume-text-1",
@@ -663,6 +682,18 @@ export const sampleApplyReviewQueue: ApplyReviewQueueResponse = {
         state: "pending",
         decision: null,
         decidedAt: null,
+        materialsGeneration: null,
+        profileVersion: null,
+        applicationUrl: null,
+        partialOverrideRunId: null,
+      },
+      approvalGate: {
+        materialsGeneration: 1,
+        profileVersion: 3,
+        applicationUrl: sampleJob.applicationUrl,
+        dryRunEvidence: null,
+        partialDryRunEvidence: null,
+        reasons: ["awaiting_approval"],
       },
       blockers: ["cover letter missing"],
     },

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -2460,11 +2460,81 @@ describe("<ApplyReviewView>", () => {
     await user.click(await screen.findByRole("button", { name: /approve submit for principal platform engineer/i }));
 
     await waitFor(() => expect(decideApplyReview).toHaveBeenCalledTimes(1));
-    expect(decideApplyReview).toHaveBeenCalledWith(
-      "job-2",
-      expect.objectContaining({ decision: "approve_submit" }),
-    );
+	    expect(decideApplyReview).toHaveBeenCalledWith(
+	      "job-2",
+	      expect.objectContaining({
+	        decision: "approve_submit",
+	        materialsGeneration: sampleApplyReviewQueue.items[0]!.approvalGate.materialsGeneration,
+	        profileVersion: sampleApplyReviewQueue.items[0]!.approvalGate.profileVersion,
+	        applicationUrl: sampleApplyReviewQueue.items[0]!.approvalGate.applicationUrl,
+	      }),
+	    );
     expect(applyJob).not.toHaveBeenCalled();
+  });
+
+  it("offers submit approval with a partial dry-run override only when partial evidence exists", async () => {
+    const user = userEvent.setup();
+    const decideApplyReview = vi.fn(async () => ({
+      ok: true as const,
+      decision: {
+        decisionId: "decision-partial",
+        jobKey: "job-2",
+        decision: "approve_submit" as const,
+        reason: "approved",
+        decidedBy: "user",
+        decidedAt: "2026-05-06T08:30:00Z",
+      },
+    }));
+    const partialQueue = {
+      ...sampleApplyReviewQueue,
+      items: sampleApplyReviewQueue.items.map((item, index) =>
+        index === 0
+          ? {
+              ...item,
+              approvalGate: {
+                ...item.approvalGate,
+                dryRunEvidence: null,
+                partialDryRunEvidence: {
+                  runId: "dry-run-partial",
+                  coverage: "partial" as const,
+                  finishedAt: "2026-05-06T06:35:00Z",
+                  blockedChannels: ["Document"],
+                },
+                reasons: ["awaiting_dry_run" as const],
+              },
+            }
+          : item,
+      ),
+    };
+
+    renderWithProviders(<ApplyReviewView />, {
+      ports: buildTestPorts({
+        api: {
+          applyReviewQueue: vi.fn(async () => partialQueue),
+          decideApplyReview,
+        },
+      }),
+    });
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/Partial dry-run evidence only/i);
+    expect(screen.getByRole("button", { name: /Approve submit for Principal Platform Engineer/i })).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", {
+        name: /Approve with partial dry-run evidence for Principal Platform Engineer/i,
+      }),
+    );
+
+    await waitFor(() => expect(decideApplyReview).toHaveBeenCalledTimes(1));
+	    expect(decideApplyReview).toHaveBeenCalledWith(
+	      "job-2",
+	      expect.objectContaining({
+	        decision: "approve_submit",
+	        materialsGeneration: partialQueue.items[0]!.approvalGate.materialsGeneration,
+	        profileVersion: partialQueue.items[0]!.approvalGate.profileVersion,
+	        applicationUrl: partialQueue.items[0]!.approvalGate.applicationUrl,
+	        partialOverrideRunId: "dry-run-partial",
+	      }),
+	    );
   });
 
   it("does not depend on outcome suggestions to render the queue route", async () => {

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -531,8 +531,15 @@ verification-code MCP server:
   remains available.
 - `POST /v1/jobs/:jobKey/apply-review/decision` appends an
   `approve_submit`, `approve_dry_run`, `defer`, `decline`, or `reset`
-  decision. Approval records intent only in this slice; it does not dispatch
-  the apply worker.
+  decision. `approve_submit` records the reviewed materials generation, profile
+  version, and application URL, and it is accepted only when matching full
+  dry-run evidence exists or the request explicitly names a matching partial
+  dry-run run. `approve_submit` requests must include the displayed
+  `materialsGeneration`, `profileVersion`, and `applicationUrl`; if any value
+  no longer matches the current review row, the API returns `409` with
+  `approval_stale_materials`, `approval_stale_profile`, or `approval_stale_url`
+  before inserting a decision row. Approval records intent only in this slice;
+  it does not dispatch the apply worker.
 - `GET /v1/outcomes` and `GET /v1/jobs/:jobKey/outcomes` return reviewed
   outcomes and any outcome suggestions.
 - `POST /v1/jobs/:jobKey/outcomes` writes a manual reviewed outcome.
@@ -545,11 +552,11 @@ verification-code MCP server:
   plus evidence/suggestion IDs, job keys, kinds, and confidence values only; it
   never returns raw Gmail body text.
 
-The web review queue records approval facts only, with no ordering
-constraint between decisions: `approve_submit` can be recorded at any time —
-the web app offers it as the primary gate action even before any dry run has
-run — and the live-apply gate is enforced later, at the Python worker's claim
-transaction, not by decision order. `approve_submit` does not dispatch browser
+The web review queue records approval facts only. `approve_submit` is bound to
+the material, profile, URL, and dry-run evidence shown in Apply Review; stale
+bindings, missing dry-run evidence, and invalid partial-run overrides are refused
+before the decision row is written. The live-apply gate is enforced again at the
+Python worker's claim transaction. `approve_submit` does not dispatch browser
 submission, and `approve_dry_run` does not start a dry run.
 Manual outcomes and suggestion corrections require canonical ISO-8601 UTC
 `occurredAt` timestamps when the field is supplied.

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -67,12 +67,14 @@ Review configuration before running large pipelines.
 ## Auto-Apply Safety
 
 Apply automation can submit real applications, so it is guarded by approval
-gates: a rehearsal dry run (recommended before approving anything), an explicit
-approval before any live submission, a browser-level guard during dry runs, no
-application submitted twice, and a daily spend ceiling. The apply agent also reads untrusted job pages, so prompt
-injection is a real exposure. The full gate model, the apply agent's automation
-posture, and how credentials appear in the apply prompt live in
-[Security](security.md).
+gates: a rehearsal dry run before live submission, an explicit approval bound to
+the reviewed materials generation, profile version, and application URL, a
+browser-level guard during dry runs, no application submitted twice, and a daily
+spend ceiling. Apply Review allows a partial dry-run override only when it names
+the specific partial run and shows the blocked channels you are accepting. The
+apply agent also reads untrusted job pages, so prompt injection is a real
+exposure. The full gate model, the apply agent's automation posture, and how
+credentials appear in the apply prompt live in [Security](security.md).
 
 Two guarantees stay here because they are about your local artifacts:
 

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -33,8 +33,8 @@ flowchart TD
 
 *Blue steps are yours; green steps are JobHunter's. Setup happens once, the
 loop repeats. Under the hood, Discover runs Enrich, Score, and Materials for
-each eligible job — and the dry run is the recommended rehearsal, not an
-enforced prerequisite.*
+each eligible job. Live submission approval is bound to the current materials,
+profile version, application URL, and dry-run evidence.*
 
 ## 1. Build The Candidate Profile
 
@@ -165,8 +165,11 @@ by URL. A dry run never submits — it shows what would happen without sending
 anything.
 
 Only approve real submission after inspecting the dry run, final materials,
-field mapping, blockers, and apply-run history. The full approval model is on the
-[Security](security.md) page.
+field mapping, blockers, and apply-run history. Submit approval is valid only
+for the materials generation, profile version, and application URL shown in
+Apply Review, and requires full dry-run evidence unless you explicitly accept a
+listed partial dry-run with its blocked channels. The full approval model is on
+the [Security](security.md) page.
 
 ## 8. Inspect Progress
 

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -73,22 +73,25 @@ shared locations, or attach it to bug reports.
 
 Applying to jobs is JobHunter's one genuinely risky action, because it can drive
 a real browser and submit a real application. Several gates stand between a
-discovered job and a submitted one. In plain terms: you can rehearse any
-application with a dry run (recommended, but not an enforced prerequisite),
-nothing is submitted for real until you explicitly approve that exact job, and
-the same application is never submitted twice.
+discovered job and a submitted one. In plain terms: you rehearse the application
+with a dry run before live submission, nothing is submitted for real until you
+explicitly approve that exact job with current evidence, and the same application
+is never submitted twice.
 
 ### Apply Approval Is Required By Default
 
 Live submission is gated on an explicit decision. With the default
 `applyApprovalRequired: true`, a live apply run starts only when the latest Apply
-Review decision for that job is `approve_submit`; otherwise the backend claim
-rolls back and the browser never launches. The gate is enforced in the worker's
-claim transaction, not merely surfaced in the UI, so no UI or command path can
-submit without a recorded approval while the gate is on. You can turn the gate
-off in Preferences, which is why the settings form shows a persistent warning
-when it is off — with the gate off, the agent may submit immediately after
-claiming a job.
+Review decision for that job is `approve_submit`, that approval is bound to the
+current materials generation, profile version, and application URL, and matching
+dry-run evidence exists. Full dry-run evidence satisfies the gate. A partial dry
+run satisfies it only when you use the explicit partial-evidence approval action
+for that specific run. Otherwise the backend claim rolls back and the browser
+never launches. The gate is enforced in the worker's claim transaction, not
+merely surfaced in the UI, so no UI or command path can submit without a fresh
+recorded approval while the gate is on. You can turn the gate off in Preferences,
+which is why the settings form shows a persistent warning when it is off — with
+the gate off, the agent may submit immediately after claiming a job.
 
 ### Dry-Run Cannot Submit
 
@@ -170,8 +173,8 @@ Those controls:
 
 - the dry-run guard inside the browser makes it impossible to submit a form off
   your machine during a dry run;
-- the approval gate keeps live submission behind an explicit `approve_submit`
-  decision;
+- the approval gate keeps live submission behind a fresh `approve_submit`
+  decision bound to the reviewed materials, profile, URL, and dry-run evidence;
 - the spend ceiling caps how much LLM cost a runaway loop can incur;
 - credentials stay local — the LLM keys are not in the page's reach, and Gmail
   write tools (draft, send, delete, modify, label, filter) are explicitly

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -244,6 +244,10 @@ export const ApplyReviewDecisionRequestSchema = z
     decision: z.enum(APPLY_REVIEW_DECISION_VALUES),
     reason: z.string().trim().max(400).optional(),
     decidedBy: z.string().trim().min(1).max(120).default("user"),
+    materialsGeneration: z.number().int().nonnegative().nullable().optional(),
+    profileVersion: z.number().int().positive().nullable().optional(),
+    applicationUrl: z.string().trim().min(1).max(2048).nullable().optional(),
+    partialOverrideRunId: z.string().trim().min(1).max(120).optional(),
   })
   .strict();
 export type ApplyReviewDecisionRequest = z.infer<typeof ApplyReviewDecisionRequestSchema>;
@@ -255,6 +259,10 @@ export interface ApplyReviewDecision {
   reason: string | null;
   decidedBy: string;
   decidedAt: string;
+  materialsGeneration?: number | null;
+  profileVersion?: number | null;
+  applicationUrl?: string | null;
+  partialOverrideRunId?: string | null;
 }
 
 export interface ApplyReviewDecisionResponse {
@@ -375,6 +383,7 @@ export interface ApplyReviewRequirementLedAudit {
 }
 
 export interface ApplyReviewMaterialsPreview {
+  materialsGeneration: number | null;
   resumeText: string | null;
   resumeTextArtifactId: string | null;
   resumePdfArtifactId: string | null;
@@ -663,6 +672,31 @@ export interface ApplyAudit {
   sources: ApplyAuditSource[];
 }
 
+export type ApplyReviewDryRunCoverage = "full" | "partial";
+export type ApplyReviewApprovalGateReason =
+  | "awaiting_approval"
+  | "awaiting_dry_run"
+  | "approval_stale_materials"
+  | "approval_stale_profile"
+  | "approval_stale_url"
+  | "override_evidence_invalid";
+
+export interface ApplyReviewDryRunEvidence {
+  runId: string;
+  coverage: ApplyReviewDryRunCoverage;
+  finishedAt: string | null;
+  blockedChannels: string[];
+}
+
+export interface ApplyReviewApprovalGate {
+  materialsGeneration: number | null;
+  profileVersion: number | null;
+  applicationUrl: string | null;
+  dryRunEvidence: ApplyReviewDryRunEvidence | null;
+  partialDryRunEvidence: ApplyReviewDryRunEvidence | null;
+  reasons: ApplyReviewApprovalGateReason[];
+}
+
 export interface ApplyReviewQueueItem {
   jobKey: string;
   title: string;
@@ -701,7 +735,12 @@ export interface ApplyReviewQueueItem {
     state: "pending" | "approved_submit" | "approved_dry_run" | "deferred" | "declined";
     decision: ApplyReviewDecisionValue | null;
     decidedAt: string | null;
+    materialsGeneration?: number | null;
+    profileVersion?: number | null;
+    applicationUrl?: string | null;
+    partialOverrideRunId?: string | null;
   };
+  approvalGate: ApplyReviewApprovalGate;
   blockers: string[];
 }
 

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -174,10 +174,12 @@ def _attempt_count_for(conn, url: str) -> int:
     return int(row[0] or 0) if row else 0
 
 
-def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> str | None:
+def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> dict[str, Any] | None:
     row = conn.execute(
         """
-        SELECT decision FROM application_review_decisions
+        SELECT decision, materials_generation, profile_version, application_url,
+               partial_override_run_id
+        FROM application_review_decisions
         WHERE tenant_id = ? AND job_key = ?
         ORDER BY decided_at DESC, decision_id DESC
         LIMIT 1
@@ -186,7 +188,260 @@ def _latest_apply_review_decision(conn, *, tenant_id: str, job_key: str) -> str 
     ).fetchone()
     if row is None:
         return None
-    return str(row["decision"] if hasattr(row, "keys") else row[0])
+    return dict(row) if hasattr(row, "keys") else {
+        "decision": row[0],
+        "materials_generation": row[1],
+        "profile_version": row[2],
+        "application_url": row[3],
+        "partial_override_run_id": row[4],
+    }
+
+
+def _current_profile_version(conn, *, tenant_id: str = "local") -> int | None:
+    columns = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(candidate_profiles)").fetchall()
+    }
+    if "version" not in columns:
+        return None
+    row = conn.execute(
+        "SELECT version FROM candidate_profiles WHERE tenant_id = ? AND profile_id = 'default'",
+        (tenant_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    value = row["version"] if hasattr(row, "keys") else row[0]
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _payload_from_row(row) -> dict[str, Any]:
+    payload_json = row["payload_json"] if hasattr(row, "keys") else row[0]
+    if not payload_json:
+        return {}
+    try:
+        payload = json.loads(payload_json)
+    except (TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _payload_value(payload: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in payload:
+            return payload[name]
+    return None
+
+
+def _payload_int(payload: dict[str, Any], *names: str) -> int | None:
+    value = _payload_value(payload, *names)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _dry_run_evidence_exists(
+    conn,
+    *,
+    job_key: str,
+    materials_generation: int,
+    profile_version: int,
+    application_url: str,
+    coverage: str,
+    run_id: str | None = None,
+) -> bool:
+    rows = conn.execute(
+        """
+        SELECT payload_json FROM job_events
+        WHERE job_url = ? AND stage = 'apply' AND event_type = 'DryRunCompleted'
+        ORDER BY event_id DESC
+        LIMIT 24
+        """,
+        (job_key,),
+    ).fetchall()
+    for row in rows:
+        payload = _payload_from_row(row)
+        payload_run_id = str(_payload_value(payload, "run_id", "runId") or "")
+        if not payload_run_id:
+            continue
+        if run_id and payload_run_id != run_id:
+            continue
+        if str(_payload_value(payload, "coverage", "dry_run_coverage") or "") != coverage:
+            continue
+        payload_generation = _payload_int(payload, "materials_generation", "materialsGeneration")
+        payload_profile_version = _payload_int(payload, "profile_version", "profileVersion")
+        payload_url = str(_payload_value(payload, "application_url", "applicationUrl") or "")
+        started_rows = conn.execute(
+            """
+            SELECT payload_json FROM job_events
+            WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted'
+            ORDER BY event_id DESC
+            LIMIT 48
+            """,
+            (job_key,),
+        ).fetchall()
+        for started_row in started_rows:
+            started_payload = _payload_from_row(started_row)
+            if str(_payload_value(started_payload, "run_id", "runId") or "") != payload_run_id:
+                continue
+            if (
+                (
+                    payload_generation
+                    if payload_generation is not None
+                    else _payload_int(
+                        started_payload,
+                        "materials_generation",
+                        "materialsGeneration",
+                    )
+                )
+                == materials_generation
+                and (
+                    payload_profile_version
+                    if payload_profile_version is not None
+                    else _payload_int(
+                        started_payload,
+                        "profile_version",
+                        "profileVersion",
+                    )
+                )
+                == profile_version
+                and (
+                    payload_url
+                    or str(
+                        _payload_value(
+                            started_payload,
+                            "application_url",
+                            "applicationUrl",
+                        )
+                        or ""
+                    )
+                )
+                == application_url
+            ):
+                return True
+    return False
+
+
+def _apply_run_started_payload(conn, *, job_key: str, run_id: str) -> dict[str, Any]:
+    rows = conn.execute(
+        """
+        SELECT payload_json FROM job_events
+        WHERE job_url = ? AND stage = 'apply' AND event_type = 'ApplyRunStarted'
+        ORDER BY event_id DESC
+        LIMIT 48
+        """,
+        (job_key,),
+    ).fetchall()
+    for row in rows:
+        payload = _payload_from_row(row)
+        if str(_payload_value(payload, "run_id", "runId") or "") == run_id:
+            return payload
+    return {}
+
+
+def _dry_run_completion_binding(
+    conn,
+    *,
+    job_key: str,
+    run_id: str,
+    run_ctx: dict | None,
+) -> dict[str, Any]:
+    ctx = run_ctx or {}
+    started_payload = _apply_run_started_payload(conn, job_key=job_key, run_id=run_id)
+    materials_generation = _payload_int(ctx, "materials_generation", "materialsGeneration")
+    if materials_generation is None:
+        materials_generation = _payload_int(
+            started_payload,
+            "materials_generation",
+            "materialsGeneration",
+        )
+    application_url = str(
+        _payload_value(ctx, "application_url", "applicationUrl")
+        or _payload_value(started_payload, "application_url", "applicationUrl")
+        or ""
+    )
+    profile_version = _payload_int(ctx, "profile_version", "profileVersion")
+    if profile_version is None:
+        profile_version = _payload_int(started_payload, "profile_version", "profileVersion")
+    coverage = str(_payload_value(ctx, "coverage", "dry_run_coverage") or "full")
+    if coverage not in {"full", "partial"}:
+        coverage = "full"
+    blocked_channels = _payload_value(ctx, "blocked_channels", "blockedChannels") or []
+    if not isinstance(blocked_channels, list):
+        blocked_channels = [str(blocked_channels)]
+    return {
+        "materials_generation": materials_generation,
+        "application_url": application_url or None,
+        "profile_version": profile_version,
+        "coverage": coverage,
+        "blocked_channels": [
+            str(channel)
+            for channel in blocked_channels
+            if channel is not None and str(channel)
+        ],
+    }
+
+
+def _approval_refusal_reason(
+    conn,
+    *,
+    tenant_id: str,
+    job_key: str,
+    materials_generation: Any,
+    profile_version: int | None,
+    application_url: str,
+) -> str | None:
+    decision = _latest_apply_review_decision(
+        conn,
+        tenant_id=tenant_id,
+        job_key=job_key,
+    )
+    if not decision or decision.get("decision") != "approve_submit":
+        return "awaiting_approval"
+    try:
+        current_materials_generation = int(materials_generation)
+    except (TypeError, ValueError):
+        return "approval_stale_materials"
+    try:
+        decision_materials_generation = int(decision.get("materials_generation"))
+    except (TypeError, ValueError):
+        return "approval_stale_materials"
+    if decision_materials_generation != current_materials_generation:
+        return "approval_stale_materials"
+    try:
+        decision_profile_version = int(decision.get("profile_version"))
+    except (TypeError, ValueError):
+        return "approval_stale_profile"
+    if profile_version is None or decision_profile_version != profile_version:
+        return "approval_stale_profile"
+    if str(decision.get("application_url") or "") != application_url:
+        return "approval_stale_url"
+    if _dry_run_evidence_exists(
+        conn,
+        job_key=job_key,
+        materials_generation=current_materials_generation,
+        profile_version=decision_profile_version,
+        application_url=application_url,
+        coverage="full",
+    ):
+        return None
+    partial_override_run_id = str(decision.get("partial_override_run_id") or "")
+    if partial_override_run_id:
+        if _dry_run_evidence_exists(
+            conn,
+            job_key=job_key,
+            materials_generation=current_materials_generation,
+            profile_version=decision_profile_version,
+            application_url=application_url,
+            coverage="partial",
+            run_id=partial_override_run_id,
+        ):
+            return None
+        return "override_evidence_invalid"
+    return "awaiting_dry_run"
 
 
 def _load_blocked():
@@ -373,21 +628,24 @@ def acquire_job(
             return None
         dry_run = bool(run_ctx.get("dry_run")) if run_ctx else False
         if approval_required and not dry_run:
-            decision = _latest_apply_review_decision(
+            refusal_reason = _approval_refusal_reason(
                 conn,
                 tenant_id=LOCAL_TENANT,
                 job_key=url,
+                materials_generation=row["materials_generation"],
+                profile_version=_current_profile_version(conn, tenant_id=LOCAL_TENANT),
+                application_url=apply_url,
             )
-            if decision != "approve_submit":
+            if refusal_reason:
                 conn.rollback()
                 add_event(
-                    f"[W{worker_id}] Awaiting apply approval for "
-                    f"{(row['title'] or url)[:40]}"
+                    f"[W{worker_id}] Awaiting apply approval "
+                    f"({refusal_reason}) for {(row['title'] or url)[:40]}"
                 )
                 logger.info(
-                    "Apply approval required for %s; latest decision=%s",
+                    "Apply approval required for %s; refusal_reason=%s",
                     url,
-                    decision or "none",
+                    refusal_reason,
                 )
                 return None
 
@@ -440,6 +698,9 @@ def acquire_job(
                 "headless": bool(run_ctx.get("headless")) if run_ctx else False,
                 "attempts": attempts + 1,
                 "workflow_id": run_ctx.get("workflow_id") if run_ctx else None,
+                "materials_generation": row["materials_generation"],
+                "application_url": apply_url,
+                "profile_version": _current_profile_version(conn, tenant_id=LOCAL_TENANT),
             },
         )
         conn.commit()
@@ -447,6 +708,12 @@ def acquire_job(
         if run_ctx is not None:
             run_ctx["run_id"] = str(run_id)
             run_ctx.setdefault("worker_id", worker_id)
+            run_ctx["materials_generation"] = row["materials_generation"]
+            run_ctx["application_url"] = apply_url
+            run_ctx["profile_version"] = _current_profile_version(
+                conn,
+                tenant_id=LOCAL_TENANT,
+            )
 
         return _row_to_job_dict(row, run_id=run_id)
     except Exception:
@@ -538,6 +805,12 @@ def mark_result(
             },
         )
     elif status == "dry_run":
+        binding = _dry_run_completion_binding(
+            conn,
+            job_key=url,
+            run_id=str(run_id),
+            run_ctx=run_ctx,
+        )
         # Launcher owns lock-release policy: Running -> Skipped is a launcher
         # convention (dry-run completed), not in the canonical §8.5 table.
         set_stage_state(
@@ -567,6 +840,11 @@ def mark_result(
                 "worker_id": worker_id,
                 "model": model,
                 "dry_run": True,
+                "coverage": binding["coverage"],
+                "blocked_channels": binding["blocked_channels"],
+                "materials_generation": binding["materials_generation"],
+                "application_url": binding["application_url"],
+                "profile_version": binding["profile_version"],
             },
         )
     else:

--- a/workers/automation/src/jobhunter/database.py
+++ b/workers/automation/src/jobhunter/database.py
@@ -250,9 +250,14 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
             decision            TEXT NOT NULL,
             reason              TEXT,
             decided_by          TEXT,
-            decided_at          TEXT NOT NULL
+            decided_at          TEXT NOT NULL,
+            materials_generation INTEGER,
+            profile_version     INTEGER,
+            application_url     TEXT,
+            partial_override_run_id TEXT
         )
     """)
+    ensure_application_review_decision_columns(conn)
     conn.execute("""
         CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
         ON application_review_decisions(tenant_id, job_key, decided_at DESC)
@@ -601,6 +606,36 @@ def ensure_market_compensation_tables(conn: sqlite3.Connection | None = None) ->
         ON job_market_compensation_estimates (tenant_id, normalized_company, normalized_role)
         """
     )
+    conn.commit()
+    return added
+
+
+def ensure_application_review_decision_columns(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Add approval-binding columns to application_review_decisions."""
+    if conn is None:
+        conn = get_connection()
+
+    existing = {
+        row[1]
+        for row in conn.execute(
+            "PRAGMA table_info(application_review_decisions)"
+        ).fetchall()
+    }
+    additions = {
+        "materials_generation": "INTEGER",
+        "profile_version": "INTEGER",
+        "application_url": "TEXT",
+        "partial_override_run_id": "TEXT",
+    }
+    added: list[str] = []
+    for column, definition in additions.items():
+        if column not in existing:
+            conn.execute(
+                f"ALTER TABLE application_review_decisions ADD COLUMN {column} {definition}"
+            )
+            added.append(column)
     conn.commit()
     return added
 

--- a/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
+++ b/workers/automation/src/jobhunter/infrastructure/gmail/feedback.py
@@ -257,6 +257,10 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
           reason       TEXT,
           decided_by   TEXT NOT NULL DEFAULT 'user',
           decided_at   TEXT NOT NULL,
+          materials_generation INTEGER,
+          profile_version INTEGER,
+          application_url TEXT,
+          partial_override_run_id TEXT,
           PRIMARY KEY (tenant_id, decision_id)
         );
         CREATE INDEX IF NOT EXISTS idx_application_review_decisions_job
@@ -324,6 +328,16 @@ def ensure_application_feedback_tables(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_application_outcome_suggestions_status
           ON application_outcome_suggestions(tenant_id, status, created_at DESC);
         """
+    )
+    _ensure_columns(
+        conn,
+        "application_review_decisions",
+        {
+            "materials_generation": "INTEGER",
+            "profile_version": "INTEGER",
+            "application_url": "TEXT",
+            "partial_override_run_id": "TEXT",
+        },
     )
 
 
@@ -838,7 +852,21 @@ def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
 
 
 def _columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
-    return {row["name"] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+    return {
+        row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+
+
+def _ensure_columns(
+    conn: sqlite3.Connection,
+    table_name: str,
+    additions: dict[str, str],
+) -> None:
+    columns = _columns(conn, table_name)
+    for column, definition in additions.items():
+        if column not in columns:
+            conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column} {definition}")
 
 
 def _column_expr(columns: set[str], column: str, *, prefix: str | None = None) -> str:

--- a/workers/automation/tests/test_apply_regressions.py
+++ b/workers/automation/tests/test_apply_regressions.py
@@ -15,6 +15,8 @@ import threading
 from collections import Counter
 from pathlib import Path
 
+import pytest
+
 from jobhunter.apply import launcher as launcher_module
 from jobhunter.apply.launcher import (
     _kill_claude_processes_for_interrupt,
@@ -130,15 +132,104 @@ def _insert_review_decision(
     decision: str = "approve_submit",
     decided_at: str = "2026-01-01T00:00:00+00:00",
     decision_id: str | None = None,
+    materials_generation: int | None = None,
+    profile_version: int | None = None,
+    application_url: str | None = None,
+    partial_override_run_id: str | None = None,
 ) -> None:
     conn.execute(
         """
         INSERT INTO application_review_decisions (
-            tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at
-        ) VALUES ('local', ?, ?, ?, 'test', 'pytest', ?)
+            tenant_id, decision_id, job_key, decision, reason, decided_by, decided_at,
+            materials_generation, profile_version, application_url, partial_override_run_id
+        ) VALUES ('local', ?, ?, ?, 'test', 'pytest', ?, ?, ?, ?, ?)
         """,
-        (decision_id or f"decision-{decision}-{decided_at}", job_key, decision, decided_at),
+        (
+            decision_id or f"decision-{decision}-{decided_at}",
+            job_key,
+            decision,
+            decided_at,
+            materials_generation,
+            profile_version,
+            application_url,
+            partial_override_run_id,
+        ),
     )
+    conn.commit()
+
+
+def _seed_current_apply_binding(
+    conn: sqlite3.Connection,
+    *,
+    job_key: str = "https://example.com/job",
+    application_url: str = "https://example.com/apply",
+    generation: int = 1,
+    profile_version: int = 1,
+    coverage: str | None = "full",
+    run_id: str = "dry-run-full",
+) -> None:
+    now = "2026-01-01T00:00:00+00:00"
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO candidate_profiles (
+            tenant_id, profile_id, version, updated_at
+        ) VALUES ('local', 'default', ?, ?)
+        """,
+        (profile_version, now),
+    )
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO job_materials (
+            job_url, generation, tenant_id, status, created_at, updated_at
+        ) VALUES (?, ?, 'local', 'approved', ?, ?)
+        """,
+        (job_key, generation, now, now),
+    )
+    for artifact_type, artifact_id, path in (
+        ("tailored_resume", "resume-text-1", "/tmp/resume.txt"),
+        ("resume_pdf", "resume-pdf-1", "/tmp/resume.pdf"),
+    ):
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO job_materials_artifacts (
+                job_url, generation, artifact_type, artifact_id, status, path,
+                render_format, created_at
+            ) VALUES (?, ?, ?, ?, 'approved', ?, 'text', ?)
+            """,
+            (job_key, generation, artifact_type, artifact_id, path, now),
+        )
+    if coverage is not None:
+        record_job_event(
+            conn,
+            job_key,
+            "apply",
+            "ApplyRunStarted",
+            message="Apply dry-run started",
+            payload={
+                "run_id": run_id,
+                "dry_run": True,
+                "materials_generation": generation,
+                "profile_version": profile_version,
+                "application_url": application_url,
+            },
+        )
+        record_job_event(
+            conn,
+            job_key,
+            "apply",
+            "DryRunCompleted",
+            message="Dry run completed",
+            payload={
+                "run_id": run_id,
+                "result": "dry_run_complete",
+                "dry_run": True,
+                "coverage": coverage,
+                "materials_generation": generation,
+                "application_url": application_url,
+                "profile_version": profile_version,
+                "finished_at": now,
+            },
+        )
     conn.commit()
 
 
@@ -258,11 +349,15 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
     db_path = Path(tmp_path) / "jobs.db"
     conn = init_db(db_path)
     _insert_ready_job(conn)
+    _seed_current_apply_binding(conn)
     _insert_review_decision(
         conn,
         decision="approve_submit",
         decided_at="2026-01-01T00:00:00+00:00",
         decision_id="decision-old-approve",
+        materials_generation=1,
+        profile_version=1,
+        application_url="https://example.com/apply",
     )
     _insert_review_decision(
         conn,
@@ -281,8 +376,271 @@ def test_apply_approval_gate_requires_latest_approve_submit(tmp_path, monkeypatc
             decision="approve_submit",
             decided_at="2026-01-03T00:00:00+00:00",
             decision_id="decision-new-approve",
+            materials_generation=1,
+            profile_version=1,
+            application_url="https://example.com/apply",
         )
         assert acquire_job(target_url="https://example.com/job", worker_id=1) is not None
+    finally:
+        close_connection(db_path)
+
+
+def test_apply_approval_gate_requires_matching_full_dry_run(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, coverage=None)
+    _insert_review_decision(
+        conn,
+        decision="approve_submit",
+        materials_generation=1,
+        profile_version=1,
+        application_url="https://example.com/apply",
+    )
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        prior_event_count = len(get_recent_events())
+        assert acquire_job(target_url="https://example.com/job", worker_id=1) is None
+        assert any(
+            "awaiting_dry_run" in event
+            for event in get_recent_events()[prior_event_count:]
+        )
+    finally:
+        close_connection(db_path)
+
+
+def test_normal_dry_run_completion_satisfies_approval_gate(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, coverage=None)
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        run_ctx: dict = {"dry_run": True}
+        dry_run_job = acquire_job(
+            target_url="https://example.com/job",
+            worker_id=1,
+            run_ctx=run_ctx,
+            approval_required=True,
+        )
+        assert dry_run_job is not None
+        mark_result(
+            "https://example.com/job",
+            "dry_run",
+            duration_ms=123,
+            task_id=run_ctx["run_id"],
+            run_ctx=run_ctx,
+        )
+        completion = conn.execute(
+            "SELECT payload_json FROM job_events "
+            "WHERE job_url = ? AND event_type = 'DryRunCompleted' "
+            "ORDER BY event_id DESC LIMIT 1",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert completion is not None
+        payload = json.loads(completion["payload_json"])
+        assert payload["coverage"] == "full"
+        assert payload["materials_generation"] == 1
+        assert payload["application_url"] == "https://example.com/apply"
+
+        _insert_review_decision(
+            conn,
+            decision="approve_submit",
+            decided_at="2026-01-02T00:00:00+00:00",
+            materials_generation=1,
+            profile_version=1,
+            application_url="https://example.com/apply",
+        )
+
+        live_job = acquire_job(
+            target_url="https://example.com/job",
+            worker_id=2,
+            approval_required=True,
+        )
+        assert live_job is not None
+    finally:
+        close_connection(db_path)
+
+
+@pytest.mark.parametrize(
+    ("decision_bindings", "expected_reason"),
+    [
+        ({"materials_generation": 0, "profile_version": 1, "application_url": "https://example.com/apply"}, "approval_stale_materials"),
+        ({"materials_generation": 1, "profile_version": 0, "application_url": "https://example.com/apply"}, "approval_stale_profile"),
+        ({"materials_generation": 1, "profile_version": 1, "application_url": "https://example.com/old-apply"}, "approval_stale_url"),
+    ],
+)
+def test_apply_approval_gate_rejects_stale_bindings(
+    tmp_path,
+    monkeypatch,
+    decision_bindings,
+    expected_reason,
+):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(conn)
+    _insert_review_decision(conn, decision="approve_submit", **decision_bindings)
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        worker_id = {
+            "approval_stale_materials": 11,
+            "approval_stale_profile": 12,
+            "approval_stale_url": 13,
+        }[expected_reason]
+        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
+        assert any(
+            f"[W{worker_id}]" in event and expected_reason in event
+            for event in get_recent_events()
+        )
+    finally:
+        close_connection(db_path)
+
+
+def test_apply_approval_gate_accepts_partial_override_bound_to_run(tmp_path, monkeypatch):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, coverage="partial", run_id="dry-run-partial")
+    _insert_review_decision(
+        conn,
+        decision="approve_submit",
+        materials_generation=1,
+        profile_version=1,
+        application_url="https://example.com/apply",
+        partial_override_run_id="dry-run-partial",
+    )
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        assert acquire_job(target_url="https://example.com/job", worker_id=1) is not None
+    finally:
+        close_connection(db_path)
+
+
+@pytest.mark.parametrize(
+    ("coverage", "partial_override_run_id", "expected_reason"),
+    [
+        ("full", None, "awaiting_dry_run"),
+        ("partial", "dry-run-profile-v1", "override_evidence_invalid"),
+    ],
+)
+def test_apply_approval_gate_rejects_dry_run_evidence_for_stale_profile(
+    tmp_path,
+    monkeypatch,
+    coverage,
+    partial_override_run_id,
+    expected_reason,
+):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(
+        conn,
+        coverage=coverage,
+        profile_version=1,
+        run_id="dry-run-profile-v1",
+    )
+    conn.execute(
+        """
+        UPDATE candidate_profiles
+        SET version = 2, updated_at = ?
+        WHERE tenant_id = 'local' AND profile_id = 'default'
+        """,
+        (utc_now(),),
+    )
+    conn.commit()
+    _insert_review_decision(
+        conn,
+        decision="approve_submit",
+        materials_generation=1,
+        profile_version=2,
+        application_url="https://example.com/apply",
+        partial_override_run_id=partial_override_run_id,
+    )
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        worker_id = 21 if coverage == "full" else 22
+        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
+        assert any(
+            f"[W{worker_id}]" in event and expected_reason in event
+            for event in get_recent_events()
+        )
+    finally:
+        close_connection(db_path)
+
+
+@pytest.mark.parametrize("seed_stale_run", [False, True])
+def test_apply_approval_gate_rejects_invalid_partial_override(
+    tmp_path,
+    monkeypatch,
+    seed_stale_run,
+):
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_ready_job(conn)
+    _seed_current_apply_binding(conn, coverage=None)
+    if seed_stale_run:
+        record_job_event(
+            conn,
+            "https://example.com/job",
+            "apply",
+            "ApplyRunStarted",
+            message="stale partial dry-run started",
+            payload={
+                "run_id": "dry-run-partial",
+                "dry_run": True,
+                "materials_generation": 0,
+                "profile_version": 1,
+                "application_url": "https://example.com/apply",
+            },
+        )
+        record_job_event(
+            conn,
+            "https://example.com/job",
+            "apply",
+            "DryRunCompleted",
+            message="stale partial dry-run completed",
+            payload={
+                "run_id": "dry-run-partial",
+                "dry_run": True,
+                "coverage": "partial",
+            },
+        )
+        conn.commit()
+    _insert_review_decision(
+        conn,
+        decision="approve_submit",
+        materials_generation=1,
+        profile_version=1,
+        application_url="https://example.com/apply",
+        partial_override_run_id="dry-run-partial",
+    )
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection", lambda: get_connection(db_path)
+        )
+        worker_id = 23 if seed_stale_run else 24
+        assert acquire_job(target_url="https://example.com/job", worker_id=worker_id) is None
+        assert any(
+            f"[W{worker_id}]" in event and "override_evidence_invalid" in event
+            for event in get_recent_events()
+        )
     finally:
         close_connection(db_path)
 


### PR DESCRIPTION
## What

- Extends apply-review decisions so `approve_submit` persists the reviewed materials generation, profile version, application URL, and optional explicit partial dry-run run ID.
- Requires `approve_submit` requests to carry the displayed materials/profile/URL tuple, and rejects stale displayed bindings before inserting a decision row.
- Binds full and partial dry-run evidence to the same materials generation, profile version, and application URL in both the TypeScript API and the Python worker claim gate.
- Surfaces approval-gate binding details and skip reasons in Apply Review, including the explicit partial-evidence override affordance required by W1.1.
- Adds API, UI, and worker regressions for stale materials/profile/URL, stale dry-run profile evidence, invalid partial overrides, and selected-candidate generation binding.

## Why

W1.1 closes the gap between what the human reviewed and what a later live apply run may claim. Submit approval is now stale by default unless the current materials, profile, URL, and dry-run evidence still match the reviewed tuple.

## Validation

- W1.0 substrate greps were run before this branch was cut; the expected symbols were present.
- `corepack pnpm check`
- `corepack pnpm test` (API 343 tests, web build, Python 1816 tests)
- `corepack pnpm qa:test` (3 tests)
- `corepack pnpm --filter @jobhunter/web test -- --run` (146 files / 906 tests)
- `corepack pnpm --filter @jobhunter/web test-d` (9 tests, no type errors)
- `corepack pnpm docs:build` (4545 references / 230 emitted files)
- `uv --project workers/automation run --extra dev python -m build workers/automation`
- `python3 scripts/release_check.py` (passes with the three expected W0 prompt warnings called out in the remediation prompt)
- `git diff --check`
- Focused API regression: `corepack pnpm --filter @jobhunter/api exec vitest run test/application-feedback.test.ts --reporter=dot` (30 tests)
- Focused UI regression: `corepack pnpm --filter @jobhunter/web exec vitest run src/views/apply-review/ApplyReviewView.test.tsx src/contexts/apply/hooks/useApplyReviewMutations.test.ts --reporter=dot` (44 tests)
- Focused worker regression: `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_regressions.py -k "approval_gate or normal_dry_run_completion"` (13 passed, 21 deselected)
- Review: W1.1 reviewer Gate: PASS
- QA: W1.1 QA Gate: PASS, including injected API probes for implicit partial rejection, stale displayed bindings, stale dry-run profile evidence, and explicit matching partial override persistence

## Deviations

None. W2.1 rename/publish work is explicitly out of scope, so this PR keeps all `JobHunter`/`jobhunter` names unchanged.

## Deferred

No live browser/Temporal submit run was performed; validation used injected API calls, UI tests, worker acquisition tests, and build/type/lint checks to avoid real application submission behavior.