### PR TITLE
fix(apply): bind credential typing to approved origin

### DIFF
--- a/workers/automation/src/jobctrl/domain/apply/services.py
+++ b/workers/automation/src/jobctrl/domain/apply/services.py
@@ -232,6 +232,9 @@ def _default_mcp_config(
     apply_tools_env = {
         "JOBCTRL_APPLY_CDP_ENDPOINT": f"http://localhost:{cdp_port}",
         "JOBCTRL_APPLY_APPROVED_APPLICATION_URL": application_url,
+        "JOBCTRL_APPLY_ALLOWED_CREDENTIAL_ORIGINS": ",".join(
+            _credential_origins(application_url)
+        ),
         "JOBCTRL_APPLY_PROFILE_DB_PATH": str(_config.DB_PATH),
         "JOBCTRL_APPLY_UPLOAD_DIR": upload_root,
     }
@@ -279,6 +282,26 @@ def _verification_sender_domains(application_url: str) -> tuple[str, ...]:
     if len(labels) >= 2:
         return (".".join(labels[-2:]),)
     return (hostname,)
+
+
+def _credential_origins(application_url: str) -> tuple[str, ...]:
+    try:
+        parsed = urlparse(application_url)
+    except Exception:
+        return ()
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed.hostname:
+        return ()
+    host = parsed.hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        return ()
+    default_port = 443 if scheme == "https" else 80
+    port_suffix = "" if port is None or port == default_port else f":{port}"
+    return (f"{scheme}://{host}{port_suffix}",)
 
 
 __all__ = [

--- a/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
+++ b/workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import sys
 import uuid
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -42,6 +43,7 @@ class ApplyToolsMcpServer:
         uploader: Any | None = None,
         credential_resolver: Any | None = None,
         credential_typer: Any | None = None,
+        allowed_credential_origins: Iterable[str] | None = None,
         captcha_key_resolver: Any | None = None,
         captcha_solver: Any | None = None,
         captcha_injector: Any | None = None,
@@ -57,6 +59,11 @@ class ApplyToolsMcpServer:
         self._uploader = uploader or _upload_file_to_current_input
         self._credential_resolver = credential_resolver or _profile_credential
         self._credential_typer = credential_typer or _type_credential_into_active_field
+        self._allowed_credential_origins = _normalize_allowed_origins(
+            allowed_credential_origins
+            if allowed_credential_origins is not None
+            else _credential_origins_from_env()
+        )
         self._captcha_key_resolver = captcha_key_resolver or _captcha_api_key
         self._captcha_solver = captcha_solver or _solve_with_capsolver
         self._captcha_injector = captcha_injector or _inject_captcha_token
@@ -145,10 +152,16 @@ class ApplyToolsMcpServer:
 
     def _call_type_credential(self, args: dict[str, Any]) -> dict[str, Any]:
         kind = str(args.get("kind") or "")
+        if not self._allowed_credential_origins:
+            raise ValueError("credential origin policy is not configured")
         credential = self._credential_resolver(kind)
         if not credential:
             raise ValueError(f"{kind or 'credential'} is not configured")
-        self._credential_typer(self._cdp_endpoint, credential)
+        self._credential_typer(
+            self._cdp_endpoint,
+            credential,
+            self._allowed_credential_origins,
+        )
         return {
             "content": [
                 {
@@ -325,6 +338,42 @@ def _solve_with_capsolver(api_key: str, challenge: CaptchaChallenge) -> CaptchaS
     return solve_with_capsolver(api_key, challenge)
 
 
+def _credential_origins_from_env() -> tuple[str, ...]:
+    raw = os.environ.get("JOBCTRL_APPLY_ALLOWED_CREDENTIAL_ORIGINS", "")
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def _normalize_allowed_origins(origins: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for origin in origins:
+        value = _origin_from_url(str(origin))
+        if value and value not in seen:
+            normalized.append(value)
+            seen.add(value)
+    return tuple(normalized)
+
+
+def _origin_from_url(value: str) -> str | None:
+    try:
+        parsed = urlparse(value.strip())
+    except Exception:
+        return None
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    host = parsed.hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = parsed.port
+    except ValueError:
+        return None
+    default_port = 443 if scheme == "https" else 80
+    port_suffix = "" if port is None or port == default_port else f":{port}"
+    return f"{scheme}://{host}{port_suffix}"
+
+
 def _captcha_challenge_from_args(args: dict[str, Any]) -> CaptchaChallenge:
     kind = str(args.get("kind") or "")
     sitekey = str(args.get("sitekey") or "")
@@ -389,7 +438,14 @@ def _inject_captcha_token(cdp_endpoint: str, challenge: CaptchaChallenge, token:
     )
 
 
-def _type_credential_into_active_field(cdp_endpoint: str, credential: str) -> None:
+def _type_credential_into_active_field(
+    cdp_endpoint: str,
+    credential: str,
+    allowed_origins: Iterable[str],
+) -> None:
+    origin_policy = _normalize_allowed_origins(allowed_origins)
+    if not origin_policy:
+        raise RuntimeError("credential origin policy is not configured")
     ws_url = _first_page_ws_url(cdp_endpoint)
     try:
         import websocket
@@ -429,7 +485,8 @@ def _type_credential_into_active_field(cdp_endpoint: str, credential: str) -> No
   const name = (el.getAttribute("name") || "").toLowerCase();
   const id = (el.getAttribute("id") || "").toLowerCase();
   return {
-    ok: type === "password" || autocomplete.includes("password") ||
+    origin: window.location.origin,
+    fieldOk: type === "password" || autocomplete.includes("password") ||
       name.includes("password") || id.includes("password")
   };
 })()
@@ -438,7 +495,9 @@ def _type_credential_into_active_field(cdp_endpoint: str, credential: str) -> No
             )
         )
         active = guard.get("result", {}).get("result", {}).get("value") or {}
-        if not active.get("ok"):
+        if str(active.get("origin") or "") not in origin_policy:
+            raise RuntimeError("stored credential is not approved for this page origin")
+        if not active.get("fieldOk"):
             raise RuntimeError("active element is not a password credential field")
         response(send("Input.insertText", {"text": credential}))
     finally:

--- a/workers/automation/tests/test_apply_prompt_builder.py
+++ b/workers/automation/tests/test_apply_prompt_builder.py
@@ -264,6 +264,10 @@ def test_default_mcp_config_includes_scoped_owned_connectors(monkeypatch) -> Non
     assert apply_tools["args"] == ["-m", "jobctrl.infrastructure.apply_tools.mcp_server"]
     assert apply_tools["env"]["JOBCTRL_APPLY_CDP_ENDPOINT"] == "http://localhost:9222"
     assert apply_tools["env"]["JOBCTRL_APPLY_APPROVED_APPLICATION_URL"] == "https://apply.example.com/job"
+    assert (
+        apply_tools["env"]["JOBCTRL_APPLY_ALLOWED_CREDENTIAL_ORIGINS"]
+        == "https://apply.example.com"
+    )
     assert apply_tools["env"]["JOBCTRL_APPLY_UPLOAD_DIR"] == "/tmp/worker-0"
     assert "JOBCTRL_APPLY_PROFILE_DB_PATH" in apply_tools["env"]
     assert "CAPSOLVER_API_KEY" not in apply_tools["env"]

--- a/workers/automation/tests/test_apply_tools_mcp_server.py
+++ b/workers/automation/tests/test_apply_tools_mcp_server.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 from types import SimpleNamespace
 
+from jobctrl.infrastructure.apply_tools import mcp_server as apply_tools_mcp
 from jobctrl.infrastructure.apply_tools.mcp_server import (
     ApplyToolsMcpServer,
     CaptchaChallenge,
@@ -16,6 +17,7 @@ from jobctrl.infrastructure.apply_tools.mcp_server import (
     _upload_input_guard_expression,
     _upload_file_to_current_input,
     _profile_credential,
+    _type_credential_into_active_field,
 )
 
 
@@ -154,17 +156,26 @@ def test_upload_artifact_refuses_missing_run_artifact(tmp_path):
 
 
 def test_type_credential_types_resolved_password_without_returning_secret(tmp_path):
-    typed: list[tuple[str, str]] = []
+    typed: list[tuple[str, str, tuple[str, ...]]] = []
     server = ApplyToolsMcpServer(
         upload_dir=tmp_path,
         cdp_endpoint="http://localhost:9222",
         credential_resolver=lambda kind: "SyntheticPasswordNeverReturned" if kind == "job_site_password" else "",
-        credential_typer=lambda endpoint, credential: typed.append((endpoint, credential)),
+        credential_typer=lambda endpoint, credential, origins: typed.append(
+            (endpoint, credential, origins)
+        ),
+        allowed_credential_origins=("https://apply.example.com",),
     )
 
     response = _call(server, "type_credential", {"kind": "job_site_password"})
 
-    assert typed == [("http://localhost:9222", "SyntheticPasswordNeverReturned")]
+    assert typed == [
+        (
+            "http://localhost:9222",
+            "SyntheticPasswordNeverReturned",
+            ("https://apply.example.com",),
+        )
+    ]
     text = response["result"]["content"][0]["text"]
     assert "SyntheticPasswordNeverReturned" not in text
     assert json.loads(text) == {
@@ -361,7 +372,10 @@ def test_type_credential_refuses_missing_profile_db(monkeypatch, tmp_path):
     monkeypatch.setenv("JOBCTRL_APPLY_PROFILE_DB_PATH", str(tmp_path / "missing.db"))
 
     response = _call(
-        ApplyToolsMcpServer(cdp_endpoint="http://localhost:9222"),
+        ApplyToolsMcpServer(
+            cdp_endpoint="http://localhost:9222",
+            allowed_credential_origins=("https://apply.example.com",),
+        ),
         "type_credential",
         {"kind": "job_site_password"},
     )
@@ -375,12 +389,67 @@ def test_type_credential_refuses_unknown_kind(tmp_path):
         upload_dir=tmp_path,
         cdp_endpoint="http://localhost:9222",
         credential_typer=lambda _endpoint, _credential: None,
+        allowed_credential_origins=("https://apply.example.com",),
     )
 
     response = _call(server, "type_credential", {"kind": "api_key"})
 
     assert response["error"]["code"] == -32000
     assert "kind must be job_site_password" in response["error"]["message"]
+
+
+def test_type_credential_fails_closed_without_origin_policy(tmp_path):
+    resolved: list[str] = []
+    server = ApplyToolsMcpServer(
+        upload_dir=tmp_path,
+        cdp_endpoint="http://localhost:9222",
+        credential_resolver=lambda kind: resolved.append(kind) or "SyntheticPassword",
+        credential_typer=lambda _endpoint, _credential, _origins: None,
+    )
+
+    response = _call(server, "type_credential", {"kind": "job_site_password"})
+
+    assert resolved == []
+    assert response["error"]["code"] == -32000
+    assert "credential origin policy is not configured" in response["error"]["message"]
+
+
+def test_type_credential_rejects_unapproved_page_origin(monkeypatch):
+    ws = _FakeCdpWebSocket(
+        origin="https://evil.example",
+        field_ok=True,
+    )
+    _install_fake_cdp(monkeypatch, ws)
+
+    try:
+        _type_credential_into_active_field(
+            "http://localhost:9222",
+            "SyntheticPasswordNeverTyped",
+            ("https://apply.example.com",),
+        )
+    except RuntimeError as exc:
+        assert "stored credential is not approved for this page origin" in str(exc)
+    else:
+        raise AssertionError("credential typing should fail for mismatched origins")
+
+    assert not any(message.get("method") == "Input.insertText" for message in ws.sent)
+
+
+def test_type_credential_types_only_on_approved_page_origin(monkeypatch):
+    ws = _FakeCdpWebSocket(
+        origin="https://apply.example.com",
+        field_ok=True,
+    )
+    _install_fake_cdp(monkeypatch, ws)
+
+    _type_credential_into_active_field(
+        "http://localhost:9222",
+        "SyntheticPasswordTyped",
+        ("https://apply.example.com",),
+    )
+
+    insert = [message for message in ws.sent if message.get("method") == "Input.insertText"]
+    assert insert == [{"id": 2, "method": "Input.insertText", "params": {"text": "SyntheticPasswordTyped"}}]
 
 
 def test_solve_captcha_uses_owned_solver_without_returning_secret(tmp_path):
@@ -490,3 +559,60 @@ def test_apply_tools_mcp_lists_captcha_tool_when_key_present(tmp_path):
     assert set(tools) == {"solve_captcha", "type_credential", "upload_artifact"}
     solve_schema = tools["solve_captcha"]["inputSchema"]
     assert solve_schema["required"] == ["kind", "sitekey", "page_url"]
+
+
+class _FakeCdpResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info):
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(
+            [
+                {
+                    "type": "page",
+                    "webSocketDebuggerUrl": "ws://127.0.0.1/devtools/page/1",
+                }
+            ]
+        ).encode("utf-8")
+
+
+class _FakeCdpWebSocket:
+    def __init__(self, *, origin: str, field_ok: bool) -> None:
+        self._origin = origin
+        self._field_ok = field_ok
+        self.sent: list[dict] = []
+        self._last_id = 0
+        self.closed = False
+
+    def send(self, payload: str) -> None:
+        message = json.loads(payload)
+        self.sent.append(message)
+        self._last_id = int(message["id"])
+
+    def recv(self) -> str:
+        method = self.sent[-1]["method"]
+        if method == "Runtime.evaluate":
+            result = {"origin": self._origin, "fieldOk": self._field_ok}
+        else:
+            result = True
+        return json.dumps(
+            {
+                "id": self._last_id,
+                "result": {"result": {"value": result}},
+            }
+        )
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _install_fake_cdp(monkeypatch, ws: _FakeCdpWebSocket) -> None:
+    monkeypatch.setattr(apply_tools_mcp, "urlopen", lambda _url, timeout: _FakeCdpResponse())
+    monkeypatch.setitem(
+        sys.modules,
+        "websocket",
+        SimpleNamespace(create_connection=lambda *_args, **_kwargs: ws),
+    )


### PR DESCRIPTION
## Summary

- Bind the owned apply `type_credential` tool to the approved application origin derived from the apply target URL.
- Fail closed when the credential-origin policy is missing or when the active browser page origin does not match before inserting the stored password.
- Add focused regression coverage for missing policy, mismatched origin rejection, approved-origin typing, and MCP config wiring.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_tools_mcp_server.py workers/automation/tests/test_apply_prompt_builder.py` (`22 passed`)
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobctrl/infrastructure/apply_tools/mcp_server.py workers/automation/src/jobctrl/domain/apply/services.py workers/automation/tests/test_apply_tools_mcp_server.py workers/automation/tests/test_apply_prompt_builder.py`
- `git diff --check`

## Docs

No documentation update: this is an internal safety-boundary fix for the owned apply-tools MCP server and does not add user-facing commands, configuration, or workflow steps.