### PR TITLE
fix(contact): block private research redirects

### DIFF
--- a/workers/automation/src/jobhunter/contact/activities.py
+++ b/workers/automation/src/jobhunter/contact/activities.py
@@ -156,7 +156,7 @@ def _run_contact_research(
 
 def _host(url: str) -> str:
     try:
-        return (urlsplit(url).netloc or "").lower()
+        return (urlsplit(url).hostname or "").lower().rstrip(".")
     except ValueError:
         return ""
 

--- a/workers/automation/src/jobhunter/domain/contact/source_policy.py
+++ b/workers/automation/src/jobhunter/domain/contact/source_policy.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+import ipaddress
+import socket
 from urllib.parse import urlsplit
 
 from jobhunter.domain.discovery.source_registry import (
@@ -93,11 +95,45 @@ def looks_protected(url: str) -> bool:
     return any(marker in text for marker in _PROTECTED_URL_MARKERS)
 
 
+_BLOCKED_HOSTNAMES: frozenset[str] = frozenset(
+    {
+        "localhost",
+        "metadata.google.internal",
+    }
+)
+
+
 def _host(url: str) -> str:
     try:
-        return (urlsplit(url).netloc or "").lower()
+        return (urlsplit(url).hostname or "").lower().rstrip(".")
     except ValueError:
         return ""
+
+
+def _is_blocked_ip_address(address: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _hostname_resolves_to_blocked_address(hostname: str) -> bool:
+    try:
+        addresses = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        # Keep the policy focused on the SSRF boundary without making source
+        # configuration depend on local DNS reachability; the fetch will fail
+        # later if the host truly cannot resolve.
+        return False
+    return any(_is_blocked_ip_address(result[4][0]) for result in addresses)
 
 
 def _is_public_web_url(url: str) -> bool:
@@ -105,7 +141,16 @@ def _is_public_web_url(url: str) -> bool:
         parts = urlsplit(url.strip())
     except ValueError:
         return False
-    return parts.scheme in {"http", "https"} and bool(parts.netloc)
+    if parts.scheme not in {"http", "https"} or not parts.netloc:
+        return False
+    hostname = (parts.hostname or "").lower().rstrip(".")
+    if not hostname:
+        return False
+    if hostname in _BLOCKED_HOSTNAMES or hostname.endswith(".localhost"):
+        return False
+    if _is_blocked_ip_address(hostname):
+        return False
+    return not _hostname_resolves_to_blocked_address(hostname)
 
 
 def contact_research_source_policy() -> SourcePolicy:

--- a/workers/automation/src/jobhunter/infrastructure/contact/research_fetcher.py
+++ b/workers/automation/src/jobhunter/infrastructure/contact/research_fetcher.py
@@ -14,19 +14,23 @@ from __future__ import annotations
 
 import logging
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from bs4 import BeautifulSoup
 
 from jobhunter.domain.contact.research import ResearchSourceOutcome
-from jobhunter.domain.contact.source_policy import ContactResearchSourcePolicy
+from jobhunter.domain.contact.source_policy import (
+    ContactResearchSourcePolicy,
+    ResearchSourceCategory,
+    ResearchSourceDecision,
+)
 from jobhunter.domain.ports.contact import ResearchPageFetch
 from jobhunter.infrastructure.network import (
     PolitenessGateway,
     PolitenessSession,
     PolitenessSourceContext,
     RunBudgetCounter,
-    build_opener,
     parse_retry_after,
 )
 
@@ -50,7 +54,7 @@ class GatewayContactResearchFetcher:
     ) -> None:
         self._policy = policy
         self._timeout = timeout
-        self._opener = opener or build_opener()
+        self._opener = opener or urllib.request.build_opener(_NoRedirectHandler())
         self._session = session or PolitenessSession(
             PolitenessGateway(),
             policy=policy.source_policy,
@@ -67,15 +71,47 @@ class GatewayContactResearchFetcher:
                 return ResearchPageFetch(outcome=decision.outcome.value)
             return self._get(url, decision.user_agent)
 
-    def _get(self, url: str, user_agent: str) -> ResearchPageFetch:
+    def _get(
+        self, url: str, user_agent: str, *, redirects_remaining: int = 5
+    ) -> ResearchPageFetch:
         request = urllib.request.Request(url, method="GET")
         request.add_header("User-Agent", user_agent)
         request.add_header("Accept", "text/html, */*;q=0.8")
         try:
             with self._opener.open(request, timeout=self._timeout) as response:
+                final_url = response.geturl()
+                final_decision = self._policy.authorize(
+                    category=ResearchSourceCategory.PUBLIC_WEB_PAGE.value, url=final_url
+                )
+                if final_decision is not ResearchSourceDecision.ALLOWED:
+                    log.warning("Contact research final URL rejected for %s -> %s", url, final_url)
+                    return ResearchPageFetch(outcome=ResearchSourceOutcome.REJECTED.value)
                 status = getattr(response, "status", None)
                 body = response.read()
         except urllib.error.HTTPError as exc:
+            if exc.code in (301, 302, 303, 307, 308):
+                if redirects_remaining <= 0:
+                    log.warning("Contact research redirect limit exceeded for %s", url)
+                    return ResearchPageFetch(
+                        outcome=ResearchSourceOutcome.REJECTED.value,
+                        final_url=url,
+                        status=exc.code,
+                    )
+                location = exc.headers.get("Location") if exc.headers else None
+                redirect_url = urllib.parse.urljoin(url, location or "")
+                decision = self._policy.authorize(
+                    category=ResearchSourceCategory.PUBLIC_WEB_PAGE.value, url=redirect_url
+                )
+                if decision is not ResearchSourceDecision.ALLOWED:
+                    log.warning("Contact research redirect rejected for %s -> %s", url, redirect_url)
+                    return ResearchPageFetch(
+                        outcome=ResearchSourceOutcome.REJECTED.value,
+                        final_url=redirect_url,
+                        status=exc.code,
+                    )
+                return self._get(
+                    redirect_url, user_agent, redirects_remaining=redirects_remaining - 1
+                )
             if exc.code in (429, 503):
                 retry_after = parse_retry_after(
                     exc.headers.get("Retry-After") if exc.headers else None
@@ -94,9 +130,14 @@ class GatewayContactResearchFetcher:
         return ResearchPageFetch(
             outcome=ResearchSourceOutcome.ALLOWED.value,
             text=_visible_text(body),
-            final_url=url,
+            final_url=final_url,
             status=int(status) if status is not None else None,
         )
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001, ARG002
+        return None
 
 
 def _visible_text(body: bytes) -> str:

--- a/workers/automation/tests/test_contact_research_source_policy.py
+++ b/workers/automation/tests/test_contact_research_source_policy.py
@@ -101,6 +101,23 @@ def test_public_source_must_use_http_or_https() -> None:
         )
 
 
+def test_public_source_rejects_local_private_and_metadata_targets() -> None:
+    policy = ContactResearchSourcePolicy(
+        domain_allowlist=("localhost", "127.0.0.1", "10.0.0.1", "169.254.169.254")
+    )
+    for url in (
+        "http://localhost:8766/v1/profile",
+        "http://127.0.0.1:8766/v1/profile",
+        "http://10.0.0.1/team",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://metadata.google.internal/computeMetadata/v1/",
+    ):
+        assert (
+            policy.authorize(category=ResearchSourceCategory.PUBLIC_WEB_PAGE.value, url=url)
+            is ResearchSourceDecision.REJECTED
+        )
+
+
 def test_protected_url_routes_to_manual_capture_not_auto_fetch() -> None:
     policy = ContactResearchSourcePolicy(domain_allowlist=(_ALLOWED_HOST,))
     for path in ("/login", "/sso/start", "/members?paywall=1"):

--- a/workers/automation/tests/test_contact_research_workflow.py
+++ b/workers/automation/tests/test_contact_research_workflow.py
@@ -10,6 +10,8 @@ and the LLM spend preflight is the existing shared one (§5.4 — no second syst
 from __future__ import annotations
 
 import sqlite3
+import urllib.error
+from email.message import Message
 from pathlib import Path
 
 import pytest
@@ -282,6 +284,46 @@ class _BlockedSession:
         return None
 
 
+class _AllowedSession:
+    @property
+    def user_agent(self) -> str:
+        return "JobHunter/test"
+
+    def guard(self, url: str):  # noqa: ARG002
+        from contextlib import contextmanager
+
+        from jobhunter.domain.ports.politeness import PolitenessDecision, PolitenessOutcome
+
+        @contextmanager
+        def _cm():
+            yield PolitenessDecision(
+                allowed=True,
+                outcome=PolitenessOutcome.ALLOWED,
+                user_agent="JobHunter/test",
+            )
+
+        return _cm()
+
+    def note_retry_after(self, url: str, seconds: float) -> None:  # noqa: ARG002
+        return None
+
+    def record_server_rate_limit(self, url: str, seconds=None) -> None:  # noqa: ARG002
+        return None
+
+
+class _RedirectOpener:
+    def open(self, request, timeout):  # noqa: ANN001, ARG002
+        headers = Message()
+        headers["Location"] = "http://127.0.0.1:8766/v1/profile"
+        raise urllib.error.HTTPError(
+            request.full_url,
+            302,
+            "Found",
+            headers,
+            fp=None,
+        )
+
+
 def test_gateway_fetcher_returns_block_outcome_without_fetching() -> None:
     policy = ContactResearchSourcePolicy(domain_allowlist=(_HOST,))
     fetcher = GatewayContactResearchFetcher(
@@ -289,4 +331,17 @@ def test_gateway_fetcher_returns_block_outcome_without_fetching() -> None:
     )
     result = fetcher.fetch(_TEAM_URL)
     assert result.outcome == ResearchSourceOutcome.ROBOTS_DISALLOWED.value
+    assert result.text == ""
+
+
+def test_gateway_fetcher_rejects_private_redirect_target() -> None:
+    policy = ContactResearchSourcePolicy(domain_allowlist=(_HOST,))
+    fetcher = GatewayContactResearchFetcher(
+        policy=policy, session=_AllowedSession(), opener=_RedirectOpener()
+    )
+
+    result = fetcher.fetch(_TEAM_URL)
+
+    assert result.outcome == ResearchSourceOutcome.REJECTED.value
+    assert result.final_url == "http://127.0.0.1:8766/v1/profile"
     assert result.text == ""


### PR DESCRIPTION
### Motivation
- Supervised contact research previously authorized only the originally supplied public URL but followed redirects server-side with `urllib`, allowing attacker-controlled redirects to loopback/RFC1918/metadata endpoints whose responses were passed to the LLM, creating an SSRF/exfiltration vector.
- The change hardens the SSRF boundary by rejecting private/metadata targets and by preventing automatic redirect-driven fetches that bypass the original allowlist.

### Description
- Normalize allowlist extraction to use parsed `hostname` (via `urlsplit(...).hostname`) and strip trailing dots so host comparison is robust; update `_host` used when building per-run allowlists.
- Add hostname and address checks in `ContactResearchSourcePolicy`: `_BLOCKED_HOSTNAMES`, `_is_blocked_ip_address` (using `ipaddress`), and `_hostname_resolves_to_blocked_address` (using `socket.getaddrinfo`), and update `_is_public_web_url` to reject localhost, metadata hostnames, IPs in private/link-local/loopback/reserved/multicast/unspecified ranges, and hostnames resolving to such addresses.
- Disable automatic `urllib` redirects for contact research by using a no-redirect handler, re-authorize each redirect/final URL with the `ContactResearchSourcePolicy` before reading response bodies, enforce a redirect limit, and record the actual `final_url` on accepted fetches in the gateway fetcher.
- Add regression tests exercising the policy and fetcher: `test_public_source_rejects_local_private_and_metadata_targets` and `test_gateway_fetcher_rejects_private_redirect_target`, and update unit test scaffolding that exercises the gateway fetcher behavior.

### Testing
- Ran style/lint checks with `python -m ruff check` against the modified sources which passed.
- Verified syntax by running `python -m compileall -q` on the changed modules which completed without errors.
- Added targeted pytest cases but full `pytest` runs could not be executed in this environment due to unavailable Python dependencies (`opentelemetry`) and an inability to fetch packages via the `uv` toolchain; therefore the new tests are present but not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c6f6fb04c8324b309572f539aea46)