### PR TITLE
fix(apply): bind artifact uploads to application origin

### DIFF
--- a/workers/automation/src/jobctrl/apply/prompt.py
+++ b/workers/automation/src/jobctrl/apply/prompt.py
@@ -489,7 +489,7 @@ RESULT:FAILED:reason -- any other failure (brief reason)
 == FORM TRICKS ==
 - Popup/new window opened? browser_tabs action "list" to see all tabs. browser_tabs action "select" with the tab index to switch. ALWAYS check for new tabs after clicking login/apply/sign-in buttons.
 - "Upload your resume" pre-fill page: This is NOT the application form yet. Click "Select file" or the upload area, then call upload_artifact(kind="resume"). Wait for parsing to finish. Then click Next/Continue to reach the actual form.
-- File upload not working? Try: (1) browser_click the visible upload button/area or "Select file" control, (2) upload_artifact with the required artifact kind. Do not upload into hidden controls or any page that is not the approved application destination.
+- File upload not working? Try: (1) browser_click the visible upload button/area or "Select file" control, (2) upload_artifact with the required artifact kind. Never call upload_artifact on any page that is not the approved application destination.
 - Dropdown won't fill? browser_click to open it, then browser_click the option.
 - Checkbox won't check via fill_form? Use browser_click on it instead. Snapshot to verify.
 - Phone field with country prefix: just type digits {phone_digits}

--- a/workers/automation/src/jobctrl/apply/prompt.py
+++ b/workers/automation/src/jobctrl/apply/prompt.py
@@ -210,7 +210,7 @@ def _build_screening_section(profile: dict) -> str:
     return f"""== SCREENING QUESTIONS (be strategic) ==
 Hard facts -> answer truthfully from the profile. No guessing. This includes:
   - Location/relocation: lives in {city}, cannot relocate
-  - Work authorization: {work_auth.get('legally_authorized_to_work', 'see profile')}
+  - Work authorization: {work_auth.get("legally_authorized_to_work", "see profile")}
   - Citizenship, clearance, licenses, certifications: answer from profile only
   - Criminal/background: answer from profile only
   - Age, felony/criminal-history, background-check consent, and prior-employer attestations: answer only when the APPLICANT PROFILE has an explicit Application Attestations value. If required and missing, output RESULT:FAILED:missing_profile_data:<field>.
@@ -240,9 +240,11 @@ def _build_hard_rules(profile: dict) -> str:
     if permit_type:
         work_auth_rule = f"Work auth: {permit_type}. Sponsorship needed: {sponsorship}."
 
-    name_rule = f'Name: Legal name = {full_name}.'
+    name_rule = f"Name: Legal name = {full_name}."
     if preferred_name and preferred_name != full_name.split()[0]:
-        name_rule += f' Preferred name = {preferred_name}. Use "{display_name}" unless a field specifically says "legal name".'
+        name_rule += (
+            f' Preferred name = {preferred_name}. Use "{display_name}" unless a field specifically says "legal name".'
+        )
 
     return f"""== HARD RULES (never break these) ==
 1. Never lie about: citizenship, work authorization, criminal history, education credentials, security clearance, licenses.
@@ -274,11 +276,7 @@ def _build_email_verification_section(profile: dict) -> str:
     personal = profile["personal"]
     email = personal.get("email", "")
     gmail_ok, gmail_note = config.gmail_mcp_auth_status()
-    auth_line = (
-        "Gmail connector auth: available."
-        if gmail_ok
-        else f"Gmail connector auth: unavailable ({gmail_note})."
-    )
+    auth_line = "Gmail connector auth: available." if gmail_ok else f"Gmail connector auth: unavailable ({gmail_note})."
 
     return f"""== EMAIL VERIFICATION ==
 {auth_line}
@@ -292,12 +290,15 @@ Do not open Gmail in the browser.
 If Gmail connector tools are unavailable or unauthenticated, do not wait for manual help. Output RESULT:LOGIN_ISSUE and stop."""
 
 
-def build_prompt(job: dict, tailored_resume: str,
-                 cover_letter: str | None = None,
-                 dry_run: bool = False,
-                 snapshot: ProfileSnapshot | None = None,
-                 search_config: dict | None = None,
-                 upload_dir: str | os.PathLike[str] | None = None) -> str:
+def build_prompt(
+    job: dict,
+    tailored_resume: str,
+    cover_letter: str | None = None,
+    dry_run: bool = False,
+    snapshot: ProfileSnapshot | None = None,
+    search_config: dict | None = None,
+    upload_dir: str | os.PathLike[str] | None = None,
+) -> str:
     """Build the full instruction prompt for the apply agent.
 
     Args:
@@ -318,6 +319,7 @@ def build_prompt(job: dict, tailored_resume: str,
     if snapshot is None:
         from jobctrl.infrastructure.profile import get_profile_repository
         from jobctrl.domain.tenant import LOCAL_TENANT
+
         snapshot = get_profile_repository().load_snapshot(LOCAL_TENANT)
     if search_config is None:
         search_config = config.load_search_config()
@@ -380,9 +382,7 @@ def build_prompt(job: dict, tailored_resume: str,
     else:
         cl_display = cover_letter_text
     cover_letter_artifact = (
-        'reviewed artifact available through upload_artifact(kind="cover_letter")'
-        if cl_upload_path
-        else "N/A"
+        'reviewed artifact available through upload_artifact(kind="cover_letter")' if cl_upload_path else "N/A"
     )
 
     # Phone digits only (for fields with country prefix)
@@ -390,6 +390,7 @@ def build_prompt(job: dict, tailored_resume: str,
 
     # SSO domains the agent cannot sign into (loaded from config/sites.yaml)
     from jobctrl.config import load_blocked_sso
+
     blocked_sso = load_blocked_sso()
 
     # Dry-run: override submit instruction
@@ -401,10 +402,10 @@ def build_prompt(job: dict, tailored_resume: str,
     prompt = f"""You are an autonomous job application agent. Your ONE mission: get this candidate an interview. You have all the information and tools. Think strategically. Act decisively. Submit the application.
 
 == JOB ==
-URL: {job.get('application_url') or job['url']}
-Title: {job['title']}
-Company: {job.get('site', 'Unknown')}
-Fit Score: {job.get('fit_score', 'N/A')}/10
+URL: {job.get("application_url") or job["url"]}
+Title: {job["title"]}
+Company: {job.get("site", "Unknown")}
+Fit Score: {job.get("fit_score", "N/A")}/10
 
 == FILES ==
 Resume: reviewed artifact available through upload_artifact(kind="resume")
@@ -450,7 +451,7 @@ If something unexpected happens and these instructions don't cover it, figure it
    - Output RESULT:EMAIL_ONLY:<address> using only the email address visible on the page, then stop. Do not draft, send, or claim an email application was submitted.
    After clicking Apply: browser_snapshot. Many sites trigger CAPTCHAs right after the Apply click; if one appears, follow the CAPTCHA section and stop.
 5. Login wall?
-   5a. FIRST: check the URL. If you landed on {', '.join(blocked_sso)}, or any SSO/OAuth page -> STOP. Output RESULT:FAILED:sso_required. Do NOT try to sign in to Google/Microsoft/SSO.
+   5a. FIRST: check the URL. If you landed on {", ".join(blocked_sso)}, or any SSO/OAuth page -> STOP. Output RESULT:FAILED:sso_required. Do NOT try to sign in to Google/Microsoft/SSO.
    5b. Check for popups. Run browser_tabs action "list". If a new tab/window appeared (login popup), switch to it with browser_tabs action "select". Check the URL there too -- if it's SSO -> RESULT:FAILED:sso_required.
    5c. Regular login form (employer's own site)? You may enter the profile email address if requested. If a password is required, focus the password field and call type_credential(kind="job_site_password"). Never ask for, print, or type the password yourself; if the tool fails, output RESULT:LOGIN_ISSUE and stop.
    5d. After clicking Login/Sign-in: if a CAPTCHA appears, follow the CAPTCHA section and stop.
@@ -488,11 +489,11 @@ RESULT:FAILED:reason -- any other failure (brief reason)
 == FORM TRICKS ==
 - Popup/new window opened? browser_tabs action "list" to see all tabs. browser_tabs action "select" with the tab index to switch. ALWAYS check for new tabs after clicking login/apply/sign-in buttons.
 - "Upload your resume" pre-fill page: This is NOT the application form yet. Click "Select file" or the upload area, then call upload_artifact(kind="resume"). Wait for parsing to finish. Then click Next/Continue to reach the actual form.
-- File upload not working? Try: (1) browser_click the upload button/area, (2) upload_artifact with the required artifact kind. If still failing, look for a hidden file input or a "Select file" link and click that first.
+- File upload not working? Try: (1) browser_click the visible upload button/area or "Select file" control, (2) upload_artifact with the required artifact kind. Do not upload into hidden controls or any page that is not the approved application destination.
 - Dropdown won't fill? browser_click to open it, then browser_click the option.
 - Checkbox won't check via fill_form? Use browser_click on it instead. Snapshot to verify.
 - Phone field with country prefix: just type digits {phone_digits}
-- Date fields: {datetime.now().strftime('%m/%d/%Y')}
+- Date fields: {datetime.now().strftime("%m/%d/%Y")}
 - Validation errors after submit? Take BOTH snapshot AND screenshot. Snapshot shows text errors, screenshot shows red-highlighted fields. Fix all, retry.
 - Honeypot fields (hidden, "leave blank"): skip them.
 - Format-sensitive fields: read the placeholder text, match it exactly.

--- a/workers/automation/src/jobctrl/domain/apply/services.py
+++ b/workers/automation/src/jobctrl/domain/apply/services.py
@@ -83,9 +83,7 @@ class ApplyEligibilityChecker:
 
     def __init__(self, *, max_attempts: int) -> None:
         if not isinstance(max_attempts, int) or max_attempts <= 0:
-            raise ValueError(
-                "ApplyEligibilityChecker.max_attempts must be a positive int"
-            )
+            raise ValueError("ApplyEligibilityChecker.max_attempts must be a positive int")
         self._max_attempts = max_attempts
 
     @property
@@ -98,10 +96,7 @@ class ApplyEligibilityChecker:
         job: Mapping[str, Any],
         attempts: int = 0,
     ) -> EligibilityResult:
-        apply_target_url = (
-            (job.get("application_url") or "").strip()
-            or (job.get("url") or "").strip()
-        )
+        apply_target_url = (job.get("application_url") or "").strip() or (job.get("url") or "").strip()
         if not apply_target_url:
             return EligibilityResult(ok=False, reason="missing_apply_target_url")
 
@@ -233,12 +228,10 @@ def _default_mcp_config(
 
     application_url = str((job or {}).get("application_url") or (job or {}).get("url") or "")
     personal = snapshot.personal if snapshot is not None else {}
-    upload_root = str(
-        upload_dir
-        or (_config.APPLY_WORKER_DIR / "current")
-    )
+    upload_root = str(upload_dir or (_config.APPLY_WORKER_DIR / "current"))
     apply_tools_env = {
         "JOBCTRL_APPLY_CDP_ENDPOINT": f"http://localhost:{cdp_port}",
+        "JOBCTRL_APPLY_APPROVED_APPLICATION_URL": application_url,
         "JOBCTRL_APPLY_PROFILE_DB_PATH": str(_config.DB_PATH),
         "JOBCTRL_APPLY_UPLOAD_DIR": upload_root,
     }
@@ -259,9 +252,7 @@ def _default_mcp_config(
                 "command": sys.executable,
                 "args": ["-m", "jobctrl.infrastructure.gmail.mcp_server"],
                 "env": {
-                    "JOBCTRL_GMAIL_ALLOWED_DOMAINS": ",".join(
-                        _verification_sender_domains(application_url)
-                    ),
+                    "JOBCTRL_GMAIL_ALLOWED_DOMAINS": ",".join(_verification_sender_domains(application_url)),
                     "JOBCTRL_GMAIL_AFTER_MS": str(int(time.time() * 1000)),
                     "JOBCTRL_GMAIL_TO_EMAIL": str(personal.get("email") or ""),
                     "JOBCTRL_GMAIL_TOKEN_PATH": str(_config.get_gmail_mcp_credentials_path()),

--- a/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
+++ b/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
@@ -6,6 +6,8 @@ import json
 import os
 import sqlite3
 import sys
+import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -36,6 +38,7 @@ class ApplyToolsMcpServer:
         *,
         upload_dir: str | os.PathLike[str] | None = None,
         cdp_endpoint: str | None = None,
+        approved_application_url: str | None = None,
         uploader: Any | None = None,
         credential_resolver: Any | None = None,
         credential_typer: Any | None = None,
@@ -46,6 +49,11 @@ class ApplyToolsMcpServer:
         raw_upload_dir = upload_dir or os.environ.get("JOBCTRL_APPLY_UPLOAD_DIR")
         self._upload_dir = Path(raw_upload_dir).expanduser() if raw_upload_dir else None
         self._cdp_endpoint = cdp_endpoint or os.environ.get("JOBCTRL_APPLY_CDP_ENDPOINT", "")
+        self._approved_application_url = (
+            approved_application_url
+            if approved_application_url is not None
+            else os.environ.get("JOBCTRL_APPLY_APPROVED_APPLICATION_URL", "")
+        )
         self._uploader = uploader or _upload_file_to_current_input
         self._credential_resolver = credential_resolver or _profile_credential
         self._credential_typer = credential_typer or _type_credential_into_active_field
@@ -96,15 +104,27 @@ class ApplyToolsMcpServer:
     def _call_upload_artifact(self, args: dict[str, Any]) -> dict[str, Any]:
         kind = str(args.get("kind") or "")
         artifact = self._resolve_artifact(kind)
-        self._uploader(self._cdp_endpoint, artifact)
+        approved_url = self._approved_application_url.strip()
+        if not approved_url:
+            raise ValueError("upload_artifact approved application URL is not configured")
+        upload_result = self._uploader(self._cdp_endpoint, artifact, approved_url)
+        destination_url = _upload_destination_url(upload_result)
+        _record_artifact_upload(
+            self._upload_dir,
+            {
+                "kind": kind,
+                "filename": artifact.name,
+                "destination_url": destination_url,
+            },
+        )
+        payload = {"ok": True, "kind": kind, "filename": artifact.name}
+        if destination_url:
+            payload["destination_url"] = destination_url
         return {
             "content": [
                 {
                     "type": "text",
-                    "text": json.dumps(
-                        {"ok": True, "kind": kind, "filename": artifact.name},
-                        ensure_ascii=False,
-                    ),
+                    "text": json.dumps(payload, ensure_ascii=False),
                 }
             ]
         }
@@ -309,9 +329,20 @@ def _record_captcha_usage(upload_dir: Path | None, payload: dict[str, Any]) -> N
         fh.write(json.dumps(event, sort_keys=True) + "\n")
 
 
-def _inject_captcha_token(
-    cdp_endpoint: str, challenge: CaptchaChallenge, token: str
-) -> None:
+def _record_artifact_upload(upload_dir: Path | None, payload: dict[str, Any]) -> None:
+    if upload_dir is None:
+        return
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event_type": "ApplyArtifactUpload",
+        "occurred_at": datetime.now(timezone.utc).isoformat(),
+        "payload": payload,
+    }
+    with (upload_dir / "artifact_upload_events.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _inject_captcha_token(cdp_endpoint: str, challenge: CaptchaChallenge, token: str) -> None:
     escaped = json.dumps(token)
     _evaluate_on_page(
         cdp_endpoint,
@@ -420,7 +451,7 @@ def _evaluate_on_page(cdp_endpoint: str, expression: str) -> Any:
         ws.close()
 
 
-def _upload_file_to_current_input(cdp_endpoint: str, path: Path) -> None:
+def _upload_file_to_current_input(cdp_endpoint: str, path: Path, approved_application_url: str) -> dict[str, str]:
     ws_url = _first_page_ws_url(cdp_endpoint)
     try:
         import websocket
@@ -443,21 +474,143 @@ def _upload_file_to_current_input(cdp_endpoint: str, path: Path) -> None:
                     raise RuntimeError(str(message["error"]))
                 return message
 
+    marker = f"jobctrl-upload-{uuid.uuid4().hex}"
     try:
         response(send("DOM.enable"))
+        state = response(
+            send(
+                "Runtime.evaluate",
+                {
+                    "returnByValue": True,
+                    "expression": _upload_input_guard_expression(marker),
+                },
+            )
+        )
+        guard = state.get("result", {}).get("result", {}).get("value") or {}
+        if not isinstance(guard, dict):
+            raise RuntimeError("could not inspect current upload destination")
+        destination_url = str(guard.get("href") or "")
+        _assert_approved_upload_destination(destination_url, approved_application_url)
+        if not guard.get("ok"):
+            reason = str(guard.get("reason") or "no visible file input is currently available")
+            raise RuntimeError(reason)
         root = response(send("DOM.getDocument", {"depth": 1}))
         root_id = root.get("result", {}).get("root", {}).get("nodeId")
         if not root_id:
             raise RuntimeError("could not inspect current page DOM")
         query = response(
-            send("DOM.querySelector", {"nodeId": root_id, "selector": "input[type=file]"})
+            send(
+                "DOM.querySelector",
+                {
+                    "nodeId": root_id,
+                    "selector": f'input[type=file][data-jobctrl-upload-target="{marker}"]',
+                },
+            )
         )
         node_id = query.get("result", {}).get("nodeId")
         if not node_id:
-            raise RuntimeError("no file input is currently available")
+            raise RuntimeError("selected file input is no longer available")
         response(send("DOM.setFileInputFiles", {"nodeId": node_id, "files": [str(path)]}))
+        return {"destination_url": destination_url}
     finally:
+        try:
+            response(
+                send(
+                    "Runtime.evaluate",
+                    {"expression": _clear_upload_input_marker_expression(marker)},
+                )
+            )
+        except Exception:  # noqa: BLE001 - marker cleanup must not mask upload errors
+            pass
         ws.close()
+
+
+def _upload_input_guard_expression(marker: str) -> str:
+    escaped_marker = json.dumps(marker)
+    return f"""
+(() => {{
+  const marker = {escaped_marker};
+  const inputs = Array.from(document.querySelectorAll('input[type="file"]'));
+  const isVisible = (input) => {{
+    const style = window.getComputedStyle(input);
+    const rect = input.getBoundingClientRect();
+    return !input.disabled &&
+      style.display !== "none" &&
+      style.visibility !== "hidden" &&
+      Number(style.opacity || "1") > 0 &&
+      rect.width > 0 &&
+      rect.height > 0;
+  }};
+  const visible = inputs.filter(isVisible);
+  if (visible.length === 0) {{
+    return {{
+      ok: false,
+      href: window.location.href,
+      reason: "no visible file input is currently available"
+    }};
+  }}
+  let selected = visible[0];
+  if (visible.length > 1) {{
+    const active = document.activeElement;
+    if (!(active instanceof HTMLInputElement) ||
+        (active.getAttribute("type") || "").toLowerCase() !== "file" ||
+        !visible.includes(active)) {{
+      return {{
+        ok: false,
+        href: window.location.href,
+        reason: "multiple visible file inputs are available; click the intended upload control first"
+      }};
+    }}
+    selected = active;
+  }}
+  selected.setAttribute("data-jobctrl-upload-target", marker);
+  return {{ok: true, href: window.location.href}};
+}})()
+"""
+
+
+def _clear_upload_input_marker_expression(marker: str) -> str:
+    escaped_marker = json.dumps(marker)
+    return f"""
+(() => {{
+  const input = document.querySelector(`[data-jobctrl-upload-target=${{CSS.escape({escaped_marker})}}]`);
+  if (input) {{
+    input.removeAttribute("data-jobctrl-upload-target");
+  }}
+  return true;
+}})()
+"""
+
+
+def _upload_destination_url(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("destination_url") or "")
+    return ""
+
+
+def _assert_approved_upload_destination(destination_url: str, approved_application_url: str) -> None:
+    destination_origin = _url_origin(destination_url)
+    approved_origin = _url_origin(approved_application_url)
+    if not approved_origin:
+        raise ValueError("upload_artifact approved application URL is invalid")
+    if not destination_origin:
+        raise RuntimeError("current upload destination is not an HTTP(S) page")
+    if destination_origin != approved_origin:
+        raise RuntimeError("current upload destination does not match the approved application origin")
+
+
+def _url_origin(value: str) -> str:
+    try:
+        parsed = urlparse(value.strip())
+        port = parsed.port
+    except ValueError:
+        return ""
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        return ""
+    scheme = parsed.scheme.lower()
+    host = parsed.hostname.rstrip(".").lower()
+    effective_port = port or (443 if scheme == "https" else 80)
+    return f"{scheme}://{host}:{effective_port}"
 
 
 def _first_page_ws_url(cdp_endpoint: str) -> str:

--- a/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
+++ b/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
@@ -107,7 +107,21 @@ class ApplyToolsMcpServer:
         approved_url = self._approved_application_url.strip()
         if not approved_url:
             raise ValueError("upload_artifact approved application URL is not configured")
-        upload_result = self._uploader(self._cdp_endpoint, artifact, approved_url)
+        try:
+            upload_result = self._uploader(self._cdp_endpoint, artifact, approved_url)
+        except _UploadDestinationRejected as exc:
+            _record_artifact_upload(
+                self._upload_dir,
+                {
+                    "kind": kind,
+                    "filename": artifact.name,
+                    "status": "blocked",
+                    "destination_url": exc.destination_url,
+                    "approved_origin": _url_origin(exc.approved_application_url),
+                    "reason": str(exc),
+                },
+            )
+            raise
         destination_url = _upload_destination_url(upload_result)
         _record_artifact_upload(
             self._upload_dir,
@@ -198,6 +212,13 @@ class ApplyToolsMcpServer:
 
     def _tools(self) -> list[dict[str, Any]]:
         return _tools(captcha_configured=bool(self._captcha_key_resolver()))
+
+
+class _UploadDestinationRejected(RuntimeError):
+    def __init__(self, message: str, *, destination_url: str, approved_application_url: str) -> None:
+        super().__init__(message)
+        self.destination_url = destination_url
+        self.approved_application_url = approved_application_url
 
 
 def _tools(*, captcha_configured: bool | None = None) -> list[dict[str, Any]]:
@@ -474,111 +495,149 @@ def _upload_file_to_current_input(cdp_endpoint: str, path: Path, approved_applic
                     raise RuntimeError(str(message["error"]))
                 return message
 
-    marker = f"jobctrl-upload-{uuid.uuid4().hex}"
+    object_group = f"jobctrl-upload-{uuid.uuid4().hex}"
     try:
         response(send("DOM.enable"))
-        state = response(
+        selection = response(
             send(
                 "Runtime.evaluate",
                 {
-                    "returnByValue": True,
-                    "expression": _upload_input_guard_expression(marker),
+                    "objectGroup": object_group,
+                    "returnByValue": False,
+                    "expression": _upload_input_guard_expression(),
                 },
             )
         )
-        guard = state.get("result", {}).get("result", {}).get("value") or {}
-        if not isinstance(guard, dict):
+        selection_object_id = str(selection.get("result", {}).get("result", {}).get("objectId") or "")
+        if not selection_object_id:
             raise RuntimeError("could not inspect current upload destination")
+        guard = _runtime_object_properties(response(send("Runtime.getProperties", {"objectId": selection_object_id})))
         destination_url = str(guard.get("href") or "")
         _assert_approved_upload_destination(destination_url, approved_application_url)
         if not guard.get("ok"):
-            reason = str(guard.get("reason") or "no visible file input is currently available")
+            reason = str(guard.get("reason") or "no file input is currently available")
             raise RuntimeError(reason)
-        root = response(send("DOM.getDocument", {"depth": 1}))
-        root_id = root.get("result", {}).get("root", {}).get("nodeId")
-        if not root_id:
-            raise RuntimeError("could not inspect current page DOM")
-        query = response(
+        input_object_id = str(guard.get("input_object_id") or "")
+        if not input_object_id:
+            raise RuntimeError("selected file input is no longer available")
+        current_state = response(
             send(
-                "DOM.querySelector",
+                "Runtime.callFunctionOn",
                 {
-                    "nodeId": root_id,
-                    "selector": f'input[type=file][data-jobctrl-upload-target="{marker}"]',
+                    "objectId": input_object_id,
+                    "returnByValue": True,
+                    "functionDeclaration": _upload_input_verification_expression(),
                 },
             )
         )
-        node_id = query.get("result", {}).get("nodeId")
+        current_guard = current_state.get("result", {}).get("result", {}).get("value") or {}
+        if not isinstance(current_guard, dict):
+            raise RuntimeError("could not verify current upload destination")
+        destination_url = str(current_guard.get("href") or "")
+        _assert_approved_upload_destination(destination_url, approved_application_url)
+        if not current_guard.get("ok"):
+            reason = str(current_guard.get("reason") or "selected file input is no longer available")
+            raise RuntimeError(reason)
+        node = response(send("DOM.requestNode", {"objectId": input_object_id}))
+        node_id = node.get("result", {}).get("nodeId")
         if not node_id:
             raise RuntimeError("selected file input is no longer available")
         response(send("DOM.setFileInputFiles", {"nodeId": node_id, "files": [str(path)]}))
         return {"destination_url": destination_url}
     finally:
         try:
-            response(
-                send(
-                    "Runtime.evaluate",
-                    {"expression": _clear_upload_input_marker_expression(marker)},
-                )
-            )
+            response(send("Runtime.releaseObjectGroup", {"objectGroup": object_group}))
         except Exception:  # noqa: BLE001 - marker cleanup must not mask upload errors
             pass
         ws.close()
 
 
-def _upload_input_guard_expression(marker: str) -> str:
-    escaped_marker = json.dumps(marker)
-    return f"""
-(() => {{
-  const marker = {escaped_marker};
-  const inputs = Array.from(document.querySelectorAll('input[type="file"]'));
-  const isVisible = (input) => {{
+def _runtime_object_properties(message: dict[str, Any]) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for prop in message.get("result", {}).get("result", []):
+        if not isinstance(prop, dict):
+            continue
+        name = str(prop.get("name") or "")
+        value = prop.get("value") or {}
+        if not isinstance(value, dict) or not name:
+            continue
+        if name == "input" and value.get("objectId"):
+            values["input_object_id"] = value["objectId"]
+        elif "value" in value:
+            values[name] = value["value"]
+    return values
+
+
+def _upload_input_guard_expression() -> str:
+    return """
+(() => {
+  const inputs = Array.from(document.querySelectorAll('input[type="file"]'))
+    .filter((input) => !input.disabled);
+  const isVisible = (input) => {
     const style = window.getComputedStyle(input);
     const rect = input.getBoundingClientRect();
-    return !input.disabled &&
-      style.display !== "none" &&
+    return style.display !== "none" &&
       style.visibility !== "hidden" &&
       Number(style.opacity || "1") > 0 &&
       rect.width > 0 &&
       rect.height > 0;
-  }};
+  };
   const visible = inputs.filter(isVisible);
-  if (visible.length === 0) {{
-    return {{
+  if (inputs.length === 0) {
+    return {
       ok: false,
       href: window.location.href,
-      reason: "no visible file input is currently available"
-    }};
-  }}
-  let selected = visible[0];
-  if (visible.length > 1) {{
+      reason: "no file input is currently available"
+    };
+  }
+  let selected = null;
+  if (visible.length === 1) {
+    selected = visible[0];
+  } else if (visible.length > 1) {
     const active = document.activeElement;
     if (!(active instanceof HTMLInputElement) ||
         (active.getAttribute("type") || "").toLowerCase() !== "file" ||
-        !visible.includes(active)) {{
-      return {{
+        !visible.includes(active)) {
+      return {
         ok: false,
         href: window.location.href,
         reason: "multiple visible file inputs are available; click the intended upload control first"
-      }};
-    }}
+      };
+    }
     selected = active;
-  }}
-  selected.setAttribute("data-jobctrl-upload-target", marker);
-  return {{ok: true, href: window.location.href}};
-}})()
+  } else if (inputs.length === 1) {
+    selected = inputs[0];
+  } else {
+    return {
+      ok: false,
+      href: window.location.href,
+      reason: "multiple file inputs are available; click the intended upload control first"
+    };
+  }
+  return {ok: true, href: window.location.href, input: selected};
+})()
 """
 
 
-def _clear_upload_input_marker_expression(marker: str) -> str:
-    escaped_marker = json.dumps(marker)
-    return f"""
-(() => {{
-  const input = document.querySelector(`[data-jobctrl-upload-target=${{CSS.escape({escaped_marker})}}]`);
-  if (input) {{
-    input.removeAttribute("data-jobctrl-upload-target");
-  }}
-  return true;
-}})()
+def _upload_input_verification_expression() -> str:
+    return """
+function() {
+  const input = this;
+  const href = input && input.ownerDocument && input.ownerDocument.defaultView
+    ? input.ownerDocument.defaultView.location.href
+    : window.location.href;
+  if (!(input instanceof HTMLInputElement) ||
+      (input.getAttribute("type") || "").toLowerCase() !== "file") {
+    return {ok: false, href, reason: "selected file input is no longer available"};
+  }
+  if (input.ownerDocument !== document || input.ownerDocument.defaultView !== window) {
+    return {ok: false, href, reason: "selected file input is no longer on the current page"};
+  }
+  if (input.disabled) {
+    return {ok: false, href, reason: "selected file input is disabled"};
+  }
+  return {ok: true, href};
+}
 """
 
 
@@ -594,9 +653,17 @@ def _assert_approved_upload_destination(destination_url: str, approved_applicati
     if not approved_origin:
         raise ValueError("upload_artifact approved application URL is invalid")
     if not destination_origin:
-        raise RuntimeError("current upload destination is not an HTTP(S) page")
+        raise _UploadDestinationRejected(
+            "current upload destination is not an HTTP(S) page",
+            destination_url=destination_url,
+            approved_application_url=approved_application_url,
+        )
     if destination_origin != approved_origin:
-        raise RuntimeError("current upload destination does not match the approved application origin")
+        raise _UploadDestinationRejected(
+            "current upload destination does not match the approved application origin",
+            destination_url=destination_url,
+            approved_application_url=approved_application_url,
+        )
 
 
 def _url_origin(value: str) -> str:

--- a/workers/automation/tests/test_apply_prompt_builder.py
+++ b/workers/automation/tests/test_apply_prompt_builder.py
@@ -154,6 +154,8 @@ def test_legacy_prompt_copies_upload_files_into_worker_upload_dir(monkeypatch, t
     assert "Do not open Gmail in the browser" in rendered
     assert 'type_credential(kind="job_site_password")' in rendered
     assert "RESULT:LOGIN_ISSUE" in rendered
+    assert "Do not upload into hidden controls" not in rendered
+    assert "Never call upload_artifact on any page that is not the approved application destination" in rendered
 
 
 def test_legacy_prompt_keeps_apply_secrets_and_fake_capabilities_out_of_model_context(monkeypatch, tmp_path):

--- a/workers/automation/tests/test_apply_prompt_builder.py
+++ b/workers/automation/tests/test_apply_prompt_builder.py
@@ -54,9 +54,7 @@ class _FakeSnapshot:
 
 @pytest.fixture()
 def builder():
-    return ApplyPromptBuilder(
-        mcp_config_factory=lambda port: {"playwright": {"port": port}}
-    )
+    return ApplyPromptBuilder(mcp_config_factory=lambda port: {"playwright": {"port": port}})
 
 
 def test_build_returns_apply_prompt(monkeypatch, builder):
@@ -106,9 +104,7 @@ def test_build_passes_dry_run_through_to_legacy_builder(monkeypatch, builder):
     assert seen["upload_dir"] == "/tmp/worker-0"
 
 
-def test_legacy_prompt_copies_upload_files_into_worker_upload_dir(
-    monkeypatch, tmp_path
-):
+def test_legacy_prompt_copies_upload_files_into_worker_upload_dir(monkeypatch, tmp_path):
     worker_dir = tmp_path / "worker-0"
     materials_dir = tmp_path / "materials"
     materials_dir.mkdir()
@@ -160,9 +156,7 @@ def test_legacy_prompt_copies_upload_files_into_worker_upload_dir(
     assert "RESULT:LOGIN_ISSUE" in rendered
 
 
-def test_legacy_prompt_keeps_apply_secrets_and_fake_capabilities_out_of_model_context(
-    monkeypatch, tmp_path
-):
+def test_legacy_prompt_keeps_apply_secrets_and_fake_capabilities_out_of_model_context(monkeypatch, tmp_path):
     worker_dir = tmp_path / "worker-0"
     materials_dir = tmp_path / "materials"
     materials_dir.mkdir()
@@ -267,6 +261,7 @@ def test_default_mcp_config_includes_scoped_owned_connectors(monkeypatch) -> Non
     assert apply_tools["command"] == sys.executable
     assert apply_tools["args"] == ["-m", "jobctrl.infrastructure.apply_tools.mcp_server"]
     assert apply_tools["env"]["JOBCTRL_APPLY_CDP_ENDPOINT"] == "http://localhost:9222"
+    assert apply_tools["env"]["JOBCTRL_APPLY_APPROVED_APPLICATION_URL"] == "https://apply.example.com/job"
     assert apply_tools["env"]["JOBCTRL_APPLY_UPLOAD_DIR"] == "/tmp/worker-0"
     assert "JOBCTRL_APPLY_PROFILE_DB_PATH" in apply_tools["env"]
     assert "CAPSOLVER_API_KEY" not in apply_tools["env"]

--- a/workers/automation/tests/test_apply_tools_mcp_server.py
+++ b/workers/automation/tests/test_apply_tools_mcp_server.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import sys
+from types import SimpleNamespace
 
 from jobctrl.infrastructure.apply_tools.mcp_server import (
     ApplyToolsMcpServer,
     CaptchaChallenge,
     CaptchaSolveResult,
     _captcha_api_key,
+    _upload_file_to_current_input,
     _profile_credential,
 )
 
@@ -32,29 +35,64 @@ def test_upload_artifact_resolves_reviewed_resume_without_model_path(tmp_path):
     upload_dir.mkdir()
     resume = upload_dir / "Candidate_Resume.pdf"
     resume.write_bytes(b"%PDF")
-    uploaded: list[tuple[str, str]] = []
+    uploaded: list[tuple[str, str, str]] = []
     server = ApplyToolsMcpServer(
         upload_dir=upload_dir,
         cdp_endpoint="http://localhost:9222",
-        uploader=lambda endpoint, path: uploaded.append((endpoint, path.name)),
+        approved_application_url="https://apply.example.com/job",
+        uploader=lambda endpoint, path, approved_url: (
+            uploaded.append((endpoint, path.name, approved_url)) or {"destination_url": "https://apply.example.com/job"}
+        ),
     )
 
     response = _call(server, "upload_artifact", {"kind": "resume"})
 
-    assert uploaded == [("http://localhost:9222", "Candidate_Resume.pdf")]
+    assert uploaded == [
+        (
+            "http://localhost:9222",
+            "Candidate_Resume.pdf",
+            "https://apply.example.com/job",
+        )
+    ]
     payload = json.loads(response["result"]["content"][0]["text"])
     assert payload == {
         "ok": True,
         "kind": "resume",
         "filename": "Candidate_Resume.pdf",
+        "destination_url": "https://apply.example.com/job",
     }
+    audit_event = json.loads((upload_dir / "artifact_upload_events.jsonl").read_text(encoding="utf-8"))
+    assert audit_event["event_type"] == "ApplyArtifactUpload"
+    assert audit_event["payload"] == {
+        "kind": "resume",
+        "filename": "Candidate_Resume.pdf",
+        "destination_url": "https://apply.example.com/job",
+    }
+
+
+def test_upload_artifact_refuses_missing_approved_application_url(tmp_path):
+    resume = tmp_path / "Candidate_Resume.pdf"
+    resume.write_bytes(b"%PDF")
+    uploaded: list[str] = []
+    server = ApplyToolsMcpServer(
+        upload_dir=tmp_path,
+        cdp_endpoint="http://localhost:9222",
+        uploader=lambda _endpoint, path, _approved_url: uploaded.append(path.name),
+    )
+
+    response = _call(server, "upload_artifact", {"kind": "resume"})
+
+    assert uploaded == []
+    assert response["error"]["code"] == -32000
+    assert "approved application URL is not configured" in response["error"]["message"]
 
 
 def test_upload_artifact_refuses_unknown_kind(tmp_path):
     server = ApplyToolsMcpServer(
         upload_dir=tmp_path,
         cdp_endpoint="http://localhost:9222",
-        uploader=lambda _endpoint, _path: None,
+        approved_application_url="https://apply.example.com/job",
+        uploader=lambda _endpoint, _path, _approved_url: None,
     )
 
     response = _call(server, "upload_artifact", {"kind": "secrets"})
@@ -67,7 +105,8 @@ def test_upload_artifact_refuses_missing_run_artifact(tmp_path):
     server = ApplyToolsMcpServer(
         upload_dir=tmp_path,
         cdp_endpoint="http://localhost:9222",
-        uploader=lambda _endpoint, _path: None,
+        approved_application_url="https://apply.example.com/job",
+        uploader=lambda _endpoint, _path, _approved_url: None,
     )
 
     response = _call(server, "upload_artifact", {"kind": "resume"})
@@ -95,6 +134,144 @@ def test_type_credential_types_resolved_password_without_returning_secret(tmp_pa
         "kind": "job_site_password",
         "typed": True,
     }
+
+
+class _FakeHttpResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return None
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+
+class _FakeWebSocket:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.sent: list[dict] = []
+        self.closed = False
+
+    def send(self, payload):
+        self.sent.append(json.loads(payload))
+
+    def recv(self):
+        assert self._responses
+        return json.dumps(self._responses.pop(0))
+
+    def close(self):
+        self.closed = True
+
+
+def test_upload_file_to_current_input_refuses_cross_origin_page(monkeypatch, tmp_path):
+    artifact = tmp_path / "Candidate_Resume.pdf"
+    artifact.write_bytes(b"%PDF")
+    fake_ws = _FakeWebSocket(
+        [
+            {"id": 1, "result": {}},
+            {
+                "id": 2,
+                "result": {
+                    "result": {
+                        "value": {
+                            "ok": True,
+                            "href": "https://attacker.example/upload",
+                        }
+                    }
+                },
+            },
+            {"id": 3, "result": {"result": {"value": True}}},
+        ]
+    )
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.apply_tools.mcp_server.urlopen",
+        lambda *_args, **_kwargs: _FakeHttpResponse(
+            [
+                {
+                    "type": "page",
+                    "url": "https://attacker.example/upload",
+                    "webSocketDebuggerUrl": "ws://localhost/devtools/page/1",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "websocket",
+        SimpleNamespace(create_connection=lambda *_args, **_kwargs: fake_ws),
+    )
+
+    try:
+        _upload_file_to_current_input(
+            "http://localhost:9222",
+            artifact,
+            "https://apply.example.com/job",
+        )
+    except RuntimeError as exc:
+        assert "approved application origin" in str(exc)
+    else:  # pragma: no cover - explicit assertion branch
+        raise AssertionError("cross-origin upload destination was accepted")
+
+    assert fake_ws.closed is True
+    assert not any(message.get("method") == "DOM.setFileInputFiles" for message in fake_ws.sent)
+
+
+def test_upload_file_to_current_input_uploads_visible_same_origin_input(monkeypatch, tmp_path):
+    artifact = tmp_path / "Candidate_Resume.pdf"
+    artifact.write_bytes(b"%PDF")
+    fake_ws = _FakeWebSocket(
+        [
+            {"id": 1, "result": {}},
+            {
+                "id": 2,
+                "result": {
+                    "result": {
+                        "value": {
+                            "ok": True,
+                            "href": "https://apply.example.com/job/form",
+                        }
+                    }
+                },
+            },
+            {"id": 3, "result": {"root": {"nodeId": 1}}},
+            {"id": 4, "result": {"nodeId": 7}},
+            {"id": 5, "result": {}},
+            {"id": 6, "result": {"result": {"value": True}}},
+        ]
+    )
+    monkeypatch.setattr(
+        "jobctrl.infrastructure.apply_tools.mcp_server.urlopen",
+        lambda *_args, **_kwargs: _FakeHttpResponse(
+            [
+                {
+                    "type": "page",
+                    "url": "https://apply.example.com/job/form",
+                    "webSocketDebuggerUrl": "ws://localhost/devtools/page/1",
+                }
+            ]
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "websocket",
+        SimpleNamespace(create_connection=lambda *_args, **_kwargs: fake_ws),
+    )
+
+    result = _upload_file_to_current_input(
+        "http://localhost:9222",
+        artifact,
+        "https://apply.example.com/job",
+    )
+
+    assert result == {"destination_url": "https://apply.example.com/job/form"}
+    set_files = [message for message in fake_ws.sent if message.get("method") == "DOM.setFileInputFiles"]
+    assert len(set_files) == 1
+    assert set_files[0]["params"]["nodeId"] == 7
+    assert set_files[0]["params"]["files"] == [str(artifact)]
 
 
 def test_type_credential_resolves_password_from_profile_db(monkeypatch, tmp_path):
@@ -161,12 +338,14 @@ def test_solve_captcha_uses_owned_solver_without_returning_secret(tmp_path):
         upload_dir=tmp_path,
         cdp_endpoint="http://localhost:9222",
         captcha_key_resolver=lambda: "capsolver-secret-never-returned",
-        captcha_solver=lambda api_key, detected: calls.append((api_key, detected))
-        or CaptchaSolveResult(
-            token="solver-token",
-            kind=detected.kind,
-            elapsed_s=1.25,
-            cost_usd=0.002,
+        captcha_solver=lambda api_key, detected: (
+            calls.append((api_key, detected))
+            or CaptchaSolveResult(
+                token="solver-token",
+                kind=detected.kind,
+                elapsed_s=1.25,
+                cost_usd=0.002,
+            )
         ),
         captcha_injector=lambda _endpoint, _challenge, token: injected.append((_challenge.kind, token)),
     )
@@ -233,9 +412,7 @@ def test_apply_tools_mcp_omits_captcha_tool_when_key_absent(tmp_path):
         captcha_key_resolver=lambda: "",
     )
 
-    response = server.handle_json(
-        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-    )
+    response = server.handle_json(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
 
     assert {tool["name"] for tool in response["result"]["tools"]} == {
         "type_credential",
@@ -250,9 +427,7 @@ def test_apply_tools_mcp_lists_captcha_tool_when_key_present(tmp_path):
         captcha_key_resolver=lambda: "configured-key",
     )
 
-    response = server.handle_json(
-        json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
-    )
+    response = server.handle_json(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}))
 
     tools = {tool["name"]: tool for tool in response["result"]["tools"]}
     assert set(tools) == {"solve_captcha", "type_credential", "upload_artifact"}

--- a/workers/automation/tests/test_apply_tools_mcp_server.py
+++ b/workers/automation/tests/test_apply_tools_mcp_server.py
@@ -11,7 +11,9 @@ from jobctrl.infrastructure.apply_tools.mcp_server import (
     ApplyToolsMcpServer,
     CaptchaChallenge,
     CaptchaSolveResult,
+    _UploadDestinationRejected,
     _captcha_api_key,
+    _upload_input_guard_expression,
     _upload_file_to_current_input,
     _profile_credential,
 )
@@ -67,6 +69,42 @@ def test_upload_artifact_resolves_reviewed_resume_without_model_path(tmp_path):
         "kind": "resume",
         "filename": "Candidate_Resume.pdf",
         "destination_url": "https://apply.example.com/job",
+    }
+
+
+def test_upload_artifact_records_blocked_cross_origin_attempt(tmp_path):
+    upload_dir = tmp_path / "upload"
+    upload_dir.mkdir()
+    resume = upload_dir / "Candidate_Resume.pdf"
+    resume.write_bytes(b"%PDF")
+
+    def rejected_upload(_endpoint, _path, approved_url):
+        raise _UploadDestinationRejected(
+            "current upload destination does not match the approved application origin",
+            destination_url="https://attacker.example/upload",
+            approved_application_url=approved_url,
+        )
+
+    server = ApplyToolsMcpServer(
+        upload_dir=upload_dir,
+        cdp_endpoint="http://localhost:9222",
+        approved_application_url="https://apply.example.com/job",
+        uploader=rejected_upload,
+    )
+
+    response = _call(server, "upload_artifact", {"kind": "resume"})
+
+    assert response["error"]["code"] == -32000
+    assert "approved application origin" in response["error"]["message"]
+    audit_event = json.loads((upload_dir / "artifact_upload_events.jsonl").read_text(encoding="utf-8"))
+    assert audit_event["event_type"] == "ApplyArtifactUpload"
+    assert audit_event["payload"] == {
+        "approved_origin": "https://apply.example.com:443",
+        "destination_url": "https://attacker.example/upload",
+        "filename": "Candidate_Resume.pdf",
+        "kind": "resume",
+        "reason": "current upload destination does not match the approved application origin",
+        "status": "blocked",
     }
 
 
@@ -173,18 +211,18 @@ def test_upload_file_to_current_input_refuses_cross_origin_page(monkeypatch, tmp
     fake_ws = _FakeWebSocket(
         [
             {"id": 1, "result": {}},
+            {"id": 2, "result": {"result": {"objectId": "selection-1"}}},
             {
-                "id": 2,
+                "id": 3,
                 "result": {
-                    "result": {
-                        "value": {
-                            "ok": True,
-                            "href": "https://attacker.example/upload",
-                        }
-                    }
+                    "result": [
+                        {"name": "ok", "value": {"value": True}},
+                        {"name": "href", "value": {"value": "https://attacker.example/upload"}},
+                        {"name": "input", "value": {"objectId": "input-1"}},
+                    ]
                 },
             },
-            {"id": 3, "result": {"result": {"value": True}}},
+            {"id": 4, "result": {}},
         ]
     )
     monkeypatch.setattr(
@@ -226,8 +264,19 @@ def test_upload_file_to_current_input_uploads_visible_same_origin_input(monkeypa
     fake_ws = _FakeWebSocket(
         [
             {"id": 1, "result": {}},
+            {"id": 2, "result": {"result": {"objectId": "selection-1"}}},
             {
-                "id": 2,
+                "id": 3,
+                "result": {
+                    "result": [
+                        {"name": "ok", "value": {"value": True}},
+                        {"name": "href", "value": {"value": "https://apply.example.com/job/form"}},
+                        {"name": "input", "value": {"objectId": "input-1"}},
+                    ]
+                },
+            },
+            {
+                "id": 4,
                 "result": {
                     "result": {
                         "value": {
@@ -237,10 +286,9 @@ def test_upload_file_to_current_input_uploads_visible_same_origin_input(monkeypa
                     }
                 },
             },
-            {"id": 3, "result": {"root": {"nodeId": 1}}},
-            {"id": 4, "result": {"nodeId": 7}},
-            {"id": 5, "result": {}},
-            {"id": 6, "result": {"result": {"value": True}}},
+            {"id": 5, "result": {"nodeId": 7}},
+            {"id": 6, "result": {}},
+            {"id": 7, "result": {}},
         ]
     )
     monkeypatch.setattr(
@@ -272,6 +320,15 @@ def test_upload_file_to_current_input_uploads_visible_same_origin_input(monkeypa
     assert len(set_files) == 1
     assert set_files[0]["params"]["nodeId"] == 7
     assert set_files[0]["params"]["files"] == [str(artifact)]
+
+
+def test_upload_input_guard_allows_sole_hidden_enabled_file_input():
+    expression = _upload_input_guard_expression()
+
+    assert "visible.length === 1" in expression
+    assert "} else if (inputs.length === 1) {" in expression
+    assert "multiple file inputs are available" in expression
+    assert "no visible file input is currently available" not in expression
 
 
 def test_type_credential_resolves_password_from_profile_db(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Pass the approved application URL into the apply-tools MCP server.
- Require `upload_artifact` to verify the current browser page is still on the approved application origin before calling `DOM.setFileInputFiles`.
- Reject hidden or ambiguous file inputs, record upload destination audit events, and update prompt/test coverage for the new fail-closed behavior.

## Root Cause

`upload_artifact` constrained the local artifact path but trusted the current browser page. A malicious apply-flow page could steer the browser to a different origin and then trigger resume or cover-letter upload to that destination.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_tools_mcp_server.py workers/automation/tests/test_apply_prompt_builder.py` - 22 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_use_cases.py` - 12 passed
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py workers/automation/src/jobctrl/domain/apply/services.py workers/automation/src/jobctrl/apply/prompt.py workers/automation/tests/test_apply_tools_mcp_server.py workers/automation/tests/test_apply_prompt_builder.py` - passed
- `uv --project workers/automation run --extra dev ruff format workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py workers/automation/src/jobctrl/domain/apply/services.py workers/automation/src/jobctrl/apply/prompt.py workers/automation/tests/test_apply_tools_mcp_server.py workers/automation/tests/test_apply_prompt_builder.py --check` - passed
- `git diff --check` - passed

Docs were not updated because this is a security bug fix to an internal apply-tool guard and prompt behavior, not a new public capability or user-facing command.