### PR TITLE
fix: derive profile evidence and repair link toolbar

### DIFF
--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -49,6 +49,27 @@ const DEFAULT_STYLE = {
 };
 
 const DEFAULT_RESUME_TEMPLATE = "{{ personal_data }}\n\n{{ resume_body }}\n";
+const LEGACY_BULLET_METRIC_PATTERN =
+  /(?:\$\s?\d+(?:[,.]\d+)*(?:\.\d+)?\s?(?:k|m|b|million|billion)?|\d+(?:\.\d+)?%|\d+(?:\.\d+)?x|\d+(?:\.\d+)?\s?(?:ms|milliseconds?|seconds?|minutes?|hours?|days?|weeks?|months?|years?|qps|req\/s))/gi;
+const LEGACY_BULLET_SENIORITY_TERMS = [
+  "own",
+  "owned",
+  "ownership",
+  "scope",
+  "influence",
+  "influenced",
+  "cross-team",
+  "stakeholder",
+  "stakeholders",
+  "led",
+  "lead",
+  "mentor",
+  "mentored",
+  "architect",
+  "architected",
+  "strategy",
+  "technical leadership",
+] as const;
 
 const SUPPORTED_PROFILE_TOP_LEVEL_KEYS = new Set([
   "personal",
@@ -389,6 +410,8 @@ function ensureCandidateProfileColumns(db: SqliteDatabase): void {
       db.exec(`ALTER TABLE candidate_profiles ADD COLUMN ${column} ${definition}`);
     }
   }
+
+  backfillAchievementEvidenceFromBullets(db);
 }
 
 export function readProfileConfig(db: SqliteDatabase): ProfileConfigResponse {
@@ -534,7 +557,7 @@ function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
     asTextArray(entry.bullets).forEach((bullet, bulletIndex) => {
       insertBullet.run(TENANT_ID, PROFILE_ID, entryId, bulletIndex, bullet);
     });
-    asRecordArray(entry.achievement_evidence).forEach((evidence, evidenceIndex) => {
+    achievementEvidenceForEntry(entry, entryId).forEach((evidence, evidenceIndex) => {
       insertEvidence.run(
         TENANT_ID,
         PROFILE_ID,
@@ -623,6 +646,106 @@ function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
   asTextArray(record(profile.resume_constraints).real_metrics).forEach((metric, index) => {
     insertMetric.run(TENANT_ID, PROFILE_ID, index, metric);
   });
+}
+
+function achievementEvidenceForEntry(entry: Record<string, unknown>, entryId: string): Array<Record<string, unknown>> {
+  const explicitEvidence = asRecordArray(entry.achievement_evidence);
+  if (explicitEvidence.length > 0 || !entryId) {
+    return explicitEvidence;
+  }
+  const scope = [text(entry.title), text(entry.company)].filter(Boolean).join(" ");
+  return asTextArray(entry.bullets).map((bullet, index) => {
+    const sourceText = bullet.trim();
+    const normalized = [text(entry.title), text(entry.company), sourceText].join(" ").toLowerCase().replace(/\s+/g, " ");
+    return {
+      id: legacyBulletEvidenceId(entryId, index + 1),
+      source_text: sourceText,
+      scope,
+      action: sourceText,
+      tools: [],
+      metrics: extractedLegacyBulletMetrics(sourceText),
+      outcome: sourceText,
+      seniority_signal: LEGACY_BULLET_SENIORITY_TERMS.some((term) => normalized.includes(term))
+        ? "resume bullet contains seniority signal"
+        : "",
+      evidence_strength: "supported",
+      claim_confidence: 0.8,
+      user_confirmed: true,
+      tags: [],
+    };
+  });
+}
+
+function backfillAchievementEvidenceFromBullets(db: SqliteDatabase): void {
+  const rows = db.prepare(`
+    SELECT entries.tenant_id, entries.profile_id, entries.entry_id, entries.title, entries.company,
+           bullets.bullet_index, bullets.bullet_text
+    FROM candidate_profile_experience_entries AS entries
+    JOIN candidate_profile_experience_bullets AS bullets
+      ON bullets.tenant_id = entries.tenant_id
+     AND bullets.profile_id = entries.profile_id
+     AND bullets.entry_id = entries.entry_id
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM candidate_profile_achievement_evidence AS evidence
+      WHERE evidence.tenant_id = entries.tenant_id
+        AND evidence.profile_id = entries.profile_id
+        AND evidence.entry_id = entries.entry_id
+    )
+    ORDER BY entries.tenant_id, entries.profile_id, entries.position_index, bullets.bullet_index
+  `).all() as Array<Record<string, unknown>>;
+  if (rows.length === 0) {
+    return;
+  }
+  const insertEvidence = db.prepare(`
+    INSERT INTO candidate_profile_achievement_evidence (
+      tenant_id, profile_id, entry_id, evidence_index,
+      evidence_id, source_text, scope, action, tools_json,
+      metrics_json, outcome, seniority_signal, evidence_strength,
+      claim_confidence, user_confirmed, tags_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  const transaction = db.transaction(() => {
+    for (const row of rows) {
+      const entryId = text(row.entry_id);
+      const sourceText = text(row.bullet_text).trim();
+      const scope = [text(row.title), text(row.company)].filter(Boolean).join(" ");
+      const normalized = [text(row.title), text(row.company), sourceText].join(" ").toLowerCase().replace(/\s+/g, " ");
+      const bulletIndex = Number(row.bullet_index ?? 0);
+      insertEvidence.run(
+        text(row.tenant_id, TENANT_ID),
+        text(row.profile_id, PROFILE_ID),
+        entryId,
+        bulletIndex,
+        legacyBulletEvidenceId(entryId, bulletIndex + 1),
+        sourceText,
+        scope,
+        sourceText,
+        "[]",
+        JSON.stringify(extractedLegacyBulletMetrics(sourceText)),
+        sourceText,
+        LEGACY_BULLET_SENIORITY_TERMS.some((term) => normalized.includes(term))
+          ? "resume bullet contains seniority signal"
+          : "",
+        "supported",
+        0.8,
+        1,
+        "[]",
+      );
+    }
+  });
+  transaction();
+}
+
+function legacyBulletEvidenceId(entryId: string, bulletIndex: number): string {
+  const safeEntryId = entryId.replace(/[^a-zA-Z0-9_.-]+/g, "_").replace(/^_+|_+$/g, "") || "experience";
+  return `${safeEntryId}_bullet_${Math.max(1, Math.trunc(bulletIndex))}`;
+}
+
+function extractedLegacyBulletMetrics(sourceText: string): string[] {
+  return Array.from(sourceText.matchAll(LEGACY_BULLET_METRIC_PATTERN), (match) =>
+    match[0].trim().replace(/\s+/g, " "),
+  );
 }
 
 function insertRequiredIds(db: SqliteDatabase, table: string, column: string, values: string[]): void {

--- a/apps/api/src/profile-store.ts
+++ b/apps/api/src/profile-store.ts
@@ -650,13 +650,34 @@ function insertChildren(db: SqliteDatabase, profile: ProfileShape): void {
 
 function achievementEvidenceForEntry(entry: Record<string, unknown>, entryId: string): Array<Record<string, unknown>> {
   const explicitEvidence = asRecordArray(entry.achievement_evidence);
-  if (explicitEvidence.length > 0 || !entryId) {
+  if (!entryId) {
     return explicitEvidence;
   }
-  const scope = [text(entry.title), text(entry.company)].filter(Boolean).join(" ");
+  const derivedEvidence = legacyBulletAchievementEvidenceForEntry(entry, entryId);
+  if (explicitEvidence.length === 0) {
+    return derivedEvidence;
+  }
+  if (explicitEvidence.every((evidence) => isMaterializedLegacyBulletEvidence(evidence, entryId))) {
+    return derivedEvidence;
+  }
+  const derivedById = new Map(derivedEvidence.map((evidence) => [text(evidence.id), evidence]));
+  return explicitEvidence.flatMap((evidence) => {
+    if (!isMaterializedLegacyBulletEvidence(evidence, entryId)) {
+      return [evidence];
+    }
+    const replacement = derivedById.get(text(evidence.id));
+    return replacement ? [replacement] : [];
+  });
+}
+
+function legacyBulletAchievementEvidenceForEntry(
+  entry: Record<string, unknown>,
+  entryId: string,
+): Array<Record<string, unknown>> {
+  const scope = legacyBulletEvidenceScope(entry);
   return asTextArray(entry.bullets).map((bullet, index) => {
     const sourceText = bullet.trim();
-    const normalized = [text(entry.title), text(entry.company), sourceText].join(" ").toLowerCase().replace(/\s+/g, " ");
+    const normalized = legacyBulletEvidenceNormalizedText(entry, sourceText);
     return {
       id: legacyBulletEvidenceId(entryId, index + 1),
       source_text: sourceText,
@@ -674,6 +695,24 @@ function achievementEvidenceForEntry(entry: Record<string, unknown>, entryId: st
       tags: [],
     };
   });
+}
+
+function isMaterializedLegacyBulletEvidence(evidence: Record<string, unknown>, entryId: string): boolean {
+  if (!legacyBulletEvidenceIndex(text(evidence.id), entryId)) {
+    return false;
+  }
+  const sourceText = text(evidence.source_text).trim();
+  if (!sourceText) {
+    return false;
+  }
+  return text(evidence.action).trim() === sourceText
+    && text(evidence.outcome).trim() === sourceText
+    && asTextArray(evidence.tools).length === 0
+    && arraysEqual(asTextArray(evidence.metrics), extractedLegacyBulletMetrics(sourceText))
+    && text(evidence.evidence_strength, "supported").trim() === "supported"
+    && confidenceNumber(evidence.claim_confidence) === 0.8
+    && boolValue(evidence.user_confirmed, false)
+    && asTextArray(evidence.tags).length === 0;
 }
 
 function backfillAchievementEvidenceFromBullets(db: SqliteDatabase): void {
@@ -709,8 +748,8 @@ function backfillAchievementEvidenceFromBullets(db: SqliteDatabase): void {
     for (const row of rows) {
       const entryId = text(row.entry_id);
       const sourceText = text(row.bullet_text).trim();
-      const scope = [text(row.title), text(row.company)].filter(Boolean).join(" ");
-      const normalized = [text(row.title), text(row.company), sourceText].join(" ").toLowerCase().replace(/\s+/g, " ");
+      const scope = legacyBulletEvidenceScope(row);
+      const normalized = legacyBulletEvidenceNormalizedText(row, sourceText);
       const bulletIndex = Number(row.bullet_index ?? 0);
       insertEvidence.run(
         text(row.tenant_id, TENANT_ID),
@@ -737,15 +776,37 @@ function backfillAchievementEvidenceFromBullets(db: SqliteDatabase): void {
   transaction();
 }
 
+function legacyBulletEvidenceScope(entry: Record<string, unknown>): string {
+  return [text(entry.title), text(entry.company)].filter(Boolean).join(" ");
+}
+
+function legacyBulletEvidenceNormalizedText(entry: Record<string, unknown>, sourceText: string): string {
+  return [text(entry.title), text(entry.company), sourceText].join(" ").toLowerCase().replace(/\s+/g, " ");
+}
+
 function legacyBulletEvidenceId(entryId: string, bulletIndex: number): string {
   const safeEntryId = entryId.replace(/[^a-zA-Z0-9_.-]+/g, "_").replace(/^_+|_+$/g, "") || "experience";
   return `${safeEntryId}_bullet_${Math.max(1, Math.trunc(bulletIndex))}`;
+}
+
+function legacyBulletEvidenceIndex(evidenceId: string, entryId: string): number | null {
+  const match = evidenceId.match(/_bullet_([1-9]\d*)$/);
+  const rawIndex = match?.[1];
+  if (!rawIndex) {
+    return null;
+  }
+  const bulletIndex = Number(rawIndex);
+  return evidenceId === legacyBulletEvidenceId(entryId, bulletIndex) ? bulletIndex : null;
 }
 
 function extractedLegacyBulletMetrics(sourceText: string): string[] {
   return Array.from(sourceText.matchAll(LEGACY_BULLET_METRIC_PATTERN), (match) =>
     match[0].trim().replace(/\s+/g, " "),
   );
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 function insertRequiredIds(db: SqliteDatabase, table: string, column: string, values: string[]): void {
@@ -1352,8 +1413,12 @@ function nullableBoolInt(value: unknown): number | null {
 }
 
 function boolInt(value: unknown, fallback: boolean): number {
-  if (value === undefined || value === null) return fallback ? 1 : 0;
-  if (typeof value === "boolean") return value ? 1 : 0;
-  if (typeof value === "string") return ["true", "yes", "y", "1", "on"].includes(value.trim().toLowerCase()) ? 1 : 0;
-  return value ? 1 : 0;
+  return boolValue(value, fallback) ? 1 : 0;
+}
+
+function boolValue(value: unknown, fallback: boolean): boolean {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") return ["true", "yes", "y", "1", "on"].includes(value.trim().toLowerCase());
+  return Boolean(value);
 }

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -7541,6 +7541,56 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("rederives materialized bullet evidence when a profile bullet changes", async () => {
+    const app = buildApp(options);
+    const profile = validProfileFixture("Updated Bullet Evidence Candidate");
+    const resume = profile.resume as Record<string, unknown>;
+    const entries = resume.experience_entries as Array<Record<string, unknown>>;
+    entries[0]!.bullets = ["Reduced incidents 40% by hardening service ownership."];
+
+    const initial = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile },
+    });
+
+    expect(initial.statusCode, initial.body).toBe(200);
+    const materializedProfile = initial.json().profile as Record<string, unknown>;
+    const materializedResume = materializedProfile.resume as Record<string, unknown>;
+    const materializedEntries = materializedResume.experience_entries as Array<Record<string, unknown>>;
+    materializedEntries[0]!.bullets = ["Reduced incidents 55% by hardening service ownership."];
+
+    const updated = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile: materializedProfile },
+    });
+
+    expect(updated.statusCode, updated.body).toBe(200);
+    expect(updated.json().profile.resume.experience_entries[0].achievement_evidence).toEqual([
+      expect.objectContaining({
+        id: "role_1_bullet_1",
+        source_text: "Reduced incidents 55% by hardening service ownership.",
+        metrics: ["55%"],
+      }),
+    ]);
+
+    const db = new Database(options.dbPath);
+    try {
+      expect(
+        db.prepare("SELECT evidence_id, source_text, metrics_json FROM candidate_profile_achievement_evidence").get(),
+      ).toMatchObject({
+        evidence_id: "role_1_bullet_1",
+        source_text: "Reduced incidents 55% by hardening service ownership.",
+        metrics_json: '["55%"]',
+      });
+    } finally {
+      db.close();
+    }
+
+    await app.close();
+  });
+
   it("keeps explicit claim policy when legacy strict mode is present", async () => {
     const app = buildApp(options);
     const profile = validProfileFixture("Explicit Claim Policy Candidate");

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -7485,6 +7485,62 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
+  it("materializes profile achievement evidence from bullets when explicit evidence is absent", async () => {
+    const app = buildApp(options);
+    const profile = validProfileFixture("Bullet Evidence Candidate");
+    const resume = profile.resume as Record<string, unknown>;
+    const entries = resume.experience_entries as Array<Record<string, unknown>>;
+    entries[0]!.bullets = ["Reduced incidents 40% by hardening service ownership."];
+
+    const response = await app.inject({
+      method: "PATCH",
+      url: "/v1/profile",
+      payload: { profile },
+    });
+
+    expect(response.statusCode, response.body).toBe(200);
+    const body = response.json();
+    expect(body.profile.resume.experience_entries[0].achievement_evidence).toEqual([
+      expect.objectContaining({
+        id: "role_1_bullet_1",
+        source_text: "Reduced incidents 40% by hardening service ownership.",
+        metrics: ["40%"],
+        evidence_strength: "supported",
+        claim_confidence: 0.8,
+        user_confirmed: true,
+      }),
+    ]);
+
+    const db = new Database(options.dbPath);
+    try {
+      expect(db.prepare("SELECT COUNT(*) AS count FROM candidate_profile_achievement_evidence").get()).toMatchObject({
+        count: 1,
+      });
+      expect(
+        db.prepare("SELECT evidence_id, source_text, metrics_json FROM candidate_profile_achievement_evidence").get(),
+      ).toMatchObject({
+        evidence_id: "role_1_bullet_1",
+        source_text: "Reduced incidents 40% by hardening service ownership.",
+        metrics_json: '["40%"]',
+      });
+      db.prepare("DELETE FROM candidate_profile_achievement_evidence").run();
+    } finally {
+      db.close();
+    }
+
+    const repaired = await app.inject({ method: "GET", url: "/v1/profile" });
+    expect(repaired.statusCode, repaired.body).toBe(200);
+    expect(repaired.json().profile.resume.experience_entries[0].achievement_evidence).toEqual([
+      expect.objectContaining({
+        id: "role_1_bullet_1",
+        source_text: "Reduced incidents 40% by hardening service ownership.",
+        metrics: ["40%"],
+      }),
+    ]);
+
+    await app.close();
+  });
+
   it("keeps explicit claim policy when legacy strict mode is present", async () => {
     const app = buildApp(options);
     const profile = validProfileFixture("Explicit Claim Policy Candidate");

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -16,10 +16,12 @@ import {
   IconAlignLeft,
   IconAlignRight,
   IconBold,
+  IconCheck,
   IconItalic,
   IconLink,
   IconUnlink,
   IconUnderline,
+  IconX,
 } from "@tabler/icons-react";
 import type { Descendant, TElement, Value } from "platejs";
 import {
@@ -45,6 +47,7 @@ import {
   type Dispatch,
   type FormEvent,
   type JSX,
+  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent,
   type SetStateAction,
 } from "react";
@@ -2020,6 +2023,12 @@ function keepEditorSelection(event: MouseEvent<HTMLButtonElement>): void {
   event.preventDefault();
 }
 
+function elementContainsNode(element: Element, node: Node | null | undefined): boolean {
+  if (!node) return false;
+  if (node instanceof Element) return element.contains(node);
+  return node.parentElement ? element.contains(node.parentElement) : false;
+}
+
 function ResumeEditorToolbarControls({
   disabled,
   onAlign,
@@ -2041,13 +2050,66 @@ function ResumeEditorToolbarControls({
   readonly onToggleItalic: () => void;
   readonly onToggleUnderline: () => void;
 }): JSX.Element {
+  const toolbarRef = useRef<HTMLDivElement | null>(null);
+  const linkInputRef = useRef<HTMLInputElement | null>(null);
   const fontFamilyId = useId();
   const fontSizeId = useId();
   const linkInputId = useId();
   const linkErrorId = useId();
+  const linkPopoverId = useId();
   const [fontSizeScale, setFontSizeScale] = useState(String(RESUME_EDITOR_DEFAULT_SIZE_SCALE));
   const [linkUrl, setLinkUrl] = useState("");
   const [linkError, setLinkError] = useState<string | null>(null);
+  const [linkPopoverOpen, setLinkPopoverOpen] = useState(false);
+  const openLinkPopover = useCallback(() => {
+    if (disabled) return;
+    setLinkError(null);
+    setLinkPopoverOpen(true);
+  }, [disabled]);
+  const closeLinkPopover = useCallback(() => {
+    setLinkError(null);
+    setLinkPopoverOpen(false);
+  }, []);
+  useEffect(() => {
+    if (!linkPopoverOpen) return;
+    const frame = window.requestAnimationFrame(() => {
+      linkInputRef.current?.focus();
+      linkInputRef.current?.select();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [linkPopoverOpen]);
+  useEffect(() => {
+    if (!linkPopoverOpen) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      const toolbar = toolbarRef.current;
+      if (!toolbar || !(event.target instanceof Node) || toolbar.contains(event.target)) return;
+      closeLinkPopover();
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [closeLinkPopover, linkPopoverOpen]);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (disabled || event.defaultPrevented || event.key.toLowerCase() !== "k" || (!event.metaKey && !event.ctrlKey)) {
+        return;
+      }
+      const toolbar = toolbarRef.current;
+      const editor = toolbar?.closest(".resume-plate-editor");
+      if (!toolbar || !editor) return;
+      const activeElement = document.activeElement;
+      const selection = document.getSelection();
+      const activeWithinEditor = activeElement instanceof Element && editor.contains(activeElement);
+      const selectionWithinEditor =
+        Boolean(selection?.rangeCount) &&
+        (elementContainsNode(editor, selection?.anchorNode) || elementContainsNode(editor, selection?.focusNode));
+      const selectedLineWithinEditor = Boolean(editor.querySelector(".jobctrl-selected-line"));
+      if (!activeWithinEditor && !selectionWithinEditor && !selectedLineWithinEditor) return;
+      event.preventDefault();
+      openLinkPopover();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [disabled, openLinkPopover]);
   const applyFontSizeScale = useCallback(
     (rawValue: string) => {
       const value = Number(rawValue);
@@ -2086,11 +2148,26 @@ function ResumeEditorToolbarControls({
       setLinkError(null);
       setLinkUrl(href);
       onSetLink(href);
+      setLinkPopoverOpen(false);
     },
     [linkUrl, onSetLink],
   );
+  const handleLinkPopoverKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLFormElement>) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      event.stopPropagation();
+      closeLinkPopover();
+    },
+    [closeLinkPopover],
+  );
   return (
-    <div className="resume-format-toolbar" aria-label="Resume formatting controls" data-resume-editor-chrome="true">
+    <div
+      ref={toolbarRef}
+      className="resume-format-toolbar"
+      aria-label="Resume formatting controls"
+      data-resume-editor-chrome="true"
+    >
       <div className="resume-format-button-group" aria-label="Text style">
         <button
           aria-label="Bold"
@@ -2126,33 +2203,22 @@ function ResumeEditorToolbarControls({
           <IconUnderline aria-hidden="true" size={16} stroke={2.2} />
         </button>
       </div>
-      <form className="resume-link-control" aria-label="Hyperlink" onSubmit={applyLink}>
-        <label className="resume-format-select" htmlFor={linkInputId}>
-          <span>Link</span>
-          <input
-            aria-describedby={linkError ? linkErrorId : undefined}
-            aria-invalid={linkError ? "true" : undefined}
-            aria-label="Link URL"
-            disabled={disabled}
-            id={linkInputId}
-            inputMode="url"
-            placeholder="example.com"
-            type="text"
-            value={linkUrl}
-            onChange={(event: ChangeEvent<HTMLInputElement>) => {
-              setLinkUrl(event.currentTarget.value);
-              setLinkError(null);
-            }}
-          />
-        </label>
+      <div className="resume-link-popover-anchor">
         <div className="resume-format-button-group" aria-label="Hyperlink actions">
           <button
-            aria-label="Apply link"
-            className="resume-format-button"
-            disabled={disabled || !linkUrl.trim()}
-            title="Apply link to selected text or selected resume line"
-            type="submit"
-            onMouseDown={keepEditorSelection}
+            aria-controls={linkPopoverOpen ? linkPopoverId : undefined}
+            aria-expanded={linkPopoverOpen}
+            aria-keyshortcuts="Meta+K Control+K"
+            aria-label="Insert link"
+            className={`resume-format-button${linkPopoverOpen ? " active" : ""}`}
+            disabled={disabled}
+            title="Insert link (⌘K)"
+            type="button"
+            onClick={openLinkPopover}
+            onMouseDown={(event) => {
+              keepEditorSelection(event);
+              openLinkPopover();
+            }}
           >
             <IconLink aria-hidden="true" size={16} stroke={2.2} />
           </button>
@@ -2163,7 +2229,7 @@ function ResumeEditorToolbarControls({
             title="Remove link from selected text or selected resume line"
             type="button"
             onClick={() => {
-              setLinkError(null);
+              closeLinkPopover();
               onClearLink();
             }}
             onMouseDown={keepEditorSelection}
@@ -2171,12 +2237,65 @@ function ResumeEditorToolbarControls({
             <IconUnlink aria-hidden="true" size={16} stroke={2.2} />
           </button>
         </div>
-        {linkError ? (
-          <span className="resume-link-error" id={linkErrorId} role="status">
-            {linkError}
-          </span>
+        {linkPopoverOpen ? (
+          <form
+            id={linkPopoverId}
+            className="resume-link-popover"
+            aria-label="Insert link"
+            role="dialog"
+            onKeyDown={handleLinkPopoverKeyDown}
+            onSubmit={applyLink}
+          >
+            <label className="resume-format-select" htmlFor={linkInputId}>
+              <span>URL</span>
+              <input
+                ref={linkInputRef}
+                aria-describedby={linkError ? linkErrorId : undefined}
+                aria-invalid={linkError ? "true" : undefined}
+                aria-label="Link URL"
+                disabled={disabled}
+                id={linkInputId}
+                inputMode="url"
+                placeholder="example.com"
+                type="text"
+                value={linkUrl}
+                onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                  setLinkUrl(event.currentTarget.value);
+                  setLinkError(null);
+                }}
+              />
+            </label>
+            <div className="resume-format-button-group" aria-label="Link popover actions">
+              <button
+                aria-label="Apply link"
+                className="resume-format-button"
+                disabled={disabled || !linkUrl.trim()}
+                title="Apply link"
+                type="submit"
+                onMouseDown={keepEditorSelection}
+              >
+                <IconCheck aria-hidden="true" size={16} stroke={2.2} />
+              </button>
+              <button
+                aria-label="Cancel link"
+                className="resume-format-button"
+                disabled={disabled}
+                title="Cancel"
+                type="button"
+                onClick={closeLinkPopover}
+                onMouseDown={keepEditorSelection}
+              >
+                <IconX aria-hidden="true" size={16} stroke={2.2} />
+              </button>
+            </div>
+            {linkError ? (
+              <span className="resume-link-error" id={linkErrorId} role="status">
+                {linkError}
+              </span>
+            ) : null}
+          </form>
         ) : null}
-      </form>
+      </div>
       <label className="resume-format-select" htmlFor={fontFamilyId}>
         <span>Font</span>
         <select

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -2052,6 +2052,7 @@ function ResumeEditorToolbarControls({
 }): JSX.Element {
   const toolbarRef = useRef<HTMLDivElement | null>(null);
   const linkInputRef = useRef<HTMLInputElement | null>(null);
+  const linkTriggerRef = useRef<HTMLButtonElement | null>(null);
   const fontFamilyId = useId();
   const fontSizeId = useId();
   const linkInputId = useId();
@@ -2069,6 +2070,7 @@ function ResumeEditorToolbarControls({
   const closeLinkPopover = useCallback(() => {
     setLinkError(null);
     setLinkPopoverOpen(false);
+    window.requestAnimationFrame(() => linkTriggerRef.current?.focus());
   }, []);
   useEffect(() => {
     if (!linkPopoverOpen) return;
@@ -2148,9 +2150,9 @@ function ResumeEditorToolbarControls({
       setLinkError(null);
       setLinkUrl(href);
       onSetLink(href);
-      setLinkPopoverOpen(false);
+      closeLinkPopover();
     },
-    [linkUrl, onSetLink],
+    [closeLinkPopover, linkUrl, onSetLink],
   );
   const handleLinkPopoverKeyDown = useCallback(
     (event: ReactKeyboardEvent<HTMLFormElement>) => {
@@ -2206,6 +2208,7 @@ function ResumeEditorToolbarControls({
       <div className="resume-link-popover-anchor">
         <div className="resume-format-button-group" aria-label="Hyperlink actions">
           <button
+            ref={linkTriggerRef}
             aria-controls={linkPopoverOpen ? linkPopoverId : undefined}
             aria-expanded={linkPopoverOpen}
             aria-keyshortcuts="Meta+K Control+K"

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
@@ -215,29 +215,42 @@ describe("<StructuredProfileEditor>", () => {
     expect(screen.getByRole("checkbox", { name: "Leadership" })).toBeChecked();
   });
 
-  it("adds, edits, and removes achievement evidence", async () => {
-    let latestProfile = JSON.stringify(sampleProfileResponse.profile, null, 2);
-    render(<StatefulEditor onLatestProfile={(value) => { latestProfile = value; }} />);
+  it("preserves extracted achievement evidence without exposing it as profile input", () => {
+    const initialProfile = JSON.parse(JSON.stringify(sampleProfileResponse.profile));
+    initialProfile.resume.experience_entries[0].achievement_evidence = [
+      {
+        id: "exp-1_bullet_1",
+        source_text: "Scaled the platform 10x.",
+        scope: "Director of Platform Initech",
+        action: "Scaled the platform 10x.",
+        tools: [],
+        metrics: ["10x"],
+        outcome: "Scaled the platform 10x.",
+        seniority_signal: "",
+        evidence_strength: "supported",
+        claim_confidence: 0.8,
+        user_confirmed: true,
+        tags: [],
+      },
+    ];
+    let latestProfile = JSON.stringify(initialProfile, null, 2);
 
-    fireEvent.click(screen.getByRole("button", { name: "add evidence" }));
-    expect(
-      JSON.parse(latestProfile).resume.experience_entries[0].achievement_evidence[0],
-    ).toMatchObject({
-      id: "ev_exp-1_1",
-      evidence_strength: "supported",
-      user_confirmed: false,
-    });
+    render(<StatefulEditor initialProfile={initialProfile} onLatestProfile={(value) => { latestProfile = value; }} />);
 
-    fireEvent.change(await screen.findByLabelText("Source text"), {
-      target: { value: "Reduced incident response time 35%." },
-    });
-    expect(
-      JSON.parse(latestProfile).resume.experience_entries[0].achievement_evidence[0]
-        .source_text,
-    ).toBe("Reduced incident response time 35%.");
+    expect(screen.queryByRole("group", { name: "Achievement evidence" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Proof points for generated claims" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add evidence/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add proof point/i })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Evidence ID")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Source text")).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove achievement evidence 1" }));
-    expect(JSON.parse(latestProfile).resume.experience_entries[0].achievement_evidence).toEqual([]);
+    fireEvent.change(screen.getByLabelText("Title"), { target: { value: "Director of Reliability" } });
+
+    const profile = JSON.parse(latestProfile);
+    expect(profile.resume.experience_entries[0].title).toBe("Director of Reliability");
+    expect(profile.resume.experience_entries[0].achievement_evidence).toEqual(
+      initialProfile.resume.experience_entries[0].achievement_evidence,
+    );
   });
 
   it("hides state/province for non-US profiles", () => {

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -294,42 +294,6 @@ export function StructuredProfileEditor({
     });
   };
 
-  const addAchievementEvidence = (entryIndex: number, entryId: string) => {
-    updateProfileDraft((draft) => {
-      const path = `resume.experience_entries.${entryIndex}.achievement_evidence`;
-      const items = recordArrayAt(draft, path);
-      const defaultId = entryId ? `ev_${entryId}_${items.length + 1}` : "";
-      setPathValue(draft, path, [
-        ...items,
-        {
-          id: defaultId,
-          source_text: "",
-          scope: "",
-          action: "",
-          tools: [],
-          metrics: [],
-          outcome: "",
-          seniority_signal: "",
-          evidence_strength: "supported",
-          claim_confidence: 0,
-          user_confirmed: false,
-          tags: [],
-        },
-      ]);
-    });
-  };
-
-  const removeAchievementEvidence = (entryIndex: number, evidenceIndex: number) => {
-    updateProfileDraft((draft) => {
-      const path = `resume.experience_entries.${entryIndex}.achievement_evidence`;
-      setPathValue(
-        draft,
-        path,
-        recordArrayAt(draft, path).filter((_, index) => index !== evidenceIndex),
-      );
-    });
-  };
-
   const removeRepeatItem = (path: string, index: number) => {
     updateProfileDraft((draft) => {
       const items = recordArrayAt(draft, path);
@@ -1166,10 +1130,6 @@ export function StructuredProfileEditor({
           {experienceEntries.map((entry, index) => {
             const entryId = textFrom(entry["id"]);
             const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
-            const evidenceItems = recordArrayAt(
-              profile,
-              `resume.experience_entries.${index}.achievement_evidence`,
-            );
             const requiredBullets = new Set(
               asTextArray(
                 recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
@@ -1253,96 +1213,6 @@ export function StructuredProfileEditor({
                     add bullet
                   </button>
                 </div>
-                <fieldset className="achievement-evidence-list">
-                  <legend>Achievement evidence</legend>
-                  {evidenceItems.map((_, evidenceIndex) => (
-                    <div
-                      className="achievement-evidence-card"
-                      key={`${entryId || "experience"}-evidence-${evidenceIndex}`}
-                    >
-                      <div className="repeat-hd">
-                        <b>Evidence {evidenceIndex + 1}</b>
-                        <button
-                          className="icon-button"
-                          type="button"
-                          aria-label={`Remove achievement evidence ${evidenceIndex + 1}`}
-                          title="Remove achievement evidence"
-                          onClick={() => removeAchievementEvidence(index, evidenceIndex)}
-                        >
-                          <IconTrash size={14} aria-hidden="true" />
-                        </button>
-                      </div>
-                      <div className="field-grid">
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.id`,
-                          "Evidence ID",
-                        )}
-                        {selectField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.evidence_strength`,
-                          "Evidence strength",
-                          [
-                            ["verified", "Verified"],
-                            ["supported", "Supported"],
-                            ["inferred", "Inferred"],
-                            ["draft", "Draft"],
-                          ],
-                        )}
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.scope`,
-                          "Scope",
-                        )}
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.action`,
-                          "Action",
-                        )}
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.outcome`,
-                          "Outcome",
-                        )}
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.seniority_signal`,
-                          "Seniority signal",
-                        )}
-                        {textField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.claim_confidence`,
-                          "Claim confidence",
-                          "number",
-                          { min: 0, max: 1, step: 0.05 },
-                        )}
-                        {checkboxField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.user_confirmed`,
-                          "User confirmed",
-                        )}
-                      </div>
-                      <div className="field-grid one">
-                        {textareaField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.source_text`,
-                          "Source text",
-                        )}
-                        {listField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.tools`,
-                          "Tools",
-                        )}
-                        {listField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.metrics`,
-                          "Metrics",
-                        )}
-                        {listField(
-                          `resume.experience_entries.${index}.achievement_evidence.${evidenceIndex}.tags`,
-                          "Tags",
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                  <button
-                    className="tab add-bullet"
-                    type="button"
-                    onClick={() => addAchievementEvidence(index, entryId)}
-                  >
-                    <IconPlus size={14} aria-hidden="true" />
-                    add evidence
-                  </button>
-                </fieldset>
               </div>
             );
           })}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1824,17 +1824,17 @@ input[type="radio"] {
 
 .resume-format-toolbar {
   display: flex;
+  position: relative;
   flex: 1 1 520px;
   min-width: 360px;
   align-items: center;
   gap: 8px;
 }
 
-.resume-link-control {
+.resume-link-popover-anchor {
   display: inline-flex;
   position: relative;
   align-items: center;
-  gap: 6px;
 }
 
 .resume-format-button-group {
@@ -1862,7 +1862,8 @@ input[type="radio"] {
 }
 
 .resume-format-button:hover:not(:disabled),
-.resume-format-button:focus-visible {
+.resume-format-button:focus-visible,
+.resume-format-button.active {
   background: rgb(255 255 255 / 13%);
 }
 
@@ -1905,16 +1906,34 @@ input[type="radio"] {
   inline-size: 64px;
 }
 
-.resume-link-control .resume-format-select input {
-  inline-size: min(24vw, 180px);
-  min-inline-size: 116px;
+.resume-link-popover {
+  display: grid;
+  position: absolute;
+  z-index: 5;
+  inset-block-start: calc(100% + 8px);
+  inset-inline-start: 0;
+  grid-template-columns: minmax(190px, min(46vw, 260px)) auto;
+  align-items: end;
+  gap: 7px;
+  padding: 8px;
+  border: 1px solid rgb(255 255 255 / 18%);
+  border-radius: 6px;
+  background: #242424;
+  box-shadow: 0 12px 28px rgb(0 0 0 / 35%);
+}
+
+.resume-link-popover .resume-format-select {
+  display: grid;
+  gap: 4px;
+}
+
+.resume-link-popover .resume-format-select input {
+  inline-size: 100%;
+  min-inline-size: 0;
 }
 
 .resume-link-error {
-  position: absolute;
-  inset-block-start: calc(100% + 4px);
-  inset-inline-start: 0;
-  z-index: 2;
+  grid-column: 1 / -1;
   max-inline-size: 280px;
   border: 1px solid rgb(248 113 113 / 50%);
   border-radius: 5px;

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -919,6 +919,13 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Italic" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Underline" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert link" })).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Insert link" }));
+    const toolbarLinkInput = await screen.findByRole("textbox", { name: "Link URL" });
+    await waitFor(() => expect(toolbarLinkInput).toHaveFocus());
+    await userEvent.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument());
     expect(screen.getByLabelText("Font")).toBeInTheDocument();
     expect(screen.getByLabelText("Size")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();
@@ -1392,8 +1399,13 @@ describe("<ApplyReviewView>", () => {
 
     let shadow = await findResumeShadowRoot();
     await selectResumeLine(shadow, "Owned platform reliability improvements for incident response.");
-    await userEvent.type(screen.getByRole("textbox", { name: "Link URL" }), "portfolio.example.test");
+    expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    const linkInput = await screen.findByRole("textbox", { name: "Link URL" });
+    await waitFor(() => expect(linkInput).toHaveFocus());
+    await userEvent.type(linkInput, "portfolio.example.test");
     await userEvent.click(screen.getByRole("button", { name: "Apply link" }));
+    await waitFor(() => expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument());
 
     shadow = await findResumeShadowRoot();
     await waitFor(() =>

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -919,13 +919,15 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Italic" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Underline" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Insert link" })).toBeInTheDocument();
+    const insertLinkButton = screen.getByRole("button", { name: "Insert link" });
+    expect(insertLinkButton).toBeInTheDocument();
     expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: "Insert link" }));
+    await userEvent.click(insertLinkButton);
     const toolbarLinkInput = await screen.findByRole("textbox", { name: "Link URL" });
     await waitFor(() => expect(toolbarLinkInput).toHaveFocus());
     await userEvent.keyboard("{Escape}");
     await waitFor(() => expect(screen.queryByRole("textbox", { name: "Link URL" })).not.toBeInTheDocument());
+    await waitFor(() => expect(insertLinkButton).toHaveFocus());
     expect(screen.getByLabelText("Font")).toBeInTheDocument();
     expect(screen.getByLabelText("Size")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Align left" })).toBeInTheDocument();

--- a/workers/automation/src/jobctrl/infrastructure/profile/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/profile/sqlite_repository.py
@@ -31,6 +31,7 @@ from jobctrl.infrastructure.materials.resume_style import (
     DEFAULT_RESUME_TEMPLATE_TEXT,
     normalize_resume_style,
 )
+from jobctrl.resume_profile import get_achievement_evidence
 
 logger = logging.getLogger(__name__)
 
@@ -333,6 +334,7 @@ class SqliteProfileRepository:
             self._insert_children(str(tenant_id), profile_id, profile)
 
     def _insert_children(self, tenant_id: str, profile_id: str, profile: Profile) -> None:
+        achievement_evidence_by_entry = _achievement_evidence_by_entry(profile)
         for index, entry in enumerate(profile.experience_entries):
             self._conn.execute(
                 """
@@ -352,7 +354,7 @@ class SqliteProfileRepository:
                     """,
                     (tenant_id, profile_id, entry.id, bullet_index, bullet),
                 )
-            for evidence_index, evidence in enumerate(entry.achievement_evidence):
+            for evidence_index, evidence in enumerate(achievement_evidence_by_entry.get(entry.id, ())):
                 self._conn.execute(
                     """
                     INSERT INTO candidate_profile_achievement_evidence (
@@ -367,18 +369,18 @@ class SqliteProfileRepository:
                         profile_id,
                         entry.id,
                         evidence_index,
-                        evidence.id,
-                        evidence.source_text,
-                        evidence.scope,
-                        evidence.action,
-                        _json_array(evidence.tools),
-                        _json_array(evidence.metrics),
-                        evidence.outcome,
-                        evidence.seniority_signal,
-                        evidence.evidence_strength,
-                        evidence.claim_confidence,
-                        1 if evidence.user_confirmed else 0,
-                        _json_array(evidence.tags),
+                        str(evidence.get("id", "")),
+                        str(evidence.get("source_text", "")),
+                        str(evidence.get("scope", "")),
+                        str(evidence.get("action", "")),
+                        _json_array(_json_str_list(evidence.get("tools"))),
+                        _json_array(_json_str_list(evidence.get("metrics"))),
+                        str(evidence.get("outcome", "")),
+                        str(evidence.get("seniority_signal", "")),
+                        str(evidence.get("evidence_strength", "supported")),
+                        _bounded_float(evidence.get("claim_confidence"), 0.0, 0.0, 1.0),
+                        1 if bool(evidence.get("user_confirmed", False)) else 0,
+                        _json_array(_json_str_list(evidence.get("tags"))),
                     ),
                 )
 
@@ -919,6 +921,16 @@ def _style_from_row(row: sqlite3.Row) -> dict[str, Any]:
             "body_alignment": row["resume_style_body_alignment"],
         }
     )
+
+
+def _achievement_evidence_by_entry(profile: Profile) -> dict[str, list[dict[str, Any]]]:
+    by_entry: dict[str, list[dict[str, Any]]] = {}
+    for item in get_achievement_evidence(profile.to_dict()):
+        entry_id = str(item.get("experience_entry_id", "")).strip()
+        if not entry_id:
+            continue
+        by_entry.setdefault(entry_id, []).append(item)
+    return by_entry
 
 
 def _record(value: Any) -> dict[str, Any]:

--- a/workers/automation/src/jobctrl/resume_profile.py
+++ b/workers/automation/src/jobctrl/resume_profile.py
@@ -263,19 +263,11 @@ def get_achievement_evidence(profile: dict) -> list[dict]:
                 normalized["experience_entry_id"] = entry_id
                 normalized_items.append(normalized)
         if normalized_items:
-            evidence.extend(normalized_items)
+            evidence.extend(_reconciled_achievement_evidence(entry, entry_id, normalized_items))
             continue
         if not entry_id:
             continue
-        for bullet_index, bullet in enumerate(_text_list(entry.get("bullets")), start=1):
-            normalized = _legacy_bullet_achievement_evidence(
-                entry=entry,
-                entry_id=entry_id,
-                bullet=bullet,
-                bullet_index=bullet_index,
-            )
-            normalized["experience_entry_id"] = entry_id
-            evidence.append(normalized)
+        evidence.extend(_legacy_bullet_achievement_evidence_for_entry(entry, entry_id))
     return evidence
 
 
@@ -353,11 +345,69 @@ def _normalize_achievement_evidence(item: dict) -> dict:
     }
 
 
+def _reconciled_achievement_evidence(entry: dict, entry_id: str, items: list[dict]) -> list[dict]:
+    if not entry_id:
+        return items
+    derived_items = _legacy_bullet_achievement_evidence_for_entry(entry, entry_id)
+    if all(_is_materialized_legacy_bullet_evidence(item, entry_id) for item in items):
+        return derived_items
+    derived_by_id = {str(item["id"]): item for item in derived_items}
+    reconciled: list[dict] = []
+    for item in items:
+        if not _is_materialized_legacy_bullet_evidence(item, entry_id):
+            reconciled.append(item)
+            continue
+        replacement = derived_by_id.get(str(item["id"]))
+        if replacement is not None:
+            reconciled.append(replacement)
+    return reconciled
+
+
+def _legacy_bullet_achievement_evidence_for_entry(entry: dict, entry_id: str) -> list[dict]:
+    evidence: list[dict] = []
+    for bullet_index, bullet in enumerate(_text_list(entry.get("bullets")), start=1):
+        normalized = _legacy_bullet_achievement_evidence(
+            entry=entry,
+            entry_id=entry_id,
+            bullet=bullet,
+            bullet_index=bullet_index,
+        )
+        normalized["experience_entry_id"] = entry_id
+        evidence.append(normalized)
+    return evidence
+
+
+def _is_materialized_legacy_bullet_evidence(item: dict, entry_id: str) -> bool:
+    if _legacy_bullet_evidence_index(str(item.get("id", "")), entry_id) is None:
+        return False
+    source_text = str(item.get("source_text", "")).strip()
+    if not source_text:
+        return False
+    return (
+        str(item.get("action", "")).strip() == source_text
+        and str(item.get("outcome", "")).strip() == source_text
+        and _text_list(item.get("tools")) == []
+        and _text_list(item.get("metrics")) == _legacy_bullet_metrics(source_text)
+        and str(item.get("evidence_strength", "supported")).strip() == "supported"
+        and float(item.get("claim_confidence", 0.0)) == 0.8
+        and bool(item.get("user_confirmed", False)) is True
+        and _text_list(item.get("tags")) == []
+    )
+
+
 def legacy_bullet_evidence_id(entry_id: str, bullet_index: int) -> str:
     """Return the stable evidence id used for legacy resume bullets."""
     safe_entry_id = re.sub(r"[^a-zA-Z0-9_.-]+", "_", str(entry_id).strip()).strip("_")
     safe_entry_id = safe_entry_id or "experience"
     return f"{safe_entry_id}_bullet_{max(1, int(bullet_index))}"
+
+
+def _legacy_bullet_evidence_index(evidence_id: str, entry_id: str) -> int | None:
+    match = re.search(r"_bullet_([1-9]\d*)$", evidence_id)
+    if match is None:
+        return None
+    bullet_index = int(match.group(1))
+    return bullet_index if evidence_id == legacy_bullet_evidence_id(entry_id, bullet_index) else None
 
 
 def _legacy_bullet_achievement_evidence(
@@ -382,10 +432,7 @@ def _legacy_bullet_achievement_evidence(
         "scope": " ".join(part for part in [title, company] if part),
         "action": source_text,
         "tools": [],
-        "metrics": [
-            re.sub(r"\s+", " ", match.group(0).strip())
-            for match in _LEGACY_BULLET_METRIC_RE.finditer(source_text)
-        ],
+        "metrics": _legacy_bullet_metrics(source_text),
         "outcome": source_text,
         "seniority_signal": seniority_signal,
         "evidence_strength": "supported",
@@ -393,6 +440,13 @@ def _legacy_bullet_achievement_evidence(
         "user_confirmed": True,
         "tags": [],
     }
+
+
+def _legacy_bullet_metrics(source_text: str) -> list[str]:
+    return [
+        re.sub(r"\s+", " ", match.group(0).strip())
+        for match in _LEGACY_BULLET_METRIC_RE.finditer(source_text)
+    ]
 
 
 def _text_list(value: object) -> list[str]:

--- a/workers/automation/tests/test_profile_aggregate.py
+++ b/workers/automation/tests/test_profile_aggregate.py
@@ -103,6 +103,34 @@ def test_get_achievement_evidence_derives_legacy_bullets_when_explicit_evidence_
     assert all(item["user_confirmed"] is True for item in evidence)
 
 
+def test_get_achievement_evidence_rederives_materialized_legacy_bullets():
+    profile = _valid_profile_dict()
+    entry = profile["resume"]["experience_entries"][0]
+    entry["achievement_evidence"] = [
+        {
+            "id": "role_1_bullet_1",
+            "source_text": "Reduced incidents 40%.",
+            "scope": "Software Engineer Acme",
+            "action": "Reduced incidents 40%.",
+            "tools": [],
+            "metrics": ["40%"],
+            "outcome": "Reduced incidents 40%.",
+            "seniority_signal": "",
+            "evidence_strength": "supported",
+            "claim_confidence": 0.8,
+            "user_confirmed": True,
+            "tags": [],
+        }
+    ]
+    entry["bullets"] = ["Reduced incidents 55%."]
+
+    evidence = get_achievement_evidence(profile)
+
+    assert [item["id"] for item in evidence] == ["role_1_bullet_1"]
+    assert evidence[0]["source_text"] == "Reduced incidents 55%."
+    assert evidence[0]["metrics"] == ["55%"]
+
+
 def test_from_dict_rejects_missing_resume_block():
     with pytest.raises(InvalidProfileError) as exc:
         Profile.from_dict(LOCAL_TENANT, {"personal": {"full_name": "X"}})

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -118,6 +118,7 @@ def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
     assert conn.execute("SELECT COUNT(*) FROM candidate_profiles").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM candidate_profile_experience_entries").fetchone()[0] == 1
     assert conn.execute("SELECT COUNT(*) FROM candidate_profile_experience_bullets").fetchone()[0] == 2
+    assert conn.execute("SELECT COUNT(*) FROM candidate_profile_achievement_evidence").fetchone()[0] == 2
     assert conn.execute("SELECT COUNT(*) FROM candidate_profile_skill_items").fetchone()[0] == 2
     root = conn.execute(
         "SELECT writing_tone, max_experience_bullets FROM candidate_profiles"
@@ -127,7 +128,17 @@ def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
 
     loaded = repo.load(LOCAL_TENANT)
     assert loaded is not None
-    assert loaded.to_dict() == Profile.from_dict(LOCAL_TENANT, _valid_profile()).to_dict()
+    loaded_entry = loaded.to_dict()["resume"]["experience_entries"][0]
+    assert loaded_entry["bullets"] == ["Built APIs.", "Reduced incidents 40%."]
+    assert [item["id"] for item in loaded_entry["achievement_evidence"]] == [
+        "role_1_bullet_1",
+        "role_1_bullet_2",
+    ]
+    assert [item["source_text"] for item in loaded_entry["achievement_evidence"]] == [
+        "Built APIs.",
+        "Reduced incidents 40%.",
+    ]
+    assert loaded_entry["achievement_evidence"][1]["metrics"] == ["40%"]
     assert [event.event_type for event in events] == ["ProfileUpdated"]
 
 

--- a/workers/automation/tests/test_sqlite_profile_repository.py
+++ b/workers/automation/tests/test_sqlite_profile_repository.py
@@ -142,6 +142,30 @@ def test_save_and_load_round_trips_profile_through_relational_rows(tmp_path):
     assert [event.event_type for event in events] == ["ProfileUpdated"]
 
 
+def test_save_rederives_materialized_achievement_evidence_when_bullets_change(tmp_path):
+    repo, _, _ = _new_repo(tmp_path)
+
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, _valid_profile()))
+    loaded = repo.load(LOCAL_TENANT)
+    assert loaded is not None
+    updated = loaded.to_dict()
+    updated["resume"]["experience_entries"][0]["bullets"] = [
+        "Built APIs.",
+        "Reduced incidents 55%.",
+    ]
+
+    repo.save(LOCAL_TENANT, Profile.from_dict(LOCAL_TENANT, updated))
+
+    refreshed = repo.load(LOCAL_TENANT)
+    assert refreshed is not None
+    refreshed_entry = refreshed.to_dict()["resume"]["experience_entries"][0]
+    assert [item["source_text"] for item in refreshed_entry["achievement_evidence"]] == [
+        "Built APIs.",
+        "Reduced incidents 55%.",
+    ]
+    assert refreshed_entry["achievement_evidence"][1]["metrics"] == ["55%"]
+
+
 def test_save_and_load_preserves_achievement_evidence_and_tailoring_controls(tmp_path):
     repo, conn, _ = _new_repo(tmp_path)
     raw = _valid_profile()


### PR DESCRIPTION
## Summary

- Remove editable achievement-evidence controls from the structured profile editor so extracted evidence is no longer presented as user input.
- Persist bullet-derived achievement evidence in both the TypeScript profile store and Python SQLite profile repository so tailoring can reuse materialized evidence across future runs.
- Replace the always-visible resume toolbar URL field with an editor-style Insert link command that opens a focused URL popover from the toolbar button or Cmd/Ctrl+K.

## Why

Achievement evidence is derived from resume bullets and should be stored as reusable profile audit data, not manually entered by the user. The resume editor also exposed hyperlinking as a permanent toolbar text field, which did not match normal rich-text editor behavior.

## Validation

- `corepack pnpm check`
- `corepack pnpm test`
- `git diff --check`
- Browser check on `/profile`: no persistent Link URL field; Cmd+K opens and focuses the link popover; Escape closes it; no console warnings/errors observed.

Note: the browser annotation overlay intercepted pointer hit-testing on the toolbar icon during live inspection, so the icon-click path is covered by the web regression test instead.