### PR TITLE
fix(security): restrict analysis command filesystem reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,9 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 - `tailored_resumes/`, `cover_letters/`, `logs/` — generated artifacts and
   logs.
 - `chrome-workers/`, `apply-workers/` — local browser/apply worker state.
-- `codex_home/` — isolated Codex SDK home when apply/review agents need it.
+- `codex_home/` — JobCtrl-owned Codex home for local analysis. The adapter
+  copies Codex auth here from the user's regular Codex home and runs
+  prompt-driven commands from `codex_home/workspace/` only.
 - `backups/` — timestamped database snapshots written by `jobctrl backup`.
 
 The daily digest is local-only: `jobctrl digest` and the Dashboard panel read

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -111,7 +111,7 @@ that stays red until Claude auth is present.
 | `ANTHROPIC_AUTH_TOKEN` | Alternate Claude auth token path. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Local/dev Claude subscription convenience. The distributed product path remains API/provider auth. |
 | `CLAUDE_CONFIG_DIR` | Overrides the local Claude credential directory checked for `.credentials.json`. |
-| `CODEX_HOME` | Codex home containing `auth.json`. Defaults to `~/.codex`; the JobCtrl adapter copies this auth into isolated `~/.jobctrl/codex_home`. |
+| `CODEX_HOME` | Source Codex home containing `auth.json`. Defaults to `~/.codex`; the JobCtrl adapter copies this auth into a JobCtrl-owned Codex home so app-server history does not clutter the user's Codex app, then restricts sandboxed analysis commands to that home’s `workspace/` directory. |
 | `JOBCTRL_CODEX_BIN` | Explicit Codex runtime override. The default is the pinned `openai-codex-cli-bin` bundled binary. |
 | `GOOGLE_GENAI_USE_VERTEXAI` | Set to `1` to allow the Antigravity leg to use Vertex AI ADC instead of an API key. |
 | `GOOGLE_CLOUD_PROJECT` / `GOOGLE_PROJECT_ID` / `GCLOUD_PROJECT` | Project used with Vertex AI ADC. |

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -39,7 +39,7 @@ Common files and directories:
 | `logs/` | Local worker and apply logs. |
 | `chrome-workers/` | Browser profiles and state for local browser tasks. |
 | `apply-workers/` | Apply-run worker state. |
-| `codex_home/` | Isolated SDK state used by local agent integrations when configured. |
+| `codex_home/` | JobCtrl-owned Codex home used by local analysis integrations; it keeps app-server state out of the user's normal Codex app and gives sandboxed analysis commands read access only to `codex_home/workspace/` plus minimal runtime paths. |
 | `backups/` | Timestamped SQLite snapshots written by `jobctrl backup`; restore steps are in the README. |
 | `resume.txt`, `resume.pdf`, legacy `resume_style.json`, legacy `resume_template.tex` | Baseline resume inputs and older local style/template files that may remain from prior installs. |
 | `gmail/` | Gmail OAuth client and token (`oauth-client.json`, `token.json`). |

--- a/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
@@ -6,13 +6,12 @@ Node sidecar, no CLI-subprocess wrapper), forcing JSON-schema-constrained
 output via ``output_schema`` on ``thread.run`` and parsing the structured
 result off ``TurnResult.final_response``.
 
-CODEX_HOME isolation: the live factory redirects the Codex SDK's ``CODEX_HOME``
-to an isolated dir under the JobCtrl runtime root (``~/.jobctrl/codex_home``)
-seeded with a copy of the user's effective ``CODEX_HOME/auth.json`` (default
-``~/.codex/auth.json``), so Codex session rollouts never land in — and pollute
-— the user's real Codex chat history. The SDK merges ``CodexConfig.env`` over
-the parent environment, so only ``CODEX_HOME`` is overridden; PATH/HOME/etc.
-are preserved.
+Codex isolation + permissions: the live factory redirects the SDK to a
+JobCtrl-owned ``CODEX_HOME`` so Codex app-server state does not pollute the
+user's normal Codex app history. Prompt-driven commands run from the dedicated
+``CODEX_HOME/workspace`` directory under a Codex permissions profile that denies
+root filesystem reads and grants only that workspace plus Codex's minimal
+runtime paths.
 
 Test-mockability (no live auth in tests — D-04): the ``AsyncCodex`` class is
 resolved through an injectable factory that defaults to a lazy import, so tests
@@ -25,8 +24,10 @@ No timeout (D-19): ``thread.run`` is awaited to completion; effort is pinned to
 
 from __future__ import annotations
 
+import os
 import shutil
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -47,71 +48,96 @@ CODEX_ANALYSIS_MODEL = "gpt-5.5"
 # OTel instrumentation scope for the Codex draft leg's generation span.
 _CODEX_SCOPE = "jobctrl.analysis.codex"
 
-# Disable Codex plugins/apps so the isolated home only ever holds JobCtrl's
-# analysis rollouts + the copied auth token (mirrors mestre's vendor lane).
-_CODEX_CONFIG_OVERRIDES = ("features.plugins=false", "features.apps=false")
-# Isolated Codex home lives under the JobCtrl runtime root, NOT ``~/.codex``.
+# Disable Codex plugins/apps and force prompt-driven commands into a minimal
+# read-only permissions profile. The profile is supplied as a TOML CLI override
+# because openai-codex==0.1.0b3 exposes only legacy Sandbox presets in its
+# public Python wrapper, while the pinned app-server runtime supports
+# default_permissions profiles.
+_CODEX_PERMISSION_PROFILE = "jobctrl-analysis-readonly"
+_CODEX_PERMISSION_PROFILE_OVERRIDE = (
+    f"permissions.{_CODEX_PERMISSION_PROFILE}="
+    '{filesystem={":root"="deny",":minimal"="read",":workspace_roots"={"."="read"}},'
+    "network={enabled=false}}"
+)
+_CODEX_CONFIG_OVERRIDES = (
+    "features.plugins=false",
+    "features.apps=false",
+    f'default_permissions="{_CODEX_PERMISSION_PROFILE}"',
+    _CODEX_PERMISSION_PROFILE_OVERRIDE,
+)
 _CODEX_HOME_DIRNAME = "codex_home"
+_CODEX_WORKSPACE_DIRNAME = "workspace"
+_CODEX_PROCESS_HOME_DIRNAME = "home"
+
+
+@dataclass(frozen=True)
+class _CodexHomeDirs:
+    codex_home: Path
+    workdir: Path
+    process_home: Path
 
 
 def _isolated_codex_home() -> Path:
-    """Return ``<JOBCTRL_DIR>/codex_home`` (config imported lazily to avoid cycles)."""
+    """Return the JobCtrl-owned Codex home used by analysis app-server sessions."""
     from jobctrl.config import APP_DIR
 
     return APP_DIR / _CODEX_HOME_DIRNAME
 
 
-def _copy_newer_file(source: Path, target: Path, *, mode: int | None = None) -> bool:
-    """Copy ``source`` to ``target`` when it is newer or ``target`` is missing.
+def _copy_codex_auth(source: Path, target: Path) -> None:
+    """Copy Codex auth into the JobCtrl-owned SDK home when a source auth exists."""
 
-    Returns ``True`` when a copy happened, ``False`` otherwise. When ``source``
-    is missing but ``target`` exists, the target is still re-chmod'd (if ``mode``
-    is given) so a stale copy keeps its locked-down permissions.
-    """
     if not source.exists():
-        if target.exists() and mode is not None:
-            target.chmod(mode)
-        return False
+        return
     target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     target.parent.chmod(0o700)
-    if target.exists() and target.stat().st_mtime >= source.stat().st_mtime:
-        if mode is not None:
-            target.chmod(mode)
-        return False
+    if source.resolve() == target.resolve():
+        target.chmod(0o600)
+        return
     shutil.copy2(source, target)
-    if mode is not None:
-        target.chmod(mode)
-    return True
+    target.chmod(0o600)
 
 
-def _prepare_isolated_codex_home() -> Path:
-    """Create the isolated Codex home and refresh auth from the user's real login."""
-    home = _isolated_codex_home()
-    home.mkdir(mode=0o700, parents=True, exist_ok=True)
-    home.chmod(0o700)
-    # The copied auth token is sensitive; lock it to 0600. Honor CODEX_HOME
-    # for users who enrolled Codex outside the default ~/.codex directory.
-    _copy_newer_file(codex_auth_path(), home / "auth.json", mode=0o600)
-    return home
+def _prepare_isolated_codex_home() -> _CodexHomeDirs:
+    """Create the isolated Codex home with auth outside the command workspace."""
+
+    codex_home = _isolated_codex_home()
+    codex_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    codex_home.chmod(0o700)
+    workdir = codex_home / _CODEX_WORKSPACE_DIRNAME
+    process_home = codex_home / _CODEX_PROCESS_HOME_DIRNAME
+    for directory in (workdir, process_home):
+        directory.mkdir(mode=0o700, exist_ok=True)
+        directory.chmod(0o700)
+    _copy_codex_auth(codex_auth_path(), codex_home / "auth.json")
+    return _CodexHomeDirs(
+        codex_home=codex_home,
+        workdir=workdir,
+        process_home=process_home,
+    )
 
 
-def _isolated_codex_env(codex_home: Path) -> dict[str, str]:
+def _isolated_codex_env(codex_home: Path, process_home: Path) -> dict[str, str]:
     """Return the minimal env override; the SDK merges this over ``os.environ``."""
-    return {"CODEX_HOME": str(codex_home)}
+
+    env = {"CODEX_HOME": str(codex_home), "HOME": str(process_home)}
+    if os.name == "nt":
+        env["USERPROFILE"] = str(process_home)
+    return env
 
 
 def _load_async_codex_factory() -> AsyncCodexFactory:
-    """Build an isolated ``AsyncCodex`` CM: redirect ``CODEX_HOME`` so Codex
-    session rollouts never land in the user's real ``~/.codex``.
+    """Build an ``AsyncCodex`` CM with a locked-down command permissions profile.
 
     Lazy-imports ``openai_codex`` so the package imports without it installed.
     """
     from openai_codex import AsyncCodex, CodexConfig  # type: ignore[import-untyped]
 
     def _make() -> Any:
-        codex_home = _prepare_isolated_codex_home()
+        dirs = _prepare_isolated_codex_home()
         config_kwargs: dict[str, Any] = {
-            "env": _isolated_codex_env(codex_home),
+            "cwd": str(dirs.workdir),
+            "env": _isolated_codex_env(dirs.codex_home, dirs.process_home),
             "config_overrides": _CODEX_CONFIG_OVERRIDES,
         }
         # Prefer the SDK-pinned bundled runtime. A system ``codex`` on PATH may
@@ -121,18 +147,6 @@ def _load_async_codex_factory() -> AsyncCodexFactory:
         return AsyncCodex(config=CodexConfig(**config_kwargs))
 
     return _make
-
-
-def _load_sandbox_read_only() -> Any:
-    """Return the read-only sandbox enum value, tolerating SDK shape drift."""
-    try:
-        from openai_codex import Sandbox  # type: ignore[import-untyped]
-    except ImportError:
-        return "read-only"
-    try:
-        return Sandbox.read_only
-    except AttributeError:
-        return Sandbox("read-only")
 
 
 class CodexAnalysisAdapter:
@@ -167,9 +181,9 @@ class CodexAnalysisAdapter:
             async with factory() as codex:  # reuses existing Codex login (D-04)
                 thread = await codex.thread_start(
                     model=self._model,
-                    # Max reasoning effort (D-18); analysis reads the JD, no FS writes.
+                    # Max reasoning effort (D-18). Command filesystem access is
+                    # governed by the configured Codex permissions profile.
                     config={"model_reasoning_effort": "high"},
-                    sandbox=_load_sandbox_read_only(),
                 )
                 result = await thread.run(
                     prompt,

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -1,164 +1,205 @@
-"""Codex SDK ``CODEX_HOME`` isolation — pure-helper regression.
+"""Codex SDK CODEX_HOME isolation + permissions-profile regression tests.
 
-These tests pin the invariant that the Codex analysis leg writes its session
-rollouts (and a copied auth token) into an isolated home under the JobCtrl
-runtime root instead of the user's real ``~/.codex`` chat history. They exercise
-ONLY the pure helpers — no ``openai_codex`` import, no app-server, no network —
-by pointing both ``jobctrl.config.APP_DIR`` and ``Path.home()`` at tmp dirs.
+These tests pin both invariants for the Codex analysis leg:
+
+* JobCtrl uses its own ``<APP_DIR>/codex_home`` so app-server session state does
+  not clutter the user's normal Codex app history;
+* prompt-driven commands can read only ``CODEX_HOME/workspace`` plus Codex's
+  minimal runtime paths, not ``CODEX_HOME/auth.json``.
 """
 
 from __future__ import annotations
 
-import os
 import stat
 from pathlib import Path
+from typing import Any
+
+import pytest
 
 import jobctrl.config
 from jobctrl.infrastructure.analysis import codex_analysis_adapter as adapter
 
 
-def _isolate_homes(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
-    """Redirect ``APP_DIR`` and ``Path.home()`` under ``tmp_path``.
+def _isolate_homes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, Path]:
+    """Redirect ``APP_DIR`` and source ``CODEX_HOME`` under ``tmp_path``."""
 
-    ``APP_DIR`` is read lazily via ``from jobctrl.config import APP_DIR`` inside
-    the helper, so patching ``jobctrl.config.APP_DIR`` is what takes effect.
-    Returns ``(app_dir, user_home)``.
-    """
     app_dir = tmp_path / "jobctrl"
-    user_home = tmp_path / "home"
-    user_home.mkdir(parents=True, exist_ok=True)
+    source_codex_home = tmp_path / "source-codex"
+    source_codex_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
-    monkeypatch.setattr(Path, "home", classmethod(lambda cls: user_home))
-    return app_dir, user_home
+    monkeypatch.setenv("CODEX_HOME", str(source_codex_home))
+    return app_dir, source_codex_home
 
 
 def _mode(path: Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
 
 
-def test_isolated_codex_home_is_under_app_dir(monkeypatch, tmp_path: Path) -> None:
-    app_dir, _ = _isolate_homes(monkeypatch, tmp_path)
-    home = adapter._isolated_codex_home()
-    assert home == app_dir / "codex_home"
-    # Patch actually took effect: the path is under our tmp app dir.
-    assert tmp_path in home.parents
+def test_config_overrides_select_workspace_only_permission_profile() -> None:
+    profile = adapter._CODEX_PERMISSION_PROFILE
+    overrides = adapter._CODEX_CONFIG_OVERRIDES
+
+    assert "features.plugins=false" in overrides
+    assert "features.apps=false" in overrides
+    assert f'default_permissions="{profile}"' in overrides
+
+    profile_override = next(value for value in overrides if value.startswith(f"permissions.{profile}="))
+    assert '":root"="deny"' in profile_override
+    assert '":minimal"="read"' in profile_override
+    assert '":workspace_roots"={"."="read"}' in profile_override
+    assert "network={enabled=false}" in profile_override
 
 
-def test_prepare_creates_home_0700_and_copies_auth_0600(monkeypatch, tmp_path: Path) -> None:
-    app_dir, user_home = _isolate_homes(monkeypatch, tmp_path)
-    source_auth = user_home / ".codex" / "auth.json"
-    source_auth.parent.mkdir(parents=True, exist_ok=True)
+def test_prepare_isolated_codex_home_copies_auth_outside_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
     payload = b'{"OPENAI_API_KEY":"sk-isolation-token"}'
-    source_auth.write_bytes(payload)
+    (source_codex_home / "auth.json").write_bytes(payload)
 
-    home = adapter._prepare_isolated_codex_home()
+    dirs = adapter._prepare_isolated_codex_home()
 
-    assert home == app_dir / "codex_home"
-    assert home.is_dir()
-    assert _mode(home) == 0o700
-    target_auth = home / "auth.json"
-    assert target_auth.is_file()
-    assert target_auth.read_bytes() == payload  # identical bytes
-    assert _mode(target_auth) == 0o600
+    assert dirs.codex_home == app_dir / "codex_home"
+    assert dirs.workdir == dirs.codex_home / "workspace"
+    assert dirs.process_home == dirs.codex_home / "home"
+    assert _mode(dirs.codex_home) == 0o700
+    assert _mode(dirs.workdir) == 0o700
+    assert _mode(dirs.process_home) == 0o700
 
-
-def test_prepare_without_source_auth_still_creates_home(monkeypatch, tmp_path: Path) -> None:
-    app_dir, user_home = _isolate_homes(monkeypatch, tmp_path)
-    # No ~/.codex/auth.json on disk.
-    assert not (user_home / ".codex" / "auth.json").exists()
-
-    home = adapter._prepare_isolated_codex_home()  # must not raise
-
-    assert home == app_dir / "codex_home"
-    assert home.is_dir()
-    assert _mode(home) == 0o700
-    assert not (home / "auth.json").exists()
+    copied_auth = dirs.codex_home / "auth.json"
+    assert copied_auth.is_file()
+    assert copied_auth.read_bytes() == payload
+    assert _mode(copied_auth) == 0o600
+    assert not (dirs.workdir / "auth.json").exists()
 
 
-def test_isolated_codex_env_is_minimal(monkeypatch, tmp_path: Path) -> None:
-    _, _ = _isolate_homes(monkeypatch, tmp_path)
-    home = tmp_path / "codex_home"
-    env = adapter._isolated_codex_env(home)
-    # Minimal — the SDK merges this over os.environ, so only CODEX_HOME is set.
-    assert env == {"CODEX_HOME": str(home)}
+def test_isolated_codex_env_is_minimal_for_jobctrl_home(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex_home"
+    process_home = codex_home / "home"
+
+    env = adapter._isolated_codex_env(codex_home, process_home)
+
+    assert env == {"CODEX_HOME": str(codex_home), "HOME": str(process_home)}
 
 
-def test_copy_newer_file_copies_when_target_missing(tmp_path: Path) -> None:
-    source = tmp_path / "src.json"
-    target = tmp_path / "dst" / "auth.json"
-    source.write_bytes(b"first")
+@pytest.mark.asyncio
+async def test_live_factory_uses_jobctrl_codex_home_without_cleanup(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
+    (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-fake-factory"}')
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: tmp_path / "codex-bin")
 
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
+    class FakeAsyncCodex:
+        instances: list["FakeAsyncCodex"] = []
 
-    assert copied is True
-    assert target.read_bytes() == b"first"
-    assert _mode(target) == 0o600
-    # Parent dir is locked down to 0700.
-    assert _mode(target.parent) == 0o700
+        def __init__(self, *, config: Any) -> None:
+            self.config = config
+            self.exited = False
+            FakeAsyncCodex.instances.append(self)
 
+        async def __aenter__(self) -> "FakeAsyncCodex":
+            codex_home = Path(self.config.env["CODEX_HOME"])
+            assert codex_home == app_dir / "codex_home"
+            assert Path(self.config.cwd) == codex_home / "workspace"
+            assert Path(self.config.env["HOME"]) == codex_home / "home"
+            assert (codex_home / "auth.json").is_file()
+            assert not (Path(self.config.cwd) / "auth.json").exists()
+            assert self.config.config_overrides == adapter._CODEX_CONFIG_OVERRIDES
+            return self
 
-def test_copy_newer_file_skips_when_target_is_newer(tmp_path: Path) -> None:
-    source = tmp_path / "src.json"
-    target = tmp_path / "dst.json"
-    source.write_bytes(b"source")
-    target.write_bytes(b"existing-newer")
-    # Make the target strictly newer than the source.
-    os.utime(source, (1_000, 1_000))
-    os.utime(target, (2_000, 2_000))
+        async def __aexit__(self, *exc: Any) -> None:
+            self.exited = True
 
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
+    import openai_codex
 
-    assert copied is False
-    assert target.read_bytes() == b"existing-newer"  # not overwritten
-    assert _mode(target) == 0o600  # still re-chmod'd
+    monkeypatch.setattr(openai_codex, "AsyncCodex", FakeAsyncCodex)
 
+    factory = adapter._load_async_codex_factory()
+    async with factory() as codex:
+        config = codex.config
+        codex_home = Path(config.env["CODEX_HOME"])
+        assert Path(config.cwd) == codex_home / "workspace"
+        assert (source_codex_home / "auth.json").is_file()
 
-def test_copy_newer_file_skips_when_mtimes_equal(tmp_path: Path) -> None:
-    source = tmp_path / "src.json"
-    target = tmp_path / "dst.json"
-    source.write_bytes(b"source")
-    target.write_bytes(b"existing-equal")
-    os.utime(source, (1_500, 1_500))
-    os.utime(target, (1_500, 1_500))  # equal mtime -> skip (>=)
-
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
-
-    assert copied is False
-    assert target.read_bytes() == b"existing-equal"
-
-
-def test_copy_newer_file_overwrites_when_source_is_newer(tmp_path: Path) -> None:
-    source = tmp_path / "src.json"
-    target = tmp_path / "dst.json"
-    target.write_bytes(b"stale")
-    source.write_bytes(b"fresh")
-    os.utime(target, (1_000, 1_000))
-    os.utime(source, (2_000, 2_000))  # source newer -> copy
-
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
-
-    assert copied is True
-    assert target.read_bytes() == b"fresh"
-    assert _mode(target) == 0o600
+    assert FakeAsyncCodex.instances[0].exited is True
+    assert codex_home.exists()
+    assert (source_codex_home / "auth.json").is_file()
 
 
-def test_copy_newer_file_rechmods_when_source_missing_but_target_exists(tmp_path: Path) -> None:
-    source = tmp_path / "missing.json"  # does not exist
-    target = tmp_path / "dst.json"
-    target.write_bytes(b"existing")
-    target.chmod(0o644)
+@pytest.mark.asyncio
+async def test_live_factory_uses_same_jobctrl_codex_home_when_contexts_overlap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
+    (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-fake-concurrent"}')
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: tmp_path / "codex-bin")
 
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
+    class FakeAsyncCodex:
+        instances: list["FakeAsyncCodex"] = []
 
-    assert copied is False
-    assert _mode(target) == 0o600  # re-chmod'd despite missing source
+        def __init__(self, *, config: Any) -> None:
+            self.config = config
+            FakeAsyncCodex.instances.append(self)
+
+        async def __aenter__(self) -> "FakeAsyncCodex":
+            assert (Path(self.config.env["CODEX_HOME"]) / "auth.json").is_file()
+            return self
+
+        async def __aexit__(self, *exc: Any) -> None:
+            return None
+
+    import openai_codex
+
+    monkeypatch.setattr(openai_codex, "AsyncCodex", FakeAsyncCodex)
+
+    factory = adapter._load_async_codex_factory()
+    first_context = factory()
+    second_context = factory()
+
+    first_home = Path(FakeAsyncCodex.instances[0].config.env["CODEX_HOME"])
+    second_home = Path(FakeAsyncCodex.instances[1].config.env["CODEX_HOME"])
+    assert first_home == second_home == app_dir / "codex_home"
+
+    async with first_context as first_codex:
+        async with second_context as second_codex:
+            assert Path(first_codex.config.cwd) == first_home / "workspace"
+            assert Path(second_codex.config.cwd) == first_home / "workspace"
+            assert (first_home / "auth.json").is_file()
 
 
-def test_copy_newer_file_missing_source_and_target_is_noop(tmp_path: Path) -> None:
-    source = tmp_path / "missing-src.json"
-    target = tmp_path / "missing-dst.json"
+@pytest.mark.asyncio
+async def test_pinned_app_server_permission_profile_denies_jobctrl_codex_home_auth(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
+    (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-fake-runtime"}')
 
-    copied = adapter._copy_newer_file(source, target, mode=0o600)
+    from openai_codex.generated.v2_all import CommandExecResponse
 
-    assert copied is False
-    assert not target.exists()
+    factory = adapter._load_async_codex_factory()
+    async with factory() as codex:
+        config = codex._client._sync.config
+        codex_home = Path(config.env["CODEX_HOME"])
+        assert Path(config.cwd) == codex_home / "workspace"
+        assert (codex_home / "auth.json").is_file()
+
+        response = await codex._client.request(
+            "command/exec",
+            {
+                "command": [
+                    "/bin/sh",
+                    "-c",
+                    'if cat "$CODEX_HOME/auth.json" >/dev/null 2>&1; then printf READABLE; else printf DENIED; fi',
+                ],
+                "cwd": config.cwd,
+                "permissionProfile": adapter._CODEX_PERMISSION_PROFILE,
+                "timeoutMs": 5000,
+            },
+            response_model=CommandExecResponse,
+        )
+
+    assert response.exit_code == 0
+    assert "sk-fake-runtime" not in response.stdout
+    assert response.stdout == "DENIED"
+    assert codex_home.exists()

--- a/workers/automation/tests/test_employer_analysis_ensemble.py
+++ b/workers/automation/tests/test_employer_analysis_ensemble.py
@@ -324,6 +324,7 @@ class TestCodexAdapter:
         assert run_kwargs["effort"] == "high"
         assert run_kwargs["output_schema"]["type"] == "object"
         assert fake.thread_start_calls[0]["config"] == {"model_reasoning_effort": "high"}
+        assert "sandbox" not in fake.thread_start_calls[0]
 
     async def test_raises_on_failed_turn(self) -> None:
         adapter = CodexAnalysisAdapter(


### PR DESCRIPTION
## Summary

- Keep Codex analysis on a JobCtrl-owned `codex_home/` so app-server session state does not clutter the user's normal Codex app history.
- Run prompt-driven analysis commands from `codex_home/workspace/` and make that directory the only command-readable workspace root through a Codex permissions profile.
- Copy source Codex auth from the user's regular `CODEX_HOME` into the JobCtrl-owned Codex home for app-server auth, while keeping `auth.json` outside the command-readable workspace.
- Update docs and regression tests for the `codex_home/workspace` layout.

## Root Cause

The vulnerable path was prompt-driven read-only command execution. The analysis adapter needs a separate Codex home to avoid polluting the user's normal Codex app state, but copied auth must not be readable to command tooling that can be influenced by untrusted job descriptions.

This change keeps the separate JobCtrl-owned Codex home and adds the runtime-enforced boundary: only `codex_home/workspace/` is readable to sandboxed analysis commands, while `codex_home/auth.json` remains outside that subtree.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_codex_home_isolation.py workers/automation/tests/test_employer_analysis_ensemble.py::TestCodexAdapter` -> `10 passed`
- `uv --project workers/automation run --extra dev pytest -q` -> `2129 passed, 1 warning`
- `uv --project workers/automation run --extra dev ruff check .` -> `All checks passed!`
- `corepack pnpm docs:build` -> passed; docs site link check passed across 4,813 references / 236 emitted files
- `python3 scripts/release_check.py` -> `Release check passed.`
- `git diff --cached --check` -> passed before commit

## Notes

The live pinned app-server regression uses fake auth and asserts the configured permissions profile returns `DENIED` for `$CODEX_HOME/auth.json`, because only `$CODEX_HOME/workspace/` is granted as the command workspace root.
