### PR TITLE
test(web): fix Node-20 apply-review saved-revision flake at its root

### DIFF
--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -1448,7 +1448,7 @@ describe("<ApplyReviewView>", () => {
 
     const shadow = await findResumeShadowRoot();
     expect(shadowText(shadow)).toContain("Restored human rewrite for incident response.");
-    expect(screen.getByText("saved revision 1")).toBeInTheDocument();
+    expect(await screen.findByText("saved revision 1")).toBeInTheDocument();
     expect(screen.queryByText("loading draft")).not.toBeInTheDocument();
     expect(createResumeReviewDraft).toHaveBeenCalled();
   });

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -1442,13 +1442,24 @@ describe("<ApplyReviewView>", () => {
         api: {
           applyReviewQueue: vi.fn(async () => sampleApplyReviewQueue),
           createResumeReviewDraft,
+          // The editor auto-seeds comment threads on mount; production returns the
+          // draft with its persisted latest revision, so echo the cached draft back.
+          // Without this the shared fetch mock returns a revision-less draft that
+          // clobbers the cached "saved revision 1" state under the query cache.
+          seedResumeReviewCommentThreads: vi.fn(async () => ({
+            ok: true as const,
+            draft,
+            commentThreads: draft.commentThreads,
+            seededCount: draft.commentThreads.length,
+            updatedCount: 0,
+          })),
         },
       }),
     });
 
     const shadow = await findResumeShadowRoot();
     expect(shadowText(shadow)).toContain("Restored human rewrite for incident response.");
-    expect(await screen.findByText("saved revision 1")).toBeInTheDocument();
+    expect(screen.getByText("saved revision 1")).toBeInTheDocument();
     expect(screen.queryByText("loading draft")).not.toBeInTheDocument();
     expect(createResumeReviewDraft).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Problem

The `apps/web` unit test `ApplyReviewView.test.tsx > "keeps the cached resume review draft visible while create/load is pending"` is flaky and Node-version-sensitive: it fails on CI (Node pinned to `20.19` in `.github/workflows/typescript.yml`) and passes on macOS/Node 22. Run in isolation under Node 20.19.6 it fails 6/6.

## Root cause (corrected diagnosis)

The failure is a **test-fixture fidelity bug**, not a Plate/normalization or timing bug.

On mount the resume editor auto-seeds comment threads (`onSeedCommentThreads` -> `useSeedResumeReviewCommentThreadsMutation`). This test seeded a `saved revision 1` draft into the query cache but did **not** stub `seedResumeReviewCommentThreads` in its ports. The mutation therefore fell through to the shared `fetch` mock, whose seed-threads route returns `makeResumeReviewDraft(..., null)` — a draft with **no `latestRevision`**. Its `onSuccess` (`apps/web/src/contexts/apply/hooks/useApplyReviewMutations.ts`) does `setQueryData(draftKey, { ok: true, draft: data.draft })`, overwriting the cached revision-1 draft with the revision-less one.

Result: the draft-status badge cascade in `ResumeAuditPins.tsx` falls past `` `saved revision ${n}` `` (because `latestRevision` is now null) to `"draft ready"`, so `"saved revision 1"` is never rendered. On Node 22 the badge is caught in the brief window before the seed round-trip resolves; on Node 20 the seed resolves first and the window never opens — hence the flake.

**Why this is a fixture bug, not production:** production's seed endpoint (`apps/api/src/resume-review-drafts.ts` `seedResumeReviewCommentThreads` -> `draftFromRow`) returns the draft *with* its persisted `latestRevision`. The shared mock was infidelious to that contract. Every other editor-rendering test in this file already overrides `seedResumeReviewCommentThreads` to echo the real draft back; this test was the lone anomaly missing it.

### On the earlier "unsaved changes / Plate normalization" theory
Probing showed `"unsaved changes"` only as a **transient** during mount, not the steady state. The fixture is already a Slate/Plate normalization fixed point (verified headless with `createSlateEditor` and `createPlateEditor` from `platejs` v53 + the resume plugins: `drifted: false`, `fixedpoint: true`). With the seed clobber removed, the badge reads `"saved revision 1"` the moment the editor mounts and stays there. So no product change to `ResumeAuditPins` is warranted, and the `initialDraftSignature`/`draftDirty` cascade is correct as written.

## Fix

- Add `seedResumeReviewCommentThreads` to the test's port overrides, echoing the cached revision-1 draft back (matching production behavior and the file's existing convention).
- Revert the `getByText` -> `findByText` band-aid from 7d00cfec: with the clobber gone the assertion is deterministic, so the synchronous `getByText` is correct again and better documents intent.

Test-only change; no product/behavior change, so no doc updates.

## Validation

- Target test, Node 20.19.6, 6 runs: **6/6 pass** (was 6/6 fail in isolation before the fix).
- Full `ApplyReviewView.test.tsx`, Node 20.19.6, 6 runs: **38/38 pass each**.
- Full web unit suite (`pnpm --filter @jobhunter/web test`), Node 22.21.1: **990/990 pass** (169 files).
- `pnpm check` (contracts/api-client/api/web/extension typechecks + Python ruff): **all checks passed**.