### PR TITLE
docs(launch): [R7] lead README with outcome, add roadmap boundary + egress section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # JobHunter
 
-JobHunter is a local-first job search automation system. It keeps your profile,
-job database, generated materials, browser state, and logs on your machine while
-helping you move jobs through a focused pipeline:
+JobHunter helps you **find jobs worth applying to, judge them against your real
+profile, tailor audited materials, and apply — safely and entirely on your own
+machine.** Your profile, job database, generated resumes and cover letters,
+browser state, and logs stay on your computer; nothing leaves it except the
+specific steps you configure and run.
+
+Work moves through a focused pipeline:
 
 ```text
 discover -> apply
 ```
 
 Discovery finds and enriches jobs, scores them against your candidate profile,
-and prepares tailored materials when the job is eligible. Apply is separate
-because it can drive browser automation and submit applications.
+and prepares tailored materials when a job is eligible. Apply is a separate,
+supervised step because it can drive browser automation and submit applications.
 
 ## What It Does
 
@@ -79,6 +83,15 @@ employers, accounts, provider APIs, and third-party sites as live operations:
   local worker state are sensitive local artifacts. Public bug reports,
   screenshots, and reproduction cases should use synthetic data only; `pnpm
   qa:seed` creates a disposable synthetic workspace for that purpose.
+
+## Current vs Roadmap
+
+Everything in [What It Does](#what-it-does) above is **shipped and runs on your
+machine today**. Work that is planned but **not built yet** — desktop packaging,
+workspace export/import, and any hosted or multi-user deployment (accounts,
+billing, managed browsers, object storage, cloud sync) — lives in
+[ROADMAP.md](ROADMAP.md) and is never presented as current here. Nothing above
+the roadmap boundary depends on a hosted service.
 
 ## Current System
 
@@ -221,6 +234,35 @@ or override that identity before crawling real sites via
 ([Configuration → Crawl Politeness](docs/user/configuration.md#crawl-politeness));
 `jobhunter doctor` prints the effective value. JobHunter never bypasses login,
 paywall, CAPTCHA, rate-limit, or bot-control gates.
+
+### What Leaves Your Machine
+
+Nothing leaves your machine by default. Privacy-sensitive content leaves only
+when you deliberately run a step that needs an outside service, and each path is
+opt-in and configuration-gated:
+
+- **LLM providers** — scoring, employer analysis, resume tailoring, and
+  cover-letter generation (job text, your profile evidence, and generated
+  material text).
+- **The apply agent's model** — the apply prompt during apply or dry-run (your
+  profile summary, the tailored materials, and, only if you configured them, a
+  login password and the CapSolver key).
+- **Job boards, ATS APIs, and posting pages** — discovery and enrichment
+  fetches.
+- **Gmail (read-only)** — verification-code and application-outcome lookups, only
+  if you authenticate the connector; it never requests `gmail.send`.
+- **Google Maps** — address autocomplete, only if you set
+  `VITE_GOOGLE_MAPS_API_KEY`.
+- **CAPTCHA solving** — site keys and page URLs, only if you set
+  `CAPSOLVER_API_KEY` for a live apply.
+- **Langfuse / OpenTelemetry** — traces, only when you configure it
+  (`LANGFUSE_DISABLE=1` opts out even with credentials present).
+
+The apply prompt is the largest single batch of personal data that can leave. For
+the full per-call breakdown of what is sent and when, see
+[Security → What Leaves Your Machine](docs/user/security.md#what-leaves-your-machine);
+for the storage-and-privacy inventory, see
+[docs/user/data-and-safety.md](docs/user/data-and-safety.md).
 
 ### Back Up And Restore
 


### PR DESCRIPTION
## What

Targeted re-lead of `README.md` delivering **Phase B / Goal 1** (plan §6):

1. **Outcome-first opening** — leads with what the user achieves (find, judge, tailor, apply — safely and locally) instead of the runtime component breakdown.
2. **Current vs Roadmap boundary** — a new, clearly labelled section that separates shipped behavior from `ROADMAP.md`; no roadmap content appears in the opening.
3. **"What Leaves Your Machine" section** — short and scannable, enumerating the opt-in egress paths, consistent with and linking to `docs/user/security.md` (its *What Leaves Your Machine* table) and `docs/user/data-and-safety.md`.

## Why

Per §6 this is a re-lead + claim-audit, not a capability change. Every asserted capability above the boundary maps to a **Current** row in `docs/claims-ledger.md` (PR #298). The egress section introduces no claim absent from the Security / Data & Safety pages. All existing content and safety notes are preserved (Responsible Use, digest note, backup/restore, CLI, configuration). The product name is left as-is for the rename train to sweep last.

## Stacking

Stacked on **#298** (claims ledger). Base is `docs/r7a-1-claims-ledger`; retarget to `main` after #298 merges.

## Validation

- `pnpm docs:build` — passes (4545 references resolve across 230 files).
- `python3 scripts/release_check.py` — passes (exit 0; the 3 warnings are pre-existing in `apply/prompt.py`).
- `git diff --check` — clean.
- No code or product behavior changed (README only).

## Scope note

The README rewrite (§6) is a borderline R7a/R7b item (it is the most rename-coupled doc). I treated it as R7a because §6 does not *depend* on the rename and the change is name-preserving + conflict-free with a later token sweep. Flagging for redirect if you intended it for R7b.