### PR TITLE
fix(security): validate local API peer address

### DIFF
--- a/apps/api/src/local-origin.ts
+++ b/apps/api/src/local-origin.ts
@@ -24,6 +24,25 @@ export function isLoopbackHostHeader(hostHeader: string | string[] | undefined):
   );
 }
 
+export function isLoopbackPeerAddress(peerAddress: string | undefined): boolean {
+  const normalized = peerAddress?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  if (normalized === "::1" || normalized === "0:0:0:0:0:0:0:1") {
+    return true;
+  }
+  if (normalized.startsWith("::ffff:")) {
+    return isLoopbackPeerAddress(normalized.slice("::ffff:".length));
+  }
+  const octets = normalized.split(".");
+  return (
+    octets.length === 4 &&
+    octets.every((octet) => /^\d{1,3}$/.test(octet) && Number.parseInt(octet, 10) <= 255) &&
+    Number.parseInt(octets[0] ?? "", 10) === 127
+  );
+}
+
 export function isTrustedMutationSource(
   originHeader: string | string[] | undefined,
   refererHeader: string | string[] | undefined,

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -233,6 +233,7 @@ import {
 } from "./resume-templates.js";
 import {
   isLoopbackHostHeader,
+  isLoopbackPeerAddress,
   isTrustedMutationSource,
   LOCAL_CORS_ALLOWED_HEADERS,
   LOCAL_CORS_METHODS,
@@ -367,6 +368,13 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
         ok: false,
         error: "forbidden_host",
         message: "Requests must target a loopback host (127.0.0.1, localhost, or [::1]).",
+      });
+    }
+    if (!isLoopbackPeerAddress(request.ip || request.raw.socket.remoteAddress)) {
+      return reply.code(403).send({
+        ok: false,
+        error: "forbidden_remote_client",
+        message: "Requests must originate from a loopback network address.",
       });
     }
     if (!UNSAFE_METHODS.has(request.method)) {

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -1044,6 +1044,22 @@ describe("local TypeScript API", () => {
     }
   });
 
+  it("rejects spoofed loopback Host headers from non-loopback peers", async () => {
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/v1/profile",
+        headers: { host: "127.0.0.1:8766" },
+        remoteAddress: "203.0.113.10",
+      });
+      expect(response.statusCode, response.body).toBe(403);
+      expect(response.json()).toMatchObject({ ok: false, error: "forbidden_remote_client" });
+    } finally {
+      await app.close();
+    }
+  });
+
   it("rejects DNS-rebinding Host headers that embed a loopback label in a foreign name", async () => {
     const app = buildApp(options);
     const rebindingHosts = [
@@ -1116,6 +1132,24 @@ describe("local TypeScript API", () => {
       for (const host of ["localhost", "localhost:8766", "127.0.0.1", "127.0.0.1:8766", "[::1]", "[::1]:8766"]) {
         const response = await app.inject({ method: "GET", url: "/v1/health", headers: { host } });
         expect(response.statusCode, `${host}: ${response.body}`).toBe(200);
+        expect(response.json()).toMatchObject({ ok: true });
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("allows loopback peer addresses with loopback Host headers", async () => {
+    const app = buildApp(options);
+    try {
+      for (const remoteAddress of ["127.0.0.1", "::1", "::ffff:127.0.0.1"]) {
+        const response = await app.inject({
+          method: "GET",
+          url: "/v1/health",
+          headers: { host: "127.0.0.1:8766" },
+          remoteAddress,
+        });
+        expect(response.statusCode, `${remoteAddress}: ${response.body}`).toBe(200);
         expect(response.json()).toMatchObject({ ok: true });
       }
     } finally {


### PR DESCRIPTION
## Summary
- require the accepted socket peer address to be loopback in addition to a loopback Host header
- reject spoofed loopback Host headers from remote clients with `forbidden_remote_client`
- cover IPv4, IPv6, and IPv4-mapped loopback peers with regression tests

## Validation
- corepack pnpm install
- corepack pnpm --filter @jobctrl/api exec vitest run test/server.test.ts -t "spoofed loopback|loopback peer|Host headers"
- corepack pnpm api:test
- corepack pnpm api:check
- corepack pnpm check
- corepack pnpm test
- git diff --check
