### PR TITLE
fix(apply): enforce dry-run browser boundary

### DIFF
--- a/workers/automation/src/jobhunter/apply/chrome.py
+++ b/workers/automation/src/jobhunter/apply/chrome.py
@@ -25,6 +25,8 @@ BASE_CDP_PORT = 9222
 # Track Chrome processes per worker for cleanup
 _chrome_procs: dict[int, subprocess.Popen] = {}
 _chrome_lock = threading.Lock()
+_dry_run_guards: dict[int, "_DryRunCdpGuard"] = {}
+_dry_run_guards_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -257,35 +259,127 @@ def launch_chrome(worker_id: int, port: int | None = None,
 _FORM_SUBMIT_GUARD_SOURCE = """
 (() => {
   window.__jobhunter_dryrun_installed = true;
-  const block = (event) => {
+  const bindingName = "jobhunterDryRunBlocked";
+  const absoluteUrl = (url) => {
+    try { return new URL(String(url || window.location.href), window.location.href).toString(); }
+    catch (_) { return String(url || window.location.href); }
+  };
+  const report = (details) => {
+    try {
+      const binding = window[bindingName];
+      if (typeof binding === "function") {
+        binding(JSON.stringify({
+          channel: details.channel || "dom",
+          method: details.method || "POST",
+          url: absoluteUrl(details.url),
+          resourceType: details.resourceType || "Document",
+        }));
+      }
+    } catch (_) {}
+  };
+  const block = (event, details) => {
     window.__jobhunter_dryrun_blocked = true;
+    report(details || {});
     if (event) {
       event.preventDefault();
       event.stopImmediatePropagation();
     }
-    throw new Error("JobHunter dry-run blocked browser form submission");
+    throw new Error("JobHunter dry-run blocked browser submission channel");
   };
   const originalSubmit = HTMLFormElement.prototype.submit;
   const originalRequestSubmit = HTMLFormElement.prototype.requestSubmit;
-  HTMLFormElement.prototype.submit = function submit() { return block(); };
-  HTMLFormElement.prototype.requestSubmit = function requestSubmit() { return block(); };
+  HTMLFormElement.prototype.submit = function submit() {
+    return block(null, {
+      channel: "form_submit",
+      method: (this.method || "POST").toUpperCase(),
+      url: this.action || window.location.href,
+      resourceType: "Document",
+    });
+  };
+  HTMLFormElement.prototype.requestSubmit = function requestSubmit() {
+    return block(null, {
+      channel: "form_request_submit",
+      method: (this.method || "POST").toUpperCase(),
+      url: this.action || window.location.href,
+      resourceType: "Document",
+    });
+  };
   Object.defineProperty(HTMLFormElement.prototype.submit, "name", { value: originalSubmit.name });
   Object.defineProperty(HTMLFormElement.prototype.requestSubmit, "name", { value: originalRequestSubmit.name });
-  document.addEventListener("submit", block, true);
+  document.addEventListener("submit", (event) => {
+    const form = event.target;
+    return block(event, {
+      channel: "form_submit",
+      method: ((form && form.method) || "POST").toUpperCase(),
+      url: (form && form.action) || window.location.href,
+      resourceType: "Document",
+    });
+  }, true);
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon = function sendBeacon(url, data) {
+      window.__jobhunter_dryrun_blocked = true;
+      report({
+        channel: "sendBeacon",
+        method: "POST",
+        url,
+        resourceType: "Ping",
+      });
+      return false;
+    };
+  }
+
+  if (window.WebSocket) {
+    const OriginalWebSocket = window.WebSocket;
+    function DryRunWebSocket(url, protocols) {
+      window.__jobhunter_dryrun_blocked = true;
+      report({
+        channel: "WebSocket",
+        method: "WEBSOCKET",
+        url,
+        resourceType: "WebSocket",
+      });
+      throw new Error("JobHunter dry-run blocked WebSocket creation");
+    }
+    DryRunWebSocket.prototype = OriginalWebSocket.prototype;
+    for (const key of ["CONNECTING", "OPEN", "CLOSING", "CLOSED"]) {
+      try { Object.defineProperty(DryRunWebSocket, key, { value: OriginalWebSocket[key] }); }
+      catch (_) {}
+    }
+    window.WebSocket = DryRunWebSocket;
+  }
 })();
 """
 
 
-def install_dry_run_cdp_guard(port: int) -> None:
+def install_dry_run_cdp_guard(port: int) -> "_DryRunCdpGuard":
     """Install a CDP dry-run guard on Chrome pages for this worker."""
     guard = _DryRunCdpGuard(port)
+    with _dry_run_guards_lock:
+        _dry_run_guards[int(port)] = guard
     guard.start()
+    return guard
+
+
+def get_dry_run_cdp_guard_evidence(port: int) -> dict[str, object]:
+    """Return sanitized dry-run guard evidence collected for ``port``."""
+    with _dry_run_guards_lock:
+        guard = _dry_run_guards.get(int(port))
+    if guard is None:
+        return {
+            "coverage": "full",
+            "blocked_channels": (),
+            "blocked_requests": (),
+        }
+    return guard.evidence()
 
 
 class _DryRunCdpGuard:
     def __init__(self, port: int) -> None:
         self._port = int(port)
         self._seen: set[str] = set()
+        self._blocked: list[dict[str, str]] = []
+        self._blocked_keys: set[tuple[str, str, str, str]] = set()
         self._lock = threading.Lock()
 
     def start(self) -> None:
@@ -316,11 +410,47 @@ class _DryRunCdpGuard:
                 self._seen.add(target_id)
             thread = threading.Thread(
                 target=_run_dry_run_page_session,
-                args=(ws_url,),
+                args=(ws_url, self),
                 name=f"apply-cdp-page-{target_id[:8]}",
                 daemon=True,
             )
             thread.start()
+
+    def record_blocked_request(
+        self,
+        *,
+        channel: str,
+        method: str,
+        url: str,
+        resource_type: str,
+    ) -> None:
+        request = {
+            "channel": (channel or "network")[:80],
+            "method": (method or "GET").upper()[:16],
+            "url": _sanitize_evidence_url(url),
+            "resource_type": (resource_type or "Other")[:80],
+        }
+        key = (
+            request["channel"],
+            request["method"],
+            request["url"],
+            request["resource_type"],
+        )
+        with self._lock:
+            if key in self._blocked_keys:
+                return
+            self._blocked_keys.add(key)
+            if len(self._blocked) < 100:
+                self._blocked.append(request)
+
+    def evidence(self) -> dict[str, object]:
+        with self._lock:
+            blocked = tuple(dict(item) for item in self._blocked)
+        return {
+            "coverage": _dry_run_coverage(blocked),
+            "blocked_channels": _dry_run_blocked_channels(blocked),
+            "blocked_requests": blocked,
+        }
 
 
 def _cdp_json(port: int, path: str) -> object:
@@ -332,7 +462,7 @@ def _cdp_json(port: int, path: str) -> object:
         return []
 
 
-def _run_dry_run_page_session(ws_url: str) -> None:
+def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
     try:
         import websocket
     except Exception:
@@ -352,7 +482,9 @@ def _run_dry_run_page_session(ws_url: str) -> None:
 
     try:
         send("Page.enable")
+        send("Network.enable")
         send("Runtime.enable")
+        send("Runtime.addBinding", {"name": "jobhunterDryRunBlocked"})
         send("Page.addScriptToEvaluateOnNewDocument", {"source": _FORM_SUBMIT_GUARD_SOURCE})
         send(
             "Fetch.enable",
@@ -372,14 +504,34 @@ def _run_dry_run_page_session(ws_url: str) -> None:
             except websocket.WebSocketTimeoutException:
                 continue
             message = json.loads(raw_message)
-            if message.get("method") != "Fetch.requestPaused":
+            method_name = message.get("method")
+            if method_name == "Runtime.bindingCalled":
+                _record_binding_call(message, guard)
+                continue
+            if method_name == "Network.webSocketCreated":
+                params = message.get("params") or {}
+                guard.record_blocked_request(
+                    channel="WebSocket",
+                    method="WEBSOCKET",
+                    url=str(params.get("url") or ""),
+                    resource_type="WebSocket",
+                )
+                continue
+            if method_name != "Fetch.requestPaused":
                 continue
             params = message.get("params") or {}
             request = params.get("request") or {}
             request_id = params.get("requestId")
             method = str(request.get("method") or "GET").upper()
             url = str(request.get("url") or "")
-            if request_id and method in {"POST", "PUT", "PATCH"} and not _is_local_url(url):
+            resource_type = str(params.get("resourceType") or "Other")
+            if request_id and _should_block_dry_run_request(method):
+                guard.record_blocked_request(
+                    channel="network",
+                    method=method,
+                    url=url,
+                    resource_type=resource_type,
+                )
                 send("Fetch.failRequest", {"requestId": request_id, "errorReason": "BlockedByClient"})
             elif request_id:
                 send("Fetch.continueRequest", {"requestId": request_id})
@@ -392,12 +544,58 @@ def _run_dry_run_page_session(ws_url: str) -> None:
             pass
 
 
-def _is_local_url(url: str) -> bool:
+def _record_binding_call(message: dict, guard: _DryRunCdpGuard) -> None:
+    params = message.get("params") or {}
+    if params.get("name") != "jobhunterDryRunBlocked":
+        return
     try:
-        host = (urlparse(url).hostname or "").lower()
+        payload = json.loads(str(params.get("payload") or "{}"))
+    except (TypeError, ValueError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    guard.record_blocked_request(
+        channel=str(payload.get("channel") or "dom"),
+        method=str(payload.get("method") or "POST"),
+        url=str(payload.get("url") or ""),
+        resource_type=str(payload.get("resourceType") or payload.get("resource_type") or "Document"),
+    )
+
+
+def _should_block_dry_run_request(method: str) -> bool:
+    return str(method or "GET").upper() not in {"GET", "HEAD"}
+
+
+def _sanitize_evidence_url(url: str) -> str:
+    try:
+        parsed = urlparse(str(url or ""))
     except Exception:
-        return False
-    return host in {"localhost", "127.0.0.1", "::1"} or host.endswith(".localhost")
+        return ""
+    if not parsed.scheme or not parsed.netloc:
+        return str(url or "").split("?", 1)[0].split("#", 1)[0][:500]
+    path = parsed.path or "/"
+    if len(path) > 200:
+        path = path[:200]
+    return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+
+def _dry_run_coverage(blocked: tuple[dict[str, str], ...]) -> str:
+    partial_resources = {"Document", "Fetch", "XHR", "WebSocket"}
+    partial_channels = {"form_submit", "form_request_submit", "WebSocket"}
+    for item in blocked:
+        if item.get("resource_type") in partial_resources:
+            return "partial"
+        if item.get("channel") in partial_channels:
+            return "partial"
+    return "full"
+
+
+def _dry_run_blocked_channels(blocked: tuple[dict[str, str], ...]) -> tuple[str, ...]:
+    channels = {
+        f"{item.get('channel') or 'network'}:{item.get('method') or 'GET'}"
+        for item in blocked
+    }
+    return tuple(sorted(channels))
 
 
 def cleanup_worker(worker_id: int, process: subprocess.Popen | None) -> None:

--- a/workers/automation/src/jobhunter/apply/launcher.py
+++ b/workers/automation/src/jobhunter/apply/launcher.py
@@ -1324,13 +1324,46 @@ def _persist_agent_artifacts(
     event_type: str,
     payload: dict[str, Any],
 ) -> None:
+    safe_run = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in run_id)
+    artifact_dir = config.LOG_DIR / "apply-artifacts"
+    if event_type == "DryRunBlockedChannels":
+        blocked_requests = payload.get("blocked_requests")
+        if not isinstance(blocked_requests, list) or not blocked_requests:
+            return
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        blocked_path = artifact_dir / f"{safe_run}-dry-run-blocked.json"
+        blocked_path.write_text(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "coverage": payload.get("coverage") or "partial",
+                    "blocked_channels": payload.get("blocked_channels") or [],
+                    "blocked_requests": blocked_requests,
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        record_job_artifact(
+            conn,
+            job_url,
+            "apply",
+            "apply_dryrun_blocked",
+            blocked_path,
+            status="active",
+            metadata={
+                "run_id": run_id,
+                "coverage": payload.get("coverage") or "partial",
+                "blocked_count": len(blocked_requests),
+            },
+        )
+        return
     if event_type != "AgentResult":
         return
     raw_output = str(payload.get("raw_output") or "")
     if not raw_output:
         return
-    safe_run = "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in run_id)
-    artifact_dir = config.LOG_DIR / "apply-artifacts"
     artifact_dir.mkdir(parents=True, exist_ok=True)
     output_path = artifact_dir / f"{safe_run}-agent-output.txt"
     output_path.write_text(raw_output, encoding="utf-8")

--- a/workers/automation/src/jobhunter/domain/apply/aggregate.py
+++ b/workers/automation/src/jobhunter/domain/apply/aggregate.py
@@ -434,6 +434,8 @@ def _result_to_dict(result: SubmissionResult) -> dict[str, Any]:
         payload["reason"] = result.reason
     elif isinstance(result, DryRunComplete):
         payload["navigated_to"] = result.navigated_to
+        payload["coverage"] = result.coverage
+        payload["blocked_channels"] = list(result.blocked_channels)
     elif isinstance(result, Expired):
         pass  # No additional fields.
     return payload
@@ -461,5 +463,14 @@ def submission_result_from_dict(data: Mapping[str, Any]) -> SubmissionResult:
     if kind == "manual":
         return Manual(reason=str(data.get("reason", "")))
     if kind == "dry_run_complete":
-        return DryRunComplete(navigated_to=str(data.get("navigated_to", "")))
+        blocked_channels = data.get("blocked_channels") or ()
+        if isinstance(blocked_channels, list):
+            blocked_channels = tuple(str(channel) for channel in blocked_channels)
+        elif not isinstance(blocked_channels, tuple):
+            blocked_channels = (str(blocked_channels),) if blocked_channels else ()
+        return DryRunComplete(
+            navigated_to=str(data.get("navigated_to", "")),
+            coverage=str(data.get("coverage") or "full"),
+            blocked_channels=blocked_channels,
+        )
     raise ValueError(f"Unknown SubmissionResult kind: {kind!r}")

--- a/workers/automation/src/jobhunter/domain/apply/process_manager.py
+++ b/workers/automation/src/jobhunter/domain/apply/process_manager.py
@@ -45,10 +45,13 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any, Mapping
+
 from jobhunter.domain.apply.aggregate import ApplyRun
 from jobhunter.domain.apply.value_objects import (
     ApplyPrompt,
     BrowserWorkerConfig,
+    DryRunComplete,
     Failed,
     SubmissionResult,
 )
@@ -137,6 +140,9 @@ class ApplySaga:
         prompt: ApplyPrompt,
         model: str,
         material_version: str = "",
+        materials_generation: int | str | None = None,
+        application_url: str | None = None,
+        profile_version: int | str | None = None,
     ) -> SagaOutcome:
         """Run the saga end-to-end.
 
@@ -299,20 +305,70 @@ class ApplySaga:
                 if agent_result.duration_ms is not None
                 else int((time.time() - start) * 1000)
             )
+            submission_result = agent_result.submission_result
+            dry_run_evidence = _empty_dry_run_evidence()
+            if run.dry_run and isinstance(submission_result, DryRunComplete):
+                dry_run_evidence = _collect_dry_run_evidence(session)
+                submission_result = DryRunComplete(
+                    navigated_to=submission_result.navigated_to,
+                    coverage=str(dry_run_evidence["coverage"]),
+                    blocked_channels=tuple(dry_run_evidence["blocked_channels"]),
+                )
             run = run.record_event(
                 event_type="AgentResult",
                 occurred_at=_utc_now(),
                 level="info",
-                message=f"agent returned {_describe_result(agent_result.submission_result)}",
+                message=f"agent returned {_describe_result(submission_result)}",
                 payload={
-                    "kind": agent_result.submission_result.kind,
+                    "kind": submission_result.kind,
                     "duration_ms": duration_ms,
                     "raw_output": agent_result.raw_output,
                 },
             )
+            if run.dry_run and isinstance(submission_result, DryRunComplete):
+                blocked_requests = tuple(dry_run_evidence["blocked_requests"])
+                if blocked_requests:
+                    run = run.record_event(
+                        event_type="DryRunBlockedChannels",
+                        occurred_at=_utc_now(),
+                        level="warn",
+                        message="dry-run guard blocked browser submission channels",
+                        payload={
+                            "coverage": submission_result.coverage,
+                            "blocked_channels": list(submission_result.blocked_channels),
+                            "blocked_requests": list(blocked_requests),
+                        },
+                    )
+                finished_at = _utc_now()
+                run = run.record_event(
+                    event_type="DryRunCompleted",
+                    occurred_at=finished_at,
+                    level="info",
+                    message="Dry run completed without submitting",
+                    payload={
+                        "run_id": str(run.run_id),
+                        "result": "dry_run_complete",
+                        "finished_at": finished_at,
+                        "duration_ms": duration_ms,
+                        "worker_id": run.worker_id,
+                        "model": model,
+                        "dry_run": True,
+                        "coverage": submission_result.coverage,
+                        "blocked_channels": list(submission_result.blocked_channels),
+                        "materials_generation": _coerce_optional_int(
+                            materials_generation
+                            if materials_generation is not None
+                            else material_version
+                        ),
+                        "application_url": application_url or str(run.job_id),
+                        "profile_version": _coerce_optional_int(profile_version),
+                    },
+                )
+            else:
+                finished_at = _utc_now()
             run = run.complete(
-                result=agent_result.submission_result,
-                finished_at=_utc_now(),
+                result=submission_result,
+                finished_at=finished_at,
                 token_usage=agent_result.token_usage,
                 duration_ms=duration_ms,
             )
@@ -367,6 +423,54 @@ class ApplySaga:
 def _describe_result(result: SubmissionResult) -> str:
     """Compact human-readable description of a submission result."""
     return result.kind
+
+
+def _empty_dry_run_evidence() -> dict[str, object]:
+    return {
+        "coverage": "full",
+        "blocked_channels": (),
+        "blocked_requests": (),
+    }
+
+
+def _collect_dry_run_evidence(session: BrowserSession | None) -> dict[str, object]:
+    if session is None or session.dry_run_evidence is None:
+        return _empty_dry_run_evidence()
+    try:
+        raw = dict(session.dry_run_evidence() or {})
+    except Exception:  # noqa: BLE001 — evidence must not turn a completed dry run into a crash
+        log.exception("ApplySaga: failed to collect dry-run guard evidence")
+        return _empty_dry_run_evidence()
+    return _normalise_dry_run_evidence(raw)
+
+
+def _normalise_dry_run_evidence(raw: Mapping[str, Any]) -> dict[str, object]:
+    coverage = str(raw.get("coverage") or "full")
+    if coverage not in {"full", "partial"}:
+        coverage = "partial"
+    raw_channels = raw.get("blocked_channels") or ()
+    if isinstance(raw_channels, str):
+        raw_channels = (raw_channels,)
+    blocked_channels = tuple(str(channel) for channel in raw_channels if str(channel).strip())
+    blocked_requests = tuple(
+        dict(item)
+        for item in (raw.get("blocked_requests") or ())
+        if isinstance(item, Mapping)
+    )
+    return {
+        "coverage": coverage,
+        "blocked_channels": blocked_channels,
+        "blocked_requests": blocked_requests,
+    }
+
+
+def _coerce_optional_int(value: int | str | None) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 __all__ = [

--- a/workers/automation/src/jobhunter/domain/apply/use_cases.py
+++ b/workers/automation/src/jobhunter/domain/apply/use_cases.py
@@ -234,6 +234,9 @@ class SubmitApplicationUseCase:
             prompt=prompt,
             model=model,
             material_version=str(job.get("materials_generation") or ""),
+            materials_generation=job.get("materials_generation"),
+            application_url=str(job.get("application_url") or job.get("url") or ""),
+            profile_version=getattr(snapshot, "version", None),
         )
 
         # 6. Publish per-event records + final result
@@ -343,9 +346,18 @@ def _result_payload(result: SubmissionResult) -> dict[str, Any]:
     if isinstance(result, Failed):
         return {"error": result.error, "retryable": result.retryable}
     payload: dict[str, Any] = {}
-    for attr in ("details", "reason", "navigated_to", "applied_at", "verification_confidence"):
+    for attr in (
+        "details",
+        "reason",
+        "navigated_to",
+        "coverage",
+        "blocked_channels",
+        "applied_at",
+        "verification_confidence",
+    ):
         if hasattr(result, attr):
-            payload[attr] = getattr(result, attr)
+            value = getattr(result, attr)
+            payload[attr] = list(value) if isinstance(value, tuple) else value
     return payload
 
 

--- a/workers/automation/src/jobhunter/domain/apply/value_objects.py
+++ b/workers/automation/src/jobhunter/domain/apply/value_objects.py
@@ -215,6 +215,23 @@ class DryRunComplete:
 
     kind: str = field(default="dry_run_complete", init=False)
     navigated_to: str = ""
+    coverage: str = "full"
+    blocked_channels: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.coverage not in {"full", "partial"}:
+            raise ValueError("DryRunComplete.coverage must be 'full' or 'partial'")
+        if isinstance(self.blocked_channels, str):
+            object.__setattr__(self, "blocked_channels", (self.blocked_channels,))
+        elif not isinstance(self.blocked_channels, tuple):
+            object.__setattr__(
+                self,
+                "blocked_channels",
+                tuple(str(channel) for channel in self.blocked_channels),
+            )
+        for channel in self.blocked_channels:
+            if not isinstance(channel, str):
+                raise ValueError("DryRunComplete.blocked_channels must contain strings")
 
 
 SubmissionResult = Union[

--- a/workers/automation/src/jobhunter/domain/ports/apply.py
+++ b/workers/automation/src/jobhunter/domain/ports/apply.py
@@ -14,7 +14,7 @@ needing to know.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Callable, Mapping, Protocol
 
 from jobhunter.domain.apply.aggregate import ApplyRun
 from jobhunter.domain.apply.value_objects import (
@@ -58,6 +58,7 @@ class BrowserSession:
     pid: int | None = None
     worker_dir: str | None = None
     handle: Any | None = None
+    dry_run_evidence: Callable[[], Mapping[str, Any]] | None = None
 
     @property
     def cdp_port(self) -> int:

--- a/workers/automation/src/jobhunter/infrastructure/apply/local_chrome.py
+++ b/workers/automation/src/jobhunter/infrastructure/apply/local_chrome.py
@@ -60,6 +60,11 @@ class LocalChromeAdapter:
             pid=proc.pid,
             worker_dir=str(worker_dir),
             handle=proc,
+            dry_run_evidence=(
+                lambda port=config.cdp_port: _chrome.get_dry_run_cdp_guard_evidence(port)
+            )
+            if config.dry_run
+            else None,
         )
 
     def cleanup(self, session: BrowserSession) -> None:

--- a/workers/automation/tests/test_apply_chrome_dry_run_guard.py
+++ b/workers/automation/tests/test_apply_chrome_dry_run_guard.py
@@ -16,9 +16,11 @@ from jobhunter.apply import chrome
 
 class _HostileEmployerHandler(BaseHTTPRequestHandler):
     posts: list[str] = []
+    deletes: list[str] = []
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib hook name
-        employer_origin = f"http://127.0.0.1.nip.io:{self.server.server_port}"
+        employer_origin = f"http://127.0.0.1:{self.server.server_port}"
+        websocket_origin = f"ws://127.0.0.1:{self.server.server_port}"
         body = f"""
         <!doctype html>
         <html>
@@ -28,6 +30,9 @@ class _HostileEmployerHandler(BaseHTTPRequestHandler):
             </form>
             <script>
               fetch("{employer_origin}/auto-submit", {{ method: "POST", body: "auto" }}).catch(() => {{}});
+              fetch("{employer_origin}/delete-submit", {{ method: "DELETE" }}).catch(() => {{}});
+              try {{ navigator.sendBeacon("{employer_origin}/beacon", "beacon"); }} catch (_) {{}}
+              try {{ new WebSocket("{websocket_origin}/socket"); }} catch (_) {{}}
               window.addEventListener("load", () => {{
                 setTimeout(() => {{
                   document.getElementById("application-form").requestSubmit();
@@ -48,6 +53,11 @@ class _HostileEmployerHandler(BaseHTTPRequestHandler):
         self.send_response(204)
         self.end_headers()
 
+    def do_DELETE(self) -> None:  # noqa: N802 - stdlib hook name
+        type(self).deletes.append(self.path)
+        self.send_response(204)
+        self.end_headers()
+
     def log_message(self, _format: str, *_args: object) -> None:
         return
 
@@ -59,6 +69,7 @@ def test_dry_run_cdp_guard_blocks_hostile_employer_posts(tmp_path, monkeypatch):
         pytest.skip(str(exc))
 
     _HostileEmployerHandler.posts = []
+    _HostileEmployerHandler.deletes = []
     server = ThreadingHTTPServer(("127.0.0.1", 0), _HostileEmployerHandler)
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
@@ -69,17 +80,6 @@ def test_dry_run_cdp_guard_blocks_hostile_employer_posts(tmp_path, monkeypatch):
         return profile
 
     monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
-    real_popen = chrome.subprocess.Popen
-
-    def popen_with_loopback_host_mapping(cmd, **kwargs):
-        mapped_cmd = [
-            *cmd,
-            "--host-resolver-rules=MAP 127.0.0.1.nip.io 127.0.0.1",
-            "--no-proxy-server",
-        ]
-        return real_popen(mapped_cmd, **kwargs)
-
-    monkeypatch.setattr(chrome.subprocess, "Popen", popen_with_loopback_host_mapping)
     try:
         dry_port = _free_port()
         dry_proc = chrome.launch_chrome(
@@ -98,6 +98,12 @@ def test_dry_run_cdp_guard_blocks_hostile_employer_posts(tmp_path, monkeypatch):
             time.sleep(1.0)
             assert blocked is True
             assert _HostileEmployerHandler.posts == []
+            assert _HostileEmployerHandler.deletes == []
+            evidence = chrome.get_dry_run_cdp_guard_evidence(dry_port)
+            channels = set(evidence["blocked_channels"])
+            assert evidence["coverage"] == "partial"
+            assert "network:POST" in channels
+            assert "network:DELETE" in channels
         finally:
             chrome.cleanup_worker(901, dry_proc)
 
@@ -114,14 +120,78 @@ def test_dry_run_cdp_guard_blocks_hostile_employer_posts(tmp_path, monkeypatch):
                 f"http://127.0.0.1:{server.server_port}/",
             )
             deadline = time.time() + 5
-            while not _HostileEmployerHandler.posts and time.time() < deadline:
+            while (
+                (not _HostileEmployerHandler.posts or not _HostileEmployerHandler.deletes)
+                and time.time() < deadline
+            ):
                 time.sleep(0.1)
             assert _HostileEmployerHandler.posts
+            assert _HostileEmployerHandler.deletes
         finally:
             chrome.cleanup_worker(902, live_proc)
     finally:
         server.shutdown()
         server.server_close()
+
+
+def test_dry_run_request_policy_blocks_all_mutating_methods():
+    assert chrome._should_block_dry_run_request("POST") is True
+    assert chrome._should_block_dry_run_request("PUT") is True
+    assert chrome._should_block_dry_run_request("PATCH") is True
+    assert chrome._should_block_dry_run_request("DELETE") is True
+    assert chrome._should_block_dry_run_request("OPTIONS") is True
+    assert chrome._should_block_dry_run_request("GET") is False
+    assert chrome._should_block_dry_run_request("HEAD") is False
+
+
+def test_dry_run_guard_evidence_records_sanitized_submission_channels():
+    guard = chrome._DryRunCdpGuard(port=1)
+    guard.record_blocked_request(
+        channel="network",
+        method="DELETE",
+        url="https://example.com/apply?token=secret#frag",
+        resource_type="Fetch",
+    )
+    guard.record_blocked_request(
+        channel="sendBeacon",
+        method="POST",
+        url="https://example.com/analytics?token=secret",
+        resource_type="Ping",
+    )
+    guard.record_blocked_request(
+        channel="WebSocket",
+        method="WEBSOCKET",
+        url="wss://example.com/socket?token=secret",
+        resource_type="WebSocket",
+    )
+
+    evidence = guard.evidence()
+    assert evidence["coverage"] == "partial"
+    assert evidence["blocked_channels"] == (
+        "WebSocket:WEBSOCKET",
+        "network:DELETE",
+        "sendBeacon:POST",
+    )
+    assert evidence["blocked_requests"] == (
+        {
+            "channel": "network",
+            "method": "DELETE",
+            "url": "https://example.com/apply",
+            "resource_type": "Fetch",
+        },
+        {
+            "channel": "sendBeacon",
+            "method": "POST",
+            "url": "https://example.com/analytics",
+            "resource_type": "Ping",
+        },
+        {
+            "channel": "WebSocket",
+            "method": "WEBSOCKET",
+            "url": "wss://example.com/socket",
+            "resource_type": "WebSocket",
+        },
+    )
 
 
 def _free_port() -> int:

--- a/workers/automation/tests/test_apply_log_artifact_registration.py
+++ b/workers/automation/tests/test_apply_log_artifact_registration.py
@@ -11,11 +11,15 @@ existing ``artifact_list_projections`` projector picks up.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from jobhunter import config
-from jobhunter.apply.launcher import mark_result
+from jobhunter.apply.launcher import SqliteApplyRunRepository, mark_result
 from jobhunter.database import close_connection, get_connection, init_db
+from jobhunter.domain.apply import ApplyRun, ApplyRunId, DryRunComplete
+from jobhunter.domain.identifiers import JobId
+from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.infrastructure.projections.projection_builder import ProjectionBuilder
 from jobhunter.state import ensure_job_stage_rows, set_stage_state
 
@@ -182,6 +186,90 @@ def test_mark_result_dry_run_registers_apply_log_artifact(
         ).fetchone()
         assert row is not None
         assert row["path"] == str(log_dir / "worker-0.log")
+    finally:
+        close_connection(db_path)
+
+
+def test_repository_persists_dry_run_blocked_channel_artifact(
+    tmp_path, monkeypatch
+):
+    """Blocked browser channels are durable local evidence for the dry-run gate."""
+    db_path = Path(tmp_path) / "jobs.db"
+    conn = init_db(db_path)
+    _insert_running_apply_job(conn)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+
+    try:
+        monkeypatch.setattr(
+            "jobhunter.apply.launcher.get_connection",
+            lambda: get_connection(db_path),
+        )
+        run = ApplyRun.start(
+            tenant_id=LOCAL_TENANT,
+            run_id=ApplyRunId("run-dry-blocked"),
+            job_id=JobId("https://example.com/job"),
+            started_at="2026-07-06T10:00:00+00:00",
+            worker_id=1,
+            model="haiku",
+            dry_run=True,
+        )
+        run = run.record_event(
+            event_type="DryRunBlockedChannels",
+            occurred_at="2026-07-06T10:00:01+00:00",
+            level="warn",
+            payload={
+                "coverage": "partial",
+                "blocked_channels": ["network:POST"],
+                "blocked_requests": [
+                    {
+                        "channel": "network",
+                        "method": "POST",
+                        "url": "https://example.com/apply",
+                        "resource_type": "Fetch",
+                    }
+                ],
+            },
+        )
+        run = run.complete(
+            result=DryRunComplete(
+                navigated_to="https://example.com/job",
+                coverage="partial",
+                blocked_channels=("network:POST",),
+            ),
+            finished_at="2026-07-06T10:00:02+00:00",
+        )
+
+        SqliteApplyRunRepository().save(run)
+
+        row = conn.execute(
+            "SELECT path, metadata_json FROM job_artifacts "
+            "WHERE job_url = ? AND artifact_type = 'apply_dryrun_blocked'",
+            ("https://example.com/job",),
+        ).fetchone()
+        assert row is not None
+        artifact_path = Path(row["path"])
+        assert artifact_path.exists()
+        assert json.loads(row["metadata_json"]) == {
+            "run_id": "run-dry-blocked",
+            "coverage": "partial",
+            "blocked_count": 1,
+        }
+        assert json.loads(artifact_path.read_text(encoding="utf-8")) == {
+            "run_id": "run-dry-blocked",
+            "coverage": "partial",
+            "blocked_channels": ["network:POST"],
+            "blocked_requests": [
+                {
+                    "channel": "network",
+                    "method": "POST",
+                    "url": "https://example.com/apply",
+                    "resource_type": "Fetch",
+                }
+            ],
+        }
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_apply_saga.py
+++ b/workers/automation/tests/test_apply_saga.py
@@ -52,16 +52,22 @@ class _InMemoryApplyRunRepository:
 
 
 class _FakeBrowser:
-    def __init__(self, *, raise_on_launch: bool = False):
+    def __init__(self, *, raise_on_launch: bool = False, dry_run_evidence=None):
         self.launches = 0
         self.cleanups = 0
         self.raise_on_launch = raise_on_launch
+        self.dry_run_evidence = dry_run_evidence
 
     def launch(self, config):
         self.launches += 1
         if self.raise_on_launch:
             raise RuntimeError("chrome failed to start")
-        return BrowserSession(config=config, pid=42, worker_dir="/tmp/w")
+        return BrowserSession(
+            config=config,
+            pid=42,
+            worker_dir="/tmp/w",
+            dry_run_evidence=self.dry_run_evidence,
+        )
 
     def cleanup(self, session):
         self.cleanups += 1
@@ -78,6 +84,12 @@ class _FakeAgent:
             raise TimeoutError("agent timed out")
         if self.behaviour == "crash":
             raise RuntimeError("agent crashed")
+        if self.behaviour == "dry_run_violation":
+            return AgentResult(
+                submission_result=Failed(error="dry_run_violation: RESULT:APPLIED", retryable=False),
+                duration_ms=1000,
+                raw_output="RESULT:APPLIED",
+            )
         if kwargs.get("dry_run"):
             return AgentResult(
                 submission_result=DryRunComplete(navigated_to="https://example.com/job"),
@@ -224,6 +236,111 @@ def test_dry_run_saga_does_not_record_submit_intent(repo):
         model="sonnet",
     )
     assert "ApplySubmitIntended" not in [event.event_type for event in outcome.apply_run.events]
+
+
+def test_dry_run_saga_records_guard_evidence_for_approval_gate(repo):
+    dry_run = ApplyRun.start(
+        tenant_id=LOCAL_TENANT,
+        run_id=new_apply_run_id(),
+        job_id=JobId("https://example.com/job"),
+        started_at="t0",
+        worker_id=1,
+        model="sonnet",
+        dry_run=True,
+    )
+    browser = _FakeBrowser(
+        dry_run_evidence=lambda: {
+            "coverage": "partial",
+            "blocked_channels": ("network:POST", "form_submit:POST"),
+            "blocked_requests": (
+                {
+                    "channel": "network",
+                    "method": "POST",
+                    "url": "https://example.com/apply",
+                    "resource_type": "Fetch",
+                },
+            ),
+        }
+    )
+    saga = ApplySaga(browser_port=browser, agent_port=_FakeAgent(), repository=repo)
+    outcome = saga.run(
+        apply_run=dry_run,
+        browser_config=_config(),
+        prompt=_prompt(),
+        model="sonnet",
+        material_version="12",
+        materials_generation=12,
+        application_url="https://example.com/job",
+        profile_version=3,
+    )
+
+    result = outcome.apply_run.submission_result
+    assert isinstance(result, DryRunComplete)
+    assert result.coverage == "partial"
+    assert result.blocked_channels == ("network:POST", "form_submit:POST")
+
+    dry_run_completed = next(
+        event for event in outcome.apply_run.events if event.event_type == "DryRunCompleted"
+    )
+    assert dry_run_completed.payload == {
+        "run_id": str(outcome.apply_run.run_id),
+        "result": "dry_run_complete",
+        "finished_at": dry_run_completed.payload["finished_at"],
+        "duration_ms": 1000,
+        "worker_id": 1,
+        "model": "sonnet",
+        "dry_run": True,
+        "coverage": "partial",
+        "blocked_channels": ["network:POST", "form_submit:POST"],
+        "materials_generation": 12,
+        "application_url": "https://example.com/job",
+        "profile_version": 3,
+    }
+    blocked = next(
+        event for event in outcome.apply_run.events if event.event_type == "DryRunBlockedChannels"
+    )
+    assert blocked.payload["blocked_requests"] == [
+        {
+            "channel": "network",
+            "method": "POST",
+            "url": "https://example.com/apply",
+            "resource_type": "Fetch",
+        }
+    ]
+
+
+def test_dry_run_violation_does_not_record_completion_evidence(repo):
+    dry_run = ApplyRun.start(
+        tenant_id=LOCAL_TENANT,
+        run_id=new_apply_run_id(),
+        job_id=JobId("https://example.com/job"),
+        started_at="t0",
+        worker_id=1,
+        model="sonnet",
+        dry_run=True,
+    )
+    saga = ApplySaga(
+        browser_port=_FakeBrowser(
+            dry_run_evidence=lambda: {
+                "coverage": "partial",
+                "blocked_channels": ("network:POST",),
+                "blocked_requests": (),
+            }
+        ),
+        agent_port=_FakeAgent(behaviour="dry_run_violation"),
+        repository=repo,
+    )
+    outcome = saga.run(
+        apply_run=dry_run,
+        browser_config=_config(),
+        prompt=_prompt(),
+        model="sonnet",
+    )
+
+    assert outcome.apply_run.is_failed
+    assert "DryRunCompleted" not in [
+        event.event_type for event in outcome.apply_run.events
+    ]
 
 
 def test_lifecycle_state_coverage_exercises_each_terminal_status(repo):


### PR DESCRIPTION
## Summary
- Block all non-GET/HEAD browser requests during apply dry-runs, including localhost targets, through the CDP guard.
- Add DOM guards for form submit/requestSubmit, sendBeacon, and WebSocket creation with sanitized blocked-channel evidence.
- Persist dry-run approval evidence only for real `DryRunComplete` results, plus a local `apply_dryrun_blocked` artifact when submission channels were blocked.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_saga.py workers/automation/tests/test_apply_chrome_dry_run_guard.py workers/automation/tests/test_apply_log_artifact_registration.py` -> 18 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_use_cases.py workers/automation/tests/test_apply_run_aggregate.py workers/automation/tests/test_apply_runs_projection_from_events.py workers/automation/tests/test_claude_code_cli_adapter.py` -> 44 passed
- `uv --project workers/automation run --extra dev pytest -q` -> 1967 passed, 1 warning
- `uv --project workers/automation run --extra dev ruff check .` -> passed
- `git diff --check` -> passed

## Train Notes
- Stack car: W1.2 dry-run enforcement evidence.
- Full cross-stack gate is still pending for the completed train.