### PR TITLE
feat(web): [R8] add saved jobs table views

### DIFF
--- a/apps/web/src/shared/stores/saved-table-views.test.ts
+++ b/apps/web/src/shared/stores/saved-table-views.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SAVED_TABLE_VIEW_ID,
+  JOBS_TABLE_COLUMN_IDS,
+  JOBS_TABLE_ID,
+  normalizeSavedTableViewsState,
+  useSavedTableViewsStore,
+  type SavedTableViewSnapshot,
+} from "./saved-table-views.js";
+
+const snapshot: SavedTableViewSnapshot = {
+  columns: {
+    order: [...JOBS_TABLE_COLUMN_IDS],
+    hidden: ["company"],
+    widths: { title: 320 },
+  },
+  density: "compact",
+  sort: { columnId: "fit_score", direction: "desc" },
+  urlFilters: { q: "platform", stage: "apply", pageSize: 25 },
+  gridFilters: {
+    source: { operator: "contains", text: "greenhouse", selectedValues: [] },
+  },
+  grouping: null,
+  colorRules: [],
+};
+
+beforeEach(() => {
+  window.localStorage.removeItem("jh:saved-table-views");
+  useSavedTableViewsStore.getState().reset();
+});
+
+describe("saved table views store", () => {
+  it("migrates persisted views by dropping unknown columns and reconstructing Default", () => {
+    const normalized = normalizeSavedTableViewsState({
+      views: [
+        {
+          id: "legacy",
+          tableId: JOBS_TABLE_ID,
+          name: "Legacy",
+          columns: {
+            order: ["company", "ghost", "title"],
+            hidden: ["ghost", "source"],
+            widths: { company: 222, ghost: 999 },
+          },
+          sort: { columnId: "ghost", direction: "asc" },
+          urlFilters: { stage: "apply", deleted: "hidden" },
+          gridFilters: {
+            ghost: {
+              operator: "contains",
+              text: "bad",
+              selectedValues: ["bad"],
+            },
+            company: {
+              operator: "does_not_contain",
+              text: "agency",
+              selectedValues: [],
+            },
+          },
+          grouping: { columnId: "ghost" },
+          colorRules: [
+            {
+              columnId: "ghost",
+              predicate: { op: "eq", value: "x" },
+              tone: "danger",
+            },
+            {
+              columnId: "company",
+              predicate: { op: "contains", value: "Acme" },
+              tone: "info",
+            },
+          ],
+        },
+      ],
+      activeViewIdByTable: { [JOBS_TABLE_ID]: "legacy" },
+    });
+
+    const defaultView = normalized.views.find(
+      (view) => view.id === DEFAULT_SAVED_TABLE_VIEW_ID,
+    );
+    const legacy = normalized.views.find((view) => view.id === "legacy");
+
+    expect(defaultView).toMatchObject({
+      builtIn: true,
+      name: "Default",
+      tableId: JOBS_TABLE_ID,
+    });
+    expect(legacy).toBeDefined();
+    expect(legacy?.columns.order).toContain("company");
+    expect(legacy?.columns.order).toContain("title");
+    expect(legacy?.columns.order).not.toContain("ghost");
+    expect(legacy?.columns.hidden).toEqual(["source"]);
+    expect(legacy?.columns.widths).toEqual({ company: 222 });
+    expect(legacy?.sort).toEqual({
+      columnId: "discovered_at",
+      direction: "desc",
+    });
+    expect(legacy?.gridFilters).toEqual({
+      company: {
+        operator: "does_not_contain",
+        text: "agency",
+        selectedValues: [],
+      },
+    });
+    expect(legacy?.grouping).toBeNull();
+    expect(legacy?.colorRules).toEqual([
+      {
+        columnId: "company",
+        predicate: { op: "contains", value: "Acme" },
+        tone: "info",
+      },
+    ]);
+    expect(normalized.activeViewIdByTable[JOBS_TABLE_ID]).toBe("legacy");
+  });
+
+  it("keeps templates unchanged until an explicit save/update action", () => {
+    const store = useSavedTableViewsStore.getState();
+    const createdId = store.createView(JOBS_TABLE_ID, "Apply review", snapshot);
+
+    expect(useSavedTableViewsStore.getState().activeViewIdByTable[JOBS_TABLE_ID]).toBe(
+      createdId,
+    );
+
+    useSavedTableViewsStore.getState().setTablePresentation(JOBS_TABLE_ID, {
+      ...snapshot,
+      columns: { ...snapshot.columns, hidden: ["company", "source"] },
+    });
+    expect(
+      useSavedTableViewsStore
+        .getState()
+        .views.find((view) => view.id === createdId)?.columns.hidden,
+    ).toEqual(["company"]);
+
+    expect(
+      useSavedTableViewsStore.getState().updateActiveView(JOBS_TABLE_ID, {
+        ...snapshot,
+        columns: { ...snapshot.columns, hidden: ["company", "source"] },
+      }),
+    ).toBe(true);
+    expect(
+      useSavedTableViewsStore
+        .getState()
+        .views.find((view) => view.id === createdId)?.columns.hidden,
+    ).toEqual(["company", "source"]);
+
+    expect(
+      useSavedTableViewsStore
+        .getState()
+        .renameView(JOBS_TABLE_ID, createdId, "Saved apply"),
+    ).toBe(true);
+    expect(
+      useSavedTableViewsStore.getState().deleteView(JOBS_TABLE_ID, createdId),
+    ).toBe(true);
+    expect(useSavedTableViewsStore.getState().activeViewIdByTable[JOBS_TABLE_ID]).toBe(
+      DEFAULT_SAVED_TABLE_VIEW_ID,
+    );
+  });
+});

--- a/apps/web/src/shared/stores/saved-table-views.ts
+++ b/apps/web/src/shared/stores/saved-table-views.ts
@@ -1,0 +1,586 @@
+import {
+  JOB_APPLY_STATUS_FILTERS,
+  JOB_SORT_FIELDS,
+  STAGES,
+  STAGE_STATES,
+  type JobSortField,
+  type SavedTableView,
+  type SavedTableViewDensity,
+  type SavedTableViewGridFilters,
+  type SavedTableViewUrlFilters,
+  type TableId,
+} from "@jobhunter/contracts";
+import { create } from "zustand";
+import { createJSONStorage, persist, type StateStorage } from "zustand/middleware";
+
+export const SAVED_TABLE_VIEW_STORE_VERSION = 1;
+export const SAVED_TABLE_VIEW_SCHEMA_VERSION = 1;
+export const DEFAULT_SAVED_TABLE_VIEW_ID = "default";
+export const JOBS_TABLE_ID = "jobs" satisfies TableId;
+export const JOBS_TABLE_COLUMN_IDS = [
+  "select",
+  "fit_score",
+  "title",
+  "company",
+  "source",
+  "compensation_min_eur",
+  "compensation_max_eur",
+  "compensation_market",
+  "compensation_confidence",
+  "compensation_warnings",
+  "location",
+  "current_stage",
+  "current_state",
+  "resume_template",
+  "discovered_at",
+  "apply_status",
+] as const;
+
+const STAGE_OR_ALL = [...STAGES, "all"] as const;
+const STATE_OR_ALL = [...STAGE_STATES, "all"] as const;
+const JOB_DELETED_VIEW_FILTERS = ["active", "closed", "deleted", "hidden"] as const;
+const DENSITIES = ["compact", "regular", "comfy"] as const;
+const COLOR_RULE_OPERATORS = ["eq", "neq", "gte", "lte", "contains"] as const;
+const COLOR_RULE_TONES = ["success", "warning", "danger", "info"] as const;
+
+type KnownTableConfig = {
+  tableId: TableId;
+  columnIds: readonly string[];
+  defaultSort: SavedTableView["sort"];
+  defaultUrlFilters: SavedTableViewUrlFilters;
+};
+
+const TABLE_CONFIGS: Record<string, KnownTableConfig> = {
+  [JOBS_TABLE_ID]: {
+    tableId: JOBS_TABLE_ID,
+    columnIds: JOBS_TABLE_COLUMN_IDS,
+    defaultSort: { columnId: "discovered_at", direction: "desc" },
+    defaultUrlFilters: {
+      q: "",
+      stage: "all",
+      state: "all",
+      applyStatus: "all",
+      deleted: "active",
+      pageSize: 50,
+    },
+  },
+};
+
+export interface SavedTablePresentation {
+  columns: SavedTableView["columns"];
+  density: SavedTableViewDensity | null;
+  grouping: SavedTableView["grouping"];
+  colorRules: SavedTableView["colorRules"];
+}
+
+export interface SavedTableViewSnapshot extends SavedTablePresentation {
+  sort: SavedTableView["sort"];
+  urlFilters: SavedTableViewUrlFilters;
+  gridFilters: SavedTableViewGridFilters;
+}
+
+interface SavedTableViewsState {
+  views: SavedTableView[];
+  activeViewIdByTable: Partial<Record<TableId, string>>;
+  presentationByTable: Partial<Record<TableId, SavedTablePresentation>>;
+  applyView: (tableId: TableId, viewId: string) => void;
+  setTablePresentation: (
+    tableId: TableId,
+    presentation: SavedTablePresentation,
+  ) => void;
+  createView: (
+    tableId: TableId,
+    name: string,
+    snapshot: SavedTableViewSnapshot,
+  ) => string;
+  updateActiveView: (tableId: TableId, snapshot: SavedTableViewSnapshot) => boolean;
+  renameView: (tableId: TableId, viewId: string, name: string) => boolean;
+  deleteView: (tableId: TableId, viewId: string) => boolean;
+  reset: () => void;
+}
+
+function createMemoryStorage(): StateStorage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}
+
+const fallbackStorage = createMemoryStorage();
+
+function getStorage(): StateStorage {
+  if (typeof window === "undefined") {
+    return fallbackStorage;
+  }
+  const storage = window.localStorage as Partial<StateStorage> | undefined;
+  if (
+    storage &&
+    typeof storage.getItem === "function" &&
+    typeof storage.setItem === "function" &&
+    typeof storage.removeItem === "function"
+  ) {
+    return storage as StateStorage;
+  }
+  return fallbackStorage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOneOf<const T extends readonly string[]>(
+  value: unknown,
+  values: T,
+): value is T[number] {
+  return typeof value === "string" && values.includes(value);
+}
+
+function createId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `view-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function uniqueKnownStrings(
+  value: unknown,
+  knownIds: ReadonlySet<string>,
+): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const next: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || !knownIds.has(item) || seen.has(item)) {
+      continue;
+    }
+    seen.add(item);
+    next.push(item);
+  }
+  return next;
+}
+
+function normalizeColumns(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableView["columns"] {
+  const source = isRecord(value) ? value : {};
+  const knownIds = new Set(config.columnIds);
+  const order = uniqueKnownStrings(source["order"], knownIds);
+  for (const columnId of config.columnIds) {
+    if (!order.includes(columnId)) {
+      order.push(columnId);
+    }
+  }
+  const hidden = uniqueKnownStrings(source["hidden"], knownIds);
+  if (hidden.length >= config.columnIds.length) {
+    hidden.shift();
+  }
+  const widths: Record<string, number> = {};
+  const rawWidths = isRecord(source["widths"]) ? source["widths"] : {};
+  for (const [columnId, width] of Object.entries(rawWidths)) {
+    if (!knownIds.has(columnId)) continue;
+    const numeric = Number(width);
+    if (Number.isFinite(numeric) && numeric >= 24 && numeric <= 2000) {
+      widths[columnId] = Math.round(numeric);
+    }
+  }
+  return { order, hidden, widths };
+}
+
+function normalizeDensity(value: unknown): SavedTableViewDensity | null {
+  return isOneOf(value, DENSITIES) ? value : null;
+}
+
+function normalizeSort(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableView["sort"] {
+  const source = isRecord(value) ? value : {};
+  const columnId = source["columnId"];
+  const direction = source["direction"];
+  if (
+    typeof columnId === "string" &&
+    config.columnIds.includes(columnId) &&
+    isOneOf(columnId, JOB_SORT_FIELDS) &&
+    (direction === "asc" || direction === "desc")
+  ) {
+    return { columnId: columnId as JobSortField, direction };
+  }
+  return config.defaultSort;
+}
+
+function normalizeUrlFilters(value: unknown): SavedTableViewUrlFilters {
+  const source = isRecord(value) ? value : {};
+  const next: SavedTableViewUrlFilters = {};
+  if (typeof source["q"] === "string") next.q = source["q"];
+  if (isOneOf(source["stage"], STAGE_OR_ALL)) next.stage = source["stage"];
+  if (isOneOf(source["state"], STATE_OR_ALL)) next.state = source["state"];
+  if (isOneOf(source["applyStatus"], JOB_APPLY_STATUS_FILTERS)) {
+    next.applyStatus = source["applyStatus"];
+  }
+  if (isOneOf(source["deleted"], JOB_DELETED_VIEW_FILTERS)) {
+    next.deleted = source["deleted"];
+  }
+  for (const key of ["pageSize", "minFitScore", "maxFitScore"] as const) {
+    const numeric = Number(source[key]);
+    if (Number.isFinite(numeric)) {
+      next[key] = Math.round(numeric);
+    }
+  }
+  return next;
+}
+
+function normalizeGridFilters(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableViewGridFilters {
+  const source = isRecord(value) ? value : {};
+  const knownIds = new Set(config.columnIds);
+  const next: SavedTableViewGridFilters = {};
+  for (const [columnId, rawFilter] of Object.entries(source)) {
+    if (!knownIds.has(columnId) || !isRecord(rawFilter)) continue;
+    const selectedValues = Array.isArray(rawFilter["selectedValues"])
+      ? rawFilter["selectedValues"].filter(
+          (item): item is string => typeof item === "string",
+        )
+      : [];
+    next[columnId] = {
+      operator:
+        rawFilter["operator"] === "does_not_contain"
+          ? "does_not_contain"
+          : "contains",
+      text: typeof rawFilter["text"] === "string" ? rawFilter["text"] : "",
+      selectedValues,
+    };
+  }
+  return next;
+}
+
+function normalizeGrouping(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableView["grouping"] {
+  if (!isRecord(value)) return null;
+  const columnId = value["columnId"];
+  return typeof columnId === "string" && config.columnIds.includes(columnId)
+    ? { columnId }
+    : null;
+}
+
+function normalizeColorRules(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableView["colorRules"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((rule) => {
+    if (!isRecord(rule) || !isRecord(rule["predicate"])) return [];
+    const columnId = rule["columnId"];
+    const op = rule["predicate"]["op"];
+    const predicateValue = rule["predicate"]["value"];
+    const tone = rule["tone"];
+    if (
+      typeof columnId !== "string" ||
+      !config.columnIds.includes(columnId) ||
+      !isOneOf(op, COLOR_RULE_OPERATORS) ||
+      !isOneOf(tone, COLOR_RULE_TONES) ||
+      (typeof predicateValue !== "string" && typeof predicateValue !== "number")
+    ) {
+      return [];
+    }
+    return [{ columnId, predicate: { op, value: predicateValue }, tone }];
+  });
+}
+
+function defaultView(config: KnownTableConfig): SavedTableView {
+  return {
+    id: DEFAULT_SAVED_TABLE_VIEW_ID,
+    tableId: config.tableId,
+    name: "Default",
+    builtIn: true,
+    columns: normalizeColumns({}, config),
+    density: null,
+    sort: config.defaultSort,
+    urlFilters: config.defaultUrlFilters,
+    gridFilters: {},
+    grouping: null,
+    colorRules: [],
+    schemaVersion: SAVED_TABLE_VIEW_SCHEMA_VERSION,
+  };
+}
+
+function presentationFromView(view: SavedTableView): SavedTablePresentation {
+  return {
+    columns: view.columns,
+    density: view.density,
+    grouping: view.grouping,
+    colorRules: view.colorRules,
+  };
+}
+
+function normalizePresentation(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTablePresentation | null {
+  if (!isRecord(value)) return null;
+  return {
+    columns: normalizeColumns(value["columns"], config),
+    density: normalizeDensity(value["density"]),
+    grouping: normalizeGrouping(value["grouping"], config),
+    colorRules: normalizeColorRules(value["colorRules"], config),
+  };
+}
+
+function normalizeSnapshot(
+  value: SavedTableViewSnapshot,
+  config: KnownTableConfig,
+): SavedTableViewSnapshot {
+  return {
+    columns: normalizeColumns(value.columns, config),
+    density: normalizeDensity(value.density),
+    sort: normalizeSort(value.sort, config),
+    urlFilters: normalizeUrlFilters(value.urlFilters),
+    gridFilters: normalizeGridFilters(value.gridFilters, config),
+    grouping: normalizeGrouping(value.grouping, config),
+    colorRules: normalizeColorRules(value.colorRules, config),
+  };
+}
+
+function viewFromSnapshot(
+  tableId: TableId,
+  id: string,
+  name: string,
+  snapshot: SavedTableViewSnapshot,
+  config: KnownTableConfig,
+): SavedTableView {
+  const normalized = normalizeSnapshot(snapshot, config);
+  return {
+    id,
+    tableId,
+    name: name.trim() || "Untitled view",
+    builtIn: false,
+    ...normalized,
+    schemaVersion: SAVED_TABLE_VIEW_SCHEMA_VERSION,
+  };
+}
+
+function normalizeView(
+  value: unknown,
+  config: KnownTableConfig,
+): SavedTableView | null {
+  if (!isRecord(value)) return null;
+  const id = typeof value["id"] === "string" ? value["id"].trim() : "";
+  const name = typeof value["name"] === "string" ? value["name"].trim() : "";
+  if (!id || id === DEFAULT_SAVED_TABLE_VIEW_ID) return null;
+  return {
+    id,
+    tableId: config.tableId,
+    name: name || "Untitled view",
+    builtIn: false,
+    columns: normalizeColumns(value["columns"], config),
+    density: normalizeDensity(value["density"]),
+    sort: normalizeSort(value["sort"], config),
+    urlFilters: normalizeUrlFilters(value["urlFilters"]),
+    gridFilters: normalizeGridFilters(value["gridFilters"], config),
+    grouping: normalizeGrouping(value["grouping"], config),
+    colorRules: normalizeColorRules(value["colorRules"], config),
+    schemaVersion: SAVED_TABLE_VIEW_SCHEMA_VERSION,
+  };
+}
+
+export function normalizeSavedTableViewsState(value: unknown): Pick<
+  SavedTableViewsState,
+  "views" | "activeViewIdByTable" | "presentationByTable"
+> {
+  const source = isRecord(value) ? value : {};
+  const sourceViews = Array.isArray(source["views"]) ? source["views"] : [];
+  const activeSource = isRecord(source["activeViewIdByTable"])
+    ? source["activeViewIdByTable"]
+    : {};
+  const presentationSource = isRecord(source["presentationByTable"])
+    ? source["presentationByTable"]
+    : {};
+  const views: SavedTableView[] = [];
+  const activeViewIdByTable: Partial<Record<TableId, string>> = {};
+  const presentationByTable: Partial<Record<TableId, SavedTablePresentation>> = {};
+
+  for (const config of Object.values(TABLE_CONFIGS)) {
+    const tableDefault = defaultView(config);
+    const tableViews = [tableDefault];
+    const seen = new Set([tableDefault.id]);
+    for (const rawView of sourceViews) {
+      if (!isRecord(rawView) || rawView["tableId"] !== config.tableId) continue;
+      const normalized = normalizeView(rawView, config);
+      if (!normalized || seen.has(normalized.id)) continue;
+      seen.add(normalized.id);
+      tableViews.push(normalized);
+    }
+    const activeCandidate = activeSource[config.tableId];
+    const activeView = tableViews.find((view) => view.id === activeCandidate) ?? tableDefault;
+    const persistedPresentation = normalizePresentation(
+      presentationSource[config.tableId],
+      config,
+    );
+    views.push(...tableViews);
+    activeViewIdByTable[config.tableId] = activeView.id;
+    presentationByTable[config.tableId] =
+      persistedPresentation ?? presentationFromView(activeView);
+  }
+
+  return { views, activeViewIdByTable, presentationByTable };
+}
+
+const initialState = normalizeSavedTableViewsState({});
+
+function configFor(tableId: TableId): KnownTableConfig {
+  const config = TABLE_CONFIGS[tableId];
+  if (!config) {
+    throw new Error(`Unknown table id: ${tableId}`);
+  }
+  return config;
+}
+
+export const useSavedTableViewsStore = create<SavedTableViewsState>()(
+  persist(
+    (set, get) => ({
+      ...initialState,
+      applyView: (tableId, viewId) =>
+        set((state) => {
+          const config = configFor(tableId);
+          const view =
+            state.views.find(
+              (candidate) =>
+                candidate.tableId === tableId && candidate.id === viewId,
+            ) ?? defaultView(config);
+          return {
+            activeViewIdByTable: {
+              ...state.activeViewIdByTable,
+              [tableId]: view.id,
+            },
+            presentationByTable: {
+              ...state.presentationByTable,
+              [tableId]: presentationFromView(view),
+            },
+          };
+        }),
+      setTablePresentation: (tableId, presentation) =>
+        set((state) => {
+          const config = configFor(tableId);
+          return {
+            presentationByTable: {
+              ...state.presentationByTable,
+              [tableId]: normalizePresentation(presentation, config) ?? presentation,
+            },
+          };
+        }),
+      createView: (tableId, name, snapshot) => {
+        const config = configFor(tableId);
+        const id = createId();
+        const view = viewFromSnapshot(tableId, id, name, snapshot, config);
+        set((state) => ({
+          views: [...state.views, view],
+          activeViewIdByTable: {
+            ...state.activeViewIdByTable,
+            [tableId]: id,
+          },
+          presentationByTable: {
+            ...state.presentationByTable,
+            [tableId]: presentationFromView(view),
+          },
+        }));
+        return id;
+      },
+      updateActiveView: (tableId, snapshot) => {
+        const state = get();
+        const activeId =
+          state.activeViewIdByTable[tableId] ?? DEFAULT_SAVED_TABLE_VIEW_ID;
+        const current = state.views.find(
+          (view) => view.tableId === tableId && view.id === activeId,
+        );
+        if (!current || current.builtIn) return false;
+        const config = configFor(tableId);
+        const nextView = viewFromSnapshot(
+          tableId,
+          current.id,
+          current.name,
+          snapshot,
+          config,
+        );
+        set((currentState) => ({
+          views: currentState.views.map((view) =>
+            view.tableId === tableId && view.id === activeId ? nextView : view,
+          ),
+          presentationByTable: {
+            ...currentState.presentationByTable,
+            [tableId]: presentationFromView(nextView),
+          },
+        }));
+        return true;
+      },
+      renameView: (tableId, viewId, name) => {
+        const normalizedName = name.trim();
+        if (!normalizedName) return false;
+        const state = get();
+        const current = state.views.find(
+          (view) => view.tableId === tableId && view.id === viewId,
+        );
+        if (!current || current.builtIn) return false;
+        set((currentState) => ({
+          views: currentState.views.map((view) =>
+            view.tableId === tableId && view.id === viewId
+              ? { ...view, name: normalizedName }
+              : view,
+          ),
+        }));
+        return true;
+      },
+      deleteView: (tableId, viewId) => {
+        const state = get();
+        const current = state.views.find(
+          (view) => view.tableId === tableId && view.id === viewId,
+        );
+        if (!current || current.builtIn) return false;
+        const tableDefault = defaultView(configFor(tableId));
+        set((currentState) => ({
+          views: currentState.views.filter(
+            (view) => !(view.tableId === tableId && view.id === viewId),
+          ),
+          activeViewIdByTable: {
+            ...currentState.activeViewIdByTable,
+            [tableId]:
+              currentState.activeViewIdByTable[tableId] === viewId
+                ? DEFAULT_SAVED_TABLE_VIEW_ID
+                : currentState.activeViewIdByTable[tableId],
+          },
+          presentationByTable: {
+            ...currentState.presentationByTable,
+            ...(currentState.activeViewIdByTable[tableId] === viewId
+              ? { [tableId]: presentationFromView(tableDefault) }
+              : {}),
+          },
+        }));
+        return true;
+      },
+      reset: () => set(normalizeSavedTableViewsState({})),
+    }),
+    {
+      name: "jh:saved-table-views",
+      storage: createJSONStorage(getStorage),
+      version: SAVED_TABLE_VIEW_STORE_VERSION,
+      partialize: ({ views, activeViewIdByTable, presentationByTable }) => ({
+        views,
+        activeViewIdByTable,
+        presentationByTable,
+      }),
+      merge: (persisted, current) => ({
+        ...current,
+        ...normalizeSavedTableViewsState(persisted),
+      }),
+    },
+  ),
+);

--- a/apps/web/src/shared/ui/filterable-data-grid.test.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.test.tsx
@@ -305,6 +305,55 @@ describe("FilterableDataGrid", () => {
     expect(companyCol).toHaveStyle({ width: "276px" });
   });
 
+  it("applies controlled column order, visibility, widths, and density", async () => {
+    const onColumnWidthsChange = vi.fn();
+    render(
+      <FilterableDataGrid
+        title="Grid view"
+        data={rows}
+        columns={resizableColumns}
+        getRowId={(row) => row.id}
+        loading={false}
+        loadingMessage="Loading rows."
+        emptyMessage="No rows."
+        initialSort={{ columnId: "company", direction: "asc" }}
+        columnOrder={["observed", "company", "provider"]}
+        columnVisibility={{ provider: false }}
+        columnWidths={{ observed: 160 }}
+        onColumnWidthsChange={onColumnWidthsChange}
+        density="compact"
+      />,
+    );
+    const user = userEvent.setup();
+    const headers = screen.getAllByRole("columnheader");
+
+    expect(headers.map((header) => header.textContent)).toEqual([
+      expect.stringContaining("Observed"),
+      expect.stringContaining("Company"),
+    ]);
+    expect(screen.queryByText("Provider")).not.toBeInTheDocument();
+    expect(document.querySelector(".filterable-data-grid")).toHaveAttribute(
+      "data-density",
+      "compact",
+    );
+    expect(
+      document.querySelector<HTMLTableColElement>(
+        'col[data-column-id="observed"]',
+      ),
+    ).toHaveStyle({ width: "160px" });
+
+    await user.keyboard("{Tab}");
+    await user.click(
+      screen.getByRole("button", { name: "Resize Observed column" }),
+    );
+    screen.getByRole("button", { name: "Resize Observed column" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(onColumnWidthsChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ observed: 176 }),
+    );
+  });
+
   it("keeps dense grid focus indicators tied to the standard ring token", () => {
     const css = readFileSync("src/styles/globals.css", "utf8");
 

--- a/apps/web/src/shared/ui/filterable-data-grid.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.tsx
@@ -66,6 +66,10 @@ export interface DataGridSortState {
   direction: DataGridSortDirection;
 }
 
+export type DataGridDensity = "compact" | "regular" | "comfy";
+export type DataGridColumnVisibilityState = Record<string, boolean>;
+export type DataGridColumnWidthsState = Record<string, number>;
+
 export interface DataGridHeaderContext<TData> {
   pageRows: readonly TData[];
   visibleRows: readonly TData[];
@@ -112,6 +116,11 @@ export interface FilterableDataGridProps<TData> {
   toolbarActions?: ReactNode;
   tableClassName?: string;
   resizableColumns?: boolean;
+  columnVisibility?: DataGridColumnVisibilityState;
+  columnOrder?: readonly string[];
+  columnWidths?: DataGridColumnWidthsState;
+  onColumnWidthsChange?: (next: DataGridColumnWidthsState) => void;
+  density?: DataGridDensity | null;
   rowClassName?: (row: TData) => string | undefined;
   rowAriaSelected?: (row: TData) => boolean;
   onRowActivate?: (row: TData) => void;
@@ -184,6 +193,43 @@ function classNames(...values: Array<string | undefined | false>): string | unde
 
 function clampWidth(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function orderColumns<TData>(
+  columns: Array<DataGridColumn<TData>>,
+  order: readonly string[] | undefined,
+): Array<DataGridColumn<TData>> {
+  if (!order?.length) return columns;
+  const byId = new Map(columns.map((column) => [column.id, column]));
+  const ordered: Array<DataGridColumn<TData>> = [];
+  const seen = new Set<string>();
+  for (const columnId of order) {
+    const column = byId.get(columnId);
+    if (!column || seen.has(columnId)) continue;
+    ordered.push(column);
+    seen.add(columnId);
+  }
+  for (const column of columns) {
+    if (!seen.has(column.id)) {
+      ordered.push(column);
+    }
+  }
+  return ordered;
+}
+
+function filterVisibleColumns<TData>(
+  columns: Array<DataGridColumn<TData>>,
+  visibility: DataGridColumnVisibilityState | undefined,
+): Array<DataGridColumn<TData>> {
+  if (!visibility) return columns;
+  return columns.filter((column) => visibility[column.id] !== false);
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }
 
 export function isActiveDataGridFilter(
@@ -359,6 +405,11 @@ export function FilterableDataGrid<TData>({
   toolbarActions,
   tableClassName,
   resizableColumns = true,
+  columnVisibility,
+  columnOrder,
+  columnWidths: controlledColumnWidths,
+  onColumnWidthsChange,
+  density,
   rowClassName,
   rowAriaSelected,
   onRowActivate,
@@ -371,20 +422,31 @@ export function FilterableDataGrid<TData>({
   const [localPage, setLocalPage] = useState(1);
   const [localPageSize, setLocalPageSize] = useState(initialPageSize);
   const [valueQueries, setValueQueries] = useState<Record<string, string>>({});
-  const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  const [localColumnWidths, setLocalColumnWidths] =
+    useState<DataGridColumnWidthsState>({});
   const tableRef = useRef<HTMLTableElement | null>(null);
   const stopColumnResizeRef = useRef<(() => void) | null>(null);
+  const lastPageRowIdsRef = useRef<string[]>([]);
   const sort = controlledSort ?? localSort;
   const filters = controlledFilters ?? localFilters;
+  const columnWidths = controlledColumnWidths ?? localColumnWidths;
   const paginationEnabled = paginate || Boolean(pagination);
   const page = pagination?.page ?? localPage;
   const pageSize = pagination?.pageSize ?? localPageSize;
   const effectivePageSizeOptions =
     pagination?.pageSizeOptions ?? pageSizeOptions;
+  const orderedColumns = useMemo(
+    () => orderColumns(columns, columnOrder),
+    [columns, columnOrder],
+  );
+  const displayColumns = useMemo(
+    () => filterVisibleColumns(orderedColumns, columnVisibility),
+    [columnVisibility, orderedColumns],
+  );
   const activationColumnIndex = useMemo(() => {
-    const rowHeaderIndex = columns.findIndex((column) => column.rowHeader);
+    const rowHeaderIndex = displayColumns.findIndex((column) => column.rowHeader);
     return rowHeaderIndex >= 0 ? rowHeaderIndex : 0;
-  }, [columns]);
+  }, [displayColumns]);
 
   const filterableColumns = useMemo(
     () => columns.filter((column) => Boolean(column.getFilterValue)),
@@ -473,8 +535,14 @@ export function FilterableDataGrid<TData>({
     .filter(({ filter }) => isActiveDataGridFilter(filter));
 
   useEffect(() => {
-    onPageRowsChange?.(pageRows);
-  }, [onPageRowsChange, pageRows]);
+    if (!onPageRowsChange) return;
+    const nextIds = pageRows.map(getRowId);
+    if (sameStrings(lastPageRowIdsRef.current, nextIds)) {
+      return;
+    }
+    lastPageRowIdsRef.current = nextIds;
+    onPageRowsChange(pageRows);
+  }, [getRowId, onPageRowsChange, pageRows]);
 
   useEffect(() => {
     setColumnWidths((current) => {
@@ -492,6 +560,22 @@ export function FilterableDataGrid<TData>({
     },
     [],
   );
+
+  function setColumnWidths(
+    updater: (
+      current: DataGridColumnWidthsState,
+    ) => DataGridColumnWidthsState,
+  ) {
+    const next = updater(columnWidths);
+    if (next === columnWidths) {
+      return;
+    }
+    if (onColumnWidthsChange) {
+      onColumnWidthsChange(next);
+    } else {
+      setLocalColumnWidths(next);
+    }
+  }
 
   const setFilters = (
     updater: (current: DataGridFilterState) => DataGridFilterState,
@@ -663,14 +747,17 @@ export function FilterableDataGrid<TData>({
       ? `${pageRows.length} shown / ${visibleRows.length} filtered / ${data.length} loaded`
       : `${visibleRows.length} shown / ${data.length} loaded`;
   const columnWidthTotal = resizableColumns
-    ? columns.reduce((total, column) => total + (columnWidths[column.id] ?? column.width ?? 0), 0)
+    ? displayColumns.reduce((total, column) => total + (columnWidths[column.id] ?? column.width ?? 0), 0)
     : 0;
   const tableStyle = columnWidthTotal
     ? { width: `max(100%, ${columnWidthTotal}px)` }
     : undefined;
 
   return (
-    <div className="filterable-data-grid">
+    <div
+      className="filterable-data-grid"
+      data-density={density ?? undefined}
+    >
       <div className="data-grid-toolbar">
         <div className="data-grid-view-title">
           <IconTable size={15} aria-hidden="true" />
@@ -716,7 +803,7 @@ export function FilterableDataGrid<TData>({
         >
           {resizableColumns ? (
             <colgroup>
-              {columns.map((column) => {
+              {displayColumns.map((column) => {
                 const width = columnWidths[column.id] ?? column.width;
                 return (
                   <col
@@ -730,7 +817,7 @@ export function FilterableDataGrid<TData>({
           ) : null}
           <thead>
             <tr>
-              {columns.map((column) => {
+              {displayColumns.map((column) => {
                 const active = sort.columnId === column.id;
                 const SortIcon = sort.direction === "desc" ? IconSortDescending : IconSortAscending;
                 const sortable =
@@ -862,7 +949,7 @@ export function FilterableDataGrid<TData>({
                       : undefined
                   }
                 >
-                  {columns.map((column, columnIndex) => {
+                  {displayColumns.map((column, columnIndex) => {
                     const content = column.render(row, { pageRows, rowId, rowIndex });
                     const isActivationCell =
                       Boolean(onRowActivate) && columnIndex === activationColumnIndex;

--- a/apps/web/src/shared/ui/saved-table-views-control.tsx
+++ b/apps/web/src/shared/ui/saved-table-views-control.tsx
@@ -1,0 +1,376 @@
+import {
+  IconArrowDown,
+  IconArrowUp,
+  IconColumns3,
+  IconDeviceFloppy,
+  IconEdit,
+  IconPlus,
+  IconTrash,
+} from "@tabler/icons-react";
+import type { FormEvent } from "react";
+import { useMemo, useState } from "react";
+import type { SavedTableView, TableId } from "@jobhunter/contracts";
+
+import {
+  DEFAULT_SAVED_TABLE_VIEW_ID,
+  type SavedTablePresentation,
+  type SavedTableViewSnapshot,
+  useSavedTableViewsStore,
+} from "../stores/saved-table-views.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog.js";
+import { Input } from "./input.js";
+
+export interface SavedTableColumnOption {
+  id: string;
+  label: string;
+  locked?: boolean;
+}
+
+export interface SavedTableViewsControlProps {
+  tableId: TableId;
+  columnOptions: readonly SavedTableColumnOption[];
+  snapshot: SavedTableViewSnapshot;
+  onApplyView: (view: SavedTableView) => void;
+  onPresentationChange: (presentation: SavedTablePresentation) => void;
+}
+
+function moveColumn(
+  order: readonly string[],
+  columnId: string,
+  delta: -1 | 1,
+): string[] {
+  const index = order.indexOf(columnId);
+  const nextIndex = index + delta;
+  if (index < 0 || nextIndex < 0 || nextIndex >= order.length) {
+    return [...order];
+  }
+  const next = [...order];
+  const [item] = next.splice(index, 1);
+  next.splice(nextIndex, 0, item!);
+  return next;
+}
+
+function viewNameForInput(value: string): string {
+  return value.trim().slice(0, 80);
+}
+
+export function SavedTableViewsControl({
+  tableId,
+  columnOptions,
+  snapshot,
+  onApplyView,
+  onPresentationChange,
+}: SavedTableViewsControlProps) {
+  const allViews = useSavedTableViewsStore((state) => state.views);
+  const views = useMemo(
+    () => allViews.filter((view) => view.tableId === tableId),
+    [allViews, tableId],
+  );
+  const activeViewId = useSavedTableViewsStore(
+    (state) =>
+      state.activeViewIdByTable[tableId] ?? DEFAULT_SAVED_TABLE_VIEW_ID,
+  );
+  const applyView = useSavedTableViewsStore((state) => state.applyView);
+  const createView = useSavedTableViewsStore((state) => state.createView);
+  const updateActiveView = useSavedTableViewsStore(
+    (state) => state.updateActiveView,
+  );
+  const renameView = useSavedTableViewsStore((state) => state.renameView);
+  const deleteView = useSavedTableViewsStore((state) => state.deleteView);
+  const [saveAsOpen, setSaveAsOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [columnOpen, setColumnOpen] = useState(false);
+  const [nameInput, setNameInput] = useState("");
+  const [renameInput, setRenameInput] = useState("");
+
+  const activeView = useMemo(
+    () =>
+      views.find((view) => view.id === activeViewId) ??
+      views.find((view) => view.id === DEFAULT_SAVED_TABLE_VIEW_ID),
+    [activeViewId, views],
+  );
+  const defaultView = useMemo(
+    () => views.find((view) => view.id === DEFAULT_SAVED_TABLE_VIEW_ID),
+    [views],
+  );
+  const visibleIds = useMemo(
+    () =>
+      columnOptions
+        .map((column) => column.id)
+        .filter((columnId) => !snapshot.columns.hidden.includes(columnId)),
+    [columnOptions, snapshot.columns.hidden],
+  );
+
+  const setPresentation = (presentation: SavedTablePresentation) => {
+    onPresentationChange(presentation);
+  };
+
+  const applySelectedView = (viewId: string) => {
+    const nextView =
+      views.find((view) => view.id === viewId) ?? defaultView ?? null;
+    if (!nextView) return;
+    applyView(tableId, nextView.id);
+    onApplyView(nextView);
+  };
+
+  const submitSaveAs = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = viewNameForInput(nameInput);
+    if (!name) return;
+    createView(tableId, name, snapshot);
+    setSaveAsOpen(false);
+    setNameInput("");
+  };
+
+  const submitRename = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!activeView) return;
+    const name = viewNameForInput(renameInput);
+    if (!name) return;
+    if (renameView(tableId, activeView.id, name)) {
+      setRenameOpen(false);
+    }
+  };
+
+  const updateCurrentView = () => {
+    updateActiveView(tableId, snapshot);
+  };
+
+  const deleteCurrentView = () => {
+    if (!activeView || activeView.builtIn) return;
+    if (!window.confirm(`Delete saved view "${activeView.name}"?`)) return;
+    const deletingActive = activeView.id === activeViewId;
+    if (deleteView(tableId, activeView.id) && deletingActive && defaultView) {
+      onApplyView(defaultView);
+    }
+  };
+
+  const toggleColumn = (columnId: string) => {
+    const hidden = new Set(snapshot.columns.hidden);
+    if (hidden.has(columnId)) {
+      hidden.delete(columnId);
+    } else if (visibleIds.length > 1) {
+      hidden.add(columnId);
+    }
+    setPresentation({
+      columns: { ...snapshot.columns, hidden: [...hidden] },
+      density: snapshot.density,
+      grouping: snapshot.grouping,
+      colorRules: snapshot.colorRules,
+    });
+  };
+
+  const reorderColumn = (columnId: string, delta: -1 | 1) => {
+    setPresentation({
+      columns: {
+        ...snapshot.columns,
+        order: moveColumn(snapshot.columns.order, columnId, delta),
+      },
+      density: snapshot.density,
+      grouping: snapshot.grouping,
+      colorRules: snapshot.colorRules,
+    });
+  };
+
+  const setDensity = (density: SavedTablePresentation["density"]) => {
+    setPresentation({
+      columns: snapshot.columns,
+      density,
+      grouping: snapshot.grouping,
+      colorRules: snapshot.colorRules,
+    });
+  };
+
+  return (
+    <div className="saved-table-views-control">
+      <label className="saved-table-views-select">
+        <span>View</span>
+        <select
+          aria-label="Saved table view"
+          value={activeView?.id ?? DEFAULT_SAVED_TABLE_VIEW_ID}
+          onChange={(event) => applySelectedView(event.target.value)}
+        >
+          {views.map((view) => (
+            <option key={view.id} value={view.id}>
+              {view.name}
+            </option>
+          ))}
+        </select>
+      </label>
+      <button
+        type="button"
+        aria-label="Save current view"
+        title="Save current view"
+        disabled={!activeView || activeView.builtIn}
+        onClick={updateCurrentView}
+      >
+        <IconDeviceFloppy size={14} aria-hidden="true" />
+      </button>
+      <Dialog open={saveAsOpen} onOpenChange={setSaveAsOpen}>
+        <DialogTrigger asChild>
+          <button type="button" aria-label="Save as view" title="Save as view">
+            <IconPlus size={14} aria-hidden="true" />
+          </button>
+        </DialogTrigger>
+        <DialogContent className="saved-table-view-dialog">
+          <DialogHeader>
+            <DialogTitle>Save view</DialogTitle>
+            <DialogDescription>
+              Save the current table template under a new name.
+            </DialogDescription>
+          </DialogHeader>
+          <form className="saved-table-view-form" onSubmit={submitSaveAs}>
+            <label className="field">
+              <span>Name</span>
+              <Input
+                autoFocus
+                value={nameInput}
+                maxLength={80}
+                onChange={(event) => setNameInput(event.target.value)}
+              />
+            </label>
+            <DialogFooter>
+              <button type="submit" disabled={!nameInput.trim()}>
+                Save
+              </button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={renameOpen}
+        onOpenChange={(open) => {
+          setRenameOpen(open);
+          if (open) setRenameInput(activeView?.name ?? "");
+        }}
+      >
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            aria-label="Rename view"
+            title="Rename view"
+            disabled={!activeView || activeView.builtIn}
+          >
+            <IconEdit size={14} aria-hidden="true" />
+          </button>
+        </DialogTrigger>
+        <DialogContent className="saved-table-view-dialog">
+          <DialogHeader>
+            <DialogTitle>Rename view</DialogTitle>
+            <DialogDescription>Rename the selected saved view.</DialogDescription>
+          </DialogHeader>
+          <form className="saved-table-view-form" onSubmit={submitRename}>
+            <label className="field">
+              <span>Name</span>
+              <Input
+                autoFocus
+                value={renameInput}
+                maxLength={80}
+                onChange={(event) => setRenameInput(event.target.value)}
+              />
+            </label>
+            <DialogFooter>
+              <button type="submit" disabled={!renameInput.trim()}>
+                Rename
+              </button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+      <button
+        type="button"
+        aria-label="Delete view"
+        title="Delete view"
+        disabled={!activeView || activeView.builtIn}
+        onClick={deleteCurrentView}
+      >
+        <IconTrash size={14} aria-hidden="true" />
+      </button>
+      <Dialog open={columnOpen} onOpenChange={setColumnOpen}>
+        <DialogTrigger asChild>
+          <button
+            type="button"
+            aria-label="Configure table columns"
+            title="Configure table columns"
+          >
+            <IconColumns3 size={14} aria-hidden="true" />
+          </button>
+        </DialogTrigger>
+        <DialogContent className="saved-table-columns-dialog">
+          <DialogHeader>
+            <DialogTitle>Columns</DialogTitle>
+            <DialogDescription>
+              Choose columns, order, and table density for this table.
+            </DialogDescription>
+          </DialogHeader>
+          <section className="saved-table-density" aria-label="Table density">
+            {[
+              { value: null, label: "Inherit" },
+              { value: "compact", label: "Compact" },
+              { value: "regular", label: "Regular" },
+              { value: "comfy", label: "Comfy" },
+            ].map((option) => (
+              <button
+                key={option.label}
+                type="button"
+                aria-pressed={snapshot.density === option.value}
+                onClick={() => setDensity(option.value as SavedTablePresentation["density"])}
+              >
+                {option.label}
+              </button>
+            ))}
+          </section>
+          <div className="saved-table-column-list">
+            {snapshot.columns.order.map((columnId, index) => {
+              const column = columnOptions.find((option) => option.id === columnId);
+              if (!column) return null;
+              const visible = !snapshot.columns.hidden.includes(columnId);
+              const canHide = !column.locked && (visibleIds.length > 1 || !visible);
+              return (
+                <div key={column.id} className="saved-table-column-row">
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={visible}
+                      disabled={!canHide}
+                      onChange={() => toggleColumn(column.id)}
+                    />
+                    <span>{column.label}</span>
+                  </label>
+                  <div>
+                    <button
+                      type="button"
+                      aria-label={`Move ${column.label} earlier`}
+                      title={`Move ${column.label} earlier`}
+                      disabled={index === 0}
+                      onClick={() => reorderColumn(column.id, -1)}
+                    >
+                      <IconArrowUp size={13} aria-hidden="true" />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={`Move ${column.label} later`}
+                      title={`Move ${column.label} later`}
+                      disabled={index === snapshot.columns.order.length - 1}
+                      onClick={() => reorderColumn(column.id, 1)}
+                    >
+                      <IconArrowDown size={13} aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2672,6 +2672,141 @@ textarea:focus-visible {
   font-size: 10px;
 }
 
+.saved-table-views-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.saved-table-views-control button,
+.saved-table-view-form button,
+.saved-table-density button,
+.saved-table-column-row button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 12px;
+}
+
+.saved-table-views-control button:hover,
+.saved-table-view-form button:hover,
+.saved-table-density button:hover,
+.saved-table-column-row button:hover {
+  background: var(--muted);
+}
+
+.saved-table-views-control button:disabled,
+.saved-table-view-form button:disabled,
+.saved-table-column-row button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.saved-table-views-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.saved-table-views-select span {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.saved-table-views-select select {
+  max-width: 180px;
+  min-height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 12px;
+}
+
+.saved-table-view-dialog,
+.saved-table-columns-dialog {
+  width: min(560px, calc(100vw - 32px));
+  max-width: min(560px, calc(100vw - 32px));
+}
+
+.saved-table-view-form {
+  display: grid;
+  gap: 12px;
+}
+
+.saved-table-density {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.saved-table-density button {
+  border-width: 0 1px 0 0;
+  border-radius: 0;
+}
+
+.saved-table-density button:last-child {
+  border-right: 0;
+}
+
+.saved-table-density button[aria-pressed="true"] {
+  background: var(--foreground);
+  color: var(--card);
+  font-weight: 650;
+}
+
+.saved-table-column-list {
+  display: grid;
+  gap: 4px;
+  max-height: min(520px, calc(100vh - 280px));
+  overflow: auto;
+  margin-top: 12px;
+}
+
+.saved-table-column-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+}
+
+.saved-table-column-row label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.saved-table-column-row label span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.saved-table-column-row div {
+  display: inline-flex;
+  gap: 4px;
+}
+
 .data-grid-filter-popover {
   width: min(920px, calc(100vw - 32px));
   max-height: min(760px, calc(100vh - 120px));
@@ -2860,6 +2995,18 @@ textarea:focus-visible {
   text-align: left;
   vertical-align: top;
   white-space: nowrap;
+}
+
+.filterable-data-grid[data-density="compact"] .filterable-data-grid-table th,
+.filterable-data-grid[data-density="compact"] .filterable-data-grid-table td {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.filterable-data-grid[data-density="comfy"] .filterable-data-grid-table th,
+.filterable-data-grid[data-density="comfy"] .filterable-data-grid-table td {
+  padding-top: 12px;
+  padding-bottom: 12px;
 }
 
 .filterable-data-grid-table thead th {

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -1,5 +1,5 @@
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import type {
   JobSummary,
@@ -7,6 +7,9 @@ import type {
 } from "../../contexts/operations/types.js";
 import {
   FilterableDataGrid,
+  type DataGridColumn,
+  type DataGridColumnWidthsState,
+  type DataGridDensity,
   type DataGridFilterState,
   type DataGridSortState,
 } from "../../shared/ui/filterable-data-grid.js";
@@ -32,6 +35,12 @@ export interface JobsTableProps {
   filters?: DataGridFilterState;
   onFiltersChange?: (next: DataGridFilterState) => void;
   onVisiblePageRowsChange?: (rows: readonly JobSummary[]) => void;
+  columnOrder?: readonly string[];
+  hiddenColumnIds?: readonly string[];
+  columnWidths?: DataGridColumnWidthsState;
+  onColumnWidthsChange?: (next: DataGridColumnWidthsState) => void;
+  density?: DataGridDensity | null;
+  toolbarActions?: (columns: Array<DataGridColumn<JobSummary>>) => ReactNode;
 }
 
 export function JobsTable({
@@ -50,6 +59,12 @@ export function JobsTable({
   filters = EMPTY_FILTERS,
   onFiltersChange = noopFiltersChange,
   onVisiblePageRowsChange = noopVisiblePageRowsChange,
+  columnOrder,
+  hiddenColumnIds = [],
+  columnWidths,
+  onColumnWidthsChange,
+  density,
+  toolbarActions,
 }: JobsTableProps) {
   const [selectionAnchorJobKey, setSelectionAnchorJobKey] = useState<
     string | null
@@ -89,6 +104,15 @@ export function JobsTable({
   const handleSortChange = (next: DataGridSortState) => {
     onSortingChange([{ id: next.columnId, desc: next.direction === "desc" }]);
   };
+  const columnVisibility = useMemo(
+    () =>
+      Object.fromEntries(hiddenColumnIds.map((columnId) => [columnId, false])),
+    [hiddenColumnIds],
+  );
+  const renderedToolbarActions = useMemo(
+    () => toolbarActions?.(columns),
+    [columns, toolbarActions],
+  );
 
   return (
     <FilterableDataGrid<JobSummary>
@@ -105,6 +129,12 @@ export function JobsTable({
       manualSorting
       filters={filters}
       onFiltersChange={onFiltersChange}
+      columnVisibility={columnVisibility}
+      toolbarActions={renderedToolbarActions}
+      {...(columnOrder ? { columnOrder } : {})}
+      {...(columnWidths ? { columnWidths } : {})}
+      {...(onColumnWidthsChange ? { onColumnWidthsChange } : {})}
+      {...(density !== undefined ? { density } : {})}
       tableClassName="jobs-data-grid-table"
       rowAriaSelected={(row) =>
         allMatchingSelected || Boolean(rowSelection[row.jobKey])

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -29,6 +29,7 @@ import { server } from "../../test/msw/server.js";
 import { buildProviderHarness } from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
+import { useSavedTableViewsStore } from "../../shared/stores/saved-table-views.js";
 import { JobsView } from "./JobsView.js";
 
 const SEARCH =
@@ -61,6 +62,8 @@ const originalConfirm = globalThis.window?.confirm;
 
 beforeEach(() => {
   useStageTriggerStore.getState().reset();
+  useSavedTableViewsStore.getState().reset();
+  window.localStorage.removeItem("jh:saved-table-views");
   Object.defineProperty(window, "confirm", {
     configurable: true,
     writable: true,
@@ -70,6 +73,7 @@ beforeEach(() => {
 
 afterEach(() => {
   useStageTriggerStore.getState().reset();
+  useSavedTableViewsStore.getState().reset();
   if (typeof originalConfirm === "function") {
     Object.defineProperty(window, "confirm", {
       configurable: true,
@@ -266,6 +270,67 @@ describe("<JobsView> bulk delete integration", () => {
     expect(await screen.findByText(appliedJob.title)).toBeInTheDocument();
     expect(jobs).toHaveBeenCalledWith(
       expect.objectContaining({ applyStatus: "applied" }),
+    );
+  });
+
+  it("saves and reapplies Jobs table views through URL-backed filters", async () => {
+    const user = userEvent.setup();
+    const discoverJob = jobWithStage("job-discover-view", "Discovery view job", "discover");
+    const applyJob = jobWithStage("job-apply-view", "Apply view job", "apply");
+    const jobs = vi.fn(async (query?: Partial<JobListQuery>) =>
+      makeJobsPage(query?.stage === "apply" ? [applyJob] : [discoverJob, applyJob]),
+    );
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { jobs } }),
+    });
+    const { router, Wrapper } = buildRouter(harness);
+
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    expect(await screen.findByText(discoverJob.title)).toBeInTheDocument();
+    expect(screen.getByText(applyJob.title)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /filter stage column/i }));
+    await user.click(screen.getByRole("checkbox", { name: "apply" }));
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    await waitFor(() =>
+      expect(jobs).toHaveBeenLastCalledWith(expect.objectContaining({ stage: "apply" })),
+    );
+    expect(router.state.location.search).toMatchObject({ stage: "apply" });
+
+    await user.click(screen.getByRole("button", { name: "Configure table columns" }));
+    const columnsDialog = screen.getByRole("dialog", { name: "Columns" });
+    await user.click(within(columnsDialog).getByRole("checkbox", { name: "Company" }));
+    await user.click(within(columnsDialog).getByRole("button", { name: "Compact" }));
+    await user.click(within(columnsDialog).getByRole("button", { name: /close/i }));
+    expect(screen.queryByRole("columnheader", { name: /Company/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Save as view" }));
+    const saveDialog = screen.getByRole("dialog", { name: "Save view" });
+    await user.type(within(saveDialog).getByLabelText("Name"), "Apply compact");
+    await user.click(within(saveDialog).getByRole("button", { name: "Save" }));
+
+    const viewSelect = screen.getByRole("combobox", { name: "Saved table view" });
+    await user.selectOptions(viewSelect, "default");
+    await waitFor(() =>
+      expect(router.state.location.search).toMatchObject({ stage: "all" }),
+    );
+    expect(jobs.mock.lastCall?.[0]).not.toHaveProperty("stage");
+    expect(router.state.location.search).toMatchObject({ stage: "all" });
+    expect(screen.getByRole("columnheader", { name: /Company/ })).toBeInTheDocument();
+
+    await user.selectOptions(
+      viewSelect,
+      screen.getByRole("option", { name: "Apply compact" }),
+    );
+    await waitFor(() =>
+      expect(jobs).toHaveBeenLastCalledWith(expect.objectContaining({ stage: "apply" })),
+    );
+    expect(router.state.location.search).toMatchObject({ stage: "apply" });
+    expect(screen.queryByRole("columnheader", { name: /Company/ })).not.toBeInTheDocument();
+    expect(document.querySelector(".filterable-data-grid")).toHaveAttribute(
+      "data-density",
+      "compact",
     );
   });
 

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -6,6 +6,7 @@ import {
   type JobMutationResponse,
   type JobSortField,
   type JobSummary,
+  type SavedTableView,
   STAGE_STATES,
 } from "@jobhunter/contracts";
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
@@ -23,12 +24,25 @@ import { useRetryFailedJobsMutation } from "../../contexts/pipeline/hooks/useRet
 import { useRunPendingPreparationMutation } from "../../contexts/pipeline/hooks/useRunPendingPreparationMutation.js";
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
+import {
+  JOBS_TABLE_COLUMN_IDS,
+  JOBS_TABLE_ID,
+  type SavedTablePresentation,
+  type SavedTableViewSnapshot,
+  useSavedTableViewsStore,
+} from "../../shared/stores/saved-table-views.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import {
+  type DataGridColumn,
+  type DataGridColumnWidthsState,
   hasActiveDataGridFilters,
   type DataGridFilterState,
   type DataGridTextFilter,
 } from "../../shared/ui/filterable-data-grid.js";
+import {
+  SavedTableViewsControl,
+  type SavedTableColumnOption,
+} from "../../shared/ui/saved-table-views-control.js";
 import { JobBulkActions } from "./JobBulkActions.js";
 import { JobsTable } from "./JobsTable.js";
 import { bulkJobFilters, jobsListInput } from "./jobStageFilters.js";
@@ -65,6 +79,22 @@ const SEARCH_FILTER_COLUMNS = new Set([
   "apply_status",
 ]);
 const JOB_TABLE_STAGE_FILTERS = ["discover", "apply"] as const;
+const DEFAULT_JOBS_PRESENTATION: SavedTablePresentation = {
+  columns: { order: [...JOBS_TABLE_COLUMN_IDS], hidden: [], widths: {} },
+  density: null,
+  grouping: null,
+  colorRules: [],
+};
+const DEFAULT_SAVED_URL_FILTERS = {
+  q: "",
+  stage: "all",
+  state: "all",
+  applyStatus: "all",
+  deleted: "active",
+  pageSize: 50,
+  minFitScore: undefined,
+  maxFitScore: undefined,
+} satisfies SavedTableViewSnapshot["urlFilters"];
 
 function filterFor(value: string | undefined): DataGridTextFilter | undefined {
   if (!value) return undefined;
@@ -147,6 +177,50 @@ function isJobSortField(value: string): value is JobSortField {
   return SORTABLE_JOB_FIELDS.has(value as JobSortField);
 }
 
+function savedUrlFiltersFromSearch(
+  search: JobsSearch,
+): SavedTableViewSnapshot["urlFilters"] {
+  return {
+    q: search.q,
+    stage: search.stage,
+    state: search.state,
+    applyStatus: search.applyStatus,
+    deleted: search.deleted,
+    pageSize: search.pageSize,
+    minFitScore: search.minFitScore,
+    maxFitScore: search.maxFitScore,
+  };
+}
+
+function searchPatchFromSavedView(
+  view: SavedTableView,
+): Partial<JobsSearch> {
+  const filters = { ...DEFAULT_SAVED_URL_FILTERS, ...view.urlFilters };
+  return {
+    q: filters.q ?? "",
+    stage: filters.stage ?? "all",
+    state: filters.state ?? "all",
+    applyStatus: filters.applyStatus ?? "all",
+    deleted: filters.deleted ?? "active",
+    pageSize: filters.pageSize ?? 50,
+    minFitScore: filters.minFitScore,
+    maxFitScore: filters.maxFitScore,
+    sort: isJobSortField(view.sort.columnId) ? view.sort.columnId : "discovered_at",
+    dir: view.sort.direction,
+    page: 1,
+  };
+}
+
+function columnOptionsFor(
+  columns: Array<DataGridColumn<JobSummary>>,
+): SavedTableColumnOption[] {
+  return columns.map((column) => ({
+    id: column.id,
+    label: column.label,
+    locked: column.id === "select",
+  }));
+}
+
 function sameKeys(
   current: readonly string[],
   next: readonly string[],
@@ -170,6 +244,13 @@ export function JobsView() {
   const retryFailedJobs = useRetryFailedJobsMutation();
   const runPendingPreparation = useRunPendingPreparationMutation();
   const stageTriggerConfigs = useStageTriggerStore((state) => state.configs);
+  const savedPresentation =
+    useSavedTableViewsStore(
+      (state) => state.presentationByTable[JOBS_TABLE_ID],
+    ) ?? DEFAULT_JOBS_PRESENTATION;
+  const setSavedPresentation = useSavedTableViewsStore(
+    (state) => state.setTablePresentation,
+  );
   const message = error instanceof Error ? error.message : null;
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -191,6 +272,28 @@ export function JobsView() {
     ],
   );
   const hasLocalFilters = hasActiveDataGridFilters(localTableFilters);
+  const savedViewSnapshot = useMemo<SavedTableViewSnapshot>(
+    () => ({
+      ...savedPresentation,
+      sort: { columnId: search.sort, direction: search.dir },
+      urlFilters: savedUrlFiltersFromSearch(search),
+      gridFilters: localTableFilters,
+    }),
+    [
+      localTableFilters,
+      savedPresentation,
+      search.applyStatus,
+      search.deleted,
+      search.dir,
+      search.maxFitScore,
+      search.minFitScore,
+      search.pageSize,
+      search.q,
+      search.sort,
+      search.stage,
+      search.state,
+    ],
+  );
 
   useEffect(() => {
     setRowSelection({});
@@ -218,6 +321,48 @@ export function JobsView() {
       void navigate({ search: (prev: JobsSearch) => ({ ...prev, ...next }) });
     },
     [navigate],
+  );
+
+  const handleSavedPresentationChange = useCallback(
+    (presentation: SavedTablePresentation) => {
+      setSavedPresentation(JOBS_TABLE_ID, presentation);
+    },
+    [setSavedPresentation],
+  );
+
+  const handleColumnWidthsChange = useCallback(
+    (widths: DataGridColumnWidthsState) => {
+      setSavedPresentation(JOBS_TABLE_ID, {
+        ...savedPresentation,
+        columns: { ...savedPresentation.columns, widths },
+      });
+    },
+    [savedPresentation, setSavedPresentation],
+  );
+
+  const handleSavedViewApply = useCallback(
+    (view: SavedTableView) => {
+      setLocalTableFilters(view.gridFilters as DataGridFilterState);
+      setSearch(searchPatchFromSavedView(view));
+    },
+    [setSearch],
+  );
+
+  const renderSavedTableActions = useCallback(
+    (columns: Array<DataGridColumn<JobSummary>>) => (
+      <SavedTableViewsControl
+        tableId={JOBS_TABLE_ID}
+        columnOptions={columnOptionsFor(columns)}
+        snapshot={savedViewSnapshot}
+        onApplyView={handleSavedViewApply}
+        onPresentationChange={handleSavedPresentationChange}
+      />
+    ),
+    [
+      handleSavedPresentationChange,
+      handleSavedViewApply,
+      savedViewSnapshot,
+    ],
   );
 
   const handleTableFiltersChange = useCallback(
@@ -574,6 +719,12 @@ export function JobsView() {
           filters={tableFilters}
           onFiltersChange={handleTableFiltersChange}
           onVisiblePageRowsChange={handleVisiblePageRowsChange}
+          columnOrder={savedPresentation.columns.order}
+          hiddenColumnIds={savedPresentation.columns.hidden}
+          columnWidths={savedPresentation.columns.widths}
+          onColumnWidthsChange={handleColumnWidthsChange}
+          density={savedPresentation.density}
+          toolbarActions={renderSavedTableActions}
         />
       </section>
       <Outlet />

--- a/docs/architecture/frontend/patterns.md
+++ b/docs/architecture/frontend/patterns.md
@@ -482,15 +482,20 @@ controls. Density is scoped to the app shell: `.app-shell` owns
   dashboard / Pipelines `<StageTriggerPanel>` (limit, workers, minScore,
   validationMode, `dryRun` defaulting to **true**, model, …); persisted to
   `jh:stage-trigger-config`.
+- **Saved table views** — table-scoped view templates and presentation state
+  for high-density operational tables; persisted to `jh:saved-table-views`.
+  Active Jobs filters/sort remain URL state, and applying a view writes the URL
+  rather than creating a second live copy of those facts.
 - **Anything cross-cutting that we discover later** that fits the pattern
   "I want to dispatch from a deep tree without prop drilling, and the
   state is not server-derived." Examples we anticipate: a `commandPalette`
   open/close (cmd-k UX), a `confirmDialog` queue.
 
-Five Zustand stores exist today: `ui-preferences`, `toasts`, and
+Six Zustand stores exist today: `ui-preferences`, `toasts`, and
 `command-palette` (transient), plus `profile-import` and
-`stage-trigger-config` (persisted). Three carry `persist` middleware —
-`jh:ui-preferences`, `jh:profile-import`, and `jh:stage-trigger-config`.
+`stage-trigger-config` and `saved-table-views` (persisted). Four carry
+`persist` middleware — `jh:ui-preferences`, `jh:profile-import`,
+`jh:stage-trigger-config`, and `jh:saved-table-views`.
 
 **Why this split (not "all Zustand" or "all context"):**
 
@@ -522,6 +527,11 @@ from the store (or thin context wrappers if a context proves ergonomic).
 A `<ThemeEffect />` component subscribes to the store and writes the
 `data-theme` attribute on `<html>` and the `data-density` attribute on
 the AppShell root.
+
+Saved table views can provide a table-scoped density override. `null` inherits
+the global `jh:ui-preferences` density; a concrete `compact` / `regular` /
+`comfy` value applies only to the mounted table through the grid's
+`data-density` attribute.
 
 **Why Zustand, not raw `useState` + context:** persistence is built in;
 no "save on every change" useEffect; SSR-safe later; no cascade

--- a/docs/architecture/frontend/state-and-ports.md
+++ b/docs/architecture/frontend/state-and-ports.md
@@ -29,6 +29,7 @@ is the canonical decision matrix.
 | Currently active route | **URL** (path) | Trivially. |
 | Global text search ("Filter jobs, errors, companies...") | **URL** | Bookmarkable searches. |
 | Bulk-selection set (checked job keys) | **Component** (`useState`) | Intentionally ephemeral; selecting 50 jobs and refreshing should not preserve the selection. Documented exception. |
+| Saved table view definitions, active view id, column visibility/order/widths, and table density override | **Client** (Zustand+persist) | Local UI preference/template data. Applying a view writes URL-owned filters/sort through `navigate`; active filters/sort are not shadowed in the store. |
 | Theme (light/dark) | **Client** (Zustand+persist) | User preference; not URL-bound; persists across sessions. |
 | Density (compact/regular/comfy) | **Client** (Zustand+persist) | Same. |
 | Tenant identity | **Client** (context fed by Zustand+session in cloud) | Determined by session; not navigation-controlled. |

--- a/docs/architecture/frontend/structure.md
+++ b/docs/architecture/frontend/structure.md
@@ -179,6 +179,7 @@ apps/web/
 │   │   │   ├── form.tsx                    # TanStack Form bindings
 │   │   │   ├── table.tsx                   # native table primitives
 │   │   │   ├── filterable-data-grid.tsx     # custom FilterableDataGrid — the table engine (DataGridColumn<T>)
+│   │   │   ├── saved-table-views-control.tsx # shared table-view switcher + save/rename/delete/columns UI
 │   │   │   ├── data-table.tsx               # shadcn wrapper over @tanstack/react-table — unused by any view
 │   │   │   └── copyable-command.tsx        # `<CopyableCommand command={...} />` — preserves the "copyable CLI commands" affordance per docs/decisions.md (2026-05-03)
 │   │   ├── layout/
@@ -217,6 +218,7 @@ apps/web/
 │   │   │       └── StaticFeatureFlagAdapter.ts
 │   │   ├── stores/
 │   │   │   ├── ui-preferences.ts           # Zustand+persist → jh:ui-preferences (theme, density)
+│   │   │   ├── saved-table-views.ts        # Zustand+persist → jh:saved-table-views (table templates + presentation)
 │   │   │   ├── toasts.ts                   # Zustand
 │   │   │   └── command-palette.ts          # Zustand (open/close + search)
 │   │   ├── hooks/

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -43,6 +43,7 @@ the Historical Spec Ledger in `plans/README.md`.
 - [Frontend Hexagonal Ports With Local + Hosted Adapters Named](#_2026-05-06-frontend-hexagonal-ports-with-local-hosted-adapters-named) · 2026-05-06
 - [SSE Realtime Via `GET /v1/events/stream` + Invalidation Router](#_2026-05-06-sse-realtime-via-get-v1-events-stream-invalidation-router) · 2026-05-06
 - [View-vs-Context Dichotomy + 1:1 Backend Bounded-Context Mirror](#_2026-05-06-view-vs-context-dichotomy-1-1-backend-bounded-context-mirror) · 2026-05-06
+- [Saved Table Views Stay Client-Persisted Templates](#_2026-07-05-saved-table-views-stay-client-persisted-templates) · 2026-07-05
 
 **Orchestration & workflow reliability (Temporal)**
 
@@ -1316,3 +1317,31 @@ Consequences:
 - the in-process preparation queue and its reaper are removed
 
 Cites: PR #237 (P3).
+
+## 2026-07-05: Saved Table Views Stay Client-Persisted Templates
+
+Status: accepted
+
+Decision: saved table-view definitions and table presentation state live in a
+versioned Zustand `persist` store (`jh:saved-table-views`). Active Jobs filters,
+sort, page, and page size remain URL state. Applying a saved view writes those
+URL-owned dimensions through router navigation and applies only presentation
+dimensions directly from the client store.
+
+Rationale:
+
+- filters and sort are already bookmarkable URL state and feed the route loader
+  query key
+- table views are local UI templates, not backend domain data or cross-device
+  settings
+- the client store follows the same migration-safe pattern as other persisted
+  UI preferences and can drop renamed/removed column ids without corrupting a
+  view
+
+Consequences:
+
+- a saved view is not a live second copy of the current URL filters/sort
+- editing filters after applying a view does not mutate the saved template
+  unless the user explicitly saves/updates that view
+- server-side or shareable saved views would require a separate future
+  aggregate/API decision rather than repurposing this local store

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -111,6 +111,7 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 | A cover letter ships to the employer with a fabricated metric/date/title/employer or a job-target skill/tool the profile cannot back, because its only gate is structural (banned words, dashes, word count, salutation/closing). The cover-letter body must run the same deterministic grounding gates the resume uses (never-fabricate detector + prose skill/tool gate) before acceptance, hard-reject a fabrication (letter REJECTED, aggregate stays `resume_approved`, failure kept as `fabrication_audit` history), and never false-reject legitimate content (the `Dear` salutation, the target company/role, declared skills, evidence tools, real profile numbers, or JD concept keywords in varied word forms such as scalability/reliability/observability — the skill gate is scoped to named technologies with word-form-tolerant grounding) | `workers/automation/tests/test_materials_use_cases.py` |
 | Profile PDF import corrupts defaults or drops tailoring claim/evidence controls | `workers/automation/tests/test_profile_import.py`; `workers/automation/tests/test_profile_aggregate.py`; `workers/automation/tests/test_sqlite_profile_repository.py`; `apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx` |
 | API list filtering/sorting/pagination or shared data-grid filtering/sorting/pagination/column resizing regresses | `apps/api/test/server.test.ts`; `apps/web/src/shared/ui/filterable-data-grid.test.tsx`; `apps/web/src/views/debug/DebugActivityTable.test.tsx` |
+| Saved Jobs table views stop treating URL filters/sort as the active source of truth, lose migration safety for renamed/removed columns, or fail to restore column visibility/order/widths and table density after a reload | `apps/web/src/shared/stores/saved-table-views.test.ts`; `apps/web/src/shared/ui/filterable-data-grid.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx`; browser smoke on `/jobs` |
 | Dashboard KPI drilldowns stop matching their Jobs list filters | `apps/api/test/server.test.ts`; `apps/web/src/views/dashboard/KpiGrid.test.tsx`; `apps/web/src/views/jobs/JobsView.test.tsx` |
 | Apply-run drawers show roadmap placeholder copy instead of persisted timeline events | `apps/api/test/server.test.ts`; `apps/web/src/contexts/apply/components/ApplyRunTimeline.test.tsx` |
 | Activity events overload Dashboard or stop being inspectable from the Debug tab | `apps/api/test/server.test.ts`; `apps/web/src/views/dashboard/DashboardView.test.tsx`; `apps/web/src/views/debug/DebugActivityTable.test.tsx`; `apps/web/src/views/debug/DebugView.test.tsx` |
@@ -178,6 +179,27 @@ synthetic dimensions, deterministic policy outputs, aggregate anchor/stale
 counts, and correction agreement. Do not add raw job URLs, correction
 rationales, anchors, resumes, or local paths to eval reports or committed
 fixtures.
+
+### Saved Views Smoke
+
+For Jobs table saved-view changes, run the targeted web fixtures and one browser
+smoke on `/jobs`:
+
+```bash
+pnpm --dir apps/web exec vitest run src/shared/stores/saved-table-views.test.ts src/shared/ui/filterable-data-grid.test.tsx src/views/jobs/JobsView.test.tsx
+```
+
+Manual smoke:
+
+1. Open `/jobs` with at least one Discover-stage and one Apply-stage synthetic
+   job.
+2. Filter the Stage column to `apply`, hide one non-critical column, reorder a
+   column, resize a column, and set the table density to `compact`.
+3. Save the current template as a named view, switch to `Default`, then switch
+   back to the named view.
+4. Reload the page and confirm the named template restores column visibility,
+   order, widths, density, and the URL-backed stage filter/sort.
+5. Rename the view, delete it, and confirm the table falls back to `Default`.
 
 ### Resume Tailoring Quality Eval Gate
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -40,6 +40,8 @@ export const JOB_DELETED_FILTERS = ["active", "closed", "deleted", "hidden", "al
 export type JobDeletedFilter = (typeof JOB_DELETED_FILTERS)[number];
 export const JOB_APPLY_STATUS_FILTERS = ["all", "applied"] as const;
 export type JobApplyStatusFilter = (typeof JOB_APPLY_STATUS_FILTERS)[number];
+const STAGE_OR_ALL = [...STAGES, "all"] as const;
+const STATE_OR_ALL = [...STAGE_STATES, "all"] as const;
 
 export const JOB_SORT_FIELDS = [
   "discovered_at",
@@ -74,6 +76,89 @@ export const ACTIVITY_SORT_FIELDS = [
 export type ActivitySortField = (typeof ACTIVITY_SORT_FIELDS)[number];
 
 export const SortDirectionSchema = z.enum(["asc", "desc"]).default("desc").catch("desc");
+export const TableIdSchema = z.enum(["jobs", "discovery-sources"]);
+export type TableId = z.infer<typeof TableIdSchema>;
+
+export const SavedTableViewDensitySchema = z.enum(["compact", "regular", "comfy"]);
+export type SavedTableViewDensity = z.infer<typeof SavedTableViewDensitySchema>;
+
+export const SavedTableViewTextFilterSchema = z
+  .object({
+    operator: z.enum(["contains", "does_not_contain"]).default("contains").catch("contains"),
+    text: z.string().default("").catch(""),
+    selectedValues: z.array(z.string()).default([]).catch([]),
+  })
+  .strict();
+export type SavedTableViewTextFilter = z.infer<typeof SavedTableViewTextFilterSchema>;
+
+export const SavedTableViewGridFiltersSchema = z.record(
+  z.string(),
+  SavedTableViewTextFilterSchema.optional(),
+);
+export type SavedTableViewGridFilters = z.infer<typeof SavedTableViewGridFiltersSchema>;
+
+export const SavedTableViewUrlFiltersSchema = z
+  .object({
+    q: z.string().optional().catch(undefined),
+    stage: z.enum(STAGE_OR_ALL).optional().catch(undefined),
+    state: z.enum(STATE_OR_ALL).optional().catch(undefined),
+    applyStatus: z.enum(JOB_APPLY_STATUS_FILTERS).optional().catch(undefined),
+    deleted: z.enum(["active", "closed", "deleted", "hidden"]).optional().catch(undefined),
+    pageSize: z.coerce.number().int().min(1).max(200).optional().catch(undefined),
+    minFitScore: z.coerce.number().int().min(1).max(10).optional().catch(undefined),
+    maxFitScore: z.coerce.number().int().min(1).max(10).optional().catch(undefined),
+  })
+  .strict();
+export type SavedTableViewUrlFilters = z.infer<typeof SavedTableViewUrlFiltersSchema>;
+
+export const SavedTableViewSchema = z
+  .object({
+    id: z.string().trim().min(1).max(120),
+    tableId: TableIdSchema,
+    name: z.string().trim().min(1).max(80),
+    builtIn: z.boolean(),
+    columns: z
+      .object({
+        order: z.array(z.string()).default([]).catch([]),
+        hidden: z.array(z.string()).default([]).catch([]),
+        widths: z.record(z.string(), z.coerce.number().int().min(24).max(2000)).default({}).catch({}),
+      })
+      .strict(),
+    density: SavedTableViewDensitySchema.nullable(),
+    sort: z
+      .object({
+        columnId: z.string(),
+        direction: z.enum(["asc", "desc"]),
+      })
+      .strict(),
+    urlFilters: SavedTableViewUrlFiltersSchema.default({}),
+    gridFilters: SavedTableViewGridFiltersSchema.default({}),
+    grouping: z
+      .object({
+        columnId: z.string(),
+      })
+      .strict()
+      .nullable(),
+    colorRules: z
+      .array(
+        z
+          .object({
+            columnId: z.string(),
+            predicate: z
+              .object({
+                op: z.enum(["eq", "neq", "gte", "lte", "contains"]),
+                value: z.union([z.string(), z.number()]),
+              })
+              .strict(),
+            tone: z.enum(["success", "warning", "danger", "info"]),
+          })
+          .strict(),
+      )
+      .default([]),
+    schemaVersion: z.number().int().min(1),
+  })
+  .strict();
+export type SavedTableView = z.infer<typeof SavedTableViewSchema>;
 
 const optionalText = z
   .string()


### PR DESCRIPTION
## Summary
- Adds reusable saved table view contracts for the Jobs table.
- Extends `FilterableDataGrid` with additive presentation controls for column order, visibility, widths, density, and saved-view actions.
- Wires Jobs view snapshots while keeping active filters and sort URL-owned.

## Stack
- Base: #267 (`docs/plan-saved-views-digest`)
- Next: `feat/r8-p2-saved-view-rules`

## Validation
Full stack validation was run from `feat/r8-p5-digest-cli`:
- `pnpm check`
- `pnpm test`
- `pnpm --filter @jobhunter/web test-d`
- `pnpm --filter @jobhunter/web test`
- `pnpm --filter @jobhunter/web e2e -- tests/dashboard.spec.ts`
- `pnpm web:storybook:build`
- `pnpm docs:build`
- `git diff --check`

Review gates:
- pr-reviewer: Gate: PASS
- QA: Gate: PASS
