### PR TITLE
fix(api): restrict extension pairing token origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,10 @@ employers, accounts, provider APIs, and third-party sites as live operations:
   to query automatically.
 - The local API is intended for loopback use. Browser-extension routes
   additionally require a local capability token shown in Settings and stored
-  under `~/.jobctrl/`. Do not bind the API to a network interface or tunnel
-  it unless you accept exposing private profile, job, and artifact data.
+  under `~/.jobctrl/`; token display and rotation are restricted to CLI or the
+  same-origin Settings surface, not arbitrary loopback web origins. Do not bind
+  the API to a network interface or tunnel it unless you accept exposing
+  private profile, job, and artifact data.
 - LLM work can spend money and send job, profile, and generated-material text
   to configured providers. `dailyBudgetUsd` caps new spendful workflows
   locally, but it is an estimate rather than the provider bill.

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -291,6 +291,7 @@ const APPLY_REVIEW_PRECONDITION_ERRORS = new Set([
 ]);
 const TRUSTED_SEC_FETCH_SITE_VALUES = new Set(["same-origin", "none"]);
 const LOOPBACK_ORIGIN_SEC_FETCH_SITE_VALUES = new Set(["same-origin", "same-site", "none"]);
+const FIRST_PARTY_PAIRING_SEC_FETCH_SITE_VALUES = new Set(["same-origin"]);
 const EXTENSION_API_PREFIX = "/v1/extension/";
 const EXTENSION_PAIRING_TOKEN_PATH = "/v1/extension/pairing-token";
 const EXTENSION_PAIRING_TOKEN_ROTATE_PATH = "/v1/extension/pairing-token/rotate";
@@ -411,9 +412,9 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   }));
 
   app.get(EXTENSION_PAIRING_TOKEN_PATH, async (request, reply) => {
-    if (resolveExtensionCorsOrigin(request.headers.origin)) {
+    if (!isTrustedExtensionPairingRequest(request)) {
       void reply.code(403);
-      return { ok: false, error: "extension_origin_not_allowed" };
+      return { ok: false, error: "untrusted_extension_pairing_request" };
     }
     const token = ensureLocalCapabilityToken(appDir);
     void reply.header("cache-control", "no-store");
@@ -426,9 +427,9 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
   });
 
   app.post(EXTENSION_PAIRING_TOKEN_ROTATE_PATH, async (request, reply) => {
-    if (resolveExtensionCorsOrigin(request.headers.origin)) {
+    if (!isTrustedExtensionPairingRequest(request)) {
       void reply.code(403);
-      return { ok: false, error: "extension_origin_not_allowed" };
+      return { ok: false, error: "untrusted_extension_pairing_request" };
     }
     const token = rotateLocalCapabilityToken(appDir);
     void reply.header("cache-control", "no-store");
@@ -2706,6 +2707,29 @@ function isAuthorizedExtensionApiRequest(request: FastifyRequest, appDir: string
   return isAuthorizedLocalCapabilityToken(request.headers.authorization, appDir);
 }
 
+function isTrustedExtensionPairingRequest(request: FastifyRequest): boolean {
+  if (resolveExtensionCorsOrigin(request.headers.origin)) {
+    return false;
+  }
+  const hasBrowserOriginMetadata =
+    hasRequestHeader(request.headers.origin) || hasRequestHeader(request.headers.referer);
+  if (!hasBrowserOriginMetadata) {
+    return true;
+  }
+  return (
+    isTrustedMutationSource(request.headers.origin, request.headers.referer) &&
+    isFirstPartyPairingFetch(request.headers["sec-fetch-site"])
+  );
+}
+
+function isFirstPartyPairingFetch(secFetchSiteHeader: string | string[] | undefined): boolean {
+  const values = requestHeaderValues(secFetchSiteHeader);
+  return (
+    values.length > 0 &&
+    values.every((value) => FIRST_PARTY_PAIRING_SEC_FETCH_SITE_VALUES.has(value.trim()))
+  );
+}
+
 function rejectInvalidExtensionToken(request: FastifyRequest, reply: FastifyReply): FastifyReply | undefined {
   if (!isExtensionAuthenticatedApiPath(request.url)) {
     return undefined;
@@ -3633,15 +3657,15 @@ function isTrustedSecFetchSite(
   secFetchSiteHeader: string | string[] | undefined,
   options: { allowLoopbackSameSite?: boolean } = {},
 ): boolean {
-  const values = Array.isArray(secFetchSiteHeader)
-    ? secFetchSiteHeader
-    : secFetchSiteHeader
-      ? [secFetchSiteHeader]
-      : [];
+  const values = requestHeaderValues(secFetchSiteHeader);
   const trustedValues = options.allowLoopbackSameSite
     ? LOOPBACK_ORIGIN_SEC_FETCH_SITE_VALUES
     : TRUSTED_SEC_FETCH_SITE_VALUES;
   return values.length === 0 || values.every((value) => trustedValues.has(value.trim()));
+}
+
+function requestHeaderValues(header: string | string[] | undefined): string[] {
+  return Array.isArray(header) ? header : header ? [header] : [];
 }
 
 function hasRequestHeader(header: string | string[] | undefined): boolean {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -534,13 +534,12 @@ describe("local TypeScript API", () => {
     await app.close();
   });
 
-  it("issues and rotates a local extension capability token from loopback settings callers", async () => {
+  it("issues and rotates a local extension capability token only for CLI and same-origin settings callers", async () => {
     const app = buildApp(options);
     try {
       const first = await app.inject({
         method: "GET",
         url: "/v1/extension/pairing-token",
-        headers: { origin: "http://127.0.0.1:5173" },
       });
       expect(first.statusCode, first.body).toBe(200);
       expect(first.headers["cache-control"]).toBe("no-store");
@@ -552,6 +551,39 @@ describe("local TypeScript API", () => {
         expect(fs.statSync(firstBody.tokenPath).mode & 0o777).toBe(0o600);
       }
 
+      const sameOriginSettingsRead = await app.inject({
+        method: "GET",
+        url: "/v1/extension/pairing-token",
+        headers: {
+          origin: "http://127.0.0.1:5173",
+          "sec-fetch-site": "same-origin",
+        },
+      });
+      expect(sameOriginSettingsRead.statusCode, sameOriginSettingsRead.body).toBe(200);
+      expect((sameOriginSettingsRead.json() as { token: string }).token).toBe(firstBody.token);
+
+      const loopbackWebRead = await app.inject({
+        method: "GET",
+        url: "/v1/extension/pairing-token",
+        headers: {
+          origin: "http://127.0.0.1:9999",
+          "sec-fetch-site": "same-site",
+        },
+      });
+      expect(loopbackWebRead.statusCode, loopbackWebRead.body).toBe(403);
+      expect(loopbackWebRead.json()).toMatchObject({ ok: false, error: "untrusted_extension_pairing_request" });
+
+      const loopbackWebReadWithoutFetchMetadata = await app.inject({
+        method: "GET",
+        url: "/v1/extension/pairing-token",
+        headers: { origin: "http://localhost:9999" },
+      });
+      expect(loopbackWebReadWithoutFetchMetadata.statusCode, loopbackWebReadWithoutFetchMetadata.body).toBe(403);
+      expect(loopbackWebReadWithoutFetchMetadata.json()).toMatchObject({
+        ok: false,
+        error: "untrusted_extension_pairing_request",
+      });
+
       const extensionRead = await app.inject({
         method: "GET",
         url: "/v1/extension/pairing-token",
@@ -559,16 +591,32 @@ describe("local TypeScript API", () => {
       });
       expect(extensionRead.statusCode, extensionRead.body).toBe(403);
       expect(extensionRead.headers["access-control-allow-origin"]).toBeUndefined();
+      expect(extensionRead.json()).toMatchObject({ ok: false, error: "untrusted_extension_pairing_request" });
 
       const rotated = await app.inject({
         method: "POST",
         url: "/v1/extension/pairing-token/rotate",
-        headers: { origin: "http://127.0.0.1:5173" },
+        headers: {
+          origin: "http://127.0.0.1:5173",
+          "sec-fetch-site": "same-origin",
+        },
       });
       expect(rotated.statusCode, rotated.body).toBe(200);
       const rotatedBody = rotated.json() as { token: string; tokenPath: string };
       expect(rotatedBody.tokenPath).toBe(firstBody.tokenPath);
       expect(rotatedBody.token).not.toBe(firstBody.token);
+      expect(fs.readFileSync(rotatedBody.tokenPath, "utf8").trim()).toBe(rotatedBody.token);
+
+      const loopbackWebRotate = await app.inject({
+        method: "POST",
+        url: "/v1/extension/pairing-token/rotate",
+        headers: {
+          origin: "http://127.0.0.1:9999",
+          "sec-fetch-site": "same-site",
+        },
+      });
+      expect(loopbackWebRotate.statusCode, loopbackWebRotate.body).toBe(403);
+      expect(loopbackWebRotate.json()).toMatchObject({ ok: false, error: "untrusted_extension_pairing_request" });
       expect(fs.readFileSync(rotatedBody.tokenPath, "utf8").trim()).toBe(rotatedBody.token);
     } finally {
       await app.close();

--- a/docs/local-ts-api.md
+++ b/docs/local-ts-api.md
@@ -1087,8 +1087,9 @@ event-history cap.
   capability token for the Settings pairing surface; `POST
   /v1/extension/pairing-token/rotate` replaces it. The token is generated under
   the app dir (`~/.jobctrl/extension-capability-token` by default) with
-  restrictive file permissions. These pairing routes are for loopback web/CLI
-  callers, not extension-origin CORS.
+  restrictive file permissions. These pairing routes are for CLI callers and
+  same-origin Settings requests only; arbitrary loopback web origins and
+  extension-origin CORS cannot mint or rotate the token.
 - Authenticated extension routes under `/v1/extension/*` require `Authorization:
   Bearer <token>`. A valid token allows a `chrome-extension://` origin through
   the route-scoped CORS and unsafe-mutation guards, but only after the loopback

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -76,8 +76,10 @@ shared locations, or attach it to bug reports.
 The browser-extension API surface uses a local capability token so an installed
 extension can prove it is paired with your local JobCtrl stack. The token is
 generated under `~/.jobctrl/`, shown in Settings for pairing, and only
-accepted on `/v1/extension/*` routes that still target a loopback host. It does
-not grant application-submission authority; live submission remains behind
+accepted on `/v1/extension/*` routes that still target a loopback host. Settings
+token display and rotation are limited to CLI or same-origin Settings requests,
+so arbitrary loopback web origins cannot mint or rotate the extension token. It
+does not grant application-submission authority; live submission remains behind
 Apply Review.
 
 In Phase 1, the extension can only capture the active http(s) page after you


### PR DESCRIPTION
## Summary
- restrict extension pairing-token read and rotate routes to CLI/no-browser-metadata callers or same-origin Settings requests with trusted Fetch Metadata
- reject arbitrary loopback web origins and extension-origin callers at the token issuance boundary
- update API regression coverage and user/API docs for the narrowed pairing-token policy

## Root Cause
The pairing-token routes treated any loopback web origin as a settings caller. A non-first-party loopback page could therefore read or rotate the extension capability token, then reuse it against bearer-token extension APIs.

## Validation
- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "issues and rotates a local extension capability token only for CLI and same-origin settings callers"`
- `corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "extension|Host"`
- `corepack pnpm --filter @jobctrl/api check`
- `corepack pnpm docs:build`
- `git diff --check --cached`