### PR TITLE
docs(backlog): [R1] record OSS closeout no-go items

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -33,6 +33,12 @@ frontend adapters remain deferred until the local product is solid.
 
 ## Release Hardening Follow-Ups
 
+- Close the OSS remediation no-go items before any public visibility flip:
+  finish the remaining W1 apply/runtime safety sequence, the W2.2 doctor
+  capability notices, W2.4 per-lane spend attribution and defaults, and W2.6
+  Tier-2 auth-chain checks. The drive-to-done plan keeps volatile status in PR
+  descriptions; this durable backlog entry records that the release gate is not
+  satisfied until those items and owner checkpoints are closed.
 - Add a shared schema-contract check for database tables initialized by both
   the TypeScript API and Python worker so cross-runtime table ownership cannot
   drift silently.


### PR DESCRIPTION
## What

- Adds one sanitized `docs/backlog.md` release-hardening follow-up recording that the OSS remediation closeout is currently a no-go.
- Names only high-level W-item routes: remaining W1 apply/runtime safety, W2.2 doctor notices, W2.4 spend attribution/defaults, and W2.6 Tier-2 auth-chain checks.

## Why

The refreshed drive-to-done inventory against `origin/main` at `59e031b94faf3810a73b75bb742a114c1bd9a783` disproves the reported full W1-W2 closeout. The plan requires residual or no-go gaps to have a public sanitized route while sensitive details stay out of committed docs and PR text. This PR adds that durable route; the volatile per-item inventory remains in PR descriptions.

## Refreshed inventory

Result: **NO-GO**.

- **Merged / DoD-probed enough for this closeout pass:** W0.1-W0.6, W1.1, W2.3, W2.5.
- **Landed with residual:** W2.2. Responsible-use docs landed, but the doctor capability-notice residual remains open.
- **Not started or not proven on `main`:** W1.2, W1.3, W1.4, W1.5, W1.6, W1.7, W1.8, W2.4, W2.6.
- **Owner decision still open:** W2.1 / rename train remains unresolved because PR #257 is still open and the distribution is still `jobhunter` with tag publishing disabled.
- **Strict release gate:** `python3 scripts/release_check.py --strict-prompt` fails on the W1 tripwires, so W1 is not complete. Normal `python3 scripts/release_check.py` still exits 0 with zero findings.

## Validation

- `git diff --check` -> clean.
- `python3 scripts/release_check.py` -> exit 0, `Release check passed.` with the three expected W1-gated warnings.
- `python3 scripts/release_check.py --strict-prompt` -> exit 1 on the W1 prompt tripwires; expected no-go proof, not a PR failure.
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_release_check.py workers/automation/tests/test_apply_regressions.py -k "release_check or approval_gate"` -> 19 passed, 21 deselected.
- `corepack pnpm --filter @jobhunter/api test -- test/application-feedback.test.ts test/server.test.ts` -> 20 test files passed, 350 tests passed.
- `corepack pnpm --filter @jobhunter/web test -- src/contexts/apply/hooks/useApplyReviewMutations.test.ts src/views/apply-review/ApplyReviewView.test.tsx` -> 146 test files passed, 908 tests passed.
- `corepack pnpm docs:build` -> VitePress build passed; docs site link check passed with 4545 references across 230 emitted files.
- `corepack pnpm check` -> all checks passed.

## Deviations

- Full `pnpm test` was not run locally because the closeout inventory is already a release no-go via strict prompt failure and this PR is docs-only. CI remains the merge gate.
- No product code, real browser submission, mailbox scan, profile data, generated materials, or real application flow was run.

## Deferred

- Actual W-item implementation remains outside this plan stack and must follow the OSS remediation spec train.


