### PR TITLE
fix(enrichment): gate LinkedIn resolver by URL host

### DIFF
--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -31,7 +31,7 @@ import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 from playwright.sync_api import sync_playwright
 
@@ -163,9 +163,27 @@ def set_proxy(proxy_str: str | None) -> None:
 
 
 def _is_linkedin_job(site: str | None, url: str) -> bool:
-    site_text = str(site or "").strip().lower()
-    url_text = str(url or "").strip().lower()
-    return site_text == "linkedin" or "linkedin.com/jobs/" in url_text
+    url_text = str(url or "").strip()
+    if not url_text:
+        return False
+
+    # Source labels are hints only. The authenticated LinkedIn profile boundary
+    # is selected from the parsed URL itself so URL paths/fragments cannot opt in.
+    source_is_linkedin = str(site or "").strip().lower() == "linkedin"
+    if not source_is_linkedin and "linkedin" not in url_text.lower():
+        return False
+
+    try:
+        parsed = urlparse(url_text)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    hostname = (parsed.hostname or "").lower().rstrip(".")
+    if hostname != "linkedin.com" and not hostname.endswith(".linkedin.com"):
+        return False
+    path = parsed.path.lower()
+    return path == "/jobs" or path.startswith("/jobs/")
 
 
 # -- URL resolution ----------------------------------------------------------
@@ -947,7 +965,11 @@ def scrape_site_batch(
         with sync_playwright() as p:
             browser = None
             resolver: LinkedInApplyUrlResolver | None = None
-            if linkedin_apply_resolver_enabled() and _is_linkedin_job(site, jobs[0][0]):
+            authenticated_page = None
+            anonymous_page = None
+            if linkedin_apply_resolver_enabled() and any(
+                _is_linkedin_job(site, job[0]) for job in jobs
+            ):
                 # Owner-scoped authenticated context: present the real logged-in
                 # browser identity (user_agent=None), never the bot UA, matching
                 # _default_linkedin_apply_resolver_factory (D1/D3, see module top).
@@ -958,10 +980,10 @@ def scrape_site_batch(
                 )
                 try:
                     resolver.start()
-                    page = resolver.new_page()
+                    authenticated_page = resolver.new_page()
                     log.info(
                         "LinkedIn authenticated browser enabled for %d enrichment job(s)",
-                        len(jobs),
+                        sum(1 for job in jobs if _is_linkedin_job(site, job[0])),
                     )
                 except Exception as exc:  # noqa: BLE001 - fallback to static browser
                     log.warning(
@@ -970,38 +992,52 @@ def scrape_site_batch(
                     )
                     resolver.close()
                     resolver = None
-                    page = None
-            else:
-                page = None
 
-            # The authenticated LinkedIn context is the owner's logged-in session,
-            # so robots.txt is an owner decision there (D1/D3) — pace + budget it,
-            # but do not enforce an anonymous robots verdict on the owner's own
-            # account. Every other (anonymous) batch honors robots. This gateway
-            # also resolves the honest UA for the anonymous context below, so the
-            # identity robots is evaluated with is exactly the identity the fetch
-            # presents (never an import-time constant, so an owner UA override
-            # reaches the browser).
-            if resolver is not None:
-                batch_gateway: PolitenessGateway = PolitenessGateway(
-                    robots=_OwnerAuthenticatedRobots(),
-                    rate_limiter=get_shared_rate_limiter(),
+            # The authenticated LinkedIn context is the owner's logged-in
+            # session, so robots.txt is an owner decision there (D1/D3) — pace +
+            # budget it, but do not enforce an anonymous robots verdict on the
+            # owner's own LinkedIn account. Anonymous rows keep the normal
+            # gateway and never share the authenticated browser/profile.
+            owner_authenticated_session: PolitenessSession | None = None
+            if resolver is not None and authenticated_page is not None:
+                owner_authenticated_session = _enrichment_session(
+                    PolitenessGateway(
+                        robots=_OwnerAuthenticatedRobots(),
+                        rate_limiter=get_shared_rate_limiter(),
+                    ),
+                    run_budget,
+                    conn,
+                    site=site,
                 )
-            else:
-                batch_gateway = gateway or PolitenessGateway()
+            anonymous_gateway = gateway or PolitenessGateway()
+            anonymous_session = _enrichment_session(
+                anonymous_gateway,
+                run_budget,
+                conn,
+                site=site,
+            )
 
-            if page is None:
+            def _ensure_anonymous_page():
+                nonlocal browser, anonymous_page
+                if anonymous_page is not None:
+                    return anonymous_page
                 launch_opts: dict = {"headless": True}
                 if _PROXY_CONFIG is not None:
                     launch_opts["proxy"] = _PROXY_CONFIG.playwright
                 browser = p.chromium.launch(**launch_opts)
-                # Anonymous context presents the gateway's honest UA; the
-                # authenticated-LinkedIn page above keeps the owner's real
-                # browser identity (user_agent=None) and never enters here.
-                context = browser.new_context(user_agent=batch_gateway.user_agent)
-                page = context.new_page()
+                context = browser.new_context(user_agent=anonymous_gateway.user_agent)
+                anonymous_page = context.new_page()
+                return anonymous_page
 
-            session = _enrichment_session(batch_gateway, run_budget, conn, site=site)
+            def _page_and_session_for(url: str) -> tuple[object, PolitenessSession, object | None]:
+                if (
+                    resolver is not None
+                    and authenticated_page is not None
+                    and owner_authenticated_session is not None
+                    and _is_linkedin_job(site, url)
+                ):
+                    return authenticated_page, owner_authenticated_session, resolver
+                return _ensure_anonymous_page(), anonymous_session, None
 
             for i, (url, title) in enumerate(jobs):
                 if cancel_event is not None and cancel_event.is_set():
@@ -1038,6 +1074,8 @@ def scrape_site_batch(
                     )
                     conn.commit()
                     continue
+
+                page, session, active_resolver = _page_and_session_for(url)
 
                 # R10 pre-navigation gate (peek). A block folds into the lifecycle
                 # WITHOUT entering 'running' (Running->Blocked is not valid;
@@ -1092,7 +1130,7 @@ def scrape_site_batch(
                         site=site,
                         url=url,
                         cascade_result=cascade_result,
-                        resolver=resolver,
+                        resolver=active_resolver,
                         page=page,
                     )
                     stats["processed"] += 1

--- a/workers/automation/tests/test_enrichment_politeness_gate.py
+++ b/workers/automation/tests/test_enrichment_politeness_gate.py
@@ -393,31 +393,101 @@ class _FakeResolver:
 def test_authenticated_linkedin_session_skips_robots_but_keeps_budget(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tier1_extraction: None
 ) -> None:
-    with _disallow_all_robots() as server:
-        db_path = tmp_path / "jobs.db"
-        conn = init_db(db_path)
-        url = f"{server.base_url}/jobs/linkedin-1"
-        try:
-            _seed_pending(conn, url, "linkedin")
-            sink: list[str] = []
-            monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "1")
-            monkeypatch.setattr(
-                detail, "LinkedInApplyUrlResolver", lambda **kw: _FakeResolver(sink, **kw)
-            )
-            # sync_playwright is only used for the anonymous fallback; the fake
-            # resolver supplies the page here.
-            monkeypatch.setattr(detail, "sync_playwright", lambda: _SpyPlaywright())
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    url = "https://www.linkedin.com/jobs/view/1"
+    try:
+        _seed_pending(conn, url, "linkedin")
+        sink: list[str] = []
+        monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "1")
+        monkeypatch.setattr(
+            detail, "LinkedInApplyUrlResolver", lambda **kw: _FakeResolver(sink, **kw)
+        )
+        # sync_playwright is only used for the anonymous fallback; the fake
+        # resolver supplies the page here.
+        monkeypatch.setattr(detail, "sync_playwright", lambda: _SpyPlaywright())
 
-            stats = scrape_site_batch(conn, "linkedin", [(url, "Role")], gateway=offline_gateway())
+        stats = scrape_site_batch(
+            conn,
+            "linkedin",
+            [(url, "Role")],
+            gateway=offline_gateway(robots=DenyAllRobots()),
+        )
 
-            # Robots disallows the host, yet the owner's authenticated session
-            # navigates (D1/D3 carve-out) — it is NOT folded as robots-blocked.
-            assert sink == [url]
-            assert stats["blocked"] == 0
-            assert _blocked_metric(conn, url) is None
-            assert _enrich_stage(conn, url)["state"] == "succeeded"
-        finally:
-            close_connection(db_path)
+        # Robots disallows the host, yet the owner's authenticated LinkedIn
+        # session navigates (D1/D3 carve-out) — it is NOT folded as robots-blocked.
+        assert sink == [url]
+        assert stats["blocked"] == 0
+        assert _blocked_metric(conn, url) is None
+        assert _enrich_stage(conn, url)["state"] == "succeeded"
+    finally:
+        close_connection(db_path)
+
+
+def test_non_linkedin_url_with_linkedin_substring_uses_anonymous_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tier1_extraction: None
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    url = "https://mail.google.com/mail/u/0/#inbox/linkedin.com/jobs/123"
+    try:
+        _seed_pending(conn, url, "linkedin")
+        authenticated_constructed: list[object] = []
+        anonymous_playwright = _SpyPlaywright()
+
+        def _resolver_factory(**kwargs: object) -> _FakeResolver:
+            authenticated_constructed.append(kwargs)
+            return _FakeResolver([], **kwargs)
+
+        monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "1")
+        monkeypatch.setattr(detail, "LinkedInApplyUrlResolver", _resolver_factory)
+        monkeypatch.setattr(detail, "sync_playwright", lambda: anonymous_playwright)
+
+        stats = scrape_site_batch(conn, "linkedin", [(url, "Role")], gateway=offline_gateway())
+
+        assert authenticated_constructed == []
+        assert anonymous_playwright.goto_calls == [url]
+        assert stats["ok"] == 1
+        assert _enrich_stage(conn, url)["state"] == "succeeded"
+    finally:
+        close_connection(db_path)
+
+
+def test_mixed_linkedin_batch_does_not_reuse_authenticated_page_for_other_hosts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tier1_extraction: None
+) -> None:
+    db_path = tmp_path / "jobs.db"
+    conn = init_db(db_path)
+    linkedin_url = "https://www.linkedin.com/jobs/view/1"
+    non_linkedin_url = "https://mail.google.com/mail/u/0/#inbox/linkedin.com/jobs/123"
+    try:
+        _seed_pending(conn, linkedin_url, "linkedin")
+        _seed_pending(conn, non_linkedin_url, "linkedin")
+        authenticated_gotos: list[str] = []
+        anonymous_playwright = _SpyPlaywright()
+
+        monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "1")
+        monkeypatch.setattr(
+            detail,
+            "LinkedInApplyUrlResolver",
+            lambda **kw: _FakeResolver(authenticated_gotos, **kw),
+        )
+        monkeypatch.setattr(detail, "sync_playwright", lambda: anonymous_playwright)
+
+        stats = scrape_site_batch(
+            conn,
+            "linkedin",
+            [(linkedin_url, "LinkedIn role"), (non_linkedin_url, "Spoofed role")],
+            gateway=offline_gateway(),
+        )
+
+        assert authenticated_gotos == [linkedin_url]
+        assert anonymous_playwright.goto_calls == [non_linkedin_url]
+        assert stats["ok"] == 2
+        assert _enrich_stage(conn, linkedin_url)["state"] == "succeeded"
+        assert _enrich_stage(conn, non_linkedin_url)["state"] == "succeeded"
+    finally:
+        close_connection(db_path)
 
 
 def test_owner_authenticated_robots_allows_but_budget_still_applies() -> None:

--- a/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
+++ b/workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py
@@ -19,6 +19,7 @@ from jobctrl.domain.tenant import LOCAL_TENANT
 from jobctrl.enrichment.detail import (
     _MAX_AUTHENTICATED_LINKEDIN_RETRY_ATTEMPTS,
     _apply_authenticated_linkedin_apply_url,
+    _is_linkedin_job,
     _reset_authenticated_linkedin_retry_candidates,
 )
 from jobctrl.infrastructure.enrichment import SqliteEnrichmentRepository
@@ -130,6 +131,38 @@ def _save_failed(
         if attempt_index < attempts - 1:
             aggregate = aggregate.reset(reset_at=now)
     repo.save(aggregate)
+
+
+@pytest.mark.parametrize(
+    ("site", "url"),
+    [
+        ("linkedin", "https://www.linkedin.com/jobs/view/123"),
+        (None, "https://linkedin.com/jobs/view/123"),
+        ("LinkedIn", "https://ca.linkedin.com/jobs/apply/123"),
+    ],
+)
+def test_linkedin_job_classifier_accepts_linkedin_job_hosts(
+    site: str | None, url: str
+) -> None:
+    assert _is_linkedin_job(site, url)
+
+
+@pytest.mark.parametrize(
+    ("site", "url"),
+    [
+        (
+            "linkedin",
+            "https://mail.google.com/mail/u/0/#inbox/linkedin.com/jobs/123",
+        ),
+        (None, "https://example.com/linkedin.com/jobs/123"),
+        (None, "https://linkedin.com.evil.test/jobs/view/123"),
+        ("linkedin", "not a url linkedin.com/jobs/123"),
+    ],
+)
+def test_linkedin_job_classifier_rejects_non_linkedin_hosts(
+    site: str | None, url: str
+) -> None:
+    assert not _is_linkedin_job(site, url)
 
 
 def test_authenticated_apply_url_upgrades_partial_linkedin_enrichment() -> None:


### PR DESCRIPTION
## Summary
- Gate authenticated LinkedIn resolver selection on the parsed `http(s)` URL hostname plus `/jobs` path, not source labels or raw substring matches.
- Keep actual LinkedIn jobs eligible for the owner-authenticated resolver path.
- Select the browser page/session per job so mixed batches cannot reuse the authenticated profile for non-LinkedIn URLs.
- Add regressions for hostile non-LinkedIn URLs that contain `linkedin.com/jobs/` in attacker-controlled URL components, including a mixed-batch case.

## Root Cause
The enrichment batch selector treated the source label and raw URL text as sufficient proof of a LinkedIn job. It also selected one browser page/session for the whole batch, so a batch starting with a real LinkedIn job could reuse the copied, owner-authenticated profile for a later non-LinkedIn URL.

## Validation
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_linkedin_authenticated_enrichment_retry.py workers/automation/tests/test_linkedin_apply_resolver.py workers/automation/tests/test_enrichment_politeness_gate.py::test_authenticated_linkedin_session_skips_robots_but_keeps_budget workers/automation/tests/test_enrichment_politeness_gate.py::test_non_linkedin_url_with_linkedin_substring_uses_anonymous_context workers/automation/tests/test_enrichment_politeness_gate.py::test_mixed_linkedin_batch_does_not_reuse_authenticated_page_for_other_hosts` -> 25 passed
- `uv --project workers/automation run --extra dev ruff check .` -> passed
- `uv --project workers/automation run --extra dev pytest -q` -> 2124 passed, 1 warning
- `git diff --check` -> passed
