### PR TITLE
feat(launcher): centralize bundled runtime lifecycle

### DIFF
--- a/.github/workflows/launcher.yml
+++ b/.github/workflows/launcher.yml
@@ -1,0 +1,62 @@
+name: Native Launcher CI
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "launcher/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "scripts/**"
+      - "packaging/distribution/**"
+      - ".github/workflows/launcher.yml"
+  pull_request:
+    paths:
+      - "launcher/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "scripts/**"
+      - "packaging/distribution/**"
+      - ".github/workflows/launcher.yml"
+  workflow_dispatch:
+
+jobs:
+  launcher:
+    name: Darwin launcher (vet + race)
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pinned Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.4"
+          cache-dependency-path: launcher/go.mod
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.21.1"
+          cache: pnpm
+
+      - name: Install Node dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Vet native launcher
+        working-directory: launcher
+        run: go vet ./...
+
+      - name: Test native launcher
+        working-directory: launcher
+        run: go test -race ./...
+
+      - name: Test pinned distribution build contracts
+        run: corepack pnpm scripts:test
+
+      - name: Audit distribution contracts
+        run: corepack pnpm distribution:audit

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ All commands run as `uv --project workers/automation run jobctrl <command>`
 | `retry <stage> <url>` | Reset one failed stage for one job (`--reset-attempts`, `--run`). |
 | `action <stage>` | Low-level single-action dispatch with JSON output (used by scripts). |
 | `compensation-refresh` | Re-parse posted salaries and refresh market estimates (`--url`, `--observations-json`). |
-| `status` / `runs` | Inspect database stats and run telemetry (`runs --failed-only`). |
+| `pipeline-status` / `runs` | Inspect database stats and run telemetry (`runs --failed-only`). |
 | `digest` | Print the local daily digest (`--json`, `--acknowledge`, `--min-fit-score`). |
 | `worker` | Run the long-lived Temporal worker. |
 | `rpc` | JSON-RPC server spawned by the TypeScript API (internal). |

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -68,10 +68,17 @@ instead of requiring system `npx`. Nested Python setup/doctor and MCP processes
 run with isolated mode plus bytecode suppression (`-I -B`) so they cannot write
 `__pycache__` into the launcher-verified payload.
 
-The Phase 1 payload uses an intentionally non-promotable local launcher stub.
-The native lifecycle supervisor and signed release acquisition are separate
-distribution phases; until those land, this payload is build evidence rather
-than a public install surface.
+The Phase 2 payload replaces the local stub with a native `jobctrl` supervisor.
+It verifies the manifest envelope/tree before dispatch, starts fixed loopback
+Temporal (gRPC `7233`, Web UI `8233`) → worker → API (`8766`) in that order,
+and waits for Temporal plus API worker-heartbeat health. Each canonical
+`JOBCTRL_DIR` gets one `flock`-protected registry at
+`~/Library/Application Support/JobCtrl/instances/<sha256>` (or
+`JOBCTRL_RUNTIME_HOME`); records bind PID, PGID, start identity, executable,
+build ID, manifest digest, and ports so lifecycle cleanup cannot target a
+reused PID. The local artifact remains unsigned/non-promotable until later
+signing and installer phases, so this is still build evidence rather than a
+public install surface.
 
 ## Frontend
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -157,8 +157,10 @@ Regenerate public documentation screenshots with `pnpm docs:screenshots` — see
 
 The production-payload builder currently targets Apple-silicon macOS. It is a
 release-engineering path, not an alternative contributor setup: the build
-machine still needs the source toolchain above, while the resulting payload is
-self-contained and does not.
+machine still needs the source toolchain above plus the pinned `go1.26.4`
+launcher compiler, while the resulting payload is self-contained and does not.
+The artifact ships only the statically linked launcher and the Go standard
+library BSD-3-Clause attribution — never the compiler.
 
 ```bash
 pnpm distribution:audit
@@ -177,9 +179,15 @@ development tool, provider runtime, source path, unowned file, unresolved
 license, or unpinned external input enters the payload.
 
 The local artifact is deliberately marked `unsigned-local` and cannot be
-promoted as a stable release. Native launcher, installer, signing, and
-notarization gates are owned by the later phases of the bundled-distribution
-plan. Use the much smaller contract fixture while changing the builder itself:
+promoted as a stable release. It includes the Phase 2 native launcher at
+`payload/launcher/jobctrl`: its private runtime manifest starts the fixed
+loopback Temporal (`7233`/`8233`), worker, and API (`8766`) fleet without Vite,
+and records each canonical `JOBCTRL_DIR` under
+`~/Library/Application Support/JobCtrl/instances/<sha256>` (override with
+`JOBCTRL_RUNTIME_HOME`). This is an artifact smoke/development surface only;
+`scripts/dev` remains the source-contributor launcher until the installer and
+signing phases land. Use the much smaller contract fixture while changing the
+builder itself:
 
 ```bash
 pnpm distribution:build:fixture

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -240,7 +240,7 @@ real `~/.jobctrl` workspace so real data never mixes in.
 ## 6. First Useful Checks
 
 ```bash
-uv --project workers/automation run jobctrl status
+uv --project workers/automation run jobctrl pipeline-status
 uv --project workers/automation run jobctrl runs
 curl http://127.0.0.1:8766/v1/health
 ```

--- a/docs/user/normal-flows.md
+++ b/docs/user/normal-flows.md
@@ -175,7 +175,7 @@ Use the CLI to inspect workflow health, then review the jobs themselves in the
 web app:
 
 ```bash
-uv --project workers/automation run jobctrl status
+uv --project workers/automation run jobctrl pipeline-status
 uv --project workers/automation run jobctrl runs --failed-only
 ```
 
@@ -402,7 +402,7 @@ Useful web app views:
 <WorkflowSurfacePanel surface="cli">
 
 ```bash
-uv --project workers/automation run jobctrl status
+uv --project workers/automation run jobctrl pipeline-status
 uv --project workers/automation run jobctrl digest
 uv --project workers/automation run jobctrl runs
 uv --project workers/automation run jobctrl runs --failed-only

--- a/launcher/GO-LICENSE
+++ b/launcher/GO-LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/launcher/cmd/jobctrl/main.go
+++ b/launcher/cmd/jobctrl/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ebarti/jobctrl/launcher/internal/launcher"
+)
+
+func main() {
+	executable, err := installedExecutable()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "jobctrl:", err)
+		os.Exit(1)
+	}
+	if err := launcher.Run(executable, os.Args[1:], os.Environ(), os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "jobctrl:", err)
+		os.Exit(launcher.ExitCode(err))
+	}
+}
+
+// installedExecutable deliberately ignores argv[0] and does not re-resolve a
+// mutable PATH after process start. PATH and Homebrew shims may leave argv[0]
+// or os.Executable() bare; the kernel's current-process path is the authority
+// used to bind lifecycle re-exec to the payload that is already running.
+func installedExecutable() (string, error) {
+	executable, kernelErr := launcher.CurrentProcessExecutable()
+	if kernelErr != nil {
+		var osErr error
+		executable, osErr = os.Executable()
+		if osErr != nil {
+			return "", fmt.Errorf("locate running launcher executable (kernel: %v): %w", kernelErr, osErr)
+		}
+		if !filepath.IsAbs(executable) {
+			return "", fmt.Errorf("kernel executable lookup failed (%v) and os.Executable returned non-absolute path %q", kernelErr, executable)
+		}
+	}
+	if !filepath.IsAbs(executable) {
+		return "", fmt.Errorf("kernel returned non-absolute launcher executable path %q", executable)
+	}
+	executable, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize running launcher executable: %w", err)
+	}
+	return executable, nil
+}

--- a/launcher/go.mod
+++ b/launcher/go.mod
@@ -1,0 +1,3 @@
+module github.com/ebarti/jobctrl/launcher
+
+go 1.24.0

--- a/launcher/internal/launcher/launcher.go
+++ b/launcher/internal/launcher/launcher.go
@@ -1,0 +1,1756 @@
+// Package launcher owns the installed JobCtrl process boundary. It deliberately
+// has no domain logic: it validates payload metadata, manages bundled processes,
+// and transparently dispatches the embedded Python CLI.
+package launcher
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	pathpkg "path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var (
+	sha256Pattern        = regexp.MustCompile(`^[a-f0-9]{64}$`)
+	componentIDPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,63}$`)
+	buildIDPattern       = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$`)
+	semverPattern        = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	minimumOSPattern     = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+){1,2}$`)
+	requiredComponentIDs = []string{"jobctrl-launcher", "jobctrl-api", "jobctrl-web", "jobctrl-worker", "node-runtime", "python-runtime", "temporal-runtime"}
+)
+
+const (
+	launcherProtocol   = 1
+	stateSchemaVersion = 1
+	logLineLimit       = 200
+	startupTimeout     = 30 * time.Second
+	shutdownTimeout    = 5 * time.Second
+)
+
+var (
+	ErrAlreadyRunning     = errors.New("an active JobCtrl instance already owns this state directory")
+	ErrPortInUse          = errors.New("a required fixed loopback port is already in use")
+	ErrLockHeld           = errors.New("the JobCtrl instance lock is held")
+	errStartupInterrupted = errors.New("supervisor startup interrupted")
+)
+
+type commandSpec struct {
+	Name       string   `json:"name"`
+	Executable string   `json:"executable"`
+	Arguments  []string `json:"arguments"`
+}
+
+type runtimeManifest struct {
+	SchemaVersion    int `json:"schemaVersion"`
+	LauncherProtocol int `json:"launcherProtocol"`
+	Ports            struct {
+		TemporalGRPC int `json:"temporalGrpc"`
+		TemporalUI   int `json:"temporalUi"`
+		API          int `json:"api"`
+	} `json:"ports"`
+	Components []commandSpec `json:"components"`
+	Health     struct {
+		Temporal struct {
+			Component string   `json:"component"`
+			Arguments []string `json:"arguments"`
+		} `json:"temporal"`
+		API struct {
+			Path                 string `json:"path"`
+			RequireWorkerHealthy bool   `json:"requireWorkerHealthy"`
+			RequireWorkerPID     bool   `json:"requireWorkerPid"`
+		} `json:"api"`
+	} `json:"health"`
+}
+
+// This is the full v1 public envelope shape. Strict decoding means a launcher
+// never makes a permissive map-shaped assumption about a signed artifact.
+type distributionManifest struct {
+	SchemaVersion   int    `json:"schemaVersion"`
+	AppVersion      string `json:"appVersion"`
+	BuildID         string `json:"buildId"`
+	ReleaseChannel  string `json:"releaseChannel"`
+	SourceDateEpoch int64  `json:"sourceDateEpoch"`
+	Platform        struct {
+		ID               string `json:"id"`
+		OS               string `json:"os"`
+		Arch             string `json:"arch"`
+		MinimumOSVersion string `json:"minimumOsVersion"`
+	} `json:"platform"`
+	LauncherCompatibility struct {
+		Minimum int `json:"minimum"`
+		Maximum int `json:"maximum"`
+	} `json:"launcherCompatibility"`
+	Components []struct {
+		ID             string `json:"id"`
+		Classification string `json:"classification"`
+		Version        string `json:"version"`
+		Owner          string `json:"owner"`
+		Source         string `json:"source"`
+		License        string `json:"license"`
+		Redistribution string `json:"redistribution"`
+		Path           string `json:"path"`
+		SHA256         string `json:"sha256"`
+		SizeBytes      int64  `json:"sizeBytes"`
+		Required       bool   `json:"required"`
+	} `json:"components"`
+	Capabilities []struct {
+		ID             string   `json:"id"`
+		DefaultEnabled bool     `json:"defaultEnabled"`
+		ComponentIDs   []string `json:"componentIds"`
+	} `json:"capabilities"`
+	Files []struct {
+		Type      string `json:"type"`
+		Path      string `json:"path"`
+		SHA256    string `json:"sha256,omitempty"`
+		Target    string `json:"target,omitempty"`
+		SizeBytes int64  `json:"sizeBytes"`
+		Mode      string `json:"mode,omitempty"`
+	} `json:"files"`
+	Signing struct {
+		ManifestAlgorithm string `json:"manifestAlgorithm"`
+		ManifestKeyID     string `json:"manifestKeyId"`
+		CodeSigning       string `json:"codeSigning"`
+		Notarized         bool   `json:"notarized"`
+	} `json:"signing"`
+}
+
+type manifestSignature struct {
+	SchemaVersion     int     `json:"schemaVersion"`
+	Status            string  `json:"status"`
+	ManifestAlgorithm string  `json:"manifestAlgorithm"`
+	ManifestKeyID     string  `json:"manifestKeyId"`
+	Signature         *string `json:"signature"`
+	Promotable        bool    `json:"promotable"`
+}
+
+type componentRecord struct {
+	PID           int        `json:"pid"`
+	PGID          int        `json:"pgid"`
+	StartIdentity string     `json:"startIdentity"`
+	Executable    string     `json:"executable"`
+	StartedAt     time.Time  `json:"startedAt"`
+	LogPath       string     `json:"logPath"`
+	ExitedAt      *time.Time `json:"exitedAt,omitempty"`
+	ExitError     string     `json:"exitError,omitempty"`
+}
+
+type instanceState struct {
+	SchemaVersion     int                        `json:"schemaVersion"`
+	InstanceID        string                     `json:"instanceId"`
+	CanonicalStateDir string                     `json:"canonicalStateDir"`
+	PayloadRoot       string                     `json:"payloadRoot"`
+	BuildID           string                     `json:"buildId"`
+	ManifestSHA256    string                     `json:"manifestSha256"`
+	Ports             runtimePorts               `json:"ports"`
+	StartedAt         time.Time                  `json:"startedAt"`
+	StoppedAt         *time.Time                 `json:"stoppedAt,omitempty"`
+	Supervisor        componentRecord            `json:"supervisor"`
+	Components        map[string]componentRecord `json:"components"`
+}
+
+type runtimePorts struct {
+	TemporalGRPC int `json:"temporalGrpc"`
+	TemporalUI   int `json:"temporalUi"`
+	API          int `json:"api"`
+}
+
+type instance struct {
+	RuntimeHome string
+	StateDir    string
+	ID          string
+	Dir         string
+	LockPath    string
+	ControlPath string
+	StatePath   string
+	LogDir      string
+}
+type launchContext struct {
+	Executable   string
+	PayloadRoot  string
+	Manifest     runtimeManifest
+	Distribution distributionManifest
+	Instance     instance
+	Environment  []string
+}
+type readyMessage struct {
+	Error string `json:"error,omitempty"`
+}
+type processIdentityReader func(int) (string, error)
+type groupSignaler func(int, syscall.Signal) error
+
+var readProcessIdentity processIdentityReader = processStartIdentity
+var readProcessExecutable processIdentityReader = processExecutable
+var signalProcessGroup groupSignaler = func(pgid int, signal syscall.Signal) error { return syscall.Kill(-pgid, signal) }
+var openBrowser = func(url string) error { return exec.Command("/usr/bin/open", url).Run() }
+var temporalHealthProbe = probeTemporal
+
+// Run is the only public CLI entrypoint. __supervise is reachable only through
+// the re-exec made by `jobctrl start`.
+func Run(executable string, args, inheritedEnv []string, stdout, stderr io.Writer) error {
+	ctx, err := prepare(executable, inheritedEnv)
+	if err != nil {
+		return err
+	}
+	if len(args) > 0 && args[0] == "__supervise" {
+		return supervise(ctx, readyWriterFromEnv(inheritedEnv))
+	}
+	if len(args) == 0 || args[0] == "--help" || args[0] == "help" {
+		printHelp(stdout)
+		return nil
+	}
+	switch args[0] {
+	case "start":
+		foreground, noOpen, err := parseStartArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		if foreground {
+			return supervise(ctx, nil)
+		}
+		if err := startDetached(ctx); err != nil {
+			return err
+		}
+		if !noOpen {
+			return openURL(ctx)
+		}
+		_, err = fmt.Fprintf(stdout, "JobCtrl is ready at http://127.0.0.1:%d\n", ctx.Manifest.Ports.API)
+		return err
+	case "stop":
+		if len(args) != 1 {
+			return errors.New("usage: jobctrl stop")
+		}
+		return stop(ctx)
+	case "status":
+		if len(args) == 2 && args[1] == "--pipeline" {
+			return dispatchPython(ctx, []string{"pipeline-status"})
+		}
+		jsonOutput, err := parseStatusArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		return status(ctx, stdout, jsonOutput)
+	case "logs":
+		return logs(ctx, args[1:], stdout)
+	case "open":
+		if len(args) != 1 {
+			return errors.New("usage: jobctrl open")
+		}
+		return openURL(ctx)
+	case "version":
+		jsonOutput, err := parseVersionArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		return version(ctx, stdout, jsonOutput)
+	default:
+		return dispatchPython(ctx, args)
+	}
+}
+
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	if errors.Is(err, ErrAlreadyRunning) || errors.Is(err, ErrLockHeld) {
+		return 75
+	}
+	if errors.Is(err, ErrPortInUse) {
+		return 69
+	}
+	return 1
+}
+func printHelp(out io.Writer) {
+	fmt.Fprint(out, "JobCtrl bundled launcher\n\nUsage:\n  jobctrl start [--no-open] [--foreground]\n  jobctrl stop\n  jobctrl status [--pipeline] [--json]\n  jobctrl logs [temporal|worker|api]\n  jobctrl open\n  jobctrl version [--json]\n  jobctrl pipeline-status\n  jobctrl <Python domain command>\n")
+}
+func parseStartArgs(args []string) (foreground, noOpen bool, err error) {
+	for _, arg := range args {
+		switch arg {
+		case "--foreground":
+			foreground = true
+		case "--no-open":
+			noOpen = true
+		default:
+			return false, false, fmt.Errorf("unknown start option %q", arg)
+		}
+	}
+	return
+}
+func parseStatusArgs(args []string) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	if len(args) == 1 && args[0] == "--json" {
+		return true, nil
+	}
+	return false, errors.New("usage: jobctrl status [--pipeline] [--json]")
+}
+func parseVersionArgs(args []string) (bool, error) {
+	if len(args) == 0 {
+		return false, nil
+	}
+	if len(args) == 1 && args[0] == "--json" {
+		return true, nil
+	}
+	return false, errors.New("usage: jobctrl version [--json]")
+}
+
+func prepare(executable string, inheritedEnv []string) (launchContext, error) {
+	payloadRoot, err := locatePayloadRoot(executable)
+	if err != nil {
+		return launchContext{}, err
+	}
+	distribution, err := loadAndVerifyDistributionManifest(payloadRoot)
+	if err != nil {
+		return launchContext{}, err
+	}
+	manifest, err := loadRuntimeManifest(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"))
+	if err != nil {
+		return launchContext{}, err
+	}
+	if distribution.LauncherCompatibility.Minimum > launcherProtocol || distribution.LauncherCompatibility.Maximum < launcherProtocol {
+		return launchContext{}, fmt.Errorf("payload supports launcher protocol %d-%d, this launcher is protocol %d", distribution.LauncherCompatibility.Minimum, distribution.LauncherCompatibility.Maximum, launcherProtocol)
+	}
+	inst, err := resolveInstance(inheritedEnv)
+	if err != nil {
+		return launchContext{}, err
+	}
+	return launchContext{executable, payloadRoot, manifest, distribution, inst, childEnvironment(inheritedEnv, payloadRoot, inst.StateDir, manifest)}, nil
+}
+func locatePayloadRoot(executable string) (string, error) {
+	path, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return "", fmt.Errorf("resolve launcher executable: %w", err)
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if filepath.Base(path) != "jobctrl" || filepath.Base(filepath.Dir(path)) != "launcher" {
+		return "", fmt.Errorf("launcher must be installed as <payload>/launcher/jobctrl, got %q", path)
+	}
+	return filepath.Dir(filepath.Dir(path)), nil
+}
+func decodeStrict(path string, destination any) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return fmt.Errorf("decode %s: %w", filepath.Base(path), err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return fmt.Errorf("decode %s: trailing JSON value", filepath.Base(path))
+	}
+	return nil
+}
+func safeRelativePath(path string) bool {
+	if !isPrintableASCII(path) || strings.Contains(path, "\\") || strings.HasPrefix(path, "/") {
+		return false
+	}
+	clean := pathpkg.Clean(path)
+	return clean == path && clean != "." && clean != ".." && !strings.HasPrefix(clean, "../")
+}
+
+func safeSymlinkTarget(target string) bool {
+	return isPrintableASCII(target) && !strings.Contains(target, "\\") && !strings.HasPrefix(target, "/") && pathpkg.Clean(target) == target
+}
+
+func isPrintableASCII(value string) bool {
+	if value == "" {
+		return false
+	}
+	for index := 0; index < len(value); index++ {
+		if value[index] < 0x20 || value[index] > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+func loadRuntimeManifest(path string) (runtimeManifest, error) {
+	var manifest runtimeManifest
+	if err := decodeStrict(path, &manifest); err != nil {
+		return manifest, err
+	}
+	if manifest.SchemaVersion != 1 || manifest.LauncherProtocol != launcherProtocol {
+		return manifest, errors.New("unsupported runtime manifest protocol")
+	}
+	if manifest.Ports.TemporalGRPC != 7233 || manifest.Ports.TemporalUI != 8233 || manifest.Ports.API != 8766 {
+		return manifest, errors.New("runtime manifest must use JobCtrl fixed loopback ports 7233, 8233, and 8766")
+	}
+	if len(manifest.Components) != 3 {
+		return manifest, errors.New("runtime manifest must define exactly temporal, worker, and api")
+	}
+	for i, expected := range []string{"temporal", "worker", "api"} {
+		component := manifest.Components[i]
+		if component.Name != expected || !safeRelativePath(component.Executable) {
+			return manifest, fmt.Errorf("invalid runtime component %q", component.Name)
+		}
+	}
+	if manifest.Health.Temporal.Component != "temporal" || manifest.Health.API.Path != "/v1/health" || !manifest.Health.API.RequireWorkerHealthy || !manifest.Health.API.RequireWorkerPID {
+		return manifest, errors.New("runtime manifest health contract is invalid")
+	}
+	return manifest, nil
+}
+
+func decodeRawJSONObject(raw json.RawMessage, label string, keys ...string) (map[string]json.RawMessage, error) {
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return nil, fmt.Errorf("%s must be an object: %w", label, err)
+	}
+	if len(object) != len(keys) {
+		return nil, fmt.Errorf("%s has missing or unknown fields", label)
+	}
+	for _, key := range keys {
+		if _, exists := object[key]; !exists {
+			return nil, fmt.Errorf("%s is missing required field %q", label, key)
+		}
+	}
+	return object, nil
+}
+
+func decodeRawJSONArray(raw json.RawMessage, label string) ([]json.RawMessage, error) {
+	var values []json.RawMessage
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("%s must be an array: %w", label, err)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("%s must not be empty", label)
+	}
+	return values, nil
+}
+
+func rawBoolean(raw json.RawMessage) bool {
+	return string(raw) == "true" || string(raw) == "false"
+}
+
+func rawNonNegativeInteger(raw json.RawMessage) bool {
+	var value int64
+	return string(raw) != "null" && json.Unmarshal(raw, &value) == nil && value >= 0
+}
+
+func pathOwnedBy(filePath, componentPath string) bool {
+	return filePath == componentPath || strings.HasPrefix(filePath, componentPath+"/")
+}
+
+func validateDistributionManifestShape(raw []byte, manifest distributionManifest) error {
+	var root json.RawMessage = raw
+	object, err := decodeRawJSONObject(root, "distribution manifest", "schemaVersion", "appVersion", "buildId", "releaseChannel", "sourceDateEpoch", "platform", "launcherCompatibility", "components", "capabilities", "files", "signing")
+	if err != nil {
+		return err
+	}
+	if !rawNonNegativeInteger(object["sourceDateEpoch"]) || manifest.SchemaVersion != 1 || !semverPattern.MatchString(manifest.AppVersion) || !buildIDPattern.MatchString(manifest.BuildID) || manifest.SourceDateEpoch < 0 {
+		return errors.New("invalid distribution manifest format")
+	}
+	if manifest.ReleaseChannel != "local" {
+		return errors.New("this launcher accepts only local release manifests until release-signature verification is provisioned")
+	}
+	platform, err := decodeRawJSONObject(object["platform"], "distribution manifest platform", "id", "os", "arch", "minimumOsVersion")
+	if err != nil {
+		return err
+	}
+	if !isPrintableASCII(manifest.Platform.ID) || !isPrintableASCII(manifest.Platform.OS) || !isPrintableASCII(manifest.Platform.Arch) || !minimumOSPattern.MatchString(manifest.Platform.MinimumOSVersion) || manifest.Platform.ID != "darwin-arm64" || manifest.Platform.OS != "darwin" || manifest.Platform.Arch != "arm64" || string(platform["id"]) == "null" {
+		return errors.New("distribution manifest platform must be the supported darwin-arm64 format")
+	}
+	compatibility, err := decodeRawJSONObject(object["launcherCompatibility"], "distribution manifest launcherCompatibility", "minimum", "maximum")
+	if err != nil {
+		return err
+	}
+	if !rawNonNegativeInteger(compatibility["minimum"]) || !rawNonNegativeInteger(compatibility["maximum"]) || manifest.LauncherCompatibility.Minimum < 1 || manifest.LauncherCompatibility.Maximum < manifest.LauncherCompatibility.Minimum {
+		return errors.New("invalid distribution manifest launcher compatibility")
+	}
+
+	componentRaw, err := decodeRawJSONArray(object["components"], "distribution manifest components")
+	if err != nil {
+		return err
+	}
+	if len(componentRaw) != len(manifest.Components) {
+		return errors.New("distribution manifest components do not decode consistently")
+	}
+	componentByID := make(map[string]int, len(manifest.Components))
+	for index, component := range manifest.Components {
+		fields, err := decodeRawJSONObject(componentRaw[index], "distribution manifest component", "id", "classification", "version", "owner", "source", "license", "redistribution", "path", "sha256", "sizeBytes", "required")
+		if err != nil {
+			return err
+		}
+		if !rawBoolean(fields["required"]) || !rawNonNegativeInteger(fields["sizeBytes"]) || !componentIDPattern.MatchString(component.ID) || !isPrintableASCII(component.Classification) || !isPrintableASCII(component.Version) || !isPrintableASCII(component.Owner) || !isPrintableASCII(component.Source) || !isPrintableASCII(component.License) || component.Source == "" || !strings.HasPrefix(component.Source, "https://") || component.Redistribution != "bundle" || !safeRelativePath(component.Path) || !sha256Pattern.MatchString(component.SHA256) || component.SizeBytes < 0 {
+			return fmt.Errorf("invalid distribution component %q", component.ID)
+		}
+		if component.Classification != "core-runtime" && component.Classification != "optional-capability" && component.Classification != "provider-pack" {
+			return fmt.Errorf("invalid distribution component classification for %q", component.ID)
+		}
+		if _, exists := componentByID[component.ID]; exists {
+			return fmt.Errorf("distribution manifest repeats component %q", component.ID)
+		}
+		componentByID[component.ID] = index
+		if index > 0 && manifest.Components[index-1].ID >= component.ID {
+			return errors.New("distribution manifest components must be bytewise sorted")
+		}
+	}
+	for _, required := range requiredComponentIDs {
+		if _, exists := componentByID[required]; !exists {
+			return fmt.Errorf("distribution manifest is missing runtime component %q", required)
+		}
+	}
+	for left := range manifest.Components {
+		for right := left + 1; right < len(manifest.Components); right++ {
+			if pathOwnedBy(manifest.Components[left].Path, manifest.Components[right].Path) || pathOwnedBy(manifest.Components[right].Path, manifest.Components[left].Path) {
+				return fmt.Errorf("distribution component roots overlap: %q and %q", manifest.Components[left].Path, manifest.Components[right].Path)
+			}
+		}
+	}
+
+	capabilityRaw, err := decodeRawJSONArray(object["capabilities"], "distribution manifest capabilities")
+	if err != nil {
+		return err
+	}
+	if len(capabilityRaw) != len(manifest.Capabilities) {
+		return errors.New("distribution manifest capabilities do not decode consistently")
+	}
+	capabilities := make(map[string]bool, len(manifest.Capabilities))
+	for index, capability := range manifest.Capabilities {
+		fields, err := decodeRawJSONObject(capabilityRaw[index], "distribution manifest capability", "id", "defaultEnabled", "componentIds")
+		if err != nil {
+			return err
+		}
+		if !componentIDPattern.MatchString(capability.ID) || !rawBoolean(fields["defaultEnabled"]) || len(capability.ComponentIDs) == 0 {
+			return fmt.Errorf("invalid distribution capability %q", capability.ID)
+		}
+		if capabilities[capability.ID] {
+			return fmt.Errorf("distribution manifest repeats capability %q", capability.ID)
+		}
+		capabilities[capability.ID] = true
+		if index > 0 && manifest.Capabilities[index-1].ID >= capability.ID {
+			return errors.New("distribution manifest capabilities must be bytewise sorted")
+		}
+		seen := map[string]bool{}
+		for componentIndex, componentID := range capability.ComponentIDs {
+			if !componentIDPattern.MatchString(componentID) || seen[componentID] {
+				return fmt.Errorf("invalid capability component reference %q", componentID)
+			}
+			if _, exists := componentByID[componentID]; !exists {
+				return fmt.Errorf("capability %q references unknown component %q", capability.ID, componentID)
+			}
+			if componentIndex > 0 && capability.ComponentIDs[componentIndex-1] >= componentID {
+				return fmt.Errorf("capability %q component ids must be bytewise sorted", capability.ID)
+			}
+			seen[componentID] = true
+		}
+	}
+
+	fileRaw, err := decodeRawJSONArray(object["files"], "distribution manifest files")
+	if err != nil {
+		return err
+	}
+	if len(fileRaw) != len(manifest.Files) {
+		return errors.New("distribution manifest files do not decode consistently")
+	}
+	filesByComponent := make([][]int, len(manifest.Components))
+	seenFiles := make(map[string]bool, len(manifest.Files))
+	for index, file := range manifest.Files {
+		keys := []string{"type", "path", "target", "sizeBytes"}
+		if file.Type == "file" {
+			keys = []string{"type", "path", "sha256", "sizeBytes", "mode"}
+		}
+		fields, err := decodeRawJSONObject(fileRaw[index], "distribution manifest file", keys...)
+		if err != nil {
+			return err
+		}
+		if !rawNonNegativeInteger(fields["sizeBytes"]) || !safeRelativePath(file.Path) || seenFiles[file.Path] || file.SizeBytes < 0 {
+			return fmt.Errorf("invalid distribution manifest file %q", file.Path)
+		}
+		if index > 0 && manifest.Files[index-1].Path >= file.Path {
+			return errors.New("distribution manifest files must be bytewise sorted")
+		}
+		seenFiles[file.Path] = true
+		if file.Type == "file" {
+			if !sha256Pattern.MatchString(file.SHA256) || (file.Mode != "0644" && file.Mode != "0755") {
+				return fmt.Errorf("invalid regular distribution file %q", file.Path)
+			}
+		} else if file.Type == "symlink" {
+			if !safeSymlinkTarget(file.Target) || file.SizeBytes != int64(len(file.Target)) {
+				return fmt.Errorf("invalid distribution symlink %q", file.Path)
+			}
+		} else {
+			return fmt.Errorf("invalid distribution file type for %q", file.Path)
+		}
+		owner := -1
+		for componentIndex, component := range manifest.Components {
+			if pathOwnedBy(file.Path, component.Path) {
+				if owner != -1 {
+					return fmt.Errorf("distribution file %q has more than one component owner", file.Path)
+				}
+				owner = componentIndex
+			}
+		}
+		if owner == -1 {
+			return fmt.Errorf("distribution file %q has no component owner", file.Path)
+		}
+		filesByComponent[owner] = append(filesByComponent[owner], index)
+	}
+	for componentIndex, component := range manifest.Components {
+		if len(filesByComponent[componentIndex]) == 0 {
+			return fmt.Errorf("distribution component %q owns no files", component.ID)
+		}
+		canonical := strings.Builder{}
+		var size int64
+		for _, fileIndex := range filesByComponent[componentIndex] {
+			file := manifest.Files[fileIndex]
+			if file.Type == "symlink" {
+				fmt.Fprintf(&canonical, "%s\x00symlink\x00%s\x00%d\n", file.Path, file.Target, file.SizeBytes)
+			} else {
+				fmt.Fprintf(&canonical, "%s\x00file\x00%s\x00%d\x00%s\n", file.Path, file.SHA256, file.SizeBytes, file.Mode)
+			}
+			size += file.SizeBytes
+		}
+		digest := sha256.Sum256([]byte(canonical.String()))
+		if component.SizeBytes != size || component.SHA256 != hex.EncodeToString(digest[:]) {
+			return fmt.Errorf("distribution component %q summary does not match its owned files", component.ID)
+		}
+	}
+
+	fields, err := decodeRawJSONObject(object["signing"], "distribution manifest signing", "manifestAlgorithm", "manifestKeyId", "codeSigning", "notarized")
+	if err != nil {
+		return err
+	}
+	if !rawBoolean(fields["notarized"]) || manifest.Signing.ManifestAlgorithm != "ed25519" || manifest.Signing.ManifestKeyID != "local-development" || manifest.Signing.CodeSigning != "unsigned-local" || manifest.Signing.Notarized {
+		return errors.New("invalid local distribution signing envelope")
+	}
+	return nil
+}
+
+func validateManifestSignatureShape(raw []byte, signature manifestSignature, manifest distributionManifest) error {
+	fields, err := decodeRawJSONObject(raw, "distribution manifest signature", "schemaVersion", "status", "manifestAlgorithm", "manifestKeyId", "signature", "promotable")
+	if err != nil {
+		return err
+	}
+	if !rawNonNegativeInteger(fields["schemaVersion"]) || !rawBoolean(fields["promotable"]) || string(fields["signature"]) != "null" || signature.SchemaVersion != 1 || signature.Status != "unsigned-local" || signature.Signature != nil || signature.Promotable || signature.ManifestAlgorithm != manifest.Signing.ManifestAlgorithm || signature.ManifestKeyID != manifest.Signing.ManifestKeyID {
+		return errors.New("invalid local distribution manifest signature binding")
+	}
+	return nil
+}
+
+func loadAndVerifyDistributionManifest(payloadRoot string) (distributionManifest, error) {
+	var manifest distributionManifest
+	manifestPath := filepath.Join(payloadRoot, "manifest.json")
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return manifest, err
+	}
+	if err := decodeStrict(manifestPath, &manifest); err != nil {
+		return manifest, err
+	}
+	if err := validateDistributionManifestShape(manifestBytes, manifest); err != nil {
+		return manifest, err
+	}
+	if err := verifyPayloadTree(payloadRoot, manifest); err != nil {
+		return manifest, err
+	}
+	var signature manifestSignature
+	signaturePath := filepath.Join(payloadRoot, "manifest.sig")
+	signatureBytes, err := os.ReadFile(signaturePath)
+	if err != nil {
+		return manifest, err
+	}
+	if err := decodeStrict(signaturePath, &signature); err != nil {
+		return manifest, err
+	}
+	if err := validateManifestSignatureShape(signatureBytes, signature, manifest); err != nil {
+		return manifest, err
+	}
+	// P6 replaces this seam with Ed25519 verification. P1's local artifact is
+	// permitted only when every relevant envelope field says local/non-promotable.
+	if signature.Status == "unsigned-local" && signature.Signature == nil && !signature.Promotable && manifest.ReleaseChannel == "local" && manifest.Signing.CodeSigning == "unsigned-local" && !manifest.Signing.Notarized && signature.ManifestAlgorithm == "ed25519" && signature.ManifestKeyID == "local-development" {
+		return manifest, nil
+	}
+	return manifest, errors.New("release manifest signature verification is unavailable for this artifact; only P1 unsigned-local non-promotable artifacts are accepted")
+}
+
+// verifyPayloadTree is deliberately performed before any lifecycle action or
+// Python dispatch. manifest.json and manifest.sig are the two documented
+// envelope exclusions; every other regular file or symlink must match exactly.
+func verifyPayloadTree(payloadRoot string, manifest distributionManifest) error {
+	expected := make(map[string]struct {
+		typeName string
+		sha256   string
+		target   string
+		size     int64
+		mode     string
+	}, len(manifest.Files))
+	for _, file := range manifest.Files {
+		if _, exists := expected[file.Path]; exists {
+			return fmt.Errorf("distribution manifest repeats file %q", file.Path)
+		}
+		expected[file.Path] = struct {
+			typeName string
+			sha256   string
+			target   string
+			size     int64
+			mode     string
+		}{file.Type, file.SHA256, file.Target, file.SizeBytes, file.Mode}
+	}
+	actual := make(map[string]bool, len(expected))
+	err := filepath.WalkDir(payloadRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == payloadRoot || entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(payloadRoot, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if relative == "manifest.json" || relative == "manifest.sig" {
+			return nil
+		}
+		expectedFile, recorded := expected[relative]
+		if !recorded {
+			return fmt.Errorf("payload contains unrecorded file %q", relative)
+		}
+		if actual[relative] {
+			return fmt.Errorf("payload contains duplicate file %q", relative)
+		}
+		actual[relative] = true
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			if expectedFile.typeName != "symlink" {
+				return fmt.Errorf("payload file type mismatch for %q", relative)
+			}
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			if target != expectedFile.target || int64(len(target)) != expectedFile.size {
+				return fmt.Errorf("payload symlink does not match manifest for %q", relative)
+			}
+			return verifySafeSymlink(payloadRoot, relative, target)
+		}
+		if !info.Mode().IsRegular() || expectedFile.typeName != "file" {
+			return fmt.Errorf("payload file type mismatch for %q", relative)
+		}
+		if info.Size() != expectedFile.size {
+			return fmt.Errorf("payload size does not match manifest for %q", relative)
+		}
+		mode, err := strconv.ParseUint(expectedFile.mode, 8, 32)
+		if err != nil || info.Mode().Perm() != os.FileMode(mode) {
+			return fmt.Errorf("payload mode does not match manifest for %q", relative)
+		}
+		digest, err := sha256Path(path)
+		if err != nil {
+			return err
+		}
+		if digest != expectedFile.sha256 {
+			return fmt.Errorf("payload sha256 does not match manifest for %q", relative)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for relative := range expected {
+		if !actual[relative] {
+			return fmt.Errorf("payload is missing manifest file %q", relative)
+		}
+	}
+	return nil
+}
+
+func sha256Path(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
+func verifySafeSymlink(payloadRoot, relative, target string) error {
+	if filepath.IsAbs(target) {
+		return fmt.Errorf("payload symlink %q has absolute target", relative)
+	}
+	// A relative target may legitimately start with ../. The confinement test is
+	// made after resolving it from its link parent, not by treating that spelling
+	// as an escape in isolation.
+	resolvedRelative := filepath.Clean(filepath.Join(filepath.Dir(relative), target))
+	if resolvedRelative == "." || resolvedRelative == ".." || strings.HasPrefix(resolvedRelative, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("payload symlink %q escapes payload root", relative)
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(payloadRoot, relative))
+	if err != nil {
+		return fmt.Errorf("resolve payload symlink %q: %w", relative, err)
+	}
+	payloadCanonical, err := filepath.EvalSymlinks(payloadRoot)
+	if err != nil {
+		return err
+	}
+	if resolved != payloadCanonical && !strings.HasPrefix(resolved, payloadCanonical+string(filepath.Separator)) {
+		return fmt.Errorf("payload symlink %q resolves outside payload root", relative)
+	}
+	return nil
+}
+
+func resolveInstance(env []string) (instance, error) {
+	values := environmentMap(env)
+	home := values["HOME"]
+	if home == "" {
+		return instance{}, errors.New("HOME is required")
+	}
+	stateDir := values["JOBCTRL_DIR"]
+	if stateDir == "" {
+		stateDir = filepath.Join(home, ".jobctrl")
+	}
+	var err error
+	stateDir, err = filepath.Abs(stateDir)
+	if err != nil {
+		return instance{}, err
+	}
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return instance{}, fmt.Errorf("create JobCtrl state directory: %w", err)
+	}
+	canonical, err := filepath.EvalSymlinks(stateDir)
+	if err != nil {
+		return instance{}, fmt.Errorf("canonicalize JobCtrl state directory: %w", err)
+	}
+	runtimeHome := values["JOBCTRL_RUNTIME_HOME"]
+	if runtimeHome == "" {
+		runtimeHome = filepath.Join(home, "Library", "Application Support", "JobCtrl")
+	}
+	runtimeHome, err = filepath.Abs(runtimeHome)
+	if err != nil {
+		return instance{}, err
+	}
+	if err := os.MkdirAll(runtimeHome, 0o700); err != nil {
+		return instance{}, fmt.Errorf("create JobCtrl runtime home: %w", err)
+	}
+	hash := sha256.Sum256([]byte(canonical))
+	id := hex.EncodeToString(hash[:])
+	dir := filepath.Join(runtimeHome, "instances", id)
+	if err := os.MkdirAll(filepath.Join(dir, "logs"), 0o700); err != nil {
+		return instance{}, fmt.Errorf("create JobCtrl runtime instance: %w", err)
+	}
+	return instance{runtimeHome, canonical, id, dir, filepath.Join(dir, "instance.lock"), filepath.Join(dir, "control.lock"), filepath.Join(dir, "state.json"), filepath.Join(dir, "logs")}, nil
+}
+func environmentMap(env []string) map[string]string {
+	values := make(map[string]string, len(env))
+	for _, pair := range env {
+		key, value, found := strings.Cut(pair, "=")
+		if found {
+			values[key] = value
+		}
+	}
+	return values
+}
+func childEnvironment(inherited []string, payloadRoot, stateDir string, manifest runtimeManifest) []string {
+	blocked := map[string]bool{"VIRTUAL_ENV": true, "NODE_PATH": true, "NODE_OPTIONS": true, "PORT": true, "JOBCTRL_API_ALLOW_REMOTE_BIND": true, "JOBCTRL_API_HOST": true, "JOBCTRL_API_PORT": true, "JOBCTRL_WEB_PORT": true, "TEMPORAL_ADDRESS": true, "TEMPORAL_NAMESPACE": true, "JOBCTRL_TEMPORAL_DB": true, "PATH": true, "JOBCTRL_PAYLOAD_DIR": true, "JOBCTRL_RUNTIME_MODE": true, "JOBCTRL_WEB_ASSETS_DIR": true, "PLAYWRIGHT_BROWSERS_PATH": true, "JOBCTRL_PYTHON_EXECUTABLE": true}
+	values := make(map[string]string, len(inherited))
+	for _, pair := range inherited {
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok || blocked[key] || strings.HasPrefix(key, "PYTHON") {
+			continue
+		}
+		values[key] = value
+	}
+	values["JOBCTRL_DIR"] = stateDir
+	values["JOBCTRL_PAYLOAD_DIR"] = payloadRoot
+	values["JOBCTRL_RUNTIME_MODE"] = "bundled"
+	values["JOBCTRL_WEB_ASSETS_DIR"] = filepath.Join(payloadRoot, "web")
+	values["PLAYWRIGHT_BROWSERS_PATH"] = filepath.Join(payloadRoot, "chromium")
+	values["JOBCTRL_PYTHON_EXECUTABLE"] = filepath.Join(payloadRoot, "python", "bin", "python3")
+	values["TEMPORAL_ADDRESS"] = fmt.Sprintf("127.0.0.1:%d", manifest.Ports.TemporalGRPC)
+	values["TEMPORAL_NAMESPACE"] = "default"
+	values["JOBCTRL_API_HOST"] = "127.0.0.1"
+	values["JOBCTRL_API_PORT"] = strconv.Itoa(manifest.Ports.API)
+	values["JOBCTRL_TEMPORAL_DB"] = filepath.Join(stateDir, "temporal.db")
+	values["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+	values["PYTHONNOUSERSITE"] = "1"
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		result = append(result, key+"="+values[key])
+	}
+	return result
+}
+func substitute(argument string, ctx launchContext) string {
+	return strings.NewReplacer("${PAYLOAD_ROOT}", ctx.PayloadRoot, "${TEMPORAL_GRPC_PORT}", strconv.Itoa(ctx.Manifest.Ports.TemporalGRPC), "${TEMPORAL_UI_PORT}", strconv.Itoa(ctx.Manifest.Ports.TemporalUI), "${TEMPORAL_DB}", filepath.Join(ctx.Instance.StateDir, "temporal.db")).Replace(argument)
+}
+func componentByName(manifest runtimeManifest, name string) (commandSpec, error) {
+	for _, component := range manifest.Components {
+		if component.Name == name {
+			return component, nil
+		}
+	}
+	return commandSpec{}, fmt.Errorf("runtime manifest has no %s component", name)
+}
+func acquireLock(path string, nonBlocking bool) (*os.File, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	flags := syscall.LOCK_EX
+	if nonBlocking {
+		flags |= syscall.LOCK_NB
+	}
+	if err := syscall.Flock(int(file.Fd()), flags); err != nil {
+		file.Close()
+		if errors.Is(err, syscall.EWOULDBLOCK) {
+			return nil, ErrLockHeld
+		}
+		return nil, err
+	}
+	return file, nil
+}
+func releaseLock(file *os.File) {
+	if file != nil {
+		_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		_ = file.Close()
+	}
+}
+func writeState(path string, state instanceState) error {
+	encoded, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	temporary := path + ".tmp-" + strconv.Itoa(os.Getpid())
+	if err := os.WriteFile(temporary, append(encoded, '\n'), 0o600); err != nil {
+		return err
+	}
+	if err := os.Chmod(temporary, 0o600); err != nil {
+		_ = os.Remove(temporary)
+		return err
+	}
+	return os.Rename(temporary, path)
+}
+func readState(path string) (instanceState, error) {
+	var state instanceState
+	if err := decodeStrict(path, &state); err != nil {
+		return state, err
+	}
+	if state.SchemaVersion != stateSchemaVersion || state.InstanceID == "" || state.CanonicalStateDir == "" || state.PayloadRoot == "" || state.BuildID == "" || state.ManifestSHA256 == "" || state.Components == nil {
+		return state, errors.New("invalid runtime registry state")
+	}
+	return state, nil
+}
+
+func manifestDigest(payloadRoot string) (string, error) {
+	digest, err := sha256Path(filepath.Join(payloadRoot, "manifest.json"))
+	if err != nil {
+		return "", err
+	}
+	return digest, nil
+}
+
+func validateStateIdentity(ctx launchContext, state instanceState) error {
+	if state.InstanceID != ctx.Instance.ID || state.CanonicalStateDir != ctx.Instance.StateDir {
+		return errors.New("runtime registry does not belong to this canonical state directory")
+	}
+	return nil
+}
+func validateStateBinding(ctx launchContext, state instanceState) error {
+	if err := validateStateIdentity(ctx, state); err != nil {
+		return err
+	}
+	digest, err := manifestDigest(ctx.PayloadRoot)
+	if err != nil {
+		return err
+	}
+	if filepath.Clean(state.PayloadRoot) != filepath.Clean(ctx.PayloadRoot) || state.BuildID != ctx.Distribution.BuildID || state.ManifestSHA256 != digest || state.Ports != (runtimePorts{ctx.Manifest.Ports.TemporalGRPC, ctx.Manifest.Ports.TemporalUI, ctx.Manifest.Ports.API}) {
+		return errors.New("runtime registry belongs to a different release")
+	}
+	return nil
+}
+func stateHasLiveProcesses(state instanceState) bool {
+	if recordMatchesLiveProcess(state.Supervisor) {
+		return true
+	}
+	for _, record := range state.Components {
+		if recordMatchesLiveProcess(record) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateStartState(ctx launchContext, state instanceState) error {
+	if err := validateStateIdentity(ctx, state); err != nil {
+		return err
+	}
+	if err := validateStateBinding(ctx, state); err != nil && stateHasLiveProcesses(state) {
+		return fmt.Errorf("different JobCtrl release is still running for this state directory; run jobctrl status then jobctrl stop before starting this release")
+	}
+	if recordMatchesLiveProcess(state.Supervisor) {
+		return ErrAlreadyRunning
+	}
+	for _, name := range []string{"temporal", "worker", "api"} {
+		if record, exists := state.Components[name]; exists && recordMatchesLiveProcess(record) {
+			return fmt.Errorf("%w: recorded %s component is still live; run jobctrl stop before starting", ErrAlreadyRunning, name)
+		}
+	}
+	return nil
+}
+func recordForProcess(pid int, logPath, executable string) (componentRecord, error) {
+	identity, err := readProcessIdentity(pid)
+	if err != nil {
+		return componentRecord{}, err
+	}
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		return componentRecord{}, err
+	}
+	return componentRecord{PID: pid, PGID: pgid, StartIdentity: identity, Executable: executable, StartedAt: time.Now().UTC(), LogPath: logPath}, nil
+}
+func recordMatchesLiveProcess(record componentRecord) bool {
+	if record.PID <= 0 || record.PGID <= 0 || record.StartIdentity == "" || record.Executable == "" {
+		return false
+	}
+	identity, err := readProcessIdentity(record.PID)
+	if err != nil || identity != record.StartIdentity {
+		return false
+	}
+	executable, err := readProcessExecutable(record.PID)
+	if err != nil || !sameExecutable(executable, record.Executable) {
+		return false
+	}
+	pgid, err := syscall.Getpgid(record.PID)
+	return err == nil && pgid == record.PGID
+}
+
+func sameExecutable(actual, expected string) bool {
+	if actual == expected {
+		return true
+	}
+	actualResolved, actualErr := filepath.EvalSymlinks(actual)
+	expectedResolved, expectedErr := filepath.EvalSymlinks(expected)
+	return actualErr == nil && expectedErr == nil && actualResolved == expectedResolved
+}
+func ensureFixedPortsAvailable(manifest runtimeManifest) error {
+	for _, port := range []int{manifest.Ports.TemporalGRPC, manifest.Ports.TemporalUI, manifest.Ports.API} {
+		listener, err := net.Listen("tcp4", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			return fmt.Errorf("%w: 127.0.0.1:%d (%v)", ErrPortInUse, port, err)
+		}
+		_ = listener.Close()
+	}
+	return nil
+}
+
+func processPIDAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func startDetached(ctx launchContext) error {
+	if state, err := readState(ctx.Instance.StatePath); err == nil {
+		if err := validateStartState(ctx, state); err != nil {
+			return err
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read existing runtime registry: %w", err)
+	}
+	read, write, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer read.Close()
+	command := exec.Command(ctx.Executable, "__supervise")
+	command.Env = append(ctx.Environment, "JOBCTRL_READY_FD=3")
+	command.ExtraFiles = []*os.File{write}
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		write.Close()
+		return err
+	}
+	defer devNull.Close()
+	command.Stdout, command.Stderr = devNull, devNull
+	command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	if err := command.Start(); err != nil {
+		write.Close()
+		return err
+	}
+	_ = write.Close()
+	messages := make(chan readyMessage, 1)
+	go func() {
+		var message readyMessage
+		if err := json.NewDecoder(read).Decode(&message); err != nil {
+			message.Error = fmt.Sprintf("supervisor did not report readiness: %v", err)
+		}
+		messages <- message
+	}()
+	select {
+	case message := <-messages:
+		if message.Error != "" {
+			_ = command.Wait()
+			return errors.New(message.Error)
+		}
+		// The detached supervisor is intentionally not a child that this short
+		// command waits on. Release its handle after the readiness handshake so
+		// a successful `start` cannot leave a waitable child behind.
+		_ = command.Process.Release()
+		return nil
+	case <-time.After(startupTimeout + 5*time.Second):
+		_ = syscall.Kill(command.Process.Pid, syscall.SIGTERM)
+		_ = command.Wait()
+		return errors.New("timed out waiting for detached JobCtrl supervisor")
+	}
+}
+func readyWriterFromEnv(env []string) io.Writer {
+	fd, err := strconv.Atoi(environmentMap(env)["JOBCTRL_READY_FD"])
+	if err != nil || fd < 3 {
+		return nil
+	}
+	return os.NewFile(uintptr(fd), "jobctrl-ready")
+}
+func sendReady(writer io.Writer, err error) {
+	if writer == nil {
+		return
+	}
+	message := readyMessage{}
+	if err != nil {
+		message.Error = err.Error()
+	}
+	_ = json.NewEncoder(writer).Encode(message)
+	if closer, ok := writer.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
+func supervise(ctx launchContext, ready io.Writer) (result error) {
+	lock, err := acquireLock(ctx.Instance.LockPath, true)
+	if err != nil {
+		sendReady(ready, err)
+		return err
+	}
+	defer releaseLock(lock)
+	// startDetached validates before it forks. Repeat under the instance lock so
+	// a supervisor killed between that check and this re-exec cannot have its
+	// still-live component registry overwritten.
+	if previous, readErr := readState(ctx.Instance.StatePath); readErr == nil {
+		if validationErr := validateStartState(ctx, previous); validationErr != nil {
+			sendReady(ready, validationErr)
+			return validationErr
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		err = fmt.Errorf("read existing runtime registry: %w", readErr)
+		sendReady(ready, err)
+		return err
+	}
+	supervisor, err := recordForProcess(os.Getpid(), "", ctx.Executable)
+	if err != nil {
+		sendReady(ready, err)
+		return err
+	}
+	digest, err := manifestDigest(ctx.PayloadRoot)
+	if err != nil {
+		sendReady(ready, err)
+		return err
+	}
+	state := instanceState{SchemaVersion: stateSchemaVersion, InstanceID: ctx.Instance.ID, CanonicalStateDir: ctx.Instance.StateDir, PayloadRoot: ctx.PayloadRoot, BuildID: ctx.Distribution.BuildID, ManifestSHA256: digest, Ports: runtimePorts{TemporalGRPC: ctx.Manifest.Ports.TemporalGRPC, TemporalUI: ctx.Manifest.Ports.TemporalUI, API: ctx.Manifest.Ports.API}, StartedAt: time.Now().UTC(), Supervisor: supervisor, Components: map[string]componentRecord{}}
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		sendReady(ready, err)
+		return err
+	}
+	signals := make(chan os.Signal, 2)
+	signalNotify(signals)
+	defer signalStop(signals)
+	exits := make(chan componentExit, 3)
+	children := map[string]*exec.Cmd{}
+	defer func() {
+		shutdownComponents(&state, children, ctx.Instance.StatePath)
+		if allRecordedComponentsStopped(state) {
+			now := time.Now().UTC()
+			state.StoppedAt = &now
+		} else {
+			// Never convert a cleanup failure into a misleading stopped registry:
+			// the remaining records must stay inspectable and `stop` must be able
+			// to retry their identity-verified groups.
+			state.StoppedAt = nil
+		}
+		_ = writeState(ctx.Instance.StatePath, state)
+		if result != nil {
+			sendReady(ready, result)
+		}
+	}()
+	if err := ensureFixedPortsAvailable(ctx.Manifest); err != nil {
+		return err
+	}
+	if children["temporal"], err = startComponent(ctx, state.Components, "temporal"); err != nil {
+		return err
+	}
+	go waitComponent("temporal", children["temporal"], exits)
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		return err
+	}
+	if err := waitForTemporal(ctx, children["temporal"], exits, signals); err != nil {
+		if errors.Is(err, errStartupInterrupted) {
+			return nil
+		}
+		markStartupComponentExit(&state, err)
+		return err
+	}
+	if children["worker"], err = startComponent(ctx, state.Components, "worker"); err != nil {
+		return err
+	}
+	go waitComponent("worker", children["worker"], exits)
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		return err
+	}
+	if children["api"], err = startComponent(ctx, state.Components, "api"); err != nil {
+		return err
+	}
+	go waitComponent("api", children["api"], exits)
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		return err
+	}
+	if err := waitForAPIWorker(ctx, children["api"], children["worker"], exits, signals); err != nil {
+		if errors.Is(err, errStartupInterrupted) {
+			return nil
+		}
+		markStartupComponentExit(&state, err)
+		return err
+	}
+	sendReady(ready, nil)
+	for {
+		select {
+		case <-signals:
+			return nil
+		case exit := <-exits:
+			record := state.Components[exit.Name]
+			now := time.Now().UTC()
+			record.ExitedAt = &now
+			if exit.Err != nil {
+				record.ExitError = exit.Err.Error()
+			}
+			state.Components[exit.Name] = record
+			// Keep ownership of the healthy siblings and lock after an unexpected
+			// child exit. This makes lifecycle status accurately degraded and lets
+			// `stop` perform a PID-safe recovery instead of erasing the evidence.
+			_ = writeState(ctx.Instance.StatePath, state)
+		}
+	}
+}
+
+var signalNotify = func(channel chan<- os.Signal) { signal.Notify(channel, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP) }
+var signalStop = func(channel chan<- os.Signal) { signal.Stop(channel) }
+
+type componentExit struct {
+	Name string
+	Err  error
+}
+
+type startupComponentExitError struct{ componentExit }
+
+func (err startupComponentExitError) Error() string {
+	return fmt.Sprintf("%s exited before startup completed: %v", err.Name, err.Err)
+}
+
+func (err startupComponentExitError) Unwrap() error { return err.Err }
+
+func markStartupComponentExit(state *instanceState, cause error) {
+	var exited startupComponentExitError
+	if !errors.As(cause, &exited) {
+		return
+	}
+	record, found := state.Components[exited.Name]
+	if !found {
+		return
+	}
+	now := time.Now().UTC()
+	record.ExitedAt = &now
+	if exited.Err != nil {
+		record.ExitError = exited.Err.Error()
+	}
+	state.Components[exited.Name] = record
+}
+
+func waitComponent(name string, command *exec.Cmd, exits chan<- componentExit) {
+	exits <- componentExit{name, command.Wait()}
+}
+func startComponent(ctx launchContext, records map[string]componentRecord, name string) (*exec.Cmd, error) {
+	spec, err := componentByName(ctx.Manifest, name)
+	if err != nil {
+		return nil, err
+	}
+	executable := filepath.Join(ctx.PayloadRoot, spec.Executable)
+	if !safeRelativePath(spec.Executable) || !strings.HasPrefix(filepath.Clean(executable), filepath.Clean(ctx.PayloadRoot)+string(filepath.Separator)) {
+		return nil, errors.New("unsafe component executable")
+	}
+	arguments := make([]string, len(spec.Arguments))
+	for index, argument := range spec.Arguments {
+		arguments[index] = substitute(argument, ctx)
+	}
+	logPath := filepath.Join(ctx.Instance.LogDir, name+".log")
+	if info, err := os.Stat(logPath); err == nil && info.Size() > 0 {
+		_ = os.Remove(logPath + ".1")
+		if err := os.Rename(logPath, logPath+".1"); err != nil {
+			return nil, fmt.Errorf("rotate %s log: %w", name, err)
+		}
+	}
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	command := exec.Command(executable, arguments...)
+	command.Env, command.Dir, command.Stdout, command.Stderr = ctx.Environment, ctx.Instance.StateDir, logFile, logFile
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := command.Start(); err != nil {
+		logFile.Close()
+		return nil, fmt.Errorf("start %s: %w", name, err)
+	}
+	_ = logFile.Close()
+	record, err := recordForProcess(command.Process.Pid, logPath, executable)
+	if err != nil {
+		_ = signalProcessGroup(command.Process.Pid, syscall.SIGTERM)
+		return nil, err
+	}
+	records[name] = record
+	return command, nil
+}
+func waitForTemporal(ctx launchContext, temporal *exec.Cmd, exits <-chan componentExit, signals <-chan os.Signal) error {
+	deadline := time.Now().Add(startupTimeout)
+	var last error
+	for time.Now().Before(deadline) {
+		select {
+		case <-signals:
+			return errStartupInterrupted
+		case exit := <-exits:
+			return startupComponentExitError{exit}
+		default:
+		}
+		if !processPIDAlive(temporal.Process.Pid) {
+			return errors.New("Temporal exited before becoming healthy")
+		}
+		if err := temporalHealthProbe(ctx); err == nil {
+			return nil
+		} else {
+			last = err
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+	return fmt.Errorf("embedded Temporal did not become healthy: %w", last)
+}
+
+func probeTemporal(ctx launchContext) error {
+	spec, err := componentByName(ctx.Manifest, ctx.Manifest.Health.Temporal.Component)
+	if err != nil {
+		return err
+	}
+	executable := filepath.Join(ctx.PayloadRoot, spec.Executable)
+	arguments := make([]string, len(ctx.Manifest.Health.Temporal.Arguments))
+	for i, argument := range ctx.Manifest.Health.Temporal.Arguments {
+		arguments[i] = substitute(argument, ctx)
+	}
+	probe := exec.Command(executable, arguments...)
+	probe.Env, probe.Dir = ctx.Environment, ctx.Instance.StateDir
+	if output, err := probe.CombinedOutput(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+func waitForAPIWorker(ctx launchContext, api, worker *exec.Cmd, exits <-chan componentExit, signals <-chan os.Signal) error {
+	deadline := time.Now().Add(startupTimeout)
+	var last error
+	for time.Now().Before(deadline) {
+		select {
+		case <-signals:
+			return errStartupInterrupted
+		case exit := <-exits:
+			return startupComponentExitError{exit}
+		default:
+		}
+		if !processPIDAlive(api.Process.Pid) {
+			return errors.New("API exited before becoming healthy")
+		}
+		if !processPIDAlive(worker.Process.Pid) {
+			return errors.New("worker exited before becoming healthy")
+		}
+		err := probeAPIWorker(ctx, worker.Process.Pid)
+		if err == nil {
+			return nil
+		}
+		last = err
+		time.Sleep(150 * time.Millisecond)
+	}
+	return fmt.Errorf("API and worker did not become healthy: %w", last)
+}
+
+func probeAPIWorker(ctx launchContext, expectedWorkerPID int) error {
+	client := &http.Client{Timeout: 750 * time.Millisecond}
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", ctx.Manifest.Ports.API, ctx.Manifest.Health.API.Path)
+	response, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("API health returned HTTP %d", response.StatusCode)
+	}
+	var health struct {
+		Worker struct {
+			Status    string `json:"status"`
+			Heartbeat *struct {
+				PID int `json:"pid"`
+			} `json:"heartbeat"`
+		} `json:"worker"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&health); err != nil {
+		return err
+	}
+	if health.Worker.Status != "healthy" {
+		return fmt.Errorf("worker health is %q", health.Worker.Status)
+	}
+	if health.Worker.Heartbeat == nil || health.Worker.Heartbeat.PID != expectedWorkerPID {
+		return fmt.Errorf("worker heartbeat pid is not owned worker pid %d", expectedWorkerPID)
+	}
+	return nil
+}
+func waitForPIDExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processPIDAlive(pid) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return !processPIDAlive(pid)
+}
+
+func processGroupAlive(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func waitForProcessGroupExit(pgid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if !processGroupAlive(pgid) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return !processGroupAlive(pgid)
+}
+
+func signalOwnedRecord(record componentRecord, signal syscall.Signal) error {
+	if !recordMatchesLiveProcess(record) {
+		return errors.New("record does not match a live owned process")
+	}
+	if err := signalProcessGroup(record.PGID, signal); err == nil {
+		return nil
+	} else {
+		groupErr := err
+		// sandbox-exec can reject a negative-PGID signal even when it permits a
+		// signal to the exact child. Re-verify all ownership fields immediately
+		// before that narrower fallback; never send it to a reused PID.
+		if !recordMatchesLiveProcess(record) {
+			return fmt.Errorf("signal process group: %w; direct PID fallback refused because ownership changed", groupErr)
+		}
+		if directErr := syscall.Kill(record.PID, signal); directErr != nil {
+			return fmt.Errorf("signal process group: %w; direct PID fallback: %w", groupErr, directErr)
+		}
+		return nil
+	}
+}
+
+func terminateRecord(record componentRecord) error {
+	if err := signalOwnedRecord(record, syscall.SIGTERM); err != nil {
+		return err
+	}
+	if waitForPIDExit(record.PID, shutdownTimeout) && waitForProcessGroupExit(record.PGID, shutdownTimeout) {
+		return nil
+	}
+	// The leading process may have exited while a child still occupies its
+	// original process group. Only a still-verified leader authorizes another
+	// group signal; otherwise report the surviving group rather than risking a
+	// reused PGID.
+	if !recordMatchesLiveProcess(record) {
+		return errors.New("component leader exited but its owned process group remains live")
+	}
+	if err := signalOwnedRecord(record, syscall.SIGKILL); err != nil {
+		return err
+	}
+	if waitForPIDExit(record.PID, shutdownTimeout) && waitForProcessGroupExit(record.PGID, shutdownTimeout) {
+		return nil
+	}
+	return errors.New("component process tree remained live after SIGTERM and SIGKILL")
+}
+func shutdownComponents(state *instanceState, children map[string]*exec.Cmd, statePath string) {
+	for _, name := range []string{"api", "worker", "temporal"} {
+		record, exists := state.Components[name]
+		if !exists || record.ExitedAt != nil {
+			continue
+		}
+		if err := terminateRecord(record); err == nil {
+			now := time.Now().UTC()
+			record.ExitedAt = &now
+		} else {
+			record.ExitError = "cleanup could not confirm this component exited: " + err.Error()
+		}
+		state.Components[name] = record
+		_ = writeState(statePath, *state)
+	}
+}
+
+func allRecordedComponentsStopped(state instanceState) bool {
+	for _, record := range state.Components {
+		// A still-existing PID might have been reused after identity verification
+		// failed. Keep the registry in a recoverable non-stopped state rather
+		// than claim that an unknown live process exited.
+		if processPIDAlive(record.PID) {
+			return false
+		}
+	}
+	return true
+}
+func stop(ctx launchContext) error {
+	control, err := acquireLock(ctx.Instance.ControlPath, false)
+	if err != nil {
+		return fmt.Errorf("acquire stop control lock: %w", err)
+	}
+	defer releaseLock(control)
+	state, err := readState(ctx.Instance.StatePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateStateIdentity(ctx, state); err != nil {
+		return err
+	}
+	failed := make([]string, 0)
+	for _, name := range []string{"api", "worker", "temporal"} {
+		if record, exists := state.Components[name]; exists {
+			if err := terminateRecord(record); err != nil && processPIDAlive(record.PID) {
+				failed = append(failed, name+": "+err.Error())
+			}
+		}
+	}
+	if recordMatchesLiveProcess(state.Supervisor) {
+		_ = syscall.Kill(state.Supervisor.PID, syscall.SIGTERM)
+		deadline := time.Now().Add(shutdownTimeout)
+		for time.Now().Before(deadline) {
+			if !recordMatchesLiveProcess(state.Supervisor) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+	if len(failed) > 0 || !allRecordedComponentsStopped(state) {
+		state.StoppedAt = nil
+		if err := writeState(ctx.Instance.StatePath, state); err != nil {
+			return err
+		}
+		if len(failed) > 0 {
+			return fmt.Errorf("could not safely stop live component groups: %s", strings.Join(failed, ", "))
+		}
+		return errors.New("JobCtrl still has live recorded component PIDs after stop")
+	}
+	now := time.Now().UTC()
+	state.StoppedAt = &now
+	return writeState(ctx.Instance.StatePath, state)
+}
+func status(ctx launchContext, output io.Writer, jsonOutput bool) error {
+	state, err := readState(ctx.Instance.StatePath)
+	if errors.Is(err, os.ErrNotExist) {
+		if jsonOutput {
+			_, _ = io.WriteString(output, "{\"status\":\"stopped\",\"components\":{}}\n")
+		} else {
+			_, _ = io.WriteString(output, "JobCtrl is stopped.\n")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := validateStateIdentity(ctx, state); err != nil {
+		return err
+	}
+	differentRelease := validateStateBinding(ctx, state) != nil
+	type componentStatus struct {
+		State     string     `json:"state"`
+		PID       int        `json:"pid"`
+		Log       string     `json:"log"`
+		ExitedAt  *time.Time `json:"exitedAt,omitempty"`
+		ExitError string     `json:"exitError,omitempty"`
+	}
+	components := map[string]componentStatus{}
+	allReady := true
+	workerRecord := state.Components["worker"]
+	apiRecord := state.Components["api"]
+	apiWorkerHealth := errors.New("API is not running")
+	if !differentRelease && recordMatchesLiveProcess(apiRecord) && recordMatchesLiveProcess(workerRecord) {
+		apiWorkerHealth = probeAPIWorker(ctx, workerRecord.PID)
+	}
+	for _, name := range []string{"temporal", "worker", "api"} {
+		record, found := state.Components[name]
+		live := found && recordMatchesLiveProcess(record)
+		stateName := "stopped"
+		if live {
+			stateName = "running"
+			if !differentRelease && name == "temporal" && probeTemporal(ctx) != nil {
+				stateName = "unhealthy"
+				allReady = false
+			}
+			if !differentRelease && (name == "worker" || name == "api") && apiWorkerHealth != nil {
+				stateName = "unhealthy"
+				allReady = false
+			}
+		} else {
+			allReady = false
+			if found && record.ExitedAt == nil {
+				stateName = "stale"
+			}
+		}
+		components[name] = componentStatus{stateName, record.PID, record.LogPath, record.ExitedAt, record.ExitError}
+	}
+	supervisorLive := recordMatchesLiveProcess(state.Supervisor)
+	overall := "stopped"
+	if allReady && supervisorLive {
+		overall = "running"
+	} else if !allReady && supervisorLive {
+		overall = "degraded"
+	} else if allReady {
+		overall = "orphaned"
+	}
+	if differentRelease {
+		overall = "different-release"
+	}
+	if state.StoppedAt != nil && !stateHasLiveProcesses(state) {
+		overall = "stopped"
+	}
+	if jsonOutput {
+		return json.NewEncoder(output).Encode(struct {
+			Status        string                     `json:"status"`
+			InstanceID    string                     `json:"instanceId"`
+			StateDir      string                     `json:"stateDir"`
+			SupervisorPID int                        `json:"supervisorPid"`
+			Components    map[string]componentStatus `json:"components"`
+		}{overall, state.InstanceID, state.CanonicalStateDir, state.Supervisor.PID, components})
+	}
+	fmt.Fprintf(output, "JobCtrl: %s\n", overall)
+	for _, name := range []string{"temporal", "worker", "api"} {
+		item := components[name]
+		fmt.Fprintf(output, "%-9s %-8s pid=%d\n", name, item.State, item.PID)
+	}
+	return nil
+}
+func logs(ctx launchContext, args []string, output io.Writer) error {
+	if len(args) > 1 || (len(args) == 1 && args[0] == "--follow") {
+		return errors.New("usage: jobctrl logs [temporal|worker|api]; logs are bounded to the last 200 lines")
+	}
+	if len(args) == 0 {
+		for _, name := range []string{"temporal", "worker", "api"} {
+			fmt.Fprintf(output, "== %s ==\n", name)
+			if err := tailFile(filepath.Join(ctx.Instance.LogDir, name+".log"), logLineLimit, output); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	name := args[0]
+	if name != "temporal" && name != "worker" && name != "api" {
+		return fmt.Errorf("unknown component %q", name)
+	}
+	return tailFile(filepath.Join(ctx.Instance.LogDir, name+".log"), logLineLimit, output)
+}
+func tailFile(path string, limit int, output io.Writer) error {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	lines := make([]string, 0, limit)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if len(lines) == limit {
+			copy(lines, lines[1:])
+			lines[len(lines)-1] = scanner.Text()
+		} else {
+			lines = append(lines, scanner.Text())
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	for _, line := range lines {
+		fmt.Fprintln(output, line)
+	}
+	return nil
+}
+func openURL(ctx launchContext) error {
+	state, err := readState(ctx.Instance.StatePath)
+	if err != nil {
+		return errors.New("JobCtrl is not running")
+	}
+	if err := validateStateBinding(ctx, state); err != nil {
+		return err
+	}
+	api, apiFound := state.Components["api"]
+	worker, workerFound := state.Components["worker"]
+	if !apiFound || !workerFound || !recordMatchesLiveProcess(api) || !recordMatchesLiveProcess(worker) || probeAPIWorker(ctx, worker.PID) != nil {
+		return errors.New("JobCtrl API is not running")
+	}
+	return openBrowser(fmt.Sprintf("http://127.0.0.1:%d", ctx.Manifest.Ports.API))
+}
+func version(ctx launchContext, output io.Writer, jsonOutput bool) error {
+	manifestBytes, err := os.ReadFile(filepath.Join(ctx.PayloadRoot, "manifest.json"))
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(manifestBytes)
+	if jsonOutput {
+		return json.NewEncoder(output).Encode(struct {
+			Version          string `json:"version"`
+			BuildID          string `json:"buildId"`
+			ManifestSHA256   string `json:"manifestSha256"`
+			LauncherProtocol int    `json:"launcherProtocol"`
+		}{ctx.Distribution.AppVersion, ctx.Distribution.BuildID, hex.EncodeToString(digest[:]), launcherProtocol})
+	}
+	_, err = fmt.Fprintf(output, "JobCtrl %s (%s)\nmanifest sha256: %s\n", ctx.Distribution.AppVersion, ctx.Distribution.BuildID, hex.EncodeToString(digest[:]))
+	return err
+}
+func dispatchPython(ctx launchContext, args []string) error {
+	python := filepath.Join(ctx.PayloadRoot, "python", "bin", "python3")
+	argv := append([]string{python, "-I", "-B", "-m", "jobctrl"}, args...)
+	return syscall.Exec(python, argv, ctx.Environment)
+}

--- a/launcher/internal/launcher/launcher.go
+++ b/launcher/internal/launcher/launcher.go
@@ -40,7 +40,11 @@ const (
 	stateSchemaVersion = 1
 	logLineLimit       = 200
 	startupTimeout     = 30 * time.Second
-	shutdownTimeout    = 5 * time.Second
+	// Detached start spans two sequential supervisor health phases: Temporal,
+	// then API/worker. The parent must not kill a supervisor that is still
+	// within those valid phase deadlines.
+	detachedStartupTimeout = 2*startupTimeout + 5*time.Second
+	shutdownTimeout        = 5 * time.Second
 )
 
 var (
@@ -1121,7 +1125,7 @@ func startDetached(ctx launchContext) error {
 		// a successful `start` cannot leave a waitable child behind.
 		_ = command.Process.Release()
 		return nil
-	case <-time.After(startupTimeout + 5*time.Second):
+	case <-time.After(detachedStartupTimeout):
 		_ = syscall.Kill(command.Process.Pid, syscall.SIGTERM)
 		_ = command.Wait()
 		return errors.New("timed out waiting for detached JobCtrl supervisor")

--- a/launcher/internal/launcher/launcher_test.go
+++ b/launcher/internal/launcher/launcher_test.go
@@ -994,6 +994,13 @@ func TestStartupSignalIsCleanCancellation(t *testing.T) {
 	}
 }
 
+func TestDetachedReadinessBudgetCoversBothSequentialStartupPhases(t *testing.T) {
+	minimum := 2 * startupTimeout
+	if detachedStartupTimeout <= minimum {
+		t.Fatalf("detached readiness budget = %s, must exceed both sequential startup phases (%s)", detachedStartupTimeout, minimum)
+	}
+}
+
 func TestStatusActivelyProbesAPIWorkerReadiness(t *testing.T) {
 	listener, err := net.Listen("tcp4", "127.0.0.1:8766")
 	if err != nil {

--- a/launcher/internal/launcher/launcher_test.go
+++ b/launcher/internal/launcher/launcher_test.go
@@ -1,0 +1,1186 @@
+package launcher
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const validRuntimeManifest = `{
+  "schemaVersion":1,"launcherProtocol":1,
+  "ports":{"temporalGrpc":7233,"temporalUi":8233,"api":8766},
+  "components":[
+    {"name":"temporal","executable":"temporal/temporal","arguments":["server"]},
+    {"name":"worker","executable":"python/bin/python3","arguments":["-I","-B","-m","jobctrl","worker"]},
+    {"name":"api","executable":"node/bin/node","arguments":["${PAYLOAD_ROOT}/api/server.mjs"]}
+  ],
+  "health":{"temporal":{"component":"temporal","arguments":["operator"]},"api":{"path":"/v1/health","requireWorkerHealthy":true,"requireWorkerPid":true}}
+}`
+
+const loopbackOnlySandboxProfile = `(version 1)
+(allow default)
+(deny network-outbound (remote ip))
+(allow network-outbound (remote ip "localhost:*"))`
+
+func TestSandboxedNativeProcessIdentity(t *testing.T) {
+	if os.Getenv("JOBCTRL_SANDBOX_IDENTITY_HELPER") == "1" {
+		identity, err := processStartIdentity(os.Getpid())
+		if err != nil || identity == "" {
+			fmt.Fprintf(os.Stderr, "identity: %v", err)
+			os.Exit(2)
+		}
+		executable, err := CurrentProcessExecutable()
+		if err != nil || executable == "" {
+			fmt.Fprintf(os.Stderr, "executable: %v", err)
+			os.Exit(3)
+		}
+		os.Exit(0)
+	}
+	if _, err := os.Stat("/usr/bin/sandbox-exec"); err != nil {
+		t.Skip("sandbox-exec is unavailable")
+	}
+	command := exec.Command("/usr/bin/sandbox-exec", "-p", loopbackOnlySandboxProfile, os.Args[0], "-test.run=^TestSandboxedNativeProcessIdentity$")
+	command.Env = append(os.Environ(), "JOBCTRL_SANDBOX_IDENTITY_HELPER=1")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("native process identity failed in exact loopback sandbox: %v\n%s", err, output)
+	}
+}
+
+func writeTestFile(t *testing.T, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRuntimeManifestRejectsUnknownFieldsAndUnsafePaths(t *testing.T) {
+	for name, manifest := range map[string]string{
+		"unknown":           strings.Replace(validRuntimeManifest, `"schemaVersion":1`, `"schemaVersion":1,"surprise":true`, 1),
+		"unsafe executable": strings.Replace(validRuntimeManifest, `"temporal/temporal"`, `"../temporal"`, 1),
+		"dynamic port":      strings.Replace(validRuntimeManifest, `"api":8766`, `"api":9876`, 1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := loadRuntimeManifest(writeTestFile(t, "runtime.json", manifest)); err == nil {
+				t.Fatal("expected manifest rejection")
+			}
+		})
+	}
+}
+
+func TestLifecycleExitCodesAreStable(t *testing.T) {
+	for _, item := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"success", nil, 0},
+		{"general", errors.New("general failure"), 1},
+		{"lock", ErrLockHeld, 75},
+		{"wrapped lock", fmt.Errorf("context: %w", ErrLockHeld), 75},
+		{"already running", ErrAlreadyRunning, 75},
+		{"port conflict", ErrPortInUse, 69},
+	} {
+		t.Run(item.name, func(t *testing.T) {
+			if got := ExitCode(item.err); got != item.want {
+				t.Fatalf("ExitCode(%v) = %d, want %d", item.err, got, item.want)
+			}
+		})
+	}
+}
+
+func TestPayloadVerificationRejectsTamperingUnknownFilesAndEscapingSymlinks(t *testing.T) {
+	for _, mutate := range []struct {
+		name  string
+		apply func(t *testing.T, root string)
+	}{
+		{"tampered file", func(t *testing.T, root string) {
+			t.Helper()
+			if err := os.WriteFile(filepath.Join(root, "safe.txt"), []byte("changed"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"unrecorded file", func(t *testing.T, root string) {
+			t.Helper()
+			if err := os.WriteFile(filepath.Join(root, "extra.txt"), []byte("extra"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"escaping symlink", func(t *testing.T, root string) {
+			t.Helper()
+			if err := os.Remove(filepath.Join(root, "launcher", "links", "to-safe")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("../../outside", filepath.Join(root, "launcher", "links", "to-safe")); err != nil {
+				t.Fatal(err)
+			}
+		}},
+	} {
+		t.Run(mutate.name, func(t *testing.T) {
+			root, manifest := verifiedPayloadFixture(t)
+			writeLocalEnvelope(t, root, manifest)
+			mutate.apply(t, root)
+			if _, err := loadAndVerifyDistributionManifest(root); err == nil {
+				t.Fatal("expected manifest loader payload verification failure")
+			}
+		})
+	}
+}
+
+func TestPayloadVerificationPermitsSafeRelativeParentSymlink(t *testing.T) {
+	root, manifest := verifiedPayloadFixture(t)
+	if err := verifyPayloadTree(root, manifest); err != nil {
+		t.Fatalf("safe relative symlink rejected: %v", err)
+	}
+}
+
+func TestDistributionLoaderPermitsConfinedParentRelativeSymlink(t *testing.T) {
+	root, manifest := verifiedPayloadFixture(t)
+	writeLocalEnvelope(t, root, manifest)
+	if _, err := loadAndVerifyDistributionManifest(root); err != nil {
+		t.Fatalf("safe parent-relative symlink rejected by envelope loader: %v", err)
+	}
+}
+
+func mutateJSONFile(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]any
+	if err := json.Unmarshal(contents, &value); err != nil {
+		t.Fatal(err)
+	}
+	mutate(value)
+	contents, err = json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDistributionLoaderRejectsIncompleteAndMalformedV1Envelopes(t *testing.T) {
+	for name, mutate := range map[string]func(t *testing.T, root string){
+		"missing platform": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) { delete(value, "platform") })
+		},
+		"missing runtime component": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) {
+				components := value["components"].([]any)
+				value["components"] = components[1:]
+			})
+		},
+		"capability references unknown component": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) {
+				capabilities := value["capabilities"].([]any)
+				capabilities[0].(map[string]any)["componentIds"] = []string{"not-a-component"}
+			})
+		},
+		"unsafe regular mode": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) {
+				value["files"].([]any)[0].(map[string]any)["mode"] = "0777"
+			})
+		},
+		"nonprintable file path": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) {
+				value["files"].([]any)[0].(map[string]any)["path"] = "api/\x01payload"
+			})
+		},
+		"file without exactly one owner": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.json"), func(value map[string]any) {
+				value["files"].([]any)[0].(map[string]any)["path"] = "orphan/payload"
+			})
+		},
+		"signature key binding mismatch": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.sig"), func(value map[string]any) { value["manifestKeyId"] = "wrong-key" })
+		},
+		"signature schema missing promotable": func(t *testing.T, root string) {
+			mutateJSONFile(t, filepath.Join(root, "manifest.sig"), func(value map[string]any) { delete(value, "promotable") })
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, manifest := verifiedPayloadFixture(t)
+			writeLocalEnvelope(t, root, manifest)
+			mutate(t, root)
+			if _, err := loadAndVerifyDistributionManifest(root); err == nil {
+				t.Fatal("malformed v1 distribution envelope was accepted")
+			}
+		})
+	}
+}
+
+func verifiedPayloadFixture(t *testing.T) (string, distributionManifest) {
+	t.Helper()
+	root := t.TempDir()
+	type fixtureFile struct {
+		path     string
+		contents string
+		mode     os.FileMode
+		target   string
+	}
+	files := []fixtureFile{
+		{path: "api/payload", contents: "api", mode: 0o644},
+		{path: "launcher/links/to-safe", target: "../safe.txt"},
+		{path: "launcher/safe.txt", contents: "safe payload", mode: 0o644},
+		{path: "node/payload", contents: "node", mode: 0o644},
+		{path: "python/payload", contents: "python", mode: 0o644},
+		{path: "temporal/payload", contents: "temporal", mode: 0o644},
+		{path: "web/payload", contents: "web", mode: 0o644},
+		{path: "worker/payload", contents: "worker", mode: 0o644},
+	}
+	for _, file := range files {
+		path := filepath.Join(root, file.path)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if file.target != "" {
+			if err := os.Symlink(file.target, path); err != nil {
+				t.Fatal(err)
+			}
+		} else if err := os.WriteFile(path, []byte(file.contents), file.mode); err != nil {
+			t.Fatal(err)
+		}
+	}
+	type fileRecord struct {
+		typeName string
+		path     string
+		sha256   string
+		target   string
+		size     int64
+		mode     string
+	}
+	records := make([]fileRecord, 0, len(files))
+	for _, file := range files {
+		if file.target != "" {
+			records = append(records, fileRecord{typeName: "symlink", path: file.path, target: file.target, size: int64(len(file.target))})
+			continue
+		}
+		digest := sha256.Sum256([]byte(file.contents))
+		records = append(records, fileRecord{typeName: "file", path: file.path, sha256: hex.EncodeToString(digest[:]), size: int64(len(file.contents)), mode: "0644"})
+	}
+	sort.Slice(records, func(left, right int) bool { return records[left].path < records[right].path })
+	componentPaths := []struct{ id, path string }{
+		{"jobctrl-api", "api"},
+		{"jobctrl-launcher", "launcher"},
+		{"jobctrl-web", "web"},
+		{"jobctrl-worker", "worker"},
+		{"node-runtime", "node"},
+		{"python-runtime", "python"},
+		{"temporal-runtime", "temporal"},
+	}
+	components := make([]map[string]any, 0, len(componentPaths))
+	for _, component := range componentPaths {
+		var canonical strings.Builder
+		var size int64
+		for _, file := range records {
+			if file.path != component.path && !strings.HasPrefix(file.path, component.path+"/") {
+				continue
+			}
+			if file.typeName == "symlink" {
+				fmt.Fprintf(&canonical, "%s\x00symlink\x00%s\x00%d\n", file.path, file.target, file.size)
+			} else {
+				fmt.Fprintf(&canonical, "%s\x00file\x00%s\x00%d\x00%s\n", file.path, file.sha256, file.size, file.mode)
+			}
+			size += file.size
+		}
+		digest := sha256.Sum256([]byte(canonical.String()))
+		components = append(components, map[string]any{
+			"id": component.id, "classification": "core-runtime", "version": "2.0.0", "owner": "Test Owner", "source": "https://example.invalid/source", "license": "AGPL-3.0-only", "redistribution": "bundle", "path": component.path, "sha256": hex.EncodeToString(digest[:]), "sizeBytes": size, "required": true,
+		})
+	}
+	filesJSON := make([]map[string]any, 0, len(records))
+	for _, file := range records {
+		if file.typeName == "symlink" {
+			filesJSON = append(filesJSON, map[string]any{"type": "symlink", "path": file.path, "target": file.target, "sizeBytes": file.size})
+		} else {
+			filesJSON = append(filesJSON, map[string]any{"type": "file", "path": file.path, "sha256": file.sha256, "sizeBytes": file.size, "mode": file.mode})
+		}
+	}
+	value := map[string]any{
+		"schemaVersion": 1, "appVersion": "2.0.0", "buildId": "local-test-build", "releaseChannel": "local", "sourceDateEpoch": 0,
+		"platform":              map[string]any{"id": "darwin-arm64", "os": "darwin", "arch": "arm64", "minimumOsVersion": "15.0"},
+		"launcherCompatibility": map[string]any{"minimum": 1, "maximum": 1},
+		"components":            components,
+		"capabilities":          []map[string]any{{"id": "core-browser", "defaultEnabled": true, "componentIds": []string{"jobctrl-web"}}},
+		"files":                 filesJSON,
+		"signing":               map[string]any{"manifestAlgorithm": "ed25519", "manifestKeyId": "local-development", "codeSigning": "unsigned-local", "notarized": false},
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest distributionManifest
+	if err := json.Unmarshal(encoded, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	return root, manifest
+}
+
+func writeLocalEnvelope(t *testing.T, root string, manifest distributionManifest) {
+	t.Helper()
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "manifest.json"), encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	signature := manifestSignature{SchemaVersion: 1, Status: "unsigned-local", ManifestAlgorithm: "ed25519", ManifestKeyID: "local-development", Promotable: false}
+	encoded, err = json.Marshal(signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "manifest.sig"), encoded, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func refreshFixtureManifest(t *testing.T, root string, manifest *distributionManifest) {
+	t.Helper()
+	files := make([]struct {
+		Type      string `json:"type"`
+		Path      string `json:"path"`
+		SHA256    string `json:"sha256,omitempty"`
+		Target    string `json:"target,omitempty"`
+		SizeBytes int64  `json:"sizeBytes"`
+		Mode      string `json:"mode,omitempty"`
+	}, 0)
+	if err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == root || entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if relative == "manifest.json" || relative == "manifest.sig" {
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			files = append(files, struct {
+				Type      string `json:"type"`
+				Path      string `json:"path"`
+				SHA256    string `json:"sha256,omitempty"`
+				Target    string `json:"target,omitempty"`
+				SizeBytes int64  `json:"sizeBytes"`
+				Mode      string `json:"mode,omitempty"`
+			}{Type: "symlink", Path: relative, Target: target, SizeBytes: int64(len(target))})
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		digest, err := sha256Path(path)
+		if err != nil {
+			return err
+		}
+		mode := "0644"
+		if info.Mode()&0o111 != 0 {
+			mode = "0755"
+		}
+		files = append(files, struct {
+			Type      string `json:"type"`
+			Path      string `json:"path"`
+			SHA256    string `json:"sha256,omitempty"`
+			Target    string `json:"target,omitempty"`
+			SizeBytes int64  `json:"sizeBytes"`
+			Mode      string `json:"mode,omitempty"`
+		}{Type: "file", Path: relative, SHA256: digest, SizeBytes: info.Size(), Mode: mode})
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(files, func(left, right int) bool { return files[left].Path < files[right].Path })
+	manifest.Files = files
+	for componentIndex := range manifest.Components {
+		component := &manifest.Components[componentIndex]
+		var canonical strings.Builder
+		var size int64
+		for _, file := range files {
+			if file.Path != component.Path && !strings.HasPrefix(file.Path, component.Path+"/") {
+				continue
+			}
+			if file.Type == "symlink" {
+				fmt.Fprintf(&canonical, "%s\x00symlink\x00%s\x00%d\n", file.Path, file.Target, file.SizeBytes)
+			} else {
+				fmt.Fprintf(&canonical, "%s\x00file\x00%s\x00%d\x00%s\n", file.Path, file.SHA256, file.SizeBytes, file.Mode)
+			}
+			size += file.SizeBytes
+		}
+		digest := sha256.Sum256([]byte(canonical.String()))
+		component.SHA256, component.SizeBytes = hex.EncodeToString(digest[:]), size
+	}
+}
+
+func runLauncherCommand(t *testing.T, commandPath, directory string, environment []string, args ...string) (string, error) {
+	t.Helper()
+	command := exec.Command(commandPath, args...)
+	command.Dir, command.Env = directory, environment
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func runLauncherThroughShellPATH(t *testing.T, directory string, environment []string, args ...string) (string, error) {
+	t.Helper()
+	commandArgs := []string{"-lc", `exec jobctrl "$@"`, "jobctrl"}
+	commandArgs = append(commandArgs, args...)
+	command := exec.Command("/bin/zsh", commandArgs...)
+	command.Dir, command.Env = directory, environment
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+func TestHermeticLauncherLifecycleViaPathAndHomebrewStyleShim(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:8766")
+	if err != nil {
+		t.Skipf("fixed API port unavailable for integration test: %v", err)
+	}
+	_ = listener.Close()
+	payload, manifest := verifiedPayloadFixture(t)
+	prefix := t.TempDir()
+	payloadRoot := filepath.Join(prefix, "libexec")
+	if err := os.Rename(payload, payloadRoot); err != nil {
+		t.Fatal(err)
+	}
+	launcherPath := filepath.Join(payloadRoot, "launcher", "jobctrl")
+	moduleRoot := filepath.Clean(filepath.Join("..", ".."))
+	build := exec.Command("go", "build", "-o", launcherPath, "./cmd/jobctrl")
+	build.Dir = moduleRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build hermetic launcher fixture: %v\n%s", err, output)
+	}
+	componentSource := filepath.Join(t.TempDir(), "fixture-component.go")
+	componentProgram := `package main
+import (
+  "encoding/json"
+  "net/http"
+  "os"
+  "path/filepath"
+  "strconv"
+  "time"
+)
+func main() {
+  switch filepath.Base(os.Args[0]) {
+  case "temporal":
+    if len(os.Args) > 1 && os.Args[1] == "operator" { return }
+  case "python3":
+    _ = os.WriteFile(filepath.Join(os.Getenv("JOBCTRL_DIR"), "worker.pid"), []byte(strconv.Itoa(os.Getpid())), 0600)
+  case "node":
+    http.HandleFunc("/v1/health", func(w http.ResponseWriter, r *http.Request) {
+      workerPID := 0
+      for i := 0; i < 100; i++ {
+        if value, err := os.ReadFile(filepath.Join(os.Getenv("JOBCTRL_DIR"), "worker.pid")); err == nil {
+          workerPID, _ = strconv.Atoi(string(value)); break
+        }
+        time.Sleep(10 * time.Millisecond)
+      }
+      _ = json.NewEncoder(w).Encode(map[string]any{"worker": map[string]any{"status": "healthy", "heartbeat": map[string]int{"pid": workerPID}}})
+    })
+    _ = http.ListenAndServe("127.0.0.1:8766", nil)
+    return
+  }
+	for { time.Sleep(time.Hour) }
+}`
+	if err := os.WriteFile(componentSource, []byte(componentProgram), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	componentBinary := filepath.Join(t.TempDir(), "fixture-component")
+	build = exec.Command("go", "build", "-o", componentBinary, componentSource)
+	build.Dir = moduleRoot
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build fixture components: %v\n%s", err, output)
+	}
+	componentBytes, err := os.ReadFile(componentBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, target := range []string{
+		filepath.Join(payloadRoot, "temporal", "temporal"),
+		filepath.Join(payloadRoot, "python", "bin", "python3"),
+		filepath.Join(payloadRoot, "node", "bin", "node"),
+	} {
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, componentBytes, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"), []byte(validRuntimeManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, payloadRoot, &manifest)
+	writeLocalEnvelope(t, payloadRoot, manifest)
+	binDirectory := filepath.Join(prefix, "bin")
+	if err := os.MkdirAll(binDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(binDirectory, "jobctrl")
+	if err := os.Symlink(filepath.Join("..", "libexec", "launcher", "jobctrl"), shim); err != nil {
+		t.Fatal(err)
+	}
+	home, otherCWD := t.TempDir(), t.TempDir()
+	environment := []string{"HOME=" + home, "JOBCTRL_DIR=" + filepath.Join(home, ".jobctrl"), "JOBCTRL_RUNTIME_HOME=" + filepath.Join(home, "runtime"), "PATH=" + binDirectory + ":/usr/bin:/bin:/usr/sbin:/sbin"}
+	t.Setenv("PATH", binDirectory+":/usr/bin:/bin:/usr/sbin:/sbin")
+	if resolved, err := exec.LookPath("jobctrl"); err != nil || resolved != shim {
+		t.Fatalf("PATH did not resolve Homebrew-style shim: %q, %v", resolved, err)
+	}
+	if output, err := runLauncherThroughShellPATH(t, otherCWD, environment, "version", "--json"); err != nil || !strings.Contains(output, `"buildId":"local-test-build"`) {
+		t.Fatalf("PATH + shim version invocation failed from another cwd: %v\n%s", err, output)
+	}
+	defer func() { _, _ = runLauncherCommand(t, "jobctrl", otherCWD, environment, "stop") }()
+	if output, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "start", "--no-open"); err != nil {
+		logs, _ := filepath.Glob(filepath.Join(home, "runtime", "instances", "*", "logs", "*.log"))
+		logOutput := make([]string, 0, len(logs))
+		for _, logPath := range logs {
+			contents, _ := os.ReadFile(logPath)
+			logOutput = append(logOutput, logPath+": "+string(contents))
+		}
+		t.Fatalf("start hermetic launcher fixture: %v\n%s\n%s", err, output, strings.Join(logOutput, "\n"))
+	}
+	statusOutput, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "status", "--json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var status struct {
+		Status        string `json:"status"`
+		SupervisorPID int    `json:"supervisorPid"`
+	}
+	if err := json.Unmarshal([]byte(statusOutput), &status); err != nil || status.Status != "running" || status.SupervisorPID <= 0 {
+		t.Fatalf("fixture launcher did not become running: %#v, %v, %s", status, err, statusOutput)
+	}
+	if err := syscall.Kill(status.SupervisorPID, syscall.SIGKILL); err != nil {
+		t.Fatal(err)
+	}
+	instanceRoot := filepath.Join(home, "runtime")
+	stateFiles, err := filepath.Glob(filepath.Join(instanceRoot, "instances", "*", "state.json"))
+	if err != nil || len(stateFiles) != 1 {
+		t.Fatalf("find orphan registry: %v, %v", err, stateFiles)
+	}
+	before, err := os.ReadFile(stateFiles[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "start", "--no-open"); err == nil || !strings.Contains(output, "recorded") {
+		t.Fatalf("immediate restart after SIGKILL supervisor was accepted: %v\n%s", err, output)
+	}
+	after, err := os.ReadFile(stateFiles[0])
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("immediate restart overwrote orphan registry: %v", err)
+	}
+	if output, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "stop"); err != nil {
+		t.Fatalf("stop orphaned fixture: %v\n%s", err, output)
+	}
+	if output, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "start", "--no-open"); err != nil {
+		t.Fatalf("restart after orphan cleanup: %v\n%s", err, output)
+	}
+	if output, err := runLauncherCommand(t, "jobctrl", otherCWD, environment, "stop"); err != nil {
+		t.Fatalf("final fixture stop: %v\n%s", err, output)
+	}
+}
+
+func TestDefaultRuntimeRegistryUsesCanonicalStateHash(t *testing.T) {
+	home := t.TempDir()
+	state := filepath.Join(home, "state")
+	if err := os.MkdirAll(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(home, "alias")
+	if err := os.Symlink(state, alias); err != nil {
+		t.Fatal(err)
+	}
+	first, err := resolveInstance([]string{"HOME=" + home, "JOBCTRL_DIR=" + state})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := resolveInstance([]string{"HOME=" + home, "JOBCTRL_DIR=" + alias})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != second.ID || first.Dir != second.Dir {
+		t.Fatalf("same canonical state must share instance: %#v %#v", first, second)
+	}
+	wantHome := filepath.Join(home, "Library", "Application Support", "JobCtrl")
+	if first.RuntimeHome != wantHome {
+		t.Fatalf("runtime home = %q, want %q", first.RuntimeHome, wantHome)
+	}
+	if !strings.Contains(first.Dir, filepath.Join("instances", first.ID)) {
+		t.Fatalf("instance directory is not hash scoped: %q", first.Dir)
+	}
+}
+
+func TestChildEnvironmentStripsAmbientRuntimeOverrides(t *testing.T) {
+	var manifest runtimeManifest
+	if err := json.Unmarshal([]byte(validRuntimeManifest), &manifest); err != nil {
+		t.Fatal(err)
+	}
+	env := childEnvironment([]string{
+		"HOME=/home/test", "PYTHONPATH=/evil", "PYTHONHOME=/evil", "VIRTUAL_ENV=/evil",
+		"NODE_OPTIONS=--require=/evil", "NODE_PATH=/evil", "PORT=1234",
+		"JOBCTRL_API_ALLOW_REMOTE_BIND=1", "JOBCTRL_API_HOST=0.0.0.0", "JOBCTRL_API_PORT=9999",
+		"TEMPORAL_ADDRESS=evil:7233", "PATH=/evil", "OPENAI_API_KEY=kept",
+	}, "/payload", "/state", manifest)
+	values := environmentMap(env)
+	for _, key := range []string{"PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV", "NODE_OPTIONS", "NODE_PATH", "PORT", "JOBCTRL_API_ALLOW_REMOTE_BIND"} {
+		if _, exists := values[key]; exists {
+			t.Fatalf("child inherited forbidden %s", key)
+		}
+	}
+	if values["JOBCTRL_API_HOST"] != "127.0.0.1" || values["JOBCTRL_API_PORT"] != "8766" || values["TEMPORAL_ADDRESS"] != "127.0.0.1:7233" {
+		t.Fatalf("fixed loopback environment missing: %#v", values)
+	}
+	if values["JOBCTRL_PYTHON_EXECUTABLE"] != "/payload/python/bin/python3" {
+		t.Fatalf("bundled API Python executable missing: %#v", values)
+	}
+	if values["PATH"] != "/usr/bin:/bin:/usr/sbin:/sbin" || values["OPENAI_API_KEY"] != "kept" {
+		t.Fatalf("environment isolation lost needed values: %#v", values)
+	}
+}
+
+func TestInstanceLockExcludesSecondLauncher(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "instance.lock")
+	first, err := acquireLock(path, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseLock(first)
+	if second, err := acquireLock(path, true); !errors.Is(err, ErrLockHeld) || second != nil {
+		t.Fatalf("second lock = %v, %v", second, err)
+	}
+}
+
+func TestStopDoesNotSignalPIDReuseOrForeignProcessGroup(t *testing.T) {
+	previousIdentity, previousExecutable, previousSignaler := readProcessIdentity, readProcessExecutable, signalProcessGroup
+	t.Cleanup(func() {
+		readProcessIdentity, readProcessExecutable, signalProcessGroup = previousIdentity, previousExecutable, previousSignaler
+	})
+	called := 0
+	signalProcessGroup = func(int, syscall.Signal) error { called++; return nil }
+	readProcessIdentity = func(int) (string, error) { return "different-start", nil }
+	readProcessExecutable = func(int) (string, error) { return "/expected", nil }
+	if err := terminateRecord(componentRecord{PID: 42, PGID: 42, StartIdentity: "original-start", Executable: "/expected"}); err == nil {
+		t.Fatal("reused PID must not be treated as owned")
+	}
+	if called != 0 {
+		t.Fatalf("PID reuse must not signal a foreign process, got %d signals", called)
+	}
+}
+
+func TestProcessRecordBindsStartIdentityProcessGroupAndExecutable(t *testing.T) {
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordMatchesLiveProcess(record) {
+		t.Fatalf("live process record did not match: %#v", record)
+	}
+	previousExecutable := readProcessExecutable
+	t.Cleanup(func() { readProcessExecutable = previousExecutable })
+	readProcessExecutable = func(int) (string, error) { return "/different-program", nil }
+	if recordMatchesLiveProcess(record) {
+		t.Fatal("matching lstart and PGID is insufficient when executable changed")
+	}
+}
+
+func TestProcessRecordMatchesOwnedChildAfterSeparateExec(t *testing.T) {
+	child := exec.Command("/bin/sleep", "30")
+	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Kill(-child.Process.Pid, syscall.SIGTERM)
+		_, _ = child.Process.Wait()
+	})
+	executable, err := processExecutable(child.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executable != "/bin/sleep" {
+		t.Fatalf("child executable = %q, want NUL-terminated PROC_PIDPATHINFO path", executable)
+	}
+	record, err := recordForProcess(child.Process.Pid, "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recordMatchesLiveProcess(record) {
+		identity, identityErr := processStartIdentity(child.Process.Pid)
+		liveExecutable, executableErr := processExecutable(child.Process.Pid)
+		pgid, pgidErr := syscall.Getpgid(child.Process.Pid)
+		t.Fatalf("owned child record did not match: record=%#v liveIdentity=%q identityErr=%v liveExecutable=%q executableErr=%v pgid=%d pgidErr=%v", record, identity, identityErr, liveExecutable, executableErr, pgid, pgidErr)
+	}
+}
+
+func startOwnedSleep(t *testing.T) (*exec.Cmd, componentRecord, <-chan error) {
+	t.Helper()
+	child := exec.Command("/bin/sleep", "30")
+	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	executable, err := processExecutable(child.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(child.Process.Pid, "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reaped := make(chan error, 1)
+	go func() { reaped <- child.Wait() }()
+	t.Cleanup(func() {
+		if processPIDAlive(child.Process.Pid) {
+			_ = syscall.Kill(-record.PGID, syscall.SIGKILL)
+		}
+		select {
+		case <-reaped:
+		case <-time.After(time.Second):
+		}
+	})
+	return child, record, reaped
+}
+
+func TestTerminateRecordFallsBackToVerifiedPIDWhenSandboxRejectsProcessGroup(t *testing.T) {
+	child, record, reaped := startOwnedSleep(t)
+	previousSignaler := signalProcessGroup
+	signalProcessGroup = func(int, syscall.Signal) error { return syscall.EPERM }
+	t.Cleanup(func() { signalProcessGroup = previousSignaler })
+	if err := terminateRecord(record); err != nil {
+		t.Fatalf("verified direct-PID fallback failed: %v", err)
+	}
+	if err := <-reaped; err == nil {
+		t.Fatal("sleep unexpectedly exited cleanly after TERM")
+	}
+	if processPIDAlive(child.Process.Pid) || processGroupAlive(record.PGID) {
+		t.Fatal("direct PID fallback left an owned process or group live")
+	}
+}
+
+func TestTerminateRecordProvesOwnedProcessGroupIsEmpty(t *testing.T) {
+	child := exec.Command("/bin/sh", "-c", "sleep 30 & wait")
+	child.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := child.Start(); err != nil {
+		t.Fatal(err)
+	}
+	executable, err := processExecutable(child.Process.Pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(child.Process.Pid, "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reaped := make(chan error, 1)
+	go func() { reaped <- child.Wait() }()
+	t.Cleanup(func() {
+		if processGroupAlive(record.PGID) {
+			_ = syscall.Kill(-record.PGID, syscall.SIGKILL)
+		}
+		select {
+		case <-reaped:
+		case <-time.After(time.Second):
+		}
+	})
+	if err := terminateRecord(record); err != nil {
+		t.Fatalf("owned group termination failed: %v", err)
+	}
+	if err := <-reaped; err == nil {
+		t.Fatal("shell unexpectedly exited cleanly after group termination")
+	}
+	if processPIDAlive(record.PID) || processGroupAlive(record.PGID) {
+		t.Fatal("leader or descendant remained in the owned process group")
+	}
+}
+
+func TestStartupFailureCleanupTerminatesOwnedSiblingGroups(t *testing.T) {
+	_, temporal, temporalReaped := startOwnedSleep(t)
+	_, worker, workerReaped := startOwnedSleep(t)
+	state := instanceState{Components: map[string]componentRecord{"temporal": temporal, "worker": worker}}
+	shutdownComponents(&state, nil, filepath.Join(t.TempDir(), "state.json"))
+	for name, reaped := range map[string]<-chan error{"temporal": temporalReaped, "worker": workerReaped} {
+		if err := <-reaped; err == nil {
+			t.Fatalf("%s unexpectedly exited cleanly after shutdown", name)
+		}
+		record := state.Components[name]
+		if record.ExitedAt == nil || processPIDAlive(record.PID) || processGroupAlive(record.PGID) {
+			t.Fatalf("startup cleanup did not prove %s process-tree termination: %#v", name, record)
+		}
+	}
+}
+
+func TestStopTerminatesLiveRecordEvenWhenAnOldStateMarkedItExited(t *testing.T) {
+	_, record, reaped := startOwnedSleep(t)
+	payload, stateRoot := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(payload, "manifest.json"), []byte("manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := manifestDigest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := runtimeManifest{}
+	manifest.Ports.TemporalGRPC, manifest.Ports.TemporalUI, manifest.Ports.API = 7233, 8233, 8766
+	ctx := launchContext{PayloadRoot: payload, Manifest: manifest, Distribution: distributionManifest{BuildID: "build"}, Instance: instance{ID: "instance", StateDir: stateRoot, StatePath: filepath.Join(stateRoot, "state.json"), ControlPath: filepath.Join(stateRoot, "control.lock")}}
+	oldExit := time.Now().UTC().Add(-time.Minute)
+	record.ExitedAt = &oldExit
+	state := instanceState{SchemaVersion: stateSchemaVersion, InstanceID: "instance", CanonicalStateDir: stateRoot, PayloadRoot: payload, BuildID: "build", ManifestSHA256: digest, Ports: runtimePorts{TemporalGRPC: 7233, TemporalUI: 8233, API: 8766}, Components: map[string]componentRecord{"worker": record}}
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		t.Fatal(err)
+	}
+	if err := stop(ctx); err != nil {
+		t.Fatalf("stop must repair stale live process record: %v", err)
+	}
+	if err := <-reaped; err == nil {
+		t.Fatal("sleep unexpectedly exited cleanly after stop")
+	}
+	if processPIDAlive(record.PID) || processGroupAlive(record.PGID) {
+		t.Fatal("stop left the falsely marked-live owned process group running")
+	}
+	updated, err := readState(ctx.Instance.StatePath)
+	if err != nil || updated.StoppedAt == nil {
+		t.Fatalf("stop did not persist a proven stopped state: %#v, %v", updated, err)
+	}
+}
+
+func TestCleanupDoesNotMarkAnUnverifiedLiveRecordExited(t *testing.T) {
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousIdentity := readProcessIdentity
+	readProcessIdentity = func(int) (string, error) { return "different-start", nil }
+	t.Cleanup(func() { readProcessIdentity = previousIdentity })
+	state := instanceState{Components: map[string]componentRecord{"worker": record}}
+	shutdownComponents(&state, nil, filepath.Join(t.TempDir(), "state.json"))
+	updated := state.Components["worker"]
+	if updated.ExitedAt != nil || !strings.Contains(updated.ExitError, "could not confirm") {
+		t.Fatalf("unverified live record was falsely marked exited: %#v", updated)
+	}
+}
+
+func TestStartupComponentExitIsRecordedBeforeSiblingCleanup(t *testing.T) {
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := instanceState{Components: map[string]componentRecord{"api": record}}
+	markStartupComponentExit(&state, startupComponentExitError{componentExit{Name: "api", Err: errors.New("fixture API exit")}})
+	updated := state.Components["api"]
+	if updated.ExitedAt == nil || updated.ExitError != "fixture API exit" {
+		t.Fatalf("startup exit was not persisted: %#v", updated)
+	}
+}
+
+func TestForeignListenerIsRefusedAndNeverSignaled(t *testing.T) {
+	for _, port := range []int{7233, 8233, 8766} {
+		t.Run(strconv.Itoa(port), func(t *testing.T) {
+			listener, err := net.Listen("tcp4", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+			if err != nil {
+				t.Skipf("fixed port unavailable for test: %v", err)
+			}
+			defer listener.Close()
+			previousSignaler := signalProcessGroup
+			t.Cleanup(func() { signalProcessGroup = previousSignaler })
+			called := 0
+			signalProcessGroup = func(int, syscall.Signal) error { called++; return nil }
+			var manifest runtimeManifest
+			if err := json.Unmarshal([]byte(validRuntimeManifest), &manifest); err != nil {
+				t.Fatal(err)
+			}
+			if err := ensureFixedPortsAvailable(manifest); !errors.Is(err, ErrPortInUse) {
+				t.Fatalf("expected foreign listener refusal, got %v", err)
+			}
+			if called != 0 {
+				t.Fatalf("port refusal must never signal foreign listener, got %d signals", called)
+			}
+		})
+	}
+}
+
+func TestLogsAreBoundedAndNonFollowing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "api.log")
+	var source strings.Builder
+	for i := 0; i < logLineLimit+10; i++ {
+		source.WriteString("line-" + strconv.Itoa(i) + "\n")
+	}
+	if err := os.WriteFile(path, []byte(source.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := tailFile(path, logLineLimit, &output); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "line-0\n") || !strings.Contains(output.String(), "line-209\n") {
+		t.Fatalf("bounded tail output is wrong: %q", output.String())
+	}
+}
+
+func TestStartupObservesEarlyChildExitWithoutWaitingForTimeout(t *testing.T) {
+	exits := make(chan componentExit, 1)
+	exits <- componentExit{Name: "temporal", Err: errors.New("fixture exit")}
+	started := time.Now()
+	err := waitForTemporal(launchContext{}, nil, exits, make(chan os.Signal))
+	if err == nil || !strings.Contains(err.Error(), "fixture exit") {
+		t.Fatalf("early child exit = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("early child exit waited too long: %s", elapsed)
+	}
+}
+
+func TestTemporalReadinessProbesAHealthyLiveChild(t *testing.T) {
+	previous := temporalHealthProbe
+	t.Cleanup(func() { temporalHealthProbe = previous })
+	called := 0
+	temporalHealthProbe = func(launchContext) error { called++; return nil }
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	if err := waitForTemporal(launchContext{}, &exec.Cmd{Process: process}, make(chan componentExit), make(chan os.Signal)); err != nil {
+		t.Fatal(err)
+	}
+	if called != 1 || time.Since(started) > time.Second {
+		t.Fatalf("healthy temporal readiness did not probe immediately: calls=%d elapsed=%s", called, time.Since(started))
+	}
+}
+
+func TestStartupSignalIsCleanCancellation(t *testing.T) {
+	signals := make(chan os.Signal, 1)
+	signals <- os.Interrupt
+	if err := waitForTemporal(launchContext{}, nil, make(chan componentExit), signals); !errors.Is(err, errStartupInterrupted) {
+		t.Fatalf("startup signal = %v, want clean interruption", err)
+	}
+}
+
+func TestStatusActivelyProbesAPIWorkerReadiness(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:8766")
+	if err != nil {
+		t.Skipf("fixed API port unavailable for test: %v", err)
+	}
+	defer listener.Close()
+	payload, stateRoot := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(payload, "manifest.json"), []byte("manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := manifestDigest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var probes atomic.Int32
+	server := &http.Server{Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		probes.Add(1)
+		writer.Header().Set("content-type", "application/json")
+		_, _ = writer.Write([]byte(`{"worker":{"status":"healthy","heartbeat":{"pid":` + strconv.Itoa(os.Getpid()) + `}}}`))
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	manifest := runtimeManifest{}
+	manifest.Ports.TemporalGRPC, manifest.Ports.TemporalUI, manifest.Ports.API = 7233, 8233, 8766
+	ctx := launchContext{PayloadRoot: payload, Manifest: manifest, Distribution: distributionManifest{BuildID: "build"}, Instance: instance{ID: "instance", StateDir: stateRoot, StatePath: filepath.Join(stateRoot, "state.json")}}
+	state := instanceState{SchemaVersion: stateSchemaVersion, InstanceID: "instance", CanonicalStateDir: stateRoot, PayloadRoot: payload, BuildID: "build", ManifestSHA256: digest, Ports: runtimePorts{TemporalGRPC: 7233, TemporalUI: 8233, API: 8766}, Components: map[string]componentRecord{"worker": record, "api": record}}
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := status(ctx, &output, false); err != nil {
+		t.Fatal(err)
+	}
+	if probes.Load() == 0 || !strings.Contains(output.String(), "worker    running") || !strings.Contains(output.String(), "api       running") {
+		t.Fatalf("status did not use healthy API readiness probe: probes=%d output=%q", probes.Load(), output.String())
+	}
+}
+
+func TestOpenRequiresHealthyOwnedAPIAndWorkerBeforeInvokingBrowser(t *testing.T) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:8766")
+	if err != nil {
+		t.Skipf("fixed API port unavailable for test: %v", err)
+	}
+	defer listener.Close()
+	payload, stateRoot := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(payload, "manifest.json"), []byte("manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := manifestDigest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var healthy atomic.Bool
+	healthy.Store(true)
+	server := &http.Server{Handler: http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Set("content-type", "application/json")
+		if healthy.Load() {
+			_, _ = writer.Write([]byte(`{"worker":{"status":"healthy","heartbeat":{"pid":` + strconv.Itoa(os.Getpid()) + `}}}`))
+			return
+		}
+		_, _ = writer.Write([]byte(`{"worker":{"status":"degraded"}}`))
+	})}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+	manifest := runtimeManifest{}
+	manifest.Ports.TemporalGRPC, manifest.Ports.TemporalUI, manifest.Ports.API = 7233, 8233, 8766
+	manifest.Health.API.Path = "/v1/health"
+	ctx := launchContext{PayloadRoot: payload, Manifest: manifest, Distribution: distributionManifest{BuildID: "build"}, Instance: instance{ID: "instance", StateDir: stateRoot, StatePath: filepath.Join(stateRoot, "state.json")}}
+	state := instanceState{SchemaVersion: stateSchemaVersion, InstanceID: "instance", CanonicalStateDir: stateRoot, PayloadRoot: payload, BuildID: "build", ManifestSHA256: digest, Ports: runtimePorts{TemporalGRPC: 7233, TemporalUI: 8233, API: 8766}, Components: map[string]componentRecord{"worker": record, "api": record}}
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		t.Fatal(err)
+	}
+	previousOpenBrowser := openBrowser
+	var opened []string
+	openBrowser = func(url string) error {
+		opened = append(opened, url)
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = previousOpenBrowser })
+	if err := openURL(ctx); err != nil {
+		t.Fatalf("open with healthy owned API and worker: %v", err)
+	}
+	if len(opened) != 1 || opened[0] != "http://127.0.0.1:8766" {
+		t.Fatalf("open invoked browser with %#v", opened)
+	}
+	healthy.Store(false)
+	if err := openURL(ctx); err == nil {
+		t.Fatal("open accepted an unhealthy API")
+	}
+	if len(opened) != 1 {
+		t.Fatalf("unhealthy API must not invoke browser, got %#v", opened)
+	}
+}
+
+func TestStateIdentitySeparatesStaleAndLiveDifferentReleaseRecords(t *testing.T) {
+	payload := t.TempDir()
+	if err := os.WriteFile(filepath.Join(payload, "manifest.json"), []byte("new manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{PayloadRoot: payload, Distribution: distributionManifest{BuildID: "new"}, Manifest: runtimeManifest{}, Instance: instance{ID: "instance", StateDir: "/state"}}
+	stale := instanceState{InstanceID: "instance", CanonicalStateDir: "/state", PayloadRoot: "/old", BuildID: "old", ManifestSHA256: "old", Components: map[string]componentRecord{}}
+	if err := validateStateIdentity(ctx, stale); err != nil {
+		t.Fatal(err)
+	}
+	if stateHasLiveProcesses(stale) {
+		t.Fatal("empty old registry must be safe to replace")
+	}
+	if err := validateStartState(ctx, stale); err != nil {
+		t.Fatalf("dead prior release must be replaceable: %v", err)
+	}
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	live, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.Supervisor = live
+	if err := validateStartState(ctx, stale); err == nil || !strings.Contains(err.Error(), "different JobCtrl release") {
+		t.Fatalf("live prior release must block replacement, got %v", err)
+	}
+	wrong := stale
+	wrong.CanonicalStateDir = "/other"
+	if err := validateStateIdentity(ctx, wrong); err == nil {
+		t.Fatal("registry from another state directory must not be adopted")
+	}
+}
+
+func TestStartRefusesLiveComponentWhenSupervisorIsGoneAndSupervisePreservesRegistry(t *testing.T) {
+	payload, stateRoot := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(payload, "manifest.json"), []byte("new manifest"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := manifestDigest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := processExecutable(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	liveWorker, err := recordForProcess(os.Getpid(), "", executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := runtimeManifest{}
+	manifest.Ports.TemporalGRPC, manifest.Ports.TemporalUI, manifest.Ports.API = 7233, 8233, 8766
+	ctx := launchContext{
+		Executable: executable, PayloadRoot: payload, Manifest: manifest, Distribution: distributionManifest{BuildID: "new"},
+		Instance: instance{ID: "instance", StateDir: stateRoot, StatePath: filepath.Join(stateRoot, "state.json"), LockPath: filepath.Join(stateRoot, "instance.lock")},
+	}
+	state := instanceState{SchemaVersion: stateSchemaVersion, InstanceID: "instance", CanonicalStateDir: stateRoot, PayloadRoot: payload, BuildID: "new", ManifestSHA256: digest, Ports: runtimePorts{TemporalGRPC: 7233, TemporalUI: 8233, API: 8766}, Components: map[string]componentRecord{"worker": liveWorker}}
+	if err := writeState(ctx.Instance.StatePath, state); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateStartState(ctx, state); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("orphaned live component must block start, got %v", err)
+	}
+	before, err := os.ReadFile(ctx.Instance.StatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := supervise(ctx, nil); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("supervise must revalidate after lock, got %v", err)
+	}
+	after, err := os.ReadFile(ctx.Instance.StatePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(before) {
+		t.Fatal("supervise overwrote an orphaned live component registry")
+	}
+}

--- a/launcher/internal/launcher/process_darwin.go
+++ b/launcher/internal/launcher/process_darwin.go
@@ -1,0 +1,99 @@
+//go:build darwin
+
+package launcher
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// CurrentProcessExecutable returns the kernel-recorded executable path for the
+// running launcher. Unlike argv[0], PATH, and os.Executable on some Darwin
+// launch paths, PROC_PIDPATHINFO is bound to the current process identity.
+func CurrentProcessExecutable() (string, error) {
+	return processExecutable(os.Getpid())
+}
+
+// These are the Darwin kernel proc_info ABI values from
+// <sys/proc_info.h>. Calling SYS_PROC_INFO directly keeps lifecycle identity
+// checks inside the native launcher: sandbox-exec may deny /bin/ps even under
+// `(allow default)`, while this syscall neither executes a helper nor needs
+// network access.
+const (
+	procInfoCallPIDInfo = 2
+	procPIDTBSDInfo     = 3
+	procPIDPathInfo     = 11
+	procBSDInfoSize     = 136
+	procPathInfoSize    = 4096
+
+	procBSDPIDOffset        = 12
+	procBSDStartSeconds     = 120
+	procBSDStartMicrosecond = 128
+)
+
+func processStartIdentity(pid int) (string, error) {
+	info, err := procInfo(pid, procPIDTBSDInfo, procBSDInfoSize)
+	if err != nil {
+		return "", err
+	}
+	if len(info) != procBSDInfoSize {
+		return "", fmt.Errorf("Darwin proc_bsdinfo size is %d, expected %d", len(info), procBSDInfoSize)
+	}
+	if int(binary.LittleEndian.Uint32(info[procBSDPIDOffset:])) != pid {
+		return "", errors.New("process identity PID mismatch")
+	}
+	seconds := binary.LittleEndian.Uint64(info[procBSDStartSeconds:])
+	microseconds := binary.LittleEndian.Uint64(info[procBSDStartMicrosecond:])
+	if seconds == 0 && microseconds == 0 {
+		return "", errors.New("process has no start identity")
+	}
+	return fmt.Sprintf("%d:%d:%d", pid, seconds, microseconds), nil
+}
+
+func processExecutable(pid int) (string, error) {
+	path, err := procInfo(pid, procPIDPathInfo, procPathInfoSize)
+	if err != nil {
+		return "", err
+	}
+	terminator := 0
+	for terminator < len(path) && path[terminator] != 0 {
+		terminator++
+	}
+	if terminator == 0 {
+		return "", errors.New("process has no executable path")
+	}
+	// PROC_PIDPATHINFO promises a NUL-terminated path. Its unused buffer tail
+	// is not a stable part of that path, so never TrimRight and retain it: doing
+	// so can make the same live child fail identity comparison on the next read.
+	return string(path[:terminator]), nil
+}
+
+func procInfo(pid, flavor, size int) ([]byte, error) {
+	if pid <= 0 {
+		return nil, errors.New("invalid pid")
+	}
+	buffer := make([]byte, size)
+	returned, _, errno := syscall.Syscall6(
+		syscall.SYS_PROC_INFO,
+		procInfoCallPIDInfo,
+		uintptr(pid),
+		uintptr(flavor),
+		0,
+		uintptr(unsafe.Pointer(&buffer[0])),
+		uintptr(len(buffer)),
+	)
+	if errno != 0 {
+		return nil, errno
+	}
+	// PROC_PIDPATHINFO returns 0 on success on current Darwin releases but
+	// fills its fixed-size output buffer. PROC_PIDTBSDINFO returns its struct
+	// size. The actual non-NUL path/struct validation lives in the callers.
+	if flavor == procPIDTBSDInfo && returned != procBSDInfoSize {
+		return nil, fmt.Errorf("Darwin proc_bsdinfo returned %d bytes", returned)
+	}
+	return buffer, nil
+}

--- a/launcher/runtime-manifest.json
+++ b/launcher/runtime-manifest.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "launcherProtocol": 1,
+  "ports": { "temporalGrpc": 7233, "temporalUi": 8233, "api": 8766 },
+  "components": [
+    { "name": "temporal", "executable": "temporal/temporal", "arguments": ["server", "start-dev", "--ip", "127.0.0.1", "--port", "${TEMPORAL_GRPC_PORT}", "--ui-ip", "127.0.0.1", "--ui-port", "${TEMPORAL_UI_PORT}", "--db-filename", "${TEMPORAL_DB}", "--log-level", "error", "--disable-config-file", "--disable-config-env"] },
+    { "name": "worker", "executable": "python/bin/python3", "arguments": ["-I", "-B", "-m", "jobctrl", "worker"] },
+    { "name": "api", "executable": "node/bin/node", "arguments": ["${PAYLOAD_ROOT}/api/server.mjs"] }
+  ],
+  "health": {
+    "temporal": { "component": "temporal", "arguments": ["operator", "cluster", "health", "--address", "127.0.0.1:${TEMPORAL_GRPC_PORT}", "--command-timeout", "2s", "--output", "json", "--disable-config-file", "--disable-config-env"] },
+    "api": { "path": "/v1/health", "requireWorkerHealthy": true, "requireWorkerPid": true }
+  }
+}

--- a/launcher/runtime-manifest.schema.json
+++ b/launcher/runtime-manifest.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jobctrl.dev/schemas/runtime-manifest-v1.json",
+  "title": "JobCtrl launcher runtime manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "launcherProtocol", "ports", "components", "health"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "launcherProtocol": { "const": 1 },
+    "ports": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["temporalGrpc", "temporalUi", "api"],
+      "properties": {
+        "temporalGrpc": { "const": 7233 },
+        "temporalUi": { "const": 8233 },
+        "api": { "const": 8766 }
+      }
+    },
+    "components": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "executable", "arguments"],
+        "properties": {
+          "name": { "enum": ["temporal", "worker", "api"] },
+          "executable": { "type": "string" },
+          "arguments": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    },
+    "health": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["temporal", "api"],
+      "properties": {
+        "temporal": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["component", "arguments"],
+          "properties": {
+            "component": { "const": "temporal" },
+            "arguments": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "api": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "requireWorkerHealthy", "requireWorkerPid"],
+          "properties": {
+            "path": { "const": "/v1/health" },
+            "requireWorkerHealthy": { "const": true },
+            "requireWorkerPid": { "const": true }
+          }
+        }
+      }
+    }
+  }
+}

--- a/launcher/toolchain.json
+++ b/launcher/toolchain.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "goVersion": "go1.26.4",
+  "archive": {
+    "type": "tar.gz",
+    "url": "https://go.dev/dl/go1.26.4.darwin-arm64.tar.gz",
+    "sha256": "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53",
+    "sizeBytes": 64723756,
+    "officialMetadataUrl": "https://go.dev/dl/?mode=json&include=all"
+  },
+  "moduleClosure": "standard-library-only",
+  "license": "BSD-3-Clause",
+  "licenseSource": "https://go.dev/LICENSE",
+  "licenseSha256": "911f8f5782931320f5b8d1160a76365b83aea6447ee6c04fa6d5591467db9dad"
+}

--- a/package.json
+++ b/package.json
@@ -44,12 +44,14 @@
     "docs:build": "node scripts/check-install-asset.mjs && vitepress build docs && node scripts/check-docs-site-links.mjs",
     "docs:check:runtime": "node scripts/check-docs-site-runtime.mjs",
     "docs:preview": "vitepress preview docs",
-    "distribution:audit": "node scripts/distribution-provider-lock.mjs check && node scripts/distribution-manifest.mjs audit",
+    "distribution:audit": "node scripts/distribution-provider-lock.mjs check && node scripts/distribution-manifest.mjs audit && node scripts/distribution-build.mjs audit",
     "distribution:build:fixture": "node scripts/distribution-build.mjs fixture",
     "distribution:build": "node scripts/distribution-build.mjs real",
     "distribution:provider-lock:check": "node scripts/distribution-provider-lock.mjs check",
     "distribution:provider-lock:generate": "node scripts/distribution-provider-lock.mjs generate",
     "distribution:measure": "node scripts/distribution-manifest.mjs measure",
+    "launcher:check": "cd launcher && test \"$(go env GOVERSION)\" = \"go1.26.4\" && go vet ./...",
+    "launcher:test": "cd launcher && test \"$(go env GOVERSION)\" = \"go1.26.4\" && go test -race ./...",
     "ttfv:real": "node scripts/ttfv-real.mjs run",
     "ttfv:probe": "node scripts/ttfv-real.mjs probe",
     "ttfv:summary": "node scripts/ttfv-real.mjs summarize",
@@ -57,8 +59,8 @@
     "python:test": "uv --project workers/automation run --extra dev pytest -q",
     "python:lint": "uv --project workers/automation run --extra dev ruff check .",
     "python:build": "uv --project workers/automation run --extra dev python -m build workers/automation",
-    "check": "corepack pnpm --filter @jobctrl/contracts check && corepack pnpm --filter @jobctrl/api-client check && corepack pnpm api:check && corepack pnpm web:check && corepack pnpm extension:check && corepack pnpm python:lint",
-    "test": "corepack pnpm scripts:test && corepack pnpm api:test && corepack pnpm web:build && corepack pnpm extension:test && corepack pnpm extension:e2e && corepack pnpm python:test"
+    "check": "corepack pnpm --filter @jobctrl/contracts check && corepack pnpm --filter @jobctrl/api-client check && corepack pnpm api:check && corepack pnpm web:check && corepack pnpm extension:check && corepack pnpm python:lint && corepack pnpm launcher:check",
+    "test": "corepack pnpm scripts:test && corepack pnpm api:test && corepack pnpm web:build && corepack pnpm extension:test && corepack pnpm extension:e2e && corepack pnpm python:test && corepack pnpm launcher:test"
   },
   "repository": {
     "type": "git",

--- a/scripts/distribution-archive.mjs
+++ b/scripts/distribution-archive.mjs
@@ -110,7 +110,7 @@ export async function verifyLockedArchive(archivePath, lock) {
   return actual;
 }
 
-export function parseTarGzArchive(archive, { stripComponents = 0 } = {}) {
+export function parseTarGzArchive(archive, { stripComponents = 0, skipEntry = null } = {}) {
   invariant(Number.isInteger(stripComponents) && stripComponents >= 0, "stripComponents must be non-negative");
   const tar = gunzipSync(archive);
   const entries = [];
@@ -150,6 +150,17 @@ export function parseTarGzArchive(archive, { stripComponents = 0 } = {}) {
       continue;
     }
 
+    // A caller may discard an explicitly non-runtime upstream subtree before
+    // path normalization. This is deliberately a raw-path hook: it lets a
+    // verified toolchain archive omit its test corpus, including filenames
+    // outside the payload's portable ASCII path policy, without weakening that
+    // policy for any entry that can be extracted.
+    if (skipEntry?.(rawPath, { type, rawLink })) {
+      nextPax = {};
+      nextLongPath = null;
+      nextLongLink = null;
+      continue;
+    }
     const relativePath = stripArchivePath(rawPath, stripComponents, "tar entry path");
     nextPax = {};
     nextLongPath = null;
@@ -304,12 +315,12 @@ export async function extractArchiveEntries(entries, destination) {
   return entries;
 }
 
-export async function extractVerifiedArchive({ archivePath, lock, destination, stripComponents = 0, include = null }) {
+export async function extractVerifiedArchive({ archivePath, lock, destination, stripComponents = 0, include = null, skipEntry = null }) {
   await verifyLockedArchive(archivePath, lock);
   const archive = await readFile(archivePath);
   let entries;
   if (lock.archiveType === "tar.gz") {
-    entries = parseTarGzArchive(archive, { stripComponents });
+    entries = parseTarGzArchive(archive, { stripComponents, skipEntry });
   } else if (lock.archiveType === "zip") {
     entries = parseZipArchive(archive, { stripComponents });
   } else {

--- a/scripts/distribution-build.mjs
+++ b/scripts/distribution-build.mjs
@@ -47,6 +47,12 @@ import {
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const DISTRIBUTION_DIR = path.join(REPO_ROOT, "packaging", "distribution");
 const ENVELOPE_FILES = new Set(["manifest.json", "manifest.sig"]);
+const GO_TOOLCHAIN_VERSION = "go1.26.4";
+const GO_TOOLCHAIN_LICENSE_SHA256 = "911f8f5782931320f5b8d1160a76365b83aea6447ee6c04fa6d5591467db9dad";
+const GO_TOOLCHAIN_ARCHIVE_URL = "https://go.dev/dl/go1.26.4.darwin-arm64.tar.gz";
+const GO_TOOLCHAIN_ARCHIVE_SHA256 = "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53";
+const GO_TOOLCHAIN_ARCHIVE_SIZE_BYTES = 64723756;
+const GO_TOOLCHAIN_OFFICIAL_METADATA_URL = "https://go.dev/dl/?mode=json&include=all";
 const SAFE_MODES = new Set(["0644", "0755"]);
 const FORBIDDEN_PROVIDER_PATTERNS = [
   /(^|[/_.-])claude[-_]agent[-_]sdk([/_.-]|$)/i,
@@ -302,21 +308,63 @@ export function validateSharedComponentLayout(layout, contracts) {
   return specs;
 }
 
+export async function loadNativeLauncherToolchain(root = REPO_ROOT) {
+  const toolchain = JSON.parse(await readFile(path.join(root, "launcher", "toolchain.json"), "utf8"));
+  invariant(
+    JSON.stringify(Object.keys(toolchain).sort(bytewiseCompare)) === JSON.stringify(["archive", "goVersion", "license", "licenseSha256", "licenseSource", "moduleClosure", "schemaVersion"]),
+    "native launcher toolchain contract has unknown fields",
+  );
+  invariant(toolchain.archive && typeof toolchain.archive === "object", "native launcher toolchain archive is missing");
+  invariant(
+    JSON.stringify(Object.keys(toolchain.archive).sort(bytewiseCompare)) === JSON.stringify(["officialMetadataUrl", "sha256", "sizeBytes", "type", "url"]),
+    "native launcher toolchain archive has unknown fields",
+  );
+  invariant(
+    toolchain.schemaVersion === 1
+      && toolchain.goVersion === GO_TOOLCHAIN_VERSION
+      && toolchain.moduleClosure === "standard-library-only"
+      && toolchain.license === "BSD-3-Clause"
+      && toolchain.licenseSource === "https://go.dev/LICENSE"
+      && toolchain.licenseSha256 === GO_TOOLCHAIN_LICENSE_SHA256
+      && toolchain.archive.type === "tar.gz"
+      && toolchain.archive.url === GO_TOOLCHAIN_ARCHIVE_URL
+      && toolchain.archive.sha256 === GO_TOOLCHAIN_ARCHIVE_SHA256
+      && toolchain.archive.sizeBytes === GO_TOOLCHAIN_ARCHIVE_SIZE_BYTES
+      && toolchain.archive.officialMetadataUrl === GO_TOOLCHAIN_OFFICIAL_METADATA_URL,
+    "native launcher toolchain contract is invalid",
+  );
+  invariant(await sha256File(path.join(root, "launcher", "GO-LICENSE")) === toolchain.licenseSha256, "native launcher Go license does not match the pinned Go toolchain license");
+  return toolchain;
+}
+
+function nativeGoArchiveLock(toolchain) {
+  return {
+    id: "go-toolchain-darwin-arm64",
+    componentId: "jobctrl-launcher",
+    version: toolchain.goVersion,
+    archiveType: toolchain.archive.type,
+    url: toolchain.archive.url,
+    sha256: toolchain.archive.sha256,
+    sizeBytes: toolchain.archive.sizeBytes,
+  };
+}
+
 async function loadBuildContracts(root = REPO_ROOT) {
-  const [contracts, layout, locks, providerPackLocks, licenseEvidenceLocks, nodeLicenseEvidenceLocks] = await Promise.all([
+  const [contracts, layout, locks, providerPackLocks, licenseEvidenceLocks, nodeLicenseEvidenceLocks, launcherToolchain] = await Promise.all([
     loadManifestValidationContracts(root),
     readFile(path.join(root, "packaging", "distribution", "payload-layout.json"), "utf8").then(JSON.parse),
     readFile(path.join(root, "packaging", "distribution", "components.lock.json"), "utf8").then(JSON.parse),
     readFile(path.join(root, "packaging", "distribution", "provider-packs.lock.json"), "utf8").then(JSON.parse),
     readFile(path.join(root, "packaging", "distribution", "license-evidence.lock.json"), "utf8").then(JSON.parse),
     readFile(path.join(root, "packaging", "distribution", "node-license-evidence.lock.json"), "utf8").then(JSON.parse),
+    loadNativeLauncherToolchain(root),
   ]);
   const componentPaths = validatePayloadLayout(layout, contracts, locks.platform);
   const embeddedComponentSpecs = validateEmbeddedComponentLayout(layout, contracts);
   const sharedComponentSpecs = validateSharedComponentLayout(layout, contracts);
   invariant(licenseEvidenceLocks.schemaVersion === 1 && Array.isArray(licenseEvidenceLocks.inputs), "license evidence lock is invalid");
   invariant(nodeLicenseEvidenceLocks.schemaVersion === 1 && Array.isArray(nodeLicenseEvidenceLocks.inputs), "Node license evidence lock is invalid");
-  return { ...contracts, layout, locks, providerPackLocks, licenseEvidenceLocks, nodeLicenseEvidenceLocks, componentPaths, embeddedComponentSpecs, sharedComponentSpecs, platform: contracts.platformsById.get(locks.platform) };
+  return { ...contracts, layout, locks, providerPackLocks, licenseEvidenceLocks, nodeLicenseEvidenceLocks, launcherToolchain, componentPaths, embeddedComponentSpecs, sharedComponentSpecs, platform: contracts.platformsById.get(locks.platform) };
 }
 
 async function copyTree(source, destination, { exclude = () => false } = {}) {
@@ -374,6 +422,7 @@ async function downloadLockedArchive(lock, cacheDirectory) {
   const cached = path.join(cacheDirectory, `${lock.id}-${lock.sha256}${suffix}`);
   if (await exists(cached)) {
     await verifyLockedArchive(cached, lock);
+    if (lock.sizeBytes !== undefined) invariant((await stat(cached)).size === lock.sizeBytes, `${lock.id}: archive size mismatch`);
     return cached;
   }
   const partial = `${cached}.partial-${process.pid}`;
@@ -383,6 +432,7 @@ async function downloadLockedArchive(lock, cacheDirectory) {
   try {
     await pipeline(Readable.fromWeb(response.body), createWriteStream(partial, { mode: 0o644, flags: "wx" }));
     await verifyLockedArchive(partial, lock);
+    if (lock.sizeBytes !== undefined) invariant((await stat(partial)).size === lock.sizeBytes, `${lock.id}: archive size mismatch`);
     await rename(partial, cached);
   } catch (error) {
     await rm(partial, { force: true });
@@ -998,15 +1048,86 @@ async function measureProviderPackInstalledTrees(payloadRoot, root, contracts, s
   return measurement;
 }
 
-async function writeGeneratedComponents(payloadRoot, contracts) {
+export function createNativeLauncherBuildPlan({ payloadRoot, root, platform, sourceDateEpoch, goExecutable, goRoot }) {
+  invariant(platform?.os === "darwin" && platform?.arch === "arm64", "native launcher build target must be darwin-arm64");
+  invariant(Number.isInteger(sourceDateEpoch) && sourceDateEpoch >= 0, "native launcher SOURCE_DATE_EPOCH must be non-negative");
+  invariant(typeof goExecutable === "string" && path.isAbsolute(goExecutable), "native launcher compiler executable must be an absolute verified path");
+  invariant(typeof goRoot === "string" && path.isAbsolute(goRoot), "native launcher GOROOT must be an absolute verified path");
+  return {
+    command: goExecutable,
+    args: ["build", "-buildvcs=false", "-trimpath", "-ldflags=-s -w -buildid=", "-o", path.join(payloadRoot, "launcher", "jobctrl"), "./cmd/jobctrl"],
+    cwd: path.join(root, "launcher"),
+    environment: {
+      CGO_ENABLED: "0",
+      GOOS: "darwin",
+      GOARCH: "arm64",
+      // The extracted, checksum-verified official archive is the only GOROOT
+      // accepted by the release builder. This blocks ambient Go installations,
+      // user configuration, experiments, and architecture tuning from changing
+      // launcher bytes.
+      GOROOT: goRoot,
+      GOENV: "off",
+      GOFLAGS: "",
+      GOWORK: "off",
+      GOTOOLCHAIN: "local",
+      GOEXPERIMENT: "",
+      GOARM64: "v8.0",
+      SOURCE_DATE_EPOCH: String(sourceDateEpoch),
+    },
+  };
+}
+
+async function prepareNativeGoToolchain(root, cacheDirectory, scratchDirectory, toolchain) {
+  const lock = nativeGoArchiveLock(toolchain);
+  const archivePath = await downloadLockedArchive(lock, cacheDirectory);
+  const goRoot = path.join(scratchDirectory, "go-toolchain");
+  const entries = await extractVerifiedArchive({
+    archivePath,
+    lock,
+    destination: goRoot,
+    stripComponents: 1,
+    // The official Go archive's `go/test` corpus is not needed to compile the
+    // launcher. It contains upstream regression fixtures with non-ASCII names
+    // that intentionally violate the portable payload path policy, so discard
+    // only that fixed top-level test subtree before extraction.
+    skipEntry: (rawPath) => rawPath.startsWith("go/test/"),
+  });
+  await assertSymlinksPreserved(goRoot, entries);
+  const goExecutable = await requireFile(path.join(goRoot, "bin", "go"), "pinned Go compiler executable");
+  await chmod(goExecutable, 0o755);
+  const licensePath = await requireFile(path.join(goRoot, "LICENSE"), "pinned Go compiler license");
+  invariant(await sha256File(licensePath) === toolchain.licenseSha256, "pinned Go compiler license does not match the toolchain contract");
+  const environment = {
+    ...process.env,
+    GOROOT: goRoot,
+    GOENV: "off",
+    GOFLAGS: "",
+    GOWORK: "off",
+    GOTOOLCHAIN: "local",
+    GOEXPERIMENT: "",
+    GOARM64: "v8.0",
+  };
+  const version = (await run(goExecutable, ["version"], { cwd: root, env: environment })).stdout.trim();
+  invariant(version === `go version ${toolchain.goVersion} darwin/arm64`, `pinned Go compiler version is ${version}, expected ${toolchain.goVersion} darwin/arm64`);
+  return { archivePath, lock, goExecutable, goRoot, version };
+}
+
+async function writeGeneratedComponents(payloadRoot, root, contracts, sourceDateEpoch, nativeGoToolchain) {
   const launcherRoot = componentRoot(payloadRoot, contracts, "jobctrl-launcher");
   await mkdir(launcherRoot, { recursive: true, mode: 0o755 });
-  await writeFile(
-    path.join(launcherRoot, "jobctrl"),
-    "#!/bin/sh\necho 'This P1 payload requires the P2 native JobCtrl launcher.' >&2\nexit 70\n",
-    { mode: 0o755 },
-  );
+  invariant(nativeGoToolchain?.lock?.sha256 === contracts.launcherToolchain.archive.sha256, "native launcher compiler does not match the locked toolchain contract");
+  const plan = createNativeLauncherBuildPlan({
+    payloadRoot,
+    root,
+    platform: contracts.platform,
+    sourceDateEpoch,
+    goExecutable: nativeGoToolchain.goExecutable,
+    goRoot: nativeGoToolchain.goRoot,
+  });
+  await run(plan.command, plan.args, { cwd: plan.cwd, env: { ...process.env, ...plan.environment } });
   await chmod(path.join(launcherRoot, "jobctrl"), 0o755);
+  await copyFile(path.join(root, "launcher", "runtime-manifest.json"), path.join(launcherRoot, "runtime-manifest.json"));
+  await chmod(path.join(launcherRoot, "runtime-manifest.json"), 0o644);
 
   const pdfjsRoot = componentRoot(payloadRoot, contracts, "pdfjs-renderer");
   await mkdir(pdfjsRoot, { recursive: true, mode: 0o755 });
@@ -1420,6 +1541,7 @@ async function collectTopLevelLicenseEvidence(payloadRoot, root, contracts) {
   const sources = [];
   const add = async (subject, candidates) => sources.push({ subject, source: await firstExisting(candidates, subject) });
   await add("jobctrl", [path.join(root, "LICENSE")]);
+  await add("go-standard-library", [path.join(root, "launcher", "GO-LICENSE")]);
   await add("node-runtime", [path.join(nodeRoot, "LICENSE"), path.join(nodeRoot, "LICENSE.md"), path.join(nodeRoot, "LICENSE.txt")]);
   await add("python-runtime", [
     path.join(pythonRoot, "LICENSE.txt"),
@@ -1890,6 +2012,101 @@ async function terminateExtractedRuntimeStack(stack) {
   };
 }
 
+async function smokeNativeLauncherLifecycle({ payloadRoot, extractedRoot, stockEnvironment }) {
+  const launcher = path.join(payloadRoot, "launcher", "jobctrl");
+  await requireFile(launcher, "native JobCtrl launcher");
+  const environment = {
+    ...stockEnvironment,
+    JOBCTRL_RUNTIME_HOME: path.join(extractedRoot, "runtime"),
+  };
+  const statusJson = async () => JSON.parse((await runLoopbackSandboxed(launcher, ["status", "--json"], { cwd: extractedRoot, env: environment })).stdout);
+  const waitForStatus = async (expected, label) => {
+    let observed = null;
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      observed = await statusJson();
+      if (expected.includes(observed.status)) return observed;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error(`${label}: lifecycle status remained ${observed?.status}`);
+  };
+  const start = async () => runLoopbackSandboxed(launcher, ["start", "--no-open"], { cwd: extractedRoot, env: environment });
+  const stop = async () => runLoopbackSandboxed(launcher, ["stop"], { cwd: extractedRoot, env: environment });
+  let lifecycleStarted = false;
+  try {
+    const firstStart = await start();
+    lifecycleStarted = true;
+    invariant(firstStart.stdout.includes("http://127.0.0.1:8766"), "native launcher did not report fixed API URL");
+    let health = null;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      try {
+        const response = await fetch("http://127.0.0.1:8766/v1/health");
+        if (response.ok) {
+          health = await response.json();
+          if (health?.worker?.status === "healthy") break;
+        }
+      } catch {}
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    invariant(health?.worker?.status === "healthy", "native launcher API health was not healthy");
+    let status = await statusJson();
+    invariant(status.status === "running", `native launcher status is ${status.status}`);
+    for (const component of ["temporal", "worker", "api"]) invariant(status.components?.[component]?.state === "running", `native launcher ${component} status is not running`);
+    const logs = await runLoopbackSandboxed(launcher, ["logs"], { cwd: extractedRoot, env: environment });
+    invariant(logs.stdout.includes("== temporal ==") && logs.stdout.includes("== worker ==") && logs.stdout.includes("== api =="), "native launcher logs did not route all bounded component logs");
+    const version = JSON.parse((await runLoopbackSandboxed(launcher, ["version", "--json"], { cwd: extractedRoot, env: environment })).stdout);
+    invariant(typeof version.buildId === "string" && /^[a-f0-9]{64}$/.test(version.manifestSha256), "native launcher version JSON is incomplete");
+    await runLoopbackSandboxed(launcher, ["doctor"], { cwd: extractedRoot, env: environment });
+    const digest = await runLoopbackSandboxed(launcher, ["digest", "--json"], { cwd: extractedRoot, env: environment });
+    invariant(digest.stdout.trim().startsWith("{"), "native launcher did not transparently dispatch JSON Python CLI command");
+    await runLoopbackSandboxed(launcher, ["pipeline-status"], { cwd: extractedRoot, env: environment });
+    await runLoopbackSandboxed(launcher, ["status", "--pipeline"], { cwd: extractedRoot, env: environment });
+    // A killed owned worker leaves a degraded registry rather than a misleading
+    // healthy status. stop then obtains a clean restart from that evidence.
+    process.kill(status.components.worker.pid, "SIGKILL");
+    const degraded = await waitForStatus(["degraded"], "worker-kill recovery");
+    invariant(degraded.components.worker.state !== "running", "killed worker remained reported as running");
+    await stop();
+    await waitForStatus(["stopped"], "worker-kill stop");
+    await start();
+    status = await waitForStatus(["running"], "worker-kill restart");
+    // SIGKILL of the supervisor cannot run its cleanup handler. Status must
+    // report the still-owned component trees as orphaned, and stop must clean
+    // only the identity-matching recorded groups before restart.
+    invariant(Number.isInteger(status.supervisorPid) && status.supervisorPid > 0, "native status omitted supervisor PID");
+    process.kill(status.supervisorPid, "SIGKILL");
+    const orphaned = await waitForStatus(["orphaned"], "supervisor-kill recovery");
+    invariant(orphaned.components.api.state === "running", "orphaned API ownership was not reported");
+    await stop();
+    await waitForStatus(["stopped"], "supervisor-kill stop");
+    await start();
+    status = await waitForStatus(["running"], "supervisor-kill restart");
+    await stop();
+    const stopped = await waitForStatus(["stopped"], "final stop");
+    return { startUrl: "http://127.0.0.1:8766", components: Object.keys(status.components).sort(bytewiseCompare), manifestSha256: version.manifestSha256, pipelineStatusCompatibility: "passed", pythonDispatch: ["doctor", "digest --json"], recovery: { workerKill: "degraded-stop-restart", supervisorKill: "orphaned-stop-restart" } };
+  } finally {
+    if (lifecycleStarted) await stop().catch(() => null);
+  }
+}
+
+async function cleanupNativeLauncherRuntime(extractedRoot) {
+  const canonicalRoot = await realpath(extractedRoot).catch(() => null);
+  if (!canonicalRoot) return { status: "not-created" };
+  const launcher = path.join(canonicalRoot, "payload", "launcher", "jobctrl");
+  if (!(await exists(launcher))) return { status: "launcher-not-created" };
+  const environment = {
+    HOME: path.join(canonicalRoot, "home"),
+    JOBCTRL_DIR: path.join(canonicalRoot, "home", ".jobctrl"),
+    JOBCTRL_RUNTIME_HOME: path.join(canonicalRoot, "runtime"),
+    PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+  };
+  try {
+    await runLoopbackSandboxed(launcher, ["stop"], { cwd: canonicalRoot, env: environment });
+    return { status: "stopped" };
+  } catch (error) {
+    return { status: "stop-failed", error: error.message };
+  }
+}
+
 async function requireJsonResponse(url, options, label) {
   const response = await fetch(url, options);
   const text = await response.text();
@@ -2127,15 +2344,20 @@ async function smokeExtractedPayload(archivePath, outputRoot, contracts) {
   await rm(extractedRoot, { recursive: true, force: true });
   await mkdir(extractedRoot, { recursive: true, mode: 0o755 });
   await run("/usr/bin/tar", ["-xzf", archivePath, "-C", extractedRoot], { cwd: outputRoot });
-  const payloadRoot = path.join(extractedRoot, "payload");
+  // Python resolves the state directory before writing its heartbeat while
+  // Node's path.resolve does not collapse macOS /tmp -> /private/tmp. Anchor
+  // the full extracted runtime to one canonical identity before either child
+  // starts so the API correctly accepts its worker heartbeat.
+  const canonicalExtractedRoot = await realpath(extractedRoot);
+  const payloadRoot = path.join(canonicalExtractedRoot, "payload");
   const manifest = JSON.parse(await readFile(path.join(payloadRoot, "manifest.json"), "utf8"));
   validateDistributionManifest(manifest, contracts);
   await verifyExactPayloadTree(payloadRoot, manifest);
   const extractionForbiddenAudit = await scanForbiddenPayload(payloadRoot, { forbiddenAbsolutePaths: [REPO_ROOT, outputRoot] });
 
   const stockEnvironment = {
-    HOME: path.join(extractedRoot, "home"),
-    JOBCTRL_DIR: path.join(extractedRoot, "home", ".jobctrl"),
+    HOME: path.join(canonicalExtractedRoot, "home"),
+    JOBCTRL_DIR: path.join(canonicalExtractedRoot, "home", ".jobctrl"),
     JOBCTRL_PAYLOAD_DIR: payloadRoot,
     JOBCTRL_RUNTIME_MODE: "bundled",
     JOBCTRL_WEB_ASSETS_DIR: path.join(payloadRoot, contracts.componentPaths.get("jobctrl-web")),
@@ -2175,7 +2397,7 @@ finally:
     [
       "--headless",
       "--isolated",
-      "--output-dir", path.join(extractedRoot, "playwright-mcp-smoke-output"),
+      "--output-dir", path.join(canonicalExtractedRoot, "playwright-mcp-smoke-output"),
       "--executable-path", await managedMcpChromiumExecutable(payloadRoot, contracts),
       "--output-mode", "stdout",
       "--codegen", "none",
@@ -2243,7 +2465,7 @@ print(json.dumps({"pdfPath": str(pdf_path), "pdfBytes": len(pdf_bytes)}, sort_ke
   const temporalPort = await reserveLoopbackPort();
   const runtimePlan = createExtractedRuntimeStackPlan({
     payloadRoot,
-    stateRoot: extractedRoot,
+    stateRoot: canonicalExtractedRoot,
     temporalPort,
     apiPort,
     contracts,
@@ -2430,6 +2652,7 @@ with sync_playwright() as playwright:
     secondTermination = await terminateExtractedRuntimeStack(secondStack);
   }
   invariant(secondTermination?.api?.status === "exited" && secondTermination.worker?.status === "exited" && secondTermination.temporal?.status === "exited", "restarted extracted runtime stack did not terminate");
+  const nativeLauncherLifecycle = await smokeNativeLauncherLifecycle({ payloadRoot, extractedRoot: canonicalExtractedRoot, stockEnvironment });
   await verifyExactPayloadTree(payloadRoot, manifest);
   return {
     status: "pass",
@@ -2449,6 +2672,7 @@ with sync_playwright() as playwright:
     pdfPreview: pdfPreviewEvidence,
     runtimeRestart: restartEvidence,
     runtimeTermination: { first: firstTermination, second: secondTermination },
+    nativeLauncherLifecycle,
     networkIsolation,
     postSmokePayloadTree: "exact-manifest-match",
     extractionForbiddenAudit,
@@ -2708,6 +2932,18 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
 
   const preliminaryFiles = (await buildFileInventory(payloadRoot)).filter((file) => !file.path.startsWith(`${contracts.componentPaths.get("jobctrl-release-metadata")}/`));
   const components = topLevelSbomComponents(contracts, preliminaryFiles);
+  if (mode === "real") {
+    components.push({
+      type: "framework",
+      "bom-ref": `pkg:golang/go@${GO_TOOLCHAIN_VERSION.slice(2)}`,
+      name: "Go standard library",
+      version: GO_TOOLCHAIN_VERSION.slice(2),
+      supplier: { name: "The Go Authors" },
+      licenses: [{ expression: "BSD-3-Clause" }],
+      externalReferences: [{ type: "distribution", url: "https://go.dev/" }],
+      properties: [{ name: "jobctrl:launcher-closure", value: "standard-library-only" }],
+    });
+  }
   if (pythonSbom) {
     const python = JSON.parse(await readFile(pythonSbom, "utf8"));
     for (const component of python.components ?? []) components.push(component);
@@ -2783,6 +3019,15 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
     sourceDateEpoch,
     platform: contracts.platform.id,
     source: "https://github.com/ebarti/JobCtrl",
+    launcherToolchain: {
+      version: contracts.launcherToolchain.goVersion,
+      moduleClosure: contracts.launcherToolchain.moduleClosure,
+      license: contracts.launcherToolchain.license,
+      licenseSource: contracts.launcherToolchain.licenseSource,
+      licenseSha256: contracts.launcherToolchain.licenseSha256,
+      archive: nativeGoArchiveLock(contracts.launcherToolchain),
+      officialMetadataUrl: contracts.launcherToolchain.archive.officialMetadataUrl,
+    },
     providerPacks: {
       included: false,
       policy: "official-download",
@@ -3230,13 +3475,17 @@ export async function buildRealPayload({
   await rm(outputRoot, { recursive: true, force: true });
   await mkdir(payloadRoot, { recursive: true, mode: 0o755 });
   try {
-    const externalInputs = await assembleExternalRuntimes(payloadRoot, contracts, path.resolve(cacheDirectory), scratchDirectory);
+    const resolvedCacheDirectory = path.resolve(cacheDirectory);
+    const [externalInputs, nativeGoToolchain] = await Promise.all([
+      assembleExternalRuntimes(payloadRoot, contracts, resolvedCacheDirectory, scratchDirectory),
+      prepareNativeGoToolchain(root, resolvedCacheDirectory, scratchDirectory, contracts.launcherToolchain),
+    ]);
     const pythonRuntimePrune = await pruneUnusedPythonRuntime(componentRoot(payloadRoot, contracts, "python-runtime"));
     await prepareStandardProductionInputs(root, contracts, externalInputs);
     await copyPreparedApplicationInputs(payloadRoot, root, contracts);
     await Promise.all([
       assemblePlaywrightMcp(payloadRoot, root, contracts, externalInputs),
-      writeGeneratedComponents(payloadRoot, contracts),
+      writeGeneratedComponents(payloadRoot, root, contracts, sourceDateEpoch, nativeGoToolchain),
     ]);
     const pythonSbom = await preparePythonWorker(payloadRoot, root, contracts, scratchDirectory);
     const providerPackMeasurement = await measureProviderPackInstalledTrees(payloadRoot, root, contracts, scratchDirectory);
@@ -3362,6 +3611,17 @@ export async function buildRealPayload({
     };
     await writeJson(path.join(outputRoot, "build-result.json"), result);
     return { ...result, manifest, sizeReport };
+  } catch (error) {
+    const nativeLifecycleCleanup = await cleanupNativeLauncherRuntime(path.join(outputRoot, "clean-extraction"));
+    await writeJson(path.join(outputRoot, "build-failure.json"), {
+      schemaVersion: 1,
+      mode: "real",
+      buildId,
+      status: "failed",
+      error: error.message,
+      nativeLifecycleCleanup,
+    });
+    throw error;
   } finally {
     await rm(scratchDirectory, { recursive: true, force: true });
   }
@@ -3386,6 +3646,18 @@ function parseCliOptions(argv) {
 async function main(argv = process.argv.slice(2)) {
   const command = argv[0] ?? "fixture";
   const options = parseCliOptions(argv.slice(1));
+  if (command === "audit") {
+    invariant(Object.keys(options).length === 0, "distribution audit accepts no options");
+    const contracts = await loadBuildContracts(REPO_ROOT);
+    process.stdout.write(canonicalJson({
+      status: "pass",
+      launcherToolchain: {
+        version: contracts.launcherToolchain.goVersion,
+        archive: nativeGoArchiveLock(contracts.launcherToolchain),
+      },
+    }));
+    return;
+  }
   if (command === "fixture") {
     const result = await buildFixturePayload({
       outputDirectory: path.resolve(options.output ?? path.join(REPO_ROOT, "dist", "distribution-fixture")),

--- a/scripts/distribution-build.test.mjs
+++ b/scripts/distribution-build.test.mjs
@@ -15,10 +15,12 @@ import {
   collectPayloadNpmContributors,
   compareMacOsVersions,
   compareSizeReports,
+  createNativeLauncherBuildPlan,
   createExtractedRuntimeStackPlan,
   createDeterministicTarGz,
   extensionCaptureSmokeHeaders,
   normalizeInstalledPythonMetadata,
+  loadNativeLauncherToolchain,
   npmIdentityForContributingSource,
   parseMachOMinimumVersions,
   parseOtoolDependencies,
@@ -42,6 +44,64 @@ import { buildFileInventory } from "./distribution-manifest.mjs";
 import { parseExportedRequirements } from "./distribution-provider-lock.mjs";
 
 const execFileAsync = promisify(execFile);
+
+test("native launcher build pins an official verified darwin-arm64 compiler contract", async (context) => {
+  const root = process.cwd();
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "jobctrl-launcher-build-"));
+  context.after(async () => rm(temporary, { recursive: true, force: true }));
+  const firstPayload = path.join(temporary, "first");
+  const secondPayload = path.join(temporary, "second");
+  await Promise.all([mkdir(path.join(firstPayload, "launcher"), { recursive: true }), mkdir(path.join(secondPayload, "launcher"), { recursive: true })]);
+  const options = {
+    root,
+    platform: { os: "darwin", arch: "arm64" },
+    sourceDateEpoch: 0,
+    goExecutable: "/verified/go/bin/go",
+    goRoot: "/verified/go",
+  };
+  const first = createNativeLauncherBuildPlan({ ...options, payloadRoot: firstPayload });
+  const second = createNativeLauncherBuildPlan({ ...options, payloadRoot: secondPayload });
+  assert.equal(first.command, "/verified/go/bin/go");
+  assert.deepEqual(first.environment, {
+    CGO_ENABLED: "0",
+    GOOS: "darwin",
+    GOARCH: "arm64",
+    GOROOT: "/verified/go",
+    GOENV: "off",
+    GOFLAGS: "",
+    GOWORK: "off",
+    GOTOOLCHAIN: "local",
+    GOEXPERIMENT: "",
+    GOARM64: "v8.0",
+    SOURCE_DATE_EPOCH: "0",
+  });
+  assert.deepEqual(first.args.slice(0, 4), ["build", "-buildvcs=false", "-trimpath", "-ldflags=-s -w -buildid="]);
+  assert.equal(first.args.at(-1), "./cmd/jobctrl");
+  assert.equal(first.args[5], path.join(firstPayload, "launcher", "jobctrl"));
+  assert.equal(second.args[5], path.join(secondPayload, "launcher", "jobctrl"));
+  const runtimeManifest = JSON.parse(await readFile(path.join(root, "launcher", "runtime-manifest.json"), "utf8"));
+  assert.equal(runtimeManifest.ports.api, 8766);
+  assert.equal(runtimeManifest.ports.temporalGrpc, 7233);
+  assert.equal(runtimeManifest.ports.temporalUi, 8233);
+  assert.deepEqual(JSON.parse(await readFile(path.join(root, "launcher", "toolchain.json"), "utf8")), {
+    schemaVersion: 1,
+    goVersion: "go1.26.4",
+    archive: {
+      type: "tar.gz",
+      url: "https://go.dev/dl/go1.26.4.darwin-arm64.tar.gz",
+      sha256: "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53",
+      sizeBytes: 64723756,
+      officialMetadataUrl: "https://go.dev/dl/?mode=json&include=all",
+    },
+    moduleClosure: "standard-library-only",
+    license: "BSD-3-Clause",
+    licenseSource: "https://go.dev/LICENSE",
+    licenseSha256: "911f8f5782931320f5b8d1160a76365b83aea6447ee6c04fa6d5591467db9dad",
+  });
+  const toolchain = await loadNativeLauncherToolchain(root);
+  assert.equal(toolchain.archive.sizeBytes, 64723756);
+  assert.equal(await sha256File(path.join(root, "launcher", "GO-LICENSE")), "911f8f5782931320f5b8d1160a76365b83aea6447ee6c04fa6d5591467db9dad");
+});
 
 function tarField(value, width) {
   return `${value.toString(8).padStart(width - 1, "0")}\0`;
@@ -613,6 +673,19 @@ test("tar parser preserves safe links and rejects traversal, hard links, and spe
     () => parseTarGzArchive(tarArchive([{ path: "Dir/File", contents: "a" }, { path: "dir/file", contents: "b" }])),
     /collides case-insensitively/,
   );
+});
+
+test("tar parser may skip an explicit upstream test subtree before portable path validation", () => {
+  const archive = tarArchive([
+    { path: "go/bin/go", mode: 0o755, contents: "compiler" },
+    { path: "go/test/Þfixture.go", contents: "nonportable fixture" },
+  ]);
+  const entries = parseTarGzArchive(archive, {
+    stripComponents: 1,
+    skipEntry: (rawPath) => rawPath.startsWith("go/test/"),
+  });
+  assert.deepEqual(entries.map((entry) => entry.path), ["bin/go"]);
+  assert.throws(() => parseTarGzArchive(archive, { stripComponents: 1 }), /printable ASCII/);
 });
 
 test("zip parser preserves Unix symlinks and rejects traversal and special entries", () => {

--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -1722,8 +1722,8 @@ def _budget_note(budget: dict[str, Any]) -> str:
     return f"${estimated:.2f} estimated, ${float(remaining):.2f} remaining of ${daily:.2f}"
 
 
-@app.command()
-def status() -> None:
+@app.command("pipeline-status")
+def pipeline_status() -> None:
     """Show pipeline statistics from the database."""
     _bootstrap()
 

--- a/workers/automation/tests/test_pipeline_status_cli.py
+++ b/workers/automation/tests/test_pipeline_status_cli.py
@@ -1,0 +1,12 @@
+from typer.testing import CliRunner
+
+from jobctrl.cli import app
+
+
+def test_python_pipeline_statistics_command_uses_unambiguous_name() -> None:
+    """Native `status` owns lifecycle; Python retains statistics explicitly."""
+
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "pipeline-status" in result.output


### PR DESCRIPTION
## What changed

- add the native Darwin jobctrl launcher with one lifecycle and Python CLI command surface
- verify the complete local distribution envelope and exact payload tree before dispatch
- supervise Temporal, worker, and API with loopback health gates, ownership-safe stop/recovery, bounded logs, and cross-process state
- compile with the checksum-locked Go 1.26.4 toolchain and add pinned launcher CI
- document the bundled runtime boundary while preserving contributor source commands

## Why

Installed users need one real jobctrl executable that works from any directory without exposing Node, pnpm, uv, Python, Temporal, or source-checkout commands.

## Validation

- corepack pnpm check
- corepack pnpm test: 64 script, 517 API, 29 extension unit, 4 extension e2e, 2,282 Python tests, web production build, launcher race suite
- corepack pnpm docs:build: 5,839 references across 262 files
- python3 scripts/release_check.py --strict-prompt
- independent review: Gate PASS
- independent QA: Gate PASS
- two full real builds from clean output directories were byte-identical
  - archive SHA-256: 0ac0d1bd2c4d4911018437dd8ad7f3c2fb6f47af5b4c527a13e56b2e26a90d3f
  - manifest SHA-256: b31295f553051e77a71001257b32f23596b8411bc82c8141f2f6be39fc23f973
  - compressed: 501,740,370 bytes; installed: 1,572,088,598 bytes
- lifecycle smoke covers bare PATH invocation, start/status/logs/version, Python dispatch, worker-kill recovery, supervisor-kill recovery, restart, exact-tree verification, and zero leaked fixed-port listeners

## Stack

Depends on #399.