### PR TITLE
fix(enrichment): isolate authenticated LinkedIn resolver

### DIFF
--- a/workers/automation/src/jobhunter/enrichment/detail.py
+++ b/workers/automation/src/jobhunter/enrichment/detail.py
@@ -31,7 +31,7 @@ import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from playwright.sync_api import sync_playwright
 
@@ -104,8 +104,13 @@ def set_proxy(proxy_str: str | None) -> None:
 
 def _is_linkedin_job(site: str | None, url: str) -> bool:
     site_text = str(site or "").strip().lower()
-    url_text = str(url or "").strip().lower()
-    return site_text == "linkedin" or "linkedin.com/jobs/" in url_text
+    url_text = str(url or "").strip()
+    parsed = urlparse(url_text)
+    host = (parsed.hostname or "").lower()
+    path = parsed.path.rstrip("/").lower()
+    if host == "linkedin.com" or host.endswith(".linkedin.com"):
+        return path == "/jobs" or path.startswith("/jobs/")
+    return site_text == "linkedin" and not parsed.scheme and url_text.startswith("/jobs/")
 
 
 # -- URL resolution ----------------------------------------------------------
@@ -681,6 +686,15 @@ def scrape_site_batch(
         with sync_playwright() as p:
             browser = None
             resolver: LinkedInApplyUrlResolver | None = None
+            resolver_page = None
+
+            launch_opts: dict = {"headless": True}
+            if _PROXY_CONFIG is not None:
+                launch_opts["proxy"] = _PROXY_CONFIG.playwright
+            browser = p.chromium.launch(**launch_opts)
+            context = browser.new_context(user_agent=UA)
+            page = context.new_page()
+
             if linkedin_apply_resolver_enabled() and _is_linkedin_job(site, jobs[0][0]):
                 resolver = LinkedInApplyUrlResolver(
                     proxy=_PROXY_CONFIG,
@@ -689,29 +703,19 @@ def scrape_site_batch(
                 )
                 try:
                     resolver.start()
-                    page = resolver.new_page()
+                    resolver_page = resolver.new_page()
                     log.info(
-                        "LinkedIn authenticated browser enabled for %d enrichment job(s)",
+                        "LinkedIn authenticated apply resolver enabled for %d enrichment job(s)",
                         len(jobs),
                     )
                 except Exception as exc:  # noqa: BLE001 - fallback to static browser
                     log.warning(
-                        "LinkedIn authenticated browser unavailable; falling back to unauthenticated enrichment: %s",
+                        "LinkedIn authenticated apply resolver unavailable; falling back to unauthenticated enrichment: %s",
                         exc,
                     )
                     resolver.close()
                     resolver = None
-                    page = None
-            else:
-                page = None
-
-            if page is None:
-                launch_opts: dict = {"headless": True}
-                if _PROXY_CONFIG is not None:
-                    launch_opts["proxy"] = _PROXY_CONFIG.playwright
-                browser = p.chromium.launch(**launch_opts)
-                context = browser.new_context(user_agent=UA)
-                page = context.new_page()
+                    resolver_page = None
 
             for i, (url, title) in enumerate(jobs):
                 if cancel_event is not None and cancel_event.is_set():
@@ -775,7 +779,7 @@ def scrape_site_batch(
                         url=url,
                         cascade_result=cascade_result,
                         resolver=resolver,
-                        page=page,
+                        page=resolver_page,
                     )
                     stats["processed"] += 1
 

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -19,6 +19,7 @@ from jobhunter.domain.tenant import LOCAL_TENANT
 from jobhunter.enrichment.detail import (
     _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS,
     _apply_authenticated_linkedin_apply_url,
+    _is_linkedin_job,
     _reset_authenticated_linkedin_retry_candidates,
 )
 from jobhunter.infrastructure.enrichment import SqliteEnrichmentRepository
@@ -128,6 +129,18 @@ def _save_failed(
         if attempt_index < attempts - 1:
             aggregate = aggregate.reset(reset_at=now)
     repo.save(aggregate)
+
+
+def test_linkedin_job_detection_requires_linkedin_host() -> None:
+    assert _is_linkedin_job("linkedin", "https://www.linkedin.com/jobs/view/123")
+    assert _is_linkedin_job(None, "https://linkedin.com/jobs/view/123")
+    assert _is_linkedin_job("linkedin", "/jobs/view/123")
+
+    assert not _is_linkedin_job(
+        "linkedin", "https://mail.google.com/mail/u/0/#inbox/linkedin.com/jobs/123"
+    )
+    assert not _is_linkedin_job(None, "https://evil.example/linkedin.com/jobs/123")
+    assert not _is_linkedin_job(None, "https://notlinkedin.com/jobs/view/123")
 
 
 def test_authenticated_apply_url_upgrades_partial_linkedin_enrichment() -> None:


### PR DESCRIPTION
### Motivation
- Prevent a data-exfiltration path where a weak substring match (`linkedin.com/jobs/`) and a default-enabled authenticated resolver could cause an authenticated browser context to navigate to attacker-controlled URLs and leak page HTML into the LLM prompt. 
- Ensure normal detail scraping uses a fresh unauthenticated browser context while the authenticated resolver is used only for apply-URL resolution.

### Description
- Tighten LinkedIn detection in `._is_linkedin_job` to parse the URL and require a `linkedin.com` hostname (or subdomain) with a `/jobs` path for absolute URLs, and only accept discovery-local relative `/jobs/...` paths when `site == "linkedin"` (file: `workers/automation/src/jobhunter/enrichment/detail.py`).
- Always create a fresh unauthenticated Playwright page for `scrape_detail_page` and reserve the resolver's persistent authenticated page (`resolver_page`) only for authenticated apply-URL resolution; pass `resolver_page` into `_apply_authenticated_linkedin_apply_url` instead of reusing the normal scrape page (file: `workers/automation/src/jobhunter/enrichment/detail.py`).
- Update log messages to reflect the clarified behavior and failure paths (file: `workers/automation/src/jobhunter/enrichment/detail.py`).
- Add a regression test `test_linkedin_job_detection_requires_linkedin_host` to ensure spoofed URLs like Gmail fragments or non-LinkedIn hosts containing `linkedin.com/jobs/` do not trigger the authenticated resolver (file: `workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py`).

### Testing
- Ran `python -m compileall -q workers/automation/src/jobhunter/enrichment/detail.py workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py` which succeeded.  
- Attempted `PYTHONPATH=workers/automation/src python -m pytest -q workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py workers/automation/tests/test_linkedin_apply_resolver.py`, which failed due to missing test dependency `opentelemetry` in the execution environment.  
- Attempted project test/lint commands via the `uv` wrapper (`uv --project workers/automation run --extra dev pytest` and `uv --project workers/automation run --extra dev ruff check`) but these were blocked by environment dependency resolution and PyPI network failures and therefore could not be completed.  
- Performed static diffs and local formatting checks (`git diff --check`, local file syntax checks) to verify the change is syntactically correct and the new test is present.  

If you want, I can add an environment-only gate or an explicit opt-in env var to disable the authenticated resolver by default as an additional safety measure, but the current changes remove the immediate cross-host substring-trigger and isolate authenticated navigation to the resolver-only page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a7644c7008324bf6cfa2ab1abed75)