### PR TITLE
docs(plans): record 2026-07-06 owner decision resolutions (R3, R7, R8)

### DIFF
--- a/docs/plans/2026-07-05-browser-extension-plan.md
+++ b/docs/plans/2026-07-05-browser-extension-plan.md
@@ -378,15 +378,26 @@ Beyond §0.3:
 
 ## 13. Open owner decisions
 
+All nine decisions were resolved by the owner on 2026-07-06:
+
 - **D-1 (P0):** Exact token model — header name, storage location under `~/.jobhunter/`, pairing UX (Settings copy vs. localhost pairing page), and whether a valid token relaxes the mutation-origin gate (recommended: yes, with loopback `Host` still required).
+  - **Resolved (2026-07-06):** recommended defaults accepted — token under `~/.jobhunter/` with restrictive permissions, one-time pairing via the Settings surface, `Authorization: Bearer <token>`; a valid token satisfies the trusted-mutation-source requirement while the loopback `Host` gate remains mandatory.
 - **D-2 (P0):** Do existing unauthenticated loopback API reads stay open, or does the owner want auth required for all non-web clients? (Recommended: keep additive; extension routes require token; web app unchanged.)
+  - **Resolved (2026-07-06):** keep additive. Extension routes require the token; existing unauthenticated loopback reads and the web app are unchanged.
 - **D-3 (P1):** Extension provenance fields and source-id scheme (recommended `source_id = manual_capture:extension`, provenance `capture_client="browser_extension"` + version) and whether to add a `browser_extension_capture` manual-action reason.
+  - **Resolved (2026-07-06):** recommended defaults accepted (`source_id = manual_capture:extension`, `capture_client="browser_extension"` + version, new `browser_extension_capture` manual-action reason).
 - **D-4 (P2):** Starting ATS family set and rollout order among Workday/Greenhouse/Lever/Ashby.
+  - **Resolved (2026-07-06):** all four families (Greenhouse, Lever, Workday, Ashby) ship in the first P2a release. The content-script host allowlist is exactly these ATS domains.
 - **D-5 (P0/P1):** Offline capture queue retention policy (size/age limits, clear-on-pair-change).
+  - **Resolved (2026-07-06):** recommended defaults accepted — bounded size + age caps, queue cleared on pair change.
 - **D-6 (P3):** Go/no-go to begin Phase 3 once §6.1 is satisfied.
+  - **Resolved (2026-07-06):** Phase 3 (R11) stays **closed until an explicit owner go**, even after §6.1's technical preconditions (P1–P2 shipped + QA'd, W1 apply hardening merged) are satisfied. The owner is the third lock; the decision brief in the R1 close-out inventory is the input for that future call. No agent may start R11 work without the explicit go.
 - **D-7 (§9):** Distribution channel (self-distributed signed package vs. public store) and signing key ownership.
+  - **Resolved (2026-07-06):** self-distributed signed package for v1; a Chrome Web Store listing is a post-launch follow-up. Signing key owned by the owner.
 - **D-8 (§3):** Target browser/engine for v1 (single MV3 target vs. more).
+  - **Resolved (2026-07-06):** single Chromium MV3 target for v1; Firefox later.
 - **D-9 (P2b):** Whether to ship LLM-assisted free-text drafts at all, or keep Phase 2 deterministic-only for v1.
+  - **Resolved (2026-07-06):** deterministic **values** with LLM-assisted **field matching**. Fill values come only from actual profile data (source-attributed, never generated). When deterministic label matching fails, an LLM may map the form label to an existing profile field (e.g. "Birth name" → the profile's "Maiden name" fact). The LLM never authors fill content — it only resolves label synonyms; unmatched fields stay empty and are visibly flagged. Free-text answer drafting (P2b as originally scoped) stays deferred.
 
 ## 14. Requirements traceability
 

--- a/docs/plans/2026-07-05-launch-readiness-artifacts-plan.md
+++ b/docs/plans/2026-07-05-launch-readiness-artifacts-plan.md
@@ -515,6 +515,12 @@ Notes:
    specific rows, the external approaches that become the columns, the cadence
    interval, and the final sidebar label stay owner-supplied (kept private until
    facts-verified) and do not block merging this plan or the R7a train.
+
+   → **RESOLVED 2026-07-06 (owner).** Delegated draft: the maintainer agent
+   derives the neutral capability rows and the anonymized external-approach
+   columns, verifies every cell against live sources, and the owner approves
+   the result before it is committed. Maintenance cadence: quarterly
+   re-verification. Sidebar label stays "How It Compares".
 4. **Demo-asset launch set** — which assets ship in the initial launch vs are
    deferred until their capability merges: asset 7's live blocked-channel
    evidence (OSS spec W1.1/W1.2) and asset 8's spend-ceiling stop (OSS spec
@@ -531,6 +537,11 @@ Notes:
    fixture, not the capability. Asset 8's health-surface capture and assets 1–2
    are deferred launch-set follow-ups. Confirming the initial launch set remains
    OWNER-PENDING.
+
+   → **RESOLVED 2026-07-06 (owner).** Ship what's ready: launch proceeds with
+   the assets already captured or scripted; assets 1–2, 7-evidence, and
+   8-spend-stop remain deferred post-launch follow-ups exactly as the
+   inventory records them. Launch is not blocked on producing the full set.
 5. **Reliability-demo format** — asset 9 as a scripted e2e artifact vs a
    synthetic screen recording vs a documented walkthrough, and where the
    artifact lives (must be synthetic and privacy-safe; recordings are binary).
@@ -553,12 +564,31 @@ Notes:
    carries into a high-stakes interview. CL-029 is already listed as a §11.6
    reclassification candidate. The threshold itself and this specific verdict
    await the owner's bar-setting.
+
+   → **RESOLVED 2026-07-06 (owner).** Bar set: any brand-new LLM-generated
+   user-facing surface without real-usage validation is labeled `Beta` in
+   public copy even when its truthfulness gates pass — the gates guarantee a
+   no-fabrication floor, not output quality. Verdict: **CL-029 reclassifies to
+   `Beta`** (apply in the next ledger currency pass). Additional owner rule
+   recorded the same day: **synthetic data may illustrate, never measure** —
+   screenshots/GIFs may use clearly-captioned fictional data, but no
+   performance, speed, or outcome number in public copy may ever be derived
+   from synthetic data (see the R2 plan's TTFV amendment).
 7. **Sign-off owners** — who owns the claim-freeze sign-off and each Phase C
    publish step.
 
    → **OWNER-PENDING 2026-07-06.** Unresolved by implementation — an owner
    decision. The claims-freeze stays PROVISIONAL until the owner signs off, and
    the owner of each Phase C publish step is still to be named.
+
+   → **RESOLVED 2026-07-06 (owner).** The owner is the single sign-off holder
+   for the claims freeze and executes every Phase C publish step (repository
+   visibility flip, DNS, git tag, PyPI upload). The freeze converts from
+   PROVISIONAL to signed only after a mandatory guided review in which the
+   maintainer agent walks the owner through every ledger claim and its
+   evidence anchor. Follow-up recorded: re-enable the "Python CI" GitHub
+   workflow (currently disabled to conserve Actions minutes) before the
+   repository goes public.
 
 ## 12. Risks and mitigations
 

--- a/docs/plans/2026-07-05-saved-views-daily-digest-plan.md
+++ b/docs/plans/2026-07-05-saved-views-daily-digest-plan.md
@@ -615,22 +615,38 @@ pnpm test
 
 ## Open owner decisions
 
+All seven decisions were resolved by the owner on 2026-07-06:
+
 1. **Saved-views persistence tier** — client-only (this plan) vs server-side
    for cross-device/shareable views (promotion via `StoragePort`/a new
    aggregate). Ties to the hosted "share a jobs filter view" fitness function.
+   - **Resolved (2026-07-06):** client-only. Views persist in the local
+     Zustand store; server-side promotion remains a future hosted seam.
 2. **Digest acknowledge mechanism** — `DigestReviewed` domain event
    (architecturally consistent, realtime, +1 parity-tested event) vs direct
    `digest_state` write + invalidation (lighter).
+   - **Resolved (2026-07-06):** `DigestReviewed` domain event through the
+     standard event/projection/SSE machinery, parity-tested like every other
+     event.
 3. **Review-needed materials scope** — apply-review-queue signal only (this
    plan) vs a new global aggregate over `resume_review_drafts`.
+   - **Resolved (2026-07-06):** apply-review-queue signal only, as planned.
 4. **Follow-ups-due model** — derived heuristic (this plan) vs a first-class
    user reminder aggregate with due dates + snooze.
+   - **Resolved (2026-07-06):** derived heuristic, as planned. No new reminder
+     aggregate. (Outreach follow-ups are a separate, already-decided R6
+     surface.)
 5. **Follow-up threshold + day boundary** — the N-days value for "follow-ups
    due" and the canonical day boundary (local vs UTC) for the digest.
+   - **Resolved (2026-07-06):** N = 7 days; day boundary = the operator's
+     local timezone. The heuristic caveat is displayed alongside the number.
 6. **Scheduled digest** — keep on-demand only (this plan) vs an opt-in,
    default-off Temporal schedule mirroring discovery.
+   - **Resolved (2026-07-06):** on-demand only. No schedule, not even opt-in,
+     in this workstream.
 7. **Optional additive Jobs search params** — `stale=only` and/or
    `discoveredSince` as first-class URL filters to make digest deep-links exact.
+   - **Resolved (2026-07-06):** add both as first-class URL filters.
 
 ## Phasing (suggested, non-binding)
 


### PR DESCRIPTION
## What

Records the owner's 2026-07-06 decision-round resolutions inside the three owning plan documents, in the same Resolved-inline format the other plans use:

- **R3 browser extension (§13):** D-1..D-9 all resolved — recommended token/auth defaults (D-1/D-2/D-3/D-5), all four ATS families in the first P2a release (D-4), R11/Phase-3 closed until an explicit owner go on top of the technical gates (D-6), self-distributed Chrome MV3 package for v1 (D-7/D-8), and deterministic fill values with LLM-assisted label-synonym matching only — the LLM never authors content (D-9).
- **R7 launch readiness (§11):** items 3, 4, 6, 7 resolved — agent-drafted owner-approved comparison page with quarterly cadence; ship-what's-ready demo-asset launch set; Current-vs-Beta bar set with CL-029→Beta (ledger edit rides the next currency pass); owner as single sign-off holder with a mandatory guided claims review; the new 'synthetic may illustrate, never measure' rule; Python CI re-enable recorded as a pre-publication follow-up.
- **R8 saved views + digest:** all seven decisions resolved (client-only views, DigestReviewed event, apply-review-queue scope, derived follow-up heuristic at N=7/local-time, on-demand only, both additive URL filters).

## Why

The owner cleared the full open-decision backlog in one review round so implementation can proceed without decision latency. Plans are the canonical decision record.

## How validated

Docs-only. `pnpm docs:build` link gate covered by CI's existing docs job; no behavior changes.