### PR TITLE
fix(security): guard apply browser private navigations

### DIFF
--- a/workers/automation/src/jobctrl/apply/chrome.py
+++ b/workers/automation/src/jobctrl/apply/chrome.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse
 from urllib.request import urlopen
 
 from jobctrl import config
+from jobctrl.infrastructure.network import validate_public_http_url
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,8 @@ _chrome_procs: dict[int, subprocess.Popen] = {}
 _chrome_lock = threading.Lock()
 _dry_run_guards: dict[int, "_DryRunCdpGuard"] = {}
 _dry_run_guards_lock = threading.Lock()
+_public_destination_guards: dict[int, "_PublicDestinationCdpGuard"] = {}
+_public_destination_guards_lock = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +254,8 @@ def launch_chrome(worker_id: int, port: int | None = None,
     time.sleep(3)
     if dry_run:
         install_dry_run_cdp_guard(port)
+    else:
+        install_public_destination_cdp_guard(port)
     logger.info("[worker-%d] Chrome started on port %d (pid %d)",
                 worker_id, port, proc.pid)
     return proc
@@ -353,10 +358,19 @@ _FORM_SUBMIT_GUARD_SOURCE = """
 
 
 def install_dry_run_cdp_guard(port: int) -> "_DryRunCdpGuard":
-    """Install a CDP dry-run guard on Chrome pages for this worker."""
+    """Install the public-destination + dry-run CDP guard for this worker."""
     guard = _DryRunCdpGuard(port)
     with _dry_run_guards_lock:
         _dry_run_guards[int(port)] = guard
+    guard.start()
+    return guard
+
+
+def install_public_destination_cdp_guard(port: int) -> "_PublicDestinationCdpGuard":
+    """Install the live apply public-destination guard on Chrome pages."""
+    guard = _PublicDestinationCdpGuard(port)
+    with _public_destination_guards_lock:
+        _public_destination_guards[int(port)] = guard
     guard.start()
     return guard
 
@@ -374,20 +388,25 @@ def get_dry_run_cdp_guard_evidence(port: int) -> dict[str, object]:
     return guard.evidence()
 
 
-class _DryRunCdpGuard:
-    def __init__(self, port: int) -> None:
+class _ApplyCdpGuard:
+    def __init__(self, port: int, *, enforce_dry_run: bool) -> None:
         self._port = int(port)
+        self._enforce_dry_run = enforce_dry_run
         self._seen: set[str] = set()
         self._blocked: list[dict[str, str]] = []
         self._blocked_keys: set[tuple[str, str, str, str]] = set()
         self._request_initiators: dict[str, str] = {}
         self._lock = threading.Lock()
 
+    @property
+    def enforce_dry_run(self) -> bool:
+        return self._enforce_dry_run
+
     def start(self) -> None:
         self._attach_existing_targets()
         watcher = threading.Thread(
             target=self._watch_targets,
-            name=f"apply-cdp-dry-run-{self._port}",
+            name=f"apply-cdp-guard-{self._port}",
             daemon=True,
         )
         watcher.start()
@@ -410,7 +429,7 @@ class _DryRunCdpGuard:
                     continue
                 self._seen.add(target_id)
             thread = threading.Thread(
-                target=_run_dry_run_page_session,
+                target=_run_apply_page_session,
                 args=(ws_url, self),
                 name=f"apply-cdp-page-{target_id[:8]}",
                 daemon=True,
@@ -466,6 +485,16 @@ class _DryRunCdpGuard:
             return self._request_initiators.pop(request_id, "")
 
 
+class _DryRunCdpGuard(_ApplyCdpGuard):
+    def __init__(self, port: int) -> None:
+        super().__init__(port, enforce_dry_run=True)
+
+
+class _PublicDestinationCdpGuard(_ApplyCdpGuard):
+    def __init__(self, port: int) -> None:
+        super().__init__(port, enforce_dry_run=False)
+
+
 def _cdp_json(port: int, path: str) -> object:
     try:
         with urlopen(f"http://127.0.0.1:{port}{path}", timeout=2) as response:
@@ -475,11 +504,11 @@ def _cdp_json(port: int, path: str) -> object:
         return []
 
 
-def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
+def _run_apply_page_session(ws_url: str, guard: _ApplyCdpGuard) -> None:
     try:
         import websocket
     except Exception:
-        logger.exception("websocket-client is required for apply dry-run CDP enforcement")
+        logger.exception("websocket-client is required for apply CDP enforcement")
         return
     try:
         ws = websocket.create_connection(ws_url, timeout=2, suppress_origin=True)
@@ -496,9 +525,10 @@ def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
     try:
         send("Page.enable")
         send("Network.enable")
-        send("Runtime.enable")
-        send("Runtime.addBinding", {"name": "jobctrlDryRunBlocked"})
-        send("Page.addScriptToEvaluateOnNewDocument", {"source": _FORM_SUBMIT_GUARD_SOURCE})
+        if guard.enforce_dry_run:
+            send("Runtime.enable")
+            send("Runtime.addBinding", {"name": "jobctrlDryRunBlocked"})
+            send("Page.addScriptToEvaluateOnNewDocument", {"source": _FORM_SUBMIT_GUARD_SOURCE})
         send(
             "Fetch.enable",
             {
@@ -510,7 +540,8 @@ def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
                 ]
             },
         )
-        send("Runtime.evaluate", {"expression": _FORM_SUBMIT_GUARD_SOURCE})
+        if guard.enforce_dry_run:
+            send("Runtime.evaluate", {"expression": _FORM_SUBMIT_GUARD_SOURCE})
         while True:
             try:
                 raw_message = ws.recv()
@@ -518,10 +549,10 @@ def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
                 continue
             message = json.loads(raw_message)
             method_name = message.get("method")
-            if method_name == "Runtime.bindingCalled":
+            if guard.enforce_dry_run and method_name == "Runtime.bindingCalled":
                 _record_binding_call(message, guard)
                 continue
-            if method_name == "Network.webSocketCreated":
+            if guard.enforce_dry_run and method_name == "Network.webSocketCreated":
                 params = message.get("params") or {}
                 guard.record_blocked_request(
                     channel="WebSocket",
@@ -531,7 +562,8 @@ def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
                 )
                 continue
             if method_name == "Network.requestWillBeSent":
-                _record_request_initiator(message, guard)
+                if guard.enforce_dry_run:
+                    _record_request_initiator(message, guard)
                 continue
             if method_name != "Fetch.requestPaused":
                 continue
@@ -543,7 +575,16 @@ def _run_dry_run_page_session(ws_url: str, guard: _DryRunCdpGuard) -> None:
             url = str(request.get("url") or "")
             resource_type = str(params.get("resourceType") or "Other")
             initiator_type = guard.request_initiator(network_id)
-            if request_id and _should_block_dry_run_request(
+            public_decision = validate_public_http_url(url)
+            if request_id and not public_decision.allowed:
+                guard.record_blocked_request(
+                    channel="public_destination",
+                    method=method,
+                    url=url,
+                    resource_type=resource_type,
+                )
+                send("Fetch.failRequest", {"requestId": request_id, "errorReason": "BlockedByClient"})
+            elif request_id and guard.enforce_dry_run and _should_block_dry_run_request(
                 method,
                 resource_type=resource_type,
                 initiator_type=initiator_type,

--- a/workers/automation/tests/test_apply_chrome_dry_run_guard.py
+++ b/workers/automation/tests/test_apply_chrome_dry_run_guard.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from jobctrl.apply import chrome
+from jobctrl.infrastructure.network import PublicUrlDecision
 
 
 class _HostileEmployerHandler(BaseHTTPRequestHandler):
@@ -102,6 +103,7 @@ def test_dry_run_cdp_guard_blocks_hostile_employer_exfiltration(tmp_path, monkey
         return profile
 
     monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
+    monkeypatch.setattr(chrome, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
     try:
         dry_port = _free_port()
         dry_proc = chrome.launch_chrome(
@@ -205,6 +207,174 @@ def test_dry_run_request_policy_blocks_all_mutating_methods():
         )
         is False
     )
+
+
+def test_launch_chrome_installs_public_destination_guard_for_live_runs(tmp_path, monkeypatch):
+    calls: list[tuple[str, int]] = []
+
+    class _FakeProcess:
+        pid = 4242
+
+        def poll(self) -> None:
+            return None
+
+    def setup_profile(worker_id: int) -> Path:
+        profile = tmp_path / f"profile-{worker_id}"
+        (profile / "Default").mkdir(parents=True, exist_ok=True)
+        return profile
+
+    monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
+    monkeypatch.setattr(chrome, "_kill_on_port", lambda _port: None)
+    monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
+    monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
+    monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(chrome.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        chrome,
+        "install_public_destination_cdp_guard",
+        lambda port: calls.append(("public", port)),
+    )
+    monkeypatch.setattr(
+        chrome,
+        "install_dry_run_cdp_guard",
+        lambda port: calls.append(("dry_run", port)),
+    )
+
+    chrome.launch_chrome(worker_id=903, port=9555, headless=True, dry_run=False)
+
+    assert calls == [("public", 9555)]
+
+
+def test_launch_chrome_uses_combined_dry_run_guard_for_dry_runs(tmp_path, monkeypatch):
+    calls: list[tuple[str, int]] = []
+
+    class _FakeProcess:
+        pid = 4343
+
+        def poll(self) -> None:
+            return None
+
+    def setup_profile(worker_id: int) -> Path:
+        profile = tmp_path / f"profile-{worker_id}"
+        (profile / "Default").mkdir(parents=True, exist_ok=True)
+        return profile
+
+    monkeypatch.setattr(chrome, "setup_worker_profile", setup_profile)
+    monkeypatch.setattr(chrome, "_kill_on_port", lambda _port: None)
+    monkeypatch.setattr(chrome, "_suppress_restore_nag", lambda _profile: None)
+    monkeypatch.setattr(chrome.config, "get_chrome_path", lambda: "/bin/echo")
+    monkeypatch.setattr(chrome.subprocess, "Popen", lambda *_args, **_kwargs: _FakeProcess())
+    monkeypatch.setattr(chrome.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        chrome,
+        "install_public_destination_cdp_guard",
+        lambda port: calls.append(("public", port)),
+    )
+    monkeypatch.setattr(
+        chrome,
+        "install_dry_run_cdp_guard",
+        lambda port: calls.append(("dry_run", port)),
+    )
+
+    chrome.launch_chrome(worker_id=904, port=9666, headless=True, dry_run=True)
+
+    assert calls == [("dry_run", 9666)]
+    assert chrome._DryRunCdpGuard(port=1).enforce_dry_run is True
+    assert chrome._PublicDestinationCdpGuard(port=1).enforce_dry_run is False
+
+
+def test_public_destination_cdp_guard_fails_loopback_requests(monkeypatch):
+    websocket = pytest.importorskip("websocket")
+    sent: list[dict] = []
+
+    class _FakeWebSocket:
+        def __init__(self) -> None:
+            self._delivered = False
+
+        def send(self, payload: str) -> None:
+            sent.append(json.loads(payload))
+
+        def recv(self) -> str:
+            if self._delivered:
+                raise RuntimeError("end test session")
+            self._delivered = True
+            return json.dumps(
+                {
+                    "method": "Fetch.requestPaused",
+                    "params": {
+                        "requestId": "intercept-1",
+                        "networkId": "network-1",
+                        "resourceType": "Document",
+                        "request": {
+                            "method": "GET",
+                            "url": "http://127.0.0.1:8766/v1/profile",
+                        },
+                    },
+                }
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(websocket, "create_connection", lambda *_args, **_kwargs: _FakeWebSocket())
+
+    guard = chrome._PublicDestinationCdpGuard(port=1)
+    chrome._run_apply_page_session("ws://example.invalid/devtools/page/1", guard)
+
+    assert {
+        "id": 4,
+        "method": "Fetch.failRequest",
+        "params": {"requestId": "intercept-1", "errorReason": "BlockedByClient"},
+    } in sent
+    assert all(message.get("method") != "Fetch.continueRequest" for message in sent)
+    assert guard.evidence()["blocked_channels"] == ("public_destination:GET",)
+
+
+def test_public_destination_cdp_guard_continues_public_requests(monkeypatch):
+    websocket = pytest.importorskip("websocket")
+    sent: list[dict] = []
+
+    class _FakeWebSocket:
+        def __init__(self) -> None:
+            self._delivered = False
+
+        def send(self, payload: str) -> None:
+            sent.append(json.loads(payload))
+
+        def recv(self) -> str:
+            if self._delivered:
+                raise RuntimeError("end test session")
+            self._delivered = True
+            return json.dumps(
+                {
+                    "method": "Fetch.requestPaused",
+                    "params": {
+                        "requestId": "intercept-2",
+                        "networkId": "network-2",
+                        "resourceType": "Document",
+                        "request": {
+                            "method": "GET",
+                            "url": "https://careers.example.com/apply",
+                        },
+                    },
+                }
+            )
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(websocket, "create_connection", lambda *_args, **_kwargs: _FakeWebSocket())
+    monkeypatch.setattr(chrome, "validate_public_http_url", lambda _url: PublicUrlDecision(True))
+
+    guard = chrome._PublicDestinationCdpGuard(port=1)
+    chrome._run_apply_page_session("ws://example.invalid/devtools/page/2", guard)
+
+    assert {
+        "id": 4,
+        "method": "Fetch.continueRequest",
+        "params": {"requestId": "intercept-2"},
+    } in sent
+    assert all(message.get("method") != "Fetch.failRequest" for message in sent)
 
 
 def test_dry_run_guard_evidence_records_sanitized_submission_channels():


### PR DESCRIPTION
## Summary

- Install a live CDP public-destination guard for non-dry-run apply Chrome sessions.
- Reuse the same public-destination enforcement inside the existing dry-run guard before dry-run submission controls run.
- Add focused regressions proving loopback/private requests are failed and public HTTP(S) requests continue.

## Root cause

The apply flow checked the initial application URL before prompt construction, but live Chrome sessions did not keep enforcing the public-destination boundary after the autonomous browser was running. A malicious job or ATS page could steer allowed navigation/snapshot tools toward loopback or private-network resources.

## Validation

- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_chrome_dry_run_guard.py` (7 passed)
- `uv --project workers/automation run --extra dev ruff check workers/automation/src/jobctrl/apply/chrome.py workers/automation/tests/test_apply_chrome_dry_run_guard.py`
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_apply_use_cases.py::test_execute_blocks_private_network_application_url_before_agent` (1 passed)
- `git diff --check`

Docs not updated: this is a bug fix to an existing safety boundary, not a new user-facing capability.