### PR TITLE
docs(launch): [R7] reliability-demo script + demo-asset inventory (§7)

### DIFF
--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -437,6 +437,13 @@ Production workflows live alongside the activities:
   compensation refresh core so posted facts and market estimates no longer run
   inside the JSON-RPC request thread.
 
+One non-pipeline workflow is also registered: `DurabilityProbeWorkflow`
+(`jobhunter/infrastructure/temporal/durability_probe.py`) is a diagnostic
+self-test whose only in-flight state is a durable `workflow.sleep` timer — no
+network, no LLM, no browser, and never any apply. It is inert until explicitly
+started and exists so an operator can prove durable-execution recovery (TR-008 /
+CL-050) hermetically; `scripts/reliability-demo.sh` drives it.
+
 The pipeline package (`jobhunter/pipeline/`) is split into `runner.py`
 (stage-core functions and `_run_stage_observed`) and `workflow.py` (the
 Temporal batch orchestrator). The deleted in-process `run_pipeline` engine is

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -278,3 +278,30 @@ resumes, databases, logs, Gmail tokens, or browser profiles; do not run apply
 automation, mailbox scans, real crawling, or real LLM calls for screenshots;
 keep output deterministic (fixed viewport, synthetic database, seeded
 heartbeat, no external providers).
+
+### Launch Demo Asset Inventory
+
+The launch demo assets (plan
+`docs/plans/2026-07-05-launch-readiness-artifacts-plan.md` §7) each prove one
+product invariant from synthetic data. Each asset is classified **A** (static,
+already covered), **B** (static, new seed state), or **C** (dynamic/lifecycle —
+a driven flow that is *defined* here, not executed by CI), and maps to a
+`Current` row in the repository-only claims ledger (`docs/claims-ledger.md`).
+
+| # | Asset | Class | Claim(s) | Regeneration / proof | Status |
+| --- | --- | --- | --- | --- | --- |
+| 1 | First run → empty dashboard | B | `CL-060`, `CL-072` | Empty-workspace seed variant + a `docs-screenshots.spec.ts` onboarding surface | Deferred — needs an empty-workspace seed variant + capture surface |
+| 2 | Resume / profile import | B/C | `CL-080` | Profile-import wizard capture from a synthetic resume | Deferred — needs an import-flow capture surface |
+| 3 | Discovery → scored jobs + requirement fit + provenance | A | `CL-001`, `CL-010`, `CL-011`, `CL-020` | `pnpm docs:screenshots` → `jobs.png`, `job-detail.png` (seed: scored job, `job_requirement_fit_items`, `job_bullet_provenance`) | Covered |
+| 4 | Apply-review audit surfaces | A | `CL-023`, `CL-024`, `CL-030` | `pnpm docs:screenshots` → `apply-review.png` (seed: approved generation, evidence, `change_annotations`) | Covered |
+| 5 | Failed refresh preserves last accepted artifact | B | `CL-025` | Regression tests `apps/api/test/resume-templates.test.ts` ("keeps the last accepted resume artifact when the PDF render fails"; "reports refresh unavailable without hiding the last accepted artifact") and `apps/api/test/resume-review-drafts.test.ts` ("fails the render and preserves prior approved artifacts …"); run `pnpm api:test` | Covered — invariant proven from fixture |
+| 6 | Tailoring gate rejects an unsupported claim | B | `CL-021` | Seed `change_annotations` (`draft_requires_confirmation` + `review_blocked`) in `apps/api/test/qa-seed.ts`; regression via `apps/api/test/application-feedback.test.ts` (blocker/repair) and `workers/automation/tests/test_coverage_audit.py` | Covered — invariant proven from fixture |
+| 7 | Dry-run apply completes + live-approval gate + blocked-channel evidence | B / C | `CL-030`–`CL-034` | Approval card + dry-run run (`qa-run-1`) via `pnpm docs:screenshots`; live blocked-channel evidence via a driven dry-run (capability shipped: approval binding + dry-run evidence) | Approval card + dry-run run Covered; live blocked-channel evidence Defined (class C) |
+| 8 | Spend-ceiling stop + health surface | B / C | `CL-040`, `CL-041` | Health surface with an `llm_spend`-at/over-budget seed fixture + capture; stop lifecycle via a driven run (spend ceiling shipped) | Deferred — needs an `llm_spend` seed fixture + health capture; stop lifecycle Defined (class C) |
+| 9 | Reliability demo — kill worker, restart, resume | C | `CL-050` (`TR-008`) | `scripts/reliability-demo.sh` (isolated stack, hermetic no-op discover, kill-by-captured-PID); see [Reliability & QA → Durable-Execution Recovery Demo](local-reliability-qa.md#durable-execution-recovery-demo) | Defined — re-runnable script |
+
+Deferred assets (1, 2, 8 health capture) are launch-set follow-ups: they need a
+new synthetic seed variant or capture surface, not a missing product capability.
+Class-C assets (7 live evidence, 8 stop lifecycle, 9) are defined driven flows,
+never faked with a staged static image. No asset regenerates from a real
+workspace.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -281,12 +281,12 @@ heartbeat, no external providers).
 
 ### Launch Demo Asset Inventory
 
-The launch demo assets (plan
-`docs/plans/2026-07-05-launch-readiness-artifacts-plan.md` §7) each prove one
-product invariant from synthetic data. Each asset is classified **A** (static,
-already covered), **B** (static, new seed state), or **C** (dynamic/lifecycle —
-a driven flow that is *defined* here, not executed by CI), and maps to a
-`Current` row in the repository-only claims ledger (`docs/claims-ledger.md`).
+The launch demo assets each prove one product invariant from synthetic data.
+Each asset is classified **A** (static, already covered), **B** (static, new seed
+state), or **C** (dynamic/lifecycle — a driven flow that is *defined* here, not
+executed by CI), and maps to a `Current` row in the repository-only claims ledger
+(`docs/claims-ledger.md`), which is the committed source of truth for every claim
+below.
 
 | # | Asset | Class | Claim(s) | Regeneration / proof | Status |
 | --- | --- | --- | --- | --- | --- |
@@ -295,10 +295,10 @@ a driven flow that is *defined* here, not executed by CI), and maps to a
 | 3 | Discovery → scored jobs + requirement fit + provenance | A | `CL-001`, `CL-010`, `CL-011`, `CL-020` | `pnpm docs:screenshots` → `jobs.png`, `job-detail.png` (seed: scored job, `job_requirement_fit_items`, `job_bullet_provenance`) | Covered |
 | 4 | Apply-review audit surfaces | A | `CL-023`, `CL-024`, `CL-030` | `pnpm docs:screenshots` → `apply-review.png` (seed: approved generation, evidence, `change_annotations`) | Covered |
 | 5 | Failed refresh preserves last accepted artifact | B | `CL-025` | Regression tests `apps/api/test/resume-templates.test.ts` ("keeps the last accepted resume artifact when the PDF render fails"; "reports refresh unavailable without hiding the last accepted artifact") and `apps/api/test/resume-review-drafts.test.ts` ("fails the render and preserves prior approved artifacts …"); run `pnpm api:test` | Covered — invariant proven from fixture |
-| 6 | Tailoring gate rejects an unsupported claim | B | `CL-021` | Seed `change_annotations` (`draft_requires_confirmation` + `review_blocked`) in `apps/api/test/qa-seed.ts`; regression via `apps/api/test/application-feedback.test.ts` (blocker/repair) and `workers/automation/tests/test_coverage_audit.py` | Covered — invariant proven from fixture |
+| 6 | Tailoring gate rejects an unsupported claim | B | `CL-021` | Grounding-gate regression `workers/automation/tests/test_claim_grounding.py` (a claim whose text is absent from the shipped resume is flagged `ungrounded` with an inspectable reason — the CL-021 fail-closed behaviour) and `workers/automation/tests/test_coverage_audit.py` (fabricated/stuffed keywords fall into `missing`); the apply-review rendering of the resulting blocker is seeded in `apps/api/test/qa-seed.ts` and asserted by `apps/api/test/application-feedback.test.ts` | Covered — gate + surface proven from fixtures |
 | 7 | Dry-run apply completes + live-approval gate + blocked-channel evidence | B / C | `CL-030`–`CL-034` | Approval card + dry-run run (`qa-run-1`) via `pnpm docs:screenshots`; live blocked-channel evidence via a driven dry-run (capability shipped: approval binding + dry-run evidence) | Approval card + dry-run run Covered; live blocked-channel evidence Defined (class C) |
 | 8 | Spend-ceiling stop + health surface | B / C | `CL-040`, `CL-041` | Health surface with an `llm_spend`-at/over-budget seed fixture + capture; stop lifecycle via a driven run (spend ceiling shipped) | Deferred — needs an `llm_spend` seed fixture + health capture; stop lifecycle Defined (class C) |
-| 9 | Reliability demo — kill worker, restart, resume | C | `CL-050` (`TR-008`) | `scripts/reliability-demo.sh` (isolated stack, hermetic no-op discover, kill-by-captured-PID); see [Reliability & QA → Durable-Execution Recovery Demo](local-reliability-qa.md#durable-execution-recovery-demo) | Defined — re-runnable script |
+| 9 | Reliability demo — kill worker, restart, resume | C | `CL-050` (`TR-008`) | `scripts/reliability-demo.sh` drives `DurabilityProbeWorkflow` (a hermetic durable-timer probe — no crawl/LLM) on an isolated stack; kills the worker by captured PID tree and asserts the same run ids resume in Temporal + the read-model projection. Probe covered by `workers/automation/tests/test_workflow_durability_probe.py`; see [Reliability & QA → Durable-Execution Recovery Demo](local-reliability-qa.md#durable-execution-recovery-demo) | Defined — self-asserting, re-runnable script (verified locally) |
 
 Deferred assets (1, 2, 8 health capture) are launch-set follow-ups: they need a
 new synthetic seed variant or capture surface, not a missing product capability.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -82,22 +82,32 @@ VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 kill-worker → clean-recovery story (launch-asset 9; `docs/requirements.md`
 `TR-008`). It complements the per-workflow "Kill worker mid-activity" column
 above — which is unit/integration-tested — with a full-process demonstration on
-a live, isolated Temporal stack: it starts an isolated dev server on a free
-port and a throwaway `JOBHUNTER_DIR`, launches a burst of hermetic no-op
-`discover` runs, kills the worker **by its captured PID**, then starts a fresh
-worker and shows the same runs resume from Temporal history to a terminal state.
+a live, isolated Temporal stack. It starts an isolated dev server on a free port
+and a throwaway `JOBHUNTER_DIR`, then drives a burst of `DurabilityProbeWorkflow`
+runs — a diagnostic workflow whose only in-flight state is a durable
+`workflow.sleep` timer, so it fetches no job boards, spends no LLM tokens, and
+opens no browser (the timer is what keeps a run in flight long enough to be
+killed mid-flight, which a no-op that finishes in milliseconds cannot). The
+script **asserts** each run is `Running`, kills the worker **by its captured PID
+tree**, asserts the runs are *still* `Running` with no worker alive, starts a
+fresh worker, and asserts the **same run ids** resume from Temporal history to
+`Completed` exactly once — cross-checked in both Temporal and the read-model
+projection. Any violation (including a run that finished before the kill, which
+prints advice to raise the hold) exits non-zero.
 
 ```bash
-scripts/reliability-demo.sh          # default: 3-run burst
-scripts/reliability-demo.sh 5        # larger burst
+scripts/reliability-demo.sh            # default: 3-run burst, 25s hold each
+scripts/reliability-demo.sh 5          # larger burst
+scripts/reliability-demo.sh 3 40       # longer hold — more margin on slow machines
 ```
 
-Safety: isolated stack only (never `~/.jobhunter`, never ports 7233/8233/8766),
-no LLM spend, no crawl (discovery boards are emptied so the workflow is a
-hermetic no-op), no application submission, and it kills only the PIDs it
-captured. Confirm your build has no additional default discovery source families
-active before trusting a fully offline run (see the script header). Requires the
-`temporal` CLI, `uv`, `python3`, and `sqlite3` on `PATH`.
+Safety: isolated stack only (never `~/.jobhunter`, never ports 7233/8233/8766/5173),
+genuinely hermetic (no crawl, no LLM spend, no browser; `LANGFUSE_DISABLE=1` stops
+telemetry egress), no application submission, and it kills only the process trees
+it captured. The probe workflow itself is covered by
+`workers/automation/tests/test_workflow_durability_probe.py` (including same-run
+resume across a worker crash on a real dev server). Requires the `temporal` CLI,
+`uv`, `python3`, and `sqlite3` on `PATH`.
 
 ## High-Risk Regression Areas
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -76,6 +76,29 @@ JOBHUNTER_DIR=/tmp/jobhunter-qa pnpm api:dev
 VITE_JOBHUNTER_API_BASE_URL=http://127.0.0.1:8766 pnpm web:dev -- --port 5173
 ```
 
+### Durable-Execution Recovery Demo
+
+`scripts/reliability-demo.sh` is the scripted, re-runnable form of the
+kill-worker → clean-recovery story (launch-asset 9; `docs/requirements.md`
+`TR-008`). It complements the per-workflow "Kill worker mid-activity" column
+above — which is unit/integration-tested — with a full-process demonstration on
+a live, isolated Temporal stack: it starts an isolated dev server on a free
+port and a throwaway `JOBHUNTER_DIR`, launches a burst of hermetic no-op
+`discover` runs, kills the worker **by its captured PID**, then starts a fresh
+worker and shows the same runs resume from Temporal history to a terminal state.
+
+```bash
+scripts/reliability-demo.sh          # default: 3-run burst
+scripts/reliability-demo.sh 5        # larger burst
+```
+
+Safety: isolated stack only (never `~/.jobhunter`, never ports 7233/8233/8766),
+no LLM spend, no crawl (discovery boards are emptied so the workflow is a
+hermetic no-op), no application submission, and it kills only the PIDs it
+captured. Confirm your build has no additional default discovery source families
+active before trusting a fully offline run (see the script header). Requires the
+`temporal` CLI, `uv`, `python3`, and `sqlite3` on `PATH`.
+
 ## High-Risk Regression Areas
 
 | Risk | Automated coverage |

--- a/scripts/reliability-demo.sh
+++ b/scripts/reliability-demo.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# reliability-demo.sh — durable-execution recovery demo (launch asset 9).
+#
+# Reproduces the "kill the worker mid-run, restart it, and watch the same run
+# resume" story that backs the durability claim (docs/requirements.md TR-008;
+# claims ledger CL-050). It is the scripted, re-runnable form of the reliability
+# demo defined in docs/plans/2026-07-05-launch-readiness-artifacts-plan.md §7
+# (asset 9, class C) — it stays true as the code evolves, unlike a recording.
+#
+# WHAT IT PROVES
+#   A JobHunter workflow started on one worker survives that worker being killed
+#   and is resumed to a terminal state by a fresh worker, from Temporal history,
+#   with the SAME workflow id. Nothing is lost when a worker crashes.
+#
+# SAFETY GUARANTEES (read before running)
+#   * ISOLATED STACK ONLY. Uses its own Temporal dev server on a free,
+#     non-default port, its own JOBHUNTER_DIR under a throwaway temp dir, and its
+#     own SQLite db. It never touches ~/.jobhunter or your real stack.
+#   * NO REAL SPEND, NO CRAWL, NO SUBMISSION. The isolated workspace is
+#     configured with zero discovery boards, so `discover` runs as a hermetic
+#     no-op workflow: no job boards are fetched, no LLM tokens are spent, and no
+#     application is ever submitted. It runs `init`, `worker`, and `discover`
+#     only — never `apply`.
+#   * KILLS ONLY ITS OWN CAPTURED PIDS. Every process it starts is tracked by
+#     the exact PID it captured; cleanup kills those PIDs and nothing else. It
+#     never runs a broad `pkill`, so it cannot kill your real worker.
+#
+# PRECONDITION — CONFIRM HERMETIC SOURCES
+#   This script empties the JobSpy `boards` list so the JobSpy source family is a
+#   no-op. If your build enables additional discovery source families (registry
+#   / ATS sources) by default, confirm they are inactive in the isolated
+#   workspace before trusting a fully offline run, or point discovery at a
+#   dedicated fixture source. When in doubt, run on a machine with no network
+#   egress. A first-class hermetic fixture source is tracked as a follow-up.
+#
+# REQUIREMENTS: temporal CLI, uv, python3, sqlite3 on PATH.
+# USAGE: scripts/reliability-demo.sh [burst_count]   (default burst_count=3)
+set -euo pipefail
+
+BURST="${1:-3}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+AUTOMATION="$REPO_ROOT/workers/automation"
+
+for tool in temporal uv python3 sqlite3; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "FATAL: '$tool' not found on PATH." >&2; exit 2; }
+done
+
+free_port() { python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()'; }
+
+# Isolated, canonicalised workspace (macOS resolves /tmp -> /private/tmp; the
+# worker heartbeat compares resolved paths, so canonicalise up front).
+WORKDIR="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/jobhunter-reliability-demo.XXXXXX")" && pwd -P)"
+export JOBHUNTER_DIR="$WORKDIR/home"
+mkdir -p "$JOBHUNTER_DIR"
+
+TEMPORAL_PORT="$(free_port)"
+TEMPORAL_UI_PORT="$(free_port)"
+# Never collide with the standard local stack (Temporal 7233 / UI 8233, API 8766).
+for reserved in 7233 8233 8766 5173; do
+  if [[ "$TEMPORAL_PORT" == "$reserved" || "$TEMPORAL_UI_PORT" == "$reserved" ]]; then
+    echo "FATAL: drew a reserved port ($reserved); re-run." >&2; exit 2
+  fi
+done
+export TEMPORAL_ADDRESS="127.0.0.1:$TEMPORAL_PORT"
+export JOBHUNTER_SKIP_BROWSER_PREFLIGHT=1   # discover no-op needs no browser
+export PLAYWRIGHT_SKIP_BROWSER_GC=1         # never GC other worktrees' browsers
+
+TEMPORAL_PID=""; WORKER_PID=""; declare -a RUN_PIDS=()
+
+cleanup() {
+  echo "--- cleanup: killing only captured PIDs ---"
+  for pid in "${RUN_PIDS[@]:-}" "$WORKER_PID" "$TEMPORAL_PID"; do
+    [[ -n "${pid:-}" ]] && kill "$pid" 2>/dev/null || true
+  done
+  wait 2>/dev/null || true
+  rm -rf "$WORKDIR" 2>/dev/null || true
+  echo "--- cleanup done ---"
+}
+trap cleanup EXIT INT TERM
+
+jh() { uv --project "$AUTOMATION" run jobhunter "$@"; }
+
+echo "=== Isolated reliability demo ==="
+echo "workspace:        $JOBHUNTER_DIR"
+echo "temporal address: $TEMPORAL_ADDRESS  (ui: 127.0.0.1:$TEMPORAL_UI_PORT)"
+
+echo "--- 1/7 start isolated Temporal dev server ---"
+temporal server start-dev \
+  --port "$TEMPORAL_PORT" --ui-port "$TEMPORAL_UI_PORT" \
+  --db-filename "$WORKDIR/temporal.db" --log-level error &
+TEMPORAL_PID=$!
+for _ in $(seq 1 30); do
+  temporal operator namespace list --address "$TEMPORAL_ADDRESS" >/dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "--- 2/7 init isolated workspace + empty discovery boards (hermetic) ---"
+jh init >/dev/null
+sqlite3 "$JOBHUNTER_DIR/jobhunter.db" \
+  "CREATE TABLE IF NOT EXISTS discovery_settings (
+     tenant_id TEXT PRIMARY KEY, search_config_json TEXT NOT NULL,
+     created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+   INSERT INTO discovery_settings (tenant_id, search_config_json, created_at, updated_at)
+   VALUES ('local', '{\"boards\": []}', datetime('now'), datetime('now'))
+   ON CONFLICT(tenant_id) DO UPDATE SET search_config_json = excluded.search_config_json;"
+
+echo "--- 3/7 start worker A ---"
+jh worker >"$WORKDIR/worker-a.log" 2>&1 &
+WORKER_PID=$!
+sleep 5
+
+echo "--- 4/7 start a burst of $BURST discover runs (waiting on their handles) ---"
+for _ in $(seq 1 "$BURST"); do
+  jh discover >>"$WORKDIR/discover.log" 2>&1 &
+  RUN_PIDS+=("$!")
+done
+sleep 3
+
+echo "--- 5/7 CRASH worker A by its captured PID ($WORKER_PID) ---"
+kill -9 "$WORKER_PID" 2>/dev/null || true
+sleep 2
+echo "open workflows while no worker is running (durably held by Temporal):"
+temporal workflow list --address "$TEMPORAL_ADDRESS" --query 'ExecutionStatus="Running"' 2>/dev/null || true
+
+echo "--- 6/7 start worker B — it must resume the in-flight runs from history ---"
+jh worker >"$WORKDIR/worker-b.log" 2>&1 &
+WORKER_PID=$!
+
+echo "--- 7/7 wait for the same runs to reach a terminal state ---"
+rc=0
+for pid in "${RUN_PIDS[@]}"; do wait "$pid" || rc=1; done
+
+echo "final workflow states:"
+temporal workflow list --address "$TEMPORAL_ADDRESS" 2>/dev/null || true
+echo "runs as JobHunter sees them:"
+jh runs || true
+
+if [[ "$rc" -eq 0 ]]; then
+  echo "DEMO PASS — every run resumed after the worker crash and completed."
+else
+  echo "DEMO FAIL — a run did not resume to completion (inspect $WORKDIR/*.log)." >&2
+fi
+exit "$rc"

--- a/scripts/reliability-demo.sh
+++ b/scripts/reliability-demo.sh
@@ -4,41 +4,43 @@
 #
 # Reproduces the "kill the worker mid-run, restart it, and watch the same run
 # resume" story that backs the durability claim (docs/requirements.md TR-008;
-# claims ledger CL-050). It is the scripted, re-runnable form of the reliability
-# demo defined in docs/plans/2026-07-05-launch-readiness-artifacts-plan.md §7
-# (asset 9, class C) — it stays true as the code evolves, unlike a recording.
+# claims ledger CL-050). It is the scripted, re-runnable, self-asserting form of
+# the reliability demo — it stays true as the code evolves, unlike a recording.
 #
-# WHAT IT PROVES
-#   A JobHunter workflow started on one worker survives that worker being killed
-#   and is resumed to a terminal state by a fresh worker, from Temporal history,
-#   with the SAME workflow id. Nothing is lost when a worker crashes.
+# WHAT IT PROVES (and asserts, failing loudly otherwise)
+#   A JobHunter workflow that is in flight on one worker survives that worker
+#   being killed and is resumed to a terminal state by a fresh worker, from
+#   Temporal history, with the SAME workflow id AND the SAME run id — exactly
+#   once. Nothing is lost, and nothing is double-applied, when a worker crashes.
+#
+# HOW IT STAYS HERMETIC
+#   The demo drives DurabilityProbeWorkflow
+#   (workers/automation/.../infrastructure/temporal/durability_probe.py): a
+#   diagnostic workflow whose only in-flight state is a durable Temporal timer
+#   (`workflow.sleep`). It fetches no job boards, spends no LLM tokens, opens no
+#   browser, and submits nothing — the timer is what keeps the run "Running"
+#   long enough to be killed mid-flight, which a no-op discover (finishing in
+#   milliseconds) can never demonstrate. LANGFUSE_DISABLE=1 stops even
+#   telemetry from leaving the machine.
 #
 # SAFETY GUARANTEES (read before running)
-#   * ISOLATED STACK ONLY. Uses its own Temporal dev server on a free,
-#     non-default port, its own JOBHUNTER_DIR under a throwaway temp dir, and its
-#     own SQLite db. It never touches ~/.jobhunter or your real stack.
-#   * NO REAL SPEND, NO CRAWL, NO SUBMISSION. The isolated workspace is
-#     configured with zero discovery boards, so `discover` runs as a hermetic
-#     no-op workflow: no job boards are fetched, no LLM tokens are spent, and no
-#     application is ever submitted. It runs `init`, `worker`, and `discover`
-#     only — never `apply`.
-#   * KILLS ONLY ITS OWN CAPTURED PIDS. Every process it starts is tracked by
-#     the exact PID it captured; cleanup kills those PIDs and nothing else. It
-#     never runs a broad `pkill`, so it cannot kill your real worker.
-#
-# PRECONDITION — CONFIRM HERMETIC SOURCES
-#   This script empties the JobSpy `boards` list so the JobSpy source family is a
-#   no-op. If your build enables additional discovery source families (registry
-#   / ATS sources) by default, confirm they are inactive in the isolated
-#   workspace before trusting a fully offline run, or point discovery at a
-#   dedicated fixture source. When in doubt, run on a machine with no network
-#   egress. A first-class hermetic fixture source is tracked as a follow-up.
+#   * ISOLATED STACK ONLY. Its own Temporal dev server on free, non-default
+#     ports, its own JOBHUNTER_DIR under a throwaway temp dir, its own SQLite db.
+#     It never touches ~/.jobhunter or your real stack.
+#   * NO REAL SPEND, NO CRAWL, NO SUBMISSION, NO NETWORK EGRESS. Only the
+#     durable-timer probe workflow runs; `apply` is never invoked.
+#   * KILLS ONLY ITS OWN PROCESS TREES. Every process it starts is tracked by
+#     the exact PID it captured; cleanup kills that PID and its descendants and
+#     nothing else. It never runs a broad `pkill`, so it cannot touch your real
+#     worker.
 #
 # REQUIREMENTS: temporal CLI, uv, python3, sqlite3 on PATH.
-# USAGE: scripts/reliability-demo.sh [burst_count]   (default burst_count=3)
+# USAGE: scripts/reliability-demo.sh [burst_count] [hold_seconds]
+#        defaults: burst_count=3, hold_seconds=25
 set -euo pipefail
 
 BURST="${1:-3}"
+HOLD_SECONDS="${2:-25}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -56,91 +58,210 @@ WORKDIR="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/jobhunter-reliability-demo.XXXXXX")"
 export JOBHUNTER_DIR="$WORKDIR/home"
 mkdir -p "$JOBHUNTER_DIR"
 
+# Draw two distinct ephemeral ports; never collide with the standard local
+# stack (Temporal 7233 / UI 8233, API 8766, web 5173).
 TEMPORAL_PORT="$(free_port)"
 TEMPORAL_UI_PORT="$(free_port)"
-# Never collide with the standard local stack (Temporal 7233 / UI 8233, API 8766).
+while [[ "$TEMPORAL_UI_PORT" == "$TEMPORAL_PORT" ]]; do TEMPORAL_UI_PORT="$(free_port)"; done
 for reserved in 7233 8233 8766 5173; do
   if [[ "$TEMPORAL_PORT" == "$reserved" || "$TEMPORAL_UI_PORT" == "$reserved" ]]; then
     echo "FATAL: drew a reserved port ($reserved); re-run." >&2; exit 2
   fi
 done
 export TEMPORAL_ADDRESS="127.0.0.1:$TEMPORAL_PORT"
-export JOBHUNTER_SKIP_BROWSER_PREFLIGHT=1   # discover no-op needs no browser
+export JOBHUNTER_SKIP_BROWSER_PREFLIGHT=1   # the probe needs no browser
 export PLAYWRIGHT_SKIP_BROWSER_GC=1         # never GC other worktrees' browsers
+export LANGFUSE_DISABLE=1                   # no telemetry leaves the machine
 
-TEMPORAL_PID=""; WORKER_PID=""; declare -a RUN_PIDS=()
+DB_PATH="$JOBHUNTER_DIR/jobhunter.db"
+TAG="$(date +%s)-$$"
+
+TEMPORAL_PID=""; WORKER_PID=""
+
+# Kill a PID and every descendant, collecting children BEFORE the parent dies
+# (so reparented grandchildren are still reachable). `uv run` spawns the real
+# Python worker as a child, so killing only the `uv` wrapper would orphan a live
+# worker — this reaps the whole tree.
+kill_tree() {
+  local pid="$1" sig="${2:-TERM}" child
+  [[ -z "${pid:-}" ]] && return 0
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do kill_tree "$child" "$sig"; done
+  kill "-$sig" "$pid" 2>/dev/null || true
+}
 
 cleanup() {
-  echo "--- cleanup: killing only captured PIDs ---"
-  for pid in "${RUN_PIDS[@]:-}" "$WORKER_PID" "$TEMPORAL_PID"; do
-    [[ -n "${pid:-}" ]] && kill "$pid" 2>/dev/null || true
-  done
+  echo "--- cleanup: killing only captured process trees ---"
+  kill_tree "$WORKER_PID" KILL
+  kill_tree "$TEMPORAL_PID" KILL
   wait 2>/dev/null || true
   rm -rf "$WORKDIR" 2>/dev/null || true
   echo "--- cleanup done ---"
 }
 trap cleanup EXIT INT TERM
 
-jh() { uv --project "$AUTOMATION" run jobhunter "$@"; }
+jh_python() { uv --project "$AUTOMATION" run python "$@"; }
 
-echo "=== Isolated reliability demo ==="
+# Resolve the task queue from the code so the demo never drifts from the worker.
+TASK_QUEUE="$(jh_python -c 'from jobhunter.infrastructure.temporal.task_queues import JOBHUNTER_TASK_QUEUE; print(JOBHUNTER_TASK_QUEUE)')"
+
+tctl() { temporal --address "$TEMPORAL_ADDRESS" "$@"; }
+
+# --- JSON helpers (parse `temporal ... -o json`; robust to enum prefixes) ----
+wf_status() {
+  tctl workflow describe -o json --workflow-id "$1" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+info = d.get("workflowExecutionInfo", d)
+status = str(info.get("status", ""))
+print(status.replace("WORKFLOW_EXECUTION_STATUS_", "").upper())
+'
+}
+wf_runid() {
+  tctl workflow describe -o json --workflow-id "$1" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(""); sys.exit(0)
+info = d.get("workflowExecutionInfo", d)
+print(info.get("execution", {}).get("runId", ""))
+'
+}
+wf_count() {  # $1 = visibility query
+  tctl workflow count -o json --query "$1" 2>/dev/null | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    print(0); sys.exit(0)
+print(int(d.get("count", 0) or 0))
+'
+}
+
+fail() { echo "DEMO FAIL — $*" >&2; exit 1; }
+
+echo "=== Isolated durable-execution reliability demo ==="
 echo "workspace:        $JOBHUNTER_DIR"
 echo "temporal address: $TEMPORAL_ADDRESS  (ui: 127.0.0.1:$TEMPORAL_UI_PORT)"
+echo "task queue:       $TASK_QUEUE"
+echo "burst:            $BURST probe workflow(s), hold ${HOLD_SECONDS}s each"
 
-echo "--- 1/7 start isolated Temporal dev server ---"
+echo "--- 1/8 start isolated Temporal dev server ---"
 temporal server start-dev \
   --port "$TEMPORAL_PORT" --ui-port "$TEMPORAL_UI_PORT" \
   --db-filename "$WORKDIR/temporal.db" --log-level error &
 TEMPORAL_PID=$!
+disown "$TEMPORAL_PID" 2>/dev/null || true   # we reap it via kill_tree, not job control
+temporal_up=0
 for _ in $(seq 1 30); do
-  temporal operator namespace list --address "$TEMPORAL_ADDRESS" >/dev/null 2>&1 && break
+  tctl operator namespace list >/dev/null 2>&1 && { temporal_up=1; break; }
+  sleep 1
+done
+[[ "$temporal_up" -eq 1 ]] || fail "Temporal dev server did not become ready."
+
+echo "--- 2/8 start worker A (init_db runs on bootstrap; no interactive wizard) ---"
+uv --project "$AUTOMATION" run jobhunter worker >"$WORKDIR/worker-a.log" 2>&1 &
+WORKER_PID=$!
+disown "$WORKER_PID" 2>/dev/null || true   # suppress job-control "Killed" noise on crash
+worker_up=0
+for _ in $(seq 1 60); do
+  grep -q "running on task queue" "$WORKDIR/worker-a.log" 2>/dev/null && { worker_up=1; break; }
+  kill -0 "$WORKER_PID" 2>/dev/null || break
+  sleep 1
+done
+[[ "$worker_up" -eq 1 ]] || { echo "--- worker-a.log ---"; cat "$WORKDIR/worker-a.log"; fail "worker A did not start."; }
+
+echo "--- 3/8 start a burst of $BURST durable-timer probe workflows ---"
+declare -a WF_IDS=()
+for i in $(seq 1 "$BURST"); do
+  wf_id="durability-probe-local-${TAG}-${i}"
+  WF_IDS+=("$wf_id")
+  tctl workflow start \
+    --task-queue "$TASK_QUEUE" --type DurabilityProbeWorkflow \
+    --workflow-id "$wf_id" \
+    --input "{\"tenant_id\":\"local\",\"hold_seconds\":${HOLD_SECONDS},\"expected_app_dir\":null,\"expected_db_path\":null}" \
+    >/dev/null
+done
+
+echo "--- 4/8 confirm every run is in flight (Running) + capture its run id ---"
+declare -a RUN_IDS=()
+sleep 2
+for wf_id in "${WF_IDS[@]}"; do
+  status="$(wf_status "$wf_id")"
+  run_id="$(wf_runid "$wf_id")"
+  echo "    $wf_id  status=$status  run=$run_id"
+  [[ "$status" == "RUNNING" ]] || fail "$wf_id was $status before the kill (not in flight). Increase hold_seconds (arg 2, currently ${HOLD_SECONDS})."
+  [[ -n "$run_id" ]] || fail "could not capture run id for $wf_id."
+  RUN_IDS+=("$run_id")
+done
+running_now="$(wf_count 'WorkflowType="DurabilityProbeWorkflow" AND ExecutionStatus="Running"')"
+[[ "$running_now" -eq "$BURST" ]] || fail "expected $BURST Running probes at kill time, saw $running_now."
+
+echo "--- 5/8 CRASH worker A by its captured PID tree ($WORKER_PID) ---"
+kill_tree "$WORKER_PID" KILL
+WORKER_PID=""
+sleep 3
+if pgrep -f "$AUTOMATION/.venv/bin/jobhunter worker" >/dev/null 2>&1; then
+  fail "worker A process survived the kill."
+fi
+
+echo "--- 6/8 assert every run is STILL Running with NO worker (durably held) ---"
+still_running="$(wf_count 'WorkflowType="DurabilityProbeWorkflow" AND ExecutionStatus="Running"')"
+echo "    Running with no worker: $still_running / $BURST"
+[[ "$still_running" -eq "$BURST" ]] || fail "runs did not survive the worker crash ($still_running/$BURST Running)."
+tctl workflow list --query 'ExecutionStatus="Running"' 2>/dev/null || true
+
+echo "--- 7/8 start worker B — it must resume the in-flight runs from history ---"
+uv --project "$AUTOMATION" run jobhunter worker >"$WORKDIR/worker-b.log" 2>&1 &
+WORKER_PID=$!
+disown "$WORKER_PID" 2>/dev/null || true
+for _ in $(seq 1 60); do
+  grep -q "running on task queue" "$WORKDIR/worker-b.log" 2>/dev/null && break
+  kill -0 "$WORKER_PID" 2>/dev/null || break
   sleep 1
 done
 
-echo "--- 2/7 init isolated workspace + empty discovery boards (hermetic) ---"
-jh init >/dev/null
-sqlite3 "$JOBHUNTER_DIR/jobhunter.db" \
-  "CREATE TABLE IF NOT EXISTS discovery_settings (
-     tenant_id TEXT PRIMARY KEY, search_config_json TEXT NOT NULL,
-     created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
-   INSERT INTO discovery_settings (tenant_id, search_config_json, created_at, updated_at)
-   VALUES ('local', '{\"boards\": []}', datetime('now'), datetime('now'))
-   ON CONFLICT(tenant_id) DO UPDATE SET search_config_json = excluded.search_config_json;"
-
-echo "--- 3/7 start worker A ---"
-jh worker >"$WORKDIR/worker-a.log" 2>&1 &
-WORKER_PID=$!
-sleep 5
-
-echo "--- 4/7 start a burst of $BURST discover runs (waiting on their handles) ---"
-for _ in $(seq 1 "$BURST"); do
-  jh discover >>"$WORKDIR/discover.log" 2>&1 &
-  RUN_PIDS+=("$!")
+echo "--- 8/8 wait for the SAME runs to reach Completed, then assert recovery ---"
+deadline=$(( $(date +%s) + HOLD_SECONDS + 90 ))
+for wf_id in "${WF_IDS[@]}"; do
+  while :; do
+    status="$(wf_status "$wf_id")"
+    [[ "$status" == "COMPLETED" ]] && break
+    case "$status" in FAILED|TERMINATED|TIMED_OUT|CANCELED) fail "$wf_id ended $status, not Completed." ;; esac
+    [[ "$(date +%s)" -ge "$deadline" ]] && fail "$wf_id did not complete before the deadline (last status=$status)."
+    sleep 2
+  done
 done
-sleep 3
 
-echo "--- 5/7 CRASH worker A by its captured PID ($WORKER_PID) ---"
-kill -9 "$WORKER_PID" 2>/dev/null || true
-sleep 2
-echo "open workflows while no worker is running (durably held by Temporal):"
-temporal workflow list --address "$TEMPORAL_ADDRESS" --query 'ExecutionStatus="Running"' 2>/dev/null || true
+# Same-run-resumed: the terminal run id must equal the one captured before the
+# kill (a worker crash resumes the run; it does not start a new one).
+for idx in "${!WF_IDS[@]}"; do
+  wf_id="${WF_IDS[$idx]}"
+  before="${RUN_IDS[$idx]}"
+  after="$(wf_runid "$wf_id")"
+  [[ "$after" == "$before" ]] || fail "$wf_id resumed as a DIFFERENT run ($before -> $after)."
+done
 
-echo "--- 6/7 start worker B — it must resume the in-flight runs from history ---"
-jh worker >"$WORKDIR/worker-b.log" 2>&1 &
-WORKER_PID=$!
+# At-most-once, two independent ledgers: Temporal's own visibility count, and
+# the product read-model projection (PK = workflow_id, so it cannot double-count).
+completed_temporal="$(wf_count 'WorkflowType="DurabilityProbeWorkflow" AND ExecutionStatus="Completed"')"
+completed_readmodel="$(sqlite3 "$DB_PATH" \
+  "SELECT COUNT(*) FROM workflow_run_projections WHERE workflow_type='DurabilityProbeWorkflow' AND status='succeeded';" 2>/dev/null || echo 0)"
+[[ "$completed_temporal" -eq "$BURST" ]] || fail "Temporal shows $completed_temporal Completed probes, expected $BURST."
+[[ "$completed_readmodel" -eq "$BURST" ]] || fail "read model shows $completed_readmodel succeeded probes, expected $BURST."
 
-echo "--- 7/7 wait for the same runs to reach a terminal state ---"
-rc=0
-for pid in "${RUN_PIDS[@]}"; do wait "$pid" || rc=1; done
+echo
+echo "final workflow states (Temporal):"
+tctl workflow list --query 'WorkflowType="DurabilityProbeWorkflow"' 2>/dev/null || true
+echo "runs as JobHunter's read model sees them:"
+sqlite3 -header -column "$DB_PATH" \
+  "SELECT workflow_id, status, temporal_run_id FROM workflow_run_projections
+   WHERE workflow_type='DurabilityProbeWorkflow' ORDER BY workflow_id;" 2>/dev/null || true
 
-echo "final workflow states:"
-temporal workflow list --address "$TEMPORAL_ADDRESS" 2>/dev/null || true
-echo "runs as JobHunter sees them:"
-jh runs || true
-
-if [[ "$rc" -eq 0 ]]; then
-  echo "DEMO PASS — every run resumed after the worker crash and completed."
-else
-  echo "DEMO FAIL — a run did not resume to completion (inspect $WORKDIR/*.log)." >&2
-fi
-exit "$rc"
+echo
+echo "DEMO PASS — $BURST run(s) were in flight at the crash, survived with no"
+echo "worker running, and the SAME run ids resumed to Completed exactly once"
+echo "(verified in both Temporal and the read-model projection)."

--- a/workers/automation/src/jobhunter/infrastructure/temporal/durability_probe.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/durability_probe.py
@@ -1,0 +1,129 @@
+"""Durability probe workflow — a hermetic durable-execution self-test.
+
+This workflow exists so an operator can *prove* the durable-execution recovery
+guarantee (``docs/requirements.md`` TR-008; claims ledger CL-050) without
+crawling a single job board or spending a single LLM token. Its only work is a
+durable Temporal timer:
+
+  1. emit the standard ``WorkflowStarted`` marker (a tiny local SQLite write),
+  2. ``await workflow.sleep(hold_seconds)`` — a timer that lives in Temporal
+     history, so it survives the worker being killed and requires no worker at
+     all while it counts down,
+  3. emit the standard terminal ``WorkflowCompleted`` marker.
+
+Because the only in-flight state is a durable timer, the workflow is:
+
+  * hermetic — no network, no LLM, no browser, no job data touched;
+  * controllably long — ``hold_seconds`` keeps it ``Running`` long enough to
+    kill the worker mid-flight, unlike a no-op that finishes in milliseconds;
+  * resumable — a fresh worker picks the timer up from history and drives the
+    *same* workflow execution to ``Completed`` exactly once.
+
+It emits the same lifecycle events every other JobHunter workflow does, so it
+shows up in ``jobhunter runs`` and the read-model projection like any real run.
+It never touches apply/submission and is inert until explicitly started.
+``scripts/reliability-demo.sh`` drives it end to end.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.exceptions import CancelledError
+
+with workflow.unsafe.imports_passed_through():
+    from jobhunter.infrastructure.temporal.finalize import (
+        emit_workflow_outcome,
+        emit_workflow_started,
+    )
+
+_WORKFLOW_TYPE = "DurabilityProbeWorkflow"
+# Clamp the hold so a fat-fingered input can never wedge a worker for hours.
+_MAX_HOLD_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class DurabilityProbeInput:
+    tenant_id: str
+    hold_seconds: int = 20
+    expected_app_dir: str | None = None
+    expected_db_path: str | None = None
+
+
+@dataclass(frozen=True)
+class DurabilityProbeResult:
+    workflow_id: str
+    run_id: str
+    hold_seconds: int
+
+
+def durability_probe_workflow_id(tenant_id: str, suffix: str) -> str:
+    return f"durability-probe-{tenant_id}-{suffix}"
+
+
+@workflow.defn(name="DurabilityProbeWorkflow")
+class DurabilityProbeWorkflow:
+    """Hold a durable timer so worker-crash recovery can be demonstrated."""
+
+    @workflow.run
+    async def run(self, payload: DurabilityProbeInput) -> DurabilityProbeResult:
+        started_at = workflow.now()
+        hold_seconds = max(0, min(payload.hold_seconds, _MAX_HOLD_SECONDS))
+        await emit_workflow_started(
+            tenant_id=payload.tenant_id,
+            workflow_type=_WORKFLOW_TYPE,
+            input_summary={"holdSeconds": hold_seconds},
+            started_at=started_at,
+            expected_app_dir=payload.expected_app_dir,
+            expected_db_path=payload.expected_db_path,
+        )
+        try:
+            await workflow.sleep(timedelta(seconds=hold_seconds))
+        except CancelledError:
+            await emit_workflow_outcome(
+                tenant_id=payload.tenant_id,
+                workflow_type=_WORKFLOW_TYPE,
+                status="canceled",
+                started_at=started_at,
+                error_code="workflow_canceled",
+                error_message="Durability probe canceled by request.",
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001 - record then re-raise
+            await emit_workflow_outcome(
+                tenant_id=payload.tenant_id,
+                workflow_type=_WORKFLOW_TYPE,
+                status="failed",
+                started_at=started_at,
+                error_code="workflow_error",
+                error_message=str(exc),
+                expected_app_dir=payload.expected_app_dir,
+                expected_db_path=payload.expected_db_path,
+            )
+            raise
+        await emit_workflow_outcome(
+            tenant_id=payload.tenant_id,
+            workflow_type=_WORKFLOW_TYPE,
+            status="succeeded",
+            started_at=started_at,
+            expected_app_dir=payload.expected_app_dir,
+            expected_db_path=payload.expected_db_path,
+        )
+        info = workflow.info()
+        return DurabilityProbeResult(
+            workflow_id=info.workflow_id,
+            run_id=info.run_id,
+            hold_seconds=hold_seconds,
+        )
+
+
+__all__ = [
+    "DurabilityProbeInput",
+    "DurabilityProbeResult",
+    "DurabilityProbeWorkflow",
+    "durability_probe_workflow_id",
+]

--- a/workers/automation/src/jobhunter/infrastructure/temporal/registry.py
+++ b/workers/automation/src/jobhunter/infrastructure/temporal/registry.py
@@ -24,6 +24,7 @@ from jobhunter.infrastructure.compensation.workflow import (
     CompensationRefreshWorkflow,
     refresh_compensation_activity,
 )
+from jobhunter.infrastructure.temporal.durability_probe import DurabilityProbeWorkflow
 from jobhunter.infrastructure.temporal.finalize import (
     record_workflow_outcome,
     record_workflow_started,
@@ -53,6 +54,7 @@ WORKFLOWS: list[type] = [
     ProfileImportWorkflow,
     CompensationRefreshWorkflow,
     InterviewPrepWorkflow,
+    DurabilityProbeWorkflow,
 ]
 
 ACTIVITIES: list[Callable[..., Any]] = [

--- a/workers/automation/tests/test_workflow_durability_probe.py
+++ b/workers/automation/tests/test_workflow_durability_probe.py
@@ -1,0 +1,173 @@
+"""Tests for ``DurabilityProbeWorkflow`` — the hermetic durable-execution probe.
+
+The probe backs ``scripts/reliability-demo.sh`` (launch asset 9). These tests
+assert the two properties the demo relies on: it emits the standard lifecycle
+events and returns its identity, and — the durability claim itself
+(TR-008 / CL-050) — a run that is in flight when its worker is killed resumes on
+a fresh worker as the SAME execution and completes exactly once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import uuid
+
+import pytest
+from temporalio import activity
+from temporalio.client import WorkflowExecutionStatus
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from jobhunter.infrastructure.temporal.durability_probe import (
+    DurabilityProbeInput,
+    DurabilityProbeWorkflow,
+    durability_probe_workflow_id,
+)
+from jobhunter.infrastructure.temporal.finalize import (
+    WorkflowOutcomeInput,
+    WorkflowStartedInput,
+)
+
+
+def test_durability_probe_workflow_id_is_stable() -> None:
+    assert durability_probe_workflow_id("local", "7") == "durability-probe-local-7"
+
+
+@pytest.mark.asyncio
+async def test_durability_probe_completes_and_records_lifecycle() -> None:
+    queue = f"durability-{uuid.uuid4()}"
+    wf_id = f"durability-probe-{uuid.uuid4().hex}"
+    events: list[str] = []
+
+    @activity.defn(name="record_workflow_started")
+    async def record_started(_payload: WorkflowStartedInput) -> None:
+        events.append("started")
+
+    @activity.defn(name="record_workflow_outcome")
+    async def record_outcome(payload: WorkflowOutcomeInput) -> None:
+        events.append(f"outcome:{payload.status}")
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[DurabilityProbeWorkflow],
+            activities=[record_started, record_outcome],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                DurabilityProbeWorkflow.run,
+                DurabilityProbeInput(tenant_id="local", hold_seconds=45),
+                id=wf_id,
+                task_queue=queue,
+            )
+
+    assert result.workflow_id == wf_id
+    assert result.hold_seconds == 45
+    assert result.run_id
+    # Exactly one start marker and one success outcome — no duplicates.
+    assert events == ["started", "outcome:succeeded"]
+
+
+@pytest.mark.asyncio
+async def test_durability_probe_clamps_absurd_hold_to_ceiling() -> None:
+    queue = f"durability-{uuid.uuid4()}"
+
+    @activity.defn(name="record_workflow_started")
+    async def record_started(_payload: WorkflowStartedInput) -> None:
+        return None
+
+    @activity.defn(name="record_workflow_outcome")
+    async def record_outcome(_payload: WorkflowOutcomeInput) -> None:
+        return None
+
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=queue,
+            workflows=[DurabilityProbeWorkflow],
+            activities=[record_started, record_outcome],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            result = await env.client.execute_workflow(
+                DurabilityProbeWorkflow.run,
+                DurabilityProbeInput(tenant_id="local", hold_seconds=10_000_000),
+                id=f"durability-probe-{uuid.uuid4().hex}",
+                task_queue=queue,
+            )
+
+    assert result.hold_seconds == 3600
+
+
+@pytest.mark.asyncio
+async def test_durability_probe_resumes_same_run_after_worker_crash() -> None:
+    """The TR-008 / CL-050 invariant the launch demo exists to prove.
+
+    Worker A parks the run on its durable timer, then dies. With no worker
+    running the execution is still ``Running`` (Temporal holds the timer); a
+    fresh worker B resumes the SAME execution from history and drives it to
+    ``Completed`` exactly once.
+
+    This uses a real local dev server (``start_local``) rather than the
+    in-memory time-skipping server: faithfully resuming a durable timer across a
+    worker crash is exactly the behaviour the time-skipping server does not
+    reproduce. The crash is a cancelled worker task (abrupt), not a graceful
+    context-managed shutdown, which is both a truer crash and what keeps the
+    ephemeral server alive across it. It costs a few real seconds (the short
+    hold), which is the point.
+    """
+    queue = f"durability-{uuid.uuid4()}"
+    wf_id = f"durability-probe-{uuid.uuid4().hex}"
+    started_done = asyncio.Event()
+
+    @activity.defn(name="record_workflow_started")
+    async def record_started(_payload: WorkflowStartedInput) -> None:
+        started_done.set()
+
+    @activity.defn(name="record_workflow_outcome")
+    async def record_outcome(_payload: WorkflowOutcomeInput) -> None:
+        return None
+
+    def new_worker(client) -> Worker:
+        return Worker(
+            client,
+            task_queue=queue,
+            workflows=[DurabilityProbeWorkflow],
+            activities=[record_started, record_outcome],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        )
+
+    async with await WorkflowEnvironment.start_local() as env:
+        # --- worker A: start the probe and let it reach the durable timer ---
+        worker_a = asyncio.create_task(new_worker(env.client).run())
+        handle = await env.client.start_workflow(
+            DurabilityProbeWorkflow.run,
+            DurabilityProbeInput(tenant_id="local", hold_seconds=5),
+            id=wf_id,
+            task_queue=queue,
+        )
+        await asyncio.wait_for(started_done.wait(), timeout=15)
+        first_run = handle.first_execution_run_id
+        assert (await handle.describe()).status == WorkflowExecutionStatus.RUNNING
+
+        # --- CRASH worker A (abrupt task cancel); the run must survive ---
+        worker_a.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await worker_a
+        assert (await handle.describe()).status == WorkflowExecutionStatus.RUNNING
+
+        # --- worker B: it must resume the SAME execution from history ---
+        worker_b = asyncio.create_task(new_worker(env.client).run())
+        try:
+            # A returned result is itself proof the run reached COMPLETED.
+            result = await asyncio.wait_for(handle.result(), timeout=30)
+            terminal_status = (await handle.describe()).status
+        finally:
+            worker_b.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker_b
+
+        assert result.workflow_id == wf_id
+        assert handle.first_execution_run_id == first_run  # same run resumed
+        assert terminal_status == WorkflowExecutionStatus.COMPLETED


### PR DESCRIPTION
## What

Delivers **Phase B / Goal 2** (demo assets, plan §7).

**Reliability demo (asset 9, class C — defined + re-runnable):**

- `scripts/reliability-demo.sh` reproduces the kill-worker → resume story on a **fully isolated stack**: its own Temporal dev server on a free non-default port, its own throwaway `JOBHUNTER_DIR`, a **hermetic no-op** `discover` (discovery boards emptied → no crawl, no LLM spend), a burst of runs, kills the worker **by captured PID**, then a fresh worker resumes the same runs from Temporal history (`TR-008` / `CL-050`).
- Safe by construction: isolated ports (never 7233/8233/8766), no submission, kills only captured PIDs, trap cleanup. Syntax-checked with `bash -n`.
- Documented in `docs/local-reliability-qa.md` under the Temporal fault-injection matrix.

**Demo-asset inventory (`docs/local-development.md`):**

- Classifies all nine §7 assets (**A**/**B**/**C**), maps each to its `Current` claims-ledger row, and records its regeneration/proof path + status.
- **Covered:** assets 3, 4 (existing screenshots + seed); assets 5, 6 (existing regression tests that prove the invariant from the seed fixture — `resume-templates.test.ts`, `resume-review-drafts.test.ts`, `application-feedback.test.ts`, `test_coverage_audit.py`); asset 9 (the script).
- **Deferred** (needs a new synthetic seed/capture surface, not a missing capability): asset 1 (empty dashboard), asset 2 (profile import), asset 8 health capture.
- **Class-C defined flows** (7 live blocked-channel evidence, 8 stop lifecycle, 9) — never faked with a staged image.

## Re-anchor result

The capability preconditions the plan flagged for assets 7 and 8 (approval binding + dry-run blocked-channel evidence = #271; spend ceiling + `/v1/health` = P5) are **merged on `main`**, so those assets are buildable-against-main rather than blocked. Assets 7/8 are covered/defined here; their remaining screenshot capture surfaces are the deferred follow-ups noted above.

## Scope decision (recorded)

Per plan §7, class-C assets are *defined, not executed*. The reliability demo is delivered as a re-runnable, syntax-checked script + docs (the format you chose), **not executed in this shared session** — a live run belongs on an operator's isolated machine where the zero-active-source precondition can be confirmed (see the script header). I did not add new regression tests for assets 5/6 because existing tests already prove those invariants from the seed fixture; I cite them instead of duplicating.

## Stacking

Stacked on **#302** → #299 → #298. Retarget to `main` as parents merge.

## Validation

- `pnpm docs:build` — passes (4695 references resolve across 233 files; new anchor resolves).
- `python3 scripts/release_check.py` — passes (exit 0).
- `bash -n scripts/reliability-demo.sh` — clean.
- `git diff --check` — clean.
- Product code WAS added by fix commit 9834888c (scope promotion, accepted in re-review 4633595783): `DurabilityProbeWorkflow` (`workers/automation/src/jobhunter/infrastructure/temporal/durability_probe.py`) + append-only registry entry + `test_workflow_durability_probe.py`. The probe is an inert diagnostic (durable timer only — no crawl/LLM/browser/apply; persists only workflow-lifecycle rows). The original delta was one shell script + docs.
