### PR TITLE
feat(demo): add browser workspace

### DIFF
--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -1,0 +1,280 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import type {
+  DemoWorkspaceInitialization,
+  DemoWorkspaceSnapshot,
+} from "../../src/demo/workspace/contracts.js";
+import type { DemoWorkspaceRepository } from "../../src/demo/workspace/DemoWorkspaceRepository.js";
+
+const MODULE_URLS = {
+  repository: "/src/demo/workspace/DemoWorkspaceRepository.ts",
+  storage: "/src/demo/workspace/storage.ts",
+  eventStream: "/src/demo/workspace/DemoWorkspaceEventStreamAdapter.ts",
+} as const;
+const STATIC_HOST = "/demo/source-preview.html";
+
+declare global {
+  interface Window {
+    __jobctrlDemoWorkspace?: DemoWorkspaceRepository;
+  }
+}
+
+async function initializeWorkspace(
+  page: Page,
+): Promise<DemoWorkspaceInitialization> {
+  return page.evaluate(async (moduleUrls) => {
+    const [repositoryModule, storageModule] = await Promise.all([
+      import(moduleUrls.repository),
+      import(moduleUrls.storage),
+    ]);
+    const workspace = new repositoryModule.DemoWorkspaceRepository({
+      store: new storageModule.IndexedDbDemoWorkspaceStore(),
+    });
+    window.__jobctrlDemoWorkspace = workspace;
+    return workspace.initialize();
+  }, MODULE_URLS);
+}
+
+async function snapshot(page: Page): Promise<DemoWorkspaceSnapshot> {
+  return page.evaluate(async () => {
+    if (!window.__jobctrlDemoWorkspace)
+      throw new Error("workspace not initialized");
+    return window.__jobctrlDemoWorkspace.snapshot();
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(STATIC_HOST);
+});
+
+test("demo shell renders the shared-profile and personal-data boundary without product network", async ({
+  page,
+  context,
+}) => {
+  const productRequests: string[] = [];
+  context.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname.startsWith("/v1/")) {
+      productRequests.push(url.pathname);
+    }
+  });
+
+  await page.goto("/");
+  const notice = page.getByRole("status", {
+    name: "Public demo data boundary",
+  });
+  await expect(notice).toContainText(
+    "shared with other tabs and people using this browser profile",
+  );
+  await expect(notice).toContainText("Do not enter personal data or secrets");
+  await expect(
+    page.getByText("Demo mode — shared browser profile"),
+  ).toBeVisible();
+  expect(productRequests).toEqual([]);
+});
+
+test("same-context tabs share, serialize concurrent writes, and survive reload without product network", async ({
+  page,
+  context,
+}) => {
+  const productRequests: string[] = [];
+  context.on("request", (request) => {
+    const url = new URL(request.url());
+    if (
+      url.pathname.startsWith("/v1/") ||
+      url.pathname === "/v1/events/stream"
+    ) {
+      productRequests.push(url.pathname);
+    }
+  });
+  const second = await context.newPage();
+  await second.goto(STATIC_HOST);
+  const [firstInit, secondInit] = await Promise.all([
+    initializeWorkspace(page),
+    initializeWorkspace(second),
+  ]);
+  expect(firstInit).toMatchObject({ kind: "ready", storageMode: "indexeddb" });
+  expect(secondInit).toMatchObject({ kind: "ready", storageMode: "indexeddb" });
+  if (firstInit.kind !== "ready" || secondInit.kind !== "ready") return;
+  expect(firstInit.snapshot.workspaceId).toBe(secondInit.snapshot.workspaceId);
+
+  await Promise.all([
+    page.evaluate(async () => {
+      if (!window.__jobctrlDemoWorkspace)
+        throw new Error("workspace not initialized");
+      await window.__jobctrlDemoWorkspace.queueScenario({
+        scenarioId: "tab-one",
+        deadlineAt: "2026-07-11T12:01:00.000Z",
+        resetEpoch: 0,
+      });
+    }),
+    second.evaluate(async () => {
+      if (!window.__jobctrlDemoWorkspace)
+        throw new Error("workspace not initialized");
+      await window.__jobctrlDemoWorkspace.queueScenario({
+        scenarioId: "tab-two",
+        deadlineAt: "2026-07-11T12:02:00.000Z",
+        resetEpoch: 0,
+      });
+    }),
+  ]);
+  const shared = await snapshot(page);
+  expect(shared.revision).toBe(2);
+  expect(
+    shared.pendingScenarios.map((scenario) => scenario.scenarioId).toSorted(),
+  ).toEqual(["tab-one", "tab-two"]);
+
+  await page.reload();
+  const reloaded = await initializeWorkspace(page);
+  expect(reloaded).toMatchObject({
+    kind: "ready",
+    snapshot: {
+      workspaceId: shared.workspaceId,
+      revision: 2,
+    },
+  });
+  expect(productRequests).toEqual([]);
+});
+
+test("separate browser contexts isolate workspaces", async ({
+  page,
+  browser,
+}) => {
+  const first = await initializeWorkspace(page);
+  const isolatedContext = await browser.newContext();
+  try {
+    const isolatedPage = await isolatedContext.newPage();
+    await isolatedPage.goto(STATIC_HOST);
+    const isolated = await initializeWorkspace(isolatedPage);
+    expect(first.kind).toBe("ready");
+    expect(isolated.kind).toBe("ready");
+    if (first.kind !== "ready" || isolated.kind !== "ready") return;
+    expect(first.snapshot.workspaceId).not.toBe(isolated.snapshot.workspaceId);
+  } finally {
+    await isolatedContext.close();
+  }
+});
+
+test("reset rotates identity, fences state, and deletes generated blobs", async ({
+  page,
+}) => {
+  const initialized = await initializeWorkspace(page);
+  expect(initialized.kind).toBe("ready");
+  if (initialized.kind !== "ready") return;
+  await page.evaluate(async () => {
+    if (!window.__jobctrlDemoWorkspace)
+      throw new Error("workspace not initialized");
+    await window.__jobctrlDemoWorkspace.putBlob(
+      "generated-preview",
+      new Blob(["synthetic visitor edit"], { type: "text/plain" }),
+    );
+    await window.__jobctrlDemoWorkspace.queueScenario({
+      scenarioId: "reset-me",
+      deadlineAt: "2026-07-11T12:03:00.000Z",
+      resetEpoch: 0,
+    });
+    await window.__jobctrlDemoWorkspace.reset();
+  });
+  const reset = await snapshot(page);
+  expect(reset.workspaceId).not.toBe(initialized.snapshot.workspaceId);
+  expect(reset).toMatchObject({
+    resetEpoch: 1,
+    resetCount: 1,
+    pendingScenarios: [],
+  });
+  expect(
+    await page.evaluate(async () => {
+      if (!window.__jobctrlDemoWorkspace)
+        throw new Error("workspace not initialized");
+      return (
+        (await window.__jobctrlDemoWorkspace.blob("generated-preview")) === null
+      );
+    }),
+  ).toBe(true);
+});
+
+test("future native database version is upgrade-required without downgrade", async ({
+  page,
+}) => {
+  await page.evaluate(async () => {
+    const request = indexedDB.open("jobctrl-demo", 2);
+    await new Promise<void>((resolve, reject) => {
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains("workspace")) {
+          request.result.createObjectStore("workspace", { keyPath: "key" });
+        }
+        if (!request.result.objectStoreNames.contains("blobs")) {
+          request.result.createObjectStore("blobs");
+        }
+      };
+      request.onsuccess = () => {
+        request.result.close();
+        resolve();
+      };
+      request.onerror = () => reject(request.error);
+    });
+  });
+
+  const result = await initializeWorkspace(page);
+  expect(result).toMatchObject({
+    kind: "upgrade_required",
+    scope: "database_version",
+    foundDatabaseVersion: 2,
+    supportedDatabaseVersion: 1,
+  });
+  expect(
+    await page.evaluate(
+      async () =>
+        (await indexedDB.databases()).find(
+          (database) => database.name === "jobctrl-demo",
+        )?.version,
+    ),
+  ).toBe(2);
+});
+
+test("postcommit event adapter emits only valid ordered domain events", async ({
+  page,
+}) => {
+  const result = await page.evaluate(async (moduleUrls) => {
+    const [repositoryModule, storageModule, eventStreamModule] =
+      await Promise.all([
+        import(moduleUrls.repository),
+        import(moduleUrls.storage),
+        import(moduleUrls.eventStream),
+      ]);
+    const workspace = new repositoryModule.DemoWorkspaceRepository({
+      store: new storageModule.IndexedDbDemoWorkspaceStore(),
+    });
+    await workspace.initialize();
+    const adapter = new eventStreamModule.DemoWorkspaceEventStreamAdapter(
+      workspace,
+    );
+    const subscription = adapter.subscribe({ tenantId: "local" });
+    const events: string[] = [];
+    let resolveEvent!: () => void;
+    const eventDelivered = new Promise<void>((resolve) => {
+      resolveEvent = resolve;
+    });
+    subscription.on((event: { eventType: string }) => {
+      events.push(event.eventType);
+      resolveEvent();
+    });
+    await workspace.mutate(
+      (
+        _draft: unknown,
+        context: { appendDomainEvent(event: unknown): void },
+      ) => {
+        context.appendDomainEvent({
+          eventType: "JobUpdated",
+          tenantId: "local",
+          occurredAt: "2026-07-11T12:00:00.000Z",
+          payload: { jobId: "job-demo", changedFields: { title: "Updated" } },
+        });
+      },
+    );
+    await eventDelivered;
+    subscription.close();
+    return events;
+  }, MODULE_URLS);
+  expect(result).toEqual(["JobUpdated"]);
+});

--- a/apps/web/e2e/demo-workspace.playwright.config.ts
+++ b/apps/web/e2e/demo-workspace.playwright.config.ts
@@ -1,0 +1,41 @@
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = path.resolve(here, "..", "..", "..");
+const port = Number(process.env["JOBCTRL_DEMO_E2E_WEB_PORT"] ?? "5198");
+
+export default defineConfig({
+  testDir: "./demo-workspace-tests",
+  outputDir: path.join(os.tmpdir(), "jobctrl-demo-workspace-playwright"),
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env["CI"]),
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `corepack pnpm --filter @jobctrl/web exec vite --host 127.0.0.1 --port ${port} --strictPort`,
+    port,
+    cwd: repoRoot,
+    env: {
+      VITE_JOBCTRL_APP_MODE: "demo",
+      VITE_JOBCTRL_HIDE_DEVTOOLS: "1",
+    },
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage",
     "test-d": "vitest run --config vitest.types.config.ts",
     "e2e": "playwright test --config=e2e/playwright.config.ts",
+    "e2e:demo-workspace": "playwright test --config=e2e/demo-workspace.playwright.config.ts",
     "e2e:headed": "playwright test --config=e2e/playwright.config.ts --headed",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build -o ../../dist/web-storybook",

--- a/apps/web/src/demo/index.ts
+++ b/apps/web/src/demo/index.ts
@@ -11,6 +11,13 @@ export { assertDemoSeedInvariants } from "./invariants.js";
 export { scanDemoPrivacy } from "./privacy.js";
 export { DEMO_READ_MODEL } from "./read-model.js";
 export { DEMO_SEED } from "./seed.js";
+export {
+  createAppComposition,
+  createLocalPorts,
+  resolveAppMode,
+} from "./portFactory.js";
+export { DemoCapabilityError } from "./ports.js";
+export * from "./workspace/index.js";
 export type {
   ApiClientResponse,
   AppMode,

--- a/apps/web/src/demo/portFactory.test.ts
+++ b/apps/web/src/demo/portFactory.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ConsoleTelemetryAdapter } from "../shared/adapters/local/ConsoleTelemetryAdapter.js";
+import { FetchApiClientAdapter } from "../shared/adapters/local/FetchApiClientAdapter.js";
+import { LocalSessionAdapter } from "../shared/adapters/local/LocalSessionAdapter.js";
+import { LocalStorageAdapter } from "../shared/adapters/local/LocalStorageAdapter.js";
+import { NavigatorClipboardAdapter } from "../shared/adapters/local/NavigatorClipboardAdapter.js";
+import { OpenArtifactAdapter } from "../shared/adapters/local/OpenArtifactAdapter.js";
+import { SseEventStreamAdapter } from "../shared/adapters/local/SseEventStreamAdapter.js";
+import { StaticFeatureFlagAdapter } from "../shared/adapters/local/StaticFeatureFlagAdapter.js";
+import type {
+  DemoWorkspaceSnapshot,
+  DemoWorkspaceStore,
+  DemoWorkspaceTransaction,
+} from "./workspace/index.js";
+import {
+  DemoWorkspaceStorageError,
+  InMemoryDemoWorkspaceStore,
+} from "./workspace/index.js";
+import {
+  createAppComposition,
+  createLocalPorts,
+  resolveAppMode,
+} from "./portFactory.js";
+import {
+  DemoCapabilityError,
+  DemoFeatureFlagAdapter,
+  DemoOpenInOsAdapter,
+  DemoSessionAdapter,
+  DemoStorageAdapter,
+} from "./ports.js";
+import { DemoWorkspaceEventStreamAdapter } from "./workspace/DemoWorkspaceEventStreamAdapter.js";
+
+class UnavailableWorkspaceStore implements DemoWorkspaceStore {
+  readonly storageMode = "indexeddb" as const;
+
+  async readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    throw new DemoWorkspaceStorageError("unavailable");
+  }
+
+  async readBlob(): Promise<Blob | null> {
+    throw new DemoWorkspaceStorageError("unavailable");
+  }
+
+  async readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    throw new DemoWorkspaceStorageError("unavailable");
+  }
+
+  async transact<TResult>(
+    _operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    throw new DemoWorkspaceStorageError("unavailable");
+  }
+}
+
+describe("port factory", () => {
+  it("defaults to local and preserves every original local adapter", async () => {
+    expect(resolveAppMode(undefined)).toBe("local");
+    expect(resolveAppMode("")).toBe("local");
+    expect(resolveAppMode("local")).toBe("local");
+    expect(resolveAppMode("preview")).toBe("local");
+
+    const direct = createLocalPorts("http://127.0.0.1:8787");
+    const composition = await createAppComposition({
+      mode: "local",
+      apiBaseUrl: "http://127.0.0.1:8787",
+    });
+    expect(composition.kind).toBe("local");
+    expect(direct.api).toBeInstanceOf(FetchApiClientAdapter);
+    expect(direct.eventStream).toBeInstanceOf(SseEventStreamAdapter);
+    expect(direct.storage).toBeInstanceOf(LocalStorageAdapter);
+    expect(direct.session).toBeInstanceOf(LocalSessionAdapter);
+    expect(direct.clipboard).toBeInstanceOf(NavigatorClipboardAdapter);
+    expect(direct.openInOs).toBeInstanceOf(OpenArtifactAdapter);
+    expect(direct.telemetry).toBeInstanceOf(ConsoleTelemetryAdapter);
+    expect(direct.featureFlags).toBeInstanceOf(StaticFeatureFlagAdapter);
+    expect(composition.ports.api).toBeInstanceOf(FetchApiClientAdapter);
+  });
+
+  it("selects demo only explicitly and constructs no product-network, SSE, or host-OS adapter", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      expect(resolveAppMode("demo")).toBe("demo");
+      const composition = await createAppComposition({
+        mode: "demo",
+        demoWorkspace: { store: new InMemoryDemoWorkspaceStore() },
+      });
+
+      expect(composition.kind).toBe("demo");
+      if (composition.kind !== "demo") return;
+      expect(composition.ports.api).not.toBeInstanceOf(FetchApiClientAdapter);
+      expect(composition.ports.eventStream).toBeInstanceOf(
+        DemoWorkspaceEventStreamAdapter,
+      );
+      expect(composition.ports.eventStream).not.toBeInstanceOf(
+        SseEventStreamAdapter,
+      );
+      expect(composition.ports.session).toBeInstanceOf(DemoSessionAdapter);
+      expect(composition.ports.storage).toBeInstanceOf(DemoStorageAdapter);
+      expect(composition.ports.openInOs).toBeInstanceOf(DemoOpenInOsAdapter);
+      expect(composition.ports.openInOs).not.toBeInstanceOf(
+        OpenArtifactAdapter,
+      );
+      expect(composition.ports.featureFlags).toBeInstanceOf(
+        DemoFeatureFlagAdapter,
+      );
+      await expect(composition.ports.api.health()).rejects.toBeInstanceOf(
+        DemoCapabilityError,
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("falls back to local adapters for an invalid build-time mode", async () => {
+    const composition = await createAppComposition({
+      mode: resolveAppMode("preview"),
+    });
+    expect(composition.kind).toBe("local");
+    expect(composition.ports.api).toBeInstanceOf(FetchApiClientAdapter);
+  });
+
+  it("continues demo initialization in typed tab-local memory mode when IndexedDB is unavailable", async () => {
+    const composition = await createAppComposition({
+      mode: "demo",
+      demoWorkspace: { store: new UnavailableWorkspaceStore() },
+    });
+    expect(composition).toMatchObject({
+      kind: "demo",
+      initialization: {
+        kind: "ready",
+        storageMode: "memory",
+        warning: { code: "indexeddb_unavailable" },
+      },
+    });
+  });
+});

--- a/apps/web/src/demo/portFactory.ts
+++ b/apps/web/src/demo/portFactory.ts
@@ -1,0 +1,92 @@
+import { ConsoleTelemetryAdapter } from "../shared/adapters/local/ConsoleTelemetryAdapter.js";
+import { FetchApiClientAdapter } from "../shared/adapters/local/FetchApiClientAdapter.js";
+import { LocalSessionAdapter } from "../shared/adapters/local/LocalSessionAdapter.js";
+import { LocalStorageAdapter } from "../shared/adapters/local/LocalStorageAdapter.js";
+import { NavigatorClipboardAdapter } from "../shared/adapters/local/NavigatorClipboardAdapter.js";
+import { OpenArtifactAdapter } from "../shared/adapters/local/OpenArtifactAdapter.js";
+import { SseEventStreamAdapter } from "../shared/adapters/local/SseEventStreamAdapter.js";
+import { StaticFeatureFlagAdapter } from "../shared/adapters/local/StaticFeatureFlagAdapter.js";
+import type { Ports } from "../shared/providers/PortsProvider.js";
+import type { AppMode } from "./contracts.js";
+import {
+  DemoWorkspaceEventStreamAdapter,
+  DemoWorkspaceRepository,
+  IndexedDbDemoWorkspaceStore,
+  type DemoWorkspaceInitialization,
+  type DemoWorkspaceRepositoryOptions,
+} from "./workspace/index.js";
+import {
+  createDemoApiClientPlaceholder,
+  DemoFeatureFlagAdapter,
+  DemoOpenInOsAdapter,
+  DemoSessionAdapter,
+  DemoStorageAdapter,
+} from "./ports.js";
+
+export interface PortFactoryOptions {
+  readonly mode: AppMode;
+  readonly apiBaseUrl?: string;
+  readonly demoWorkspace?: Omit<DemoWorkspaceRepositoryOptions, "store"> & {
+    readonly store?: DemoWorkspaceRepositoryOptions["store"];
+  };
+}
+
+export type AppComposition =
+  | {
+      readonly kind: "local";
+      readonly ports: Ports;
+    }
+  | {
+      readonly kind: "demo";
+      readonly ports: Ports;
+      readonly workspace: DemoWorkspaceRepository;
+      readonly initialization: DemoWorkspaceInitialization;
+    };
+
+export function resolveAppMode(value: unknown): AppMode {
+  return value === "demo" ? "demo" : "local";
+}
+
+/** Preserves the original local composition in one named, directly testable factory. */
+export function createLocalPorts(apiBaseUrl = ""): Ports {
+  const api = new FetchApiClientAdapter(apiBaseUrl);
+  return {
+    api,
+    eventStream: new SseEventStreamAdapter(apiBaseUrl),
+    storage: new LocalStorageAdapter("jh:"),
+    session: new LocalSessionAdapter(),
+    clipboard: new NavigatorClipboardAdapter(),
+    openInOs: new OpenArtifactAdapter(api),
+    telemetry: new ConsoleTelemetryAdapter(),
+    featureFlags: new StaticFeatureFlagAdapter(),
+  };
+}
+
+export async function createAppComposition(
+  options: PortFactoryOptions,
+): Promise<AppComposition> {
+  if (options.mode === "local") {
+    return { kind: "local", ports: createLocalPorts(options.apiBaseUrl) };
+  }
+
+  const workspace = new DemoWorkspaceRepository({
+    store: options.demoWorkspace?.store ?? new IndexedDbDemoWorkspaceStore(),
+    ...options.demoWorkspace,
+  });
+  const initialization = await workspace.initialize();
+  return {
+    kind: "demo",
+    ports: {
+      api: createDemoApiClientPlaceholder(),
+      eventStream: new DemoWorkspaceEventStreamAdapter(workspace),
+      storage: new DemoStorageAdapter(),
+      session: new DemoSessionAdapter(),
+      clipboard: new NavigatorClipboardAdapter(),
+      openInOs: new DemoOpenInOsAdapter(),
+      telemetry: new ConsoleTelemetryAdapter(),
+      featureFlags: new DemoFeatureFlagAdapter(),
+    },
+    workspace,
+    initialization,
+  };
+}

--- a/apps/web/src/demo/ports.ts
+++ b/apps/web/src/demo/ports.ts
@@ -1,0 +1,72 @@
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+
+import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
+import type { FeatureFlagPort } from "../shared/ports/FeatureFlagPort.js";
+import type { OpenInOsPort } from "../shared/ports/OpenInOsPort.js";
+import type { Session, SessionPort } from "../shared/ports/SessionPort.js";
+import type { StoragePort } from "../shared/ports/StoragePort.js";
+
+export class DemoCapabilityError extends Error {
+  readonly code = "demo_capability_not_implemented" as const;
+
+  constructor(method: string) {
+    super(
+      `Demo capability ${method} is not available until the demo adapter is initialized.`,
+    );
+    this.name = "DemoCapabilityError";
+  }
+}
+
+/** P2 replaces these deliberate rejections with the complete read adapter. */
+export function createDemoApiClientPlaceholder(): ApiClientPort {
+  return new Proxy(
+    {},
+    {
+      get(_target, property) {
+        const method = String(property);
+        return () => {
+          if (method.endsWith("Url")) {
+            throw new DemoCapabilityError(method);
+          }
+          return Promise.reject(new DemoCapabilityError(method));
+        };
+      },
+    },
+  ) as ApiClientPort;
+}
+
+export class DemoSessionAdapter implements SessionPort {
+  getSession(): Session {
+    return { tenantId: LOCAL_TENANT, userId: null };
+  }
+}
+
+/** UI preferences are intentionally tab-local until P5 exposes a resettable UI. */
+export class DemoStorageAdapter implements StoragePort {
+  private readonly values = new Map<string, unknown>();
+
+  get<T = unknown>(key: string): T | null {
+    return (this.values.get(key) as T | undefined) ?? null;
+  }
+
+  set<T = unknown>(key: string, value: T): void {
+    this.values.set(key, value);
+  }
+
+  remove(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+export class DemoFeatureFlagAdapter implements FeatureFlagPort {
+  get<T extends boolean | number | string>(_key: string, defaultValue: T): T {
+    return defaultValue;
+  }
+}
+
+/** The public demo cannot invoke the local host OS opener. */
+export class DemoOpenInOsAdapter implements OpenInOsPort {
+  async open(_artifactId: string): Promise<never> {
+    throw new DemoCapabilityError("openInOs");
+  }
+}

--- a/apps/web/src/demo/workspace/DemoWorkspaceEventStreamAdapter.test.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceEventStreamAdapter.test.tsx
@@ -1,0 +1,217 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  createJobUpdated,
+  LOCAL_TENANT,
+  type DomainEventUnion,
+} from "@jobctrl/domain-types";
+
+import { EventStreamProvider } from "../../contexts/operations/providers/EventStreamProvider.js";
+import { jobsKeys } from "../../contexts/operations/jobsKeys.js";
+import { buildProviderHarness } from "../../test/render.js";
+import { buildTestPorts } from "../../test/testPorts.js";
+import { DEMO_WORKSPACE_EVENT_LOG_LIMIT } from "./contracts.js";
+import { DemoWorkspaceEventStreamAdapter } from "./DemoWorkspaceEventStreamAdapter.js";
+import { DemoWorkspaceRepository } from "./DemoWorkspaceRepository.js";
+import {
+  InMemoryDemoWorkspaceStore,
+  type DemoWorkspaceStore,
+  type DemoWorkspaceTransaction,
+} from "./storage.js";
+import type { DemoWorkspaceSnapshot } from "./contracts.js";
+
+class ControlledStore implements DemoWorkspaceStore {
+  readonly storageMode = "indexeddb" as const;
+  private readonly memory = new InMemoryDemoWorkspaceStore();
+  private gate: Promise<void> | null = null;
+  private releaseGate: (() => void) | null = null;
+
+  readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    return this.memory.readSnapshot();
+  }
+
+  readBlob(blobId: string): Promise<Blob | null> {
+    return this.memory.readBlob(blobId);
+  }
+
+  readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    return this.memory.readAllBlobs();
+  }
+
+  transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    const gate = this.gate;
+    this.gate = null;
+    return gate
+      ? gate.then(() => this.memory.transact(operation))
+      : this.memory.transact(operation);
+  }
+
+  deferNextTransaction(): void {
+    this.gate = new Promise((resolve) => {
+      this.releaseGate = resolve;
+    });
+  }
+
+  release(): void {
+    this.releaseGate?.();
+    this.releaseGate = null;
+  }
+}
+
+function createWorkspace(store: DemoWorkspaceStore = new ControlledStore()) {
+  return new DemoWorkspaceRepository({
+    store,
+    channelFactory: { create: () => null },
+    createWorkspaceId: () => "event-workspace",
+  });
+}
+
+function event(index: number): DomainEventUnion {
+  return createJobUpdated(LOCAL_TENANT, {
+    jobId: `job-${index}`,
+    changedFields: { title: `Title ${index}` },
+  });
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("DemoWorkspaceEventStreamAdapter", () => {
+  it("serializes rapid revisions and emits each triggering committed sequence in order", async () => {
+    const workspace = createWorkspace();
+    await workspace.initialize();
+    const adapter = new DemoWorkspaceEventStreamAdapter(workspace);
+    const subscription = adapter.subscribe({ tenantId: LOCAL_TENANT });
+    const received: string[] = [];
+    subscription.on((envelope) =>
+      received.push(String((envelope.payload as { jobId: string }).jobId)),
+    );
+
+    await Promise.all([
+      workspace.mutate((_draft, context) =>
+        context.appendDomainEvent(event(1)),
+      ),
+      workspace.mutate((_draft, context) =>
+        context.appendDomainEvent(event(2)),
+      ),
+    ]);
+    await settle();
+
+    expect(received).toEqual(["job-1", "job-2"]);
+    subscription.close();
+  });
+
+  it("never emits a domain event before its transaction commits", async () => {
+    const store = new ControlledStore();
+    const workspace = createWorkspace(store);
+    await workspace.initialize();
+    const adapter = new DemoWorkspaceEventStreamAdapter(workspace);
+    const subscription = adapter.subscribe({ tenantId: LOCAL_TENANT });
+    const received: string[] = [];
+    subscription.on((envelope) => received.push(envelope.eventType));
+
+    store.deferNextTransaction();
+    const pending = workspace.mutate((_draft, context) =>
+      context.appendDomainEvent(event(1)),
+    );
+    await Promise.resolve();
+    expect(received).toEqual([]);
+    store.release();
+    await pending;
+    await settle();
+    expect(received).toEqual(["JobUpdated"]);
+    subscription.close();
+  });
+
+  it("cycles closed to open on reset and bounded event-log loss", async () => {
+    const workspace = createWorkspace();
+    await workspace.initialize();
+    const adapter = new DemoWorkspaceEventStreamAdapter(workspace);
+    const subscription = adapter.subscribe({ tenantId: LOCAL_TENANT });
+    const statuses: string[] = [];
+    subscription.onStatusChange((status) => statuses.push(status));
+    await settle();
+
+    await workspace.reset();
+    await settle();
+    expect(statuses).toContain("closed");
+    expect(statuses.at(-1)).toBe("open");
+
+    statuses.length = 0;
+    await workspace.mutate((_draft, context) => {
+      for (
+        let index = 1;
+        index <= DEMO_WORKSPACE_EVENT_LOG_LIMIT + 1;
+        index += 1
+      ) {
+        context.appendDomainEvent(event(index));
+      }
+    });
+    await settle();
+    expect(statuses).toEqual(["closed", "open"]);
+    subscription.close();
+  });
+
+  it("uses the unchanged provider/router for event invalidation and reconnect broad invalidation", async () => {
+    const workspace = createWorkspace();
+    await workspace.initialize();
+    const eventStream = new DemoWorkspaceEventStreamAdapter(workspace);
+    const ports = buildTestPorts({ eventStream });
+    const harness = buildProviderHarness({ ports });
+    const unrelatedKey = ["unrelated-demo-query"] as const;
+    harness.queryClient.setQueryData(jobsKeys.lists(LOCAL_TENANT), {
+      items: [],
+    });
+    harness.queryClient.setQueryData(unrelatedKey, { retained: true });
+    render(
+      <EventStreamProvider>
+        <span>child</span>
+      </EventStreamProvider>,
+      { wrapper: harness.Wrapper },
+    );
+    await waitFor(() => expect(eventStream.status).toBe("open"));
+
+    await act(async () => {
+      await workspace.mutate((draft) => {
+        (draft.state as { title: string }).title = "No domain event";
+      });
+    });
+    await settle();
+    expect(
+      harness.queryClient.getQueryState(jobsKeys.lists(LOCAL_TENANT))
+        ?.isInvalidated,
+    ).toBe(false);
+    expect(harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated).toBe(
+      false,
+    );
+
+    await act(async () => {
+      await workspace.mutate((_draft, context) =>
+        context.appendDomainEvent(event(1)),
+      );
+    });
+    await waitFor(() =>
+      expect(
+        harness.queryClient.getQueryState(jobsKeys.lists(LOCAL_TENANT))
+          ?.isInvalidated,
+      ).toBe(true),
+    );
+
+    harness.queryClient.setQueryData(unrelatedKey, { retained: true });
+    await act(async () => {
+      await workspace.reset();
+    });
+    await waitFor(() =>
+      expect(
+        harness.queryClient.getQueryState(unrelatedKey)?.isInvalidated,
+      ).toBe(true),
+    );
+  });
+});

--- a/apps/web/src/demo/workspace/DemoWorkspaceEventStreamAdapter.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceEventStreamAdapter.ts
@@ -1,0 +1,159 @@
+import type { DomainEventUnion, TenantId } from "@jobctrl/domain-types";
+
+import type { DemoWorkspaceNotification } from "./contracts.js";
+import { DemoWorkspaceRepository } from "./DemoWorkspaceRepository.js";
+import type {
+  DomainEventEnvelope,
+  EventStreamPort,
+  EventStreamStatus,
+  EventStreamSubscription,
+} from "../../shared/ports/EventStreamPort.js";
+
+/**
+ * Serially drains the committed workspace domain-event log through the normal
+ * EventStreamPort. Reset, revision gaps, and bounded-log loss are represented
+ * as closed -> open recovery, which activates the existing provider backstop.
+ */
+export class DemoWorkspaceEventStreamAdapter implements EventStreamPort {
+  private currentStatus: EventStreamStatus = "connecting";
+
+  constructor(private readonly workspace: DemoWorkspaceRepository) {}
+
+  get status(): EventStreamStatus {
+    return this.currentStatus;
+  }
+
+  subscribe({ tenantId }: { tenantId: TenantId }): EventStreamSubscription {
+    return new DemoWorkspaceSubscription(this.workspace, tenantId, (status) => {
+      this.currentStatus = status;
+    });
+  }
+}
+
+class DemoWorkspaceSubscription implements EventStreamSubscription {
+  private readonly eventHandlers = new Set<
+    (event: DomainEventEnvelope) => void
+  >();
+  private readonly statusHandlers = new Set<
+    (status: EventStreamStatus) => void
+  >();
+  private statusValue: EventStreamStatus = "connecting";
+  private closed = false;
+  private lastDeliveredSequence = 0;
+  private readonly stop: () => void;
+  private notificationQueue: Promise<void>;
+
+  constructor(
+    private readonly workspace: DemoWorkspaceRepository,
+    private readonly tenantId: TenantId,
+    private readonly setParentStatus: (status: EventStreamStatus) => void,
+  ) {
+    this.notificationQueue = this.open();
+    this.stop = workspace.subscribe((notification) => {
+      this.notificationQueue = this.notificationQueue
+        .then(() => this.handleNotification(notification))
+        .catch(() => this.setStatus("closed"));
+    });
+  }
+
+  get status(): EventStreamStatus {
+    return this.statusValue;
+  }
+
+  on(handler: (event: DomainEventEnvelope) => void): () => void {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  onStatusChange(handler: (status: EventStreamStatus) => void): () => void {
+    this.statusHandlers.add(handler);
+    return () => this.statusHandlers.delete(handler);
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.stop();
+    this.setStatus("closed");
+  }
+
+  private async open(): Promise<void> {
+    try {
+      const initialization = await this.workspace.initialize();
+      if (initialization.kind === "upgrade_required") {
+        this.setStatus("closed");
+        return;
+      }
+      this.lastDeliveredSequence = initialization.snapshot.lastEventSequence;
+      if (!this.closed) {
+        this.setStatus("open");
+      }
+    } catch {
+      if (!this.closed) {
+        this.setStatus("closed");
+      }
+    }
+  }
+
+  private async handleNotification(
+    notification: DemoWorkspaceNotification,
+  ): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    if (notification.kind === "reset" || notification.kind === "resync") {
+      this.lastDeliveredSequence = notification.lastEventSequence;
+      this.cycleConnection();
+      return;
+    }
+    if (notification.lastEventSequence <= this.lastDeliveredSequence) {
+      return;
+    }
+
+    const result = await this.workspace.readEventsForNotification(
+      notification,
+      this.lastDeliveredSequence,
+    );
+    if (result.kind === "event_log_lost") {
+      this.lastDeliveredSequence = notification.lastEventSequence;
+      this.cycleConnection();
+      return;
+    }
+    for (const event of result.events) {
+      if (this.closed) {
+        return;
+      }
+      this.emit(event);
+    }
+    this.lastDeliveredSequence = notification.lastEventSequence;
+  }
+
+  private emit(event: DomainEventUnion): void {
+    if (event.tenantId !== this.tenantId) {
+      return;
+    }
+    for (const handler of this.eventHandlers) {
+      handler(event);
+    }
+  }
+
+  private cycleConnection(): void {
+    this.setStatus("closed");
+    if (!this.closed) {
+      this.setStatus("open");
+    }
+  }
+
+  private setStatus(next: EventStreamStatus): void {
+    if (this.statusValue === next) {
+      return;
+    }
+    this.statusValue = next;
+    this.setParentStatus(next);
+    for (const handler of this.statusHandlers) {
+      handler(next);
+    }
+  }
+}

--- a/apps/web/src/demo/workspace/DemoWorkspaceNotice.test.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceNotice.test.tsx
@@ -1,0 +1,141 @@
+import { act, render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { describe, expect, it } from "vitest";
+
+import { LocalModeCard } from "../../shared/layout/SideRail.js";
+import { DemoWorkspaceNotice } from "./DemoWorkspaceNotice.js";
+import { DemoWorkspaceProvider } from "./DemoWorkspaceProvider.js";
+import { DemoWorkspaceRepository } from "./DemoWorkspaceRepository.js";
+import {
+  DemoWorkspaceStorageError,
+  InMemoryDemoWorkspaceStore,
+  type DemoWorkspaceStore,
+  type DemoWorkspaceTransaction,
+} from "./storage.js";
+import type { DemoWorkspaceSnapshot } from "./contracts.js";
+
+class QuotaStore implements DemoWorkspaceStore {
+  readonly storageMode = "indexeddb" as const;
+  readonly memory = new InMemoryDemoWorkspaceStore();
+  failNext: "quota" | "unavailable" | null = null;
+
+  readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    return this.memory.readSnapshot();
+  }
+
+  readBlob(blobId: string): Promise<Blob | null> {
+    return this.memory.readBlob(blobId);
+  }
+
+  readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    return this.memory.readAllBlobs();
+  }
+
+  transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    if (this.failNext) {
+      const failure = this.failNext;
+      this.failNext = null;
+      return Promise.reject(new DemoWorkspaceStorageError(failure));
+    }
+    return this.memory.transact(operation);
+  }
+}
+
+describe("<DemoWorkspaceNotice>", () => {
+  it("always explains browser-profile sharing and personal-data boundaries in demo mode", async () => {
+    const workspace = new DemoWorkspaceRepository({
+      store: new QuotaStore(),
+      createWorkspaceId: () => "notice-workspace",
+    });
+    await workspace.initialize();
+    const view = render(
+      <DemoWorkspaceProvider workspace={workspace}>
+        <DemoWorkspaceNotice />
+        <LocalModeCard />
+      </DemoWorkspaceProvider>,
+    );
+
+    expect(
+      screen.getByRole("status", { name: "Public demo data boundary" }),
+    ).toHaveTextContent(
+      "shared with other tabs and people using this browser profile",
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Do not enter personal data or secrets",
+    );
+    expect(
+      screen.getByText("Demo mode — shared browser profile"),
+    ).toBeInTheDocument();
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("reacts immediately when a later quota failure switches the tab to memory", async () => {
+    const store = new QuotaStore();
+    const workspace = new DemoWorkspaceRepository({
+      store,
+      createWorkspaceId: () => "quota-workspace",
+    });
+    await workspace.initialize();
+    render(
+      <DemoWorkspaceProvider workspace={workspace}>
+        <DemoWorkspaceNotice />
+        <LocalModeCard />
+      </DemoWorkspaceProvider>,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    store.failNext = "quota";
+    await act(async () => {
+      await workspace.mutate(() => undefined);
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Browser storage is full",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "stays only in this tab and is not shared",
+    );
+    expect(screen.getByText("Demo mode — this tab only")).toBeInTheDocument();
+    expect(workspace.getRuntimeSnapshot()).toMatchObject({
+      status: "ready",
+      storageMode: "memory",
+      warning: { code: "quota_exceeded" },
+    });
+  });
+
+  it("reacts when a later browser security failure switches the tab to memory", async () => {
+    const store = new QuotaStore();
+    const workspace = new DemoWorkspaceRepository({
+      store,
+      createWorkspaceId: () => "security-workspace",
+    });
+    await workspace.initialize();
+    render(
+      <DemoWorkspaceProvider workspace={workspace}>
+        <DemoWorkspaceNotice />
+      </DemoWorkspaceProvider>,
+    );
+
+    store.failNext = "unavailable";
+    await act(async () => {
+      await workspace.mutate(() => undefined);
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Browser storage is unavailable",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "stays only in this tab and is not shared",
+    );
+    expect(workspace.getRuntimeSnapshot()).toMatchObject({
+      status: "ready",
+      storageMode: "memory",
+      warning: { code: "indexeddb_unavailable" },
+    });
+  });
+});

--- a/apps/web/src/demo/workspace/DemoWorkspaceNotice.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceNotice.tsx
@@ -1,0 +1,37 @@
+import { useDemoWorkspace } from "./DemoWorkspaceProvider.js";
+
+export function DemoWorkspaceNotice() {
+  const context = useDemoWorkspace();
+  if (context.mode === "local") {
+    return null;
+  }
+
+  const { runtime } = context;
+  const urgent =
+    runtime.status === "upgrade_required" || runtime.warning !== null;
+  return (
+    <section
+      className="demo-workspace-notice"
+      role={urgent ? "alert" : "status"}
+      aria-label="Public demo data boundary"
+    >
+      <strong>Public demo · synthetic browser-local data</strong>
+      {runtime.storageMode === "indexeddb" ? (
+        <span>
+          This workspace is shared with other tabs and people using this browser
+          profile. Do not enter personal data or secrets.
+        </span>
+      ) : (
+        <span>
+          This fallback workspace stays only in this tab and is not shared or
+          retained after it closes. Do not enter personal data or secrets.
+        </span>
+      )}
+      {runtime.status === "upgrade_required" ? (
+        <span>{runtime.upgrade.message}</span>
+      ) : runtime.warning ? (
+        <span>{runtime.warning.message}</span>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/demo/workspace/DemoWorkspaceProvider.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceProvider.tsx
@@ -1,0 +1,57 @@
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+import type { DemoWorkspaceRuntimeSnapshot } from "./contracts.js";
+import type { DemoWorkspaceRepository } from "./DemoWorkspaceRepository.js";
+
+export type DemoWorkspaceContextValue =
+  | { readonly mode: "local" }
+  | {
+      readonly mode: "demo";
+      readonly workspace: DemoWorkspaceRepository;
+      readonly runtime: DemoWorkspaceRuntimeSnapshot;
+    };
+
+const LOCAL_CONTEXT: DemoWorkspaceContextValue = { mode: "local" };
+const EMPTY_RUNTIME: DemoWorkspaceRuntimeSnapshot = {
+  status: "initializing",
+  storageMode: "memory",
+  warning: null,
+};
+const subscribeEmpty = () => () => undefined;
+const getEmptyRuntime = () => EMPTY_RUNTIME;
+
+const DemoWorkspaceContext =
+  createContext<DemoWorkspaceContextValue>(LOCAL_CONTEXT);
+
+export function DemoWorkspaceProvider({
+  workspace,
+  children,
+}: {
+  readonly workspace: DemoWorkspaceRepository | null;
+  readonly children: ReactNode;
+}) {
+  const runtime = useSyncExternalStore(
+    workspace?.subscribeRuntime ?? subscribeEmpty,
+    workspace?.getRuntimeSnapshot ?? getEmptyRuntime,
+    workspace?.getRuntimeSnapshot ?? getEmptyRuntime,
+  );
+  const value = useMemo<DemoWorkspaceContextValue>(
+    () => (workspace ? { mode: "demo", workspace, runtime } : LOCAL_CONTEXT),
+    [runtime, workspace],
+  );
+  return (
+    <DemoWorkspaceContext.Provider value={value}>
+      {children}
+    </DemoWorkspaceContext.Provider>
+  );
+}
+
+export function useDemoWorkspace(): DemoWorkspaceContextValue {
+  return useContext(DemoWorkspaceContext);
+}

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
@@ -1,0 +1,1011 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createJobUpdated, LOCAL_TENANT } from "@jobctrl/domain-types";
+
+import type {
+  DemoWorkspaceChannel,
+  DemoWorkspaceChannelFactory,
+} from "./channel.js";
+import type {
+  DemoWorkspaceClock,
+  DemoWorkspaceNotification,
+  DemoWorkspaceSnapshot,
+} from "./contracts.js";
+import { DemoWorkspaceEventStreamAdapter } from "./DemoWorkspaceEventStreamAdapter.js";
+import {
+  DemoWorkspaceRepository,
+  DemoWorkspaceStaleEpochError,
+} from "./DemoWorkspaceRepository.js";
+import {
+  DemoWorkspaceScheduler,
+  type DemoSchedulerClock,
+} from "./DemoWorkspaceScheduler.js";
+import {
+  DemoWorkspaceStorageError,
+  InMemoryDemoWorkspaceStore,
+  type DemoWorkspaceStore,
+  type DemoWorkspaceTransaction,
+} from "./storage.js";
+
+const fixedClock: DemoWorkspaceClock = {
+  now: () => new Date("2026-07-11T12:00:00.000Z"),
+};
+
+class SharedPersistentStore implements DemoWorkspaceStore {
+  readonly storageMode = "indexeddb" as const;
+  failNext: DemoWorkspaceStorageError | null = null;
+
+  constructor(readonly memory = new InMemoryDemoWorkspaceStore()) {}
+
+  readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    return this.memory.readSnapshot();
+  }
+
+  readBlob(blobId: string): Promise<Blob | null> {
+    return this.memory.readBlob(blobId);
+  }
+
+  readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    return this.memory.readAllBlobs();
+  }
+
+  transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    if (this.failNext) {
+      const error = this.failNext;
+      this.failNext = null;
+      return Promise.reject(error);
+    }
+    return this.memory.transact(operation);
+  }
+}
+
+class DeferredPersistentStore extends SharedPersistentStore {
+  private resolveGate!: () => void;
+  private readonly gate = new Promise<void>((resolve) => {
+    this.resolveGate = resolve;
+  });
+
+  release(): void {
+    this.resolveGate();
+  }
+
+  override async transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    await this.gate;
+    return super.transact(operation);
+  }
+}
+
+class ChannelHub {
+  private readonly endpoints = new Set<HubEndpoint>();
+
+  createFactory(): DemoWorkspaceChannelFactory {
+    return { create: () => new HubEndpoint(this) };
+  }
+
+  connect(endpoint: HubEndpoint): void {
+    this.endpoints.add(endpoint);
+  }
+
+  disconnect(endpoint: HubEndpoint): void {
+    this.endpoints.delete(endpoint);
+  }
+
+  publish(sender: HubEndpoint, notification: DemoWorkspaceNotification): void {
+    for (const endpoint of this.endpoints) {
+      if (endpoint !== sender) {
+        endpoint.deliver(notification);
+      }
+    }
+  }
+
+  send(notification: DemoWorkspaceNotification): void {
+    for (const endpoint of this.endpoints) {
+      endpoint.deliver(notification);
+    }
+  }
+}
+
+class HubEndpoint implements DemoWorkspaceChannel {
+  private readonly listeners = new Set<
+    (event: MessageEvent<DemoWorkspaceNotification>) => void
+  >();
+
+  constructor(private readonly hub: ChannelHub) {
+    hub.connect(this);
+  }
+
+  postMessage(notification: DemoWorkspaceNotification): void {
+    this.hub.publish(this, notification);
+  }
+
+  addEventListener(
+    _type: "message",
+    listener: (event: MessageEvent<DemoWorkspaceNotification>) => void,
+  ): void {
+    this.listeners.add(listener);
+  }
+
+  removeEventListener(
+    _type: "message",
+    listener: (event: MessageEvent<DemoWorkspaceNotification>) => void,
+  ): void {
+    this.listeners.delete(listener);
+  }
+
+  close(): void {
+    this.hub.disconnect(this);
+    this.listeners.clear();
+  }
+
+  deliver(notification: DemoWorkspaceNotification): void {
+    queueMicrotask(() => {
+      for (const listener of this.listeners) {
+        listener({
+          data: notification,
+        } as MessageEvent<DemoWorkspaceNotification>);
+      }
+    });
+  }
+}
+
+async function settleBroadcast(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function buildRepository(
+  store: DemoWorkspaceStore,
+  channelFactory?: DemoWorkspaceChannelFactory,
+): DemoWorkspaceRepository {
+  let index = 0;
+  return new DemoWorkspaceRepository({
+    store,
+    clock: fixedClock,
+    ...(channelFactory ? { channelFactory } : {}),
+    createWorkspaceId: () => `workspace-${++index}`,
+  });
+}
+
+describe("DemoWorkspaceRepository", () => {
+  it("seeds once, persists every required snapshot field, and reloads the same workspace", async () => {
+    const store = new SharedPersistentStore();
+    const first = buildRepository(store);
+    const initial = await first.initialize();
+    expect(initial.kind).toBe("ready");
+    if (initial.kind !== "ready") return;
+    expect(initial.snapshot).toMatchObject({
+      schemaVersion: 2,
+      seedVersion: "2026-07-11.1",
+      workspaceId: "workspace-1",
+      resetCount: 0,
+      revision: 0,
+      resetEpoch: 0,
+      lastEventSequence: 0,
+      eventLog: [],
+      blobIds: [],
+      pendingScenarios: [],
+    });
+    expect(initial.snapshot.state.readModel.jobs.list.items).toHaveLength(3);
+
+    const second = buildRepository(store);
+    const reloaded = await second.initialize();
+    expect(reloaded).toMatchObject({
+      kind: "ready",
+      snapshot: { workspaceId: "workspace-1", revision: 0 },
+    });
+  });
+
+  it("serializes concurrent read-modify-write transactions", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    await repository.initialize();
+    await Promise.all([
+      repository.queueScenario({
+        scenarioId: "one",
+        deadlineAt: "2026-07-11T12:01:00.000Z",
+        resetEpoch: 0,
+      }),
+      repository.queueScenario({
+        scenarioId: "two",
+        deadlineAt: "2026-07-11T12:02:00.000Z",
+        resetEpoch: 0,
+      }),
+    ]);
+    const snapshot = await repository.snapshot();
+    expect(
+      snapshot.pendingScenarios.map((pending) => pending.scenarioId).toSorted(),
+    ).toEqual(["one", "two"]);
+    expect(snapshot.revision).toBe(2);
+    expect(snapshot.lastEventSequence).toBe(0);
+  });
+
+  it("notifies a second tab only after a shared-profile revision commits", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const first = buildRepository(store, hub.createFactory());
+    const second = buildRepository(store, hub.createFactory());
+    await Promise.all([first.initialize(), second.initialize()]);
+    const notifications: DemoWorkspaceNotification[] = [];
+    second.subscribe((notification) => notifications.push(notification));
+
+    await first.queueScenario({
+      scenarioId: "shared",
+      deadlineAt: "2026-07-11T12:03:00.000Z",
+      resetEpoch: 0,
+    });
+    await settleBroadcast();
+
+    expect(notifications).toContainEqual(
+      expect.objectContaining({ source: "broadcast", revision: 1 }),
+    );
+    expect((await second.snapshot()).pendingScenarios).toHaveLength(1);
+  });
+
+  it("keeps notification watermarks separate and rereads IDB before exposing a contiguous external revision", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const first = buildRepository(store, hub.createFactory());
+    const second = buildRepository(store, hub.createFactory());
+    await Promise.all([first.initialize(), second.initialize()]);
+    const observedTitles: string[] = [];
+    second.subscribe((notification) => {
+      if (notification.source === "broadcast") {
+        void second.snapshot().then((snapshot) => {
+          observedTitles.push(snapshot.state.title);
+        });
+      }
+    });
+
+    await first.mutate((draft) => {
+      (draft.state as { title: string }).title = "Authoritative IDB title";
+    });
+    await settleBroadcast();
+
+    expect(observedTitles).toEqual(["Authoritative IDB title"]);
+    expect((await second.snapshot()).state.title).toBe(
+      "Authoritative IDB title",
+    );
+  });
+
+  it("ignores duplicate/old revisions and rereads broadly on a gap or remote reset", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const first = buildRepository(store, hub.createFactory());
+    const second = buildRepository(store, hub.createFactory());
+    await Promise.all([first.initialize(), second.initialize()]);
+    const notifications: DemoWorkspaceNotification[] = [];
+    second.subscribe((notification) => notifications.push(notification));
+    const eventStream = new DemoWorkspaceEventStreamAdapter(second);
+    const subscription = eventStream.subscribe({ tenantId: LOCAL_TENANT });
+    const statuses: string[] = [];
+    subscription.onStatusChange((status) => statuses.push(status));
+    await settleBroadcast();
+    statuses.length = 0;
+    const initial = await first.snapshot();
+
+    await store.memory.transact((current, transaction) => {
+      if (!current) throw new Error("missing fixture workspace");
+      transaction.putSnapshot({ ...current, revision: 3 });
+    });
+    hub.send({
+      source: "local",
+      kind: "commit",
+      workspaceId: initial.workspaceId,
+      revision: 0,
+      resetEpoch: 0,
+      lastEventSequence: 0,
+    });
+    await settleBroadcast();
+    expect(notifications).toHaveLength(0);
+
+    hub.send({
+      source: "local",
+      kind: "commit",
+      workspaceId: initial.workspaceId,
+      revision: 3,
+      resetEpoch: 0,
+      lastEventSequence: 0,
+    });
+    await settleBroadcast();
+    expect(notifications).toContainEqual(
+      expect.objectContaining({ kind: "resync" }),
+    );
+    expect(statuses).toEqual(["closed", "open"]);
+
+    statuses.length = 0;
+    await first.reset();
+    await settleBroadcast();
+    expect(notifications).toContainEqual(
+      expect.objectContaining({ kind: "reset", resetEpoch: 1 }),
+    );
+    const reset = await second.snapshot();
+    expect(reset).toMatchObject({
+      resetEpoch: 1,
+      resetCount: 1,
+      workspaceId: "workspace-2",
+    });
+    expect(statuses).toEqual(["closed", "open"]);
+    subscription.close();
+  });
+
+  it("resyncs through the authoritative revision when only an older broadcast watermark arrives", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const repository = buildRepository(store, hub.createFactory());
+    await repository.initialize();
+    const current = await repository.snapshot();
+    const notifications: DemoWorkspaceNotification[] = [];
+    repository.subscribe((notification) => notifications.push(notification));
+
+    await store.memory.transact((_stored, transaction) => {
+      transaction.putSnapshot({
+        ...current,
+        revision: 2,
+        state: { ...current.state, title: "Authoritative revision two" },
+      });
+    });
+    hub.send({
+      source: "local",
+      kind: "commit",
+      workspaceId: current.workspaceId,
+      revision: 1,
+      resetEpoch: current.resetEpoch,
+      lastEventSequence: current.lastEventSequence,
+    });
+    await settleBroadcast();
+
+    expect(notifications).toEqual([
+      expect.objectContaining({ kind: "resync", revision: 2 }),
+    ]);
+    expect((await repository.snapshot()).state.title).toBe(
+      "Authoritative revision two",
+    );
+  });
+
+  it("does not emit a local or broadcast event before the committing transaction completes", async () => {
+    const store = new DeferredPersistentStore();
+    const repository = buildRepository(store);
+    const notices: DemoWorkspaceNotification[] = [];
+    repository.subscribe((notice) => notices.push(notice));
+    const starting = repository.initialize();
+    await settleBroadcast();
+    expect(notices).toHaveLength(0);
+    store.release();
+    await starting;
+    expect(notices).toHaveLength(1);
+  });
+
+  it("atomically deletes blobs and fences stale deadline callbacks on reset", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const repository = buildRepository(new SharedPersistentStore());
+      await repository.initialize();
+      await repository.putBlob("visitor-edit", new Blob(["local only"]));
+      const scheduler = new DemoWorkspaceScheduler(repository, schedulerClock);
+      const fired = vi.fn();
+      await scheduler.schedule(
+        {
+          scenarioId: "fenced",
+          deadlineAt: new Date(25).toISOString(),
+          resetEpoch: 0,
+        },
+        fired,
+      );
+      await repository.reset();
+      now = 25;
+      await vi.advanceTimersByTimeAsync(25);
+
+      expect(await repository.blob("visitor-edit")).toBeNull();
+      expect(fired).not.toHaveBeenCalled();
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rearms a still-valid pending deadline when a cross-tab revision gap forces resync", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const hub = new ChannelHub();
+      const store = new SharedPersistentStore();
+      const repository = buildRepository(store, hub.createFactory());
+      await repository.initialize();
+      const scheduler = new DemoWorkspaceScheduler(repository, schedulerClock);
+      const fired = vi.fn();
+      await scheduler.schedule(
+        {
+          scenarioId: "gap-fenced",
+          deadlineAt: new Date(25).toISOString(),
+          resetEpoch: 0,
+        },
+        fired,
+      );
+      const current = await repository.snapshot();
+      await store.memory.transact((_stored, transaction) => {
+        transaction.putSnapshot({ ...current, revision: current.revision + 2 });
+      });
+      hub.send({
+        source: "local",
+        kind: "commit",
+        workspaceId: current.workspaceId,
+        revision: current.revision + 2,
+        resetEpoch: current.resetEpoch,
+        lastEventSequence: current.lastEventSequence,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 25;
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fired).toHaveBeenCalledTimes(1);
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not rearm a scenario removed by the authoritative resync", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const hub = new ChannelHub();
+      const store = new SharedPersistentStore();
+      const repository = buildRepository(store, hub.createFactory());
+      await repository.initialize();
+      const scheduler = new DemoWorkspaceScheduler(repository, schedulerClock);
+      const fired = vi.fn();
+      await scheduler.schedule(
+        {
+          scenarioId: "removed-during-gap",
+          deadlineAt: new Date(25).toISOString(),
+          resetEpoch: 0,
+        },
+        fired,
+      );
+      const current = await repository.snapshot();
+      await store.memory.transact((_stored, transaction) => {
+        transaction.putSnapshot({
+          ...current,
+          revision: current.revision + 2,
+          pendingScenarios: [],
+        });
+      });
+      hub.send({
+        source: "local",
+        kind: "commit",
+        workspaceId: current.workspaceId,
+        revision: current.revision + 2,
+        resetEpoch: current.resetEpoch,
+        lastEventSequence: current.lastEventSequence,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 25;
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fired).not.toHaveBeenCalled();
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reconciles a deadline changed by the next contiguous broadcast commit", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const hub = new ChannelHub();
+      const store = new SharedPersistentStore();
+      const repository = buildRepository(store, hub.createFactory());
+      await repository.initialize();
+      const scheduler = new DemoWorkspaceScheduler(repository, schedulerClock);
+      const fired = vi.fn();
+      await scheduler.schedule(
+        {
+          scenarioId: "changed-contiguously",
+          deadlineAt: new Date(25).toISOString(),
+          resetEpoch: 0,
+        },
+        fired,
+      );
+      const current = await repository.snapshot();
+      const replacement = {
+        ...current.pendingScenarios[0]!,
+        deadlineAt: new Date(50).toISOString(),
+      };
+      await store.memory.transact((_stored, transaction) => {
+        transaction.putSnapshot({
+          ...current,
+          revision: current.revision + 1,
+          pendingScenarios: [replacement],
+        });
+      });
+      hub.send({
+        source: "local",
+        kind: "commit",
+        workspaceId: current.workspaceId,
+        revision: current.revision + 1,
+        resetEpoch: current.resetEpoch,
+        lastEventSequence: current.lastEventSequence,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 25;
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fired).not.toHaveBeenCalled();
+      now = 50;
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fired).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scenarioId: "changed-contiguously",
+          deadlineAt: new Date(50).toISOString(),
+        }),
+        expect.any(Object),
+        expect.any(Object),
+      );
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects stale scenario enqueues after reset inside the transaction", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    await repository.initialize();
+    await repository.reset();
+
+    await expect(
+      repository.queueScenario({
+        scenarioId: "stale-after-reset",
+        deadlineAt: "2026-07-11T12:05:00.000Z",
+        resetEpoch: 0,
+      }),
+    ).rejects.toBeInstanceOf(DemoWorkspaceStaleEpochError);
+    expect((await repository.snapshot()).pendingScenarios).toEqual([]);
+  });
+
+  it("fences an expected-epoch mutation when reset wins the transaction race", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    await repository.initialize();
+    const reset = repository.reset();
+    const staleMutation = repository.mutate(
+      (draft) => {
+        (
+          draft.pendingScenarios as Array<{
+            scenarioId: string;
+            deadlineAt: string;
+            resetEpoch: number;
+          }>
+        ).push({
+          scenarioId: "raced",
+          deadlineAt: "2026-07-11T12:06:00.000Z",
+          resetEpoch: 0,
+        });
+      },
+      { expectedResetEpoch: 0 },
+    );
+
+    await expect(reset).resolves.toMatchObject({ kind: "committed" });
+    await expect(staleMutation).rejects.toBeInstanceOf(
+      DemoWorkspaceStaleEpochError,
+    );
+    expect((await repository.snapshot()).pendingScenarios).toEqual([]);
+  });
+
+  it("preserves future-schema data and returns a typed upgrade-required result", async () => {
+    const seedStore = new SharedPersistentStore();
+    const builder = buildRepository(seedStore);
+    await builder.initialize();
+    const future = {
+      ...(await builder.snapshot()),
+      schemaVersion: 3,
+      workspaceId: "future-workspace",
+    };
+    const store = new InMemoryDemoWorkspaceStore(future);
+    const repository = buildRepository(store);
+
+    await expect(repository.initialize()).resolves.toMatchObject({
+      kind: "upgrade_required",
+      scope: "workspace_schema",
+      foundSchemaVersion: 3,
+      supportedSchemaVersion: 2,
+    });
+    expect((await store.readSnapshot())?.workspaceId).toBe("future-workspace");
+  });
+
+  it("revalidates a future snapshot reached through a cross-tab notification", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const repository = buildRepository(store, hub.createFactory());
+    await repository.initialize();
+    const current = await repository.snapshot();
+    await store.memory.transact((_stored, transaction) => {
+      transaction.putSnapshot({
+        ...current,
+        schemaVersion: 3,
+        revision: 1,
+      });
+    });
+
+    hub.send({
+      source: "local",
+      kind: "commit",
+      workspaceId: current.workspaceId,
+      revision: 1,
+      resetEpoch: 0,
+      lastEventSequence: 0,
+    });
+    await settleBroadcast();
+
+    expect(repository.getRuntimeSnapshot()).toMatchObject({
+      status: "upgrade_required",
+      upgrade: {
+        scope: "workspace_schema",
+        foundSchemaVersion: 3,
+      },
+    });
+  });
+
+  it("migrates an older schema atomically without resetting its workspace", async () => {
+    const seedStore = new SharedPersistentStore();
+    const builder = buildRepository(seedStore);
+    await builder.initialize();
+    await builder.putBlob("legacy-preview", new Blob(["legacy preview"]));
+    const current = await builder.snapshot();
+    const { blobIds: _omittedLegacyManifest, ...withoutBlobManifest } = current;
+    const legacy = {
+      ...withoutBlobManifest,
+      schemaVersion: 1,
+      workspaceId: "legacy-workspace",
+    } as DemoWorkspaceSnapshot;
+    const store = new InMemoryDemoWorkspaceStore(legacy);
+    await store.transact((_stored, transaction) => {
+      transaction.putBlob("legacy-preview", new Blob(["legacy preview"]));
+    });
+    const repository = buildRepository(store);
+    const ready = await repository.initialize();
+    expect(ready).toMatchObject({
+      kind: "ready",
+      snapshot: {
+        schemaVersion: 2,
+        workspaceId: "legacy-workspace",
+        revision: 2,
+        blobIds: ["legacy-preview"],
+      },
+    });
+    expect(await repository.blob("legacy-preview")).toEqual(
+      expect.objectContaining({ size: 14 }),
+    );
+  });
+
+  it("normalizes a legacy snapshot and its blobs when migration falls back on quota", async () => {
+    const seedStore = new SharedPersistentStore();
+    const builder = buildRepository(seedStore);
+    await builder.initialize();
+    const current = await builder.snapshot();
+    const { blobIds: _omittedLegacyManifest, ...withoutBlobManifest } = current;
+    const legacy = {
+      ...withoutBlobManifest,
+      schemaVersion: 1,
+      workspaceId: "legacy-quota-workspace",
+    } as DemoWorkspaceSnapshot;
+    const memory = new InMemoryDemoWorkspaceStore(legacy);
+    await memory.transact((_stored, transaction) => {
+      transaction.putBlob("legacy-quota-preview", new Blob(["quota legacy"]));
+    });
+    const store = new SharedPersistentStore(memory);
+    store.failNext = new DemoWorkspaceStorageError("quota");
+    const repository = buildRepository(store);
+
+    await expect(repository.initialize()).resolves.toMatchObject({
+      kind: "ready",
+      storageMode: "memory",
+      snapshot: {
+        schemaVersion: 2,
+        workspaceId: "legacy-quota-workspace",
+        blobIds: ["legacy-quota-preview"],
+      },
+    });
+    expect(await repository.blob("legacy-quota-preview")).toEqual(
+      expect.objectContaining({ size: 12 }),
+    );
+  });
+
+  it("falls back fresh to tab-local memory when IndexedDB is denied", async () => {
+    const unavailable: DemoWorkspaceStore = {
+      storageMode: "indexeddb",
+      readSnapshot: async () =>
+        Promise.reject(new DemoWorkspaceStorageError("unavailable")),
+      readBlob: async () =>
+        Promise.reject(new DemoWorkspaceStorageError("unavailable")),
+      readAllBlobs: async () =>
+        Promise.reject(new DemoWorkspaceStorageError("unavailable")),
+      transact: async () =>
+        Promise.reject(new DemoWorkspaceStorageError("unavailable")),
+    };
+    const repository = buildRepository(unavailable);
+    const result = await repository.initialize();
+    expect(result).toMatchObject({
+      kind: "ready",
+      storageMode: "memory",
+      warning: { code: "indexeddb_unavailable" },
+    });
+  });
+
+  it("returns typed upgrade-required for a newer browser database without memory fallback", async () => {
+    const futureDatabase: DemoWorkspaceStore = {
+      storageMode: "indexeddb",
+      readSnapshot: async () =>
+        Promise.reject(
+          new DemoWorkspaceStorageError("upgrade_required", undefined, 2),
+        ),
+      readBlob: async () => null,
+      readAllBlobs: async () => new Map(),
+      transact: async () =>
+        Promise.reject(
+          new DemoWorkspaceStorageError("upgrade_required", undefined, 2),
+        ),
+    };
+    const repository = buildRepository(futureDatabase);
+    await expect(repository.initialize()).resolves.toMatchObject({
+      kind: "upgrade_required",
+      scope: "database_version",
+      foundDatabaseVersion: 2,
+      supportedDatabaseVersion: 1,
+    });
+    expect(repository.getRuntimeSnapshot()).toMatchObject({
+      status: "upgrade_required",
+      storageMode: "indexeddb",
+    });
+  });
+
+  it("aborts a quota-exceeded persistent write and retains only the last confirmed state in this tab", async () => {
+    const store = new SharedPersistentStore();
+    const repository = buildRepository(store);
+    await repository.initialize();
+    const confirmed = await repository.snapshot();
+    store.failNext = new DemoWorkspaceStorageError("quota");
+
+    const result = await repository.queueScenario({
+      scenarioId: "lost-write",
+      deadlineAt: "2026-07-11T12:04:00.000Z",
+      resetEpoch: 0,
+    });
+    expect(result).toMatchObject({
+      kind: "persistence_warning",
+      warning: { code: "quota_exceeded" },
+    });
+    expect(await repository.snapshot()).toMatchObject({
+      workspaceId: confirmed.workspaceId,
+      revision: confirmed.revision,
+      pendingScenarios: [],
+    });
+  });
+
+  it("keeps confirmed durable blobs readable after a later quota fallback", async () => {
+    const store = new SharedPersistentStore();
+    const repository = buildRepository(store);
+    await repository.initialize();
+    await repository.putBlob("confirmed-preview", new Blob(["preview body"]));
+    expect((await repository.snapshot()).blobIds).toEqual([
+      "confirmed-preview",
+    ]);
+
+    store.failNext = new DemoWorkspaceStorageError("quota");
+    await expect(
+      repository.mutate((draft) => {
+        (draft.state as { title: string }).title = "uncommitted";
+      }),
+    ).resolves.toMatchObject({
+      kind: "persistence_warning",
+      warning: { code: "quota_exceeded" },
+    });
+
+    expect(await repository.blob("confirmed-preview")).toEqual(
+      expect.objectContaining({ size: 12 }),
+    );
+    await store.memory.transact((current, transaction) => {
+      if (!current) throw new Error("missing durable fixture workspace");
+      transaction.putBlob("confirmed-preview", new Blob(["replacement"]));
+      transaction.putSnapshot({ ...current, revision: current.revision + 1 });
+    });
+    expect(await repository.blob("confirmed-preview")).toEqual(
+      expect.objectContaining({ size: 12 }),
+    );
+    await store.memory.transact((current, transaction) => {
+      if (!current) throw new Error("missing durable fixture workspace");
+      transaction.clearBlobs();
+      transaction.putSnapshot({
+        ...current,
+        revision: current.revision + 1,
+        resetEpoch: current.resetEpoch + 1,
+        blobIds: [],
+      });
+    });
+    expect(await repository.blob("confirmed-preview")).toEqual(
+      expect.objectContaining({ size: 12 }),
+    );
+    await repository.deleteBlob("confirmed-preview");
+    expect(await repository.blob("confirmed-preview")).toBeNull();
+  });
+
+  it("preserves another tab's newest durable commit when quota aborts the local write", async () => {
+    class QuotaRaceStore extends SharedPersistentStore {
+      failWithExternalCommit = false;
+
+      override async transact<TResult>(
+        operation: (
+          current: DemoWorkspaceSnapshot | null,
+          transaction: DemoWorkspaceTransaction,
+        ) => TResult,
+      ): Promise<TResult> {
+        if (!this.failWithExternalCommit) {
+          return super.transact(operation);
+        }
+        this.failWithExternalCommit = false;
+        await this.memory.transact((current, transaction) => {
+          if (!current) throw new Error("missing fixture workspace");
+          transaction.putSnapshot({
+            ...current,
+            revision: current.revision + 1,
+            state: { ...current.state, title: "Committed by another tab" },
+          });
+        });
+        throw new DemoWorkspaceStorageError("quota");
+      }
+    }
+
+    const store = new QuotaRaceStore();
+    const repository = buildRepository(store);
+    await repository.initialize();
+    store.failWithExternalCommit = true;
+    const result = await repository.mutate((draft) => {
+      (draft.state as { title: string }).title = "Uncommitted local title";
+    });
+
+    expect(result).toMatchObject({
+      kind: "persistence_warning",
+      snapshot: {
+        revision: 1,
+        state: { title: "Committed by another tab" },
+      },
+    });
+    expect(await repository.snapshot()).toMatchObject({
+      revision: 1,
+      state: { title: "Committed by another tab" },
+    });
+  });
+
+  it("starts a fresh tab-local workspace when quota prevents the first seed commit", async () => {
+    const store = new SharedPersistentStore();
+    store.failNext = new DemoWorkspaceStorageError("quota");
+    const result = await buildRepository(store).initialize();
+    expect(result).toMatchObject({
+      kind: "ready",
+      storageMode: "memory",
+      warning: { code: "quota_exceeded" },
+      snapshot: { revision: 0, pendingScenarios: [] },
+    });
+  });
+
+  it("recovers a persisted deadline scaffold with a fake clock without inventing P3 outcomes", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const store = new SharedPersistentStore();
+      const first = buildRepository(store);
+      await first.initialize();
+      const scheduler = new DemoWorkspaceScheduler(first, schedulerClock);
+      await scheduler.schedule(
+        {
+          scenarioId: "recover",
+          deadlineAt: new Date(10).toISOString(),
+          resetEpoch: 0,
+        },
+        vi.fn(),
+      );
+      scheduler.dispose();
+
+      const reloaded = buildRepository(store);
+      await reloaded.initialize();
+      const recovered = vi.fn();
+      const recoveryScheduler = new DemoWorkspaceScheduler(
+        reloaded,
+        schedulerClock,
+      );
+      await recoveryScheduler.recover(recovered);
+      now = 10;
+      await vi.advanceTimersByTimeAsync(10);
+      expect(recovered).toHaveBeenCalledWith(
+        expect.objectContaining({ scenarioId: "recover" }),
+        expect.any(Object),
+        expect.any(Object),
+      );
+      recoveryScheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("delivers only persisted valid domain events through EventStreamPort", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    await repository.initialize();
+    const adapter = new DemoWorkspaceEventStreamAdapter(repository);
+    const subscription = adapter.subscribe({ tenantId: LOCAL_TENANT });
+    const events: unknown[] = [];
+    subscription.on((event) => events.push(event));
+    await repository.mutate((_draft, context) => {
+      context.appendDomainEvent(
+        createJobUpdated(LOCAL_TENANT, {
+          jobId: "job-demo-northwind-platform",
+          changedFields: { title: "Updated title" },
+        }),
+      );
+    });
+    await settleBroadcast();
+    expect(events).toEqual([
+      expect.objectContaining({
+        eventType: "JobUpdated",
+        payload: expect.objectContaining({
+          jobId: "job-demo-northwind-platform",
+        }),
+      }),
+    ]);
+    subscription.close();
+  });
+
+  it("rejects malformed events before they can enter the committed event log", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    await repository.initialize();
+
+    await expect(
+      repository.mutate((_draft, context) => {
+        context.appendDomainEvent({
+          eventType: "NotADomainEvent",
+          tenantId: LOCAL_TENANT,
+          occurredAt: fixedClock.now().toISOString(),
+          payload: {},
+        } as never);
+      }),
+    ).rejects.toThrow("valid local domain events");
+    expect(await repository.snapshot()).toMatchObject({
+      revision: 0,
+      lastEventSequence: 0,
+      eventLog: [],
+    });
+  });
+});

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
@@ -1,0 +1,1009 @@
+import {
+  DOMAIN_EVENT_TYPES,
+  LOCAL_TENANT,
+  type DomainEventUnion,
+} from "@jobctrl/domain-types";
+
+import { materializeDemoSeed } from "../clock.js";
+import { DEMO_SEED } from "../seed.js";
+import {
+  DEMO_WORKSPACE_DATABASE_VERSION,
+  DEMO_WORKSPACE_EVENT_LOG_LIMIT,
+  DEMO_WORKSPACE_SCHEMA_VERSION,
+  systemDemoWorkspaceClock,
+  type DemoPendingScenario,
+  type DemoWorkspaceClock,
+  type DemoWorkspaceCommit,
+  type DemoWorkspaceEventRecord,
+  type DemoWorkspaceInitialization,
+  type DemoWorkspaceMutationOptions,
+  type DemoWorkspaceNotification,
+  type DemoWorkspaceReady,
+  type DemoWorkspaceRuntimeSnapshot,
+  type DemoWorkspaceSnapshot,
+  type DemoWorkspaceUpgradeRequired,
+  type DemoWorkspaceWarning,
+} from "./contracts.js";
+import {
+  browserDemoWorkspaceChannelFactory,
+  type DemoWorkspaceChannel,
+  type DemoWorkspaceChannelFactory,
+} from "./channel.js";
+import {
+  DemoWorkspaceStorageError,
+  InMemoryDemoWorkspaceStore,
+  type DemoWorkspaceStore,
+  type DemoWorkspaceTransaction,
+} from "./storage.js";
+
+const KNOWN_DOMAIN_EVENT_TYPES = new Set<string>(DOMAIN_EVENT_TYPES);
+
+export class DemoWorkspaceUpgradeRequiredError extends Error {
+  constructor(readonly upgrade: DemoWorkspaceUpgradeRequired) {
+    super(upgrade.message);
+    this.name = "DemoWorkspaceUpgradeRequiredError";
+  }
+}
+
+export class DemoWorkspaceStaleEpochError extends Error {
+  readonly code = "demo_workspace_stale_epoch" as const;
+
+  constructor(
+    readonly expectedResetEpoch: number,
+    readonly actualResetEpoch: number,
+  ) {
+    super(
+      `Demo workspace reset epoch changed from ${expectedResetEpoch} to ${actualResetEpoch}.`,
+    );
+    this.name = "DemoWorkspaceStaleEpochError";
+  }
+}
+
+export interface DemoWorkspaceMutationContext {
+  putBlob(blobId: string, value: Blob): void;
+  deleteBlob(blobId: string): void;
+  appendDomainEvent(event: DomainEventUnion): void;
+}
+
+export interface DemoWorkspaceRepositoryOptions {
+  readonly store: DemoWorkspaceStore;
+  readonly fallbackStore?: DemoWorkspaceStore;
+  readonly clock?: DemoWorkspaceClock;
+  readonly createWorkspaceId?: () => string;
+  readonly channelFactory?: DemoWorkspaceChannelFactory;
+}
+
+type DraftMutation = (
+  draft: DemoWorkspaceSnapshot,
+  context: DemoWorkspaceMutationContext,
+) => void;
+
+interface NotificationWatermark {
+  readonly workspaceId: string;
+  readonly revision: number;
+  readonly resetEpoch: number;
+  readonly lastEventSequence: number;
+}
+
+export type DemoWorkspaceEventRead =
+  | { readonly kind: "events"; readonly events: readonly DomainEventUnion[] }
+  | { readonly kind: "event_log_lost" };
+
+/**
+ * IndexedDB is the sole workspace authority. BroadcastChannel messages carry
+ * only post-commit watermarks; every accepted external message is followed by
+ * an authoritative IDB reread before subscribers can observe it.
+ */
+export class DemoWorkspaceRepository {
+  private store: DemoWorkspaceStore;
+  private readonly fallbackStore: DemoWorkspaceStore;
+  private readonly clock: DemoWorkspaceClock;
+  private readonly createWorkspaceId: () => string;
+  private readonly channelFactory: DemoWorkspaceChannelFactory;
+  private channel: DemoWorkspaceChannel | null = null;
+  private authoritativeSnapshot: DemoWorkspaceSnapshot | null = null;
+  private notificationWatermark: NotificationWatermark | null = null;
+  private initialization: DemoWorkspaceInitialization | null = null;
+  private warning: DemoWorkspaceWarning | undefined;
+  private runtimeSnapshot: DemoWorkspaceRuntimeSnapshot;
+  private readonly notificationListeners = new Set<
+    (notification: DemoWorkspaceNotification) => void
+  >();
+  private readonly runtimeListeners = new Set<() => void>();
+  private broadcastQueue = Promise.resolve();
+
+  constructor(options: DemoWorkspaceRepositoryOptions) {
+    this.store = options.store;
+    this.fallbackStore =
+      options.fallbackStore ?? new InMemoryDemoWorkspaceStore();
+    this.clock = options.clock ?? systemDemoWorkspaceClock;
+    this.createWorkspaceId = options.createWorkspaceId ?? defaultWorkspaceId;
+    this.channelFactory =
+      options.channelFactory ?? browserDemoWorkspaceChannelFactory;
+    this.runtimeSnapshot = {
+      status: "initializing",
+      storageMode: options.store.storageMode,
+      warning: null,
+    };
+  }
+
+  async initialize(): Promise<DemoWorkspaceInitialization> {
+    if (this.initialization) {
+      return this.initialization;
+    }
+    let knownSnapshot: DemoWorkspaceSnapshot | null = null;
+    try {
+      const current = await this.store.readSnapshot();
+      knownSnapshot = current;
+      if (!current) {
+        return this.setReady(await this.seed());
+      }
+      const upgrade = workspaceUpgrade(current);
+      if (upgrade) {
+        return this.setUpgrade(upgrade);
+      }
+      const migrated =
+        current.schemaVersion < DEMO_WORKSPACE_SCHEMA_VERSION
+          ? await this.migrate(current)
+          : current;
+      this.adoptAuthoritativeSnapshot(migrated, true);
+      return this.setReady(migrated);
+    } catch (error) {
+      const upgrade = upgradeFromError(error);
+      if (upgrade) {
+        return this.setUpgrade(upgrade);
+      }
+      if (isQuotaExceeded(error)) {
+        return this.fallbackFromQuota(knownSnapshot);
+      }
+      if (!isStorageUnavailable(error)) {
+        throw error;
+      }
+      return this.fallbackFromUnavailable(knownSnapshot);
+    }
+  }
+
+  async snapshot(): Promise<DemoWorkspaceSnapshot> {
+    this.requireReady();
+    try {
+      return await this.readAuthoritativeSnapshot();
+    } catch (error) {
+      if (error instanceof DemoWorkspaceUpgradeRequiredError) {
+        throw error;
+      }
+      if (!isStorageUnavailable(error)) {
+        throw error;
+      }
+      const ready = await this.fallbackFromUnavailable(
+        this.authoritativeSnapshot,
+      );
+      return ready.snapshot;
+    }
+  }
+
+  subscribe(
+    listener: (notification: DemoWorkspaceNotification) => void,
+  ): () => void {
+    this.notificationListeners.add(listener);
+    return () => this.notificationListeners.delete(listener);
+  }
+
+  readonly subscribeRuntime = (listener: () => void): (() => void) => {
+    this.runtimeListeners.add(listener);
+    return () => this.runtimeListeners.delete(listener);
+  };
+
+  readonly getRuntimeSnapshot = (): DemoWorkspaceRuntimeSnapshot =>
+    this.runtimeSnapshot;
+
+  async mutate(
+    mutation: DraftMutation,
+    options: DemoWorkspaceMutationOptions = {},
+  ): Promise<DemoWorkspaceCommit> {
+    this.requireReady();
+    const confirmed =
+      this.authoritativeSnapshot ?? (await this.readAuthoritativeSnapshot());
+    try {
+      const committed = await this.store.transact((current, transaction) => {
+        if (!current) {
+          throw new Error("Demo workspace disappeared during a transaction.");
+        }
+        throwIfFutureWorkspace(current);
+        if (
+          options.expectedResetEpoch !== undefined &&
+          current.resetEpoch !== options.expectedResetEpoch
+        ) {
+          throw new DemoWorkspaceStaleEpochError(
+            options.expectedResetEpoch,
+            current.resetEpoch,
+          );
+        }
+
+        const draft = clone(current);
+        const appendedEvents: DomainEventUnion[] = [];
+        const context: DemoWorkspaceMutationContext = {
+          putBlob: (blobId, value) => {
+            transaction.putBlob(blobId, value);
+            if (!draft.blobIds.includes(blobId)) {
+              (draft as unknown as { blobIds: string[] }).blobIds = [
+                ...draft.blobIds,
+                blobId,
+              ];
+            }
+          },
+          deleteBlob: (blobId) => {
+            transaction.deleteBlob(blobId);
+            (draft as unknown as { blobIds: string[] }).blobIds =
+              draft.blobIds.filter((candidate) => candidate !== blobId);
+          },
+          appendDomainEvent: (event) => {
+            assertDemoDomainEvent(event);
+            appendedEvents.push(clone(event));
+          },
+        };
+        mutation(draft, context);
+
+        const revision = current.revision + 1;
+        const eventRecords = appendedEvents.map<DemoWorkspaceEventRecord>(
+          (event, index) => ({
+            sequence: current.lastEventSequence + index + 1,
+            revision,
+            resetEpoch: current.resetEpoch,
+            event,
+          }),
+        );
+        const nextEventLog = [
+          ...(current.eventLog ?? []),
+          ...eventRecords,
+        ].slice(-DEMO_WORKSPACE_EVENT_LOG_LIMIT);
+        const next: DemoWorkspaceSnapshot = {
+          ...draft,
+          revision,
+          lastEventSequence: current.lastEventSequence + appendedEvents.length,
+          eventLog: nextEventLog,
+          updatedAt: this.clock.now().toISOString(),
+        };
+        transaction.putSnapshot(next);
+        return next;
+      });
+      this.adoptAuthoritativeSnapshot(committed, true);
+      this.setReady(committed);
+      this.publishLocal("commit", committed);
+      return { kind: "committed", snapshot: committed };
+    } catch (error) {
+      const upgrade = upgradeFromError(error);
+      if (upgrade) {
+        this.setUpgrade(upgrade);
+        throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+      }
+      return this.handleCommitStorageFailure(error, confirmed);
+    }
+  }
+
+  async putBlob(
+    blobId: string,
+    value: Blob,
+    options: DemoWorkspaceMutationOptions = {},
+  ): Promise<DemoWorkspaceCommit> {
+    return this.mutate(
+      (_draft, context) => context.putBlob(blobId, value),
+      options,
+    );
+  }
+
+  async deleteBlob(
+    blobId: string,
+    options: DemoWorkspaceMutationOptions = {},
+  ): Promise<DemoWorkspaceCommit> {
+    return this.mutate(
+      (_draft, context) => context.deleteBlob(blobId),
+      options,
+    );
+  }
+
+  async blob(blobId: string): Promise<Blob | null> {
+    this.requireReady();
+    if (!this.authoritativeSnapshot?.blobIds.includes(blobId)) {
+      return null;
+    }
+    try {
+      return await this.store.readBlob(blobId);
+    } catch (error) {
+      const upgrade = upgradeFromError(error);
+      if (upgrade) {
+        this.setUpgrade(upgrade);
+        throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+      }
+      if (!isStorageUnavailable(error)) {
+        throw error;
+      }
+      await this.fallbackFromUnavailable(this.authoritativeSnapshot);
+      return this.store.readBlob(blobId);
+    }
+  }
+
+  async queueScenario(
+    pending: DemoPendingScenario,
+  ): Promise<DemoWorkspaceCommit> {
+    return this.mutate(
+      (draft) => {
+        if (
+          draft.pendingScenarios.some(
+            (scenario) => scenario.scenarioId === pending.scenarioId,
+          )
+        ) {
+          throw new Error(
+            `Demo scenario ${pending.scenarioId} is already pending.`,
+          );
+        }
+        (draft.pendingScenarios as DemoPendingScenario[]).push(pending);
+      },
+      { expectedResetEpoch: pending.resetEpoch },
+    );
+  }
+
+  async reset(): Promise<DemoWorkspaceCommit> {
+    this.requireReady();
+    const confirmed =
+      this.authoritativeSnapshot ?? (await this.readAuthoritativeSnapshot());
+    try {
+      const committed = await this.store.transact((stored, transaction) => {
+        if (!stored) {
+          throw new Error("Demo workspace disappeared during reset.");
+        }
+        throwIfFutureWorkspace(stored);
+        const now = this.clock.now().toISOString();
+        const next = this.makeSeedSnapshot({
+          createdAt: now,
+          resetCount: stored.resetCount + 1,
+          resetEpoch: stored.resetEpoch + 1,
+          revision: stored.revision + 1,
+          lastEventSequence: stored.lastEventSequence,
+        });
+        transaction.clearBlobs();
+        transaction.putSnapshot(next);
+        return next;
+      });
+      this.adoptAuthoritativeSnapshot(committed, true);
+      this.setReady(committed);
+      this.publishLocal("reset", committed);
+      return { kind: "committed", snapshot: committed };
+    } catch (error) {
+      const upgrade = upgradeFromError(error);
+      if (upgrade) {
+        this.setUpgrade(upgrade);
+        throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+      }
+      return this.handleCommitStorageFailure(error, confirmed);
+    }
+  }
+
+  async readEventsForNotification(
+    notification: DemoWorkspaceNotification,
+    afterSequence: number,
+  ): Promise<DemoWorkspaceEventRead> {
+    const snapshot = await this.readAuthoritativeSnapshot();
+    const throughSequence = notification.lastEventSequence;
+    if (throughSequence <= afterSequence) {
+      return { kind: "events", events: [] };
+    }
+    const records = snapshot.eventLog
+      .filter(
+        (record) =>
+          record.sequence > afterSequence &&
+          record.sequence <= throughSequence &&
+          record.resetEpoch === notification.resetEpoch,
+      )
+      .sort((left, right) => left.sequence - right.sequence);
+    let expectedSequence = afterSequence + 1;
+    for (const record of records) {
+      if (record.sequence !== expectedSequence) {
+        return { kind: "event_log_lost" };
+      }
+      expectedSequence += 1;
+    }
+    if (expectedSequence - 1 !== throughSequence) {
+      return { kind: "event_log_lost" };
+    }
+    const events = records.map((record) => {
+      assertDemoDomainEvent(record.event);
+      return record.event;
+    });
+    return { kind: "events", events };
+  }
+
+  async rereadAfterExternalChange(): Promise<DemoWorkspaceSnapshot> {
+    return this.readAuthoritativeSnapshot();
+  }
+
+  dispose(): void {
+    if (this.channel) {
+      this.channel.removeEventListener("message", this.onChannelMessage);
+      this.channel.close();
+    }
+    this.channel = null;
+    this.store.close?.();
+    this.notificationListeners.clear();
+    this.runtimeListeners.clear();
+  }
+
+  private async seed(): Promise<DemoWorkspaceSnapshot> {
+    const candidate = this.makeSeedSnapshot({
+      createdAt: this.clock.now().toISOString(),
+      resetCount: 0,
+      resetEpoch: 0,
+      revision: 0,
+      lastEventSequence: 0,
+    });
+    const committed = await this.store.transact((current, transaction) => {
+      if (current) {
+        throwIfFutureWorkspace(current);
+        return current;
+      }
+      transaction.putSnapshot(candidate);
+      return candidate;
+    });
+    this.adoptAuthoritativeSnapshot(committed, true);
+    if (committed.workspaceId === candidate.workspaceId) {
+      this.publishLocal("commit", committed);
+    }
+    return committed;
+  }
+
+  private async migrate(
+    original: DemoWorkspaceSnapshot,
+  ): Promise<DemoWorkspaceSnapshot> {
+    const originalBlobIds = optionalBlobIds(original);
+    const migratedBlobIds =
+      originalBlobIds ?? [...(await this.store.readAllBlobs()).keys()];
+    const committed = await this.store.transact((stored, transaction) => {
+      if (!stored) {
+        throw new Error("Demo workspace disappeared during migration.");
+      }
+      throwIfFutureWorkspace(stored);
+      if (stored.schemaVersion >= DEMO_WORKSPACE_SCHEMA_VERSION) {
+        return stored;
+      }
+      const migrated: DemoWorkspaceSnapshot = {
+        ...stored,
+        schemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
+        revision: stored.revision + 1,
+        eventLog: stored.eventLog ?? [],
+        blobIds: optionalBlobIds(stored) ?? migratedBlobIds,
+        updatedAt: this.clock.now().toISOString(),
+      };
+      transaction.putSnapshot(migrated);
+      return migrated;
+    });
+    this.adoptAuthoritativeSnapshot(committed, true);
+    if (committed.revision > original.revision) {
+      this.publishLocal("commit", committed);
+    }
+    return committed;
+  }
+
+  private async handleCommitStorageFailure(
+    error: unknown,
+    confirmed: DemoWorkspaceSnapshot,
+  ): Promise<DemoWorkspaceCommit> {
+    if (isQuotaExceeded(error)) {
+      const warning: DemoWorkspaceWarning = {
+        code: "quota_exceeded",
+        message:
+          "Browser storage is full; this tab preserved the last confirmed demo state in memory only.",
+      };
+      const newestDurable = await this.readNewestDurableSnapshot(confirmed);
+      const memorySnapshot = await this.switchToMemory(
+        newestDurable,
+        warning,
+        true,
+      );
+      return {
+        kind: "persistence_warning",
+        snapshot: memorySnapshot,
+        warning,
+      };
+    }
+    if (isStorageUnavailable(error)) {
+      const ready = await this.fallbackFromUnavailable(confirmed);
+      return {
+        kind: "persistence_warning",
+        snapshot: ready.snapshot,
+        warning: ready.warning!,
+      };
+    }
+    throw error;
+  }
+
+  private async readNewestDurableSnapshot(
+    fallback: DemoWorkspaceSnapshot,
+  ): Promise<DemoWorkspaceSnapshot> {
+    try {
+      const snapshot = await this.store.readSnapshot();
+      if (!snapshot) {
+        return fallback;
+      }
+      const upgrade = workspaceUpgrade(snapshot);
+      if (upgrade) {
+        this.setUpgrade(upgrade);
+        throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+      }
+      return snapshot;
+    } catch (error) {
+      if (error instanceof DemoWorkspaceUpgradeRequiredError) {
+        throw error;
+      }
+      const upgrade = upgradeFromError(error);
+      if (upgrade) {
+        this.setUpgrade(upgrade);
+        throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+      }
+      return fallback;
+    }
+  }
+
+  private async fallbackFromUnavailable(
+    confirmed: DemoWorkspaceSnapshot | null,
+  ): Promise<DemoWorkspaceReady> {
+    const warning: DemoWorkspaceWarning = {
+      code: "indexeddb_unavailable",
+      message:
+        "Browser storage is unavailable; this tab will not share or retain demo changes.",
+    };
+    const candidate =
+      confirmed ??
+      this.makeSeedSnapshot({
+        createdAt: this.clock.now().toISOString(),
+        resetCount: 0,
+        resetEpoch: 0,
+        revision: 0,
+        lastEventSequence: 0,
+      });
+    const snapshot = await this.switchToMemory(candidate, warning, true);
+    if (!confirmed) {
+      this.publishLocal("commit", snapshot);
+    }
+    return this.setReady(snapshot);
+  }
+
+  private async fallbackFromQuota(
+    confirmed: DemoWorkspaceSnapshot | null,
+  ): Promise<DemoWorkspaceReady> {
+    const warning: DemoWorkspaceWarning = {
+      code: "quota_exceeded",
+      message:
+        "Browser storage is full; this tab preserved the last confirmed demo state in memory only.",
+    };
+    const candidate =
+      confirmed ??
+      this.makeSeedSnapshot({
+        createdAt: this.clock.now().toISOString(),
+        resetCount: 0,
+        resetEpoch: 0,
+        revision: 0,
+        lastEventSequence: 0,
+      });
+    const snapshot = await this.switchToMemory(candidate, warning, true);
+    if (!confirmed) {
+      this.publishLocal("commit", snapshot);
+    }
+    return this.setReady(snapshot);
+  }
+
+  private async switchToMemory(
+    snapshot: DemoWorkspaceSnapshot,
+    warning: DemoWorkspaceWarning,
+    copyDurableBlobs: boolean,
+  ): Promise<DemoWorkspaceSnapshot> {
+    const durableStore = this.store;
+    let durableBlobs: ReadonlyMap<string, Blob> = new Map();
+    if (copyDurableBlobs) {
+      try {
+        durableBlobs = await durableStore.readAllBlobs();
+      } catch (error) {
+        if (warning.code === "quota_exceeded") {
+          throw error;
+        }
+      }
+    }
+    const declaredBlobIds = optionalBlobIds(snapshot) ?? [
+      ...durableBlobs.keys(),
+    ];
+    const copiedBlobIds = declaredBlobIds.filter((blobId) =>
+      durableBlobs.has(blobId),
+    );
+    const memorySnapshot: DemoWorkspaceSnapshot = {
+      ...snapshot,
+      schemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
+      eventLog: snapshot.eventLog ?? [],
+      blobIds: copiedBlobIds,
+    };
+    if (this.channel) {
+      this.channel.removeEventListener("message", this.onChannelMessage);
+      this.channel.close();
+    }
+    this.channel = null;
+    this.store = this.fallbackStore;
+    this.warning = warning;
+    await this.store.transact((_current, transaction) => {
+      transaction.clearBlobs();
+      for (const blobId of copiedBlobIds) {
+        transaction.putBlob(blobId, durableBlobs.get(blobId)!);
+      }
+      transaction.putSnapshot(memorySnapshot);
+    });
+    durableStore.close?.();
+    this.adoptAuthoritativeSnapshot(memorySnapshot, true);
+    this.setReady(memorySnapshot);
+    return memorySnapshot;
+  }
+
+  private async readAuthoritativeSnapshot(): Promise<DemoWorkspaceSnapshot> {
+    const snapshot = await this.store.readSnapshot();
+    if (!snapshot) {
+      throw new Error("Demo workspace disappeared after initialization.");
+    }
+    const upgrade = workspaceUpgrade(snapshot);
+    if (upgrade) {
+      this.setUpgrade(upgrade);
+      throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+    }
+    this.adoptAuthoritativeSnapshot(snapshot, false);
+    return snapshot;
+  }
+
+  private adoptAuthoritativeSnapshot(
+    snapshot: DemoWorkspaceSnapshot,
+    advanceWatermark: boolean,
+  ): void {
+    this.authoritativeSnapshot = snapshot;
+    if (advanceWatermark) {
+      this.notificationWatermark = watermarkFromSnapshot(snapshot);
+    }
+  }
+
+  private installChannel(): void {
+    if (this.store.storageMode !== "indexeddb" || this.channel) {
+      return;
+    }
+    const channel = this.channelFactory.create();
+    if (!channel) {
+      return;
+    }
+    channel.addEventListener("message", this.onChannelMessage);
+    this.channel = channel;
+  }
+
+  private readonly onChannelMessage = (
+    event: MessageEvent<DemoWorkspaceNotification>,
+  ): void => {
+    const queued = this.broadcastQueue.then(() =>
+      this.handleExternalNotification(event.data),
+    );
+    this.broadcastQueue = queued.catch(async (error: unknown) => {
+      if (error instanceof DemoWorkspaceUpgradeRequiredError) {
+        return;
+      }
+      if (isQuotaExceeded(error)) {
+        await this.fallbackFromQuota(this.authoritativeSnapshot);
+        return;
+      }
+      if (isStorageUnavailable(error)) {
+        await this.fallbackFromUnavailable(this.authoritativeSnapshot);
+      }
+    });
+  };
+
+  private async handleExternalNotification(
+    incoming: DemoWorkspaceNotification,
+  ): Promise<void> {
+    const watermark =
+      this.notificationWatermark ??
+      (this.authoritativeSnapshot
+        ? watermarkFromSnapshot(this.authoritativeSnapshot)
+        : watermarkFromSnapshot(await this.readAuthoritativeSnapshot()));
+
+    if (incoming.resetEpoch < watermark.resetEpoch) {
+      return;
+    }
+    const reset = incoming.resetEpoch > watermark.resetEpoch;
+    if (
+      !reset &&
+      (incoming.workspaceId !== watermark.workspaceId ||
+        incoming.revision <= watermark.revision)
+    ) {
+      return;
+    }
+    const gap = !reset && incoming.revision !== watermark.revision + 1;
+
+    const authoritative = await this.readAuthoritativeSnapshot();
+    if (
+      authoritative.resetEpoch < incoming.resetEpoch ||
+      authoritative.revision < incoming.revision
+    ) {
+      return;
+    }
+
+    if (
+      authoritative.resetEpoch > incoming.resetEpoch ||
+      authoritative.workspaceId !== incoming.workspaceId
+    ) {
+      this.notificationWatermark = watermarkFromSnapshot(authoritative);
+      this.notify({
+        source: "broadcast",
+        kind: "reset",
+        ...watermarkFromSnapshot(authoritative),
+      });
+      return;
+    }
+
+    if (
+      authoritative.revision > incoming.revision ||
+      authoritative.lastEventSequence > incoming.lastEventSequence
+    ) {
+      const authoritativeWatermark = watermarkFromSnapshot(authoritative);
+      this.notificationWatermark = authoritativeWatermark;
+      this.notify({
+        source: "broadcast",
+        kind: "resync",
+        ...authoritativeWatermark,
+      });
+      return;
+    }
+
+    // Advance only the notification watermark. The authoritative snapshot was
+    // replaced by the IDB reread above and is never synthesized from this data.
+    this.notificationWatermark = {
+      workspaceId: incoming.workspaceId,
+      revision: incoming.revision,
+      resetEpoch: incoming.resetEpoch,
+      lastEventSequence: incoming.lastEventSequence,
+    };
+    this.notify({
+      source: "broadcast",
+      kind:
+        reset || incoming.kind === "reset"
+          ? "reset"
+          : gap
+            ? "resync"
+            : "commit",
+      workspaceId: incoming.workspaceId,
+      revision: incoming.revision,
+      resetEpoch: incoming.resetEpoch,
+      lastEventSequence: incoming.lastEventSequence,
+    });
+  }
+
+  private publishLocal(
+    kind: "commit" | "reset",
+    snapshot: DemoWorkspaceSnapshot,
+  ): void {
+    const notification: DemoWorkspaceNotification = {
+      source: "local",
+      kind,
+      workspaceId: snapshot.workspaceId,
+      revision: snapshot.revision,
+      resetEpoch: snapshot.resetEpoch,
+      lastEventSequence: snapshot.lastEventSequence,
+    };
+    this.notificationWatermark = watermarkFromSnapshot(snapshot);
+    this.notify(notification);
+    this.channel?.postMessage(notification);
+  }
+
+  private notify(notification: DemoWorkspaceNotification): void {
+    for (const listener of this.notificationListeners) {
+      listener(notification);
+    }
+  }
+
+  private setReady(snapshot: DemoWorkspaceSnapshot): DemoWorkspaceReady {
+    this.authoritativeSnapshot = snapshot;
+    this.installChannel();
+    const ready: DemoWorkspaceReady = {
+      kind: "ready",
+      snapshot,
+      storageMode: this.store.storageMode,
+      ...(this.warning ? { warning: this.warning } : {}),
+    };
+    this.initialization = ready;
+    this.setRuntimeSnapshot({
+      status: "ready",
+      storageMode: this.store.storageMode,
+      warning: this.warning ?? null,
+    });
+    return ready;
+  }
+
+  private setUpgrade(
+    upgrade: DemoWorkspaceUpgradeRequired,
+  ): DemoWorkspaceUpgradeRequired {
+    this.initialization = upgrade;
+    this.setRuntimeSnapshot({
+      status: "upgrade_required",
+      storageMode: "indexeddb",
+      warning: null,
+      upgrade,
+    });
+    return upgrade;
+  }
+
+  private setRuntimeSnapshot(next: DemoWorkspaceRuntimeSnapshot): void {
+    const current = this.runtimeSnapshot;
+    const unchanged =
+      current.status === next.status &&
+      current.storageMode === next.storageMode &&
+      current.warning?.code === next.warning?.code &&
+      (current.status !== "upgrade_required" ||
+        next.status !== "upgrade_required" ||
+        current.upgrade.message === next.upgrade.message);
+    if (unchanged) {
+      return;
+    }
+    this.runtimeSnapshot = next;
+    for (const listener of this.runtimeListeners) {
+      listener();
+    }
+  }
+
+  private requireReady(): void {
+    if (!this.initialization) {
+      throw new Error("DemoWorkspaceRepository must initialize before use.");
+    }
+    if (this.initialization.kind === "upgrade_required") {
+      throw new DemoWorkspaceUpgradeRequiredError(this.initialization);
+    }
+  }
+
+  private makeSeedSnapshot(input: {
+    readonly createdAt: string;
+    readonly resetCount: number;
+    readonly resetEpoch: number;
+    readonly revision: number;
+    readonly lastEventSequence: number;
+  }): DemoWorkspaceSnapshot {
+    const materialized = materializeDemoSeed(DEMO_SEED, {
+      anchor: input.createdAt,
+    });
+    return {
+      schemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
+      seedVersion: DEMO_SEED.seedVersion,
+      workspaceId: this.createWorkspaceId(),
+      createdAt: input.createdAt,
+      updatedAt: input.createdAt,
+      resetCount: input.resetCount,
+      revision: input.revision,
+      resetEpoch: input.resetEpoch,
+      lastEventSequence: input.lastEventSequence,
+      eventLog: [],
+      blobIds: [],
+      state: {
+        title: materialized.title,
+        generatedAt: materialized.generatedAt,
+        artifacts: materialized.artifacts,
+        readModel: materialized.readModel,
+        routeData: materialized.routeData,
+        receipts: materialized.receipts,
+      },
+      pendingScenarios: [],
+    };
+  }
+}
+
+export const DEMO_WORKSPACE_TENANT = LOCAL_TENANT;
+
+function defaultWorkspaceId(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  return `demo-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function workspaceUpgrade(
+  snapshot: DemoWorkspaceSnapshot,
+): DemoWorkspaceUpgradeRequired | null {
+  return snapshot.schemaVersion > DEMO_WORKSPACE_SCHEMA_VERSION
+    ? {
+        kind: "upgrade_required",
+        scope: "workspace_schema",
+        foundSchemaVersion: snapshot.schemaVersion,
+        supportedSchemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
+        message:
+          "This demo workspace was created by a newer version. Reload after updating the demo.",
+      }
+    : null;
+}
+
+function throwIfFutureWorkspace(snapshot: DemoWorkspaceSnapshot): void {
+  const upgrade = workspaceUpgrade(snapshot);
+  if (upgrade) {
+    throw new DemoWorkspaceUpgradeRequiredError(upgrade);
+  }
+}
+
+function upgradeFromError(error: unknown): DemoWorkspaceUpgradeRequired | null {
+  if (error instanceof DemoWorkspaceUpgradeRequiredError) {
+    return error.upgrade;
+  }
+  if (
+    error instanceof DemoWorkspaceStorageError &&
+    error.kind === "upgrade_required" &&
+    error.foundDatabaseVersion !== undefined
+  ) {
+    return {
+      kind: "upgrade_required",
+      scope: "database_version",
+      foundDatabaseVersion: error.foundDatabaseVersion,
+      supportedDatabaseVersion: DEMO_WORKSPACE_DATABASE_VERSION,
+      message:
+        "This browser database was created by a newer demo version. Reload after updating the demo.",
+    };
+  }
+  return null;
+}
+
+function watermarkFromSnapshot(
+  snapshot: DemoWorkspaceSnapshot,
+): NotificationWatermark {
+  return {
+    workspaceId: snapshot.workspaceId,
+    revision: snapshot.revision,
+    resetEpoch: snapshot.resetEpoch,
+    lastEventSequence: snapshot.lastEventSequence,
+  };
+}
+
+function optionalBlobIds(
+  snapshot: DemoWorkspaceSnapshot,
+): readonly string[] | undefined {
+  const candidate = snapshot as DemoWorkspaceSnapshot & {
+    readonly blobIds?: readonly string[];
+  };
+  return Array.isArray(candidate.blobIds) ? candidate.blobIds : undefined;
+}
+
+function assertDemoDomainEvent(
+  event: unknown,
+): asserts event is DomainEventUnion {
+  const candidate = event as Partial<{
+    eventType: string;
+    tenantId: string;
+    occurredAt: string;
+    payload: unknown;
+  }>;
+  if (
+    typeof event !== "object" ||
+    event === null ||
+    typeof candidate.eventType !== "string" ||
+    !KNOWN_DOMAIN_EVENT_TYPES.has(candidate.eventType) ||
+    candidate.tenantId !== LOCAL_TENANT ||
+    typeof candidate.occurredAt !== "string" ||
+    candidate.occurredAt.length === 0 ||
+    typeof candidate.payload !== "object" ||
+    candidate.payload === null ||
+    Array.isArray(candidate.payload)
+  ) {
+    throw new TypeError(
+      "Demo workspace events must be valid local domain events.",
+    );
+  }
+}
+
+function isQuotaExceeded(error: unknown): boolean {
+  return error instanceof DemoWorkspaceStorageError
+    ? error.kind === "quota"
+    : error instanceof DOMException && error.name === "QuotaExceededError";
+}
+
+function isStorageUnavailable(error: unknown): boolean {
+  return error instanceof DemoWorkspaceStorageError
+    ? error.kind === "unavailable"
+    : error instanceof DOMException && error.name === "SecurityError";
+}
+
+function clone<TValue>(value: TValue): TValue {
+  return structuredClone(value);
+}

--- a/apps/web/src/demo/workspace/DemoWorkspaceScheduler.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceScheduler.ts
@@ -1,0 +1,211 @@
+import type {
+  DemoPendingScenario,
+  DemoWorkspaceSnapshot,
+} from "./contracts.js";
+import {
+  DemoWorkspaceRepository,
+  DemoWorkspaceStaleEpochError,
+  type DemoWorkspaceMutationContext,
+} from "./DemoWorkspaceRepository.js";
+
+export interface DemoSchedulerClock {
+  now(): number;
+  setTimeout(
+    handler: () => void,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout>;
+  clearTimeout(timer: ReturnType<typeof setTimeout>): void;
+}
+
+export type DemoWorkspaceDeadlineHandler = (
+  pending: DemoPendingScenario,
+  draft: DemoWorkspaceSnapshot,
+  context: DemoWorkspaceMutationContext,
+) => void;
+
+const browserSchedulerClock: DemoSchedulerClock = {
+  now: () => Date.now(),
+  setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+/**
+ * P1 persists deterministic deadline metadata only. Deadline handlers run as
+ * synchronous, epoch-fenced workspace mutations; P3 owns their outcome data.
+ */
+export class DemoWorkspaceScheduler {
+  private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly registrations = new Map<
+    string,
+    {
+      readonly pending: DemoPendingScenario;
+      readonly onDeadline: DemoWorkspaceDeadlineHandler;
+    }
+  >();
+  private recoveryHandler: DemoWorkspaceDeadlineHandler | null = null;
+  private reconcileQueue = Promise.resolve();
+  private reconcileGeneration = 0;
+  private disposed = false;
+  private readonly stop: () => void;
+
+  constructor(
+    private readonly workspace: DemoWorkspaceRepository,
+    private readonly clock: DemoSchedulerClock = browserSchedulerClock,
+  ) {
+    this.stop = workspace.subscribe((notification) => {
+      if (notification.kind === "reset") {
+        this.reconcileGeneration += 1;
+        this.clearTimersAndRegistrations();
+      } else if (
+        notification.kind === "resync" ||
+        notification.source === "broadcast"
+      ) {
+        this.clearTimers();
+        this.queueReconcile(++this.reconcileGeneration);
+      }
+    });
+  }
+
+  async schedule(
+    pending: DemoPendingScenario,
+    onDeadline: DemoWorkspaceDeadlineHandler,
+  ): Promise<void> {
+    const result = await this.workspace.queueScenario(pending);
+    if (result.kind === "persistence_warning") {
+      return;
+    }
+    this.arm(pending, onDeadline);
+  }
+
+  async recover(onDeadline: DemoWorkspaceDeadlineHandler): Promise<void> {
+    this.recoveryHandler = onDeadline;
+    await this.reconcile(++this.reconcileGeneration);
+  }
+
+  dispose(): void {
+    this.stop();
+    this.disposed = true;
+    this.reconcileGeneration += 1;
+    this.clearTimersAndRegistrations();
+    this.recoveryHandler = null;
+  }
+
+  private clearTimers(): void {
+    for (const timer of this.timers.values()) {
+      this.clock.clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+
+  private clearTimersAndRegistrations(): void {
+    this.clearTimers();
+    this.registrations.clear();
+  }
+
+  private queueReconcile(generation: number): void {
+    this.reconcileQueue = this.reconcileQueue
+      .then(() => this.reconcile(generation))
+      .catch(() => {
+        // A later workspace notification or explicit recovery can retry. The
+        // safe failure mode is to leave no unfenced deadline callback armed.
+        this.clearTimers();
+      });
+  }
+
+  private async reconcile(generation: number): Promise<void> {
+    const snapshot = await this.workspace.snapshot();
+    if (this.disposed || generation !== this.reconcileGeneration) {
+      return;
+    }
+    const persisted = new Map(
+      snapshot.pendingScenarios.map((pending) => [
+        pending.scenarioId,
+        pending,
+      ]),
+    );
+
+    for (const [scenarioId, registration] of this.registrations) {
+      const current = persisted.get(scenarioId);
+      if (
+        !current ||
+        current.resetEpoch !== snapshot.resetEpoch ||
+        current.resetEpoch !== registration.pending.resetEpoch
+      ) {
+        this.disarm(scenarioId);
+        continue;
+      }
+      this.arm(current, registration.onDeadline);
+      persisted.delete(scenarioId);
+    }
+
+    if (this.recoveryHandler) {
+      for (const pending of persisted.values()) {
+        if (pending.resetEpoch === snapshot.resetEpoch) {
+          this.arm(pending, this.recoveryHandler);
+        }
+      }
+    }
+  }
+
+  private disarm(scenarioId: string): void {
+    const timer = this.timers.get(scenarioId);
+    if (timer) {
+      this.clock.clearTimeout(timer);
+    }
+    this.timers.delete(scenarioId);
+    this.registrations.delete(scenarioId);
+  }
+
+  private arm(
+    pending: DemoPendingScenario,
+    onDeadline: DemoWorkspaceDeadlineHandler,
+  ): void {
+    if (this.disposed) {
+      return;
+    }
+    const previous = this.timers.get(pending.scenarioId);
+    if (previous) {
+      this.clock.clearTimeout(previous);
+    }
+    const deadline = Date.parse(pending.deadlineAt);
+    if (!Number.isFinite(deadline)) {
+      throw new TypeError(
+        `Demo scenario ${pending.scenarioId} has an invalid deadline.`,
+      );
+    }
+    const timer = this.clock.setTimeout(
+      () => {
+        void this.fireIfCurrent(pending, onDeadline);
+      },
+      Math.max(0, deadline - this.clock.now()),
+    );
+    this.timers.set(pending.scenarioId, timer);
+    this.registrations.set(pending.scenarioId, { pending, onDeadline });
+  }
+
+  private async fireIfCurrent(
+    pending: DemoPendingScenario,
+    onDeadline: DemoWorkspaceDeadlineHandler,
+  ): Promise<void> {
+    this.timers.delete(pending.scenarioId);
+    this.registrations.delete(pending.scenarioId);
+    try {
+      await this.workspace.mutate(
+        (draft, context) => {
+          const persisted = draft.pendingScenarios.find(
+            (candidate) => candidate.scenarioId === pending.scenarioId,
+          );
+          if (!persisted || persisted.deadlineAt !== pending.deadlineAt) {
+            return;
+          }
+          onDeadline(persisted, draft, context);
+        },
+        { expectedResetEpoch: pending.resetEpoch },
+      );
+    } catch (error) {
+      if (!(error instanceof DemoWorkspaceStaleEpochError)) {
+        throw error;
+      }
+    }
+  }
+}

--- a/apps/web/src/demo/workspace/channel.ts
+++ b/apps/web/src/demo/workspace/channel.ts
@@ -1,0 +1,29 @@
+import type { DemoWorkspaceNotification } from "./contracts.js";
+
+export interface DemoWorkspaceChannel {
+  postMessage(notification: DemoWorkspaceNotification): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent<DemoWorkspaceNotification>) => void,
+  ): void;
+  removeEventListener(
+    type: "message",
+    listener: (event: MessageEvent<DemoWorkspaceNotification>) => void,
+  ): void;
+  close(): void;
+}
+
+export interface DemoWorkspaceChannelFactory {
+  create(): DemoWorkspaceChannel | null;
+}
+
+const CHANNEL_NAME = "jobctrl-demo-workspace";
+
+export const browserDemoWorkspaceChannelFactory: DemoWorkspaceChannelFactory = {
+  create() {
+    if (typeof BroadcastChannel === "undefined") {
+      return null;
+    }
+    return new BroadcastChannel(CHANNEL_NAME) as DemoWorkspaceChannel;
+  },
+};

--- a/apps/web/src/demo/workspace/contracts.ts
+++ b/apps/web/src/demo/workspace/contracts.ts
@@ -1,0 +1,146 @@
+import type { DomainEventUnion } from "@jobctrl/domain-types";
+
+import type { MaterializedDemoSeed } from "../clock.js";
+import type { DemoReadModel } from "../contracts.js";
+
+export const DEMO_WORKSPACE_DATABASE = "jobctrl-demo";
+export const DEMO_WORKSPACE_DATABASE_VERSION = 1;
+export const DEMO_WORKSPACE_STORE = "workspace";
+export const DEMO_BLOBS_STORE = "blobs";
+export const DEMO_WORKSPACE_SCHEMA_VERSION = 2;
+export const DEMO_WORKSPACE_EVENT_LOG_LIMIT = 128;
+
+export interface DemoPendingScenario {
+  readonly scenarioId: string;
+  readonly deadlineAt: string;
+  readonly resetEpoch: number;
+}
+
+export interface DemoWorkspaceEventRecord {
+  readonly sequence: number;
+  readonly revision: number;
+  readonly resetEpoch: number;
+  readonly event: DomainEventUnion;
+}
+
+/**
+ * The complete mutable browser-local aggregate. Its `state` is the sole
+ * canonical copy of the P0 projection seed; Query is deliberately a cache,
+ * never a second persistence authority.
+ */
+export interface DemoWorkspaceSnapshot {
+  readonly schemaVersion: number;
+  readonly seedVersion: string;
+  readonly workspaceId: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly resetCount: number;
+  readonly revision: number;
+  readonly resetEpoch: number;
+  readonly lastEventSequence: number;
+  readonly eventLog: readonly DemoWorkspaceEventRecord[];
+  /**
+   * Durable blob identifiers owned by this snapshot. Keeping the manifest in
+   * the aggregate lets a memory fallback continue reading confirmed blobs
+   * without resurrecting blobs deleted by a later local mutation or reset.
+   */
+  readonly blobIds: readonly string[];
+  readonly state: {
+    readonly title: string;
+    readonly generatedAt: string;
+    readonly artifacts: MaterializedDemoSeed["artifacts"];
+    readonly readModel: DemoReadModel;
+    readonly routeData: MaterializedDemoSeed["routeData"];
+    readonly receipts: MaterializedDemoSeed["receipts"];
+  };
+  readonly pendingScenarios: readonly DemoPendingScenario[];
+}
+
+export type DemoWorkspaceStorageMode = "indexeddb" | "memory";
+
+export type DemoWorkspaceWarning =
+  | {
+      readonly code: "indexeddb_unavailable";
+      readonly message: "Browser storage is unavailable; this tab will not share or retain demo changes.";
+    }
+  | {
+      readonly code: "quota_exceeded";
+      readonly message: "Browser storage is full; this tab preserved the last confirmed demo state in memory only.";
+    };
+
+export interface DemoWorkspaceReady {
+  readonly kind: "ready";
+  readonly snapshot: DemoWorkspaceSnapshot;
+  readonly storageMode: DemoWorkspaceStorageMode;
+  readonly warning?: DemoWorkspaceWarning;
+}
+
+export type DemoWorkspaceUpgradeRequired =
+  | {
+      readonly kind: "upgrade_required";
+      readonly scope: "workspace_schema";
+      readonly foundSchemaVersion: number;
+      readonly supportedSchemaVersion: number;
+      readonly message: "This demo workspace was created by a newer version. Reload after updating the demo.";
+    }
+  | {
+      readonly kind: "upgrade_required";
+      readonly scope: "database_version";
+      readonly foundDatabaseVersion: number;
+      readonly supportedDatabaseVersion: number;
+      readonly message: "This browser database was created by a newer demo version. Reload after updating the demo.";
+    };
+
+export type DemoWorkspaceInitialization =
+  | DemoWorkspaceReady
+  | DemoWorkspaceUpgradeRequired;
+
+export type DemoWorkspaceCommit =
+  | {
+      readonly kind: "committed";
+      readonly snapshot: DemoWorkspaceSnapshot;
+    }
+  | {
+      readonly kind: "persistence_warning";
+      readonly snapshot: DemoWorkspaceSnapshot;
+      readonly warning: DemoWorkspaceWarning;
+    };
+
+export interface DemoWorkspaceNotification {
+  readonly source: "local" | "broadcast";
+  readonly kind: "commit" | "reset" | "resync";
+  readonly workspaceId: string;
+  readonly revision: number;
+  readonly resetEpoch: number;
+  readonly lastEventSequence: number;
+}
+
+export interface DemoWorkspaceMutationOptions {
+  readonly expectedResetEpoch?: number;
+}
+
+export type DemoWorkspaceRuntimeSnapshot =
+  | {
+      readonly status: "initializing";
+      readonly storageMode: DemoWorkspaceStorageMode;
+      readonly warning: null;
+    }
+  | {
+      readonly status: "ready";
+      readonly storageMode: DemoWorkspaceStorageMode;
+      readonly warning: DemoWorkspaceWarning | null;
+    }
+  | {
+      readonly status: "upgrade_required";
+      readonly storageMode: "indexeddb";
+      readonly warning: null;
+      readonly upgrade: DemoWorkspaceUpgradeRequired;
+    };
+
+export interface DemoWorkspaceClock {
+  now(): Date;
+}
+
+export const systemDemoWorkspaceClock: DemoWorkspaceClock = {
+  now: () => new Date(),
+};

--- a/apps/web/src/demo/workspace/index.ts
+++ b/apps/web/src/demo/workspace/index.ts
@@ -1,0 +1,49 @@
+export { DemoWorkspaceEventStreamAdapter } from "./DemoWorkspaceEventStreamAdapter.js";
+export { DemoWorkspaceNotice } from "./DemoWorkspaceNotice.js";
+export {
+  DemoWorkspaceProvider,
+  useDemoWorkspace,
+} from "./DemoWorkspaceProvider.js";
+export {
+  DemoWorkspaceRepository,
+  DemoWorkspaceStaleEpochError,
+  DemoWorkspaceUpgradeRequiredError,
+} from "./DemoWorkspaceRepository.js";
+export type {
+  DemoWorkspaceEventRead,
+  DemoWorkspaceMutationContext,
+  DemoWorkspaceRepositoryOptions,
+} from "./DemoWorkspaceRepository.js";
+export { DemoWorkspaceScheduler } from "./DemoWorkspaceScheduler.js";
+export {
+  DEMO_BLOBS_STORE,
+  DEMO_WORKSPACE_DATABASE,
+  DEMO_WORKSPACE_DATABASE_VERSION,
+  DEMO_WORKSPACE_EVENT_LOG_LIMIT,
+  DEMO_WORKSPACE_SCHEMA_VERSION,
+  DEMO_WORKSPACE_STORE,
+} from "./contracts.js";
+export type {
+  DemoPendingScenario,
+  DemoWorkspaceClock,
+  DemoWorkspaceCommit,
+  DemoWorkspaceEventRecord,
+  DemoWorkspaceInitialization,
+  DemoWorkspaceMutationOptions,
+  DemoWorkspaceNotification,
+  DemoWorkspaceReady,
+  DemoWorkspaceRuntimeSnapshot,
+  DemoWorkspaceSnapshot,
+  DemoWorkspaceStorageMode,
+  DemoWorkspaceUpgradeRequired,
+  DemoWorkspaceWarning,
+} from "./contracts.js";
+export {
+  DemoWorkspaceStorageError,
+  IndexedDbDemoWorkspaceStore,
+  InMemoryDemoWorkspaceStore,
+} from "./storage.js";
+export type {
+  DemoWorkspaceStore,
+  DemoWorkspaceTransaction,
+} from "./storage.js";

--- a/apps/web/src/demo/workspace/storage.test.ts
+++ b/apps/web/src/demo/workspace/storage.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DEMO_WORKSPACE_DATABASE,
+  DEMO_WORKSPACE_DATABASE_VERSION,
+} from "./contracts.js";
+import { IndexedDbDemoWorkspaceStore } from "./storage.js";
+
+describe("IndexedDbDemoWorkspaceStore", () => {
+  it("opens without a requested version and rejects a future database without writing or downgrading it", async () => {
+    const close = vi.fn();
+    const database = {
+      version: DEMO_WORKSPACE_DATABASE_VERSION + 1,
+      close,
+      objectStoreNames: { contains: () => true },
+    } as unknown as IDBDatabase;
+    const request = { result: database } as IDBOpenDBRequest;
+    const open = vi.fn(() => {
+      queueMicrotask(() => request.onsuccess?.(new Event("success")));
+      return request;
+    });
+    const store = new IndexedDbDemoWorkspaceStore({
+      open,
+    } as unknown as IDBFactory);
+
+    await expect(store.readSnapshot()).rejects.toMatchObject({
+      kind: "upgrade_required",
+      foundDatabaseVersion: DEMO_WORKSPACE_DATABASE_VERSION + 1,
+    });
+    expect(open.mock.calls).toEqual([[DEMO_WORKSPACE_DATABASE]]);
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/demo/workspace/storage.ts
+++ b/apps/web/src/demo/workspace/storage.ts
@@ -1,0 +1,301 @@
+import {
+  DEMO_BLOBS_STORE,
+  DEMO_WORKSPACE_DATABASE,
+  DEMO_WORKSPACE_DATABASE_VERSION,
+  DEMO_WORKSPACE_STORE,
+  type DemoWorkspaceSnapshot,
+  type DemoWorkspaceStorageMode,
+} from "./contracts.js";
+
+const SNAPSHOT_KEY = "current";
+
+export class DemoWorkspaceStorageError extends Error {
+  constructor(
+    readonly kind: "unavailable" | "quota" | "upgrade_required",
+    cause?: unknown,
+    readonly foundDatabaseVersion?: number,
+  ) {
+    super(
+      kind === "quota"
+        ? "Demo workspace storage quota exceeded."
+        : kind === "upgrade_required"
+          ? "Demo workspace database requires a newer application version."
+          : "Demo workspace storage unavailable.",
+      {
+        cause,
+      },
+    );
+    this.name = "DemoWorkspaceStorageError";
+  }
+}
+
+export interface DemoWorkspaceTransaction {
+  putSnapshot(snapshot: DemoWorkspaceSnapshot): void;
+  putBlob(blobId: string, value: Blob): void;
+  deleteBlob(blobId: string): void;
+  clearBlobs(): void;
+}
+
+export interface DemoWorkspaceStore {
+  readonly storageMode: DemoWorkspaceStorageMode;
+  readSnapshot(): Promise<DemoWorkspaceSnapshot | null>;
+  readBlob(blobId: string): Promise<Blob | null>;
+  readAllBlobs(): Promise<ReadonlyMap<string, Blob>>;
+  transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult>;
+  close?(): void;
+}
+
+interface WorkspaceRow {
+  readonly key: typeof SNAPSHOT_KEY;
+  readonly snapshot: DemoWorkspaceSnapshot;
+}
+
+function classifyStorageError(error: unknown): DemoWorkspaceStorageError {
+  if (error instanceof DemoWorkspaceStorageError) {
+    return error;
+  }
+  if (error instanceof DOMException && error.name === "QuotaExceededError") {
+    return new DemoWorkspaceStorageError("quota", error);
+  }
+  return new DemoWorkspaceStorageError("unavailable", error);
+}
+
+/** IndexedDB is the only durable authority for a demo workspace. */
+export class IndexedDbDemoWorkspaceStore implements DemoWorkspaceStore {
+  readonly storageMode = "indexeddb" as const;
+  private databasePromise: Promise<IDBDatabase> | null = null;
+
+  constructor(
+    private readonly indexedDb: IDBFactory | undefined = globalThis.indexedDB,
+  ) {}
+
+  async readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    const database = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = database.transaction(
+        DEMO_WORKSPACE_STORE,
+        "readonly",
+      );
+      const request = transaction
+        .objectStore(DEMO_WORKSPACE_STORE)
+        .get(SNAPSHOT_KEY);
+      request.onsuccess = () =>
+        resolve((request.result as WorkspaceRow | undefined)?.snapshot ?? null);
+      request.onerror = () => reject(classifyStorageError(request.error));
+      transaction.onabort = () =>
+        reject(classifyStorageError(transaction.error));
+    });
+  }
+
+  async readBlob(blobId: string): Promise<Blob | null> {
+    const database = await this.open();
+    return new Promise((resolve, reject) => {
+      const transaction = database.transaction(DEMO_BLOBS_STORE, "readonly");
+      const request = transaction.objectStore(DEMO_BLOBS_STORE).get(blobId);
+      request.onsuccess = () =>
+        resolve((request.result as Blob | undefined) ?? null);
+      request.onerror = () => reject(classifyStorageError(request.error));
+      transaction.onabort = () =>
+        reject(classifyStorageError(transaction.error));
+    });
+  }
+
+  async readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    const database = await this.open();
+    return new Promise((resolve, reject) => {
+      const values = new Map<string, Blob>();
+      const transaction = database.transaction(DEMO_BLOBS_STORE, "readonly");
+      const request = transaction
+        .objectStore(DEMO_BLOBS_STORE)
+        .openCursor();
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          return;
+        }
+        values.set(String(cursor.key), cursor.value as Blob);
+        cursor.continue();
+      };
+      request.onerror = () => reject(classifyStorageError(request.error));
+      transaction.oncomplete = () => resolve(values);
+      transaction.onabort = () =>
+        reject(classifyStorageError(transaction.error));
+    });
+  }
+
+  async transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    const database = await this.open();
+    return new Promise<TResult>((resolve, reject) => {
+      const transaction = database.transaction(
+        [DEMO_WORKSPACE_STORE, DEMO_BLOBS_STORE],
+        "readwrite",
+      );
+      const workspaces = transaction.objectStore(DEMO_WORKSPACE_STORE);
+      const blobs = transaction.objectStore(DEMO_BLOBS_STORE);
+      const request = workspaces.get(SNAPSHOT_KEY);
+      let result: TResult;
+      let operationError: unknown;
+
+      request.onsuccess = () => {
+        try {
+          result = operation(
+            (request.result as WorkspaceRow | undefined)?.snapshot ?? null,
+            {
+              putSnapshot: (snapshot) =>
+                workspaces.put({
+                  key: SNAPSHOT_KEY,
+                  snapshot,
+                } satisfies WorkspaceRow),
+              putBlob: (blobId, value) => blobs.put(value, blobId),
+              deleteBlob: (blobId) => blobs.delete(blobId),
+              clearBlobs: () => blobs.clear(),
+            },
+          );
+        } catch (error) {
+          operationError = error;
+          transaction.abort();
+        }
+      };
+      request.onerror = () => transaction.abort();
+      transaction.oncomplete = () => resolve(result!);
+      transaction.onabort = () =>
+        reject(operationError ?? classifyStorageError(transaction.error));
+      transaction.onerror = () => undefined;
+    });
+  }
+
+  private open(): Promise<IDBDatabase> {
+    if (!this.indexedDb) {
+      return Promise.reject(new DemoWorkspaceStorageError("unavailable"));
+    }
+    if (this.databasePromise) {
+      return this.databasePromise;
+    }
+    const indexedDb = this.indexedDb;
+    this.databasePromise = new Promise<IDBDatabase>((resolve, reject) => {
+      let request: IDBOpenDBRequest;
+      try {
+        // Opening without a requested version can create a missing v1 database,
+        // but can never downgrade or upgrade an existing database. A future
+        // version is inspected read-only and rejected below.
+        request = indexedDb.open(DEMO_WORKSPACE_DATABASE);
+      } catch (error) {
+        reject(classifyStorageError(error));
+        return;
+      }
+      request.onupgradeneeded = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains(DEMO_WORKSPACE_STORE)) {
+          database.createObjectStore(DEMO_WORKSPACE_STORE, { keyPath: "key" });
+        }
+        if (!database.objectStoreNames.contains(DEMO_BLOBS_STORE)) {
+          database.createObjectStore(DEMO_BLOBS_STORE);
+        }
+      };
+      request.onsuccess = () => {
+        const database = request.result;
+        if (database.version > DEMO_WORKSPACE_DATABASE_VERSION) {
+          const foundDatabaseVersion = database.version;
+          database.close();
+          reject(
+            new DemoWorkspaceStorageError(
+              "upgrade_required",
+              undefined,
+              foundDatabaseVersion,
+            ),
+          );
+          return;
+        }
+        if (
+          !database.objectStoreNames.contains(DEMO_WORKSPACE_STORE) ||
+          !database.objectStoreNames.contains(DEMO_BLOBS_STORE)
+        ) {
+          database.close();
+          reject(new DemoWorkspaceStorageError("unavailable"));
+          return;
+        }
+        resolve(database);
+      };
+      request.onerror = () => reject(classifyStorageError(request.error));
+      request.onblocked = () =>
+        reject(new DemoWorkspaceStorageError("unavailable"));
+    });
+    return this.databasePromise;
+  }
+
+  close(): void {
+    void this.databasePromise
+      ?.then((database) => database.close())
+      .catch(() => undefined);
+    this.databasePromise = null;
+  }
+}
+
+/** Tab-local fallback and deterministic test store. It never crosses a channel. */
+export class InMemoryDemoWorkspaceStore implements DemoWorkspaceStore {
+  readonly storageMode = "memory" as const;
+  private readonly blobs = new Map<string, Blob>();
+  private snapshot: DemoWorkspaceSnapshot | null;
+  private queue = Promise.resolve();
+
+  constructor(snapshot: DemoWorkspaceSnapshot | null = null) {
+    this.snapshot = snapshot ? clone(snapshot) : null;
+  }
+
+  async readSnapshot(): Promise<DemoWorkspaceSnapshot | null> {
+    return this.snapshot ? clone(this.snapshot) : null;
+  }
+
+  async readBlob(blobId: string): Promise<Blob | null> {
+    return this.blobs.get(blobId) ?? null;
+  }
+
+  async readAllBlobs(): Promise<ReadonlyMap<string, Blob>> {
+    return new Map(this.blobs);
+  }
+
+  transact<TResult>(
+    operation: (
+      current: DemoWorkspaceSnapshot | null,
+      transaction: DemoWorkspaceTransaction,
+    ) => TResult,
+  ): Promise<TResult> {
+    const run = this.queue.then(() => {
+      let nextSnapshot = this.snapshot ? clone(this.snapshot) : null;
+      const nextBlobs = new Map(this.blobs);
+      const result = operation(nextSnapshot, {
+        putSnapshot: (snapshot) => {
+          nextSnapshot = clone(snapshot);
+        },
+        putBlob: (blobId, value) => nextBlobs.set(blobId, value),
+        deleteBlob: (blobId) => nextBlobs.delete(blobId),
+        clearBlobs: () => nextBlobs.clear(),
+      });
+      this.snapshot = nextSnapshot;
+      this.blobs.clear();
+      for (const [blobId, value] of nextBlobs) {
+        this.blobs.set(blobId, value);
+      }
+      return result;
+    });
+    this.queue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+}
+
+function clone<TValue>(value: TValue): TValue {
+  return structuredClone(value);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,17 +3,11 @@ import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
 import { EventStreamProvider } from "./contexts/operations/providers/EventStreamProvider.js";
-import { ConsoleTelemetryAdapter } from "./shared/adapters/local/ConsoleTelemetryAdapter.js";
-import { FetchApiClientAdapter } from "./shared/adapters/local/FetchApiClientAdapter.js";
-import { LocalSessionAdapter } from "./shared/adapters/local/LocalSessionAdapter.js";
-import { LocalStorageAdapter } from "./shared/adapters/local/LocalStorageAdapter.js";
-import { NavigatorClipboardAdapter } from "./shared/adapters/local/NavigatorClipboardAdapter.js";
-import { OpenArtifactAdapter } from "./shared/adapters/local/OpenArtifactAdapter.js";
-import { SseEventStreamAdapter } from "./shared/adapters/local/SseEventStreamAdapter.js";
-import { StaticFeatureFlagAdapter } from "./shared/adapters/local/StaticFeatureFlagAdapter.js";
+import { createAppComposition, resolveAppMode } from "./demo/portFactory.js";
+import { DemoWorkspaceProvider } from "./demo/workspace/DemoWorkspaceProvider.js";
 import { createQueryClient } from "./shared/lib/queryClient.js";
 import { DensityProvider } from "./shared/providers/DensityProvider.js";
-import { PortsProvider, type Ports } from "./shared/providers/PortsProvider.js";
+import { PortsProvider } from "./shared/providers/PortsProvider.js";
 import { QueryClientProvider } from "./shared/providers/QueryClientProvider.js";
 import { TenantProvider } from "./shared/providers/TenantProvider.js";
 import { ThemeProvider } from "./shared/providers/ThemeProvider.js";
@@ -21,40 +15,50 @@ import { ToasterProvider } from "./shared/providers/ToasterProvider.js";
 import { TooltipProvider } from "./shared/ui/tooltip.js";
 import "./styles/globals.css";
 
-const apiBaseUrl = import.meta.env.VITE_JOBCTRL_API_BASE_URL ?? "";
-const api = new FetchApiClientAdapter(apiBaseUrl);
-
-const ports: Ports = {
-  api,
-  eventStream: new SseEventStreamAdapter(apiBaseUrl),
-  storage: new LocalStorageAdapter("jh:"),
-  session: new LocalSessionAdapter(),
-  clipboard: new NavigatorClipboardAdapter(),
-  openInOs: new OpenArtifactAdapter(api),
-  telemetry: new ConsoleTelemetryAdapter(),
-  featureFlags: new StaticFeatureFlagAdapter(),
-};
-
 const queryClient = createQueryClient();
+const root = createRoot(document.getElementById("root")!);
 
-createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <PortsProvider ports={ports}>
-      <TenantProvider>
-        <QueryClientProvider client={queryClient}>
-          <EventStreamProvider>
-            <ThemeProvider>
-              <DensityProvider>
-                <TooltipProvider>
-                  <ToasterProvider>
-                    <App queryClient={queryClient} />
-                  </ToasterProvider>
-                </TooltipProvider>
-              </DensityProvider>
-            </ThemeProvider>
-          </EventStreamProvider>
-        </QueryClientProvider>
-      </TenantProvider>
-    </PortsProvider>
-  </React.StrictMode>,
-);
+void mount();
+
+async function mount(): Promise<void> {
+  const composition = await createAppComposition({
+    mode: resolveAppMode(import.meta.env.VITE_JOBCTRL_APP_MODE),
+    apiBaseUrl: import.meta.env.VITE_JOBCTRL_API_BASE_URL ?? "",
+  });
+  if (
+    composition.kind === "demo" &&
+    composition.initialization.kind === "upgrade_required"
+  ) {
+    root.render(
+      <main role="alert">
+        <h1>Demo update required</h1>
+        <p>{composition.initialization.message}</p>
+      </main>,
+    );
+    return;
+  }
+  const workspace = composition.kind === "demo" ? composition.workspace : null;
+  root.render(
+    <React.StrictMode>
+      <DemoWorkspaceProvider workspace={workspace}>
+        <PortsProvider ports={composition.ports}>
+          <TenantProvider>
+            <QueryClientProvider client={queryClient}>
+              <EventStreamProvider>
+                <ThemeProvider>
+                  <DensityProvider>
+                    <TooltipProvider>
+                      <ToasterProvider>
+                        <App queryClient={queryClient} />
+                      </ToasterProvider>
+                    </TooltipProvider>
+                  </DensityProvider>
+                </ThemeProvider>
+              </EventStreamProvider>
+            </QueryClientProvider>
+          </TenantProvider>
+        </PortsProvider>
+      </DemoWorkspaceProvider>
+    </React.StrictMode>,
+  );
+}

--- a/apps/web/src/shared/layout/AppShell.tsx
+++ b/apps/web/src/shared/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "@tanstack/react-router";
 
+import { DemoWorkspaceNotice } from "../../demo/workspace/DemoWorkspaceNotice.js";
 import { useDensity } from "../hooks/useDensity.js";
 import { usePageTitle } from "../hooks/usePageTitle.js";
 import { SideRail } from "./SideRail.js";
@@ -12,6 +13,7 @@ export function AppShell() {
     <div className="app-shell" data-density={density}>
       <SideRail />
       <div className="main-shell">
+        <DemoWorkspaceNotice />
         <Topbar />
         <main className="main">
           <Outlet />

--- a/apps/web/src/shared/layout/SideRail.tsx
+++ b/apps/web/src/shared/layout/SideRail.tsx
@@ -17,6 +17,7 @@ import {
 } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
+import { useDemoWorkspace } from "../../demo/workspace/DemoWorkspaceProvider.js";
 import { cn } from "../lib/cn.js";
 import { BrandMark } from "./BrandMark.js";
 import { LegalNotice } from "./LegalNotice.js";
@@ -122,10 +123,17 @@ export function RailNav({ className, onNavigate }: RailNavProps) {
 }
 
 export function LocalModeCard() {
+  const workspace = useDemoWorkspace();
+  const text =
+    workspace.mode === "demo"
+      ? workspace.runtime.storageMode === "indexeddb"
+        ? "Demo mode — shared browser profile"
+        : "Demo mode — this tab only"
+      : "Local mode — all data stays on device";
   return (
     <div className="side-rail__footer">
       <span className="side-rail__status-dot" aria-hidden="true" />
-      <span className="side-rail__footer-text">Local mode — all data stays on device</span>
+      <span className="side-rail__footer-text">{text}</span>
     </div>
   );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -68,6 +68,28 @@ code,
   min-width: 0;
 }
 
+.demo-workspace-notice {
+  position: sticky;
+  top: 0;
+  z-index: 110;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  margin: 12px 16px 0;
+  padding: 10px 12px;
+  border: 1px solid var(--warning);
+  border-radius: calc(var(--radius) * 0.8);
+  background: color-mix(in oklch, var(--warning) 10%, var(--card));
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.demo-workspace-notice strong {
+  color: var(--warning-foreground);
+}
+
 .side-rail {
   position: sticky;
   top: 0;

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -137,6 +137,28 @@ launcher restarts instead of disappearing when the process exits. With Temporal
 running, `jobctrl doctor` reports `Temporal: reachable`. The Vite web dev
 server proxies `/v1/*` to the TypeScript API by default.
 
+### Public demo browser workspace
+
+Run the frontend-only public demo with synthetic data and no JobCtrl API,
+Temporal, worker, SSE, or host-OS integration:
+
+```bash
+VITE_JOBCTRL_APP_MODE=demo corepack pnpm web:dev
+```
+
+Only the exact value `demo` selects this composition. A missing or invalid
+`VITE_JOBCTRL_APP_MODE` keeps the normal local composition, so a mistyped value
+cannot produce a partially mounted app.
+
+The demo workspace persists in IndexedDB and is shared by tabs and people using
+the same browser profile. Separate browser profiles and private/incognito
+contexts are isolated. Reset rotates the workspace identity, clears pending
+demo actions, and deletes generated demo blobs in the same transaction. If
+IndexedDB is unavailable or full, the page warns that it has switched to
+tab-local memory; those fallback changes are neither shared nor retained after
+the tab closes. The demo contains synthetic data, but visitors should still not
+enter personal data or secrets.
+
 ## Verify
 
 ```bash
@@ -153,6 +175,7 @@ pnpm api:check
 pnpm api:test
 pnpm web:check
 pnpm web:build
+corepack pnpm --filter @jobctrl/web e2e:demo-workspace
 pnpm scripts:test
 pnpm qa:test
 pnpm extension:check

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -16,6 +16,7 @@ changed, then add a browser/product-path check for user-visible behavior.
 | Web UI | `corepack pnpm web:check`, `corepack pnpm --filter @jobctrl/web test`, and `corepack pnpm web:build` |
 | Frontend types | `corepack pnpm --filter @jobctrl/web test-d` |
 | Browser flow | `corepack pnpm --filter @jobctrl/web e2e -- tests/<flow>.spec.ts` |
+| Public demo browser workspace | `corepack pnpm --filter @jobctrl/web e2e:demo-workspace` |
 | Python worker | `uv --project workers/automation run --extra dev ruff check .` and `uv --project workers/automation run --extra dev pytest -q` |
 | Any patch | `git diff --check` |
 
@@ -64,6 +65,16 @@ Frontend verification has four distinct jobs: logic/type correctness,
 component accessibility, route-level browser behavior, and visual consistency.
 The [Frontend QA guide](developer/qa/frontend.md) gives the commands and the
 [Browser Smoke guide](developer/qa/browser-smoke.md) gives the user paths.
+
+The dedicated demo-workspace Playwright lane starts Vite only; it must not
+start or contact the product API or SSE endpoint. It proves same-profile tab
+sharing and concurrent writes, separate-context isolation, reload persistence,
+atomic reset/blob deletion, future IndexedDB-version refusal without downgrade,
+and post-commit domain-event delivery. Unit and component tests cover injected
+quota/security fallbacks, schema revalidation, reset-epoch races, event-log
+loss, the reactive data-boundary warning, and the unchanged canonical event
+provider/invalidation router. Playwright artifacts are written outside the
+repository under the system temporary directory.
 
 <a id="token-foundation-qa-gate"></a>
 <a id="shared-primitive-qa-gate"></a>


### PR DESCRIPTION
## Summary

- adds an explicit local/demo composition root while preserving the existing local adapters for local and invalid modes
- adds a versioned IndexedDB demo workspace with atomic mutations, generated-blob ownership, migrations, browser-profile sharing, tab-local fallback, deterministic reset, and typed runtime warnings
- adds BroadcastChannel post-commit coordination backed by authoritative storage rereads and the existing domain-event/invalidation path
- adds an epoch-fenced deterministic deadline scheduler for later scenario slices
- makes Demo mode and its browser-profile/personal-data boundary persistently visible, including on mobile
- adds a committed native Playwright lane for persistence, profile isolation, reset/blob deletion, future-database refusal, event ordering, and product-network isolation
- documents the browser workspace development and QA contract

## Why

The public demo needs an isolated browser-local authority before read adapters or simulated workflows can become interactive. This slice establishes that authority without exposing the local API, SSE endpoint, filesystem, host OS, or any external product capability.

## Validation

- focused workspace/adapter/composition suite: 5 files, 38 tests
- full web Vitest suite: 230 files, 1,289 tests
- `corepack pnpm web:check`
- web type-level suite: 11 files, 13 tests, no type errors
- `corepack pnpm --filter @jobctrl/web e2e:demo-workspace`: 6/6 Chromium tests
- `corepack pnpm web:build`
- `corepack pnpm docs:build`
- `corepack pnpm docs:check:runtime`
- `python3 scripts/release_check.py`
- tracked and untracked whitespace checks
- independent review gate: PASS (0 Blocker, 0 High, 1 Medium)
- independent QA gate: PASS (0 findings)

## Known follow-up

A stale failed scheduler reconciliation can still clear timers armed by a newer generation because its rejection handler is not generation-fenced. This is non-blocking for the P1 scaffold and is the first required acceptance item for P3, where deterministic workflow scenarios begin using the scheduler.

## Stack

- Base plan: #407
- P0 contract and canonical seed: #408
- This PR: P1 browser workspace
- Next: P2 complete read adapter