### PR TITLE
fix(security): guard LinkedIn apply resolver URLs

### DIFF
--- a/workers/automation/src/jobctrl/infrastructure/enrichment/linkedin_apply_resolver.py
+++ b/workers/automation/src/jobctrl/infrastructure/enrichment/linkedin_apply_resolver.py
@@ -14,10 +14,15 @@ import shutil
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import parse_qsl, unquote, urljoin, urlparse
 
 from jobctrl import config
+from jobctrl.infrastructure.network import (
+    PublicHttpUrlRouteGuard,
+    PublicUrlDecision,
+    validate_public_http_url,
+)
 from jobctrl.infrastructure.network.proxy import ProxyConfig
 
 log = logging.getLogger(__name__)
@@ -45,6 +50,8 @@ _EXTERNAL_URL_PARAM_NAMES = {
     "externalurl",
 }
 _APPLY_TEXT_RE = re.compile(r"\b(apply|solicitar)\b", re.IGNORECASE)
+
+UrlSafetyChecker = Callable[[str], PublicUrlDecision]
 
 
 @dataclass(frozen=True)
@@ -119,6 +126,7 @@ class LinkedInApplyUrlResolver:
         user_agent: str | None = None,
         playwright: Any | None = None,
         chrome_profile: str | None = None,
+        url_safety_checker: UrlSafetyChecker | None = None,
     ) -> None:
         self._profile_dir = profile_dir or default_linkedin_apply_profile_dir()
         self._chrome_profile = chrome_profile or linkedin_apply_chrome_profile()
@@ -127,6 +135,7 @@ class LinkedInApplyUrlResolver:
         self._timeout_seconds = timeout_seconds or linkedin_apply_timeout_seconds()
         self._user_agent = user_agent
         self._external_playwright = playwright
+        self._url_safety_checker = url_safety_checker or validate_public_http_url
         self._playwright: Any | None = None
         self._context: Any | None = None
 
@@ -200,7 +209,12 @@ class LinkedInApplyUrlResolver:
     def resolve(self, job_url: str) -> LinkedInApplyResolution:
         """Navigate to ``job_url`` and capture the external apply target."""
 
+        initial_safety = self._url_safety_checker(job_url)
+        if not initial_safety.allowed:
+            return _unsafe_url_resolution(initial_safety.reason)
+
         page = self.new_page()
+        route_guard = PublicHttpUrlRouteGuard(page).install()
         try:
             try:
                 page.goto(job_url, timeout=_NAV_TIMEOUT_MS)
@@ -210,9 +224,15 @@ class LinkedInApplyUrlResolver:
                 except Exception:
                     pass
             except Exception as exc:
+                if route_guard.blocked:
+                    return _unsafe_url_resolution(route_guard.blocked_reason)
                 return LinkedInApplyResolution(None, "navigation_error", str(exc)[:300])
-            return self.resolve_loaded_page(page, job_url)
+            result = self._resolve_loaded_page(page, job_url)
+            if route_guard.blocked:
+                return _unsafe_url_resolution(route_guard.blocked_reason)
+            return result
         finally:
+            route_guard.close()
             try:
                 page.close()
             except Exception:
@@ -221,7 +241,21 @@ class LinkedInApplyUrlResolver:
     def resolve_loaded_page(self, page: Any, job_url: str) -> LinkedInApplyResolution:
         """Capture the apply target from an already-loaded LinkedIn page."""
 
-        direct = _extract_external_from_redirect_url(getattr(page, "url", "") or "", job_url)
+        route_guard = PublicHttpUrlRouteGuard(page).install()
+        try:
+            result = self._resolve_loaded_page(page, job_url)
+            if route_guard.blocked:
+                return _unsafe_url_resolution(route_guard.blocked_reason)
+            return result
+        finally:
+            route_guard.close()
+
+    def _resolve_loaded_page(self, page: Any, job_url: str) -> LinkedInApplyResolution:
+        direct = _extract_external_from_redirect_url(
+            getattr(page, "url", "") or "",
+            job_url,
+            url_safety_checker=self._url_safety_checker,
+        )
         if direct:
             return LinkedInApplyResolution(direct, "current_url")
 
@@ -231,10 +265,14 @@ class LinkedInApplyUrlResolver:
 
         href = _locator_href(locator, getattr(page, "url", "") or job_url)
         if href:
-            direct = _extract_external_from_redirect_url(href, job_url)
+            direct = _extract_external_from_redirect_url(
+                href,
+                job_url,
+                url_safety_checker=self._url_safety_checker,
+            )
             if direct:
                 return LinkedInApplyResolution(direct, "href_redirect")
-            if _is_external_apply_url(href, job_url):
+            if _is_safe_external_apply_url(href, job_url, self._url_safety_checker):
                 return LinkedInApplyResolution(href, "href")
 
         clicked = _click_and_capture_apply_target(
@@ -242,6 +280,7 @@ class LinkedInApplyUrlResolver:
             locator,
             job_url,
             timeout_seconds=self._timeout_seconds,
+            url_safety_checker=self._url_safety_checker,
         )
         if clicked:
             return LinkedInApplyResolution(clicked, "click")
@@ -360,6 +399,7 @@ def _click_and_capture_apply_target(
     original_job_url: str,
     *,
     timeout_seconds: float,
+    url_safety_checker: UrlSafetyChecker,
 ) -> str | None:
     popup = None
     try:
@@ -380,12 +420,14 @@ def _click_and_capture_apply_target(
                 popup,
                 original_job_url,
                 timeout_seconds=timeout_seconds,
+                url_safety_checker=url_safety_checker,
             )
         except PlaywrightTimeoutError:
             return _wait_for_external_apply_url(
                 page,
                 original_job_url,
                 timeout_seconds=timeout_seconds,
+                url_safety_checker=url_safety_checker,
             )
     except Exception as exc:
         log.debug("LinkedIn apply click capture failed for %s: %s", original_job_url, exc)
@@ -403,6 +445,7 @@ def _wait_for_external_apply_url(
     original_job_url: str,
     *,
     timeout_seconds: float,
+    url_safety_checker: UrlSafetyChecker,
 ) -> str | None:
     deadline = time.monotonic() + timeout_seconds
     last_url = ""
@@ -412,10 +455,14 @@ def _wait_for_external_apply_url(
         except Exception:
             current = ""
         if current and current != last_url:
-            extracted = _extract_external_from_redirect_url(current, original_job_url)
+            extracted = _extract_external_from_redirect_url(
+                current,
+                original_job_url,
+                url_safety_checker=url_safety_checker,
+            )
             if extracted:
                 return extracted
-            if _is_external_apply_url(current, original_job_url):
+            if _is_safe_external_apply_url(current, original_job_url, url_safety_checker):
                 return current
             last_url = current
         try:
@@ -425,7 +472,12 @@ def _wait_for_external_apply_url(
     return None
 
 
-def _extract_external_from_redirect_url(url: str, original_job_url: str) -> str | None:
+def _extract_external_from_redirect_url(
+    url: str,
+    original_job_url: str,
+    *,
+    url_safety_checker: UrlSafetyChecker = validate_public_http_url,
+) -> str | None:
     """Extract an external target embedded inside a redirect/tracking URL."""
 
     if not url:
@@ -436,7 +488,7 @@ def _extract_external_from_redirect_url(url: str, original_job_url: str) -> str 
         if normalized_key not in _EXTERNAL_URL_PARAM_NAMES:
             continue
         candidate = unquote(value.strip())
-        if _is_external_apply_url(candidate, original_job_url):
+        if _is_safe_external_apply_url(candidate, original_job_url, url_safety_checker):
             return candidate
     return None
 
@@ -455,6 +507,32 @@ def _is_external_apply_url(candidate_url: str, original_job_url: str) -> bool:
     if original_host and host == original_host:
         return False
     return True
+
+
+def _is_safe_external_apply_url(
+    candidate_url: str,
+    original_job_url: str,
+    url_safety_checker: UrlSafetyChecker,
+) -> bool:
+    if not _is_external_apply_url(candidate_url, original_job_url):
+        return False
+    decision = url_safety_checker(candidate_url)
+    if decision.allowed:
+        return True
+    log.debug(
+        "Rejected LinkedIn apply resolver target %s: %s",
+        candidate_url,
+        decision.reason or "URL is not a public HTTP(S) destination",
+    )
+    return False
+
+
+def _unsafe_url_resolution(reason: str | None) -> LinkedInApplyResolution:
+    return LinkedInApplyResolution(
+        None,
+        "unsafe_url",
+        reason or "URL is not a public HTTP(S) destination",
+    )
 
 
 def _is_linkedin_host(host: str) -> bool:

--- a/workers/automation/tests/test_linkedin_apply_resolver.py
+++ b/workers/automation/tests/test_linkedin_apply_resolver.py
@@ -1,9 +1,23 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from jobctrl.infrastructure.network import PublicUrlDecision
 from jobctrl.infrastructure.enrichment.linkedin_apply_resolver import (
+    LinkedInApplyUrlResolver,
     _extract_external_from_redirect_url,
     _is_external_apply_url,
 )
+
+
+def _allow_public_url(_url: str) -> PublicUrlDecision:
+    return PublicUrlDecision(True)
+
+
+def _deny_loopback_url(url: str) -> PublicUrlDecision:
+    if "127.0.0.1" in url or "localhost" in url or "169.254.169.254" in url:
+        return PublicUrlDecision(False, "non-public test target")
+    return PublicUrlDecision(True)
 
 
 def test_external_apply_url_rejects_linkedin_hosts() -> None:
@@ -28,8 +42,13 @@ def test_extract_external_url_from_linkedin_redirect_query() -> None:
         "url=https%3A%2F%2Fjobs.ashbyhq.com%2Facme%2Frole"
     )
 
-    assert _extract_external_from_redirect_url(redirect, original) == (
-        "https://jobs.ashbyhq.com/acme/role"
+    assert (
+        _extract_external_from_redirect_url(
+            redirect,
+            original,
+            url_safety_checker=_allow_public_url,
+        )
+        == "https://jobs.ashbyhq.com/acme/role"
     )
 
 
@@ -41,3 +60,127 @@ def test_extract_external_url_ignores_linkedin_redirect_target() -> None:
     )
 
     assert _extract_external_from_redirect_url(redirect, original) is None
+
+
+def test_extract_external_url_rejects_non_public_redirect_target() -> None:
+    original = "https://www.linkedin.com/jobs/view/123"
+    redirect = (
+        "https://www.linkedin.com/jobs/apply/123?"
+        "url=http%3A%2F%2F127.0.0.1%3A8766%2Fv1%2Fprofile"
+    )
+
+    assert (
+        _extract_external_from_redirect_url(
+            redirect,
+            original,
+            url_safety_checker=_deny_loopback_url,
+        )
+        is None
+    )
+
+
+class _ExplodingContext:
+    def new_page(self) -> object:
+        raise AssertionError("unsafe resolver URL must be blocked before opening a page")
+
+
+def test_resolve_blocks_unsafe_job_url_before_opening_page() -> None:
+    resolver = LinkedInApplyUrlResolver(
+        url_safety_checker=lambda _url: PublicUrlDecision(False, "non-public test target")
+    )
+    resolver._context = _ExplodingContext()
+
+    result = resolver.resolve("http://127.0.0.1:8766/jobs/view/123")
+
+    assert result.application_url is None
+    assert result.method == "unsafe_url"
+    assert result.error == "non-public test target"
+
+
+class _AbortRoute:
+    aborted = False
+    continued = False
+
+    def abort(self, _code: str | None = None) -> None:
+        self.aborted = True
+
+    def continue_(self) -> None:
+        self.continued = True
+
+
+class _RouteBlockedPage:
+    url = "https://www.linkedin.com/jobs/view/123"
+
+    def __init__(self) -> None:
+        self._handler = None
+        self.closed = False
+        self.unrouted = False
+
+    def route(self, _pattern: str, handler) -> None:  # noqa: ANN001 - Playwright-shaped double
+        self._handler = handler
+
+    def unroute(self, _pattern: str, _handler) -> None:  # noqa: ANN001 - Playwright-shaped double
+        self.unrouted = True
+
+    def goto(self, _url: str, **_kwargs: object) -> object:
+        assert self._handler is not None
+        route = _AbortRoute()
+        self._handler(route, SimpleNamespace(url="http://127.0.0.1:8766/v1/profile"))
+        assert route.aborted
+        raise RuntimeError("net::ERR_BLOCKED_BY_CLIENT")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_resolve_installs_public_route_guard_before_navigation() -> None:
+    page = _RouteBlockedPage()
+    resolver = LinkedInApplyUrlResolver(url_safety_checker=_allow_public_url)
+    resolver._context = SimpleNamespace(new_page=lambda: page)
+
+    result = resolver.resolve("https://www.linkedin.com/jobs/view/123")
+
+    assert result.application_url is None
+    assert result.method == "unsafe_url"
+    assert "public" in str(result.error)
+    assert page.unrouted is True
+    assert page.closed is True
+
+
+class _VisibleApplyLocator:
+    def wait_for(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def get_attribute(self, *_args: object, **_kwargs: object) -> str:
+        return "http://127.0.0.1:8766/v1/profile"
+
+
+class _LoadedPageWithUnsafeHref:
+    url = "https://www.linkedin.com/jobs/view/123"
+
+    def __init__(self) -> None:
+        self._locator = _VisibleApplyLocator()
+
+    def route(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def unroute(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    def locator(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(first=self._locator)
+
+    def get_by_role(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(first=self._locator)
+
+
+def test_resolve_loaded_page_rejects_unsafe_href_before_returning_it() -> None:
+    resolver = LinkedInApplyUrlResolver(url_safety_checker=_deny_loopback_url)
+
+    result = resolver.resolve_loaded_page(
+        _LoadedPageWithUnsafeHref(),
+        "https://www.linkedin.com/jobs/view/123",
+    )
+
+    assert result.application_url is None
+    assert result.method == "external_url_missing"


### PR DESCRIPTION
## Summary

- Validate the LinkedIn apply resolver starting URL before opening a browser page.
- Install the existing public HTTP(S) Playwright route guard around authenticated LinkedIn apply navigation and loaded-page click capture.
- Validate redirect, href, current-page, and popup targets before returning an external apply URL.
- Add focused offline regression coverage for unsafe redirect targets, pre-navigation blocking, route-guard blocking, and unsafe href rejection.

## Root Cause

The authenticated LinkedIn apply resolver reused the public-destination URL policy indirectly in nearby enrichment paths, but did not enforce that policy across its own browser navigation and captured target URLs. A non-public target could be reached or returned after the initial LinkedIn page was loaded.

## Documentation

No documentation update: this is a security bug fix that preserves the existing public-destination safety model rather than adding a new user-facing capability or command.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/python -m pytest -q workers/automation/tests/test_linkedin_apply_resolver.py` -> `8 passed`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD/workers/automation/src /Users/eloibarti/Github/JobHunter/workers/automation/.venv/bin/ruff check workers/automation/src/jobctrl/infrastructure/enrichment/linkedin_apply_resolver.py workers/automation/tests/test_linkedin_apply_resolver.py` -> passed
- `git diff --check` -> passed