### PR TITLE
chore(governance): exempt repository owner from DCO

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,4 +8,4 @@
 
 ## Checklist
 
-- [ ] Every commit in this PR includes a DCO `Signed-off-by:` trailer (`git commit -s`).
+- [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,6 +9,9 @@ permissions:
 
 jobs:
   dco:
+    # Exempt repository-owner PRs by GitHub actor so the workflow does not
+    # publish maintainer email addresses in configuration.
+    if: ${{ github.event.pull_request.user.login != github.repository_owner }}
     name: DCO sign-off
     runs-on: ubuntu-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
 
 - Keep changes scoped to one behavior or documentation concern.
 - Use Conventional Commits for commit messages and PR titles.
-- Sign off every commit with the Developer Certificate of Origin trailer.
+- External contributors should sign off every commit with the Developer
+  Certificate of Origin trailer.
 - Update documentation when public behavior, commands, runtime requirements,
   configuration, architecture, or QA expectations change.
 - Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
@@ -35,9 +36,11 @@ JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm dev
 
 ## Developer Certificate of Origin Sign-Off
 
-Every pull request commit must include a `Signed-off-by:` trailer. This is a
-DCO sign-off that says you have the right to submit the contribution; it is
-separate from GPG or SSH commit signing.
+External contributor pull request commits must include a `Signed-off-by:`
+trailer. This is a DCO sign-off that says you have the right to submit the
+contribution; it is separate from GPG or SSH commit signing. Repository-owner
+PRs are exempted by GitHub actor in CI so maintainer email addresses do not need
+to be published in workflow configuration.
 
 Use `git commit -s` for new commits:
 


### PR DESCRIPTION
## What

- Skips the DCO job when the pull request author is the repository owner.
- Keeps DCO enforcement for external contributor PRs.
- Updates contributor and PR-template wording so the sign-off checklist applies to external contributor commits.

## Why

The DCO action's author exemption config is email-pattern based, which would require publishing a maintainer email address in workflow configuration. This uses GitHub actor metadata instead.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dco.yml"); puts "yaml ok"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dco.yml`
- `rg -n "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}|eloibarti@gmail|Signed-off-by:.*<|exempt-authors" .github/workflows/dco.yml CONTRIBUTING.md .github/pull_request_template.md` (no matches)
- `python3 scripts/release_check.py` (passes with the existing W1 prompt warnings)
- `corepack pnpm docs:build`
- `git diff --check`

## Notes

This PR intentionally uses an unsigned local commit so the workflow change can prove the owner exemption without exposing an email address.