### PR TITLE
docs(plans): [R1] index OSS drive-to-done tracker

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -4,7 +4,7 @@ Plans are historical working documents. Canonical project documentation lives
 at the top of `docs/`.
 
 - Top level: accepted plans that are not fully delivered (currently the OSS
-  release remediation spec).
+  release remediation spec and its drive-to-done verification plan).
 - `implemented/`: plans, specs, QA checklists, and delivery notes for work
   that has landed or been superseded by canonical docs.
 
@@ -53,6 +53,7 @@ and frontend plans were renamed from working titles (`ddd-target-plan.md`,
 | 2026-07-03 | [Temporal-Native Rearchitecture](implemented/2026-07-03-temporal-native-rearchitecture.md) | Implemented — #230 (plan), #233, #231, #235, #238, #237, #239, #240; ADRs 2026-07-03 |
 | 2026-07-03 | [Temporal Rearchitecture — Implementation Spec (P1b–P5)](implemented/2026-07-03-temporal-rearch-implementation-spec.md) | Implemented — spec #232 |
 | 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](2026-07-03-oss-release-remediation-spec.md) | **Active** — spec #234; W0 landed #242–#247 |
+| 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](2026-07-05-oss-release-drive-to-done-plan.md) | **Active** — plan #258; #274 inventory keeps the release gate open on W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints |
 
 Two 2026-05-17 backlog specs (`…-add-react`, `…-add-brows`) were drafted on
 `origin/mestre/develop-*` branches and never merged to `main`; only `…-add-root`


### PR DESCRIPTION
## What

- Adds the new OSS drive-to-done plan to `docs/plans/README.md` so the active plan index points at PR #258.
- Keeps the refreshed status inventory out of committed docs, per the plan's Delivery Model and §2.5 rule that current status belongs in PR descriptions.

## Why

This is the first [R1] stack item on `docs/plan-oss-drive-to-done`. It establishes the tracking surface for the drive-to-done proof while keeping volatile status out of the repo. The refreshed inventory below was run against `origin/main` at `59e031b94faf3810a73b75bb742a114c1bd9a783` after the reported W1-W2 merge wave.

## Refreshed inventory

Result: **NO-GO**. The owner report that W1-W2 closed the OSS remediation spec is not proven by current `main`.

- **Merged / DoD-probed enough for this closeout pass:** W0.1-W0.6, W1.1, W2.3, W2.5.
- **Landed with residual:** W2.2. Responsible-use docs landed, but the doctor capability-notice residual remains open.
- **Not started or not proven on `main`:** W1.2, W1.3, W1.4, W1.5, W1.6, W1.7, W1.8, W2.4, W2.6.
- **Owner decision still open:** W2.1 / rename train remains unresolved because PR #257 is still open and the distribution is still `jobhunter` with tag publishing disabled.
- **Strict release gate:** `python3 scripts/release_check.py --strict-prompt` fails on the W1 tripwires, so W1 is not complete. Normal `python3 scripts/release_check.py` still exits 0 with zero findings, as required.

## Validation

- `git diff --check` -> clean.
- `python3 scripts/release_check.py` -> exit 0, `Release check passed.` with the three expected W1-gated warnings.
- `python3 scripts/release_check.py --strict-prompt` -> exit 1 on the W1 prompt tripwires; expected no-go proof, not a PR failure.
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_release_check.py workers/automation/tests/test_apply_regressions.py -k "release_check or approval_gate"` -> 19 passed, 21 deselected.
- `corepack pnpm --filter @jobhunter/api test -- test/application-feedback.test.ts test/server.test.ts` -> 20 test files passed, 350 tests passed.
- `corepack pnpm --filter @jobhunter/web test -- src/contexts/apply/hooks/useApplyReviewMutations.test.ts src/views/apply-review/ApplyReviewView.test.tsx` -> 146 test files passed, 908 tests passed.
- `corepack pnpm docs:build` -> VitePress build passed; docs site link check passed with 4545 references across 230 emitted files.
- `corepack pnpm check` -> all checks passed.

## Deviations

- Full `pnpm test` was not run locally because the closeout inventory is already a release no-go via strict prompt failure and this PR is docs-only. CI remains the merge gate.
- No product code, real browser submission, mailbox scan, profile data, generated materials, or real application flow was run.

## Deferred

- Close W1.2-W1.8, W2.2 doctor notices, W2.4, W2.6, and owner checkpoints before any publication go decision.


