### PR TITLE
feat(launcher): add transactional release lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 
 - `jobctrl.db` — local SQLite database with profile, jobs, events,
   projections, settings, and artifact metadata.
+- `temporal.db` — bundled-runtime Temporal persistence. It is rollback-critical
+  alongside `jobctrl.db`: a bundled release transition snapshots and restores
+  the two databases as one verified pair, never as independent files.
 - `.env` — plaintext, cross-platform fallback for provider/API credentials
   and local runtime settings; it is not encrypted at rest.
 - `tailored_resumes/`, `cover_letters/`, `logs/` — generated artifacts and
@@ -312,7 +315,8 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 - `codex_home/` — JobCtrl-owned Codex home for local analysis. The adapter
   copies Codex auth here from the user's regular Codex home and runs
   prompt-driven commands from `codex_home/workspace/` only.
-- `backups/` — timestamped database snapshots written by `jobctrl backup`.
+- `backups/` — source-mode `jobctrl backup` snapshots and, once the P6-signed
+  bundled channel is public, verified paired lifecycle snapshots.
 
 Unless noted otherwise, those paths are relative to `JOBCTRL_DIR`, whose
 default is `~/.jobctrl/`. On macOS, the three provider settings supported by
@@ -349,7 +353,7 @@ rate-limit, or bot-control gates.
 
 ### Back Up And Restore
 
-All product state lives in `jobctrl.db`. Snapshot it any time — even while
+Application records live in `jobctrl.db`. Snapshot them any time — even while
 the app runs:
 
 ```bash
@@ -379,6 +383,11 @@ database piecemeal, delete the watermark row so projections rebuild:
 sqlite3 ~/.jobctrl/jobctrl.db \
   "DELETE FROM event_watermarks WHERE projection_name = 'operations_projections';"
 ```
+
+The P6-gated bundled distribution adds a separate `temporal.db` runtime store.
+Its native update, rollback, and backup boundary treats `jobctrl.db` and
+`temporal.db` as one hash-verified pair. That channel is not public yet; do
+not use local distribution fixtures as a production upgrade path.
 
 </details>
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -80,6 +80,25 @@ reused PID. The local artifact remains unsigned/non-promotable until later
 signing and installer phases, so this is still build evidence rather than a
 public install surface.
 
+The P5 lifecycle store is user-owned (`JOBCTRL_RUNTIME_HOME`), not a package
+manager Cellar. `active.json` atomically records the selected payload, the
+compatible immutable selector build, and the current acquisition adapter;
+immutable release receipts never contain acquisition ownership. A durable
+transition journal records selector handoff, database-pair backup, pending and
+finalized channel policy, and promotion. Acquisition, update, rollback,
+backup, retention, and uninstall serialize through transition then selection
+locking; selector resolution holds a shared selection lock through supervisor
+readiness. Before a candidate is promoted, the old process tree is quiesced
+with the registry's PID/PGID identity checks and both `JOBCTRL_DIR/jobctrl.db`
+and `JOBCTRL_DIR/temporal.db` receive online, hash-verified paired backups.
+Policy finalization happens only after the candidate has passed readiness and
+the paired backup is durable, so a failed health gate cannot revoke the only
+runnable release. A pre-finalization failure restores the full pair and
+restarts the still-permitted prior release. An interruption after a healthy
+candidate finalizes a revocation fails closed to that authenticated candidate
+instead of executing revoked code. This remains an internal release-engineering
+seam until P6 publishes signing and notarization evidence.
+
 ## Frontend
 
 The web app under `apps/web` owns user interaction:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -181,8 +181,11 @@ promoted as a stable release. It includes both native binaries at
 `payload/launcher/jobctrl` and `payload/launcher/jobctrl-installer`, compiled
 with the locked official Go toolchain. Its local descriptor, detached
 unsigned-local envelope, and curl fixture contract bind the ZIP's build ID,
-manifest SHA-256, size, and archive SHA-256; those fixtures are file-only and
-cannot select a network channel. The launcher's private runtime manifest starts the fixed
+manifest SHA-256, size, archive SHA-256, an explicit minimum-safe sequence
+(`0` locally), and an explicit empty revocation list; those fixtures are
+file-only and cannot select a network channel. Signed stable/prerelease
+descriptors use the same canonical fields with a positive floor and sorted,
+unique revocation tombstones. The launcher's private runtime manifest starts the fixed
 loopback Temporal (`7233`/`8233`), worker, and API (`8766`) fleet without Vite,
 and records each canonical `JOBCTRL_DIR` under
 `~/Library/Application Support/JobCtrl/instances/<sha256>` (override with

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -73,6 +73,7 @@ login_profile() {
 append_managed_path() {
   local bin_dir="$1" profile mode temporary line
   profile="$(login_profile)"
+  require_safe_profile_path "$profile" "login profile"
   line="export PATH=\"$bin_dir:\$PATH\" # JobCtrl managed path"
   if [[ -L "$profile" ]]; then fail "refusing to modify symlinked login profile $profile"; fi
   if [[ -e "$profile" && ! -f "$profile" ]]; then fail "login profile is not a regular file: $profile"; fi
@@ -112,6 +113,22 @@ expose_command() {
   else
     append_managed_path "$bin_dir"
   fi
+}
+persist_curl_acquisition() {
+  local release_home="$1" bin_dir="$2" profile encoded_line record temporary
+  profile=""
+  encoded_line=""
+  if [[ "$NO_MODIFY_PATH" -eq 0 ]] && ! path_contains "$bin_dir"; then
+    profile="$(login_profile)"
+    require_safe_profile_path "$profile" "login profile"
+    encoded_line="export PATH=\\\"$bin_dir:\$PATH\\\" # JobCtrl managed path"
+  fi
+  record="$release_home/acquisition.json"
+  [[ ! -L "$record" ]] || fail "refusing symlinked acquisition record $record"
+  temporary="$(/usr/bin/mktemp "$release_home/.acquisition.XXXXXX")"
+  /usr/bin/printf '{"schemaVersion":1,"source":"curl","publicLink":"%s/jobctrl","selector":"%s/bin/jobctrl","profile":"%s","pathLine":"%s"}\n' "$bin_dir" "$release_home" "$profile" "$encoded_line" > "$temporary" || { /bin/rm -f "$temporary"; fail "could not write acquisition record"; }
+  /bin/chmod 0600 "$temporary"
+  /bin/mv -f "$temporary" "$record" || { /bin/rm -f "$temporary"; fail "could not commit acquisition record"; }
 }
 
 HOME_OVERRIDE=""
@@ -169,4 +186,5 @@ else
   [[ -n "$RELEASE_URL" ]] && installer_args+=(--release-url "$RELEASE_URL")
   "$INSTALLER_PATH" ${installer_args[@]+"${installer_args[@]}"}
 fi
+persist_curl_acquisition "$RELEASE_HOME" "$BIN_DIR"
 expose_command "$RELEASE_HOME" "$BIN_DIR"

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -151,7 +151,10 @@ claim. P6 renders it from the signed stable descriptor, independently verifies
 that descriptor against `packaging/distribution/release-keys.json`, smoke-tests
 the published ZIP, and supplies matching promotion evidence to the reusable
 tap workflow. The workflow never triggers from `main` or merely from a
-published GitHub Release.
+published GitHub Release. The formula writes only its Homebrew prefix: its
+`bin/jobctrl` target is a native first-invocation bootstrap holding the signed
+descriptor resources and cached ZIP. It must not create `~/.jobctrl`, mutate a
+Cellar payload, or link a runtime payload from the Cellar during `brew install`.
 
 - **Action.** Run P6's signed descriptor, published-ZIP smoke, formula render,
   Ruby syntax, and Homebrew audit/test gates; then call the reusable sync

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -43,6 +43,7 @@ Unless a row says otherwise, every path below is relative to JOBCTRL_DIR
 | Path | Contents |
 | --- | --- |
 | `jobctrl.db` plus `-wal` / `-shm` | Profile, jobs, events, projections, settings, artifact metadata, review drafts, contacts, and workflows. Treat all three files as one database. |
+| `temporal.db` plus `-wal` / `-shm` | Bundled-runtime Temporal state. During a native bundled update or rollback, it is hash-snapshotted and restored only together with `jobctrl.db`; never restore just one member of that pair. The signed bundled channel remains P6-gated. |
 | `.env` | Plaintext provider credentials and runtime settings. Not encrypted at rest. |
 | `tailored_resumes/`, `cover_letters/` | Generated text, HTML, and PDF artifacts. |
 | `logs/`, `apply-workers/`, `chrome-workers/` | Logs and local browser/apply state. |

--- a/launcher/cmd/jobctrl-installer/main.go
+++ b/launcher/cmd/jobctrl-installer/main.go
@@ -3,18 +3,24 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"runtime"
 
 	"github.com/ebarti/jobctrl/launcher/internal/installer"
 	"github.com/ebarti/jobctrl/launcher/internal/launcher"
+	"github.com/ebarti/jobctrl/launcher/internal/release"
 )
 
 func main() {
-	var releaseURL, home, descriptorURL, descriptorFile, signatureFile, archiveFile string
-	var allowUnsignedLocal bool
+	var releaseURL, home, descriptorURL, descriptorFile, signatureFile, archiveFile, source string
+	var allowUnsignedLocal, stageOnly, jsonOutput bool
 	flag.StringVar(&releaseURL, "release-url", installer.DefaultReleaseURL, "signed stable release descriptor URL")
 	flag.StringVar(&home, "home", "", "JobCtrl runtime home (default: ~/Library/Application Support/JobCtrl)")
 	flag.StringVar(&descriptorURL, "descriptor-url", "", "canonical HTTPS URL for a signed cached descriptor")
@@ -22,6 +28,9 @@ func main() {
 	flag.StringVar(&descriptorFile, "descriptor-file", "", "local fixture descriptor JSON")
 	flag.StringVar(&signatureFile, "signature-file", "", "local fixture descriptor signature JSON")
 	flag.StringVar(&archiveFile, "archive-file", "", "local fixture ZIP archive")
+	flag.StringVar(&source, "source", "curl", "acquisition adapter: curl or homebrew")
+	flag.BoolVar(&stageOnly, "stage-only", false, "commit an authenticated immutable release without promoting it")
+	flag.BoolVar(&jsonOutput, "json", false, "write the exact immutable install receipt as JSON")
 	flag.Parse()
 	if runtime.GOOS != "darwin" || runtime.GOARCH != "arm64" {
 		fail("only darwin-arm64 is supported")
@@ -31,7 +40,16 @@ func main() {
 	if policyErr != nil {
 		fail(policyErr.Error())
 	}
-	options := installer.Options{Home: home, ReleaseURL: releaseURL, Trust: trust, Policy: policy, AllowUnsignedLocal: allowUnsignedLocal}
+	if source != "curl" && source != "homebrew" {
+		fail("--source must be curl or homebrew")
+	}
+	if source == "homebrew" && (allowUnsignedLocal || descriptorURL == "" || descriptorFile == "" || signatureFile == "" || archiveFile == "") {
+		fail("--source homebrew requires the complete signed cached formula descriptor, signature, and archive mode")
+	}
+	if source == "curl" && descriptorURL != "" {
+		fail("signed cached release inputs are reserved for the Homebrew acquisition adapter")
+	}
+	options := installer.Options{Home: home, ReleaseURL: releaseURL, Trust: trust, Policy: policy, AllowUnsignedLocal: allowUnsignedLocal, AcquisitionSource: source, StageOnly: stageOnly}
 	var receipt installer.Receipt
 	var err error
 	if allowUnsignedLocal {
@@ -53,7 +71,63 @@ func main() {
 	if err != nil {
 		fail(err.Error())
 	}
-	fmt.Printf("Installed JobCtrl %s (%s, manifest %s)\n", receipt.BuildID, receipt.ArtifactSHA256, receipt.ManifestSHA256)
+	if !stageOnly {
+		if err := promoteStagedIfNeeded(home, source, receipt); err != nil {
+			fail(err.Error())
+		}
+	}
+	if jsonOutput {
+		if err := writeReceipt(os.Stdout, receipt, true); err != nil {
+			fail(err.Error())
+		}
+		return
+	}
+	if err := writeReceipt(os.Stdout, receipt, false); err != nil {
+		fail(err.Error())
+	}
+}
+
+func writeReceipt(output io.Writer, receipt installer.Receipt, jsonOutput bool) error {
+	if jsonOutput {
+		return json.NewEncoder(output).Encode(receipt)
+	}
+	_, err := fmt.Fprintf(output, "Installed JobCtrl %s (%s, manifest %s)\n", receipt.BuildID, receipt.ArtifactSHA256, receipt.ManifestSHA256)
+	return err
+}
+
+// A different already-installed build is only an acquisition result. The
+// existing authenticated selector performs the health-gated promotion, which
+// preserves paired database rollback and selector compatibility. First install
+// was activated inside the installer because no predecessor existed.
+func promoteStagedIfNeeded(home, source string, candidate installer.Receipt) error {
+	runtimeHome, err := installer.RuntimeHome(home)
+	if err != nil {
+		return err
+	}
+	store, err := release.Open(runtimeHome)
+	if err != nil {
+		return err
+	}
+	active, err := store.ReadActive()
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read active release before staged promotion: %w", err)
+	}
+	if active.Receipt.BuildID == candidate.BuildID {
+		return nil
+	}
+	selector := filepath.Join(runtimeHome, "bin", "jobctrl")
+	if err := launcher.VerifyPublicSelectorForExecution(runtimeHome); err != nil {
+		return fmt.Errorf("verify public selector before promotion: %w", err)
+	}
+	command := exec.Command(selector, "update", "--to", candidate.BuildID)
+	command.Env = append(os.Environ(), "JOBCTRL_RUNTIME_HOME="+runtimeHome, "JOBCTRL_ACQUISITION_SOURCE="+source, "JOBCTRL_ACQUISITION_INTERNAL=1")
+	if output, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("promote staged release through authenticated selector: %w: %s", err, output)
+	}
+	return nil
 }
 
 func fail(message string) { fmt.Fprintln(os.Stderr, "jobctrl-installer:", message); os.Exit(1) }

--- a/launcher/cmd/jobctrl-installer/main_test.go
+++ b/launcher/cmd/jobctrl-installer/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/ebarti/jobctrl/launcher/internal/installer"
+)
+
+func TestWriteReceiptJSONIsMachineReadableAndExact(t *testing.T) {
+	receipt := installer.Receipt{
+		SchemaVersion:    2,
+		BuildID:          "fixture-build-0001",
+		Channel:          "stable",
+		Sequence:         7,
+		ArtifactSHA256:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		ManifestSHA256:   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		DescriptorSHA256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		PolicySHA256:     "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		DescriptorURL:    "https://releases.example.test/v1/stable/darwin-arm64.json",
+		InstalledAt:      "2026-07-11T12:00:00Z",
+	}
+	var output bytes.Buffer
+	if err := writeReceipt(&output, receipt, true); err != nil {
+		t.Fatal(err)
+	}
+	var decoded installer.Receipt
+	decoder := json.NewDecoder(&output)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil || decoded != receipt {
+		t.Fatalf("JSON receipt = %#v, %v", decoded, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		t.Fatalf("JSON receipt contained a second value: %v", err)
+	}
+}
+
+func TestWriteReceiptHumanOutputRemainsHumanReadable(t *testing.T) {
+	var output bytes.Buffer
+	if err := writeReceipt(&output, installer.Receipt{BuildID: "fixture-build-0001", ArtifactSHA256: "artifact", ManifestSHA256: "manifest"}, false); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := output.String(), "Installed JobCtrl fixture-build-0001 (artifact, manifest manifest)\n"; got != want {
+		t.Fatalf("human receipt = %q, want %q", got, want)
+	}
+}

--- a/launcher/internal/installer/installer.go
+++ b/launcher/internal/installer/installer.go
@@ -24,11 +24,14 @@ import (
 	pathpkg "path"
 	"path/filepath"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/ebarti/jobctrl/launcher/internal/launcher"
+	"github.com/ebarti/jobctrl/launcher/internal/release"
 )
 
 const (
@@ -42,21 +45,30 @@ const (
 	maxCompressionRatio = uint64(100)
 	metadataTimeout     = 45 * time.Second
 	archiveStallTimeout = 60 * time.Second
+	maxJSONSafeInteger  = uint64(1<<53 - 1)
+	stagedArchiveName   = "archive.zip"
+	partialArchiveName  = "archive.zip.part"
 )
 
 var (
-	sha256Pattern  = regexp.MustCompile(`^[a-f0-9]{64}$`)
-	buildIDPattern = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$`)
-	semverPattern  = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	sha256Pattern       = regexp.MustCompile(`^[a-f0-9]{64}$`)
+	buildIDPattern      = regexp.MustCompile(`^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$`)
+	semverPattern       = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	contentRangePattern = regexp.MustCompile(`^bytes ([0-9]+)-([0-9]+)/([0-9]+)$`)
 )
 
 type Descriptor struct {
 	SchemaVersion int    `json:"schemaVersion"`
 	Channel       string `json:"channel"`
 	Sequence      uint64 `json:"sequence"`
-	BuildID       string `json:"buildId"`
-	AppVersion    string `json:"appVersion"`
-	Platform      struct {
+	// MinimumSafeSequence and RevokedBuildIDs are signed channel tombstones.
+	// They are optional for local fixtures, but non-local channels persist and
+	// enforce them as a monotonic security boundary.
+	MinimumSafeSequence uint64   `json:"minimumSafeSequence"`
+	RevokedBuildIDs     []string `json:"revokedBuildIds"`
+	BuildID             string   `json:"buildId"`
+	AppVersion          string   `json:"appVersion"`
+	Platform            struct {
 		ID   string `json:"id"`
 		OS   string `json:"os"`
 		Arch string `json:"arch"`
@@ -86,6 +98,7 @@ type Receipt struct {
 	ArtifactSHA256   string `json:"artifactSha256"`
 	ManifestSHA256   string `json:"manifestSha256"`
 	DescriptorSHA256 string `json:"descriptorSha256"`
+	PolicySHA256     string `json:"policySha256"`
 	DescriptorURL    string `json:"descriptorUrl"`
 	InstalledAt      string `json:"installedAt"`
 }
@@ -98,6 +111,14 @@ type Options struct {
 	HTTPClient         *http.Client
 	AllowHTTPLoopback  bool
 	AllowUnsignedLocal bool
+	// AcquisitionSource is a short adapter identifier (curl, homebrew, or
+	// local-fixture), not a filesystem path. It is persisted in active.json,
+	// never in immutable release receipt.json.
+	AcquisitionSource string
+	// StageOnly commits an authenticated immutable release but leaves active
+	// selection untouched. The launcher uses it for Homebrew's first-invocation
+	// bootstrap before running the shared health-gated promoter.
+	StageOnly bool
 	// RunCommand is a test seam for macOS code-signing/notarization checks.
 	// Production leaves it nil and executes the system tools by absolute path.
 	RunCommand func(string, ...string) (string, error)
@@ -261,6 +282,17 @@ func validateTransportURL(rawURL string, allowHTTPLoopback bool) (*url.URL, erro
 	return nil, errors.New("must use HTTPS (HTTP is permitted only for explicit loopback tests)")
 }
 
+func validateDescriptorArtifactURL(rawURL, channel string, allowHTTPLoopback bool) (*url.URL, error) {
+	if channel == "local" {
+		parsed, err := url.Parse(rawURL)
+		if err != nil || parsed == nil || parsed.Scheme != "file" || parsed.Host != "" || parsed.User != nil || parsed.Fragment != "" || parsed.RawQuery != "" || !strings.HasPrefix(parsed.Path, "/") {
+			return nil, errors.New("local release artifact URL must be a canonical absolute file:// URL")
+		}
+		return parsed, nil
+	}
+	return validateTransportURL(rawURL, allowHTTPLoopback)
+}
+
 func isLoopbackHost(host string) bool {
 	if strings.EqualFold(host, "localhost") {
 		return true
@@ -286,18 +318,43 @@ func verifyDescriptor(raw, signatureRaw []byte, trust map[string]ed25519.PublicK
 	if err := decodeStrict(raw, "release descriptor", &descriptor); err != nil {
 		return descriptor, err
 	}
+	var descriptorFields map[string]json.RawMessage
+	if err := decodeStrict(raw, "release descriptor fields", &descriptorFields); err != nil {
+		return descriptor, err
+	}
+	for _, required := range []string{"minimumSafeSequence", "revokedBuildIds"} {
+		if _, exists := descriptorFields[required]; !exists {
+			return descriptor, fmt.Errorf("release descriptor is missing %s", required)
+		}
+	}
+	var canonicalRevocations []string
+	if err := json.Unmarshal(descriptorFields["revokedBuildIds"], &canonicalRevocations); err != nil || canonicalRevocations == nil {
+		return descriptor, errors.New("release descriptor revokedBuildIds must be an array")
+	}
 	var signature descriptorSignature
 	if err := decodeStrict(signatureRaw, "release descriptor signature", &signature); err != nil {
 		return descriptor, err
 	}
-	if descriptor.SchemaVersion != 1 || descriptor.Sequence == 0 || !buildIDPattern.MatchString(descriptor.BuildID) || !semverPattern.MatchString(descriptor.AppVersion) || descriptor.Platform.ID != "darwin-arm64" || descriptor.Platform.OS != "darwin" || descriptor.Platform.Arch != "arm64" {
+	if descriptor.SchemaVersion != 1 || descriptor.Sequence == 0 || descriptor.Sequence > maxJSONSafeInteger || !buildIDPattern.MatchString(descriptor.BuildID) || !semverPattern.MatchString(descriptor.AppVersion) || descriptor.Platform.ID != "darwin-arm64" || descriptor.Platform.OS != "darwin" || descriptor.Platform.Arch != "arm64" {
 		return descriptor, errors.New("invalid release descriptor identity")
 	}
 	if descriptor.Channel != "local" && descriptor.Channel != "stable" && descriptor.Channel != "prerelease" {
 		return descriptor, errors.New("invalid release descriptor channel")
 	}
+	if descriptor.MinimumSafeSequence > maxJSONSafeInteger || descriptor.MinimumSafeSequence > descriptor.Sequence || (descriptor.Channel != "local" && descriptor.MinimumSafeSequence == 0) {
+		return descriptor, errors.New("invalid release minimum-safe sequence")
+	}
+	for index, build := range descriptor.RevokedBuildIDs {
+		if !buildIDPattern.MatchString(build) || (index > 0 && descriptor.RevokedBuildIDs[index-1] >= build) {
+			return descriptor, errors.New("invalid release revocation tombstones")
+		}
+	}
 	if descriptor.Artifact.ArchiveType != "zip" || !sha256Pattern.MatchString(descriptor.Artifact.SHA256) || !sha256Pattern.MatchString(descriptor.Artifact.ManifestSHA256) || descriptor.Artifact.SizeBytes <= 0 || descriptor.Artifact.SizeBytes > maxArchiveBytes {
 		return descriptor, errors.New("invalid release artifact contract")
+	}
+	artifactURL, err := validateDescriptorArtifactURL(descriptor.Artifact.URL, descriptor.Channel, allowHTTPLoopback)
+	if err != nil {
+		return descriptor, fmt.Errorf("artifact URL: %w", err)
 	}
 	if signature.SchemaVersion != 1 || signature.Algorithm != "ed25519" || signature.KeyID == "" {
 		return descriptor, errors.New("invalid release descriptor signature envelope")
@@ -310,10 +367,6 @@ func verifyDescriptor(raw, signatureRaw []byte, trust map[string]ed25519.PublicK
 	}
 	if sourceURL == nil || signature.Status != "signed" || signature.Signature == nil {
 		return descriptor, errors.New("network release descriptor must have a detached Ed25519 signature")
-	}
-	artifactURL, err := validateTransportURL(descriptor.Artifact.URL, allowHTTPLoopback)
-	if err != nil {
-		return descriptor, fmt.Errorf("artifact URL: %w", err)
 	}
 	if !strings.EqualFold(artifactURL.Host, sourceURL.Host) || artifactURL.Scheme != sourceURL.Scheme {
 		return descriptor, errors.New("artifact URL must stay on the authenticated release origin")
@@ -331,64 +384,36 @@ func verifyDescriptor(raw, signatureRaw []byte, trust map[string]ed25519.PublicK
 
 func downloadAndInstall(options Options, descriptor Descriptor, descriptorBytes []byte, descriptorURL string, client *http.Client) (Receipt, error) {
 	artifactURL, _ := url.Parse(descriptor.Artifact.URL)
-	archivePath, err := downloadArchive(client, artifactURL.String(), descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256)
+	home, err := RuntimeHome(options.Home)
 	if err != nil {
 		return Receipt{}, fmt.Errorf("download release archive: %w", err)
 	}
-	defer os.Remove(archivePath)
-	return installArchive(options, descriptor, descriptorBytes, descriptorURL, archivePath)
-}
-
-// downloadArchive streams an archive to disk while hashing it. A release may
-// be hundreds of MiB; keeping it in memory would turn a valid signed download
-// into an avoidable denial-of-service vector.
-func downloadArchive(client *http.Client, rawURL string, expectedSize int64, expectedSHA256 string) (string, error) {
-	return downloadArchiveWithStallTimeout(client, rawURL, expectedSize, expectedSHA256, archiveStallTimeout)
-}
-
-func downloadArchiveWithStallTimeout(client *http.Client, rawURL string, expectedSize int64, expectedSHA256 string, stallTimeout time.Duration) (string, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	shared, err := release.Open(home)
 	if err != nil {
-		return "", err
+		return Receipt{}, err
 	}
-	response, err := client.Do(request)
+	transition, err := shared.TransitionLock()
 	if err != nil {
-		return "", err
+		return Receipt{}, err
 	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("unexpected HTTP status %s", response.Status)
-	}
-	if response.ContentLength != expectedSize {
-		return "", fmt.Errorf("archive content length mismatch: expected %d, received %d", expectedSize, response.ContentLength)
-	}
-	cache, err := os.CreateTemp("", "jobctrl-release-*.zip")
+	defer transition.Close()
+	store, err := openStore(home)
 	if err != nil {
-		return "", err
+		return Receipt{}, err
 	}
-	path := cache.Name()
-	hash := sha256.New()
-	written, copyErr := copyWithProgressTimeout(io.MultiWriter(cache, hash), io.LimitReader(response.Body, expectedSize+1), stallTimeout, cancel)
-	if copyErr != nil || written != expectedSize || hex.EncodeToString(hash.Sum(nil)) != expectedSHA256 {
-		cache.Close()
-		os.Remove(path)
-		if copyErr != nil {
-			return "", copyErr
-		}
-		return "", errors.New("archive size or SHA-256 does not match signed release descriptor")
+	defer store.Close()
+	if err := store.cleanupStaging(); err != nil {
+		return Receipt{}, err
 	}
-	if err := cache.Sync(); err != nil {
-		cache.Close()
-		os.Remove(path)
-		return "", err
+	stage, err := prepareDescriptorStage(shared, descriptorBytes)
+	if err != nil {
+		return Receipt{}, err
 	}
-	if err := cache.Close(); err != nil {
-		os.Remove(path)
-		return "", err
+	archivePath, err := downloadArchiveToStage(client, artifactURL.String(), descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("download release archive: %w", err)
 	}
-	return path, nil
+	return installArchiveLocked(options, descriptor, descriptorBytes, descriptorURL, archivePath, shared, store)
 }
 
 type progressReader struct {
@@ -444,38 +469,297 @@ func copyWithProgressTimeout(destination io.Writer, source io.Reader, stallTimeo
 	}
 }
 
-func installArchive(options Options, descriptor Descriptor, descriptorBytes []byte, descriptorURL, archivePath string) (Receipt, error) {
-	if info, err := os.Lstat(archivePath); err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-		return Receipt{}, errors.New("release archive must be a regular non-symlink file")
-	} else if info.Size() != descriptor.Artifact.SizeBytes {
-		return Receipt{}, fmt.Errorf("archive size mismatch: expected %d, received %d", descriptor.Artifact.SizeBytes, info.Size())
+// downloadArchiveToStage keeps both its partial and completed cache under the
+// signed descriptor digest. Callers hold the shared transition lock for the
+// whole acquisition, so uninstall, promotion, and a second installer cannot
+// mutate the same release store while an archive is being resumed.
+func downloadArchiveToStage(client *http.Client, rawURL string, expectedSize int64, expectedSHA256, stage string) (string, error) {
+	return downloadArchiveToStageWithStallTimeout(client, rawURL, expectedSize, expectedSHA256, stage, archiveStallTimeout)
+}
+
+func downloadArchiveToStageWithStallTimeout(client *http.Client, rawURL string, expectedSize int64, expectedSHA256, stage string, stallTimeout time.Duration) (string, error) {
+	if expectedSize <= 0 || !sha256Pattern.MatchString(expectedSHA256) {
+		return "", errors.New("invalid signed archive identity")
 	}
-	if digest, err := digestFile(archivePath); err != nil || digest != descriptor.Artifact.SHA256 {
-		if err != nil {
-			return Receipt{}, err
+	final := filepath.Join(stage, stagedArchiveName)
+	partial := filepath.Join(stage, partialArchiveName)
+	if info, err := os.Lstat(final); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("descriptor-bound archive cache is not a regular file")
 		}
-		return Receipt{}, errors.New("archive SHA-256 does not match release descriptor")
+		if err := verifyArchiveFile(final, expectedSize, expectedSHA256); err != nil {
+			return "", fmt.Errorf("cached archive does not match signed release descriptor: %w", err)
+		}
+		return final, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
 	}
-	home, err := runtimeHome(options.Home)
+
+	offset := int64(0)
+	if info, err := os.Lstat(partial); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("descriptor-bound partial archive is not a regular file")
+		}
+		offset = info.Size()
+		if offset > expectedSize {
+			return "", fmt.Errorf("partial archive size %d exceeds signed size %d", offset, expectedSize)
+		}
+		if offset == expectedSize {
+			if err := verifyArchiveFile(partial, expectedSize, expectedSHA256); err != nil {
+				return "", fmt.Errorf("partial archive does not match signed release descriptor: %w", err)
+			}
+			if err := finalizeArchiveCache(partial, final, stage); err != nil {
+				return "", err
+			}
+			return final, nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return "", err
+	}
+	if offset > 0 {
+		request.Header.Set("Range", fmt.Sprintf("bytes=%d-", offset))
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+	appendToPartial := offset > 0 && response.StatusCode == http.StatusPartialContent
+	if offset == 0 {
+		if response.StatusCode != http.StatusOK {
+			return "", fmt.Errorf("unexpected HTTP status %s", response.Status)
+		}
+		if err := requireFullArchiveResponse(response, expectedSize); err != nil {
+			return "", err
+		}
+	} else if appendToPartial {
+		if err := requirePartialArchiveResponse(response, offset, expectedSize); err != nil {
+			return "", err
+		}
+	} else if response.StatusCode == http.StatusOK {
+		// A server is allowed to ignore Range. Its full response is safe only if
+		// it is descriptor-sized and replaces (rather than appends to) the cache.
+		if err := requireFullArchiveResponse(response, expectedSize); err != nil {
+			return "", err
+		}
+		offset, appendToPartial = 0, false
+	} else {
+		return "", fmt.Errorf("unexpected HTTP status %s while resuming archive", response.Status)
+	}
+	if err := writeArchiveResponse(partial, response.Body, offset, expectedSize, appendToPartial, stallTimeout, cancel); err != nil {
+		return "", err
+	}
+	if err := verifyArchiveFile(partial, expectedSize, expectedSHA256); err != nil {
+		return "", fmt.Errorf("archive size or SHA-256 does not match signed release descriptor: %w", err)
+	}
+	if err := finalizeArchiveCache(partial, final, stage); err != nil {
+		return "", err
+	}
+	return final, nil
+}
+
+func requireFullArchiveResponse(response *http.Response, expectedSize int64) error {
+	if response.ContentLength != expectedSize {
+		return fmt.Errorf("archive content length mismatch: expected %d, received %d", expectedSize, response.ContentLength)
+	}
+	return nil
+}
+
+func requirePartialArchiveResponse(response *http.Response, offset, expectedSize int64) error {
+	remaining := expectedSize - offset
+	if response.ContentLength != remaining {
+		return fmt.Errorf("partial archive content length mismatch: expected %d, received %d", remaining, response.ContentLength)
+	}
+	parts := contentRangePattern.FindStringSubmatch(response.Header.Get("Content-Range"))
+	if len(parts) != 4 {
+		return errors.New("partial archive Content-Range does not bind the signed descriptor size")
+	}
+	start, startErr := strconv.ParseInt(parts[1], 10, 64)
+	end, endErr := strconv.ParseInt(parts[2], 10, 64)
+	total, totalErr := strconv.ParseInt(parts[3], 10, 64)
+	if startErr != nil || endErr != nil || totalErr != nil || start != offset || end != expectedSize-1 || total != expectedSize {
+		return errors.New("partial archive Content-Range does not bind the signed descriptor size")
+	}
+	return nil
+}
+
+func writeArchiveResponse(path string, body io.Reader, offset, expectedSize int64, appendToPartial bool, stallTimeout time.Duration, cancel context.CancelFunc) error {
+	flags := os.O_WRONLY | os.O_CREATE | syscall.O_NOFOLLOW
+	if appendToPartial {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+	file, err := os.OpenFile(path, flags, 0o600)
+	if err != nil {
+		return err
+	}
+	if info, statErr := file.Stat(); statErr != nil || !info.Mode().IsRegular() || (appendToPartial && info.Size() != offset) {
+		_ = file.Close()
+		if statErr != nil {
+			return statErr
+		}
+		return errors.New("partial archive changed while resuming")
+	}
+	remaining := expectedSize - offset
+	written, copyErr := copyWithProgressTimeout(file, io.LimitReader(body, remaining+1), stallTimeout, cancel)
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if syncErr != nil {
+		return syncErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written != remaining {
+		return fmt.Errorf("archive body length mismatch: expected %d, received %d", remaining, written)
+	}
+	return nil
+}
+
+func verifyArchiveFile(path string, expectedSize int64, expectedSHA256 string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("archive cache is not a regular file")
+	}
+	if info.Size() != expectedSize {
+		return fmt.Errorf("archive size mismatch: expected %d, received %d", expectedSize, info.Size())
+	}
+	digest, err := digestFile(path)
+	if err != nil {
+		return err
+	}
+	if digest != expectedSHA256 {
+		return errors.New("archive SHA-256 mismatch")
+	}
+	return nil
+}
+
+func finalizeArchiveCache(partial, final, stage string) error {
+	if _, err := os.Lstat(final); err == nil {
+		return errors.New("descriptor-bound final archive appeared during download")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Link first so a same-user process cannot race this cache finalization by
+	// planting a final path between Lstat and a replacement-style rename.
+	// Both names are in one descriptor directory, so the link is atomic and
+	// cannot cross filesystems.
+	if err := os.Link(partial, final); err != nil {
+		return err
+	}
+	if err := os.Remove(partial); err != nil {
+		return err
+	}
+	return syncDirectory(stage)
+}
+
+// prepareDescriptorStage creates or verifies the sole staging location that
+// may be associated with descriptorBytes. Its metadata is deliberately small
+// and exact: the path is not enough evidence if a user-owned directory was
+// prepositioned or reused for a different descriptor.
+func prepareDescriptorStage(shared *release.Store, descriptorBytes []byte) (string, error) {
+	descriptorDigest := digestBytes(descriptorBytes)
+	stage, err := shared.StageDir(descriptorDigest)
+	if err != nil {
+		return "", err
+	}
+	if info, statErr := os.Lstat(stage); statErr == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return "", errors.New("descriptor-bound staging path is not a regular directory")
+		}
+		var staged struct {
+			DescriptorSHA256 string `json:"descriptorSha256"`
+		}
+		metaRaw, metaErr := readBoundedFile(filepath.Join(stage, "stage.json"), maxSignatureBytes)
+		if metaErr != nil || decodeStrict(metaRaw, "staging metadata", &staged) != nil || staged.DescriptorSHA256 != descriptorDigest {
+			return "", errors.New("staging metadata does not bind the authenticated descriptor")
+		}
+		return stage, nil
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return "", statErr
+	}
+	if err := os.Mkdir(stage, 0o700); err != nil {
+		return "", err
+	}
+	if err := writeBytesAtomic(filepath.Join(stage, "stage.json"), []byte(`{"descriptorSha256":"`+descriptorDigest+`"}`+"\n"), 0o600); err != nil {
+		return "", err
+	}
+	if err := syncDirectory(filepath.Dir(stage)); err != nil {
+		return "", err
+	}
+	return stage, nil
+}
+
+func installArchive(options Options, descriptor Descriptor, descriptorBytes []byte, descriptorURL, archivePath string) (Receipt, error) {
+	home, err := RuntimeHome(options.Home)
 	if err != nil {
 		return Receipt{}, err
 	}
+	// Acquisition participates in the same transition -> selection hierarchy as
+	// promotion, rollback, backup, retention, and uninstall. There is no
+	// independent installer flock that can deadlock or race an active record.
+	shared, err := release.Open(home)
+	if err != nil {
+		return Receipt{}, err
+	}
+	transition, err := shared.TransitionLock()
+	if err != nil {
+		return Receipt{}, err
+	}
+	defer transition.Close()
 	store, err := openStore(home)
 	if err != nil {
 		return Receipt{}, err
 	}
 	defer store.Close()
+	return installArchiveLocked(options, descriptor, descriptorBytes, descriptorURL, archivePath, shared, store)
+}
+
+func installArchiveLocked(options Options, descriptor Descriptor, descriptorBytes []byte, descriptorURL, archivePath string, shared *release.Store, store *store) (Receipt, error) {
+	if err := verifyArchiveFile(archivePath, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256); err != nil {
+		return Receipt{}, fmt.Errorf("release archive does not match signed descriptor: %w", err)
+	}
+	// P4's random stage-* directories have no authenticated identity and cannot
+	// be resumed. Descriptor-digest directories are intentionally retained.
 	if err := store.cleanupStaging(); err != nil {
 		return Receipt{}, err
 	}
-	stage, err := os.MkdirTemp(filepath.Join(store.home, "staging"), "stage-")
+	descriptorDigest := digestBytes(descriptorBytes)
+	stage, err := prepareDescriptorStage(shared, descriptorBytes)
 	if err != nil {
 		return Receipt{}, err
 	}
-	defer os.RemoveAll(stage)
 	payload := filepath.Join(stage, "payload")
-	if err := extractZIP(archivePath, payload); err != nil {
-		return Receipt{}, err
+	// A complete payload can be reused after interruption only after re-running
+	// the full verifier. A partial payload remains descriptor-bound, but is
+	// discarded before a fresh extraction rather than being trusted by shape.
+	reuse := false
+	if _, err := os.Lstat(payload); err == nil {
+		trust := launcher.DistributionTrust{PublicKeys: options.Trust, AllowUnsignedLocal: options.AllowUnsignedLocal, ExpectedChannel: descriptor.Channel}
+		if _, verifyErr := launcher.VerifyDistributionPayload(payload, trust); verifyErr == nil {
+			reuse = true
+		} else if removeErr := os.RemoveAll(payload); removeErr != nil {
+			return Receipt{}, removeErr
+		}
+	}
+	if !reuse {
+		if err := extractZIP(archivePath, payload); err != nil {
+			return Receipt{}, err
+		}
 	}
 	trust := launcher.DistributionTrust{PublicKeys: options.Trust, AllowUnsignedLocal: options.AllowUnsignedLocal, ExpectedChannel: descriptor.Channel}
 	manifest, err := launcher.VerifyDistributionPayload(payload, trust)
@@ -495,18 +779,29 @@ func installArchive(options Options, descriptor Descriptor, descriptorBytes []by
 			return Receipt{}, err
 		}
 	}
-	receipt := Receipt{1, descriptor.BuildID, descriptor.Channel, descriptor.Sequence, descriptor.Artifact.SHA256, manifestDigest, digestBytes(descriptorBytes), descriptorURL, time.Now().UTC().Format(time.RFC3339Nano)}
+	// The archive cache is useful only until the authenticated payload is fully
+	// verified. Never move it into releases/<build>: immutable releases contain
+	// the payload, receipts, and policy evidence—not a duplicate mutable cache.
+	if archivePath == filepath.Join(stage, stagedArchiveName) {
+		if err := os.Remove(archivePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return Receipt{}, err
+		}
+		if err := syncDirectory(stage); err != nil {
+			return Receipt{}, err
+		}
+	}
+	metadata := release.ChannelMetadata{Channel: descriptor.Channel, Sequence: descriptor.Sequence, Minimum: descriptor.MinimumSafeSequence, BuildID: descriptor.BuildID, DescriptorDigest: descriptorDigest, Revoked: descriptor.RevokedBuildIDs}
+	policyBytes, err := encodeJSON(metadata)
+	if err != nil {
+		return Receipt{}, err
+	}
+	receipt := Receipt{SchemaVersion: 2, BuildID: descriptor.BuildID, Channel: descriptor.Channel, Sequence: descriptor.Sequence, ArtifactSHA256: descriptor.Artifact.SHA256, ManifestSHA256: manifestDigest, DescriptorSHA256: descriptorDigest, PolicySHA256: digestBytes(policyBytes), DescriptorURL: descriptorURL, InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)}
 	receiptBytes, err := encodeJSON(receipt)
 	if err != nil {
 		return Receipt{}, err
 	}
-	if err := syncDirectory(payload); err != nil {
-		return Receipt{}, err
-	}
-	if err := syncDirectory(stage); err != nil {
-		return Receipt{}, err
-	}
 	releasePath := filepath.Join(store.home, "releases", descriptor.BuildID)
+	releaseExists := false
 	if _, err := os.Lstat(releasePath); err == nil {
 		if info, statErr := os.Lstat(releasePath); statErr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 			return Receipt{}, errors.New("existing release path is not a regular directory")
@@ -516,10 +811,28 @@ func installArchive(options Options, descriptor Descriptor, descriptorBytes []by
 			return Receipt{}, fmt.Errorf("existing release %q is not idempotent-safe: %w", descriptor.BuildID, err)
 		}
 		receipt, receiptBytes = immutableReceipt, immutableBytes
+		releaseExists = true
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return Receipt{}, err
-	} else {
+	}
+	// Validate authenticated policy before writing, but do not make it durable
+	// yet. Durable policy finalization is journaled by the shared promoter only
+	// after this candidate is immutable and a coherent predecessor pair exists.
+	// This is the critical crash boundary for security revocations.
+	if _, err := shared.ValidateMetadata(metadata); err != nil {
+		return Receipt{}, err
+	}
+	if !releaseExists {
+		if err := syncDirectory(payload); err != nil {
+			return Receipt{}, err
+		}
+		if err := syncDirectory(stage); err != nil {
+			return Receipt{}, err
+		}
 		if err := writeBytesAtomic(filepath.Join(stage, "receipt.json"), receiptBytes, 0o600); err != nil {
+			return Receipt{}, err
+		}
+		if err := writeBytesAtomic(filepath.Join(stage, "policy.json"), policyBytes, 0o600); err != nil {
 			return Receipt{}, err
 		}
 		if err := syncDirectory(stage); err != nil {
@@ -532,10 +845,75 @@ func installArchive(options Options, descriptor Descriptor, descriptorBytes []by
 			return Receipt{}, err
 		}
 	}
+	if options.StageOnly {
+		// Staging never writes bin/jobctrl. In particular, an upgraded Homebrew
+		// formula must not replace a selector that may be supervising an older
+		// protocol payload; the shared promoter performs the compatible handoff.
+		return receipt, nil
+	}
+	source := options.AcquisitionSource
+	if source == "" {
+		source = "curl"
+	}
+	if descriptor.Channel == "local" {
+		source = "local-fixture"
+	}
+	// First installation has no predecessor to protect. It still takes the
+	// common transition -> selection lock order and journals policy before
+	// finalization. Existing installations must remain staged for the shared
+	// health-gated launcher promoter; acquisition is never an activation path.
+	selection, err := shared.SelectionLock(true)
+	if err != nil {
+		return Receipt{}, err
+	}
+	defer selection.Close()
+	prior := uint64(0)
+	if active, activeErr := shared.ReadActive(); activeErr == nil {
+		if active.Receipt.BuildID == receipt.BuildID {
+			if active.Receipt != (release.Receipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: receipt.Sequence, ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}) {
+				return Receipt{}, errors.New("active build identity conflicts with authenticated immutable receipt")
+			}
+			if active.Acquisition != source {
+				if _, err := shared.WriteSelectedActive(active.Receipt, active.Generation, active.SelectorBuildID, source); err != nil {
+					return Receipt{}, err
+				}
+			}
+		}
+		return receipt, nil
+	} else if !errors.Is(activeErr, os.ErrNotExist) {
+		return Receipt{}, activeErr
+	}
+	journal, err := shared.Begin("install", nil, &release.Receipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: receipt.Sequence, ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}, receipt.DescriptorSHA256)
+	if err != nil {
+		return Receipt{}, err
+	}
+	journal.PendingPolicy = &metadata
+	if err := shared.Advance(&journal, release.PolicyPending, nil); err != nil {
+		return Receipt{}, err
+	}
+	state, err := shared.ValidateMetadata(metadata)
+	if err != nil {
+		return Receipt{}, err
+	}
+	if err := shared.CommitMetadata(state); err != nil {
+		return Receipt{}, err
+	}
+	if err := shared.Advance(&journal, release.PolicyFinalized, nil); err != nil {
+		return Receipt{}, err
+	}
 	if err := installPublicSelector(store.home, releasePath, descriptor.Channel); err != nil {
 		return Receipt{}, err
 	}
+	if _, err := shared.WriteSelectedActive(release.Receipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: receipt.Sequence, ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}, prior, receipt.BuildID, source); err != nil {
+		return Receipt{}, err
+	}
+	// current.json is a read-only P4 compatibility artifact. P5 resolution
+	// exclusively reads active.json, so this second write cannot form a pointer
+	// pair with the public selector.
 	if err := writeBytesAtomic(filepath.Join(store.home, "current.json"), receiptBytes, 0o600); err != nil {
+		return Receipt{}, err
+	}
+	if err := shared.Advance(&journal, release.Promoted, nil); err != nil {
 		return Receipt{}, err
 	}
 	return receipt, nil
@@ -598,7 +976,10 @@ func installPublicSelector(home, releasePath, channel string) error {
 	return syncDirectory(bin)
 }
 
-func runtimeHome(explicit string) (string, error) {
+// RuntimeHome resolves the user-owned store for the command front-end after a
+// successful acquisition. It intentionally exposes only the path, never a
+// mutable package-manager location.
+func RuntimeHome(explicit string) (string, error) {
 	if explicit != "" {
 		return filepath.Abs(explicit)
 	}
@@ -614,7 +995,6 @@ func runtimeHome(explicit string) (string, error) {
 
 type store struct {
 	home string
-	lock *os.File
 }
 
 func openStore(home string) (*store, error) {
@@ -626,21 +1006,7 @@ func openStore(home string) (*store, error) {
 			return nil, err
 		}
 	}
-	lockPath := filepath.Join(home, "install.lock")
-	if info, err := os.Lstat(lockPath); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
-		return nil, errors.New("release store lock is not a regular file")
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-	lock, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
-	if err != nil {
-		return nil, err
-	}
-	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
-		lock.Close()
-		return nil, fmt.Errorf("lock release store: %w", err)
-	}
-	return &store{home, lock}, nil
+	return &store{home: home}, nil
 }
 
 func ensureManagedDirectory(path string) error {
@@ -667,10 +1033,7 @@ func ensureManagedDirectory(path string) error {
 	}
 	return os.Chmod(path, 0o700)
 }
-func (s *store) Close() error {
-	defer s.lock.Close()
-	return syscall.Flock(int(s.lock.Fd()), syscall.LOCK_UN)
-}
+func (s *store) Close() error { return nil }
 func (s *store) cleanupStaging() error {
 	entries, err := os.ReadDir(filepath.Join(s.home, "staging"))
 	if err != nil {
@@ -720,10 +1083,41 @@ func verifyInstalledRelease(releasePath string, descriptor Descriptor, trust lau
 	if err := decodeStrict(raw, "release receipt", &receipt); err != nil {
 		return receipt, nil, err
 	}
-	if receipt.SchemaVersion != expected.SchemaVersion || receipt.BuildID != expected.BuildID || receipt.Channel != expected.Channel || receipt.Sequence != expected.Sequence || receipt.ArtifactSHA256 != expected.ArtifactSHA256 || receipt.ManifestSHA256 != expected.ManifestSHA256 || receipt.DescriptorSHA256 != expected.DescriptorSHA256 || receipt.DescriptorURL != expected.DescriptorURL || receipt.InstalledAt == "" {
+	if receipt.SchemaVersion != expected.SchemaVersion || receipt.BuildID != expected.BuildID || receipt.Channel != expected.Channel || receipt.Sequence != expected.Sequence || receipt.ArtifactSHA256 != expected.ArtifactSHA256 || receipt.ManifestSHA256 != expected.ManifestSHA256 || receipt.DescriptorSHA256 != expected.DescriptorSHA256 || receipt.PolicySHA256 != expected.PolicySHA256 || receipt.DescriptorURL != expected.DescriptorURL || receipt.InstalledAt == "" {
 		return receipt, nil, errors.New("release receipt does not match descriptor identity")
 	}
+	policyPath := filepath.Join(releasePath, "policy.json")
+	policyInfo, err := os.Lstat(policyPath)
+	if err != nil || !policyInfo.Mode().IsRegular() || policyInfo.Mode()&os.ModeSymlink != 0 {
+		return receipt, nil, errors.New("release policy is not a regular file")
+	}
+	policyRaw, err := os.ReadFile(policyPath)
+	if err != nil {
+		return receipt, nil, err
+	}
+	var policy release.ChannelMetadata
+	if err := decodeStrict(policyRaw, "release policy", &policy); err != nil {
+		return receipt, nil, err
+	}
+	if digestBytes(policyRaw) != receipt.PolicySHA256 {
+		return receipt, nil, errors.New("release policy digest does not match immutable receipt")
+	}
+	if policy.Channel != descriptor.Channel || policy.Sequence != descriptor.Sequence || policy.Minimum != descriptor.MinimumSafeSequence || policy.BuildID != descriptor.BuildID || policy.DescriptorDigest != expected.DescriptorSHA256 || !sameStrings(policy.Revoked, descriptor.RevokedBuildIDs) {
+		return receipt, nil, errors.New("release policy does not match descriptor identity")
+	}
 	return receipt, raw, nil
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func extractZIP(archivePath, destination string) error {
@@ -964,24 +1358,47 @@ func verifyMacOSPayloadTrust(payloadRoot string, runner func(string, ...string) 
 			return string(output), err
 		}
 	}
-	targets := []string{launcherPath}
+	targets := map[string]bool{launcherPath: true}
 	err := filepath.WalkDir(payloadRoot, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if path == payloadRoot || !entry.IsDir() {
+		if path == payloadRoot {
 			return nil
 		}
-		if strings.Contains(strings.ToLower(entry.Name()), "chrom") && strings.HasSuffix(entry.Name(), ".app") {
-			targets = append(targets, path)
-			return filepath.SkipDir
+		if entry.IsDir() {
+			if strings.HasSuffix(entry.Name(), ".app") {
+				targets[path] = true
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
+			machO, err := isMachO(path)
+			if err != nil {
+				return err
+			}
+			if machO {
+				targets[path] = true
+			}
 		}
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	for _, target := range targets {
+	ordered := make([]string, 0, len(targets))
+	for target := range targets {
+		ordered = append(ordered, target)
+	}
+	sort.Strings(ordered)
+	for _, target := range ordered {
 		if _, err := runner("/usr/bin/codesign", "--verify", "--deep", "--strict", "--check-notarization", "-R=notarized", target); err != nil {
 			return fmt.Errorf("Developer ID/notarization verification failed for %s: %w", filepath.Base(target), err)
 		}
@@ -994,4 +1411,26 @@ func verifyMacOSPayloadTrust(payloadRoot string, runner func(string, ...string) 
 		}
 	}
 	return nil
+}
+
+func isMachO(path string) (bool, error) {
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+	var header [4]byte
+	read, err := io.ReadFull(file, header[:])
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return false, err
+	}
+	if read < len(header) {
+		return false, nil
+	}
+	switch header {
+	case [4]byte{0xfe, 0xed, 0xfa, 0xce}, [4]byte{0xce, 0xfa, 0xed, 0xfe}, [4]byte{0xfe, 0xed, 0xfa, 0xcf}, [4]byte{0xcf, 0xfa, 0xed, 0xfe}, [4]byte{0xca, 0xfe, 0xba, 0xbe}, [4]byte{0xbe, 0xba, 0xfe, 0xca}, [4]byte{0xca, 0xfe, 0xba, 0xbf}, [4]byte{0xbf, 0xba, 0xfe, 0xca}:
+		return true, nil
+	default:
+		return false, nil
+	}
 }

--- a/launcher/internal/installer/installer_test.go
+++ b/launcher/internal/installer/installer_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,7 @@ import (
 	"time"
 
 	"github.com/ebarti/jobctrl/launcher/internal/launcher"
+	"github.com/ebarti/jobctrl/launcher/internal/release"
 )
 
 func TestReleaseDescriptorAuthenticatesExactBytesAndOrigin(t *testing.T) {
@@ -91,14 +93,40 @@ func TestStablePayloadRequiresCodeSigningAndNotarizationAssessment(t *testing.T)
 	if err := verifyMacOSPayloadTrust(payload, runner); err != nil {
 		t.Fatal(err)
 	}
-	if len(calls) != 4 || !strings.Contains(calls[2], "Chromium.app") || !strings.Contains(calls[3], "Chromium.app") {
+	if len(calls) != 4 || !strings.Contains(strings.Join(calls, "\n"), "Chromium.app") {
 		t.Fatalf("Chromium app was not independently assessed: %#v", calls)
+	}
+	for _, path := range []string{"node/bin/node", "python/bin/python3", "temporal/temporal", "components/native/addon.node"} {
+		full := filepath.Join(payload, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte{0xcf, 0xfa, 0xed, 0xfe, 0, 0, 0, 0}, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	calls = nil
+	if err := verifyMacOSPayloadTrust(payload, runner); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"node", "python3", "temporal", "addon.node"} {
+		found := false
+		for _, call := range calls {
+			if strings.Contains(call, name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("native executable %s was not independently code-trust assessed: %#v", name, calls)
+		}
 	}
 }
 
 func TestUnsignedLocalDescriptorCannotCrossNetworkBoundary(t *testing.T) {
 	descriptor := stableDescriptor("https://example.test/jobctrl.zip")
 	descriptor.Channel = "local"
+	descriptor.Artifact.URL = "file:///jobctrl-local-release/fixture.zip"
 	raw, _ := json.Marshal(descriptor)
 	signatureRaw, _ := json.Marshal(descriptorSignature{SchemaVersion: 1, Status: "unsigned-local", Algorithm: "ed25519", KeyID: "local-development"})
 	source, _ := validateTransportURL("https://example.test/release.json", false)
@@ -110,6 +138,28 @@ func TestUnsignedLocalDescriptorCannotCrossNetworkBoundary(t *testing.T) {
 	}
 	if _, err := verifyDescriptor(raw, signatureRaw, nil, true, nil, false); err != nil {
 		t.Fatalf("explicit local fixture rejected: %v", err)
+	}
+}
+
+func TestDescriptorValidationMatchesSafeIntegerAndCanonicalLocalFileRules(t *testing.T) {
+	descriptor := stableDescriptor("file:///jobctrl-local-release/fixture.zip")
+	descriptor.Channel = "local"
+	descriptor.MinimumSafeSequence = 0
+	raw, _ := json.Marshal(descriptor)
+	signatureRaw, _ := json.Marshal(descriptorSignature{SchemaVersion: 1, Status: "unsigned-local", Algorithm: "ed25519", KeyID: "local-development"})
+	if _, err := verifyDescriptor(raw, signatureRaw, nil, true, nil, false); err != nil {
+		t.Fatalf("canonical local descriptor rejected: %v", err)
+	}
+	descriptor.Artifact.URL = "file://attacker.example/jobctrl.zip"
+	raw, _ = json.Marshal(descriptor)
+	if _, err := verifyDescriptor(raw, signatureRaw, nil, true, nil, false); err == nil {
+		t.Fatal("local descriptor with file authority accepted")
+	}
+	descriptor.Artifact.URL = "file:///jobctrl-local-release/fixture.zip"
+	descriptor.Sequence = maxJSONSafeInteger + 1
+	raw, _ = json.Marshal(descriptor)
+	if _, err := verifyDescriptor(raw, signatureRaw, nil, true, nil, false); err == nil {
+		t.Fatal("unsafe JSON sequence accepted")
 	}
 }
 
@@ -146,11 +196,12 @@ func TestArchiveDownloadAllowsSlowProgressBeyondMetadataDeadline(t *testing.T) {
 	defer server.Close()
 	metadata := server.Client()
 	metadata.Timeout = 25 * time.Millisecond
-	path, err := downloadArchiveWithStallTimeout(archiveHTTPClient(metadata), server.URL, int64(len(archive)), digestBytes(archive), 250*time.Millisecond)
+	descriptor, descriptorRaw := signedLoopbackArchiveDescriptor(t, server.URL, archive)
+	stage := descriptorStageForTest(t, descriptorRaw)
+	path, err := downloadArchiveToStage(archiveHTTPClient(metadata), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage)
 	if err != nil {
 		t.Fatalf("slow but progressing archive was rejected: %v", err)
 	}
-	defer os.Remove(path)
 	if downloaded, err := os.ReadFile(path); err != nil || !bytes.Equal(downloaded, archive) {
 		t.Fatalf("downloaded archive = %q, %v", downloaded, err)
 	}
@@ -165,10 +216,190 @@ func TestArchiveDownloadCancelsAStalledBody(t *testing.T) {
 		<-request.Context().Done()
 	}))
 	defer server.Close()
-	_, err := downloadArchiveWithStallTimeout(server.Client(), server.URL, int64(len(archive)), digestBytes(archive), 25*time.Millisecond)
+	descriptor, descriptorRaw := signedLoopbackArchiveDescriptor(t, server.URL, archive)
+	stage := descriptorStageForTest(t, descriptorRaw)
+	archiveStallTimeoutForTest := 25 * time.Millisecond
+	_, err := downloadArchiveToStageWithStallTimeout(server.Client(), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage, archiveStallTimeoutForTest)
 	if err == nil || !strings.Contains(err.Error(), "archive download stalled") {
 		t.Fatalf("stalled archive result = %v", err)
 	}
+	partial, readErr := os.ReadFile(filepath.Join(stage, partialArchiveName))
+	if readErr != nil || !bytes.Equal(partial, archive[:1]) {
+		t.Fatalf("stalled archive did not preserve resumable bytes: %q, %v", partial, readErr)
+	}
+}
+
+func TestDescriptorBoundArchiveCacheResumesInterruptedLoopbackDownload(t *testing.T) {
+	archive := []byte("a resumable signed archive payload")
+	var calls []string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		calls = append(calls, request.Header.Get("Range"))
+		response.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)))
+		if len(calls) == 1 {
+			_, _ = response.Write(archive[:7])
+			return
+		}
+		if got := request.Header.Get("Range"); got != "bytes=7-" {
+			t.Fatalf("resume Range = %q", got)
+		}
+		response.Header().Set("Content-Range", fmt.Sprintf("bytes 7-%d/%d", len(archive)-1, len(archive)))
+		response.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)-7))
+		response.WriteHeader(http.StatusPartialContent)
+		_, _ = response.Write(archive[7:])
+	}))
+	defer server.Close()
+	descriptor, descriptorRaw := signedLoopbackArchiveDescriptor(t, server.URL, archive)
+	stage := descriptorStageForTest(t, descriptorRaw)
+	if _, err := downloadArchiveToStage(server.Client(), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage); err == nil {
+		t.Fatal("interrupted archive download accepted")
+	}
+	partial, err := os.ReadFile(filepath.Join(stage, partialArchiveName))
+	if err != nil || !bytes.Equal(partial, archive[:7]) {
+		t.Fatalf("resumable partial = %q, %v", partial, err)
+	}
+	path, err := downloadArchiveToStage(server.Client(), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage)
+	if err != nil {
+		t.Fatalf("resume signed archive: %v", err)
+	}
+	completed, err := os.ReadFile(path)
+	if err != nil || !bytes.Equal(completed, archive) || len(calls) != 2 {
+		t.Fatalf("completed archive = %q, calls=%v, err=%v", completed, calls, err)
+	}
+}
+
+func TestDescriptorBoundArchiveCacheRestartsWhenRangeIsIgnored(t *testing.T) {
+	archive := []byte("full archive returned after the server ignores Range")
+	var sawRange string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		sawRange = request.Header.Get("Range")
+		response.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)))
+		_, _ = response.Write(archive)
+	}))
+	defer server.Close()
+	descriptor, descriptorRaw := signedLoopbackArchiveDescriptor(t, server.URL, archive)
+	stage := descriptorStageForTest(t, descriptorRaw)
+	if err := os.WriteFile(filepath.Join(stage, partialArchiveName), archive[:9], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path, err := downloadArchiveToStage(server.Client(), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage)
+	if err != nil {
+		t.Fatalf("restart after ignored Range: %v", err)
+	}
+	completed, err := os.ReadFile(path)
+	if sawRange != "bytes=9-" || err != nil || !bytes.Equal(completed, archive) {
+		t.Fatalf("ignored Range restart=%q archive=%q err=%v", sawRange, completed, err)
+	}
+}
+
+func TestDescriptorBoundArchiveCacheRejectsTamperAndOversize(t *testing.T) {
+	archive := []byte("exactly signed archive bytes")
+	for _, testCase := range []struct {
+		name    string
+		respond func(http.ResponseWriter)
+	}{
+		{
+			name: "tamper",
+			respond: func(response http.ResponseWriter) {
+				response.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)))
+				_, _ = response.Write(bytes.Repeat([]byte("x"), len(archive)))
+			},
+		},
+		{
+			name: "oversize",
+			respond: func(response http.ResponseWriter) {
+				response.Header().Set("Content-Length", fmt.Sprintf("%d", len(archive)+1))
+				_, _ = response.Write(append(append([]byte{}, archive...), '!'))
+			},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) { testCase.respond(response) }))
+			defer server.Close()
+			descriptor, descriptorRaw := signedLoopbackArchiveDescriptor(t, server.URL, archive)
+			stage := descriptorStageForTest(t, descriptorRaw)
+			if _, err := downloadArchiveToStage(server.Client(), descriptor.Artifact.URL, descriptor.Artifact.SizeBytes, descriptor.Artifact.SHA256, stage); err == nil {
+				t.Fatalf("%s archive was accepted", testCase.name)
+			}
+		})
+	}
+}
+
+func TestImmutableReleaseDoesNotRetainDescriptorArchiveCache(t *testing.T) {
+	root := t.TempDir()
+	archivePath, descriptorPath, _ := localFixture(t, root)
+	descriptorRaw, err := os.ReadFile(descriptorPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var descriptor Descriptor
+	if err := json.Unmarshal(descriptorRaw, &descriptor); err != nil {
+		t.Fatal(err)
+	}
+	home := filepath.Join(root, "runtime")
+	shared, err := release.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, err := prepareDescriptorStage(shared, descriptorRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stagedArchive := filepath.Join(stage, stagedArchiveName)
+	if err := os.WriteFile(stagedArchive, archive, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := installArchive(Options{Home: home, Policy: localAcquisitionPolicy(), AllowUnsignedLocal: true}, descriptor, descriptorRaw, "local-fixture", stagedArchive); err != nil {
+		t.Fatalf("install staged local archive: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(home, "releases", descriptor.BuildID, stagedArchiveName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("immutable release retained archive cache: %v", err)
+	}
+}
+
+func signedLoopbackArchiveDescriptor(t *testing.T, origin string, archive []byte) (Descriptor, []byte) {
+	t.Helper()
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor := stableDescriptor(origin + "/archive.zip")
+	digest := sha256.Sum256(archive)
+	descriptor.Artifact.SHA256 = hex.EncodeToString(digest[:])
+	descriptor.Artifact.SizeBytes = int64(len(archive))
+	raw, err := json.Marshal(descriptor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signatureRaw, err := json.Marshal(signedDescriptorSignature(private, raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := validateTransportURL(origin+"/descriptor.json", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := verifyDescriptor(raw, signatureRaw, map[string]ed25519.PublicKey{"jobctrl-release-v1": public}, false, source, true)
+	if err != nil {
+		t.Fatalf("generated Ed25519 loopback descriptor rejected: %v", err)
+	}
+	return verified, raw
+}
+
+func descriptorStageForTest(t *testing.T, descriptorRaw []byte) string {
+	t.Helper()
+	store, err := release.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, err := prepareDescriptorStage(store, descriptorRaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage
 }
 
 func TestZIPExtractionRejectsTraversalLinksSpecialEntriesAndCollisions(t *testing.T) {
@@ -233,6 +464,10 @@ func TestLocalInstallIsAtomicIdempotentConcurrentAndRecoversPointer(t *testing.T
 	if _, err := os.Stat(filepath.Join(home, "staging", "stage-interrupted")); !os.IsNotExist(err) {
 		t.Fatalf("interrupted stage survived: %v", err)
 	}
+	activeBefore, err := os.ReadFile(filepath.Join(home, release.ActiveFile))
+	if err != nil {
+		t.Fatal(err)
+	}
 	var group sync.WaitGroup
 	errs := make(chan error, 2)
 	for range 2 {
@@ -249,6 +484,10 @@ func TestLocalInstallIsAtomicIdempotentConcurrentAndRecoversPointer(t *testing.T
 		if err != nil {
 			t.Fatalf("concurrent/idempotent install: %v", err)
 		}
+	}
+	activeAfter, err := os.ReadFile(filepath.Join(home, release.ActiveFile))
+	if err != nil || !bytes.Equal(activeBefore, activeAfter) {
+		t.Fatalf("idempotent concurrent install changed active selection: %v", err)
 	}
 	var current Receipt
 	raw, err := os.ReadFile(filepath.Join(home, "current.json"))
@@ -337,6 +576,56 @@ func TestExistingReleaseRejectsChangedDescriptorIdentityWithoutReactivation(t *t
 	immutableAfter, _ := os.ReadFile(filepath.Join(home, "releases", first.BuildID, "receipt.json"))
 	if !bytes.Equal(currentBefore, currentAfter) || !bytes.Equal(immutableBefore, immutableAfter) {
 		t.Fatal("descriptor mismatch mutated current or immutable receipt")
+	}
+}
+
+func TestStageOnlyNeverReplacesAnExistingSelector(t *testing.T) {
+	root := t.TempDir()
+	archive, descriptor, signature := localFixture(t, root)
+	home := filepath.Join(root, "runtime")
+	options := Options{Home: home, Policy: localAcquisitionPolicy(), AllowUnsignedLocal: true}
+	if _, err := InstallFromLocalFiles(options, descriptor, signature, archive); err != nil {
+		t.Fatal(err)
+	}
+	selector := filepath.Join(home, "bin", "jobctrl")
+	before, err := os.ReadFile(selector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallFromLocalFiles(Options{Home: home, Policy: localAcquisitionPolicy(), AllowUnsignedLocal: true, StageOnly: true}, descriptor, signature, archive); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(selector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("stage-only acquisition replaced the existing stable selector")
+	}
+}
+
+func TestRejectedChannelMetadataLeavesReleaseAndSelectorUntouched(t *testing.T) {
+	root := t.TempDir()
+	archive, descriptorPath, signaturePath := localFixture(t, root)
+	home := filepath.Join(root, "runtime")
+	store, err := release.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordMetadata("local", 2, 0, "fixture-build-0002", strings.Repeat("d", 64), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := InstallFromLocalFiles(Options{Home: home, Policy: localAcquisitionPolicy(), AllowUnsignedLocal: true}, descriptorPath, signaturePath, archive); err == nil || !strings.Contains(err.Error(), "below recorded maximum") {
+		t.Fatalf("downgrade result = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "releases", "fixture-build-0001")); !os.IsNotExist(err) {
+		t.Fatalf("rejected metadata committed release: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "bin", "jobctrl")); !os.IsNotExist(err) {
+		t.Fatalf("rejected metadata changed selector: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, "active.json")); !os.IsNotExist(err) {
+		t.Fatalf("rejected metadata changed active pointer: %v", err)
 	}
 }
 
@@ -527,6 +816,7 @@ func writeZIP(t *testing.T, entries []zipEntry) string {
 func stableDescriptor(archiveURL string) Descriptor {
 	var descriptor Descriptor
 	descriptor.SchemaVersion, descriptor.Channel, descriptor.Sequence, descriptor.BuildID, descriptor.AppVersion = 1, "stable", 1, "fixture-build-0001", "2.0.0"
+	descriptor.MinimumSafeSequence, descriptor.RevokedBuildIDs = 1, []string{}
 	descriptor.Platform.ID, descriptor.Platform.OS, descriptor.Platform.Arch = "darwin-arm64", "darwin", "arm64"
 	descriptor.Artifact.URL, descriptor.Artifact.SHA256, descriptor.Artifact.SizeBytes, descriptor.Artifact.ArchiveType, descriptor.Artifact.ManifestSHA256 = archiveURL, strings.Repeat("a", 64), 1, "zip", strings.Repeat("b", 64)
 	return descriptor
@@ -592,6 +882,8 @@ func localFixture(t *testing.T, root string) (archivePath, descriptorPath, signa
 	}
 	descriptor := stableDescriptor("")
 	descriptor.Channel = "local"
+	descriptor.Artifact.URL = "file:///jobctrl-local-release/fixture.zip"
+	descriptor.MinimumSafeSequence, descriptor.RevokedBuildIDs = 0, []string{}
 	descriptor.Artifact.SHA256 = digestBytes(archiveBytes)
 	descriptor.Artifact.SizeBytes = int64(len(archiveBytes))
 	descriptor.Artifact.ManifestSHA256 = digestBytes(manifestRaw)

--- a/launcher/internal/launcher/homebrew_bootstrap.go
+++ b/launcher/internal/launcher/homebrew_bootstrap.go
@@ -1,0 +1,302 @@
+package launcher
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+// homebrewBootstrapConfig lives next to the formula-owned bootstrap binaries,
+// never inside a signed payload tree. Formula installation writes only this
+// prefix-owned directory; first invocation is the first time user state can be
+// created.
+type homebrewBootstrapConfig struct {
+	SchemaVersion    int    `json:"schemaVersion"`
+	DescriptorURL    string `json:"descriptorUrl"`
+	Descriptor       string `json:"descriptor"`
+	Signature        string `json:"signature"`
+	Archive          string `json:"archive"`
+	BuildID          string `json:"buildId"`
+	DescriptorSHA256 string `json:"descriptorSha256"`
+}
+
+var homebrewInstallerCommand = func(path string, args []string, env []string) (string, error) {
+	command := exec.Command(path, args...)
+	command.Env = env
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+var execPublicSelector = func(selector string, args, env []string) error {
+	return syscall.Exec(selector, append([]string{selector}, args...), env)
+}
+
+func maybeHomebrewBootstrap(executable string, args, inheritedEnv []string, stdout, stderr io.Writer) (bool, error) {
+	path, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return false, nil
+	}
+	path, err = filepath.Abs(path)
+	if err != nil || filepath.Base(path) != "jobctrl" {
+		return false, nil
+	}
+	root := filepath.Dir(path)
+	configPath := filepath.Join(root, "homebrew-bootstrap.json")
+	if _, err := os.Lstat(configPath); errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else if err != nil {
+		return true, err
+	}
+	var config homebrewBootstrapConfig
+	if err := decodeBootstrapConfig(configPath, &config); err != nil {
+		return true, err
+	}
+	if config.SchemaVersion != 1 || config.DescriptorURL == "" || !buildIDPattern.MatchString(config.BuildID) || !sha256Pattern.MatchString(config.DescriptorSHA256) || !safeRelativePath(config.Descriptor) || !safeRelativePath(config.Signature) || !safeRelativePath(config.Archive) {
+		return true, errors.New("invalid Homebrew bootstrap configuration")
+	}
+	for _, name := range []string{config.Descriptor, config.Signature, config.Archive} {
+		file := filepath.Join(root, name)
+		info, err := os.Lstat(file)
+		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return true, fmt.Errorf("Homebrew bootstrap resource %q is not a regular file", name)
+		}
+	}
+	// Config is prefix-owned, but bind its candidate identity to the exact
+	// bundled descriptor bytes before using the idempotent fast path.
+	descriptorRaw, err := os.ReadFile(filepath.Join(root, config.Descriptor))
+	if err != nil {
+		return true, err
+	}
+	digest := sha256.Sum256(descriptorRaw)
+	if hex.EncodeToString(digest[:]) != config.DescriptorSHA256 {
+		return true, errors.New("Homebrew bootstrap descriptor digest mismatch")
+	}
+	runtimeHome, err := runtimeHomeFromEnv(inheritedEnv)
+	if err != nil {
+		return true, err
+	}
+	store, err := release.Open(runtimeHome)
+	if err != nil {
+		return true, err
+	}
+	if len(args) > 0 && args[0] == "uninstall" {
+		if _, activeErr := store.ReadActive(); activeErr == nil {
+			if err := VerifyPublicSelectorForExecution(store.Home); err != nil {
+				return true, err
+			}
+			env := append(append([]string{}, inheritedEnv...), "JOBCTRL_HOMEBREW_FRONTEND=1")
+			return true, execPublicSelector(filepath.Join(store.Home, "bin", "jobctrl"), args, env)
+		} else if errors.Is(activeErr, os.ErrNotExist) {
+			instance, err := resolveInstance(inheritedEnv)
+			if err != nil {
+				return true, err
+			}
+			env := append(append([]string{}, inheritedEnv...), "JOBCTRL_HOMEBREW_FRONTEND=1")
+			return true, uninstall(launchContext{Executable: executable, Instance: instance, Environment: env}, args[1:], stdout)
+		} else {
+			return true, activeErr
+		}
+	}
+	if active, activeErr := store.ReadActive(); activeErr == nil && active.Receipt.Channel == "stable" && active.Receipt.BuildID == config.BuildID && active.Receipt.DescriptorSHA256 == config.DescriptorSHA256 && active.Receipt.DescriptorURL == config.DescriptorURL && VerifyPublicSelectorForExecution(store.Home) == nil {
+		return true, bootstrapPromoteOrExec(executable, args, inheritedEnv, stdout, stderr, store, active.Receipt)
+	}
+	// A merely prepositioned release directory never qualifies for the fast
+	// path. Authenticate via the formula cache before it can become selection.
+	installer := filepath.Join(root, "jobctrl-installer")
+	if info, err := os.Lstat(installer); err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return true, errors.New("Homebrew bootstrap installer is not a regular executable")
+	}
+	installerArgs := []string{
+		"--source", "homebrew", "--stage-only", "--home", store.Home,
+		"--descriptor-url", config.DescriptorURL,
+		"--descriptor-file", filepath.Join(root, config.Descriptor),
+		"--signature-file", filepath.Join(root, config.Signature),
+		"--archive-file", filepath.Join(root, config.Archive),
+	}
+	if output, err := homebrewInstallerCommand(installer, installerArgs, inheritedEnv); err != nil {
+		return true, fmt.Errorf("stage Homebrew release in user store: %w: %s", err, string(output))
+	}
+	candidate, err := readInstalledReceipt(store.Home, config.BuildID)
+	if err != nil {
+		return true, err
+	}
+	if candidate.Channel != "stable" || candidate.BuildID != config.BuildID || candidate.DescriptorSHA256 != config.DescriptorSHA256 {
+		return true, errors.New("Homebrew installer did not stage the exact stable descriptor-bound candidate")
+	}
+	return true, bootstrapPromoteOrExec(executable, args, inheritedEnv, stdout, stderr, store, candidate)
+}
+
+func decodeBootstrapConfig(path string, destination any) error {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("Homebrew bootstrap configuration is not a regular file")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return errors.New("Homebrew bootstrap configuration has trailing data")
+	}
+	return nil
+}
+
+func runtimeHomeFromEnv(env []string) (string, error) {
+	values := environmentMap(env)
+	if home := values["JOBCTRL_RUNTIME_HOME"]; home != "" {
+		return filepath.Abs(home)
+	}
+	if values["HOME"] == "" {
+		return "", errors.New("HOME is required for Homebrew bootstrap")
+	}
+	return filepath.Join(values["HOME"], "Library", "Application Support", "JobCtrl"), nil
+}
+
+func bootstrapPromoteOrExec(executable string, args, inheritedEnv []string, stdout, stderr io.Writer, store *release.Store, candidate release.Receipt) error {
+	promoted := false
+	var promotedContext launchContext
+	active, err := store.ReadActive()
+	if errors.Is(err, os.ErrNotExist) {
+		if err := bootstrapFirstInstall(store, candidate); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else if active.Receipt.BuildID != candidate.BuildID {
+		ctx, err := transitionContextForReceipt(inheritedEnv, store, candidate)
+		if err != nil {
+			return err
+		}
+		ctx.Environment = append(ctx.Environment, "JOBCTRL_ACQUISITION_SOURCE=homebrew")
+		if err := promoteExisting(ctx, store, active, candidate.BuildID, "update", stdout); err != nil {
+			return err
+		}
+		promoted, promotedContext = true, ctx
+	} else {
+		// The selector verifier below takes a shared selection lock. Keep this
+		// exact-candidate check scoped so its exclusive locks are released
+		// before we verify and exec the public selector.
+		if err := func() error {
+			transition, lockErr := store.TransitionLock()
+			if lockErr != nil {
+				return lockErr
+			}
+			defer transition.Close()
+			selection, lockErr := store.SelectionLock(true)
+			if lockErr != nil {
+				return lockErr
+			}
+			defer selection.Close()
+			active, lockErr = store.ReadActive()
+			if lockErr != nil {
+				return lockErr
+			}
+			if active.Receipt.BuildID != candidate.BuildID || active.Receipt.DescriptorSHA256 != candidate.DescriptorSHA256 {
+				return errors.New("Homebrew active release changed while acquiring selection; retry through the authenticated selector")
+			}
+			// A Homebrew-owned selection that already matches the authenticated
+			// formula candidate is the invocation fast path. Do not rewrite the
+			// active record (and advance its generation) for every command. A
+			// matching curl/migration selection still records its acquisition
+			// adoption once so later `jobctrl update` routes through Homebrew.
+			if active.Acquisition != "homebrew" {
+				if _, lockErr = store.WriteSelectedActive(active.Receipt, active.Generation, active.SelectorBuildID, "homebrew"); lockErr != nil {
+					return lockErr
+				}
+			}
+			return nil
+		}(); err != nil {
+			return err
+		}
+	}
+	if promoted && len(args) > 0 && args[0] == "start" {
+		foreground, noOpen, err := parseStartArgs(args[1:])
+		if err != nil {
+			return err
+		}
+		if foreground {
+			return errors.New("Homebrew upgrade already started the healthy candidate; rerun `jobctrl status` instead of requesting foreground supervision")
+		}
+		if !noOpen {
+			return openURL(promotedContext)
+		}
+		_, err = fmt.Fprintf(stdout, "JobCtrl is ready at http://127.0.0.1:%d\n", promotedContext.Manifest.Ports.API)
+		return err
+	}
+	selector := filepath.Join(store.Home, "bin", "jobctrl")
+	if err := VerifyPublicSelectorForExecution(store.Home); err != nil {
+		return fmt.Errorf("verify Homebrew public selector before execution: %w", err)
+	}
+	return execPublicSelector(selector, args, inheritedEnv)
+}
+
+func bootstrapFirstInstall(store *release.Store, candidate release.Receipt) error {
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return err
+	}
+	defer selection.Close()
+	if _, err := store.ReadActive(); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, candidate)
+	if err != nil {
+		return err
+	}
+	policy, err := readInstalledPolicy(store.Home, candidate)
+	if err != nil {
+		return err
+	}
+	journal, err := store.Begin("install", nil, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		return err
+	}
+	if err := advance(store, &journal, release.ReleaseCommitted); err != nil {
+		return err
+	}
+	journal.PendingPolicy = &policy
+	if err := advance(store, &journal, release.PolicyPending); err != nil {
+		return err
+	}
+	state, err := store.ValidateMetadata(policy)
+	if err != nil {
+		return err
+	}
+	if err := store.CommitMetadata(state); err != nil {
+		return err
+	}
+	if err := advance(store, &journal, release.PolicyFinalized); err != nil {
+		return err
+	}
+	if err := handoffPublicSelector(store.Home, verified); err != nil {
+		return err
+	}
+	if _, err := store.WriteSelectedActive(candidate, 0, candidate.BuildID, "homebrew"); err != nil {
+		return err
+	}
+	if err := writeLegacyCurrent(store.Home, candidate); err != nil {
+		return err
+	}
+	return advance(store, &journal, release.Promoted)
+}

--- a/launcher/internal/launcher/homebrew_bootstrap_test.go
+++ b/launcher/internal/launcher/homebrew_bootstrap_test.go
@@ -1,0 +1,593 @@
+package launcher
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+// TestHomebrewBootstrapSignedFirstRunFastPathAndCompatibleUpgrade exercises
+// the boundary exactly as a formula-installed bootstrap sees it. The formula
+// cache is deliberately treated as untrusted until the injected installer
+// boundary authenticates its descriptor and payload; everything after that
+// point is the real first-install, selector, and common promotion code.
+func TestHomebrewBootstrapSignedFirstRunFastPathAndCompatibleUpgrade(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is required for the common promotion fixture")
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setSignedHomebrewTrust(t, public)
+
+	initial := newSignedHomebrewBootstrapFixture(t, private, "stable-homebrew-build-0001", 1, 1, python)
+	upgrade := newSignedHomebrewBootstrapFixture(t, private, "stable-homebrew-build-0002", 2, 2, python)
+	formulaRoot := t.TempDir()
+	formulaExecutable := writeHomebrewBootstrapFormula(t, formulaRoot, initial)
+	runtimeHome, stateHome := t.TempDir(), t.TempDir()
+	stateDir := filepath.Join(stateHome, "state")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	seedHomebrewSQLitePair(t, python, stateDir)
+	environment := []string{
+		"HOME=" + t.TempDir(),
+		"JOBCTRL_RUNTIME_HOME=" + runtimeHome,
+		"JOBCTRL_DIR=" + stateDir,
+		"JOBCTRL_TEST_START_MARKER=" + filepath.Join(stateHome, "candidate-started"),
+	}
+
+	previousInstaller, previousExec := homebrewInstallerCommand, execPublicSelector
+	t.Cleanup(func() {
+		homebrewInstallerCommand, execPublicSelector = previousInstaller, previousExec
+	})
+	installerCalls := 0
+	homebrewInstallerCommand = authenticatedHomebrewFixtureInstaller(t, public, map[string]homebrewBootstrapFixture{
+		initial.descriptorSHA256: initial,
+		upgrade.descriptorSHA256: upgrade,
+	}, &installerCalls)
+	var selectorCalls []homebrewSelectorCall
+	execPublicSelector = func(selector string, args, env []string) error {
+		selectorCalls = append(selectorCalls, homebrewSelectorCall{selector: selector, args: append([]string(nil), args...)})
+		if !sameStringSet(env, environment) {
+			return errors.New("Homebrew selector execution changed the inherited environment")
+		}
+		return VerifyPublicSelectorForExecution(runtimeHome)
+	}
+
+	var stdout, stderr bytes.Buffer
+	bootstrapped, err := maybeHomebrewBootstrap(formulaExecutable, []string{"status"}, environment, &stdout, &stderr)
+	if !bootstrapped || err != nil {
+		t.Fatalf("first signed Homebrew invocation = bootstrapped:%v err:%v stdout=%q stderr=%q", bootstrapped, err, stdout.String(), stderr.String())
+	}
+	if installerCalls != 1 {
+		t.Fatalf("first invocation installer calls = %d, want 1", installerCalls)
+	}
+	assertHomebrewSelectorCalls(t, selectorCalls, runtimeHome, 1)
+	store, err := release.Open(runtimeHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active, err := store.ReadActive()
+	if err != nil || active.Receipt != initial.receipt || active.Acquisition != "homebrew" || active.SelectorBuildID != initial.receipt.BuildID {
+		t.Fatalf("first invocation active record = %#v, %v", active, err)
+	}
+	if channel, err := store.ReadChannelState("stable"); err != nil || channel.MaxSequence != initial.receipt.Sequence || channel.SequenceBuildIDs["1"] != initial.receipt.BuildID {
+		t.Fatalf("first invocation did not finalize signed stable policy: %#v, %v", channel, err)
+	}
+	if err := VerifyPublicSelectorForExecution(runtimeHome); err != nil {
+		t.Fatalf("first invocation selector is not executable: %v", err)
+	}
+	firstGeneration := active.Generation
+
+	bootstrapped, err = maybeHomebrewBootstrap(formulaExecutable, []string{"status"}, environment, &stdout, &stderr)
+	if !bootstrapped || err != nil {
+		t.Fatalf("second exact Homebrew invocation = bootstrapped:%v err:%v", bootstrapped, err)
+	}
+	if installerCalls != 1 {
+		t.Fatalf("idempotent fast path reinvoked the installer: %d calls", installerCalls)
+	}
+	assertHomebrewSelectorCalls(t, selectorCalls, runtimeHome, 2)
+	second, err := store.ReadActive()
+	if err != nil || second.Receipt != initial.receipt || second.SelectorBuildID != initial.receipt.BuildID || second.Acquisition != "homebrew" || second.Generation != firstGeneration {
+		t.Fatalf("fast path changed selected release identity: %#v, %v", second, err)
+	}
+
+	writeHomebrewBootstrapFormula(t, formulaRoot, upgrade)
+	bootstrapped, err = maybeHomebrewBootstrap(formulaExecutable, []string{"status"}, environment, &stdout, &stderr)
+	if !bootstrapped || err != nil {
+		t.Fatalf("compatible protocol-changing Homebrew upgrade = bootstrapped:%v err:%v stdout=%q stderr=%q", bootstrapped, err, stdout.String(), stderr.String())
+	}
+	if installerCalls != 2 {
+		t.Fatalf("upgrade installer calls = %d, want 2", installerCalls)
+	}
+	assertHomebrewSelectorCalls(t, selectorCalls, runtimeHome, 3)
+	active, err = store.ReadActive()
+	if err != nil || active.Receipt != upgrade.receipt || active.Acquisition != "homebrew" || active.SelectorBuildID != upgrade.receipt.BuildID {
+		t.Fatalf("common promotion did not select the upgraded release: %#v, %v", active, err)
+	}
+	journal, err := store.ReadJournal()
+	if err != nil || journal.Operation != "update" || journal.State != release.Promoted || journal.Old == nil || journal.Candidate == nil || *journal.Old != initial.receipt || *journal.Candidate != upgrade.receipt {
+		t.Fatalf("upgrade did not complete the common health-gated promotion journal: %#v, %v", journal, err)
+	}
+	started, err := os.ReadFile(filepath.Join(stateHome, "candidate-started"))
+	if err != nil || string(started) != "start --no-open\n" {
+		t.Fatalf("candidate launcher was not started by the common health gate: %q, %v", started, err)
+	}
+	selector, err := os.ReadFile(filepath.Join(runtimeHome, "bin", "jobctrl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateSelector, err := os.ReadFile(filepath.Join(runtimeHome, "releases", upgrade.receipt.BuildID, "payload", "launcher", "jobctrl"))
+	if err != nil || !bytes.Equal(selector, candidateSelector) {
+		t.Fatalf("compatible upgrade did not hand off the candidate public selector: %v", err)
+	}
+	if err := VerifyPublicSelectorForExecution(runtimeHome); err != nil {
+		t.Fatalf("upgraded public selector is not executable: %v", err)
+	}
+}
+
+func TestHomebrewBootstrapRejectsPreseededUnsignedLocalRelease(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setSignedHomebrewTrust(t, public)
+	fixture := newSignedHomebrewBootstrapFixture(t, private, "stable-homebrew-build-0010", 10, 1, "/usr/bin/python3")
+	formulaRoot := t.TempDir()
+	formulaExecutable := writeHomebrewBootstrapFormula(t, formulaRoot, fixture)
+	runtimeHome := t.TempDir()
+	store, err := release.Open(runtimeHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preseedUnsignedHomebrewRelease(t, runtimeHome, fixture)
+	if err := bootstrapFirstInstall(store, fixture.receipt); err == nil || !strings.Contains(err.Error(), "distribution channel") {
+		t.Fatalf("preseeded unsigned-local release was accepted by real first-install verification: %v", err)
+	}
+	if _, err := store.ReadActive(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected preseed unexpectedly became active: %v", err)
+	}
+
+	previousInstaller := homebrewInstallerCommand
+	t.Cleanup(func() { homebrewInstallerCommand = previousInstaller })
+	homebrewInstallerCommand = func(_ string, _ []string, _ []string) (string, error) {
+		if _, err := verifyInstalledReleaseForExecution(store, fixture.receipt); err == nil {
+			t.Fatal("preseeded unsigned-local release unexpectedly passed signed execution verification")
+		} else {
+			return "", fmt.Errorf("authenticated installer rejected preseeded release: %w", err)
+		}
+		return "", nil
+	}
+	bootstrapped, err := maybeHomebrewBootstrap(formulaExecutable, []string{"status"}, []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtimeHome}, io.Discard, io.Discard)
+	if !bootstrapped || err == nil || !strings.Contains(err.Error(), "authenticated installer rejected preseeded release") {
+		t.Fatalf("Homebrew bootstrap did not reject the preseeded unsigned-local release: bootstrapped:%v err:%v", bootstrapped, err)
+	}
+}
+
+func TestHomebrewBootstrapUninstallWithoutActiveReleaseDoesNotInstallFirst(t *testing.T) {
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	setSignedHomebrewTrust(t, public)
+	fixture := newSignedHomebrewBootstrapFixture(t, private, "stable-homebrew-build-0099", 99, 1, "/usr/bin/python3")
+	formulaExecutable := writeHomebrewBootstrapFormula(t, t.TempDir(), fixture)
+	runtimeHome, stateDir := t.TempDir(), t.TempDir()
+	preserved := filepath.Join(stateDir, "profile.json")
+	if err := os.WriteFile(preserved, []byte("preserve me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldInstaller, oldBrew := homebrewInstallerCommand, homebrewCommand
+	t.Cleanup(func() { homebrewInstallerCommand, homebrewCommand = oldInstaller, oldBrew })
+	homebrewInstallerCommand = func(_ string, _ []string, _ []string) (string, error) {
+		t.Fatal("uninstall without an active release invoked the acquisition installer")
+		return "", nil
+	}
+	brewCalls := 0
+	homebrewCommand = func(args ...string) (string, error) {
+		brewCalls++
+		if strings.Join(args, " ") != "uninstall ebarti/tap/jobctrl" {
+			t.Fatalf("unexpected Homebrew command: %v", args)
+		}
+		return "uninstalled\n", nil
+	}
+	environment := []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtimeHome, "JOBCTRL_DIR=" + stateDir}
+	var output bytes.Buffer
+	bootstrapped, err := maybeHomebrewBootstrap(formulaExecutable, []string{"uninstall"}, environment, &output, io.Discard)
+	if !bootstrapped || err != nil || brewCalls != 1 {
+		t.Fatalf("no-active Homebrew uninstall = bootstrapped:%v err:%v brewCalls:%d output:%q", bootstrapped, err, brewCalls, output.String())
+	}
+	if raw, err := os.ReadFile(preserved); err != nil || string(raw) != "preserve me" {
+		t.Fatalf("default no-active uninstall changed user data: %q, %v", raw, err)
+	}
+	store, err := release.Open(runtimeHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.ReadActive(); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("uninstall unexpectedly activated formula release: %v", err)
+	}
+}
+
+type homebrewBootstrapFixture struct {
+	buildID          string
+	descriptorURL    string
+	descriptorRaw    []byte
+	signatureRaw     []byte
+	archive          []byte
+	descriptorSHA256 string
+	payloadRoot      string
+	receipt          release.Receipt
+	policy           release.ChannelMetadata
+}
+
+type homebrewSelectorCall struct {
+	selector string
+	args     []string
+}
+
+type homebrewFixtureDescriptor struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Channel       string `json:"channel"`
+	Sequence      uint64 `json:"sequence"`
+	BuildID       string `json:"buildId"`
+	AppVersion    string `json:"appVersion"`
+	Artifact      struct {
+		URL            string `json:"url"`
+		SHA256         string `json:"sha256"`
+		SizeBytes      int64  `json:"sizeBytes"`
+		ArchiveType    string `json:"archiveType"`
+		ManifestSHA256 string `json:"manifestSha256"`
+	} `json:"artifact"`
+}
+
+type homebrewFixtureSignature struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Status        string `json:"status"`
+	Algorithm     string `json:"algorithm"`
+	KeyID         string `json:"keyId"`
+	Signature     string `json:"signature"`
+}
+
+func setSignedHomebrewTrust(t *testing.T, public ed25519.PublicKey) {
+	t.Helper()
+	previousChannel, previousKey := releaseChannel, releaseTrustKeyBase64
+	t.Cleanup(func() { releaseChannel, releaseTrustKeyBase64 = previousChannel, previousKey })
+	releaseChannel = "stable"
+	releaseTrustKeyBase64 = base64.StdEncoding.EncodeToString(public)
+	if policy, err := AcquisitionBuildPolicy(); err != nil || policy.ExpectedChannel != "stable" || policy.AllowUnsignedLocal || !policy.AllowNetwork {
+		t.Fatalf("injected signed Homebrew trust policy = %#v, %v", policy, err)
+	}
+}
+
+func newSignedHomebrewBootstrapFixture(t *testing.T, private ed25519.PrivateKey, buildID string, sequence uint64, launcherRuntimeProtocol int, python string) homebrewBootstrapFixture {
+	t.Helper()
+	payloadRoot, manifest := verifiedPayloadFixture(t)
+	launcher := "#!/bin/sh\nif [ \"$1\" = start ] && [ -n \"${JOBCTRL_TEST_START_MARKER:-}\" ]; then\n  printf '%s %s\\n' \"$1\" \"${2:-}\" > \"$JOBCTRL_TEST_START_MARKER\"\nfi\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(payloadRoot, "launcher", "jobctrl"), []byte(launcher), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runtime := strings.Replace(validRuntimeManifest, `"launcherProtocol":1`, fmt.Sprintf(`"launcherProtocol":%d`, launcherRuntimeProtocol), 1)
+	if err := os.WriteFile(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"), []byte(runtime), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pythonWrapper := "#!/bin/sh\nexec " + strconv.Quote(python) + " \"$@\"\n"
+	pythonPath := filepath.Join(payloadRoot, "python", "bin", "python3")
+	if err := os.MkdirAll(filepath.Dir(pythonPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pythonPath, []byte(pythonWrapper), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest.BuildID = buildID
+	manifest.ReleaseChannel = "stable"
+	manifest.LauncherCompatibility.Minimum, manifest.LauncherCompatibility.Maximum = 1, 2
+	manifest.Signing.ManifestKeyID = "jobctrl-release-v1"
+	manifest.Signing.CodeSigning = "developer-id"
+	manifest.Signing.Notarized = true
+	refreshFixtureManifest(t, payloadRoot, &manifest)
+	manifestRaw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestSignatureEncoded := base64.StdEncoding.EncodeToString(ed25519.Sign(private, signedMessage("jobctrl:manifest:v1\x00", manifestRaw)))
+	manifestSignatureRaw, err := json.Marshal(manifestSignature{SchemaVersion: 1, Status: "signed", ManifestAlgorithm: "ed25519", ManifestKeyID: "jobctrl-release-v1", Signature: &manifestSignatureEncoded, Promotable: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payloadRoot, "manifest.json"), manifestRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payloadRoot, "manifest.sig"), manifestSignatureRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifestDigest := sha256.Sum256(manifestRaw)
+	archive := []byte("signed Homebrew cache fixture for " + buildID + "\n")
+	archiveDigest := sha256.Sum256(archive)
+	descriptorURL := "https://releases.example.test/v1/stable/darwin-arm64.json"
+	descriptor := homebrewFixtureDescriptor{SchemaVersion: 1, Channel: "stable", Sequence: sequence, BuildID: buildID, AppVersion: "2.0.0"}
+	descriptor.Artifact.URL = "https://releases.example.test/v1/stable/" + buildID + ".zip"
+	descriptor.Artifact.SHA256 = hex.EncodeToString(archiveDigest[:])
+	descriptor.Artifact.SizeBytes = int64(len(archive))
+	descriptor.Artifact.ArchiveType = "zip"
+	descriptor.Artifact.ManifestSHA256 = hex.EncodeToString(manifestDigest[:])
+	// Keep the descriptor in the same exact public shape the cached installer
+	// receives, including its minimum-safe and revocation policy fields.
+	descriptorEnvelope := map[string]any{
+		"schemaVersion": 1, "channel": "stable", "sequence": sequence, "minimumSafeSequence": sequence, "revokedBuildIds": []string{}, "buildId": buildID, "appVersion": "2.0.0",
+		"platform": map[string]any{"id": "darwin-arm64", "os": "darwin", "arch": "arm64"},
+		"artifact": map[string]any{"url": descriptor.Artifact.URL, "sha256": descriptor.Artifact.SHA256, "sizeBytes": descriptor.Artifact.SizeBytes, "archiveType": descriptor.Artifact.ArchiveType, "manifestSha256": descriptor.Artifact.ManifestSHA256},
+	}
+	descriptorRaw, err := json.Marshal(descriptorEnvelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptorSignature := base64.StdEncoding.EncodeToString(ed25519.Sign(private, signedMessage("jobctrl:release-descriptor:v1\x00", descriptorRaw)))
+	signatureRaw, err := json.Marshal(homebrewFixtureSignature{SchemaVersion: 1, Status: "signed", Algorithm: "ed25519", KeyID: "jobctrl-release-v1", Signature: descriptorSignature})
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptorDigest := sha256.Sum256(descriptorRaw)
+	policy := release.ChannelMetadata{Channel: "stable", Sequence: sequence, Minimum: sequence, BuildID: buildID, DescriptorDigest: hex.EncodeToString(descriptorDigest[:]), Revoked: []string{}}
+	fixture := homebrewBootstrapFixture{
+		buildID: buildID, descriptorURL: descriptorURL, descriptorRaw: descriptorRaw, signatureRaw: signatureRaw, archive: archive,
+		descriptorSHA256: hex.EncodeToString(descriptorDigest[:]), payloadRoot: payloadRoot,
+		receipt: release.Receipt{SchemaVersion: 2, BuildID: buildID, Channel: "stable", Sequence: sequence, ArtifactSHA256: descriptor.Artifact.SHA256, ManifestSHA256: hex.EncodeToString(manifestDigest[:]), DescriptorSHA256: hex.EncodeToString(descriptorDigest[:]), PolicySHA256: lifecyclePolicyDigest(t, policy), DescriptorURL: descriptorURL, InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)},
+		policy:  policy,
+	}
+	return fixture
+}
+
+func writeHomebrewBootstrapFormula(t *testing.T, root string, fixture homebrewBootstrapFixture) string {
+	t.Helper()
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	executable := filepath.Join(root, "jobctrl")
+	if err := os.WriteFile(executable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installer := filepath.Join(root, "jobctrl-installer")
+	if err := os.WriteFile(installer, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, contents := range map[string][]byte{"descriptor.json": fixture.descriptorRaw, "descriptor.json.sig": fixture.signatureRaw, "archive.zip": fixture.archive} {
+		if err := os.WriteFile(filepath.Join(root, name), contents, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	config, err := json.Marshal(homebrewBootstrapConfig{SchemaVersion: 1, DescriptorURL: fixture.descriptorURL, Descriptor: "descriptor.json", Signature: "descriptor.json.sig", Archive: "archive.zip", BuildID: fixture.buildID, DescriptorSHA256: fixture.descriptorSHA256})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "homebrew-bootstrap.json"), config, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return executable
+}
+
+func authenticatedHomebrewFixtureInstaller(t *testing.T, public ed25519.PublicKey, fixtures map[string]homebrewBootstrapFixture, calls *int) func(string, []string, []string) (string, error) {
+	t.Helper()
+	return func(path string, args []string, env []string) (string, error) {
+		*calls++
+		if filepath.Base(path) != "jobctrl-installer" || homebrewArgument(args, "--source") != "homebrew" || !homebrewHasArgument(args, "--stage-only") {
+			return "", fmt.Errorf("unexpected Homebrew installer boundary invocation: %s %v", path, args)
+		}
+		if environmentMap(env)["JOBCTRL_RUNTIME_HOME"] == "" {
+			return "", errors.New("Homebrew installer lost its runtime-home environment")
+		}
+		descriptorPath, signaturePath, archivePath, home := homebrewArgument(args, "--descriptor-file"), homebrewArgument(args, "--signature-file"), homebrewArgument(args, "--archive-file"), homebrewArgument(args, "--home")
+		descriptorRaw, err := os.ReadFile(descriptorPath)
+		if err != nil {
+			return "", err
+		}
+		digest := sha256.Sum256(descriptorRaw)
+		fixture, exists := fixtures[hex.EncodeToString(digest[:])]
+		if !exists || homebrewArgument(args, "--descriptor-url") != fixture.descriptorURL {
+			return "", errors.New("Homebrew installer received an unknown descriptor-bound candidate")
+		}
+		signatureRaw, err := os.ReadFile(signaturePath)
+		if err != nil || !bytes.Equal(descriptorRaw, fixture.descriptorRaw) || !bytes.Equal(signatureRaw, fixture.signatureRaw) {
+			return "", errors.New("Homebrew installer cache files do not match the signed fixture")
+		}
+		archive, err := os.ReadFile(archivePath)
+		if err != nil || !bytes.Equal(archive, fixture.archive) {
+			return "", errors.New("Homebrew installer archive cache does not match the signed fixture")
+		}
+		if err := verifyHomebrewFixtureDescriptor(public, fixture); err != nil {
+			return "", err
+		}
+		if _, err := VerifyDistributionPayload(fixture.payloadRoot, DistributionTrust{PublicKeys: map[string]ed25519.PublicKey{"jobctrl-release-v1": public}, ExpectedChannel: "stable"}); err != nil {
+			return "", fmt.Errorf("authenticate signed Homebrew payload: %w", err)
+		}
+		if err := stageHomebrewFixture(home, fixture, public); err != nil {
+			return "", err
+		}
+		return "staged " + fixture.buildID, nil
+	}
+}
+
+func verifyHomebrewFixtureDescriptor(public ed25519.PublicKey, fixture homebrewBootstrapFixture) error {
+	var descriptor homebrewFixtureDescriptor
+	if err := json.Unmarshal(fixture.descriptorRaw, &descriptor); err != nil {
+		return err
+	}
+	var signature homebrewFixtureSignature
+	if err := json.Unmarshal(fixture.signatureRaw, &signature); err != nil {
+		return err
+	}
+	encoded, err := base64.StdEncoding.DecodeString(signature.Signature)
+	if err != nil || signature.SchemaVersion != 1 || signature.Status != "signed" || signature.Algorithm != "ed25519" || signature.KeyID != "jobctrl-release-v1" || !ed25519.Verify(public, signedMessage("jobctrl:release-descriptor:v1\x00", fixture.descriptorRaw), encoded) {
+		return errors.New("Homebrew fixture descriptor is not signed by injected release trust")
+	}
+	archiveDigest := sha256.Sum256(fixture.archive)
+	if descriptor.SchemaVersion != 1 || descriptor.Channel != "stable" || descriptor.Sequence != fixture.receipt.Sequence || descriptor.BuildID != fixture.receipt.BuildID || descriptor.AppVersion != "2.0.0" || descriptor.Artifact.URL == "" || descriptor.Artifact.ArchiveType != "zip" || descriptor.Artifact.SizeBytes != int64(len(fixture.archive)) || descriptor.Artifact.SHA256 != hex.EncodeToString(archiveDigest[:]) || descriptor.Artifact.ManifestSHA256 != fixture.receipt.ManifestSHA256 {
+		return errors.New("Homebrew fixture descriptor does not bind the stable receipt and archive")
+	}
+	return nil
+}
+
+func stageHomebrewFixture(home string, fixture homebrewBootstrapFixture, public ed25519.PublicKey) error {
+	store, err := release.Open(home)
+	if err != nil {
+		return err
+	}
+	destination := filepath.Join(store.Home, "releases", fixture.receipt.BuildID)
+	if err := os.Mkdir(destination, 0o700); err != nil {
+		return fmt.Errorf("create staged release: %w", err)
+	}
+	if err := copyHomebrewFixtureTree(fixture.payloadRoot, filepath.Join(destination, "payload")); err != nil {
+		return err
+	}
+	if _, err := VerifyDistributionPayload(filepath.Join(destination, "payload"), DistributionTrust{PublicKeys: map[string]ed25519.PublicKey{"jobctrl-release-v1": public}, ExpectedChannel: "stable"}); err != nil {
+		return fmt.Errorf("verify staged signed Homebrew payload: %w", err)
+	}
+	if err := writeJSONAtomic(filepath.Join(destination, "receipt.json"), selectorReceipt{SchemaVersion: fixture.receipt.SchemaVersion, BuildID: fixture.receipt.BuildID, Channel: fixture.receipt.Channel, Sequence: int64(fixture.receipt.Sequence), ArtifactSHA256: fixture.receipt.ArtifactSHA256, ManifestSHA256: fixture.receipt.ManifestSHA256, DescriptorSHA256: fixture.receipt.DescriptorSHA256, PolicySHA256: fixture.receipt.PolicySHA256, DescriptorURL: fixture.receipt.DescriptorURL, InstalledAt: fixture.receipt.InstalledAt}); err != nil {
+		return err
+	}
+	return writeJSONAtomic(filepath.Join(destination, "policy.json"), fixture.policy)
+}
+
+func copyHomebrewFixtureTree(source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := destination
+		if relative != "." {
+			target = filepath.Join(destination, relative)
+		}
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o700)
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, target)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		output, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+		if err == nil {
+			_, err = io.Copy(output, input)
+		}
+		closeOutput, closeInput := output.Close(), input.Close()
+		if err != nil {
+			return err
+		}
+		if closeOutput != nil {
+			return closeOutput
+		}
+		return closeInput
+	})
+}
+
+func preseedUnsignedHomebrewRelease(t *testing.T, home string, fixture homebrewBootstrapFixture) {
+	t.Helper()
+	payload, manifest := verifiedPayloadFixture(t)
+	manifest.BuildID = fixture.buildID
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "jobctrl"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "runtime-manifest.json"), []byte(validRuntimeManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, payload, &manifest)
+	writeLocalEnvelope(t, payload, manifest)
+	destination := filepath.Join(home, "releases", fixture.buildID)
+	if err := os.Mkdir(destination, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyHomebrewFixtureTree(payload, filepath.Join(destination, "payload")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(destination, "receipt.json"), selectorReceipt{SchemaVersion: fixture.receipt.SchemaVersion, BuildID: fixture.receipt.BuildID, Channel: fixture.receipt.Channel, Sequence: int64(fixture.receipt.Sequence), ArtifactSHA256: fixture.receipt.ArtifactSHA256, ManifestSHA256: fixture.receipt.ManifestSHA256, DescriptorSHA256: fixture.receipt.DescriptorSHA256, PolicySHA256: fixture.receipt.PolicySHA256, DescriptorURL: fixture.receipt.DescriptorURL, InstalledAt: fixture.receipt.InstalledAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(destination, "policy.json"), fixture.policy); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedHomebrewSQLitePair(t *testing.T, python, state string) {
+	t.Helper()
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.commit()"
+		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput(); err != nil {
+			t.Fatalf("seed %s: %v %s", name, err, output)
+		}
+	}
+}
+
+func assertHomebrewSelectorCalls(t *testing.T, calls []homebrewSelectorCall, home string, want int) {
+	t.Helper()
+	if len(calls) != want {
+		t.Fatalf("selector calls = %d, want %d", len(calls), want)
+	}
+	call := calls[len(calls)-1]
+	if call.selector != filepath.Join(home, "bin", "jobctrl") || !sameStringSet(call.args, []string{"status"}) {
+		t.Fatalf("selector call = %#v", call)
+	}
+}
+
+func homebrewArgument(args []string, name string) string {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == name {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func homebrewHasArgument(args []string, name string) bool {
+	for _, argument := range args {
+		if argument == name {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStringSet(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/launcher/internal/launcher/launcher.go
+++ b/launcher/internal/launcher/launcher.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
 )
 
 var (
@@ -153,8 +155,10 @@ type selectorReceipt struct {
 	ArtifactSHA256   string `json:"artifactSha256"`
 	ManifestSHA256   string `json:"manifestSha256"`
 	DescriptorSHA256 string `json:"descriptorSha256"`
+	PolicySHA256     string `json:"policySha256,omitempty"`
 	DescriptorURL    string `json:"descriptorUrl"`
 	InstalledAt      string `json:"installedAt"`
+	Source           string `json:"source,omitempty"`
 }
 
 // DistributionManifest is the native release-payload contract shared by the
@@ -254,6 +258,7 @@ type launchContext struct {
 	Distribution distributionManifest
 	Instance     instance
 	Environment  []string
+	selection    *release.Lock
 }
 type readyMessage struct {
 	Error string `json:"error,omitempty"`
@@ -271,14 +276,40 @@ var startCommand = executeStart
 // Run is the only public CLI entrypoint. __supervise is reachable only through
 // the re-exec made by `jobctrl start`.
 func Run(executable string, args, inheritedEnv []string, stdout, stderr io.Writer) error {
+	if len(args) > 0 && args[0] == "rollback" {
+		if handled, recoveryErr := recoverRevokedTransitionBeforePrepare(inheritedEnv, stdout); handled {
+			return recoveryErr
+		}
+		if handled, recoveryErr := recoverInterruptedTransitionBeforeBootstrap(inheritedEnv, stdout); handled {
+			return recoveryErr
+		}
+	}
+	if handled, uninstallErr := uninstallUnsafeActiveBeforePrepare(args, inheritedEnv, stdout); handled {
+		return uninstallErr
+	}
+	if bootstrapped, bootstrapErr := maybeHomebrewBootstrap(executable, args, inheritedEnv, stdout, stderr); bootstrapped {
+		return bootstrapErr
+	}
 	ctx, err := prepare(executable, inheritedEnv)
 	if err != nil {
 		return err
+	}
+	defer func() { _ = ctx.selection.Close() }()
+	if store, storeErr := release.Open(ctx.Instance.RuntimeHome); storeErr == nil {
+		if journal, journalErr := store.ReadJournal(); journalErr == nil && journal.Resumable() && !transitionRecoveryCommand(args) {
+			return fmt.Errorf("unfinished %s transition at %s; run `jobctrl rollback` to recover before starting or dispatching commands", journal.Operation, journal.State)
+		} else if journalErr != nil && !errors.Is(journalErr, os.ErrNotExist) {
+			return fmt.Errorf("read release transition journal: %w", journalErr)
+		}
 	}
 	if len(args) > 0 && args[0] == "__supervise" {
 		return supervise(ctx, readyWriterFromEnv(inheritedEnv))
 	}
 	return dispatchCommand(ctx, args, stdout, stderr)
+}
+
+func transitionRecoveryCommand(args []string) bool {
+	return len(args) > 0 && (args[0] == "rollback" || args[0] == "uninstall")
 }
 
 // dispatchCommand keeps the one-release dev compatibility alias on the exact
@@ -324,6 +355,14 @@ func dispatchCommand(ctx launchContext, args []string, stdout, stderr io.Writer)
 			return err
 		}
 		return version(ctx, stdout, jsonOutput)
+	case "update":
+		return update(ctx, args[1:], stdout)
+	case "rollback":
+		return rollback(ctx, args[1:], stdout)
+	case "backup":
+		return backup(ctx, args[1:], stdout)
+	case "uninstall":
+		return uninstall(ctx, args[1:], stdout)
 	default:
 		return dispatchPython(ctx, args)
 	}
@@ -360,7 +399,7 @@ func ExitCode(err error) int {
 	return 1
 }
 func printHelp(out io.Writer) {
-	fmt.Fprint(out, "JobCtrl bundled launcher\n\nUsage:\n  jobctrl start [--no-open] [--foreground]\n  jobctrl dev [--no-open] [--foreground]  (deprecated alias for start)\n  jobctrl stop\n  jobctrl status [--pipeline] [--json]\n  jobctrl logs [temporal|worker|api]\n  jobctrl open\n  jobctrl version [--json]\n  jobctrl pipeline-status\n  jobctrl <Python domain command>\n")
+	fmt.Fprint(out, "JobCtrl bundled launcher\n\nUsage:\n  jobctrl start [--no-open] [--foreground]\n  jobctrl dev [--no-open] [--foreground]  (deprecated alias for start)\n  jobctrl stop\n  jobctrl status [--pipeline] [--json]\n  jobctrl logs [temporal|worker|api]\n  jobctrl open\n  jobctrl version [--json]\n  jobctrl update\n  jobctrl rollback [--to BUILD_ID]\n  jobctrl backup [--output DIRECTORY]\n  jobctrl uninstall [--remove-data]\n  jobctrl pipeline-status\n  jobctrl <Python domain command>\n")
 }
 func parseStartArgs(args []string) (foreground, noOpen bool, err error) {
 	for _, arg := range args {
@@ -395,13 +434,24 @@ func parseVersionArgs(args []string) (bool, error) {
 }
 
 func prepare(executable string, inheritedEnv []string) (launchContext, error) {
-	payloadRoot, receipt, err := locatePayloadRoot(executable, inheritedEnv)
+	payloadRoot, receipt, selection, err := locatePayloadRootLocked(executable, inheritedEnv)
 	if err != nil {
 		return launchContext{}, err
 	}
+	keepSelection := false
+	defer func() {
+		if !keepSelection && selection != nil {
+			_ = selection.Close()
+		}
+	}()
 	distribution, err := loadAndVerifyDistributionManifest(payloadRoot)
 	if err != nil {
 		return launchContext{}, err
+	}
+	if receipt == nil && distribution.ReleaseChannel != "local" {
+		if err := verifyDirectTransitionExecution(payloadRoot, distribution, inheritedEnv); err != nil {
+			return launchContext{}, err
+		}
 	}
 	if receipt != nil {
 		if err := verifySelectorReceipt(payloadRoot, distribution, *receipt); err != nil {
@@ -419,48 +469,223 @@ func prepare(executable string, inheritedEnv []string) (launchContext, error) {
 	if err != nil {
 		return launchContext{}, err
 	}
-	return launchContext{executable, payloadRoot, manifest, distribution, inst, childEnvironment(inheritedEnv, payloadRoot, inst.StateDir, manifest)}, nil
+	keepSelection = true
+	return launchContext{executable, payloadRoot, manifest, distribution, inst, childEnvironment(inheritedEnv, payloadRoot, inst.StateDir, manifest), selection}, nil
 }
+
+// Stable and prerelease payload launchers are never a second public command
+// surface. They may execute only from a durable, authenticated transition
+// journal; local standalone fixtures retain their contributor-only direct
+// invocation path.
+func verifyDirectTransitionExecution(payloadRoot string, distribution distributionManifest, env []string) error {
+	values := environmentMap(env)
+	journalID := values["JOBCTRL_TRANSITION_JOURNAL"]
+	if journalID == "" {
+		return errors.New("signed payload launchers may execute only through the authenticated public selector")
+	}
+	home, err := runtimeHomeFromEnv(env)
+	if err != nil {
+		return err
+	}
+	store, err := release.Open(home)
+	if err != nil {
+		return err
+	}
+	journal, err := store.ReadJournal()
+	if err != nil || journal.ID != journalID {
+		return errors.New("payload transition authorization does not match a durable journal")
+	}
+	var expected *release.Receipt
+	switch journal.State {
+	case release.CandidateStarting:
+		expected = journal.Candidate
+	case release.RollbackRestoring:
+		expected = journal.Old
+	default:
+		return errors.New("payload transition authorization is not in an executable state")
+	}
+	if expected == nil || expected.BuildID != distribution.BuildID || expected.Channel != distribution.ReleaseChannel {
+		return errors.New("payload does not match authorized transition release")
+	}
+	if err := store.Permit(*expected); err != nil {
+		return fmt.Errorf("authorized transition release is no longer permitted: %w", err)
+	}
+	digest, err := sha256Path(filepath.Join(payloadRoot, "manifest.json"))
+	if err != nil || digest != expected.ManifestSHA256 {
+		return errors.New("authorized transition manifest differs from immutable receipt")
+	}
+	return nil
+}
+
+// locatePayloadRoot is retained as an inspection-compatible seam. The actual
+// launcher holds the selection lock through its start/readiness boundary.
 func locatePayloadRoot(executable string, inheritedEnv []string) (string, *selectorReceipt, error) {
+	payload, receipt, lock, err := locatePayloadRootLocked(executable, inheritedEnv)
+	if lock != nil {
+		_ = lock.Close()
+	}
+	return payload, receipt, err
+}
+
+func locatePayloadRootLocked(executable string, inheritedEnv []string) (string, *selectorReceipt, *release.Lock, error) {
 	path, err := filepath.EvalSymlinks(executable)
 	if err != nil {
-		return "", nil, fmt.Errorf("resolve launcher executable: %w", err)
+		return "", nil, nil, fmt.Errorf("resolve launcher executable: %w", err)
 	}
 	path, err = filepath.Abs(path)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
 	if filepath.Base(path) == "jobctrl" && filepath.Base(filepath.Dir(path)) == "launcher" {
-		return filepath.Dir(filepath.Dir(path)), nil, nil
+		return filepath.Dir(filepath.Dir(path)), nil, nil, nil
 	}
 	values := environmentMap(inheritedEnv)
 	home := values["JOBCTRL_RUNTIME_HOME"]
 	if home == "" {
 		if values["HOME"] == "" {
-			return "", nil, errors.New("HOME is required to resolve the installed JobCtrl selector")
+			return "", nil, nil, errors.New("HOME is required to resolve the installed JobCtrl selector")
 		}
 		home = filepath.Join(values["HOME"], "Library", "Application Support", "JobCtrl")
 	}
 	home, err = filepath.Abs(home)
 	if err != nil {
-		return "", nil, err
+		return "", nil, nil, err
 	}
-	home, err = filepath.EvalSymlinks(home)
+	store, err := release.Open(home)
 	if err != nil {
-		return "", nil, fmt.Errorf("canonicalize JobCtrl runtime home: %w", err)
+		return "", nil, nil, fmt.Errorf("open JobCtrl release store: %w", err)
+	}
+	// Open has already rejected a symlinked management root. Canonicalizing now
+	// also normalizes macOS's system /var -> /private/var alias before comparing
+	// the kernel executable path with the stable selector path.
+	home, err = filepath.EvalSymlinks(store.Home)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("canonicalize JobCtrl runtime home: %w", err)
+	}
+	store.Home = home
+	lock, err := store.SelectionLock(false)
+	if err != nil {
+		return "", nil, nil, fmt.Errorf("acquire release selection lock: %w", err)
+	}
+	fail := func(cause error) (string, *selectorReceipt, *release.Lock, error) {
+		_ = lock.Close()
+		return "", nil, nil, cause
 	}
 	selector := filepath.Join(home, "bin", "jobctrl")
 	if path != selector {
-		return "", nil, fmt.Errorf("launcher must be installed as <payload>/launcher/jobctrl or the JobCtrl runtime selector, got %q", path)
+		return fail(fmt.Errorf("launcher must be installed as <payload>/launcher/jobctrl or the JobCtrl runtime selector, got %q", path))
 	}
-	var current selectorReceipt
-	if err := decodeStrictRegular(filepath.Join(home, "current.json"), &current); err != nil {
-		return "", nil, fmt.Errorf("read installed JobCtrl selector: %w", err)
+	active, err := store.ReadActive()
+	hasActiveRecord := err == nil
+	if err != nil {
+		// A P4 store has no active record. Read its legacy receipt only as a
+		// one-time migration source; P5 never uses it as a selector pointer.
+		var legacy selectorReceipt
+		if legacyErr := decodeStrictRegular(filepath.Join(home, "current.json"), &legacy); legacyErr != nil {
+			return fail(fmt.Errorf("read installed JobCtrl selector: %w", err))
+		}
+		active = release.Active{SchemaVersion: 1, Generation: 1, Receipt: release.Receipt{SchemaVersion: legacy.SchemaVersion, BuildID: legacy.BuildID, Channel: legacy.Channel, Sequence: uint64(legacy.Sequence), ArtifactSHA256: legacy.ArtifactSHA256, ManifestSHA256: legacy.ManifestSHA256, DescriptorSHA256: legacy.DescriptorSHA256, PolicySHA256: legacy.PolicySHA256, DescriptorURL: legacy.DescriptorURL, InstalledAt: legacy.InstalledAt}, SelectorBuildID: legacy.BuildID, Acquisition: legacy.Source}
 	}
-	if current.SchemaVersion != 1 || !buildIDPattern.MatchString(current.BuildID) || (current.Channel != "local" && current.Channel != "stable" && current.Channel != "prerelease") || current.Sequence < 1 || !sha256Pattern.MatchString(current.ArtifactSHA256) || !sha256Pattern.MatchString(current.ManifestSHA256) || !sha256Pattern.MatchString(current.DescriptorSHA256) {
-		return "", nil, errors.New("installed JobCtrl selector receipt is invalid")
+	current := selectorReceipt{SchemaVersion: active.Receipt.SchemaVersion, BuildID: active.Receipt.BuildID, Channel: active.Receipt.Channel, Sequence: int64(active.Receipt.Sequence), ArtifactSHA256: active.Receipt.ArtifactSHA256, ManifestSHA256: active.Receipt.ManifestSHA256, DescriptorSHA256: active.Receipt.DescriptorSHA256, PolicySHA256: active.Receipt.PolicySHA256, DescriptorURL: active.Receipt.DescriptorURL, InstalledAt: active.Receipt.InstalledAt}
+	if err := store.Permit(active.Receipt); err != nil {
+		return fail(fmt.Errorf("active release is no longer safe to launch: %w", err))
 	}
-	return filepath.Join(home, "releases", current.BuildID, "payload"), &current, nil
+	if hasActiveRecord {
+		if _, verifyErr := verifyInstalledReleaseForExecution(store, active.Receipt); verifyErr != nil {
+			return fail(fmt.Errorf("active release immutable evidence is not executable: %w", verifyErr))
+		}
+	}
+	versionValid := (current.SchemaVersion == 1 && current.PolicySHA256 == "") || (current.SchemaVersion == 2 && sha256Pattern.MatchString(current.PolicySHA256))
+	if !versionValid || !buildIDPattern.MatchString(current.BuildID) || (current.Channel != "local" && current.Channel != "stable" && current.Channel != "prerelease") || current.Sequence < 1 || !sha256Pattern.MatchString(current.ArtifactSHA256) || !sha256Pattern.MatchString(current.ManifestSHA256) || !sha256Pattern.MatchString(current.DescriptorSHA256) {
+		return fail(errors.New("installed JobCtrl selector receipt is invalid"))
+	}
+	if hasActiveRecord {
+		if err := verifyPublicSelector(home, selector, active); err != nil {
+			return fail(err)
+		}
+	}
+	return filepath.Join(home, "releases", current.BuildID, "payload"), &current, lock, nil
+}
+
+// verifyPublicSelector proves the stable executable is byte-for-byte the
+// launcher committed by its own immutable signed payload. active.json names
+// this selector separately from the selected payload because a compatible
+// newer selector may intentionally continue supervising an older payload
+// after a failed promotion.
+func verifyPublicSelector(home, selector string, active release.Active) error {
+	builds := []string{active.SelectorBuildID}
+	store, err := release.Open(home)
+	if err == nil {
+		if journal, journalErr := store.ReadJournal(); journalErr == nil && journal.Resumable() && journal.Candidate != nil && (journal.State == release.SelectorHandoffPending || journal.State == release.SelectorReplaced) {
+			// Between durable selector replacement and active-record handoff the
+			// journal is the recovery authority. Both candidate and old selector
+			// must be accepted only if their exact signed executable matches.
+			builds = append(builds, journal.Candidate.BuildID)
+		}
+	}
+	for _, build := range builds {
+		if selectorMatchesRelease(store, selector, build) {
+			return nil
+		}
+	}
+	return errors.New("public selector executable does not match an authenticated compatible selector release")
+}
+
+func selectorMatchesRelease(store *release.Store, selector, build string) bool {
+	if build == "" {
+		return false
+	}
+	receipt, err := readInstalledReceipt(store.Home, build)
+	if err != nil {
+		return false
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, receipt)
+	if err != nil || !protocolSupports(verified.distribution, launcherProtocol) {
+		return false
+	}
+	expected, err := manifestExecutableDigest(verified.distribution, "launcher/jobctrl")
+	if err != nil {
+		return false
+	}
+	info, err := os.Lstat(selector)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0o111 == 0 {
+		return false
+	}
+	actual, err := sha256Path(selector)
+	return err == nil && actual == expected
+}
+
+// VerifyPublicSelectorForExecution is the narrow acquisition boundary used by
+// curl/Homebrew bootstrap code immediately before it execs the user-store
+// selector. It rejects a symlink, tampered regular file, unsafe active receipt,
+// or selector/active protocol mismatch before any untrusted bytes execute.
+func VerifyPublicSelectorForExecution(home string) error {
+	store, err := release.Open(home)
+	if err != nil {
+		return err
+	}
+	lock, err := store.SelectionLock(false)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+	active, err := store.ReadActive()
+	if err != nil {
+		return err
+	}
+	if err := store.Permit(active.Receipt); err != nil {
+		return err
+	}
+	return verifyPublicSelector(store.Home, filepath.Join(store.Home, "bin", "jobctrl"), active)
+}
+
+func manifestExecutableDigest(manifest distributionManifest, path string) (string, error) {
+	for _, file := range manifest.Files {
+		if file.Path == path && file.Type == "file" && file.Mode == "0755" {
+			return file.SHA256, nil
+		}
+	}
+	return "", fmt.Errorf("manifest does not declare executable %q", path)
 }
 
 func verifySelectorReceipt(payloadRoot string, manifest distributionManifest, current selectorReceipt) error {
@@ -533,11 +758,30 @@ func isPrintableASCII(value string) bool {
 }
 
 func loadRuntimeManifest(path string) (runtimeManifest, error) {
+	return loadRuntimeManifestShape(path)
+}
+
+// loadRuntimeManifestForProtocol keeps the structural contract independent of
+// the running launcher binary. The lifecycle reads a staged launcher's own
+// protocol before replacing bin/jobctrl, so it can prove the replacement can
+// supervise both the old and candidate payloads.
+func loadRuntimeManifestForProtocol(path string, protocol int) (runtimeManifest, error) {
+	manifest, err := loadRuntimeManifestShape(path)
+	if err != nil {
+		return manifest, err
+	}
+	if manifest.LauncherProtocol != protocol {
+		return manifest, errors.New("unsupported runtime manifest protocol")
+	}
+	return manifest, nil
+}
+
+func loadRuntimeManifestShape(path string) (runtimeManifest, error) {
 	var manifest runtimeManifest
 	if err := decodeStrict(path, &manifest); err != nil {
 		return manifest, err
 	}
-	if manifest.SchemaVersion != 1 || manifest.LauncherProtocol != launcherProtocol {
+	if manifest.SchemaVersion != 1 || manifest.LauncherProtocol < 1 {
 		return manifest, errors.New("unsupported runtime manifest protocol")
 	}
 	if manifest.Ports.TemporalGRPC != 7233 || manifest.Ports.TemporalUI != 8233 || manifest.Ports.API != 8766 {
@@ -1465,6 +1709,14 @@ func supervise(ctx launchContext, ready io.Writer) (result error) {
 		return err
 	}
 	sendReady(ready, nil)
+	// The shared selection lock protects resolution through the point at which
+	// this supervisor has claimed the instance and proved readiness. Keeping it
+	// for the full daemon lifetime would deadlock an updater: update needs the
+	// exclusive selection lock before it can issue the PID-safe stop request.
+	if ctx.selection != nil {
+		_ = ctx.selection.Close()
+		ctx.selection = nil
+	}
 	for {
 		select {
 		case <-signals:

--- a/launcher/internal/launcher/launcher_test.go
+++ b/launcher/internal/launcher/launcher_test.go
@@ -110,6 +110,19 @@ func TestLifecycleExitCodesAreStable(t *testing.T) {
 	}
 }
 
+func TestUninstallRemainsAvailableDuringInterruptedTransition(t *testing.T) {
+	for _, args := range [][]string{{"rollback"}, {"uninstall"}, {"uninstall", "--remove-data"}} {
+		if !transitionRecoveryCommand(args) {
+			t.Fatalf("recovery command was blocked by transition journal: %v", args)
+		}
+	}
+	for _, args := range [][]string{nil, {"start"}, {"update"}, {"status"}} {
+		if transitionRecoveryCommand(args) {
+			t.Fatalf("ordinary command bypassed transition journal: %v", args)
+		}
+	}
+}
+
 func TestAcquisitionBuildPolicyFailsClosedOutsideItsCompiledChannel(t *testing.T) {
 	previousChannel, previousKey := releaseChannel, releaseTrustKeyBase64
 	t.Cleanup(func() { releaseChannel, releaseTrustKeyBase64 = previousChannel, previousKey })

--- a/launcher/internal/launcher/lifecycle.go
+++ b/launcher/internal/launcher/lifecycle.go
@@ -1,0 +1,1945 @@
+package launcher
+
+// This file contains the native distribution lifecycle commands. They are
+// intentionally not Python fallbacks: the Python payload is application code,
+// while promotion, rollback, database-pair recovery, and uninstall own the
+// trusted launcher boundary.
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+const removeDataPhrase = "REMOVE JOBCTRL DATA"
+
+// transitionFailure is an intentionally narrow test seam. Production leaves
+// it nil; tests inject each durable boundary and prove journal recovery rather
+// than trying to simulate a process crash between arbitrary instructions.
+var transitionFailure func(release.State) error
+var uninstallInput io.Reader = os.Stdin
+var errTransitionInterrupted = errors.New("injected abrupt transition interruption")
+var homebrewExecutableLookup = exec.LookPath
+var homebrewCommand = func(args ...string) (string, error) {
+	path, err := homebrewExecutableLookup("brew")
+	if err != nil {
+		return "", fmt.Errorf("locate Homebrew executable: %w", err)
+	}
+	if !filepath.IsAbs(path) {
+		return "", errors.New("Homebrew executable resolved to a relative path")
+	}
+	path, err = filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve Homebrew executable: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0o111 == 0 || info.Mode().Perm()&0o022 != 0 {
+		return "", errors.New("Homebrew executable is not a non-writable regular executable")
+	}
+	output, err := exec.Command(path, args...).CombinedOutput()
+	return string(output), err
+}
+var homebrewBootstrapCommand = func(path string, args []string, env []string) (string, error) {
+	command := exec.Command(path, args...)
+	command.Env = env
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+var curlInstallerCommand = func(path string, args []string, env []string) (string, error) {
+	command := exec.Command(path, args...)
+	command.Env = env
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+var homebrewAssetsReader = readHomebrewFormulaAssets
+var homebrewPromotion = promoteExisting
+var curlPromotion = promoteExisting
+var startReleaseCommand = startRelease
+
+type databaseFile struct {
+	Name          string `json:"name"`
+	SHA256        string `json:"sha256"`
+	SizeBytes     int64  `json:"sizeBytes"`
+	SQLiteUserVer int64  `json:"sqliteUserVersion"`
+}
+type databasePair struct {
+	SchemaVersion  int             `json:"schemaVersion"`
+	ID             string          `json:"id"`
+	ReleaseReceipt release.Receipt `json:"releaseReceipt"`
+	CreatedAt      time.Time       `json:"createdAt"`
+	Files          []databaseFile  `json:"files"`
+}
+
+type curlAcquisitionRecord struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Source        string `json:"source"`
+	PublicLink    string `json:"publicLink"`
+	Selector      string `json:"selector"`
+	Profile       string `json:"profile"`
+	PathLine      string `json:"pathLine"`
+}
+
+func releaseSelection(ctx *launchContext) {
+	if ctx.selection != nil {
+		_ = ctx.selection.Close()
+		ctx.selection = nil
+	}
+}
+
+func releaseStore(ctx launchContext) (*release.Store, error) {
+	return release.Open(ctx.Instance.RuntimeHome)
+}
+
+// recoverRevokedTransitionBeforePrepare is the one path deliberately placed
+// before normal selector preparation. After policy finalization a revoked old
+// active release correctly fails Permit(), which otherwise prevents even the
+// `rollback` command from reaching recovery. This path never starts old code:
+// it restores the durable pre-candidate pair and resumes only the authenticated
+// candidate recorded in the journal.
+func recoverRevokedTransitionBeforePrepare(env []string, output io.Writer) (bool, error) {
+	home, err := runtimeHomeFromEnv(env)
+	if err != nil {
+		return false, nil
+	}
+	store, err := release.Open(home)
+	if err != nil {
+		return false, nil
+	}
+	journal, err := store.ReadJournal()
+	if errors.Is(err, os.ErrNotExist) || err != nil || !journal.Resumable() || journal.Old == nil || journal.Candidate == nil {
+		return false, nil
+	}
+	if store.Permit(*journal.Old) == nil {
+		return false, nil
+	}
+	if err := store.Permit(*journal.Candidate); err != nil {
+		return true, fmt.Errorf("security transition recovery is fail-closed: prior release is revoked and staged candidate is not permitted: %w", err)
+	}
+	if journal.BackupID == "" {
+		return true, errors.New("security transition recovery is fail-closed: revoked predecessor has no durable paired backup; preserve the journal and repair from the staged candidate")
+	}
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return true, err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return true, err
+	}
+	defer selection.Close()
+	// Re-read while holding both locks so a concurrent acquisition cannot alter
+	// the candidate/policy decision after our preflight.
+	journal, err = store.ReadJournal()
+	if err != nil || journal.Candidate == nil || journal.Old == nil || store.Permit(*journal.Old) == nil {
+		return true, errors.New("security transition changed while recovery was acquiring locks")
+	}
+	ctx, err := transitionContextForReceipt(env, store, *journal.Candidate)
+	if err != nil {
+		return true, err
+	}
+	var pair databasePair
+	if err := decodeStrictRegular(filepath.Join(ctx.Instance.StateDir, "backups", journal.BackupID, "pair.json"), &pair); err != nil || pair.ReleaseReceipt != *journal.Old {
+		return true, errors.New("security transition recovery has no verified predecessor database pair")
+	}
+	if err := store.Advance(&journal, release.RollbackRestoring, nil); err != nil {
+		return true, err
+	}
+	if err := stop(ctx); err != nil {
+		return true, fmt.Errorf("quiesce possibly-live candidate before security recovery restore: %w", err)
+	}
+	if err := restorePair(ctx, pair); err != nil {
+		return true, err
+	}
+	if err := store.Advance(&journal, release.CandidateStarting, nil); err != nil {
+		return true, err
+	}
+	if err := startReleaseCommand(ctx, *journal.Candidate, journal.ID); err != nil {
+		_ = store.Advance(&journal, release.Failed, err)
+		return true, fmt.Errorf("security transition candidate did not become healthy; revoked predecessor was not started: %w", err)
+	}
+	if err := store.Advance(&journal, release.CandidateHealthy, nil); err != nil {
+		return true, err
+	}
+	active, _ := store.ReadActive()
+	if _, err := store.WriteSelectedActive(*journal.Candidate, active.Generation, journal.Candidate.BuildID, active.Acquisition); err != nil {
+		return true, err
+	}
+	if err := writeLegacyCurrent(store.Home, *journal.Candidate); err != nil {
+		return true, err
+	}
+	if err := store.Advance(&journal, release.Promoted, nil); err != nil {
+		return true, err
+	}
+	_, err = fmt.Fprintf(output, "Recovered the verified security-update candidate %s; revoked predecessor was not started.\n", journal.Candidate.BuildID)
+	return true, err
+}
+
+// recoverInterruptedTransitionBeforeBootstrap prevents a formula-owned
+// frontend from trying to stage or promote another candidate over a durable
+// ordinary transition. Revoked-predecessor recovery runs first; this path is
+// only for a still-permitted prior release.
+func recoverInterruptedTransitionBeforeBootstrap(env []string, output io.Writer) (bool, error) {
+	home, err := runtimeHomeFromEnv(env)
+	if err != nil {
+		return false, nil
+	}
+	store, err := release.Open(home)
+	if err != nil {
+		return true, err
+	}
+	journal, err := store.ReadJournal()
+	if errors.Is(err, os.ErrNotExist) || (err == nil && !journal.Resumable()) {
+		return false, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("read interrupted release transition before acquisition bootstrap: %w", err)
+	}
+	if journal.Old == nil {
+		return true, errors.New("unfinished release transition has no prior release receipt")
+	}
+	if err := store.Permit(*journal.Old); err != nil {
+		return true, fmt.Errorf("interrupted transition prior release is no longer permitted and safe candidate recovery was unavailable: %w", err)
+	}
+	ctx, err := transitionContextForReceipt(env, store, *journal.Old)
+	if err != nil {
+		return true, err
+	}
+	recovered, err := recoverInterruptedTransition(ctx, store)
+	if err != nil {
+		return true, err
+	}
+	if !recovered {
+		return true, errors.New("interrupted release transition changed while recovery was acquiring locks; retry rollback")
+	}
+	_, err = io.WriteString(output, "Interrupted JobCtrl transition was restored to its previous release.\n")
+	return true, err
+}
+
+// uninstallUnsafeActiveBeforePrepare keeps the public escape hatch available
+// when authenticated policy has revoked the selected release (or its immutable
+// execution evidence is damaged). Normal commands still fail closed, but an
+// exact uninstall never needs to execute the untrusted payload it is removing.
+func uninstallUnsafeActiveBeforePrepare(args, env []string, output io.Writer) (bool, error) {
+	if len(args) == 0 || args[0] != "uninstall" {
+		return false, nil
+	}
+	home, err := runtimeHomeFromEnv(env)
+	if err != nil {
+		return false, nil
+	}
+	store, err := release.Open(home)
+	if err != nil {
+		return true, err
+	}
+	active, err := store.ReadActive()
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return true, fmt.Errorf("read active release before fail-closed uninstall: %w", err)
+	}
+	_, releaseErr := verifyInstalledReleaseForExecution(store, active.Receipt)
+	selectorErr := VerifyPublicSelectorForExecution(store.Home)
+	if releaseErr == nil && selectorErr == nil {
+		return false, nil
+	}
+	instance, err := resolveInstance(env)
+	if err != nil {
+		return true, err
+	}
+	ctx := launchContext{Executable: filepath.Join(store.Home, "bin", "jobctrl"), Instance: instance, Environment: append([]string{}, env...)}
+	return true, uninstall(ctx, args[1:], output)
+}
+
+func transitionContextForReceipt(env []string, store *release.Store, receipt release.Receipt) (launchContext, error) {
+	verified, err := verifyInstalledReleaseForExecution(store, receipt)
+	if err != nil {
+		return launchContext{}, err
+	}
+	instance, err := resolveInstance(env)
+	if err != nil {
+		return launchContext{}, err
+	}
+	return launchContext{Executable: filepath.Join(verified.payloadRoot, "launcher", "jobctrl"), PayloadRoot: verified.payloadRoot, Manifest: verified.runtime, Distribution: verified.distribution, Instance: instance, Environment: childEnvironment(env, verified.payloadRoot, instance.StateDir, verified.runtime)}, nil
+}
+
+// rebindActiveContext closes the selector/update race after a lifecycle
+// command drops its initial shared selection lock. All quiesce, SQLite, and
+// restart actions then use the release observed under exclusive selection.
+func rebindActiveContext(ctx launchContext, build string) (launchContext, error) {
+	path := filepath.Join(ctx.Instance.RuntimeHome, "releases", build, "payload", "launcher", "jobctrl")
+	payloadRoot := filepath.Dir(filepath.Dir(path))
+	distribution, err := loadAndVerifyDistributionManifest(payloadRoot)
+	if err != nil {
+		return launchContext{}, err
+	}
+	manifest, err := loadRuntimeManifest(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"))
+	if err != nil {
+		return launchContext{}, err
+	}
+	if distribution.LauncherCompatibility.Minimum > launcherProtocol || distribution.LauncherCompatibility.Maximum < launcherProtocol {
+		return launchContext{}, fmt.Errorf("payload supports launcher protocol %d-%d, this launcher is protocol %d", distribution.LauncherCompatibility.Minimum, distribution.LauncherCompatibility.Maximum, launcherProtocol)
+	}
+	env := append([]string{}, ctx.Environment...)
+	env = append(env, "JOBCTRL_RUNTIME_HOME="+ctx.Instance.RuntimeHome, "JOBCTRL_DIR="+ctx.Instance.StateDir)
+	return launchContext{Executable: path, PayloadRoot: payloadRoot, Manifest: manifest, Distribution: distribution, Instance: ctx.Instance, Environment: childEnvironment(env, payloadRoot, ctx.Instance.StateDir, manifest)}, nil
+}
+
+type verifiedRelease struct {
+	receipt      release.Receipt
+	payloadRoot  string
+	distribution distributionManifest
+	runtime      runtimeManifest
+}
+
+// verifyInstalledReleaseForExecution is intentionally repeated immediately
+// before every lifecycle exec. A release being immutable on disk is not a
+// substitute for re-checking it when another process may have modified it
+// since staging or since the initial candidate validation.
+func verifyInstalledReleaseForExecution(store *release.Store, receipt release.Receipt) (verifiedRelease, error) {
+	installed, err := readInstalledReceipt(store.Home, receipt.BuildID)
+	if err != nil {
+		return verifiedRelease{}, err
+	}
+	if installed != receipt {
+		return verifiedRelease{}, errors.New("installed receipt identity changed since transition began")
+	}
+	if receipt.SchemaVersion == 2 {
+		if _, err := readInstalledPolicy(store.Home, receipt); err != nil {
+			return verifiedRelease{}, fmt.Errorf("verify immutable release policy: %w", err)
+		}
+	}
+	if err := store.Permit(receipt); err != nil {
+		return verifiedRelease{}, fmt.Errorf("release is not permitted by authenticated channel policy: %w", err)
+	}
+	payloadRoot := filepath.Join(store.Home, "releases", receipt.BuildID, "payload")
+	distribution, err := loadAndVerifyDistributionManifest(payloadRoot)
+	if err != nil {
+		return verifiedRelease{}, fmt.Errorf("verify release payload: %w", err)
+	}
+	manifestDigest, err := sha256Path(filepath.Join(payloadRoot, "manifest.json"))
+	if err != nil {
+		return verifiedRelease{}, err
+	}
+	if manifestDigest != receipt.ManifestSHA256 {
+		return verifiedRelease{}, errors.New("verified manifest digest differs from immutable receipt")
+	}
+	if distribution.BuildID != receipt.BuildID || distribution.ReleaseChannel != receipt.Channel {
+		return verifiedRelease{}, errors.New("verified payload does not match immutable receipt")
+	}
+	var probe runtimeManifest
+	if err := decodeStrict(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"), &probe); err != nil {
+		return verifiedRelease{}, err
+	}
+	runtime, err := loadRuntimeManifestForProtocol(filepath.Join(payloadRoot, "launcher", "runtime-manifest.json"), probe.LauncherProtocol)
+	if err != nil {
+		return verifiedRelease{}, err
+	}
+	if distribution.LauncherCompatibility.Minimum > runtime.LauncherProtocol || distribution.LauncherCompatibility.Maximum < runtime.LauncherProtocol {
+		return verifiedRelease{}, errors.New("release launcher is not compatible with its payload")
+	}
+	launcherPath := filepath.Join(payloadRoot, "launcher", "jobctrl")
+	if info, err := os.Lstat(launcherPath); err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0o111 == 0 {
+		return verifiedRelease{}, errors.New("release launcher is not a regular executable")
+	}
+	return verifiedRelease{receipt: receipt, payloadRoot: payloadRoot, distribution: distribution, runtime: runtime}, nil
+}
+
+func protocolSupports(manifest distributionManifest, protocol int) bool {
+	return manifest.LauncherCompatibility.Minimum <= protocol && protocol <= manifest.LauncherCompatibility.Maximum
+}
+
+func manifestRegularFile(manifest distributionManifest, path string) (string, error) {
+	for _, file := range manifest.Files {
+		if file.Path == path && file.Type == "file" && file.Mode == "0755" {
+			return file.SHA256, nil
+		}
+	}
+	return "", fmt.Errorf("manifest does not declare executable %q", path)
+}
+
+// handoffPublicSelector is called only with transition then exclusive
+// selection locking held. The caller has already proven candidate protocol
+// compatibility with both active and candidate payloads. The rename plus
+// directory fsync makes either the old or candidate selector durable; both are
+// able to supervise the active payload at their corresponding journal state.
+func handoffPublicSelector(home string, candidate verifiedRelease) error {
+	expectedDigest, err := manifestRegularFile(candidate.distribution, "launcher/jobctrl")
+	if err != nil {
+		return err
+	}
+	sourcePath := filepath.Join(candidate.payloadRoot, "launcher", "jobctrl")
+	sourceInfo, err := os.Lstat(sourcePath)
+	if err != nil || !sourceInfo.Mode().IsRegular() || sourceInfo.Mode()&os.ModeSymlink != 0 || sourceInfo.Mode()&0o111 == 0 {
+		return errors.New("candidate selector source is not a regular executable")
+	}
+	bin := filepath.Join(home, "bin")
+	if err := ensureSafeDirectory(bin); err != nil {
+		return err
+	}
+	target := filepath.Join(bin, "jobctrl")
+	if info, err := os.Lstat(target); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return errors.New("public selector is not a regular file")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	random, err := releaseRandomID()
+	if err != nil {
+		return err
+	}
+	temporary := filepath.Join(bin, ".jobctrl-handoff-"+random)
+	source, err := os.OpenFile(sourcePath, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, sourceInfo.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	_, copyErr := io.Copy(io.MultiWriter(destination, hash), source)
+	if copyErr == nil {
+		copyErr = destination.Sync()
+	}
+	if closeErr := destination.Close(); copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		_ = os.Remove(temporary)
+		return copyErr
+	}
+	if hex.EncodeToString(hash.Sum(nil)) != expectedDigest {
+		_ = os.Remove(temporary)
+		return errors.New("candidate selector digest changed before handoff")
+	}
+	if err := os.Rename(temporary, target); err != nil {
+		_ = os.Remove(temporary)
+		return err
+	}
+	return syncDirectory(bin)
+}
+
+func releaseRandomID() (string, error) {
+	var raw [16]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw[:]), nil
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer directory.Close()
+	return directory.Sync()
+}
+
+func advance(store *release.Store, journal *release.Journal, state release.State) error {
+	if err := store.Advance(journal, state, nil); err != nil {
+		return err
+	}
+	if transitionFailure != nil {
+		if err := transitionFailure(state); err != nil {
+			// An abrupt interruption models SIGKILL/power loss after the journal
+			// fsync. Do not relabel it failed: the next lifecycle invocation must
+			// see the durable milestone and recover from it.
+			if errors.Is(err, errTransitionInterrupted) {
+				return err
+			}
+			_ = store.Advance(journal, release.Failed, err)
+			return err
+		}
+	}
+	return nil
+}
+
+func update(ctx launchContext, args []string, output io.Writer) error {
+	releaseSelection(&ctx)
+	if len(args) == 1 && args[0] == "--help" {
+		_, err := io.WriteString(output, "usage: jobctrl update [--to BUILD_ID]\n")
+		return err
+	}
+	build, err := parseBuildTarget(args, "update")
+	if err != nil {
+		return err
+	}
+	store, err := releaseStore(ctx)
+	if err != nil {
+		return err
+	}
+	active, err := store.ReadActive()
+	if err != nil {
+		return fmt.Errorf("read active release: %w", err)
+	}
+	if active.Acquisition == "homebrew" {
+		if build != "" && environmentMap(ctx.Environment)["JOBCTRL_ACQUISITION_INTERNAL"] != "1" {
+			return errors.New("Homebrew updates select the formula's authenticated build; `jobctrl update --to` is unavailable")
+		}
+		if build != "" {
+			return promoteExisting(ctx, store, active, build, "update", output)
+		}
+		return updateHomebrew(ctx, store, active, output)
+	}
+	if build == "" {
+		policy, policyErr := AcquisitionBuildPolicy()
+		if policyErr != nil || !policy.AllowNetwork {
+			return errors.New("signed public update metadata is not available until P6 signing/notarization; use a verified local fixture only in development")
+		}
+		if active.Acquisition == "curl" {
+			return updateCurl(ctx, store, active, output)
+		}
+		return errors.New("the signed public update transport is enabled only by the P6 release integration")
+	}
+	return promoteExisting(ctx, store, active, build, "update", output)
+}
+
+// updateCurl is the public curl acquisition adapter. It deliberately executes
+// only the installer shipped in the current authenticated payload, asks it to
+// stage (not promote) a candidate, and accepts only an exact JSON receipt for
+// the immutable candidate that appeared in the user-owned release store.
+func updateCurl(ctx launchContext, store *release.Store, active release.Active, output io.Writer) error {
+	current, err := store.ReadActive()
+	if err != nil {
+		return fmt.Errorf("re-read active release before curl staging: %w", err)
+	}
+	if current.Receipt != active.Receipt || current.Acquisition != "curl" {
+		return errors.New("active JobCtrl acquisition changed during curl update; retry the command")
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, current.Receipt)
+	if err != nil {
+		return fmt.Errorf("re-verify active release before curl staging: %w", err)
+	}
+	active = current
+	installerPath := filepath.Join(verified.payloadRoot, "launcher", "jobctrl-installer")
+	expectedDigest, err := manifestExecutableDigest(verified.distribution, "launcher/jobctrl-installer")
+	if err != nil {
+		return fmt.Errorf("current active payload does not provide a manifest-declared acquisition installer: %w", err)
+	}
+	info, err := os.Lstat(installerPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0o111 == 0 {
+		return errors.New("current active acquisition installer is not a regular executable")
+	}
+	digest, err := sha256Path(installerPath)
+	if err != nil || digest != expectedDigest {
+		return errors.New("current active acquisition installer differs from its authenticated manifest")
+	}
+	installerArgs := []string{"--source", "curl", "--stage-only", "--json", "--home", store.Home}
+	stagedOutput, err := curlInstallerCommand(installerPath, installerArgs, ctx.Environment)
+	if err != nil {
+		return fmt.Errorf("stage upgraded curl JobCtrl release through current authenticated installer: %w: %s", err, strings.TrimSpace(stagedOutput))
+	}
+	candidate, err := decodeInstallerReceipt(stagedOutput)
+	if err != nil {
+		return fmt.Errorf("current authenticated installer returned an invalid staged receipt: %w", err)
+	}
+	installed, err := readInstalledReceipt(store.Home, candidate.BuildID)
+	if err != nil || installed != candidate {
+		return errors.New("current authenticated installer did not stage the exact receipt it returned")
+	}
+	if candidate.Channel != active.Receipt.Channel {
+		return errors.New("curl installer staged a candidate for a different channel")
+	}
+	if candidate.BuildID == active.Receipt.BuildID {
+		if candidate != active.Receipt {
+			return errors.New("curl installer returned a conflicting receipt for the active build")
+		}
+		_, err := fmt.Fprintf(output, "JobCtrl %s is already active.\n", candidate.BuildID)
+		return err
+	}
+	ctx.Environment = append(ctx.Environment, "JOBCTRL_ACQUISITION_SOURCE=curl")
+	return curlPromotion(ctx, store, active, candidate.BuildID, "update", output)
+}
+
+func decodeInstallerReceipt(raw string) (release.Receipt, error) {
+	var receipt release.Receipt
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&receipt); err != nil {
+		return receipt, err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return receipt, errors.New("multiple JSON values")
+		}
+		return receipt, err
+	}
+	if !receipt.Valid() {
+		return receipt, errors.New("invalid immutable receipt")
+	}
+	return receipt, nil
+}
+
+// updateHomebrew keeps `jobctrl update` as the one public update command. The
+// acquisition adapter lets Homebrew replace only its formula-owned cache, then
+// feeds those assets to the already-authenticated active installer. The new
+// Cellar bootstrap is never executed by this path.
+func updateHomebrew(ctx launchContext, store *release.Store, active release.Active, output io.Writer) error {
+	upgradeOutput, err := homebrewCommand("upgrade", "ebarti/tap/jobctrl")
+	if err != nil {
+		return fmt.Errorf("Homebrew acquisition update failed: %w: %s", err, strings.TrimSpace(upgradeOutput))
+	}
+	prefixOutput, err := homebrewCommand("--prefix", "ebarti/tap/jobctrl")
+	if err != nil {
+		return fmt.Errorf("resolve upgraded Homebrew JobCtrl prefix: %w: %s", err, strings.TrimSpace(prefixOutput))
+	}
+	prefix := strings.TrimSpace(prefixOutput)
+	if !filepath.IsAbs(prefix) {
+		return errors.New("Homebrew returned an invalid JobCtrl prefix")
+	}
+	assets, err := homebrewAssetsReader(prefix)
+	if err != nil {
+		return err
+	}
+	current, err := store.ReadActive()
+	if err != nil {
+		return fmt.Errorf("re-read active release before Homebrew staging: %w", err)
+	}
+	if current.Receipt != active.Receipt || current.Acquisition != "homebrew" {
+		return errors.New("active JobCtrl acquisition changed during Homebrew update; retry the command")
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, current.Receipt)
+	if err != nil {
+		return fmt.Errorf("re-verify active release before Homebrew staging: %w", err)
+	}
+	active = current
+	installerPath := filepath.Join(verified.payloadRoot, "launcher", "jobctrl-installer")
+	expectedDigest, err := manifestExecutableDigest(verified.distribution, "launcher/jobctrl-installer")
+	if err != nil {
+		return fmt.Errorf("current active payload does not provide a manifest-declared acquisition installer: %w", err)
+	}
+	info, err := os.Lstat(installerPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode()&0o111 == 0 {
+		return errors.New("current active acquisition installer is not a regular executable")
+	}
+	digest, err := sha256Path(installerPath)
+	if err != nil || digest != expectedDigest {
+		return errors.New("current active acquisition installer differs from its authenticated manifest")
+	}
+	installerArgs := []string{"--source", "homebrew", "--stage-only", "--home", store.Home, "--descriptor-url", assets.DescriptorURL, "--descriptor-file", assets.DescriptorPath, "--signature-file", assets.SignaturePath, "--archive-file", assets.ArchivePath}
+	bootstrapOutput, err := homebrewBootstrapCommand(installerPath, installerArgs, ctx.Environment)
+	if err != nil {
+		return fmt.Errorf("stage upgraded Homebrew JobCtrl release through current authenticated installer: %w: %s", err, strings.TrimSpace(bootstrapOutput))
+	}
+	candidate, err := readInstalledReceipt(store.Home, assets.BuildID)
+	if err != nil || candidate.DescriptorSHA256 != assets.DescriptorSHA256 {
+		return errors.New("current authenticated installer did not stage the formula's exact descriptor-bound candidate")
+	}
+	if candidate.BuildID == active.Receipt.BuildID {
+		if candidate != active.Receipt {
+			return errors.New("Homebrew installer returned a conflicting receipt for the active build")
+		}
+		_, err := fmt.Fprintf(output, "JobCtrl %s is already active.\n", candidate.BuildID)
+		return err
+	}
+	ctx.Environment = append(ctx.Environment, "JOBCTRL_ACQUISITION_SOURCE=homebrew")
+	return homebrewPromotion(ctx, store, active, candidate.BuildID, "update", output)
+}
+
+type homebrewFormulaAssets struct {
+	BuildID          string
+	DescriptorURL    string
+	DescriptorSHA256 string
+	DescriptorPath   string
+	SignaturePath    string
+	ArchivePath      string
+}
+
+// readHomebrewFormulaAssets treats the upgraded Cellar only as an acquisition
+// cache. No formula executable runs here: the currently authenticated active
+// payload installer validates these exact bytes before staging.
+func readHomebrewFormulaAssets(prefix string) (homebrewFormulaAssets, error) {
+	root := filepath.Join(prefix, "libexec", "bootstrap")
+	configPath := filepath.Join(root, "homebrew-bootstrap.json")
+	var config homebrewBootstrapConfig
+	if err := decodeBootstrapConfig(configPath, &config); err != nil {
+		return homebrewFormulaAssets{}, err
+	}
+	if config.SchemaVersion != 1 || config.DescriptorURL == "" || !buildIDPattern.MatchString(config.BuildID) || !sha256Pattern.MatchString(config.DescriptorSHA256) || !safeRelativePath(config.Descriptor) || !safeRelativePath(config.Signature) || !safeRelativePath(config.Archive) {
+		return homebrewFormulaAssets{}, errors.New("invalid upgraded Homebrew acquisition configuration")
+	}
+	descriptorPath := filepath.Join(root, config.Descriptor)
+	signaturePath := filepath.Join(root, config.Signature)
+	archivePath := filepath.Join(root, config.Archive)
+	for _, path := range []string{descriptorPath, signaturePath, archivePath} {
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return homebrewFormulaAssets{}, errors.New("upgraded Homebrew acquisition resource is not a regular file")
+		}
+	}
+	descriptorRaw, err := os.ReadFile(descriptorPath)
+	if err != nil {
+		return homebrewFormulaAssets{}, err
+	}
+	digest := sha256.Sum256(descriptorRaw)
+	if hex.EncodeToString(digest[:]) != config.DescriptorSHA256 {
+		return homebrewFormulaAssets{}, errors.New("upgraded Homebrew descriptor digest mismatch")
+	}
+	return homebrewFormulaAssets{BuildID: config.BuildID, DescriptorURL: config.DescriptorURL, DescriptorSHA256: config.DescriptorSHA256, DescriptorPath: descriptorPath, SignaturePath: signaturePath, ArchivePath: archivePath}, nil
+}
+
+func rollback(ctx launchContext, args []string, output io.Writer) error {
+	releaseSelection(&ctx)
+	build, err := parseBuildTarget(args, "rollback")
+	if err != nil {
+		return err
+	}
+	store, err := releaseStore(ctx)
+	if err != nil {
+		return err
+	}
+	if recovered, err := recoverInterruptedTransition(ctx, store); err != nil {
+		return err
+	} else if recovered {
+		_, err := io.WriteString(output, "Interrupted JobCtrl transition was restored to its previous release.\n")
+		return err
+	}
+	active, err := store.ReadActive()
+	if err != nil {
+		return fmt.Errorf("read active release: %w", err)
+	}
+	if build == "" {
+		build, err = previousRelease(store, active.Receipt)
+		if err != nil {
+			return err
+		}
+	}
+	return rollbackExisting(ctx, store, active, build, output)
+}
+
+// rollbackExisting restores the precise retained pair for the target release
+// before it ever starts that target. Reusing update promotion here would run
+// old code against the new schema, which is explicitly unsafe.
+func rollbackExisting(ctx launchContext, store *release.Store, active release.Active, build string, output io.Writer) (result error) {
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return err
+	}
+	defer selection.Close()
+	active, err = store.ReadActive()
+	if err != nil {
+		return err
+	}
+	target, err := readInstalledReceipt(store.Home, build)
+	if err != nil {
+		return err
+	}
+	if target.Channel != active.Receipt.Channel {
+		return errors.New("rollback target channel differs from active channel")
+	}
+	if err := store.Permit(target); err != nil {
+		return fmt.Errorf("rollback target is not safe: %w", err)
+	}
+	targetPair, err := retainedPairForReceipt(ctx.Instance.StateDir, target)
+	if err != nil {
+		return fmt.Errorf("rollback requires a verified paired backup for %s: %w", target.BuildID, err)
+	}
+	ctx, err = rebindActiveContext(ctx, active.Receipt.BuildID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ctx.selection.Close() }()
+	activeVerified, err := verifyInstalledReleaseForExecution(store, active.Receipt)
+	if err != nil {
+		return err
+	}
+	targetVerified, err := verifyInstalledReleaseForExecution(store, target)
+	if err != nil {
+		return err
+	}
+	if active.SelectorBuildID != target.BuildID {
+		targetProtocol := targetVerified.runtime.LauncherProtocol
+		if !protocolSupports(activeVerified.distribution, targetProtocol) || !protocolSupports(targetVerified.distribution, targetProtocol) {
+			return fmt.Errorf("rollback launcher protocol %d cannot supervise both active and target payloads; choose a retained compatible bridge release", targetProtocol)
+		}
+	}
+	journal, err := store.Begin("rollback", &active.Receipt, &target, target.DescriptorSHA256)
+	if err != nil {
+		return err
+	}
+	journal.TargetBackupID = targetPair.ID
+	if err := advance(store, &journal, release.MetadataVerified); err != nil {
+		return err
+	}
+	if active.SelectorBuildID != target.BuildID {
+		if err := advance(store, &journal, release.SelectorHandoffPending); err != nil {
+			return err
+		}
+		if err := handoffPublicSelector(store.Home, targetVerified); err != nil {
+			return err
+		}
+		if err := advance(store, &journal, release.SelectorReplaced); err != nil {
+			return err
+		}
+		active, err = store.WriteSelectedActive(active.Receipt, active.Generation, target.BuildID, active.Acquisition)
+		if err != nil {
+			return err
+		}
+	}
+	if err := advance(store, &journal, release.Quiescing); err != nil {
+		return err
+	}
+	if err := stop(ctx); err != nil {
+		_ = store.Advance(&journal, release.Failed, err)
+		return err
+	}
+	currentPair, err := snapshotPair(ctx, active.Receipt)
+	if err != nil {
+		_ = store.Advance(&journal, release.Failed, err)
+		return err
+	}
+	journal.BackupID = currentPair.ID
+	if err := advance(store, &journal, release.PairBackedUp); err != nil {
+		return err
+	}
+	fail := func(cause error) error {
+		_ = store.Advance(&journal, release.RollbackRestoring, cause)
+		if stopErr := stop(ctx); stopErr != nil {
+			return fmt.Errorf("%v; refusing to restore the current database pair while the rollback target could not be quiesced: %w", cause, stopErr)
+		}
+		if restoreErr := restorePair(ctx, currentPair); restoreErr != nil {
+			return fmt.Errorf("%v; restore current pair: %w", cause, restoreErr)
+		}
+		if _, pointerErr := store.WriteSelectedActive(active.Receipt, active.Generation, active.SelectorBuildID, active.Acquisition); pointerErr != nil {
+			return fmt.Errorf("%v; restore current active record: %w", cause, pointerErr)
+		}
+		if err := writeLegacyCurrent(store.Home, active.Receipt); err != nil {
+			return err
+		}
+		if permitErr := store.Permit(active.Receipt); permitErr != nil {
+			_ = store.Advance(&journal, release.Failed, permitErr)
+			return fmt.Errorf("%v; restored database pair but refused to restart revoked active release: %w", cause, permitErr)
+		}
+		if err := startReleaseCommand(ctx, active.Receipt, journal.ID); err != nil {
+			return fmt.Errorf("%v; restart current release: %w", cause, err)
+		}
+		_ = store.Advance(&journal, release.RolledBack, cause)
+		return cause
+	}
+	if err := store.Advance(&journal, release.RollbackRestoring, nil); err != nil {
+		return fail(err)
+	}
+	if err := restorePair(ctx, targetPair); err != nil {
+		return fail(fmt.Errorf("restore rollback target pair: %w", err))
+	}
+	if err := advance(store, &journal, release.CandidateStarting); err != nil {
+		return fail(err)
+	}
+	if err := startReleaseCommand(ctx, target, journal.ID); err != nil {
+		return fail(fmt.Errorf("rollback target startup failed: %w", err))
+	}
+	if err := advance(store, &journal, release.CandidateHealthy); err != nil {
+		return fail(err)
+	}
+	if _, err := store.WriteSelectedActive(target, active.Generation, target.BuildID, active.Acquisition); err != nil {
+		return fail(err)
+	}
+	if err := writeLegacyCurrent(store.Home, target); err != nil {
+		return fail(err)
+	}
+	if err := advance(store, &journal, release.Promoted); err != nil {
+		return fail(err)
+	}
+	_, err = fmt.Fprintf(output, "JobCtrl rolled back to %s.\n", target.BuildID)
+	return err
+}
+
+func retainedPairForReceipt(stateDir string, target release.Receipt) (databasePair, error) {
+	entries, err := os.ReadDir(filepath.Join(stateDir, "backups"))
+	if err != nil {
+		return databasePair{}, err
+	}
+	var matches []databasePair
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		var pair databasePair
+		if err := decodeStrictRegular(filepath.Join(stateDir, "backups", entry.Name(), "pair.json"), &pair); err == nil && pair.SchemaVersion == 1 && pair.ReleaseReceipt == target && len(pair.Files) == 2 {
+			matches = append(matches, pair)
+		}
+	}
+	if len(matches) == 0 {
+		return databasePair{}, errors.New("no retained complete pair")
+	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].CreatedAt.After(matches[j].CreatedAt) })
+	return matches[0], nil
+}
+
+// recoverInterruptedTransition is intentionally conservative: the only
+// automatic resume action is to restore the complete old tuple. It never
+// guesses that a partially started candidate should be promoted.
+func recoverInterruptedTransition(ctx launchContext, store *release.Store) (bool, error) {
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return false, err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return false, err
+	}
+	defer selection.Close()
+	journal, err := store.ReadJournal()
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !journal.Resumable() {
+		return false, nil
+	}
+	if journal.Old == nil {
+		return false, errors.New("unfinished transition has no prior release receipt")
+	}
+	if err := store.Permit(*journal.Old); err != nil {
+		// A revocation/floor raise may have been finalized after the paired
+		// backup but before promotion. Restoring or starting old code here would
+		// turn the recovery mechanism into a security rollback. Preserve the
+		// journal and both database copies; the caller gets an actionable,
+		// fail-closed status instead of a revoked runtime.
+		_ = store.Advance(&journal, release.Failed, err)
+		return false, fmt.Errorf("interrupted transition cannot restore revoked prior release: %w; verified candidate %q remains staged for explicit recovery", err, receiptBuild(journal.Candidate))
+	}
+	// Make the old release executable through the direct transition gate before
+	// any stop/restart action, including crashes before PairBackedUp.
+	if err := store.Advance(&journal, release.RollbackRestoring, nil); err != nil {
+		return false, err
+	}
+	if err := stop(ctx); err != nil {
+		return false, fmt.Errorf("quiesce interrupted transition: %w", err)
+	}
+	if journal.BackupID != "" {
+		var pair databasePair
+		if err := decodeStrictRegular(filepath.Join(ctx.Instance.StateDir, "backups", journal.BackupID, "pair.json"), &pair); err != nil {
+			return false, fmt.Errorf("read interrupted transition database pair: %w", err)
+		}
+		if pair.ReleaseReceipt != *journal.Old {
+			return false, errors.New("interrupted transition backup does not bind the prior release")
+		}
+		if err := restorePair(ctx, pair); err != nil {
+			return false, err
+		}
+	}
+	active, activeErr := store.ReadActive()
+	generation := uint64(0)
+	if activeErr == nil {
+		generation = active.Generation
+	} else if !errors.Is(activeErr, os.ErrNotExist) {
+		return false, activeErr
+	}
+	selector := filepath.Join(store.Home, "bin", "jobctrl")
+	selectorBuild := ""
+	// Selector replacement is durable separately from the following journal or
+	// active-record write. Identify the bytes actually installed rather than
+	// trusting the pre-crash record, then preserve that compatible identity in
+	// the recovered active record so terminal journals cannot hide a mismatch.
+	if selectorMatchesRelease(store, selector, journal.Old.BuildID) {
+		selectorBuild = journal.Old.BuildID
+	} else if journal.Candidate != nil && selectorMatchesRelease(store, selector, journal.Candidate.BuildID) {
+		selectorBuild = journal.Candidate.BuildID
+	}
+	if selectorBuild == "" {
+		return false, errors.New("interrupted transition selector does not match an authenticated old or candidate release")
+	}
+	if _, err := store.WriteSelectedActive(*journal.Old, generation, selectorBuild, active.Acquisition); err != nil {
+		return false, err
+	}
+	if err := writeLegacyCurrent(store.Home, *journal.Old); err != nil {
+		return false, err
+	}
+	if err := startReleaseCommand(ctx, *journal.Old, journal.ID); err != nil {
+		return false, err
+	}
+	if err := store.Advance(&journal, release.RolledBack, nil); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func receiptBuild(receipt *release.Receipt) string {
+	if receipt == nil {
+		return "<none>"
+	}
+	return receipt.BuildID
+}
+
+func parseBuildTarget(args []string, command string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	if len(args) == 2 && args[0] == "--to" && buildIDPattern.MatchString(args[1]) {
+		return args[1], nil
+	}
+	return "", fmt.Errorf("usage: jobctrl %s [--to BUILD_ID]", command)
+}
+
+// promoteExisting uses the same promotion path for a staged update and a
+// rollback. Candidate code starts while active.json still names old, then the
+// only selection pointer changes after the real launcher readiness probe.
+func promoteExisting(ctx launchContext, store *release.Store, active release.Active, build, operation string, output io.Writer) (result error) {
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return fmt.Errorf("acquire lifecycle transition lock: %w", err)
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return fmt.Errorf("acquire exclusive release selection lock: %w", err)
+	}
+	defer selection.Close()
+	if existing, journalErr := store.ReadJournal(); journalErr == nil && existing.Resumable() {
+		return fmt.Errorf("unfinished %s transition at %s must be recovered before another promotion", existing.Operation, existing.State)
+	} else if journalErr != nil && !errors.Is(journalErr, os.ErrNotExist) {
+		return fmt.Errorf("read existing release transition journal: %w", journalErr)
+	}
+	// Another updater may have completed while this command was waiting.
+	active, err = store.ReadActive()
+	if err != nil {
+		return err
+	}
+	ctx, err = rebindActiveContext(ctx, active.Receipt.BuildID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ctx.selection.Close() }()
+	candidate, err := readInstalledReceipt(store.Home, build)
+	if err != nil {
+		return err
+	}
+	if candidate.Channel != active.Receipt.Channel {
+		return errors.New("candidate channel differs from the active channel")
+	}
+	if candidate.BuildID == active.Receipt.BuildID {
+		if candidate != active.Receipt {
+			return errors.New("candidate build identity conflicts with the active immutable receipt")
+		}
+		_, err := fmt.Fprintf(output, "JobCtrl %s is already active.\n", candidate.BuildID)
+		return err
+	}
+	activeVerified, err := verifyInstalledReleaseForExecution(store, active.Receipt)
+	if err != nil {
+		return fmt.Errorf("active release is not safe to transition: %w", err)
+	}
+	candidateVerified, err := verifyInstalledReleaseForExecution(store, candidate)
+	if err != nil {
+		return fmt.Errorf("candidate is not safe to promote: %w", err)
+	}
+	if candidate.Sequence <= active.Receipt.Sequence {
+		return errors.New("update refuses a lower or equal-sequence different release; use explicit rollback for an eligible predecessor")
+	}
+	policy, err := readInstalledPolicy(store.Home, candidate)
+	if err != nil {
+		return err
+	}
+	if active.SelectorBuildID != candidate.BuildID {
+		candidateProtocol := candidateVerified.runtime.LauncherProtocol
+		if !protocolSupports(activeVerified.distribution, candidateProtocol) || !protocolSupports(candidateVerified.distribution, candidateProtocol) {
+			return fmt.Errorf("candidate launcher protocol %d cannot supervise both active and candidate payloads; stage an explicit compatible bridge release", candidateProtocol)
+		}
+	}
+	journal, err := store.Begin(operation, &active.Receipt, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		return err
+	}
+	if err := advance(store, &journal, release.MetadataVerified); err != nil {
+		return err
+	}
+	if err := advance(store, &journal, release.ReleaseCommitted); err != nil {
+		return err
+	}
+	if active.SelectorBuildID != candidate.BuildID {
+		if err := advance(store, &journal, release.SelectorHandoffPending); err != nil {
+			return err
+		}
+		if err := handoffPublicSelector(store.Home, candidateVerified); err != nil {
+			return err
+		}
+		if err := advance(store, &journal, release.SelectorReplaced); err != nil {
+			return err
+		}
+		updated, err := store.WriteSelectedActive(active.Receipt, active.Generation, candidate.BuildID, active.Acquisition)
+		if err != nil {
+			return err
+		}
+		active = updated
+	}
+	if err := advance(store, &journal, release.Quiescing); err != nil {
+		return err
+	}
+	if err := stop(ctx); err != nil {
+		_ = store.Advance(&journal, release.Failed, err)
+		return fmt.Errorf("quiesce active release: %w", err)
+	}
+	pair, err := snapshotPair(ctx, active.Receipt)
+	if err != nil {
+		_ = store.Advance(&journal, release.Failed, err)
+		return err
+	}
+	journal.BackupID = pair.ID
+	if err := advance(store, &journal, release.PairBackedUp); err != nil {
+		return err
+	}
+	journal.PendingPolicy = &policy
+	if err := advance(store, &journal, release.PolicyPending); err != nil {
+		return err
+	}
+	channelState, err := store.ValidateMetadata(policy)
+	if err != nil {
+		return err
+	}
+
+	rollbackFailure := func(cause error) error {
+		_ = store.Advance(&journal, release.RollbackRestoring, cause)
+		if stopErr := stop(ctx); stopErr != nil { // Candidate records share the canonical state identity.
+			return fmt.Errorf("%v; refusing paired rollback restore while the candidate could not be quiesced: %w", cause, stopErr)
+		}
+		if restoreErr := restorePair(ctx, pair); restoreErr != nil {
+			return fmt.Errorf("%v; paired rollback restore failed: %w", cause, restoreErr)
+		}
+		if _, activateErr := store.WriteSelectedActive(active.Receipt, active.Generation, active.SelectorBuildID, active.Acquisition); activateErr != nil {
+			return fmt.Errorf("%v; restore active release pointer: %w", cause, activateErr)
+		}
+		if legacyErr := writeLegacyCurrent(store.Home, active.Receipt); legacyErr != nil {
+			return fmt.Errorf("%v; restore legacy receipt: %w", cause, legacyErr)
+		}
+		if restartErr := startReleaseCommand(ctx, active.Receipt, journal.ID); restartErr != nil {
+			return fmt.Errorf("%v; old release restart failed: %w", cause, restartErr)
+		}
+		_ = store.Advance(&journal, release.RolledBack, cause)
+		return cause
+	}
+	if err := advance(store, &journal, release.CandidateStarting); err != nil {
+		return rollbackFailure(err)
+	}
+	if err := startReleaseCommand(ctx, candidate, journal.ID); err != nil {
+		return rollbackFailure(fmt.Errorf("candidate start/readiness failed: %w", err))
+	}
+	if err := advance(store, &journal, release.CandidateHealthy); err != nil {
+		return rollbackFailure(err)
+	}
+	// The authenticated candidate policy may raise the safety floor or revoke
+	// the predecessor. Commit it only after real readiness succeeds so every
+	// earlier interruption can still restore and execute the prior release.
+	if err := store.CommitMetadata(channelState); err != nil {
+		if permitErr := store.Permit(active.Receipt); permitErr != nil {
+			return fmt.Errorf("finalize authenticated policy after candidate readiness: %w; predecessor is no longer permitted, preserve the journal for explicit safe recovery: %v", err, permitErr)
+		}
+		return rollbackFailure(fmt.Errorf("finalize authenticated policy after candidate readiness: %w", err))
+	}
+	if err := advance(store, &journal, release.PolicyFinalized); err != nil {
+		return err
+	}
+	source := environmentMap(ctx.Environment)["JOBCTRL_ACQUISITION_SOURCE"]
+	if source == "" {
+		source = active.Acquisition
+	}
+	if _, err := store.WriteSelectedActive(candidate, active.Generation, candidate.BuildID, source); err != nil {
+		return err
+	}
+	if err := writeLegacyCurrent(store.Home, candidate); err != nil {
+		return err
+	}
+	if err := advance(store, &journal, release.Promoted); err != nil {
+		return err
+	}
+	if err := retainReleases(store, ctx.Instance.RuntimeHome); err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "JobCtrl %s is active.\n", candidate.BuildID)
+	return err
+}
+
+func startRelease(ctx launchContext, receipt release.Receipt, journalID string) error {
+	store, err := releaseStore(ctx)
+	if err != nil {
+		return err
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, receipt)
+	if err != nil {
+		return fmt.Errorf("verify release immediately before execution: %w", err)
+	}
+	path := filepath.Join(verified.payloadRoot, "launcher", "jobctrl")
+	cmd := exec.Command(path, "start", "--no-open")
+	cmd.Env = append(append([]string{}, ctx.Environment...), "JOBCTRL_TRANSITION_CANDIDATE=1")
+	if journalID != "" {
+		cmd.Env = append(cmd.Env, "JOBCTRL_TRANSITION_JOURNAL="+journalID)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func backup(ctx launchContext, args []string, output io.Writer) error {
+	releaseSelection(&ctx)
+	directory := ""
+	if len(args) == 2 && args[0] == "--output" {
+		directory = args[1]
+	} else if len(args) != 0 {
+		return errors.New("usage: jobctrl backup [--output DIRECTORY]")
+	}
+	if directory == "" {
+		directory = filepath.Join(ctx.Instance.StateDir, "backups")
+	}
+	if !filepath.IsAbs(directory) {
+		return errors.New("backup output must be an absolute directory")
+	}
+	if err := ensureSafeDirectory(directory); err != nil {
+		return err
+	}
+	store, err := releaseStore(ctx)
+	if err != nil {
+		return err
+	}
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return err
+	}
+	defer selection.Close()
+	active, err := store.ReadActive()
+	if err != nil {
+		return err
+	}
+	ctx, err = rebindActiveContext(ctx, active.Receipt.BuildID)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ctx.selection.Close() }()
+	wasRunning := false
+	if state, stateErr := readState(ctx.Instance.StatePath); stateErr == nil {
+		wasRunning = stateHasLiveProcesses(state)
+	} else if !errors.Is(stateErr, os.ErrNotExist) {
+		return stateErr
+	}
+	if wasRunning {
+		if err := stop(ctx); err != nil {
+			return fmt.Errorf("quiesce runtime for coherent paired backup: %w", err)
+		}
+	}
+	pair, err := snapshotPairTo(ctx, active.Receipt, directory)
+	if wasRunning {
+		// A stable selector takes a shared selection lock through readiness, so
+		// restart only after releasing our exclusive selection lock. We retain
+		// the transition lock to serialize lifecycle work, and route through the
+		// authenticated public selector rather than direct payload execution.
+		if closeErr := selection.Close(); closeErr != nil {
+			return closeErr
+		}
+		if restartErr := startSelectedRelease(ctx); restartErr != nil {
+			if err != nil {
+				return fmt.Errorf("%v; restart after backup failed: %w", err, restartErr)
+			}
+			return restartErr
+		}
+	}
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(output, "JobCtrl database pair backup written: %s\n", filepath.Join(directory, pair.ID))
+	return err
+}
+
+func startSelectedRelease(ctx launchContext) error {
+	selector := filepath.Join(ctx.Instance.RuntimeHome, "bin", "jobctrl")
+	if err := VerifyPublicSelectorForExecution(ctx.Instance.RuntimeHome); err != nil {
+		return fmt.Errorf("verify public selector before restart: %w", err)
+	}
+	command := exec.Command(selector, "start", "--no-open")
+	command.Env = append([]string{}, ctx.Environment...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("restart through public selector: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func snapshotPair(ctx launchContext, receipt release.Receipt) (databasePair, error) {
+	return snapshotPairTo(ctx, receipt, filepath.Join(ctx.Instance.StateDir, "backups"))
+}
+func snapshotPairTo(ctx launchContext, receipt release.Receipt, parent string) (databasePair, error) {
+	if err := ensureSafeDirectory(parent); err != nil {
+		return databasePair{}, err
+	}
+	random, err := releaseRandomID()
+	if err != nil {
+		return databasePair{}, err
+	}
+	id := "pair-" + random
+	dir := filepath.Join(parent, id)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return databasePair{}, err
+	}
+	pair := databasePair{SchemaVersion: 1, ID: id, ReleaseReceipt: receipt, CreatedAt: time.Now().UTC()}
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		source := filepath.Join(ctx.Instance.StateDir, name)
+		destination := filepath.Join(dir, name)
+		version, err := sqliteOnlineBackup(filepath.Join(ctx.PayloadRoot, "python", "bin", "python3"), source, destination)
+		if err != nil {
+			return databasePair{}, fmt.Errorf("snapshot %s: %w", name, err)
+		}
+		file, err := describeDatabase(destination, name, version)
+		if err != nil {
+			return databasePair{}, err
+		}
+		pair.Files = append(pair.Files, file)
+	}
+	if err := writeJSONAtomic(filepath.Join(dir, "pair.json"), pair); err != nil {
+		return databasePair{}, err
+	}
+	if err := syncDirectory(dir); err != nil {
+		return databasePair{}, err
+	}
+	if err := syncDirectory(parent); err != nil {
+		return databasePair{}, err
+	}
+	return pair, nil
+}
+
+func sqliteOnlineBackup(python, source, destination string) (int64, error) {
+	info, err := os.Lstat(source)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return 0, errors.New("source database is not a regular file")
+	}
+	if _, err := os.Lstat(destination); !errors.Is(err, os.ErrNotExist) {
+		return 0, errors.New("backup destination already exists")
+	}
+	code := `import os,sqlite3,sys
+src,dst=sys.argv[1:3]
+c=sqlite3.connect(src, timeout=30)
+try:
+ r=c.execute("PRAGMA integrity_check").fetchone()
+ if not r or r[0] != "ok": raise RuntimeError("source integrity_check failed")
+ c.execute("VACUUM INTO ?", (dst,))
+finally: c.close()
+d=sqlite3.connect(dst)
+try:
+ r=d.execute("PRAGMA integrity_check").fetchone()
+ if not r or r[0] != "ok": raise RuntimeError("backup integrity_check failed")
+ print(d.execute("PRAGMA user_version").fetchone()[0])
+finally: d.close()`
+	out, err := exec.Command(python, "-I", "-B", "-c", code, source, destination).CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("SQLite online backup: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	var version int64
+	if _, err := fmt.Sscan(strings.TrimSpace(string(out)), &version); err != nil {
+		return 0, errors.New("SQLite backup returned invalid schema version")
+	}
+	file, err := os.OpenFile(destination, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return 0, err
+	}
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if syncErr != nil {
+		return 0, syncErr
+	}
+	if closeErr != nil {
+		return 0, closeErr
+	}
+	return version, nil
+}
+
+func describeDatabase(path, name string, version int64) (databaseFile, error) {
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return databaseFile{}, errors.New("backup database is not a regular file")
+	}
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return databaseFile{}, err
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return databaseFile{}, err
+	}
+	return databaseFile{Name: name, SHA256: hex.EncodeToString(hash.Sum(nil)), SizeBytes: info.Size(), SQLiteUserVer: version}, nil
+}
+
+func restorePair(ctx launchContext, pair databasePair) error {
+	if pair.SchemaVersion != 1 || !pair.ReleaseReceipt.Valid() || len(pair.Files) != 2 {
+		return errors.New("backup is not a complete database pair")
+	}
+	dir := filepath.Join(ctx.Instance.StateDir, "backups", pair.ID)
+	if info, err := os.Lstat(dir); err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("backup pair directory is not a regular directory")
+	}
+	for _, expected := range pair.Files {
+		if expected.Name != "jobctrl.db" && expected.Name != "temporal.db" {
+			return errors.New("backup pair has an unknown database")
+		}
+		actual, err := describeDatabase(filepath.Join(dir, expected.Name), expected.Name, expected.SQLiteUserVer)
+		if err != nil || actual.SHA256 != expected.SHA256 || actual.SizeBytes != expected.SizeBytes {
+			return errors.New("backup database pair digest/size verification failed")
+		}
+	}
+	random, err := releaseRandomID()
+	if err != nil {
+		return err
+	}
+	staging := filepath.Join(ctx.Instance.StateDir, ".restore-"+random)
+	if err := os.Mkdir(staging, 0o700); err != nil {
+		return err
+	}
+	defer os.RemoveAll(staging)
+	for _, expected := range pair.Files {
+		staged := filepath.Join(staging, expected.Name)
+		if err := copyRegular(filepath.Join(dir, expected.Name), staged); err != nil {
+			return err
+		}
+	}
+	// No runtime is live (quiescing happened first). The journal makes a crash
+	// between the two renames recoverable; never restore a single DB by itself.
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		if err := os.Rename(filepath.Join(staging, name), filepath.Join(ctx.Instance.StateDir, name)); err != nil {
+			return err
+		}
+	}
+	for _, name := range []string{"jobctrl.db-wal", "jobctrl.db-shm", "temporal.db-wal", "temporal.db-shm"} {
+		_ = os.Remove(filepath.Join(ctx.Instance.StateDir, name))
+	}
+	return syncDirectory(ctx.Instance.StateDir)
+}
+
+func copyRegular(source, destination string) error {
+	input, err := os.OpenFile(source, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	info, err := input.Stat()
+	if err != nil || !info.Mode().IsRegular() {
+		return errors.New("copy source is not a regular file")
+	}
+	output, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(output, input)
+	if copyErr == nil {
+		copyErr = output.Sync()
+	}
+	if closeErr := output.Close(); copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		_ = os.Remove(destination)
+	}
+	return copyErr
+}
+func ensureSafeDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("managed path is not a regular directory")
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return os.MkdirAll(path, 0o700)
+}
+func writeJSONAtomic(path string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	random, err := releaseRandomID()
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+"."+random)
+	file, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+func writeLegacyCurrent(home string, receipt release.Receipt) error {
+	// current.json is only a one-time P4 migration input. New P5 records keep
+	// acquisition ownership in active.json and never copy it into immutable
+	// release evidence.
+	return writeJSONAtomic(filepath.Join(home, "current.json"), selectorReceipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: int64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt})
+}
+func readInstalledReceipt(home, build string) (release.Receipt, error) {
+	var receipt selectorReceipt
+	if !buildIDPattern.MatchString(build) {
+		return release.Receipt{}, errors.New("invalid release build id")
+	}
+	if err := decodeStrictRegular(filepath.Join(home, "releases", build, "receipt.json"), &receipt); err != nil {
+		return release.Receipt{}, fmt.Errorf("read candidate release receipt: %w", err)
+	}
+	r := release.Receipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: uint64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}
+	if !r.Valid() {
+		return release.Receipt{}, errors.New("candidate release receipt is invalid")
+	}
+	return r, nil
+}
+
+func readInstalledPolicy(home string, receipt release.Receipt) (release.ChannelMetadata, error) {
+	if receipt.SchemaVersion != 2 || !sha256Pattern.MatchString(receipt.PolicySHA256) {
+		return release.ChannelMetadata{}, errors.New("candidate release receipt does not bind authenticated policy")
+	}
+	path := filepath.Join(home, "releases", receipt.BuildID, "policy.json")
+	file, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NOFOLLOW, 0)
+	if err != nil {
+		return release.ChannelMetadata{}, fmt.Errorf("read candidate release policy: %w", err)
+	}
+	raw, readErr := io.ReadAll(file)
+	info, statErr := file.Stat()
+	closeErr := file.Close()
+	if readErr != nil {
+		return release.ChannelMetadata{}, fmt.Errorf("read candidate release policy: %w", readErr)
+	}
+	if statErr != nil {
+		return release.ChannelMetadata{}, fmt.Errorf("stat candidate release policy: %w", statErr)
+	}
+	if closeErr != nil {
+		return release.ChannelMetadata{}, fmt.Errorf("close candidate release policy: %w", closeErr)
+	}
+	if !info.Mode().IsRegular() {
+		return release.ChannelMetadata{}, errors.New("candidate release policy is not a regular file")
+	}
+	digest := sha256.Sum256(raw)
+	if hex.EncodeToString(digest[:]) != receipt.PolicySHA256 {
+		return release.ChannelMetadata{}, errors.New("candidate release policy digest differs from immutable receipt")
+	}
+	var policy release.ChannelMetadata
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&policy); err != nil {
+		return policy, fmt.Errorf("read candidate release policy: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return policy, errors.New("read candidate release policy: trailing JSON value")
+	}
+	if policy.Channel != receipt.Channel || policy.Sequence != receipt.Sequence || policy.BuildID != receipt.BuildID || policy.DescriptorDigest != receipt.DescriptorSHA256 || policy.Minimum > policy.Sequence {
+		return policy, errors.New("candidate release policy does not bind immutable receipt")
+	}
+	return policy, nil
+}
+func previousRelease(store *release.Store, active release.Receipt) (string, error) {
+	entries, err := os.ReadDir(filepath.Join(store.Home, "releases"))
+	if err != nil {
+		return "", err
+	}
+	var candidates []release.Receipt
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		r, err := readInstalledReceipt(store.Home, entry.Name())
+		if err == nil && r.Channel == active.Channel && r.BuildID != active.BuildID && r.Sequence <= active.Sequence && store.Permit(r) == nil {
+			candidates = append(candidates, r)
+		}
+	}
+	if len(candidates) == 0 {
+		return "", errors.New("no safe previous release is retained for rollback")
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Sequence > candidates[j].Sequence })
+	return candidates[0].BuildID, nil
+}
+
+func retainReleases(store *release.Store, runtimeHome string) error {
+	active, err := store.ReadActive()
+	if err != nil {
+		return err
+	}
+	keep := map[string]bool{active.Receipt.BuildID: true}
+	if active.SelectorBuildID != "" {
+		keep[active.SelectorBuildID] = true
+	}
+	if journal, err := store.ReadJournal(); err == nil {
+		if journal.Old != nil {
+			keep[journal.Old.BuildID] = true
+		}
+		if journal.Candidate != nil {
+			keep[journal.Candidate.BuildID] = true
+		}
+	}
+	if prior, err := previousRelease(store, active.Receipt); err == nil {
+		keep[prior] = true
+	}
+	instances, _ := os.ReadDir(filepath.Join(runtimeHome, "instances"))
+	for _, instance := range instances {
+		backups, _ := os.ReadDir(filepath.Join(runtimeHome, "instances", instance.Name(), "backups"))
+		for _, backup := range backups {
+			var pair databasePair
+			if decodeStrictRegular(filepath.Join(runtimeHome, "instances", instance.Name(), "backups", backup.Name(), "pair.json"), &pair) == nil && pair.ReleaseReceipt.BuildID != "" {
+				keep[pair.ReleaseReceipt.BuildID] = true
+			}
+		}
+		var state instanceState
+		if decodeStrictRegular(filepath.Join(runtimeHome, "instances", instance.Name(), "state.json"), &state) == nil && stateHasLiveProcesses(state) {
+			keep[state.BuildID] = true
+		}
+	}
+	entries, err := os.ReadDir(filepath.Join(store.Home, "releases"))
+	if err != nil {
+		return err
+	}
+	deleted := false
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 || keep[entry.Name()] {
+			continue
+		}
+		receipt, err := readInstalledReceipt(store.Home, entry.Name())
+		if err != nil || receipt.Channel != "stable" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(store.Home, "releases", entry.Name())); err != nil {
+			return err
+		}
+		deleted = true
+	}
+	if deleted {
+		return syncDirectory(filepath.Join(store.Home, "releases"))
+	}
+	return nil
+}
+
+func uninstall(ctx launchContext, args []string, output io.Writer) error {
+	releaseSelection(&ctx)
+	deleteData := false
+	if len(args) == 0 {
+	} else if len(args) == 1 && args[0] == "--remove-data" {
+		if uninstallInput == os.Stdin {
+			info, err := os.Stdin.Stat()
+			if err != nil || info.Mode()&os.ModeCharDevice == 0 {
+				return errors.New("--remove-data requires the exact phrase from an interactive terminal; non-interactive input is refused")
+			}
+		}
+		if _, err := fmt.Fprintf(output, "Type %s to permanently remove local JobCtrl data: ", removeDataPhrase); err != nil {
+			return err
+		}
+		line, err := bufio.NewReader(uninstallInput).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("read data removal confirmation: %w", err)
+		}
+		if strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r") != removeDataPhrase {
+			return errors.New("local data was not removed: exact typed confirmation is required")
+		}
+		deleteData = true
+	} else {
+		return errors.New("usage: jobctrl uninstall [--remove-data]; --yes and --confirm are never accepted")
+	}
+	store, err := releaseStore(ctx)
+	if err != nil {
+		return err
+	}
+	transition, err := store.TransitionLock()
+	if err != nil {
+		return err
+	}
+	defer transition.Close()
+	selection, err := store.SelectionLock(true)
+	if err != nil {
+		return err
+	}
+	defer selection.Close()
+	if pathsOverlap(ctx.Instance.StateDir, store.Home) {
+		return errors.New("refusing uninstall because JobCtrl data path overlaps the runtime store")
+	}
+	if err := validateManagedUninstallPaths(store.Home); err != nil {
+		return err
+	}
+	if deleteData {
+		info, stateErr := os.Lstat(ctx.Instance.StateDir)
+		if stateErr != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("refusing unsafe JobCtrl data path")
+		}
+	}
+	if err := validateCurlAcquisitionPreflight(store.Home); err != nil {
+		return err
+	}
+	active, activeErr := store.ReadActive()
+	if activeErr != nil && !errors.Is(activeErr, os.ErrNotExist) {
+		return activeErr
+	}
+	wasRunning := false
+	if state, stateErr := readState(ctx.Instance.StatePath); stateErr == nil {
+		wasRunning = stateHasLiveProcesses(state)
+	} else if !errors.Is(stateErr, os.ErrNotExist) {
+		return stateErr
+	}
+	if err := stop(ctx); err != nil {
+		return err
+	}
+	fromHomebrewFrontend := environmentMap(ctx.Environment)["JOBCTRL_HOMEBREW_FRONTEND"] == "1"
+	if (activeErr == nil && active.Acquisition == "homebrew") || fromHomebrewFrontend {
+		brewOutput, brewErr := homebrewCommand("uninstall", "ebarti/tap/jobctrl")
+		if brewErr != nil {
+			if wasRunning {
+				if closeErr := selection.Close(); closeErr == nil {
+					_ = startSelectedRelease(ctx)
+				}
+			}
+			return fmt.Errorf("Homebrew acquisition uninstall failed; local data and runtime were preserved: %w: %s", brewErr, strings.TrimSpace(brewOutput))
+		}
+	}
+	if err := removeExactCurlExposure(store.Home); err != nil {
+		return err
+	}
+	// Keep transition/selection lock inodes and authenticated channel state in
+	// place. Unlinking a held flock creates a second inode that another process
+	// can lock around an in-progress uninstall; deleting revocation tombstones
+	// would also make a later reinstall accept a signed downgrade.
+	for _, name := range []string{"bin", "releases", "staging", "instances", release.ActiveFile, "current.json", "acquisition.json", release.JournalFile, "install.lock"} {
+		path := filepath.Join(store.Home, name)
+		if info, err := os.Lstat(path); err == nil && info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing symlinked managed uninstall path %q", name)
+		}
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+	if deleteData {
+		info, err := os.Lstat(ctx.Instance.StateDir)
+		if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return errors.New("refusing unsafe JobCtrl data path")
+		}
+		if err := os.RemoveAll(ctx.Instance.StateDir); err != nil {
+			return err
+		}
+		_, err = io.WriteString(output, "JobCtrl runtime and confirmed local data removed.\n")
+		return err
+	}
+	_, err = io.WriteString(output, "JobCtrl runtime removed; local data and capability profiles were preserved.\n")
+	return err
+}
+
+func validateManagedUninstallPaths(home string) error {
+	for _, name := range []string{"bin", "releases", "staging", "instances"} {
+		path := filepath.Join(home, name)
+		if info, err := os.Lstat(path); err == nil && (!info.IsDir() || info.Mode()&os.ModeSymlink != 0) {
+			return fmt.Errorf("managed uninstall path %q is not a regular directory", name)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	for _, name := range []string{release.ActiveFile, "current.json", "acquisition.json", release.JournalFile, "install.lock"} {
+		path := filepath.Join(home, name)
+		if info, err := os.Lstat(path); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+			return fmt.Errorf("managed uninstall path %q is not a regular file", name)
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateCurlAcquisitionPreflight(runtimeHome string) error {
+	path := filepath.Join(runtimeHome, "acquisition.json")
+	var record curlAcquisitionRecord
+	if err := decodeStrictRegular(path, &record); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("read curl acquisition record: %w", err)
+	}
+	selector := filepath.Join(runtimeHome, "bin", "jobctrl")
+	if record.SchemaVersion != 1 || record.Source != "curl" || record.Selector != selector || !filepath.IsAbs(record.PublicLink) || filepath.Base(record.PublicLink) != "jobctrl" || (record.Profile == "") != (record.PathLine == "") {
+		return errors.New("invalid curl acquisition record")
+	}
+	if record.Profile == "" {
+		return nil
+	}
+	if !filepath.IsAbs(record.Profile) || record.PathLine != `export PATH="`+filepath.Dir(record.PublicLink)+`:$PATH" # JobCtrl managed path` {
+		return errors.New("invalid curl profile ownership record")
+	}
+	if info, err := os.Lstat(record.Profile); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return errors.New("curl profile is not a regular file")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func pathsOverlap(left, right string) bool {
+	left, leftErr := canonicalPathForOverlap(left)
+	right, rightErr := canonicalPathForOverlap(right)
+	if leftErr != nil || rightErr != nil {
+		return true
+	}
+	return pathContains(left, right) || pathContains(right, left)
+}
+
+// canonicalPathForOverlap resolves symlinks in the longest existing ancestor,
+// then appends any not-yet-created suffix. This catches parent-symlink aliases
+// without making an absent default JOBCTRL_DIR impossible to uninstall.
+func canonicalPathForOverlap(path string) (string, error) {
+	absolute, err := filepath.Abs(filepath.Clean(path))
+	if err != nil {
+		return "", err
+	}
+	probe := absolute
+	suffix := make([]string, 0)
+	for {
+		resolved, resolveErr := filepath.EvalSymlinks(probe)
+		if resolveErr == nil {
+			parts := append([]string{resolved}, suffix...)
+			return filepath.Clean(filepath.Join(parts...)), nil
+		}
+		if !errors.Is(resolveErr, os.ErrNotExist) {
+			return "", resolveErr
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			return "", resolveErr
+		}
+		suffix = append([]string{filepath.Base(probe)}, suffix...)
+		probe = parent
+	}
+}
+
+func pathContains(parent, child string) bool {
+	relative, err := filepath.Rel(parent, child)
+	if err != nil {
+		return true
+	}
+	return relative == "." || (relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)))
+}
+
+// removeExactCurlExposure removes only the link and profile line the curl
+// script recorded. It never follows a link, never guesses a default bin dir,
+// and leaves unrelated shell/profile content untouched. Homebrew has no such
+// record and its Cellar/prefix remains exclusively Homebrew-owned.
+func removeExactCurlExposure(runtimeHome string) error {
+	path := filepath.Join(runtimeHome, "acquisition.json")
+	var record curlAcquisitionRecord
+	if err := decodeStrictRegular(path, &record); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("read curl acquisition record: %w", err)
+	}
+	selector := filepath.Join(runtimeHome, "bin", "jobctrl")
+	if record.SchemaVersion != 1 || record.Source != "curl" || record.Selector != selector || !filepath.IsAbs(record.PublicLink) || filepath.Base(record.PublicLink) != "jobctrl" || (record.Profile == "") != (record.PathLine == "") {
+		return errors.New("invalid curl acquisition record")
+	}
+	if info, err := os.Lstat(record.PublicLink); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, readErr := os.Readlink(record.PublicLink)
+			if readErr != nil {
+				return readErr
+			}
+			if target == selector {
+				if err := os.Remove(record.PublicLink); err != nil {
+					return err
+				}
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if record.Profile == "" {
+		return nil
+	}
+	if !filepath.IsAbs(record.Profile) || record.PathLine != `export PATH="`+filepath.Dir(record.PublicLink)+`:$PATH" # JobCtrl managed path` {
+		return errors.New("invalid curl profile ownership record")
+	}
+	info, err := os.Lstat(record.Profile)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("curl profile is not a regular file")
+	}
+	raw, err := os.ReadFile(record.Profile)
+	if err != nil {
+		return err
+	}
+	updated := strings.ReplaceAll(string(raw), record.PathLine+"\n", "")
+	if updated == string(raw) {
+		updated = strings.ReplaceAll(updated, record.PathLine, "")
+	}
+	if updated == string(raw) {
+		return nil
+	}
+	return writeBytesPrivateAtomic(record.Profile, []byte(updated), info.Mode().Perm())
+}
+
+func writeBytesPrivateAtomic(path string, raw []byte, mode os.FileMode) error {
+	random, err := releaseRandomID()
+	if err != nil {
+		return err
+	}
+	temporary := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+"."+random)
+	file, err := os.OpenFile(temporary, os.O_WRONLY|os.O_CREATE|os.O_EXCL|syscall.O_NOFOLLOW, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err == nil {
+		err = file.Sync()
+	}
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(temporary)
+		return err
+	}
+	if err := os.Rename(temporary, path); err != nil {
+		_ = os.Remove(temporary)
+		return err
+	}
+	return syncDirectory(filepath.Dir(path))
+}
+
+// Keep bytes imported on all supported Go versions where json decoding of
+// backup fixtures is optimized through a bytes.Reader in tests.
+var _ = bytes.NewReader

--- a/launcher/internal/launcher/lifecycle_activation_boundaries_test.go
+++ b/launcher/internal/launcher/lifecycle_activation_boundaries_test.go
@@ -1,0 +1,449 @@
+package launcher
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+// writePolicyBoundLifecycleReceipt rewrites the release-local, immutable
+// policy evidence together.  Tests that subsequently alter policy.json leave
+// this receipt untouched, which is the hostile-disk condition a launcher must
+// reject before it can start or promote that release.
+func writePolicyBoundLifecycleReceipt(t *testing.T, runtime string, receipt *release.Receipt, policy release.ChannelMetadata) {
+	t.Helper()
+	receipt.SchemaVersion = 2
+	receipt.PolicySHA256 = writeLifecyclePolicy(t, filepath.Join(runtime, "releases", receipt.BuildID, "policy.json"), policy)
+	if err := writeJSONAtomic(filepath.Join(runtime, "releases", receipt.BuildID, "receipt.json"), selectorReceipt{
+		SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel,
+		Sequence: int64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256,
+		ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256,
+		PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestP5PolicyTamperingFailsBeforePromotion(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+
+	for _, mutation := range []struct {
+		name   string
+		mutate func(release.ChannelMetadata) release.ChannelMetadata
+	}{
+		{
+			name: "lowered minimum safe sequence",
+			mutate: func(policy release.ChannelMetadata) release.ChannelMetadata {
+				policy.Minimum = 0
+				return policy
+			},
+		},
+		{
+			name: "removed predecessor revocation",
+			mutate: func(policy release.ChannelMetadata) release.ChannelMetadata {
+				policy.Revoked = nil
+				return policy
+			},
+		},
+	} {
+		t.Run(mutation.name, func(t *testing.T) {
+			runtime, state := t.TempDir(), t.TempDir()
+			store, err := release.Open(runtime)
+			if err != nil {
+				t.Fatal(err)
+			}
+			old := installLifecycleRelease(t, runtime, "local-policy-old-0001", 1, python)
+			candidate := installLifecycleRelease(t, runtime, "local-policy-new-0002", 2, python)
+			policy := release.ChannelMetadata{
+				Channel: candidate.Channel, Sequence: candidate.Sequence, Minimum: candidate.Sequence,
+				BuildID: candidate.BuildID, DescriptorDigest: candidate.DescriptorSHA256,
+				Revoked: []string{old.BuildID},
+			}
+			writePolicyBoundLifecycleReceipt(t, runtime, &candidate, policy)
+			if _, err := store.WriteSelectedActive(old, 0, old.BuildID, "local-fixture"); err != nil {
+				t.Fatal(err)
+			}
+			verifiedOld, err := verifyInstalledReleaseForExecution(store, old)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := handoffPublicSelector(runtime, verifiedOld); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := verifyInstalledReleaseForExecution(store, candidate); err != nil {
+				t.Fatalf("receipt-bound policy was not initially executable: %v", err)
+			}
+
+			// This write changes only policy.json.  An attacker who can modify the
+			// install directory must not be able to lower the floor or discard a
+			// revocation without also changing the receipt-bound digest.
+			if err := writeJSONAtomic(filepath.Join(runtime, "releases", candidate.BuildID, "policy.json"), mutation.mutate(policy)); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := verifyInstalledReleaseForExecution(store, candidate); err == nil || !strings.Contains(err.Error(), "policy") {
+				t.Fatalf("tampered policy passed immediate candidate execution verification: %v", err)
+			}
+
+			oldStart, oldFailure := startReleaseCommand, transitionFailure
+			t.Cleanup(func() { startReleaseCommand, transitionFailure = oldStart, oldFailure })
+			starts := 0
+			startReleaseCommand = func(_ launchContext, _ release.Receipt, _ string) error {
+				starts++
+				return nil
+			}
+			ctx := launchContext{Instance: instance{
+				RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(state, "state.json"), ControlPath: filepath.Join(state, "control.lock"),
+			}, Environment: []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime, "JOBCTRL_DIR=" + state}}
+			err = promoteExisting(ctx, store, release.Active{SchemaVersion: 1, Generation: 1, Receipt: old, SelectorBuildID: old.BuildID, Acquisition: "local-fixture"}, candidate.BuildID, "update", io.Discard)
+			if err == nil || !strings.Contains(err.Error(), "candidate is not safe to promote") {
+				t.Fatalf("tampered policy reached promotion: %v", err)
+			}
+			if starts != 0 {
+				t.Fatalf("tampered policy started a release before promotion was rejected: starts=%d", starts)
+			}
+			if active, activeErr := store.ReadActive(); activeErr != nil || active.Receipt != old {
+				t.Fatalf("tampered policy changed active release before promotion: %#v, %v", active, activeErr)
+			}
+			if _, journalErr := store.ReadJournal(); !errors.Is(journalErr, os.ErrNotExist) {
+				t.Fatalf("tampered policy created a transition journal before rejection: %v", journalErr)
+			}
+			if err := store.Permit(old); err != nil {
+				t.Fatalf("uncommitted tampered candidate policy changed predecessor permission: %v", err)
+			}
+		})
+	}
+}
+
+type promotionBoundaryFixture struct {
+	runtime   string
+	state     string
+	store     *release.Store
+	old       release.Receipt
+	candidate release.Receipt
+	ctx       launchContext
+	env       []string
+}
+
+func newPromotionBoundaryFixture(t *testing.T, python string) promotionBoundaryFixture {
+	t.Helper()
+	runtime, state := t.TempDir(), t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := installLifecycleRelease(t, runtime, "local-boundary-old-0001", 1, python)
+	candidate := installLifecycleRelease(t, runtime, "local-boundary-new-0002", 2, python)
+	writePolicyBoundLifecycleReceipt(t, runtime, &candidate, release.ChannelMetadata{
+		Channel: candidate.Channel, Sequence: candidate.Sequence, Minimum: candidate.Sequence,
+		BuildID: candidate.BuildID, DescriptorDigest: candidate.DescriptorSHA256,
+		Revoked: []string{old.BuildID},
+	})
+	if _, err := store.WriteSelectedActive(old, 0, old.BuildID, "local-fixture"); err != nil {
+		t.Fatal(err)
+	}
+	verifiedOld, err := verifyInstalledReleaseForExecution(store, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handoffPublicSelector(runtime, verifiedOld); err != nil {
+		t.Fatal(err)
+	}
+	seedLifecycleSQLitePair(t, python, state, "old")
+	env := []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime, "JOBCTRL_DIR=" + state}
+	return promotionBoundaryFixture{
+		runtime: runtime, state: state, store: store, old: old, candidate: candidate, env: env,
+		ctx: launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(state, "missing-state.json"), ControlPath: filepath.Join(state, "control.lock")}, Environment: env},
+	}
+}
+
+// This exercises the actual promotion transaction at each durable activation
+// milestone—not just advance's journal write.  Before PolicyFinalized the
+// authenticated channel state is unchanged, so recovery must restore and run
+// the predecessor.  At and after PolicyFinalized, the old release is revoked;
+// recovery must instead remain fail-closed to the independently verified,
+// already healthy candidate.
+func TestP5PromotionRecoveryRespectsEveryActivationBoundary(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	cases := []struct {
+		state               release.State
+		postPolicy          bool
+		terminal            bool
+		synchronousRollback bool
+	}{
+		{state: release.MetadataVerified},
+		{state: release.ReleaseCommitted},
+		{state: release.SelectorHandoffPending},
+		{state: release.SelectorReplaced},
+		{state: release.Quiescing},
+		{state: release.PairBackedUp},
+		{state: release.PolicyPending},
+		// These two boundaries are inside promoteExisting's rollback guard:
+		// an injected error is recovered synchronously rather than left for a
+		// later command.  They still prove the pre-policy invariant through
+		// the same durable pair and predecessor restart.
+		{state: release.CandidateStarting, synchronousRollback: true},
+		{state: release.CandidateHealthy, synchronousRollback: true},
+		{state: release.PolicyFinalized, postPolicy: true},
+		{state: release.Promoted, postPolicy: true, terminal: true},
+	}
+	for _, testCase := range cases {
+		t.Run(string(testCase.state), func(t *testing.T) {
+			fixture := newPromotionBoundaryFixture(t, python)
+			oldStart, oldFailure := startReleaseCommand, transitionFailure
+			t.Cleanup(func() { startReleaseCommand, transitionFailure = oldStart, oldFailure })
+			oldStarts, candidateStarts := 0, 0
+			startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+				if journalID == "" {
+					t.Fatal("promotion/recovery execution was not bound to a durable journal")
+				}
+				switch receipt.BuildID {
+				case fixture.old.BuildID:
+					oldStarts++
+				case fixture.candidate.BuildID:
+					candidateStarts++
+					setLifecycleSQLitePair(t, python, fixture.state, "candidate")
+				default:
+					t.Fatalf("unexpected release execution %q", receipt.BuildID)
+				}
+				return nil
+			}
+			transitionFailure = func(state release.State) error {
+				if state == testCase.state {
+					return errTransitionInterrupted
+				}
+				return nil
+			}
+
+			err := promoteExisting(fixture.ctx, fixture.store, release.Active{
+				SchemaVersion: 1, Generation: 1, Receipt: fixture.old,
+				SelectorBuildID: fixture.old.BuildID, Acquisition: "local-fixture",
+			}, fixture.candidate.BuildID, "update", io.Discard)
+			if !errors.Is(err, errTransitionInterrupted) {
+				t.Fatalf("promotion interruption at %s = %v", testCase.state, err)
+			}
+			transitionFailure = nil
+			journal, err := fixture.store.ReadJournal()
+			if err != nil {
+				t.Fatalf("read durable boundary %s: %v", testCase.state, err)
+			}
+			if testCase.synchronousRollback {
+				if journal.State != release.RolledBack || journal.Resumable() {
+					t.Fatalf("guarded boundary %s did not durably roll back: %#v", testCase.state, journal)
+				}
+			} else if journal.State != testCase.state {
+				t.Fatalf("durable boundary %s was not retained: %#v", testCase.state, journal)
+			}
+
+			if !testCase.postPolicy {
+				if err := fixture.store.Permit(fixture.old); err != nil {
+					t.Fatalf("pre-policy boundary %s revoked predecessor: %v", testCase.state, err)
+				}
+				if testCase.synchronousRollback {
+					active, activeErr := fixture.store.ReadActive()
+					if activeErr != nil || active.Receipt != fixture.old {
+						t.Fatalf("guarded pre-policy rollback at %s did not restore prior release: %#v, %v", testCase.state, active, activeErr)
+					}
+					if oldStarts != 1 {
+						t.Fatalf("guarded pre-policy rollback at %s did not make predecessor runnable exactly once: old starts=%d", testCase.state, oldStarts)
+					}
+					if _, err := verifyInstalledReleaseForExecution(fixture.store, fixture.old); err != nil {
+						t.Fatalf("guarded pre-policy rollback at %s left predecessor unverifiable: %v", testCase.state, err)
+					}
+					return
+				}
+				recovered, recoverErr := recoverInterruptedTransition(fixture.ctx, fixture.store)
+				if !recovered || recoverErr != nil {
+					t.Fatalf("pre-policy recovery at %s = recovered:%v err:%v", testCase.state, recovered, recoverErr)
+				}
+				active, activeErr := fixture.store.ReadActive()
+				if activeErr != nil || active.Receipt != fixture.old {
+					t.Fatalf("pre-policy recovery at %s did not restore prior release: %#v, %v", testCase.state, active, activeErr)
+				}
+				if oldStarts != 1 {
+					t.Fatalf("pre-policy recovery at %s did not make predecessor runnable exactly once: old starts=%d", testCase.state, oldStarts)
+				}
+				if _, err := verifyInstalledReleaseForExecution(fixture.store, fixture.old); err != nil {
+					t.Fatalf("pre-policy recovery at %s left predecessor unverifiable: %v", testCase.state, err)
+				}
+				return
+			}
+
+			if err := fixture.store.Permit(fixture.old); err == nil {
+				t.Fatalf("post-policy boundary %s left revoked predecessor permitted", testCase.state)
+			}
+			if _, err := verifyInstalledReleaseForExecution(fixture.store, fixture.candidate); err != nil {
+				t.Fatalf("post-policy boundary %s did not retain authenticated candidate: %v", testCase.state, err)
+			}
+			if testCase.terminal {
+				if journal.Resumable() {
+					t.Fatalf("terminal post-policy boundary %s remained resumable", testCase.state)
+				}
+				active, activeErr := fixture.store.ReadActive()
+				if activeErr != nil || active.Receipt != fixture.candidate {
+					t.Fatalf("terminal post-policy boundary did not select candidate: %#v, %v", active, activeErr)
+				}
+				if oldStarts != 0 || candidateStarts != 1 {
+					t.Fatalf("terminal post-policy boundary executed wrong releases: old=%d candidate=%d", oldStarts, candidateStarts)
+				}
+				return
+			}
+
+			handled, recoverErr := recoverRevokedTransitionBeforePrepare(fixture.env, io.Discard)
+			if !handled || recoverErr != nil {
+				t.Fatalf("post-policy recovery at %s = handled:%v err:%v", testCase.state, handled, recoverErr)
+			}
+			active, activeErr := fixture.store.ReadActive()
+			if activeErr != nil || active.Receipt != fixture.candidate {
+				t.Fatalf("post-policy recovery at %s did not select candidate: %#v, %v", testCase.state, active, activeErr)
+			}
+			if oldStarts != 0 || candidateStarts != 2 {
+				t.Fatalf("post-policy recovery at %s was not fail-closed to candidate: old=%d candidate=%d", testCase.state, oldStarts, candidateStarts)
+			}
+		})
+	}
+}
+
+func TestP5RevokedActiveCanUninstallWithoutPayloadExecution(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime, state := t.TempDir(), t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := installLifecycleRelease(t, runtime, "local-revoked-active-0001", 1, python)
+
+	// Keep the release self-consistent while making an accidental payload exec
+	// observable.  The fail-closed uninstall path must never create this marker.
+	payload := filepath.Join(runtime, "releases", active.BuildID, "payload")
+	manifest, err := loadAndVerifyDistributionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(t.TempDir(), "payload-executed")
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "jobctrl"), []byte("#!/bin/sh\nprintf executed > "+marker+"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, payload, &manifest)
+	writeLocalEnvelope(t, payload, manifest)
+	active.ManifestSHA256, err = sha256Path(filepath.Join(payload, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(runtime, "releases", active.BuildID, "receipt.json"), selectorReceipt{
+		SchemaVersion: active.SchemaVersion, BuildID: active.BuildID, Channel: active.Channel,
+		Sequence: int64(active.Sequence), ArtifactSHA256: active.ArtifactSHA256,
+		ManifestSHA256: active.ManifestSHA256, DescriptorSHA256: active.DescriptorSHA256,
+		PolicySHA256: active.PolicySHA256, DescriptorURL: active.DescriptorURL, InstalledAt: active.InstalledAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.WriteSelectedActive(active, 0, active.BuildID, "local-fixture"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordMetadata(active.Channel, 2, 0, "local-safe-build-0002", strings.Repeat("e", 64), []string{active.BuildID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Permit(active); err == nil {
+		t.Fatal("fixture did not revoke active release")
+	}
+	profile := filepath.Join(state, "profile.json")
+	if err := os.WriteFile(profile, []byte("private local data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime, "JOBCTRL_DIR=" + state}
+	var output bytes.Buffer
+	if err := Run(filepath.Join(runtime, "bin", "jobctrl"), []string{"uninstall"}, env, &output, io.Discard); err != nil {
+		t.Fatalf("revoked active uninstall = %v", err)
+	}
+	if _, err := os.Lstat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("uninstall executed revoked payload: %v", err)
+	}
+	if raw, err := os.ReadFile(profile); err != nil || string(raw) != "private local data" {
+		t.Fatalf("default revoked-release uninstall changed user data: %q, %v", raw, err)
+	}
+	if _, err := os.Lstat(filepath.Join(runtime, "releases")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("uninstall did not remove revoked runtime releases: %v", err)
+	}
+	if !strings.Contains(output.String(), "local data and capability profiles were preserved") {
+		t.Fatalf("uninstall did not report default data preservation: %q", output.String())
+	}
+}
+
+func TestP5OrdinaryHomebrewRollbackRecoversBeforeFormulaBootstrap(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	fixture := newPromotionBoundaryFixture(t, python)
+	selected, err := fixture.store.ReadActive()
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected, err = fixture.store.WriteSelectedActive(fixture.old, selected.Generation, fixture.old.BuildID, "homebrew")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStart, oldFailure := startReleaseCommand, transitionFailure
+	t.Cleanup(func() { startReleaseCommand, transitionFailure = oldStart, oldFailure })
+	oldStarts := 0
+	startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+		if receipt != fixture.old || journalID == "" {
+			t.Fatalf("ordinary recovery executed unexpected release %#v journal=%q", receipt, journalID)
+		}
+		oldStarts++
+		return nil
+	}
+	transitionFailure = func(state release.State) error {
+		if state == release.MetadataVerified {
+			return errTransitionInterrupted
+		}
+		return nil
+	}
+	err = promoteExisting(fixture.ctx, fixture.store, selected, fixture.candidate.BuildID, "update", io.Discard)
+	if !errors.Is(err, errTransitionInterrupted) {
+		t.Fatalf("ordinary Homebrew interruption = %v", err)
+	}
+	transitionFailure = nil
+
+	// If formula bootstrap runs first it will reject this intentionally invalid
+	// configuration. The durable ordinary journal must take precedence.
+	formulaRoot := t.TempDir()
+	formulaExecutable := filepath.Join(formulaRoot, "jobctrl")
+	if err := os.WriteFile(formulaExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaRoot, "homebrew-bootstrap.json"), []byte("not-json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var output bytes.Buffer
+	if err := Run(formulaExecutable, []string{"rollback"}, fixture.env, &output, io.Discard); err != nil {
+		t.Fatalf("ordinary Homebrew rollback through public Run: %v", err)
+	}
+	if oldStarts != 1 || !strings.Contains(output.String(), "restored to its previous release") {
+		t.Fatalf("ordinary Homebrew recovery oldStarts=%d output=%q", oldStarts, output.String())
+	}
+	active, err := fixture.store.ReadActive()
+	if err != nil || active.Receipt != fixture.old || active.Acquisition != "homebrew" {
+		t.Fatalf("ordinary Homebrew recovery active=%#v err=%v", active, err)
+	}
+	journal, err := fixture.store.ReadJournal()
+	if err != nil || journal.State != release.RolledBack || journal.Resumable() {
+		t.Fatalf("ordinary Homebrew recovery journal=%#v err=%v", journal, err)
+	}
+}

--- a/launcher/internal/launcher/lifecycle_security_recovery_test.go
+++ b/launcher/internal/launcher/lifecycle_security_recovery_test.go
@@ -1,0 +1,212 @@
+package launcher
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+func TestPolicyFinalizationInterruptionRecoversCandidateBeforeHomebrewBootstrap(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+
+	runtime, state := t.TempDir(), t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := installLifecycleRelease(t, runtime, "local-old-build-0101", 1, python)
+	candidate := installLifecycleRelease(t, runtime, "local-new-build-0102", 2, python)
+
+	// A payload execution marker lets the test distinguish a rejected launch
+	// authorization from executing the revoked old launcher. Rebuild the local
+	// fixture's immutable manifest and receipt around that marker before
+	// selecting it as the initial runtime.
+	oldPayload := filepath.Join(runtime, "releases", old.BuildID, "payload")
+	oldManifest, err := loadAndVerifyDistributionManifest(oldPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldExecutionMarker := filepath.Join(t.TempDir(), "revoked-old-executed")
+	if err := os.WriteFile(
+		filepath.Join(oldPayload, "launcher", "jobctrl"),
+		[]byte("#!/bin/sh\nprintf old-executed > "+oldExecutionMarker+"\nexit 0\n"),
+		0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, oldPayload, &oldManifest)
+	writeLocalEnvelope(t, oldPayload, oldManifest)
+	old.ManifestSHA256, err = sha256Path(filepath.Join(oldPayload, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(
+		filepath.Join(runtime, "releases", old.BuildID, "receipt.json"),
+		selectorReceipt{
+			SchemaVersion: old.SchemaVersion, BuildID: old.BuildID, Channel: old.Channel,
+			Sequence: int64(old.Sequence), ArtifactSHA256: old.ArtifactSHA256,
+			ManifestSHA256: old.ManifestSHA256, DescriptorSHA256: old.DescriptorSHA256,
+			PolicySHA256: old.PolicySHA256, DescriptorURL: old.DescriptorURL, InstalledAt: old.InstalledAt,
+		},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// The authenticated candidate policy raises the safe floor and revokes the
+	// predecessor. Promotion must prove candidate health before committing it,
+	// then a crash at the durable policy boundary must never execute old code.
+	policy := release.ChannelMetadata{
+		Channel: candidate.Channel, Sequence: candidate.Sequence, Minimum: candidate.Sequence,
+		BuildID: candidate.BuildID, DescriptorDigest: candidate.DescriptorSHA256,
+		Revoked: []string{old.BuildID},
+	}
+	candidate.PolicySHA256 = writeLifecyclePolicy(t, filepath.Join(runtime, "releases", candidate.BuildID, "policy.json"), policy)
+	if err := writeJSONAtomic(filepath.Join(runtime, "releases", candidate.BuildID, "receipt.json"), selectorReceipt{
+		SchemaVersion: candidate.SchemaVersion, BuildID: candidate.BuildID, Channel: candidate.Channel,
+		Sequence: int64(candidate.Sequence), ArtifactSHA256: candidate.ArtifactSHA256,
+		ManifestSHA256: candidate.ManifestSHA256, DescriptorSHA256: candidate.DescriptorSHA256,
+		PolicySHA256: candidate.PolicySHA256, DescriptorURL: candidate.DescriptorURL, InstalledAt: candidate.InstalledAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.WriteSelectedActive(old, 0, old.BuildID, "local-fixture"); err != nil {
+		t.Fatal(err)
+	}
+	verifiedOld, err := verifyInstalledReleaseForExecution(store, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handoffPublicSelector(runtime, verifiedOld); err != nil {
+		t.Fatal(err)
+	}
+	seedLifecycleSQLitePair(t, python, state, "old")
+	before := lifecycleDatabaseValues(t, python, state)
+	environment := []string{
+		"HOME=" + t.TempDir(),
+		"JOBCTRL_RUNTIME_HOME=" + runtime,
+		"JOBCTRL_DIR=" + state,
+	}
+	ctx := launchContext{
+		Instance: instance{
+			RuntimeHome: runtime, StateDir: state,
+			StatePath:   filepath.Join(state, "missing-state.json"),
+			ControlPath: filepath.Join(state, "control.lock"),
+		},
+		Environment: environment,
+	}
+
+	originalStart, originalFailure := startReleaseCommand, transitionFailure
+	t.Cleanup(func() { startReleaseCommand, transitionFailure = originalStart, originalFailure })
+	candidateStarts, oldStartChecks := 0, 0
+	restoredBeforeRetry := false
+	startReleaseCommand = func(_ launchContext, receipt release.Receipt, journalID string) error {
+		switch receipt.BuildID {
+		case candidate.BuildID:
+			candidateStarts++
+			if journalID == "" {
+				t.Fatal("security recovery started the candidate outside its durable journal")
+			}
+			if candidateStarts == 2 {
+				restoredBeforeRetry = sameDatabaseDigests(lifecycleDatabaseValues(t, python, state), before)
+			}
+			setLifecycleSQLitePair(t, python, state, "candidate")
+			return nil
+		case old.BuildID:
+			oldStartChecks++
+			return errors.New("revoked predecessor must never be restarted")
+		default:
+			t.Fatalf("unexpected release start request: %s", receipt.BuildID)
+			return nil
+		}
+	}
+	transitionFailure = func(state release.State) error {
+		if state == release.PolicyFinalized {
+			return errTransitionInterrupted
+		}
+		return nil
+	}
+
+	err = promoteExisting(
+		ctx, store,
+		release.Active{
+			SchemaVersion: 1, Generation: 1, Receipt: old,
+			SelectorBuildID: old.BuildID, Acquisition: "local-fixture",
+		},
+		candidate.BuildID, "update", io.Discard,
+	)
+	if !errors.Is(err, errTransitionInterrupted) {
+		t.Fatalf("policy-finalization interruption = %v", err)
+	}
+	transitionFailure = nil
+	if candidateStarts != 1 || oldStartChecks != 0 {
+		t.Fatalf("interrupted promotion starts candidate=%d old=%d, want 1/0", candidateStarts, oldStartChecks)
+	}
+	if _, err := os.Lstat(oldExecutionMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("revoked predecessor payload executed during recovery: %v", err)
+	}
+	if err := store.Permit(old); err == nil {
+		t.Fatal("revoked predecessor remained permitted after candidate policy finalization")
+	}
+	journal, err := store.ReadJournal()
+	if err != nil || journal.State != release.PolicyFinalized || !journal.Resumable() {
+		t.Fatalf("policy-finalization interruption was not durably resumable: %#v, %v", journal, err)
+	}
+	if got := lifecycleDatabaseValues(t, python, state); got["jobctrl.db"] != "candidatejobctrl.db" || got["temporal.db"] != "candidatetemporal.db" {
+		t.Fatalf("healthy candidate did not reach both SQLite databases before interruption: %v", got)
+	}
+
+	// Use an intentionally invalid Homebrew bootstrap record. Recovery must run
+	// before that frontend is even parsed; the prior ordering would fail here.
+	formulaRoot := t.TempDir()
+	formulaExecutable := filepath.Join(formulaRoot, "jobctrl")
+	if err := os.WriteFile(formulaExecutable, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(formulaRoot, "homebrew-bootstrap.json"), []byte("not-json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A safe retry is explicit: the public rollback command sees the resumable
+	// revoked-predecessor journal, restores the durable pair, and resumes only
+	// the still-permitted candidate.
+	var output bytes.Buffer
+	if err := Run(formulaExecutable, []string{"rollback"}, environment, &output, io.Discard); err != nil {
+		t.Fatalf("explicit security recovery through jobctrl rollback: %v", err)
+	}
+	if !strings.Contains(output.String(), "Recovered the verified security-update candidate") {
+		t.Fatalf("security recovery output = %q", output.String())
+	}
+	if candidateStarts != 2 {
+		t.Fatalf("candidate starts = %d, want healthy attempt plus explicit safe recovery", candidateStarts)
+	}
+	if oldStartChecks != 0 {
+		t.Fatalf("security recovery retried the revoked predecessor: checks=%d", oldStartChecks)
+	}
+	if !restoredBeforeRetry {
+		t.Fatal("security recovery did not restore the exact paired database backup before restarting the candidate")
+	}
+	if _, err := os.Lstat(oldExecutionMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("revoked predecessor payload executed during explicit recovery: %v", err)
+	}
+	active, err := store.ReadActive()
+	if err != nil || active.Receipt != candidate {
+		t.Fatalf("explicit security recovery active receipt = %#v, %v", active, err)
+	}
+	journal, err = store.ReadJournal()
+	if err != nil || journal.State != release.Promoted {
+		t.Fatalf("explicit security recovery did not close the promotion audit: %#v, %v", journal, err)
+	}
+	if got := lifecycleDatabaseValues(t, python, state); got["jobctrl.db"] != "candidatejobctrl.db" || got["temporal.db"] != "candidatetemporal.db" {
+		t.Fatalf("explicit security recovery did not rerun the candidate against both restored databases: %v", got)
+	}
+}

--- a/launcher/internal/launcher/lifecycle_test.go
+++ b/launcher/internal/launcher/lifecycle_test.go
@@ -1,0 +1,984 @@
+package launcher
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ebarti/jobctrl/launcher/internal/release"
+)
+
+func lifecycleReceipt(build, source string, sequence uint64) release.Receipt {
+	_ = source
+	return release.Receipt{SchemaVersion: 1, BuildID: build, Channel: "local", Sequence: sequence, ArtifactSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSHA256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", DescriptorSHA256: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", DescriptorURL: "local-fixture", InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+func lifecyclePolicyDigest(t *testing.T, policy release.ChannelMetadata) string {
+	t.Helper()
+	raw, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, '\n')
+	digest := sha256.Sum256(raw)
+	return hex.EncodeToString(digest[:])
+}
+
+func writeLifecyclePolicy(t *testing.T, path string, policy release.ChannelMetadata) string {
+	t.Helper()
+	digest := lifecyclePolicyDigest(t, policy)
+	if err := writeJSONAtomic(path, policy); err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func TestHomebrewExecutableIsDiscoveredAndValidatedAtRuntime(t *testing.T) {
+	oldLookup := homebrewExecutableLookup
+	t.Cleanup(func() { homebrewExecutableLookup = oldLookup })
+	brew := filepath.Join(t.TempDir(), "brew")
+	if err := os.WriteFile(brew, []byte("#!/bin/sh\nprintf discovered\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	homebrewExecutableLookup = func(name string) (string, error) {
+		if name != "brew" {
+			t.Fatalf("unexpected executable lookup %q", name)
+		}
+		return brew, nil
+	}
+	if output, err := homebrewCommand("--version"); err != nil || strings.TrimSpace(output) != "discovered" {
+		t.Fatalf("runtime-discovered Homebrew command = %q, %v", output, err)
+	}
+	if err := os.Chmod(brew, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := homebrewCommand("--version"); err == nil || !strings.Contains(err.Error(), "non-writable") {
+		t.Fatalf("writable Homebrew executable was not rejected: %v", err)
+	}
+}
+
+func TestNativeUpdateHomebrewUsesPrivateAcquisitionAdapter(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime := t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := installLifecycleRelease(t, runtime, "local-build-0000001", 1, python)
+	if _, err := store.WriteSelectedActive(r, 0, r.BuildID, "homebrew"); err != nil {
+		t.Fatal(err)
+	}
+	payload := filepath.Join(runtime, "releases", r.BuildID, "payload")
+	distribution, err := loadAndVerifyDistributionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix := t.TempDir()
+	installerPath := filepath.Join(payload, "launcher", "jobctrl-installer")
+	candidate := lifecycleReceipt("local-build-0000002", "homebrew", 2)
+	candidate.DescriptorSHA256 = strings.Repeat("d", 64)
+	candidateDir := filepath.Join(runtime, "releases", candidate.BuildID)
+	if err := os.MkdirAll(candidateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(candidateDir, "receipt.json"), selectorReceipt{SchemaVersion: candidate.SchemaVersion, BuildID: candidate.BuildID, Channel: candidate.Channel, Sequence: int64(candidate.Sequence), ArtifactSHA256: candidate.ArtifactSHA256, ManifestSHA256: candidate.ManifestSHA256, DescriptorSHA256: candidate.DescriptorSHA256, DescriptorURL: candidate.DescriptorURL, InstalledAt: candidate.InstalledAt}); err != nil {
+		t.Fatal(err)
+	}
+	oldBrew, oldBootstrap, oldAssets, oldPromotion := homebrewCommand, homebrewBootstrapCommand, homebrewAssetsReader, homebrewPromotion
+	t.Cleanup(func() {
+		homebrewCommand, homebrewBootstrapCommand, homebrewAssetsReader, homebrewPromotion = oldBrew, oldBootstrap, oldAssets, oldPromotion
+	})
+	var calls []string
+	homebrewCommand = func(args ...string) (string, error) {
+		calls = append(calls, strings.Join(args, " "))
+		if len(args) == 2 && args[0] == "--prefix" {
+			return prefix + "\n", nil
+		}
+		return "Already up-to-date\n", nil
+	}
+	homebrewBootstrapCommand = func(path string, args []string, _ []string) (string, error) {
+		if path != installerPath || !strings.Contains(strings.Join(args, " "), "--stage-only") {
+			t.Fatalf("unexpected bootstrap invocation: %s %v", path, args)
+		}
+		return "staged", nil
+	}
+	formulaCandidate := candidate
+	homebrewAssetsReader = func(_ string) (homebrewFormulaAssets, error) {
+		return homebrewFormulaAssets{BuildID: formulaCandidate.BuildID, DescriptorURL: "https://example.test/release.json", DescriptorSHA256: formulaCandidate.DescriptorSHA256, DescriptorPath: "/tmp/descriptor", SignaturePath: "/tmp/signature", ArchivePath: "/tmp/archive"}, nil
+	}
+	promotions := 0
+	homebrewPromotion = func(_ launchContext, _ *release.Store, got release.Active, build, operation string, _ io.Writer) error {
+		promotions++
+		if got.Receipt != r || build != candidate.BuildID || operation != "update" {
+			t.Fatalf("unexpected common promotion: %#v %s %s", got, build, operation)
+		}
+		return nil
+	}
+	ctx := launchContext{PayloadRoot: payload, Distribution: distribution, Instance: instance{RuntimeHome: runtime}, Environment: []string{"HOME=" + t.TempDir()}}
+	var out bytes.Buffer
+	err = update(ctx, nil, &out)
+	if err != nil || promotions != 1 || strings.Join(calls, ",") != "upgrade ebarti/tap/jobctrl,--prefix ebarti/tap/jobctrl" {
+		t.Fatalf("update result = %v output=%q calls=%v", err, out.String(), calls)
+	}
+	formulaCandidate = r
+	out.Reset()
+	if err := update(ctx, nil, &out); err != nil || promotions != 1 || !strings.Contains(out.String(), "already active") {
+		t.Fatalf("already-current Homebrew update = %v output=%q promotions=%d", err, out.String(), promotions)
+	}
+}
+
+func TestNativeUpdateHomebrewReportsAcquisitionAndBootstrapFailures(t *testing.T) {
+	oldBrew, oldBootstrap, oldAssets, oldPromotion := homebrewCommand, homebrewBootstrapCommand, homebrewAssetsReader, homebrewPromotion
+	t.Cleanup(func() {
+		homebrewCommand, homebrewBootstrapCommand, homebrewAssetsReader, homebrewPromotion = oldBrew, oldBootstrap, oldAssets, oldPromotion
+	})
+	ctx := launchContext{Environment: []string{"HOME=" + t.TempDir()}}
+	homebrewCommand = func(_ ...string) (string, error) { return "brew failed", errors.New("exit 1") }
+	if err := updateHomebrew(ctx, nil, release.Active{}, io.Discard); err == nil || !strings.Contains(err.Error(), "acquisition update failed") {
+		t.Fatalf("brew failure = %v", err)
+	}
+	prefix := t.TempDir()
+	homebrewCommand = func(args ...string) (string, error) {
+		if args[0] == "--prefix" {
+			return prefix, nil
+		}
+		return "", nil
+	}
+	homebrewAssetsReader = func(_ string) (homebrewFormulaAssets, error) {
+		return homebrewFormulaAssets{}, errors.New("assets failed")
+	}
+	if err := updateHomebrew(ctx, nil, release.Active{}, io.Discard); err == nil || !strings.Contains(err.Error(), "assets failed") {
+		t.Fatalf("asset failure = %v", err)
+	}
+}
+
+func TestNativeUpdateCurlStagesExactReceiptPromotesAndNoops(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime := t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := installLifecycleRelease(t, runtime, "local-curl-active-0101", 1, python)
+	candidate := installLifecycleRelease(t, runtime, "local-curl-candidate-0102", 2, python)
+	if _, err := store.WriteSelectedActive(active, 0, active.BuildID, "curl"); err != nil {
+		t.Fatal(err)
+	}
+	payload := filepath.Join(runtime, "releases", active.BuildID, "payload")
+	distribution, err := loadAndVerifyDistributionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCommand, oldPromotion := curlInstallerCommand, curlPromotion
+	t.Cleanup(func() { curlInstallerCommand, curlPromotion = oldCommand, oldPromotion })
+	var commandCalls int
+	curlInstallerCommand = func(path string, args []string, env []string) (string, error) {
+		commandCalls++
+		if path != filepath.Join(payload, "launcher", "jobctrl-installer") || !curlHasArgument(args, "--source", "curl") || !curlHasArgument(args, "--stage-only", "") || !curlHasArgument(args, "--json", "") || curlArgument(args, "--home") != runtime {
+			t.Fatalf("unexpected curl installer invocation: %s %v", path, args)
+		}
+		if environmentMap(env)["JOBCTRL_RUNTIME_HOME"] != runtime {
+			t.Fatalf("curl installer lost runtime home: %v", env)
+		}
+		raw, marshalErr := json.Marshal(candidate)
+		return string(raw), marshalErr
+	}
+	var promoted bool
+	curlPromotion = func(got launchContext, _ *release.Store, gotActive release.Active, build, operation string, _ io.Writer) error {
+		promoted = true
+		if gotActive.Receipt != active || build != candidate.BuildID || operation != "update" || environmentMap(got.Environment)["JOBCTRL_ACQUISITION_SOURCE"] != "curl" {
+			t.Fatalf("unexpected curl promotion: active=%#v build=%s operation=%s env=%v", gotActive, build, operation, got.Environment)
+		}
+		return nil
+	}
+	ctx := launchContext{PayloadRoot: payload, Distribution: distribution, Instance: instance{RuntimeHome: runtime}, Environment: []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime}}
+	if err := updateCurl(ctx, store, release.Active{SchemaVersion: 1, Generation: 1, Receipt: active, SelectorBuildID: active.BuildID, Acquisition: "curl"}, io.Discard); err != nil {
+		t.Fatalf("curl stage and promotion: %v", err)
+	}
+	if commandCalls != 1 || !promoted {
+		t.Fatalf("curl stage/promote calls=%d promoted=%v", commandCalls, promoted)
+	}
+
+	// A same-build receipt is a successful idempotent acquisition. It must not
+	// enter the health-gated promotion path or advance active selection.
+	curlInstallerCommand = func(_ string, _ []string, _ []string) (string, error) {
+		raw, marshalErr := json.Marshal(active)
+		return string(raw), marshalErr
+	}
+	curlPromotion = func(_ launchContext, _ *release.Store, _ release.Active, _ string, _ string, _ io.Writer) error {
+		t.Fatal("same-build curl receipt attempted promotion")
+		return nil
+	}
+	var output bytes.Buffer
+	if err := updateCurl(ctx, store, release.Active{SchemaVersion: 1, Generation: 1, Receipt: active, SelectorBuildID: active.BuildID, Acquisition: "curl"}, &output); err != nil {
+		t.Fatalf("same-build curl no-op: %v", err)
+	}
+	if !strings.Contains(output.String(), "already active") {
+		t.Fatalf("same-build curl output = %q", output.String())
+	}
+}
+
+func TestNativeUpdateCurlRejectsNonExactReceiptAndKeepsP6Gate(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime := t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := installLifecycleRelease(t, runtime, "local-curl-gate-0101", 1, python)
+	if _, err := store.WriteSelectedActive(active, 0, active.BuildID, "curl"); err != nil {
+		t.Fatal(err)
+	}
+	payload := filepath.Join(runtime, "releases", active.BuildID, "payload")
+	distribution, err := loadAndVerifyDistributionManifest(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldCommand, oldPromotion := curlInstallerCommand, curlPromotion
+	t.Cleanup(func() { curlInstallerCommand, curlPromotion = oldCommand, oldPromotion })
+	called := false
+	curlInstallerCommand = func(_ string, _ []string, _ []string) (string, error) {
+		called = true
+		return `{"schemaVersion":1}`, nil
+	}
+	ctx := launchContext{PayloadRoot: payload, Distribution: distribution, Instance: instance{RuntimeHome: runtime}, Environment: []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime}}
+	if err := update(ctx, nil, io.Discard); err == nil || !strings.Contains(err.Error(), "not available until P6") {
+		t.Fatalf("unsigned P5 curl update bypassed network policy gate: %v", err)
+	}
+	if called {
+		t.Fatal("P6 policy gate executed curl installer")
+	}
+	if err := updateCurl(ctx, store, release.Active{SchemaVersion: 1, Generation: 1, Receipt: active, SelectorBuildID: active.BuildID, Acquisition: "curl"}, io.Discard); err == nil || !strings.Contains(err.Error(), "invalid staged receipt") {
+		t.Fatalf("non-exact curl receipt accepted: %v", err)
+	}
+}
+
+func curlArgument(args []string, name string) string {
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] == name {
+			return args[index+1]
+		}
+	}
+	return ""
+}
+
+func curlHasArgument(args []string, name, value string) bool {
+	for index, argument := range args {
+		if argument != name {
+			continue
+		}
+		return value == "" || (index+1 < len(args) && args[index+1] == value)
+	}
+	return false
+}
+
+func TestUninstallRequiresRemoveDataFlagAndExactTypedPhrase(t *testing.T) {
+	runtime, state := t.TempDir(), t.TempDir()
+	ctx := launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(runtime, "missing-state.json"), ControlPath: filepath.Join(runtime, "control.lock")}}
+	old := uninstallInput
+	t.Cleanup(func() { uninstallInput = old })
+	var out bytes.Buffer
+	if err := uninstall(ctx, []string{"--yes"}, &out); err == nil {
+		t.Fatal("--yes bypass accepted")
+	}
+	uninstallInput = strings.NewReader("REMOVE JOBCTRL DATA\n")
+	if err := uninstall(ctx, []string{"--confirm", "REMOVE JOBCTRL DATA"}, &out); err == nil {
+		t.Fatal("--confirm bypass accepted")
+	}
+	uninstallInput = strings.NewReader("no\n")
+	if err := uninstall(ctx, []string{"--remove-data"}, &out); err == nil {
+		t.Fatal("wrong typed phrase accepted")
+	}
+	uninstallInput = strings.NewReader("REMOVE JOBCTRL DATA\n")
+	if err := uninstall(ctx, []string{"--remove-data"}, &out); err != nil {
+		t.Fatalf("typed removal: %v", err)
+	}
+	if _, err := os.Lstat(state); !os.IsNotExist(err) {
+		t.Fatalf("state still exists: %v", err)
+	}
+}
+
+func TestDefaultUninstallPreservesUserDataAndRejectsForeignLinks(t *testing.T) {
+	runtime, state := t.TempDir(), t.TempDir()
+	if err := os.WriteFile(filepath.Join(state, "profile.json"), []byte("private"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(runtime, "missing-state.json"), ControlPath: filepath.Join(runtime, "control.lock")}}
+	var out bytes.Buffer
+	if err := uninstall(ctx, nil, &out); err != nil {
+		t.Fatal(err)
+	}
+	if raw, err := os.ReadFile(filepath.Join(state, "profile.json")); err != nil || string(raw) != "private" {
+		t.Fatalf("default uninstall changed user data: %q, %v", raw, err)
+	}
+	unsafeRuntime := t.TempDir()
+	if err := os.Symlink(state, filepath.Join(unsafeRuntime, "bin")); err != nil {
+		t.Fatal(err)
+	}
+	unsafe := ctx
+	unsafe.Instance.RuntimeHome = unsafeRuntime
+	if err := uninstall(unsafe, nil, &out); err == nil {
+		t.Fatal("uninstall accepted a symlinked managed path")
+	}
+}
+
+func TestCurlUninstallRemovesOnlyRecordedLinkAndPathLine(t *testing.T) {
+	runtime := t.TempDir()
+	bin := filepath.Join(runtime, "bin")
+	if err := os.MkdirAll(bin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	selector := filepath.Join(bin, "jobctrl")
+	if err := os.WriteFile(selector, []byte("selector"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	publicBin := filepath.Join(t.TempDir(), "custom-bin")
+	if err := os.MkdirAll(publicBin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	publicLink := filepath.Join(publicBin, "jobctrl")
+	if err := os.Symlink(selector, publicLink); err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(publicBin, "foreign")
+	if err := os.Symlink("/bin/echo", foreign); err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(t.TempDir(), ".zprofile")
+	line := `export PATH="` + publicBin + `:$PATH" # JobCtrl managed path`
+	contents := "export KEEP=1\n" + line + "\nexport OTHER=2\n"
+	if err := os.WriteFile(profile, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	record := curlAcquisitionRecord{SchemaVersion: 1, Source: "curl", PublicLink: publicLink, Selector: selector, Profile: profile, PathLine: line}
+	if err := writeJSONAtomic(filepath.Join(runtime, "acquisition.json"), record); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeExactCurlExposure(runtime); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(publicLink); !os.IsNotExist(err) {
+		t.Fatalf("recorded public link remains: %v", err)
+	}
+	if _, err := os.Lstat(foreign); err != nil {
+		t.Fatalf("foreign link changed: %v", err)
+	}
+	if raw, err := os.ReadFile(profile); err != nil || string(raw) != "export KEEP=1\nexport OTHER=2\n" {
+		t.Fatalf("profile cleanup changed foreign content: %q, %v", raw, err)
+	}
+}
+
+func TestUninstallRejectsOverlappingStateBeforeMutatingRuntime(t *testing.T) {
+	runtime := t.TempDir()
+	state := filepath.Join(runtime, "nested-state")
+	if err := os.MkdirAll(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(runtime, "releases", "keep")
+	if err := os.MkdirAll(filepath.Dir(marker), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(runtime, "missing-state.json"), ControlPath: filepath.Join(runtime, "control.lock")}}
+	if err := uninstall(ctx, nil, io.Discard); err == nil || !strings.Contains(err.Error(), "overlaps") {
+		t.Fatalf("overlapping uninstall = %v", err)
+	}
+	if raw, err := os.ReadFile(marker); err != nil || string(raw) != "keep" {
+		t.Fatalf("overlap preflight mutated runtime: %q, %v", raw, err)
+	}
+}
+
+func TestUninstallPreflightResolvesParentSymlinkAliasesAndManagedTypes(t *testing.T) {
+	root := t.TempDir()
+	runtime := filepath.Join(root, "runtime")
+	if _, err := release.Open(runtime); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(root, "runtime-alias")
+	if err := os.Symlink(runtime, alias); err != nil {
+		t.Fatal(err)
+	}
+	if !pathsOverlap(filepath.Join(alias, "future-state"), runtime) {
+		t.Fatal("parent-symlink alias bypassed runtime/data overlap detection")
+	}
+	staging := filepath.Join(runtime, "staging")
+	if err := os.Remove(staging); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(staging, []byte("not a managed directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateManagedUninstallPaths(runtime); err == nil || !strings.Contains(err.Error(), "regular directory") {
+		t.Fatalf("wrong managed path type passed uninstall preflight: %v", err)
+	}
+}
+
+func TestPairedSQLiteBackupUsesOnlineBackupAndHashesBothFiles(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	state := t.TempDir()
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.commit(); c.execute('insert into t values (2)'); c.commit()"
+		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput(); err != nil {
+			t.Fatalf("seed %s: %v %s", name, err, output)
+		}
+	}
+	ctx := launchContext{PayloadRoot: filepath.Dir(filepath.Dir(filepath.Dir(python))), Instance: instance{StateDir: state}}
+	// snapshotPairTo calls the payload Python path. Use a tiny regular mirror
+	// directory so the test exercises the launcher boundary rather than copying
+	// live SQLite bytes directly.
+	payload := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(payload, "python", "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(python, filepath.Join(payload, "python", "bin", "python3")); err != nil {
+		t.Fatal(err)
+	}
+	ctx.PayloadRoot = payload
+	pair, err := snapshotPairTo(ctx, lifecycleReceipt("local-build-0000001", "curl", 1), filepath.Join(state, "backups"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pair.Files) != 2 || pair.Files[0].SHA256 == "" || pair.Files[1].SHA256 == "" || !pair.ReleaseReceipt.Valid() {
+		t.Fatalf("pair = %#v", pair)
+	}
+	if err := restorePair(ctx, pair); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRestorePairDoesNotFollowPrepositionedLegacyRestoreSymlink(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	state := t.TempDir()
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (1)'); c.commit()"
+		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput(); err != nil {
+			t.Fatalf("seed %s: %v %s", name, err, output)
+		}
+	}
+	payload := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(payload, "python", "bin"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(python, filepath.Join(payload, "python", "bin", "python3")); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{PayloadRoot: payload, Instance: instance{StateDir: state}}
+	pair, err := snapshotPairTo(ctx, lifecycleReceipt("local-build-0000001", "curl", 1), filepath.Join(state, "backups"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := filepath.Join(t.TempDir(), "external-target")
+	if err := os.WriteFile(outside, []byte("must-not-change"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	legacyStage := filepath.Join(state, ".jobctrl.db.restore")
+	if err := os.Symlink(outside, legacyStage); err != nil {
+		t.Fatal(err)
+	}
+	if err := restorePair(ctx, pair); err != nil {
+		t.Fatalf("restore rejected safe random staging because of legacy symlink: %v", err)
+	}
+	if raw, err := os.ReadFile(outside); err != nil || string(raw) != "must-not-change" {
+		t.Fatalf("restore followed prepositioned symlink: %q, %v", raw, err)
+	}
+	info, err := os.Lstat(filepath.Join(state, "jobctrl.db"))
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("restored database is not a regular file: %v, %v", info, err)
+	}
+}
+
+func TestRollbackPairRequiresExactImmutableReceiptNotJustBuild(t *testing.T) {
+	state := t.TempDir()
+	target := lifecycleReceipt("local-build-0000001", "curl", 1)
+	pair := databasePair{SchemaVersion: 1, ID: "pair-fixture", ReleaseReceipt: target, CreatedAt: time.Now(), Files: []databaseFile{{Name: "jobctrl.db"}, {Name: "temporal.db"}}}
+	dir := filepath.Join(state, "backups", pair.ID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(dir, "pair.json"), pair); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := retainedPairForReceipt(state, target); err != nil {
+		t.Fatal(err)
+	}
+	other := target
+	other.DescriptorSHA256 = strings.Repeat("d", 64)
+	if _, err := retainedPairForReceipt(state, other); err == nil {
+		t.Fatal("same build with different descriptor accepted a rollback pair")
+	}
+}
+
+func TestTransitionFailureIsJournaledAtEveryBoundary(t *testing.T) {
+	store, err := release.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, err := store.Begin("update", nil, nil, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := transitionFailure
+	t.Cleanup(func() { transitionFailure = old })
+	for _, state := range []release.State{release.MetadataVerified, release.Staging, release.PayloadVerified, release.ReleaseCommitted, release.SelectorHandoffPending, release.SelectorReplaced, release.Quiescing, release.PairBackedUp, release.PolicyPending, release.PolicyFinalized, release.CandidateStarting, release.CandidateHealthy, release.Promoted, release.RollbackRestoring, release.RolledBack} {
+		transitionFailure = func(got release.State) error {
+			if got == state {
+				return errTransitionInterrupted
+			}
+			return nil
+		}
+		if err := advance(store, &j, state); err == nil {
+			t.Fatalf("boundary %s did not inject failure", state)
+		}
+		loaded, err := store.ReadJournal()
+		if err != nil || loaded.State != state || (state != release.Promoted && state != release.RolledBack && !loaded.Resumable()) {
+			t.Fatalf("boundary %s journal = %#v, %v", state, loaded, err)
+		}
+	}
+}
+
+func TestNewPromotionCannotOverwriteAnUnfinishedTransitionJournal(t *testing.T) {
+	store, err := release.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := lifecycleReceipt("local-old-build-0001", "local-fixture", 1)
+	candidate := lifecycleReceipt("local-new-build-0002", "local-fixture", 2)
+	journal, err := store.Begin("update", &old, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Advance(&journal, release.PairBackedUp, nil); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{Instance: instance{RuntimeHome: store.Home}}
+	if err := promoteExisting(ctx, store, release.Active{}, candidate.BuildID, "update", io.Discard); err == nil || !strings.Contains(err.Error(), "must be recovered") {
+		t.Fatalf("new promotion overwrote or ignored unfinished journal: %v", err)
+	}
+	loaded, err := store.ReadJournal()
+	if err != nil || loaded.ID != journal.ID || loaded.State != release.PairBackedUp {
+		t.Fatalf("unfinished journal identity changed: %#v, %v", loaded, err)
+	}
+}
+
+func TestCandidateExecutionRevalidatesTamperedImmutableLauncher(t *testing.T) {
+	home := t.TempDir()
+	store, err := release.Open(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, manifest := verifiedPayloadFixture(t)
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "jobctrl"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "runtime-manifest.json"), []byte(validRuntimeManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, payload, &manifest)
+	writeLocalEnvelope(t, payload, manifest)
+	releaseDir := filepath.Join(home, "releases", manifest.BuildID)
+	if err := os.MkdirAll(releaseDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(payload, filepath.Join(releaseDir, "payload")); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := sha256Path(filepath.Join(releaseDir, "payload", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := release.Receipt{SchemaVersion: 1, BuildID: manifest.BuildID, Channel: "local", Sequence: 1, ArtifactSHA256: strings.Repeat("a", 64), ManifestSHA256: digest, DescriptorSHA256: strings.Repeat("b", 64), DescriptorURL: "local-fixture", InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)}
+	if err := writeJSONAtomic(filepath.Join(releaseDir, "receipt.json"), selectorReceipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: int64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(releaseDir, "policy.json"), release.ChannelMetadata{Channel: receipt.Channel, Sequence: receipt.Sequence, Minimum: 0, BuildID: receipt.BuildID, DescriptorDigest: receipt.DescriptorSHA256, Revoked: []string{}}); err != nil {
+		t.Fatal(err)
+	}
+	verified, err := verifyInstalledReleaseForExecution(store, receipt)
+	if err != nil {
+		t.Fatalf("untampered candidate rejected: %v", err)
+	}
+	if err := handoffPublicSelector(store.Home, verified); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.WriteSelectedActive(receipt, 0, receipt.BuildID, "curl"); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyPublicSelectorForExecution(store.Home); err != nil {
+		t.Fatalf("authenticated selector rejected: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(store.Home, "bin", "jobctrl"), []byte("tampered selector"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyPublicSelectorForExecution(store.Home); err == nil {
+		t.Fatal("tampered public selector passed immediate execution verification")
+	}
+	if err := os.WriteFile(filepath.Join(releaseDir, "payload", "launcher", "jobctrl"), []byte("tampered"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifyInstalledReleaseForExecution(store, receipt); err == nil {
+		t.Fatal("tampered candidate launcher passed immediate execution verification")
+	}
+}
+
+func TestInterruptedTransitionWithRevokedPredecessorFailsClosed(t *testing.T) {
+	store, err := release.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := lifecycleReceipt("local-build-0000001", "curl", 1)
+	candidate := lifecycleReceipt("local-build-0000002", "curl", 2)
+	if _, err := store.RecordMetadata("local", old.Sequence, 0, old.BuildID, old.DescriptorSHA256, nil); err != nil {
+		t.Fatal(err)
+	}
+	journal, err := store.Begin("update", &old, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal.BackupID = "pair-before-revocation"
+	if err := store.Advance(&journal, release.PolicyPending, nil); err != nil {
+		t.Fatal(err)
+	}
+	state, err := store.ValidateMetadata(release.ChannelMetadata{Channel: "local", Sequence: candidate.Sequence, Minimum: 2, BuildID: candidate.BuildID, DescriptorDigest: candidate.DescriptorSHA256, Revoked: []string{old.BuildID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.CommitMetadata(state); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{Instance: instance{RuntimeHome: store.Home, StateDir: t.TempDir(), StatePath: filepath.Join(t.TempDir(), "state.json")}}
+	if recovered, err := recoverInterruptedTransition(ctx, store); recovered || err == nil || !strings.Contains(err.Error(), "revoked") {
+		t.Fatalf("revoked predecessor recovery = recovered:%v err:%v", recovered, err)
+	}
+	loaded, err := store.ReadJournal()
+	if err != nil || loaded.State != release.Failed {
+		t.Fatalf("revoked recovery did not preserve fail-closed audit state: %#v, %v", loaded, err)
+	}
+}
+
+func TestRetentionPreservesReferencedAndNonStableEvidence(t *testing.T) {
+	runtime := t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	makeReceipt := func(build, channel string, sequence uint64) release.Receipt {
+		r := lifecycleReceipt(build, "curl", sequence)
+		r.Channel = channel
+		return r
+	}
+	active := makeReceipt("stable-build-0000003", "stable", 3)
+	prior := makeReceipt("stable-build-0000002", "stable", 2)
+	referenced := makeReceipt("stable-build-0000001", "stable", 1)
+	prunable := makeReceipt("stable-build-0000000", "stable", 0)
+	prunable.Sequence = 1
+	prunable.BuildID = "stable-build-0000000"
+	local := makeReceipt("local-build-0000001", "local", 1)
+	pre := makeReceipt("pre-build-00000001", "prerelease", 1)
+	for _, receipt := range []release.Receipt{active, prior, referenced, prunable, local, pre} {
+		directory := filepath.Join(runtime, "releases", receipt.BuildID)
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := writeJSONAtomic(filepath.Join(directory, "receipt.json"), selectorReceipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: int64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := store.WriteSelectedActive(active, 0, active.BuildID, "curl"); err != nil {
+		t.Fatal(err)
+	}
+	backupDirectory := filepath.Join(runtime, "instances", "fixture", "backups", "pair-reference")
+	if err := os.MkdirAll(backupDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeJSONAtomic(filepath.Join(backupDirectory, "pair.json"), databasePair{SchemaVersion: 1, ID: "pair-reference", ReleaseReceipt: referenced, CreatedAt: time.Now(), Files: []databaseFile{{Name: "jobctrl.db"}, {Name: "temporal.db"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := retainReleases(store, runtime); err != nil {
+		t.Fatal(err)
+	}
+	for _, build := range []string{active.BuildID, prior.BuildID, referenced.BuildID, local.BuildID, pre.BuildID} {
+		if _, err := os.Lstat(filepath.Join(runtime, "releases", build)); err != nil {
+			t.Fatalf("retention removed protected %s: %v", build, err)
+		}
+	}
+	if _, err := os.Lstat(filepath.Join(runtime, "releases", prunable.BuildID)); !os.IsNotExist(err) {
+		t.Fatalf("retention kept unreferenced stable release: %v", err)
+	}
+}
+
+// TestRealTwoReleasePromotionRollbackRestoresPairedSQLiteState runs the real
+// lifecycle transaction, receipt/payload verification, selector handoff,
+// SQLite online backup, restoration, and active-pointer writes. Only launcher
+// process execution is injected: component supervision itself is covered by
+// the hermetic launcher lifecycle test, while this test deliberately forces
+// candidate health failure at the exact promotion boundary.
+func TestRealTwoReleasePromotionRollbackRestoresPairedSQLiteState(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime, state := t.TempDir(), t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := installLifecycleRelease(t, runtime, "local-old-build-0001", 1, python)
+	candidate := installLifecycleRelease(t, runtime, "local-new-build-0002", 2, python)
+	if _, err := store.WriteSelectedActive(old, 0, old.BuildID, "local-fixture"); err != nil {
+		t.Fatal(err)
+	}
+	oldVerified, err := verifyInstalledReleaseForExecution(store, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handoffPublicSelector(runtime, oldVerified); err != nil {
+		t.Fatal(err)
+	}
+	seedLifecycleSQLitePair(t, python, state, "old")
+	before := lifecycleDatabaseValues(t, python, state)
+	ctx := launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(state, "missing-state.json"), ControlPath: filepath.Join(state, "control.lock")}, Environment: []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime, "JOBCTRL_DIR=" + state}}
+	oldStart := startReleaseCommand
+	t.Cleanup(func() { startReleaseCommand = oldStart })
+	startReleaseCommand = func(_ launchContext, receipt release.Receipt, _ string) error {
+		if receipt.BuildID == candidate.BuildID {
+			setLifecycleSQLitePair(t, python, state, "candidate")
+			return errors.New("forced candidate health failure")
+		}
+		return nil
+	}
+	var output bytes.Buffer
+	if err := promoteExisting(ctx, store, release.Active{SchemaVersion: 1, Generation: 1, Receipt: old, SelectorBuildID: old.BuildID, Acquisition: "local-fixture"}, candidate.BuildID, "update", &output); err == nil || !strings.Contains(err.Error(), "forced candidate health failure") {
+		t.Fatalf("forced promotion failure = %v", err)
+	}
+	active, err := store.ReadActive()
+	if err != nil || active.Receipt != old {
+		t.Fatalf("failed promotion did not restore old active receipt: %#v, %v", active, err)
+	}
+	if after := lifecycleDatabaseValues(t, python, state); !sameDatabaseDigests(after, before) {
+		t.Fatalf("failed promotion did not restore exact SQLite pair: before=%v after=%v", before, after)
+	}
+	startReleaseCommand = func(_ launchContext, receipt release.Receipt, _ string) error {
+		if receipt.BuildID == candidate.BuildID {
+			setLifecycleSQLitePair(t, python, state, "candidate")
+		}
+		return nil
+	}
+	if err := promoteExisting(ctx, store, active, candidate.BuildID, "update", &output); err != nil {
+		t.Fatalf("successful promotion: %v", err)
+	}
+	active, err = store.ReadActive()
+	if err != nil || active.Receipt != candidate {
+		t.Fatalf("promotion did not select candidate: %#v, %v", active, err)
+	}
+	if values := lifecycleDatabaseValues(t, python, state); values["jobctrl.db"] != "candidatejobctrl.db" || values["temporal.db"] != "candidatetemporal.db" {
+		t.Fatalf("successful promotion did not run candidate against both databases: %v", values)
+	}
+	if err := rollbackExisting(ctx, store, active, old.BuildID, &output); err != nil {
+		t.Fatalf("explicit rollback: %v", err)
+	}
+	active, err = store.ReadActive()
+	if err != nil || active.Receipt != old {
+		t.Fatalf("rollback did not restore old pointer: %#v, %v", active, err)
+	}
+	if after := lifecycleDatabaseValues(t, python, state); !sameDatabaseDigests(after, before) {
+		t.Fatalf("rollback did not restore exact target SQLite pair: before=%v after=%v", before, after)
+	}
+}
+
+func TestRealInterruptedPreBackupAndSelectorHandoffRecovery(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 unavailable")
+	}
+	runtime, state := t.TempDir(), t.TempDir()
+	store, err := release.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := installLifecycleRelease(t, runtime, "local-old-build-0001", 1, python)
+	candidate := installLifecycleRelease(t, runtime, "local-new-build-0002", 2, python)
+	if _, err := store.WriteSelectedActive(old, 0, old.BuildID, "local-fixture"); err != nil {
+		t.Fatal(err)
+	}
+	oldVerified, err := verifyInstalledReleaseForExecution(store, old)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handoffPublicSelector(runtime, oldVerified); err != nil {
+		t.Fatal(err)
+	}
+	ctx := launchContext{Instance: instance{RuntimeHome: runtime, StateDir: state, StatePath: filepath.Join(state, "missing-state.json"), ControlPath: filepath.Join(state, "control.lock")}, Environment: []string{"HOME=" + t.TempDir(), "JOBCTRL_RUNTIME_HOME=" + runtime, "JOBCTRL_DIR=" + state}}
+	oldStart := startReleaseCommand
+	t.Cleanup(func() { startReleaseCommand = oldStart })
+	startReleaseCommand = func(_ launchContext, got release.Receipt, journalID string) error {
+		if got != old || journalID == "" {
+			t.Fatalf("recovery executed an unexpected release: %#v journal=%q", got, journalID)
+		}
+		return nil
+	}
+	journal, err := store.Begin("update", &old, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Advance(&journal, release.ReleaseCommitted, nil); err != nil {
+		t.Fatal(err)
+	}
+	if recovered, err := recoverInterruptedTransition(ctx, store); !recovered || err != nil {
+		t.Fatalf("pre-backup recovery = %v, %v", recovered, err)
+	}
+	journal, err = store.Begin("update", &old, &candidate, candidate.DescriptorSHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Advance(&journal, release.SelectorHandoffPending, nil); err != nil {
+		t.Fatal(err)
+	}
+	candidateVerified, err := verifyInstalledReleaseForExecution(store, candidate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := handoffPublicSelector(runtime, candidateVerified); err != nil {
+		t.Fatal(err)
+	}
+	if recovered, err := recoverInterruptedTransition(ctx, store); !recovered || err != nil {
+		t.Fatalf("selector-handoff recovery = %v, %v", recovered, err)
+	}
+	active, err := store.ReadActive()
+	if err != nil || active.Receipt != old || active.SelectorBuildID != candidate.BuildID {
+		t.Fatalf("handoff recovery lost actual selector identity: %#v, %v", active, err)
+	}
+	if journal, err := store.ReadJournal(); err != nil || journal.State != release.RolledBack || journal.Resumable() {
+		t.Fatalf("handoff recovery did not close its transition journal: %#v, %v", journal, err)
+	}
+	if err := VerifyPublicSelectorForExecution(runtime); err != nil {
+		t.Fatalf("terminal handoff recovery left an unusable selector: %v", err)
+	}
+}
+
+func installLifecycleRelease(t *testing.T, runtime, build string, sequence uint64, python string) release.Receipt {
+	t.Helper()
+	payload, manifest := verifiedPayloadFixture(t)
+	manifest.BuildID = build
+	launcherPath := filepath.Join(payload, "launcher", "jobctrl")
+	if err := os.WriteFile(launcherPath, []byte("#!/bin/sh\n# "+build+"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "jobctrl-installer"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(payload, "launcher", "runtime-manifest.json"), []byte(validRuntimeManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pythonPath := filepath.Join(payload, "python", "bin", "python3")
+	if err := os.MkdirAll(filepath.Dir(pythonPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pythonPath, []byte("#!/bin/sh\nexec \""+python+"\" \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	refreshFixtureManifest(t, payload, &manifest)
+	writeLocalEnvelope(t, payload, manifest)
+	releaseDir := filepath.Join(runtime, "releases", build)
+	if err := os.MkdirAll(releaseDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(payload, filepath.Join(releaseDir, "payload")); err != nil {
+		t.Fatal(err)
+	}
+	digest, err := sha256Path(filepath.Join(releaseDir, "payload", "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := release.ChannelMetadata{Channel: "local", Sequence: sequence, Minimum: 0, BuildID: build, DescriptorDigest: strings.Repeat("d", 64), Revoked: []string{}}
+	policyDigest := writeLifecyclePolicy(t, filepath.Join(releaseDir, "policy.json"), policy)
+	receipt := release.Receipt{SchemaVersion: 2, BuildID: build, Channel: "local", Sequence: sequence, ArtifactSHA256: strings.Repeat("a", 64), ManifestSHA256: digest, DescriptorSHA256: strings.Repeat("d", 64), PolicySHA256: policyDigest, DescriptorURL: "local-fixture", InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)}
+	if err := writeJSONAtomic(filepath.Join(releaseDir, "receipt.json"), selectorReceipt{SchemaVersion: receipt.SchemaVersion, BuildID: receipt.BuildID, Channel: receipt.Channel, Sequence: int64(receipt.Sequence), ArtifactSHA256: receipt.ArtifactSHA256, ManifestSHA256: receipt.ManifestSHA256, DescriptorSHA256: receipt.DescriptorSHA256, PolicySHA256: receipt.PolicySHA256, DescriptorURL: receipt.DescriptorURL, InstalledAt: receipt.InstalledAt}); err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}
+
+func seedLifecycleSQLitePair(t *testing.T, python, state, marker string) {
+	t.Helper()
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('create table t(v)'); c.execute('insert into t values (?)',(sys.argv[2],)); c.commit()"
+		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name), marker+name).CombinedOutput(); err != nil {
+			t.Fatalf("seed %s: %v %s", name, err, output)
+		}
+	}
+}
+
+func setLifecycleSQLitePair(t *testing.T, python, state, marker string) {
+	t.Helper()
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); c.execute('update t set v=?',(sys.argv[2],)); c.commit()"
+		if output, err := exec.Command(python, "-c", code, filepath.Join(state, name), marker+name).CombinedOutput(); err != nil {
+			t.Fatalf("update %s: %v %s", name, err, output)
+		}
+	}
+}
+
+func lifecycleDatabaseDigests(t *testing.T, state string) map[string]string {
+	t.Helper()
+	result := map[string]string{}
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		digest, err := sha256Path(filepath.Join(state, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		result[name] = digest
+	}
+	return result
+}
+
+func lifecycleDatabaseValues(t *testing.T, python, state string) map[string]string {
+	t.Helper()
+	result := map[string]string{}
+	for _, name := range []string{"jobctrl.db", "temporal.db"} {
+		code := "import sqlite3,sys; c=sqlite3.connect(sys.argv[1]); print(c.execute('select v from t').fetchone()[0])"
+		output, err := exec.Command(python, "-c", code, filepath.Join(state, name)).CombinedOutput()
+		if err != nil {
+			t.Fatalf("read %s content: %v %s", name, err, output)
+		}
+		result[name] = strings.TrimSpace(string(output))
+	}
+	return result
+}
+
+func sameDatabaseDigests(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name, digest := range left {
+		if right[name] != digest {
+			return false
+		}
+	}
+	return true
+}

--- a/launcher/internal/release/store.go
+++ b/launcher/internal/release/store.go
@@ -1,0 +1,490 @@
+// Package release owns the durable, user-owned release selection state.  It is
+// deliberately independent from acquisition and process supervision so the
+// launcher and installer can share one transaction boundary without an import
+// cycle.
+package release
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+var digestPattern = regexp.MustCompile(`^[a-f0-9]{64}$`)
+
+const (
+	ActiveFile  = "active.json"
+	JournalFile = "transition.json"
+)
+
+// Receipt is immutable release evidence. Acquisition is intentionally not a
+// receipt property: the same immutable artifact may be acquired first through
+// curl and later through Homebrew (or the reverse) without changing its
+// identity. Acquisition ownership belongs to Active instead.
+type Receipt struct {
+	SchemaVersion    int    `json:"schemaVersion"`
+	BuildID          string `json:"buildId"`
+	Channel          string `json:"channel"`
+	Sequence         uint64 `json:"sequence"`
+	ArtifactSHA256   string `json:"artifactSha256"`
+	ManifestSHA256   string `json:"manifestSha256"`
+	DescriptorSHA256 string `json:"descriptorSha256"`
+	PolicySHA256     string `json:"policySha256,omitempty"`
+	DescriptorURL    string `json:"descriptorUrl"`
+	InstalledAt      string `json:"installedAt"`
+}
+
+func (r Receipt) Valid() bool {
+	versionValid := (r.SchemaVersion == 1 && r.PolicySHA256 == "") || (r.SchemaVersion == 2 && digestPattern.MatchString(r.PolicySHA256))
+	return versionValid && r.BuildID != "" && r.Sequence > 0 &&
+		(r.Channel == "local" || r.Channel == "stable" || r.Channel == "prerelease") &&
+		digestPattern.MatchString(r.ArtifactSHA256) && digestPattern.MatchString(r.ManifestSHA256) &&
+		digestPattern.MatchString(r.DescriptorSHA256) && r.InstalledAt != ""
+}
+
+type Active struct {
+	SchemaVersion   int     `json:"schemaVersion"`
+	Generation      uint64  `json:"generation"`
+	Receipt         Receipt `json:"receipt"`
+	SelectorBuildID string  `json:"selectorBuildId"`
+	Acquisition     string  `json:"acquisition,omitempty"`
+}
+
+// ChannelState is signed-channel safety evidence accumulated monotonically.
+// Its union semantics mean a later descriptor can never quietly un-revoke a
+// build, lower a safety floor, or reuse a sequence for another identity.
+type ChannelState struct {
+	SchemaVersion       int               `json:"schemaVersion"`
+	Channel             string            `json:"channel"`
+	MaxSequence         uint64            `json:"maxSequence"`
+	MinimumSafeSequence uint64            `json:"minimumSafeSequence"`
+	RevokedBuildIDs     map[string]bool   `json:"revokedBuildIds"`
+	SequenceBuildIDs    map[string]string `json:"sequenceBuildIds"`
+	SequenceDescriptors map[string]string `json:"sequenceDescriptors"`
+}
+
+// ChannelMetadata is authenticated but not yet durable policy state. The
+// installer validates it before committing a candidate and the lifecycle
+// finalizes it only after the candidate and old database pair are durable.
+// This prevents a crash from revoking the active release while the replacement
+// exists only in staging.
+type ChannelMetadata struct {
+	Channel          string   `json:"channel"`
+	Sequence         uint64   `json:"sequence"`
+	Minimum          uint64   `json:"minimumSafeSequence"`
+	BuildID          string   `json:"buildId"`
+	DescriptorDigest string   `json:"descriptorSha256"`
+	Revoked          []string `json:"revokedBuildIds"`
+}
+
+func (s *Store) ReadChannelState(channel string) (ChannelState, error) {
+	var state ChannelState
+	err := readStrictRegular(filepath.Join(s.Home, "channel-"+channel+".json"), &state)
+	if errors.Is(err, os.ErrNotExist) {
+		return ChannelState{SchemaVersion: 1, Channel: channel, RevokedBuildIDs: map[string]bool{}, SequenceBuildIDs: map[string]string{}, SequenceDescriptors: map[string]string{}}, nil
+	}
+	if err != nil {
+		return state, err
+	}
+	if state.SchemaVersion != 1 || state.Channel != channel || state.RevokedBuildIDs == nil || state.SequenceBuildIDs == nil || state.SequenceDescriptors == nil {
+		return state, errors.New("invalid channel safety record")
+	}
+	return state, nil
+}
+
+// ValidateMetadata rejects replay/downgrade/identity drift without changing
+// durable policy. It is safe to call before candidate extraction/commit.
+func (s *Store) ValidateMetadata(metadata ChannelMetadata) (ChannelState, error) {
+	if metadata.Channel == "" || metadata.Sequence == 0 || metadata.BuildID == "" || !digestPattern.MatchString(metadata.DescriptorDigest) || metadata.Minimum > metadata.Sequence {
+		return ChannelState{}, errors.New("invalid signed channel metadata")
+	}
+	state, err := s.ReadChannelState(metadata.Channel)
+	if err != nil {
+		return state, err
+	}
+	if metadata.Sequence < state.MaxSequence {
+		return state, fmt.Errorf("release sequence %d is below recorded maximum %d", metadata.Sequence, state.MaxSequence)
+	}
+	if metadata.Sequence < state.MinimumSafeSequence || metadata.Minimum < state.MinimumSafeSequence {
+		return state, fmt.Errorf("release sequence %d is below recorded minimum-safe sequence %d", metadata.Sequence, state.MinimumSafeSequence)
+	}
+	key := fmt.Sprintf("%d", metadata.Sequence)
+	if prior := state.SequenceBuildIDs[key]; prior != "" && prior != metadata.BuildID {
+		return state, fmt.Errorf("release sequence %d was already bound to build %q", metadata.Sequence, prior)
+	}
+	if prior := state.SequenceDescriptors[key]; prior != "" && prior != metadata.DescriptorDigest {
+		return state, fmt.Errorf("release sequence %d descriptor identity drift", metadata.Sequence)
+	}
+	if state.RevokedBuildIDs[metadata.BuildID] {
+		return state, fmt.Errorf("release build %q is revoked", metadata.BuildID)
+	}
+	for _, id := range metadata.Revoked {
+		if id == "" {
+			return state, errors.New("invalid revoked build identity")
+		}
+		state.RevokedBuildIDs[id] = true
+	}
+	if state.RevokedBuildIDs[metadata.BuildID] {
+		return state, fmt.Errorf("release build %q is revoked", metadata.BuildID)
+	}
+	if metadata.Sequence > state.MaxSequence {
+		state.MaxSequence = metadata.Sequence
+	}
+	if metadata.Minimum > state.MinimumSafeSequence {
+		state.MinimumSafeSequence = metadata.Minimum
+	}
+	state.SequenceBuildIDs[key] = metadata.BuildID
+	state.SequenceDescriptors[key] = metadata.DescriptorDigest
+	return state, nil
+}
+
+// CommitMetadata persists a state already produced by ValidateMetadata. The
+// caller journals PolicyPending before this directory-synced write.
+func (s *Store) CommitMetadata(state ChannelState) error {
+	if state.SchemaVersion != 1 || state.Channel == "" || state.RevokedBuildIDs == nil || state.SequenceBuildIDs == nil || state.SequenceDescriptors == nil {
+		return errors.New("invalid channel safety record")
+	}
+	if err := writeAtomic(filepath.Join(s.Home, "channel-"+state.Channel+".json"), state); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RecordMetadata is retained for first-install callers and focused tests. A
+// lifecycle promotion must instead validate, journal, and then commit.
+func (s *Store) RecordMetadata(channel string, sequence, minimum uint64, buildID, descriptorDigest string, revoked []string) (ChannelState, error) {
+	state, err := s.ValidateMetadata(ChannelMetadata{Channel: channel, Sequence: sequence, Minimum: minimum, BuildID: buildID, DescriptorDigest: descriptorDigest, Revoked: revoked})
+	if err != nil {
+		return state, err
+	}
+	return state, s.CommitMetadata(state)
+}
+
+func (s *Store) Permit(receipt Receipt) error {
+	state, err := s.ReadChannelState(receipt.Channel)
+	if err != nil {
+		return err
+	}
+	if receipt.Sequence < state.MinimumSafeSequence {
+		return fmt.Errorf("release sequence %d is below minimum-safe sequence %d", receipt.Sequence, state.MinimumSafeSequence)
+	}
+	if state.RevokedBuildIDs[receipt.BuildID] {
+		return fmt.Errorf("release build %q is revoked", receipt.BuildID)
+	}
+	key := fmt.Sprintf("%d", receipt.Sequence)
+	if prior := state.SequenceBuildIDs[key]; prior != "" && prior != receipt.BuildID {
+		return fmt.Errorf("release sequence %d identity drift", receipt.Sequence)
+	}
+	if prior := state.SequenceDescriptors[key]; prior != "" && prior != receipt.DescriptorSHA256 {
+		return fmt.Errorf("release sequence %d descriptor identity drift", receipt.Sequence)
+	}
+	return nil
+}
+
+// States are append-only audit milestones. A journal is deliberately kept
+// after success; a following lifecycle operation begins a new journal ID.
+type State string
+
+const (
+	Idle                   State = "idle"
+	MetadataVerified       State = "metadata_verified"
+	Staging                State = "staging"
+	PayloadVerified        State = "payload_verified"
+	ReleaseCommitted       State = "release_committed"
+	SelectorHandoffPending State = "selector_handoff_pending"
+	SelectorReplaced       State = "selector_replaced"
+	Quiescing              State = "quiescing"
+	PairBackedUp           State = "pair_backed_up"
+	PolicyPending          State = "policy_pending"
+	PolicyFinalized        State = "policy_finalized"
+	CandidateStarting      State = "candidate_starting"
+	CandidateHealthy       State = "candidate_healthy"
+	Promoted               State = "promoted"
+	RollbackRestoring      State = "rollback_restoring"
+	RolledBack             State = "rolled_back"
+	Failed                 State = "failed"
+)
+
+type Journal struct {
+	SchemaVersion    int              `json:"schemaVersion"`
+	ID               string           `json:"id"`
+	Operation        string           `json:"operation"`
+	State            State            `json:"state"`
+	Old              *Receipt         `json:"old,omitempty"`
+	Candidate        *Receipt         `json:"candidate,omitempty"`
+	DescriptorSHA256 string           `json:"descriptorSha256,omitempty"`
+	PendingPolicy    *ChannelMetadata `json:"pendingPolicy,omitempty"`
+	BackupID         string           `json:"backupId,omitempty"`
+	TargetBackupID   string           `json:"targetBackupId,omitempty"`
+	Error            string           `json:"error,omitempty"`
+	UpdatedAt        time.Time        `json:"updatedAt"`
+}
+
+func (j Journal) Resumable() bool {
+	return j.State != Idle && j.State != Promoted && j.State != RolledBack && j.State != Failed
+}
+
+type Store struct{ Home string }
+
+// Open refuses symlinked management roots and creates only owner-private
+// paths. It never follows a user-controlled final component.
+func Open(home string) (*Store, error) {
+	abs, err := filepath.Abs(home)
+	if err != nil {
+		return nil, err
+	}
+	if err := ensureDirectory(abs); err != nil {
+		return nil, err
+	}
+	for _, child := range []string{"releases", "staging", "backups", "bin"} {
+		if err := ensureDirectory(filepath.Join(abs, child)); err != nil {
+			return nil, err
+		}
+	}
+	return &Store{Home: abs}, nil
+}
+
+func ensureDirectory(path string) error {
+	if info, err := os.Lstat(path); err == nil {
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("managed path %q is not a regular directory", path)
+		}
+		return os.Chmod(path, 0o700)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("managed path %q is not a regular directory", path)
+	}
+	return os.Chmod(path, 0o700)
+}
+
+type Lock struct{ file *os.File }
+
+func (l *Lock) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	err := syscall.Flock(int(l.file.Fd()), syscall.LOCK_UN)
+	closeErr := l.file.Close()
+	l.file = nil
+	if err != nil {
+		return err
+	}
+	return closeErr
+}
+
+func (s *Store) lock(name string, flags int) (*Lock, error) {
+	path := filepath.Join(s.Home, name)
+	if info, err := os.Lstat(path); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		return nil, fmt.Errorf("release lock %q is not a regular file", name)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|syscall.O_NOFOLLOW, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), flags); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return &Lock{f}, nil
+}
+
+// SelectionLock protects active resolution through candidate readiness. Update,
+// rollback and uninstall use an exclusive lock; start uses shared.
+func (s *Store) SelectionLock(exclusive bool) (*Lock, error) {
+	flags := syscall.LOCK_SH
+	if exclusive {
+		flags = syscall.LOCK_EX
+	}
+	return s.lock("selection.lock", flags)
+}
+
+// TransitionLock serializes durable lifecycle transitions independently from
+// process ownership. Callers take it before the exclusive selection lock.
+func (s *Store) TransitionLock() (*Lock, error) { return s.lock("transition.lock", syscall.LOCK_EX) }
+
+func (s *Store) ReadActive() (Active, error) {
+	var active Active
+	if err := readStrictRegular(filepath.Join(s.Home, ActiveFile), &active); err != nil {
+		return active, err
+	}
+	if active.SchemaVersion != 1 || active.Generation == 0 || !active.Receipt.Valid() || active.SelectorBuildID == "" || !validAcquisition(active.Acquisition) {
+		return active, errors.New("invalid active release record")
+	}
+	return active, nil
+}
+
+func (s *Store) WriteActive(receipt Receipt, prior uint64) (Active, error) {
+	return s.WriteSelectedActive(receipt, prior, receipt.BuildID, "")
+}
+
+// WriteSelectedActive is the sole selected-pair write. SelectorBuildID names
+// the immutable launcher copied into bin/jobctrl and must be compatible with
+// Receipt; Acquisition describes the mutable acquisition adapter only.
+func (s *Store) WriteSelectedActive(receipt Receipt, prior uint64, selectorBuildID, acquisition string) (Active, error) {
+	if !receipt.Valid() {
+		return Active{}, errors.New("invalid release receipt for activation")
+	}
+	if selectorBuildID == "" || !validAcquisition(acquisition) {
+		return Active{}, errors.New("missing selector build identity")
+	}
+	active := Active{SchemaVersion: 1, Generation: prior + 1, Receipt: receipt, SelectorBuildID: selectorBuildID, Acquisition: acquisition}
+	if active.Generation == 0 {
+		active.Generation = 1
+	}
+	if err := writeAtomic(filepath.Join(s.Home, ActiveFile), active); err != nil {
+		return Active{}, err
+	}
+	return active, nil
+}
+
+func validAcquisition(value string) bool {
+	// Empty is read-only migration state for P5 records written before
+	// acquisition ownership moved out of immutable receipts. New installers
+	// always write one of the explicit adapters below.
+	return value == "" || value == "curl" || value == "homebrew" || value == "local-fixture"
+}
+
+func (s *Store) ReadJournal() (Journal, error) {
+	var journal Journal
+	if err := readStrictRegular(filepath.Join(s.Home, JournalFile), &journal); err != nil {
+		return journal, err
+	}
+	if journal.SchemaVersion != 1 || journal.ID == "" || journal.Operation == "" || journal.State == "" {
+		return journal, errors.New("invalid release transition journal")
+	}
+	return journal, nil
+}
+
+func (s *Store) Begin(operation string, old, candidate *Receipt, descriptorDigest string) (Journal, error) {
+	if operation == "" || (descriptorDigest != "" && !digestPattern.MatchString(descriptorDigest)) {
+		return Journal{}, errors.New("invalid release transition identity")
+	}
+	id, err := randomID()
+	if err != nil {
+		return Journal{}, err
+	}
+	j := Journal{SchemaVersion: 1, ID: id, Operation: operation, State: Idle, Old: old, Candidate: candidate, DescriptorSHA256: descriptorDigest, UpdatedAt: time.Now().UTC()}
+	return j, s.writeJournal(j)
+}
+
+func (s *Store) Advance(j *Journal, state State, cause error) error {
+	if j == nil || j.SchemaVersion != 1 || j.ID == "" {
+		return errors.New("invalid transition journal")
+	}
+	j.State, j.UpdatedAt = state, time.Now().UTC()
+	if cause != nil {
+		j.Error = cause.Error()
+	}
+	return s.writeJournal(*j)
+}
+func (s *Store) writeJournal(j Journal) error {
+	return writeAtomic(filepath.Join(s.Home, JournalFile), j)
+}
+
+// StageDir names staging solely by authenticated descriptor bytes. An
+// interrupted download therefore resumes only when it has exactly the same
+// descriptor digest; unrelated staging is never adopted.
+func (s *Store) StageDir(descriptorDigest string) (string, error) {
+	if !digestPattern.MatchString(descriptorDigest) {
+		return "", errors.New("invalid descriptor digest")
+	}
+	return filepath.Join(s.Home, "staging", descriptorDigest), nil
+}
+
+func readStrictRegular(path string, dst any) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%s is not a regular file", filepath.Base(path))
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	d := json.NewDecoder(f)
+	d.DisallowUnknownFields()
+	if err := d.Decode(dst); err != nil {
+		return err
+	}
+	if err := d.Decode(&struct{}{}); err != io.EOF {
+		return errors.New("trailing JSON value")
+	}
+	return nil
+}
+func writeAtomic(path string, value any) error {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	random, err := randomID()
+	if err != nil {
+		return err
+	}
+	tmp := filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+"."+random)
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err = f.Write(raw); err == nil {
+		err = f.Sync()
+	}
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil && (!info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0) {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("managed file %q is not regular", filepath.Base(path))
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	d, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}
+func randomID() (string, error) {
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+func Digest(raw []byte) string { sum := sha256.Sum256(raw); return hex.EncodeToString(sum[:]) }

--- a/launcher/internal/release/store_test.go
+++ b/launcher/internal/release/store_test.go
@@ -1,0 +1,196 @@
+package release
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func receipt(build string, sequence uint64, descriptor string) Receipt {
+	return Receipt{SchemaVersion: 1, BuildID: build, Channel: "stable", Sequence: sequence, ArtifactSHA256: "a" + descriptor[1:], ManifestSHA256: "b" + descriptor[1:], DescriptorSHA256: descriptor, DescriptorURL: "https://releases.example.test/stable.json", InstalledAt: time.Now().UTC().Format(time.RFC3339Nano)}
+}
+
+func TestSharedSelectionBlocksExclusiveTransitionUntilReadinessReleases(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reader, err := store.SelectionLock(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		writer, err := store.SelectionLock(true)
+		if err == nil {
+			err = writer.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("exclusive selection acquired before readiness released: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("exclusive selection did not acquire after readiness release")
+	}
+}
+
+func TestActiveRecordIsOneAtomicSelectionObject(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := receipt("stable-build-0000001", 1, "c"+string(make([]byte, 63)))
+	// Fill the synthetic digest without weakening the production validator.
+	r.ArtifactSHA256 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	r.ManifestSHA256 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	r.DescriptorSHA256 = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	active, err := store.WriteActive(r, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active.Generation != 1 || active.Receipt.BuildID != r.BuildID {
+		t.Fatalf("active = %#v", active)
+	}
+	loaded, err := store.ReadActive()
+	if err != nil || loaded != active {
+		t.Fatalf("read active = %#v, %v", loaded, err)
+	}
+}
+
+func TestActiveRejectsUnknownAcquisitionOwnership(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := receipt("stable-build-0000001", 1, "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
+	if _, err := store.WriteSelectedActive(r, 0, r.BuildID, "unknown-adapter"); err == nil {
+		t.Fatal("unknown acquisition adapter was accepted")
+	}
+}
+
+func TestChannelEvidenceRejectsRollbackRevocationAndIdentityDrift(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	d1 := "1111111111111111111111111111111111111111111111111111111111111111"
+	if _, err := store.RecordMetadata("stable", 7, 5, "stable-build-0000007", d1, []string{"stable-build-0000004"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.RecordMetadata("stable", 6, 5, "stable-build-0000006", "2222222222222222222222222222222222222222222222222222222222222222", nil); err == nil {
+		t.Fatal("accepted sequence downgrade")
+	}
+	if _, err := store.RecordMetadata("stable", 7, 5, "stable-build-other0007", d1, nil); err == nil {
+		t.Fatal("accepted same sequence different build")
+	}
+	if _, err := store.RecordMetadata("stable", 7, 5, "stable-build-0000007", "3333333333333333333333333333333333333333333333333333333333333333", nil); err == nil {
+		t.Fatal("accepted same sequence descriptor drift")
+	}
+	if _, err := store.RecordMetadata("stable", 8, 4, "stable-build-0000008", "4444444444444444444444444444444444444444444444444444444444444444", nil); err == nil {
+		t.Fatal("accepted lower minimum-safe sequence")
+	}
+	revoked := receipt("stable-build-0000004", 5, "5555555555555555555555555555555555555555555555555555555555555555")
+	if err := store.Permit(revoked); err == nil {
+		t.Fatal("permitted revoked build")
+	}
+	below := receipt("stable-build-0000003", 3, "6666666666666666666666666666666666666666666666666666666666666666")
+	if err := store.Permit(below); err == nil {
+		t.Fatal("permitted below minimum-safe sequence")
+	}
+}
+
+func TestPolicyValidationDoesNotRevokeActiveUntilJournaledFinalization(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := receipt("stable-build-0000001", 1, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if _, err := store.RecordMetadata(old.Channel, old.Sequence, 1, old.BuildID, old.DescriptorSHA256, nil); err != nil {
+		t.Fatal(err)
+	}
+	// This is the exact candidate-committed/policy-pending crash window: the
+	// authenticated policy is validated but must not yet make old unrunnable.
+	pending, err := store.ValidateMetadata(ChannelMetadata{Channel: "stable", Sequence: 2, Minimum: 2, BuildID: "stable-build-0000002", DescriptorDigest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Revoked: []string{old.BuildID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Permit(old); err != nil {
+		t.Fatalf("old release was blocked before policy finalization: %v", err)
+	}
+	if err := store.CommitMetadata(pending); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Permit(old); err == nil {
+		t.Fatal("old release remained permitted after policy finalization")
+	}
+}
+
+func TestTransitionLockSerializesInstallerAndUninstallBoundary(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := store.TransitionLock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		second, err := store.TransitionLock()
+		if err == nil {
+			err = second.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("second lifecycle owner acquired transition lock early: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if err := first.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second lifecycle owner did not acquire transition lock")
+	}
+}
+
+func TestJournalPersistsFailureForSafeRecovery(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	j, err := store.Begin("update", nil, nil, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Advance(&j, CandidateStarting, errors.New("injected")); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.ReadJournal()
+	if err != nil || loaded.State != CandidateStarting || !loaded.Resumable() || loaded.Error != "injected" {
+		t.Fatalf("journal = %#v, %v", loaded, err)
+	}
+	if err := store.Advance(&loaded, RolledBack, nil); err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Resumable() {
+		t.Fatal("rolled back journal remained resumable")
+	}
+}

--- a/packaging/homebrew/Formula/jobctrl.rb.tmpl
+++ b/packaging/homebrew/Formula/jobctrl.rb.tmpl
@@ -4,6 +4,7 @@
 # It intentionally has no HEAD/source-build path and no developer toolchain
 # dependencies. The ZIP is the same immutable payload resolved by curl.
 require "open3"
+require "json"
 
 class Jobctrl < Formula
   desc "Local-first job search mission control: discover, score, tailor, apply"
@@ -18,6 +19,17 @@ class Jobctrl < Formula
   JOBCTRL_MANIFEST_SHA256 = "{{MANIFEST_SHA256}}"
   JOBCTRL_DESCRIPTOR_URL = "{{DESCRIPTOR_URL}}"
   JOBCTRL_DESCRIPTOR_SHA256 = "{{DESCRIPTOR_SHA256}}"
+  JOBCTRL_SIGNATURE_SHA256 = "{{SIGNATURE_SHA256}}"
+
+  resource "jobctrl-release-descriptor" do
+    url JOBCTRL_DESCRIPTOR_URL
+    sha256 JOBCTRL_DESCRIPTOR_SHA256
+  end
+
+  resource "jobctrl-release-descriptor-signature" do
+    url "#{JOBCTRL_DESCRIPTOR_URL}.sig"
+    sha256 JOBCTRL_SIGNATURE_SHA256
+  end
 
   def verify_notarized_bundle!(bundle)
     codesign_output, codesign_status = Open3.capture2e(
@@ -39,16 +51,31 @@ class Jobctrl < Formula
   end
 
   def install
-    # The release ZIP has a payload root, not a source checkout. Keep that
-    # exact verified payload together under libexec and expose its one native
-    # launcher through Homebrew's normal bin symlink. P5 moves selection and
-    # updates into the user-owned release store transactionally.
+    # Formula installation remains entirely prefix-owned. The executable in
+    # libexec/bootstrap is a native bootstrap, not the runtime selector: on its first
+    # normal-user invocation it authenticates these resources into the user
+    # store, then re-execs that stable selector.
     verify_notarized_bundle!(buildpath/"launcher/jobctrl")
+    verify_notarized_bundle!(buildpath/"launcher/jobctrl-installer")
     chromium_apps = outermost_chromium_apps
     odie "JobCtrl release has no managed Chromium app bundle to verify" if chromium_apps.empty?
     chromium_apps.each { |bundle| verify_notarized_bundle!(Pathname.new(bundle)) }
-    libexec.install Dir["*"]
-    bin.install_symlink libexec/"launcher/jobctrl"
+    bootstrap = libexec/"bootstrap"
+    bootstrap.install buildpath/"launcher/jobctrl"
+    bootstrap.install buildpath/"launcher/jobctrl-installer"
+    bootstrap.install cached_download => "jobctrl-release.zip"
+    resource("jobctrl-release-descriptor").stage { bootstrap.install "darwin-arm64.json" => "homebrew-release.json" }
+    resource("jobctrl-release-descriptor-signature").stage { bootstrap.install "darwin-arm64.json.sig" => "homebrew-release.json.sig" }
+    (bootstrap/"homebrew-bootstrap.json").write(JSON.generate({
+      schemaVersion: 1,
+      descriptorUrl: JOBCTRL_DESCRIPTOR_URL,
+      descriptor: "homebrew-release.json",
+      signature: "homebrew-release.json.sig",
+      archive: "jobctrl-release.zip",
+      buildId: JOBCTRL_BUILD_ID,
+      descriptorSha256: JOBCTRL_DESCRIPTOR_SHA256
+    }))
+    bin.install_symlink bootstrap/"jobctrl"
   end
 
   def caveats
@@ -63,10 +90,7 @@ class Jobctrl < Formula
   end
 
   test do
-    assert_predicate libexec/"launcher/jobctrl", :executable?
+    assert_predicate libexec/"bootstrap"/"homebrew-bootstrap.json", :exist?
     assert_predicate bin/"jobctrl", :symlink?
-    version = shell_output("#{bin}/jobctrl version --json")
-    assert_match %Q("buildId":"#{JOBCTRL_BUILD_ID}"), version.delete(" ")
-    assert_match %Q("manifestSha256":"#{JOBCTRL_MANIFEST_SHA256}"), version.delete(" ")
   end
 end

--- a/scripts/distribution-homebrew.mjs
+++ b/scripts/distribution-homebrew.mjs
@@ -87,7 +87,7 @@ export function verifyReleaseDescriptorSignature({ descriptorRaw, signatureRaw, 
   return descriptor;
 }
 
-function templateValues({ descriptor, descriptorRaw, descriptorUrl }) {
+function templateValues({ descriptor, descriptorRaw, signatureRaw, descriptorUrl }) {
   validateReleaseDescriptor(descriptor);
   invariant(descriptor.channel === "stable", "Homebrew formula rendering requires a stable descriptor");
   const descriptorOrigin = requireCanonicalReleaseUrl(descriptorUrl, "Homebrew descriptor URL");
@@ -101,16 +101,17 @@ function templateValues({ descriptor, descriptorRaw, descriptorUrl }) {
     MANIFEST_SHA256: descriptor.artifact.manifestSha256,
     DESCRIPTOR_URL: descriptorUrl,
     DESCRIPTOR_SHA256: sha256(descriptorRaw),
+    SIGNATURE_SHA256: sha256(signatureRaw ?? ""),
   };
 }
 
 export async function renderHomebrewFormula({ descriptorRaw, signatureRaw, descriptorUrl, trust }) {
   const descriptor = verifyReleaseDescriptorSignature({ descriptorRaw, signatureRaw, trust });
-  const values = templateValues({ descriptor, descriptorRaw, descriptorUrl });
+  const values = templateValues({ descriptor, descriptorRaw, signatureRaw, descriptorUrl });
   let formula = await readFile(FORMULA_TEMPLATE_PATH, "utf8");
   for (const [token, value] of Object.entries(values)) formula = formula.replaceAll(`{{${token}}}`, value);
   invariant(!/{{[A-Z_]+}}/.test(formula), "Homebrew formula template has an unresolved token");
-  validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, descriptorUrl });
+  validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, signatureRaw, descriptorUrl });
   return { formula, descriptor, descriptorSha256: values.DESCRIPTOR_SHA256, publicationInputs: releasePublicationInputs({ descriptorRaw, descriptorUrl }) };
 }
 
@@ -118,9 +119,9 @@ export function homebrewPublicationInputs({ descriptorRaw, descriptorUrl }) {
   return releasePublicationInputs({ descriptorRaw, descriptorUrl });
 }
 
-export function validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, descriptorUrl }) {
+export function validateRenderedHomebrewFormula({ formula, descriptor, descriptorRaw, signatureRaw = "", descriptorUrl }) {
   validateReleaseDescriptor(descriptor);
-  const values = templateValues({ descriptor, descriptorRaw, descriptorUrl });
+  const values = templateValues({ descriptor, descriptorRaw, signatureRaw, descriptorUrl });
   const required = [
     `url "${values.ARTIFACT_URL}"`,
     `sha256 "${values.ARTIFACT_SHA256}"`,
@@ -129,17 +130,24 @@ export function validateRenderedHomebrewFormula({ formula, descriptor, descripto
     `JOBCTRL_MANIFEST_SHA256 = "${values.MANIFEST_SHA256}"`,
     `JOBCTRL_DESCRIPTOR_URL = "${values.DESCRIPTOR_URL}"`,
     `JOBCTRL_DESCRIPTOR_SHA256 = "${values.DESCRIPTOR_SHA256}"`,
+    `JOBCTRL_SIGNATURE_SHA256 = "${values.SIGNATURE_SHA256}"`,
     'require "open3"',
     '"/usr/bin/codesign", "--verify", "--deep", "--strict", "--check-notarization", "-R=notarized", "--verbose=2", bundle.to_s',
     '"/usr/sbin/spctl", "--assess", "--type", "execute", "--verbose=4", bundle.to_s',
     'gatekeeper_output.include?("source=Notarized Developer ID")',
     "verify_notarized_bundle!(buildpath/\"launcher/jobctrl\")",
+    "verify_notarized_bundle!(buildpath/\"launcher/jobctrl-installer\")",
     "outermost_chromium_apps",
     "chromium_apps.each { |bundle| verify_notarized_bundle!(Pathname.new(bundle)) }",
-    "libexec.install Dir[\"*\"]",
-    "bin.install_symlink libexec/\"launcher/jobctrl\"",
+    'resource "jobctrl-release-descriptor"',
+    'resource "jobctrl-release-descriptor-signature"',
+    'bootstrap.install cached_download => "jobctrl-release.zip"',
+    'bootstrap/"homebrew-bootstrap.json"',
+    'bin.install_symlink bootstrap/"jobctrl"',
   ];
   for (const marker of required) invariant(formula.includes(marker), `rendered Homebrew formula is missing ${marker}`);
+  invariant(formula.includes("Formula installation remains entirely prefix-owned"), "rendered Homebrew formula must use first-invocation bootstrap");
+  invariant(!formula.includes('Pathname.new(Dir.home)'), "rendered Homebrew formula must not write the user home during install");
   invariant(!/\bhead\s+/.test(formula), "rendered Homebrew formula must not have a HEAD/source path");
   invariant(!/depends_on\s+/.test(formula), "rendered Homebrew formula must not install a developer-toolchain dependency");
   for (const forbidden of ["corepack", "git", "node", "uv", "temporal", "poppler", "chrome"]) {

--- a/scripts/distribution-homebrew.test.mjs
+++ b/scripts/distribution-homebrew.test.mjs
@@ -23,6 +23,8 @@ function stableDescriptor() {
     schemaVersion: 1,
     channel: "stable",
     sequence: 42,
+    minimumSafeSequence: 1,
+    revokedBuildIds: [],
     buildId: "stable-build-0000042",
     appVersion: "2.0.0",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
@@ -61,12 +63,15 @@ test("Homebrew render uses the exact signed curl ZIP identity without a toolchai
   const rendered = await renderHomebrewFormula({ descriptorRaw, signatureRaw, descriptorUrl, trust: signed.trust });
   const formulaPath = path.join(root, "jobctrl.rb");
   await writeFile(formulaPath, rendered.formula);
-  assert.equal(validateRenderedHomebrewFormula({ formula: rendered.formula, descriptor: stableDescriptor(), descriptorRaw, descriptorUrl }), true);
+  assert.equal(validateRenderedHomebrewFormula({ formula: rendered.formula, descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }), true);
   assert.match(rendered.formula, /url "https:\/\/releases\.jobctrl\.dev\/v1\/stable\/jobctrl-2\.0\.0-darwin-arm64\.zip"/);
   assert.match(rendered.formula, /JOBCTRL_MANIFEST_SHA256 = "b{64}"/);
   assert.match(rendered.formula, /JOBCTRL_BUILD_ID = "stable-build-0000042"/);
-  assert.match(rendered.formula, /libexec\.install Dir\["\*"\]/);
-  assert.match(rendered.formula, /bin\.install_symlink libexec\/"launcher\/jobctrl"/);
+  assert.match(rendered.formula, /resource "jobctrl-release-descriptor"/);
+  assert.match(rendered.formula, /bootstrap\.install cached_download => "jobctrl-release\.zip"/);
+  assert.match(rendered.formula, /homebrew-bootstrap\.json/);
+  assert.match(rendered.formula, /bin\.install_symlink bootstrap\/"jobctrl"/);
+  assert.doesNotMatch(rendered.formula, /Pathname\.new\(Dir\.home\)/);
   assert.match(rendered.formula, /Open3\.capture2e/);
   assert.match(rendered.formula, /--verify", "--deep", "--strict", "--check-notarization", "-R=notarized/);
   assert.match(rendered.formula, /--assess", "--type", "execute", "--verbose=4/);
@@ -126,7 +131,7 @@ test("Homebrew promotion verification fails closed without P6 signature and publ
       'desc "Local-first job search mission control: discover, score, tailor, apply"',
       'desc "Tampered JobCtrl formula"',
     ),
-    rendered.formula.replace('    version = shell_output("#{bin}/jobctrl version --json")\n', ""),
+    rendered.formula.replace('    verify_notarized_bundle!(buildpath/"launcher/jobctrl-installer")\n', ""),
   ];
   for (const mutatedFormula of mutations) {
     assert.notEqual(mutatedFormula, rendered.formula);
@@ -193,15 +198,15 @@ test("Homebrew formula validation rejects a render that omits launcher or Chromi
   const descriptorUrl = "https://releases.jobctrl.dev/v1/stable/darwin-arm64.json";
   const rendered = await renderHomebrewFormula({ descriptorRaw, signatureRaw, descriptorUrl, trust: signed.trust });
   assert.throws(
-    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('verify_notarized_bundle!(buildpath/"launcher/jobctrl")', ""), descriptor: stableDescriptor(), descriptorRaw, descriptorUrl }),
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('verify_notarized_bundle!(buildpath/"launcher/jobctrl")', ""), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
     /launcher\/jobctrl/,
   );
   assert.throws(
-    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('gatekeeper_output.include?("source=Notarized Developer ID")', "true"), descriptor: stableDescriptor(), descriptorRaw, descriptorUrl }),
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replace('gatekeeper_output.include?("source=Notarized Developer ID")', "true"), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
     /source=Notarized Developer ID/,
   );
   assert.throws(
-    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replaceAll("outermost_chromium_apps", "chromium_apps"), descriptor: stableDescriptor(), descriptorRaw, descriptorUrl }),
+    () => validateRenderedHomebrewFormula({ formula: rendered.formula.replaceAll("outermost_chromium_apps", "chromium_apps"), descriptor: stableDescriptor(), descriptorRaw, signatureRaw, descriptorUrl }),
     /outermost_chromium_apps/,
   );
 });

--- a/scripts/distribution-release.mjs
+++ b/scripts/distribution-release.mjs
@@ -12,6 +12,7 @@ const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 const BUILD_ID_PATTERN = /^[0-9A-Za-z][0-9A-Za-z._-]{7,127}$/;
 const VERSION_PATTERN = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
 const CHANNELS = new Set(["local", "prerelease", "stable"]);
+const MAX_ARCHIVE_BYTES = 4 * 1024 * 1024 * 1024;
 
 function invariant(condition, message) {
   if (!condition) throw new Error(message);
@@ -55,10 +56,16 @@ function validateDescriptorPlatform(platform) {
 }
 
 export function validateReleaseDescriptor(descriptor, { requireLocalFileTransport = false } = {}) {
-  assertExactKeys(descriptor, ["schemaVersion", "channel", "sequence", "buildId", "appVersion", "platform", "artifact"], "release descriptor");
+  assertExactKeys(descriptor, ["schemaVersion", "channel", "sequence", "minimumSafeSequence", "revokedBuildIds", "buildId", "appVersion", "platform", "artifact"], "release descriptor");
   invariant(descriptor.schemaVersion === 1, "release descriptor schemaVersion must be 1");
   invariant(CHANNELS.has(descriptor.channel), "release descriptor channel is invalid");
   invariant(Number.isSafeInteger(descriptor.sequence) && descriptor.sequence > 0, "release descriptor sequence must be a positive integer");
+  invariant(Number.isSafeInteger(descriptor.minimumSafeSequence) && descriptor.minimumSafeSequence >= 0 && descriptor.minimumSafeSequence <= descriptor.sequence, "release descriptor minimumSafeSequence is invalid");
+  invariant(Array.isArray(descriptor.revokedBuildIds), "release descriptor revokedBuildIds must be an array");
+  const sortedRevocations = [...descriptor.revokedBuildIds].sort(bytewiseCompare);
+  invariant(JSON.stringify(sortedRevocations) === JSON.stringify(descriptor.revokedBuildIds) && new Set(descriptor.revokedBuildIds).size === descriptor.revokedBuildIds.length, "release descriptor revokedBuildIds must be bytewise sorted and unique");
+  for (const buildId of descriptor.revokedBuildIds) invariant(typeof buildId === "string" && BUILD_ID_PATTERN.test(buildId), "release descriptor revoked buildId is invalid");
+  if (descriptor.channel !== "local") invariant(descriptor.minimumSafeSequence > 0, "network release descriptor minimumSafeSequence must be positive");
   invariant(BUILD_ID_PATTERN.test(descriptor.buildId), "release descriptor buildId is invalid");
   invariant(VERSION_PATTERN.test(descriptor.appVersion), "release descriptor appVersion is invalid");
   validateDescriptorPlatform(descriptor.platform);
@@ -66,7 +73,7 @@ export function validateReleaseDescriptor(descriptor, { requireLocalFileTranspor
   invariant(descriptor.artifact.archiveType === "zip", "release artifact must be a ZIP");
   invariant(SHA256_PATTERN.test(descriptor.artifact.sha256), "release artifact SHA-256 is invalid");
   invariant(SHA256_PATTERN.test(descriptor.artifact.manifestSha256), "release artifact manifest SHA-256 is invalid");
-  invariant(Number.isSafeInteger(descriptor.artifact.sizeBytes) && descriptor.artifact.sizeBytes > 0, "release artifact sizeBytes is invalid");
+  invariant(Number.isSafeInteger(descriptor.artifact.sizeBytes) && descriptor.artifact.sizeBytes > 0 && descriptor.artifact.sizeBytes <= MAX_ARCHIVE_BYTES, "release artifact sizeBytes is invalid");
   let artifactUrl;
   try {
     artifactUrl = new URL(descriptor.artifact.url);
@@ -74,7 +81,7 @@ export function validateReleaseDescriptor(descriptor, { requireLocalFileTranspor
     throw new Error("release artifact URL is invalid");
   }
   if (descriptor.channel === "local") {
-    invariant(artifactUrl.protocol === "file:", "local release descriptor requires a file:// artifact URL");
+    invariant(artifactUrl.protocol === "file:" && artifactUrl.host === "" && artifactUrl.username === "" && artifactUrl.password === "" && artifactUrl.hash === "" && artifactUrl.search === "" && artifactUrl.pathname.startsWith("/"), "local release descriptor requires a canonical absolute file:// artifact URL");
   } else {
     invariant(artifactUrl.protocol === "https:", "network release descriptor requires an HTTPS artifact URL");
   }
@@ -177,6 +184,8 @@ export async function writeLocalReleaseBundle({ outputDirectory, archivePath, ma
     schemaVersion: 1,
     channel: "local",
     sequence,
+    minimumSafeSequence: 0,
+    revokedBuildIds: [],
     buildId,
     appVersion,
     platform: { id: platform.id, os: platform.os, arch: platform.arch },

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -36,6 +36,8 @@ test("local fixture release descriptor, signature, and curl contract bind one ZI
     schemaVersion: 1,
     channel: "local",
     sequence: 1,
+    minimumSafeSequence: 0,
+    revokedBuildIds: [],
     buildId: "fixture-build-0001",
     appVersion: "2.0.0",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
@@ -67,14 +69,36 @@ test("local descriptor rejects network transport and signed channels reject an u
     schemaVersion: 1,
     channel: "local",
     sequence: 1,
+    minimumSafeSequence: 0,
+    revokedBuildIds: [],
     buildId: "fixture-build-0001",
     appVersion: "2.0.0",
     platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
     artifact: { url: "https://releases.example.test/jobctrl.zip", sha256: "a".repeat(64), sizeBytes: 1, archiveType: "zip", manifestSha256: "b".repeat(64) },
   };
   assert.throws(() => validateReleaseDescriptor(descriptor), /file:\/\//);
+  assert.throws(() => validateReleaseDescriptor({ ...descriptor, minimumSafeSequence: 2 }), /minimumSafeSequence/);
+  assert.throws(() => validateReleaseDescriptor({ ...descriptor, revokedBuildIds: ["fixture-build-0002", "fixture-build-0002"] }), /sorted and unique/);
   assert.throws(
     () => validateReleaseDescriptorSignature({ schemaVersion: 1, status: "unsigned-local", algorithm: "ed25519", keyId: "local-development", signature: null }, { channel: "stable" }),
     /network release descriptor requires a release signature/,
   );
+});
+
+test("descriptor bounds and local file URLs match the native installer contract", () => {
+  const descriptor = {
+    schemaVersion: 1,
+    channel: "local",
+    sequence: 1,
+    minimumSafeSequence: 0,
+    revokedBuildIds: [],
+    buildId: "fixture-build-0001",
+    appVersion: "2.0.0",
+    platform: { id: "darwin-arm64", os: "darwin", arch: "arm64" },
+    artifact: { url: "file:///jobctrl-local-release/fixture.zip", sha256: "a".repeat(64), sizeBytes: 1, archiveType: "zip", manifestSha256: "b".repeat(64) },
+  };
+  assert.doesNotThrow(() => validateReleaseDescriptor(descriptor));
+  assert.throws(() => validateReleaseDescriptor({ ...descriptor, artifact: { ...descriptor.artifact, url: "file://attacker.example/fixture.zip" } }), /canonical absolute file/);
+  assert.throws(() => validateReleaseDescriptor({ ...descriptor, sequence: Number.MAX_SAFE_INTEGER + 1 }), /positive integer/);
+  assert.throws(() => validateReleaseDescriptor({ ...descriptor, artifact: { ...descriptor.artifact, sizeBytes: 4 * 1024 * 1024 * 1024 + 1 } }), /sizeBytes/);
 });

--- a/scripts/get
+++ b/scripts/get
@@ -73,6 +73,7 @@ login_profile() {
 append_managed_path() {
   local bin_dir="$1" profile mode temporary line
   profile="$(login_profile)"
+  require_safe_profile_path "$profile" "login profile"
   line="export PATH=\"$bin_dir:\$PATH\" # JobCtrl managed path"
   if [[ -L "$profile" ]]; then fail "refusing to modify symlinked login profile $profile"; fi
   if [[ -e "$profile" && ! -f "$profile" ]]; then fail "login profile is not a regular file: $profile"; fi
@@ -112,6 +113,22 @@ expose_command() {
   else
     append_managed_path "$bin_dir"
   fi
+}
+persist_curl_acquisition() {
+  local release_home="$1" bin_dir="$2" profile encoded_line record temporary
+  profile=""
+  encoded_line=""
+  if [[ "$NO_MODIFY_PATH" -eq 0 ]] && ! path_contains "$bin_dir"; then
+    profile="$(login_profile)"
+    require_safe_profile_path "$profile" "login profile"
+    encoded_line="export PATH=\\\"$bin_dir:\$PATH\\\" # JobCtrl managed path"
+  fi
+  record="$release_home/acquisition.json"
+  [[ ! -L "$record" ]] || fail "refusing symlinked acquisition record $record"
+  temporary="$(/usr/bin/mktemp "$release_home/.acquisition.XXXXXX")"
+  /usr/bin/printf '{"schemaVersion":1,"source":"curl","publicLink":"%s/jobctrl","selector":"%s/bin/jobctrl","profile":"%s","pathLine":"%s"}\n' "$bin_dir" "$release_home" "$profile" "$encoded_line" > "$temporary" || { /bin/rm -f "$temporary"; fail "could not write acquisition record"; }
+  /bin/chmod 0600 "$temporary"
+  /bin/mv -f "$temporary" "$record" || { /bin/rm -f "$temporary"; fail "could not commit acquisition record"; }
 }
 
 HOME_OVERRIDE=""
@@ -169,4 +186,5 @@ else
   [[ -n "$RELEASE_URL" ]] && installer_args+=(--release-url "$RELEASE_URL")
   "$INSTALLER_PATH" ${installer_args[@]+"${installer_args[@]}"}
 fi
+persist_curl_acquisition "$RELEASE_HOME" "$BIN_DIR"
 expose_command "$RELEASE_HOME" "$BIN_DIR"

--- a/scripts/get.test.mjs
+++ b/scripts/get.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const GET = path.join(ROOT, "scripts", "get");
+const PUBLIC_INSTALL = path.join(ROOT, "docs", "public", "install.sh");
 const SYSTEM_BASH = "/bin/bash";
 
 function makeTmp() { return mkdtempSync(path.join(os.tmpdir(), "jobctrl-get-test-")); }
@@ -55,10 +56,20 @@ test("get is transport-only and delegates an explicit local fixture to the nativ
     const firstProfile = readFileSync(profile, "utf8");
     assert.match(firstProfile, /JobCtrl managed path/);
     assert.equal(statSync(profile).mode & 0o777, 0o600);
+    assert.deepEqual(JSON.parse(readFileSync(path.join(value.runtime, "acquisition.json"), "utf8")), {
+      schemaVersion: 1,
+      source: "curl",
+      publicLink: link,
+      selector: path.join(value.runtime, "bin", "jobctrl"),
+      profile,
+      pathLine: `export PATH="${path.dirname(link)}:$PATH" # JobCtrl managed path`,
+    });
     const repeated = run(["--local-fixture-contract", value.contract, "--home", value.runtime], value.env);
     assert.equal(repeated.status, 0, repeated.stderr);
     assert.equal(readFileSync(profile, "utf8"), firstProfile);
     const source = readFileSync(GET, "utf8");
+    assert.ok(source.lastIndexOf("persist_curl_acquisition \"$RELEASE_HOME\" \"$BIN_DIR\"") < source.lastIndexOf("expose_command \"$RELEASE_HOME\" \"$BIN_DIR\""));
+    assert.equal(readFileSync(PUBLIC_INSTALL, "utf8"), source);
     assert.doesNotMatch(source, /git clone|git pull|corepack|pnpm|uv sync|scripts\/install/);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## What changed

- add one user-owned immutable release store shared by curl and Homebrew acquisition
- implement signed channel floors/revocations, descriptor-bound resumable downloads, and receipt-bound policy evidence
- make `jobctrl update`, rollback, paired SQLite backup/restore, retention, and uninstall native launcher operations
- health-gate promotion, recover every durable activation boundary, and fail closed after a security revocation
- keep Homebrew installation prefix-only while first invocation seeds the same user store used by curl
- preserve local data by default and remove only the exact curl/Homebrew exposure owned by the acquisition record

## Why

The bundled distribution needs one command and one runtime lifecycle regardless of acquisition method. Updates must not depend on mutating a Homebrew Cellar, run an older payload against migrated state, or strand a user between a revoked predecessor and an unhealthy candidate.

## Validation

- `cd launcher && go vet ./...`
- `cd launcher && go test -race -count=1 ./...`
- `corepack pnpm check`
- `corepack pnpm test` (73 script tests, 517 API tests, web/extension builds and tests, 2,315 Python tests, launcher race suite)
- `corepack pnpm docs:build` (5,839 references across 262 emitted files)
- `python3 scripts/release_check.py`
- `corepack pnpm distribution:audit`
- two real bundled artifact builds during final hardening; final build passed native lifecycle, Chromium, PDF, offline-network, restart/recovery, exact-tree, and forbidden-content smokes
- real `scripts/get` local-fixture install run twice with unchanged `active.json`, followed by `jobctrl uninstall`; runtime removed and local data preserved
- independent final code-review and QA gates: PASS, no Blocker/High findings

Final local artifact evidence:

- manifest SHA-256: `776f8d7168da9e25b23837e6b21434056ca31d17fd08428f7d5a8d28697157dc`
- archive SHA-256: `1c410c735577ad8bd68c615bf2de3085888ae40dca90e9ba8de86a28d9d75a40`
- compressed: 507,847,585 bytes
- installed: 1,578,963,342 bytes

## Stack

Depends on #402 (`feat/distribution-p4`).
