### PR TITLE
feat(cli): [R8] add local digest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Important local files include:
 - `codex_home/`: isolated Codex SDK home when apply/review agents need it.
 - `backups/`: timestamped database snapshots written by `jobhunter backup`.
 
+The daily digest is local-only. `jobhunter digest` and the Dashboard digest read
+from `jobhunter.db` without sending notifications or advancing review state;
+only the explicit Dashboard acknowledge action or `jobhunter digest
+--acknowledge` updates the `digest_state` watermark.
+
 Never commit profiles, API keys, generated resumes, cover letters, PDFs, browser
 profiles, logs, SQLite databases, screenshots containing real data, or local
 worker state. See [docs/user/data-and-safety.md](docs/user/data-and-safety.md)
@@ -232,6 +237,7 @@ Work-starting commands need the Temporal dev server plus a running worker
 | `action <stage>` | Low-level single-action dispatch with JSON output (used by scripts). |
 | `compensation-refresh` | Re-parse posted salaries and refresh market estimates (`--url`, `--observations-json`). |
 | `status` / `runs` | Inspect database stats and run telemetry (`runs --failed-only`). |
+| `digest` | Print the local daily digest (`--json`, `--acknowledge`, `--min-fit-score`). |
 | `worker` | Run the long-lived Temporal worker. |
 | `rpc` | JSON-RPC server spawned by the TypeScript API (internal). |
 | `backup` | Snapshot the SQLite database via `VACUUM INTO` (`--output`). |

--- a/docs/architecture/storage.md
+++ b/docs/architecture/storage.md
@@ -66,6 +66,9 @@ rendering settings/template text, run visibility, apply-review decisions,
 application outcomes, linked email evidence, and outcome suggestions. The
 projection tables (above) are also stored here. Dashboard settings remain
 file-backed until their own storage migration.
+The `digest_state` projection table stores the local daily digest review
+watermark; passive Dashboard and CLI reads do not update it, and only explicit
+acknowledge actions advance it.
 Posted compensation facts live in the canonical
 `job_posted_compensation_facts` table. The parser consumes only bounded salary
 source text such as `jobs.salary`, records explicit parse states and warnings,

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -203,6 +203,27 @@ Manual smoke:
    filter/sort.
 5. Rename the view, delete it, and confirm the table falls back to `Default`.
 
+### Daily Digest Smoke
+
+For daily digest changes, run the TypeScript/Python parity fixtures plus the
+CLI smoke:
+
+```bash
+pnpm --dir apps/api exec vitest run test/digest.test.ts
+uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_digest_parity.py workers/automation/tests/test_digest_cli.py
+```
+
+Manual smoke:
+
+1. Open Dashboard and confirm the Digest panel renders the same counts as
+   `uv --project workers/automation run jobhunter digest --json` for the same
+   local database.
+2. Run `uv --project workers/automation run jobhunter digest` and confirm it
+   does not change `digest_state.last_acknowledged_at`.
+3. Run `uv --project workers/automation run jobhunter digest --acknowledge`
+   and confirm the watermark advances to the displayed digest timestamp and a
+   `DigestReviewed` event is recorded.
+
 ### Resume Tailoring Quality Eval Gate
 
 For resume tailoring prompt, evidence policy, deterministic quality checks,

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -177,12 +177,14 @@ Useful command-line checks:
 
 ```bash
 uv --project workers/automation run jobhunter status
+uv --project workers/automation run jobhunter digest
 uv --project workers/automation run jobhunter runs
 uv --project workers/automation run jobhunter runs --failed-only
 ```
 
-These print your pipeline status, list all workflow runs, and list only failed
-runs, respectively.
+These print your pipeline status, show the local daily digest, list all workflow
+runs, and list only failed runs, respectively. The digest is read-only unless
+you pass `--acknowledge`, which marks the displayed digest as reviewed.
 
 Useful web app views:
 

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1135,6 +1135,173 @@ def job(
 
 
 @app.command()
+def digest(
+    acknowledge: bool = typer.Option(
+        False,
+        "--acknowledge",
+        help="Mark the generated digest as reviewed after printing it.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Print machine-readable JSON."),
+    min_fit_score: Optional[int] = typer.Option(
+        None,
+        "--min-fit-score",
+        min=1,
+        max=10,
+        help="Override the high-fit score threshold for this digest.",
+    ),
+) -> None:
+    """Show the local daily digest."""
+    _bootstrap()
+
+    from jobhunter.database import get_connection
+    from jobhunter.digest import acknowledge_digest, build_digest
+    from jobhunter.infrastructure.scoring.criteria_provider import read_min_fit_score
+
+    threshold = min_fit_score if min_fit_score is not None else read_min_fit_score()
+    conn = get_connection()
+    digest_payload = build_digest(conn, min_fit_score=threshold)
+    acknowledge_payload = None
+    if acknowledge:
+        acknowledge_payload = acknowledge_digest(
+            conn,
+            acknowledged_at=str(digest_payload["generatedAt"]),
+        )
+
+    if json_output:
+        payload = (
+            {"digest": digest_payload, "acknowledge": acknowledge_payload}
+            if acknowledge_payload
+            else digest_payload
+        )
+        console.print_json(data=payload)
+        return
+
+    since = digest_payload.get("since") or "first run"
+    console.print("\n[bold]Daily digest[/bold]")
+    console.print(
+        "[dim]"
+        f"Since {since} · generated {digest_payload.get('generatedAt')} · "
+        f"high-fit {digest_payload.get('highFitThreshold')}+"
+        "[/dim]\n"
+    )
+    console.print(_render_digest_table(digest_payload))
+    links_table = _render_digest_links_table(digest_payload)
+    if links_table:
+        console.print()
+        console.print(links_table)
+    if acknowledge_payload:
+        state = acknowledge_payload.get("state", {})
+        console.print(f"\n[green]Marked reviewed:[/green] {state.get('lastAcknowledgedAt')}")
+    else:
+        console.print("\n[dim]Run with --acknowledge after reviewing to move the digest watermark.[/dim]")
+
+
+def _render_digest_table(digest_payload: dict[str, Any]) -> Table:
+    new_matches = _dict(digest_payload.get("newMatches"))
+    blocked_sources = _dict(digest_payload.get("blockedSources"))
+    follow_ups = _dict(digest_payload.get("followUpsDue"))
+    budget = _dict(digest_payload.get("budget"))
+    table = Table(title="Review Queue", show_lines=False)
+    table.add_column("Area", style="bold")
+    table.add_column("Count", justify="right")
+    table.add_column("Notes")
+    table.add_row(
+        "New matches",
+        str(new_matches.get("count", 0)),
+        f"{new_matches.get('highFitCount', 0)} at high-fit threshold",
+    )
+    table.add_row(
+        "Blocked sources",
+        str(blocked_sources.get("count", 0)),
+        _blocked_source_note(blocked_sources),
+    )
+    table.add_row(
+        "Materials review",
+        str(_dict(digest_payload.get("reviewNeededMaterials")).get("count", 0)),
+        "Candidates needing resume or cover-letter review",
+    )
+    table.add_row(
+        "Pending approvals",
+        str(_dict(digest_payload.get("pendingApprovals")).get("count", 0)),
+        "Apply-review decisions waiting on the user",
+    )
+    table.add_row(
+        "Stale scores",
+        str(_dict(digest_payload.get("staleScores")).get("count", 0)),
+        "Jobs needing current-policy score refresh",
+    )
+    table.add_row(
+        "Follow-ups due",
+        str(follow_ups.get("count", 0)),
+        f"{follow_ups.get('thresholdDays', 7)} days, {follow_ups.get('dayBoundary', 'UTC')} boundary",
+    )
+    table.add_row("Budget", _budget_status_label(budget), _budget_note(budget))
+    return table
+
+
+def _render_digest_links_table(digest_payload: dict[str, Any]) -> Table | None:
+    links = _dict(digest_payload.get("deepLinks"))
+    if not links:
+        return None
+    table = Table(title="Open In Web App", show_lines=False)
+    table.add_column("Area", style="bold")
+    table.add_column("Path")
+    labels = {
+        "newMatches": "New matches",
+        "blockedSources": "Blocked sources",
+        "reviewNeededMaterials": "Materials review",
+        "staleScores": "Stale scores",
+        "pendingApprovals": "Pending approvals",
+        "followUpsDue": "Follow-ups due",
+        "budget": "Budget",
+    }
+    for key, label in labels.items():
+        value = links.get(key)
+        if value:
+            table.add_row(label, str(value))
+    return table
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _blocked_source_note(blocked_sources: dict[str, Any]) -> str:
+    sources = blocked_sources.get("sources")
+    if not isinstance(sources, list) or not sources:
+        return "No blocked or failing sources"
+    names = [
+        str(_dict(source).get("sourceId") or "")
+        for source in sources[:3]
+        if str(_dict(source).get("sourceId") or "")
+    ]
+    extra = len(sources) - len(names)
+    if extra > 0:
+        names.append(f"+{extra} more")
+    return ", ".join(names)
+
+
+def _budget_status_label(budget: dict[str, Any]) -> str:
+    status = str(budget.get("status") or "unknown")
+    if status == "over_budget":
+        return "[red]over budget[/red]"
+    if status == "ok":
+        return "[green]ok[/green]"
+    return status
+
+
+def _budget_note(budget: dict[str, Any]) -> str:
+    if budget.get("unlimited"):
+        return "Unlimited local daily budget"
+    estimated = float(budget.get("estimatedUsd") or 0.0)
+    daily = float(budget.get("dailyBudgetUsd") or 0.0)
+    remaining = budget.get("remainingUsd")
+    if remaining is None:
+        return f"${estimated:.2f} estimated of ${daily:.2f}"
+    return f"${estimated:.2f} estimated, ${float(remaining):.2f} remaining of ${daily:.2f}"
+
+
+@app.command()
 def status() -> None:
     """Show pipeline statistics from the database."""
     _bootstrap()

--- a/workers/automation/src/jobhunter/digest.py
+++ b/workers/automation/src/jobhunter/digest.py
@@ -107,6 +107,45 @@ def build_digest(
     }
 
 
+def acknowledge_digest(
+    conn: sqlite3.Connection | None = None,
+    *,
+    acknowledged_at: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    if conn is None:
+        conn = get_connection()
+    ensure_digest_state_table(conn)
+    previous = read_digest_state(conn)["lastAcknowledgedAt"]
+    reviewed_at = _format_utc_timestamp(_utc_now(now))
+    requested_acknowledged_at = acknowledged_at or reviewed_at
+    bounded_acknowledged_at = _bounded_acknowledge_timestamp(requested_acknowledged_at, reviewed_at)
+    next_acknowledged_at = (
+        previous
+        if previous and _timestamp_after(previous, bounded_acknowledged_at)
+        else bounded_acknowledged_at
+    )
+
+    conn.execute(
+        """
+        INSERT INTO digest_state (tenant_id, last_acknowledged_at, updated_at)
+        VALUES (?, ?, ?)
+        ON CONFLICT(tenant_id) DO UPDATE SET
+            last_acknowledged_at = excluded.last_acknowledged_at,
+            updated_at = excluded.updated_at
+        """,
+        (TENANT_ID, next_acknowledged_at, reviewed_at),
+    )
+    _record_digest_reviewed_event(
+        conn,
+        acknowledged_at=next_acknowledged_at,
+        previous_acknowledged_at=previous,
+        reviewed_at=reviewed_at,
+    )
+    conn.commit()
+    return {"ok": True, "state": read_digest_state(conn)}
+
+
 def _normalize_threshold(value: int | None) -> int:
     try:
         numeric = int(value if value is not None else 7)
@@ -125,6 +164,71 @@ def _utc_now(value: datetime | None) -> datetime:
 
 def _format_utc_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _bounded_acknowledge_timestamp(candidate: str, now_iso: str) -> str:
+    candidate_time = _parse_utc_timestamp(candidate)
+    now_time = _parse_utc_timestamp(now_iso)
+    if candidate_time is None or now_time is None:
+        return now_iso
+    if candidate_time > now_time:
+        return now_iso
+    return candidate
+
+
+def _timestamp_after(left: str, right: str) -> bool:
+    left_time = _parse_utc_timestamp(left)
+    right_time = _parse_utc_timestamp(right)
+    if left_time is None or right_time is None:
+        return False
+    return left_time > right_time
+
+
+def _parse_utc_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _record_digest_reviewed_event(
+    conn: sqlite3.Connection,
+    *,
+    acknowledged_at: str,
+    previous_acknowledged_at: str | None,
+    reviewed_at: str,
+) -> None:
+    if not _table_exists(conn, "job_events"):
+        return
+    columns = _table_columns(conn, "job_events")
+    values: dict[str, Any] = {
+        "job_url": None,
+        "stage": None,
+        "event_type": "DigestReviewed",
+        "level": "info",
+        "message": "Digest reviewed.",
+        "occurred_at": reviewed_at,
+        "payload_json": json.dumps(
+            {
+                "tenantId": TENANT_ID,
+                "acknowledgedAt": acknowledged_at,
+                "previousAcknowledgedAt": previous_acknowledged_at,
+                "reviewedAt": reviewed_at,
+            },
+            separators=(",", ":"),
+        ),
+    }
+    entries = [(name, value) for name, value in values.items() if name in columns]
+    if not entries:
+        return
+    column_sql = ", ".join(name for name, _ in entries)
+    placeholders = ", ".join("?" for _ in entries)
+    conn.execute(
+        f"INSERT INTO job_events ({column_sql}) VALUES ({placeholders})",
+        [value for _, value in entries],
+    )
 
 
 def _budget_payload(status: SpendBudgetStatus) -> dict[str, Any]:
@@ -612,6 +716,10 @@ def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
         (table_name,),
     ).fetchone()
     return row is not None
+
+
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
 
 
 def _row_get(row: Any, key: str) -> Any:

--- a/workers/automation/src/jobhunter/infrastructure/scoring/criteria_provider.py
+++ b/workers/automation/src/jobhunter/infrastructure/scoring/criteria_provider.py
@@ -81,6 +81,18 @@ def read_daily_budget_usd(
     return max(0.0, budget)
 
 
+def read_min_fit_score(
+    path: Path | str | None = None,
+    *,
+    default: int = 7,
+) -> int:
+    settings = LocalScoringCriteriaProvider(path or DEFAULT_SETTINGS_PATH)._read_settings()
+    value = settings.get("min_fit_score")
+    if value is None:
+        value = settings.get("minFitScore")
+    return min(10, max(1, _int(value, default)))
+
+
 def _int(value: Any, default: int) -> int:
     try:
         return int(value)

--- a/workers/automation/tests/test_digest_cli.py
+++ b/workers/automation/tests/test_digest_cli.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+
+from typer.testing import CliRunner
+
+from jobhunter import cli, digest as digest_module
+from jobhunter.cli import app
+from jobhunter.infrastructure.scoring import criteria_provider
+
+
+def _sample_digest() -> dict:
+    return {
+        "ok": True,
+        "generatedAt": "2026-07-05T12:00:00.000Z",
+        "since": "2026-07-01T00:00:00.000Z",
+        "highFitThreshold": 7,
+        "newMatches": {"count": 4, "highFitCount": 2},
+        "blockedSources": {
+            "count": 1,
+            "sources": [
+                {
+                    "sourceId": "linkedin",
+                    "recommendedState": "quarantined",
+                    "consecutiveFailures": 3,
+                }
+            ],
+        },
+        "reviewNeededMaterials": {"count": 3},
+        "staleScores": {"count": 1},
+        "pendingApprovals": {"count": 2},
+        "followUpsDue": {
+            "count": 1,
+            "derived": True,
+            "thresholdDays": 7,
+            "dayBoundary": "UTC",
+        },
+        "budget": {
+            "status": "ok",
+            "estimatedUsd": 8.5,
+            "dailyBudgetUsd": 25,
+            "remainingUsd": 16.5,
+            "unlimited": False,
+        },
+        "deepLinks": {
+            "newMatches": "/jobs?discoveredSince=2026-07-01T00%3A00%3A00.000Z",
+            "blockedSources": "/discovery",
+            "reviewNeededMaterials": "/apply-review",
+            "staleScores": "/jobs?state=stale",
+            "pendingApprovals": "/apply-review",
+            "followUpsDue": "/jobs?applyStatus=applied",
+            "budget": "/settings",
+        },
+    }
+
+
+def test_digest_cli_prints_read_only_summary(monkeypatch) -> None:
+    build_calls: list[int] = []
+    acknowledge_calls: list[str] = []
+
+    monkeypatch.setattr(cli, "_bootstrap", lambda: None)
+    monkeypatch.setattr("jobhunter.database.get_connection", lambda: object())
+    monkeypatch.setattr(criteria_provider, "read_min_fit_score", lambda: 7)
+    monkeypatch.setattr(
+        digest_module,
+        "build_digest",
+        lambda conn, *, min_fit_score: build_calls.append(min_fit_score) or _sample_digest(),
+    )
+    monkeypatch.setattr(
+        digest_module,
+        "acknowledge_digest",
+        lambda conn, *, acknowledged_at: acknowledge_calls.append(acknowledged_at),
+    )
+
+    result = CliRunner().invoke(app, ["digest"])
+
+    assert result.exit_code == 0, result.output
+    assert build_calls == [7]
+    assert acknowledge_calls == []
+    assert "Daily digest" in result.output
+    assert "New matches" in result.output
+    assert "Run with --acknowledge" in result.output
+
+
+def test_digest_cli_json_acknowledges_generated_digest(monkeypatch) -> None:
+    acknowledge_calls: list[str] = []
+
+    monkeypatch.setattr(cli, "_bootstrap", lambda: None)
+    monkeypatch.setattr("jobhunter.database.get_connection", lambda: object())
+    monkeypatch.setattr(criteria_provider, "read_min_fit_score", lambda: 7)
+    monkeypatch.setattr(
+        digest_module,
+        "build_digest",
+        lambda conn, *, min_fit_score: _sample_digest(),
+    )
+
+    def acknowledge(conn, *, acknowledged_at: str) -> dict:
+        acknowledge_calls.append(acknowledged_at)
+        return {
+            "ok": True,
+            "state": {
+                "lastAcknowledgedAt": acknowledged_at,
+                "updatedAt": acknowledged_at,
+            },
+        }
+
+    monkeypatch.setattr(digest_module, "acknowledge_digest", acknowledge)
+
+    result = CliRunner().invoke(app, ["digest", "--acknowledge", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert acknowledge_calls == ["2026-07-05T12:00:00.000Z"]
+    assert payload["digest"]["newMatches"]["count"] == 4
+    assert payload["acknowledge"]["state"]["lastAcknowledgedAt"] == "2026-07-05T12:00:00.000Z"
+
+
+def test_digest_cli_allows_one_off_threshold_override(monkeypatch) -> None:
+    build_calls: list[int] = []
+
+    monkeypatch.setattr(cli, "_bootstrap", lambda: None)
+    monkeypatch.setattr("jobhunter.database.get_connection", lambda: object())
+    monkeypatch.setattr(criteria_provider, "read_min_fit_score", lambda: 3)
+    monkeypatch.setattr(
+        digest_module,
+        "build_digest",
+        lambda conn, *, min_fit_score: build_calls.append(min_fit_score) or _sample_digest(),
+    )
+
+    result = CliRunner().invoke(app, ["digest", "--min-fit-score", "9", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert build_calls == [9]

--- a/workers/automation/tests/test_digest_parity.py
+++ b/workers/automation/tests/test_digest_parity.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from jobhunter.digest import build_digest, read_digest_state
+from jobhunter.digest import acknowledge_digest, build_digest, read_digest_state
 from jobhunter.llm import SpendBudgetStatus
 
 
@@ -61,6 +61,53 @@ def test_build_digest_matches_shared_fixture_without_acknowledging(tmp_path: Pat
     assert "scoredSince=2026-07-01T00%3A00%3A00.000Z" in digest["deepLinks"]["newMatches"]
     assert digest["deepLinks"]["budget"] == "/settings"
     assert read_digest_state(conn) == before
+
+
+def test_acknowledge_digest_updates_watermark_and_records_event(tmp_path: Path) -> None:
+    fixture = json.loads(FIXTURE_PATH.read_text())
+    conn = sqlite3.connect(tmp_path / "jobhunter.db")
+    conn.row_factory = sqlite3.Row
+    _create_schema(conn)
+    _seed_fixture(conn, fixture)
+
+    result = acknowledge_digest(
+        conn,
+        acknowledged_at=fixture["expected"]["generatedAt"],
+        now=_parse_utc(fixture["now"]),
+    )
+
+    assert result == {
+        "ok": True,
+        "state": {
+            "lastAcknowledgedAt": fixture["expected"]["generatedAt"],
+            "updatedAt": fixture["expected"]["generatedAt"],
+        },
+    }
+    event = conn.execute(
+        """
+        SELECT event_type, payload_json
+        FROM job_events
+        WHERE event_type = 'DigestReviewed'
+        ORDER BY event_id DESC
+        LIMIT 1
+        """
+    ).fetchone()
+    assert event is not None
+    assert event["event_type"] == "DigestReviewed"
+    assert json.loads(event["payload_json"]) == {
+        "tenantId": "local",
+        "acknowledgedAt": fixture["expected"]["generatedAt"],
+        "previousAcknowledgedAt": fixture["since"],
+        "reviewedAt": fixture["expected"]["generatedAt"],
+    }
+
+    stale = acknowledge_digest(
+        conn,
+        acknowledged_at=fixture["since"],
+        now=_parse_utc(fixture["now"]),
+    )
+
+    assert stale["state"]["lastAcknowledgedAt"] == fixture["expected"]["generatedAt"]
 
 
 def _create_schema(conn: sqlite3.Connection) -> None:
@@ -236,6 +283,16 @@ def _create_schema(conn: sqlite3.Connection) -> None:
             run_id TEXT,
             duration_ms INTEGER,
             error_class TEXT
+        );
+        CREATE TABLE job_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_url TEXT,
+            stage TEXT,
+            event_type TEXT NOT NULL DEFAULT '',
+            level TEXT NOT NULL DEFAULT 'info',
+            message TEXT,
+            occurred_at TEXT NOT NULL,
+            payload_json TEXT
         );
         """
     )


### PR DESCRIPTION
## Summary
- Adds `jobhunter digest` for local digest reads and explicit acknowledgement.
- Keeps digest reads passive; `digest_state` advances only through `--acknowledge` or the panel acknowledge action.
- Records `DigestReviewed` events on acknowledgement and documents the CLI/user flow.

## Stack
- Previous: #291 (`feat/r8-p4-digest-panel`)
- Final PR in this stack.

## Validation
Full stack validation was run from this branch:
- `pnpm check`
- `pnpm test`
- `pnpm --filter @jobhunter/web test-d`
- `pnpm --filter @jobhunter/web test`
- `pnpm --filter @jobhunter/web e2e -- tests/dashboard.spec.ts`
- `pnpm web:storybook:build`
- `pnpm docs:build`
- `git diff --check`

Focused digest/CLI validation:
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_digest_parity.py workers/automation/tests/test_digest_cli.py`
- QA verified `GET /v1/digest` does not advance `digest_state` and `POST /v1/digest/acknowledge` records `DigestReviewed`.

Review gates:
- pr-reviewer: Gate: PASS
- QA: Gate: PASS

Known follow-up
- pr-reviewer reported a non-blocking Medium: follow-up digest counts are outcome-derived while the current deep link targets the existing applied Jobs view. No Blocker or High findings remain.
