### PR TITLE
chore(license): add copyright attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+JobCtrl
+Copyright (C) 2026 Eloi Barti
+
+JobCtrl is licensed under the GNU Affero General Public License,
+version 3 only (AGPL-3.0-only). See LICENSE.
+
+Portions contributed by others remain copyright their respective contributors.

--- a/README.md
+++ b/README.md
@@ -615,4 +615,9 @@ workflow: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-JobCtrl is licensed under AGPL-3.0-only. See [LICENSE](LICENSE).
+Copyright (C) 2026 Eloi Barti.
+
+JobCtrl is licensed under **AGPL-3.0-only**. See [LICENSE](LICENSE) and
+[NOTICE](NOTICE). The license and copyright notices must be preserved in
+redistributions. The complete corresponding source is published in this
+[repository](https://github.com/ebarti/JobCtrl).

--- a/apps/web/e2e/tests/token-foundation.spec.ts
+++ b/apps/web/e2e/tests/token-foundation.spec.ts
@@ -152,7 +152,7 @@ async function expectPaintedStatus(locator: Locator, label: string): Promise<voi
 }
 
 async function focusByKeyboard(page: Page, target: Locator): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 24; attempt += 1) {
     const isFocused = await target.evaluate((element) => element === document.activeElement);
     if (isFocused) {
       return;
@@ -375,6 +375,26 @@ test("shell chrome collapses navigation into a sheet on the mobile viewport", as
   await expect(navSheet.locator(".side-rail__group-label", { hasText: "Pipeline" })).toBeVisible();
   await navSheet.getByRole("link", { name: "Dashboard" }).click();
   await expect(page).toHaveURL(/\/dashboard\b/);
+});
+
+test("legal attribution remains visible while the side rail is icon-only", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 844 });
+  await page.goto("/jobs");
+
+  const legalNotice = page.locator(".legal-notice--topbar");
+  await expect(legalNotice).toBeVisible({ timeout: 30_000 });
+  await expect(legalNotice).toContainText("Copyright © 2026 Eloi Barti");
+  await expect(legalNotice.getByRole("link", { name: "AGPL-3.0-only" })).toHaveAttribute(
+    "href",
+    "https://github.com/ebarti/JobCtrl/blob/main/LICENSE",
+  );
+  await expect(legalNotice.getByRole("link", { name: "Source code" })).toHaveAttribute(
+    "href",
+    "https://github.com/ebarti/JobCtrl",
+  );
+  await expect(page.locator(".legal-notice--rail")).toBeHidden();
+  await expect(page.getByRole("button", { name: "Open navigation" })).toBeHidden();
+  await expectNoDocumentInlineOverflow(page);
 });
 
 test("domain status surfaces use painted semantic token classes", async ({ page }) => {

--- a/apps/web/src/shared/layout/LegalNotice.tsx
+++ b/apps/web/src/shared/layout/LegalNotice.tsx
@@ -1,0 +1,22 @@
+const REPOSITORY_URL = "https://github.com/ebarti/JobCtrl";
+
+interface LegalNoticeProps {
+  readonly className?: string;
+}
+
+export function LegalNotice({ className }: LegalNoticeProps) {
+  return (
+    <footer className={className}>
+      <span>Copyright © 2026 Eloi Barti</span>
+      <span>
+        <a href={`${REPOSITORY_URL}/blob/main/LICENSE`} target="_blank" rel="noreferrer">
+          AGPL-3.0-only
+        </a>
+        {" · "}
+        <a href={REPOSITORY_URL} target="_blank" rel="noreferrer">
+          Source code
+        </a>
+      </span>
+    </footer>
+  );
+}

--- a/apps/web/src/shared/layout/SideRail.test.tsx
+++ b/apps/web/src/shared/layout/SideRail.test.tsx
@@ -58,11 +58,20 @@ describe("<SideRail>", () => {
     }
   });
 
-  it("exposes the brand link and local-mode footer", async () => {
+  it("exposes the brand link, local-mode status, and legal attribution", async () => {
     renderRail();
 
     expect(await screen.findByRole("link", { name: "JobCtrl" })).toHaveAttribute("href", "/dashboard");
     expect(screen.getByText("Local mode — all data stays on device")).toBeInTheDocument();
+    expect(screen.getByText("Copyright © 2026 Eloi Barti")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "AGPL-3.0-only" })).toHaveAttribute(
+      "href",
+      "https://github.com/ebarti/JobCtrl/blob/main/LICENSE",
+    );
+    expect(screen.getByRole("link", { name: "Source code" })).toHaveAttribute(
+      "href",
+      "https://github.com/ebarti/JobCtrl",
+    );
   });
 
   it("marks the current route active with aria-current for accent styling", async () => {

--- a/apps/web/src/shared/layout/SideRail.tsx
+++ b/apps/web/src/shared/layout/SideRail.tsx
@@ -19,6 +19,7 @@ import { Link } from "@tanstack/react-router";
 
 import { cn } from "../lib/cn.js";
 import { BrandMark } from "./BrandMark.js";
+import { LegalNotice } from "./LegalNotice.js";
 
 type NavTarget =
   | "/dashboard"
@@ -138,6 +139,7 @@ export function SideRail() {
       <RailNav />
       <span className="side-rail__spacer" />
       <LocalModeCard />
+      <LegalNotice className="legal-notice legal-notice--rail" />
     </aside>
   );
 }

--- a/apps/web/src/shared/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/layout/Topbar.test.tsx
@@ -5,7 +5,7 @@ import {
   createRouter,
   RouterProvider,
 } from "@tanstack/react-router";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -78,6 +78,9 @@ describe("<Topbar>", () => {
     expect(screen.getByRole("option", { name: "compact" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "regular" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "comfy" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Copyright © 2026 Eloi Barti", { selector: ".legal-notice--topbar span" }),
+    ).toBeInTheDocument();
   });
 
   it("opens the responsive navigation sheet with the grouped nav links", async () => {
@@ -90,6 +93,16 @@ describe("<Topbar>", () => {
     for (const label of ["Dashboard", "Apply review", "Jobs", "Contacts", "Settings"]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
     }
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Copyright © 2026 Eloi Barti")).toBeInTheDocument();
+    expect(within(dialog).getByRole("link", { name: "AGPL-3.0-only" })).toHaveAttribute(
+      "href",
+      "https://github.com/ebarti/JobCtrl/blob/main/LICENSE",
+    );
+    expect(within(dialog).getByRole("link", { name: "Source code" })).toHaveAttribute(
+      "href",
+      "https://github.com/ebarti/JobCtrl",
+    );
     expect(nav).toBeInTheDocument();
   });
 

--- a/apps/web/src/shared/layout/Topbar.tsx
+++ b/apps/web/src/shared/layout/Topbar.tsx
@@ -7,6 +7,7 @@ import type { Density } from "../stores/ui-preferences.js";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "../ui/sheet.js";
 import { BrandMark } from "./BrandMark.js";
 import { ConnectionStatusPill } from "./ConnectionStatusPill.js";
+import { LegalNotice } from "./LegalNotice.js";
 import { RailNav } from "./SideRail.js";
 import { ThemeToggle } from "./ThemeToggle.js";
 
@@ -32,6 +33,7 @@ export function Topbar() {
             </SheetTitle>
           </SheetHeader>
           <RailNav className="sheet-nav" onNavigate={() => setNavOpen(false)} />
+          <LegalNotice className="legal-notice legal-notice--sheet" />
         </SheetContent>
       </Sheet>
       <input
@@ -60,6 +62,7 @@ export function Topbar() {
       </select>
       <ThemeToggle />
       <ConnectionStatusPill />
+      <LegalNotice className="legal-notice legal-notice--topbar" />
     </header>
   );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -228,6 +228,40 @@ code,
   box-shadow: 0 0 0 3px color-mix(in oklab, var(--success) 22%, transparent);
 }
 
+.legal-notice {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.legal-notice a {
+  color: inherit;
+  text-underline-offset: 2px;
+}
+
+.legal-notice a:hover {
+  color: var(--foreground);
+}
+
+.legal-notice--rail {
+  padding: 4px 2px 0;
+}
+
+.legal-notice--sheet {
+  margin-top: auto;
+  padding: 16px 12px 4px;
+}
+
+.legal-notice--topbar {
+  display: none;
+  margin-inline-start: auto;
+  align-items: flex-end;
+  text-align: end;
+}
+
 .side-rail__tagline {
   margin: 2px 0 0;
   color: var(--muted-foreground);
@@ -246,7 +280,8 @@ code,
   .side-rail__group-label,
   .side-rail__label,
   .side-rail__wordmark,
-  .side-rail__footer-text {
+  .side-rail__footer-text,
+  .legal-notice--rail {
     display: none;
   }
 
@@ -275,6 +310,12 @@ code,
   }
 }
 
+@media (min-width: 821px) and (max-width: 1180px) {
+  .legal-notice--topbar {
+    display: flex;
+  }
+}
+
 .topbar {
   position: sticky;
   top: 0;
@@ -292,12 +333,12 @@ code,
   color: var(--foreground);
 }
 
-.topbar__hamburger {
+.topbar .topbar__hamburger {
   display: none;
 }
 
 @media (max-width: 820px) {
-  .topbar__hamburger {
+  .topbar .topbar__hamburger {
     display: inline-flex;
   }
 }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -245,7 +245,7 @@ export default withMermaid(
       socialLinks: [{ icon: "github", link: REPO_URL }],
       footer: {
         message: "Documentation screenshots and examples use synthetic data unless noted.",
-        copyright: `Copyright © 2026 JobCtrl contributors. Licensed under <a href="${REPO_URL}/blob/main/LICENSE">AGPL-3.0-only</a>.`,
+        copyright: `Copyright © 2026 Eloi Barti and JobCtrl contributors. Licensed under <a href="${REPO_URL}/blob/main/LICENSE">AGPL-3.0-only</a>. <a href="${REPO_URL}">Source code</a>.`,
       },
       search: {
         provider: "local",

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -184,7 +184,12 @@ try {
     console.log("ok    /user/screenshots section outline");
   }
   const footerText = await page.locator(".VPFooter").innerText();
-  if (!/AGPL-3\.0-only|synthetic data/.test(footerText)) {
+  if (
+    !footerText.includes("Copyright © 2026 Eloi Barti")
+    || !footerText.includes("AGPL-3.0-only")
+    || !footerText.includes("Source code")
+    || !footerText.includes("synthetic data")
+  ) {
     fail("/user/screenshots: copyright/license footer is missing or incomplete");
   } else {
     console.log("ok    /user/screenshots footer notice");

--- a/scripts/distribution-build.mjs
+++ b/scripts/distribution-build.mjs
@@ -1602,6 +1602,7 @@ async function collectTopLevelLicenseEvidence(payloadRoot, root, contracts) {
   const sources = [];
   const add = async (subject, candidates) => sources.push({ subject, source: await firstExisting(candidates, subject) });
   await add("jobctrl", [path.join(root, "LICENSE")]);
+  await add("jobctrl-notice", [path.join(root, "NOTICE")]);
   await add("go-standard-library", [path.join(root, "launcher", "GO-LICENSE")]);
   await add("node-runtime", [path.join(nodeRoot, "LICENSE"), path.join(nodeRoot, "LICENSE.md"), path.join(nodeRoot, "LICENSE.txt")]);
   await add("python-runtime", [
@@ -3036,6 +3037,7 @@ function topLevelSbomComponents(contracts, preliminaryFiles) {
 }
 
 async function generateReleaseMetadata(payloadRoot, contracts, {
+  root,
   mode,
   sourceDateEpoch,
   pythonSbom = null,
@@ -3045,6 +3047,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   attributionEvidence = null,
   licenseSources = [],
 }) {
+  invariant(typeof root === "string" && root.length > 0, "release metadata requires a source root");
   const releaseRoot = componentRoot(payloadRoot, contracts, "jobctrl-release-metadata");
   await rm(releaseRoot, { recursive: true, force: true });
   await mkdir(path.join(releaseRoot, "licenses"), { recursive: true, mode: 0o755 });
@@ -3112,6 +3115,18 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
     });
   }
 
+  const projectLegalFiles = [
+    { source: path.join(root, "LICENSE"), path: "JobCtrl-AGPL-3.0.txt", label: "JobCtrl LICENSE" },
+    { source: path.join(root, "NOTICE"), path: "JobCtrl-NOTICE.txt", label: "JobCtrl NOTICE" },
+  ];
+  for (const legalFile of projectLegalFiles) {
+    await requireFile(legalFile.source, legalFile.label);
+    const destination = path.join(releaseRoot, "licenses", legalFile.path);
+    await copyFile(legalFile.source, destination);
+    await chmod(destination, 0o644);
+    legalFile.sha256 = await sha256File(destination);
+  }
+
   const attributions = topLevelSbomComponents(contracts, preliminaryFiles).map((component) => ({
     id: component.name,
     version: component.version,
@@ -3124,14 +3139,8 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
     schemaVersion: 1,
     status: mode === "fixture" ? "fixture-contract" : "collected-from-production-inputs",
     components: attributions,
+    projectLegalFiles: projectLegalFiles.map(({ path: legalPath, sha256 }) => ({ path: legalPath, sha256 })),
   });
-  const rootLicense = path.join(REPO_ROOT, "LICENSE");
-  if (await exists(rootLicense)) {
-    await copyFile(rootLicense, path.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"));
-    await chmod(path.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"), 0o644);
-  } else {
-    await writeFile(path.join(releaseRoot, "licenses", "fixture-notice.txt"), "Fixture build: consult component-inventory.json for declared license expressions.\n", { mode: 0o644 });
-  }
   await writeJson(path.join(releaseRoot, "provenance.json"), {
     schemaVersion: 1,
     buildMode: mode,
@@ -3158,7 +3167,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   // The Python worker reads this immutable catalog in bundled mode. It lives
   // below signed release metadata, never in mutable JOBCTRL_DIR state.
   await copyFile(
-    path.join(REPO_ROOT, "packaging", "distribution", "capability-policy.json"),
+    path.join(root, "packaging", "distribution", "capability-policy.json"),
     path.join(releaseRoot, "capability-policy.json"),
   );
   await chmod(path.join(releaseRoot, "capability-policy.json"), 0o644);
@@ -3723,7 +3732,7 @@ export async function buildFixturePayload({
   await rm(outputRoot, { recursive: true, force: true });
   await mkdir(payloadRoot, { recursive: true, mode: 0o755 });
   await writeFixtureComponents(payloadRoot, contracts);
-  await generateReleaseMetadata(payloadRoot, contracts, { mode: "fixture", sourceDateEpoch });
+  await generateReleaseMetadata(payloadRoot, contracts, { root, mode: "fixture", sourceDateEpoch });
   const manifest = await createLocalManifest(payloadRoot, contracts, { buildId, sourceDateEpoch });
   await verifyExactPayloadTree(payloadRoot, manifest);
   await scanForbiddenPayload(payloadRoot, { forbiddenAbsolutePaths: [root, outputRoot] });
@@ -3868,6 +3877,7 @@ export async function buildRealPayload({
       { subject: "chromium-core-third-party-credits", source: chromiumCredits },
     ];
     await generateReleaseMetadata(payloadRoot, contracts, {
+      root,
       mode: "real",
       sourceDateEpoch,
       pythonSbom,

--- a/scripts/distribution-build.test.mjs
+++ b/scripts/distribution-build.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { chmod, lstat, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, copyFile, lstat, mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -48,6 +48,39 @@ import { buildFileInventory } from "./distribution-manifest.mjs";
 import { parseExportedRequirements } from "./distribution-provider-lock.mjs";
 
 const execFileAsync = promisify(execFile);
+
+const FIXTURE_BUILD_ROOT_FILES = [
+  "LICENSE",
+  "NOTICE",
+  "package.json",
+  "pnpm-lock.yaml",
+  "apps/api/package.json",
+  "apps/web/package.json",
+  "workers/automation/pyproject.toml",
+  "workers/automation/uv.lock",
+  "launcher/GO-LICENSE",
+  "launcher/toolchain.json",
+  "packaging/distribution/capability-policy.json",
+  "packaging/distribution/component-inventory.json",
+  "packaging/distribution/components.lock.json",
+  "packaging/distribution/license-evidence.lock.json",
+  "packaging/distribution/manifest.schema.json",
+  "packaging/distribution/node-license-evidence.lock.json",
+  "packaging/distribution/payload-layout.json",
+  "packaging/distribution/platforms.json",
+  "packaging/distribution/provider-packs.lock.json",
+  "packaging/distribution/signing-policy.json",
+  "packaging/distribution/source-baseline.json",
+];
+
+async function createFixtureBuildRoot(root) {
+  for (const relativePath of FIXTURE_BUILD_ROOT_FILES) {
+    const destination = path.join(root, relativePath);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(path.join(process.cwd(), relativePath), destination);
+  }
+  return root;
+}
 
 test("native launcher build pins an official verified darwin-arm64 compiler contract", async (context) => {
   const root = process.cwd();
@@ -572,6 +605,43 @@ test("fixture builds are bytewise reproducible in different directories", async 
   assert.ok(first.manifest.files.some((file) => file.path === "launcher/jobctrl"));
   assert.ok(first.manifest.files.some((file) => file.path === "launcher/jobctrl-installer"));
   assert.ok(first.manifest.files.every((file) => !/claude|openai.codex|antigravity/i.test(file.path)));
+});
+
+test("fixture release metadata preserves the selected root legal files and requires NOTICE", async (context) => {
+  const parent = await mkdtemp(path.join(os.tmpdir(), "jobctrl-fixture-legal-root-"));
+  context.after(async () => rm(parent, { recursive: true, force: true }));
+  const fixtureRoot = await createFixtureBuildRoot(path.join(parent, "root"));
+  const license = "fixture root license\n";
+  const notice = "fixture root notice\n";
+  await writeFile(path.join(fixtureRoot, "LICENSE"), license, { mode: 0o644 });
+  await writeFile(path.join(fixtureRoot, "NOTICE"), notice, { mode: 0o644 });
+
+  const build = await buildFixturePayload({
+    outputDirectory: path.join(parent, "build"),
+    root: fixtureRoot,
+  });
+  const licensesRoot = path.join(build.payloadRoot, "release", "licenses");
+  const licensePath = path.join(licensesRoot, "JobCtrl-AGPL-3.0.txt");
+  const noticePath = path.join(licensesRoot, "JobCtrl-NOTICE.txt");
+  assert.equal(await readFile(licensePath, "utf8"), license);
+  assert.equal(await readFile(noticePath, "utf8"), notice);
+  assert.deepEqual(
+    JSON.parse(await readFile(path.join(licensesRoot, "index.json"), "utf8")).projectLegalFiles,
+    [
+      { path: "JobCtrl-AGPL-3.0.txt", sha256: await sha256File(licensePath) },
+      { path: "JobCtrl-NOTICE.txt", sha256: await sha256File(noticePath) },
+    ],
+  );
+  const manifestPaths = new Set(build.manifest.files.map((file) => file.path));
+  assert.ok(manifestPaths.has("release/licenses/JobCtrl-AGPL-3.0.txt"));
+  assert.ok(manifestPaths.has("release/licenses/JobCtrl-NOTICE.txt"));
+
+  const missingNoticeRoot = await createFixtureBuildRoot(path.join(parent, "missing-notice-root"));
+  await rm(path.join(missingNoticeRoot, "NOTICE"));
+  await assert.rejects(
+    buildFixturePayload({ outputDirectory: path.join(parent, "missing-notice-build"), root: missingNoticeRoot }),
+    /JobCtrl NOTICE is missing/,
+  );
 });
 
 test("fixture manifest covers the exact payload tree", async (context) => {

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -10227,6 +10227,7 @@ async function collectTopLevelLicenseEvidence(payloadRoot, root, contracts) {
   const sources = [];
   const add = async (subject, candidates) => sources.push({ subject, source: await firstExisting(candidates, subject) });
   await add("jobctrl", [path3.join(root, "LICENSE")]);
+  await add("jobctrl-notice", [path3.join(root, "NOTICE")]);
   await add("go-standard-library", [path3.join(root, "launcher", "GO-LICENSE")]);
   await add("node-runtime", [path3.join(nodeRoot, "LICENSE"), path3.join(nodeRoot, "LICENSE.md"), path3.join(nodeRoot, "LICENSE.txt")]);
   await add("python-runtime", [
@@ -11575,6 +11576,7 @@ function topLevelSbomComponents(contracts, preliminaryFiles) {
   });
 }
 async function generateReleaseMetadata(payloadRoot, contracts, {
+  root,
   mode,
   sourceDateEpoch,
   pythonSbom = null,
@@ -11584,6 +11586,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   attributionEvidence = null,
   licenseSources = []
 }) {
+  invariant3(typeof root === "string" && root.length > 0, "release metadata requires a source root");
   const releaseRoot = componentRoot(payloadRoot, contracts, "jobctrl-release-metadata");
   await rm2(releaseRoot, { recursive: true, force: true });
   await mkdir2(path3.join(releaseRoot, "licenses"), { recursive: true, mode: 493 });
@@ -11648,6 +11651,17 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
       licenseFiles: licenseRecords
     });
   }
+  const projectLegalFiles = [
+    { source: path3.join(root, "LICENSE"), path: "JobCtrl-AGPL-3.0.txt", label: "JobCtrl LICENSE" },
+    { source: path3.join(root, "NOTICE"), path: "JobCtrl-NOTICE.txt", label: "JobCtrl NOTICE" }
+  ];
+  for (const legalFile of projectLegalFiles) {
+    await requireFile(legalFile.source, legalFile.label);
+    const destination = path3.join(releaseRoot, "licenses", legalFile.path);
+    await copyFile(legalFile.source, destination);
+    await chmod2(destination, 420);
+    legalFile.sha256 = await sha256File2(destination);
+  }
   const attributions = topLevelSbomComponents(contracts, preliminaryFiles).map((component) => ({
     id: component.name,
     version: component.version,
@@ -11659,15 +11673,9 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   await writeJson(path3.join(releaseRoot, "licenses", "index.json"), {
     schemaVersion: 1,
     status: mode === "fixture" ? "fixture-contract" : "collected-from-production-inputs",
-    components: attributions
+    components: attributions,
+    projectLegalFiles: projectLegalFiles.map(({ path: legalPath, sha256: sha2562 }) => ({ path: legalPath, sha256: sha2562 }))
   });
-  const rootLicense = path3.join(REPO_ROOT, "LICENSE");
-  if (await exists(rootLicense)) {
-    await copyFile(rootLicense, path3.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"));
-    await chmod2(path3.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"), 420);
-  } else {
-    await writeFile2(path3.join(releaseRoot, "licenses", "fixture-notice.txt"), "Fixture build: consult component-inventory.json for declared license expressions.\n", { mode: 420 });
-  }
   await writeJson(path3.join(releaseRoot, "provenance.json"), {
     schemaVersion: 1,
     buildMode: mode,
@@ -11692,7 +11700,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   });
   await writeJson(path3.join(releaseRoot, "provider-packs.lock.json"), contracts.providerPackLocks);
   await copyFile(
-    path3.join(REPO_ROOT, "packaging", "distribution", "capability-policy.json"),
+    path3.join(root, "packaging", "distribution", "capability-policy.json"),
     path3.join(releaseRoot, "capability-policy.json")
   );
   await chmod2(path3.join(releaseRoot, "capability-policy.json"), 420);
@@ -12135,7 +12143,7 @@ async function buildFixturePayload({
   await rm2(outputRoot, { recursive: true, force: true });
   await mkdir2(payloadRoot, { recursive: true, mode: 493 });
   await writeFixtureComponents(payloadRoot, contracts);
-  await generateReleaseMetadata(payloadRoot, contracts, { mode: "fixture", sourceDateEpoch });
+  await generateReleaseMetadata(payloadRoot, contracts, { root, mode: "fixture", sourceDateEpoch });
   const manifest = await createLocalManifest(payloadRoot, contracts, { buildId, sourceDateEpoch });
   await verifyExactPayloadTree(payloadRoot, manifest);
   await scanForbiddenPayload(payloadRoot, { forbiddenAbsolutePaths: [root, outputRoot] });
@@ -12263,6 +12271,7 @@ async function buildRealPayload({
       { subject: "chromium-core-third-party-credits", source: chromiumCredits }
     ];
     await generateReleaseMetadata(payloadRoot, contracts, {
+      root,
       mode: "real",
       sourceDateEpoch,
       pythonSbom,

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-cd58b117265fcba282a9ed7e1a806569de8501fd620e5d4cafb981620b2c5d1a  distribution-homebrew.render.bundle.mjs
+86146e29073cf28703ca5fe07abbbd78668200f205be577b7db39ca9efb07c9a  distribution-homebrew.render.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.finalizer.bundle.mjs
+++ b/scripts/distribution-release.finalizer.bundle.mjs
@@ -10220,6 +10220,7 @@ async function collectTopLevelLicenseEvidence(payloadRoot, root, contracts) {
   const sources = [];
   const add = async (subject, candidates) => sources.push({ subject, source: await firstExisting(candidates, subject) });
   await add("jobctrl", [path3.join(root, "LICENSE")]);
+  await add("jobctrl-notice", [path3.join(root, "NOTICE")]);
   await add("go-standard-library", [path3.join(root, "launcher", "GO-LICENSE")]);
   await add("node-runtime", [path3.join(nodeRoot, "LICENSE"), path3.join(nodeRoot, "LICENSE.md"), path3.join(nodeRoot, "LICENSE.txt")]);
   await add("python-runtime", [
@@ -11568,6 +11569,7 @@ function topLevelSbomComponents(contracts, preliminaryFiles) {
   });
 }
 async function generateReleaseMetadata(payloadRoot, contracts, {
+  root,
   mode,
   sourceDateEpoch,
   pythonSbom = null,
@@ -11577,6 +11579,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   attributionEvidence = null,
   licenseSources = []
 }) {
+  invariant3(typeof root === "string" && root.length > 0, "release metadata requires a source root");
   const releaseRoot = componentRoot(payloadRoot, contracts, "jobctrl-release-metadata");
   await rm2(releaseRoot, { recursive: true, force: true });
   await mkdir2(path3.join(releaseRoot, "licenses"), { recursive: true, mode: 493 });
@@ -11641,6 +11644,17 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
       licenseFiles: licenseRecords
     });
   }
+  const projectLegalFiles = [
+    { source: path3.join(root, "LICENSE"), path: "JobCtrl-AGPL-3.0.txt", label: "JobCtrl LICENSE" },
+    { source: path3.join(root, "NOTICE"), path: "JobCtrl-NOTICE.txt", label: "JobCtrl NOTICE" }
+  ];
+  for (const legalFile of projectLegalFiles) {
+    await requireFile(legalFile.source, legalFile.label);
+    const destination = path3.join(releaseRoot, "licenses", legalFile.path);
+    await copyFile(legalFile.source, destination);
+    await chmod2(destination, 420);
+    legalFile.sha256 = await sha256File2(destination);
+  }
   const attributions = topLevelSbomComponents(contracts, preliminaryFiles).map((component) => ({
     id: component.name,
     version: component.version,
@@ -11652,15 +11666,9 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   await writeJson(path3.join(releaseRoot, "licenses", "index.json"), {
     schemaVersion: 1,
     status: mode === "fixture" ? "fixture-contract" : "collected-from-production-inputs",
-    components: attributions
+    components: attributions,
+    projectLegalFiles: projectLegalFiles.map(({ path: legalPath, sha256 }) => ({ path: legalPath, sha256 }))
   });
-  const rootLicense = path3.join(REPO_ROOT, "LICENSE");
-  if (await exists(rootLicense)) {
-    await copyFile(rootLicense, path3.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"));
-    await chmod2(path3.join(releaseRoot, "licenses", "JobCtrl-AGPL-3.0.txt"), 420);
-  } else {
-    await writeFile2(path3.join(releaseRoot, "licenses", "fixture-notice.txt"), "Fixture build: consult component-inventory.json for declared license expressions.\n", { mode: 420 });
-  }
   await writeJson(path3.join(releaseRoot, "provenance.json"), {
     schemaVersion: 1,
     buildMode: mode,
@@ -11685,7 +11693,7 @@ async function generateReleaseMetadata(payloadRoot, contracts, {
   });
   await writeJson(path3.join(releaseRoot, "provider-packs.lock.json"), contracts.providerPackLocks);
   await copyFile(
-    path3.join(REPO_ROOT, "packaging", "distribution", "capability-policy.json"),
+    path3.join(root, "packaging", "distribution", "capability-policy.json"),
     path3.join(releaseRoot, "capability-policy.json")
   );
   await chmod2(path3.join(releaseRoot, "capability-policy.json"), 420);
@@ -12128,7 +12136,7 @@ async function buildFixturePayload({
   await rm2(outputRoot, { recursive: true, force: true });
   await mkdir2(payloadRoot, { recursive: true, mode: 493 });
   await writeFixtureComponents(payloadRoot, contracts);
-  await generateReleaseMetadata(payloadRoot, contracts, { mode: "fixture", sourceDateEpoch });
+  await generateReleaseMetadata(payloadRoot, contracts, { root, mode: "fixture", sourceDateEpoch });
   const manifest = await createLocalManifest(payloadRoot, contracts, { buildId, sourceDateEpoch });
   await verifyExactPayloadTree(payloadRoot, manifest);
   await scanForbiddenPayload(payloadRoot, { forbiddenAbsolutePaths: [root, outputRoot] });
@@ -12256,6 +12264,7 @@ async function buildRealPayload({
       { subject: "chromium-core-third-party-credits", source: chromiumCredits }
     ];
     await generateReleaseMetadata(payloadRoot, contracts, {
+      root,
       mode: "real",
       sourceDateEpoch,
       pythonSbom,

--- a/scripts/distribution-release.finalizer.bundle.mjs.sha256
+++ b/scripts/distribution-release.finalizer.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-b34c66744fea70b8522ed02bf9302725a105aa4d0b7c87bb8ba70610d420223a  distribution-release.finalizer.bundle.mjs
+b768f61abf4d28a0d9c8303f33a18b3d835635bc8bfb6a8b0dc2bb2cd1c29bf7  distribution-release.finalizer.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -212,6 +212,12 @@ FORBIDDEN_TEXT = (
     ),
 )
 
+PUBLIC_COPYRIGHT_HOLDER = "El" + "oi Barti"
+PUBLIC_COPYRIGHT_SNIPPETS = (
+    f"Copyright (C) 2026 {PUBLIC_COPYRIGHT_HOLDER}",
+    f"Copyright © 2026 {PUBLIC_COPYRIGHT_HOLDER}",
+)
+
 
 def candidate_files(root: Path = ROOT) -> list[Path]:
     """Return files that Git would consider for commit."""
@@ -345,12 +351,35 @@ def scan_text(
     """Scan text content for forbidden strings and non-empty secret assignments."""
     findings = []
     for needle in needles:
-        if _contains_needle(text, needle):
+        scan_target = _redact_public_attribution(text, rel, needle)
+        if _contains_needle(scan_target, needle):
             findings.append(f"{label}: contains {needle.reason}")
 
     if _is_secret_assignment_file(rel):
         findings.extend(scan_secret_assignments(label, text))
     return findings
+
+
+def _redact_public_attribution(text: str, rel: Path, needle: ForbiddenNeedle) -> str:
+    """Exclude explicit public legal metadata from the private-name tripwire."""
+    if needle.reason != "private first name":
+        return text
+
+    redacted = text
+    for snippet in PUBLIC_COPYRIGHT_SNIPPETS:
+        redacted = redacted.replace(snippet, "<public copyright holder>")
+
+    if rel.name in {"METADATA", "PKG-INFO"}:
+        redacted = redacted.replace(
+            f"Author: {PUBLIC_COPYRIGHT_HOLDER}",
+            "Author: <public copyright holder>",
+        )
+    if rel.name == "pyproject.toml":
+        redacted = redacted.replace(
+            f'authors = [{{ name = "{PUBLIC_COPYRIGHT_HOLDER}" }}]',
+            'authors = [{ name = "<public copyright holder>" }]',
+        )
+    return redacted
 
 
 def _contains_needle(haystack: str, needle: ForbiddenNeedle) -> bool:

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -5,7 +5,7 @@ description = "AI-powered end-to-end job application pipeline"
 readme = "README.md"
 license = "AGPL-3.0-only"
 requires-python = ">=3.11"
-authors = [{name = "ebarti"}]
+authors = [{ name = "Eloi Barti" }]
 keywords = ["job-search", "automation", "ai", "resume", "apply", "job-application"]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -84,6 +84,10 @@ packages = ["src/jobctrl"]
 
 [tool.hatch.build]
 artifacts = ["src/jobctrl/config/*.yaml"]
+
+[tool.hatch.build.targets.sdist.force-include]
+"../../LICENSE" = "LICENSE"
+"../../NOTICE" = "NOTICE"
 
 [tool.ruff]
 target-version = "py311"

--- a/workers/automation/tests/test_python_package_attribution.py
+++ b/workers/automation/tests/test_python_package_attribution.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import tarfile
+import tomllib
+import zipfile
+from pathlib import Path
+
+
+_WORKER_ROOT = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _WORKER_ROOT.parents[1]
+
+
+def test_python_distributions_include_verbatim_root_license_and_notice(tmp_path: Path) -> None:
+    with (_WORKER_ROOT / "pyproject.toml").open("rb") as stream:
+        version = tomllib.load(stream)["project"]["version"]
+    license_bytes = (_REPO_ROOT / "LICENSE").read_bytes()
+    notice_bytes = (_REPO_ROOT / "NOTICE").read_bytes()
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--no-isolation",
+            "--outdir",
+            str(tmp_path),
+            ".",
+        ],
+        cwd=_WORKER_ROOT,
+        check=True,
+    )
+
+    wheel = tmp_path / f"jobctrl-{version}-py3-none-any.whl"
+    source_distribution = tmp_path / f"jobctrl-{version}.tar.gz"
+    with zipfile.ZipFile(wheel) as archive:
+        assert archive.read(f"jobctrl-{version}.dist-info/licenses/LICENSE") == license_bytes
+        assert archive.read(f"jobctrl-{version}.dist-info/licenses/NOTICE") == notice_bytes
+    with tarfile.open(source_distribution) as archive:
+        license_member = archive.getmember(f"jobctrl-{version}/LICENSE")
+        notice_member = archive.getmember(f"jobctrl-{version}/NOTICE")
+        assert archive.extractfile(license_member).read() == license_bytes
+        assert archive.extractfile(notice_member).read() == notice_bytes

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -30,6 +30,22 @@ def test_public_byline_files_do_not_trigger_default_needles() -> None:
         assert release_check.scan_text(label, text, rel) == []
 
 
+def test_public_copyright_attribution_does_not_disable_private_name_detection() -> None:
+    holder = "El" + "oi Barti"
+    first_name = "El" + "oi"
+
+    assert release_check.scan_text(
+        "NOTICE",
+        f"Copyright (C) 2026 {holder}\n",
+        Path("NOTICE"),
+    ) == []
+    assert release_check.scan_text(
+        "README.md",
+        f"Candidate profile: {first_name}\n",
+        Path("README.md"),
+    ) == ["README.md: contains private first name"]
+
+
 def test_release_check_catches_synthetic_violation_per_class(tmp_path: Path) -> None:
     blocked_distribution = "job" + "hunter"
     _write(


### PR DESCRIPTION
## Summary

- add a top-level `NOTICE` naming Eloi Barti as the 2026 copyright holder while preserving the verbatim AGPL-3.0-only license
- expose the copyright, license, and source links in the README, documentation footer, desktop rail, intermediate-width topbar, and mobile navigation sheet
- ship exact `LICENSE` and `NOTICE` bytes in bundled distributions and Python wheel/sdist artifacts
- keep the release privacy scanner strict while allowing only explicit public copyright and package-author metadata
- regenerate and reseal the tracked release-authority bundles

## Why

The standard AGPL text identified the license but did not identify the project's copyright holder. The release payload also copied the license without a project notice, and the privacy gate treated intentional public legal attribution as private profile data. This change makes attribution explicit and durable across source, UI, documentation, and every published artifact without weakening unrelated privacy checks.

The responsive review also found that attribution disappeared while the side rail was icon-only. The shared legal notice now moves to the topbar at 821-1180px and remains in the mobile sheet below that breakpoint. A selector-specificity fix keeps the mobile-menu trigger confined to the mobile breakpoint.

## Validation

- `corepack pnpm check`
- `corepack pnpm scripts:test` — 95 passed
- `corepack pnpm --filter @jobctrl/web test` — 1,241 passed
- `corepack pnpm --filter @jobctrl/web test-d` — 13 passed, no type errors
- `corepack pnpm web:build`
- focused Playwright shell tests — keyboard/900px attribution 2 passed; mobile sheet 1 passed
- `corepack pnpm docs:build` — 5,842 references across 262 files
- `corepack pnpm docs:check:runtime`
- `corepack pnpm distribution:audit`
- release-check and Python packaging suites — 36 passed
- `python3 scripts/release_check.py --strict-prompt`
- real Python wheel/sdist build plus `twine check`
- tracked release-authority bundle reproducibility and SHA-256 checks
- `git diff --check`

## Stack

This PR is stacked on `feat/distribution-p7` / #405.
