### PR TITLE
fix(apply): harden agent prompt boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ employers, accounts, provider APIs, and third-party sites as live operations:
   employer submission. The current Gmail connector is read-only; do not grant or
   wire Gmail `gmail.send` unless you intend JobHunter to send application email
   from your account.
-- Browser automation can type credentials you provide. Use a unique, dedicated
-  job-site password, not an email, banking, work, or reused personal password.
-- CAPTCHA solving is off unless `CAPSOLVER_API_KEY` is configured. Setting that
-  key sends CAPTCHA site keys and page URLs to a paid third-party solver, and
-  you are responsible for each site's terms and legal constraints.
+- Browser automation can type non-secret profile fields. The apply agent does
+  not receive profile passwords in its prompt; if a password login is required,
+  it stops for operator handling.
+- CAPTCHA challenges fail closed in the apply agent. Do not solve image/audio
+  challenges manually, switch to stealth browsers, or bypass bot controls.
 - Scraping and source access can violate site terms. Default discovery options
   include LinkedIn and Indeed; disable any source you are not allowed to query
   automatically.
@@ -245,16 +245,16 @@ opt-in and configuration-gated:
   cover-letter generation (job text, your profile evidence, and generated
   material text).
 - **The apply agent's model** — the apply prompt during apply or dry-run (your
-  profile summary, the tailored materials, and, only if you configured them, a
-  login password and the CapSolver key).
+  profile summary and the tailored materials). The prompt does not include
+  profile passwords or CAPTCHA-provider keys.
 - **Job boards, ATS APIs, and posting pages** — discovery and enrichment
   fetches.
 - **Gmail (read-only)** — verification-code and application-outcome lookups, only
   if you authenticate the connector; it never requests `gmail.send`.
 - **Google Maps** — address autocomplete, only if you set
   `VITE_GOOGLE_MAPS_API_KEY`.
-- **CAPTCHA solving** — site keys and page URLs, only if you set
-  `CAPSOLVER_API_KEY` for a live apply.
+- **CAPTCHA solving** — currently fails closed in the apply agent; no
+  CAPTCHA-provider key is sent through the model prompt.
 - **Langfuse / OpenTelemetry** — traces, only when you configure it
   (`LANGFUSE_DISABLE=1` opts out even with credentials present).
 

--- a/docs/plans/2026-07-05-browser-extension-plan.md
+++ b/docs/plans/2026-07-05-browser-extension-plan.md
@@ -37,7 +37,7 @@ P3 is **not** designed in implementation detail here (§6). Do not start it unti
 
 - Conventional Commits for every commit and PR title; PR body states What / Why / Validation.
 - Never edit code on `main`; every phase is developed in its own worktree/branch; one reviewable unit per PR.
-- **Additive:** this is a new surface. Do not remove or weaken any existing safety/privacy behavior (loopback bind, apply approval gate, dry-run guard, at-most-once, spend cap). Adding auth to the local API (P0) is a strict addition — unauthenticated loopback reads that exist today keep working unless the owner decides otherwise (§13, D-2).
+- **Additive:** this is a new surface. Do not remove or weaken any existing safety/privacy behavior (loopback bind, apply approval gate, explicit dry-run guard when dry-run is requested, at-most-once, spend cap). Adding auth to the local API (P0) is a strict addition — unauthenticated loopback reads that exist today keep working unless the owner decides otherwise (§13, D-2).
 - Public-history-safe: neutral product language only. Name ATS **integration targets** only where the repo already names them in code (`AtsKind` values: Workday, Greenhouse, Lever, Ashby). Never name or allude to rival products/companies; no marketing language.
 - Do not commit or fixture any real profile data, resumes, cover letters, PDFs, browser profiles, SQLite databases, secrets, or logs. Fixtures use synthetic, fictional employers and the existing synthetic seed (`pnpm qa:seed`).
 - Each phase that changes user-facing behavior, the local API, or safety notes MUST update the owning docs per the CLAUDE.md documentation matrix (enumerated per phase under "Docs").
@@ -297,7 +297,7 @@ All of the following must hold:
 A Phase-3 submission MUST enter through the existing apply workflow entry (`apply` JSON-RPC method → `ApplyWorkflow`), inheriting all four mechanisms — not the raw launcher, not the extension:
 
 - **Approval gate:** `apply_approval_required` (default `True`, `workers/automation/src/jobhunter/infrastructure/scoring/criteria_provider.py` » `read_apply_approval_required`) enforced in the worker's claim transaction (`workers/automation/src/jobhunter/apply/launcher.py` » `_latest_apply_review_decision`, the `approval_required and not dry_run` branch); consent recorded via `POST /v1/jobs/:jobKey/apply-review/decision` (`apps/api/src/server.ts`; `apps/api/src/application-feedback.ts` » `recordApplyReviewDecision`, decision `approve_submit` from `APPLY_REVIEW_DECISION_VALUES`).
-- **Dry-run guard:** the `dry_run` flag + aggregate invariant (`workers/automation/src/jobhunter/domain/apply/aggregate.py`) + CDP network guard (`apply/chrome.py` » `install_dry_run_cdp_guard`).
+- **Explicit dry-run guard:** the `dry_run` flag + aggregate invariant (`workers/automation/src/jobhunter/domain/apply/aggregate.py`) + CDP network guard (`apply/chrome.py` » `install_dry_run_cdp_guard`). This protects runs that explicitly opt into dry-run mode; it is not a dry-run-by-default requirement.
 - **At-most-once lifecycle:** deterministic `apply_workflow_id` = `apply-{tenant}-{job_key}` (`workers/automation/src/jobhunter/workflow_specs.py`), Temporal `USE_EXISTING` conflict policy, single live attempt (`apply/workflow.py` » `_APPLY_LIVE_RETRY`), active-run exclusion (`_has_active_apply` / `list_active`), and the `ApplySubmitIntended` checkpoint (`workers/automation/src/jobhunter/domain/apply/process_manager.py`).
 - **Spend ceiling:** the `check_spend_budget` preflight (`workers/automation/src/jobhunter/llm.py`) raising `BudgetExceededError`; daily budget default $25 (`read_daily_budget_usd`).
 - **Read model / UI:** `apply_run_projections`; Apply Review queue + `ApplyReviewDecisionControls`; apply events (`ApplyRunStarted`, `ApplySubmitIntended`, `ApplicationSubmitted`, `ApplicationFailed`, `ApplyReviewDecisionRecorded`).
@@ -305,7 +305,7 @@ A Phase-3 submission MUST enter through the existing apply workflow entry (`appl
 ### 6.3 What Phase 3 must NOT do
 
 - Must not add a submission code path to the extension or content scripts.
-- Must not weaken, flag-off, or bypass the approval gate, dry-run guard, at-most-once lifecycle, or spend cap.
+- Must not weaken, flag-off, or bypass the approval gate, explicit dry-run guard when dry-run is requested, at-most-once lifecycle, or spend cap.
 - Must not submit as a side effect of capture or autofill.
 - The extension's role is limited to handing a reviewed application to the supervised path and reflecting its status; the human `approve_submit` decision remains mandatory (I-2, I-3, BR-001, BR-023, BR-054).
 

--- a/docs/plans/2026-07-05-crawl-politeness-plan.md
+++ b/docs/plans/2026-07-05-crawl-politeness-plan.md
@@ -637,9 +637,9 @@ traffic, no applications, nothing spendful** is run during verification.
   the existing spend-budget system.
 - **No change to what is extracted or to dedup/identity logic** — this is about how
   we fetch, not what we parse.
-- **No apply-submission safety changes** — the at-most-once apply gate and dry-run
-  guard are owned by the OSS spec W1; this plan only requires that apply's browser
-  *navigation* obey the same budgets.
+- **No apply-submission safety changes** — the at-most-once apply gate and
+  explicit dry-run guard for dry-run requests are owned by the OSS spec W1; this
+  plan only requires that apply's browser *navigation* obey the same budgets.
 
 ## Risks
 

--- a/docs/plans/2026-07-05-launch-readiness-artifacts-plan.md
+++ b/docs/plans/2026-07-05-launch-readiness-artifacts-plan.md
@@ -234,8 +234,9 @@ process; it does **not** prescribe final copy.
   Services" and link to it; it must not introduce a claim absent from that
   page. Keep the existing safety/back-up guidance.
 - **No capability regressions in text.** Preserve every currently documented
-  capability and safety note (auto-apply approval gate, dry-run guard, backup/
-  restore); this is a re-lead and claim-audit, not a capability removal.
+  capability and safety note (auto-apply approval gate, explicit dry-run mode
+  guard, backup/restore); this is a re-lead and claim-audit, not a capability
+  removal.
 
 **Claim-review process for the README.**
 
@@ -309,7 +310,7 @@ that must have merged first).
 | 4 | Apply-review audit surfaces | `qa-seed.ts` approved materials generation, requirement evidence, `change_annotations` (comments), approval controls | `/apply-review` and its evidence / comments / approval-control sub-surfaces | Evidence, line comments, and explicit approval controls are inspectable before anything is submitted | A (+B for sub-surface captures) | none |
 | 5 | Artifact replacement preserves last accepted on failure | New seed state: an approved generation **plus** a later **failed** refresh that does not supersede the approved artifact | `/apply-review` (or artifact view) before/after a failed re-tailor | A failed refresh never destroys the last accepted artifact; the accepted material stays visible and openable (`BR-041`, `BR-052`, `TR-032`) | B | none (behavior shipped) |
 | 6 | Tailoring gate rejects an unsupported claim | `qa-seed.ts` change annotation with an unsupported/needs-confirmation claim label + `review_blocked` decision; extend to a clearly *fabricated* claim per `docs/architecture/tailoring.md` fabrication gates | `/apply-review` zoomed on the blocked claim + its blocker/repair reason | The gate blocks the unsupported claim and surfaces the blocker and repair instruction — proven from canonical fixture data | B | none (behavior shipped) |
-| 7 | Dry-run apply completes without submission + live-approval gate | `qa-seed.ts` dry-run run (`qa-run-1`), approval card (`applyApprovalRequired` default true), and dry-run blocked-channel evidence (`apply_dryrun_blocked`) | `/apply-review` approval card + `/runs` dry-run run + blocked-channel evidence | A dry run finishes, nothing was submitted, and live submit is gated behind an explicit fresh approval (`BR-054`) | B (approval + run) / C (live blocked-channel evidence) | Approval-binding + blocked-channel evidence: OSS spec **W1.1 / W1.2** for the evidence asset |
+| 7 | Explicit dry-run apply completes without submission + live-approval gate | `qa-seed.ts` dry-run run (`qa-run-1`), approval card (`applyApprovalRequired` default true), and dry-run blocked-channel evidence (`apply_dryrun_blocked`) | `/apply-review` approval card + `/runs` dry-run run + blocked-channel evidence | When dry-run mode is explicitly requested, nothing is submitted, and live submit is gated behind an explicit fresh approval (`BR-054`) | B (approval + run) / C (live blocked-channel evidence) | Approval-binding + blocked-channel evidence: OSS spec **W1.1 / W1.2** for the evidence asset |
 | 8 | Spend-ceiling stop + health surface | New seed state: `llm_spend` at/over `dailyBudgetUsd`; a workflow stopped with the budget error | `GET /v1/health` + web health surface showing over-budget; a run stopped by the ceiling | A daily spend ceiling stops spending work and the over-budget state is visible (`BR-050`) | B (health surface) / C (the stop lifecycle) | Spend system + per-lane visibility: OSS spec **P5 / W2.4** |
 | 9 | Reliability demo — kill worker mid-run, restart, resume | Synthetic discovery run against a stub/fake source (no real crawl/LLM); Temporal history persisted at `.dev/temporal/temporal.db` | Start a synthetic run → kill the worker **by captured PID** → restart worker → `/runs` + Temporal UI show the same run resuming | Durable Temporal execution resumes an in-flight run from workflow history after a worker crash (`TR-008`) | C | none (durability shipped) — but requires a live worker + Temporal to record |
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -52,8 +52,8 @@ and frontend plans were renamed from working titles (`ddd-target-plan.md`,
 | 2026-06-22 | [Swap LaTeX For HTML/CSS Resume Rendering](implemented/2026-06-22-swap-latex-for-html-css.md) | Implemented — #188, #210, #211, #220; ADR 2026-06-24 |
 | 2026-07-03 | [Temporal-Native Rearchitecture](implemented/2026-07-03-temporal-native-rearchitecture.md) | Implemented — #230 (plan), #233, #231, #235, #238, #237, #239, #240; ADRs 2026-07-03 |
 | 2026-07-03 | [Temporal Rearchitecture — Implementation Spec (P1b–P5)](implemented/2026-07-03-temporal-rearch-implementation-spec.md) | Implemented — spec #232 |
-| 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](implemented/2026-07-03-oss-release-remediation-spec.md) | Closed by #274 inventory; **not release-ready** — W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints remain open |
-| 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](implemented/2026-07-05-oss-release-drive-to-done-plan.md) | Closed by #274 inventory; **no-go** — remaining items are W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints |
+| 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](implemented/2026-07-03-oss-release-remediation-spec.md) | Closed by #274 inventory; **not release-ready** — W1.2–W1.7, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints remain open; W1.8 dry-run-by-default was withdrawn by owner decision |
+| 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](implemented/2026-07-05-oss-release-drive-to-done-plan.md) | Closed by #274 inventory; **no-go** — remaining items are W1.2–W1.7, W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints; W1.8 dry-run-by-default was withdrawn by owner decision |
 
 Two 2026-05-17 backlog specs (`…-add-react`, `…-add-brows`) were drafted on
 `origin/mestre/develop-*` branches and never merged to `main`; only `…-add-root`

--- a/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
@@ -2,10 +2,15 @@
 
 > **Status (2026-07-05 R1 closeout):** archived after #274 regenerated the
 > inventory against current `main`. This is **not** a release-ready outcome:
-> W1.2–W1.8, W2.2 doctor notices, W2.4, W2.6, and owner rename/release
+> W1.2–W1.7, W2.2 doctor notices, W2.4, W2.6, and owner rename/release
 > checkpoints remain open. The document is preserved as the historical work-item
 > definition source; do not treat the move to `implemented/` as proof that the
 > OSS release gate passed.
+>
+> **Owner decision (2026-07-06):** the W1.8 dry-run-by-default requirement is
+> withdrawn. `jobhunter apply` and workflow/RPC apply starts keep the existing
+> non-dry-run default unless the caller passes `--dry-run` / `dryRun: true`.
+> W1.8 is no longer a release requirement, gate, or acceptance criterion.
 >
 > **Audience:** an external implementing agent (Codex). This document is
 > self-contained and prescriptive: follow it literally. Where it says STOP,
@@ -57,7 +62,6 @@ means: start now, from `main`, in parallel with the temporal run.
 | W0.1–W0.6 | none | Only W0.2's fixture-data swaps touch files P2/P3/P4 also edit — data-only, trivial rebase. |
 | W1.1, W1.2, W1.3→W1.5→W1.6, W1.7 | temporal **P2** | Same files AND same semantics: they extend P2's gate/guard/intent/`needs_verification` substrate. |
 | W1.4 | temporal **P2** (soft — see note) | Semantically independent of P2; only file contention (`packages/contracts`, adapter result parse, apply-review UI). |
-| W1.8 | temporal **P5** | `cli.py` and `pipeline/actions.py` are P5-owned; P5 itself rewrites/deletes the legacy path W1.8 targets. |
 | W2.1, W2.2 (docs), W2.5 | none | Disjoint. (P5 also edits `README.md`/`docs/**` — different sections, trivial.) |
 | W2.3 | PR **#233** (P0) | Same `server.ts`; P2 later touches other regions of it (trivial contention). |
 | W2.4 | temporal **P5** | P5 SHIPS the base spend system (`llm_spend`, `dailyBudgetUsd`, `check_spend_budget` preflight, dual-client recording). W2.4 is a delta on it — see the rewritten §W2.4. |
@@ -74,7 +78,7 @@ now         ──► W0.1→W0.2→W0.5→W0.3→W0.4→W0.6   (first: privacy 
             ──► W2.1, W2.2(docs), W2.5            (fully parallel)
 #233 merged ──► W2.3
 P2 merged   ──► W1.1→W1.2→W1.3→W1.4→W1.5→W1.6→W1.7  (stacked; do NOT wait for P4/P5)
-P5 merged   ──► W1.8, W2.4, W2.6, W2.2(doctor)
+P5 merged   ──► W2.4, W2.6, W2.2(doctor)
 all merged  ──► §5 release flip
 ```
 
@@ -83,19 +87,16 @@ all merged  ──► §5 release flip
   files; the residual contention (P5 adds `dailyBudgetUsd` to
   `packages/contracts` and the settings form) is a trivial rebase for the
   temporal stack as W1 items land on `main`.
-- The critical path to the release flip runs through P5 only via the
-  `cli.py`-owned items (W1.8, W2.6, doctor warnings) and W2.4. If P5
-  stalls, the owner may approve pulling W1.8's CLI default flip forward
-  at the cost of a P5 rebase — owner call (§0.5), not a default.
+- The critical path to the release flip runs through P5 only via W2.4, W2.6,
+  and doctor warnings.
 - **If the entire PR #232 program is already delivered**, every gate is
   satisfied and nothing else changes: W0 first (the privacy CI gate is
-  still wanted under every later PR), then W1.1→W1.8 as one stacked
+  still wanted under every later PR), then W1.1→W1.7 as one stacked
   series with W2 fully parallel, then §5. Optional intra-W1 parallelism
   in that world: lane {W1.1→W1.2→W1.7} (claim/review/recovery) alongside
   lane {W1.3→W1.4→W1.5→W1.6} (adapter/prompt/owned tools), converging on
-  W1.8 — but both lanes touch `launcher.py`/`claude_code_cli.py` in
-  different functions, so prefer the single stacked series unless two
-  implementers actively coordinate.
+  W1.7. Prefer the single stacked series unless two implementers actively
+  coordinate.
 - W2.1 (naming) can start any time; its publish re-enable step is last.
 
 ### 0.2 Non-negotiable ground rules
@@ -420,7 +421,7 @@ line stating dispositions are complete.
 
 ---
 
-## 3. Workstream W1 — Apply and runtime safety (gated on temporal P2; W1.8 alone on P5)
+## 3. Workstream W1 — Apply and runtime safety (gated on temporal P2)
 
 ### W1.0 Substrate check (run before W1.1; STOP if any is missing)
 
@@ -741,7 +742,7 @@ Work items:
    screening questions") — do not block claims on it; the run-time
    failure path is the enforcement.
 6. Flip the W0.3 attestation tripwire from warning to strict for this
-   file once merged (see W0.3 item 8 / W1.8 item 4).
+   file once merged (see W0.3 item 8).
 
 Tests: prompt builder with full/partial/empty attestations; adapter parses
 the new failure reason; UI blocker fixture; `doctor` warning unit test.
@@ -897,47 +898,18 @@ actionable error; UI preview fixture.
 - [ ] All six test classes above pass.
 - [ ] Full sweep (§0.3) passes, including `pnpm qa:test`.
 
-### W1.8 — Fail-closed surface defaults
+### W1.8 — Withdrawn: dry-run-by-default surface defaults
 
-**Objective:** every entry point defaults to dry-run; the only live
-switch is explicit, and the claim gate (P2 + W1.1) remains the real
-enforcement behind it.
+**Owner decision (2026-07-06):** this item is removed from the release plan.
+Do not implement, verify, or gate on dry-run-by-default behavior. Bare
+`jobhunter apply` remains a live/non-dry-run apply path unless the caller passes
+`--dry-run`; RPC/workflow apply starts keep the same default unless the caller
+passes `dryRun: true`.
 
-**Branch:** `feat/w1-8-fail-closed-defaults` ·
-**PR title:** `feat(apply): dry-run-by-default surfaces and legacy live-path deletion`
-
-Work items:
-1. `jobhunter apply` (`workers/automation/src/jobhunter/cli.py`, command
-   ~:892): `dry_run` currently defaults `False` — a bare `jobhunter
-   apply` is a LIVE run today. Flip: default dry-run; add `--submit`
-   (mutually exclusive with `--dry-run`) for live mode. Startup banner
-   states the mode and that live submission additionally requires the
-   recorded approval gate. (This item runs after temporal P5, which owns
-   `cli.py` — verify P5 is merged in your base.)
-2. RPC `apply_action`
-   (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`
-   ~:499–507): `params.get("dryRun", False)` fails open — flip the
-   default to `True` and log when the caller omitted the param. (The TS
-   mapper already defaults true; this makes the Python side match.)
-3. Delete the legacy synchronous action path that hardcodes
-   `dry_run=False` (`workers/automation/src/jobhunter/actions.py` ~:196)
-   after grep-verifying all callers route through RPC/Temporal. If a
-   caller still uses it, STOP and report instead of keeping both paths.
-   Note: temporal P5 rewrites `run_local_action` to start workflows and
-   deletes the in-process execution branches — P5 may already have
-   removed this path. In that case this item reduces to the grep check;
-   verify rather than re-delete.
-4. Flip all remaining W0.3 `--strict-prompt` tripwires to strict in the
-   privacy CI workflow (W1.4/W1.5/W1.6 are merged by now).
-5. `README.md` + `docs/local-reliability-qa.md`: document the new CLI
-   semantics and add the dry-run/live QA checklist entries.
-
-**Definition of Done**
-- [ ] Bare `jobhunter apply` performs a dry run (CLI test).
-- [ ] RPC default fail-closed (test).
-- [ ] Legacy path deleted; grep clean.
-- [ ] Privacy CI runs strict tripwires and is green.
-- [ ] Full sweep (§0.3) passes.
+The safety requirements that remain in force are W1.1-W1.7: approval binding,
+dry-run violation outcomes, apply-agent sandboxing, truthful attestations,
+credential handling, CAPTCHA fail-closed/owned-tool posture, and controlled
+email-application handling.
 
 ---
 
@@ -1113,7 +1085,7 @@ first tag. Assemble this checklist, with links, as the final deliverable.
       `docs/decisions.md` (2026-07-06); plan
       `docs/plans/2026-07-05-crawl-politeness-plan.md`. Check when the R10 train
       is merged to `main`.
-- [ ] W1.1–W1.8 merged, each with review gate `Gate: PASS` and QA gate
+- [ ] W1.1–W1.7 merged, each with review gate `Gate: PASS` and QA gate
       `Gate: PASS` per repo process.
 - [ ] W2.1 name chosen and live; `publish.yml` re-enabled and gated on the
       privacy workflow.

--- a/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
+++ b/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
@@ -1,10 +1,14 @@
 # OSS Release — Drive-to-Done and Completion Verification Plan
 
 > **Closeout status (2026-07-05 R1):** #274 executed this plan's inventory
-> method against current `main` and found **NO-GO**, not release-ready. W1.2–W1.8,
+> method against current `main` and found **NO-GO**, not release-ready. W1.2–W1.7,
 > W2.2 doctor notices, W2.4, W2.6, and owner rename/release checkpoints remain
 > open. This plan is archived as executed, not as proof that the release gate
 > passed.
+>
+> **Owner decision (2026-07-06):** the spec's former W1.8 dry-run-by-default
+> requirement is withdrawn. Non-dry-run remains the default unless callers pass
+> `--dry-run` / `dryRun: true`; W1.8 must not be counted as a release gate.
 >
 > **Anchors verified against main @ `a488e4e9853dde292badc74a88c7de24160edc52`.**
 > **Type:** thin drive-to-done overlay. It does not re-specify anything.
@@ -73,12 +77,12 @@ method — not the snapshot — is the deliverable; re-run §2 to refresh it.
 - **Temporal program P0–P5 merged** — PRs #233 (P0), #231 (P1a), #235 (P1b),
   #237 (P3), #238 (P2), #239 (P4), #240 (P5). **Consequence:** every W1/W2 gate
   in spec §0.1 is satisfied, so the spec's "entire PR #232 program already
-  delivered" branch is in force — W1.1→W1.8 may proceed as one stacked series
+  delivered" branch is in force — W1.1→W1.7 may proceed as one stacked series
   and W2 items are unblocked, subject to the spec's own DoD.
 
 **Not yet landed on `main`:**
 
-- **W1.1–W1.8:** not started (diagnostic anchors in §2.4 all in pre-W1 state).
+- **W1.1–W1.7:** not started (diagnostic anchors in §2.4 all in pre-W1 state).
 - **W2.1–W2.6:** not started, with two nuances — W2.2's disclosure docs are
   **partially** present (`docs/user/data-and-safety.md` already discloses live
   submission, CAPTCHA solving, credential handling, and the spend ceiling; the
@@ -142,13 +146,8 @@ evidence.
    boundary nor the `JOBHUNTER_API_ALLOW_REMOTE_BIND` escape hatch. Rule: probe
    the item's *distinctive* symbol (here `sec-fetch-site`), not a shared one.
 2. **Anchor drift (an anchor moved or was deleted by a later phase).** The spec's
-   line hints predate P4/P5. Confirmed example: W1.8 item 2 targets
-   `params.get("dryRun", False)` in the RPC `apply_action` handler, but P5
-   rewrote that handler to `return build_apply_workflow_spec(params)`
-   (`workers/automation/src/jobhunter/infrastructure/rpc/handlers.py`), so the
-   original anchor is gone. Rule: when a symbol is absent, follow the call chain
-   (here into `build_apply_workflow_spec`) before concluding "done"; re-locate by
-   symbol per spec §0.2.
+   line hints predate P4/P5. Rule: when a symbol is absent, follow the call
+   chain before concluding "done"; re-locate by symbol per spec §0.2.
 
 ### 2.4 Diagnostic anchors and current-state snapshot
 
@@ -171,7 +170,6 @@ to refresh. Full DoD lives in the spec; this table only classifies.
 | W1.5 | profile-password interpolation in `apply/prompt.py` | removed; owned `type_credential` | not-started | B interpolation present |
 | W1.6 | `_build_captcha_section` / `CAPSOLVER_API_KEY` in `apply/prompt.py` | owned `solve_captcha` tool | not-started | B present |
 | W1.7 | email-only send path / `EmailApplicationCandidateRecorded` | owned send + candidate event | not-started | B absent |
-| W1.8 | `def apply(... dry_run=Option(False ...))` in `cli.py`; strict tripwires in CI | dry-run default; `--submit`; strict CI | not-started | B default `False`, warnings-only |
 | W2.1 | `[project] name` in `workers/automation/pyproject.toml` | renamed distribution | not-started (owner decision in-flight #257) | B `jobhunter` |
 | W2.2 | `Responsible use` in `README.md`; `doctor` capability notices | docs + `doctor` warnings | landed-with-residual (docs largely present; `doctor` warnings pending) | B partial |
 | W2.3 | `sec-fetch-site` handling in `apps/api/src/server.ts`; boundary in `SECURITY.md` | header gate + docs | not-started | B absent (collision, §2.3) |
@@ -288,14 +286,12 @@ scripts. Each recipe defers to the item's spec DoD for the exhaustive clause lis
   carries a disposition (owner's private artifact) with sanitized entries in
   `docs/backlog.md`.
 - **W1 (enforced guarantees, not intentions).** The decisive, non-negotiable
-  proofs: bare `jobhunter apply` performs a dry run (W1.8 CLI test); the apply
-  agent's argv carries no `bypassPermissions` and an explicit `--allowedTools`
-  with the budget flag (W1.3 golden + parity tests); `apply/prompt.py` contains
+  proofs: the apply agent's argv carries no broad permission bypass and uses an
+  explicit `--allowedTools` allowlist (W1.3 golden + parity tests);
+  `apply/prompt.py` contains
   no fabricated screening block, no interpolated profile password, and no
-  CapSolver key or embedded REST/JS (W1.4/W1.5/W1.6) — **proven by promoting the
-  release_check tripwires to failures**: `python3 scripts/release_check.py
-  --strict-prompt` exits 0, and the privacy CI workflow runs `--strict-prompt`
-  (W1.8 item 4); the dry-run guard admits only GET/HEAD to every origin and
+  CapSolver key or embedded REST/JS (W1.4/W1.5/W1.6) — proven by the
+  release_check tripwires exiting cleanly; the dry-run guard admits only GET/HEAD to every origin and
   records blocked-channel evidence, and a synthetic `RESULT:APPLIED` under
   dry-run maps to `dry_run_violation`, not success (W1.2 adversarial fixtures);
   every new apply event lands in both registries with a web handler, fixture,
@@ -342,7 +338,7 @@ Assemble this, with links, as the final release deliverable.
 | --- | --- | --- | --- |
 | 1 | W0.1–W0.6 merged; `release-check` CI green on `main` since W0.4 | §2 shows W0.1–W0.6 = merged; `release-check` workflow green on every `main` commit since #246 | — |
 | 2 | Temporal P1b–P5 merged | §2 confirms #235, #237, #238, #239, #240 on `main` | — |
-| 3 | W1.1–W1.8 merged, each `Gate: PASS` review + QA | §2 = merged for all eight; §4.2 W1 proofs pass, incl. `--strict-prompt` green in CI | — |
+| 3 | W1.1–W1.7 merged, each `Gate: PASS` review + QA | §2 = merged for all seven; §4.2 W1 proofs pass | — |
 | 4 | Distribution name chosen and live; `publish.yml` re-enabled and gated | §4.2 W2.1 — **or** #257 deferral in force and rename train tracked as the owner action | **§0.5.1 — distribution-name decision (in-flight in #257)** |
 | 5 | W2.2, W2.3, W2.5 merged; W2.4 + W2.6 merged or owner-deferred in writing | §4.2 W2 proofs pass; any deferral recorded by the owner | **§0.5.2 — W2.4 per-lane defaults** |
 | 6 | W0.6 dispositions closed (fixed / backlogged-sanitized / owner-accepted) | Owner's private disposition artifact complete; sanitized entries in `docs/backlog.md` | **§0.5.3 — each accepted-risk entry** |
@@ -368,7 +364,7 @@ is not done while Blocker/High findings remain).
 - **Accepted-risk W0.6 concerns (spec §0.5.3).** Each acceptance is owner-only;
   no agent may self-accept. **Owner decision.**
 - **Anchor collision / drift.** Verified real on `main` (§2.3): W2.3's error
-  code exists for an unrelated gate; W1.8's `dryRun` anchor was erased by P5.
+  code exists for an unrelated gate.
   Mitigation: the method mandates probing an item's *distinctive* symbol and
   following call chains before concluding "done".
 - **Sibling-agent merge contention.** Multiple concurrent agents touch

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -93,14 +93,12 @@ These boundaries are the operator's responsibility:
   employer submission. JobHunter's shipped Gmail connector is read-only; do not
   add or grant Gmail `gmail.send` unless you intentionally want JobHunter to send
   application email from your mailbox.
-- **Credential typing:** browser automation can type credentials you put in your
-  profile, and those credentials may appear in the apply agent prompt when a
-  login form needs them. Use a unique, dedicated job-site password. Do not reuse
-  email, banking, work, or primary personal passwords.
-- **CAPTCHA solving:** CAPTCHA solving is disabled unless `CAPSOLVER_API_KEY` is
-  configured. If you configure it, CAPTCHA site keys and page URLs are sent to a
-  paid third-party service, and you are responsible for the site's terms,
-  authorization requirements, and legal risk.
+- **Credential typing:** browser automation can type non-secret profile fields.
+  Profile passwords are not inserted into the apply agent prompt; if a password
+  login is required, the apply agent stops for operator handling.
+- **CAPTCHA solving:** CAPTCHA challenges fail closed in the apply agent. It does
+  not solve image/audio challenges manually, switch to stealth browsers, or send
+  a CAPTCHA-provider key through the model prompt.
 - **Scraping and source terms:** source access can violate provider or site
   terms. Default discovery options include LinkedIn and Indeed; disable any
   source you are not allowed to query automatically.

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -33,11 +33,11 @@ run the step that needs them and have configured the relevant provider:
 | Outbound call | When it happens | What is sent |
 | --- | --- | --- |
 | LLM provider APIs | Scoring, employer analysis, resume tailoring, and cover-letter generation | Job posting text, your profile evidence (experience, skills, verified metrics), and the generated resume/cover-letter text. Employer analysis sends the posting text to a Claude, Codex, and Gemini ensemble. |
-| The apply agent's model | Only when you run apply or dry-run | The full apply prompt: your profile summary (contact details, work authorization, salary expectation, EEO answers), the tailored resume and cover-letter text, and — when you have configured them — an account password for login fields and the CapSolver API key. The apply agent is a local Claude runtime subprocess (system `claude` or the pinned SDK-bundled binary), so this prompt is sent to the model backing it. |
+| The apply agent's model | Only when you run apply or dry-run | The full apply prompt: your profile summary (contact details, work authorization, salary expectation, EEO answers) plus the tailored resume and cover-letter text. Profile passwords and CAPTCHA-provider keys are not included in the prompt. The apply agent is a local Claude runtime subprocess (system `claude` or the pinned SDK-bundled binary), so this prompt is sent to the model backing it. |
 | Job boards, ATS APIs, and posting pages | Discovery and enrichment | Search queries and page fetches. JobHunter never bypasses login, paywall, CAPTCHA, rate-limit, or bot-control gates (see [No Third-Party Bypass](#no-third-party-bypass)). |
 | Gmail (read-only) | Only if you authenticate the Gmail connector | Bounded search queries for verification codes and application-outcome emails. The connector requests read-only scope; raw email bodies stay local and are not copied into events, telemetry, broad projections, or logs. |
 | Google Maps | Only if you set `VITE_GOOGLE_MAPS_API_KEY` | Address text you type into the Profile form's location search. |
-| CAPTCHA solving service | Only if you set `CAPSOLVER_API_KEY` and run a live apply | CAPTCHA site keys and page URLs, so an authorized apply run can clear a challenge on a site you chose to apply to. |
+| CAPTCHA solving service | Not used by the apply agent until an owned solver tool ships | CAPTCHA challenges fail closed; no CAPTCHA-provider key is sent through the model prompt. |
 | Langfuse / OpenTelemetry | Only if you configure Langfuse credentials | LLM prompts and completions, workflow spans, and JSON-RPC spans. Export is off unless configured, and `LANGFUSE_DISABLE=1` opts out even when credentials are present. |
 
 The apply prompt is the largest single batch of personal data that leaves your
@@ -205,12 +205,10 @@ Different secrets live in different places, and it is worth knowing which:
   `~/.jobhunter/.env`. When stored in the Keychain they are never written to
   SQLite, logs, traces, or artifacts.
 - **The CapSolver key** is the `CAPSOLVER_API_KEY` environment variable
-  (`.env`), read only when you run a live apply.
-- **Account passwords for login autofill** are only used if you put them in your
-  profile. Unlike the LLM keys, a profile password is profile data, and — like
-  the CapSolver key — it is inserted into the apply agent's prompt when the
-  agent hits a login form (see [The Apply Agent](#the-apply-agent) below). Only
-  add a password to your profile if you accept that trade-off.
+  (`.env`). The apply agent no longer receives this key in its model prompt.
+- **Account passwords for login autofill** are profile data if you store them,
+  but the apply agent no longer receives profile passwords in its prompt. If a
+  password login is required, it stops for operator handling.
 
 JobHunter never commits any of these; the release gate scans for accidental
 secret commits (see the [developer Security page](../developer/security.md)).
@@ -220,9 +218,9 @@ secret commits (see the [developer Security page](../developer/security.md)).
 The apply agent is a local Claude runtime subprocess that drives a real Chrome
 browser through Playwright. It uses a system `claude` when present, then the
 pinned Claude Agent SDK bundled binary unless `JOBHUNTER_CLAUDE_BIN` is set. It
-runs with per-action permission prompts turned off
-(`--permission-mode bypassPermissions`) because it needs that autonomy to fill
-the arbitrary, unpredictable forms real applications use.
+runs with an explicit MCP tool allowlist for apply automation: browser form
+tools plus read-only Gmail verification-code tools, not shell/file access,
+Gmail write tools, raw page-script evaluation, or broad permission bypass.
 
 ::: warning Prompt injection is a real risk
 Because the agent reads live, untrusted job pages and acts on them, a malicious
@@ -244,9 +242,9 @@ Those controls:
   background, never to grant camera/mic/location permissions, and never to enter
   payment details.
 
-Keep targets narrow, review dry-run transcripts, and confirm the default
-attestations the prompt supplies (18+: yes, felony: no) match your actual
-situation before any live submission.
+Keep targets narrow and review dry-run transcripts before any live submission.
+If a required legal or screening attestation is missing from the profile, the
+agent stops instead of guessing.
 
 ## Scoring Is Applicant-Side Only
 

--- a/workers/automation/src/jobhunter/apply/prompt.py
+++ b/workers/automation/src/jobhunter/apply/prompt.py
@@ -75,14 +75,10 @@ def _build_profile_summary(profile: dict) -> str:
     # Availability
     lines.append(f"Available: {avail.get('earliest_start_date', 'Immediately')}")
 
-    # Standard responses
-    lines.extend([
-        "Age 18+: Yes",
-        "Background Check: Yes",
-        "Felony: No",
-        "Previously Worked Here: No",
-        "How Heard: Online Job Board",
-    ])
+    attestation_lines = _build_profile_attestation_lines(p)
+    if attestation_lines:
+        lines.append("Application Attestations:")
+        lines.extend(f"- {line}" for line in attestation_lines)
 
     # EEO
     lines.append(f"Gender: {eeo.get('gender', 'Decline to self-identify')}")
@@ -119,6 +115,45 @@ Read the job page. Determine the work arrangement. Then decide:
 - City is overseas (India, Philippines, Europe, etc.) with no remote option -> NOT ELIGIBLE. Output RESULT:FAILED:not_eligible_location
 - Cannot determine location -> Continue applying. If a screening question reveals it's non-local onsite, answer honestly and let the system reject if needed.
 Do NOT fill out forms for jobs that are clearly onsite in a non-acceptable location. Check EARLY, save time."""
+
+
+def _format_yes_no_unknown(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "Yes" if value else "No"
+    text = str(value).strip()
+    return text or None
+
+
+def _build_profile_attestation_lines(profile: dict) -> list[str]:
+    """Render legal/screening attestations only when the profile supplies them."""
+    attestations = profile.get("application_attestations") or {}
+    preferences = profile.get("application_preferences") or profile.get("preferences") or {}
+    lines: list[str] = []
+    known_fields = {
+        "age_18_plus": "Age 18+",
+        "background_check_consent": "Background check consent",
+        "felony_conviction": "Felony conviction",
+        "previously_worked_at_employer": "Previously worked at employer",
+    }
+    for key, label in known_fields.items():
+        value = _format_yes_no_unknown(attestations.get(key))
+        if value is not None:
+            lines.append(f"{label}: {value}")
+
+    additional = attestations.get("additional") or {}
+    if isinstance(additional, dict):
+        for key, raw_value in sorted(additional.items()):
+            value = _format_yes_no_unknown(raw_value)
+            if value is not None:
+                label = str(key).replace("_", " ").strip().capitalize()
+                lines.append(f"{label}: {value}")
+
+    how_heard = preferences.get("how_heard") or attestations.get("how_heard")
+    if how_heard:
+        lines.append(f"How heard: {how_heard}")
+    return lines
 
 
 def _build_salary_section(profile: dict) -> str:
@@ -178,6 +213,7 @@ Hard facts -> answer truthfully from the profile. No guessing. This includes:
   - Work authorization: {work_auth.get('legally_authorized_to_work', 'see profile')}
   - Citizenship, clearance, licenses, certifications: answer from profile only
   - Criminal/background: answer from profile only
+  - Age, felony/criminal-history, background-check consent, and prior-employer attestations: answer only when the APPLICANT PROFILE has an explicit Application Attestations value. If required and missing, output RESULT:FAILED:missing_attestation.
 
 Skills and tools -> be confident. This candidate is a {target_role} with {years} years experience. If the question asks "Do you have experience with [tool]?" and it's in the same domain (DevOps, backend, ML, cloud, automation), answer YES. Software engineers learn tools fast. Don't sell short.
 
@@ -211,217 +247,25 @@ def _build_hard_rules(profile: dict) -> str:
     return f"""== HARD RULES (never break these) ==
 1. Never lie about: citizenship, work authorization, criminal history, education credentials, security clearance, licenses.
 2. {work_auth_rule}
-3. {name_rule}"""
+3. {name_rule}
+4. Never invent legal attestations. If a required legal/screening question is not answered by the profile, stop with RESULT:FAILED:missing_attestation."""
 
 
 def _build_captcha_section() -> str:
     """Build the CAPTCHA detection and solving instructions.
 
-    Reads the CapSolver API key from environment. The CAPTCHA section
-    contains no personal data -- it's the same for every user.
+    The model must never receive CAPTCHA provider secrets or call third-party
+    CAPTCHA APIs directly. Until an owned CAPTCHA tool exists, CAPTCHA paths
+    fail closed for manual/operator handling.
     """
-    config.load_env()
-    capsolver_key = os.environ.get("CAPSOLVER_API_KEY", "")
+    return """== CAPTCHA ==
+Do not solve CAPTCHAs manually. Do not click through image/audio challenges, switch to stealth browsers, or call third-party CAPTCHA APIs from the page or model context.
 
-    if not capsolver_key:
-        return """== CAPTCHA ==
-CapSolver is not configured. Do not attempt to solve CAPTCHAs manually, do not click through image/audio challenges, and do not switch to stealth or anti-detection browsers.
-
---- CAPTCHA DETECT ---
-After navigation, Apply/Submit/Login clicks, or when a page appears blocked, inspect the page for hCaptcha, reCAPTCHA, Turnstile, FunCaptcha, Cloudflare checks, image/audio challenges, or any "prove you are human" gate.
+After navigation, Apply/Submit/Login clicks, or when a page appears blocked, inspect the page and visible text for hCaptcha, reCAPTCHA, Turnstile, FunCaptcha, Cloudflare checks, image/audio challenges, or any "prove you are human" gate.
 
 Result actions:
 - No CAPTCHA -> continue normally.
 - Any CAPTCHA or bot-check challenge -> output RESULT:CAPTCHA and stop."""
-
-    return f"""== CAPTCHA ==
-You solve CAPTCHAs via the CapSolver REST API. No browser extension. You control the entire flow.
-API key: {capsolver_key or 'NOT CONFIGURED — skip to MANUAL FALLBACK for all CAPTCHAs'}
-API base: https://api.capsolver.com
-
-CRITICAL RULE: When ANY CAPTCHA appears (hCaptcha, reCAPTCHA, Turnstile -- regardless of what it looks like visually), you MUST:
-1. Run CAPTCHA DETECT to get the type and sitekey
-2. Run CAPTCHA SOLVE (createTask -> poll -> inject) with the CapSolver API
-3. ONLY go to MANUAL FALLBACK if CapSolver returns errorId > 0
-Do NOT skip the API call based on what the CAPTCHA looks like. CapSolver solves CAPTCHAs server-side -- it does NOT need to see or interact with images, puzzles, or games. Even "drag the pipe" or "click all traffic lights" hCaptchas are solved via API token, not visually. ALWAYS try the API first.
-
---- CAPTCHA DETECT ---
-Run this browser_evaluate after every navigation, Apply/Submit/Login click, or when a page feels stuck.
-IMPORTANT: Detection order matters. hCaptcha elements also have data-sitekey, so check hCaptcha BEFORE reCAPTCHA.
-
-browser_evaluate function: () => {{{{
-  const r = {{}};
-  const url = window.location.href;
-  // 1. hCaptcha (check FIRST -- hCaptcha uses data-sitekey too)
-  const hc = document.querySelector('.h-captcha, [data-hcaptcha-sitekey]');
-  if (hc) {{{{
-    r.type = 'hcaptcha'; r.sitekey = hc.dataset.sitekey || hc.dataset.hcaptchaSitekey;
-  }}}}
-  if (!r.type && document.querySelector('script[src*="hcaptcha.com"], iframe[src*="hcaptcha.com"]')) {{{{
-    const el = document.querySelector('[data-sitekey]');
-    if (el) {{{{ r.type = 'hcaptcha'; r.sitekey = el.dataset.sitekey; }}}}
-  }}}}
-  // 2. Cloudflare Turnstile
-  if (!r.type) {{{{
-    const cf = document.querySelector('.cf-turnstile, [data-turnstile-sitekey]');
-    if (cf) {{{{
-      r.type = 'turnstile'; r.sitekey = cf.dataset.sitekey || cf.dataset.turnstileSitekey;
-      if (cf.dataset.action) r.action = cf.dataset.action;
-      if (cf.dataset.cdata) r.cdata = cf.dataset.cdata;
-    }}}}
-  }}}}
-  if (!r.type && document.querySelector('script[src*="challenges.cloudflare.com"]')) {{{{
-    r.type = 'turnstile_script_only'; r.note = 'Wait 3s and re-detect.';
-  }}}}
-  // 3. reCAPTCHA v3 (invisible, loaded via render= param)
-  if (!r.type) {{{{
-    const s = document.querySelector('script[src*="recaptcha"][src*="render="]');
-    if (s) {{{{
-      const m = s.src.match(/render=([^&]+)/);
-      if (m && m[1] !== 'explicit') {{{{ r.type = 'recaptchav3'; r.sitekey = m[1]; }}}}
-    }}}}
-  }}}}
-  // 4. reCAPTCHA v2 (checkbox or invisible)
-  if (!r.type) {{{{
-    const rc = document.querySelector('.g-recaptcha');
-    if (rc) {{{{ r.type = 'recaptchav2'; r.sitekey = rc.dataset.sitekey; }}}}
-  }}}}
-  if (!r.type && document.querySelector('script[src*="recaptcha"]')) {{{{
-    const el = document.querySelector('[data-sitekey]');
-    if (el) {{{{ r.type = 'recaptchav2'; r.sitekey = el.dataset.sitekey; }}}}
-  }}}}
-  // 5. FunCaptcha (Arkose Labs)
-  if (!r.type) {{{{
-    const fc = document.querySelector('#FunCaptcha, [data-pkey], .funcaptcha');
-    if (fc) {{{{ r.type = 'funcaptcha'; r.sitekey = fc.dataset.pkey; }}}}
-  }}}}
-  if (!r.type && document.querySelector('script[src*="arkoselabs"], script[src*="funcaptcha"]')) {{{{
-    const el = document.querySelector('[data-pkey]');
-    if (el) {{{{ r.type = 'funcaptcha'; r.sitekey = el.dataset.pkey; }}}}
-  }}}}
-  if (r.type) {{{{ r.url = url; return r; }}}}
-  return null;
-}}}}
-
-Result actions:
-- null -> no CAPTCHA. Continue normally.
-- "turnstile_script_only" -> browser_wait_for time: 3, re-run detect.
-- Any other type -> proceed to CAPTCHA SOLVE below.
-
---- CAPTCHA SOLVE ---
-Three steps: createTask -> poll -> inject. Do each as a separate browser_evaluate call.
-
-STEP 1 -- CREATE TASK (copy this exactly, fill in the 3 placeholders):
-browser_evaluate function: async () => {{{{
-  const r = await fetch('https://api.capsolver.com/createTask', {{{{
-    method: 'POST',
-    headers: {{{{'Content-Type': 'application/json'}}}},
-    body: JSON.stringify({{{{
-      clientKey: '{capsolver_key}',
-      task: {{{{
-        type: 'TASK_TYPE',
-        websiteURL: 'PAGE_URL',
-        websiteKey: 'SITE_KEY'
-      }}}}
-    }}}})
-  }}}});
-  return await r.json();
-}}}}
-
-TASK_TYPE values (use EXACTLY these strings):
-  hcaptcha     -> HCaptchaTaskProxyLess
-  recaptchav2  -> ReCaptchaV2TaskProxyLess
-  recaptchav3  -> ReCaptchaV3TaskProxyLess
-  turnstile    -> AntiTurnstileTaskProxyLess
-  funcaptcha   -> FunCaptchaTaskProxyLess
-
-PAGE_URL = the url from detect result. SITE_KEY = the sitekey from detect result.
-For recaptchav3: add "pageAction": "submit" to the task object (or the actual action found in page scripts).
-For turnstile: add "metadata": {{"action": "...", "cdata": "..."}} if those were in detect result.
-
-Response: {{"errorId": 0, "taskId": "abc123"}} on success.
-If errorId > 0 -> CAPTCHA SOLVE failed. Go to MANUAL FALLBACK.
-
-STEP 2 -- POLL (replace TASK_ID with the taskId from step 1):
-Loop: browser_wait_for time: 3, then run:
-browser_evaluate function: async () => {{{{
-  const r = await fetch('https://api.capsolver.com/getTaskResult', {{{{
-    method: 'POST',
-    headers: {{{{'Content-Type': 'application/json'}}}},
-    body: JSON.stringify({{{{
-      clientKey: '{capsolver_key}',
-      taskId: 'TASK_ID'
-    }}}})
-  }}}});
-  return await r.json();
-}}}}
-
-- status "processing" -> wait 3s, poll again. Max 10 polls (30s).
-- status "ready" -> extract token:
-    reCAPTCHA: solution.gRecaptchaResponse
-    hCaptcha:  solution.gRecaptchaResponse
-    Turnstile: solution.token
-- errorId > 0 or 30s timeout -> MANUAL FALLBACK.
-
-STEP 3 -- INJECT TOKEN (replace THE_TOKEN with actual token string):
-
-For reCAPTCHA v2/v3:
-browser_evaluate function: () => {{{{
-  const token = 'THE_TOKEN';
-  document.querySelectorAll('[name="g-recaptcha-response"]').forEach(el => {{{{ el.value = token; el.style.display = 'block'; }}}});
-  if (window.___grecaptcha_cfg) {{{{
-    const clients = window.___grecaptcha_cfg.clients;
-    for (const key in clients) {{{{
-      const walk = (obj, d) => {{{{
-        if (d > 4 || !obj) return;
-        for (const k in obj) {{{{
-          if (typeof obj[k] === 'function' && k.length < 3) try {{{{ obj[k](token); }}}} catch(e) {{{{}}}}
-          else if (typeof obj[k] === 'object') walk(obj[k], d+1);
-        }}}}
-      }}}};
-      walk(clients[key], 0);
-    }}}}
-  }}}}
-  return 'injected';
-}}}}
-
-For hCaptcha:
-browser_evaluate function: () => {{{{
-  const token = 'THE_TOKEN';
-  const ta = document.querySelector('[name="h-captcha-response"], textarea[name*="hcaptcha"]');
-  if (ta) ta.value = token;
-  document.querySelectorAll('iframe[data-hcaptcha-response]').forEach(f => f.setAttribute('data-hcaptcha-response', token));
-  const cb = document.querySelector('[data-hcaptcha-widget-id]');
-  if (cb && window.hcaptcha) try {{{{ window.hcaptcha.getResponse(cb.dataset.hcaptchaWidgetId); }}}} catch(e) {{{{}}}}
-  return 'injected';
-}}}}
-
-For Turnstile:
-browser_evaluate function: () => {{{{
-  const token = 'THE_TOKEN';
-  const inp = document.querySelector('[name="cf-turnstile-response"], input[name*="turnstile"]');
-  if (inp) inp.value = token;
-  if (window.turnstile) try {{{{ const w = document.querySelector('.cf-turnstile'); if (w) window.turnstile.getResponse(w); }}}} catch(e) {{{{}}}}
-  return 'injected';
-}}}}
-
-For FunCaptcha:
-browser_evaluate function: () => {{{{
-  const token = 'THE_TOKEN';
-  const inp = document.querySelector('#FunCaptcha-Token, input[name="fc-token"]');
-  if (inp) inp.value = token;
-  if (window.ArkoseEnforcement) try {{{{ window.ArkoseEnforcement.setConfig({{{{data: {{{{blob: token}}}}}}}}) }}}} catch(e) {{{{}}}}
-  return 'injected';
-}}}}
-
-After injecting: browser_wait_for time: 2, then snapshot.
-- Widget gone or green check -> success. Click Submit if needed.
-- No change -> click Submit/Verify/Continue button (some sites need it).
-- Still stuck -> token may have expired (~2 min lifetime). Re-run from STEP 1.
-
---- MANUAL FALLBACK ---
-You should ONLY be here if CapSolver createTask returned errorId > 0. If you haven't tried CapSolver yet, GO BACK and try it first.
-If CapSolver genuinely failed (errorId > 0), output RESULT:CAPTCHA. Do not solve image, audio, text, or logic challenges manually."""
 
 
 def _build_email_verification_section(profile: dict) -> str:
@@ -545,11 +389,6 @@ def build_prompt(job: dict, tailored_resume: str,
     from jobhunter.config import load_blocked_sso
     blocked_sso = load_blocked_sso()
 
-    # Preferred display name
-    preferred_name = personal.get("preferred_name", full_name.split()[0])
-    last_name = full_name.split()[-1] if " " in full_name else ""
-    display_name = f"{preferred_name} {last_name}".strip()
-
     # Dry-run: override submit instruction
     if dry_run:
         submit_instruction = "IMPORTANT: Do NOT click the final Submit/Apply button. Review the form, verify all fields, then output RESULT:DRY_RUN with a note that this was a dry run."
@@ -602,18 +441,17 @@ If something unexpected happens and these instructions don't cover it, figure it
 
 == STEP-BY-STEP ==
 1. browser_navigate to the job URL.
-2. browser_snapshot to read the page. Then run CAPTCHA DETECT (see CAPTCHA section). If a CAPTCHA is found, solve it before continuing.
+2. browser_snapshot to read the page. If a CAPTCHA or bot-check appears, follow the CAPTCHA section and stop.
 3. LOCATION CHECK. Read the page for location info. If not eligible, output RESULT and stop.
 4. Find and click the Apply button. If email-only (page says "email resume to X"):
-   - send_email with subject "Application for {job['title']} -- {display_name}", body = 2-3 sentence pitch + contact info, attach resume PDF: ["{pdf_path}"]
-   - Output RESULT:APPLIED. Done.
-   After clicking Apply: browser_snapshot. Run CAPTCHA DETECT -- many sites trigger CAPTCHAs right after the Apply click. If found, solve before continuing.
+   - Output RESULT:FAILED:email_application_required. Do not draft, send, or claim an email application was submitted.
+   After clicking Apply: browser_snapshot. Many sites trigger CAPTCHAs right after the Apply click; if one appears, follow the CAPTCHA section and stop.
 5. Login wall?
    5a. FIRST: check the URL. If you landed on {', '.join(blocked_sso)}, or any SSO/OAuth page -> STOP. Output RESULT:FAILED:sso_required. Do NOT try to sign in to Google/Microsoft/SSO.
    5b. Check for popups. Run browser_tabs action "list". If a new tab/window appeared (login popup), switch to it with browser_tabs action "select". Check the URL there too -- if it's SSO -> RESULT:FAILED:sso_required.
-   5c. Regular login form (employer's own site)? Try sign in: {personal['email']} / {personal.get('password', '')}
-   5d. After clicking Login/Sign-in: run CAPTCHA DETECT. Login pages frequently have invisible CAPTCHAs that silently block form submissions. If found, solve it then retry login.
-   5e. Sign in failed? Try sign up with same email and password.
+   5c. Regular login form (employer's own site)? You may enter the profile email address if requested, but do not enter or ask for a password. If a password is required, output RESULT:LOGIN_ISSUE and stop.
+   5d. After clicking Login/Sign-in: if a CAPTCHA appears, follow the CAPTCHA section and stop.
+   5e. Sign in failed? Output RESULT:LOGIN_ISSUE and stop.
    5f. Need email verification? Follow EMAIL VERIFICATION. Use search_emails + read_email to get the code. Do not open Gmail in the browser.
    5g. After login, run browser_tabs action "list" again. Switch back to the application tab if needed.
    5h. All failed? Output RESULT:FAILED:login_issue. Do not loop.
@@ -624,7 +462,7 @@ If something unexpected happens and these instructions don't cover it, figure it
    - Compare every other field to the APPLICANT PROFILE. Fix mismatches. Fill empty fields.
 9. Answer screening questions using the rules above.
 10. {submit_instruction}
-11. After submit: browser_snapshot. Run CAPTCHA DETECT -- submit buttons often trigger invisible CAPTCHAs. If found, solve it (the form will auto-submit once the token clears, or you may need to click Submit again). Then check for new tabs (browser_tabs action: "list"). Switch to newest, close old. Snapshot to confirm submission. Look for "thank you" or "application received".
+11. After submit: browser_snapshot. Submit buttons often trigger invisible CAPTCHAs. If one appears, follow the CAPTCHA section and stop. Then check for new tabs (browser_tabs action: "list"). Switch to newest, close old. Snapshot to confirm submission. Look for "thank you" or "application received".
 12. Output your result.
 
 == RESULT CODES (output EXACTLY one) ==
@@ -642,7 +480,7 @@ RESULT:FAILED:reason -- any other failure (brief reason)
 - Multi-page forms (Workday, Taleo, iCIMS): snapshot each new page, fill all fields, click Next/Continue. Repeat until final review page.
 - Fill ALL fields in ONE browser_fill_form call. Not one at a time.
 - Keep your thinking SHORT. Don't repeat page structure back.
-- CAPTCHA AWARENESS: After any navigation, Apply/Submit/Login click, or when a page feels stuck -- run CAPTCHA DETECT (see CAPTCHA section). Invisible CAPTCHAs (Turnstile, reCAPTCHA v3) show NO visual widget but block form submissions silently. The detect script finds them even when invisible.
+- CAPTCHA AWARENESS: After any navigation, Apply/Submit/Login click, or when a page feels stuck, inspect for CAPTCHA/bot-check text or widgets and stop if present. Do not run custom JavaScript or third-party CAPTCHA APIs.
 
 == FORM TRICKS ==
 - Popup/new window opened? browser_tabs action "list" to see all tabs. browser_tabs action "select" with the tab index to switch. ALWAYS check for new tabs after clicking login/apply/sign-in buttons.

--- a/workers/automation/src/jobhunter/cli.py
+++ b/workers/automation/src/jobhunter/cli.py
@@ -1354,7 +1354,16 @@ def apply(
         console.print(
             f"  claude {model_args}-p "
             f"--mcp-config {mcp_path} "
-            f"--permission-mode bypassPermissions < {prompt_file}"
+            f"--allowedTools mcp__playwright__browser_navigate,"
+            f"mcp__playwright__browser_snapshot,"
+            f"mcp__playwright__browser_take_screenshot,"
+            f"mcp__playwright__browser_click,"
+            f"mcp__playwright__browser_fill_form,"
+            f"mcp__playwright__browser_file_upload,"
+            f"mcp__playwright__browser_tabs,"
+            f"mcp__playwright__browser_wait_for,"
+            f"mcp__gmail__search_emails,"
+            f"mcp__gmail__read_email < {prompt_file}"
         )
         return
 
@@ -2540,13 +2549,17 @@ def doctor() -> None:
             f"{gmail_note}; email verification will stop as login_issue",
         ))
 
-    # CapSolver (optional)
+    # CapSolver (optional; apply currently fails closed until an owned solver ships)
     capsolver = os.environ.get("CAPSOLVER_API_KEY")
     if capsolver:
-        results.append(("CapSolver API key", ok_mark, "CAPTCHA solving enabled"))
+        results.append((
+            "CapSolver API key",
+            "[dim]configured[/dim]",
+            "stored, but apply agent fails closed until owned CAPTCHA solving ships",
+        ))
     else:
         results.append(("CapSolver API key", "[dim]optional[/dim]",
-                        "Set CAPSOLVER_API_KEY in .env for CAPTCHA solving"))
+                        "not required; apply agent fails closed on CAPTCHA"))
 
     # Temporal dev server (workflow engine)
     from jobhunter.infrastructure.temporal import get_temporal_client

--- a/workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py
+++ b/workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py
@@ -42,18 +42,48 @@ from jobhunter.infrastructure.setup_probes import resolve_claude_apply_binary
 log = logging.getLogger(__name__)
 
 
-# Disallowed Gmail tools — kept identical to the legacy launcher list
-# so the agent's permission posture doesn't regress.
-_DISALLOWED_TOOLS = (
-    "mcp__gmail__draft_email,mcp__gmail__modify_email,"
-    "mcp__gmail__delete_email,mcp__gmail__download_attachment,"
-    "mcp__gmail__batch_modify_emails,mcp__gmail__batch_delete_emails,"
-    "mcp__gmail__create_label,mcp__gmail__update_label,"
-    "mcp__gmail__delete_label,mcp__gmail__get_or_create_label,"
-    "mcp__gmail__list_email_labels,mcp__gmail__create_filter,"
-    "mcp__gmail__list_filters,mcp__gmail__get_filter,"
-    "mcp__gmail__delete_filter"
+# Apply runs get an explicit owned-tool allowlist rather than a broad
+# permission bypass plus a denylist. Keep this list aligned with the prompt:
+# no raw page-script evaluation, no Gmail write tools, and no shell/file tools.
+_ALLOWED_TOOLS = ",".join(
+    (
+        "mcp__playwright__browser_navigate",
+        "mcp__playwright__browser_snapshot",
+        "mcp__playwright__browser_take_screenshot",
+        "mcp__playwright__browser_click",
+        "mcp__playwright__browser_fill_form",
+        "mcp__playwright__browser_file_upload",
+        "mcp__playwright__browser_tabs",
+        "mcp__playwright__browser_wait_for",
+        "mcp__gmail__search_emails",
+        "mcp__gmail__read_email",
+    )
 )
+
+_ENV_ALLOWLIST = {
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_USE_BEDROCK",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLAUDE_CODE_USE_FOUNDRY",
+    "CLAUDE_CONFIG_DIR",
+    "GMAIL_MCP_CREDENTIALS_PATH",
+    "GMAIL_MCP_DIR",
+    "GMAIL_MCP_OAUTH_KEYS_PATH",
+    "HOME",
+    "JOBHUNTER_APP_DIR",
+    "JOBHUNTER_CLAUDE_BIN",
+    "JOBHUNTER_DB_PATH",
+    "PATH",
+    "PYTHONPATH",
+    "SHELL",
+    "SSL_CERT_FILE",
+    "USER",
+    "UV_PROJECT_ENVIRONMENT",
+    "VIRTUAL_ENV",
+}
+_ENV_PREFIX_ALLOWLIST = ("AWS_", "GOOGLE_", "JOBHUNTER_CRAWL_UA_")
 
 # Result codes the agent emits as ``RESULT:CODE`` lines.
 _RESULT_CODES = ("APPLIED", "DRY_RUN", "EXPIRED", "CAPTCHA", "LOGIN_ISSUE")
@@ -149,16 +179,13 @@ class ClaudeCodeCliAdapter:
         cmd.extend([
             "-p",
             "--mcp-config", str(mcp_config_path),
-            "--permission-mode", "bypassPermissions",
             "--no-session-persistence",
-            "--disallowedTools", _DISALLOWED_TOOLS,
+            "--allowedTools", _ALLOWED_TOOLS,
             "--output-format", "stream-json",
             "--verbose", "-",
         ])
 
-        env = os.environ.copy()
-        env.pop("CLAUDECODE", None)
-        env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+        env = _apply_subprocess_env()
 
         worker_log = self._log_dir / f"worker-{worker_id}.log"
         deadline_seconds = (
@@ -368,12 +395,10 @@ class ClaudeCodeCliAdapter:
             if f"RESULT:{code}" in output:
                 if code == "APPLIED":
                     if dry_run:
-                        # Defensive: a dry-run agent should emit
-                        # RESULT:DRY_RUN, but if it accidentally says
-                        # RESULT:APPLIED on a dry-run we MUST still
-                        # treat it as a dry-run completion (per §4.6
-                        # invariant: dry runs never mark applied).
-                        return DryRunComplete(navigated_to="")
+                        return Failed(
+                            error="dry_run_violation: agent reported applied during dry-run",
+                            retryable=False,
+                        )
                     return Applied(
                         applied_at=_utc_now(),
                         verification_confidence=_applied_confidence(output),
@@ -410,6 +435,19 @@ class ClaudeCodeCliAdapter:
             return Failed(error="unknown", retryable=True)
 
         return Failed(error="no_result_line", retryable=True)
+
+
+def _apply_subprocess_env() -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key in _ENV_ALLOWLIST or any(
+            key.startswith(prefix) for prefix in _ENV_PREFIX_ALLOWLIST
+        ):
+            env[key] = value
+    env.pop("CLAUDECODE", None)
+    env.pop("CLAUDE_CODE_ENTRYPOINT", None)
+    env.pop("CAPSOLVER_API_KEY", None)
+    return env
 
 
 def _applied_confidence(output: str) -> float:

--- a/workers/automation/src/jobhunter/wizard/init.py
+++ b/workers/automation/src/jobhunter/wizard/init.py
@@ -465,8 +465,11 @@ def _setup_auto_apply() -> None:
             "Run [bold]jobhunter setup[/bold] after dependency sync or set [bold]JOBHUNTER_CLAUDE_BIN[/bold]."
         )
 
-    # Optional: CapSolver for CAPTCHAs
-    console.print("\n[dim]Some job sites use CAPTCHAs. CapSolver can handle them automatically.[/dim]")
+    # Optional: retain a CapSolver key for future owned CAPTCHA tooling.
+    console.print(
+        "\n[dim]CAPTCHA challenges currently fail closed during apply runs. "
+        "You may still store a CapSolver key for future owned CAPTCHA tooling.[/dim]"
+    )
     if Confirm.ask("Configure CapSolver API key? (optional)", default=False):
         capsolver_key = Prompt.ask("CapSolver API key")
         # Append to existing .env or create
@@ -481,7 +484,7 @@ def _setup_auto_apply() -> None:
             ENV_PATH.write_text(f"# JobHunter configuration\nCAPSOLVER_API_KEY={capsolver_key}\n", encoding="utf-8")
         console.print("[green]CapSolver key saved.[/green]")
     else:
-        console.print("[dim]Skipped. Add CAPSOLVER_API_KEY to .env later if needed.[/dim]")
+        console.print("[dim]Skipped. CAPTCHA challenges will fail closed.[/dim]")
 
 
 # ---------------------------------------------------------------------------

--- a/workers/automation/tests/test_apply_prompt_builder.py
+++ b/workers/automation/tests/test_apply_prompt_builder.py
@@ -17,6 +17,7 @@ class _FakeSnapshot:
             "personal": {
                 "full_name": "Test Applicant",
                 "email": "test@example.com",
+                "password": "DistinctivePasswordShouldNeverRender",
                 "phone": "+1 555 0100",
                 "address": "",
                 "city": "Barcelona",
@@ -38,6 +39,10 @@ class _FakeSnapshot:
             },
             "availability": {"earliest_start_date": "Immediately"},
             "eeo_voluntary": {},
+            "application_attestations": {
+                "background_check_consent": True,
+            },
+            "application_preferences": {"how_heard": "Referral"},
         }
 
 
@@ -131,13 +136,57 @@ def test_legacy_prompt_copies_upload_files_into_worker_upload_dir(
     expected_upload = worker_dir / "Test_Applicant_Resume.pdf"
     assert expected_upload.exists()
     assert f"Resume PDF (upload this): {expected_upload}" in rendered
-    assert "Do not attempt to solve CAPTCHAs manually" in rendered
+    assert "Do not solve CAPTCHAs manually" in rendered
     assert "RESULT:CAPTCHA and stop" in rendered
     assert "== EMAIL VERIFICATION ==" in rendered
     assert "search_emails" in rendered
     assert "read_email" in rendered
     assert "Do not open Gmail in the browser" in rendered
     assert "RESULT:LOGIN_ISSUE" in rendered
+
+
+def test_legacy_prompt_keeps_apply_secrets_and_fake_capabilities_out_of_model_context(
+    monkeypatch, tmp_path
+):
+    worker_dir = tmp_path / "worker-0"
+    materials_dir = tmp_path / "materials"
+    materials_dir.mkdir()
+    resume_txt = materials_dir / "resume.txt"
+    resume_txt.write_text("Tailored resume", encoding="utf-8")
+    resume_pdf = materials_dir / "resume.pdf"
+    resume_pdf.write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setenv("CAPSOLVER_API_KEY", "capsolver-secret-never-render")
+    monkeypatch.setattr(prompt_mod.config, "load_env", lambda: None)
+    monkeypatch.setattr(
+        prompt_mod.config,
+        "gmail_mcp_auth_status",
+        lambda: (False, "missing OAuth client"),
+    )
+
+    rendered = prompt_mod.build_prompt(
+        job={
+            "url": "https://example.com/job",
+            "application_url": "https://example.com/apply",
+            "title": "Engineering Manager",
+            "site": "ExampleCo",
+            "fit_score": 9,
+            "tailored_resume_path": str(resume_txt),
+        },
+        tailored_resume="Tailored resume text",
+        snapshot=_FakeSnapshot(),
+        search_config={"location": {"accept_patterns": ["Barcelona"]}},
+        upload_dir=worker_dir,
+    )
+
+    assert "DistinctivePasswordShouldNeverRender" not in rendered
+    assert "capsolver-secret-never-render" not in rendered
+    assert "API key:" not in rendered
+    assert "browser_evaluate" not in rendered
+    assert "send_email" not in rendered
+    assert "email_application_required" in rendered
+    assert "Age 18+: Yes" not in rendered
+    assert "Felony: No" not in rendered
+    assert "Background check consent: Yes" in rendered
 
 
 def test_default_mcp_config_includes_gmail_read_connector() -> None:

--- a/workers/automation/tests/test_claude_code_cli_adapter.py
+++ b/workers/automation/tests/test_claude_code_cli_adapter.py
@@ -138,6 +138,44 @@ def test_explicit_model_is_forwarded_to_claude(monkeypatch, tmp_path) -> None:
     assert _FakePopen.calls[0][1:3] == ["--model", "opus"]
 
 
+def test_apply_adapter_uses_tool_allowlist_and_filtered_env(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    monkeypatch.setenv("CAPSOLVER_API_KEY", "capsolver-secret")
+    monkeypatch.setenv("UNRELATED_SECRET_TOKEN", "do-not-forward")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-key")
+    _FakePopen.calls.clear()
+    _FakePopen.kwargs.clear()
+
+    adapter = ClaudeCodeCliAdapter(
+        log_dir=tmp_path,
+        app_dir=tmp_path,
+        default_timeout_seconds=5,
+    )
+
+    result = adapter.submit_application(
+        prompt=ApplyPrompt(text="apply", mcp_config={}),
+        browser=_session(),
+        model="default",
+        dry_run=True,
+    )
+
+    cmd = _FakePopen.calls[0]
+    forwarded_env = _FakePopen.kwargs[0]["env"]
+    assert result.submission_result.kind == "dry_run_complete"
+    assert "--permission-mode" not in cmd
+    assert "bypassPermissions" not in cmd
+    assert "--disallowedTools" not in cmd
+    assert "--allowedTools" in cmd
+    allowed_tools = cmd[cmd.index("--allowedTools") + 1]
+    assert "mcp__playwright__browser_navigate" in allowed_tools
+    assert "mcp__gmail__search_emails" in allowed_tools
+    assert "browser_evaluate" not in allowed_tools
+    assert "gmail__draft_email" not in allowed_tools
+    assert forwarded_env["ANTHROPIC_API_KEY"] == "anthropic-key"
+    assert "CAPSOLVER_API_KEY" not in forwarded_env
+    assert "UNRELATED_SECRET_TOKEN" not in forwarded_env
+
+
 def test_adapter_records_llm_spend_from_sdk_usage(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("subprocess.Popen", _FakePopen)
     calls: list[dict[str, Any]] = []
@@ -166,6 +204,20 @@ def test_adapter_records_llm_spend_from_sdk_usage(monkeypatch, tmp_path) -> None
             "model": "opus",
         }
     ]
+
+
+def test_dry_run_applied_result_is_reported_as_violation(tmp_path) -> None:
+    adapter = ClaudeCodeCliAdapter(
+        log_dir=tmp_path,
+        app_dir=tmp_path,
+        default_timeout_seconds=5,
+    )
+
+    result = adapter._parse_result("RESULT:APPLIED\nconfirmation: submitted", dry_run=True)
+
+    assert result.kind == "failed"
+    assert result.retryable is False
+    assert "dry_run_violation" in result.error
 
 
 def test_claude_subprocess_starts_in_isolated_unix_session(


### PR DESCRIPTION
## Summary

- Fails closed instead of treating dry-run `RESULT:APPLIED` as `DryRunComplete`.
- Removes unsafe model-context paths from the apply prompt: hardcoded legal attestations, profile password interpolation, CapSolver key/API instructions, and fake `send_email` application submission.
- Replaces broad apply-agent permission bypass with an explicit MCP tool allowlist and a reduced subprocess environment.
- Updates user-facing safety/docs and doctor/setup copy to match the new fail-closed CAPTCHA and credential behavior.
- Leaves W1.8 unchanged by request: `--dry-run` remains an opt-in flag and live mode remains the non-dry-run default.
- Withdraws W1.8 dry-run-by-default from the release-plan docs and clarifies follow-on plan language as explicit dry-run mode/guard only.

## Validation

- `python3 -m compileall -q workers/automation/src/jobhunter/apply/prompt.py workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py workers/automation/src/jobhunter/cli.py workers/automation/src/jobhunter/wizard/init.py`
- `python3 scripts/release_check.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_prompt_builder.py workers/automation/tests/test_claude_code_cli_adapter.py workers/automation/tests/test_release_check.py`
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobhunter/apply/prompt.py workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py workers/automation/src/jobhunter/cli.py workers/automation/src/jobhunter/wizard/init.py workers/automation/tests/test_apply_prompt_builder.py workers/automation/tests/test_claude_code_cli_adapter.py workers/automation/tests/test_release_check.py`
- `corepack pnpm install`
- `corepack pnpm docs:build`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_*.py workers/automation/tests/test_claude_code_cli_adapter.py`
- `git diff --check`
- plan-doc stale-default scan for `W1.2-W1.8`, `W1.1-W1.8`, dry-run default wording, bare-apply dry-run wording, and `--submit`
- remote checks: Docs Site / Build (dead-link gate), Release Privacy Gate / Release check
