### PR TITLE
feat(demo): add complete read adapter

### DIFF
--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -73,6 +73,88 @@ test("demo shell renders the shared-profile and personal-data boundary without p
   expect(productRequests).toEqual([]);
 });
 
+test("every P2 product route and seeded deep link renders populated across direct refreshes", async ({
+  page,
+  context,
+}) => {
+  const productRequests: string[] = [];
+  const externalRequests: string[] = [];
+  const runtimeErrors: string[] = [];
+  context.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname.startsWith("/v1/")) {
+      productRequests.push(url.pathname);
+    }
+    if (url.origin !== "http://127.0.0.1:5198") {
+      externalRequests.push(request.url());
+    }
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+
+  const routes = [
+    ["/dashboard", "Dashboard", "3 jobs"],
+    ["/jobs", "Jobs", "Platform systems lead"],
+    ["/jobs/job-northwind-platform", "Jobs", "Preparation diagnostics"],
+    ["/evidence-map", "Career evidence map", "Delivery improvement evidence"],
+    ["/artifacts", "Artifacts", "Platform systems lead"],
+    ["/artifacts/artifact-tailored-resume", "Artifacts", "Artifact details"],
+    [
+      "/apply-review?jobKey=job-northwind-platform",
+      "Application review",
+      "Materials ready",
+    ],
+    ["/runs", "Workflow runs", "Platform systems lead"],
+    ["/runs/run-materials-progress", "Workflow runs", "Run details"],
+    ["/analytics", "Outcome analytics", "bundled-capture"],
+    ["/profile", "Profile", "Baseline resume editor"],
+    ["/settings", "Settings", "Config"],
+    ["/settings/credentials", "Settings", "OpenAI API Key"],
+    ["/outreach", "Contacts", "Synthetic hiring partner"],
+    [
+      "/outreach/contact-demo-hiring-partner",
+      "Contacts",
+      "Facts and provenance",
+    ],
+    ["/discovery", "Discovery", "Bundled synthetic source"],
+    ["/pipelines", "Pipelines", "Configuring"],
+    ["/debug", "Debug", "Synthetic score recorded."],
+    [
+      "/activity/event-demo-score",
+      "Activity details",
+      "Event details",
+      "dialog",
+    ],
+  ] as const;
+
+  for (const [route, identity, populatedText, role = "heading"] of routes) {
+    await page.goto(STATIC_HOST);
+    await page.goto(route);
+    const identityLocator =
+      role === "dialog"
+        ? page.getByRole("dialog", { name: identity })
+        : page.getByRole("heading", { name: identity }).first();
+    await expect(identityLocator).toBeVisible();
+    await expect(
+      page.getByText(populatedText, { exact: false }).first(),
+    ).toBeVisible();
+    expect(page.url()).toContain(route);
+
+    await page.reload();
+    await expect(
+      role === "dialog"
+        ? page.getByRole("dialog", { name: identity })
+        : page.getByRole("heading", { name: identity }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText(populatedText, { exact: false }).first(),
+    ).toBeVisible();
+  }
+
+  expect(runtimeErrors).toEqual([]);
+  expect(productRequests).toEqual([]);
+  expect(externalRequests).toEqual([]);
+});
+
 test("same-context tabs share, serialize concurrent writes, and survive reload without product network", async ({
   page,
   context,

--- a/apps/web/src/demo/DemoApiClientAdapter.test.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.test.ts
@@ -1,0 +1,818 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  JOB_SORT_FIELDS,
+  type ActivityEventSummary,
+  type ArtifactDetail,
+  type JobCompensationSummary,
+  type JobSummary,
+} from "@jobctrl/contracts";
+
+import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
+import { DEMO_CAPABILITY_MANIFEST } from "./capabilities.js";
+import {
+  DemoApiClientAdapter,
+  DemoResourceNotFoundError,
+} from "./DemoApiClientAdapter.js";
+import { DemoCapabilityError } from "./ports.js";
+import {
+  DemoWorkspaceRepository,
+  InMemoryDemoWorkspaceStore,
+} from "./workspace/index.js";
+
+async function createAdapter(): Promise<{
+  adapter: DemoApiClientAdapter;
+  repository: DemoWorkspaceRepository;
+}> {
+  const repository = new DemoWorkspaceRepository({
+    store: new InMemoryDemoWorkspaceStore(),
+    clock: { now: () => new Date("2026-07-11T09:00:00.000Z") },
+    createWorkspaceId: () => "workspace-adapter-test",
+  });
+  await repository.initialize();
+  return { adapter: new DemoApiClientAdapter(repository), repository };
+}
+
+function compensationSummary(
+  options: {
+    postedState?: JobCompensationSummary["posted"]["parseState"];
+    postedAmount?: number;
+    legacyRawSalary?: string | null;
+    marketRecordStatus?: JobCompensationSummary["market"]["recordStatus"];
+    marketState?: JobCompensationSummary["market"]["estimateState"];
+    marketAmount?: number;
+    confidenceBand?: JobCompensationSummary["market"]["confidenceBand"];
+    confidenceScore?: number | null;
+    warningCount?: number;
+  } = {},
+): JobCompensationSummary {
+  const range = (amount: number) => ({
+    currency: "EUR",
+    period: "year",
+    component: "base_salary",
+    minimumAmount: amount,
+    maximumAmount: amount + 1,
+    annualizedMinimumAmount: amount,
+    annualizedMaximumAmount: amount + 1,
+    annualizedMinimumEur: amount,
+    annualizedMaximumEur: amount + 1,
+    displayRange: `€${amount}–€${amount + 1}`,
+  });
+  const postedRange =
+    options.postedAmount === undefined ? null : range(options.postedAmount);
+  const marketRange =
+    options.marketAmount === undefined ? null : range(options.marketAmount);
+  return {
+    projectionVersion: 1,
+    legacyRawSalary: options.legacyRawSalary ?? null,
+    warningCount: options.warningCount ?? 0,
+    posted: {
+      sourceKind: "posted",
+      recordStatus: "recorded",
+      parseState: options.postedState ?? "parsed_range",
+      confidence: postedRange ? "high" : "none",
+      warningCount: 0,
+      range: postedRange,
+      displayRange: postedRange?.displayRange ?? null,
+    },
+    market: {
+      sourceKind: "reported_company_role_market",
+      recordStatus: options.marketRecordStatus ?? "recorded",
+      estimateState: options.marketState ?? "estimated_range",
+      confidenceBand: options.confidenceBand ?? "none",
+      confidenceScore: options.confidenceScore ?? null,
+      sourceCount: 0,
+      sampleCount: null,
+      warningCount: 0,
+      range: marketRange,
+      displayRange: marketRange?.displayRange ?? null,
+      confidenceInterval: null,
+      displayConfidenceInterval: null,
+    },
+  };
+}
+
+async function replaceJobs(
+  repository: DemoWorkspaceRepository,
+  jobs: JobSummary[],
+): Promise<void> {
+  await repository.mutate((draft) => {
+    draft.state.readModel.jobs.list.items = jobs;
+  });
+}
+
+const READ_CASES = [
+  ["health", (api: ApiClientPort) => api.health()],
+  ["dashboardSummary", (api: ApiClientPort) => api.dashboardSummary()],
+  ["outcomeAnalytics", (api: ApiClientPort) => api.outcomeAnalytics()],
+  ["digest", (api: ApiClientPort) => api.digest()],
+  ["activity", (api: ApiClientPort) => api.activity()],
+  [
+    "activityEvent",
+    (api: ApiClientPort) => api.activityEvent("event-demo-score"),
+  ],
+  ["discoverySettings", (api: ApiClientPort) => api.discoverySettings()],
+  ["discoverySources", (api: ApiClientPort) => api.discoverySources()],
+  [
+    "discoverySourcePreview",
+    (api: ApiClientPort) => api.discoverySourcePreview("demo-source:northwind"),
+  ],
+  ["compensationSources", (api: ApiClientPort) => api.compensationSources()],
+  [
+    "discoveryLocatorCandidates",
+    (api: ApiClientPort) => api.discoveryLocatorCandidates(),
+  ],
+  ["discoveryQuarantine", (api: ApiClientPort) => api.discoveryQuarantine()],
+  ["manualCaptureQueue", (api: ApiClientPort) => api.manualCaptureQueue()],
+  [
+    "roleMatchFeedbackSuggestions",
+    (api: ApiClientPort) => api.roleMatchFeedbackSuggestions(),
+  ],
+  ["applyReviewQueue", (api: ApiClientPort) => api.applyReviewQueue()],
+  [
+    "resumeReviewDraft",
+    (api: ApiClientPort) => api.resumeReviewDraft("job-northwind-platform"),
+  ],
+  [
+    "resumeReviewFeedback",
+    (api: ApiClientPort) => api.resumeReviewFeedback("job-northwind-platform"),
+  ],
+  ["resumeTemplates", (api: ApiClientPort) => api.resumeTemplates()],
+  [
+    "resumeTemplate",
+    (api: ApiClientPort) => api.resumeTemplate("demo-template"),
+  ],
+  ["applicationOutcomes", (api: ApiClientPort) => api.applicationOutcomes()],
+  [
+    "jobApplicationOutcomes",
+    (api: ApiClientPort) =>
+      api.jobApplicationOutcomes("job-northwind-platform"),
+  ],
+  ["jobs", (api: ApiClientPort) => api.jobs()],
+  ["job", (api: ApiClientPort) => api.job("job-northwind-platform")],
+  ["evidenceMap", (api: ApiClientPort) => api.evidenceMap()],
+  ["workflowRuns", (api: ApiClientPort) => api.workflowRuns()],
+  [
+    "workflowRun",
+    (api: ApiClientPort) => api.workflowRun("run-materials-progress"),
+  ],
+  ["artifacts", (api: ApiClientPort) => api.artifacts()],
+  [
+    "artifact",
+    (api: ApiClientPort) => api.artifact("artifact-tailored-resume"),
+  ],
+  [
+    "artifactPreviewPdfUrl",
+    (api: ApiClientPort) =>
+      api.artifactPreviewPdfUrl("artifact-tailored-resume", 7),
+  ],
+  [
+    "artifactPreviewHtmlUrl",
+    (api: ApiClientPort) =>
+      api.artifactPreviewHtmlUrl("artifact-tailored-resume", 7),
+  ],
+  ["profile", (api: ApiClientPort) => api.profile()],
+  ["profilePreviewPdfUrl", (api: ApiClientPort) => api.profilePreviewPdfUrl(7)],
+  [
+    "profilePreviewHtmlUrl",
+    (api: ApiClientPort) => api.profilePreviewHtmlUrl(7),
+  ],
+  ["settings", (api: ApiClientPort) => api.settings()],
+  ["credentials", (api: ApiClientPort) => api.credentials()],
+  ["listContacts", (api: ApiClientPort) => api.listContacts()],
+  [
+    "contact",
+    (api: ApiClientPort) => api.contact("contact-demo-hiring-partner"),
+  ],
+  ["researchTasks", (api: ApiClientPort) => api.researchTasks()],
+  [
+    "researchTask",
+    (api: ApiClientPort) => api.researchTask("research-demo-hiring-partner"),
+  ],
+  [
+    "outreachThread",
+    (api: ApiClientPort) => api.outreachThread("contact-demo-hiring-partner"),
+  ],
+  ["dueOutreachFollowUps", (api: ApiClientPort) => api.dueOutreachFollowUps()],
+] as const satisfies readonly (readonly [
+  keyof ApiClientPort,
+  (api: ApiClientPort) => unknown,
+])[];
+
+const READ_METHODS = new Set<keyof ApiClientPort>(
+  READ_CASES.map(([method]) => method),
+);
+
+describe("DemoApiClientAdapter", () => {
+  it("covers every port member with a populated read or an intentional mutation error", async () => {
+    const { adapter } = await createAdapter();
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      for (const [method, invoke] of READ_CASES) {
+        const result = await invoke(adapter);
+        expect(result, method).not.toBeNull();
+        expect(result, method).not.toBeUndefined();
+        if (typeof result === "string") {
+          expect(result, method).toMatch(/^\/demo\/[^\\]+/);
+          expect(result, method).not.toContain("://");
+          expect(result, method).not.toContain("..");
+        }
+      }
+
+      const manifestMethods = Object.keys(
+        DEMO_CAPABILITY_MANIFEST,
+      ) as (keyof ApiClientPort)[];
+      const mutationMethods = manifestMethods.filter(
+        (method) => !READ_METHODS.has(method),
+      );
+      expect([...READ_METHODS, ...mutationMethods].toSorted()).toEqual(
+        manifestMethods.toSorted(),
+      );
+      for (const method of mutationMethods) {
+        const invoke = adapter[method] as unknown as (
+          ...args: unknown[]
+        ) => unknown;
+        await expect(
+          Promise.resolve().then(() => invoke()),
+        ).rejects.toMatchObject({
+          name: "DemoCapabilityError",
+          code: "demo_capability_not_implemented",
+          message: expect.stringContaining(String(method)),
+        });
+      }
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("reads fresh immutable snapshots instead of exposing or caching repository authority", async () => {
+    const { adapter, repository } = await createAdapter();
+    const first = await adapter.jobs();
+    first.items[0]!.title = "caller mutation";
+    expect((await adapter.jobs()).items[0]!.title).not.toBe("caller mutation");
+
+    await repository.mutate((draft) => {
+      draft.state.readModel.jobs.details["job-northwind-platform"]!.job.title =
+        "authoritative update";
+    });
+    expect((await adapter.job("job-northwind-platform")).job.title).toBe(
+      "authoritative update",
+    );
+  });
+
+  it("resolves synchronous previews only from current repository authority", async () => {
+    const { adapter, repository } = await createAdapter();
+    expect(adapter.artifactPreviewPdfUrl("artifact-tailored-resume")).toBe(
+      "/demo/tailored-resume.pdf",
+    );
+
+    await repository.mutate((draft) => {
+      const artifacts = draft.state.artifacts as unknown as {
+        profileResumePdf: { url: `/demo/${string}` };
+        tailoredResumePdf: { url: `/demo/${string}` };
+      };
+      artifacts.profileResumePdf.url = "/demo/profile-replaced.pdf";
+      artifacts.tailoredResumePdf.url = "/demo/generated-resume.pdf";
+      const details = draft.state.readModel.materials
+        .details as unknown as Record<string, ArtifactDetail>;
+      details["artifact-tailored-resume"]!.artifact.localPath =
+        "/demo/generated-resume.pdf";
+    });
+    expect(adapter.profilePreviewPdfUrl()).toBe("/demo/profile-replaced.pdf");
+    expect(adapter.artifactPreviewPdfUrl("artifact-tailored-resume")).toBe(
+      "/demo/generated-resume.pdf",
+    );
+
+    await repository.mutate((draft) => {
+      const details = draft.state.readModel.materials
+        .details as unknown as Record<string, ArtifactDetail>;
+      delete details["artifact-tailored-resume"];
+    });
+    expect(() =>
+      adapter.artifactPreviewPdfUrl("artifact-tailored-resume"),
+    ).toThrow(DemoResourceNotFoundError);
+
+    await repository.reset();
+    expect(adapter.artifactPreviewPdfUrl("artifact-tailored-resume")).toBe(
+      "/demo/tailored-resume.pdf",
+    );
+    expect(adapter.profilePreviewPdfUrl()).toBe("/demo/profile-resume.pdf");
+
+    await repository.mutate((draft) => {
+      const details = draft.state.readModel.materials
+        .details as unknown as Record<string, ArtifactDetail>;
+      const generated = structuredClone(details["artifact-tailored-resume"]!);
+      generated.artifact.artifactId = "artifact-generated";
+      generated.artifact.localPath = "/demo/generated-new.pdf";
+      details["artifact-generated"] = generated;
+    });
+    expect(() => adapter.artifactPreviewPdfUrl("artifact-generated")).toThrow(
+      expect.objectContaining({
+        code: "artifact_preview_not_found",
+        status: 404,
+      }),
+    );
+
+    await repository.mutate((draft) => {
+      const artifacts = draft.state.artifacts as unknown as {
+        tailoredResumePdf: { url: `/demo/${string}` };
+      };
+      artifacts.tailoredResumePdf.url = "/demo/generated-new.pdf";
+    });
+    expect(adapter.artifactPreviewPdfUrl("artifact-generated")).toBe(
+      "/demo/generated-new.pdf",
+    );
+  });
+
+  it("keeps openArtifact unavailable until the P3 rehearsal owns it", async () => {
+    const { adapter } = await createAdapter();
+    await expect(
+      adapter.openArtifact("artifact-tailored-resume"),
+    ).rejects.toMatchObject({
+      name: "DemoCapabilityError",
+      code: "demo_capability_not_implemented",
+      message: expect.stringContaining("openArtifact"),
+    });
+  });
+
+  it("matches production job filters, sorting, pagination, and filter metadata", async () => {
+    const { adapter } = await createAdapter();
+    const filtered = await adapter.jobs({
+      q: "systems",
+      company: "fabrikam",
+      source: "northwind",
+      minFitScore: 7,
+      maxFitScore: 7,
+      stage: "score",
+      state: "succeeded",
+      sort: "title",
+      dir: "asc",
+      page: 3,
+      pageSize: 1,
+    });
+    expect(filtered.items.map((job) => job.jobKey)).toEqual([
+      "job-fabrikam-systems",
+    ]);
+    expect(filtered.pagination).toEqual({
+      page: 1,
+      pageSize: 1,
+      total: 1,
+      pages: 1,
+    });
+    expect(filtered.sort).toEqual({ field: "title", dir: "asc" });
+    expect(filtered.filter).toMatchObject({
+      q: "systems",
+      company: "fabrikam",
+      source: "northwind",
+      minFitScore: 7,
+      maxFitScore: 7,
+      stage: "score",
+      state: "succeeded",
+      deleted: "active",
+    });
+
+    const page = await adapter.jobs({
+      sort: "fit_score",
+      dir: "desc",
+      page: 2,
+      pageSize: 1,
+    });
+    expect(page.items.map((job) => job.jobKey)).toEqual([
+      "job-fabrikam-systems",
+    ]);
+    expect(page.pagination).toEqual({
+      page: 2,
+      pageSize: 1,
+      total: 3,
+      pages: 3,
+    });
+  });
+
+  it("matches every production job sort arm and stable key tie-break", async () => {
+    const { adapter, repository } = await createAdapter();
+    const base = repository.snapshotNow().state.readModel.jobs.list.items[0]!;
+    const low: JobSummary = {
+      ...structuredClone(base),
+      jobKey: "sort-low",
+      discoveredAt: "2026-01-01T00:00:00.000Z",
+      title: "apple",
+      company: "alpha",
+      source: "alpha",
+      discoverySource: "alpha",
+      postingSource: "",
+      location: "alpha",
+      fitScore: 1,
+      currentStage: "apply",
+      currentSubstage: "apply",
+      currentState: "failed",
+      applyStatus: null,
+      salary: "",
+      compensationSummary: compensationSummary({
+        postedAmount: 10,
+        marketAmount: 10,
+        confidenceBand: "low",
+        confidenceScore: 0.2,
+        warningCount: 0,
+      }),
+    };
+    const high: JobSummary = {
+      ...structuredClone(base),
+      jobKey: "sort-high",
+      discoveredAt: "2026-02-01T00:00:00.000Z",
+      title: "Zulu",
+      company: "Zulu",
+      source: "zulu",
+      discoverySource: "zulu",
+      postingSource: "",
+      location: "Zulu",
+      fitScore: 9,
+      currentStage: "tailor",
+      currentSubstage: "tailor",
+      currentState: "succeeded",
+      applyStatus: "applied",
+      salary: "",
+      compensationSummary: compensationSummary({
+        postedAmount: 20,
+        marketAmount: 20,
+        confidenceBand: "high",
+        confidenceScore: 0.9,
+        warningCount: 2,
+      }),
+    };
+    await replaceJobs(repository, [high, low]);
+
+    for (const sort of JOB_SORT_FIELDS) {
+      const result = await adapter.jobs({
+        sort,
+        dir: "asc",
+        deleted: "all",
+      });
+      expect(
+        result.items.map((job) => job.jobKey),
+        sort,
+      ).toEqual(["sort-low", "sort-high"]);
+    }
+
+    const tiedHighKey = { ...structuredClone(low), jobKey: "z-key" };
+    const tiedLowKey = { ...structuredClone(low), jobKey: "a-key" };
+    await replaceJobs(repository, [tiedHighKey, tiedLowKey]);
+    expect(
+      (
+        await adapter.jobs({
+          sort: "title",
+          dir: "desc",
+          deleted: "all",
+        })
+      ).items.map((job) => job.jobKey),
+    ).toEqual(["a-key", "z-key"]);
+  });
+
+  it("matches production compensation state and confidence-band ordering", async () => {
+    const { adapter, repository } = await createAdapter();
+    const base = repository.snapshotNow().state.readModel.jobs.list.items[0]!;
+    const job = (
+      jobKey: string,
+      summary: JobCompensationSummary | null,
+      salary = "",
+    ): JobSummary => ({
+      ...structuredClone(base),
+      jobKey,
+      title: jobKey,
+      salary,
+      compensationSummary: summary,
+    });
+
+    await replaceJobs(repository, [
+      job("posted-numeric", compensationSummary({ postedAmount: 10 })),
+      job("posted-fallback", null, "salary supplied"),
+      job(
+        "posted-ambiguous",
+        compensationSummary({ postedState: "ambiguous" }),
+      ),
+      job(
+        "posted-unparseable",
+        compensationSummary({ postedState: "unparseable" }),
+      ),
+      job("posted-missing", compensationSummary({ postedState: "missing" })),
+      job("posted-none", null),
+    ]);
+    expect(
+      (
+        await adapter.jobs({
+          sort: "compensation_posted",
+          dir: "asc",
+          deleted: "all",
+        })
+      ).items.map((item) => item.jobKey),
+    ).toEqual([
+      "posted-none",
+      "posted-missing",
+      "posted-unparseable",
+      "posted-ambiguous",
+      "posted-fallback",
+      "posted-numeric",
+    ]);
+
+    await replaceJobs(repository, [
+      job("market-numeric", compensationSummary({ marketAmount: 10 })),
+      job(
+        "market-estimated",
+        compensationSummary({ marketState: "estimated_range" }),
+      ),
+      job(
+        "market-insufficient",
+        compensationSummary({ marketState: "insufficient_evidence" }),
+      ),
+      job(
+        "market-unavailable",
+        compensationSummary({ marketState: "source_unavailable" }),
+      ),
+      job(
+        "market-unsupported",
+        compensationSummary({ marketState: "unsupported" }),
+      ),
+      job(
+        "market-none",
+        compensationSummary({
+          marketRecordStatus: "not_requested",
+          marketState: "not_requested",
+        }),
+      ),
+    ]);
+    expect(
+      (
+        await adapter.jobs({
+          sort: "compensation_market",
+          dir: "asc",
+          deleted: "all",
+        })
+      ).items.map((item) => item.jobKey),
+    ).toEqual([
+      "market-none",
+      "market-unsupported",
+      "market-unavailable",
+      "market-insufficient",
+      "market-estimated",
+      "market-numeric",
+    ]);
+
+    await replaceJobs(repository, [
+      job(
+        "confidence-score",
+        compensationSummary({ confidenceBand: "none", confidenceScore: 0.95 }),
+      ),
+      job("confidence-high", compensationSummary({ confidenceBand: "high" })),
+      job(
+        "confidence-medium",
+        compensationSummary({ confidenceBand: "medium" }),
+      ),
+      job("confidence-low", compensationSummary({ confidenceBand: "low" })),
+      job("confidence-none", compensationSummary({ confidenceBand: "none" })),
+      job(
+        "confidence-unrequested",
+        compensationSummary({
+          marketRecordStatus: "not_requested",
+          marketState: "not_requested",
+        }),
+      ),
+    ]);
+    expect(
+      (
+        await adapter.jobs({
+          sort: "compensation_confidence",
+          dir: "asc",
+          deleted: "all",
+        })
+      ).items.map((item) => item.jobKey),
+    ).toEqual([
+      "confidence-unrequested",
+      "confidence-none",
+      "confidence-low",
+      "confidence-medium",
+      "confidence-high",
+      "confidence-score",
+    ]);
+  });
+
+  it("matches activity, artifact, run, contact, and research query semantics", async () => {
+    const { adapter } = await createAdapter();
+    await expect(
+      adapter.activity({ q: "score", level: "INFO", eventType: "jobscored" }),
+    ).resolves.toMatchObject({
+      pagination: { total: 1 },
+      items: [{ eventId: "event-demo-score" }],
+    });
+    await expect(adapter.activity({ stage: "apply" })).resolves.toMatchObject({
+      pagination: { page: 1, total: 0, pages: 1 },
+      items: [],
+    });
+
+    const artifacts = await adapter.artifacts({
+      q: "resume",
+      status: "accepted",
+      type: "tailored_resume",
+      sort: "type",
+      dir: "asc",
+      page: 2,
+      pageSize: 1,
+    });
+    expect(artifacts.items.map((artifact) => artifact.artifactId)).toEqual([
+      "artifact-tailored-resume-html",
+    ]);
+    expect(artifacts.pagination).toEqual({
+      page: 1,
+      pageSize: 1,
+      total: 1,
+      pages: 1,
+    });
+
+    const runs = await adapter.workflowRuns({
+      status: "succeeded",
+      sort: "started_at",
+      dir: "asc",
+      page: 2,
+      pageSize: 1,
+    });
+    expect(runs.items.map((run) => run.runId)).toEqual(["run-discovery-demo"]);
+    expect(runs.pagination).toEqual({
+      page: 2,
+      pageSize: 1,
+      total: 3,
+      pages: 3,
+    });
+
+    await expect(
+      adapter.listContacts({
+        jobId: "job-northwind-platform",
+        employer: "Northwind Workshop",
+      }),
+    ).resolves.toMatchObject({
+      items: [{ contactId: "contact-demo-hiring-partner" }],
+    });
+    await expect(
+      adapter.listContacts({ employer: "northwind workshop" }),
+    ).resolves.toEqual({ ok: true, items: [] });
+    await expect(
+      adapter.researchTasks({ jobId: "job-northwind-platform" }),
+    ).resolves.toMatchObject({
+      items: [{ taskId: "research-demo-hiring-partner" }],
+    });
+    await expect(
+      adapter.researchTasks({ employer: "missing" }),
+    ).resolves.toEqual({ ok: true, items: [] });
+  });
+
+  it("matches case-normalized activity text and contact/research ordering", async () => {
+    const { adapter, repository } = await createAdapter();
+    const baseEvent =
+      repository.snapshotNow().state.readModel.dashboard.activity.items[0]!;
+    const event = (eventId: string, value: string): ActivityEventSummary => ({
+      ...structuredClone(baseEvent),
+      eventId,
+      stage: value,
+      level: value,
+      eventType: value,
+      message: value,
+    });
+    await repository.mutate((draft) => {
+      draft.state.readModel.dashboard.activity.items = [
+        event("event-z", "Zulu"),
+        event("event-a", "apple"),
+      ];
+    });
+    for (const sort of ["stage", "level", "event_type", "message"] as const) {
+      expect(
+        (await adapter.activity({ sort, dir: "asc" })).items.map(
+          (item) => item.eventId,
+        ),
+        sort,
+      ).toEqual(["event-a", "event-z"]);
+    }
+
+    const snapshot = repository.snapshotNow();
+    const baseContact = snapshot.state.readModel.contacts.list.items[0]!;
+    const baseTask = snapshot.state.readModel.contacts.researchTasks.items[0]!;
+    await repository.mutate((draft) => {
+      draft.state.readModel.contacts.list.items = [
+        {
+          ...structuredClone(baseContact),
+          contactId: "contact-z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        {
+          ...structuredClone(baseContact),
+          contactId: "contact-a",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        {
+          ...structuredClone(baseContact),
+          contactId: "contact-old",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ];
+      draft.state.readModel.contacts.researchTasks.items = [
+        {
+          ...structuredClone(baseTask),
+          taskId: "task-z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        {
+          ...structuredClone(baseTask),
+          taskId: "task-a",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        {
+          ...structuredClone(baseTask),
+          taskId: "task-old",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ];
+    });
+    expect(
+      (
+        await adapter.listContacts({ employer: baseContact.employer ?? "" })
+      ).items.map((contact) => contact.contactId),
+    ).toEqual(["contact-a", "contact-z", "contact-old"]);
+    expect(
+      (
+        await adapter.researchTasks({ employer: baseTask.employer ?? "" })
+      ).items.map((task) => task.taskId),
+    ).toEqual(["task-a", "task-z", "task-old"]);
+  });
+
+  it("resolves every seeded dynamic detail and returns stable 404 errors for unknown IDs", async () => {
+    const { adapter } = await createAdapter();
+    for (const jobKey of [
+      "job-northwind-platform",
+      "job-contoso-reliability",
+      "job-fabrikam-systems",
+    ]) {
+      await expect(adapter.job(jobKey)).resolves.toMatchObject({
+        ok: true,
+        job: { jobKey },
+      });
+      await expect(
+        adapter.jobApplicationOutcomes(jobKey),
+      ).resolves.toMatchObject({ ok: true, jobKey });
+    }
+    for (const runId of [
+      "run-materials-progress",
+      "run-failed-quality-gate",
+      "run-score-succeeded",
+      "run-application-rehearsal",
+      "run-discovery-cancelled",
+      "run-discovery-demo",
+    ]) {
+      await expect(adapter.workflowRun(runId)).resolves.toMatchObject({
+        runId,
+      });
+    }
+    for (const artifactId of [
+      "artifact-tailored-resume",
+      "artifact-tailored-resume-html",
+    ]) {
+      await expect(adapter.artifact(artifactId)).resolves.toMatchObject({
+        ok: true,
+        artifact: { artifactId },
+      });
+      for (const url of [
+        adapter.artifactPreviewPdfUrl(artifactId),
+        adapter.artifactPreviewHtmlUrl(artifactId),
+      ]) {
+        expect(url).toMatch(/^\/demo\//);
+        expect(url).not.toContain("://");
+        expect(url).not.toContain("..");
+      }
+    }
+
+    const missingReads = [
+      () => adapter.activityEvent("missing"),
+      () => adapter.discoverySourcePreview("missing"),
+      () => adapter.resumeReviewDraft("missing"),
+      () => adapter.resumeReviewFeedback("missing"),
+      () => adapter.resumeTemplate("missing"),
+      () => adapter.jobApplicationOutcomes("missing"),
+      () => adapter.job("missing"),
+      () => adapter.workflowRun("missing"),
+      () => adapter.artifact("missing"),
+      () => adapter.contact("missing"),
+      () => adapter.researchTask("missing"),
+      () => adapter.outreachThread("missing"),
+    ];
+    for (const read of missingReads) {
+      await expect(read()).rejects.toBeInstanceOf(DemoResourceNotFoundError);
+      await expect(read()).rejects.toMatchObject({ status: 404 });
+    }
+    expect(() => adapter.artifactPreviewPdfUrl("missing")).toThrow(
+      DemoResourceNotFoundError,
+    );
+  });
+
+  it("keeps the intentional capability error class stable", () => {
+    expect(new DemoCapabilityError("applyJob")).toMatchObject({
+      name: "DemoCapabilityError",
+      code: "demo_capability_not_implemented",
+    });
+  });
+});

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -1,0 +1,1008 @@
+import { JobCtrlApiError } from "@jobctrl/api-client";
+import {
+  ActivityListQuerySchema,
+  ArtifactListQuerySchema,
+  ContactListQuerySchema,
+  ContactResearchListQuerySchema,
+  JobListQuerySchema,
+  WorkflowRunsListQuerySchema,
+  type ActivityEventSummary,
+  type ArtifactSummary,
+  type JobCompensationSummary,
+  type JobSummary,
+  type PaginatedResponse,
+  type WorkflowRunSummary,
+} from "@jobctrl/contracts";
+
+import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
+import { isDemoArtifactUrl } from "./artifacts.js";
+import type { ApiClientResponse, DemoReadModel } from "./contracts.js";
+import { DemoCapabilityError } from "./ports.js";
+import type { DemoWorkspaceRepository } from "./workspace/DemoWorkspaceRepository.js";
+
+type CacheKey = number | string | undefined;
+
+const CLOSED_ACTIVE_STATES = new Set([
+  "closed",
+  "expired",
+  "removed",
+  "location_incompatible",
+]);
+
+const STATE_RANK: Readonly<Record<string, number>> = {
+  failed: 0,
+  exhausted: 1,
+  needs_verification: 2,
+  blocked: 3,
+  running: 4,
+  queued: 5,
+  pending: 6,
+  stale: 7,
+  canceled: 8,
+  skipped: 9,
+  succeeded: 10,
+};
+
+const IN_MEMORY_JOB_SORT_FIELDS = new Set([
+  "source",
+  "compensation_min_eur",
+  "compensation_max_eur",
+  "compensation_posted",
+  "compensation_market",
+  "compensation_confidence",
+  "compensation_warnings",
+  "apply_status",
+]);
+
+export class DemoResourceNotFoundError extends JobCtrlApiError {
+  readonly code: string;
+  readonly resourceId: string;
+
+  constructor(code: string, resourceId: string) {
+    super(404, code);
+    this.name = "DemoResourceNotFoundError";
+    this.code = code;
+    this.resourceId = resourceId;
+  }
+}
+
+/** Browser-local P2 adapter. Mutations remain explicit P3 capability errors. */
+export class DemoApiClientAdapter implements ApiClientPort {
+  constructor(private readonly workspace: DemoWorkspaceRepository) {}
+
+  health() {
+    return this.read((model) => model.dashboard.health);
+  }
+
+  dashboardSummary() {
+    return this.read((model) => model.dashboard.summary);
+  }
+
+  outcomeAnalytics() {
+    return this.read((model) => model.analytics.summary);
+  }
+
+  digest() {
+    return this.read((model) => model.dashboard.digest);
+  }
+
+  async activity(
+    query: Parameters<ApiClientPort["activity"]>[0] = {},
+  ): Promise<ApiClientResponse<"activity">> {
+    const normalized = ActivityListQuerySchema.parse(query);
+    const source = await this.read((model) => model.dashboard.activity.items);
+    const q = normalized.q.toLowerCase();
+    const items = source.filter((event) => {
+      if (
+        normalized.level &&
+        event.level.toLowerCase() !== normalized.level.toLowerCase()
+      )
+        return false;
+      if (
+        normalized.stage &&
+        event.stage.toLowerCase() !== normalized.stage.toLowerCase()
+      )
+        return false;
+      if (
+        normalized.eventType &&
+        event.eventType.toLowerCase() !== normalized.eventType.toLowerCase()
+      )
+        return false;
+      if (!q) return true;
+      return [
+        event.level,
+        event.stage,
+        event.eventType,
+        event.message,
+        event.title ?? "",
+        event.company ?? "",
+        event.jobKey ?? "",
+        event.eventId,
+        event.at,
+      ].some((value) =>
+        String(value ?? "")
+          .toLowerCase()
+          .includes(q),
+      );
+    });
+    items.sort((left, right) =>
+      compareActivity(left, right, normalized.sort, normalized.dir),
+    );
+    return paginate(
+      items,
+      normalized.page,
+      normalized.pageSize,
+      normalized.sort,
+      normalized.dir,
+      {
+        q: normalized.q,
+        level: normalized.level,
+        stage: normalized.stage,
+        eventType: normalized.eventType,
+      },
+    );
+  }
+
+  activityEvent(eventId: string) {
+    return this.detail(
+      (model) => model.dashboard.activityEvents,
+      eventId,
+      "activity_event_not_found",
+    );
+  }
+
+  discoverySettings() {
+    return this.read((model) => model.discovery.settings);
+  }
+
+  discoverySources() {
+    return this.read((model) => model.discovery.sources);
+  }
+
+  discoverySourcePreview(sourceId: string) {
+    return this.detail(
+      (model) => model.discovery.sourcePreviews,
+      sourceId,
+      "discovery_source_not_found",
+    );
+  }
+
+  compensationSources() {
+    return this.read((model) => model.discovery.compensationSources);
+  }
+
+  discoveryLocatorCandidates() {
+    return this.read((model) => model.discovery.locatorCandidates);
+  }
+
+  discoveryQuarantine() {
+    return this.read((model) => model.discovery.quarantine);
+  }
+
+  manualCaptureQueue() {
+    return this.read((model) => model.discovery.manualCapture);
+  }
+
+  roleMatchFeedbackSuggestions() {
+    return this.read((model) => model.discovery.roleMatchFeedback);
+  }
+
+  applyReviewQueue() {
+    return this.read((model) => model.apply.queue);
+  }
+
+  resumeReviewDraft(jobKey: string) {
+    return this.detail(
+      (model) => model.materials.resumeReviewDrafts,
+      jobKey,
+      "resume_review_draft_not_found",
+    );
+  }
+
+  resumeReviewFeedback(jobKey: string) {
+    return this.detail(
+      (model) => model.materials.resumeReviewFeedback,
+      jobKey,
+      "job_not_found",
+    );
+  }
+
+  resumeTemplates() {
+    return this.read((model) => model.materials.resumeTemplates);
+  }
+
+  resumeTemplate(templateId: string) {
+    return this.detail(
+      (model) => model.materials.templateDetails,
+      templateId,
+      "resume_template_not_found",
+    );
+  }
+
+  applicationOutcomes() {
+    return this.read((model) => model.analytics.outcomes);
+  }
+
+  jobApplicationOutcomes(jobKey: string) {
+    return this.detail(
+      (model) => model.analytics.jobOutcomes,
+      jobKey,
+      "job_not_found",
+    );
+  }
+
+  async jobs(
+    query: Parameters<ApiClientPort["jobs"]>[0] = {},
+  ): Promise<ApiClientResponse<"jobs">> {
+    const normalized = JobListQuerySchema.parse(query);
+    const source = await this.read((model) => model.jobs.list.items);
+    const q = normalized.q.toLowerCase();
+    const items = source.filter((job) => filterJob(job, normalized, q));
+    items.sort((left, right) =>
+      compareJobs(
+        left,
+        right,
+        normalized.sort,
+        normalized.dir,
+        !normalized.q && !IN_MEMORY_JOB_SORT_FIELDS.has(normalized.sort),
+      ),
+    );
+    return paginate(
+      items,
+      normalized.page,
+      normalized.pageSize,
+      normalized.sort,
+      normalized.dir,
+      {
+        q: normalized.q,
+        stage: normalized.stage ?? "",
+        state: normalized.state ?? "",
+        source: normalized.source,
+        company: normalized.company,
+        applyStatus: normalized.applyStatus,
+        minFitScore: normalized.minFitScore ?? null,
+        maxFitScore: normalized.maxFitScore ?? null,
+        discoveredSince: normalized.discoveredSince ?? null,
+        scoredSince: normalized.scoredSince ?? null,
+        deleted: normalized.deleted,
+      },
+    );
+  }
+
+  job(jobKey: string) {
+    return this.detail((model) => model.jobs.details, jobKey, "job_not_found");
+  }
+
+  evidenceMap() {
+    return this.read((model) => model.evidence);
+  }
+
+  async workflowRuns(
+    query: Parameters<ApiClientPort["workflowRuns"]>[0] = {},
+  ): Promise<ApiClientResponse<"workflowRuns">> {
+    const normalized = WorkflowRunsListQuerySchema.parse(query);
+    const source = await this.read((model) => model.runs.list.items);
+    const items = source.filter(
+      (run) => normalized.status === "all" || run.status === normalized.status,
+    );
+    items.sort((left, right) =>
+      compareWorkflowRuns(left, right, normalized.sort, normalized.dir),
+    );
+    return paginate(
+      items,
+      normalized.page,
+      normalized.pageSize,
+      normalized.sort,
+      normalized.dir,
+      {
+        status: normalized.status,
+      },
+    );
+  }
+
+  workflowRun(runId: string) {
+    return this.detail(
+      (model) => model.runs.details,
+      runId,
+      "workflow_run_not_found",
+    );
+  }
+
+  async artifacts(
+    query: Parameters<ApiClientPort["artifacts"]>[0] = {},
+  ): Promise<ApiClientResponse<"artifacts">> {
+    const normalized = ArtifactListQuerySchema.parse(query);
+    const source = await this.read((model) => model.materials.list.items);
+    const q = normalized.q.toLowerCase();
+    const items = source.filter((artifact) => {
+      if (!normalized.status && artifact.status.toLowerCase() === "suppressed")
+        return false;
+      if (normalized.status && artifact.status !== normalized.status)
+        return false;
+      if (normalized.type && artifact.type !== normalized.type) return false;
+      if (!q) return true;
+      return [
+        artifact.title,
+        artifact.company,
+        artifact.type,
+        artifact.status,
+        artifact.localPath,
+      ].some((value) => value.toLowerCase().includes(q));
+    });
+    items.sort((left, right) =>
+      compareArtifacts(left, right, normalized.sort, normalized.dir),
+    );
+    return paginate(
+      items,
+      normalized.page,
+      normalized.pageSize,
+      normalized.sort,
+      normalized.dir,
+      {
+        q: normalized.q,
+        status: normalized.status,
+        type: normalized.type,
+      },
+    );
+  }
+
+  artifact(artifactId: string) {
+    return this.detail(
+      (model) => model.materials.details,
+      artifactId,
+      "artifact_not_found",
+    );
+  }
+
+  artifactPreviewPdfUrl(artifactId: string, cacheKey?: CacheKey): string {
+    return artifactPreviewUrl(this.workspace, artifactId, "pdf", cacheKey);
+  }
+
+  artifactPreviewHtmlUrl(artifactId: string, cacheKey?: CacheKey): string {
+    return artifactPreviewUrl(this.workspace, artifactId, "html", cacheKey);
+  }
+
+  profile() {
+    return this.read((model) => model.profile.config);
+  }
+
+  profilePreviewPdfUrl(cacheKey?: CacheKey): string {
+    return profilePreviewUrl(this.workspace, "pdf", cacheKey);
+  }
+
+  profilePreviewHtmlUrl(cacheKey?: CacheKey): string {
+    return profilePreviewUrl(this.workspace, "html", cacheKey);
+  }
+
+  settings() {
+    return this.read((model) => model.settings);
+  }
+
+  credentials() {
+    return this.read((model) => model.profile.credentials);
+  }
+
+  async listContacts(
+    query: Parameters<ApiClientPort["listContacts"]>[0] = {},
+  ): Promise<ApiClientResponse<"listContacts">> {
+    const normalized = ContactListQuerySchema.parse(query);
+    const response = await this.read((model) => model.contacts.list);
+    response.items = response.items.filter(
+      (contact) =>
+        (!normalized.jobId || contact.jobId === normalized.jobId) &&
+        (!normalized.employer || contact.employer === normalized.employer),
+    );
+    response.items.sort((left, right) =>
+      compareUpdatedAtThenId(
+        left.updatedAt,
+        right.updatedAt,
+        left.contactId,
+        right.contactId,
+      ),
+    );
+    return response;
+  }
+
+  contact(contactId: string) {
+    return this.detail(
+      (model) => model.contacts.details,
+      contactId,
+      "contact_not_found",
+    );
+  }
+
+  async researchTasks(
+    query: Parameters<ApiClientPort["researchTasks"]>[0] = {},
+  ): Promise<ApiClientResponse<"researchTasks">> {
+    const normalized = ContactResearchListQuerySchema.parse(query);
+    const response = await this.read((model) => model.contacts.researchTasks);
+    response.items = response.items.filter(
+      (task) =>
+        (!normalized.jobId || task.jobId === normalized.jobId) &&
+        (!normalized.employer || task.employer === normalized.employer),
+    );
+    response.items.sort((left, right) =>
+      compareUpdatedAtThenId(
+        left.updatedAt,
+        right.updatedAt,
+        left.taskId,
+        right.taskId,
+      ),
+    );
+    return response;
+  }
+
+  researchTask(taskId: string) {
+    return this.detail(
+      (model) => model.contacts.researchTaskDetails,
+      taskId,
+      "research_task_not_found",
+    );
+  }
+
+  async outreachThread(
+    contactId: string,
+    query: { jobId?: string } = {},
+  ): Promise<ApiClientResponse<"outreachThread">> {
+    const response = await this.read((model) => model.outreach.thread);
+    if (
+      response.thread === null ||
+      response.thread.contactId !== contactId ||
+      (query.jobId !== undefined && response.thread.jobId !== query.jobId)
+    ) {
+      throw new DemoResourceNotFoundError(
+        "outreach_thread_not_found",
+        contactId,
+      );
+    }
+    return response;
+  }
+
+  dueOutreachFollowUps() {
+    return this.read((model) => model.outreach.dueFollowUps);
+  }
+
+  acknowledgeDigest = this.unsupported("acknowledgeDigest");
+  updateDiscoverySettings = this.unsupported("updateDiscoverySettings");
+  upsertDiscoverySource = this.unsupported("upsertDiscoverySource");
+  patchDiscoverySourceState = this.unsupported("patchDiscoverySourceState");
+  updateCompensationSourcePolicy = this.unsupported(
+    "updateCompensationSourcePolicy",
+  );
+  promoteSourceLocatorCandidate = this.unsupported(
+    "promoteSourceLocatorCandidate",
+  );
+  rejectSourceLocatorCandidate = this.unsupported(
+    "rejectSourceLocatorCandidate",
+  );
+  decideDiscoveryQuarantine = this.unsupported("decideDiscoveryQuarantine");
+  importManualCapture = this.unsupported("importManualCapture");
+  dismissManualCapture = this.unsupported("dismissManualCapture");
+  recordDiscoveryFeedback = this.unsupported("recordDiscoveryFeedback");
+  decideRoleMatchFeedbackSuggestion = this.unsupported(
+    "decideRoleMatchFeedbackSuggestion",
+  );
+  decideApplyReview = this.unsupported("decideApplyReview");
+  createResumeReviewDraft = this.unsupported("createResumeReviewDraft");
+  saveResumeReviewDraftRevision = this.unsupported(
+    "saveResumeReviewDraftRevision",
+  );
+  seedResumeReviewCommentThreads = this.unsupported(
+    "seedResumeReviewCommentThreads",
+  );
+  renderResumeReviewDraft = this.unsupported("renderResumeReviewDraft");
+  replyToResumeReviewComment = this.unsupported("replyToResumeReviewComment");
+  saveResumeTemplate = this.unsupported("saveResumeTemplate");
+  setDefaultResumeTemplate = this.unsupported("setDefaultResumeTemplate");
+  setJobResumeTemplate = this.unsupported("setJobResumeTemplate");
+  ensureCurrentResumeMaterials = this.unsupported(
+    "ensureCurrentResumeMaterials",
+  );
+  recordManualApplicationOutcome = this.unsupported(
+    "recordManualApplicationOutcome",
+  );
+  decideOutcomeSuggestion = this.unsupported("decideOutcomeSuggestion");
+  deleteJob = this.unsupported("deleteJob");
+  deleteJobs = this.unsupported("deleteJobs");
+  permanentlyDeleteJob = this.unsupported("permanentlyDeleteJob");
+  permanentlyDeleteJobs = this.unsupported("permanentlyDeleteJobs");
+  restoreJob = this.unsupported("restoreJob");
+  restoreJobs = this.unsupported("restoreJobs");
+  hideJob = this.unsupported("hideJob");
+  hideJobs = this.unsupported("hideJobs");
+  unhideJob = this.unsupported("unhideJob");
+  unhideJobs = this.unsupported("unhideJobs");
+  retryFailedJobs = this.unsupported("retryFailedJobs");
+  runPendingPreparation = this.unsupported("runPendingPreparation");
+  correctScore = this.unsupported("correctScore");
+  resetStaleScoresForRescore = this.unsupported("resetStaleScoresForRescore");
+  rescoreJob = this.unsupported("rescoreJob");
+  refreshCompensation = this.unsupported("refreshCompensation");
+  refreshAllCompensation = this.unsupported("refreshAllCompensation");
+  rescoreJobsNotOnCurrentScoringPolicy = this.unsupported(
+    "rescoreJobsNotOnCurrentScoringPolicy",
+  );
+  retailorJob = this.unsupported("retailorJob");
+  tailorJob = this.unsupported("tailorJob");
+  retailorCurrentPolicy = this.unsupported("retailorCurrentPolicy");
+  cancelWorkflowRun = this.unsupported("cancelWorkflowRun");
+  openArtifact = this.unsupported("openArtifact");
+  updateProfile = this.unsupported("updateProfile");
+  importResume = this.unsupported("importResume");
+  updateSettings = this.unsupported("updateSettings");
+  extensionCapabilityToken = this.unsupported("extensionCapabilityToken");
+  rotateExtensionCapabilityToken = this.unsupported(
+    "rotateExtensionCapabilityToken",
+  );
+  runPipelineStages = this.unsupported("runPipelineStages");
+  updateCredential = this.unsupported("updateCredential");
+  deleteCredential = this.unsupported("deleteCredential");
+  createContact = this.unsupported("createContact");
+  updateContact = this.unsupported("updateContact");
+  deleteContact = this.unsupported("deleteContact");
+  importContacts = this.unsupported("importContacts");
+  runContactResearch = this.unsupported("runContactResearch");
+  confirmContactCandidate = this.unsupported("confirmContactCandidate");
+  generateOutreachDraft = this.unsupported("generateOutreachDraft");
+  reviseOutreachDraft = this.unsupported("reviseOutreachDraft");
+  approveOutreachDraft = this.unsupported("approveOutreachDraft");
+  rejectOutreachDraft = this.unsupported("rejectOutreachDraft");
+  logOutreachSend = this.unsupported("logOutreachSend");
+  scheduleOutreachFollowUp = this.unsupported("scheduleOutreachFollowUp");
+  completeOutreachFollowUp = this.unsupported("completeOutreachFollowUp");
+  dismissOutreachFollowUp = this.unsupported("dismissOutreachFollowUp");
+  retryStage = this.unsupported("retryStage");
+  runJobStage = this.unsupported("runJobStage");
+  generateMaterials = this.unsupported("generateMaterials");
+  generateInterviewPrep = this.unsupported("generateInterviewPrep");
+  applyJob = this.unsupported("applyJob");
+  cancelJobAction = this.unsupported("cancelJobAction");
+  markApplied = this.unsupported("markApplied");
+  markSkipped = this.unsupported("markSkipped");
+
+  private async read<TValue>(
+    select: (model: DemoReadModel) => TValue,
+  ): Promise<TValue> {
+    const snapshot = await this.workspace.snapshot();
+    return structuredClone(select(snapshot.state.readModel));
+  }
+
+  private async detail<TValue>(
+    select: (model: DemoReadModel) => Readonly<Record<string, TValue>>,
+    id: string,
+    code: string,
+  ): Promise<TValue> {
+    const values = await this.read(select);
+    const value = values[id];
+    if (value === undefined) {
+      throw new DemoResourceNotFoundError(code, id);
+    }
+    return value;
+  }
+
+  private unsupported<TMethod extends keyof ApiClientPort>(
+    method: TMethod,
+  ): ApiClientPort[TMethod] {
+    return ((..._args: unknown[]) =>
+      Promise.reject(
+        new DemoCapabilityError(method),
+      )) as unknown as ApiClientPort[TMethod];
+  }
+}
+
+function artifactPreviewUrl(
+  workspace: DemoWorkspaceRepository,
+  artifactId: string,
+  kind: "html" | "pdf",
+  cacheKey?: CacheKey,
+): string {
+  const snapshot = workspace.snapshotNow();
+  const selected =
+    snapshot.state.readModel.materials.details[artifactId]?.artifact;
+  if (!selected) {
+    throw new DemoResourceNotFoundError("artifact_not_found", artifactId);
+  }
+  const contentType = kind === "pdf" ? "application/pdf" : "text/html";
+  const assetUrls = new Set(
+    Object.values(snapshot.state.artifacts)
+      .filter(
+        (asset) =>
+          asset.contentType === contentType && isDemoArtifactUrl(asset.url),
+      )
+      .map((asset) => asset.url),
+  );
+  const selectedPath = selected.localPath.toLowerCase();
+  const selectedKind = selectedPath.endsWith(".pdf")
+    ? "pdf"
+    : selectedPath.endsWith(".html")
+      ? "html"
+      : null;
+  const selectedStem = selectedPath.replace(/\.(?:html|pdf)$/, "");
+  const preview = Object.values(snapshot.state.readModel.materials.details)
+    .map((detail) => detail.artifact)
+    .find(
+      (artifact) =>
+        artifact.jobKey === selected.jobKey &&
+        isDemoArtifactUrl(artifact.localPath) &&
+        (selectedKind === kind
+          ? artifact.artifactId === selected.artifactId
+          : artifact.localPath.toLowerCase().replace(/\.(?:html|pdf)$/, "") ===
+            selectedStem) &&
+        assetUrls.has(artifact.localPath),
+    );
+  if (!preview || !isDemoArtifactUrl(preview.localPath)) {
+    throw new DemoResourceNotFoundError(
+      "artifact_preview_not_found",
+      artifactId,
+    );
+  }
+  return withCacheKey(preview.localPath, cacheKey);
+}
+
+function profilePreviewUrl(
+  workspace: DemoWorkspaceRepository,
+  kind: "html" | "pdf",
+  cacheKey?: CacheKey,
+): string {
+  const artifacts = workspace.snapshotNow().state.artifacts;
+  const asset =
+    kind === "pdf" ? artifacts.profileResumePdf : artifacts.profileResumeHtml;
+  const expectedType = kind === "pdf" ? "application/pdf" : "text/html";
+  if (asset.contentType !== expectedType || !isDemoArtifactUrl(asset.url)) {
+    throw new DemoResourceNotFoundError("profile_preview_not_found", "profile");
+  }
+  return withCacheKey(asset.url, cacheKey);
+}
+
+function withCacheKey(url: `/demo/${string}`, cacheKey?: CacheKey): string {
+  if (cacheKey === undefined || cacheKey === "") return url;
+  return `${url}?v=${encodeURIComponent(String(cacheKey))}`;
+}
+
+function paginate<TValue>(
+  items: TValue[],
+  page: number,
+  pageSize: number,
+  sortField: string,
+  sortDir: "asc" | "desc",
+  filter: Record<string, unknown>,
+): PaginatedResponse<TValue> {
+  const total = items.length;
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(page, pages);
+  const offset = (safePage - 1) * pageSize;
+  return {
+    ok: true,
+    items: items.slice(offset, offset + pageSize),
+    pagination: { page: safePage, pageSize, total, pages },
+    sort: { field: sortField, dir: sortDir },
+    filter,
+  };
+}
+
+function filterJob(
+  job: JobSummary,
+  query: ReturnType<typeof JobListQuerySchema.parse>,
+  normalizedQuery: string,
+): boolean {
+  const closed = CLOSED_ACTIVE_STATES.has(job.activeState);
+  if (query.deleted === "active" && (job.deletedAt || job.hiddenAt || closed))
+    return false;
+  if (query.deleted === "closed" && (job.deletedAt || job.hiddenAt || !closed))
+    return false;
+  if (query.deleted === "deleted" && (!job.deletedAt || job.hiddenAt))
+    return false;
+  if (query.deleted === "hidden" && !job.hiddenAt) return false;
+  if (query.stage && job.currentStage !== query.stage) return false;
+  if (query.state && job.currentState !== query.state) return false;
+  if (
+    query.applyStatus === "applied" &&
+    !job.appliedAt &&
+    job.applyStatus?.toLowerCase() !== "applied"
+  )
+    return false;
+  if (
+    query.source &&
+    ![
+      job.source,
+      job.discoverySource,
+      job.postingSource,
+      job.postingSourceUrl ?? "",
+    ].some((source) =>
+      source.toLowerCase().includes(query.source.toLowerCase()),
+    )
+  )
+    return false;
+  if (
+    query.company &&
+    !job.company.toLowerCase().includes(query.company.toLowerCase())
+  )
+    return false;
+  if (
+    query.minFitScore !== undefined &&
+    (job.fitScore ?? -1) < query.minFitScore
+  )
+    return false;
+  if (
+    query.maxFitScore !== undefined &&
+    (job.fitScore ?? 999) > query.maxFitScore
+  )
+    return false;
+  if (query.discoveredSince && query.scoredSince) {
+    if (
+      !timestampAtOrAfter(job.discoveredAt, query.discoveredSince) &&
+      !timestampAtOrAfter(job.scoredAt, query.scoredSince)
+    )
+      return false;
+  } else {
+    if (
+      query.discoveredSince &&
+      !timestampAtOrAfter(job.discoveredAt, query.discoveredSince)
+    )
+      return false;
+    if (
+      query.scoredSince &&
+      !timestampAtOrAfter(job.scoredAt, query.scoredSince)
+    )
+      return false;
+  }
+  if (!normalizedQuery) return true;
+  return [
+    job.title,
+    job.company,
+    job.url,
+    job.location,
+    job.source,
+    job.discoverySource,
+    job.postingSource,
+    job.postingSourceUrl ?? "",
+    job.strategy,
+    job.currentStage,
+    job.currentSubstage,
+    job.currentState,
+  ].some((value) => value.toLowerCase().includes(normalizedQuery));
+}
+
+function timestampAtOrAfter(
+  value: string | null | undefined,
+  since: string,
+): boolean {
+  if (!value) return false;
+  const valueTime = Date.parse(value);
+  const sinceTime = Date.parse(since);
+  return (
+    Number.isFinite(valueTime) &&
+    Number.isFinite(sinceTime) &&
+    valueTime >= sinceTime
+  );
+}
+
+function compareJobs(
+  left: JobSummary,
+  right: JobSummary,
+  field: string,
+  direction: "asc" | "desc",
+  normalizeSqlText: boolean,
+): number {
+  const multiplier = direction === "asc" ? 1 : -1;
+  const text = (value: string): string =>
+    normalizeSqlText ? value.toLowerCase() : value;
+  const stateSubstage = (job: JobSummary): string =>
+    normalizeSqlText
+      ? text(job.currentSubstage || job.currentStage)
+      : job.currentSubstage;
+  const values: Record<string, [unknown, unknown]> = {
+    discovered_at: [left.discoveredAt, right.discoveredAt],
+    title: [text(left.title), text(right.title)],
+    company: [text(left.company), text(right.company)],
+    source: [jobSource(left), jobSource(right)],
+    compensation_min_eur: [
+      postedCompensationAmountEur(left.compensationSummary, "min"),
+      postedCompensationAmountEur(right.compensationSummary, "min"),
+    ],
+    compensation_max_eur: [
+      postedCompensationAmountEur(left.compensationSummary, "max"),
+      postedCompensationAmountEur(right.compensationSummary, "max"),
+    ],
+    compensation_posted: [
+      postedCompensationSortValue(left.compensationSummary, left.salary),
+      postedCompensationSortValue(right.compensationSummary, right.salary),
+    ],
+    compensation_market: [
+      marketCompensationSortValue(left.compensationSummary),
+      marketCompensationSortValue(right.compensationSummary),
+    ],
+    compensation_confidence: [
+      marketConfidenceSortValue(left.compensationSummary),
+      marketConfidenceSortValue(right.compensationSummary),
+    ],
+    compensation_warnings: [
+      left.compensationSummary?.warningCount ?? 0,
+      right.compensationSummary?.warningCount ?? 0,
+    ],
+    location: [text(left.location), text(right.location)],
+    fit_score: [left.fitScore ?? -1, right.fitScore ?? -1],
+    current_stage: [text(left.currentStage), text(right.currentStage)],
+    current_state: [
+      `${STATE_RANK[left.currentState] ?? 999}:${stateSubstage(left)}`,
+      `${STATE_RANK[right.currentState] ?? 999}:${stateSubstage(right)}`,
+    ],
+    apply_status: [left.applyStatus ?? "", right.applyStatus ?? ""],
+  };
+  const [leftValue, rightValue] = values[field] ?? values.discovered_at!;
+  const compared = compareValues(leftValue, rightValue);
+  return compared
+    ? compared * multiplier
+    : left.jobKey.localeCompare(right.jobKey);
+}
+
+function jobSource(job: JobSummary): string {
+  return (
+    job.postingSource ||
+    job.discoverySource ||
+    job.source ||
+    ""
+  ).toLowerCase();
+}
+
+function postedCompensationSortValue(
+  summary: JobCompensationSummary | null,
+  fallbackSalary: string,
+): number {
+  const amount = postedCompensationAmountEur(summary, "min");
+  if (amount !== null) return amount;
+  if (
+    summary?.posted.displayRange ||
+    summary?.legacyRawSalary ||
+    fallbackSalary
+  )
+    return -1;
+  if (summary?.posted.parseState === "ambiguous") return -2;
+  if (summary?.posted.parseState === "unparseable") return -3;
+  if (summary?.posted.parseState === "missing") return -4;
+  return Number.NEGATIVE_INFINITY;
+}
+
+function postedCompensationAmountEur(
+  summary: JobCompensationSummary | null,
+  bound: "min" | "max",
+): number | null {
+  return compensationRangeAmountEur(summary?.posted.range, bound);
+}
+
+function marketCompensationSortValue(
+  summary: JobCompensationSummary | null,
+): number {
+  const amount = compensationRangeAmountEur(summary?.market.range, "min");
+  if (amount !== null) return amount;
+  switch (summary?.market.estimateState) {
+    case "estimated_range":
+      return -1;
+    case "insufficient_evidence":
+      return -2;
+    case "source_unavailable":
+      return -3;
+    case "unsupported":
+      return -4;
+    case "not_requested":
+    default:
+      return Number.NEGATIVE_INFINITY;
+  }
+}
+
+function marketConfidenceSortValue(
+  summary: JobCompensationSummary | null,
+): number {
+  const market = summary?.market;
+  if (!market || market.recordStatus === "not_requested")
+    return Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(market.confidenceScore))
+    return Number(market.confidenceScore);
+  switch (market.confidenceBand) {
+    case "high":
+      return 0.9;
+    case "medium":
+      return 0.62;
+    case "low":
+      return 0.3;
+    case "none":
+      return 0;
+  }
+}
+
+function compensationRangeAmountEur(
+  range: JobCompensationSummary["posted"]["range"] | null | undefined,
+  bound: "min" | "max",
+): number | null {
+  const normalized =
+    bound === "min" ? range?.annualizedMinimumEur : range?.annualizedMaximumEur;
+  if (Number.isFinite(normalized)) return Number(normalized);
+  if (range?.currency?.toUpperCase() !== "EUR") return null;
+  const annualized =
+    bound === "min"
+      ? range.annualizedMinimumAmount
+      : range.annualizedMaximumAmount;
+  if (Number.isFinite(annualized)) return Number(annualized);
+  if (range.period !== "year") return null;
+  const source = bound === "min" ? range.minimumAmount : range.maximumAmount;
+  return Number.isFinite(source) ? Number(source) : null;
+}
+
+function compareArtifacts(
+  left: ArtifactSummary,
+  right: ArtifactSummary,
+  field: string,
+  direction: "asc" | "desc",
+): number {
+  const values: Record<string, [unknown, unknown]> = {
+    created_at: [left.createdAt, right.createdAt],
+    title: [left.title, right.title],
+    company: [left.company, right.company],
+    type: [left.type, right.type],
+    status: [left.status, right.status],
+    size_bytes: [left.sizeBytes ?? -1, right.sizeBytes ?? -1],
+  };
+  const [leftValue, rightValue] = values[field] ?? values.created_at!;
+  return compareValues(leftValue, rightValue) * (direction === "asc" ? 1 : -1);
+}
+
+function compareActivity(
+  left: ActivityEventSummary,
+  right: ActivityEventSummary,
+  field: string,
+  direction: "asc" | "desc",
+): number {
+  const values: Record<string, [unknown, unknown]> = {
+    occurred_at: [left.at, right.at],
+    event_id: [left.eventId, right.eventId],
+    stage: [left.stage.toLowerCase(), right.stage.toLowerCase()],
+    level: [left.level.toLowerCase(), right.level.toLowerCase()],
+    event_type: [left.eventType.toLowerCase(), right.eventType.toLowerCase()],
+    message: [left.message.toLowerCase(), right.message.toLowerCase()],
+  };
+  const [leftValue, rightValue] = values[field] ?? values.occurred_at!;
+  const multiplier = direction === "asc" ? 1 : -1;
+  const compared = compareValues(leftValue, rightValue);
+  return compared
+    ? compared * multiplier
+    : left.eventId.localeCompare(right.eventId) * multiplier;
+}
+
+function compareWorkflowRuns(
+  left: WorkflowRunSummary,
+  right: WorkflowRunSummary,
+  field: string,
+  direction: "asc" | "desc",
+): number {
+  const values: Record<string, [unknown, unknown]> = {
+    started_at: [left.startedAt, right.startedAt],
+    finished_at: [left.finishedAt, right.finishedAt],
+    duration_ms: [left.durationMs ?? -1, right.durationMs ?? -1],
+    title: [left.title, right.title],
+    company: [left.company, right.company],
+    status: [left.status, right.status],
+    model: [left.model ?? "", right.model ?? ""],
+    dry_run: [left.dryRun ? 1 : 0, right.dryRun ? 1 : 0],
+  };
+  const [leftValue, rightValue] = values[field] ?? values.started_at!;
+  return compareValues(leftValue, rightValue) * (direction === "asc" ? 1 : -1);
+}
+
+function compareValues(left: unknown, right: unknown): number {
+  if (left === right) return 0;
+  if (left === null || left === undefined || left === "") return -1;
+  if (right === null || right === undefined || right === "") return 1;
+  if (typeof left === "number" && typeof right === "number")
+    return left - right;
+  return String(left).localeCompare(String(right));
+}
+
+function compareUpdatedAtThenId(
+  leftUpdatedAt: string | null,
+  rightUpdatedAt: string | null,
+  leftId: string,
+  rightId: string,
+): number {
+  const updated = compareValues(leftUpdatedAt, rightUpdatedAt);
+  return updated ? updated * -1 : leftId.localeCompare(rightId);
+}

--- a/apps/web/src/demo/index.ts
+++ b/apps/web/src/demo/index.ts
@@ -1,6 +1,10 @@
 export { DEMO_ARTIFACTS, isDemoArtifactUrl } from "./artifacts.js";
 export { DEMO_CAPABILITY_MANIFEST } from "./capabilities.js";
 export {
+  DemoApiClientAdapter,
+  DemoResourceNotFoundError,
+} from "./DemoApiClientAdapter.js";
+export {
   demoTimestamp,
   materializeDemoReadModel,
   materializeDemoSeed,

--- a/apps/web/src/demo/portFactory.test.ts
+++ b/apps/web/src/demo/portFactory.test.ts
@@ -13,6 +13,7 @@ import type {
   DemoWorkspaceStore,
   DemoWorkspaceTransaction,
 } from "./workspace/index.js";
+import { DemoApiClientAdapter } from "./DemoApiClientAdapter.js";
 import {
   DemoWorkspaceStorageError,
   InMemoryDemoWorkspaceStore,
@@ -23,7 +24,6 @@ import {
   resolveAppMode,
 } from "./portFactory.js";
 import {
-  DemoCapabilityError,
   DemoFeatureFlagAdapter,
   DemoOpenInOsAdapter,
   DemoSessionAdapter,
@@ -77,6 +77,9 @@ describe("port factory", () => {
     expect(direct.openInOs).toBeInstanceOf(OpenArtifactAdapter);
     expect(direct.telemetry).toBeInstanceOf(ConsoleTelemetryAdapter);
     expect(direct.featureFlags).toBeInstanceOf(StaticFeatureFlagAdapter);
+    expect(direct.featureFlags.get("activityDetailDirectLoad", false)).toBe(
+      false,
+    );
     expect(composition.ports.api).toBeInstanceOf(FetchApiClientAdapter);
   });
 
@@ -107,9 +110,14 @@ describe("port factory", () => {
       expect(composition.ports.featureFlags).toBeInstanceOf(
         DemoFeatureFlagAdapter,
       );
-      await expect(composition.ports.api.health()).rejects.toBeInstanceOf(
-        DemoCapabilityError,
-      );
+      expect(
+        composition.ports.featureFlags.get("activityDetailDirectLoad", false),
+      ).toBe(true);
+      expect(composition.ports.api).toBeInstanceOf(DemoApiClientAdapter);
+      await expect(composition.ports.api.health()).resolves.toMatchObject({
+        ok: true,
+        appDir: "browser-local-demo",
+      });
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();

--- a/apps/web/src/demo/portFactory.ts
+++ b/apps/web/src/demo/portFactory.ts
@@ -7,6 +7,7 @@ import { OpenArtifactAdapter } from "../shared/adapters/local/OpenArtifactAdapte
 import { SseEventStreamAdapter } from "../shared/adapters/local/SseEventStreamAdapter.js";
 import { StaticFeatureFlagAdapter } from "../shared/adapters/local/StaticFeatureFlagAdapter.js";
 import type { Ports } from "../shared/providers/PortsProvider.js";
+import { DemoApiClientAdapter } from "./DemoApiClientAdapter.js";
 import type { AppMode } from "./contracts.js";
 import {
   DemoWorkspaceEventStreamAdapter,
@@ -16,7 +17,6 @@ import {
   type DemoWorkspaceRepositoryOptions,
 } from "./workspace/index.js";
 import {
-  createDemoApiClientPlaceholder,
   DemoFeatureFlagAdapter,
   DemoOpenInOsAdapter,
   DemoSessionAdapter,
@@ -77,7 +77,7 @@ export async function createAppComposition(
   return {
     kind: "demo",
     ports: {
-      api: createDemoApiClientPlaceholder(),
+      api: new DemoApiClientAdapter(workspace),
       eventStream: new DemoWorkspaceEventStreamAdapter(workspace),
       storage: new DemoStorageAdapter(),
       session: new DemoSessionAdapter(),

--- a/apps/web/src/demo/ports.ts
+++ b/apps/web/src/demo/ports.ts
@@ -1,6 +1,5 @@
 import { LOCAL_TENANT } from "@jobctrl/domain-types";
 
-import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
 import type { FeatureFlagPort } from "../shared/ports/FeatureFlagPort.js";
 import type { OpenInOsPort } from "../shared/ports/OpenInOsPort.js";
 import type { Session, SessionPort } from "../shared/ports/SessionPort.js";
@@ -10,29 +9,9 @@ export class DemoCapabilityError extends Error {
   readonly code = "demo_capability_not_implemented" as const;
 
   constructor(method: string) {
-    super(
-      `Demo capability ${method} is not available until the demo adapter is initialized.`,
-    );
+    super(`Demo capability ${method} is not available in this demo phase.`);
     this.name = "DemoCapabilityError";
   }
-}
-
-/** P2 replaces these deliberate rejections with the complete read adapter. */
-export function createDemoApiClientPlaceholder(): ApiClientPort {
-  return new Proxy(
-    {},
-    {
-      get(_target, property) {
-        const method = String(property);
-        return () => {
-          if (method.endsWith("Url")) {
-            throw new DemoCapabilityError(method);
-          }
-          return Promise.reject(new DemoCapabilityError(method));
-        };
-      },
-    },
-  ) as ApiClientPort;
 }
 
 export class DemoSessionAdapter implements SessionPort {
@@ -59,7 +38,13 @@ export class DemoStorageAdapter implements StoragePort {
 }
 
 export class DemoFeatureFlagAdapter implements FeatureFlagPort {
-  get<T extends boolean | number | string>(_key: string, defaultValue: T): T {
+  get<T extends boolean | number | string>(key: string, defaultValue: T): T {
+    if (
+      key === "activityDetailDirectLoad" &&
+      typeof defaultValue === "boolean"
+    ) {
+      return true as T;
+    }
     return defaultValue;
   }
 }

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
@@ -177,6 +177,23 @@ function buildRepository(
 }
 
 describe("DemoWorkspaceRepository", () => {
+  it("exposes an immutable synchronous clone only after initialization", async () => {
+    const repository = buildRepository(new SharedPersistentStore());
+    expect(() => repository.snapshotNow()).toThrow(
+      "DemoWorkspaceRepository must initialize before use.",
+    );
+    await repository.initialize();
+
+    const clone = repository.snapshotNow();
+    (clone.state as { title: string }).title = "caller mutation";
+    expect(repository.snapshotNow().state.title).toBe("JobCtrl product tour");
+
+    await repository.mutate((draft) => {
+      (draft.state as { title: string }).title = "authoritative mutation";
+    });
+    expect(repository.snapshotNow().state.title).toBe("authoritative mutation");
+  });
+
   it("seeds once, persists every required snapshot field, and reloads the same workspace", async () => {
     const store = new SharedPersistentStore();
     const first = buildRepository(store);
@@ -572,6 +589,67 @@ describe("DemoWorkspaceRepository", () => {
         expect.any(Object),
         expect.any(Object),
       );
+      scheduler.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a stale rejected reconcile clear a newer scheduled timer", async () => {
+    vi.useFakeTimers();
+    try {
+      let now = 0;
+      const schedulerClock: DemoSchedulerClock = {
+        now: () => now,
+        setTimeout: (handler, delayMs) => setTimeout(handler, delayMs),
+        clearTimeout: (timer) => clearTimeout(timer),
+      };
+      const hub = new ChannelHub();
+      const store = new SharedPersistentStore();
+      const repository = buildRepository(store, hub.createFactory());
+      await repository.initialize();
+      const scheduler = new DemoWorkspaceScheduler(repository, schedulerClock);
+      const fired = vi.fn();
+      await scheduler.schedule(
+        {
+          scenarioId: "newer-than-stale-reconcile",
+          deadlineAt: new Date(25).toISOString(),
+          resetEpoch: 0,
+        },
+        fired,
+      );
+      const current = await repository.snapshot();
+      let rejectStaleSnapshot!: (error: Error) => void;
+      const staleSnapshot = new Promise<DemoWorkspaceSnapshot>(
+        (_resolve, reject) => {
+          rejectStaleSnapshot = reject;
+        },
+      );
+      const snapshotSpy = vi
+        .spyOn(repository, "snapshot")
+        .mockReturnValueOnce(staleSnapshot);
+
+      await store.memory.transact((_stored, transaction) => {
+        transaction.putSnapshot({ ...current, revision: current.revision + 2 });
+      });
+      hub.send({
+        source: "local",
+        kind: "commit",
+        workspaceId: current.workspaceId,
+        revision: current.revision + 2,
+        resetEpoch: current.resetEpoch,
+        lastEventSequence: current.lastEventSequence,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      await scheduler.recover(fired);
+      rejectStaleSnapshot(new Error("deferred stale snapshot failure"));
+      await vi.advanceTimersByTimeAsync(0);
+
+      now = 25;
+      await vi.advanceTimersByTimeAsync(25);
+      expect(fired).toHaveBeenCalledTimes(1);
+      snapshotSpy.mockRestore();
       scheduler.dispose();
     } finally {
       vi.useRealTimers();

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
@@ -181,6 +181,19 @@ export class DemoWorkspaceRepository {
     }
   }
 
+  /**
+   * Synchronous view of the repository's last authoritative adoption. This is
+   * available only after initialization and is cloned so synchronous ports can
+   * never mutate the workspace authority.
+   */
+  snapshotNow(): DemoWorkspaceSnapshot {
+    this.requireReady();
+    if (!this.authoritativeSnapshot) {
+      throw new Error("Demo workspace has no authoritative snapshot.");
+    }
+    return clone(this.authoritativeSnapshot);
+  }
+
   subscribe(
     listener: (notification: DemoWorkspaceNotification) => void,
   ): () => void {
@@ -454,8 +467,9 @@ export class DemoWorkspaceRepository {
     original: DemoWorkspaceSnapshot,
   ): Promise<DemoWorkspaceSnapshot> {
     const originalBlobIds = optionalBlobIds(original);
-    const migratedBlobIds =
-      originalBlobIds ?? [...(await this.store.readAllBlobs()).keys()];
+    const migratedBlobIds = originalBlobIds ?? [
+      ...(await this.store.readAllBlobs()).keys(),
+    ];
     const committed = await this.store.transact((stored, transaction) => {
       if (!stored) {
         throw new Error("Demo workspace disappeared during migration.");

--- a/apps/web/src/demo/workspace/DemoWorkspaceScheduler.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceScheduler.ts
@@ -108,7 +108,9 @@ export class DemoWorkspaceScheduler {
       .catch(() => {
         // A later workspace notification or explicit recovery can retry. The
         // safe failure mode is to leave no unfenced deadline callback armed.
-        this.clearTimers();
+        if (!this.disposed && generation === this.reconcileGeneration) {
+          this.clearTimers();
+        }
       });
   }
 
@@ -118,10 +120,7 @@ export class DemoWorkspaceScheduler {
       return;
     }
     const persisted = new Map(
-      snapshot.pendingScenarios.map((pending) => [
-        pending.scenarioId,
-        pending,
-      ]),
+      snapshot.pendingScenarios.map((pending) => [pending.scenarioId, pending]),
     );
 
     for (const [scenarioId, registration] of this.registrations) {

--- a/apps/web/src/routes/activity.$eventId.tsx
+++ b/apps/web/src/routes/activity.$eventId.tsx
@@ -12,7 +12,11 @@ export const Route = createFileRoute("/activity/$eventId")({
         return response.event;
       },
     });
-    if (event.jobKey) {
+    const directDetail = context.ports.featureFlags.get(
+      "activityDetailDirectLoad",
+      false,
+    );
+    if (event.jobKey && !directDetail) {
       throw redirect({
         to: "/jobs/$jobId",
         params: { jobId: event.jobKey },

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -157,7 +157,10 @@ demo actions, and deletes generated demo blobs in the same transaction. If
 IndexedDB is unavailable or full, the page warns that it has switched to
 tab-local memory; those fallback changes are neither shared nor retained after
 the tab closes. The demo contains synthetic data, but visitors should still not
-enter personal data or secrets.
+enter personal data or secrets. Product reads, filtering, sorting, pagination,
+details, and bundled previews are served from that browser-local workspace;
+write actions remain intentionally unavailable until their simulated demo
+transitions are implemented.
 
 ## Verify
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -70,11 +70,13 @@ The dedicated demo-workspace Playwright lane starts Vite only; it must not
 start or contact the product API or SSE endpoint. It proves same-profile tab
 sharing and concurrent writes, separate-context isolation, reload persistence,
 atomic reset/blob deletion, future IndexedDB-version refusal without downgrade,
-and post-commit domain-event delivery. Unit and component tests cover injected
+post-commit domain-event delivery, and populated direct-refresh coverage for
+the demo's dashboard, product routes, and seeded detail deep links. Unit and component tests cover injected
 quota/security fallbacks, schema revalidation, reset-epoch races, event-log
-loss, the reactive data-boundary warning, and the unchanged canonical event
-provider/invalidation router. Playwright artifacts are written outside the
-repository under the system temporary directory.
+loss, read-adapter query/404/capability parity, the reactive data-boundary
+warning, and the unchanged canonical event provider/invalidation router.
+Playwright artifacts are written outside the repository under the system
+temporary directory.
 
 <a id="token-foundation-qa-gate"></a>
 <a id="shared-primitive-qa-gate"></a>


### PR DESCRIPTION
## Summary

- replaces the demo API placeholder with a complete `ApiClientPort` adapter
- serves every read surface from fresh cloned browser-workspace authority, with no local API, SSE, OS, or external fallback
- matches production job, activity, artifact, workflow-run, contact, and research filtering, sorting, pagination, and stable 404 behavior
- keeps every P3 mutation/rehearsal explicit through a stable capability error
- resolves artifact and profile previews synchronously from the repository-owned authoritative mirror and accepts only mapped `/demo/*` assets
- generation-fences stale scheduler failures so they cannot clear newer timers
- enables the seeded activity-detail direct-load path only in demo mode
- covers all populated routes and seeded deep links through direct load and refresh

## Why

P1 established an isolated browser authority. This slice makes every read-only JobCtrl view useful against that authority while preserving the real frontend query, routing, and invalidation architecture. It intentionally stops before mutations and simulated external effects, which belong to P3.

## Validation

- focused adapter/composition/repository suite: 3 files, 43 tests
- full web Vitest suite: 231 files, 1,302 tests
- `corepack pnpm web:check`
- web type-level suite: 11 files, 13 tests, no type errors
- production web build
- native demo Playwright: 7/7 tests
  - 19 product routes and seeded deep links populate and survive refresh
  - includes `/pipelines`, `/debug`, and `/activity/event-demo-score`
  - zero `/v1`, SSE, external, popup, or OS requests
- tracked/untracked diff and formatting checks
- independent review gate: PASS (0 findings)
- independent QA gate: PASS (0 findings)

## Deliberate boundary

`openArtifact` and every other mutation/rehearsed capability still reject through the stable P3 capability error. P3 will add honest browser-local state changes, deterministic scenarios, and explicit no-effect receipts rather than synthesizing success.

## Stack

- Base plan: #407
- P0 contract and canonical seed: #408
- P1 browser workspace: #409
- This PR: P2 complete read adapter
- Next: P3 mutations and deterministic scenarios