### PR TITLE
docs(plans): archive implemented plans

### DIFF
--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -317,7 +317,7 @@ choke point in `infrastructure/network/`:
   (budget + pacing), since that library owns its internal transport.
 
 The plan and phase-by-phase surface inventory live in
-`docs/plans/2026-07-05-crawl-politeness-plan.md`; the ADR is in
+`docs/plans/implemented/2026-07-05-crawl-politeness-plan.md`; the ADR is in
 [`docs/decisions.md`](../decisions.md).
 
 ## Workflow Orchestration (Local Temporal)

--- a/docs/claims-ledger.md
+++ b/docs/claims-ledger.md
@@ -6,7 +6,7 @@
 > artifact, not user documentation.
 >
 > Implements Phase A / GATE G1 of
-> [`docs/plans/2026-07-05-launch-readiness-artifacts-plan.md`](plans/2026-07-05-launch-readiness-artifacts-plan.md)
+> [`docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md`](plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md)
 > §5. No listed document in `CLAUDE.md` owns "public claim provenance," so this
 > new doc is justified under the "avoid new docs unless nothing owns it" rule.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1416,7 +1416,7 @@ Consequences:
   pool/semaphore is a documented follow-up if the family cap proves insufficient.
 
 Cites: R9 streaming-pipeline-latency plan
-(`docs/plans/2026-07-05-streaming-pipeline-latency-plan.md`), Phase 1.
+(`docs/plans/implemented/2026-07-05-streaming-pipeline-latency-plan.md`), Phase 1.
 
 ## 2026-07-05: Career Evidence Map Is An Operations Read Model Over Existing Facts
 
@@ -1445,7 +1445,7 @@ Consequences:
 - if the index is projected, both the Python and TypeScript builders must emit
   the same shape and parity fixtures must cover it
 
-Cites: `docs/plans/2026-07-05-evidence-map-interview-prep-plan.md` (Phase 0).
+Cites: `docs/plans/implemented/2026-07-05-evidence-map-interview-prep-plan.md` (Phase 0).
 
 ## 2026-07-05: Interview Preparation Is Grounded, Gated, Generation-Versioned Material
 
@@ -1475,7 +1475,7 @@ Consequences:
 - post-interview reflection remains an Apply outcome note, not an interview
   assistant transcript or live-session artifact
 
-Cites: `docs/plans/2026-07-05-evidence-map-interview-prep-plan.md` (Phase 0).
+Cites: `docs/plans/implemented/2026-07-05-evidence-map-interview-prep-plan.md` (Phase 0).
 
 ## 2026-07-05: Outcome Analytics Are Read-Only And Sample-Gated
 
@@ -1621,7 +1621,7 @@ Consequences:
   each `SourcePolicy` (a registry policy editor is deferred, D4)
 
 Cites: R10 crawl-politeness train (PRs #297 → #315); plan
-`docs/plans/2026-07-05-crawl-politeness-plan.md`; gate G1 in
+`docs/plans/implemented/2026-07-05-crawl-politeness-plan.md`; gate G1 in
 `docs/plans/2026-07-03-oss-release-remediation-spec.md` §5.
 
 ## 2026-07-06: Contact and Outreach Bounded Context With No Auto-Send

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -8,6 +8,10 @@ at the top of `docs/`.
   that has landed, been superseded by canonical docs, or been closed with a
   recorded outcome.
 
+As of 2026-07-08, every dated plan currently tracked in this directory has
+landed or been closed with a recorded outcome and lives under `implemented/`.
+Add new accepted-but-not-yet-delivered plans at the top level.
+
 When a plan is fully implemented, move it into `implemented/` with a status
 banner recording the delivery PRs and any deviations, and update the canonical
 docs to describe the delivered behavior. Delivery history lives in the git log
@@ -54,8 +58,18 @@ and frontend plans were renamed from working titles (`ddd-target-plan.md`,
 | 2026-07-03 | [Temporal Rearchitecture — Implementation Spec (P1b–P5)](implemented/2026-07-03-temporal-rearch-implementation-spec.md) | Implemented — spec #232 |
 | 2026-07-03 | [OSS Release Remediation — Implementation Spec for Codex](implemented/2026-07-03-oss-release-remediation-spec.md) | Closed by #274 inventory, then W1 restamped after #336, #337, #338, #340, #342, and #345 — W1.1-W1.7 complete; W1.8 dry-run-by-default was withdrawn by owner decision; overall release remains no-go pending non-W1 owner/release checkpoints |
 | 2026-07-05 | [OSS Release — Drive-to-Done and Completion Verification Plan](implemented/2026-07-05-oss-release-drive-to-done-plan.md) | Restamped after the W1 remediation train and W0.6 owner pass — W1 apply-safety precondition satisfied; overall R1 remains no-go pending W2.1, W2.4, and final owner/release checkpoints |
+| 2026-07-05 | [Low-Friction Install & Auth Reuse](implemented/2026-07-05-low-friction-install-plan.md) | Implemented — #254 (plan), #317, #354 |
+| 2026-07-05 | [First-Run Time-to-Value: Real-Path Measurement Discipline](implemented/2026-07-05-first-run-ttfv-plan.md) | Implemented / closed — #259 (plan), #343; Goal B withdrawn and #330 closed unmerged; desktop-packaging verdict remains pending owner-run TTFV evidence |
+| 2026-07-05 | [Streaming Pipeline Latency — Score As You Discover](implemented/2026-07-05-streaming-pipeline-latency-plan.md) | Implemented — #260 (plan), #301, #306, #311; decisions recorded in #318 |
+| 2026-07-05 | [Launch-Readiness Artifacts](implemented/2026-07-05-launch-readiness-artifacts-plan.md) | Implemented / closed — #262 (plan), #298-#305, #324, #341, #354; owner-only publish actions remain in `docs/publish-checklist.md` |
+| 2026-07-05 | [Career Evidence Map + Interview Preparation](implemented/2026-07-05-evidence-map-interview-prep-plan.md) | Implemented — #263 (plan), #276, #279, #283, #285, #293, #294 |
+| 2026-07-05 | [Application Outcome Analytics And Artifact Comparison](implemented/2026-07-05-outcome-analytics-plan.md) | Implemented — #264 (plan), #273, #280, #284, #287, #295 |
+| 2026-07-05 | [Browser Extension — Capture, Assisted Autofill, and Deferred Guarded Submission](implemented/2026-07-05-browser-extension-plan.md) | Implemented through deterministic capture/autofill — #265 (plan), #277, #281, #282; P2b free-text drafts and P3 guarded submission remain deferred |
+| 2026-07-05 | [Saved Table Views + Daily Local Digest](implemented/2026-07-05-saved-views-daily-digest-plan.md) | Implemented — #267 (plan), #288-#292 |
 | 2026-07-05 | [Contact Research And Outreach Planner](implemented/2026-07-05-outreach-planner-plan.md) | Implemented — #266 (plan), #325, #331, #332, #333, #335, #347; ADR 2026-07-06 |
 | 2026-07-05 | [Product Rename to JobCtrl](implemented/2026-07-05-rename-jobctrl-plan.md) | Implemented — #261 (plan), #349; hardening #350; #351 closeout; R0.1 updates the final public spelling to JobCtrl |
+| 2026-07-05 | [Crawl Politeness Hardening](implemented/2026-07-05-crawl-politeness-plan.md) | Implemented — #272 (plan), #297-#316; pacing-test hardening #334; ADR 2026-07-06 |
+| 2026-07-08 | [Web UI/UX Revamp — Left-Rail Shell + JobCtrl Design System](implemented/2026-07-08-web-ui-revamp-plan.md) | Implemented — #356; design-system docs follow-up continues separately in #357 |
 
 Two 2026-05-17 backlog specs (`…-add-react`, `…-add-brows`) were drafted on
 `origin/mestre/develop-*` branches and never merged to `main`; only `…-add-root`

--- a/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
+++ b/docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md
@@ -1087,7 +1087,7 @@ first tag. Assemble this checklist, with links, as the final deliverable.
       recorded as non-error outcomes; no spoofed browser UA remains on any
       product fetch path. Delivered by the R10 train (PRs #297 → #315); ADR in
       `docs/decisions.md` (2026-07-06); plan
-      `docs/plans/2026-07-05-crawl-politeness-plan.md`. Check when the R10 train
+      `docs/plans/implemented/2026-07-05-crawl-politeness-plan.md`. Check when the R10 train
       is merged to `main`.
 - [x] W1.1–W1.7 merged, each with review gate `Gate: PASS` and QA gate
       `Gate: PASS` per repo process.

--- a/docs/plans/implemented/2026-07-05-browser-extension-plan.md
+++ b/docs/plans/implemented/2026-07-05-browser-extension-plan.md
@@ -1,6 +1,6 @@
 # Browser Extension — Capture, Assisted Autofill, and Deferred Guarded Submission
 
-> **Status:** Proposed. Not started. Three explicitly gated phases; on merge of this plan only Phase 0 (substrate) and Phase 1 (capture) are greenlightable. Phases 2 and 3 are gated on prior phases and on owner go/no-go.
+> **Status:** Implemented / archived 2026-07-08. Delivered by #265 (plan), #277 (local capability-token substrate), #281 (capture ingest), and #282 (deterministic autofill). Free-text answer drafting (P2b) and guarded submission (P3) remain intentionally deferred; the shipped extension has no submission path.
 > **Audience:** implementing agents (high reasoning effort) and the repository owner (gate decisions).
 > **Anchors verified against main @ `a488e4e9`.** Line numbers in this document are hints captured 2026-07-05 and WILL drift — locate every anchor by **symbol name** (grep/ripgrep). If a named symbol does not exist, STOP and report; do not create a lookalike.
 > **Style:** additive and local-first. Net-new surface under `apps/extension/`; no existing code path is deleted or replaced. Browser submission is never the default and never automatic.

--- a/docs/plans/implemented/2026-07-05-crawl-politeness-plan.md
+++ b/docs/plans/implemented/2026-07-05-crawl-politeness-plan.md
@@ -1,6 +1,6 @@
 # Crawl Politeness Hardening
 
-> **Status:** proposed — not started. Implementation plan only; no code in this PR.
+> **Status:** Implemented / archived 2026-07-08. Delivered by #272 (plan), #297-#316 (politeness model, gateway, routed fetch surfaces, UI, docs, config, gate closure), and #334 (pacing-test hardening).
 > **Gate:** this plan is a **pre-public-release gate** for the repository's
 > existing outbound fetch paths, and a **hard prerequisite** for any future
 > contact-research fetching. Both statements are load-bearing; see §"Gates".

--- a/docs/plans/implemented/2026-07-05-evidence-map-interview-prep-plan.md
+++ b/docs/plans/implemented/2026-07-05-evidence-map-interview-prep-plan.md
@@ -1,6 +1,8 @@
 # Career Evidence Map + Interview Preparation Implementation Plan
 
-> **Status:** Proposed — not yet implemented. This document specifies two coupled
+> **Status:** Implemented / archived 2026-07-08. Delivered by #263 (plan), #276 (contracts), #279 (projection), #283 (evidence-map UI), #285 (interview-prep generation), #293 (prep surface), and #294 (reflections). Live/in-session interview assistance remains out of scope.
+>
+> This document specifies two coupled
 > capabilities delivered as gated phases (the evidence map lands first; it feeds
 > preparation). It is a design/architecture plan, not a line-by-line script:
 > implementers are capable agents at high reasoning effort. Specify objectives,

--- a/docs/plans/implemented/2026-07-05-first-run-ttfv-plan.md
+++ b/docs/plans/implemented/2026-07-05-first-run-ttfv-plan.md
@@ -1,7 +1,7 @@
 # First-Run Time-to-Value: Real-Path Measurement Discipline
 
 - **Date:** 2026-07-05
-- **Status:** Amended 2026-07-06 — Goal B withdrawn; implementation now targets real-path measurement only.
+- **Status:** Implemented / archived 2026-07-08. Delivered by #259 (plan) and #343 (real-path measurement harness, probes, QA entry, and packaging-decision ADR scaffold). Goal B was withdrawn by owner decision and #330 was closed unmerged; the desktop-packaging verdict remains pending owner-run TTFV evidence in `docs/decisions.md`.
 - **Anchors verified against main @ a488e4e9.** Every path, symbol, command, and fixture cited below was checked against this worktree's HEAD. Per repo practice, machine-re-verify every anchor against the implementation base ref before handing any phase to an implementer. Content attributed to PR #254 is cited by PR number only; that plan is not yet on `main`.
 - **Owner-facing goal:** make the first ten and thirty minutes of a fresh JobCtrl install *provably* valuable on the real product path, measure that value on clean environments as an owner-run regression discipline, and define — with evidence, not guesswork — when a packaged desktop install becomes worth building.
 

--- a/docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md
+++ b/docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md
@@ -1,6 +1,6 @@
 # Launch-Readiness Artifacts Plan
 
-> **Status:** Proposed (plan only; no implementation in this PR).
+> **Status:** Implemented / archived 2026-07-08. Delivered by #262 (plan), #298-#305 (claims ledger, README/docs launch artifacts, demo inventory, publish checklist), #324 and #341 (claims-ledger currency passes), and #354 (post-rename launch README / install rewrite). Owner-only release actions remain governed by `docs/publish-checklist.md` and the release gate; they are not open implementation scope for this plan.
 > **Authored:** 2026-07-05.
 > **Anchors verified against main @ a488e4e9.**
 > **Audience:** implementing agents at high reasoning effort. This document

--- a/docs/plans/implemented/2026-07-05-low-friction-install-plan.md
+++ b/docs/plans/implemented/2026-07-05-low-friction-install-plan.md
@@ -1,7 +1,7 @@
 # Low-Friction Install & Auth Reuse Plan
 
 - **Date:** 2026-07-05
-- **Status:** Proposed — plan only, nothing implemented.
+- **Status:** Implemented / archived 2026-07-08. Delivered by #254 (plan), #317 (vendor-auth setup, setup probes, and auth reuse), and #354 (one-line bootstrap, Homebrew formula, global launcher, and launch README updates).
 - **Anchors:** All file/line references verified against `main @ ab73ea84`. Per repo practice, machine-re-verify every anchor against the implementation base ref before handing any phase to an implementer.
 - **Goal:** One-command setup that works across as many environments as the underlying tools permit, reusing whatever vendor auth is already present on the machine (Claude login/key, Codex login/key, Gemini key), and prompting only for what is genuinely missing.
 

--- a/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
+++ b/docs/plans/implemented/2026-07-05-oss-release-drive-to-done-plan.md
@@ -496,7 +496,7 @@ requirement. R11 guarded submission / browser-extension Phase 3 must not start.
 | Apply-safety hardening from the OSS spec is complete and merged | not-satisfied | W1.2-W1.7 are not done on the checked tree; see §9.2. |
 | Extension security review (§8) completed/published and privacy-invariant test (§7) enforced in CI | partially-satisfied | Privacy-invariant tests exist (`apps/extension/src/privacy.test.ts:13`-`:35`; `apps/extension/src/privacy.e2e.test.ts:19`-`:46`), but no completed/published extension security review was found in the merged docs. |
 | Release privacy gate green for extension package/archive | partially-satisfied | Release gate exists and runs scanner/self-test (`.github/workflows/release-check.yml:25`-`:29`); built extension privacy tests cover the dist package (`apps/extension/src/privacy.e2e.test.ts:19`-`:46`). This close-out did not independently run the extension package/archive privacy test suite; the PR verification runs the repository release scanner. |
-| Explicit owner go/no-go D-6 | not-satisfied | Browser plan D-6 remains an open owner decision (`docs/plans/2026-07-05-browser-extension-plan.md:386`). |
+| Explicit owner go/no-go D-6 | not-satisfied | Browser plan D-6 remains an open owner decision (`docs/plans/implemented/2026-07-05-browser-extension-plan.md:386`). |
 
 #### §6.2 safety-substrate status
 
@@ -522,7 +522,7 @@ requirement. R11 guarded submission / browser-extension Phase 3 must not start.
   the claims ledger itself says prompt injection is real and only limited, not
   removed (`docs/claims-ledger.md:141`).
 - **D-4 generic matcher confirmation:** the starting ATS family set and rollout
-  order remain owner-confirmed scope (`docs/plans/2026-07-05-browser-extension-plan.md:384`).
+  order remain owner-confirmed scope (`docs/plans/implemented/2026-07-05-browser-extension-plan.md:384`).
 - **Partial-submission behavior:** W1.2 remains open; current dry-run parsing can
   still convert `RESULT:APPLIED` during dry-run into `DryRunComplete`
   (`workers/automation/src/jobhunter/infrastructure/apply/claude_code_cli.py:369`-`:376`).
@@ -547,23 +547,23 @@ closed it as passed on 2026-07-07, with private concern details kept off-repo.
 | Confirm W2.4 default per-lane token ceilings and spend defaults. | OSS spec checkpoint `docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md:162`-`:163`; W2.4 DoD `:1052`-`:1068`. |
 | Record historical-blob acceptance and live capability posture before visibility flip. | OSS spec gate `docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md:1124`-`:1127`. |
 | Complete final manual QA and owner-only visibility flip / first release tag. | OSS spec gate `docs/plans/implemented/2026-07-03-oss-release-remediation-spec.md:1128`-`:1132`. |
-| Confirm comparison page row categories, alternative columns, maintenance cadence interval, and final sidebar label/placement; replace all alternative `TODO(owner)` placeholders only after facts are verified. | Launch-readiness plan `docs/plans/2026-07-05-launch-readiness-artifacts-plan.md:503`-`:516`; comparison placeholders `docs/comparison.md:26`-`:35`, `:44`-`:57`. |
-| Confirm the initial launch demo-asset set. | Launch-readiness plan `docs/plans/2026-07-05-launch-readiness-artifacts-plan.md:517`-`:532`. |
-| Set the Current-vs-Beta threshold and resolve the named reclassification candidates. | Launch-readiness plan `docs/plans/2026-07-05-launch-readiness-artifacts-plan.md:545`-`:554`; claims-ledger sign-off list `docs/claims-ledger.md:224`-`:237`. |
-| Name the claims-freeze sign-off owner and each Phase C publish-step owner. | Launch-readiness plan `docs/plans/2026-07-05-launch-readiness-artifacts-plan.md:555`-`:560`; claims ledger `docs/claims-ledger.md:240`-`:241`. |
+| Confirm comparison page row categories, alternative columns, maintenance cadence interval, and final sidebar label/placement; replace all alternative `TODO(owner)` placeholders only after facts are verified. | Launch-readiness plan `docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md:503`-`:516`; comparison placeholders `docs/comparison.md:26`-`:35`, `:44`-`:57`. |
+| Confirm the initial launch demo-asset set. | Launch-readiness plan `docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md:517`-`:532`. |
+| Set the Current-vs-Beta threshold and resolve the named reclassification candidates. | Launch-readiness plan `docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md:545`-`:554`; claims-ledger sign-off list `docs/claims-ledger.md:224`-`:237`. |
+| Name the claims-freeze sign-off owner and each Phase C publish-step owner. | Launch-readiness plan `docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md:555`-`:560`; claims ledger `docs/claims-ledger.md:240`-`:241`. |
 | Re-stamp the claims ledger against the final `main` SHA at actual freeze time. | Claims ledger freeze status `docs/claims-ledger.md:24`-`:38`. |
 | Confirm the claims-ledger location/publication decision. | Claims ledger owner row `docs/claims-ledger.md:222`-`:223`. |
-| Review final honest crawl user-agent contact string before real crawls. | Crawl-politeness plan `docs/plans/2026-07-05-crawl-politeness-plan.md:676`-`:697`. |
-| Decide whether per-source politeness policy editor / web knobs remain deferred or enter scope. | Crawl-politeness plan `docs/plans/2026-07-05-crawl-politeness-plan.md:737`-`:751`. |
-| Browser extension D-1: exact token model, storage, pairing UX, and whether a valid token relaxes the mutation-origin gate. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:381`. |
-| Browser extension D-2: whether unauthenticated loopback API reads stay open. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:382`. |
-| Browser extension D-3: extension provenance fields and source-id scheme. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:383`. |
-| Browser extension D-4: starting generic matcher family set and rollout order. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:384`. |
-| Browser extension D-5: offline capture queue retention policy. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:385`. |
-| Browser extension D-6: go/no-go to begin guarded-submission Phase 3 once §6.1 is satisfied. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:386`. |
-| Browser extension D-7: distribution channel and signing key ownership. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:387`. |
-| Browser extension D-8: target browser/engine for v1. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:388`. |
-| Browser extension D-9: whether to ship LLM-assisted free-text drafts or keep deterministic-only for v1. | Browser plan `docs/plans/2026-07-05-browser-extension-plan.md:389`. |
+| Review final honest crawl user-agent contact string before real crawls. | Crawl-politeness plan `docs/plans/implemented/2026-07-05-crawl-politeness-plan.md:676`-`:697`. |
+| Decide whether per-source politeness policy editor / web knobs remain deferred or enter scope. | Crawl-politeness plan `docs/plans/implemented/2026-07-05-crawl-politeness-plan.md:737`-`:751`. |
+| Browser extension D-1: exact token model, storage, pairing UX, and whether a valid token relaxes the mutation-origin gate. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:381`. |
+| Browser extension D-2: whether unauthenticated loopback API reads stay open. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:382`. |
+| Browser extension D-3: extension provenance fields and source-id scheme. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:383`. |
+| Browser extension D-4: starting generic matcher family set and rollout order. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:384`. |
+| Browser extension D-5: offline capture queue retention policy. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:385`. |
+| Browser extension D-6: go/no-go to begin guarded-submission Phase 3 once §6.1 is satisfied. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:386`. |
+| Browser extension D-7: distribution channel and signing key ownership. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:387`. |
+| Browser extension D-8: target browser/engine for v1. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:388`. |
+| Browser extension D-9: whether to ship LLM-assisted free-text drafts or keep deterministic-only for v1. | Browser plan `docs/plans/implemented/2026-07-05-browser-extension-plan.md:389`. |
 | Claims-ledger `TODO(owner)` cells. | None found by `rg -n "TODO\\(owner\\)" docs/claims-ledger.md`; remaining claims-ledger owner actions are listed above instead. |
 
 ## 10. Refreshed W1 residual inventory after remediation (2026-07-06)

--- a/docs/plans/implemented/2026-07-05-outcome-analytics-plan.md
+++ b/docs/plans/implemented/2026-07-05-outcome-analytics-plan.md
@@ -1,6 +1,6 @@
 # Application Outcome Analytics And Artifact Comparison — Implementation Plan
 
-> **Status:** Proposed. This is a planning document only; it ships no code.
+> **Status:** Implemented / archived 2026-07-08. Delivered by #264 (plan), #273 (minimum conversion sample baseline), #280 (read model), #284 (analytics view), #287 (artifact comparison), and #295 (outcome joins). Analytics remain descriptive/read-only and sample-gated.
 > **Anchors verified against `main` @ `a488e4e9`** (`fix(reliability): discover
 > fault isolation, truthful failures, honest read models`). Every path, symbol,
 > table, and column cited below was confirmed against this worktree HEAD; the

--- a/docs/plans/implemented/2026-07-05-outreach-planner-plan.md
+++ b/docs/plans/implemented/2026-07-05-outreach-planner-plan.md
@@ -357,7 +357,7 @@ per-host rate limiting** anywhere in the repository (only fixed per-site sleeps
 in the legacy `workers/automation/src/jobhunter/enrichment/detail.py`
 `SITE_DELAYS`). That gap affects every existing fetch surface, not just this
 workstream, so it is **not built here**. It is delivered by the crawl
-politeness hardening plan (`docs/plans/2026-07-05-crawl-politeness-plan.md`,
+politeness hardening plan (`docs/plans/implemented/2026-07-05-crawl-politeness-plan.md`,
 PR #272): a shared politeness gateway — robots.txt respect, per-host rate
 limiting and concurrency caps, per-run request budgets, honest user-agent —
 that all outbound fetching routes through, enforcing the declarative
@@ -895,7 +895,7 @@ Targeted tests this work must add/extend (by surface):
 | Risk | Mitigation |
 |---|---|
 | A future refactor introduces a send path and quietly breaks INV-1. | Aggregate invariant + no-send-transport grep test + adapter-never-called test + regression-matrix row (§8.3). |
-| Politeness gap (no robots/rate-limit today) leads to disrespectful fetching. | Phase 2 is hard-gated on the crawl politeness plan (`docs/plans/2026-07-05-crawl-politeness-plan.md`, PR #272) being merged and the enrichment fetch path routing through its gateway (§5.3); this plan builds no fetching before that. |
+| Politeness gap (no robots/rate-limit today) leads to disrespectful fetching. | Phase 2 is hard-gated on the crawl politeness plan (`docs/plans/implemented/2026-07-05-crawl-politeness-plan.md`, PR #272) being merged and the enrichment fetch path routing through its gateway (§5.3); this plan builds no fetching before that. |
 | Provenance omitted under time pressure, reproducing the "displayed value with no source" defect class. | INV-2 aggregate guard (no attribute without provenance) + projection + UI rendering + fixture; CLAUDE.md root-cause discipline. |
 | Registry/parity drift (event added on one side only). | Same-PR dual-registry rule (§4.6) + compile-time exhaustiveness + parity tests. |
 | Sensitive contact data (names, emails, page bodies) leaking into events/logs/telemetry. | Store only safe references + extracted fields; never raw bodies in `job_events`/projections/logs (mirrors the apply-feedback rule); treat as sensitive per CLAUDE.md. |

--- a/docs/plans/implemented/2026-07-05-saved-views-daily-digest-plan.md
+++ b/docs/plans/implemented/2026-07-05-saved-views-daily-digest-plan.md
@@ -1,6 +1,8 @@
 # Saved Table Views + Daily Local Digest Implementation Plan
 
-> **Status:** Proposed (not implemented). Two operator-productivity features
+> **Status:** Implemented / archived 2026-07-08. Delivered by #267 (plan) and #288-#292 (saved jobs table views, grouping/rules, digest read model, dashboard acknowledge flow, and `jobctrl digest`). Digest delivery remains local-only and explicitly acknowledged.
+>
+> Two operator-productivity features
 > planned together because both are read-side, local-first, and both compose
 > the existing Jobs table / dashboard surfaces.
 

--- a/docs/plans/implemented/2026-07-05-streaming-pipeline-latency-plan.md
+++ b/docs/plans/implemented/2026-07-05-streaming-pipeline-latency-plan.md
@@ -1,6 +1,6 @@
 # Streaming Pipeline Latency — Score As You Discover
 
-- **Status:** Proposed (not started)
+- **Status:** Implemented / archived 2026-07-08. Delivered by #260 (plan), #301 (per-family streaming fan-out), #306 (per-job preparation handoff), #311 (gated parallel source families), and #318 (decision-resolution record). The parallel-family cap remains default-sequential unless configured.
 - **Authored:** 2026-07-05
 - **Owning bounded contexts:** Discovery (orchestration), Enrichment, Scoring, Materials, Pipeline/Operations (read model + progress)
 - **Anchors verified against `main` @ `a488e4e9`**

--- a/docs/plans/implemented/2026-07-08-web-ui-revamp-plan.md
+++ b/docs/plans/implemented/2026-07-08-web-ui-revamp-plan.md
@@ -1,6 +1,6 @@
 # Web UI/UX Revamp — Left-Rail Shell + JobCtrl Design System
 
-- **Status:** In progress (this PR implements the plan end to end)
+- **Status:** Implemented / archived 2026-07-08. Delivered end-to-end by #356. Follow-up design-system documentation continues separately in #357 and is not blocking this plan archive.
 - **Branch:** `feat/ui-revamp`
 - **Date:** 2026-07-08
 - **Owner ask:** adopt a friendlier, more polished UX modeled on the JobCtrl

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -6,7 +6,7 @@
 > user documentation.
 >
 > Implements Phase C of
-> [`docs/plans/2026-07-05-launch-readiness-artifacts-plan.md`](plans/2026-07-05-launch-readiness-artifacts-plan.md)
+> [`docs/plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md`](plans/implemented/2026-07-05-launch-readiness-artifacts-plan.md)
 > §9.
 
 ## Purpose and boundary


### PR DESCRIPTION
## Summary
- archive implemented top-level plan files under `docs/plans/implemented/` with delivery status banners
- refresh `docs/plans/README.md` with current status and delivery PRs for the archived plans
- update ADR, launch-governance, and older plan references to the new implemented paths

## Validation
- `corepack pnpm docs:build`
- `python3 scripts/release_check.py`
- `git diff --check`
