### PR TITLE
docs(readme): clarify Homebrew bootstrap flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,18 @@ the rest:
 curl -fsSL https://jobctrl.dev/install.sh | bash
 ```
 
-**Homebrew (beta, HEAD-only until the first tagged formula)** — installs the
-toolchain and a global `jobctrl` launcher:
+**Homebrew (beta, HEAD-only until the first tagged formula)** — install the
+toolchain and global `jobctrl` launcher first, then bootstrap the app checkout:
 
 ```bash
-brew install ebarti/tap/jobctrl --HEAD && jobctrl bootstrap
+brew install ebarti/tap/jobctrl --HEAD
+jobctrl bootstrap
 ```
+
+`--HEAD` is required only because the tap does not have a stable tagged formula
+yet; it installs the launcher from `main`. After the first tagged formula, the
+install command becomes `brew install ebarti/tap/jobctrl`, while
+`jobctrl bootstrap` remains the next step that clones and configures JobCtrl.
 
 > Published to [`ebarti/homebrew-tap`](https://github.com/ebarti/homebrew-tap)
 > from the canonical formula at `packaging/homebrew/Formula/jobctrl.rb` — also


### PR DESCRIPTION
## What changed

- Split the Homebrew install and first-run bootstrap commands into explicit sequential steps.
- Explain why the beta formula currently requires `--HEAD`.
- Clarify that `jobctrl bootstrap` remains required after the future stable formula is published.

## Why

The previous one-line command was functionally correct, but it obscured the distribution boundary: Homebrew installs the toolchain and launcher, while bootstrap creates and configures the user-owned JobCtrl checkout.

## Validation

- `pnpm docs:build`
- `pnpm docs:check:runtime`
- `python3 scripts/release_check.py`
- `node --test scripts/get.test.mjs` (7/7)
- `bash -n scripts/jobctrl-launcher scripts/get`
- `ruby -c packaging/homebrew/Formula/jobctrl.rb`
- `git diff --check`
- Independent documentation review: PASS, no findings
- Independent QA: PASS, no findings
