### PR TITLE
docs(plans): [R1] archive OSS closeout plans with no-go status

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,10 +3,10 @@
 Plans are historical working documents. Canonical project documentation lives
 at the top of `docs/`.
 
-- Top level: accepted plans that are not fully delivered (currently the OSS
-  release remediation spec and its drive-to-done verification plan).
+- Top level: accepted plans that are not fully delivered.
 - `implemented/`: plans, specs, QA checklists, and delivery notes for work
-  that has landed or been superseded by canonical docs.
+  that has landed, been superseded by canonical docs, or been closed with a
+  recorded outcome.
 
 When a plan is fully implemented, move it into `implemented/` with a status
 banner recording the delivery PRs and any deviations, and update the canonical
@@ -52,8 +52,8 @@ and frontend plans were renamed from working titles (`ddd-target-plan.md`,
 | 2026-06-22 | [Swap LaTeX For HTML/CSS Resume Rendering](implemented/2026-06-22-swap-latex-for-html-css.md) | Implemented — #188, #210, #211, #220; ADR 2026-06-24 |
 | 2026-07-03 | [Temporal-Native Rearchitecture](implemented/2026-07-03-temporal-native-rearchitecture.md) | Implemented — #230 (plan), #233, #231, #235, #238, #237, #239, #240; ADRs 2026-07-03 |
 | 2026-07-03 | [Temporal Rearchitecture — Implementation Spec (P1b–P5)](implemented/2026-07-03-temporal-rearch-implementation-spec.md) | Implemented — spec #232 |
-| 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](2026-07-03-oss-release-remediation-spec.md) | **Active** — spec #234; W0 landed #242–#247 |
-| 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](2026-07-05-oss-release-drive-to-done-plan.md) | **Active** — plan #258; #274 inventory keeps the release gate open on W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints |
+| 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](implemented/2026-07-03-oss-release-remediation-spec.md) | Closed by #274 inventory; **not release-ready** — W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints remain open |
+| 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](implemented/2026-07-05-oss-release-drive-to-done-plan.md) | Closed by #274 inventory; **no-go** — remaining items are W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints |
 
 Two 2026-05-17 backlog specs (`…-add-react`, `…-add-brows`) were drafted on
 `origin/mestre/develop-*` branches and never merged to `main`; only `…-add-root`

--- a/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
@@ -1,11 +1,18 @@
 # OSS Release Remediation — Implementation Spec for Codex
 
+> **Status (2026-07-05 R1 closeout):** archived after #274 regenerated the
+> inventory against current `main`. This is **not** a release-ready outcome:
+> W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release
+> checkpoints remain open. The document is preserved as the historical work-item
+> definition source; do not treat the move to `implemented/` as proof that the
+> OSS release gate passed.
+>
 > **Audience:** an external implementing agent (Codex). This document is
 > self-contained and prescriptive: follow it literally. Where it says STOP,
 > stop and report rather than improvising.
-> **Companions:** `docs/plans/2026-07-03-temporal-native-rearchitecture.md`
+> **Companions:** `docs/plans/implemented/2026-07-03-temporal-native-rearchitecture.md`
 > (PR #230, the architectural plan) and
-> `docs/plans/2026-07-03-temporal-rearch-implementation-spec.md` (PR #232,
+> `docs/plans/implemented/2026-07-03-temporal-rearch-implementation-spec.md` (PR #232,
 > the P1b–P5 implementation spec). Workstream W1 below **builds on top of
 > temporal phase P2** and must not re-implement anything P2 delivers.
 > **Goal:** make this repository safe to publish as open source while

--- a/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
+++ b/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
@@ -1,8 +1,14 @@
 # OSS Release — Drive-to-Done and Completion Verification Plan
 
+> **Closeout status (2026-07-05 R1):** #274 executed this plan's inventory
+> method against current `main` and found **NO-GO**, not release-ready. W1.2–W1.8,
+> W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints remain
+> open. This plan is archived as executed, not as proof that the release gate
+> passed.
+>
 > **Anchors verified against main @ `a488e4e9853dde292badc74a88c7de24160edc52`.**
 > **Type:** thin drive-to-done overlay. It does not re-specify anything.
-> **Source of truth for every work item:** `docs/plans/2026-07-03-oss-release-remediation-spec.md`
+> **Source of truth for every work item:** `docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md`
 > (the "spec"). This plan tracks that spec to completion against `main`, proves
 > each item's Definition of Done actually holds, and assembles the publication
 > go/no-go gate. Where this plan and the spec disagree on WHAT an item must do,


### PR DESCRIPTION
## What

- Moves the OSS remediation spec and the drive-to-done plan from `docs/plans/` to `docs/plans/implemented/`.
- Adds closeout banners to both moved documents stating that the #274 inventory found **NO-GO**, not release-ready.
- Updates `docs/plans/README.md` so the historical ledger points to the implemented paths and lists the still-open release blockers.

## Why

This replaces the now-closed backlog-only PR #275 with a useful top-of-stack closeout artifact. The closeout plan has been executed: #274 records the current inventory and the gate remains open on W1.2-W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints. Moving the documents prevents the top-level plans directory from advertising stale active implementation docs, while the banners preserve the important truth that the OSS release gate did not pass.

## Validation

- `git diff --check` -> clean.
- `python3 scripts/release_check.py` -> exit 0, `Release check passed.` with the expected W1-gated warnings.
- `corepack pnpm docs:build` -> VitePress build passed; docs site link check passed with 4545 references across 230 emitted files.

## Deviations

- This PR intentionally does not implement the remaining W-items. It archives the executed closeout docs with no-go status.

## Deferred

- Remaining release blockers: W1.2-W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints.
