### PR TITLE
fix(reliability): harden legacy migration and route prefetch

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -72,30 +72,92 @@ export function tableExists(db: SqliteDatabase, tableName: string): boolean {
 
 const legacyProductToken = "job" + "hunter";
 
+type JobLifecycleTableSpec = {
+  suffix: "deleted_jobs" | "hidden_jobs";
+  currentTable: string;
+  createSql: string;
+  additiveColumns: Array<{ name: string; definition: string }>;
+};
+
+const jobLifecycleTableSpecs: JobLifecycleTableSpec[] = [
+  {
+    suffix: "deleted_jobs",
+    currentTable: "jobctl_deleted_jobs",
+    createSql: `CREATE TABLE IF NOT EXISTS jobctl_deleted_jobs (
+      job_url TEXT PRIMARY KEY,
+      deleted_at TEXT NOT NULL,
+      reason TEXT,
+      restored_at TEXT
+    )`,
+    additiveColumns: [
+      { name: "deleted_at", definition: "TEXT NOT NULL DEFAULT ''" },
+      { name: "reason", definition: "TEXT" },
+      { name: "restored_at", definition: "TEXT" },
+    ],
+  },
+  {
+    suffix: "hidden_jobs",
+    currentTable: "jobctl_hidden_jobs",
+    createSql: `CREATE TABLE IF NOT EXISTS jobctl_hidden_jobs (
+      job_url TEXT PRIMARY KEY,
+      hidden_at TEXT NOT NULL,
+      reason TEXT,
+      unhidden_at TEXT
+    )`,
+    additiveColumns: [
+      { name: "hidden_at", definition: "TEXT NOT NULL DEFAULT ''" },
+      { name: "reason", definition: "TEXT" },
+      { name: "unhidden_at", definition: "TEXT" },
+    ],
+  },
+];
+
 export function migrateLegacyJobTables(db: SqliteDatabase): string[] {
   const migrated: string[] = [];
-  for (const suffix of ["deleted_jobs", "hidden_jobs"]) {
+  for (const spec of jobLifecycleTableSpecs) {
+    const suffix = spec.suffix;
     const legacyTable = `${legacyProductToken}_${suffix}`;
-    const currentTable = `jobctl_${suffix}`;
-    if (!tableExists(db, legacyTable)) continue;
+    const currentTable = spec.currentTable;
+    const legacyExists = tableExists(db, legacyTable);
+    const currentExists = tableExists(db, currentTable);
+    if (!legacyExists && !currentExists) continue;
 
-    if (!tableExists(db, currentTable)) {
-      db.prepare(`ALTER TABLE ${legacyTable} RENAME TO ${currentTable}`).run();
-      migrated.push(currentTable);
+    const legacyColumns = legacyExists ? tableColumns(db, legacyTable) : [];
+    if (legacyExists) {
+      const knownColumns = new Set(["job_url", ...spec.additiveColumns.map((column) => column.name)]);
+      const commonColumns = legacyColumns.filter((column) => knownColumns.has(column));
+      if (commonColumns.length === 0) {
+        throw new Error(`Cannot migrate legacy table ${legacyTable}: no shared columns with ${currentTable}`);
+      }
+    }
+
+    ensureJobLifecycleTableSchema(db, spec);
+    if (!legacyExists) {
       continue;
     }
 
     const currentColumns = tableColumns(db, currentTable);
-    const commonColumns = tableColumns(db, legacyTable).filter((column) => currentColumns.includes(column));
-    if (commonColumns.length === 0) {
-      throw new Error(`Cannot migrate legacy table ${legacyTable}: no shared columns with ${currentTable}`);
-    }
+    const commonColumns = legacyColumns.filter((column) => currentColumns.includes(column));
     const columns = commonColumns.map(quoteIdentifier).join(", ");
-    db.prepare(`INSERT OR IGNORE INTO ${currentTable} (${columns}) SELECT ${columns} FROM ${legacyTable}`).run();
-    db.prepare(`DROP TABLE ${legacyTable}`).run();
+    db.prepare(
+      `INSERT OR IGNORE INTO ${quoteIdentifier(currentTable)} (${columns}) SELECT ${columns} FROM ${quoteIdentifier(legacyTable)}`,
+    ).run();
+    db.prepare(`DROP TABLE ${quoteIdentifier(legacyTable)}`).run();
     migrated.push(currentTable);
   }
   return migrated;
+}
+
+function ensureJobLifecycleTableSchema(db: SqliteDatabase, spec: JobLifecycleTableSpec): void {
+  db.prepare(spec.createSql).run();
+  const existingColumns = new Set(tableColumns(db, spec.currentTable));
+  for (const column of spec.additiveColumns) {
+    if (existingColumns.has(column.name)) continue;
+    db.prepare(
+      `ALTER TABLE ${quoteIdentifier(spec.currentTable)} ADD COLUMN ${quoteIdentifier(column.name)} ${column.definition}`,
+    ).run();
+    existingColumns.add(column.name);
+  }
 }
 
 function tableColumns(db: SqliteDatabase, tableName: string): string[] {

--- a/apps/api/test/schema-version-guard.test.ts
+++ b/apps/api/test/schema-version-guard.test.ts
@@ -26,6 +26,11 @@ function legacyToken(): string {
   return "job" + "hunter";
 }
 
+function tableColumns(db: Database.Database, tableName: string): string[] {
+  const quotedTable = `"${tableName.replaceAll('"', '""')}"`;
+  return db.prepare(`PRAGMA table_info(${quotedTable})`).all().map((row) => String((row as { name: unknown }).name));
+}
+
 describe("schema version guard at DB open", () => {
   it("refuses a database whose user_version is newer than the API supports", () => {
     const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION + 1);
@@ -81,21 +86,19 @@ describe("legacy tombstone table migration", () => {
         CREATE TABLE ${token}_deleted_jobs (
           job_url TEXT PRIMARY KEY,
           deleted_at TEXT NOT NULL,
-          reason TEXT,
-          restored_at TEXT
+          reason TEXT
         );
         INSERT INTO ${token}_deleted_jobs
-          (job_url, deleted_at, reason, restored_at)
-        VALUES ('https://example.test/deleted', '2026-07-07T00:00:00Z', 'test', NULL);
+          (job_url, deleted_at, reason)
+        VALUES ('https://example.test/deleted', '2026-07-07T00:00:00Z', 'test');
         CREATE TABLE ${token}_hidden_jobs (
-          tenant_id TEXT NOT NULL DEFAULT 'local',
-          job_url TEXT NOT NULL,
+          job_url TEXT PRIMARY KEY,
           hidden_at TEXT NOT NULL,
-          unhidden_at TEXT
+          reason TEXT
         );
         INSERT INTO ${token}_hidden_jobs
-          (tenant_id, job_url, hidden_at, unhidden_at)
-        VALUES ('local', 'https://example.test/hidden', '2026-07-07T00:00:00Z', NULL);
+          (job_url, hidden_at, reason)
+        VALUES ('https://example.test/hidden', '2026-07-07T00:00:00Z', 'test');
       `);
       seed.close();
 
@@ -107,6 +110,10 @@ describe("legacy tombstone table migration", () => {
         expect(tableExists(db, `${token}_hidden_jobs`)).toBe(false);
         expect(db.prepare("SELECT COUNT(*) AS count FROM jobctl_deleted_jobs").get()).toMatchObject({ count: 1 });
         expect(db.prepare("SELECT COUNT(*) AS count FROM jobctl_hidden_jobs").get()).toMatchObject({ count: 1 });
+        expect(db.prepare("SELECT restored_at FROM jobctl_deleted_jobs").get()).toMatchObject({ restored_at: null });
+        expect(db.prepare("SELECT unhidden_at FROM jobctl_hidden_jobs").get()).toMatchObject({ unhidden_at: null });
+        expect(tableColumns(db, "jobctl_deleted_jobs")).toEqual(expect.arrayContaining(["job_url", "deleted_at", "reason", "restored_at"]));
+        expect(tableColumns(db, "jobctl_hidden_jobs")).toEqual(expect.arrayContaining(["job_url", "hidden_at", "reason", "unhidden_at"]));
       } finally {
         db.close();
       }
@@ -145,6 +152,40 @@ describe("legacy tombstone table migration", () => {
       expect(migrated).toEqual(["jobctl_hidden_jobs"]);
       expect(tableExists(seed, `${token}_hidden_jobs`)).toBe(false);
       expect(seed.prepare("SELECT COUNT(*) AS count FROM jobctl_hidden_jobs").get()).toMatchObject({ count: 2 });
+      seed.close();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("normalizes tables left behind by an earlier rename-only migration", () => {
+    const { dbPath, cleanup } = makeDbWithUserVersion(SUPPORTED_SCHEMA_VERSION);
+    try {
+      const seed = new Database(dbPath);
+      seed.exec(`
+        CREATE TABLE jobctl_deleted_jobs (
+          job_url TEXT PRIMARY KEY,
+          deleted_at TEXT NOT NULL,
+          reason TEXT
+        );
+        INSERT INTO jobctl_deleted_jobs
+          (job_url, deleted_at, reason)
+        VALUES ('https://example.test/deleted', '2026-07-07T00:00:00Z', 'test');
+        CREATE TABLE jobctl_hidden_jobs (
+          job_url TEXT PRIMARY KEY,
+          hidden_at TEXT NOT NULL,
+          reason TEXT
+        );
+        INSERT INTO jobctl_hidden_jobs
+          (job_url, hidden_at, reason)
+        VALUES ('https://example.test/hidden', '2026-07-07T00:00:00Z', 'test');
+      `);
+
+      expect(migrateLegacyJobTables(seed)).toEqual([]);
+      expect(seed.prepare("SELECT restored_at FROM jobctl_deleted_jobs").get()).toMatchObject({ restored_at: null });
+      expect(seed.prepare("SELECT unhidden_at FROM jobctl_hidden_jobs").get()).toMatchObject({ unhidden_at: null });
+      expect(tableColumns(seed, "jobctl_deleted_jobs")).toEqual(expect.arrayContaining(["restored_at"]));
+      expect(tableColumns(seed, "jobctl_hidden_jobs")).toEqual(expect.arrayContaining(["unhidden_at"]));
       seed.close();
     } finally {
       cleanup();

--- a/apps/web/src/routes/analytics.tsx
+++ b/apps/web/src/routes/analytics.tsx
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/analytics")({
   validateSearch: (search) => analyticsSearchSchema.parse(search),
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) =>
-    context.queryClient.ensureQueryData({
+    context.queryClient.prefetchQuery({
       queryKey: analyticsKeys.outcomes(context.tenantId, deps.search),
       queryFn: () => context.ports.api.outcomeAnalytics(),
     }),

--- a/apps/web/src/routes/apply-review.tsx
+++ b/apps/web/src/routes/apply-review.tsx
@@ -7,7 +7,7 @@ import { applyReviewSearchSchema, type ApplyReviewSearch } from "./-apply-review
 export const Route = createFileRoute("/apply-review")({
   validateSearch: (search) => applyReviewSearchSchema.parse(search),
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData({
+    await context.queryClient.prefetchQuery({
       queryKey: applyReviewKeys.queue(context.tenantId),
       queryFn: () => context.ports.api.applyReviewQueue(),
     });

--- a/apps/web/src/routes/artifacts.tsx
+++ b/apps/web/src/routes/artifacts.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/artifacts")({
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) => {
     const input = artifactsListInput(deps.search);
-    return context.queryClient.ensureQueryData({
+    return context.queryClient.prefetchQuery({
       queryKey: artifactsKeys.list(context.tenantId, input),
       queryFn: () => context.ports.api.artifacts(input),
     });

--- a/apps/web/src/routes/dashboard.tsx
+++ b/apps/web/src/routes/dashboard.tsx
@@ -7,18 +7,18 @@ import { DashboardView } from "../views/dashboard/DashboardView.js";
 
 export const Route = createFileRoute("/dashboard")({
   loader: async ({ context }) => {
-    await context.queryClient.ensureQueryData({
+    await context.queryClient.prefetchQuery({
       queryKey: dashboardKeys.summary(context.tenantId),
       queryFn: () => context.ports.api.dashboardSummary(),
     });
     await context.queryClient
-      .ensureQueryData({
+      .prefetchQuery({
         queryKey: outcomesKeys.list(context.tenantId),
         queryFn: () => context.ports.api.applicationOutcomes(),
       })
       .catch(() => undefined);
     await context.queryClient
-      .ensureQueryData({
+      .prefetchQuery({
         queryKey: digestKeys.summary(context.tenantId),
         queryFn: () => context.ports.api.digest(),
       })

--- a/apps/web/src/routes/debug.tsx
+++ b/apps/web/src/routes/debug.tsx
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/debug")({
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) => {
     const input = activityInput(deps.search);
-    return context.queryClient.ensureQueryData({
+    return context.queryClient.prefetchQuery({
       queryKey: activityKeys.list(context.tenantId, input),
       queryFn: () => context.ports.api.activity(input),
     });

--- a/apps/web/src/routes/discovery.tsx
+++ b/apps/web/src/routes/discovery.tsx
@@ -5,7 +5,7 @@ import { DiscoveryView } from "../views/discovery/DiscoveryView.js";
 
 export const Route = createFileRoute("/discovery")({
   loader: ({ context }) =>
-    context.queryClient.ensureQueryData({
+    context.queryClient.prefetchQuery({
       queryKey: profileKeys.profile(context.tenantId),
       queryFn: () => context.ports.api.profile(),
     }),

--- a/apps/web/src/routes/evidence-map.tsx
+++ b/apps/web/src/routes/evidence-map.tsx
@@ -7,7 +7,7 @@ import { evidenceMapSearchSchema } from "./-evidence-map.search.js";
 export const Route = createFileRoute("/evidence-map")({
   validateSearch: (search) => evidenceMapSearchSchema.parse(search),
   loader: ({ context }) =>
-    context.queryClient.ensureQueryData({
+    context.queryClient.prefetchQuery({
       queryKey: evidenceMapKeys.list(context.tenantId),
       queryFn: () => context.ports.api.evidenceMap(),
     }),

--- a/apps/web/src/routes/jobs.tsx
+++ b/apps/web/src/routes/jobs.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/jobs")({
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) => {
     const input = jobsListInput(deps.search);
-    return context.queryClient.ensureQueryData({
+    return context.queryClient.prefetchQuery({
       queryKey: jobsKeys.list(context.tenantId, input),
       queryFn: () => fetchJobsList(context.ports.api, input),
     });

--- a/apps/web/src/routes/outreach.tsx
+++ b/apps/web/src/routes/outreach.tsx
@@ -20,7 +20,7 @@ export const Route = createFileRoute("/outreach")({
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) => {
     const input = contactsListInput(deps.search);
-    return context.queryClient.ensureQueryData({
+    return context.queryClient.prefetchQuery({
       queryKey: outreachKeys.contactList(context.tenantId, input),
       queryFn: () => context.ports.api.listContacts(input),
     });

--- a/apps/web/src/routes/preferences.tsx
+++ b/apps/web/src/routes/preferences.tsx
@@ -6,11 +6,11 @@ import { profileKeys } from "../contexts/profile/queryKeys.js";
 export const Route = createFileRoute("/preferences")({
   loader: ({ context }) =>
     Promise.all([
-      context.queryClient.ensureQueryData({
+      context.queryClient.prefetchQuery({
         queryKey: profileKeys.profile(context.tenantId),
         queryFn: () => context.ports.api.profile(),
       }),
-      context.queryClient.ensureQueryData({
+      context.queryClient.prefetchQuery({
         queryKey: profileKeys.settings(context.tenantId),
         queryFn: () => context.ports.api.settings(),
       }),

--- a/apps/web/src/routes/profile.index.tsx
+++ b/apps/web/src/routes/profile.index.tsx
@@ -6,11 +6,11 @@ import { profileKeys } from "../contexts/profile/queryKeys.js";
 export const Route = createFileRoute("/profile/")({
   loader: ({ context }) =>
     Promise.all([
-      context.queryClient.ensureQueryData({
+      context.queryClient.prefetchQuery({
         queryKey: profileKeys.profile(context.tenantId),
         queryFn: () => context.ports.api.profile(),
       }),
-      context.queryClient.ensureQueryData({
+      context.queryClient.prefetchQuery({
         queryKey: profileKeys.settings(context.tenantId),
         queryFn: () => context.ports.api.settings(),
       }),

--- a/apps/web/src/routes/runs.tsx
+++ b/apps/web/src/routes/runs.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute("/runs")({
   loaderDeps: ({ search }) => ({ search }),
   loader: ({ deps, context }) => {
     const input = workflowRunsInput(deps.search);
-    return context.queryClient.ensureQueryData({
+    return context.queryClient.prefetchQuery({
       queryKey: workflowRunsKeys.list(context.tenantId, input),
       queryFn: () => context.ports.api.workflowRuns(input),
     });

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
@@ -423,7 +423,7 @@ describe("<ArtifactDetailPanel>", () => {
     );
 
     expect(await screen.findByText("Artifact comparison")).toBeInTheDocument();
-    expect(screen.getByLabelText("Compare with")).toHaveValue("artifact-template-b");
+    expect(await screen.findByLabelText("Compare with")).toHaveValue("artifact-template-b");
     expect(screen.getByRole("option", { name: /candidate/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -13,6 +13,7 @@ import type {
   JobSummary,
   Stage,
 } from "@jobctl/contracts";
+import { LOCAL_TENANT } from "@jobctl/domain-types";
 import { http, HttpResponse } from "msw";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
@@ -29,6 +30,7 @@ import { server } from "../../test/msw/server.js";
 import { buildProviderHarness } from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
+import { routeTree } from "../../routeTree.gen.js";
 import {
   JOBS_TABLE_COLUMN_IDS,
   JOBS_TABLE_ID,
@@ -111,6 +113,34 @@ function rowForTitle(title: string): HTMLElement {
   }
   return row;
 }
+
+describe("<JobsRoute> loader reliability", () => {
+  it("renders the jobs surface instead of the route error boundary when prefetch fails", async () => {
+    const ports = buildTestPorts({
+      api: {
+        jobs: vi.fn(async () => {
+          throw new Error("api offline");
+        }),
+      },
+    });
+    const harness = buildProviderHarness({ ports, withEventStream: true });
+    const router = createRouter({
+      routeTree,
+      history: createMemoryHistory({ initialEntries: [`/jobs${SEARCH}`] }),
+      context: {
+        ports,
+        queryClient: harness.queryClient,
+        tenantId: LOCAL_TENANT,
+      },
+    });
+
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    expect(await screen.findByText("api offline")).toBeInTheDocument();
+    expect(screen.getByText("Jobs table")).toBeInTheDocument();
+    expect(screen.queryByText("Something went wrong!")).not.toBeInTheDocument();
+  });
+});
 
 describe("<JobsView> compensation source-conflict visibility", () => {
   it("shows salary min/max, market, and warning scan columns with every data column sortable", async () => {

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -520,7 +520,7 @@ describe("<JobsView> bulk delete integration", () => {
     );
   });
 
-  it("continues all matching pending preparation when the jobs page opens on eligible pending work", async () => {
+  it("does not continue pending preparation just because the jobs page opens", async () => {
     const pendingTailor: JobSummary = {
       ...sampleJob,
       jobKey: "job-pending-tailor",
@@ -559,21 +559,14 @@ describe("<JobsView> bulk delete integration", () => {
     render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     expect(await screen.findByText("Pending Tailor")).toBeInTheDocument();
-    await waitFor(() => expect(runPendingPreparation).toHaveBeenCalledTimes(1));
-    expect(runPendingPreparation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allMatching: true,
-        filter: expect.objectContaining({ state: "pending", deleted: "active" }),
-        jobKeys: [],
-        workers: 1,
-        minScore: 7,
-        validationMode: "normal",
-        dryRun: false,
-      }),
-    );
+    expect(
+      screen.getByRole("button", { name: /continue pending prep/i }),
+    ).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(runPendingPreparation).not.toHaveBeenCalled();
   });
 
-  it("does not clear selected rows after background pending preparation pickup", async () => {
+  it("keeps selected rows stable when pending work is visible", async () => {
     const user = userEvent.setup();
     const pendingTailor: JobSummary = {
       ...sampleJob,
@@ -611,7 +604,6 @@ describe("<JobsView> bulk delete integration", () => {
     });
 
     expect(await screen.findByText("Pending Tailor")).toBeInTheDocument();
-    await waitFor(() => expect(runPendingPreparation).toHaveBeenCalledTimes(1));
 
     const rowCheckboxes = Array.from(
       container.querySelectorAll<HTMLInputElement>("input[type='checkbox']"),
@@ -628,9 +620,10 @@ describe("<JobsView> bulk delete integration", () => {
     expect(
       screen.getByRole("button", { name: /delete selected/i }),
     ).not.toBeDisabled();
+    expect(runPendingPreparation).not.toHaveBeenCalled();
   });
 
-  it("continues pending preparation even when no visible row is frontend-eligible", async () => {
+  it("does not continue pending preparation when no visible row is frontend-eligible", async () => {
     const activeJob: JobSummary = {
       ...sampleJob,
       jobKey: "job-active-visible",
@@ -657,17 +650,11 @@ describe("<JobsView> bulk delete integration", () => {
     render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     expect(await screen.findByText("Active Visible Job")).toBeInTheDocument();
-    await waitFor(() => expect(runPendingPreparation).toHaveBeenCalledTimes(1));
-    expect(runPendingPreparation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allMatching: true,
-        filter: expect.objectContaining({ state: "pending", deleted: "active" }),
-        jobKeys: [],
-      }),
-    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(runPendingPreparation).not.toHaveBeenCalled();
   });
 
-  it("starts at most one automatic pending-preparation drain per unchanged server filter", async () => {
+  it("keeps pending preparation passive when the server filter is unchanged", async () => {
     const firstTailor: JobSummary = {
       ...sampleJob,
       jobKey: "job-pending-tailor-a",
@@ -707,16 +694,8 @@ describe("<JobsView> bulk delete integration", () => {
 
     expect(await screen.findByText("Pending Tailor A")).toBeInTheDocument();
     expect(await screen.findByText("Pending Tailor B")).toBeInTheDocument();
-    await waitFor(() => expect(runPendingPreparation).toHaveBeenCalledTimes(1));
     await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(runPendingPreparation).toHaveBeenCalledTimes(1);
-    expect(runPendingPreparation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        allMatching: true,
-        filter: expect.objectContaining({ state: "pending", deleted: "active" }),
-        jobKeys: [],
-      }),
-    );
+    expect(runPendingPreparation).not.toHaveBeenCalled();
   });
 
   it("moves product filters into the table header and keeps them URL-backed", async () => {
@@ -1375,8 +1354,8 @@ describe("<JobsView> bulk delete integration", () => {
         timeout: 5_000,
       },
     );
-    await waitFor(() => expect(calls.length).toBeGreaterThanOrEqual(1));
-    calls.length = 0;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(calls).toHaveLength(0);
     await user.click(screen.getByRole("button", { name: /continue pending prep/i }));
 
     await waitFor(() => expect(calls.length).toBe(1));

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -12,7 +12,7 @@ import {
 import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useDeleteJobsBulkMutation } from "../../contexts/discovery/hooks/useDeleteJobsBulkMutation.js";
 import { useHideJobsBulkMutation } from "../../contexts/discovery/hooks/useHideJobsBulkMutation.js";
@@ -270,7 +270,6 @@ export function JobsView() {
   const [localTableFilters, setLocalTableFilters] =
     useState<DataGridFilterState>({});
   const [visiblePageKeys, setVisiblePageKeys] = useState<string[]>([]);
-  const autoPendingPreparationKeys = useRef<Set<string>>(new Set());
   const activeSavedView = useMemo(
     () =>
       savedTableViews.find(
@@ -580,40 +579,6 @@ export function JobsView() {
       })
       .catch(() => undefined);
   };
-
-  useEffect(() => {
-    if (
-      !data ||
-      runPendingPreparation.isPending ||
-      hasLocalFilters ||
-      search.deleted !== "active"
-    ) {
-      return;
-    }
-    const payloads = pendingPreparationPayloads();
-    const requestKey = JSON.stringify(payloads);
-    if (autoPendingPreparationKeys.current.has(requestKey)) {
-      return;
-    }
-    autoPendingPreparationKeys.current.add(requestKey);
-    mutatePendingPreparationPayloads(runPendingPreparation, payloads, {
-      clearSelectionOnSuccess: false,
-    });
-  }, [
-    data?.items,
-    hasLocalFilters,
-    runPendingPreparation,
-    search.applyStatus,
-    search.deleted,
-    search.maxFitScore,
-    search.minFitScore,
-    search.q,
-    search.discoveredSince,
-    search.scoredSince,
-    search.stage,
-    search.state,
-    stageTriggerConfigs,
-  ]);
 
   const mutateSelected = (mutation: BulkJobMutation, label: string) => {
     const count = allMatchingSelected

--- a/workers/automation/src/jobctl/config.py
+++ b/workers/automation/src/jobctl/config.py
@@ -50,33 +50,95 @@ def _table_columns(conn: sqlite3.Connection, table_name: str) -> list[str]:
     return [str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall()]
 
 
+_JOB_LIFECYCLE_TABLES = {
+    "deleted_jobs": {
+        "current": "jobctl_deleted_jobs",
+        "create_sql": """
+            CREATE TABLE IF NOT EXISTS jobctl_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT,
+                restored_at TEXT
+            )
+        """,
+        "additive_columns": {
+            "deleted_at": "TEXT NOT NULL DEFAULT ''",
+            "reason": "TEXT",
+            "restored_at": "TEXT",
+        },
+    },
+    "hidden_jobs": {
+        "current": "jobctl_hidden_jobs",
+        "create_sql": """
+            CREATE TABLE IF NOT EXISTS jobctl_hidden_jobs (
+                job_url TEXT PRIMARY KEY,
+                hidden_at TEXT NOT NULL,
+                reason TEXT,
+                unhidden_at TEXT
+            )
+        """,
+        "additive_columns": {
+            "hidden_at": "TEXT NOT NULL DEFAULT ''",
+            "reason": "TEXT",
+            "unhidden_at": "TEXT",
+        },
+    },
+}
+
+
+def _ensure_job_lifecycle_table_schema(conn: sqlite3.Connection, suffix: str) -> bool:
+    spec = _JOB_LIFECYCLE_TABLES[suffix]
+    current = str(spec["current"])
+    changed = not _table_exists(conn, current)
+    conn.execute(str(spec["create_sql"]))
+    existing_columns = set(_table_columns(conn, current))
+    for column, definition in dict(spec["additive_columns"]).items():
+        if column in existing_columns:
+            continue
+        conn.execute(f'ALTER TABLE "{current}" ADD COLUMN "{column}" {definition}')
+        existing_columns.add(column)
+        changed = True
+    return changed
+
+
 def migrate_legacy_job_tables(conn: sqlite3.Connection) -> list[str]:
-    """Rename legacy tombstone tables to the JobCtl schema names.
+    """Move legacy tombstone rows to the JobCtl schema names.
 
     The owner migration is intentionally one-way: if both names exist, rows are
     merged into the new table and the legacy table is dropped so new code has a
-    single schema surface.
+    single schema surface. Legacy-only tables are copied into a freshly created
+    current table instead of renamed, because older schemas can be missing
+    lifecycle columns used by the read model.
     """
     renamed: list[str] = []
-    for suffix in ("deleted_jobs", "hidden_jobs"):
+    changed = False
+    for suffix, spec in _JOB_LIFECYCLE_TABLES.items():
         legacy = f"{_LEGACY_TOKEN}_{suffix}"
-        current = f"jobctl_{suffix}"
+        current = str(spec["current"])
         legacy_exists = _table_exists(conn, legacy)
         current_exists = _table_exists(conn, current)
-        if not legacy_exists:
+        if not legacy_exists and not current_exists:
             continue
-        if current_exists:
-            current_columns = _table_columns(conn, current)
-            common_columns = [column for column in _table_columns(conn, legacy) if column in current_columns]
+
+        legacy_columns = _table_columns(conn, legacy) if legacy_exists else []
+        if legacy_exists:
+            known_columns = {"job_url", *dict(spec["additive_columns"]).keys()}
+            common_columns = [column for column in legacy_columns if column in known_columns]
             if not common_columns:
                 raise WorkspaceMigrationError(f"cannot migrate legacy table {legacy}: no shared columns with {current}")
-            columns = ", ".join(f'"{column}"' for column in common_columns)
-            conn.execute(f"INSERT OR IGNORE INTO {current} ({columns}) SELECT {columns} FROM {legacy}")
-            conn.execute(f"DROP TABLE {legacy}")
-        else:
-            conn.execute(f"ALTER TABLE {legacy} RENAME TO {current}")
+
+        changed = _ensure_job_lifecycle_table_schema(conn, suffix) or changed
+        if not legacy_exists:
+            continue
+
+        current_columns = _table_columns(conn, current)
+        common_columns = [column for column in legacy_columns if column in current_columns]
+        columns = ", ".join(f'"{column}"' for column in common_columns)
+        conn.execute(f'INSERT OR IGNORE INTO "{current}" ({columns}) SELECT {columns} FROM "{legacy}"')
+        conn.execute(f'DROP TABLE "{legacy}"')
+        changed = True
         renamed.append(current)
-    if renamed:
+    if changed:
         conn.commit()
     return renamed
 

--- a/workers/automation/tests/test_workspace_migration.py
+++ b/workers/automation/tests/test_workspace_migration.py
@@ -31,21 +31,19 @@ def _seed_legacy_workspace(home) -> tuple[object, object]:
             CREATE TABLE {_legacy_token()}_deleted_jobs (
                 job_url TEXT PRIMARY KEY,
                 deleted_at TEXT NOT NULL,
-                reason TEXT,
-                restored_at TEXT
+                reason TEXT
             );
             INSERT INTO {_legacy_token()}_deleted_jobs
-                (job_url, deleted_at, reason, restored_at)
-            VALUES ('https://example.test/job', '2026-07-07T00:00:00Z', 'test', NULL);
+                (job_url, deleted_at, reason)
+            VALUES ('https://example.test/job', '2026-07-07T00:00:00Z', 'test');
             CREATE TABLE {_legacy_token()}_hidden_jobs (
-                tenant_id TEXT NOT NULL DEFAULT 'local',
-                job_url TEXT NOT NULL,
+                job_url TEXT PRIMARY KEY,
                 hidden_at TEXT NOT NULL,
-                unhidden_at TEXT
+                reason TEXT
             );
             INSERT INTO {_legacy_token()}_hidden_jobs
-                (tenant_id, job_url, hidden_at, unhidden_at)
-            VALUES ('local', 'https://example.test/job', '2026-07-07T00:00:00Z', NULL);
+                (job_url, hidden_at, reason)
+            VALUES ('https://example.test/job', '2026-07-07T00:00:00Z', 'test');
             """
         )
         conn.commit()
@@ -60,6 +58,14 @@ def _table_names(db_path) -> set[str]:
     conn = sqlite3.connect(db_path)
     try:
         return {str(row[0]) for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    finally:
+        conn.close()
+
+
+def _table_columns(db_path, table_name: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table_name}")')}
     finally:
         conn.close()
 
@@ -92,11 +98,64 @@ def test_default_workspace_migration_moves_files_and_renames_db_tables(tmp_path,
         assert conn.execute("SELECT COUNT(*) FROM jobs").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM jobctl_deleted_jobs").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM jobctl_hidden_jobs").fetchone()[0] == 1
+        assert conn.execute("SELECT restored_at FROM jobctl_deleted_jobs").fetchone()[0] is None
+        assert conn.execute("SELECT unhidden_at FROM jobctl_hidden_jobs").fetchone()[0] is None
     finally:
         conn.close()
+    assert {"job_url", "deleted_at", "reason", "restored_at"} <= _table_columns(
+        current / "jobctl.db",
+        "jobctl_deleted_jobs",
+    )
+    assert {"job_url", "hidden_at", "reason", "unhidden_at"} <= _table_columns(
+        current / "jobctl.db",
+        "jobctl_hidden_jobs",
+    )
     assert config.WORKSPACE_MIGRATION_NOTICE is not None
 
     assert migrate_default_workspace(tmp_path) == current
+
+
+def test_legacy_table_migration_normalizes_previously_renamed_tables(tmp_path) -> None:
+    db_path = tmp_path / "jobctl.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE jobs (url TEXT PRIMARY KEY, title TEXT);
+            INSERT INTO jobs (url, title) VALUES ('https://example.test/job', 'Engineer');
+            CREATE TABLE jobctl_deleted_jobs (
+                job_url TEXT PRIMARY KEY,
+                deleted_at TEXT NOT NULL,
+                reason TEXT
+            );
+            INSERT INTO jobctl_deleted_jobs
+                (job_url, deleted_at, reason)
+            VALUES ('https://example.test/job', '2026-07-07T00:00:00Z', 'test');
+            CREATE TABLE jobctl_hidden_jobs (
+                job_url TEXT PRIMARY KEY,
+                hidden_at TEXT NOT NULL,
+                reason TEXT
+            );
+            INSERT INTO jobctl_hidden_jobs
+                (job_url, hidden_at, reason)
+            VALUES ('https://example.test/job', '2026-07-07T00:00:00Z', 'test');
+            """
+        )
+
+        assert config.migrate_legacy_job_tables(conn) == []
+        assert conn.execute("SELECT restored_at FROM jobctl_deleted_jobs").fetchone()[0] is None
+        assert conn.execute("SELECT unhidden_at FROM jobctl_hidden_jobs").fetchone()[0] is None
+    finally:
+        conn.close()
+
+    assert {"job_url", "deleted_at", "reason", "restored_at"} <= _table_columns(
+        db_path,
+        "jobctl_deleted_jobs",
+    )
+    assert {"job_url", "hidden_at", "reason", "unhidden_at"} <= _table_columns(
+        db_path,
+        "jobctl_hidden_jobs",
+    )
 
 
 def test_default_workspace_migration_refuses_existing_current_dir(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- normalize legacy deleted/hidden job lifecycle tables during API and workspace migration so stale schemas gain restored/unhidden columns before projection reads
- convert top-level read route loaders to best-effort prefetch so a temporary API outage renders the route surface with inline query errors instead of the generic route error boundary
- keep `/jobs` pending-preparation pickup explicit: loading or refreshing the page can show pending work, but it no longer starts preparation until the toolbar action is clicked
- add regression coverage for the `/jobs` API-outage route behavior and passive pending-preparation behavior
- harden the artifact comparison test against the CI-observed async race by waiting for the comparison control before asserting its selected artifact

## Validation
- `corepack pnpm check`
- `corepack pnpm test`
- `corepack pnpm --filter @jobctl/web test`
- `corepack pnpm --filter @jobctl/web exec vitest run src/views/artifacts/ArtifactDetailPanel.test.tsx --reporter=verbose`
- `corepack pnpm --filter @jobctl/web test-d`
- `corepack pnpm --filter @jobctl/web e2e`
- `corepack pnpm docs:build`
- `uv --project workers/automation run --extra dev pytest -q`
- `uv --project workers/automation run --extra dev ruff check .`
- `python3 scripts/release_check.py`
- `git diff --check`
- live disposable-stack browser QA: 13 routes, job drawer, Generate Materials dispatch, Apply Review handoff, artifact PDF byte stream, settings persistence, resume import, outreach contact creation, and mobile `/jobs`
- interruption QA: stopped API mid-cycle, verified `/jobs` rendered inline API error without route boundary; restarted API and verified live rows recovered
- interruption QA: stopped/restarted Vite web server and verified `/jobs` recovered
- passive `/jobs` network probe on seeded disposable stack: 0 `bulk-run-pending-preparation` POSTs after passive load; 1 POST only after explicit `continue pending prep` click; no worker was running, so the explicit POST returned the expected 503 worker-health response
- `scripts/reliability-demo.sh 2 10`

## Safety
- no real vendor auth, no real LLM spend, no application submission
- browser QA used disposable local workspaces under `/tmp` with stubbed dispatch
