### PR TITLE
build(distribution): lock bundled release contract

### DIFF
--- a/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
+++ b/docs/plans/2026-07-10-bundled-jobctrl-distribution-plan.md
@@ -43,6 +43,7 @@ jobctrl open
 jobctrl setup
 jobctrl init
 jobctrl doctor
+jobctrl pipeline-status
 jobctrl <domain-command>
 
 jobctrl version
@@ -117,9 +118,11 @@ layers. A README-only rewrite would hide the defect without resolving it.
 
 ## 2. Current dependency and footprint baseline
 
-Planning measurements from the 2026-07-10 reference checkout are directional;
-Phase 0 must reproduce them with a checked-in measurement script before any size
-claim is published.
+Planning measurements from the 2026-07-10 reference checkout are directional.
+Phase 0 reproduces dependency counts and preserves the footprint observations
+with their measurement context; it does not treat machine-specific source
+footprints as reproducible release sizes. Phase 1 measures the first production
+payload from clean builds before any packaged-size claim is published.
 
 | Current source-install component | Observed logical footprint / count |
 | --- | --- |
@@ -130,6 +133,13 @@ claim is published.
 | Homebrew dependency closure | 72 formulae; approximately 1.18 GiB on the reference machine |
 | Google Chrome | approximately 1.3 GiB on the reference machine; should be excluded when authenticated browser features are disabled |
 | Source archive | approximately 23 MiB compressed |
+
+The JavaScript count in that planning snapshot predates the Phase 0 manifest
+validator. The checked-in Phase 0 audit reports 82 unique direct packages and
+40 direct development packages because it adds Ajv for full JSON Schema 2020-12
+validation; runtime-direct dependencies remain 44 and pnpm lock records remain
+1,428. `source-baseline.json` records that reproducible current count separately
+from the historical footprint observation.
 
 The current cold-machine path is therefore roughly **5–6 GiB before download
 caches**, depending on what was already present. This is not the target package
@@ -161,6 +171,9 @@ The release pipeline must publish, for every artifact:
   model as the supervisor.
 - Existing Typer domain commands are dispatched through the embedded Python
   runtime without showing its path or requiring a working directory.
+- The current Python `jobctrl status` pipeline-statistics command is preserved
+  as `jobctrl pipeline-status` (and a one-release `jobctrl status --pipeline`
+  compatibility form) so lifecycle status does not silently destroy user value.
 - Public commands never shell out to user-installed `git`, `node`, `pnpm`,
   `corepack`, `uv`, `python`, `temporal`, `pdftoppm`, or `npx`.
 
@@ -180,6 +193,10 @@ The release pipeline must publish, for every artifact:
   from its official distribution channel, pinned by version and hash, and stored
   as a JobCtrl-managed provider pack.
 - Users never run pip, uv, npm, npx, or a vendor CLI to install those packs.
+- A managed provider pack does not imply permission to reuse consumer
+  subscription credentials. Bundled Claude setup accepts Anthropic API-key or
+  supported cloud-provider authentication; it does not route Free, Pro, or Max
+  Claude Code credentials through the Agent SDK.
 - Credentials are never bundled, copied into release artifacts, or included in
   logs.
 
@@ -205,7 +222,8 @@ capabilities are disabled.
   placed inside a release directory.
 - Runtime files live in a separate versioned store, configurable through
   `JOBCTRL_RUNTIME_HOME`.
-- Upgrades back up the SQLite database before migration.
+- Upgrades back up both the JobCtrl SQLite database and the persistent Temporal
+  SQLite database before migration or candidate startup.
 - A failed health gate atomically returns to the previous runtime.
 - `jobctrl uninstall` preserves user data by default.
 - `jobctrl uninstall --remove-data` requires an explicit destructive
@@ -265,11 +283,11 @@ jobctrl-<version>-darwin-arm64/
     runtimes/node/
     runtimes/python/
     runtimes/temporal/
-    runtimes/poppler/
     browsers/core/
     node_modules/@playwright/mcp/
-    licenses/
-    sbom.cdx.json
+    release-metadata/
+      licenses/
+      sbom.cdx.json
 ```
 
 The exact internal layout may change; the manifest and public command contract
@@ -286,8 +304,8 @@ may not.
   dependencies. pytest, Ruff, build tooling, and package-manager caches do not
   ship.
 - Include the Temporal server binary privately; it is never required on `PATH`.
-- Include Poppler privately for the current PDF-page preview adapter. A later
-  replacement is allowed, but user installation of Poppler is not.
+- Replace the sole Poppler-backed PDF-page image route with the web app's
+  existing PDF.js renderer. Poppler is neither bundled nor a user prerequisite.
 - Install exactly one Python Playwright Chromium revision under a private,
   versioned `PLAYWRIGHT_BROWSERS_PATH`.
 - Include the pinned `@playwright/mcp` package under the embedded Node runtime;
@@ -317,8 +335,9 @@ artifact gate passes.
 - Add a machine-readable bundle manifest schema with app version, build ID,
   platform, minimum OS, component versions, hashes, sizes, licenses, and
   required/optional capability flags.
-- Add a reproducible dependency/footprint report for source install and
-  production payload.
+- Add a reproducible source-dependency count report and a separately labeled,
+  observational source-install footprint baseline. Define the production
+  payload measurement contract; Phase 1 supplies its build evidence.
 - Classify every shipped component as runtime, optional capability, provider
   pack, or developer-only.
 - Complete redistribution/license review, especially the Claude runtime,
@@ -329,10 +348,13 @@ artifact gate passes.
 **Tests and evidence**
 
 - Manifest schema unit tests.
-- Two identical builds from clean runners produce identical file inventories;
-  any unavoidable non-deterministic metadata is documented.
+- Deterministic inventory contract tests cover canonical ordering, hashing,
+  file-mode policy, safe relative symlinks, ownership, and rejection of
+  unclassified files.
+- External builder inputs are an exact, versioned, hash-pinned set; deleting or
+  substituting any required runtime archive fails the audit.
 - License inventory fails closed for unclassified files.
-- Baseline report reproduces or explains the measurements in `2.
+- Baseline report reproduces or explains the measurements in §2.
 
 **Exit criterion**
 
@@ -347,26 +369,40 @@ hash, size, and capability classification.
 - Build and serve the web app from the local API.
 - Compile the API and prune the Node production closure.
 - Build the relocatable Python worker/CLI runtime without the dev extra.
-- Embed Temporal and Poppler.
+- Embed Temporal and remove the Poppler-only server preview route in favor of
+  the existing client-side PDF.js renderer.
 - Bundle one Python Playwright Chromium revision and remove the Node Playwright
   browser install from the user artifact.
 - Bundle Playwright MCP with the private Node runtime and replace runtime `npx`
   dispatch with an absolute manifest-resolved command.
 - Build official-channel provider packs for components JobCtrl cannot
   redistribute.
+- Give bundled provider packs an explicit supported-auth policy; disable Claude
+  consumer-subscription credential probes while retaining Anthropic API key,
+  Bedrock, Vertex, and Foundry paths.
 - Emit the manifest, SBOM, attribution files, and component-size report.
 
 **Tests and evidence**
 
+- Two independently clean production payload builds produce identical file and
+  component inventories; any unavoidable non-deterministic metadata is
+  documented and excluded from the signed identity by an explicit rule.
+- The build reports compressed size, installed size, and per-component logical
+  size for the production payload, with deltas suitable for the release gate.
 - API unit tests cover static web serving, SPA fallback, cache headers, and path
   traversal rejection.
 - The extracted payload starts with user `PATH` reduced to stock OS locations.
 - A grep/exec audit proves no production path invokes the forbidden user
   toolchain commands.
+- Provider-pack tests prove bundled mode never reads Claude Free/Pro/Max OAuth
+  credentials and accepts only the documented API/cloud authentication paths.
 - A clean payload with network disabled can restart, discover a fixture,
   render a resume PDF, and render its page preview.
 - The artifact contains no web E2E browser, Storybook, docs, test fixtures,
   pytest/Ruff, package-manager cache, Git metadata, or source checkout.
+- Exact extracted-tree verification proves every regular file and safe relative
+  symlink is in the signed manifest and owned by one component; only the
+  manifest and its detached signature are fixed signed-envelope exclusions.
 
 **Exit criterion**
 
@@ -380,6 +416,8 @@ the repository or any system toolchain.
 - Add the Go `jobctrl` launcher and cross-process runtime registry.
 - Implement `start`, `stop`, `status`, `logs`, `open`, `version`, and
   transparent dispatch to the embedded Python CLI.
+- Rename the Python pipeline-statistics command to `pipeline-status` and retain
+  the documented compatibility form while native `status` owns lifecycle state.
 - Move production startup knowledge out of `scripts/dev` into an explicit
   runtime manifest consumed by the launcher.
 - Start Temporal, worker, and API in dependency order; the API serves the web
@@ -493,7 +531,8 @@ behavior.
   update/rollback does not depend on mutating a Homebrew Cellar.
 - Implement signed update metadata, download locking, resumable staging, atomic
   activation, previous-version retention, and health-gated promotion.
-- Back up SQLite before any schema migration and record the release/schema pair.
+- Back up both JobCtrl and Temporal SQLite state before any schema migration and
+  record the release/schema pair.
 - Implement rollback that restores the matching pre-upgrade database backup
   when the prior runtime cannot read the upgraded schema.
 - Implement safe uninstall and explicit data removal.
@@ -506,7 +545,8 @@ behavior.
 - Interrupt update at every staging/activation boundary; the prior release
   remains runnable.
 - Upgrade across a real schema migration, force the health gate to fail, and
-  prove automatic rollback restores both runtime and data coherently.
+  prove automatic rollback restores the runtime, JobCtrl data, and Temporal
+  workflow history coherently.
 - Concurrent update/start commands serialize correctly.
 - Uninstall preserves `~/.jobctrl` by default.
 - Old signed artifacts cannot be replayed below the configured minimum safe

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "docs:build": "node scripts/check-install-asset.mjs && vitepress build docs && node scripts/check-docs-site-links.mjs",
     "docs:check:runtime": "node scripts/check-docs-site-runtime.mjs",
     "docs:preview": "vitepress preview docs",
+    "distribution:audit": "node scripts/distribution-manifest.mjs audit",
+    "distribution:measure": "node scripts/distribution-manifest.mjs measure",
     "ttfv:real": "node scripts/ttfv-real.mjs run",
     "ttfv:probe": "node scripts/ttfv-real.mjs probe",
     "ttfv:summary": "node scripts/ttfv-real.mjs summarize",
@@ -73,6 +75,7 @@
   },
   "homepage": "https://github.com/ebarti/JobCtrl#readme",
   "devDependencies": {
+    "ajv": "8.20.0",
     "mermaid": "^11.16.0",
     "typescript": "^6.0.3",
     "vitepress": "^1.6.4",

--- a/packaging/distribution/LICENSE-REVIEW.md
+++ b/packaging/distribution/LICENSE-REVIEW.md
@@ -1,0 +1,53 @@
+# Distribution License Review
+
+This is the fail-closed distribution decision for every top-level component in
+`component-inventory.json`. It is an engineering release control, not legal
+advice. `bundle` means the named top-level component may enter a JobCtrl-built
+artifact only when its pinned source, license text, notices, and file ownership
+all pass the manifest checks. `official-download` means JobCtrl may download and
+verify the component from the named provider, but must not republish it.
+`exclude` means the component may not enter a user artifact.
+
+An unlisted component, a changed source or license, or an artifact without the
+required notice is denied by default. Update both this review and
+`component-inventory.json` before changing a distribution decision.
+
+## Top-level decisions
+
+| Component | Inventory class | Inventory license | Inventory decision | Release gate |
+| --- | --- | --- | --- | --- |
+| `jobctrl-launcher` | `core-runtime` | `AGPL-3.0-only` | `bundle` | Ship JobCtrl license and Go standard-library notices from the release SBOM. |
+| `jobctrl-api` | `core-runtime` | `AGPL-3.0-only` | `bundle` | Ship JobCtrl license; include its resolved production dependency notices. |
+| `jobctrl-web` | `core-runtime` | `AGPL-3.0-only` | `bundle` | Ship JobCtrl license; include bundled asset and production dependency notices. |
+| `jobctrl-worker` | `core-runtime` | `AGPL-3.0-only` | `bundle` | Ship JobCtrl license; include its resolved Python runtime dependency notices. |
+| `jobctrl-release-metadata` | `core-runtime` | `AGPL-3.0-only` | `bundle` | Own the generated SBOM, license texts, notices, provenance, and component-size report; fail when any payload file lacks attribution. |
+| `font-jetbrains-mono` | `core-runtime` | `OFL-1.1` | `bundle` | Embedded in `jobctrl-web`; ship the OFL text and JetBrains/Fontsource attribution. |
+| `font-plus-jakarta-sans` | `core-runtime` | `OFL-1.1` | `bundle` | Embedded in `jobctrl-web`; ship the OFL text and Tokotype/Fontsource attribution. |
+| `node-runtime` | `core-runtime` | `MIT` | `bundle` | Verify the pinned upstream archive and ship Node.js license and notices. |
+| `python-runtime` | `core-runtime` | `PSF-2.0` | `bundle` | Verify the pinned python-build-standalone archive and ship CPython plus included-library notices. |
+| `temporal-runtime` | `core-runtime` | `MIT` | `bundle` | Use the pinned upstream source/artifact built for the declared target; ship Temporal notices. |
+| `pdfjs-renderer` | `core-runtime` | `Apache-2.0` | `bundle` | Ship Apache-2.0 and required PDF.js notices. Poppler is not part of this component. |
+| `playwright-python` | `core-runtime` | `Apache-2.0` | `bundle` | Resolve the exact locked package and ship Playwright notices. |
+| `chromium-core` | `core-runtime` | `BSD-3-Clause` | `bundle` | Verify the pinned Playwright browser artifact and ship Chromium's complete third-party notices. |
+| `playwright-mcp` | `core-runtime` | `Apache-2.0` | `bundle` | Verify the exact locked npm artifact and ship its license and transitive notices. |
+| `system-browser-adapter` | `optional-capability` | `AGPL-3.0-only` | `bundle` | Embedded in `jobctrl-worker`; the adapter contains no browser or profile. Browser adoption requires explicit user enablement and consent. |
+| `claude-agent-sdk` | `provider-pack` | `MIT AND LicenseRef-Anthropic-Commercial-Terms` | `official-download` | The SDK package is MIT, while the included provider runtime remains subject to Anthropic's terms. No explicit redistribution grant for that runtime has been established. P1 may fetch and hash-verify the official wheel into a managed provider pack; JobCtrl releases must not republish it unless an explicit grant is recorded here. |
+| `codex-provider-runtime` | `provider-pack` | `Apache-2.0` | `official-download` | The exact wheel omits all license/notice files while embedding Codex, ripgrep, and patched zsh with separate terms. P1 may fetch and hash-verify it as a managed provider pack. Republishing remains denied until the Codex, ripgrep, zsh, and Rust transitive license/notice closure is recorded and shipped. |
+| `antigravity-provider-runtime` | `provider-pack` | `Apache-2.0` | `official-download` | The exact wheel includes its top-level license but embeds an internal-MPM `localharness` binary without a recoverable Go module or third-party notice closure. P1 may fetch and hash-verify it as a managed provider pack. Republishing remains denied until Google supplies the closure or written permission. |
+| `source-development-toolchain` | `developer-only` | `NOASSERTION` | `exclude` | Git, Go, pnpm, Corepack, uv, test, docs, and development tools never enter the user artifact. |
+| `poppler-source-compatibility` | `developer-only` | `GPL-2.0-only OR GPL-3.0-only` | `exclude` | P1 removes the Poppler-only preview route. Poppler must not enter the bundled user artifact. |
+
+## Transitive gate
+
+P0 records top-level ownership and the default distribution decision. It does
+not claim that a production payload's transitive closure has been cleared.
+
+- P1 must generate a complete CycloneDX SBOM and attribution directory from the
+  actual production payload. The builder fails on an unclassified file,
+  dependency, dynamic library, browser notice, font notice, or missing license.
+- P6 must rerun that policy on the exact signed artifact and block stable
+  promotion when the SBOM, attribution set, pinned-source evidence, or this
+  top-level decision is incomplete.
+- Provider terms are checked independently of an open-source package label.
+  Ambiguity resolves to `official-download` or `exclude`, never implicit
+  republication.

--- a/packaging/distribution/README.md
+++ b/packaging/distribution/README.md
@@ -1,0 +1,84 @@
+# Distribution Contract
+
+This directory is the machine-readable boundary between JobCtrl source
+development and the installed product.
+
+- `manifest.schema.json` defines the signed per-artifact manifest.
+- `component-inventory.json` classifies top-level runtime, optional-capability,
+  provider-pack, and developer-only components.
+- `components.lock.json` pins the six external runtime/browser archives that
+  sit outside pnpm and uv ecosystem lockfiles by immutable URL and SHA-256.
+- `capability-policy.json` fixes the required capabilities, their safe defaults,
+  and the bundled components each capability may invoke.
+- `platforms.json` defines supported targets, launcher compatibility, signing
+  policy, and the required core closure.
+- `source-baseline.json` records reproducible counts for the current source
+  dependency declarations separately from a commit-anchored observational
+  source-install footprint snapshot.
+- `LICENSE-REVIEW.md` records the fail-closed top-level license and
+  redistribution decision. It also identifies the transitive SBOM and
+  attribution gates that production builds and stable promotion must pass.
+- `signing-policy.json` names the required trust identities and records whether
+  stable promotion is externally unblocked; it never stores private material.
+- `scripts/distribution-manifest.mjs` validates these contracts and generates
+  deterministic file inventories and source/payload footprint reports.
+
+The inventory records top-level components; the release SBOM records every
+transitive package, binary, dynamic library, and license. A production builder
+must fail when a payload component is absent from the inventory, marked
+developer-only, not approved for bundling, or missing its required attribution.
+
+The manifest's `files` array covers every regular file and symbolic link except
+`manifest.json` itself and its detached `manifest.sig`; those two files form the
+signed envelope and cannot self-hash. SBOM, licenses, notices, provenance, and
+size reports live under the `jobctrl-release-metadata` component and are fully
+owned by the file inventory. Artifact verification must enumerate the extracted
+tree, allow only those two fixed envelope exclusions, and require exact equality
+with `files` before activation.
+
+Component `sha256` is the SHA-256 of its owned, printable-ASCII path-sorted
+records. Regular files encode as
+`path NUL file NUL file-sha256 NUL sizeBytes NUL mode LF`; symlinks encode as
+`path NUL symlink NUL relative-target NUL target-byte-length LF`. Component
+`sizeBytes` is the sum of regular-file sizes and symlink-target byte lengths.
+Component roots may not overlap,
+regular-file modes are normalized to `0644` or `0755`, and symlinks must be
+relative, normalized, non-cyclic, resolvable, and confined to their owning
+component. The ASCII path contract makes JavaScript and Go byte ordering
+identical while preserving the pinned Chromium app's signed framework links.
+All three current provider runtimes remain `official-download`: JobCtrl may
+fetch and verify their official artifacts into managed provider packs, but it
+cannot republish them until the component-specific evidence in
+`LICENSE-REVIEW.md` is complete. This preserves provider functionality without
+silently treating a package label as permission for its embedded binaries.
+
+## Initial platform gate
+
+The first release target is Apple-silicon macOS with a declared minimum of
+macOS 15.0. The floor is set by the full pinned provider/runtime closure, not by
+wheel tags; every Mach-O file is checked against that deployment target. Builder
+tools installed on a newer host are not assumed to be redistributable: for
+example, a Homebrew Temporal bottle compiled for the builder OS must not be
+copied into the artifact.
+
+Stable artifacts require:
+
+- a Developer ID Application signature on executable code;
+- an Ed25519-signed manifest;
+- notarization and stapling;
+- a complete CycloneDX SBOM and attribution directory;
+- checksums and provenance published beside the archive.
+
+Local artifacts remain explicitly unsigned and cannot be promoted to the stable
+channel. Prerelease artifacts use the same release manifest key, Developer ID
+code signature, and notarization gate as stable artifacts; stable promotion
+also requires `stableReleaseStatus` to be `ready`.
+
+## Commands
+
+```bash
+corepack pnpm distribution:audit
+corepack pnpm distribution:measure
+corepack pnpm distribution:measure -- --root /path/to/checkout
+corepack pnpm distribution:measure -- --artifact /path/to/extracted/payload
+```

--- a/packaging/distribution/capability-policy.json
+++ b/packaging/distribution/capability-policy.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "capabilities": [
+    {
+      "id": "core-browser",
+      "defaultEnabled": true,
+      "componentIds": ["chromium-core", "playwright-python"]
+    },
+    {
+      "id": "auto-apply-browser",
+      "defaultEnabled": false,
+      "componentIds": ["jobctrl-worker", "playwright-mcp"]
+    },
+    {
+      "id": "authenticated-linkedin-browser",
+      "defaultEnabled": false,
+      "componentIds": ["jobctrl-worker"]
+    }
+  ]
+}

--- a/packaging/distribution/component-inventory.json
+++ b/packaging/distribution/component-inventory.json
@@ -1,0 +1,223 @@
+{
+  "schemaVersion": 1,
+  "components": [
+    {
+      "id": "jobctrl-launcher",
+      "classification": "core-runtime",
+      "owner": "JobCtrl",
+      "versionSource": "package.json#version",
+      "source": "https://github.com/ebarti/JobCtrl",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Native Go launcher; Go toolchain and standard-library notices are recorded in the release SBOM."
+    },
+    {
+      "id": "jobctrl-api",
+      "classification": "core-runtime",
+      "owner": "JobCtrl",
+      "versionSource": "apps/api/package.json#version",
+      "source": "https://github.com/ebarti/JobCtrl/tree/main/apps/api",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": true
+    },
+    {
+      "id": "jobctrl-web",
+      "classification": "core-runtime",
+      "owner": "JobCtrl",
+      "versionSource": "apps/web/package.json#version",
+      "source": "https://github.com/ebarti/JobCtrl/tree/main/apps/web",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": true
+    },
+    {
+      "id": "jobctrl-worker",
+      "classification": "core-runtime",
+      "owner": "JobCtrl",
+      "versionSource": "workers/automation/pyproject.toml#project.version",
+      "source": "https://github.com/ebarti/JobCtrl/tree/main/workers/automation",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": true
+    },
+    {
+      "id": "jobctrl-release-metadata",
+      "classification": "core-runtime",
+      "owner": "JobCtrl",
+      "versionSource": "package.json#version",
+      "source": "https://github.com/ebarti/JobCtrl/tree/main/packaging/distribution",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Owns the payload SBOM, license texts, notices, provenance, and size report. The manifest and its detached signature are the only fixed signed-envelope exclusions from the manifest file list."
+    },
+    {
+      "id": "font-jetbrains-mono",
+      "classification": "core-runtime",
+      "owner": "JetBrains and Fontsource contributors",
+      "versionSource": "apps/web/package.json#dependencies.@fontsource-variable/jetbrains-mono",
+      "source": "https://github.com/fontsource/font-files/tree/main/fonts/variable/jetbrains-mono",
+      "license": "OFL-1.1",
+      "redistribution": "bundle",
+      "requiredInCore": false,
+      "embeddedIn": "jobctrl-web",
+      "notes": "Bundled web font. The OFL license text and font attribution must be present in the release."
+    },
+    {
+      "id": "font-plus-jakarta-sans",
+      "classification": "core-runtime",
+      "owner": "Tokotype and Fontsource contributors",
+      "versionSource": "apps/web/package.json#dependencies.@fontsource-variable/plus-jakarta-sans",
+      "source": "https://github.com/fontsource/font-files/tree/main/fonts/variable/plus-jakarta-sans",
+      "license": "OFL-1.1",
+      "redistribution": "bundle",
+      "requiredInCore": false,
+      "embeddedIn": "jobctrl-web",
+      "notes": "Bundled web font. The OFL license text and font attribution must be present in the release."
+    },
+    {
+      "id": "node-runtime",
+      "classification": "core-runtime",
+      "owner": "OpenJS Foundation and Node.js contributors",
+      "version": "22.21.1",
+      "source": "https://nodejs.org/download/release/v22.21.1/",
+      "license": "MIT",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Pinned production runtime. The builder verifies the upstream archive hash before extraction."
+    },
+    {
+      "id": "python-runtime",
+      "classification": "core-runtime",
+      "owner": "Python Software Foundation",
+      "version": "3.12.12+20251209",
+      "source": "https://github.com/astral-sh/python-build-standalone/releases/tag/20251209",
+      "license": "PSF-2.0",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Relocatable CPython build. The archive URL and SHA-256 are pinned by the production builder."
+    },
+    {
+      "id": "temporal-runtime",
+      "classification": "core-runtime",
+      "owner": "Temporal Technologies Inc.",
+      "version": "1.7.3",
+      "source": "https://github.com/temporalio/cli/releases/tag/v1.7.3",
+      "license": "MIT",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Built for the declared deployment target; a host Homebrew binary is never copied blindly."
+    },
+    {
+      "id": "pdfjs-renderer",
+      "classification": "core-runtime",
+      "owner": "Mozilla and PDF.js contributors",
+      "versionSource": "pnpm-lock.yaml#pdfjs-dist",
+      "source": "https://github.com/mozilla/pdf.js",
+      "license": "Apache-2.0",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Client-side PDF rendering replaces the sole pdftoppm page-preview route, so Poppler is excluded from the user artifact."
+    },
+    {
+      "id": "playwright-python",
+      "classification": "core-runtime",
+      "owner": "Microsoft Corporation",
+      "versionSource": "workers/automation/uv.lock#playwright",
+      "source": "https://github.com/microsoft/playwright-python",
+      "license": "Apache-2.0",
+      "redistribution": "bundle",
+      "requiredInCore": true
+    },
+    {
+      "id": "chromium-core",
+      "classification": "core-runtime",
+      "owner": "The Chromium Authors",
+      "version": "145.0.7632.6",
+      "source": "https://playwright.azureedge.net/",
+      "license": "BSD-3-Clause",
+      "redistribution": "bundle",
+      "requiredInCore": true,
+      "notes": "Playwright revision 1208. Chromium third-party notices must be shipped verbatim."
+    },
+    {
+      "id": "playwright-mcp",
+      "classification": "core-runtime",
+      "owner": "Microsoft Corporation",
+      "version": "0.0.77",
+      "source": "https://www.npmjs.com/package/@playwright/mcp/v/0.0.77",
+      "license": "Apache-2.0",
+      "redistribution": "bundle",
+      "requiredInCore": true
+    },
+    {
+      "id": "system-browser-adapter",
+      "classification": "optional-capability",
+      "owner": "JobCtrl",
+      "versionSource": "package.json#version",
+      "source": "https://github.com/ebarti/JobCtrl",
+      "license": "AGPL-3.0-only",
+      "redistribution": "bundle",
+      "requiredInCore": false,
+      "embeddedIn": "jobctrl-worker",
+      "notes": "Contains no browser. It can adopt a user-selected Chrome or Chromium only after explicit capability enablement."
+    },
+    {
+      "id": "claude-agent-sdk",
+      "classification": "provider-pack",
+      "owner": "Anthropic PBC",
+      "versionSource": "workers/automation/uv.lock#claude-agent-sdk",
+      "source": "https://pypi.org/project/claude-agent-sdk/",
+      "license": "MIT AND LicenseRef-Anthropic-Commercial-Terms",
+      "redistribution": "official-download",
+      "requiredInCore": false,
+      "notes": "The wheel contains a proprietary Claude runtime. JobCtrl downloads and verifies the official wheel as a provider pack instead of republishing it. Bundled mode accepts only Anthropic-supported API-key or cloud-provider auth and does not reuse Free, Pro, or Max Claude Code credentials."
+    },
+    {
+      "id": "codex-provider-runtime",
+      "classification": "provider-pack",
+      "owner": "OpenAI",
+      "versionSource": "workers/automation/uv.lock#openai-codex-cli-bin",
+      "source": "https://pypi.org/project/openai-codex-cli-bin/",
+      "license": "Apache-2.0",
+      "redistribution": "official-download",
+      "requiredInCore": false,
+      "notes": "The exact wheel embeds Codex, ripgrep, and patched zsh without their license or notice files. JobCtrl may download and verify it as a managed provider pack; republishing remains denied until the full embedded closure and notices are recorded."
+    },
+    {
+      "id": "antigravity-provider-runtime",
+      "classification": "provider-pack",
+      "owner": "Google LLC",
+      "versionSource": "workers/automation/uv.lock#google-antigravity",
+      "source": "https://pypi.org/project/google-antigravity/",
+      "license": "Apache-2.0",
+      "redistribution": "official-download",
+      "requiredInCore": false,
+      "notes": "The exact wheel embeds an internal-MPM localharness binary without a recoverable module or third-party notice closure. JobCtrl may download and verify it as a managed provider pack; republishing remains denied until Google supplies that closure or written permission."
+    },
+    {
+      "id": "source-development-toolchain",
+      "classification": "developer-only",
+      "owner": "Multiple upstream projects",
+      "versionSource": "package.json#packageManager",
+      "source": "https://github.com/ebarti/JobCtrl/blob/main/docs/local-development.md",
+      "license": "NOASSERTION",
+      "redistribution": "exclude",
+      "requiredInCore": false,
+      "notes": "Git, Go, pnpm, Corepack, uv, TypeScript, Vite, Vitest, Storybook, VitePress, pytest, Ruff, and web/extension E2E browsers never enter the user artifact."
+    },
+    {
+      "id": "poppler-source-compatibility",
+      "classification": "developer-only",
+      "owner": "Poppler contributors",
+      "version": "26.07.0",
+      "source": "https://poppler.freedesktop.org/",
+      "license": "GPL-2.0-only OR GPL-3.0-only",
+      "redistribution": "exclude",
+      "requiredInCore": false,
+      "notes": "Temporary source-install compatibility only. Phase 1 removes the API pdftoppm route before the bundled user artifact is built."
+    }
+  ]
+}

--- a/packaging/distribution/components.lock.json
+++ b/packaging/distribution/components.lock.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "platform": "darwin-arm64",
+  "inputs": [
+    {
+      "id": "node-runtime-archive",
+      "componentId": "node-runtime",
+      "version": "22.21.1",
+      "url": "https://nodejs.org/dist/v22.21.1/node-v22.21.1-darwin-arm64.tar.gz",
+      "sha256": "c170d6554fba83d41d25a76cdbad85487c077e51fa73519e41ac885aa429d8af",
+      "archiveType": "tar.gz",
+      "license": "MIT"
+    },
+    {
+      "id": "python-runtime-archive",
+      "componentId": "python-runtime",
+      "version": "3.12.12+20251209",
+      "url": "https://github.com/astral-sh/python-build-standalone/releases/download/20251209/cpython-3.12.12%2B20251209-aarch64-apple-darwin-install_only_stripped.tar.gz",
+      "sha256": "7e162bf77f6c2ecd7602960162c1b867eb61ac348863546e66db632b5731a5ea",
+      "archiveType": "tar.gz",
+      "license": "PSF-2.0"
+    },
+    {
+      "id": "temporal-runtime-archive",
+      "componentId": "temporal-runtime",
+      "version": "1.7.3",
+      "url": "https://github.com/temporalio/cli/releases/download/v1.7.3/temporal_cli_1.7.3_darwin_arm64.tar.gz",
+      "sha256": "ed0357cd77aef432021556c36c3b68bfbe38b86677dd7db86575abd312dc56c7",
+      "archiveType": "tar.gz",
+      "license": "MIT"
+    },
+    {
+      "id": "chromium-core-browser-archive",
+      "componentId": "chromium-core",
+      "version": "145.0.7632.6",
+      "url": "https://cdn.playwright.dev/chrome-for-testing-public/145.0.7632.6/mac-arm64/chrome-mac-arm64.zip",
+      "sha256": "3dbf04e28a02079148e9c7417840a0c1d3903361eceeee7e7eb59ef77021bdb2",
+      "archiveType": "zip",
+      "license": "BSD-3-Clause"
+    },
+    {
+      "id": "chromium-core-headless-archive",
+      "componentId": "chromium-core",
+      "version": "145.0.7632.6",
+      "url": "https://cdn.playwright.dev/chrome-for-testing-public/145.0.7632.6/mac-arm64/chrome-headless-shell-mac-arm64.zip",
+      "sha256": "8510b9b1575538aa6a092ed16d981738b2ebf52c5e41ea4c54a7ce16756cdcf5",
+      "archiveType": "zip",
+      "license": "BSD-3-Clause"
+    },
+    {
+      "id": "playwright-mcp-archive",
+      "componentId": "playwright-mcp",
+      "version": "0.0.77",
+      "url": "https://registry.npmjs.org/@playwright/mcp/-/mcp-0.0.77.tgz",
+      "sha256": "32a2d506d50ebc7025f48bdb1c9ba6fecbc31e416e32c56d5c848504e023f984",
+      "archiveType": "tar.gz",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/packaging/distribution/manifest.schema.json
+++ b/packaging/distribution/manifest.schema.json
@@ -1,0 +1,268 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jobctrl.dev/schemas/distribution-manifest-v1.json",
+  "title": "JobCtrl distribution manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "appVersion",
+    "buildId",
+    "releaseChannel",
+    "sourceDateEpoch",
+    "platform",
+    "launcherCompatibility",
+    "components",
+    "capabilities",
+    "files",
+    "signing"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": 1
+    },
+    "appVersion": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$"
+    },
+    "buildId": {
+      "type": "string",
+      "pattern": "^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$"
+    },
+    "releaseChannel": {
+      "enum": ["local", "prerelease", "stable"]
+    },
+    "sourceDateEpoch": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "platform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "os", "arch", "minimumOsVersion"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+-[a-z0-9_]+$"
+        },
+        "os": {
+          "enum": ["darwin", "linux", "windows"]
+        },
+        "arch": {
+          "enum": ["arm64", "amd64"]
+        },
+        "minimumOsVersion": {
+          "type": "string",
+          "pattern": "^[0-9]+(?:\\.[0-9]+){1,2}$"
+        }
+      }
+    },
+    "launcherCompatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["minimum", "maximum"],
+      "properties": {
+        "minimum": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maximum": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/component"
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/capability"
+      }
+    },
+    "files": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/file"
+      }
+    },
+    "signing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "manifestAlgorithm",
+        "manifestKeyId",
+        "codeSigning",
+        "notarized"
+      ],
+      "properties": {
+        "manifestAlgorithm": {
+          "enum": ["ed25519"]
+        },
+        "manifestKeyId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "codeSigning": {
+          "enum": ["unsigned-local", "developer-id"]
+        },
+        "notarized": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "component": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "classification",
+        "version",
+        "owner",
+        "source",
+        "license",
+        "redistribution",
+        "path",
+        "sha256",
+        "sizeBytes",
+        "required"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+        },
+        "classification": {
+          "enum": ["core-runtime", "optional-capability", "provider-pack"]
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "pattern": "^https://"
+        },
+        "license": {
+          "type": "string",
+          "minLength": 1
+        },
+        "redistribution": {
+          "const": "bundle"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[ -~]+$"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "required": {
+          "type": "boolean"
+        }
+      }
+    },
+    "capability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "defaultEnabled", "componentIds"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]{1,63}$"
+        },
+        "defaultEnabled": {
+          "type": "boolean"
+        },
+        "componentIds": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "file": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/regularFile"
+        },
+        {
+          "$ref": "#/$defs/symlinkFile"
+        }
+      ]
+    },
+    "regularFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "path", "sha256", "sizeBytes", "mode"],
+      "properties": {
+        "type": {
+          "const": "file"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[ -~]+$"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["0644", "0755"]
+        }
+      }
+    },
+    "symlinkFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "path", "target", "sizeBytes"],
+      "properties": {
+        "type": {
+          "const": "symlink"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[ -~]+$"
+        },
+        "target": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "^[ -~]+$"
+        },
+        "sizeBytes": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    }
+  }
+}

--- a/packaging/distribution/platforms.json
+++ b/packaging/distribution/platforms.json
@@ -1,0 +1,60 @@
+{
+  "schemaVersion": 1,
+  "platforms": [
+    {
+      "id": "darwin-arm64",
+      "os": "darwin",
+      "arch": "arm64",
+      "minimumOsVersion": "15.0",
+      "status": "initial-release-target",
+      "launcherCompatibility": {
+        "minimum": 1,
+        "maximum": 1
+      },
+      "signing": {
+        "identity": "Developer ID Application",
+        "notarization": "required-for-stable"
+      },
+      "minimumOsEvidence": [
+        {
+          "componentId": "chromium-core",
+          "observedMinimum": "12.0",
+          "observedPath": "Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+          "method": "Mach-O LC_BUILD_VERSION"
+        },
+        {
+          "componentId": "claude-agent-sdk",
+          "observedMinimum": "13.0",
+          "observedPath": "claude_agent_sdk/_bundled/claude",
+          "method": "Mach-O LC_BUILD_VERSION"
+        },
+        {
+          "componentId": "antigravity-provider-runtime",
+          "observedMinimum": "14.0",
+          "observedPath": "google/antigravity/bin/localharness",
+          "method": "Mach-O LC_BUILD_VERSION"
+        },
+        {
+          "componentId": "codex-provider-runtime",
+          "observedMinimum": "15.0",
+          "observedPath": "codex-resources/zsh/bin/zsh",
+          "method": "Mach-O LC_BUILD_VERSION"
+        }
+      ],
+      "requiredComponents": [
+        "jobctrl-launcher",
+        "jobctrl-api",
+        "jobctrl-web",
+        "jobctrl-worker",
+        "jobctrl-release-metadata",
+        "node-runtime",
+        "python-runtime",
+        "temporal-runtime",
+        "pdfjs-renderer",
+        "playwright-python",
+        "chromium-core",
+        "playwright-mcp"
+      ]
+    }
+  ]
+}

--- a/packaging/distribution/signing-policy.json
+++ b/packaging/distribution/signing-policy.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "stableReleaseStatus": "blocked-awaiting-credentials",
+  "manifestSigning": {
+    "algorithm": "ed25519",
+    "keyId": "jobctrl-release-v1",
+    "publicKeyStatus": "unprovisioned",
+    "privateKeySecret": "JOBCTRL_RELEASE_SIGNING_KEY"
+  },
+  "appleSigning": {
+    "identityType": "Developer ID Application",
+    "teamIdStatus": "unprovisioned",
+    "certificateSecret": "JOBCTRL_APPLE_DEVELOPER_ID_P12",
+    "certificatePasswordSecret": "JOBCTRL_APPLE_DEVELOPER_ID_PASSWORD",
+    "notaryProfileSecret": "JOBCTRL_APPLE_NOTARY_PROFILE"
+  },
+  "channelRequirements": {
+    "local": {
+      "manifestKey": "local-development",
+      "codeSigning": "unsigned-local",
+      "notarized": false
+    },
+    "prerelease": {
+      "manifestKey": "release",
+      "codeSigning": "developer-id",
+      "notarized": true
+    },
+    "stable": {
+      "manifestKey": "release",
+      "codeSigning": "developer-id",
+      "notarized": true
+    }
+  },
+  "promotionRequirements": [
+    "manifest public key is embedded in the launcher and matches the protected private key",
+    "every nested Mach-O has a valid preserved vendor signature or an explicit JobCtrl signature",
+    "the outer archive passes Apple notarization and Gatekeeper verification",
+    "the downloaded candidate passes clean-machine QA before stable release publication"
+  ]
+}

--- a/packaging/distribution/source-baseline.json
+++ b/packaging/distribution/source-baseline.json
@@ -1,0 +1,85 @@
+{
+  "schemaVersion": 1,
+  "reproducibleCounts": {
+    "javascriptPackageFiles": 8,
+    "javascriptUniqueDirect": 82,
+    "javascriptUniqueRuntimeDirect": 44,
+    "javascriptUniqueDevelopmentDirect": 40,
+    "pnpmPackageRecords": 1428,
+    "pythonRuntimeDirect": 22,
+    "pythonDevelopmentDirect": 5,
+    "uvPackageRecords": 100
+  },
+  "referenceFootprint": {
+    "status": "observational",
+    "measurementContext": {
+      "referenceCommit": "771f40c057c2b4b92b46df3fbb9bd77c25867d73",
+      "recordedOn": "2026-07-10",
+      "platform": "darwin-arm64",
+      "scope": "source-development installation on the planning machine",
+      "interpretation": "Directional planning evidence, not a reproducible release size or release artifact report"
+    },
+    "logicalBytes": {
+      "nodeModules": 734377612,
+      "pythonEnvironment": 928475103
+    },
+    "observations": [
+      {
+        "id": "pnpm-workspace",
+        "value": 897,
+        "unit": "MiB",
+        "qualifier": "approximately",
+        "note": "Installed node_modules observation from the planning checkout; collection context differs from the regular-file logical-byte snapshot above."
+      },
+      {
+        "id": "python-worker-environment",
+        "value": 909,
+        "unit": "MiB",
+        "qualifier": "approximately",
+        "note": "Installed Python worker environment, including the source-development dependency closure."
+      },
+      {
+        "id": "playwright-browser-installations",
+        "value": 1.0,
+        "unit": "GiB",
+        "qualifier": "approximately",
+        "note": "Combined Node Playwright revision 1217 and Python Playwright revision 1208 browser installations."
+      },
+      {
+        "id": "uv-managed-python",
+        "value": 319,
+        "unit": "MiB",
+        "qualifier": "approximately",
+        "note": "Additional footprint when uv provisions Python."
+      },
+      {
+        "id": "homebrew-dependency-closure",
+        "value": 1.18,
+        "unit": "GiB",
+        "qualifier": "approximately",
+        "note": "Seventy-two formulae observed on the reference machine."
+      },
+      {
+        "id": "google-chrome",
+        "value": 1.3,
+        "unit": "GiB",
+        "qualifier": "approximately",
+        "optional": true,
+        "note": "System application observed on the reference machine; excluded when authenticated-browser capabilities are disabled."
+      },
+      {
+        "id": "source-archive",
+        "value": 23,
+        "unit": "MiB",
+        "qualifier": "approximately",
+        "note": "Compressed source checkout archive."
+      }
+    ],
+    "notes": [
+      "The exact logical-byte snapshot sums the planning checkout's files and excludes filesystem block overhead and download caches.",
+      "The approximate observations came from the original planning audit and may use a different filesystem accounting context; they explain the current cold-machine estimate rather than define a reproducible target.",
+      "Only reproducibleCounts is compared for source dependency drift in P0.",
+      "P1 measures the built production payload and its components from two clean builds; never reuse this source snapshot as a release artifact report."
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
 
   .:
     devDependencies:
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0

--- a/scripts/distribution-manifest.mjs
+++ b/scripts/distribution-manifest.mjs
@@ -1,0 +1,1078 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { lstat, readFile, readdir, readlink, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+
+const CLASSIFICATIONS = new Set([
+  "core-runtime",
+  "optional-capability",
+  "provider-pack",
+  "developer-only",
+]);
+const REDISTRIBUTION_MODES = new Set(["bundle", "official-download", "exclude"]);
+const MANIFEST_CLASSIFICATIONS = new Set([
+  "core-runtime",
+  "optional-capability",
+  "provider-pack",
+]);
+const RELEASE_CHANNELS = new Set(["local", "prerelease", "stable"]);
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]{1,63}$/;
+const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const PLATFORM_ID_PATTERN = /^[a-z0-9]+-[a-z0-9_]+$/;
+const OS_VERSION_PATTERN = /^[0-9]+(?:\.[0-9]+){1,2}$/;
+const SAFE_FILE_MODES = new Set(["0644", "0755"]);
+const EXPECTED_LOCK_INPUTS = new Map([
+  ["node-runtime-archive", "node-runtime"],
+  ["python-runtime-archive", "python-runtime"],
+  ["temporal-runtime-archive", "temporal-runtime"],
+  ["chromium-core-browser-archive", "chromium-core"],
+  ["chromium-core-headless-archive", "chromium-core"],
+  ["playwright-mcp-archive", "playwright-mcp"],
+]);
+const EXPECTED_CAPABILITY_POLICY = new Map([
+  ["core-browser", { defaultEnabled: true, componentIds: ["chromium-core", "playwright-python"] }],
+  ["auto-apply-browser", { defaultEnabled: false, componentIds: ["jobctrl-worker", "playwright-mcp"] }],
+  ["authenticated-linkedin-browser", { defaultEnabled: false, componentIds: ["jobctrl-worker"] }],
+]);
+
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function assertObject(value, label) {
+  invariant(value !== null && typeof value === "object" && !Array.isArray(value), `${label} must be an object`);
+  return value;
+}
+
+function assertString(value, label) {
+  invariant(typeof value === "string" && value.trim().length > 0, `${label} must be a non-empty string`);
+  return value;
+}
+
+function assertBoolean(value, label) {
+  invariant(typeof value === "boolean", `${label} must be a boolean`);
+  return value;
+}
+
+function assertInteger(value, label, minimum = 0) {
+  invariant(Number.isInteger(value) && value >= minimum, `${label} must be an integer >= ${minimum}`);
+  return value;
+}
+
+function assertUnique(values, label) {
+  invariant(new Set(values).size === values.length, `${label} must be unique`);
+}
+
+function bytewiseCompare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function assertExactKeys(value, allowedKeys, label) {
+  const object = assertObject(value, label);
+  const actual = Object.keys(object).sort(bytewiseCompare);
+  const expected = [...allowedKeys].sort(bytewiseCompare);
+  invariant(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${label} fields must be exactly [${expected.join(", ")}]; received [${actual.join(", ")}]`,
+  );
+  return object;
+}
+
+function assertAllowedKeys(value, allowedKeys, label) {
+  const object = assertObject(value, label);
+  const unexpected = Object.keys(object).filter((key) => !allowedKeys.includes(key)).sort(bytewiseCompare);
+  invariant(unexpected.length === 0, `${label} contains unexpected fields: ${unexpected.join(", ")}`);
+  return object;
+}
+
+export function assertSafeRelativePath(value, label = "path") {
+  assertString(value, label);
+  invariant(!value.includes("\0"), `${label} must not contain NUL`);
+  invariant(!/[\u0000-\u001f\u007f]/.test(value), `${label} must not contain control characters`);
+  invariant(/^[\x20-\x7e]+$/.test(value), `${label} must contain printable ASCII only`);
+  invariant(!value.includes("\\"), `${label} must use POSIX separators`);
+  invariant(!path.posix.isAbsolute(value), `${label} must be relative`);
+  const normalized = path.posix.normalize(value);
+  invariant(normalized === value, `${label} must be normalized`);
+  invariant(value !== "." && value !== ".." && !value.startsWith("../"), `${label} escapes the payload root`);
+  return value;
+}
+
+export function resolveSafeSymlinkTarget(targetValue, linkPathValue) {
+  const target = assertString(targetValue, "symlink target");
+  const linkPath = assertSafeRelativePath(linkPathValue, "symlink path");
+  invariant(!target.includes("\\"), `${linkPath}: symlink target must use POSIX separators`);
+  invariant(!/[\u0000-\u001f\u007f]/.test(target), `${linkPath}: symlink target must not contain control characters`);
+  invariant(/^[\x20-\x7e]+$/.test(target), `${linkPath}: symlink target must contain printable ASCII only`);
+  invariant(!path.posix.isAbsolute(target), `${linkPath}: symlink target must be relative`);
+  invariant(path.posix.normalize(target) === target, `${linkPath}: symlink target must be normalized`);
+  invariant(target !== "." && target.length > 0, `${linkPath}: symlink target is invalid`);
+  const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(linkPath), target));
+  assertSafeRelativePath(resolved, `${linkPath}: resolved symlink target`);
+  return resolved;
+}
+
+async function loadJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+export async function loadDistributionContracts(root = REPO_ROOT) {
+  const distributionDir = path.join(root, "packaging", "distribution");
+  const [schema, inventory, platforms, componentLocks, capabilityPolicy, sourceBaseline, signingPolicy] = await Promise.all([
+    loadJson(path.join(distributionDir, "manifest.schema.json")),
+    loadJson(path.join(distributionDir, "component-inventory.json")),
+    loadJson(path.join(distributionDir, "platforms.json")),
+    loadJson(path.join(distributionDir, "components.lock.json")),
+    loadJson(path.join(distributionDir, "capability-policy.json")),
+    loadJson(path.join(distributionDir, "source-baseline.json")),
+    loadJson(path.join(distributionDir, "signing-policy.json")),
+  ]);
+  return { schema, inventory, platforms, componentLocks, capabilityPolicy, sourceBaseline, signingPolicy };
+}
+
+export function compileManifestSchema(schema) {
+  assertObject(schema, "manifest schema");
+  invariant(schema.$schema === "https://json-schema.org/draft/2020-12/schema", "manifest schema must use JSON Schema 2020-12");
+  invariant(schema.type === "object" && schema.additionalProperties === false, "manifest schema must be a closed object");
+  invariant(Array.isArray(schema.required), "manifest schema.required must be an array");
+  for (const key of [
+    "schemaVersion",
+    "appVersion",
+    "buildId",
+    "releaseChannel",
+    "sourceDateEpoch",
+    "platform",
+    "launcherCompatibility",
+    "components",
+    "capabilities",
+    "files",
+    "signing",
+  ]) {
+    invariant(schema.required.includes(key), `manifest schema is missing required field ${key}`);
+  }
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  return ajv.compile(schema);
+}
+
+function schemaErrors(validator) {
+  return (validator.errors ?? [])
+    .map((error) => `${error.instancePath || "/"} ${error.message}`)
+    .join("; ");
+}
+
+export function validateComponentInventory(inventory) {
+  assertExactKeys(inventory, ["schemaVersion", "components"], "component inventory");
+  invariant(inventory.schemaVersion === 1, "component inventory schemaVersion must be 1");
+  invariant(Array.isArray(inventory.components) && inventory.components.length > 0, "component inventory must not be empty");
+  const ids = inventory.components.map((component) => component.id);
+  assertUnique(ids, "component inventory ids");
+
+  for (const componentValue of inventory.components) {
+    const component = assertAllowedKeys(
+      componentValue,
+      ["id", "classification", "owner", "version", "versionSource", "source", "license", "redistribution", "requiredInCore", "embeddedIn", "notes"],
+      "component inventory entry",
+    );
+    const id = assertString(component.id, "component id");
+    invariant(ID_PATTERN.test(id), `component id is invalid: ${id}`);
+    invariant(CLASSIFICATIONS.has(component.classification), `${id}: unknown classification ${component.classification}`);
+    assertString(component.owner, `${id}.owner`);
+    assertString(component.source, `${id}.source`);
+    invariant(component.source.startsWith("https://"), `${id}.source must use HTTPS`);
+    assertString(component.license, `${id}.license`);
+    invariant(REDISTRIBUTION_MODES.has(component.redistribution), `${id}: unknown redistribution mode ${component.redistribution}`);
+    assertBoolean(component.requiredInCore, `${id}.requiredInCore`);
+    const versionFields = [component.version, component.versionSource].filter(
+      (value) => typeof value === "string" && value.length > 0,
+    );
+    invariant(versionFields.length === 1, `${id}: define exactly one of version or versionSource`);
+    if (component.notes !== undefined) assertString(component.notes, `${id}.notes`);
+
+    if (component.requiredInCore) {
+      invariant(component.classification === "core-runtime", `${id}: required core component must be core-runtime`);
+      invariant(component.redistribution === "bundle", `${id}: required core component must be approved for bundling`);
+    }
+    if (component.classification === "developer-only") {
+      invariant(component.redistribution === "exclude", `${id}: developer-only component must be excluded`);
+      invariant(component.requiredInCore === false, `${id}: developer-only component cannot be required`);
+    }
+    if (component.redistribution === "official-download") {
+      invariant(component.requiredInCore === false, `${id}: official-download component cannot be required in the core artifact`);
+    }
+  }
+  const inventoryById = new Map(inventory.components.map((component) => [component.id, component]));
+  for (const component of inventory.components) {
+    if (component.embeddedIn === undefined) continue;
+    const parentId = assertString(component.embeddedIn, `${component.id}.embeddedIn`);
+    const parent = inventoryById.get(parentId);
+    invariant(parent, `${component.id}: embeddedIn references unknown component ${parentId}`);
+    invariant(parentId !== component.id, `${component.id}: component cannot embed itself`);
+    invariant(component.redistribution === "bundle", `${component.id}: embedded component must be approved for bundling`);
+    invariant(parent.redistribution === "bundle", `${component.id}: embeddedIn target must be approved for bundling`);
+    invariant(parent.classification !== "developer-only", `${component.id}: embeddedIn target cannot be developer-only`);
+    invariant(parent.embeddedIn === undefined, `${component.id}: embedded component chains are not supported`);
+    invariant(component.requiredInCore === false, `${component.id}: embedded component cannot be a top-level required component`);
+  }
+
+  return inventoryById;
+}
+
+export function validateCapabilityPolicy(policyValue, inventoryById) {
+  const policy = assertExactKeys(policyValue, ["schemaVersion", "capabilities"], "capability policy");
+  invariant(policy.schemaVersion === 1, "capability policy schemaVersion must be 1");
+  invariant(Array.isArray(policy.capabilities), "capability policy capabilities must be an array");
+  const ids = policy.capabilities.map((capability) => capability.id);
+  assertUnique(ids, "capability policy ids");
+  invariant(ids.length === EXPECTED_CAPABILITY_POLICY.size, "capability policy must contain the complete required capability set");
+
+  const capabilitiesById = new Map();
+  for (const capabilityValue of policy.capabilities) {
+    const capability = assertExactKeys(
+      capabilityValue,
+      ["id", "defaultEnabled", "componentIds"],
+      "capability policy entry",
+    );
+    const id = assertString(capability.id, "capability policy id");
+    invariant(ID_PATTERN.test(id), `invalid capability policy id ${id}`);
+    const expected = EXPECTED_CAPABILITY_POLICY.get(id);
+    invariant(expected, `capability policy contains unknown capability ${id}`);
+    assertBoolean(capability.defaultEnabled, `${id}.defaultEnabled`);
+    invariant(capability.defaultEnabled === expected.defaultEnabled, `${id}: unsafe defaultEnabled value`);
+    invariant(Array.isArray(capability.componentIds) && capability.componentIds.length > 0, `${id}.componentIds must not be empty`);
+    assertUnique(capability.componentIds, `${id}.componentIds`);
+    const componentIds = [...capability.componentIds].sort(bytewiseCompare);
+    const expectedIds = [...expected.componentIds].sort(bytewiseCompare);
+    invariant(JSON.stringify(componentIds) === JSON.stringify(expectedIds), `${id}: component closure does not match the required policy`);
+    for (const componentId of componentIds) {
+      const component = inventoryById.get(componentId);
+      invariant(component, `${id}: unknown component ${componentId}`);
+      invariant(component.redistribution === "bundle", `${id}: ${componentId} is not approved for bundling`);
+      invariant(component.embeddedIn === undefined, `${id}: embedded component ${componentId} cannot be a capability root`);
+    }
+    capabilitiesById.set(id, { ...capability, componentIds });
+  }
+  return capabilitiesById;
+}
+
+export function validatePlatforms(platformsValue, inventoryById) {
+  const platforms = assertExactKeys(platformsValue, ["schemaVersion", "platforms"], "platform contract");
+  invariant(platforms.schemaVersion === 1, "platform contract schemaVersion must be 1");
+  invariant(Array.isArray(platforms.platforms) && platforms.platforms.length > 0, "platform list must not be empty");
+  const ids = platforms.platforms.map((platform) => platform.id);
+  assertUnique(ids, "platform ids");
+
+  for (const platformValue of platforms.platforms) {
+    const platform = assertExactKeys(
+      platformValue,
+      ["id", "os", "arch", "minimumOsVersion", "status", "launcherCompatibility", "signing", "minimumOsEvidence", "requiredComponents"],
+      "platform",
+    );
+    invariant(PLATFORM_ID_PATTERN.test(assertString(platform.id, "platform.id")), `invalid platform id ${platform.id}`);
+    invariant(["darwin", "linux", "windows"].includes(platform.os), `${platform.id}: unsupported os ${platform.os}`);
+    invariant(["arm64", "amd64"].includes(platform.arch), `${platform.id}: unsupported arch ${platform.arch}`);
+    invariant(OS_VERSION_PATTERN.test(platform.minimumOsVersion), `${platform.id}: invalid minimumOsVersion`);
+    assertString(platform.status, `${platform.id}.status`);
+    const compatibility = assertExactKeys(
+      platform.launcherCompatibility,
+      ["minimum", "maximum"],
+      `${platform.id}.launcherCompatibility`,
+    );
+    assertInteger(compatibility.minimum, `${platform.id}.launcherCompatibility.minimum`, 1);
+    assertInteger(compatibility.maximum, `${platform.id}.launcherCompatibility.maximum`, 1);
+    invariant(compatibility.maximum >= compatibility.minimum, `${platform.id}: launcher compatibility range is inverted`);
+    const signing = assertExactKeys(platform.signing, ["identity", "notarization"], `${platform.id}.signing`);
+    assertString(signing.identity, `${platform.id}.signing.identity`);
+    assertString(signing.notarization, `${platform.id}.signing.notarization`);
+    invariant(Array.isArray(platform.minimumOsEvidence) && platform.minimumOsEvidence.length > 0, `${platform.id}: minimumOsEvidence must not be empty`);
+    let highestObservedMinimum = "0.0";
+    for (const evidenceValue of platform.minimumOsEvidence) {
+      const evidence = assertExactKeys(
+        evidenceValue,
+        ["componentId", "observedMinimum", "observedPath", "method"],
+        `${platform.id}.minimumOsEvidence`,
+      );
+      invariant(inventoryById.has(evidence.componentId), `${platform.id}: minimum-OS evidence references unknown component ${evidence.componentId}`);
+      invariant(OS_VERSION_PATTERN.test(evidence.observedMinimum), `${platform.id}: invalid observedMinimum`);
+      assertSafeRelativePath(evidence.observedPath, `${platform.id}.minimumOsEvidence.observedPath`);
+      assertString(evidence.method, `${platform.id}.minimumOsEvidence.method`);
+      const current = evidence.observedMinimum.split(".").map(Number);
+      const highest = highestObservedMinimum.split(".").map(Number);
+      if (current[0] > highest[0] || (current[0] === highest[0] && current[1] > highest[1])) {
+        highestObservedMinimum = evidence.observedMinimum;
+      }
+    }
+    const declared = platform.minimumOsVersion.split(".").map(Number);
+    const highest = highestObservedMinimum.split(".").map(Number);
+    invariant(
+      declared[0] > highest[0] || (declared[0] === highest[0] && declared[1] >= highest[1]),
+      `${platform.id}: minimumOsVersion is lower than observed Mach-O evidence ${highestObservedMinimum}`,
+    );
+    invariant(Array.isArray(platform.requiredComponents) && platform.requiredComponents.length > 0, `${platform.id}: requiredComponents must not be empty`);
+    assertUnique(platform.requiredComponents, `${platform.id}.requiredComponents`);
+    for (const componentId of platform.requiredComponents) {
+      const component = inventoryById.get(componentId);
+      invariant(component, `${platform.id}: unknown required component ${componentId}`);
+      invariant(component.requiredInCore === true, `${platform.id}: ${componentId} is not marked requiredInCore`);
+      invariant(component.redistribution === "bundle", `${platform.id}: ${componentId} is not approved for bundling`);
+      invariant(component.embeddedIn === undefined, `${platform.id}: embedded component ${componentId} cannot be a top-level required component`);
+    }
+    const expectedRequired = [...inventoryById.values()]
+      .filter((component) => component.requiredInCore && component.embeddedIn === undefined)
+      .map((component) => component.id)
+      .sort(bytewiseCompare);
+    const actualRequired = [...platform.requiredComponents].sort(bytewiseCompare);
+    invariant(
+      JSON.stringify(actualRequired) === JSON.stringify(expectedRequired),
+      `${platform.id}: requiredComponents does not equal the classified core closure`,
+    );
+  }
+
+  return new Map(platforms.platforms.map((platform) => [platform.id, platform]));
+}
+
+export function validateComponentLocks(lockValue, inventoryById) {
+  const locks = assertExactKeys(lockValue, ["schemaVersion", "platform", "inputs"], "component lock");
+  invariant(locks.schemaVersion === 1, "component lock schemaVersion must be 1");
+  invariant(PLATFORM_ID_PATTERN.test(assertString(locks.platform, "component lock platform")), "component lock platform is invalid");
+  invariant(Array.isArray(locks.inputs) && locks.inputs.length > 0, "component lock inputs must not be empty");
+  const lockIds = locks.inputs.map((input) => input.id);
+  assertUnique(lockIds, "component lock ids");
+  invariant(
+    JSON.stringify([...lockIds].sort(bytewiseCompare)) === JSON.stringify([...EXPECTED_LOCK_INPUTS.keys()].sort(bytewiseCompare)),
+    "component lock does not contain the exact required external input set",
+  );
+  for (const inputValue of locks.inputs) {
+    const input = assertExactKeys(
+      inputValue,
+      ["id", "componentId", "version", "url", "sha256", "archiveType", "license"],
+      "component lock input",
+    );
+    const id = assertString(input.id, "component lock id");
+    invariant(ID_PATTERN.test(id), `${id}: invalid component lock id`);
+    invariant(input.componentId === EXPECTED_LOCK_INPUTS.get(id), `${id}: componentId does not match the required external input contract`);
+    const component = inventoryById.get(assertString(input.componentId, `${id}.componentId`));
+    invariant(component, `${id}: unknown component ${input.componentId}`);
+    invariant(component.redistribution === "bundle", `${id}: locked input is not approved for bundling`);
+    assertString(input.version, `${id}.version`);
+    assertString(input.url, `${id}.url`);
+    invariant(input.url.startsWith("https://"), `${id}.url must use HTTPS`);
+    invariant(SHA256_PATTERN.test(input.sha256), `${id}.sha256 must be lowercase SHA-256`);
+    invariant(["tar.gz", "zip"].includes(input.archiveType), `${id}: unsupported archiveType`);
+    assertString(input.license, `${id}.license`);
+    invariant(input.license === component.license, `${id}: license does not match component inventory`);
+  }
+  return locks;
+}
+
+export function validateSigningPolicy(policyValue) {
+  const policy = assertExactKeys(
+    policyValue,
+    ["schemaVersion", "stableReleaseStatus", "manifestSigning", "appleSigning", "channelRequirements", "promotionRequirements"],
+    "signing policy",
+  );
+  invariant(policy.schemaVersion === 1, "signing policy schemaVersion must be 1");
+  invariant(["blocked-awaiting-credentials", "ready"].includes(policy.stableReleaseStatus), "invalid stable release signing status");
+  const manifestSigning = assertExactKeys(
+    policy.manifestSigning,
+    ["algorithm", "keyId", "publicKeyStatus", "privateKeySecret"],
+    "manifest signing policy",
+  );
+  invariant(manifestSigning.algorithm === "ed25519", "manifest signing must use Ed25519");
+  assertString(manifestSigning.keyId, "manifest signing keyId");
+  invariant(["unprovisioned", "provisioned"].includes(manifestSigning.publicKeyStatus), "invalid manifest public-key status");
+  invariant(
+    /^JOBCTRL_[A-Z0-9_]+$/.test(assertString(manifestSigning.privateKeySecret, "manifest private-key secret name")),
+    "manifest private-key secret name is invalid",
+  );
+  const appleSigning = assertExactKeys(
+    policy.appleSigning,
+    ["identityType", "teamIdStatus", "certificateSecret", "certificatePasswordSecret", "notaryProfileSecret"],
+    "Apple signing policy",
+  );
+  invariant(appleSigning.identityType === "Developer ID Application", "Apple signing identity must be Developer ID Application");
+  invariant(["unprovisioned", "provisioned"].includes(appleSigning.teamIdStatus), "invalid Apple team-id status");
+  for (const secretName of [
+    appleSigning.certificateSecret,
+    appleSigning.certificatePasswordSecret,
+    appleSigning.notaryProfileSecret,
+  ]) {
+    invariant(/^JOBCTRL_[A-Z0-9_]+$/.test(assertString(secretName, "signing secret name")), "signing policy contains an invalid secret name");
+  }
+  const channelRequirements = assertExactKeys(
+    policy.channelRequirements,
+    ["local", "prerelease", "stable"],
+    "signing channel requirements",
+  );
+  for (const channel of ["local", "prerelease", "stable"]) {
+    const requirements = assertExactKeys(
+      channelRequirements[channel],
+      ["manifestKey", "codeSigning", "notarized"],
+      `${channel} signing requirements`,
+    );
+    invariant(["local-development", "release"].includes(requirements.manifestKey), `${channel}: invalid manifest key policy`);
+    invariant(["unsigned-local", "developer-id"].includes(requirements.codeSigning), `${channel}: invalid code-signing policy`);
+    assertBoolean(requirements.notarized, `${channel}.notarized`);
+  }
+  invariant(channelRequirements.local.manifestKey === "local-development", "local manifests must use the local-development key id");
+  invariant(channelRequirements.local.codeSigning === "unsigned-local" && channelRequirements.local.notarized === false, "local artifacts must remain explicitly unsigned and unnotarized");
+  for (const channel of ["prerelease", "stable"]) {
+    invariant(channelRequirements[channel].manifestKey === "release", `${channel} manifests must use the configured release key`);
+    invariant(channelRequirements[channel].codeSigning === "developer-id", `${channel} artifacts must use Developer ID signing`);
+    invariant(channelRequirements[channel].notarized === true, `${channel} artifacts must be notarized`);
+  }
+  invariant(Array.isArray(policy.promotionRequirements) && policy.promotionRequirements.length > 0, "signing promotion requirements must not be empty");
+  for (const requirement of policy.promotionRequirements) assertString(requirement, "signing promotion requirement");
+  if (policy.stableReleaseStatus === "ready") {
+    invariant(manifestSigning.publicKeyStatus === "provisioned", "stable signing cannot be ready without a provisioned manifest public key");
+    invariant(appleSigning.teamIdStatus === "provisioned", "stable signing cannot be ready without a provisioned Apple team id");
+  }
+  return policy;
+}
+
+function parseVersionSource(source, root) {
+  const separator = source.indexOf("#");
+  invariant(separator > 0, `versionSource must contain a # selector: ${source}`);
+  const relativePath = source.slice(0, separator);
+  const selector = source.slice(separator + 1);
+  assertSafeRelativePath(relativePath, "versionSource path");
+  return { filePath: path.join(root, relativePath), selector };
+}
+
+async function resolveJsonSelector(filePath, selector) {
+  let value = await loadJson(filePath);
+  for (const segment of selector.split(".")) value = value?.[segment];
+  return assertString(value, `${path.relative(REPO_ROOT, filePath)}#${selector}`);
+}
+
+async function resolveTomlProjectVersion(filePath) {
+  const contents = await readFile(filePath, "utf8");
+  const projectBlock = contents.match(/\[project\]([\s\S]*?)(?:\n\[|$)/);
+  invariant(projectBlock, `${filePath}: missing [project] block`);
+  const version = projectBlock[1].match(/^\s*version\s*=\s*"([^"]+)"/m);
+  invariant(version, `${filePath}: missing project.version`);
+  return version[1];
+}
+
+async function resolveUvLockVersion(filePath, packageName) {
+  const contents = await readFile(filePath, "utf8");
+  for (const block of contents.split(/\n(?=\[\[package\]\])/)) {
+    const name = block.match(/^name\s*=\s*"([^"]+)"/m)?.[1];
+    if (name !== packageName) continue;
+    const version = block.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
+    invariant(version, `${filePath}: ${packageName} has no version`);
+    return version;
+  }
+  throw new Error(`${filePath}: package ${packageName} not found`);
+}
+
+async function resolvePnpmLockVersion(filePath, packageName) {
+  const contents = await readFile(filePath, "utf8");
+  const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = contents.match(new RegExp(`^  ['\"]?${escapedName}@([^:'\"(]+)(?:\\([^\\n]+\\))?['\"]?:$`, "m"));
+  invariant(match, `${filePath}: package ${packageName} not found`);
+  return match[1];
+}
+
+export async function resolveInventoryVersions(inventory, root = REPO_ROOT) {
+  const resolved = {};
+  for (const component of inventory.components) {
+    if (component.version) {
+      resolved[component.id] = component.version;
+      continue;
+    }
+    const { filePath, selector } = parseVersionSource(component.versionSource, root);
+    if (filePath.endsWith(".json")) {
+      resolved[component.id] = await resolveJsonSelector(filePath, selector);
+    } else if (filePath.endsWith("pyproject.toml") && selector === "project.version") {
+      resolved[component.id] = await resolveTomlProjectVersion(filePath);
+    } else if (filePath.endsWith("uv.lock")) {
+      resolved[component.id] = await resolveUvLockVersion(filePath, selector);
+    } else if (filePath.endsWith("pnpm-lock.yaml")) {
+      resolved[component.id] = await resolvePnpmLockVersion(filePath, selector);
+    } else {
+      throw new Error(`${component.id}: unsupported versionSource ${component.versionSource}`);
+    }
+  }
+  return resolved;
+}
+
+export function validateLicenseReview(licenseReview, inventoryById) {
+  assertString(licenseReview, "license review");
+  const reviewedComponents = [...licenseReview.matchAll(/^\| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \| `([^`]+)` \|/gm)]
+    .map((match) => ({ id: match[1], classification: match[2], license: match[3], redistribution: match[4] }));
+  const reviewedComponentIds = reviewedComponents.map((component) => component.id).sort(bytewiseCompare);
+  const inventoryComponentIds = [...inventoryById.keys()].sort(bytewiseCompare);
+  invariant(
+    JSON.stringify(reviewedComponentIds) === JSON.stringify(inventoryComponentIds),
+    "license review component set does not match component-inventory.json",
+  );
+  for (const reviewed of reviewedComponents) {
+    const component = inventoryById.get(reviewed.id);
+    invariant(reviewed.classification === component.classification, `${reviewed.id}: license review classification does not match inventory`);
+    invariant(reviewed.license === component.license, `${reviewed.id}: license review license does not match inventory`);
+    invariant(reviewed.redistribution === component.redistribution, `${reviewed.id}: license review decision does not match inventory`);
+  }
+  return reviewedComponents;
+}
+
+export async function auditDistributionContracts(root = REPO_ROOT) {
+  const { schema, inventory, platforms, componentLocks, capabilityPolicy, sourceBaseline, signingPolicy } = await loadDistributionContracts(root);
+  compileManifestSchema(schema);
+  const inventoryById = validateComponentInventory(inventory);
+  const platformsById = validatePlatforms(platforms, inventoryById);
+  const locks = validateComponentLocks(componentLocks, inventoryById);
+  const capabilitiesById = validateCapabilityPolicy(capabilityPolicy, inventoryById);
+  const versions = await resolveInventoryVersions(inventory, root);
+  invariant(platformsById.has(locks.platform), `component locks target unsupported platform ${locks.platform}`);
+  for (const input of locks.inputs) {
+    invariant(
+      input.version === versions[input.componentId],
+      `${input.id}: locked version ${input.version} does not match inventory version ${versions[input.componentId]}`,
+    );
+  }
+  const licenseReview = await readFile(path.join(root, "packaging", "distribution", "LICENSE-REVIEW.md"), "utf8");
+  validateLicenseReview(licenseReview, inventoryById);
+  assertExactKeys(
+    sourceBaseline,
+    ["schemaVersion", "reproducibleCounts", "referenceFootprint"],
+    "source baseline",
+  );
+  invariant(sourceBaseline.schemaVersion === 1, "source baseline schemaVersion must be 1");
+  const referenceFootprint = assertExactKeys(
+    sourceBaseline.referenceFootprint,
+    ["status", "measurementContext", "logicalBytes", "observations", "notes"],
+    "source baseline referenceFootprint",
+  );
+  invariant(referenceFootprint.status === "observational", "source footprint must be explicitly observational");
+  assertExactKeys(
+    referenceFootprint.measurementContext,
+    ["referenceCommit", "recordedOn", "platform", "scope", "interpretation"],
+    "source baseline measurementContext",
+  );
+  for (const [key, value] of Object.entries(referenceFootprint.measurementContext)) {
+    assertString(value, `source baseline measurementContext.${key}`);
+  }
+  invariant(
+    /^[a-f0-9]{40}$/.test(referenceFootprint.measurementContext.referenceCommit),
+    "source footprint referenceCommit must be a full commit SHA",
+  );
+  assertExactKeys(referenceFootprint.logicalBytes, ["nodeModules", "pythonEnvironment"], "source baseline logicalBytes");
+  assertInteger(referenceFootprint.logicalBytes.nodeModules, "source baseline nodeModules bytes");
+  assertInteger(referenceFootprint.logicalBytes.pythonEnvironment, "source baseline Python environment bytes");
+  invariant(Array.isArray(referenceFootprint.observations) && referenceFootprint.observations.length > 0, "source baseline observations must not be empty");
+  const observationIds = [];
+  for (const observationValue of referenceFootprint.observations) {
+    const observation = assertAllowedKeys(
+      observationValue,
+      ["id", "value", "unit", "qualifier", "optional", "note"],
+      "source baseline observation",
+    );
+    const id = assertString(observation.id, "source baseline observation id");
+    observationIds.push(id);
+    invariant(typeof observation.value === "number" && Number.isFinite(observation.value) && observation.value >= 0, `${id}.value must be a non-negative number`);
+    assertString(observation.unit, `${id}.unit`);
+    assertString(observation.qualifier, `${id}.qualifier`);
+    if (observation.optional !== undefined) assertBoolean(observation.optional, `${id}.optional`);
+    assertString(observation.note, `${id}.note`);
+  }
+  assertUnique(observationIds, "source baseline observation ids");
+  invariant(Array.isArray(referenceFootprint.notes) && referenceFootprint.notes.length > 0, "source baseline notes must not be empty");
+  for (const note of referenceFootprint.notes) assertString(note, "source baseline note");
+  const [javascript, python, lockCounts] = await Promise.all([
+    workspaceDependencyCounts(root),
+    pythonDependencyCounts(root),
+    lockRecordCounts(root),
+  ]);
+  const expectedCounts = {
+    javascriptPackageFiles: javascript.packageFiles,
+    javascriptUniqueDirect: javascript.uniqueDirect,
+    javascriptUniqueRuntimeDirect: javascript.uniqueRuntimeDirect,
+    javascriptUniqueDevelopmentDirect: javascript.uniqueDevelopmentDirect,
+    pnpmPackageRecords: lockCounts.pnpmPackageRecords,
+    pythonRuntimeDirect: python.runtimeDirect,
+    pythonDevelopmentDirect: python.developmentDirect,
+    uvPackageRecords: lockCounts.uvPackageRecords,
+  };
+  assertExactKeys(sourceBaseline.reproducibleCounts, Object.keys(expectedCounts), "source baseline reproducibleCounts");
+  invariant(
+    JSON.stringify(sourceBaseline.reproducibleCounts) === JSON.stringify(expectedCounts),
+    "source dependency counts drifted; run distribution:measure and update source-baseline.json intentionally",
+  );
+  validateSigningPolicy(signingPolicy);
+  return {
+    schemaVersion: 1,
+    componentCount: inventory.components.length,
+    bundledComponentCount: inventory.components.filter((component) => component.redistribution === "bundle").length,
+    providerPackCount: inventory.components.filter((component) => component.classification === "provider-pack").length,
+    developerOnlyCount: inventory.components.filter((component) => component.classification === "developer-only").length,
+    lockedInputCount: locks.inputs.length,
+    capabilityCount: capabilitiesById.size,
+    footprintReferenceCommit: referenceFootprint.measurementContext.referenceCommit,
+    stableReleaseStatus: signingPolicy.stableReleaseStatus,
+    platforms: [...platformsById.keys()],
+    versions,
+  };
+}
+
+function validateManifestComponent(componentValue, contracts) {
+  const component = assertExactKeys(
+    componentValue,
+    ["id", "classification", "version", "owner", "source", "license", "redistribution", "path", "sha256", "sizeBytes", "required"],
+    "manifest component",
+  );
+  const id = assertString(component.id, "manifest component id");
+  invariant(ID_PATTERN.test(id), `invalid manifest component id ${id}`);
+  invariant(MANIFEST_CLASSIFICATIONS.has(component.classification), `${id}: invalid manifest classification`);
+  const inventory = contracts.inventoryById.get(id);
+  invariant(inventory, `${id}: component is not classified in component-inventory.json`);
+  invariant(inventory.classification !== "developer-only", `${id}: developer-only component cannot enter a payload`);
+  invariant(inventory.redistribution === "bundle", `${id}: component is not approved for bundling`);
+  invariant(inventory.embeddedIn === undefined, `${id}: embedded component cannot own an overlapping manifest root`);
+  invariant(component.classification === inventory.classification, `${id}: classification does not match inventory`);
+  invariant(assertString(component.version, `${id}.version`) === contracts.versions[id], `${id}: version does not match resolved inventory version`);
+  invariant(assertString(component.owner, `${id}.owner`) === inventory.owner, `${id}: owner does not match component inventory`);
+  invariant(assertString(component.source, `${id}.source`) === inventory.source, `${id}: source does not match component inventory`);
+  invariant(assertString(component.license, `${id}.license`) === inventory.license, `${id}: license does not match component inventory`);
+  invariant(component.redistribution === "bundle", `${id}: manifest redistribution must be bundle`);
+  assertSafeRelativePath(component.path, `${id}.path`);
+  invariant(SHA256_PATTERN.test(component.sha256), `${id}.sha256 must be lowercase SHA-256`);
+  assertInteger(component.sizeBytes, `${id}.sizeBytes`);
+  assertBoolean(component.required, `${id}.required`);
+  invariant(component.required === inventory.requiredInCore, `${id}.required does not match component inventory`);
+  return component;
+}
+
+function pathIsWithinRoot(filePath, componentPath) {
+  return filePath === componentPath || filePath.startsWith(`${componentPath}/`);
+}
+
+export function summarizeComponentFiles(componentPath, files) {
+  assertSafeRelativePath(componentPath, "component summary path");
+  const ownedFiles = files
+    .filter((file) => pathIsWithinRoot(file.path, componentPath))
+    .sort((left, right) => bytewiseCompare(left.path, right.path));
+  invariant(ownedFiles.length > 0, `no files are rooted at ${componentPath}`);
+  const canonical = ownedFiles
+    .map((file) => file.type === "symlink"
+      ? `${file.path}\0symlink\0${file.target}\0${file.sizeBytes}\n`
+      : `${file.path}\0file\0${file.sha256}\0${file.sizeBytes}\0${file.mode}\n`)
+    .join("");
+  return {
+    sha256: createHash("sha256").update(canonical).digest("hex"),
+    sizeBytes: ownedFiles.reduce((total, file) => total + file.sizeBytes, 0),
+    fileCount: ownedFiles.length,
+  };
+}
+
+function resolveManifestPathThroughSymlinks(candidatePath, symlinkByPath) {
+  let current = candidatePath;
+  const seen = new Set();
+  const links = [...symlinkByPath.keys()].sort((left, right) => right.length - left.length || bytewiseCompare(left, right));
+  for (let step = 0; step <= links.length; step += 1) {
+    invariant(!seen.has(current), `${candidatePath}: symlink cycle detected`);
+    seen.add(current);
+    const linkPath = links.find((entry) => current === entry || current.startsWith(`${entry}/`));
+    if (!linkPath) return current;
+    const link = symlinkByPath.get(linkPath);
+    const resolvedTarget = resolveSafeSymlinkTarget(link.target, link.path);
+    const suffix = current.slice(linkPath.length);
+    current = path.posix.normalize(`${resolvedTarget}${suffix}`);
+    assertSafeRelativePath(current, `${candidatePath}: resolved symlink path`);
+  }
+  throw new Error(`${candidatePath}: symlink resolution exceeded the manifest link count`);
+}
+
+export function validateDistributionManifest(manifestValue, contracts, { stable = false } = {}) {
+  invariant(contracts.schemaValidator(manifestValue), `manifest schema validation failed: ${schemaErrors(contracts.schemaValidator)}`);
+  const manifest = assertExactKeys(
+    manifestValue,
+    ["schemaVersion", "appVersion", "buildId", "releaseChannel", "sourceDateEpoch", "platform", "launcherCompatibility", "components", "capabilities", "files", "signing"],
+    "distribution manifest",
+  );
+  invariant(manifest.schemaVersion === 1, "manifest schemaVersion must be 1");
+  invariant(VERSION_PATTERN.test(assertString(manifest.appVersion, "appVersion")), "appVersion must be semver");
+  invariant(manifest.appVersion === contracts.versions["jobctrl-launcher"], "appVersion does not match the resolved JobCtrl version");
+  invariant(/^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$/.test(assertString(manifest.buildId, "buildId")), "buildId is invalid");
+  invariant(RELEASE_CHANNELS.has(manifest.releaseChannel), "releaseChannel is invalid");
+  assertInteger(manifest.sourceDateEpoch, "sourceDateEpoch");
+  if (stable) invariant(manifest.releaseChannel === "stable", "stable validation requires the stable release channel");
+
+  const platformValue = assertExactKeys(manifest.platform, ["id", "os", "arch", "minimumOsVersion"], "manifest.platform");
+  const platform = contracts.platformsById.get(platformValue.id);
+  invariant(platform, `manifest references unsupported platform ${platformValue.id}`);
+  invariant(platformValue.os === platform.os, "manifest platform.os does not match platform contract");
+  invariant(platformValue.arch === platform.arch, "manifest platform.arch does not match platform contract");
+  invariant(platformValue.minimumOsVersion === platform.minimumOsVersion, "manifest minimum OS does not match platform contract");
+
+  const compatibility = assertExactKeys(manifest.launcherCompatibility, ["minimum", "maximum"], "launcherCompatibility");
+  assertInteger(compatibility.minimum, "launcherCompatibility.minimum", 1);
+  assertInteger(compatibility.maximum, "launcherCompatibility.maximum", 1);
+  invariant(compatibility.maximum >= compatibility.minimum, "launcherCompatibility range is inverted");
+  invariant(compatibility.minimum === platform.launcherCompatibility.minimum, "launcherCompatibility.minimum does not match platform contract");
+  invariant(compatibility.maximum === platform.launcherCompatibility.maximum, "launcherCompatibility.maximum does not match platform contract");
+
+  invariant(Array.isArray(manifest.components) && manifest.components.length > 0, "manifest.components must not be empty");
+  const components = manifest.components.map((component) => validateManifestComponent(component, contracts));
+  const componentIds = components.map((component) => component.id);
+  assertUnique(componentIds, "manifest component ids");
+  invariant(
+    JSON.stringify(componentIds) === JSON.stringify([...componentIds].sort(bytewiseCompare)),
+    "manifest components must be bytewise sorted by id",
+  );
+  for (let leftIndex = 0; leftIndex < components.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < components.length; rightIndex += 1) {
+      const left = components[leftIndex];
+      const right = components[rightIndex];
+      invariant(
+        !pathIsWithinRoot(left.path, right.path) && !pathIsWithinRoot(right.path, left.path),
+        `manifest component roots overlap: ${left.id} (${left.path}) and ${right.id} (${right.path})`,
+      );
+    }
+  }
+  for (const requiredId of platform.requiredComponents) {
+    invariant(componentIds.includes(requiredId), `manifest is missing required component ${requiredId}`);
+  }
+
+  invariant(Array.isArray(manifest.capabilities) && manifest.capabilities.length > 0, "manifest.capabilities must not be empty");
+  const capabilityIds = [];
+  for (const capabilityValue of manifest.capabilities) {
+    const capability = assertExactKeys(capabilityValue, ["id", "defaultEnabled", "componentIds"], "capability");
+    const id = assertString(capability.id, "capability.id");
+    invariant(ID_PATTERN.test(id), `invalid capability id ${id}`);
+    const policy = contracts.capabilitiesById.get(id);
+    invariant(policy, `manifest contains unknown capability ${id}`);
+    capabilityIds.push(id);
+    assertBoolean(capability.defaultEnabled, `${id}.defaultEnabled`);
+    invariant(capability.defaultEnabled === policy.defaultEnabled, `${id}: defaultEnabled does not match capability policy`);
+    invariant(Array.isArray(capability.componentIds) && capability.componentIds.length > 0, `${id}.componentIds must not be empty`);
+    assertUnique(capability.componentIds, `${id}.componentIds`);
+    invariant(
+      JSON.stringify(capability.componentIds) === JSON.stringify([...capability.componentIds].sort(bytewiseCompare)),
+      `${id}.componentIds must be bytewise sorted`,
+    );
+    invariant(JSON.stringify(capability.componentIds) === JSON.stringify(policy.componentIds), `${id}: componentIds do not match capability policy`);
+    for (const componentId of capability.componentIds) {
+      invariant(componentIds.includes(componentId), `${id}: unknown component ${componentId}`);
+    }
+  }
+  assertUnique(capabilityIds, "capability ids");
+  invariant(
+    JSON.stringify(capabilityIds) === JSON.stringify([...capabilityIds].sort(bytewiseCompare)),
+    "manifest capabilities must be bytewise sorted by id",
+  );
+  invariant(capabilityIds.length === contracts.capabilitiesById.size, "manifest does not contain the complete capability policy");
+
+  invariant(Array.isArray(manifest.files) && manifest.files.length > 0, "manifest.files must not be empty");
+  const filePaths = [];
+  const files = [];
+  for (const fileValue of manifest.files) {
+    const fileObject = assertObject(fileValue, "manifest file");
+    invariant(["file", "symlink"].includes(fileObject.type), "manifest file type must be file or symlink");
+    const file = fileObject.type === "symlink"
+      ? assertExactKeys(fileObject, ["type", "path", "target", "sizeBytes"], "manifest symlink")
+      : assertExactKeys(fileObject, ["type", "path", "sha256", "sizeBytes", "mode"], "manifest file");
+    const filePath = assertSafeRelativePath(file.path, "manifest file path");
+    filePaths.push(filePath);
+    if (file.type === "symlink") {
+      resolveSafeSymlinkTarget(file.target, filePath);
+      invariant(file.sizeBytes === Buffer.byteLength(file.target, "utf8"), `${filePath}: symlink size must equal its UTF-8 target length`);
+    } else {
+      invariant(SHA256_PATTERN.test(file.sha256), `${filePath}: invalid SHA-256`);
+      assertInteger(file.sizeBytes, `${filePath}.sizeBytes`);
+      invariant(SAFE_FILE_MODES.has(file.mode), `${filePath}: unsafe mode ${file.mode}; only 0644 and 0755 are allowed`);
+    }
+    const owners = components.filter((component) => pathIsWithinRoot(filePath, component.path));
+    invariant(owners.length === 1, `${filePath}: manifest file must have exactly one component owner; found ${owners.length}`);
+    files.push(file);
+  }
+  assertUnique(filePaths, "manifest file paths");
+  invariant(
+    JSON.stringify(filePaths) === JSON.stringify([...filePaths].sort(bytewiseCompare)),
+    "manifest files must be bytewise sorted by path",
+  );
+  const symlinkByPath = new Map(files.filter((file) => file.type === "symlink").map((file) => [file.path, file]));
+  for (const link of symlinkByPath.values()) {
+    const directTarget = resolveSafeSymlinkTarget(link.target, link.path);
+    invariant(directTarget !== link.path, `${link.path}: symlink cannot target itself`);
+    const resolvedTarget = resolveManifestPathThroughSymlinks(directTarget, symlinkByPath);
+    const targetExists = files.some((file) => file.path === resolvedTarget || file.path.startsWith(`${resolvedTarget}/`));
+    invariant(targetExists, `${link.path}: symlink target is not represented by the manifest`);
+    const linkOwner = components.find((component) => pathIsWithinRoot(link.path, component.path));
+    const targetOwner = components.find((component) => pathIsWithinRoot(resolvedTarget, component.path));
+    invariant(targetOwner?.id === linkOwner?.id, `${link.path}: symlink target crosses component ownership`);
+  }
+  for (const component of components) {
+    const summary = summarizeComponentFiles(component.path, files);
+    invariant(component.sha256 === summary.sha256, `${component.id}: component SHA-256 does not match its file inventory`);
+    invariant(component.sizeBytes === summary.sizeBytes, `${component.id}: component size does not match its file inventory`);
+  }
+
+  const signing = assertExactKeys(manifest.signing, ["manifestAlgorithm", "manifestKeyId", "codeSigning", "notarized"], "manifest.signing");
+  invariant(signing.manifestAlgorithm === contracts.signingPolicy.manifestSigning.algorithm, "manifest signing algorithm does not match signing policy");
+  const channelPolicy = contracts.signingPolicy.channelRequirements[manifest.releaseChannel];
+  invariant(channelPolicy, `signing policy has no requirements for ${manifest.releaseChannel}`);
+  const expectedKeyId = channelPolicy.manifestKey === "release"
+    ? contracts.signingPolicy.manifestSigning.keyId
+    : channelPolicy.manifestKey;
+  invariant(signing.manifestKeyId === expectedKeyId, `manifest key id does not match ${manifest.releaseChannel} signing policy`);
+  invariant(signing.codeSigning === channelPolicy.codeSigning, `manifest code signing does not match ${manifest.releaseChannel} signing policy`);
+  assertBoolean(signing.notarized, "manifest.signing.notarized");
+  invariant(signing.notarized === channelPolicy.notarized, `manifest notarization does not match ${manifest.releaseChannel} signing policy`);
+  if (manifest.releaseChannel === "stable") {
+    invariant(contracts.signingPolicy.stableReleaseStatus === "ready", "stable manifest promotion is blocked until signing credentials are provisioned");
+  }
+  return manifest;
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+export async function buildFileInventory(root) {
+  const rootStat = await stat(root);
+  invariant(rootStat.isDirectory(), `artifact root is not a directory: ${root}`);
+  const files = [];
+
+  async function visit(directory, relativeDirectory = "") {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => bytewiseCompare(left.name, right.name));
+    for (const entry of entries) {
+      const relativePath = relativeDirectory ? path.posix.join(relativeDirectory, entry.name) : entry.name;
+      assertSafeRelativePath(relativePath, "artifact file path");
+      const absolutePath = path.join(directory, entry.name);
+      const fileStat = await lstat(absolutePath);
+      if (fileStat.isSymbolicLink()) {
+        const target = await readlink(absolutePath);
+        resolveSafeSymlinkTarget(target, relativePath);
+        files.push({
+          type: "symlink",
+          path: relativePath,
+          target,
+          sizeBytes: Buffer.byteLength(target, "utf8"),
+        });
+        continue;
+      }
+      if (fileStat.isDirectory()) {
+        await visit(absolutePath, relativePath);
+        continue;
+      }
+      invariant(fileStat.isFile(), `artifact contains an unsupported file type: ${relativePath}`);
+      const mode = (fileStat.mode & 0o7777).toString(8).padStart(4, "0");
+      invariant(SAFE_FILE_MODES.has(mode), `${relativePath}: unsafe mode ${mode}; normalize artifact files to 0644 or 0755`);
+      files.push({
+        type: "file",
+        path: relativePath,
+        sha256: await sha256File(absolutePath),
+        sizeBytes: fileStat.size,
+        mode,
+      });
+    }
+  }
+
+  await visit(root);
+  files.sort((left, right) => bytewiseCompare(left.path, right.path));
+  const realRoot = await realpath(root);
+  for (const file of files) {
+    if (file.type !== "symlink") continue;
+    const resolvedTarget = resolveSafeSymlinkTarget(file.target, file.path);
+    let realTarget;
+    try {
+      realTarget = await realpath(path.join(root, resolvedTarget));
+    } catch (error) {
+      if (error?.code === "ELOOP") throw new Error(`${file.path}: symlink cycle detected`);
+      throw new Error(`${file.path}: symlink target does not resolve inside the artifact`);
+    }
+    invariant(
+      realTarget === realRoot || realTarget.startsWith(`${realRoot}${path.sep}`),
+      `${file.path}: symlink target escapes the artifact root`,
+    );
+  }
+  return files;
+}
+
+async function directorySize(root) {
+  try {
+    let total = 0;
+    async function visit(directory) {
+      const entries = await readdir(directory, { withFileTypes: true });
+      for (const entry of entries) {
+        const absolutePath = path.join(directory, entry.name);
+        const fileStat = await lstat(absolutePath);
+        if (fileStat.isSymbolicLink()) continue;
+        if (fileStat.isDirectory()) {
+          await visit(absolutePath);
+        } else if (fileStat.isFile()) {
+          total += fileStat.size;
+        }
+      }
+    }
+    await visit(root);
+    return total;
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function workspaceDependencyCounts(root) {
+  const packageFiles = [path.join(root, "package.json")];
+  for (const parent of ["apps", "packages"]) {
+    const directory = path.join(root, parent);
+    let entries = [];
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    for (const entry of entries) {
+      if (entry.isDirectory()) packageFiles.push(path.join(directory, entry.name, "package.json"));
+    }
+  }
+
+  const direct = new Set();
+  const runtime = new Set();
+  const development = new Set();
+  let readPackageFiles = 0;
+  for (const packageFile of packageFiles) {
+    let packageJson;
+    try {
+      packageJson = await loadJson(packageFile);
+      readPackageFiles += 1;
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    for (const name of Object.keys(packageJson.dependencies ?? {})) {
+      direct.add(name);
+      runtime.add(name);
+    }
+    for (const name of Object.keys(packageJson.optionalDependencies ?? {})) {
+      direct.add(name);
+      runtime.add(name);
+    }
+    for (const name of Object.keys(packageJson.devDependencies ?? {})) {
+      direct.add(name);
+      development.add(name);
+    }
+  }
+  return {
+    packageFiles: readPackageFiles,
+    uniqueDirect: direct.size,
+    uniqueRuntimeDirect: runtime.size,
+    uniqueDevelopmentDirect: development.size,
+  };
+}
+
+async function pythonDependencyCounts(root) {
+  const contents = await readFile(path.join(root, "workers", "automation", "pyproject.toml"), "utf8");
+  const runtimeBlock = contents.match(/^dependencies\s*=\s*\[([\s\S]*?)^\]/m)?.[1] ?? "";
+  const runtime = [...runtimeBlock.matchAll(/^\s*"([^"]+)"/gm)].map((match) => match[1]);
+  const devLine = contents.match(/^dev\s*=\s*\[([^\]]*)\]/m)?.[1] ?? "";
+  const development = [...devLine.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  return { runtimeDirect: runtime.length, developmentDirect: development.length };
+}
+
+async function lockRecordCounts(root) {
+  const [pnpmLock, uvLock] = await Promise.all([
+    readFile(path.join(root, "pnpm-lock.yaml"), "utf8"),
+    readFile(path.join(root, "workers", "automation", "uv.lock"), "utf8"),
+  ]);
+  const packageSection = pnpmLock.match(/\npackages:\n([\s\S]*?)\nsnapshots:\n/)?.[1] ?? "";
+  const pnpmPackageRecords = [...packageSection.matchAll(/^  [^\s].*:\s*$/gm)].length;
+  const uvPackageRecords = [...uvLock.matchAll(/^\[\[package\]\]$/gm)].length;
+  return { pnpmPackageRecords, uvPackageRecords };
+}
+
+export async function measureDistribution({ root = REPO_ROOT, artifact = null } = {}) {
+  const [javascript, python, locks, nodeModulesBytes, pythonEnvironmentBytes] = await Promise.all([
+    workspaceDependencyCounts(root),
+    pythonDependencyCounts(root),
+    lockRecordCounts(root),
+    directorySize(path.join(root, "node_modules")),
+    directorySize(path.join(root, "workers", "automation", ".venv")),
+  ]);
+  const report = {
+    schemaVersion: 1,
+    source: {
+      javascript,
+      python,
+      locks,
+      environmentPresence: {
+        nodeModules: nodeModulesBytes === null ? "absent" : "present",
+        pythonEnvironment: pythonEnvironmentBytes === null ? "absent" : "present",
+      },
+      logicalBytes: {
+        nodeModules: nodeModulesBytes,
+        pythonEnvironment: pythonEnvironmentBytes,
+      },
+    },
+  };
+  if (artifact) {
+    const files = await buildFileInventory(artifact);
+    report.artifact = {
+      root: path.resolve(artifact),
+      fileCount: files.length,
+      logicalBytes: files.reduce((total, file) => total + file.sizeBytes, 0),
+      files,
+    };
+  }
+  return report;
+}
+
+export async function loadManifestValidationContracts(root = REPO_ROOT) {
+  const { schema, inventory, platforms, capabilityPolicy, signingPolicy } = await loadDistributionContracts(root);
+  const schemaValidator = compileManifestSchema(schema);
+  const inventoryById = validateComponentInventory(inventory);
+  const platformsById = validatePlatforms(platforms, inventoryById);
+  const capabilitiesById = validateCapabilityPolicy(capabilityPolicy, inventoryById);
+  const versions = await resolveInventoryVersions(inventory, root);
+  validateSigningPolicy(signingPolicy);
+  return { schema, schemaValidator, inventoryById, platformsById, capabilitiesById, versions, signingPolicy };
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const command = argv[0] ?? "audit";
+  if (command === "audit") {
+    process.stdout.write(`${JSON.stringify(await auditDistributionContracts(), null, 2)}\n`);
+    return;
+  }
+  if (command === "measure") {
+    let artifact = null;
+    let root = REPO_ROOT;
+    for (let index = 1; index < argv.length; index += 1) {
+      if (argv[index] === "--artifact") {
+        artifact = argv[index + 1];
+        invariant(artifact, "--artifact requires a directory");
+      } else if (argv[index] === "--root") {
+        root = path.resolve(argv[index + 1] ?? "");
+        invariant(argv[index + 1], "--root requires a checkout directory");
+      } else {
+        throw new Error(`unknown measure option: ${argv[index]}`);
+      }
+      index += 1;
+    }
+    process.stdout.write(`${JSON.stringify(await measureDistribution({ root, artifact }), null, 2)}\n`);
+    return;
+  }
+  throw new Error(`unknown distribution command: ${command}`);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(`distribution: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/distribution-manifest.test.mjs
+++ b/scripts/distribution-manifest.test.mjs
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  auditDistributionContracts,
+  buildFileInventory,
+  loadDistributionContracts,
+  loadManifestValidationContracts,
+  measureDistribution,
+  summarizeComponentFiles,
+  validateDistributionManifest,
+  validateComponentInventory,
+  validateComponentLocks,
+  validateLicenseReview,
+  validateSigningPolicy,
+} from "./distribution-manifest.mjs";
+
+const EMPTY_SHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+function sorted(values) {
+  return [...values].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+}
+
+async function validManifest(contracts) {
+  contracts ??= await loadManifestValidationContracts();
+  const platform = contracts.platformsById.values().next().value;
+  const componentIds = sorted(platform.requiredComponents);
+  const files = componentIds.map((id) => ({
+    type: "file",
+    path: `libexec/jobctrl/components/${id}/payload`,
+    sha256: EMPTY_SHA,
+    sizeBytes: 0,
+    mode: "0644",
+  }));
+  const components = componentIds.map((id) => {
+    const inventory = contracts.inventoryById.get(id);
+    const componentPath = `libexec/jobctrl/components/${id}`;
+    const summary = summarizeComponentFiles(componentPath, files);
+    return {
+      id,
+      classification: inventory.classification,
+      version: contracts.versions[id],
+      owner: inventory.owner,
+      source: inventory.source,
+      license: inventory.license,
+      redistribution: "bundle",
+      path: componentPath,
+      sha256: summary.sha256,
+      sizeBytes: summary.sizeBytes,
+      required: true,
+    };
+  });
+  const capabilities = sorted(contracts.capabilitiesById.keys()).map((id) => {
+    const capability = contracts.capabilitiesById.get(id);
+    return {
+      id,
+      defaultEnabled: capability.defaultEnabled,
+      componentIds: [...capability.componentIds],
+    };
+  });
+  return {
+    schemaVersion: 1,
+    appVersion: contracts.versions["jobctrl-launcher"],
+    buildId: "test-build-0001",
+    releaseChannel: "local",
+    sourceDateEpoch: 0,
+    platform: {
+      id: platform.id,
+      os: platform.os,
+      arch: platform.arch,
+      minimumOsVersion: platform.minimumOsVersion,
+    },
+    launcherCompatibility: { ...platform.launcherCompatibility },
+    components,
+    capabilities,
+    files,
+    signing: {
+      manifestAlgorithm: "ed25519",
+      manifestKeyId: "local-development",
+      codeSigning: "unsigned-local",
+      notarized: false,
+    },
+  };
+}
+
+test("distribution contracts are complete and every version source resolves", async () => {
+  const report = await auditDistributionContracts();
+  assert.equal(report.schemaVersion, 1);
+  assert.ok(report.componentCount >= 20);
+  assert.equal(report.lockedInputCount, 6);
+  assert.equal(report.capabilityCount, 3);
+  assert.deepEqual(report.platforms, ["darwin-arm64"]);
+  assert.equal(report.versions["jobctrl-launcher"], "2.0.0");
+  assert.equal(report.versions["playwright-python"], "1.58.0");
+  assert.equal(report.versions["font-jetbrains-mono"], "5.2.8");
+  assert.equal(report.versions["pdfjs-renderer"], "5.7.284");
+  assert.equal(report.versions["claude-agent-sdk"], "0.2.87");
+});
+
+test("manifest validation accepts the complete local core closure", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const manifest = await validManifest(contracts);
+  assert.equal(contracts.schemaValidator(manifest), true);
+  assert.equal(validateDistributionManifest(manifest, contracts), manifest);
+});
+
+test("schema and semantic validation reject unknown fields", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const manifest = await validManifest(contracts);
+  manifest.components[0].credentialDump = "not-a-real-secret";
+  assert.equal(contracts.schemaValidator(manifest), false);
+  assert.throws(() => validateDistributionManifest(manifest, contracts), /schema validation failed/);
+});
+
+test("manifest validation binds component identity and resolved versions to inventory", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const wrongOwner = await validManifest(contracts);
+  wrongOwner.components[0].owner = "Someone else";
+  assert.throws(() => validateDistributionManifest(wrongOwner, contracts), /owner does not match/);
+
+  const wrongVersion = await validManifest(contracts);
+  wrongVersion.components[0].version = "999.0.0";
+  assert.throws(() => validateDistributionManifest(wrongVersion, contracts), /version does not match/);
+
+  const unclassified = await validManifest(contracts);
+  unclassified.components[0].id = "mystery-runtime";
+  assert.throws(() => validateDistributionManifest(unclassified, contracts), /not classified/);
+
+  const embedded = await validManifest(contracts);
+  const embeddedInventory = contracts.inventoryById.get("system-browser-adapter");
+  Object.assign(embedded.components[0], {
+    id: embeddedInventory.id,
+    classification: embeddedInventory.classification,
+    version: contracts.versions[embeddedInventory.id],
+    owner: embeddedInventory.owner,
+    source: embeddedInventory.source,
+    license: embeddedInventory.license,
+    required: false,
+  });
+  assert.throws(() => validateDistributionManifest(embedded, contracts), /embedded component cannot own/);
+});
+
+test("manifest app and launcher compatibility versions are contract-bound", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const wrongApp = await validManifest(contracts);
+  wrongApp.appVersion = "3.0.0";
+  assert.throws(() => validateDistributionManifest(wrongApp, contracts), /appVersion does not match/);
+
+  const wrongLauncher = await validManifest(contracts);
+  wrongLauncher.launcherCompatibility.maximum += 1;
+  assert.throws(() => validateDistributionManifest(wrongLauncher, contracts), /maximum does not match/);
+});
+
+test("manifest validation rejects traversal, overlapping roots, and unowned files", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const traversal = await validManifest(contracts);
+  traversal.files[0].path = "../escape";
+  assert.throws(() => validateDistributionManifest(traversal, contracts), /escapes the payload root|must be normalized/);
+
+  const overlap = await validManifest(contracts);
+  overlap.components[1].path = `${overlap.components[0].path}/nested`;
+  assert.throws(() => validateDistributionManifest(overlap, contracts), /component roots overlap/);
+
+  const orphan = await validManifest(contracts);
+  orphan.files.push({ type: "file", path: "zz-unowned/private.txt", sha256: EMPTY_SHA, sizeBytes: 0, mode: "0644" });
+  assert.throws(() => validateDistributionManifest(orphan, contracts), /exactly one component owner; found 0/);
+});
+
+test("manifest paths are printable ASCII for cross-language byte ordering", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const manifest = await validManifest(contracts);
+  manifest.files[0].path = `${manifest.components[0].path}/\u{10000}`;
+  assert.throws(() => validateDistributionManifest(manifest, contracts), /schema validation failed|printable ASCII/);
+});
+
+test("manifest symlinks stay resolvable inside one component", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const manifest = await validManifest(contracts);
+  const component = manifest.components[0];
+  const link = {
+    type: "symlink",
+    path: `${component.path}/current`,
+    target: "payload",
+    sizeBytes: Buffer.byteLength("payload"),
+  };
+  manifest.files.push(link);
+  manifest.files = sorted(manifest.files.map((file) => file.path)).map((filePath) =>
+    manifest.files.find((file) => file.path === filePath));
+  Object.assign(component, summarizeComponentFiles(component.path, manifest.files));
+  delete component.fileCount;
+  assert.equal(validateDistributionManifest(manifest, contracts), manifest);
+
+  link.target = "../../../../../../outside";
+  link.sizeBytes = Buffer.byteLength(link.target);
+  assert.throws(() => validateDistributionManifest(manifest, contracts), /resolved symlink target.*escapes|resolved symlink target.*relative/);
+
+  const dangling = await validManifest(contracts);
+  const danglingComponent = dangling.components[0];
+  dangling.files.push({
+    type: "symlink",
+    path: `${danglingComponent.path}/dangling`,
+    target: "missing",
+    sizeBytes: Buffer.byteLength("missing"),
+  });
+  dangling.files.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  Object.assign(danglingComponent, summarizeComponentFiles(danglingComponent.path, dangling.files));
+  delete danglingComponent.fileCount;
+  assert.throws(() => validateDistributionManifest(dangling, contracts), /target is not represented/);
+
+  const cycle = await validManifest(contracts);
+  const cycleComponent = cycle.components[0];
+  cycle.files.push(
+    { type: "symlink", path: `${cycleComponent.path}/a`, target: "b", sizeBytes: 1 },
+    { type: "symlink", path: `${cycleComponent.path}/b`, target: "a", sizeBytes: 1 },
+  );
+  cycle.files.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  Object.assign(cycleComponent, summarizeComponentFiles(cycleComponent.path, cycle.files));
+  delete cycleComponent.fileCount;
+  assert.throws(() => validateDistributionManifest(cycle, contracts), /symlink cycle detected/);
+
+  const crossComponent = await validManifest(contracts);
+  const sourceComponent = crossComponent.components[0];
+  const targetComponent = crossComponent.components[1];
+  const crossTarget = path.posix.relative(sourceComponent.path, `${targetComponent.path}/payload`);
+  crossComponent.files.push({
+    type: "symlink",
+    path: `${sourceComponent.path}/cross-component`,
+    target: crossTarget,
+    sizeBytes: Buffer.byteLength(crossTarget),
+  });
+  crossComponent.files.sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0);
+  Object.assign(sourceComponent, summarizeComponentFiles(sourceComponent.path, crossComponent.files));
+  delete sourceComponent.fileCount;
+  assert.throws(() => validateDistributionManifest(crossComponent, contracts), /crosses component ownership/);
+});
+
+test("manifest validation reconciles component digests and sizes", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const wrongDigest = await validManifest(contracts);
+  wrongDigest.components[0].sha256 = "0".repeat(64);
+  assert.throws(() => validateDistributionManifest(wrongDigest, contracts), /component SHA-256 does not match/);
+
+  const wrongSize = await validManifest(contracts);
+  wrongSize.components[0].sizeBytes = 1;
+  assert.throws(() => validateDistributionManifest(wrongSize, contracts), /component size does not match/);
+});
+
+test("manifest validation rejects dangerous file modes", async () => {
+  const contracts = await loadManifestValidationContracts();
+  for (const mode of ["04755", "02755", "01777", "0777", "0000"]) {
+    const manifest = await validManifest(contracts);
+    manifest.files[0].mode = mode;
+    assert.throws(() => validateDistributionManifest(manifest, contracts), /schema validation failed|unsafe mode/);
+  }
+});
+
+test("manifest capabilities must exactly match the safe policy", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const empty = await validManifest(contracts);
+  empty.capabilities = [];
+  assert.throws(() => validateDistributionManifest(empty, contracts), /schema validation failed|must not be empty/);
+
+  const unsafeDefault = await validManifest(contracts);
+  const apply = unsafeDefault.capabilities.find((capability) => capability.id === "auto-apply-browser");
+  apply.defaultEnabled = true;
+  assert.throws(() => validateDistributionManifest(unsafeDefault, contracts), /defaultEnabled does not match/);
+
+  const missingComponent = await validManifest(contracts);
+  missingComponent.capabilities.find((capability) => capability.id === "auto-apply-browser").componentIds = ["jobctrl-worker"];
+  assert.throws(() => validateDistributionManifest(missingComponent, contracts), /componentIds do not match/);
+});
+
+test("release channels are bound to the configured signing key and trust policy", async () => {
+  const contracts = await loadManifestValidationContracts();
+  const manifest = await validManifest(contracts);
+  manifest.releaseChannel = "stable";
+  assert.throws(() => validateDistributionManifest(manifest, contracts, { stable: true }), /manifest key id does not match/);
+
+  manifest.signing.manifestKeyId = contracts.signingPolicy.manifestSigning.keyId;
+  manifest.signing.codeSigning = "developer-id";
+  manifest.signing.notarized = true;
+  assert.throws(() => validateDistributionManifest(manifest, contracts, { stable: true }), /promotion is blocked/);
+
+  const signingPolicy = structuredClone(contracts.signingPolicy);
+  signingPolicy.stableReleaseStatus = "ready";
+  signingPolicy.manifestSigning.publicKeyStatus = "provisioned";
+  signingPolicy.appleSigning.teamIdStatus = "provisioned";
+  validateSigningPolicy(signingPolicy);
+  const readyContracts = { ...contracts, signingPolicy };
+  assert.equal(validateDistributionManifest(manifest, readyContracts, { stable: true }), manifest);
+});
+
+test("external input locks require the exact pinned builder closure", async () => {
+  const { inventory, componentLocks } = await loadDistributionContracts();
+  const inventoryById = validateComponentInventory(inventory);
+  const missingTemporal = structuredClone(componentLocks);
+  missingTemporal.inputs = missingTemporal.inputs.filter((input) => input.id !== "temporal-runtime-archive");
+  assert.throws(() => validateComponentLocks(missingTemporal, inventoryById), /exact required external input set/);
+
+  const wrongChromium = structuredClone(componentLocks);
+  wrongChromium.inputs.find((input) => input.id === "chromium-core-headless-archive").componentId = "temporal-runtime";
+  assert.throws(() => validateComponentLocks(wrongChromium, inventoryById), /componentId does not match/);
+});
+
+test("human license review is machine-bound to inventory policy", async () => {
+  const { inventory } = await loadDistributionContracts();
+  const inventoryById = validateComponentInventory(inventory);
+  const review = await readFile(path.join(process.cwd(), "packaging", "distribution", "LICENSE-REVIEW.md"), "utf8");
+  assert.equal(validateLicenseReview(review, inventoryById).length, inventory.components.length);
+  assert.throws(
+    () => validateLicenseReview(review.replace("| `jobctrl-launcher` | `core-runtime` |", "| `jobctrl-launcher` | `optional-capability` |"), inventoryById),
+    /classification does not match/,
+  );
+  assert.throws(
+    () => validateLicenseReview(review.replace("| `jobctrl-launcher` | `core-runtime` | `AGPL-3.0-only` |", "| `jobctrl-launcher` | `core-runtime` | `MIT` |"), inventoryById),
+    /license does not match/,
+  );
+  assert.throws(
+    () => validateLicenseReview(review.replace("| `jobctrl-launcher` | `core-runtime` | `AGPL-3.0-only` | `bundle` |", "| `jobctrl-launcher` | `core-runtime` | `AGPL-3.0-only` | `exclude` |"), inventoryById),
+    /decision does not match/,
+  );
+});
+
+test("artifact file inventory is bytewise deterministic after mode normalization", async (context) => {
+  const first = await mkdtemp(path.join(os.tmpdir(), "jobctrl-dist-a-"));
+  const second = await mkdtemp(path.join(os.tmpdir(), "jobctrl-dist-b-"));
+  context.after(async () => Promise.all([rm(first, { recursive: true, force: true }), rm(second, { recursive: true, force: true })]));
+  for (const root of [first, second]) {
+    await mkdir(path.join(root, "bin"), { recursive: true });
+    await writeFile(path.join(root, "bin", "z-data"), "data\n");
+    await writeFile(path.join(root, "bin", "JobCtrl"), "launcher\n");
+    await chmod(path.join(root, "bin", "z-data"), 0o644);
+    await chmod(path.join(root, "bin", "JobCtrl"), 0o755);
+  }
+  const firstInventory = await buildFileInventory(first);
+  const secondInventory = await buildFileInventory(second);
+  assert.deepEqual(firstInventory, secondInventory);
+  assert.deepEqual(firstInventory.map((file) => file.path), ["bin/JobCtrl", "bin/z-data"]);
+});
+
+test("artifact file inventory preserves safe relative symlinks and rejects escapes", async (context) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "jobctrl-dist-unsafe-"));
+  context.after(async () => rm(root, { recursive: true, force: true }));
+  await mkdir(path.join(root, "Versions", "145", "Resources"), { recursive: true });
+  await writeFile(path.join(root, "Versions", "145", "Resources", "asset"), "data\n");
+  await chmod(path.join(root, "Versions", "145", "Resources", "asset"), 0o644);
+  await symlink("145", path.join(root, "Versions", "Current"));
+  await symlink("Versions/Current/Resources", path.join(root, "Resources"));
+  const inventory = await buildFileInventory(root);
+  assert.deepEqual(
+    inventory.filter((file) => file.type === "symlink").map((file) => [file.path, file.target]),
+    [["Resources", "Versions/Current/Resources"], ["Versions/Current", "145"]],
+  );
+
+  await symlink("../outside", path.join(root, "escape"));
+  await assert.rejects(buildFileInventory(root), /resolved symlink target.*escapes|resolved symlink target.*relative/);
+  await rm(path.join(root, "escape"));
+  await chmod(path.join(root, "Versions", "145", "Resources", "asset"), 0o777);
+  await assert.rejects(buildFileInventory(root), /unsafe mode 0777/);
+});
+
+test("source measurement reports dependency, lockfile, and environment presence", async () => {
+  const report = await measureDistribution();
+  assert.equal(report.schemaVersion, 1);
+  assert.ok(report.source.javascript.uniqueDirect > 0);
+  assert.ok(report.source.javascript.uniqueRuntimeDirect > 0);
+  assert.ok(report.source.python.runtimeDirect > 0);
+  assert.ok(report.source.locks.pnpmPackageRecords > 0);
+  assert.ok(report.source.locks.uvPackageRecords > 0);
+  assert.ok(["present", "absent"].includes(report.source.environmentPresence.nodeModules));
+  assert.ok(["present", "absent"].includes(report.source.environmentPresence.pythonEnvironment));
+});


### PR DESCRIPTION
## What changed

- define the signed distribution manifest schema, exact external archive locks, platform floor, capability defaults, and signing-channel policy
- classify every top-level runtime, embedded asset, provider pack, and developer-only component with fail-closed redistribution decisions
- add deterministic file/component inventory validation, including single ownership, ASCII canonical ordering, safe Chromium symlinks, modes, hashes, sizes, and schema parity
- separate reproducible dependency counts from observational source-install footprint evidence
- record that Claude, Codex, and Antigravity are managed official-download provider packs until their embedded redistribution closure is established

## Why

JobCtrl currently distributes a mutable source checkout and installs a contributor toolchain. The accepted distribution plan needs a machine-enforced boundary before a production payload or native launcher can be built.

## Impact

This PR does not claim that a user artifact exists yet. It establishes P0 of the stacked plan and deliberately reports stable signing as blocked until release and Apple credentials are provisioned.

## Validation

- `corepack pnpm distribution:audit`
- `node --test scripts/distribution-manifest.test.mjs` — 17/17
- `corepack pnpm scripts:test` — 37/37
- `corepack pnpm docs:build` — 5,025 links
- `python3 scripts/release_check.py`
- `git diff --check`
- clean reconstructed checkout: frozen install, audit, tests, measure, docs, and release check
- pinned Playwright Chromium rev1208 inventory: 333 entries, five safe relative symlinks, modes limited to 0644/0755

## Stack

Depends on #394. P1 will build and measure the production payload against this contract.