### PR TITLE
chore(github): configure open source intake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report behavior that is broken or inconsistent with the documented product.
+title: "[Bug]: "
+labels:
+  - "status: needs triage"
+  - "type: bug"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include real resumes, profile facts, generated materials, browser profiles, SQLite databases, API keys, raw logs, local paths, or vulnerability details. Use synthetic data or the `pnpm qa:seed` fixtures when possible.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Web app
+        - TypeScript API
+        - Python worker or CLI
+        - Browser extension
+        - Documentation
+        - Setup or install
+        - GitHub workflows
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior without pasting sensitive data.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Use synthetic fixtures or sanitized examples.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node, Python, browser, and command context. Avoid local usernames and paths.
+      placeholder: |
+        - OS:
+        - Browser:
+        - Node:
+        - Python:
+        - Install method:
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Checks already run
+      description: Commands, tests, or QA steps already tried. Summarize results instead of pasting private logs.
+      placeholder: "`pnpm check`, `pnpm test`, `python3 scripts/release_check.py`, etc."
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Data-safety confirmation
+      options:
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ebarti/JobCtrl/security/advisories/new
+    about: Report vulnerabilities privately. Do not put exploit details, secrets, logs, resumes, local paths, or generated materials in public issues.
+  - name: Contributor guide
+    url: https://github.com/ebarti/JobCtrl/blob/main/CONTRIBUTING.md
+    about: Read the development, validation, DCO sign-off, and PR workflow guidance before opening a pull request.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,50 @@
+name: Documentation issue
+description: Report confusing, missing, stale, or broken documentation.
+title: "[Docs]: "
+labels:
+  - "status: needs triage"
+  - "type: documentation"
+  - "area: docs"
+body:
+  - type: textarea
+    id: page
+    attributes:
+      label: Page or file
+      description: Link the page or name the repository file.
+      placeholder: "README.md, docs/user/getting-started.md, ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: problem
+    attributes:
+      label: Documentation problem
+      options:
+        - Missing information
+        - Stale information
+        - Confusing instructions
+        - Broken link
+        - Incorrect command or configuration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: What should change?
+      description: Describe the correction or the question the documentation should answer.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation context
+      description: If relevant, mention the command, page, or local flow you tried. Do not paste private logs or local paths.
+    validations:
+      required: false
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Data-safety confirmation
+      options:
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: Feature request
+description: Suggest a product, workflow, documentation, or developer-experience improvement.
+title: "[Feature]: "
+labels:
+  - "status: needs triage"
+  - "type: feature"
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Web app
+        - TypeScript API
+        - Python worker or CLI
+        - Browser extension
+        - Documentation
+        - Setup or install
+        - GitHub workflows
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user or maintainer problem does this address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should JobCtrl do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. Mention workarounds or simpler versions.
+    validations:
+      required: false
+  - type: textarea
+    id: safety
+    attributes:
+      label: Data, safety, or automation impact
+      description: Note whether this touches local data, credentials, generated materials, browser automation, apply submission, telemetry, or third-party services.
+    validations:
+      required: true
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Public issue confirmation
+      options:
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/qa_regression.yml
+++ b/.github/ISSUE_TEMPLATE/qa_regression.yml
@@ -1,0 +1,65 @@
+name: QA regression
+description: Report a visible regression in a product path, acceptance gate, or documented QA flow.
+title: "[QA]: "
+labels:
+  - "status: needs triage"
+  - "type: qa-regression"
+body:
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Regression surface
+      options:
+        - Dashboard or Jobs
+        - Apply Review
+        - Artifacts
+        - Profile or Settings
+        - Browser extension
+        - CLI or worker
+        - Documentation site
+        - GitHub workflow
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: invariant
+    attributes:
+      label: Expected invariant
+      description: What product or QA invariant is supposed to hold?
+      placeholder: "Example: a failed refresh must preserve the last accepted artifact."
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: What broke?
+      description: Describe the visible symptom and where it appears. Use synthetic data and sanitized screenshots only.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction path
+      placeholder: |
+        1. Seed ...
+        2. Run ...
+        3. Open ...
+        4. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: checks
+    attributes:
+      label: Validation already attempted
+      description: Mention local commands or browser QA steps. Summarize private output instead of pasting it.
+    validations:
+      required: false
+  - type: checkboxes
+    id: release
+    attributes:
+      label: Release impact
+      options:
+        - label: This appears to block a public release, source install, or documented first-run flow.
+          required: false
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/security_contact.yml
+++ b/.github/ISSUE_TEMPLATE/security_contact.yml
@@ -1,0 +1,29 @@
+name: Security contact request
+description: Ask for a private vulnerability reporting path without disclosing details publicly.
+title: "[Security contact]: "
+labels:
+  - "status: needs triage"
+  - "type: security-contact"
+  - "area: security"
+  - "privacy: review-needed"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not include exploit details, proof-of-concept steps, secrets, logs, local paths, resumes, generated materials, database contents, or browser state in this public issue. Prefer GitHub private vulnerability reporting if it is available for this repository.
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Confirmation
+      options:
+        - label: I need a private contact path for a possible vulnerability and have not included vulnerability details in this public issue.
+          required: true
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, local paths, or exploit details.
+          required: true
+  - type: textarea
+    id: safe_summary
+    attributes:
+      label: Minimal public summary
+      description: Optional. Keep this generic, for example "local API boundary" or "browser extension". Do not include technical exploit details.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/support_question.yml
+++ b/.github/ISSUE_TEMPLATE/support_question.yml
@@ -1,0 +1,46 @@
+name: Question or support
+description: Ask a setup, usage, or contributor-workflow question that is safe to discuss publicly.
+title: "[Question]: "
+labels:
+  - "status: needs triage"
+  - "type: question"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep public questions synthetic and privacy-safe. Do not paste real job-search data, resumes, generated materials, credentials, raw logs, browser state, SQLite data, local paths, or vulnerability details.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Setup or install
+        - Web app
+        - CLI or worker
+        - Browser extension
+        - Documentation
+        - Contributor workflow
+        - Unsure
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to understand or do?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Optional. Mention sanitized commands, docs pages, or synthetic fixture steps already tried.
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirmation
+    attributes:
+      label: Public issue confirmation
+      options:
+        - label: I have not included secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, local paths, or vulnerability details.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 ## Checklist
 
 - [ ] External contributor commits include a DCO `Signed-off-by:` trailer (`git commit -s`).
+- [ ] I ran the relevant local checks and listed them above. Heavy CI does not run automatically on public pull requests; maintainers run manual workflows or local validation after review.
+- [ ] I did not include secrets, private profile data, resumes, generated application materials, raw logs, browser profiles, SQLite databases, or local paths.

--- a/.github/workflows/docs-site.yml
+++ b/.github/workflows/docs-site.yml
@@ -8,12 +8,6 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - ".github/workflows/docs-site.yml"
-  pull_request:
-    paths:
-      - "docs/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/docs-site.yml"
   workflow_dispatch:
 
 permissions:
@@ -59,7 +53,7 @@ jobs:
     # Deploys only from main, and only once the repository variable
     # DOCS_DEPLOY_ENABLED is set to "true" alongside the two Cloudflare
     # secrets. Until then this job skips cleanly and the workflow stays green.
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && vars.DOCS_DEPLOY_ENABLED == 'true'
+    if: github.ref == 'refs/heads/main' && vars.DOCS_DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,208 @@
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, edited, reopened, transferred]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage manually.
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label:
+    name: Label issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Apply triage labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue?.number ?? Number(core.getInput("issue_number"));
+
+            const { data: issue } = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            const labelDefinitions = {
+              "status: needs triage": {
+                color: "fbca04",
+                description: "Needs maintainer review and prioritization.",
+              },
+              "type: bug": {
+                color: "d73a4a",
+                description: "Broken or incorrect behavior.",
+              },
+              "type: documentation": {
+                color: "0075ca",
+                description: "Documentation issue or improvement.",
+              },
+              "type: feature": {
+                color: "a2eeef",
+                description: "New capability or product improvement.",
+              },
+              "type: qa-regression": {
+                color: "b60205",
+                description: "Visible regression in a product or QA flow.",
+              },
+              "type: question": {
+                color: "d876e3",
+                description: "Usage, setup, or contributor-workflow question.",
+              },
+              "type: security-contact": {
+                color: "ee0701",
+                description: "Public request for a private vulnerability contact path.",
+              },
+              "area: api": {
+                color: "c2e0c6",
+                description: "TypeScript API or API contract.",
+              },
+              "area: browser-extension": {
+                color: "c2e0c6",
+                description: "Browser extension capture or autofill.",
+              },
+              "area: cli-worker": {
+                color: "c2e0c6",
+                description: "Python CLI, worker, or automation engine.",
+              },
+              "area: docs": {
+                color: "c2e0c6",
+                description: "Repository or published documentation.",
+              },
+              "area: github": {
+                color: "c2e0c6",
+                description: "GitHub workflows, templates, or contribution metadata.",
+              },
+              "area: setup": {
+                color: "c2e0c6",
+                description: "Install, setup, or local environment.",
+              },
+              "area: security": {
+                color: "c2e0c6",
+                description: "Security posture or private-reporting coordination.",
+              },
+              "area: web": {
+                color: "c2e0c6",
+                description: "React web app or frontend product flow.",
+              },
+              "privacy: review-needed": {
+                color: "5319e7",
+                description: "Maintainers should check the public issue for sensitive data exposure.",
+              },
+              "release: possible-blocker": {
+                color: "e99695",
+                description: "May block a public release, install path, or documented first-run flow.",
+              },
+            };
+
+            async function ensureLabel(name) {
+              const definition = labelDefinitions[name];
+              if (!definition) {
+                return;
+              }
+
+              try {
+                await github.rest.issues.updateLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: definition.color,
+                  description: definition.description,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name,
+                  color: definition.color,
+                  description: definition.description,
+                });
+              }
+            }
+
+            const body = issue.body ?? "";
+            const title = issue.title ?? "";
+            const userBody = body
+              .replace(/### Data-safety confirmation[\s\S]*?(?=\n### |$)/gi, "")
+              .replace(/### Public issue confirmation[\s\S]*?(?=\n### |$)/gi, "")
+              .replace(/### Confirmation[\s\S]*?(?=\n### |$)/gi, "");
+            const haystack = `${title}\n${userBody}`.toLowerCase();
+            const titleText = title.toLowerCase();
+            const currentLabels = new Set(issue.labels.map((label) => label.name));
+            const labelsToAdd = new Set();
+
+            if (![...currentLabels].some((label) => label.startsWith("status: "))) {
+              labelsToAdd.add("status: needs triage");
+            }
+
+            const typeRules = [
+              ["type: security-contact", /\[security contact\]|security contact request|minimal public summary/],
+              ["type: qa-regression", /\[qa\]|expected invariant|regression surface|what broke\?/],
+              ["type: documentation", /\[docs\]|page or file|documentation problem|broken link/],
+              ["type: feature", /\[feature\]|problem to solve|proposed behavior|data, safety, or automation impact/],
+              ["type: bug", /\[bug\]|what happened\?|expected behavior|reproduction steps/],
+              ["type: question", /\[question\]|question or support|contributor workflow/],
+            ];
+
+            for (const [label, pattern] of typeRules) {
+              if (pattern.test(haystack) && ![...currentLabels].some((existing) => existing.startsWith("type: "))) {
+                labelsToAdd.add(label);
+                break;
+              }
+            }
+
+            const areaRules = [
+              ["area: web", /web app|dashboard|jobs|apply review|artifacts|profile|settings|frontend|react|vite/],
+              ["area: api", /typescript api|api route|json-rpc|sse|server|read model|endpoint/],
+              ["area: cli-worker", /python worker|worker|cli|jobctrl doctor|temporal|automation engine/],
+              ["area: browser-extension", /browser extension|extension|capture|autofill|ats/],
+              ["area: docs", /documentation|docs site|readme|docs\//],
+              ["area: setup", /setup|install|pnpm dev:setup|environment|first run/],
+              ["area: github", /github workflow|github workflows|actions|ci|dco|pull request|issue template/],
+              ["area: security", /security|vulnerability|credential|secret|token|private contact/],
+            ];
+
+            for (const [label, pattern] of areaRules) {
+              if (pattern.test(haystack)) {
+                labelsToAdd.add(label);
+              }
+            }
+
+            if (/release blocker|blocks a public release|public release|first-run flow|source install/.test(haystack)) {
+              labelsToAdd.add("release: possible-blocker");
+            }
+
+            if (
+              labelsToAdd.has("type: security-contact") ||
+              /\b(security|vulnerability|secret|credential|token|api key|private data)\b/.test(titleText) ||
+              /\b(secret|credential|token|api key|private contact|exploit detail)\b/.test(haystack)
+            ) {
+              labelsToAdd.add("privacy: review-needed");
+            }
+
+            const finalLabels = [...labelsToAdd].filter((label) => !currentLabels.has(label));
+            for (const label of finalLabels) {
+              await ensureLabel(label);
+            }
+
+            if (finalLabels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: finalLabels,
+              });
+            }

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,12 +8,6 @@ on:
       - "scripts/**"
       - "pyproject.toml"
       - ".github/workflows/python.yml"
-  pull_request:
-    paths:
-      - "workers/**"
-      - "scripts/**"
-      - "pyproject.toml"
-      - ".github/workflows/python.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -3,7 +3,7 @@ name: Release Privacy Gate
 on:
   push:
     branches: ["main"]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   release-check:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -10,14 +10,6 @@ on:
       - "package.json"
       - "pnpm-workspace.yaml"
       - ".github/workflows/typescript.yml"
-  pull_request:
-    paths:
-      - "apps/**"
-      - "packages/**"
-      - "pnpm-lock.yaml"
-      - "package.json"
-      - "pnpm-workspace.yaml"
-      - ".github/workflows/typescript.yml"
   workflow_dispatch:
 
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,9 @@ JOBCTRL_DIR=/tmp/jobctrl-qa pnpm dev
   configuration, architecture, or QA expectations change.
 - Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
   profiles, SQLite databases, or generated application materials.
+- Heavy CI workflows do not run automatically on public pull requests. Run the
+  relevant local validation before opening a PR; maintainers run manual
+  workflows or local checks after reviewing the change.
 
 ## Developer Certificate of Origin Sign-Off
 

--- a/docs/developer/security.md
+++ b/docs/developer/security.md
@@ -128,9 +128,13 @@ CapSolver key is an env var scoped to the owned CAPTCHA tool. A job-site login
 password, if the user provides one, remains local profile data consumed by the
 owned `type_credential` tool; it is not interpolated into the apply prompt.
 
-**The release gate is enforced in CI.** `scripts/release_check.py` runs on every
-push and pull request and scans the git-tracked and untracked tree — plus any
-built wheel/sdist archives — for:
+**The release gate is enforced before release-bound changes land.**
+`scripts/release_check.py` runs automatically on every push to `main` and is
+available as a manual GitHub workflow for maintainer-reviewed branches. Public
+pull requests do not run heavyweight CI automatically, so maintainers run the
+manual workflow or local scanner before merging release-bound changes. The
+scanner checks the git-tracked and untracked tree — plus any built wheel/sdist
+archives — for:
 
 - private-profile needles (real names, emails, personal domains, employer
   evidence, home paths, and private toolchain paths);

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -257,7 +257,8 @@ pnpm docs:preview
 the built site does not resolve to a built page or asset (this catches links
 to pages relocated by `rewrites`, which VitePress's source-level dead-link
 check cannot see). Together they are the docs link-integrity gate; CI runs
-them on every pull request that touches `docs/`
+them on pushes to `main`, and maintainers can run the docs workflow manually for
+pull requests after review.
 (`.github/workflows/docs-site.yml`). Mermaid diagrams render client-side in
 the browser, so a build that passes can still contain a diagram that fails to
 parse — check edited diagrams in `pnpm docs:dev` before merging. Note that

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -38,7 +38,8 @@ to the rename train / post-rename launch assets (R7b).
 - **Verification.**
   - `release-check` (`.github/workflows/release-check.yml`) is green on `main`
     for every commit since W0.4 landed (it triggers on every `push` to `main`
-    and every `pull_request`).
+    and is also available through `workflow_dispatch` for maintainer-reviewed
+    branches).
   - `python3 scripts/release_check.py` reports zero findings locally on the
     exact commit to be published.
   - Every box in OSS spec §5 is checked, including the final human manual QA
@@ -56,8 +57,8 @@ to the rename train / post-rename launch assets (R7b).
 - **Preconditions (OSS spec §5 gate).** Deploying `docs/.vitepress/dist` to the
   public `jobctrl-docs` Cloudflare project is itself a going-public act, so it
   carries the **same OSS spec §5 gate as 9.1**. The `deploy` job in
-  `docs-site.yml` is gated only on `DOCS_DEPLOY_ENABLED`, `main`, and
-  non-`pull_request` — **not** on `release-check` — so this checklist is the
+  `docs-site.yml` is gated only on `DOCS_DEPLOY_ENABLED` and `main` — **not**
+  on `release-check` — so this checklist is the
   only guard. Before setting `DOCS_DEPLOY_ENABLED` or configuring the Cloudflare
   secrets:
   - `python3 scripts/release_check.py` reports zero findings locally on the
@@ -72,7 +73,7 @@ to the rename train / post-rename launch assets (R7b).
 - **Action.** Set the repository variable `DOCS_DEPLOY_ENABLED=true` and the two
   Cloudflare secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) so the
   `deploy` job in `.github/workflows/docs-site.yml` runs from `main` (it is
-  gated on `vars.DOCS_DEPLOY_ENABLED == 'true'`, `main`, and non-`pull_request`;
+  gated on `vars.DOCS_DEPLOY_ENABLED == 'true'` and `main`;
   it deploys `docs/.vitepress/dist` to the Cloudflare Pages project
   `jobctrl-docs`).
 - **Verification.** On the next `main` push the `deploy` job runs (not skipped),


### PR DESCRIPTION
## Summary

- add public issue forms for bugs, docs, features, QA regressions, security-contact requests, and questions
- add an issue triage workflow that creates/applies type, area, privacy-review, and release-blocker labels without checking out issue content
- keep heavyweight CI off public pull requests while preserving push-to-main and manual workflow validation paths
- update PR and contributor docs to describe local validation and maintainer-run checks

## Validation

- `ruby -ryaml -e 'paths = Dir[".github/workflows/*.yml", ".github/ISSUE_TEMPLATE/*.yml"].sort; paths.each { |path| YAML.load_file(path); puts path }'`
- `node --check /tmp/jobhunter-issue-triage-script.js`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `git diff --check`
- `python3 scripts/release_check.py`
- `corepack pnpm docs:build`

## Notes

The repository already has Issues enabled. The repository visibility flip remains an owner action outside this PR.