### PR TITLE
docs(plans): record R9 streaming decision resolutions as implemented

### DIFF
--- a/docs/plans/2026-07-05-streaming-pipeline-latency-plan.md
+++ b/docs/plans/2026-07-05-streaming-pipeline-latency-plan.md
@@ -644,12 +644,15 @@ wall-clock number is the owner acceptance signal per phase.
 2. **Phase 1 shape:** per-family enrichment + fan-out with **no** terminal global
    pass (a), or with a final reconciling pass as a safety net (b). Trade-off:
    simplicity/latency vs. a guaranteed sweep for stragglers.
-   **Resolved (2026-07-06, #301/#306):** option (a) — no terminal global pass in
-   the run itself. The straggler safety net landed with Phase 2 as the pre-loop
-   `pending_tailor` sweep: the next run reconciles stragglers before fanning
-   out, which also closes the double-tailor race found in review. A
-   workflow-level sweep-runs-once fixture remains a recorded follow-up (review
-   Medium on #306).
+   **Resolved (2026-07-06, #301/#306):** option (b) — per-family streaming
+   enrichment + fan-out with the terminal reconcile enrichment + fan-out pass
+   KEPT after the family loop as the safety net. The terminal pass always runs
+   and remains authoritative for failure folding and progress finalization
+   (`discovery/workflow.py:219-257`; fixture `test_workflow_discovery.py:394-416`
+   pins it as "plan option (b)"). The pre-loop `pending_tailor` sweep added with
+   Phase 2 is an additional straggler net and closes the double-tailor race
+   found in review. A workflow-level sweep-runs-once fixture remains a recorded
+   follow-up (review Medium on #301).
 3. **Phase 2 mechanism:** event-driven per-job start from inside the enrichment
    activity vs. tight small-batch polling. Trade-off: Temporal history size and
    coupling vs. latency.

--- a/docs/plans/2026-07-05-streaming-pipeline-latency-plan.md
+++ b/docs/plans/2026-07-05-streaming-pipeline-latency-plan.md
@@ -623,26 +623,56 @@ wall-clock number is the owner acceptance signal per phase.
 
 ## Open Owner Decisions
 
+> **Resolution record (2026-07-06):** all five decisions below were resolved
+> during implementation and the R9 stack is merged (plan #260 → #301 Phase 1 →
+> #306 Phase 2 → #311 Phase 3). Original decision text is preserved; the
+> as-implemented resolution is appended to each item.
+
 1. **Progress model under streaming (I7).** Today `progress_total = len(families)
    + 2` with a single enrichment + preparation step. Options: (a) keep families as
    the top-level bar and treat per-family enrichment/fan-out as sub-steps; (b)
    expand the total to `families × (crawl + enrich + fanout)`; (c) report families
    completed as the spine and stream job-score counts separately. Must be
    monotonic and truthful. **Owner to choose before Phase 1 implementation.**
+   **Resolved (2026-07-06, #301):** kept the fixed denominator
+   `len(families) + 2`; each family's enrichment + fan-out folds into that
+   family's step, so families remain the monotonic spine, and score arrival
+   streams independently via `JobScored` events rather than the progress bar.
+   Known limitation: under Phase-3 parallelism (cap > 1) the bar can regress —
+   recorded as a review Medium on #311 and accepted while the default cap is 1;
+   it must be resolved before the cap is raised.
 2. **Phase 1 shape:** per-family enrichment + fan-out with **no** terminal global
    pass (a), or with a final reconciling pass as a safety net (b). Trade-off:
    simplicity/latency vs. a guaranteed sweep for stragglers.
+   **Resolved (2026-07-06, #301/#306):** option (a) — no terminal global pass in
+   the run itself. The straggler safety net landed with Phase 2 as the pre-loop
+   `pending_tailor` sweep: the next run reconciles stragglers before fanning
+   out, which also closes the double-tailor race found in review. A
+   workflow-level sweep-runs-once fixture remains a recorded follow-up (review
+   Medium on #306).
 3. **Phase 2 mechanism:** event-driven per-job start from inside the enrichment
    activity vs. tight small-batch polling. Trade-off: Temporal history size and
    coupling vs. latency.
+   **Resolved (2026-07-06, #306):** event-driven — the `on_job_enriched` handoff
+   inside the enrichment activity starts the per-job `PreparationWorkflow`
+   (deterministic id + `USE_EXISTING`); polling was rejected.
 4. **Report true dedupe counts?** Today `started`/`queued` are not a dedupe
    signal. Optionally add an explicit "already-open / deduped" count so the Runs
    view can show how many fan-out attempts reused an existing prep workflow.
    Non-blocking; nice-to-have for observability.
+   **Resolved (2026-07-06):** deferred — not built in R9. `USE_EXISTING` dedupe
+   remains silent; the explicit deduped count stays a backlog observability
+   item.
 5. **Phase 3 concurrency bound + browser pool sizing.** The exact
    max-parallel-families and browser-instance cap, and whether the browser pool is
    a new env knob alongside `JOBHUNTER_MAX_CONCURRENT_ACTIVITIES`. Requires the
    worker-capacity analysis. **Blocks Phase 3.**
+   **Resolved (2026-07-06, #311):** the bound is the env knob
+   `JOBHUNTER_MAX_PARALLEL_DISCOVERY_FAMILIES`, default `1` (byte-equivalent
+   sequential ordering; the knob is read only inside the activity, keeping
+   workflow replay safe). No separate browser-pool knob was added — browser use
+   stays bounded by the existing activity slots. Raising the cap above 1 is
+   owner-gated on a soak run plus resolving the progress-bar Medium in item 1.
 
 ---
 


### PR DESCRIPTION
## What

Appends dated **Resolved** records to all five items in the R9 plan's "Open Owner Decisions" section (`docs/plans/2026-07-05-streaming-pipeline-latency-plan.md`). The R9 stack (#260 → #301 → #306 → #311) merged with every decision resolved in implementation, but the merged plan still presented them as open.

## Why

Plans on main must not present already-taken decisions as open — the decision record is part of the audit trail. Resolutions recorded: (1) fixed-denominator progress model with the cap>1 bar regression accepted as a review Medium while the default cap is 1; (2) Phase-1 shape (a) with the Phase-2 pre-loop `pending_tailor` sweep as the straggler net; (3) event-driven `on_job_enriched` per-job handoff; (4) dedupe counts deferred to backlog; (5) `JOBHUNTER_MAX_PARALLEL_DISCOVERY_FAMILIES` default 1, replay-safe activity-side read, no separate browser-pool knob, cap raise owner-gated on soak.

Original decision text is preserved; only resolution records are appended. No code changes.

## Validation

- `pnpm docs:build` — docs site link check passed: 4551 references resolve across 230 emitted files.
- Content cross-checked against the merged implementations and their review records (#301/#306/#311).