### PR TITLE
fix: block unsafe enrichment URLs before LLM extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,11 @@ bounds each run's request budget, and sends an honest `User-Agent`
 or override that identity before crawling real sites via
 `JOBCTRL_CRAWL_UA_PRODUCT` / `JOBCTRL_CRAWL_UA_CONTACT`
 ([Configuration → Crawl Politeness](docs/user/configuration.md#crawl-politeness));
-`jobctrl doctor` prints the effective value. JobCtrl never bypasses login,
-paywall, CAPTCHA, rate-limit, or bot-control gates.
+`jobctrl doctor` prints the effective value. Direct targets, redirects, and
+Playwright subrequests must also be public HTTP(S) destinations; loopback,
+private, link-local, metadata-service, and file URLs are blocked before content
+extraction or LLM enrichment. JobCtrl never bypasses login, paywall, CAPTCHA,
+rate-limit, or bot-control gates.
 
 ### Back Up And Restore
 

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -112,11 +112,14 @@ honors `robots.txt` (failing closed on an inconclusive fetch — a `5xx` or time
 DNS failure or refused connection), paces requests per host, bounds each run's
 request budget, and stamps a single honest
 `User-Agent` — `JobCtrl/<version> (+<repo url>)` by default, never a spoofed
-browser. Blocked fetches become recorded outcomes (robots-disallowed /
-rate-limited / budget-exhausted), visible per source in the Source Health card,
-not scrape errors. See [Security → Crawl Politeness](security.md#crawl-politeness)
-for the full posture and [Configuration → Crawl Politeness](configuration.md#crawl-politeness)
-to review or override the user-agent.
+browser. Direct targets, redirects, and Playwright subrequests must be public
+HTTP(S) destinations; loopback, private, link-local, metadata-service, and file
+URLs are blocked before content extraction or LLM enrichment. Blocked fetches
+become recorded outcomes (robots-disallowed / rate-limited / budget-exhausted /
+unsafe-url), not scrape errors. See
+[Security → Crawl Politeness](security.md#crawl-politeness) for the full posture
+and [Configuration → Crawl Politeness](configuration.md#crawl-politeness) to
+review or override the user-agent.
 
 ## Responsible Use Boundaries
 

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -190,20 +190,26 @@ navigations alike — routes through one crawl-politeness gateway. It:
   can override the product token and contact via
   [configuration](configuration.md#crawl-politeness); review it before real
   crawls.
+- **Rejects non-public destinations** before content extraction: direct targets,
+  redirects, and Playwright subrequests must be public HTTP(S) destinations.
+  Loopback, private, link-local, metadata-service, and file URLs are blocked
+  before page content can feed enrichment or LLM-assisted extraction.
 - **Paces requests per host** (a minimum interval + a concurrency cap) and
   **bounds each run's request budget**, so parallel crawls cannot hammer a host.
   A server `Retry-After` is honored but clamped, so a hostile header cannot
   freeze a worker.
 
 A blocked fetch is recorded as a first-class **outcome** — robots-disallowed,
-rate-limited, or budget-exhausted — never a scrape error, and is surfaced per
-source in the Source Health card (`SourcePolitenessBadges`) and discovery
-controls. Broad job boards fetched through `python-jobspy` own their internal
-per-board transport, so JobCtrl cannot robots-gate those individual requests;
-it applies budget + pacing at its own invocation boundary, and `jobctrl
-doctor` discloses when broad boards are active. The authenticated LinkedIn path
-uses your own logged-in browser session and presents its real browser identity —
-an owner-scoped exception that is still rate- and budget-limited.
+rate-limited, budget-exhausted, or unsafe-url — never a scrape error. Politeness
+blocks are surfaced per source in the Source Health card
+(`SourcePolitenessBadges`) and discovery controls; unsafe enrichment URLs are
+non-retryable detail failures. Broad job boards fetched through `python-jobspy`
+own their internal per-board transport, so JobCtrl cannot robots-gate those
+individual requests; it applies budget + pacing at its own invocation boundary,
+and `jobctrl doctor` discloses when broad boards are active. The authenticated
+LinkedIn path uses your own logged-in browser session and presents its real
+browser identity — an owner-scoped exception that is still rate- and
+budget-limited.
 
 ## Credentials
 

--- a/workers/automation/src/jobctrl/discovery/smartextract.py
+++ b/workers/automation/src/jobctrl/discovery/smartextract.py
@@ -49,7 +49,9 @@ from jobctrl.infrastructure.network import (
     PolitenessGateway,
     PolitenessSession,
     PolitenessSourceContext,
+    PublicHttpUrlRouteGuard,
     RunBudgetCounter,
+    validate_public_http_url,
 )
 from jobctrl.infrastructure.discovery.location_filter import (
     configured_location_filters,
@@ -379,15 +381,8 @@ def _normalize_job_url(url: object, source_url: str | None = None) -> str | None
 # -- Page intelligence collector ---------------------------------------------
 
 
-def collect_page_intelligence(
-    url: str, headless: bool = True, *, session: PolitenessSession | None = None
-) -> dict:
-    """Load a page with Playwright and collect every signal a scraping engineer
-    would look at in DevTools. Returns a structured intelligence report.
-
-    R10: the navigation is politeness-gated. A robots-deny / budget-exhaustion
-    performs zero navigation and returns the empty intelligence report."""
-    intel: dict = {
+def _empty_page_intelligence(url: str) -> dict:
+    return {
         "url": url,
         "json_ld": [],
         "api_responses": [],
@@ -396,6 +391,18 @@ def collect_page_intelligence(
         "dom_stats": {},
         "card_candidates": [],
     }
+
+
+def collect_page_intelligence(
+    url: str, headless: bool = True, *, session: PolitenessSession | None = None
+) -> dict:
+    """Load a page with Playwright and collect every signal a scraping engineer
+    would look at in DevTools. Returns a structured intelligence report.
+
+    R10: the navigation is public-destination checked and politeness-gated. A
+    robots-deny, unsafe destination, or budget-exhaustion performs zero
+    navigation and returns the empty intelligence report."""
+    intel: dict = _empty_page_intelligence(url)
 
     captured_responses: list[dict] = []
 
@@ -422,141 +429,184 @@ def collect_page_intelligence(
             except Exception:
                 pass
 
+    initial_safety = validate_public_http_url(url)
+    if not initial_safety.allowed:
+        log.warning("smart-extract: unsafe navigation skipped %s: %s", url, initial_safety.reason)
+        return intel
+
     session = session or _smart_extract_session()
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=headless)
-        # Present the gateway-resolved honest UA (the same identity robots is
-        # evaluated with in session.guard below), never an import-time constant —
-        # so an owner UA override reaches the browser fetch.
-        page = browser.new_page(user_agent=session.user_agent)
-        page.on("response", on_response)
+        try:
+            # Present the gateway-resolved honest UA (the same identity robots is
+            # evaluated with in session.guard below), never an import-time constant —
+            # so an owner UA override reaches the browser fetch.
+            page = browser.new_page(user_agent=session.user_agent)
+            route_guard = PublicHttpUrlRouteGuard(page).install()
+            page.on("response", on_response)
 
-        with session.guard(url) as decision:
-            if not decision.allowed:
-                log.warning(
-                    "smart-extract: navigation skipped by politeness gate %s: %s",
-                    url,
-                    decision.reason,
-                )
-                browser.close()
-                return intel
-            page.goto(url, timeout=60000)
-            page.wait_for_load_state("networkidle")
-
-        intel["page_title"] = page.title()
-
-        # 1. JSON-LD
-        for el in page.query_selector_all('script[type="application/ld+json"]'):
             try:
-                data = json.loads(el.inner_text())
-                intel["json_ld"].append(data)
-            except Exception:
-                pass
+                with session.guard(url) as decision:
+                    if not decision.allowed:
+                        log.warning(
+                            "smart-extract: navigation skipped by politeness gate %s: %s",
+                            url,
+                            decision.reason,
+                        )
+                        return intel
+                    try:
+                        page.goto(url, timeout=60000)
+                        page.wait_for_load_state("networkidle")
+                    except Exception:
+                        if route_guard.blocked:
+                            log.warning(
+                                "smart-extract: unsafe navigation blocked %s: %s",
+                                route_guard.blocked_url or url,
+                                route_guard.blocked_reason,
+                            )
+                            return intel
+                        raise
 
-        # 2. __NEXT_DATA__
-        next_data = page.query_selector("script#__NEXT_DATA__")
-        if next_data:
-            try:
-                intel["next_data"] = json.loads(next_data.inner_text())
-            except Exception:
-                pass
+                if route_guard.blocked:
+                    log.warning(
+                        "smart-extract: unsafe navigation blocked %s: %s",
+                        route_guard.blocked_url or url,
+                        route_guard.blocked_reason,
+                    )
+                    return _empty_page_intelligence(url)
 
-        # 3. data-testid attributes
-        intel["data_testids"] = page.evaluate("""
-            () => {
-                const els = document.querySelectorAll('[data-testid]');
-                const results = [];
-                els.forEach(el => {
-                    results.push({
-                        testid: el.getAttribute('data-testid'),
-                        tag: el.tagName.toLowerCase(),
-                        text: el.innerText?.slice(0, 80) || ''
+                final_safety = validate_public_http_url(str(getattr(page, "url", "") or ""))
+                if not final_safety.allowed:
+                    log.warning(
+                        "smart-extract: unsafe final URL skipped %s: %s",
+                        getattr(page, "url", ""),
+                        final_safety.reason,
+                    )
+                    return _empty_page_intelligence(url)
+
+                intel["page_title"] = page.title()
+
+                # 1. JSON-LD
+                for el in page.query_selector_all('script[type="application/ld+json"]'):
+                    try:
+                        data = json.loads(el.inner_text())
+                        intel["json_ld"].append(data)
+                    except Exception:
+                        pass
+
+                # 2. __NEXT_DATA__
+                next_data = page.query_selector("script#__NEXT_DATA__")
+                if next_data:
+                    try:
+                        intel["next_data"] = json.loads(next_data.inner_text())
+                    except Exception:
+                        pass
+
+                # 3. data-testid attributes
+                intel["data_testids"] = page.evaluate("""
+                () => {
+                    const els = document.querySelectorAll('[data-testid]');
+                    const results = [];
+                    els.forEach(el => {
+                        results.push({
+                            testid: el.getAttribute('data-testid'),
+                            tag: el.tagName.toLowerCase(),
+                            text: el.innerText?.slice(0, 80) || ''
+                        });
                     });
-                });
-                return results.slice(0, 50);
-            }
-        """)
-
-        # 4. DOM stats
-        intel["dom_stats"] = page.evaluate("""
-            () => {
-                const body = document.body;
-                return {
-                    total_elements: body.querySelectorAll('*').length,
-                    links: body.querySelectorAll('a[href]').length,
-                    headings: body.querySelectorAll('h1,h2,h3,h4').length,
-                    lists: body.querySelectorAll('ul,ol').length,
-                    tables: body.querySelectorAll('table').length,
-                    articles: body.querySelectorAll('article').length,
-                    has_data_ids: body.querySelectorAll('[data-id]').length,
-                };
-            }
-        """)
-
-        # 5. Find repeating card-like elements
-        intel["card_candidates"] = page.evaluate("""
-            () => {
-                const candidates = [];
-                const allParents = document.querySelectorAll('*');
-
-                for (const parent of allParents) {
-                    const children = Array.from(parent.children);
-                    if (children.length < 3) continue;
-
-                    const tagCounts = {};
-                    children.forEach(c => {
-                        const key = c.tagName;
-                        tagCounts[key] = (tagCounts[key] || 0) + 1;
-                    });
-
-                    const dominant = Object.entries(tagCounts).sort((a,b) => b[1]-a[1])[0];
-                    if (!dominant || dominant[1] < 3) continue;
-
-                    const repeatingChildren = children.filter(c => c.tagName === dominant[0]);
-                    const withText = repeatingChildren.filter(c => c.innerText?.trim().length > 20);
-                    if (withText.length < 3) continue;
-
-                    const withLinks = withText.filter(c => c.querySelector('a[href]'));
-                    const score = withLinks.length * 2 + withText.length;
-
-                    const parentId = parent.id ? '#' + parent.id : '';
-                    const parentClasses = Array.from(parent.classList).filter(c => c.length < 30).slice(0, 3).join('.');
-                    const parentTag = parent.tagName.toLowerCase();
-                    const parentSelector = parentTag + (parentId || (parentClasses ? '.' + parentClasses : ''));
-
-                    const childTag = dominant[0].toLowerCase();
-                    const sampleChild = withText[0];
-                    const childClasses = Array.from(sampleChild.classList).filter(c => c.length < 30).slice(0, 3).join('.');
-                    const childSelector = childTag + (childClasses ? '.' + childClasses : '');
-
-                    const examples = withText.slice(0, 3).map(c => {
-                        const clone = c.cloneNode(true);
-                        clone.querySelectorAll('script,style,svg,noscript').forEach(el => el.remove());
-                        const html = clone.outerHTML;
-                        return html.length > 5000 ? html.slice(0, 5000) + '...' : html;
-                    });
-
-                    candidates.push({
-                        parent_selector: parentSelector,
-                        child_selector: childSelector,
-                        child_tag: childTag,
-                        total_children: repeatingChildren.length,
-                        with_text: withText.length,
-                        with_links: withLinks.length,
-                        score: score,
-                        examples: examples,
-                    });
+                    return results.slice(0, 50);
                 }
+            """)
 
-                candidates.sort((a,b) => b.score - a.score);
-                return candidates.slice(0, 3);
-            }
-        """)
+                # 4. DOM stats
+                intel["dom_stats"] = page.evaluate("""
+                () => {
+                    const body = document.body;
+                    return {
+                        total_elements: body.querySelectorAll('*').length,
+                        links: body.querySelectorAll('a[href]').length,
+                        headings: body.querySelectorAll('h1,h2,h3,h4').length,
+                        lists: body.querySelectorAll('ul,ol').length,
+                        tables: body.querySelectorAll('table').length,
+                        articles: body.querySelectorAll('article').length,
+                        has_data_ids: body.querySelectorAll('[data-id]').length,
+                    };
+                }
+            """)
 
-        # Capture full rendered HTML
-        intel["full_html"] = page.content()
+                # 5. Find repeating card-like elements
+                intel["card_candidates"] = page.evaluate("""
+                () => {
+                    const candidates = [];
+                    const allParents = document.querySelectorAll('*');
 
-        browser.close()
+                    for (const parent of allParents) {
+                        const children = Array.from(parent.children);
+                        if (children.length < 3) continue;
+
+                        const tagCounts = {};
+                        children.forEach(c => {
+                            const key = c.tagName;
+                            tagCounts[key] = (tagCounts[key] || 0) + 1;
+                        });
+
+                        const dominant = Object.entries(tagCounts).sort((a,b) => b[1]-a[1])[0];
+                        if (!dominant || dominant[1] < 3) continue;
+
+                        const repeatingChildren = children.filter(c => c.tagName === dominant[0]);
+                        const withText = repeatingChildren.filter(c => c.innerText?.trim().length > 20);
+                        if (withText.length < 3) continue;
+
+                        const withLinks = withText.filter(c => c.querySelector('a[href]'));
+                        const score = withLinks.length * 2 + withText.length;
+
+                        const parentId = parent.id ? '#' + parent.id : '';
+                        const parentClasses = Array.from(parent.classList).filter(c => c.length < 30).slice(0, 3).join('.');
+                        const parentTag = parent.tagName.toLowerCase();
+                        const parentSelector = parentTag + (parentId || (parentClasses ? '.' + parentClasses : ''));
+
+                        const childTag = dominant[0].toLowerCase();
+                        const sampleChild = withText[0];
+                        const childClasses = Array.from(sampleChild.classList).filter(c => c.length < 30).slice(0, 3).join('.');
+                        const childSelector = childTag + (childClasses ? '.' + childClasses : '');
+
+                        const examples = withText.slice(0, 3).map(c => {
+                            const clone = c.cloneNode(true);
+                            clone.querySelectorAll('script,style,svg,noscript').forEach(el => el.remove());
+                            const html = clone.outerHTML;
+                            return html.length > 5000 ? html.slice(0, 5000) + '...' : html;
+                        });
+
+                        candidates.push({
+                            parent_selector: parentSelector,
+                            child_selector: childSelector,
+                            child_tag: childTag,
+                            total_children: repeatingChildren.length,
+                            with_text: withText.length,
+                            with_links: withLinks.length,
+                            score: score,
+                            examples: examples,
+                        });
+                    }
+
+                    candidates.sort((a,b) => b.score - a.score);
+                    return candidates.slice(0, 3);
+                }
+            """)
+
+                # Capture full rendered HTML
+                intel["full_html"] = page.content()
+                if route_guard.blocked:
+                    log.warning(
+                        "smart-extract: unsafe navigation blocked %s: %s",
+                        route_guard.blocked_url or url,
+                        route_guard.blocked_reason,
+                    )
+                    return _empty_page_intelligence(url)
+            finally:
+                route_guard.close()
+        finally:
+            browser.close()
 
     # Process API responses
     for resp in captured_responses:

--- a/workers/automation/src/jobctrl/enrichment/detail.py
+++ b/workers/automation/src/jobctrl/enrichment/detail.py
@@ -92,11 +92,16 @@ from jobctrl.infrastructure.network import (
     PolitenessGateway,
     PolitenessSession,
     PolitenessSourceContext,
+    PublicHttpUrlRouteGuard,
+    PublicUrlDecision,
     RunBudgetCounter,
     get_shared_rate_limiter,
+    validate_public_http_url,
 )
 
 log = logging.getLogger(__name__)
+
+_SECURITY_OUTCOME_UNSAFE_URL = "unsafe_url"
 
 
 class _OwnerAuthenticatedRobots:
@@ -118,6 +123,21 @@ class _OwnerAuthenticatedRobots:
 def _new_enrichment_budget() -> RunBudgetCounter:
     """A fresh per-run outbound-navigation budget for the enrichment crawl."""
     return RunBudgetCounter(ENRICHMENT_CRAWL_POLICY.max_requests_per_run)
+
+
+def _mark_unsafe_url_block(
+    result: dict,
+    decision: PublicUrlDecision,
+    *,
+    blocked_url: str,
+    t0: float,
+) -> dict:
+    result["status"] = "blocked"
+    result["security_outcome"] = _SECURITY_OUTCOME_UNSAFE_URL
+    result["blocked_url"] = blocked_url
+    result["error"] = decision.reason or "URL is not a public HTTP(S) destination"
+    result["elapsed"] = time.time() - t0
+    return result
 
 
 def _enrichment_session(
@@ -382,11 +402,10 @@ def scrape_detail_page(page, url: str, *, session: PolitenessSession | None = No
     ``application_url``, ``error``, ``elapsed``) so existing callers
     don't change.
 
-    R10: every ``page.goto`` runs inside a politeness-gateway verdict. A
-    robots-deny or budget-exhaustion yields ``status="blocked"`` (plus the
-    ``politeness_outcome``) and performs **zero** navigation — it never navigates
-    and relabels. ``session`` is supplied by the batch caller (bound to the run
-    budget); a one-off caller lets it self-provision.
+    Every target must first pass the public-destination guard. R10 still wraps
+    every allowed ``page.goto`` in a politeness-gateway verdict. A
+    robots-deny, budget-exhaustion, or unsafe destination yields
+    ``status="blocked"`` and performs **zero** extractor work.
     """
     result: dict = {
         "full_description": None,
@@ -397,8 +416,14 @@ def scrape_detail_page(page, url: str, *, session: PolitenessSession | None = No
         "active_state": None,
         "verification_method": None,
         "http_status": None,
+        "security_outcome": None,
+        "blocked_url": None,
     }
     t0 = time.time()
+
+    initial_safety = validate_public_http_url(url)
+    if not initial_safety.allowed:
+        return _mark_unsafe_url_block(result, initial_safety, blocked_url=url, t0=t0)
 
     if session is None:
         session = _default_enrichment_session()
@@ -414,31 +439,70 @@ def scrape_detail_page(page, url: str, *, session: PolitenessSession | None = No
 
 def _scrape_detail_page_body(page, url: str, result: dict, t0: float) -> dict:
     """Navigate + run the three-tier cascade inside the held politeness slot."""
+    route_guard = PublicHttpUrlRouteGuard(page).install()
     status_code: int | None = None
     try:
-        resp = page.goto(url, timeout=45000)
-        if resp is not None:
-            status_code = resp.status
-            if status_code in _PERMANENT_FAILURES:
-                active_state = ActiveState.REMOVED
-                result["error"] = f"HTTP {status_code}"
-                result["active_state"] = active_state.value
-                result["verification_method"] = "http_status"
-                result["http_status"] = status_code
-                result["elapsed"] = time.time() - t0
-                return result
-        page.wait_for_load_state("domcontentloaded", timeout=15000)
         try:
-            page.wait_for_load_state("networkidle", timeout=10000)
-        except Exception:
-            pass
-    except Exception as exc:
-        err_str = str(exc)
-        result["error"] = "timeout" if "timeout" in err_str.lower() else err_str[:200]
-        result["elapsed"] = time.time() - t0
-        return result
+            resp = page.goto(url, timeout=45000)
+            if resp is not None:
+                status_code = resp.status
+                if status_code in _PERMANENT_FAILURES:
+                    active_state = ActiveState.REMOVED
+                    result["error"] = f"HTTP {status_code}"
+                    result["active_state"] = active_state.value
+                    result["verification_method"] = "http_status"
+                    result["http_status"] = status_code
+                    result["elapsed"] = time.time() - t0
+                    return result
+            page.wait_for_load_state("domcontentloaded", timeout=15000)
+            try:
+                page.wait_for_load_state("networkidle", timeout=10000)
+            except Exception:
+                pass
+        except Exception as exc:
+            if route_guard.blocked:
+                decision = PublicUrlDecision(False, route_guard.blocked_reason)
+                return _mark_unsafe_url_block(
+                    result,
+                    decision,
+                    blocked_url=route_guard.blocked_url or url,
+                    t0=t0,
+                )
+            err_str = str(exc)
+            result["error"] = "timeout" if "timeout" in err_str.lower() else err_str[:200]
+            result["elapsed"] = time.time() - t0
+            return result
 
-    detail_page = _page_to_detail_page(page, url, status=status_code)
+        if route_guard.blocked:
+            decision = PublicUrlDecision(False, route_guard.blocked_reason)
+            return _mark_unsafe_url_block(
+                result,
+                decision,
+                blocked_url=route_guard.blocked_url or url,
+                t0=t0,
+            )
+
+        final_safety = validate_public_http_url(str(getattr(page, "url", "") or ""))
+        if not final_safety.allowed:
+            return _mark_unsafe_url_block(
+                result,
+                final_safety,
+                blocked_url=str(getattr(page, "url", "") or url),
+                t0=t0,
+            )
+
+        detail_page = _page_to_detail_page(page, url, status=status_code)
+        if route_guard.blocked:
+            decision = PublicUrlDecision(False, route_guard.blocked_reason)
+            return _mark_unsafe_url_block(
+                result,
+                decision,
+                blocked_url=route_guard.blocked_url or url,
+                t0=t0,
+            )
+    finally:
+        route_guard.close()
+
     active_state, verification_method = ActiveStateVerifier().verify(detail_page)
     result["active_state"] = active_state.value
     result["verification_method"] = verification_method
@@ -490,6 +554,8 @@ def _detail_failure_retryable(cascade_result: dict) -> bool:
     Extraction failures stay retryable: extractor rules, page markup, and
     timing can all change independently of the posting's active state.
     """
+    if cascade_result.get("security_outcome") == _SECURITY_OUTCOME_UNSAFE_URL:
+        return False
     status = cascade_result.get("http_status")
     if isinstance(status, int):
         if status in _RETRYABLE_STATUSES:
@@ -1081,7 +1147,10 @@ def scrape_site_batch(
                     cascade_result = _apply_discovery_description_fallback(
                         conn, url, scrape_detail_page(page, url, session=session)
                     )
-                    if cascade_result.get("status") == "blocked":
+                    if (
+                        cascade_result.get("status") == "blocked"
+                        and cascade_result.get("security_outcome") != _SECURITY_OUTCOME_UNSAFE_URL
+                    ):
                         # Rare parallel race: budget drained between peek + guard.
                         _record_enrich_politeness_deferral(
                             conn, repo, aggregate, url, started_at, cascade_result
@@ -1274,8 +1343,13 @@ def scrape_site_batch(
                     else:
                         stats["error"] += 1
                         retryable = _detail_failure_retryable(cascade_result)
+                        error_code = (
+                            "DETAIL_UNSAFE_URL"
+                            if cascade_result.get("security_outcome") == _SECURITY_OUTCOME_UNSAFE_URL
+                            else "DETAIL_ERROR"
+                        )
                         err = EnrichmentError(
-                            code="DETAIL_ERROR",
+                            code=error_code,
                             message=str(cascade_result.get("error") or "unknown")[:500],
                             retryable=retryable,
                         )
@@ -1291,7 +1365,7 @@ def scrape_site_batch(
                             attempt_count=failed.attempt_count,
                             started_at=started_at,
                             finished_at=finished_at,
-                            error_code="DETAIL_ERROR",
+                            error_code=error_code,
                             error_message=err.message,
                             retryable=retryable,
                             next_action=f"jobctrl retry enrich {url}" if retryable else None,
@@ -1304,9 +1378,11 @@ def scrape_site_batch(
                             level="error",
                             message=err.message,
                             payload={
-                                "errorCode": "DETAIL_ERROR",
+                                "errorCode": error_code,
                                 "errorMessage": err.message,
                                 "retryable": retryable,
+                                "securityOutcome": cascade_result.get("security_outcome"),
+                                "blockedUrl": cascade_result.get("blocked_url"),
                                 "attemptNumber": failed.attempt_count,
                                 "status": status,
                                 "tier": tier,

--- a/workers/automation/src/jobctrl/infrastructure/enrichment/playwright_fetcher.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/playwright_fetcher.py
@@ -31,7 +31,9 @@ from jobctrl.infrastructure.network import (
     PolitenessGateway,
     PolitenessSession,
     PolitenessSourceContext,
+    PublicHttpUrlRouteGuard,
     RunBudgetCounter,
+    validate_public_http_url,
 )
 from jobctrl.infrastructure.network.proxy import ProxyConfig
 
@@ -91,6 +93,18 @@ class PlaywrightDetailPageFetcher:
 
     def fetch(self, url: str) -> DetailPage:
         fetched_at = datetime.now(timezone.utc).isoformat()
+        initial_safety = validate_public_http_url(url)
+        if not initial_safety.allowed:
+            log.warning("PlaywrightDetailPageFetcher: unsafe navigation skipped %s: %s", url, initial_safety.reason)
+            return DetailPage(
+                url=url,
+                final_url=url,
+                page_title="",
+                html="",
+                json_ld=(),
+                status=None,
+                fetched_at=fetched_at,
+            )
         # R10 pre-navigation gate: a robots-deny / budget-exhaustion performs
         # zero navigation and returns an empty page rather than fetching.
         with self._politeness_session().guard(url) as decision:
@@ -127,51 +141,118 @@ class PlaywrightDetailPageFetcher:
             try:
                 context = browser.new_context(user_agent=user_agent)
                 page = context.new_page()
+                route_guard = PublicHttpUrlRouteGuard(page).install()
                 status: int | None = None
                 resp = None
                 try:
-                    resp = page.goto(url, timeout=_NAV_TIMEOUT_MS)
-                    if resp is not None:
-                        status = resp.status
-                    page.wait_for_load_state("domcontentloaded", timeout=_DCL_TIMEOUT_MS)
                     try:
-                        page.wait_for_load_state("networkidle", timeout=_IDLE_TIMEOUT_MS)
+                        resp = page.goto(url, timeout=_NAV_TIMEOUT_MS)
+                        if resp is not None:
+                            status = resp.status
+                        page.wait_for_load_state("domcontentloaded", timeout=_DCL_TIMEOUT_MS)
+                        try:
+                            page.wait_for_load_state("networkidle", timeout=_IDLE_TIMEOUT_MS)
+                        except Exception:
+                            # networkidle is best-effort; many pages keep
+                            # a long-poll connection open and that's fine
+                            # for our purposes.
+                            pass
+                    except Exception as exc:
+                        if route_guard.blocked:
+                            log.warning(
+                                "PlaywrightDetailPageFetcher: unsafe navigation blocked %s: %s",
+                                route_guard.blocked_url or url,
+                                route_guard.blocked_reason,
+                            )
+                            return DetailPage(
+                                url=url,
+                                final_url=route_guard.blocked_url or url,
+                                page_title="",
+                                html="",
+                                json_ld=(),
+                                status=status,
+                                fetched_at=fetched_at,
+                            )
+                        log.warning("PlaywrightDetailPageFetcher: navigation error %s: %s", url, exc)
+                        return DetailPage(
+                            url=url,
+                            final_url=url,
+                            page_title="",
+                            html="",
+                            json_ld=(),
+                            status=status,
+                            fetched_at=fetched_at,
+                        )
+
+                    if route_guard.blocked:
+                        log.warning(
+                            "PlaywrightDetailPageFetcher: unsafe navigation blocked %s: %s",
+                            route_guard.blocked_url or url,
+                            route_guard.blocked_reason,
+                        )
+                        return DetailPage(
+                            url=url,
+                            final_url=route_guard.blocked_url or url,
+                            page_title="",
+                            html="",
+                            json_ld=(),
+                            status=status,
+                            fetched_at=fetched_at,
+                        )
+
+                    final_url = page.url
+                    final_safety = validate_public_http_url(final_url)
+                    if not final_safety.allowed:
+                        log.warning(
+                            "PlaywrightDetailPageFetcher: unsafe final URL skipped %s: %s",
+                            final_url,
+                            final_safety.reason,
+                        )
+                        return DetailPage(
+                            url=url,
+                            final_url=final_url,
+                            page_title="",
+                            html="",
+                            json_ld=(),
+                            status=status,
+                            fetched_at=fetched_at,
+                        )
+                    page_title = ""
+                    try:
+                        page_title = page.title() or ""
                     except Exception:
-                        # networkidle is best-effort; many pages keep
-                        # a long-poll connection open and that's fine
-                        # for our purposes.
                         pass
-                except Exception as exc:
-                    log.warning("PlaywrightDetailPageFetcher: navigation error %s: %s", url, exc)
+
+                    json_ld_payloads = _collect_json_ld(page)
+                    html = _collect_main_content(page)
+
+                    if route_guard.blocked:
+                        log.warning(
+                            "PlaywrightDetailPageFetcher: unsafe navigation blocked %s: %s",
+                            route_guard.blocked_url or url,
+                            route_guard.blocked_reason,
+                        )
+                        return DetailPage(
+                            url=url,
+                            final_url=route_guard.blocked_url or final_url,
+                            page_title="",
+                            html="",
+                            json_ld=(),
+                            status=status,
+                            fetched_at=fetched_at,
+                        )
+
                     return DetailPage(
                         url=url,
-                        final_url=url,
-                        page_title="",
-                        html="",
-                        json_ld=(),
+                        final_url=final_url,
+                        page_title=page_title,
+                        html=html,
+                        json_ld=tuple(json_ld_payloads),
                         status=status,
                         fetched_at=fetched_at,
                     )
-
-                final_url = page.url
-                page_title = ""
-                try:
-                    page_title = page.title() or ""
-                except Exception:
-                    pass
-
-                json_ld_payloads = _collect_json_ld(page)
-                html = _collect_main_content(page)
-
-                return DetailPage(
-                    url=url,
-                    final_url=final_url,
-                    page_title=page_title,
-                    html=html,
-                    json_ld=tuple(json_ld_payloads),
-                    status=status,
-                    fetched_at=fetched_at,
-                )
+                finally:
+                    route_guard.close()
             finally:
                 browser.close()
 

--- a/workers/automation/src/jobctrl/infrastructure/network/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/network/__init__.py
@@ -34,6 +34,11 @@ from jobctrl.infrastructure.network.rate_limiter import (
     get_shared_rate_limiter,
 )
 from jobctrl.infrastructure.network.robots import RobotsCache
+from jobctrl.infrastructure.network.url_safety import (
+    PublicHttpUrlRouteGuard,
+    PublicUrlDecision,
+    validate_public_http_url,
+)
 
 __all__ = [
     "ProxyConfig",
@@ -52,4 +57,7 @@ __all__ = [
     "GatewayHttpClient",
     "build_opener",
     "parse_retry_after",
+    "PublicHttpUrlRouteGuard",
+    "PublicUrlDecision",
+    "validate_public_http_url",
 ]

--- a/workers/automation/src/jobctrl/infrastructure/network/url_safety.py
+++ b/workers/automation/src/jobctrl/infrastructure/network/url_safety.py
@@ -1,0 +1,143 @@
+"""Public-destination checks for browser/network fetches."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+
+Resolver = Callable[..., list[tuple[Any, Any, Any, Any, tuple[Any, ...]]]]
+
+
+@dataclass(frozen=True)
+class PublicUrlDecision:
+    allowed: bool
+    reason: str | None = None
+
+
+def validate_public_http_url(url: str, *, resolver: Resolver | None = None) -> PublicUrlDecision:
+    """Allow only public HTTP(S) URLs.
+
+    Hostnames are resolved and every returned address must be globally routable.
+    If resolution fails, fail closed: the browser would otherwise make the real
+    routing decision later, outside this security control.
+    """
+
+    if not isinstance(url, str) or not url.strip():
+        return PublicUrlDecision(False, "URL must be a non-empty string")
+
+    try:
+        parsed = urlsplit(url.strip())
+        port = parsed.port
+    except ValueError as exc:
+        return PublicUrlDecision(False, f"URL is invalid: {exc}")
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        return PublicUrlDecision(False, "URL scheme must be http or https")
+
+    hostname = parsed.hostname
+    if not hostname:
+        return PublicUrlDecision(False, "URL host is required")
+
+    host = hostname.rstrip(".")
+    if not host:
+        return PublicUrlDecision(False, "URL host is required")
+
+    literal = _ip_literal(host)
+    if literal is not None:
+        return _decision_for_ip(host, literal)
+
+    try:
+        ascii_host = host.encode("idna").decode("ascii")
+    except UnicodeError:
+        return PublicUrlDecision(False, "URL host is not a valid IDNA hostname")
+
+    resolve = resolver or socket.getaddrinfo
+    try:
+        infos = resolve(ascii_host, port or (443 if scheme == "https" else 80), type=socket.SOCK_STREAM)
+    except OSError as exc:
+        return PublicUrlDecision(False, f"URL host could not be resolved: {exc}")
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        try:
+            raw_address = info[4][0]
+        except (IndexError, TypeError):
+            continue
+        parsed_address = _ip_literal(str(raw_address))
+        if parsed_address is not None and parsed_address not in addresses:
+            addresses.append(parsed_address)
+
+    if not addresses:
+        return PublicUrlDecision(False, "URL host did not resolve to an IP address")
+
+    for address in addresses:
+        if not _is_public_address(address):
+            return PublicUrlDecision(
+                False,
+                f"URL host resolves to a non-public address: {address}",
+            )
+
+    return PublicUrlDecision(True)
+
+
+class PublicHttpUrlRouteGuard:
+    """Abort Playwright requests that target non-public destinations."""
+
+    def __init__(self, page: Any) -> None:
+        self._page = page
+        self._handler: Callable[[Any, Any], None] | None = None
+        self.blocked_url: str | None = None
+        self.blocked_reason: str | None = None
+
+    @property
+    def blocked(self) -> bool:
+        return self.blocked_reason is not None
+
+    def install(self) -> "PublicHttpUrlRouteGuard":
+        route = getattr(self._page, "route", None)
+        if not callable(route):
+            return self
+
+        def handler(playwright_route: Any, request: Any) -> None:
+            request_url = str(getattr(request, "url", ""))
+            decision = validate_public_http_url(request_url)
+            if decision.allowed:
+                playwright_route.continue_()
+                return
+            self.blocked_url = request_url
+            self.blocked_reason = decision.reason or "URL is not a public HTTP(S) destination"
+            playwright_route.abort("blockedbyclient")
+
+        self._handler = handler
+        route("**/*", handler)
+        return self
+
+    def close(self) -> None:
+        if self._handler is None:
+            return
+        unroute = getattr(self._page, "unroute", None)
+        if callable(unroute):
+            unroute("**/*", self._handler)
+        self._handler = None
+
+
+def _decision_for_ip(host: str, address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> PublicUrlDecision:
+    if _is_public_address(address):
+        return PublicUrlDecision(True)
+    return PublicUrlDecision(False, f"URL host is not a public address: {host}")
+
+
+def _ip_literal(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return bool(address.is_global)

--- a/workers/automation/tests/test_browser_ua_propagation.py
+++ b/workers/automation/tests/test_browser_ua_propagation.py
@@ -33,6 +33,7 @@ from jobctrl.infrastructure.network import (
     PolitenessGateway,
     PolitenessSession,
     PolitenessSourceContext,
+    PublicUrlDecision,
     RunBudgetCounter,
 )
 from jobctrl.infrastructure.network.politeness import UA_CONTACT_ENV, UA_PRODUCT_ENV
@@ -156,6 +157,21 @@ def _owner_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(UA_CONTACT_ENV, OWNER_CONTACT)
 
 
+def _allow_fetcher_url_safety(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.enrichment.playwright_fetcher.validate_public_http_url",
+        lambda _url: PublicUrlDecision(True),
+    )
+
+
+def _allow_detail_url_safety(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(detail, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+
+
+def _allow_smartextract_url_safety(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(smartextract, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+
+
 def _spy_gateway(robots: _UASpyRobots) -> PolitenessGateway:
     # Constructed after the env override so its UA reflects the owner value.
     return PolitenessGateway(robots=robots, rate_limiter=no_sleep_limiter())
@@ -170,6 +186,7 @@ def test_playwright_fetcher_context_uses_owner_overridden_ua(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _owner_override(monkeypatch)
+    _allow_fetcher_url_safety(monkeypatch)
     robots = _UASpyRobots()
     gateway = _spy_gateway(robots)
     session = PolitenessSession(
@@ -199,6 +216,7 @@ def test_playwright_fetcher_context_uses_owner_overridden_ua(
 
 def test_smartextract_page_uses_owner_overridden_ua(monkeypatch: pytest.MonkeyPatch) -> None:
     _owner_override(monkeypatch)
+    _allow_smartextract_url_safety(monkeypatch)
     robots = _UASpyRobots()
     gateway = _spy_gateway(robots)
     session = PolitenessSession(
@@ -228,6 +246,7 @@ def test_enrichment_batch_context_uses_owner_overridden_ua(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _owner_override(monkeypatch)
+    _allow_detail_url_safety(monkeypatch)
     monkeypatch.setenv("JOBCTRL_LINKEDIN_APPLY_RESOLVER", "0")
     # Tier-1 (JSON-LD) success so navigation proceeds without touching the LLM.
     monkeypatch.setattr(detail, "get_llm_adapter", lambda: _OfflineLlm())

--- a/workers/automation/tests/test_enrichment_detail_staleness.py
+++ b/workers/automation/tests/test_enrichment_detail_staleness.py
@@ -12,6 +12,7 @@ from jobctrl.enrichment.detail import (
     _record_posting_snapshot_from_cascade,
     scrape_detail_page,
 )
+from jobctrl.infrastructure.network import PublicUrlDecision
 
 from .politeness_helpers import offline_gateway, offline_session
 
@@ -88,6 +89,7 @@ class _OfflineLlmPort:
 def offline_llm_tier(monkeypatch: pytest.MonkeyPatch) -> None:
     """Swap the LlmPort the detail cascade resolves so Tier-3 construction stays
     offline-deterministic (no keys, no network)."""
+    monkeypatch.setattr(detail, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
     monkeypatch.setattr(detail, "get_llm_adapter", lambda: _OfflineLlmPort())
 
 

--- a/workers/automation/tests/test_enrichment_politeness_gate.py
+++ b/workers/automation/tests/test_enrichment_politeness_gate.py
@@ -28,6 +28,7 @@ from jobctrl.enrichment.detail import scrape_detail_page, scrape_site_batch
 from jobctrl.infrastructure.network import (
     HostRateLimiter,
     PolitenessGateway,
+    PublicUrlDecision,
     RunBudgetCounter,
 )
 
@@ -41,6 +42,10 @@ from .politeness_helpers import (
 )
 
 LONG_DESC = "Build reliable distributed systems with Python and TypeScript. " * 8
+
+
+def _allow_test_url_safety(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(detail, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
 
 
 def _seed_pending(conn: sqlite3.Connection, url: str, site: str = "RemoteOK") -> None:
@@ -163,6 +168,7 @@ class _OfflineLlm:
 @pytest.fixture
 def tier1_extraction(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make the detail cascade succeed at Tier 1 (JSON-LD) over the fake page."""
+    _allow_test_url_safety(monkeypatch)
     monkeypatch.setattr(detail, "get_llm_adapter", lambda: _OfflineLlm())
     monkeypatch.setattr(
         detail,
@@ -349,7 +355,8 @@ def test_run_budget_decrements_per_navigation_and_stops_batch(
 # ---------------------------------------------------------------------------
 
 
-def test_scrape_detail_page_blocked_skips_goto() -> None:
+def test_scrape_detail_page_blocked_skips_goto(monkeypatch: pytest.MonkeyPatch) -> None:
+    _allow_test_url_safety(monkeypatch)
     calls: list[str] = []
     page = _SpyPage(calls)
     session = offline_session(robots=DenyAllRobots())

--- a/workers/automation/tests/test_enrichment_url_safety.py
+++ b/workers/automation/tests/test_enrichment_url_safety.py
@@ -1,0 +1,368 @@
+"""Regression coverage for enrichment SSRF-to-LLM URL safety."""
+
+from __future__ import annotations
+
+import socket
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Iterator
+
+import pytest
+
+from jobctrl.discovery import smartextract
+from jobctrl.enrichment import detail
+from jobctrl.enrichment.detail import scrape_detail_page
+from jobctrl.infrastructure.enrichment.playwright_fetcher import PlaywrightDetailPageFetcher
+from jobctrl.infrastructure.network import PublicUrlDecision, validate_public_http_url
+
+from .politeness_helpers import offline_session
+
+
+def _resolver_for(*addresses: str):
+    def resolve(*_args: object, **_kwargs: object):
+        return [
+            (
+                socket.AF_INET6 if ":" in address else socket.AF_INET,
+                socket.SOCK_STREAM,
+                0,
+                "",
+                (address, 443),
+            )
+            for address in addresses
+        ]
+
+    return resolve
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/jobs/1",
+        "http://[::1]/jobs/1",
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/role",
+        "file:///etc/passwd",
+    ],
+)
+def test_validate_public_http_url_rejects_non_public_destinations(url: str) -> None:
+    decision = validate_public_http_url(url)
+
+    assert not decision.allowed
+    assert decision.reason
+
+
+def test_validate_public_http_url_rejects_hostnames_that_resolve_private() -> None:
+    decision = validate_public_http_url(
+        "https://jobs.example/internal",
+        resolver=_resolver_for("10.0.0.5"),
+    )
+
+    assert not decision.allowed
+    assert "non-public" in str(decision.reason)
+
+
+def test_validate_public_http_url_allows_public_hostname_resolution() -> None:
+    decision = validate_public_http_url(
+        "https://jobs.example/role",
+        resolver=_resolver_for("93.184.216.34"),
+    )
+
+    assert decision.allowed
+
+
+class _ExplodingPage:
+    url = "about:blank"
+
+    def goto(self, *_args: object, **_kwargs: object) -> object:
+        raise AssertionError("unsafe URL must be blocked before navigation")
+
+
+def test_scrape_detail_page_blocks_direct_loopback_before_navigation() -> None:
+    result = scrape_detail_page(
+        _ExplodingPage(),
+        "http://127.0.0.1:8123/private",
+        session=offline_session(),
+    )
+
+    assert result["status"] == "blocked"
+    assert result["security_outcome"] == "unsafe_url"
+    assert result["blocked_url"] == "http://127.0.0.1:8123/private"
+    assert "politeness_outcome" not in result
+
+
+class _AbortRoute:
+    def __init__(self) -> None:
+        self.aborted = False
+        self.continued = False
+
+    def abort(self, _code: str | None = None) -> None:
+        self.aborted = True
+
+    def continue_(self) -> None:
+        self.continued = True
+
+
+class _RedirectToLoopbackPage:
+    def __init__(self) -> None:
+        self.url = "https://jobs.example/final"
+        self._handler = None
+        self.goto_called = False
+        self.content_collected = False
+
+    def route(self, _pattern: str, handler) -> None:  # noqa: ANN001 - Playwright-shaped test double
+        self._handler = handler
+
+    def unroute(self, _pattern: str, _handler) -> None:  # noqa: ANN001 - Playwright-shaped test double
+        self._handler = None
+
+    def on(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def goto(self, _url: str, **_kwargs: object) -> object:
+        self.goto_called = True
+        route = _AbortRoute()
+        assert self._handler is not None
+        self._handler(route, SimpleNamespace(url="http://127.0.0.1:8123/latest/meta-data"))
+        if route.aborted:
+            raise RuntimeError("net::ERR_BLOCKED_BY_CLIENT")
+        raise AssertionError("unsafe redirect was not aborted")
+
+    def query_selector_all(self, *_args: object, **_kwargs: object) -> list[object]:
+        self.content_collected = True
+        return []
+
+
+class _LateLoopbackDuringContentPage:
+    def __init__(self, *, trigger_on: str) -> None:
+        self.url = "https://jobs.example/final"
+        self._handler = None
+        self.trigger_on = trigger_on
+        self.goto_called = False
+        self.content_collected = False
+        self.local_aborted = False
+
+    def route(self, _pattern: str, handler) -> None:  # noqa: ANN001 - Playwright-shaped test double
+        self._handler = handler
+
+    def unroute(self, _pattern: str, _handler) -> None:  # noqa: ANN001 - Playwright-shaped test double
+        self._handler = None
+
+    def on(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def goto(self, _url: str, **_kwargs: object) -> object:
+        self.goto_called = True
+        return SimpleNamespace(status=200)
+
+    def wait_for_load_state(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def title(self) -> str:
+        return "Role"
+
+    def query_selector_all(self, *_args: object, **_kwargs: object) -> list[object]:
+        self.content_collected = True
+        if self.trigger_on == "query_selector_all":
+            self._request_local_content()
+        return []
+
+    def query_selector(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def evaluate(self, script: str, *_args: object, **_kwargs: object) -> object:
+        if "data-testid" in script or "candidates" in script:
+            return []
+        if "total_elements" in script:
+            return {}
+        return ""
+
+    def content(self) -> str:
+        self.content_collected = True
+        if self.trigger_on == "content":
+            self._request_local_content()
+        return "<main>LOCAL SECRET</main>"
+
+    def _request_local_content(self) -> None:
+        if self._handler is None:
+            return
+        route = _AbortRoute()
+        self._handler(route, SimpleNamespace(url="http://127.0.0.1:8123/latest/meta-data"))
+        self.local_aborted = route.aborted
+
+
+def test_scrape_detail_page_blocks_redirect_to_loopback_before_extractors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(detail, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+    page = _RedirectToLoopbackPage()
+
+    result = scrape_detail_page(page, "https://jobs.example/role", session=offline_session())
+
+    assert page.goto_called
+    assert not page.content_collected
+    assert result["status"] == "blocked"
+    assert result["security_outcome"] == "unsafe_url"
+    assert result["blocked_url"] == "http://127.0.0.1:8123/latest/meta-data"
+
+
+def test_scrape_detail_page_keeps_route_guard_through_content_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(detail, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+    page = _LateLoopbackDuringContentPage(trigger_on="query_selector_all")
+
+    result = scrape_detail_page(page, "https://jobs.example/role", session=offline_session())
+
+    assert page.goto_called
+    assert page.content_collected
+    assert page.local_aborted
+    assert result["status"] == "blocked"
+    assert result["security_outcome"] == "unsafe_url"
+    assert result["blocked_url"] == "http://127.0.0.1:8123/latest/meta-data"
+
+
+def test_playwright_detail_fetcher_blocks_direct_loopback_before_browser() -> None:
+    page = PlaywrightDetailPageFetcher().fetch("http://127.0.0.1:8123/private")
+
+    assert page.final_url == "http://127.0.0.1:8123/private"
+    assert page.html == ""
+    assert page.json_ld == ()
+
+
+class _RecordingBrowser:
+    def __init__(self, page: object | None = None) -> None:
+        self.context_created = False
+        self._page = page or _RedirectToLoopbackPage()
+
+    def new_context(self, **_kwargs: object) -> "_RecordingBrowser":
+        self.context_created = True
+        return self
+
+    def new_page(self, **_kwargs: object) -> object:
+        return self._page
+
+    def close(self) -> None:
+        return None
+
+
+class _RecordingChromium:
+    def __init__(self, browser: _RecordingBrowser) -> None:
+        self._browser = browser
+
+    def launch(self, **_kwargs: object) -> _RecordingBrowser:
+        return self._browser
+
+
+class _RecordingPlaywright:
+    def __init__(self, browser: _RecordingBrowser) -> None:
+        self.chromium = _RecordingChromium(browser)
+
+    def __enter__(self) -> "_RecordingPlaywright":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_playwright_detail_fetcher_blocks_redirect_to_loopback_before_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.enrichment.playwright_fetcher.validate_public_http_url",
+        lambda _url: PublicUrlDecision(True),
+    )
+    browser = _RecordingBrowser()
+
+    @contextmanager
+    def fake_playwright() -> Iterator[_RecordingPlaywright]:
+        yield _RecordingPlaywright(browser)
+
+    monkeypatch.setattr("playwright.sync_api.sync_playwright", fake_playwright)
+
+    page = PlaywrightDetailPageFetcher(session=offline_session()).fetch("https://jobs.example/role")
+
+    assert browser.context_created
+    assert page.final_url == "http://127.0.0.1:8123/latest/meta-data"
+    assert page.html == ""
+    assert page.json_ld == ()
+
+
+def test_playwright_detail_fetcher_keeps_route_guard_through_content_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.enrichment.playwright_fetcher.validate_public_http_url",
+        lambda _url: PublicUrlDecision(True),
+    )
+    late_page = _LateLoopbackDuringContentPage(trigger_on="query_selector_all")
+    browser = _RecordingBrowser(page=late_page)
+
+    @contextmanager
+    def fake_playwright() -> Iterator[_RecordingPlaywright]:
+        yield _RecordingPlaywright(browser)
+
+    monkeypatch.setattr("playwright.sync_api.sync_playwright", fake_playwright)
+
+    detail_page = PlaywrightDetailPageFetcher(session=offline_session()).fetch("https://jobs.example/role")
+
+    assert browser.context_created
+    assert late_page.content_collected
+    assert late_page.local_aborted
+    assert detail_page.final_url == "http://127.0.0.1:8123/latest/meta-data"
+    assert detail_page.html == ""
+    assert detail_page.json_ld == ()
+
+
+def test_smartextract_blocks_direct_loopback_before_browser(monkeypatch: pytest.MonkeyPatch) -> None:
+    def explode_playwright() -> object:
+        raise AssertionError("unsafe URL must be blocked before browser startup")
+
+    monkeypatch.setattr(smartextract, "sync_playwright", explode_playwright)
+
+    intel = smartextract.collect_page_intelligence(
+        "http://127.0.0.1:8123/list",
+        session=offline_session(),
+    )
+
+    assert intel["page_title"] == ""
+    assert "full_html" not in intel
+
+
+def test_smartextract_blocks_redirect_to_loopback_before_html_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(smartextract, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+    page = _RedirectToLoopbackPage()
+    browser = _RecordingBrowser(page=page)
+
+    @contextmanager
+    def fake_playwright() -> Iterator[_RecordingPlaywright]:
+        yield _RecordingPlaywright(browser)
+
+    monkeypatch.setattr(smartextract, "sync_playwright", fake_playwright)
+
+    intel = smartextract.collect_page_intelligence("https://jobs.example/list", session=offline_session())
+
+    assert page.goto_called
+    assert not page.content_collected
+    assert intel["page_title"] == ""
+    assert "full_html" not in intel
+
+
+def test_smartextract_keeps_route_guard_through_html_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(smartextract, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+    page = _LateLoopbackDuringContentPage(trigger_on="content")
+    browser = _RecordingBrowser(page=page)
+
+    @contextmanager
+    def fake_playwright() -> Iterator[_RecordingPlaywright]:
+        yield _RecordingPlaywright(browser)
+
+    monkeypatch.setattr(smartextract, "sync_playwright", fake_playwright)
+
+    intel = smartextract.collect_page_intelligence("https://jobs.example/list", session=offline_session())
+
+    assert page.goto_called
+    assert page.content_collected
+    assert page.local_aborted
+    assert intel["page_title"] == ""
+    assert "full_html" not in intel


### PR DESCRIPTION
## Summary

- Add a shared public HTTP(S) destination guard for browser-backed discovery and enrichment fetches.
- Block direct unsafe URLs, redirects, final URLs, and Playwright subrequests to loopback, private, link-local, metadata-service, and non-HTTP(S) destinations before captured content can reach enrichment or LLM-assisted extraction.
- Record unsafe enrichment targets as non-retryable `DETAIL_UNSAFE_URL` failures and document the destination boundary.

## Root Cause

Browser-backed enrichment trusted the originally queued posting URL after navigation. An attacker-controlled page could redirect or trigger browser requests to local-only resources, then the fetched content could be included in downstream LLM extraction prompts.

## Validation

- `uv --project workers/automation run python <scanner PoC>`: original SSRF-to-LLM PoC no longer reproduced; provider request count was `0`, provider request contained no secret, and the scrape returned `security_outcome="unsafe_url"`.
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_enrichment_url_safety.py workers/automation/tests/test_enrichment_politeness_gate.py workers/automation/tests/test_enrichment_detail_staleness.py workers/automation/tests/test_browser_ua_propagation.py workers/automation/tests/test_fetch_surface_enforcement.py`: `43 passed`.
- `uv --project workers/automation run --extra dev ruff check <touched Python files>`: passed.
- `uv --project workers/automation run --extra dev pytest -q`: `2130 passed, 1 warning`.
- `corepack pnpm docs:build`: passed, docs link check resolved `4812` references.
- `git diff --check`: passed.