### PR TITLE
feat(web): [R8] add saved view grouping and rules

### DIFF
--- a/apps/web/src/shared/ui/filterable-data-grid.test.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.test.tsx
@@ -354,6 +354,51 @@ describe("FilterableDataGrid", () => {
     );
   });
 
+  it("groups page rows and applies semantic color-rule classes", () => {
+    render(
+      <FilterableDataGrid
+        title="Grid view"
+        data={rows}
+        columns={columns}
+        getRowId={(row) => row.id}
+        loading={false}
+        loadingMessage="Loading rows."
+        emptyMessage="No rows."
+        initialSort={{ columnId: "company", direction: "asc" }}
+        grouping={{ columnId: "provider" }}
+        colorRules={[
+          {
+            columnId: "company",
+            predicate: { op: "contains", value: "Acme" },
+            tone: "success",
+          },
+          {
+            columnId: "observed",
+            predicate: { op: "gte", value: 8 },
+            tone: "warning",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("row", { name: /Workday ATS 2/i })).toHaveClass(
+      "data-grid-group-row",
+    );
+    expect(screen.getByRole("row", { name: /JobSpy board 1/i })).toHaveClass(
+      "data-grid-group-row",
+    );
+    const acmeRow = screen.getByRole("row", { name: /Acme Workday ATS 3/i });
+    expect(acmeRow).toHaveClass("data-grid-row-tone-success");
+    expect(within(acmeRow).getByRole("rowheader")).toHaveClass(
+      "data-grid-cell-tone-success",
+    );
+    const boardRow = screen.getByRole("row", { name: /BoardCo JobSpy board 8/i });
+    expect(boardRow).toHaveClass("data-grid-row-tone-warning");
+    expect(within(boardRow).getByText("8").closest("td")).toHaveClass(
+      "data-grid-cell-tone-warning",
+    );
+  });
+
   it("keeps dense grid focus indicators tied to the standard ring token", () => {
     const css = readFileSync("src/styles/globals.css", "utf8");
 

--- a/apps/web/src/shared/ui/filterable-data-grid.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.tsx
@@ -6,6 +6,7 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import {
+  Fragment,
   type KeyboardEvent,
   type MouseEvent,
   type PointerEvent as ReactPointerEvent,
@@ -69,6 +70,20 @@ export interface DataGridSortState {
 export type DataGridDensity = "compact" | "regular" | "comfy";
 export type DataGridColumnVisibilityState = Record<string, boolean>;
 export type DataGridColumnWidthsState = Record<string, number>;
+export type DataGridColorTone = "success" | "warning" | "danger" | "info";
+
+export interface DataGridGroupingState {
+  columnId: string;
+}
+
+export interface DataGridColorRule {
+  columnId: string;
+  predicate: {
+    op: "eq" | "neq" | "gte" | "lte" | "contains";
+    value: string | number;
+  };
+  tone: DataGridColorTone;
+}
 
 export interface DataGridHeaderContext<TData> {
   pageRows: readonly TData[];
@@ -121,6 +136,8 @@ export interface FilterableDataGridProps<TData> {
   columnWidths?: DataGridColumnWidthsState;
   onColumnWidthsChange?: (next: DataGridColumnWidthsState) => void;
   density?: DataGridDensity | null;
+  grouping?: DataGridGroupingState | null;
+  colorRules?: readonly DataGridColorRule[];
   rowClassName?: (row: TData) => string | undefined;
   rowAriaSelected?: (row: TData) => boolean;
   onRowActivate?: (row: TData) => void;
@@ -230,6 +247,72 @@ function sameStrings(left: readonly string[], right: readonly string[]): boolean
     left.length === right.length &&
     left.every((value, index) => value === right[index])
   );
+}
+
+function columnRuleValue<TData>(
+  row: TData,
+  column: DataGridColumn<TData>,
+): string | number {
+  const filterValue =
+    column.getFilterSearchValue?.(row) ?? column.getFilterValue?.(row);
+  if (filterValue !== undefined) return filterValue;
+  return column.getSortValue?.(row) ?? "";
+}
+
+function groupLabelFor<TData>(
+  row: TData,
+  column: DataGridColumn<TData>,
+): string {
+  const value = column.getFilterValue?.(row) ?? column.getSortValue?.(row);
+  const label = String(value ?? "").trim();
+  return label || "Unspecified";
+}
+
+function matchesColorRule<TData>(
+  row: TData,
+  column: DataGridColumn<TData>,
+  rule: DataGridColorRule,
+): boolean {
+  const left = columnRuleValue(row, column);
+  const right = rule.predicate.value;
+  if (rule.predicate.op === "gte" || rule.predicate.op === "lte") {
+    const leftNumber = Number(left);
+    const rightNumber = Number(right);
+    if (!Number.isFinite(leftNumber) || !Number.isFinite(rightNumber)) {
+      return false;
+    }
+    return rule.predicate.op === "gte"
+      ? leftNumber >= rightNumber
+      : leftNumber <= rightNumber;
+  }
+  const leftText = normalize(String(left));
+  const rightText = normalize(String(right));
+  if (rule.predicate.op === "eq") return leftText === rightText;
+  if (rule.predicate.op === "neq") return leftText !== rightText;
+  return leftText.includes(rightText);
+}
+
+function firstMatchingTone<TData>(
+  row: TData,
+  columnsById: ReadonlyMap<string, DataGridColumn<TData>>,
+  colorRules: readonly DataGridColorRule[],
+  columnId?: string,
+): DataGridColorTone | null {
+  for (const rule of colorRules) {
+    if (columnId && rule.columnId !== columnId) continue;
+    const column = columnsById.get(rule.columnId);
+    if (column && matchesColorRule(row, column, rule)) {
+      return rule.tone;
+    }
+  }
+  return null;
+}
+
+function toneClass(
+  target: "row" | "cell",
+  tone: DataGridColorTone | null,
+): string | undefined {
+  return tone ? `data-grid-${target}-tone-${tone}` : undefined;
 }
 
 export function isActiveDataGridFilter(
@@ -410,6 +493,8 @@ export function FilterableDataGrid<TData>({
   columnWidths: controlledColumnWidths,
   onColumnWidthsChange,
   density,
+  grouping,
+  colorRules = [],
   rowClassName,
   rowAriaSelected,
   onRowActivate,
@@ -443,6 +528,13 @@ export function FilterableDataGrid<TData>({
     () => filterVisibleColumns(orderedColumns, columnVisibility),
     [columnVisibility, orderedColumns],
   );
+  const columnsById = useMemo(
+    () => new Map(columns.map((column) => [column.id, column])),
+    [columns],
+  );
+  const groupColumn = grouping?.columnId
+    ? columnsById.get(grouping.columnId)
+    : undefined;
   const activationColumnIndex = useMemo(() => {
     const rowHeaderIndex = displayColumns.findIndex((column) => column.rowHeader);
     return rowHeaderIndex >= 0 ? rowHeaderIndex : 0;
@@ -524,6 +616,34 @@ export function FilterableDataGrid<TData>({
     const offset = (safePage - 1) * pageSize;
     return visibleRows.slice(offset, offset + pageSize);
   }, [pageSize, pagination, paginationEnabled, safePage, visibleRows]);
+  const pageRowIndexById = useMemo(() => {
+    const next = new Map<string, number>();
+    pageRows.forEach((row, index) => {
+      next.set(getRowId(row), index);
+    });
+    return next;
+  }, [getRowId, pageRows]);
+  const pageRowGroups = useMemo(() => {
+    if (!groupColumn) {
+      return [{ key: "all", label: null, rows: pageRows }];
+    }
+    const groups = new Map<string, TData[]>();
+    for (const row of pageRows) {
+      const label = groupLabelFor(row, groupColumn);
+      const key = `${groupColumn.id}:${label}`;
+      const rows = groups.get(key);
+      if (rows) {
+        rows.push(row);
+      } else {
+        groups.set(key, [row]);
+      }
+    }
+    return Array.from(groups, ([key, rows]) => ({
+      key,
+      label: key.slice(groupColumn.id.length + 1),
+      rows,
+    }));
+  }, [groupColumn, pageRows]);
 
   const headerContext = useMemo<DataGridHeaderContext<TData>>(
     () => ({ pageRows, visibleRows, allRows: data }),
@@ -926,65 +1046,95 @@ export function FilterableDataGrid<TData>({
             </tr>
           </thead>
           <tbody>
-            {pageRows.map((row, rowIndex) => {
-              const rowId = getRowId(row);
-              const baseRowClassName = rowClassName?.(row);
-              const effectiveRowClassName = onRowActivate
-                ? [baseRowClassName, "data-grid-row-activatable"].filter(Boolean).join(" ")
-                : baseRowClassName;
-              const activationLabel = rowActivationLabel?.(row) ?? `Open row ${rowId}`;
-              return (
-                <tr
-                  key={rowId}
-                  className={effectiveRowClassName}
-                  aria-selected={rowAriaSelected?.(row)}
-                  onClick={
-                    onRowActivate
-                      ? (event) => {
-                          if (shouldIgnoreRowActivation(event)) {
-                            return;
-                          }
-                          onRowActivate(row);
-                        }
-                      : undefined
-                  }
-                >
-                  {displayColumns.map((column, columnIndex) => {
-                    const content = column.render(row, { pageRows, rowId, rowIndex });
-                    const isActivationCell =
-                      Boolean(onRowActivate) && columnIndex === activationColumnIndex;
-                    const activationButton = isActivationCell ? (
-                      <button
-                        type="button"
-                        className="data-grid-row-activation-button"
-                        aria-label={activationLabel}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onRowActivate?.(row);
-                        }}
-                      >
-                        <span aria-hidden="true">Open</span>
-                      </button>
-                    ) : null;
-                    return column.rowHeader ? (
-                      <th
-                        key={column.id}
-                        className={column.className}
-                        scope="row"
-                      >
-                        {content}
-                        {activationButton}
-                      </th>
-                    ) : (
-                      <td key={column.id} className={column.className}>
-                        {content}
-                        {activationButton}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
+            {pageRowGroups.map((group) => (
+              <Fragment key={group.key}>
+                {group.label ? (
+                  <tr className="data-grid-group-row">
+                    <th colSpan={Math.max(1, displayColumns.length)}>
+                      <span>{group.label}</span>
+                      <span>{group.rows.length}</span>
+                    </th>
+                  </tr>
+                ) : null}
+                {group.rows.map((row) => {
+                  const rowId = getRowId(row);
+                  const rowIndex = pageRowIndexById.get(rowId) ?? 0;
+                  const baseRowClassName = rowClassName?.(row);
+                  const rowTone = firstMatchingTone(
+                    row,
+                    columnsById,
+                    colorRules,
+                  );
+                  const effectiveRowClassName = classNames(
+                    baseRowClassName,
+                    toneClass("row", rowTone),
+                    onRowActivate && "data-grid-row-activatable",
+                  );
+                  const activationLabel = rowActivationLabel?.(row) ?? `Open row ${rowId}`;
+                  return (
+                    <tr
+                      key={rowId}
+                      className={effectiveRowClassName}
+                      aria-selected={rowAriaSelected?.(row)}
+                      onClick={
+                        onRowActivate
+                          ? (event) => {
+                              if (shouldIgnoreRowActivation(event)) {
+                                return;
+                              }
+                              onRowActivate(row);
+                            }
+                          : undefined
+                      }
+                    >
+                      {displayColumns.map((column, columnIndex) => {
+                        const content = column.render(row, { pageRows, rowId, rowIndex });
+                        const cellTone = firstMatchingTone(
+                          row,
+                          columnsById,
+                          colorRules,
+                          column.id,
+                        );
+                        const cellClassName = classNames(
+                          column.className,
+                          toneClass("cell", cellTone),
+                        );
+                        const isActivationCell =
+                          Boolean(onRowActivate) && columnIndex === activationColumnIndex;
+                        const activationButton = isActivationCell ? (
+                          <button
+                            type="button"
+                            className="data-grid-row-activation-button"
+                            aria-label={activationLabel}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onRowActivate?.(row);
+                            }}
+                          >
+                            <span aria-hidden="true">Open</span>
+                          </button>
+                        ) : null;
+                        return column.rowHeader ? (
+                          <th
+                            key={column.id}
+                            className={cellClassName}
+                            scope="row"
+                          >
+                            {content}
+                            {activationButton}
+                          </th>
+                        ) : (
+                          <td key={column.id} className={cellClassName}>
+                            {content}
+                            {activationButton}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  );
+                })}
+              </Fragment>
+            ))}
           </tbody>
         </table>
         {loading && !data.length ? <Empty title={loadingMessage} /> : null}

--- a/apps/web/src/shared/ui/saved-table-views-control.tsx
+++ b/apps/web/src/shared/ui/saved-table-views-control.tsx
@@ -42,6 +42,20 @@ export interface SavedTableViewsControlProps {
   onPresentationChange: (presentation: SavedTablePresentation) => void;
 }
 
+const COLOR_RULE_OPERATORS = [
+  { value: "contains", label: "contains" },
+  { value: "eq", label: "equals" },
+  { value: "neq", label: "not equal" },
+  { value: "gte", label: ">=" },
+  { value: "lte", label: "<=" },
+] as const;
+const COLOR_RULE_TONES = [
+  { value: "success", label: "Success" },
+  { value: "warning", label: "Warning" },
+  { value: "danger", label: "Danger" },
+  { value: "info", label: "Info" },
+] as const;
+
 function moveColumn(
   order: readonly string[],
   columnId: string,
@@ -90,6 +104,12 @@ export function SavedTableViewsControl({
   const [columnOpen, setColumnOpen] = useState(false);
   const [nameInput, setNameInput] = useState("");
   const [renameInput, setRenameInput] = useState("");
+  const [ruleColumnId, setRuleColumnId] = useState("");
+  const [ruleOperator, setRuleOperator] =
+    useState<(typeof COLOR_RULE_OPERATORS)[number]["value"]>("contains");
+  const [ruleValue, setRuleValue] = useState("");
+  const [ruleTone, setRuleTone] =
+    useState<(typeof COLOR_RULE_TONES)[number]["value"]>("info");
 
   const activeView = useMemo(
     () =>
@@ -186,6 +206,50 @@ export function SavedTableViewsControl({
       density,
       grouping: snapshot.grouping,
       colorRules: snapshot.colorRules,
+    });
+  };
+
+  const setGrouping = (columnId: string) => {
+    setPresentation({
+      columns: snapshot.columns,
+      density: snapshot.density,
+      grouping: columnId ? { columnId } : null,
+      colorRules: snapshot.colorRules,
+    });
+  };
+
+  const addColorRule = () => {
+    const columnId = ruleColumnId || columnOptions[0]?.id;
+    const trimmedValue = ruleValue.trim();
+    if (!columnId || !trimmedValue) return;
+    const numericValue = Number(trimmedValue);
+    const value =
+      (ruleOperator === "gte" || ruleOperator === "lte") &&
+      Number.isFinite(numericValue)
+        ? numericValue
+        : trimmedValue;
+    setPresentation({
+      columns: snapshot.columns,
+      density: snapshot.density,
+      grouping: snapshot.grouping,
+      colorRules: [
+        ...snapshot.colorRules,
+        {
+          columnId,
+          predicate: { op: ruleOperator, value },
+          tone: ruleTone,
+        },
+      ],
+    });
+    setRuleValue("");
+  };
+
+  const deleteColorRule = (index: number) => {
+    setPresentation({
+      columns: snapshot.columns,
+      density: snapshot.density,
+      grouping: snapshot.grouping,
+      colorRules: snapshot.colorRules.filter((_, ruleIndex) => ruleIndex !== index),
     });
   };
 
@@ -327,6 +391,112 @@ export function SavedTableViewsControl({
                 {option.label}
               </button>
             ))}
+          </section>
+          <label className="saved-table-rule-field">
+            <span>Group by</span>
+            <select
+              aria-label="Group table rows"
+              value={snapshot.grouping?.columnId ?? ""}
+              onChange={(event) => setGrouping(event.target.value)}
+            >
+              <option value="">No grouping</option>
+              {columnOptions.map((column) => (
+                <option key={column.id} value={column.id}>
+                  {column.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <section className="saved-table-rules" aria-label="Color rules">
+            <div className="saved-table-rule-editor">
+              <label>
+                <span>Column</span>
+                <select
+                  aria-label="Color rule column"
+                  value={ruleColumnId || columnOptions[0]?.id || ""}
+                  onChange={(event) => setRuleColumnId(event.target.value)}
+                >
+                  {columnOptions.map((column) => (
+                    <option key={column.id} value={column.id}>
+                      {column.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>Predicate</span>
+                <select
+                  aria-label="Color rule predicate"
+                  value={ruleOperator}
+                  onChange={(event) =>
+                    setRuleOperator(
+                      event.target.value as typeof ruleOperator,
+                    )
+                  }
+                >
+                  {COLOR_RULE_OPERATORS.map((operator) => (
+                    <option key={operator.value} value={operator.value}>
+                      {operator.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span>Value</span>
+                <Input
+                  aria-label="Color rule value"
+                  value={ruleValue}
+                  onChange={(event) => setRuleValue(event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Tone</span>
+                <select
+                  aria-label="Color rule tone"
+                  value={ruleTone}
+                  onChange={(event) =>
+                    setRuleTone(event.target.value as typeof ruleTone)
+                  }
+                >
+                  {COLOR_RULE_TONES.map((tone) => (
+                    <option key={tone.value} value={tone.value}>
+                      {tone.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <button
+                type="button"
+                disabled={!ruleValue.trim()}
+                onClick={addColorRule}
+              >
+                Add
+              </button>
+            </div>
+            {snapshot.colorRules.length ? (
+              <div className="saved-table-rule-list">
+                {snapshot.colorRules.map((rule, index) => {
+                  const column = columnOptions.find(
+                    (option) => option.id === rule.columnId,
+                  );
+                  return (
+                    <div key={`${rule.columnId}-${index}`}>
+                      <span>
+                        {column?.label ?? rule.columnId} {rule.predicate.op}{" "}
+                        {String(rule.predicate.value)} · {rule.tone}
+                      </span>
+                      <button
+                        type="button"
+                        aria-label={`Delete color rule ${index + 1}`}
+                        onClick={() => deleteColorRule(index)}
+                      >
+                        <IconTrash size={13} aria-hidden="true" />
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            ) : null}
           </section>
           <div className="saved-table-column-list">
             {snapshot.columns.order.map((columnId, index) => {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2767,6 +2767,71 @@ textarea:focus-visible {
   font-weight: 650;
 }
 
+.saved-table-rule-field,
+.saved-table-rule-editor label {
+  display: grid;
+  gap: 4px;
+}
+
+.saved-table-rule-field {
+  margin-top: 12px;
+}
+
+.saved-table-rule-field span,
+.saved-table-rule-editor span {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.saved-table-rule-field select,
+.saved-table-rule-editor select,
+.saved-table-rule-editor input {
+  min-height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--card);
+  color: var(--foreground);
+  font: inherit;
+  font-size: 12px;
+}
+
+.saved-table-rules {
+  display: grid;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.saved-table-rule-editor {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.1fr) minmax(88px, 0.75fr) minmax(120px, 1fr) minmax(88px, 0.75fr) auto;
+  align-items: end;
+  gap: 8px;
+}
+
+.saved-table-rule-list {
+  display: grid;
+  gap: 4px;
+}
+
+.saved-table-rule-list div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.saved-table-rule-list span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .saved-table-column-list {
   display: grid;
   gap: 4px;
@@ -3027,6 +3092,56 @@ textarea:focus-visible {
 .filterable-data-grid-table tbody th {
   min-width: 180px;
   font-weight: 500;
+}
+
+.filterable-data-grid-table tbody tr.data-grid-group-row th {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  min-width: 0;
+  background: var(--muted);
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.data-grid-group-row th {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-success {
+  box-shadow: inset 3px 0 0 var(--success);
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-warning {
+  box-shadow: inset 3px 0 0 var(--warning);
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-danger {
+  box-shadow: inset 3px 0 0 var(--destructive);
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-info {
+  box-shadow: inset 3px 0 0 var(--status-info);
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-success {
+  background: color-mix(in oklch, var(--success) 10%, var(--card));
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-warning {
+  background: color-mix(in oklch, var(--warning) 12%, var(--card));
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-danger {
+  background: color-mix(in oklch, var(--destructive) 10%, var(--card));
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-info {
+  background: color-mix(in oklch, var(--status-info) 10%, var(--card));
 }
 
 .data-grid-column-head {

--- a/apps/web/src/views/jobs/JobsTable.tsx
+++ b/apps/web/src/views/jobs/JobsTable.tsx
@@ -7,10 +7,12 @@ import type {
 } from "../../contexts/operations/types.js";
 import {
   FilterableDataGrid,
+  type DataGridColorRule,
   type DataGridColumn,
   type DataGridColumnWidthsState,
   type DataGridDensity,
   type DataGridFilterState,
+  type DataGridGroupingState,
   type DataGridSortState,
 } from "../../shared/ui/filterable-data-grid.js";
 import { jobColumns } from "./columns.js";
@@ -40,6 +42,8 @@ export interface JobsTableProps {
   columnWidths?: DataGridColumnWidthsState;
   onColumnWidthsChange?: (next: DataGridColumnWidthsState) => void;
   density?: DataGridDensity | null;
+  grouping?: DataGridGroupingState | null;
+  colorRules?: readonly DataGridColorRule[];
   toolbarActions?: (columns: Array<DataGridColumn<JobSummary>>) => ReactNode;
 }
 
@@ -64,6 +68,8 @@ export function JobsTable({
   columnWidths,
   onColumnWidthsChange,
   density,
+  grouping,
+  colorRules,
   toolbarActions,
 }: JobsTableProps) {
   const [selectionAnchorJobKey, setSelectionAnchorJobKey] = useState<
@@ -135,6 +141,8 @@ export function JobsTable({
       {...(columnWidths ? { columnWidths } : {})}
       {...(onColumnWidthsChange ? { onColumnWidthsChange } : {})}
       {...(density !== undefined ? { density } : {})}
+      {...(grouping !== undefined ? { grouping } : {})}
+      {...(colorRules ? { colorRules } : {})}
       tableClassName="jobs-data-grid-table"
       rowAriaSelected={(row) =>
         allMatchingSelected || Boolean(rowSelection[row.jobKey])

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -29,7 +29,11 @@ import { server } from "../../test/msw/server.js";
 import { buildProviderHarness } from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
-import { useSavedTableViewsStore } from "../../shared/stores/saved-table-views.js";
+import {
+  JOBS_TABLE_COLUMN_IDS,
+  JOBS_TABLE_ID,
+  useSavedTableViewsStore,
+} from "../../shared/stores/saved-table-views.js";
 import { JobsView } from "./JobsView.js";
 
 const SEARCH =
@@ -302,6 +306,23 @@ describe("<JobsView> bulk delete integration", () => {
     const columnsDialog = screen.getByRole("dialog", { name: "Columns" });
     await user.click(within(columnsDialog).getByRole("checkbox", { name: "Company" }));
     await user.click(within(columnsDialog).getByRole("button", { name: "Compact" }));
+    await user.selectOptions(
+      within(columnsDialog).getByRole("combobox", { name: "Group table rows" }),
+      "current_stage",
+    );
+    await user.selectOptions(
+      within(columnsDialog).getByRole("combobox", { name: "Color rule column" }),
+      "title",
+    );
+    await user.type(
+      within(columnsDialog).getByRole("textbox", { name: "Color rule value" }),
+      "Apply",
+    );
+    await user.selectOptions(
+      within(columnsDialog).getByRole("combobox", { name: "Color rule tone" }),
+      "warning",
+    );
+    await user.click(within(columnsDialog).getByRole("button", { name: "Add" }));
     await user.click(within(columnsDialog).getByRole("button", { name: /close/i }));
     expect(screen.queryByRole("columnheader", { name: /Company/ })).not.toBeInTheDocument();
 
@@ -332,6 +353,75 @@ describe("<JobsView> bulk delete integration", () => {
       "data-density",
       "compact",
     );
+    expect(screen.getByRole("row", { name: /apply 1/i })).toHaveClass(
+      "data-grid-group-row",
+    );
+    expect(rowForTitle(applyJob.title)).toHaveClass("data-grid-row-tone-warning");
+  });
+
+  it("hydrates active saved table view filters when the jobs view remounts", async () => {
+    const vonageJob: JobSummary = {
+      ...sampleJob,
+      jobKey: "job-saved-filter-vonage",
+      title: "Saved Filter Manager",
+      company: "Vonage",
+      source: "Greenhouse",
+      discoverySource: "greenhouse:vonage",
+      postingSource: "greenhouse:vonage",
+    };
+    const acaiJob: JobSummary = {
+      ...sampleSecondaryJob,
+      jobKey: "job-saved-filter-acai",
+      title: "Saved Filter Engineer",
+      company: "Acai",
+      source: "Ashby",
+      discoverySource: "ashby:acai",
+      postingSource: "ashby:acai",
+    };
+    const jobs = vi.fn(async () => makeJobsPage([vonageJob, acaiJob]));
+    useSavedTableViewsStore.getState().createView(JOBS_TABLE_ID, "Vonage", {
+      columns: { order: [...JOBS_TABLE_COLUMN_IDS], hidden: [], widths: {} },
+      density: null,
+      grouping: null,
+      colorRules: [],
+      sort: { columnId: "discovered_at", direction: "desc" },
+      urlFilters: {
+        q: "",
+        stage: "all",
+        state: "all",
+        applyStatus: "all",
+        deleted: "active",
+        pageSize: 50,
+      },
+      gridFilters: {
+        company: {
+          operator: "contains",
+          text: "",
+          selectedValues: ["Vonage"],
+        },
+      },
+    });
+
+    const harness = buildProviderHarness({
+      ports: buildTestPorts({ api: { jobs } }),
+    });
+    const { router, Wrapper } = buildRouter(harness);
+
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    expect(await screen.findByText(vonageJob.title)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(acaiJob.title)).not.toBeInTheDocument(),
+    );
+    expect(router.state.location.search).toMatchObject({
+      stage: "all",
+      sort: "discovered_at",
+    });
+    expect(
+      screen.getByRole("button", {
+        name: /filter company column \(active\)/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("continues all matching pending preparation when the jobs page opens on eligible pending work", async () => {

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -27,6 +27,7 @@ import type { JobsSearch } from "../../routes/-jobs.search.js";
 import {
   JOBS_TABLE_COLUMN_IDS,
   JOBS_TABLE_ID,
+  DEFAULT_SAVED_TABLE_VIEW_ID,
   type SavedTablePresentation,
   type SavedTableViewSnapshot,
   useSavedTableViewsStore,
@@ -244,6 +245,11 @@ export function JobsView() {
   const retryFailedJobs = useRetryFailedJobsMutation();
   const runPendingPreparation = useRunPendingPreparationMutation();
   const stageTriggerConfigs = useStageTriggerStore((state) => state.configs);
+  const savedTableViews = useSavedTableViewsStore((state) => state.views);
+  const activeSavedViewId = useSavedTableViewsStore(
+    (state) =>
+      state.activeViewIdByTable[JOBS_TABLE_ID] ?? DEFAULT_SAVED_TABLE_VIEW_ID,
+  );
   const savedPresentation =
     useSavedTableViewsStore(
       (state) => state.presentationByTable[JOBS_TABLE_ID],
@@ -259,6 +265,13 @@ export function JobsView() {
     useState<DataGridFilterState>({});
   const [visiblePageKeys, setVisiblePageKeys] = useState<string[]>([]);
   const autoPendingPreparationKeys = useRef<Set<string>>(new Set());
+  const activeSavedView = useMemo(
+    () =>
+      savedTableViews.find(
+        (view) => view.tableId === JOBS_TABLE_ID && view.id === activeSavedViewId,
+      ) ?? null,
+    [activeSavedViewId, savedTableViews],
+  );
   const tableFilters = useMemo<DataGridFilterState>(
     () => ({
       ...localTableFilters,
@@ -271,6 +284,13 @@ export function JobsView() {
       search.state,
     ],
   );
+
+  useEffect(() => {
+    setLocalTableFilters(
+      (activeSavedView?.gridFilters ?? {}) as DataGridFilterState,
+    );
+  }, [activeSavedView?.gridFilters]);
+
   const hasLocalFilters = hasActiveDataGridFilters(localTableFilters);
   const savedViewSnapshot = useMemo<SavedTableViewSnapshot>(
     () => ({
@@ -724,6 +744,8 @@ export function JobsView() {
           columnWidths={savedPresentation.columns.widths}
           onColumnWidthsChange={handleColumnWidthsChange}
           density={savedPresentation.density}
+          grouping={savedPresentation.grouping}
+          colorRules={savedPresentation.colorRules}
           toolbarActions={renderSavedTableActions}
         />
       </section>

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -167,16 +167,10 @@ Out of scope for the local stack (tracked under
 
 ### UI Quality
 
-- Add saved table views for high-density operational tables, starting with
-  Discovery source registry and Jobs. A view should persist column visibility,
-  column order, sort order, filters, row density, and any active grouping or
-  color rules under a user-named view, with a quick switcher in the table
-  toolbar. Filters should include both distinct-value multi-select and text
-  predicates such as "contains" and "does not contain" for text-like fields.
-- Add configurable jobs-table columns. The default Jobs table should keep
-  critical operational columns such as Source visible, but users need a
-  first-class control for choosing which columns are shown and hidden, with
-  persisted preferences per local profile or workspace.
+- Extend saved table views to the Discovery source registry. The R8 Jobs-table
+  delivery covers named views for column visibility, column order, widths, sort
+  order, filters, row density, grouping, and semantic color rules with a table
+  toolbar switcher.
 - Harden HTML/CSS resume pagination with deterministic page containers if
   browser-native print fragmentation proves unstable on dense real resumes.
   The migration record lives in

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -194,11 +194,13 @@ Manual smoke:
 1. Open `/jobs` with at least one Discover-stage and one Apply-stage synthetic
    job.
 2. Filter the Stage column to `apply`, hide one non-critical column, reorder a
-   column, resize a column, and set the table density to `compact`.
+   column, resize a column, set the table density to `compact`, group by Stage,
+   and add one semantic color rule.
 3. Save the current template as a named view, switch to `Default`, then switch
    back to the named view.
 4. Reload the page and confirm the named template restores column visibility,
-   order, widths, density, and the URL-backed stage filter/sort.
+   order, widths, density, grouping, color rules, and the URL-backed stage
+   filter/sort.
 5. Rename the view, delete it, and confirm the table falls back to `Default`.
 
 ### Resume Tailoring Quality Eval Gate


### PR DESCRIPTION
## Summary
- Adds saved Jobs table grouping, density, color-rule, and presentation controls.
- Persists templates in the versioned saved table view Zustand store.
- Restores active saved-view grid filters on Jobs view remount without moving URL-owned filters or sort out of the route state.

## Stack
- Previous: #288 (`feat/r8-p1-saved-views-core`)
- Next: `feat/r8-p3-digest-read-model`

## Validation
Full stack validation was run from `feat/r8-p5-digest-cli`:
- `pnpm check`
- `pnpm test`
- `pnpm --filter @jobhunter/web test-d`
- `pnpm --filter @jobhunter/web test`
- `pnpm --filter @jobhunter/web e2e -- tests/dashboard.spec.ts`
- `pnpm web:storybook:build`
- `pnpm docs:build`
- `git diff --check`

Review gates:
- pr-reviewer: Gate: PASS
- QA: Gate: PASS
