### PR TITLE
docs(launch): [R7] publish-mechanics checklist (§9; 9.3/9.4 rename-gated)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -12,6 +12,7 @@ const UNPUBLISHED_FILES = new Set([
   "docs/backlog.md",
   "docs/claims-ledger.md",
   "docs/delivered.md",
+  "docs/publish-checklist.md",
   "docs/README.md",
 ]);
 
@@ -175,7 +176,7 @@ export default withMermaid(
     title: "JobHunter",
     description:
       "Local-first, AI-assisted job application pipeline: discovery, scoring, tailored materials, and supervised apply.",
-    srcExclude: ["plans/**", "incidents/**", "backlog.md", "claims-ledger.md", "delivered.md", "README.md"],
+    srcExclude: ["plans/**", "incidents/**", "backlog.md", "claims-ledger.md", "delivered.md", "publish-checklist.md", "README.md"],
     cleanUrls: true,
     lastUpdated: true,
     rewrites: PAGE_REWRITES,

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -20,8 +20,8 @@ The **authoritative release gate is OSS spec §5**
 §5 "Release gate — flipping public"). That gate owns the capability and privacy
 preconditions (W0.\* privacy scanner, W1.\* apply safety, W2.\* naming/governance,
 Temporal P1b–P5). This checklist does not duplicate those; it lists only the
-publish *mechanics* that feed the gate. **Do not flip visibility or tag a release
-until every OSS spec §5 box is checked.**
+publish *mechanics* that feed the gate. **Do not flip visibility, deploy the
+public docs site, or tag a release until every OSS spec §5 box is checked.**
 
 ## Owner-only actions (do not execute here)
 
@@ -53,6 +53,22 @@ to the rename train / post-rename launch assets (R7b).
 
 ### 9.2 — Docs-site deploy (owner-only)
 
+- **Preconditions (OSS spec §5 gate).** Deploying `docs/.vitepress/dist` to the
+  public `jobctl-docs` Cloudflare project is itself a going-public act, so it
+  carries the **same OSS spec §5 gate as 9.1**. The `deploy` job in
+  `docs-site.yml` is gated only on `DOCS_DEPLOY_ENABLED`, `main`, and
+  non-`pull_request` — **not** on `release-check` — so this checklist is the
+  only guard. Before setting `DOCS_DEPLOY_ENABLED` or configuring the Cloudflare
+  secrets:
+  - `python3 scripts/release_check.py` reports zero findings locally on the
+    exact commit to be deployed, and `release-check`
+    (`.github/workflows/release-check.yml`) is green on that `main` commit.
+  - Every box in OSS spec §5 is checked — in particular the W0.\* privacy
+    scanner, the owner's recorded capability-posture acceptance, and the final
+    human manual QA — exactly as required for 9.1.
+  - The claims-ledger freeze (`docs/claims-ledger.md`, GATE G1) is re-stamped at
+    the actual freeze `main` sha and owner-signed, so the public site cannot
+    ship provisional or unsigned public claims.
 - **Action.** Set the repository variable `DOCS_DEPLOY_ENABLED=true` and the two
   Cloudflare secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) so the
   `deploy` job in `.github/workflows/docs-site.yml` runs from `main` (it is

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -1,0 +1,102 @@
+# Publish-Mechanics Checklist
+
+> **Repository-only.** Excluded from the published docs site (registered in
+> `docs/.vitepress/config.ts` `UNPUBLISHED_FILES` + `srcExclude`, like
+> `docs/backlog.md` and `docs/claims-ledger.md`). It is launch-governance, not
+> user documentation.
+>
+> Implements Phase C of
+> [`docs/plans/2026-07-05-launch-readiness-artifacts-plan.md`](plans/2026-07-05-launch-readiness-artifacts-plan.md)
+> §9.
+
+## Purpose and boundary
+
+A concrete, verifiable checklist for the **mechanical** publish steps, each with
+a verification and a rollback note. This checklist **prepares and verifies** the
+steps; it does **not** execute them.
+
+The **authoritative release gate is OSS spec §5**
+([`docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md`](plans/implemented/2026-07-03-oss-release-remediation-spec.md)
+§5 "Release gate — flipping public"). That gate owns the capability and privacy
+preconditions (W0.\* privacy scanner, W1.\* apply safety, W2.\* naming/governance,
+Temporal P1b–P5). This checklist does not duplicate those; it lists only the
+publish *mechanics* that feed the gate. **Do not flip visibility or tag a release
+until every OSS spec §5 box is checked.**
+
+## Owner-only actions (do not execute here)
+
+Every step below is an **owner-only** action. Implementing agents prepare and
+verify; the repository owner executes. Steps 9.3 and 9.4 additionally depend on
+the pre-publication rename train and are **out of scope for R7a** — they belong
+to the rename train / post-rename launch assets (R7b).
+
+## Steps
+
+### 9.1 — Repository visibility flip (owner-only)
+
+- **Action.** Owner flips `github.com/ebarti/JobHunter` from private to public.
+- **Verification.**
+  - `release-check` (`.github/workflows/release-check.yml`) is green on `main`
+    for every commit since W0.4 landed (it triggers on every `push` to `main`
+    and every `pull_request`).
+  - `python3 scripts/release_check.py` reports zero findings locally on the
+    exact commit to be published.
+  - Every box in OSS spec §5 is checked, including the final human manual QA
+    (`jobhunter doctor` clean; seeded `/apply-review` approval → dry-run
+    evidence → gated submit; one harness dry-run showing blocked-channel
+    evidence; no real applications).
+- **Rollback.** Flip back to private. **Honest limitation:** anything fetched
+  while the repository was public cannot be recalled, and git history remains
+  reachable — the real mitigation is the pre-flip privacy gate, not rollback.
+  OSS spec §1 records the owner's acceptance of historical blobs remaining
+  reachable.
+
+### 9.2 — Docs-site deploy (owner-only)
+
+- **Action.** Set the repository variable `DOCS_DEPLOY_ENABLED=true` and the two
+  Cloudflare secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) so the
+  `deploy` job in `.github/workflows/docs-site.yml` runs from `main` (it is
+  gated on `vars.DOCS_DEPLOY_ENABLED == 'true'`, `main`, and non-`pull_request`;
+  it deploys `docs/.vitepress/dist` to the Cloudflare Pages project
+  `jobctl-docs`).
+- **Verification.** On the next `main` push the `deploy` job runs (not skipped),
+  the site serves, and `pnpm docs:build` + `pnpm docs:check:runtime` are green on
+  the built artifact.
+- **Rollback.** Unset `DOCS_DEPLOY_ENABLED` → the `deploy` job skips cleanly and
+  the workflow stays green. If a bad build shipped, redeploy the previous
+  `docs-site-dist` artifact.
+
+### 9.3 — Repository-rename redirect (owner-only; RENAME-GATED — deferred to R7b)
+
+> **Deferred.** This step runs only after the pre-publication rename train
+> ([`docs/plans/2026-07-05-rename-jobctl-plan.md`](plans/2026-07-05-rename-jobctl-plan.md))
+> merges. It is **out of scope for R7a** and is not prepared or executed here.
+
+- **Action (for reference).** After the GitHub repository rename, verify GitHub's
+  automatic old-URL redirects resolve; update the absolute `REPO_URL` in
+  `docs/.vitepress/config.ts` and any absolute repo links/badges; re-run
+  `pnpm docs:build`.
+- **Rollback (for reference).** Rename back (GitHub reserves the prior name);
+  revert the `REPO_URL`/link edits.
+
+### 9.4 — Release tagging (owner-only; RENAME-GATED — deferred to R7b)
+
+> **Deferred.** Runs only after the PyPI/distribution rename in the rename train.
+> **Out of scope for R7a**; not prepared or executed here.
+
+- **Action (for reference).** Restore the tag trigger in
+  `.github/workflows/publish.yml` (currently `workflow_dispatch`-only per OSS
+  spec W0.5), gated on the release-check workflow passing, then tag the first
+  release; the build produces the renamed sdist/wheel.
+- **Rollback (for reference).** Delete the tag; if a bad artifact published to
+  PyPI, yank it. Keep the trigger `workflow_dispatch`-only until the rename train
+  is confirmed.
+
+## Status summary
+
+| Step | Owner-only | Rename-gated | R7a status |
+| --- | --- | --- | --- |
+| 9.1 Visibility flip | Yes | No | Prepared + verifiable; owner executes |
+| 9.2 Docs-site deploy | Yes | No | Prepared + verifiable; owner executes |
+| 9.3 Rename redirect | Yes | **Yes** | Deferred to rename train / R7b |
+| 9.4 Release tagging | Yes | **Yes** | Deferred to rename train / R7b |


### PR DESCRIPTION
## What

Delivers **Phase C / Goal 5** (publish-mechanics checklist, plan §9) as a **repository-only** doc `docs/publish-checklist.md` (registered in `UNPUBLISHED_FILES` + `srcExclude` like the claims ledger).

- **9.1 Repository visibility flip** and **9.2 Docs-site deploy** — each with a concrete verification and a rollback note; flagged **owner-only**.
- **9.3 Rename redirect** and **9.4 Release tagging** — marked **RENAME-GATED** and **deferred to the rename train / R7b**; documented for reference only, not prepared or executed here (per your instruction to skip the rename-gated steps).
- Cross-references **OSS spec §5** (`docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md`) as the authoritative release gate; does not duplicate its capability/privacy preconditions.

## Why

The mechanical publish steps need a concrete, verifiable home that *feeds* the OSS §5 gate without duplicating it. Repo-only because it is launch-governance (references owner-only actions), not user documentation. Verified against current CI: `release-check.yml` (push+PR), `docs-site.yml` deploy gated on `DOCS_DEPLOY_ENABLED` → the `jobctl-docs` Cloudflare project, `publish.yml` `workflow_dispatch`-only.

## Owner-only actions (for your final sign-off)

All four steps are owner-executed. This PR prepares/verifies 9.1 and 9.2; 9.3 and 9.4 wait for the rename train. See the doc's Status summary table.

## Stacking

Final PR of the R7a stack: **#304** → #302 → #299 → #298. Retarget to `main` as parents merge.

## Validation

- `pnpm docs:build` — passes; checklist **excluded** from the 233 emitted files; 4695 references resolve.
- `python3 scripts/release_check.py` — passes (exit 0).
- `git diff --check` — clean.
- No code or product behavior changed (repo-only doc + 2-line config).

## Review follow-up (HIGH — resolved)

Reviewer HIGH (thread on 9.2, review 4632343635): docs-site deploy (9.2) was not gated on OSS spec §5, so setting `DOCS_DEPLOY_ENABLED` could publish the public docs site before the release gate. Fixed in `982a718` — 9.2 now carries the **same OSS spec §5 gate as 9.1** via a `Preconditions (OSS spec §5 gate)` block that must hold **before** `DOCS_DEPLOY_ENABLED` / the Cloudflare secrets are set: `release_check.py` + `release-check` green on the exact deploy sha, every §5 box checked (W0.\* privacy, capability-posture acceptance, final human QA), and the claims-ledger GATE G1 freeze re-stamped + owner-signed. The top-of-doc gate now also names "deploy the public docs site". Docs-only, additive; no CI/workflow edits.

**Recommended follow-up (not in this PR):** harden `.github/workflows/docs-site.yml` so the `deploy` job itself requires `release-check` to pass, instead of relying on this checklist as the only guard. Today `deploy` is gated only on `DOCS_DEPLOY_ENABLED`/`main`/non-`pull_request`; the checklist must not be the sole guard forever.

The three Medium threads (9.1 claims-ledger precondition; two forward-reference plan links) remain open per owner instruction.
