### PR TITLE
feat(demo): add consent telemetry edge

### DIFF
--- a/apps/demo-edge/.gitignore
+++ b/apps/demo-edge/.gitignore
@@ -1,0 +1,4 @@
+/.wrangler/
+/.mf/
+.dev.vars*
+/worker-configuration.d.ts

--- a/apps/demo-edge/env.d.ts
+++ b/apps/demo-edge/env.d.ts
@@ -1,0 +1,30 @@
+interface DemoEdgeEnv {
+  DEMO_TELEMETRY_DB: D1Database;
+  PUBLIC_INGRESS_LIMITER: RateLimit;
+  TELEMETRY_EDGE_LIMITER: RateLimit;
+  DEMO_RELEASE: string;
+}
+
+interface RateLimit {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+interface D1Result<T = Record<string, unknown>> {
+  results: T[];
+  success: boolean;
+  meta: { changes?: number };
+}
+
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = Record<string, unknown>>(column?: string): Promise<T | null>;
+  run<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+  all<T = Record<string, unknown>>(): Promise<D1Result<T>>;
+}
+
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+  batch<T = Record<string, unknown>>(
+    statements: D1PreparedStatement[],
+  ): Promise<D1Result<T>[]>;
+}

--- a/apps/demo-edge/migrations/0001_demo_telemetry.sql
+++ b/apps/demo-edge/migrations/0001_demo_telemetry.sql
@@ -1,0 +1,73 @@
+-- Operational aggregates intentionally have no visitor, session, request, or event identifier.
+CREATE TABLE IF NOT EXISTS daily_operational_counters (
+  day_utc TEXT NOT NULL,
+  release TEXT NOT NULL,
+  consent_contract_version TEXT NOT NULL,
+  metric TEXT NOT NULL CHECK (metric IN ('consent_choice', 'initialization_result')),
+  consent_choice TEXT NOT NULL CHECK (consent_choice IN ('granted', 'denied')),
+  initialization_result TEXT NOT NULL CHECK (initialization_result IN ('not_applicable', 'success', 'failure')),
+  storage_mode TEXT NOT NULL CHECK (storage_mode IN ('not_applicable', 'persistent', 'memory')),
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  PRIMARY KEY (day_utc, release, consent_contract_version, metric, consent_choice, initialization_result, storage_mode)
+);
+
+-- This isolated table is deliberately unavailable to reporting queries. It stores only a
+-- SHA-256 retry-operation digest and expiry; it has no foreign keys or identifier columns.
+CREATE TABLE IF NOT EXISTS operational_retry_digests (
+  operation_digest TEXT PRIMARY KEY,
+  expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS operational_retry_digests_expiry_idx
+  ON operational_retry_digests (expires_at);
+
+-- Consented events retain only hashed random first-party cookie values and closed dimensions.
+CREATE TABLE IF NOT EXISTS consented_product_events (
+  id TEXT PRIMARY KEY,
+  occurred_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  visitor_hash TEXT NOT NULL,
+  session_hash TEXT NOT NULL,
+  release TEXT NOT NULL,
+  consent_contract_version TEXT NOT NULL,
+  event_name TEXT NOT NULL,
+  route_name TEXT,
+  feature_name TEXT,
+  action_name TEXT,
+  scenario_name TEXT,
+  result_code TEXT,
+  error_code TEXT,
+  duration_bucket TEXT,
+  viewport_bucket TEXT,
+  tour_step TEXT,
+  referrer_class TEXT
+);
+
+CREATE INDEX IF NOT EXISTS consented_product_events_expiry_idx
+  ON consented_product_events (expires_at);
+CREATE INDEX IF NOT EXISTS consented_product_events_visitor_idx
+  ON consented_product_events (visitor_hash);
+
+-- Short-lived, non-reporting telemetry rate state. It contains only a cookie digest and a
+-- UTC minute window, is never joined to event data, and is deleted on each retention run.
+CREATE TABLE IF NOT EXISTS telemetry_rate_windows (
+  session_hash TEXT NOT NULL,
+  window_utc TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (session_hash, window_utc)
+);
+
+CREATE INDEX IF NOT EXISTS telemetry_rate_windows_expiry_idx
+  ON telemetry_rate_windows (expires_at);
+
+CREATE TABLE IF NOT EXISTS operational_rate_windows (
+  endpoint TEXT NOT NULL CHECK (endpoint IN ('consent', 'health')),
+  window_utc TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (endpoint, window_utc)
+);
+
+CREATE INDEX IF NOT EXISTS operational_rate_windows_expiry_idx
+  ON operational_rate_windows (expires_at);

--- a/apps/demo-edge/migrations/0002_active_identity_and_retention.sql
+++ b/apps/demo-edge/migrations/0002_active_identity_and_retention.sql
@@ -1,0 +1,74 @@
+-- Forward-only upgrade from the originally deployed 0001 schema. Rebuild the
+-- aggregate table so every row has an exact, enforceable expiry timestamp.
+ALTER TABLE daily_operational_counters RENAME TO daily_operational_counters_v1;
+
+CREATE TABLE daily_operational_counters (
+  day_utc TEXT NOT NULL,
+  release TEXT NOT NULL,
+  consent_contract_version TEXT NOT NULL,
+  metric TEXT NOT NULL CHECK (metric IN ('consent_choice', 'initialization_result')),
+  consent_choice TEXT NOT NULL CHECK (consent_choice IN ('granted', 'denied')),
+  initialization_result TEXT NOT NULL CHECK (initialization_result IN ('not_applicable', 'success', 'failure')),
+  storage_mode TEXT NOT NULL CHECK (storage_mode IN ('not_applicable', 'persistent', 'memory')),
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  expires_at TEXT NOT NULL,
+  CHECK (metric = 'consent_choice' OR consent_choice = 'granted'),
+  PRIMARY KEY (day_utc, release, consent_contract_version, metric, consent_choice, initialization_result, storage_mode)
+);
+
+INSERT INTO daily_operational_counters (
+  day_utc, release, consent_contract_version, metric, consent_choice,
+  initialization_result, storage_mode, count, expires_at
+)
+SELECT
+  day_utc, release, consent_contract_version, metric, consent_choice,
+  initialization_result, storage_mode, count,
+  strftime('%Y-%m-%dT%H:%M:%fZ', day_utc || 'T00:00:00Z', '+90 days', '-2 hours')
+FROM daily_operational_counters_v1
+WHERE metric = 'consent_choice' OR consent_choice = 'granted';
+
+DROP TABLE daily_operational_counters_v1;
+
+CREATE INDEX daily_operational_counters_expiry_idx
+  ON daily_operational_counters (expires_at);
+
+ALTER TABLE consented_product_events ADD COLUMN timing_metric TEXT;
+ALTER TABLE consented_product_events ADD COLUMN metric_bucket TEXT;
+
+CREATE INDEX consented_product_events_session_idx
+  ON consented_product_events (session_hash);
+
+-- Active consent is the authoritative fence for every pseudonymous telemetry
+-- write. Multiple browser sessions may remain active for one visitor.
+CREATE TABLE active_demo_identities (
+  visitor_hash TEXT NOT NULL,
+  session_hash TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (visitor_hash, session_hash)
+);
+
+CREATE INDEX active_demo_identities_visitor_idx
+  ON active_demo_identities (visitor_hash);
+CREATE INDEX active_demo_identities_expiry_idx
+  ON active_demo_identities (expires_at);
+
+-- Preserve already-consented event pairs during upgrade. Existing eventless
+-- session-rate rows cannot be safely mapped to an active visitor/session pair,
+-- so discard that short-lived abuse state rather than carrying unfenced state.
+INSERT OR IGNORE INTO active_demo_identities (visitor_hash, session_hash, expires_at)
+SELECT visitor_hash, session_hash, MAX(expires_at)
+FROM consented_product_events
+GROUP BY visitor_hash, session_hash;
+
+DELETE FROM telemetry_rate_windows;
+
+-- D1 is the authoritative cross-location aggregate telemetry budget. This
+-- table has no visitor/session key and is never available to product reports.
+CREATE TABLE telemetry_global_rate_windows (
+  window_utc TEXT PRIMARY KEY,
+  count INTEGER NOT NULL DEFAULT 0 CHECK (count >= 0),
+  expires_at TEXT NOT NULL
+);
+
+CREATE INDEX telemetry_global_rate_windows_expiry_idx
+  ON telemetry_global_rate_windows (expires_at);

--- a/apps/demo-edge/package.json
+++ b/apps/demo-edge/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@jobctrl/demo-edge",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit --project tsconfig.json",
+    "test": "node --test scripts/wrangler-config.test.mjs && vitest run --config vitest.config.ts",
+    "types": "wrangler types --config wrangler.api.jsonc --env-interface DemoEdgeEnv",
+    "dry-run": "wrangler deploy --config wrangler.api.jsonc --dry-run && wrangler deploy --config wrangler.retention.jsonc --dry-run && wrangler types --config wrangler.api.jsonc --env-interface DemoEdgeEnv",
+    "migrate:local": "wrangler d1 migrations apply DEMO_TELEMETRY_DB --local --config wrangler.api.jsonc"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "0.18.0",
+    "@jobctrl/tsconfig": "workspace:*",
+    "@types/node": "^25.6.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5",
+    "wrangler": "4.107.0"
+  }
+}

--- a/apps/demo-edge/reports/consented-audience-reach.sql
+++ b/apps/demo-edge/reports/consented-audience-reach.sql
@@ -1,0 +1,21 @@
+WITH current_events AS (
+  SELECT * FROM consented_product_events
+  WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+), metrics AS (
+  SELECT release, 'unique_audience' AS metric, '' AS dimension_1, '' AS dimension_2,
+         COUNT(*) AS events, COUNT(DISTINCT visitor_hash) AS unique_visitors,
+         COUNT(DISTINCT session_hash) AS unique_sessions
+  FROM current_events GROUP BY release
+  UNION ALL
+  SELECT release, 'route_reach', route_name, '', COUNT(*),
+         COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events WHERE event_name = 'demo_route_viewed' AND route_name IS NOT NULL
+  GROUP BY release, route_name
+  UNION ALL
+  SELECT release, 'feature_reach', feature_name, '', COUNT(*),
+         COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events WHERE event_name = 'demo_feature_opened' AND feature_name IS NOT NULL
+  GROUP BY release, feature_name
+)
+SELECT 'consented traffic' AS population, * FROM metrics
+ORDER BY release, metric, dimension_1, dimension_2;

--- a/apps/demo-edge/reports/consented-engagement.sql
+++ b/apps/demo-edge/reports/consented-engagement.sql
@@ -1,0 +1,30 @@
+WITH current_events AS (
+  SELECT * FROM consented_product_events
+  WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+), metrics AS (
+  SELECT release, 'tour' AS metric, event_name AS dimension_1,
+         COALESCE(tour_step, '') AS dimension_2, COUNT(*) AS events,
+         COUNT(DISTINCT visitor_hash) AS unique_visitors,
+         COUNT(DISTINCT session_hash) AS unique_sessions
+  FROM current_events
+  WHERE event_name IN ('demo_tour_started', 'demo_tour_step_completed', 'demo_tour_completed')
+  GROUP BY release, event_name, tour_step
+  UNION ALL
+  SELECT release, 'action', event_name,
+         COALESCE(feature_name, '') || ':' || COALESCE(action_name, '') || ':' || COALESCE(result_code, ''),
+         COUNT(*), COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events
+  WHERE event_name IN ('demo_action_started', 'demo_action_completed', 'demo_action_failed', 'demo_action_cancelled')
+  GROUP BY release, event_name, feature_name, action_name, result_code
+  UNION ALL
+  SELECT release, 'workspace_reset', '', '', COUNT(*),
+         COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events WHERE event_name = 'demo_workspace_reset' GROUP BY release
+  UNION ALL
+  SELECT release, 'client_error', COALESCE(error_code, ''), '', COUNT(*),
+         COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events WHERE event_name = 'demo_client_error'
+  GROUP BY release, error_code
+)
+SELECT 'consented traffic' AS population, * FROM metrics
+ORDER BY release, metric, dimension_1, dimension_2;

--- a/apps/demo-edge/reports/consented-funnel.sql
+++ b/apps/demo-edge/reports/consented-funnel.sql
@@ -1,0 +1,26 @@
+WITH current_events AS (
+  SELECT * FROM consented_product_events
+  WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+), funnel AS (
+  SELECT release, 'core_funnel' AS metric,
+         CASE
+           WHEN event_name = 'demo_session_started' THEN '01_session'
+           WHEN route_name = 'job_detail' THEN '02_job_detail'
+           WHEN route_name = 'evidence' THEN '03_evidence'
+           WHEN route_name = 'tailor' THEN '04_tailor'
+           WHEN route_name = 'apply_review' THEN '05_apply_review'
+           WHEN route_name = 'apply_dry_run' THEN '06_apply_dry_run'
+           WHEN event_name = 'demo_install_cta_clicked' THEN '07_install_cta'
+         END AS dimension_1,
+         '' AS dimension_2,
+         COUNT(*) AS events,
+         COUNT(DISTINCT visitor_hash) AS unique_visitors,
+         COUNT(DISTINCT session_hash) AS unique_sessions
+  FROM current_events
+  WHERE event_name = 'demo_session_started'
+     OR event_name = 'demo_install_cta_clicked'
+     OR (event_name = 'demo_route_viewed' AND route_name IN ('job_detail', 'evidence', 'tailor', 'apply_review', 'apply_dry_run'))
+  GROUP BY release, dimension_1
+)
+SELECT 'consented traffic' AS population, * FROM funnel
+ORDER BY release, dimension_1;

--- a/apps/demo-edge/reports/consented-timing-cta.sql
+++ b/apps/demo-edge/reports/consented-timing-cta.sql
@@ -1,0 +1,18 @@
+WITH current_events AS (
+  SELECT * FROM consented_product_events
+  WHERE expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+), metrics AS (
+  SELECT release, 'timing' AS metric, COALESCE(timing_metric, '') AS dimension_1,
+         COALESCE(metric_bucket, '') AS dimension_2, COUNT(*) AS events,
+         COUNT(DISTINCT visitor_hash) AS unique_visitors,
+         COUNT(DISTINCT session_hash) AS unique_sessions
+  FROM current_events WHERE event_name = 'demo_timing'
+  GROUP BY release, timing_metric, metric_bucket
+  UNION ALL
+  SELECT release, 'cta', event_name, COALESCE(route_name, ''), COUNT(*),
+         COUNT(DISTINCT visitor_hash), COUNT(DISTINCT session_hash)
+  FROM current_events WHERE event_name IN ('demo_docs_cta_clicked', 'demo_install_cta_clicked')
+  GROUP BY release, event_name, route_name
+)
+SELECT 'consented traffic' AS population, * FROM metrics
+ORDER BY release, metric, dimension_1, dimension_2;

--- a/apps/demo-edge/reports/operational-metrics.sql
+++ b/apps/demo-edge/reports/operational-metrics.sql
@@ -1,0 +1,29 @@
+-- Non-linkable operational populations only. No event, identity, retry-digest,
+-- or rate-budget table is referenced by this report.
+SELECT
+  'all choices' AS population,
+  release,
+  'consent_choice' AS metric,
+  consent_choice AS dimension_1,
+  '' AS dimension_2,
+  SUM(count) AS observations
+FROM daily_operational_counters
+WHERE metric = 'consent_choice'
+  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+GROUP BY release, consent_choice
+
+UNION ALL
+
+SELECT
+  'granted initialization attempts' AS population,
+  release,
+  'initialization_result' AS metric,
+  consent_choice AS dimension_1,
+  storage_mode || ':' || initialization_result AS dimension_2,
+  SUM(count) AS observations
+FROM daily_operational_counters
+WHERE metric = 'initialization_result'
+  AND consent_choice = 'granted'
+  AND expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+GROUP BY release, consent_choice, storage_mode, initialization_result
+ORDER BY population, release, dimension_1, dimension_2;

--- a/apps/demo-edge/scripts/wrangler-config.test.mjs
+++ b/apps/demo-edge/scripts/wrangler-config.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const configNames = ["wrangler.api.jsonc", "wrangler.retention.jsonc", "wrangler.test.jsonc"];
+
+test("edge configs persist only allowlisted custom logs", async () => {
+  for (const name of configNames) {
+    const config = JSON.parse(await readFile(new URL(`../${name}`, import.meta.url), "utf8"));
+    assert.equal(config.compatibility_date, "2026-07-08", name);
+    assert.equal(Boolean(config.compatibility_flags?.includes("nodejs_compat")), false, name);
+    assert.equal(config.observability.enabled, true, name);
+    assert.equal(config.observability.logs.invocation_logs, false, name);
+    assert.equal(config.observability.traces.enabled, false, name);
+  }
+});
+
+test("API Worker owns the same-origin route and two distinct limiter scopes", async () => {
+  const apiConfig = JSON.parse(await readFile(new URL("../wrangler.api.jsonc", import.meta.url), "utf8"));
+  assert.equal(apiConfig.main, "./workers/api.ts");
+  assert.equal(apiConfig.workers_dev, false);
+  assert.equal("pages_build_output_dir" in apiConfig, false);
+  assert.deepEqual(apiConfig.routes, [{ pattern: "demo.jobctrl.dev/api/*", zone_name: "jobctrl.dev" }]);
+
+  for (const name of ["wrangler.api.jsonc", "wrangler.test.jsonc"]) {
+    const config = JSON.parse(await readFile(new URL(`../${name}`, import.meta.url), "utf8"));
+    assert.deepEqual(config.ratelimits, [
+      {
+        name: "PUBLIC_INGRESS_LIMITER",
+        namespace_id: "2026071101",
+        simple: { limit: 240, period: 60 },
+      },
+      {
+        name: "TELEMETRY_EDGE_LIMITER",
+        namespace_id: "2026071102",
+        simple: { limit: 2000, period: 60 },
+      },
+    ], name);
+  }
+});
+
+test("retention is hourly and both Workers are dry-run targets", async () => {
+  const retention = JSON.parse(await readFile(new URL("../wrangler.retention.jsonc", import.meta.url), "utf8"));
+  assert.equal(retention.workers_dev, false);
+  assert.deepEqual(retention.triggers.crons, ["17 * * * *"]);
+  const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
+  assert.match(packageJson.scripts["dry-run"], /deploy --config wrangler\.api\.jsonc --dry-run/);
+  assert.match(packageJson.scripts["dry-run"], /deploy --config wrangler\.retention\.jsonc --dry-run/);
+});
+
+test("reports isolate operational and consented populations from dedupe and rate state", async () => {
+  const operational = await readFile(new URL("../reports/operational-metrics.sql", import.meta.url), "utf8");
+  const consented = (await Promise.all([
+    "consented-audience-reach.sql",
+    "consented-engagement.sql",
+    "consented-funnel.sql",
+    "consented-timing-cta.sql",
+  ].map((name) => readFile(new URL(`../reports/${name}`, import.meta.url), "utf8")))).join("\n");
+  assert.match(operational, /FROM daily_operational_counters/);
+  assert.equal(operational.includes("consented_product_events"), false);
+  assert.match(consented, /FROM consented_product_events/);
+  assert.equal(consented.includes("daily_operational_counters"), false);
+  for (const report of [operational, consented]) {
+    assert.match(report, /expires_at/);
+    for (const table of [
+      "operational_retry_digests",
+      "telemetry_rate_windows",
+      "telemetry_global_rate_windows",
+      "operational_rate_windows",
+      "active_demo_identities",
+    ]) {
+      assert.equal(report.includes(table), false, table);
+    }
+  }
+});

--- a/apps/demo-edge/src/context.ts
+++ b/apps/demo-edge/src/context.ts
@@ -1,0 +1,5 @@
+export interface DemoRequestContext {
+  request: Request;
+  env: DemoEdgeEnv;
+  ingressAllowed: boolean;
+}

--- a/apps/demo-edge/src/contracts.ts
+++ b/apps/demo-edge/src/contracts.ts
@@ -1,0 +1,150 @@
+export const CONSENT_CONTRACT_VERSION = "v1";
+export const CONSENT_MAX_AGE_SECONDS = 60 * 60 * 24 * 180;
+export const MAX_REQUEST_BYTES = 2_048;
+export const OPERATIONAL_RATE_LIMIT_PER_MINUTE = 120;
+export const TELEMETRY_RATE_LIMIT_PER_MINUTE = 30;
+export const TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE = 2_000;
+export const RETENTION_SAFETY_MARGIN_SECONDS = 2 * 60 * 60;
+export const PERSISTENT_COOKIE_MAX_AGE_SECONDS = CONSENT_MAX_AGE_SECONDS - RETENTION_SAFETY_MARGIN_SECONDS;
+export const OPERATION_DIGEST_MAX_AGE_SECONDS = 24 * 60 * 60;
+export const PRODUCT_DATA_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
+
+export const consentChoices = ["granted", "denied"] as const;
+export type ConsentChoice = (typeof consentChoices)[number];
+
+export const healthResults = ["success", "failure"] as const;
+export type HealthResult = (typeof healthResults)[number];
+
+export const storageModes = ["persistent", "memory"] as const;
+export type StorageMode = (typeof storageModes)[number];
+
+export const telemetryEventNames = [
+  "demo_session_started",
+  "demo_route_viewed",
+  "demo_tour_started",
+  "demo_tour_step_completed",
+  "demo_tour_completed",
+  "demo_feature_opened",
+  "demo_action_started",
+  "demo_action_completed",
+  "demo_action_failed",
+  "demo_action_cancelled",
+  "demo_workspace_reset",
+  "demo_install_cta_clicked",
+  "demo_docs_cta_clicked",
+  "demo_client_error",
+  "demo_timing",
+] as const;
+export type TelemetryEventName = (typeof telemetryEventNames)[number];
+
+export const routeNames = [
+  "dashboard",
+  "jobs",
+  "job_detail",
+  "evidence",
+  "tailor",
+  "apply_review",
+  "apply_dry_run",
+  "runs",
+  "settings",
+  "docs",
+] as const;
+export type RouteName = (typeof routeNames)[number];
+
+export const featureNames = [
+  "discovery",
+  "scoring",
+  "evidence",
+  "materials",
+  "apply_review",
+  "apply",
+  "outreach",
+  "demo_tour",
+] as const;
+export type FeatureName = (typeof featureNames)[number];
+
+export const actionNames = [
+  "open",
+  "start",
+  "complete",
+  "fail",
+  "cancel",
+  "retry",
+  "reset",
+  "install_cta",
+  "docs_cta",
+] as const;
+export type ActionName = (typeof actionNames)[number];
+
+export const scenarioNames = ["success", "failure", "cancellation", "retry"] as const;
+export type ScenarioName = (typeof scenarioNames)[number];
+
+export const resultCodes = ["succeeded", "failed", "cancelled"] as const;
+export type ResultCode = (typeof resultCodes)[number];
+
+export const errorCodes = [
+  "network_unavailable",
+  "telemetry_unavailable",
+  "validation_rejected",
+  "scenario_failed",
+  "client_unexpected",
+] as const;
+export type ErrorCode = (typeof errorCodes)[number];
+
+export const durationBuckets = [
+  "under_100ms",
+  "100ms_to_499ms",
+  "500ms_to_999ms",
+  "1s_to_2s",
+  "2s_to_5s",
+  "5s_to_10s",
+  "over_10s",
+] as const;
+export type DurationBucket = (typeof durationBuckets)[number];
+
+export const timingMetrics = ["lcp", "inp", "cls", "ttfb", "route_transition"] as const;
+export type TimingMetric = (typeof timingMetrics)[number];
+
+export const metricBuckets = ["good", "needs_improvement", "poor"] as const;
+export type MetricBucket = (typeof metricBuckets)[number];
+
+export const viewportBuckets = ["compact", "standard", "wide"] as const;
+export type ViewportBucket = (typeof viewportBuckets)[number];
+
+export const tourSteps = ["welcome", "jobs", "evidence", "tailor", "apply", "install"] as const;
+export type TourStep = (typeof tourSteps)[number];
+
+export const referrerClasses = ["direct", "jobctrl_docs", "github", "search", "other"] as const;
+export type ReferrerClass = (typeof referrerClasses)[number];
+
+export interface TelemetryAttributes {
+  route?: RouteName;
+  feature?: FeatureName;
+  action?: ActionName;
+  scenario?: ScenarioName;
+  result?: ResultCode;
+  errorCode?: ErrorCode;
+  durationBucket?: DurationBucket;
+  timingMetric?: TimingMetric;
+  metricBucket?: MetricBucket;
+  viewportBucket?: ViewportBucket;
+  tourStep?: TourStep;
+  referrerClass?: ReferrerClass;
+}
+
+export interface TelemetryEvent {
+  name: TelemetryEventName;
+  attributes: TelemetryAttributes;
+}
+
+export interface ConsentRequest {
+  choice: ConsentChoice;
+  operationKey: string;
+}
+
+export interface HealthRequest {
+  choice: ConsentChoice;
+  result: HealthResult;
+  storageMode: StorageMode;
+  operationKey: string;
+}

--- a/apps/demo-edge/src/cookies.ts
+++ b/apps/demo-edge/src/cookies.ts
@@ -1,0 +1,80 @@
+import {
+  CONSENT_CONTRACT_VERSION,
+  PERSISTENT_COOKIE_MAX_AGE_SECONDS,
+  type ConsentChoice,
+} from "./contracts.js";
+
+export const CONSENT_COOKIE = "__Host-jobctrl_demo_consent";
+export const VISITOR_COOKIE = "__Host-jobctrl_demo_vid";
+export const SESSION_COOKIE = "__Host-jobctrl_demo_session";
+
+export interface DemoCookies {
+  consent?: ConsentChoice;
+  visitorId?: string;
+  sessionId?: string;
+  consentContractStale: boolean;
+  visitorCookiePresent: boolean;
+  sessionCookiePresent: boolean;
+}
+
+function cookieValue(name: string, cookieHeader: string | null): string | undefined {
+  if (cookieHeader === null) return undefined;
+  for (const entry of cookieHeader.split(";")) {
+    const [key, ...parts] = entry.trim().split("=");
+    if (key === name && parts.length > 0) return parts.join("=");
+  }
+  return undefined;
+}
+
+function validId(value: string | undefined): value is string {
+  return value !== undefined && /^[A-Za-z0-9_-]{32,128}$/.test(value);
+}
+
+export function readDemoCookies(request: Request): DemoCookies {
+  const header = request.headers.get("cookie");
+  const consentValue = cookieValue(CONSENT_COOKIE, header);
+  const consent = consentValue === `${CONSENT_CONTRACT_VERSION}.granted`
+    ? "granted"
+    : consentValue === `${CONSENT_CONTRACT_VERSION}.denied`
+      ? "denied"
+      : undefined;
+  const visitorId = cookieValue(VISITOR_COOKIE, header);
+  const sessionId = cookieValue(SESSION_COOKIE, header);
+  return {
+    ...(consent === undefined ? {} : { consent }),
+    ...(validId(visitorId) ? { visitorId } : {}),
+    ...(validId(sessionId) ? { sessionId } : {}),
+    consentContractStale: consentValue !== undefined && consent === undefined,
+    visitorCookiePresent: visitorId !== undefined,
+    sessionCookiePresent: sessionId !== undefined,
+  };
+}
+
+function baseCookie(name: string, value: string): string {
+  return `${name}=${value}; Max-Age=${PERSISTENT_COOKIE_MAX_AGE_SECONDS}; Path=/; Secure; SameSite=Lax`;
+}
+
+export function consentCookie(choice: ConsentChoice): string {
+  return baseCookie(CONSENT_COOKIE, `${CONSENT_CONTRACT_VERSION}.${choice}`);
+}
+
+export function visitorCookie(visitorId: string): string {
+  return `${baseCookie(VISITOR_COOKIE, visitorId)}; HttpOnly`;
+}
+
+export function sessionCookie(sessionId: string): string {
+  return `${SESSION_COOKIE}=${sessionId}; Path=/; Secure; SameSite=Lax; HttpOnly`;
+}
+
+export function expireCookie(name: string): string {
+  return `${name}=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=Lax; HttpOnly`;
+}
+
+export function expireConsentCookie(): string {
+  return `${CONSENT_COOKIE}=; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/; Secure; SameSite=Lax`;
+}
+
+export function appendCookies(response: Response, cookies: readonly string[]): Response {
+  for (const cookie of cookies) response.headers.append("set-cookie", cookie);
+  return response;
+}

--- a/apps/demo-edge/src/crypto.ts
+++ b/apps/demo-edge/src/crypto.ts
@@ -1,0 +1,13 @@
+export async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function randomId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}

--- a/apps/demo-edge/src/database.ts
+++ b/apps/demo-edge/src/database.ts
@@ -1,0 +1,305 @@
+import {
+  CONSENT_CONTRACT_VERSION,
+  OPERATION_DIGEST_MAX_AGE_SECONDS,
+  OPERATIONAL_RATE_LIMIT_PER_MINUTE,
+  PERSISTENT_COOKIE_MAX_AGE_SECONDS,
+  PRODUCT_DATA_MAX_AGE_SECONDS,
+  RETENTION_SAFETY_MARGIN_SECONDS,
+  TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE,
+  TELEMETRY_RATE_LIMIT_PER_MINUTE,
+  type ConsentChoice,
+  type HealthResult,
+  type StorageMode,
+  type TelemetryEvent,
+} from "./contracts.js";
+import { randomId, sha256 } from "./crypto.js";
+
+interface OperationalCounter {
+  metric: "consent_choice" | "initialization_result";
+  consentChoice: ConsentChoice;
+  initializationResult: "not_applicable" | HealthResult;
+  storageMode: "not_applicable" | StorageMode;
+}
+
+interface CountRow {
+  count: number;
+}
+
+const ACTIVE_IDENTITY_EXISTS_SQL = `SELECT 1 FROM active_demo_identities
+  WHERE visitor_hash = ? AND session_hash = ? AND expires_at > ?`;
+
+export interface RetentionResult {
+  operationalCounters: number;
+  retryDigests: number;
+  productEvents: number;
+  sessionRates: number;
+  globalTelemetryRates: number;
+  operationalRates: number;
+  activeIdentities: number;
+}
+
+function plusSeconds(now: Date, seconds: number): string {
+  const result = new Date(now.getTime() + seconds * 1_000);
+  return result.toISOString();
+}
+
+function boundedExpiry(now: Date, maximumAgeSeconds: number): string {
+  return plusSeconds(now, maximumAgeSeconds - RETENTION_SAFETY_MARGIN_SECONDS);
+}
+
+function counterExpiry(now: Date): string {
+  const dayStart = new Date(`${utcDay(now)}T00:00:00.000Z`);
+  return boundedExpiry(dayStart, PRODUCT_DATA_MAX_AGE_SECONDS);
+}
+
+function utcMinute(now: Date): string {
+  return now.toISOString().slice(0, 16);
+}
+
+function utcDay(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+async function isWithinOperationalRateLimit(env: DemoEdgeEnv, endpoint: "consent" | "health", now: Date): Promise<boolean> {
+  const row = await env.DEMO_TELEMETRY_DB.prepare(
+    `INSERT INTO operational_rate_windows (endpoint, window_utc, count, expires_at)
+     VALUES (?, ?, 1, ?)
+     ON CONFLICT(endpoint, window_utc) DO UPDATE SET
+       count = operational_rate_windows.count + 1,
+       expires_at = excluded.expires_at
+     WHERE operational_rate_windows.count < ?
+     RETURNING count`,
+  ).bind(
+    endpoint,
+    utcMinute(now),
+    boundedExpiry(now, OPERATION_DIGEST_MAX_AGE_SECONDS),
+    OPERATIONAL_RATE_LIMIT_PER_MINUTE,
+  ).first<CountRow>();
+  return row !== null;
+}
+
+export async function isOperationalRequestAllowed(env: DemoEdgeEnv, endpoint: "consent" | "health", now = new Date()): Promise<boolean> {
+  return isWithinOperationalRateLimit(env, endpoint, now);
+}
+
+export async function recordOperationalCounter(
+  env: DemoEdgeEnv,
+  operationKey: string,
+  counter: OperationalCounter,
+  now = new Date(),
+): Promise<void> {
+  const operationDigest = await sha256(operationKey);
+  const statements = [
+    env.DEMO_TELEMETRY_DB.prepare(
+      "INSERT OR IGNORE INTO operational_retry_digests (operation_digest, expires_at) VALUES (?, ?)",
+    ).bind(operationDigest, boundedExpiry(now, OPERATION_DIGEST_MAX_AGE_SECONDS)),
+    env.DEMO_TELEMETRY_DB.prepare(
+      `INSERT INTO daily_operational_counters (
+        day_utc, release, consent_contract_version, metric, consent_choice,
+        initialization_result, storage_mode, count, expires_at
+      )
+      SELECT ?, ?, ?, ?, ?, ?, ?, 1, ?
+      WHERE changes() = 1
+      ON CONFLICT(day_utc, release, consent_contract_version, metric, consent_choice, initialization_result, storage_mode)
+      DO UPDATE SET count = daily_operational_counters.count + 1`,
+    ).bind(
+      utcDay(now),
+      env.DEMO_RELEASE,
+      CONSENT_CONTRACT_VERSION,
+      counter.metric,
+      counter.consentChoice,
+      counter.initializationResult,
+      counter.storageMode,
+      counterExpiry(now),
+    ),
+  ];
+
+  // D1 batch executes these statements transactionally. The second statement observes
+  // changes() from the unique digest insert, so a committed retry cannot increment again.
+  await env.DEMO_TELEMETRY_DB.batch(statements);
+}
+
+export async function isTelemetryRequestAllowed(
+  env: DemoEdgeEnv,
+  visitorHash: string,
+  sessionHash: string,
+  now = new Date(),
+): Promise<boolean> {
+  const sessionRow = await env.DEMO_TELEMETRY_DB.prepare(
+    `INSERT INTO telemetry_rate_windows (session_hash, window_utc, count, expires_at)
+     SELECT ?, ?, 1, ?
+     WHERE EXISTS (
+       ${ACTIVE_IDENTITY_EXISTS_SQL}
+     )
+     ON CONFLICT(session_hash, window_utc) DO UPDATE SET
+       count = telemetry_rate_windows.count + 1,
+       expires_at = excluded.expires_at
+     WHERE telemetry_rate_windows.count < ?
+     RETURNING count`,
+  ).bind(
+    sessionHash,
+    utcMinute(now),
+    boundedExpiry(now, OPERATION_DIGEST_MAX_AGE_SECONDS),
+    visitorHash,
+    sessionHash,
+    now.toISOString(),
+    TELEMETRY_RATE_LIMIT_PER_MINUTE,
+  ).first<CountRow>();
+  if (sessionRow === null) return false;
+
+  const globalRow = await env.DEMO_TELEMETRY_DB.prepare(
+    `INSERT INTO telemetry_global_rate_windows (window_utc, count, expires_at)
+     VALUES (?, 1, ?)
+     ON CONFLICT(window_utc) DO UPDATE SET
+       count = telemetry_global_rate_windows.count + 1,
+       expires_at = excluded.expires_at
+     WHERE telemetry_global_rate_windows.count < ?
+     RETURNING count`,
+  ).bind(
+    utcMinute(now),
+    boundedExpiry(now, OPERATION_DIGEST_MAX_AGE_SECONDS),
+    TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE,
+  ).first<CountRow>();
+  if (globalRow === null) return false;
+
+  // Workers Rate Limiting counters are per edge location, so this binding is adjacent
+  // abuse protection after the authoritative D1 session and global budgets.
+  return (await env.TELEMETRY_EDGE_LIMITER.limit({ key: "telemetry" })).success;
+}
+
+export async function insertTelemetryEvent(
+  env: DemoEdgeEnv,
+  visitorHash: string,
+  sessionHash: string,
+  event: TelemetryEvent,
+  now = new Date(),
+): Promise<boolean> {
+  const inserted = await env.DEMO_TELEMETRY_DB.prepare(
+    `INSERT INTO consented_product_events (
+      id, occurred_at, expires_at, visitor_hash, session_hash, release, consent_contract_version,
+      event_name, route_name, feature_name, action_name, scenario_name, result_code, error_code,
+      duration_bucket, viewport_bucket, tour_step, referrer_class, timing_metric, metric_bucket
+    )
+    SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+    WHERE EXISTS (
+      ${ACTIVE_IDENTITY_EXISTS_SQL}
+    )
+    RETURNING id`,
+  ).bind(
+    randomId(),
+    now.toISOString(),
+    boundedExpiry(now, PRODUCT_DATA_MAX_AGE_SECONDS),
+    visitorHash,
+    sessionHash,
+    env.DEMO_RELEASE,
+    CONSENT_CONTRACT_VERSION,
+    event.name,
+    event.attributes.route ?? null,
+    event.attributes.feature ?? null,
+    event.attributes.action ?? null,
+    event.attributes.scenario ?? null,
+    event.attributes.result ?? null,
+    event.attributes.errorCode ?? null,
+    event.attributes.durationBucket ?? null,
+    event.attributes.viewportBucket ?? null,
+    event.attributes.tourStep ?? null,
+    event.attributes.referrerClass ?? null,
+    event.attributes.timingMetric ?? null,
+    event.attributes.metricBucket ?? null,
+    visitorHash,
+    sessionHash,
+    now.toISOString(),
+  ).first<{ id: string }>();
+  return inserted !== null;
+}
+
+export async function activateTelemetryIdentity(
+  env: DemoEdgeEnv,
+  visitorId: string,
+  sessionId: string,
+  now = new Date(),
+): Promise<void> {
+  const { visitorHash, sessionHash } = await hashTelemetryIds(visitorId, sessionId);
+  await env.DEMO_TELEMETRY_DB.prepare(
+    `INSERT INTO active_demo_identities (visitor_hash, session_hash, expires_at)
+     VALUES (?, ?, ?)
+     ON CONFLICT(visitor_hash, session_hash) DO UPDATE SET expires_at = excluded.expires_at`,
+  ).bind(visitorHash, sessionHash, plusSeconds(now, PERSISTENT_COOKIE_MAX_AGE_SECONDS)).run();
+}
+
+export async function refreshTelemetryIdentity(
+  env: DemoEdgeEnv,
+  visitorId: string,
+  sessionId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const { visitorHash, sessionHash } = await hashTelemetryIds(visitorId, sessionId);
+  const refreshed = await env.DEMO_TELEMETRY_DB.prepare(
+    `UPDATE active_demo_identities
+     SET expires_at = ?
+     WHERE visitor_hash = ? AND session_hash = ? AND expires_at > ?
+     RETURNING session_hash`,
+  ).bind(
+    plusSeconds(now, PERSISTENT_COOKIE_MAX_AGE_SECONDS),
+    visitorHash,
+    sessionHash,
+    now.toISOString(),
+  ).first<{ session_hash: string }>();
+  return refreshed !== null;
+}
+
+export async function hasActiveTelemetryVisitor(
+  env: DemoEdgeEnv,
+  visitorId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const visitorHash = await sha256(visitorId);
+  const row = await env.DEMO_TELEMETRY_DB.prepare(
+    `SELECT 1 AS active FROM active_demo_identities
+     WHERE visitor_hash = ? AND expires_at > ? LIMIT 1`,
+  ).bind(visitorHash, now.toISOString()).first<{ active: number }>();
+  return row !== null;
+}
+
+export async function hasActiveTelemetryIdentity(
+  env: DemoEdgeEnv,
+  visitorId: string,
+  sessionId: string,
+  now = new Date(),
+): Promise<boolean> {
+  const { visitorHash, sessionHash } = await hashTelemetryIds(visitorId, sessionId);
+  const row = await env.DEMO_TELEMETRY_DB.prepare(
+    `${ACTIVE_IDENTITY_EXISTS_SQL} LIMIT 1`,
+  ).bind(visitorHash, sessionHash, now.toISOString()).first<{ active: number }>();
+  return row !== null;
+}
+
+export async function hashTelemetryIds(visitorId: string, sessionId: string): Promise<{ visitorHash: string; sessionHash: string }> {
+  const [visitorHash, sessionHash] = await Promise.all([sha256(visitorId), sha256(sessionId)]);
+  return { visitorHash, sessionHash };
+}
+
+function changedCount(result: D1Result<unknown>): number {
+  return typeof result.meta.changes === "number" ? result.meta.changes : 0;
+}
+
+export async function cleanupExpiredData(env: DemoEdgeEnv, now = new Date()): Promise<RetentionResult> {
+  const results = await env.DEMO_TELEMETRY_DB.batch([
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM daily_operational_counters WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM operational_retry_digests WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM consented_product_events WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_rate_windows WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_global_rate_windows WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM operational_rate_windows WHERE expires_at <= ?").bind(now.toISOString()),
+    env.DEMO_TELEMETRY_DB.prepare("DELETE FROM active_demo_identities WHERE expires_at <= ?").bind(now.toISOString()),
+  ]);
+  return {
+    operationalCounters: changedCount(results[0]!),
+    retryDigests: changedCount(results[1]!),
+    productEvents: changedCount(results[2]!),
+    sessionRates: changedCount(results[3]!),
+    globalTelemetryRates: changedCount(results[4]!),
+    operationalRates: changedCount(results[5]!),
+    activeIdentities: changedCount(results[6]!),
+  };
+}

--- a/apps/demo-edge/src/handlers.ts
+++ b/apps/demo-edge/src/handlers.ts
@@ -1,0 +1,292 @@
+import {
+  appendCookies,
+  consentCookie,
+  expireConsentCookie,
+  expireCookie,
+  readDemoCookies,
+  sessionCookie,
+  SESSION_COOKIE,
+  visitorCookie,
+  VISITOR_COOKIE,
+} from "./cookies.js";
+import { CONSENT_CONTRACT_VERSION } from "./contracts.js";
+import {
+  activateTelemetryIdentity,
+  hasActiveTelemetryIdentity,
+  hasActiveTelemetryVisitor,
+  hashTelemetryIds,
+  insertTelemetryEvent,
+  isOperationalRequestAllowed,
+  isTelemetryRequestAllowed,
+  recordOperationalCounter,
+  refreshTelemetryIdentity,
+} from "./database.js";
+import { randomId } from "./crypto.js";
+import {
+  emptyResponse,
+  hasSameOriginMetadata,
+  jsonResponse,
+  logEdgeEvent,
+  methodNotAllowed,
+  readStrictJson,
+  rejectedResponse,
+  temporarilyUnavailableResponse,
+} from "./http.js";
+import { parseConsentRequest, parseHealthRequest, parseTelemetryEvent } from "./schema.js";
+import type { DemoRequestContext } from "./context.js";
+
+function sameOriginOrRejected(context: DemoRequestContext, allowMissingOrigin = false): Response | undefined {
+  return hasSameOriginMetadata(context.request, allowMissingOrigin) ? undefined : rejectedResponse(403);
+}
+
+function consentPayload(choice: "granted" | "denied" | "unknown"): Record<string, string> {
+  return {
+    choice,
+    version: CONSENT_CONTRACT_VERSION,
+  };
+}
+
+type GrantIdentityPreparation =
+  | { mode: "reuse"; visitorId: string }
+  | { mode: "new_session"; visitorId: string }
+  | { mode: "rotate" }
+  | { mode: "blocked"; response: Response };
+
+async function prepareIdentifiersForGrant(
+  context: DemoRequestContext,
+  now: Date,
+): Promise<GrantIdentityPreparation> {
+  const cookies = readDemoCookies(context.request);
+  if (cookies.visitorId === undefined && cookies.sessionId === undefined) return { mode: "rotate" };
+
+  try {
+    if (cookies.consent === "granted" && cookies.visitorId !== undefined) {
+      if (cookies.sessionId !== undefined
+        && await refreshTelemetryIdentity(context.env, cookies.visitorId, cookies.sessionId, now)) {
+        return { mode: "reuse", visitorId: cookies.visitorId };
+      }
+      if (cookies.sessionId === undefined
+        && await hasActiveTelemetryVisitor(context.env, cookies.visitorId, now)) {
+        return { mode: "new_session", visitorId: cookies.visitorId };
+      }
+    }
+  } catch {
+    return { mode: "blocked", response: temporarilyUnavailableResponse() };
+  }
+
+  // Stale, inactive, or corrupt identifiers are rotated without deleting
+  // retained rows. The ordinary expiry worker remains their only lifecycle in
+  // this acceptance-only phase.
+  return { mode: "rotate" };
+}
+
+function expiredStaleCookies(context: DemoRequestContext): string[] {
+  const cookies = readDemoCookies(context.request);
+  return [
+    expireConsentCookie(),
+    ...(cookies.visitorCookiePresent ? [expireCookie(VISITOR_COOKIE)] : []),
+    ...(cookies.sessionCookiePresent ? [expireCookie(SESSION_COOKIE)] : []),
+  ];
+}
+
+export async function handleConsentGet(context: DemoRequestContext, now = new Date()): Promise<Response> {
+  if (context.request.method !== "GET") return methodNotAllowed("GET, POST");
+  const rejected = sameOriginOrRejected(context, true);
+  if (rejected !== undefined) return rejected;
+
+  const cookies = readDemoCookies(context.request);
+  if (cookies.consentContractStale) {
+    return appendCookies(
+      jsonResponse(200, consentPayload("unknown")),
+      expiredStaleCookies(context),
+    );
+  }
+  if (cookies.consent === "denied") {
+    return jsonResponse(200, consentPayload("denied"));
+  }
+  if (!context.ingressAllowed) return rejectedResponse(429);
+  if (cookies.consent !== "granted") return jsonResponse(200, consentPayload("unknown"));
+  if (cookies.visitorId === undefined || cookies.sessionId === undefined) {
+    return appendCookies(
+      jsonResponse(200, consentPayload("unknown")),
+      expiredStaleCookies(context),
+    );
+  }
+
+  try {
+    if (!await hasActiveTelemetryIdentity(context.env, cookies.visitorId, cookies.sessionId, now)) {
+      return appendCookies(
+        jsonResponse(200, consentPayload("unknown")),
+        expiredStaleCookies(context),
+      );
+    }
+  } catch {
+    return temporarilyUnavailableResponse();
+  }
+  return jsonResponse(200, consentPayload("granted"));
+}
+
+export async function handleConsentPost(context: DemoRequestContext, now = new Date()): Promise<Response> {
+  if (context.request.method !== "POST") return methodNotAllowed("GET, POST");
+  const rejected = sameOriginOrRejected(context);
+  if (rejected !== undefined) return rejected;
+
+  const body = await readStrictJson(context.request);
+  const request = parseConsentRequest(body);
+  if (request === undefined) return rejectedResponse();
+
+  if (request.choice === "denied") {
+    const cookies = readDemoCookies(context.request);
+    if (cookies.consent === "granted" || cookies.visitorCookiePresent || cookies.sessionCookiePresent) {
+      if (context.ingressAllowed) {
+        logEdgeEvent("consent_write", { endpoint: "consent", outcome: "identity_bearing_denial_rejected" });
+      }
+      return rejectedResponse(409);
+    }
+    try {
+      if (await isOperationalRequestAllowed(context.env, "consent", now)) {
+        await recordOperationalCounter(context.env, request.operationKey, {
+          metric: "consent_choice",
+          consentChoice: "denied",
+          initializationResult: "not_applicable",
+          storageMode: "not_applicable",
+        }, now);
+      }
+    } catch {
+      // Anonymous entry-choice measurement is best-effort and never changes decline.
+    }
+    return appendCookies(
+      jsonResponse(200, consentPayload("denied")),
+      [consentCookie("denied")],
+    );
+  }
+
+  if (!context.ingressAllowed) return rejectedResponse(429);
+
+  const identityPreparation = await prepareIdentifiersForGrant(context, now);
+  if (identityPreparation.mode === "blocked") return identityPreparation.response;
+  if (identityPreparation.mode === "reuse") {
+    logEdgeEvent("consent_write", { endpoint: "consent", outcome: "granted_idempotent" });
+    return appendCookies(
+      jsonResponse(200, consentPayload("granted")),
+      [consentCookie("granted"), visitorCookie(identityPreparation.visitorId)],
+    );
+  }
+  if (identityPreparation.mode === "new_session") {
+    const sessionId = randomId();
+    try {
+      await activateTelemetryIdentity(context.env, identityPreparation.visitorId, sessionId, now);
+    } catch {
+      return temporarilyUnavailableResponse();
+    }
+    logEdgeEvent("consent_write", { endpoint: "consent", outcome: "new_session" });
+    return appendCookies(
+      jsonResponse(200, consentPayload("granted")),
+      [
+        consentCookie("granted"),
+        visitorCookie(identityPreparation.visitorId),
+        sessionCookie(sessionId),
+      ],
+    );
+  }
+
+  try {
+    if (!await isOperationalRequestAllowed(context.env, "consent", now)) return rejectedResponse(429);
+    await recordOperationalCounter(context.env, request.operationKey, {
+      metric: "consent_choice",
+      consentChoice: "granted",
+      initializationResult: "not_applicable",
+      storageMode: "not_applicable",
+    }, now);
+  } catch {
+    logEdgeEvent("consent_write", { endpoint: "consent", outcome: "database_unavailable" });
+    return temporarilyUnavailableResponse();
+  }
+
+  // Fresh and rotated grants create a new active pair. Any superseded pair is
+  // retained only until its ordinary expiry.
+  const visitorId = randomId();
+  const sessionId = randomId();
+  try {
+    await activateTelemetryIdentity(context.env, visitorId, sessionId, now);
+  } catch {
+    return temporarilyUnavailableResponse();
+  }
+  logEdgeEvent("consent_write", { endpoint: "consent", outcome: "granted" });
+  return appendCookies(
+    jsonResponse(200, consentPayload("granted")),
+    [consentCookie("granted"), visitorCookie(visitorId), sessionCookie(sessionId)],
+  );
+}
+
+export async function handleHealthPost(context: DemoRequestContext, now = new Date()): Promise<Response> {
+  if (context.request.method !== "POST") return methodNotAllowed("POST");
+  const rejected = sameOriginOrRejected(context);
+  if (rejected !== undefined) return rejected;
+  if (!context.ingressAllowed) return rejectedResponse(429);
+
+  const body = await readStrictJson(context.request);
+  const request = parseHealthRequest(body);
+  const cookies = readDemoCookies(context.request);
+  if (request === undefined
+    || request.choice !== "granted"
+    || request.choice !== cookies.consent
+    || cookies.visitorId === undefined
+    || cookies.sessionId === undefined) {
+    return rejectedResponse();
+  }
+
+  try {
+    if (!await hasActiveTelemetryIdentity(context.env, cookies.visitorId, cookies.sessionId, now)) {
+      return rejectedResponse();
+    }
+    if (!await isOperationalRequestAllowed(context.env, "health", now)) return rejectedResponse(429);
+    await recordOperationalCounter(context.env, request.operationKey, {
+      metric: "initialization_result",
+      consentChoice: request.choice,
+      initializationResult: request.result,
+      storageMode: request.storageMode,
+    }, now);
+  } catch {
+    logEdgeEvent("health_write", { endpoint: "health", outcome: "database_unavailable" });
+    return temporarilyUnavailableResponse();
+  }
+
+  logEdgeEvent("health_write", { endpoint: "health", outcome: "recorded" });
+  return emptyResponse();
+}
+
+export async function handleTelemetryPost(context: DemoRequestContext, now = new Date()): Promise<Response> {
+  if (context.request.method !== "POST") return methodNotAllowed("POST");
+  const rejected = sameOriginOrRejected(context);
+  if (rejected !== undefined) return rejected;
+  if (!context.ingressAllowed) return emptyResponse();
+
+  const body = await readStrictJson(context.request);
+  const event = parseTelemetryEvent(body);
+  if (event === undefined) return rejectedResponse();
+
+  const cookies = readDemoCookies(context.request);
+  if (cookies.consent !== "granted" || cookies.visitorId === undefined || cookies.sessionId === undefined) {
+    return emptyResponse();
+  }
+
+  try {
+    const ids = await hashTelemetryIds(cookies.visitorId, cookies.sessionId);
+    if (!await isTelemetryRequestAllowed(context.env, ids.visitorHash, ids.sessionHash, now)) {
+      logEdgeEvent("telemetry_write", { endpoint: "telemetry", outcome: "rate_dropped" });
+      return emptyResponse();
+    }
+    if (!await insertTelemetryEvent(context.env, ids.visitorHash, ids.sessionHash, event, now)) {
+      logEdgeEvent("telemetry_write", { endpoint: "telemetry", outcome: "inactive_dropped" });
+      return emptyResponse();
+    }
+  } catch {
+    // Optional analytics must never disclose database state or disrupt the demo.
+    logEdgeEvent("telemetry_write", { endpoint: "telemetry", outcome: "dropped" });
+    return emptyResponse();
+  }
+
+  logEdgeEvent("telemetry_write", { endpoint: "telemetry", outcome: "recorded" });
+  return emptyResponse();
+}

--- a/apps/demo-edge/src/http.ts
+++ b/apps/demo-edge/src/http.ts
@@ -1,0 +1,95 @@
+import { MAX_REQUEST_BYTES } from "./contracts.js";
+
+export const JSON_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "application/json; charset=utf-8",
+  "x-content-type-options": "nosniff",
+} as const;
+
+export function jsonResponse(status: number, payload: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(payload), { status, headers: JSON_HEADERS });
+}
+
+export function emptyResponse(status = 204): Response {
+  return new Response(null, { status, headers: { "cache-control": "no-store", "x-content-type-options": "nosniff" } });
+}
+
+export function rejectedResponse(status = 400): Response {
+  return jsonResponse(status, { error: "request_rejected" });
+}
+
+export function temporarilyUnavailableResponse(): Response {
+  return jsonResponse(503, { error: "temporarily_unavailable" });
+}
+
+export function methodNotAllowed(allowed: string): Response {
+  const response = rejectedResponse(405);
+  response.headers.set("allow", allowed);
+  return response;
+}
+
+export function hasSameOriginMetadata(request: Request, allowMissingOrigin = false): boolean {
+  const requestUrl = new URL(request.url);
+  const origin = request.headers.get("origin");
+  return request.headers.get("sec-fetch-site") === "same-origin"
+    && (origin === requestUrl.origin || (allowMissingOrigin && origin === null));
+}
+
+export async function readStrictJson(request: Request): Promise<unknown | undefined> {
+  const contentType = request.headers.get("content-type");
+  if (contentType === null || !/^application\/json(?:\s*;\s*charset=utf-8)?$/i.test(contentType)) {
+    return undefined;
+  }
+
+  const contentLength = request.headers.get("content-length");
+  if (contentLength !== null && (!/^\d+$/.test(contentLength) || Number(contentLength) > MAX_REQUEST_BYTES)) {
+    return undefined;
+  }
+
+  const reader = request.body?.getReader();
+  if (reader === undefined) return undefined;
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_REQUEST_BYTES) {
+        await reader.cancel();
+        return undefined;
+      }
+      chunks.push(value);
+    }
+  } catch {
+    try {
+      await reader.cancel();
+    } catch {
+      // The stream is already closed or errored; the body is still rejected.
+    }
+    return undefined;
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function logEdgeEvent(event: string, fields: Record<string, string | number | boolean>): void {
+  // Wrangler deliberately disables automatic traces and invocation logs because they can
+  // persist raw request metadata. These typed custom fields contain no request object,
+  // body, cookies, IP, URL, user agent, or referrer.
+  console.log(JSON.stringify({ component: "jobctrl-demo-edge", event, ...fields }));
+}

--- a/apps/demo-edge/src/schema.ts
+++ b/apps/demo-edge/src/schema.ts
@@ -1,0 +1,110 @@
+import {
+  actionNames,
+  consentChoices,
+  durationBuckets,
+  errorCodes,
+  featureNames,
+  healthResults,
+  metricBuckets,
+  type ConsentRequest,
+  type HealthRequest,
+  referrerClasses,
+  resultCodes,
+  routeNames,
+  scenarioNames,
+  storageModes,
+  telemetryEventNames,
+  timingMetrics,
+  type TelemetryAttributes,
+  type TelemetryEvent,
+  tourSteps,
+  viewportBuckets,
+} from "./contracts.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function isFrom<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function isOperationKey(value: unknown): value is string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]{32,128}$/.test(value);
+}
+
+export function parseConsentRequest(value: unknown): ConsentRequest | undefined {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["choice", "operationKey"]) || !isFrom(value.choice, consentChoices) || !isOperationKey(value.operationKey)) {
+    return undefined;
+  }
+  return { choice: value.choice, operationKey: value.operationKey };
+}
+
+export function parseHealthRequest(value: unknown): HealthRequest | undefined {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["choice", "result", "storageMode", "operationKey"])
+    || !isFrom(value.choice, consentChoices)
+    || !isFrom(value.result, healthResults)
+    || !isFrom(value.storageMode, storageModes)
+    || !isOperationKey(value.operationKey)) {
+    return undefined;
+  }
+  return {
+    choice: value.choice,
+    result: value.result,
+    storageMode: value.storageMode,
+    operationKey: value.operationKey,
+  };
+}
+
+const allowedAttributesByEvent: Record<TelemetryEvent["name"], readonly (keyof TelemetryAttributes)[]> = {
+  demo_session_started: ["route", "viewportBucket", "referrerClass"],
+  demo_route_viewed: ["route", "viewportBucket", "referrerClass"],
+  demo_tour_started: ["route", "tourStep"],
+  demo_tour_step_completed: ["route", "tourStep"],
+  demo_tour_completed: ["route"],
+  demo_feature_opened: ["route", "feature"],
+  demo_action_started: ["route", "feature", "action", "scenario"],
+  demo_action_completed: ["route", "feature", "action", "scenario", "result", "durationBucket"],
+  demo_action_failed: ["route", "feature", "action", "scenario", "result", "errorCode", "durationBucket"],
+  demo_action_cancelled: ["route", "feature", "action", "scenario", "result", "durationBucket"],
+  demo_workspace_reset: ["route"],
+  demo_install_cta_clicked: ["route"],
+  demo_docs_cta_clicked: ["route"],
+  demo_client_error: ["route", "errorCode"],
+  demo_timing: ["route", "timingMetric", "metricBucket", "viewportBucket"],
+};
+
+function parseTelemetryAttributes(value: unknown, name: TelemetryEvent["name"]): TelemetryAttributes | undefined {
+  if (!isRecord(value) || !hasOnlyKeys(value, allowedAttributesByEvent[name])) return undefined;
+  if (("route" in value && !isFrom(value.route, routeNames))
+    || ("feature" in value && !isFrom(value.feature, featureNames))
+    || ("action" in value && !isFrom(value.action, actionNames))
+    || ("scenario" in value && !isFrom(value.scenario, scenarioNames))
+    || ("result" in value && !isFrom(value.result, resultCodes))
+    || ("errorCode" in value && !isFrom(value.errorCode, errorCodes))
+    || ("durationBucket" in value && !isFrom(value.durationBucket, durationBuckets))
+    || ("timingMetric" in value && !isFrom(value.timingMetric, timingMetrics))
+    || ("metricBucket" in value && !isFrom(value.metricBucket, metricBuckets))
+    || ("viewportBucket" in value && !isFrom(value.viewportBucket, viewportBuckets))
+    || ("tourStep" in value && !isFrom(value.tourStep, tourSteps))
+    || ("referrerClass" in value && !isFrom(value.referrerClass, referrerClasses))) {
+    return undefined;
+  }
+  if (name === "demo_timing" && (!("timingMetric" in value) || !("metricBucket" in value))) {
+    return undefined;
+  }
+  return value as TelemetryAttributes;
+}
+
+export function parseTelemetryEvent(value: unknown): TelemetryEvent | undefined {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["name", "attributes"]) || !isFrom(value.name, telemetryEventNames)) {
+    return undefined;
+  }
+  const attributes = parseTelemetryAttributes(value.attributes, value.name);
+  if (attributes === undefined) return undefined;
+  return { name: value.name, attributes };
+}

--- a/apps/demo-edge/test/demo-edge.test.ts
+++ b/apps/demo-edge/test/demo-edge.test.ts
@@ -1,0 +1,902 @@
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { migrations } from "virtual:demo-edge-migrations";
+
+import { classifyDemoApiRoute, dispatchDemoApi, ingressRateLimitKey } from "../workers/api.js";
+import {
+  CONSENT_MAX_AGE_SECONDS,
+  CONSENT_CONTRACT_VERSION,
+  MAX_REQUEST_BYTES,
+  OPERATION_DIGEST_MAX_AGE_SECONDS,
+  OPERATIONAL_RATE_LIMIT_PER_MINUTE,
+  PERSISTENT_COOKIE_MAX_AGE_SECONDS,
+  PRODUCT_DATA_MAX_AGE_SECONDS,
+  RETENTION_SAFETY_MARGIN_SECONDS,
+  TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE,
+  TELEMETRY_RATE_LIMIT_PER_MINUTE,
+  timingMetrics,
+} from "../src/contracts.js";
+import {
+  activateTelemetryIdentity,
+  hashTelemetryIds,
+  insertTelemetryEvent,
+  isTelemetryRequestAllowed,
+  recordOperationalCounter,
+} from "../src/database.js";
+import {
+  handleConsentGet,
+  handleConsentPost,
+  handleHealthPost,
+  handleTelemetryPost,
+} from "../src/handlers.js";
+import { readStrictJson } from "../src/http.js";
+import type { DemoRequestContext } from "../src/context.js";
+import { runRetention } from "../workers/retention.js";
+
+const origin = "https://demo.jobctrl.dev";
+const visitorId = "v".repeat(32);
+const sessionId = "s".repeat(32);
+const fixedNow = new Date("2026-07-11T12:00:00.000Z");
+const testEnv = env as unknown as DemoEdgeEnv;
+const migrationTestDb = (env as unknown as { MIGRATION_TEST_DB: D1Database }).MIGRATION_TEST_DB;
+
+function cookieHeader(choice: "granted" | "denied", visitor = visitorId, session = sessionId): string {
+  return [
+    `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.${choice}`,
+    `__Host-jobctrl_demo_vid=${visitor}`,
+    `__Host-jobctrl_demo_session=${session}`,
+  ].join("; ");
+}
+
+function context(
+  path: string,
+  init: RequestInit = {},
+  targetEnv = testEnv,
+  includeOrigin = true,
+): DemoRequestContext {
+  const headers = new Headers(init.headers);
+  if (includeOrigin && !headers.has("origin")) headers.set("origin", origin);
+  headers.set("sec-fetch-site", "same-origin");
+  if (!headers.has("cf-connecting-ip")) headers.set("cf-connecting-ip", "192.0.2.10");
+  return {
+    request: new Request(`${origin}${path}`, { ...init, headers }),
+    env: targetEnv,
+    ingressAllowed: true,
+  };
+}
+
+function jsonContext(
+  path: string,
+  body: unknown,
+  cookies?: string,
+  method = "POST",
+  targetEnv = testEnv,
+  includeOrigin = true,
+): DemoRequestContext {
+  const headers = new Headers({ "content-type": "application/json; charset=utf-8" });
+  if (cookies !== undefined) headers.set("cookie", cookies);
+  return context(path, { method, headers, body: JSON.stringify(body) }, targetEnv, includeOrigin);
+}
+
+function operationKey(seed: string): string {
+  return seed.padEnd(32, "x").slice(0, 32);
+}
+
+function setCookies(response: Response): string[] {
+  const headersWithCookies = response.headers as Headers & { getSetCookie?: () => string[] };
+  return headersWithCookies.getSetCookie?.() ?? [response.headers.get("set-cookie") ?? ""];
+}
+
+function envWithLimiters(
+  telemetryLimit: (options: { key: string }) => Promise<{ success: boolean }>,
+  ingressLimit: (options: { key: string }) => Promise<{ success: boolean }> = async () => ({ success: true }),
+): DemoEdgeEnv {
+  return {
+    DEMO_TELEMETRY_DB: testEnv.DEMO_TELEMETRY_DB,
+    DEMO_RELEASE: testEnv.DEMO_RELEASE,
+    PUBLIC_INGRESS_LIMITER: { limit: ingressLimit },
+    TELEMETRY_EDGE_LIMITER: { limit: telemetryLimit },
+  } as unknown as DemoEdgeEnv;
+}
+
+async function eventCount(): Promise<number> {
+  const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+    "SELECT COUNT(*) AS count FROM consented_product_events",
+  ).first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+async function sessionRateCount(): Promise<number> {
+  const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+    "SELECT COUNT(*) AS count FROM telemetry_rate_windows",
+  ).first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+async function globalRateCount(): Promise<number> {
+  const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+    "SELECT COALESCE(SUM(count), 0) AS count FROM telemetry_global_rate_windows",
+  ).first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+async function activeIdentityCount(): Promise<number> {
+  const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+    "SELECT COUNT(*) AS count FROM active_demo_identities",
+  ).first<{ count: number }>();
+  return row?.count ?? 0;
+}
+
+async function operationalStateCounts(): Promise<{ counters: number; retries: number; rates: number }> {
+  const [counters, retries, rates] = await Promise.all([
+    testEnv.DEMO_TELEMETRY_DB.prepare("SELECT COUNT(*) AS count FROM daily_operational_counters").first<{ count: number }>(),
+    testEnv.DEMO_TELEMETRY_DB.prepare("SELECT COUNT(*) AS count FROM operational_retry_digests").first<{ count: number }>(),
+    testEnv.DEMO_TELEMETRY_DB.prepare("SELECT COUNT(*) AS count FROM operational_rate_windows").first<{ count: number }>(),
+  ]);
+  return {
+    counters: counters?.count ?? 0,
+    retries: retries?.count ?? 0,
+    rates: rates?.count ?? 0,
+  };
+}
+
+async function seedCookieDerivedState(visitor = visitorId, session = sessionId): Promise<{ visitorHash: string; sessionHash: string }> {
+  await activateTelemetryIdentity(testEnv, visitor, session, fixedNow);
+  const ids = await hashTelemetryIds(visitor, session);
+  await insertTelemetryEvent(testEnv, ids.visitorHash, ids.sessionHash, {
+    name: "demo_timing",
+    attributes: { route: "dashboard", timingMetric: "lcp", metricBucket: "good", viewportBucket: "standard" },
+  }, fixedNow);
+  await testEnv.DEMO_TELEMETRY_DB.prepare(
+    "INSERT INTO telemetry_rate_windows (session_hash, window_utc, count, expires_at) VALUES (?, ?, 1, ?)",
+  ).bind(ids.sessionHash, "2026-07-11T12:00", "2026-07-12T12:00:00.000Z").run();
+  return ids;
+}
+
+beforeAll(async () => {
+  await applyD1Migrations(testEnv.DEMO_TELEMETRY_DB, migrations);
+});
+
+beforeEach(async () => {
+  await testEnv.DEMO_TELEMETRY_DB.batch([
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM daily_operational_counters"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM operational_retry_digests"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM consented_product_events"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_rate_windows"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_global_rate_windows"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM operational_rate_windows"),
+    testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM active_demo_identities"),
+  ]);
+});
+
+describe("API Worker consent and telemetry boundaries", () => {
+  it("exercises every routed endpoint and permits browser-equivalent safe GETs without Origin", async () => {
+    expect((await dispatchDemoApi(context("/api/demo-consent", { method: "GET" }, testEnv, false).request, testEnv)).status).toBe(200);
+    expect((await dispatchDemoApi(context("/api/demo-consent", {
+      method: "GET",
+      headers: { origin: "https://not-demo.example" },
+    }).request, testEnv)).status).toBe(403);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-consent", {
+      choice: "denied",
+      operationKey: operationKey("missing-origin"),
+    }, undefined, "POST", testEnv, false).request, testEnv)).status).toBe(403);
+
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-health", {
+      choice: "granted", result: "success", storageMode: "memory", operationKey: operationKey("route-health"),
+    }, cookieHeader("granted")).request, testEnv)).status).toBe(204);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-telemetry", {
+      name: "demo_route_viewed", attributes: { route: "jobs" },
+    }, cookieHeader("denied")).request, testEnv)).status).toBe(204);
+    expect((await dispatchDemoApi(context("/api/demo-telemetry/me", {
+      method: "DELETE", headers: { cookie: cookieHeader("denied") },
+    }).request, testEnv)).status).toBe(404);
+  });
+
+  it("cancels an over-limit chunked body without consuming later chunks", async () => {
+    let pulls = 0;
+    let cancelled = false;
+    let releasePull: (() => void) | undefined;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(MAX_REQUEST_BYTES + 1));
+        return new Promise<void>((resolve) => { releasePull = resolve; });
+      },
+      cancel() {
+        cancelled = true;
+        releasePull?.();
+      },
+    });
+    const request = new Request(`${origin}/api/demo-health`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    await expect(readStrictJson(request)).resolves.toBeUndefined();
+    expect(pulls).toBe(1);
+    expect(cancelled).toBe(true);
+  });
+
+  it("sets exact host-only cookies only after a confirmed grant", async () => {
+    const grantedContext = jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("grant"),
+    });
+    const granted = await dispatchDemoApi(grantedContext.request, testEnv);
+    expect(granted.status).toBe(200);
+    const cookies = setCookies(granted);
+    expect(cookies).toContain("__Host-jobctrl_demo_consent=v1.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax");
+    expect(cookies).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^__Host-jobctrl_demo_vid=[A-Za-z0-9_-]{32,128}; Max-Age=15544800; Path=\/; Secure; SameSite=Lax; HttpOnly$/),
+      expect.stringMatching(/^__Host-jobctrl_demo_session=[A-Za-z0-9_-]{32,128}; Path=\/; Secure; SameSite=Lax; HttpOnly$/),
+    ]));
+    expect(cookies.join(";")).not.toContain("Domain=");
+    expect(await activeIdentityCount()).toBe(1);
+  });
+
+  it("keeps a repeated granted POST idempotent and preserves IDs and telemetry history", async () => {
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const ids = await hashTelemetryIds(visitorId, sessionId);
+    await insertTelemetryEvent(testEnv, ids.visitorHash, ids.sessionHash, {
+      name: "demo_session_started",
+      attributes: { route: "dashboard", viewportBucket: "standard", referrerClass: "direct" },
+    }, fixedNow);
+    await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "INSERT INTO telemetry_rate_windows (session_hash, window_utc, count, expires_at) VALUES (?, ?, 1, ?)",
+    ).bind(ids.sessionHash, "2026-07-11T12:00", "2026-07-12T12:00:00.000Z").run();
+    await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "CREATE TRIGGER block_repeat_grant_delete BEFORE DELETE ON consented_product_events BEGIN SELECT RAISE(ABORT, 'must not delete'); END",
+    ).run();
+
+    const repeatedAt = new Date(
+      fixedNow.getTime() + (PERSISTENT_COOKIE_MAX_AGE_SECONDS - 60) * 1_000,
+    );
+    const response = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("repeat-granted"),
+    }, cookieHeader("granted")), repeatedAt);
+    expect(response.status).toBe(200);
+    expect(setCookies(response)).toEqual([
+      "__Host-jobctrl_demo_consent=v1.granted; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
+      `__Host-jobctrl_demo_vid=${visitorId}; Max-Age=15544800; Path=/; Secure; SameSite=Lax; HttpOnly`,
+    ]);
+    expect(await eventCount()).toBe(1);
+    expect(await sessionRateCount()).toBe(1);
+    const refreshedIdentity = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM active_demo_identities WHERE visitor_hash = ? AND session_hash = ?",
+    ).bind(ids.visitorHash, ids.sessionHash).first<{ expires_at: string }>();
+    expect(Date.parse(refreshedIdentity!.expires_at) - repeatedAt.getTime()).toBe(
+      PERSISTENT_COOKIE_MAX_AGE_SECONDS * 1_000,
+    );
+
+    await testEnv.DEMO_TELEMETRY_DB.prepare("DROP TRIGGER block_repeat_grant_delete").run();
+    await runRetention(
+      testEnv,
+      new Date(repeatedAt.getTime() + CONSENT_MAX_AGE_SECONDS * 1_000),
+    );
+    expect(await activeIdentityCount()).toBe(0);
+  });
+
+  it("preserves a returning visitor and history while activating a new browser session", async () => {
+    await seedCookieDerivedState();
+    const visitorOnlyCookies = [
+      `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+      `__Host-jobctrl_demo_vid=${visitorId}`,
+    ].join("; ");
+
+    const visitorRotated = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("partial-visitor"),
+    }, visitorOnlyCookies), fixedNow);
+    expect(visitorRotated.status).toBe(200);
+    expect(setCookies(visitorRotated).join(";")).toContain(`__Host-jobctrl_demo_vid=${visitorId};`);
+    expect(setCookies(visitorRotated)).toEqual(expect.arrayContaining([
+      expect.stringMatching(/^__Host-jobctrl_demo_session=[A-Za-z0-9_-]{32,128};/),
+    ]));
+    expect(setCookies(visitorRotated).join(";")).not.toContain(`__Host-jobctrl_demo_session=${sessionId};`);
+    expect(await eventCount()).toBe(1);
+    expect(await sessionRateCount()).toBe(1);
+    expect(await activeIdentityCount()).toBe(2);
+
+    const returnedCookies = setCookies(visitorRotated).map((cookie) => cookie.split(";", 1)[0]).join("; ");
+    const telemetry = await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+      name: "demo_route_viewed", attributes: { route: "jobs" },
+    }, returnedCookies), fixedNow);
+    expect(telemetry.status).toBe(204);
+    expect(await eventCount()).toBe(2);
+    const audience = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT COUNT(DISTINCT visitor_hash) AS visitors, COUNT(DISTINCT session_hash) AS sessions FROM consented_product_events",
+    ).first<{ visitors: number; sessions: number }>();
+    expect(audience).toEqual({ visitors: 1, sessions: 2 });
+  });
+
+  it("rotates a corrupt session-only grant without deleting retained telemetry", async () => {
+    await seedCookieDerivedState();
+    const sessionOnlyCookies = [
+      `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+      `__Host-jobctrl_demo_session=${sessionId}`,
+    ].join("; ");
+    const rotated = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("partial-session"),
+    }, sessionOnlyCookies), fixedNow);
+    expect(rotated.status).toBe(200);
+    expect(await rotated.json()).toEqual({ choice: "granted", version: CONSENT_CONTRACT_VERSION });
+    expect(setCookies(rotated).join(";")).not.toContain(`__Host-jobctrl_demo_session=${sessionId};`);
+    expect(await eventCount()).toBe(1);
+    expect(await sessionRateCount()).toBe(1);
+    expect(await activeIdentityCount()).toBe(2);
+  });
+
+  it("keeps an initial decline identity-free when aggregate counter persistence fails", async () => {
+    const failingEnv = {
+      DEMO_RELEASE: testEnv.DEMO_RELEASE,
+      PUBLIC_INGRESS_LIMITER: { limit: async () => ({ success: true }) },
+      TELEMETRY_EDGE_LIMITER: { limit: async () => ({ success: true }) },
+      DEMO_TELEMETRY_DB: { prepare: () => { throw new Error("unavailable"); } },
+    } as unknown as DemoEdgeEnv;
+    const response = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "denied", operationKey: operationKey("denied-counter-failure"),
+    }, undefined, "POST", failingEnv), fixedNow);
+
+    expect(response.status).toBe(200);
+    expect(setCookies(response)).toEqual([
+      "__Host-jobctrl_demo_consent=v1.denied; Max-Age=15544800; Path=/; Secure; SameSite=Lax",
+    ]);
+    expect(await activeIdentityCount()).toBe(0);
+  });
+
+  it("deduplicates a committed operation when the response is lost", async () => {
+    const payload = { choice: "denied", operationKey: operationKey("lost-response") };
+    await handleConsentPost(jsonContext("/api/demo-consent", payload), fixedNow);
+    await handleConsentPost(jsonContext("/api/demo-consent", payload), fixedNow);
+    const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT count FROM daily_operational_counters WHERE metric = 'consent_choice' AND consent_choice = 'denied'",
+    ).first<{ count: number }>();
+    expect(row?.count).toBe(1);
+  });
+
+  it("classifies ingress into a closed route-key space", async () => {
+    expect([
+      classifyDemoApiRoute("/api/demo-consent"),
+      classifyDemoApiRoute("/api/demo-health"),
+      classifyDemoApiRoute("/api/demo-telemetry"),
+      classifyDemoApiRoute("/api/demo-telemetry/me"),
+      classifyDemoApiRoute("/api/not-a-route"),
+    ]).toEqual(["consent", "health", "telemetry", "unknown", "unknown"]);
+
+    const firstUnknown = await ingressRateLimitKey("192.0.2.10", "/api/random-one");
+    const secondUnknown = await ingressRateLimitKey("192.0.2.10", "/api/random-two");
+    const otherClient = await ingressRateLimitKey("198.51.100.20", "/api/random-one");
+    const known = await ingressRateLimitKey("192.0.2.10", "/api/demo-consent");
+    expect(firstUnknown).toBe(secondUnknown);
+    expect(firstUnknown).not.toBe(otherClient);
+    expect(firstUnknown).not.toBe(known);
+    expect(firstUnknown).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("invokes bounded ingress protection for every public path without overriding denial", async () => {
+    const ingressKeys: string[] = [];
+    const limitedIngressEnv = envWithLimiters(
+      async () => ({ success: true }),
+      async ({ key }) => {
+        ingressKeys.push(key);
+        return { success: false };
+      },
+    );
+
+    expect((await dispatchDemoApi(
+      context("/api/demo-consent", { method: "GET" }, limitedIngressEnv, false).request,
+      limitedIngressEnv,
+    )).status).toBe(429);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("ingress-repeat-grant"),
+    }, cookieHeader("granted"), "POST", limitedIngressEnv).request, limitedIngressEnv)).status).toBe(429);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-consent", {
+      choice: "denied", operationKey: operationKey("ingress-denial"),
+    }, undefined, "POST", limitedIngressEnv).request, limitedIngressEnv)).status).toBe(200);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-health", {
+      choice: "granted", result: "success", storageMode: "memory", operationKey: operationKey("ingress-health"),
+    }, cookieHeader("granted"), "POST", limitedIngressEnv).request, limitedIngressEnv)).status).toBe(429);
+    expect((await dispatchDemoApi(jsonContext("/api/demo-telemetry", {
+      name: "demo_route_viewed", attributes: { route: "jobs" },
+    }, cookieHeader("denied"), "POST", limitedIngressEnv).request, limitedIngressEnv)).status).toBe(204);
+    expect((await dispatchDemoApi(context("/api/demo-telemetry/me", {
+      method: "DELETE",
+      headers: { cookie: `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.denied` },
+    }, limitedIngressEnv).request, limitedIngressEnv)).status).toBe(404);
+    expect((await dispatchDemoApi(
+      context("/api/arbitrary-one", { method: "GET" }, limitedIngressEnv, false).request,
+      limitedIngressEnv,
+    )).status).toBe(404);
+    expect((await dispatchDemoApi(
+      context("/api/arbitrary-two", { method: "GET" }, limitedIngressEnv, false).request,
+      limitedIngressEnv,
+    )).status).toBe(404);
+
+    expect(ingressKeys).toHaveLength(8);
+    expect(ingressKeys.every((key) => /^[a-f0-9]{64}$/.test(key))).toBe(true);
+    expect(ingressKeys.join("")).not.toContain("192.0.2.10");
+    expect(ingressKeys[0]).toBe(ingressKeys[1]);
+    expect(ingressKeys[1]).toBe(ingressKeys[2]);
+    expect(ingressKeys[5]).toBe(ingressKeys[6]);
+    expect(ingressKeys[6]).toBe(ingressKeys[7]);
+    expect(new Set([ingressKeys[0], ingressKeys[3], ingressKeys[4], ingressKeys[5]]).size).toBe(4);
+  });
+
+  it("returns unknown and immediately expires identifiers for a stale consent contract", async () => {
+    const staleCookies = [
+      "__Host-jobctrl_demo_consent=v0.granted",
+      `__Host-jobctrl_demo_vid=${visitorId}`,
+      `__Host-jobctrl_demo_session=${sessionId}`,
+    ].join("; ");
+    const response = await handleConsentGet(context("/api/demo-consent", {
+      method: "GET", headers: { cookie: staleCookies },
+    }, testEnv, false), fixedNow);
+    expect(await response.json()).toEqual({ choice: "unknown", version: CONSENT_CONTRACT_VERSION });
+    const cookies = setCookies(response).join(";");
+    expect(cookies).toContain("__Host-jobctrl_demo_consent=; Max-Age=0");
+    expect(cookies).toContain("__Host-jobctrl_demo_vid=; Max-Age=0");
+    expect(cookies).toContain("__Host-jobctrl_demo_session=; Max-Age=0");
+  });
+
+  it("treats forged, partial, and inactive granted cookie tuples as unknown", async () => {
+    const cases = [
+      {
+        name: "forged consent only",
+        cookie: `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+        expired: ["__Host-jobctrl_demo_consent"],
+      },
+      {
+        name: "missing session",
+        cookie: [
+          `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+          `__Host-jobctrl_demo_vid=${visitorId}`,
+        ].join("; "),
+        expired: ["__Host-jobctrl_demo_consent", "__Host-jobctrl_demo_vid"],
+      },
+      {
+        name: "missing visitor",
+        cookie: [
+          `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+          `__Host-jobctrl_demo_session=${sessionId}`,
+        ].join("; "),
+        expired: ["__Host-jobctrl_demo_consent", "__Host-jobctrl_demo_session"],
+      },
+      {
+        name: "inactive pair",
+        cookie: cookieHeader("granted"),
+        expired: [
+          "__Host-jobctrl_demo_consent",
+          "__Host-jobctrl_demo_vid",
+          "__Host-jobctrl_demo_session",
+        ],
+      },
+      {
+        name: "malformed identifier",
+        cookie: [
+          `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+          "__Host-jobctrl_demo_vid=too-short",
+          `__Host-jobctrl_demo_session=${sessionId}`,
+        ].join("; "),
+        expired: [
+          "__Host-jobctrl_demo_consent",
+          "__Host-jobctrl_demo_vid",
+          "__Host-jobctrl_demo_session",
+        ],
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await handleConsentGet(context("/api/demo-consent", {
+        method: "GET", headers: { cookie: testCase.cookie },
+      }, testEnv, false), fixedNow);
+      expect(response.status, testCase.name).toBe(200);
+      expect(await response.json(), testCase.name).toEqual({
+        choice: "unknown",
+        version: CONSENT_CONTRACT_VERSION,
+      });
+      const expiredCookies = setCookies(response).join(";");
+      for (const name of testCase.expired) {
+        expect(expiredCookies, testCase.name).toContain(`${name}=; Max-Age=0`);
+      }
+    }
+
+    await activateTelemetryIdentity(
+      testEnv,
+      visitorId,
+      sessionId,
+      new Date(fixedNow.getTime() - (PERSISTENT_COOKIE_MAX_AGE_SECONDS + 1) * 1_000),
+    );
+    const expiredPair = await handleConsentGet(context("/api/demo-consent", {
+      method: "GET", headers: { cookie: cookieHeader("granted") },
+    }, testEnv, false), fixedNow);
+    expect(await expiredPair.json()).toEqual({ choice: "unknown", version: CONSENT_CONTRACT_VERSION });
+    expect(setCookies(expiredPair).join(";")).toContain("__Host-jobctrl_demo_session=; Max-Age=0");
+    expect(await operationalStateCounts()).toEqual({ counters: 0, retries: 0, rates: 0 });
+  });
+
+  it("returns granted only for the exact active pair without extending identity expiry", async () => {
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const ids = await hashTelemetryIds(visitorId, sessionId);
+    const before = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM active_demo_identities WHERE visitor_hash = ? AND session_hash = ?",
+    ).bind(ids.visitorHash, ids.sessionHash).first<{ expires_at: string }>();
+
+    const response = await handleConsentGet(context("/api/demo-consent", {
+      method: "GET", headers: { cookie: cookieHeader("granted") },
+    }, testEnv, false), new Date(fixedNow.getTime() + 60_000));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ choice: "granted", version: CONSENT_CONTRACT_VERSION });
+    expect(response.headers.get("set-cookie")).toBeNull();
+
+    const after = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM active_demo_identities WHERE visitor_hash = ? AND session_hash = ?",
+    ).bind(ids.visitorHash, ids.sessionHash).first<{ expires_at: string }>();
+    expect(after).toEqual(before);
+  });
+
+  it("fails closed without rewriting cookies when consent identity validation is unavailable", async () => {
+    const failingEnv = {
+      ...testEnv,
+      DEMO_TELEMETRY_DB: { prepare: () => { throw new Error("unavailable"); } },
+    } as unknown as DemoEdgeEnv;
+    const response = await handleConsentGet(context("/api/demo-consent", {
+      method: "GET", headers: { cookie: cookieHeader("granted") },
+    }, failingEnv, false), fixedNow);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "temporarily_unavailable" });
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("rotates stale-contract identifiers without deleting retained telemetry", async () => {
+    await seedCookieDerivedState();
+    const staleCookies = [
+      "__Host-jobctrl_demo_consent=v0.granted",
+      `__Host-jobctrl_demo_vid=${visitorId}`,
+      `__Host-jobctrl_demo_session=${sessionId}`,
+    ].join("; ");
+    const rotated = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("stale-rotation"),
+    }, staleCookies), fixedNow);
+    expect(rotated.status).toBe(200);
+    expect(await rotated.json()).toEqual({ choice: "granted", version: CONSENT_CONTRACT_VERSION });
+    const rotatedCookies = setCookies(rotated).join(";");
+    expect(rotatedCookies).not.toContain(visitorId);
+    expect(rotatedCookies).not.toContain(sessionId);
+    expect(await eventCount()).toBe(1);
+    expect(await sessionRateCount()).toBe(1);
+    expect(await activeIdentityCount()).toBe(2);
+  });
+
+  it("rejects identity-bearing denial without changing accepted state", async () => {
+    await seedCookieDerivedState();
+    const response = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "denied", operationKey: operationKey("post-accept-denial"),
+    }, cookieHeader("granted")), fixedNow);
+    expect(response.status).toBe(409);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(await eventCount()).toBe(1);
+    expect(await sessionRateCount()).toBe(1);
+    expect(await activeIdentityCount()).toBe(1);
+    const counters = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT COUNT(*) AS count FROM daily_operational_counters",
+    ).first<{ count: number }>();
+    expect(counters?.count).toBe(0);
+  });
+
+  it("rejects ingress-limited identity-bearing denial without logging or touching D1", async () => {
+    let ingressCalls = 0;
+    const limitedEnv = envWithLimiters(
+      async () => ({ success: true }),
+      async () => {
+        ingressCalls += 1;
+        return { success: false };
+      },
+    );
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      const response = await dispatchDemoApi(jsonContext("/api/demo-consent", {
+        choice: "denied", operationKey: operationKey("limited-identity-denial"),
+      }, cookieHeader("granted"), "POST", limitedEnv).request, limitedEnv);
+      expect(response.status).toBe(409);
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(ingressCalls).toBe(1);
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(await operationalStateCounts()).toEqual({ counters: 0, retries: 0, rates: 0 });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("re-prompts a clean declined entry and later grants", async () => {
+    const declined = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "denied", operationKey: operationKey("entry-decline"),
+    }), fixedNow);
+    expect(declined.status).toBe(200);
+    expect(await activeIdentityCount()).toBe(0);
+
+    const returned = await handleConsentGet(context("/api/demo-consent", {
+      method: "GET",
+      headers: { cookie: `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.denied` },
+    }, testEnv, false), fixedNow);
+    expect(await returned.json()).toEqual({ choice: "denied", version: CONSENT_CONTRACT_VERSION });
+
+    const granted = await handleConsentPost(jsonContext("/api/demo-consent", {
+      choice: "granted", operationKey: operationKey("entry-return-grant"),
+    }, `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.denied`), fixedNow);
+    expect(granted.status).toBe(200);
+    expect(await granted.json()).toEqual({ choice: "granted", version: CONSENT_CONTRACT_VERSION });
+    expect(await activeIdentityCount()).toBe(1);
+  });
+
+  it("enforces session, global D1, and per-edge telemetry limits in that order", async () => {
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const ids = await hashTelemetryIds(visitorId, sessionId);
+    await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "INSERT INTO telemetry_rate_windows (session_hash, window_utc, count, expires_at) VALUES (?, ?, ?, ?)",
+    ).bind(ids.sessionHash, "2026-07-11T12:00", TELEMETRY_RATE_LIMIT_PER_MINUTE, "2026-07-12T12:00:00.000Z").run();
+    let edgeCalls = 0;
+    const acceptedEnv = envWithLimiters(async () => {
+      edgeCalls += 1;
+      return { success: true };
+    });
+    const limited = await isTelemetryRequestAllowed(acceptedEnv, ids.visitorHash, ids.sessionHash, fixedNow);
+    expect(limited).toBe(false);
+    expect(await globalRateCount()).toBe(0);
+    expect(edgeCalls).toBe(0);
+
+    await testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_rate_windows").run();
+    expect(await isTelemetryRequestAllowed(acceptedEnv, ids.visitorHash, ids.sessionHash, fixedNow)).toBe(true);
+    expect(await globalRateCount()).toBe(1);
+    expect(edgeCalls).toBe(1);
+
+    await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "UPDATE telemetry_global_rate_windows SET count = ?",
+    ).bind(TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE).run();
+    await activateTelemetryIdentity(testEnv, visitorId, "t".repeat(32), fixedNow);
+    const otherIds = await hashTelemetryIds(visitorId, "t".repeat(32));
+    expect(await isTelemetryRequestAllowed(acceptedEnv, otherIds.visitorHash, otherIds.sessionHash, fixedNow)).toBe(false);
+    expect(await globalRateCount()).toBe(TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE);
+    expect(edgeCalls).toBe(1);
+
+    const rejected = await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+      name: "demo_route_viewed", attributes: { route: "jobs", email: "not-allowed@example.invalid" },
+    }, cookieHeader("granted"), "POST", acceptedEnv), fixedNow);
+    expect(rejected.status).toBe(400);
+    expect(await eventCount()).toBe(0);
+
+    await testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_rate_windows").run();
+    await testEnv.DEMO_TELEMETRY_DB.prepare("DELETE FROM telemetry_global_rate_windows").run();
+    const response = await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+      name: "demo_timing",
+      attributes: { route: "dashboard", timingMetric: "lcp", metricBucket: "good", viewportBucket: "standard" },
+    }, cookieHeader("granted"), "POST", acceptedEnv), fixedNow);
+    expect(response.status).toBe(204);
+    const row = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT visitor_hash, session_hash FROM consented_product_events",
+    ).first<{ visitor_hash: string; session_hash: string }>();
+    expect(row?.visitor_hash).not.toContain(visitorId);
+    expect(row?.session_hash).not.toContain(sessionId);
+  });
+
+  it("accepts only closed timing metrics and non-duration metric buckets", async () => {
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const buckets = ["good", "needs_improvement", "poor"] as const;
+    for (const [index, timingMetric] of timingMetrics.entries()) {
+      const response = await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+        name: "demo_timing",
+        attributes: {
+          route: "dashboard",
+          timingMetric,
+          metricBucket: buckets[index % buckets.length],
+          viewportBucket: "standard",
+        },
+      }, cookieHeader("granted")), fixedNow);
+      expect(response.status).toBe(204);
+    }
+    const stored = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT timing_metric, metric_bucket FROM consented_product_events ORDER BY timing_metric",
+    ).all<{ timing_metric: string; metric_bucket: string }>();
+    expect(new Set(stored.results.map(({ timing_metric }) => timing_metric))).toEqual(new Set(timingMetrics));
+    expect(stored.results.every(({ metric_bucket }) => buckets.includes(metric_bucket as typeof buckets[number]))).toBe(true);
+
+    expect((await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+      name: "demo_timing",
+      attributes: { route: "dashboard", timingMetric: "lcp" },
+    }, cookieHeader("granted")), fixedNow)).status).toBe(400);
+    expect((await handleTelemetryPost(jsonContext("/api/demo-telemetry", {
+      name: "demo_timing",
+      attributes: { route: "dashboard", timingMetric: "raw_custom_metric", metricBucket: "good" },
+    }, cookieHeader("granted")), fixedNow)).status).toBe(400);
+  });
+
+  it("enforces mutation origin, bounded body, and operational health rate guards", async () => {
+    expect((await handleHealthPost(jsonContext("/api/demo-health", {
+      choice: "granted", result: "success", storageMode: "memory", operationKey: operationKey("origin"),
+    }, cookieHeader("granted"), "POST", testEnv, false), fixedNow)).status).toBe(403);
+    expect((await handleHealthPost(jsonContext("/api/demo-health", {
+      choice: "granted", result: "success", storageMode: "memory", operationKey: operationKey("oversized"), padding: "x".repeat(2_100),
+    }, cookieHeader("granted")), fixedNow)).status).toBe(400);
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "INSERT INTO operational_rate_windows (endpoint, window_utc, count, expires_at) VALUES (?, ?, ?, ?)",
+    ).bind("health", "2026-07-11T12:00", OPERATIONAL_RATE_LIMIT_PER_MINUTE, "2026-07-12T12:00:00.000Z").run();
+    expect((await handleHealthPost(jsonContext("/api/demo-health", {
+      choice: "granted", result: "success", storageMode: "memory", operationKey: operationKey("rate-limit"),
+    }, cookieHeader("granted")), fixedNow)).status).toBe(429);
+    expect((await handleHealthPost(jsonContext("/api/demo-health", {
+      choice: "denied", result: "success", storageMode: "memory", operationKey: operationKey("denied-no-init"),
+    }, cookieHeader("denied")), fixedNow)).status).toBe(400);
+  });
+
+  it("writes initialization health only for the exact active granted pair", async () => {
+    const payload = {
+      choice: "granted" as const,
+      result: "success" as const,
+      storageMode: "memory" as const,
+      operationKey: operationKey("health-active-pair"),
+    };
+    const invalidCookies = [
+      `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+      [
+        `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+        `__Host-jobctrl_demo_vid=${visitorId}`,
+      ].join("; "),
+      [
+        `__Host-jobctrl_demo_consent=${CONSENT_CONTRACT_VERSION}.granted`,
+        `__Host-jobctrl_demo_session=${sessionId}`,
+      ].join("; "),
+      cookieHeader("granted"),
+    ];
+    for (const cookies of invalidCookies) {
+      expect((await handleHealthPost(
+        jsonContext("/api/demo-health", payload, cookies),
+        fixedNow,
+      )).status).toBe(400);
+    }
+
+    await activateTelemetryIdentity(
+      testEnv,
+      visitorId,
+      sessionId,
+      new Date(fixedNow.getTime() - (PERSISTENT_COOKIE_MAX_AGE_SECONDS + 1) * 1_000),
+    );
+    expect((await handleHealthPost(
+      jsonContext("/api/demo-health", payload, cookieHeader("granted")),
+      fixedNow,
+    )).status).toBe(400);
+    expect(await operationalStateCounts()).toEqual({ counters: 0, retries: 0, rates: 0 });
+
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const active = await handleHealthPost(
+      jsonContext("/api/demo-health", payload, cookieHeader("granted")),
+      fixedNow,
+    );
+    expect(active.status).toBe(204);
+    expect(await operationalStateCounts()).toEqual({ counters: 1, retries: 1, rates: 1 });
+  });
+
+  it("fails health closed before rate or counter writes when identity validation is unavailable", async () => {
+    const failingEnv = {
+      ...testEnv,
+      DEMO_TELEMETRY_DB: { prepare: () => { throw new Error("unavailable"); } },
+    } as unknown as DemoEdgeEnv;
+    const response = await handleHealthPost(jsonContext("/api/demo-health", {
+      choice: "granted",
+      result: "success",
+      storageMode: "memory",
+      operationKey: operationKey("health-d1-outage"),
+    }, cookieHeader("granted"), "POST", failingEnv), fixedNow);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "temporarily_unavailable" });
+    expect(await operationalStateCounts()).toEqual({ counters: 0, retries: 0, rates: 0 });
+  });
+
+  it("runs duplicate UTC retention safely", async () => {
+    await testEnv.DEMO_TELEMETRY_DB.batch([
+      testEnv.DEMO_TELEMETRY_DB.prepare(
+        "INSERT INTO daily_operational_counters VALUES ('2026-04-01', 'test-release', 'v1', 'consent_choice', 'denied', 'not_applicable', 'not_applicable', 1, '2026-07-10T12:00:00.000Z')",
+      ),
+      testEnv.DEMO_TELEMETRY_DB.prepare(
+        "INSERT INTO operational_retry_digests VALUES ('expired-digest', '2026-07-10T12:00:00.000Z')",
+      ),
+      testEnv.DEMO_TELEMETRY_DB.prepare(
+        "INSERT INTO consented_product_events (id, occurred_at, expires_at, visitor_hash, session_hash, release, consent_contract_version, event_name) VALUES ('expired-event', '2026-04-01T00:00:00.000Z', '2026-07-10T12:00:00.000Z', 'a', 'b', 'test-release', 'v1', 'demo_timing')",
+      ),
+      testEnv.DEMO_TELEMETRY_DB.prepare(
+        "INSERT INTO telemetry_global_rate_windows VALUES ('2026-07-10T12:00', 1, '2026-07-10T12:00:00.000Z')",
+      ),
+      testEnv.DEMO_TELEMETRY_DB.prepare(
+        "INSERT INTO active_demo_identities VALUES ('expired-visitor', 'expired-session', '2026-07-11T12:00:00.000Z')",
+      ),
+    ]);
+    await runRetention(testEnv, fixedNow);
+    await runRetention(testEnv, fixedNow);
+    expect(await eventCount()).toBe(0);
+    expect(await globalRateCount()).toBe(0);
+    expect(await activeIdentityCount()).toBe(0);
+  });
+
+  it("assigns conservative exact expiries below every physical retention maximum", async () => {
+    await recordOperationalCounter(testEnv, operationKey("expiry-counter"), {
+      metric: "consent_choice",
+      consentChoice: "granted",
+      initializationResult: "not_applicable",
+      storageMode: "not_applicable",
+    }, fixedNow);
+    await activateTelemetryIdentity(testEnv, visitorId, sessionId, fixedNow);
+    const ids = await hashTelemetryIds(visitorId, sessionId);
+    await insertTelemetryEvent(testEnv, ids.visitorHash, ids.sessionHash, {
+      name: "demo_route_viewed",
+      attributes: { route: "jobs" },
+    }, fixedNow);
+
+    const retry = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM operational_retry_digests",
+    ).first<{ expires_at: string }>();
+    const counter = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM daily_operational_counters",
+    ).first<{ expires_at: string }>();
+    const productEvent = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM consented_product_events",
+    ).first<{ expires_at: string }>();
+    const identity = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT expires_at FROM active_demo_identities",
+    ).first<{ expires_at: string }>();
+
+    expect(Date.parse(retry!.expires_at) - fixedNow.getTime()).toBe(
+      (OPERATION_DIGEST_MAX_AGE_SECONDS - RETENTION_SAFETY_MARGIN_SECONDS) * 1_000,
+    );
+    expect(Date.parse(productEvent!.expires_at) - fixedNow.getTime()).toBe(
+      (PRODUCT_DATA_MAX_AGE_SECONDS - RETENTION_SAFETY_MARGIN_SECONDS) * 1_000,
+    );
+    expect(Date.parse(identity!.expires_at) - fixedNow.getTime()).toBe(
+      PERSISTENT_COOKIE_MAX_AGE_SECONDS * 1_000,
+    );
+    const dayStart = new Date("2026-07-11T00:00:00.000Z");
+    expect(Date.parse(counter!.expires_at) - dayStart.getTime()).toBe(
+      (PRODUCT_DATA_MAX_AGE_SECONDS - RETENTION_SAFETY_MARGIN_SECONDS) * 1_000,
+    );
+  });
+
+  it("upgrades an applied original 0001 and fresh-installs the complete schema", async () => {
+    expect(migrations.map((migration) => migration.name)).toEqual([
+      "0001_demo_telemetry.sql",
+      "0002_active_identity_and_retention.sql",
+    ]);
+    await applyD1Migrations(migrationTestDb, [migrations[0]!]);
+    await migrationTestDb.batch([
+      migrationTestDb.prepare(
+        "INSERT INTO daily_operational_counters VALUES ('2026-07-11', 'old-release', 'v1', 'consent_choice', 'granted', 'not_applicable', 'not_applicable', 1)",
+      ),
+      migrationTestDb.prepare(
+        "INSERT INTO consented_product_events (id, occurred_at, expires_at, visitor_hash, session_hash, release, consent_contract_version, event_name) VALUES ('old-event', '2026-07-11T00:00:00.000Z', '2026-08-01T00:00:00.000Z', 'old-visitor', 'old-session', 'old-release', 'v1', 'demo_route_viewed')",
+      ),
+      migrationTestDb.prepare(
+        "INSERT INTO telemetry_rate_windows VALUES ('orphan-session', '2026-07-11T12:00', 1, '2026-07-12T12:00:00.000Z')",
+      ),
+    ]);
+    expect(await migrationTestDb.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'active_demo_identities'",
+    ).first()).toBeNull();
+
+    await applyD1Migrations(migrationTestDb, [migrations[1]!]);
+    const counterColumns = await migrationTestDb.prepare("PRAGMA table_info(daily_operational_counters)").all<{ name: string }>();
+    const eventColumns = await migrationTestDb.prepare("PRAGMA table_info(consented_product_events)").all<{ name: string }>();
+    expect(counterColumns.results.map(({ name }) => name)).toContain("expires_at");
+    expect(eventColumns.results.map(({ name }) => name)).toEqual(expect.arrayContaining(["timing_metric", "metric_bucket"]));
+    expect(await migrationTestDb.prepare("SELECT count FROM daily_operational_counters").first()).toMatchObject({ count: 1 });
+    expect(await migrationTestDb.prepare("SELECT COUNT(*) AS count FROM active_demo_identities").first()).toMatchObject({ count: 1 });
+    expect(await migrationTestDb.prepare("SELECT COUNT(*) AS count FROM telemetry_rate_windows").first()).toMatchObject({ count: 0 });
+    expect(await migrationTestDb.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'telemetry_global_rate_windows'",
+    ).first()).toMatchObject({ name: "telemetry_global_rate_windows" });
+
+    const freshTables = await testEnv.DEMO_TELEMETRY_DB.prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('active_demo_identities', 'telemetry_global_rate_windows') ORDER BY name",
+    ).all<{ name: string }>();
+    expect(freshTables.results.map(({ name }) => name)).toEqual([
+      "active_demo_identities",
+      "telemetry_global_rate_windows",
+    ]);
+  });
+});

--- a/apps/demo-edge/test/raw-sql.d.ts
+++ b/apps/demo-edge/test/raw-sql.d.ts
@@ -1,0 +1,4 @@
+declare module "*.sql?raw" {
+  const sql: string;
+  export default sql;
+}

--- a/apps/demo-edge/test/virtual-migrations.d.ts
+++ b/apps/demo-edge/test/virtual-migrations.d.ts
@@ -1,0 +1,3 @@
+declare module "virtual:demo-edge-migrations" {
+  export const migrations: import("cloudflare:test").D1Migration[];
+}

--- a/apps/demo-edge/tsconfig.json
+++ b/apps/demo-edge/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../packages/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2024", "WebWorker"],
+    "types": ["node", "vitest/globals", "@cloudflare/vitest-pool-workers/types"],
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "workers/**/*.ts",
+    "test/**/*.ts",
+    "vitest.config.ts",
+    "env.d.ts"
+  ]
+}

--- a/apps/demo-edge/vitest.config.ts
+++ b/apps/demo-edge/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+import { fileURLToPath } from "node:url";
+import { cloudflarePool, cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
+
+const migrations = await readD1Migrations(fileURLToPath(new URL("./migrations", import.meta.url)));
+const workerOptions = {
+  wrangler: { configPath: "./wrangler.test.jsonc" },
+};
+
+export default defineConfig({
+  plugins: [
+    {
+      name: "demo-edge-migrations",
+      resolveId(id) {
+        return id === "virtual:demo-edge-migrations" ? id : undefined;
+      },
+      load(id) {
+        return id === "virtual:demo-edge-migrations"
+          ? `export const migrations = ${JSON.stringify(migrations)};`
+          : undefined;
+      },
+    },
+    cloudflareTest(workerOptions),
+  ],
+  test: {
+    pool: cloudflarePool(workerOptions),
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/apps/demo-edge/workers/api.ts
+++ b/apps/demo-edge/workers/api.ts
@@ -1,0 +1,63 @@
+import {
+  handleConsentGet,
+  handleConsentPost,
+  handleHealthPost,
+  handleTelemetryPost,
+} from "../src/handlers.js";
+import { sha256 } from "../src/crypto.js";
+import type { DemoRequestContext } from "../src/context.js";
+
+export type DemoApiRouteClass = "consent" | "health" | "telemetry" | "unknown";
+
+export function classifyDemoApiRoute(pathname: string): DemoApiRouteClass {
+  switch (pathname) {
+    case "/api/demo-consent":
+      return "consent";
+    case "/api/demo-health":
+      return "health";
+    case "/api/demo-telemetry":
+      return "telemetry";
+    default:
+      return "unknown";
+  }
+}
+
+export async function ingressRateLimitKey(clientIp: string, pathname: string): Promise<string> {
+  return sha256(`${clientIp}\u0000${classifyDemoApiRoute(pathname)}`);
+}
+
+async function ingressRequestAllowed(request: Request, env: DemoEdgeEnv): Promise<boolean> {
+  const clientIp = request.headers.get("cf-connecting-ip");
+  if (clientIp === null) return false;
+  try {
+    const path = new URL(request.url).pathname;
+    // The raw address and ephemeral digest never enter D1 or application logs.
+    const key = await ingressRateLimitKey(clientIp, path);
+    return (await env.PUBLIC_INGRESS_LIMITER.limit({ key })).success;
+  } catch {
+    return false;
+  }
+}
+
+export async function dispatchDemoApi(request: Request, env: DemoEdgeEnv): Promise<Response> {
+  const routeClass = classifyDemoApiRoute(new URL(request.url).pathname);
+  const context: DemoRequestContext = {
+    request,
+    env,
+    ingressAllowed: await ingressRequestAllowed(request, env),
+  };
+  switch (routeClass) {
+    case "consent":
+      return request.method === "GET" ? handleConsentGet(context) : handleConsentPost(context);
+    case "health":
+      return handleHealthPost(context);
+    case "telemetry":
+      return handleTelemetryPost(context);
+    case "unknown":
+      return new Response(null, { status: 404 });
+  }
+}
+
+export default {
+  fetch: dispatchDemoApi,
+};

--- a/apps/demo-edge/workers/retention.ts
+++ b/apps/demo-edge/workers/retention.ts
@@ -1,0 +1,31 @@
+import { cleanupExpiredData } from "../src/database.js";
+import { logEdgeEvent } from "../src/http.js";
+
+interface ScheduledControllerLike {
+  scheduledTime: number;
+}
+
+export async function runRetention(env: DemoEdgeEnv, now: Date): Promise<void> {
+  const deleted = await cleanupExpiredData(env, now);
+  logEdgeEvent("retention", {
+    outcome: "completed",
+    operationalCounters: deleted.operationalCounters,
+    retryDigests: deleted.retryDigests,
+    productEvents: deleted.productEvents,
+    sessionRates: deleted.sessionRates,
+    globalTelemetryRates: deleted.globalTelemetryRates,
+    operationalRates: deleted.operationalRates,
+    activeIdentities: deleted.activeIdentities,
+  });
+}
+
+export default {
+  async scheduled(controller: ScheduledControllerLike, env: DemoEdgeEnv): Promise<void> {
+    try {
+      await runRetention(env, new Date(controller.scheduledTime));
+    } catch {
+      logEdgeEvent("retention", { outcome: "failed" });
+      throw new Error("retention_failed");
+    }
+  },
+};

--- a/apps/demo-edge/wrangler.api.jsonc
+++ b/apps/demo-edge/wrangler.api.jsonc
@@ -1,0 +1,53 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "jobctrl-demo-api",
+  "main": "./workers/api.ts",
+  "compatibility_date": "2026-07-08",
+  "workers_dev": false,
+  "routes": [
+    {
+      "pattern": "demo.jobctrl.dev/api/*",
+      "zone_name": "jobctrl.dev"
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": false,
+      "head_sampling_rate": 1
+    },
+    "traces": {
+      "enabled": false
+    }
+  },
+  "vars": {
+    "DEMO_RELEASE": "local-dev"
+  },
+  "d1_databases": [
+    {
+      "binding": "DEMO_TELEMETRY_DB",
+      "database_name": "jobctrl-demo-telemetry",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "./migrations"
+    }
+  ],
+  "ratelimits": [
+    {
+      "name": "PUBLIC_INGRESS_LIMITER",
+      "namespace_id": "2026071101",
+      "simple": {
+        "limit": 240,
+        "period": 60
+      }
+    },
+    {
+      "name": "TELEMETRY_EDGE_LIMITER",
+      "namespace_id": "2026071102",
+      "simple": {
+        "limit": 2000,
+        "period": 60
+      }
+    }
+  ]
+}

--- a/apps/demo-edge/wrangler.retention.jsonc
+++ b/apps/demo-edge/wrangler.retention.jsonc
@@ -1,0 +1,32 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "jobctrl-demo-retention",
+  "main": "./workers/retention.ts",
+  "compatibility_date": "2026-07-08",
+  "workers_dev": false,
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": false,
+      "head_sampling_rate": 1
+    },
+    "traces": {
+      "enabled": false
+    }
+  },
+  "triggers": {
+    "crons": ["17 * * * *"]
+  },
+  "vars": {
+    "DEMO_RELEASE": "local-dev"
+  },
+  "d1_databases": [
+    {
+      "binding": "DEMO_TELEMETRY_DB",
+      "database_name": "jobctrl-demo-telemetry",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+      "migrations_dir": "./migrations"
+    }
+  ]
+}

--- a/apps/demo-edge/wrangler.test.jsonc
+++ b/apps/demo-edge/wrangler.test.jsonc
@@ -1,0 +1,52 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "jobctrl-demo-edge-tests",
+  "main": "./workers/api.ts",
+  "compatibility_date": "2026-07-08",
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": false,
+      "head_sampling_rate": 1
+    },
+    "traces": {
+      "enabled": false
+    }
+  },
+  "vars": {
+    "DEMO_RELEASE": "test-release"
+  },
+  "d1_databases": [
+    {
+      "binding": "DEMO_TELEMETRY_DB",
+      "database_name": "jobctrl-demo-edge-tests",
+      "database_id": "00000000-0000-0000-0000-000000000001",
+      "migrations_dir": "./migrations"
+    },
+    {
+      "binding": "MIGRATION_TEST_DB",
+      "database_name": "jobctrl-demo-edge-migration-tests",
+      "database_id": "00000000-0000-0000-0000-000000000002",
+      "migrations_dir": "./migrations"
+    }
+  ],
+  "ratelimits": [
+    {
+      "name": "PUBLIC_INGRESS_LIMITER",
+      "namespace_id": "2026071101",
+      "simple": {
+        "limit": 240,
+        "period": 60
+      }
+    },
+    {
+      "name": "TELEMETRY_EDGE_LIMITER",
+      "namespace_id": "2026071102",
+      "simple": {
+        "limit": 2000,
+        "period": 60
+      }
+    }
+  ]
+}

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -24,8 +24,9 @@ flowchart LR
     class LF ext
 ```
 
-Every span originates in the Python worker; the TypeScript API and web app are
-not instrumented yet (see [Out of Scope](#out-of-scope) below).
+Every OpenTelemetry span described on this page originates in the Python
+worker; the TypeScript API and web app are not instrumented yet (see
+[Out of Scope](#out-of-scope) below).
 
 The Python worker exports OpenTelemetry spans over OTLP/HTTP to a
 Langfuse instance for LLM tracing. The wiring lives under
@@ -121,6 +122,18 @@ exit so the `BatchSpanProcessor` flushes any in-flight spans.
 `jobctrl doctor` includes a `Langfuse` row that probes the OTLP endpoint
 with a `HEAD` request — `OK reachable`, `MISSING (set
 LANGFUSE_PUBLIC_KEY/SECRET_KEY/BASE_URL)`, or `unreachable`.
+
+## Public Demo Edge Logs
+
+The deployment-gated public demo is a separate observability boundary. Static
+assets come from Cloudflare Pages, a same-origin Worker handles only
+`demo.jobctrl.dev/api/*`, and a scheduled Worker performs D1 retention.
+
+Both Worker configs disable automatic invocation logs and traces. The Workers
+emit only closed lifecycle fields and never log request bodies, cookies, IPs,
+URLs, user agents, or referrers. Optional product measurement uses the typed,
+consent-gated D1 event contract; non-linkable operational counters and
+consented reports remain separate populations.
 
 ## Out of Scope
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -170,6 +170,24 @@ in the MVP. The receipt history stays inspectable in the demo shell. The demo
 never falls back to the product API, SSE, an external origin, or a host-OS
 opener.
 
+### Public demo edge workers
+
+The public demo uses Cloudflare Pages for the Vite SPA, a same-origin Worker at
+`demo.jobctrl.dev/api/*` for consent and telemetry, and an hourly retention
+Worker. Run the edge checks with:
+
+```bash
+corepack pnpm demo-edge:check
+corepack pnpm demo-edge:test
+corepack pnpm demo-edge:migrate:local
+corepack pnpm demo-edge:dry-run
+```
+
+The zero D1 UUID in the checked-in Wrangler configs is a rollout placeholder;
+public deployment must provision D1 and replace it first. Generated Wrangler
+bindings are intentionally ignored—the checked-in environment contract contains
+only the four bindings used by this package.
+
 ## Verify
 
 ```bash

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -17,6 +17,7 @@ changed, then add a browser/product-path check for user-visible behavior.
 | Frontend types | `corepack pnpm --filter @jobctrl/web test-d` |
 | Browser flow | `corepack pnpm --filter @jobctrl/web e2e -- tests/<flow>.spec.ts` |
 | Public demo browser workspace | `corepack pnpm --filter @jobctrl/web e2e:demo-workspace` |
+| Public demo edge | `corepack pnpm demo-edge:check`, `corepack pnpm demo-edge:test`, and `corepack pnpm demo-edge:dry-run` |
 | Python worker | `uv --project workers/automation run --extra dev ruff check .` and `uv --project workers/automation run --extra dev pytest -q` |
 | Any patch | `git diff --check` |
 
@@ -53,6 +54,16 @@ containment, workflow durability, projection correctness, schema compatibility,
 and accepted-artifact preservation. The
 [Regression Catalog](developer/qa/regression-catalog.md) explains which layer
 proves each class of invariant; the complete page maps every risk to exact tests.
+
+### Public demo privacy and edge gate
+
+When consent, cookies, telemetry, D1, retention, or Cloudflare configuration
+changes, the edge suite must prove that decline creates no analytics identity,
+grant is required before telemetry, cookie attributes and versioning remain
+exact, event fields stay allowlisted, retries do not double-count, rate limits
+fail closed, and expired identities/events/counters are deleted. Before public
+cutover, also repeat the consent and retention paths through local Wrangler and
+the production-mode browser lane.
 
 <a id="scoring-policy-eval-gate"></a>
 <a id="saved-views-smoke"></a>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
     "web:storybook": "corepack pnpm --filter @jobctrl/web storybook",
     "web:storybook:build": "corepack pnpm --filter @jobctrl/web storybook:build",
     "web:storybook:test": "corepack pnpm --filter @jobctrl/web storybook:test",
+    "demo-edge:check": "corepack pnpm --filter @jobctrl/demo-edge check",
+    "demo-edge:test": "corepack pnpm --filter @jobctrl/demo-edge test",
+    "demo-edge:types": "corepack pnpm --filter @jobctrl/demo-edge types",
+    "demo-edge:dry-run": "corepack pnpm --filter @jobctrl/demo-edge dry-run",
+    "demo-edge:migrate:local": "corepack pnpm --filter @jobctrl/demo-edge migrate:local",
     "extension:check": "corepack pnpm --filter @jobctrl/extension check",
     "extension:test": "corepack pnpm --filter @jobctrl/extension test",
     "extension:build": "corepack pnpm --filter @jobctrl/extension build",
@@ -62,8 +67,8 @@
     "python:test": "uv --project workers/automation run --extra dev pytest -q",
     "python:lint": "uv --project workers/automation run --extra dev ruff check .",
     "python:build": "uv --project workers/automation run --extra dev python -m build workers/automation",
-    "check": "corepack pnpm --filter @jobctrl/contracts check && corepack pnpm --filter @jobctrl/api-client check && corepack pnpm api:check && corepack pnpm web:check && corepack pnpm extension:check && corepack pnpm python:lint && corepack pnpm launcher:check",
-    "test": "corepack pnpm scripts:test && corepack pnpm api:test && corepack pnpm web:build && corepack pnpm extension:test && corepack pnpm extension:e2e && corepack pnpm python:test && corepack pnpm launcher:test"
+    "check": "corepack pnpm --filter @jobctrl/contracts check && corepack pnpm --filter @jobctrl/api-client check && corepack pnpm api:check && corepack pnpm web:check && corepack pnpm extension:check && corepack pnpm demo-edge:check && corepack pnpm python:lint && corepack pnpm launcher:check",
+    "test": "corepack pnpm scripts:test && corepack pnpm demo-edge:test && corepack pnpm api:test && corepack pnpm web:build && corepack pnpm extension:test && corepack pnpm extension:e2e && corepack pnpm python:test && corepack pnpm launcher:test"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,27 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
 
+  apps/demo-edge:
+    devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: 0.18.0
+        version: 0.18.0(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5)
+      '@jobctrl/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.9.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.9.2)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      wrangler:
+        specifier: 4.107.0
+        version: 4.107.0
+
   apps/extension:
     dependencies:
       '@jobctrl/contracts':
@@ -764,6 +785,60 @@ packages:
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/vitest-pool-workers@0.18.0':
+    resolution: {integrity: sha512-h4yFk1SmL5OT2HP2LEE8CzX0UuF+jS40MYPo2o/wlYn/qQIj1cBbWeGh20h6Wn/HFcx9KqxecAGWb8EENIKTTQ==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    resolution: {integrity: sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    resolution: {integrity: sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    resolution: {integrity: sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    resolution: {integrity: sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    resolution: {integrity: sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
@@ -1073,6 +1148,159 @@ packages:
   '@iconify/utils@3.1.3':
     resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
@@ -1234,6 +1462,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@juggle/resize-observer@3.4.0':
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
@@ -1415,6 +1646,15 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2213,6 +2453,10 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -2222,6 +2466,9 @@ packages:
 
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3371,6 +3618,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -3492,6 +3742,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
   cjs-module-lexer@2.2.0:
     resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
@@ -4052,6 +4305,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -5270,6 +5526,11 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  miniflare@4.20260701.0:
+    resolution: {integrity: sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -6014,6 +6275,10 @@ packages:
     resolution: {integrity: sha512-UV0cchFea9hO7poV1CuEP0wvmYjpAqcxCKdy23bndl2Du2ARtDs8A4xdzfhUjDBeOW1nNpJ6lXmsEpsply2SfQ==}
     hasBin: true
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -6236,6 +6501,10 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -6426,6 +6695,13 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -6780,6 +7056,21 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  workerd@1.20260701.1:
+    resolution: {integrity: sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.107.0:
+    resolution: {integrity: sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260701.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -6873,6 +7164,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -7383,6 +7680,48 @@ snapshots:
 
   '@chevrotain/types@11.1.2': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260701.1
+
+  '@cloudflare/vitest-pool-workers@0.18.0(@vitest/runner@4.1.5)(@vitest/snapshot@4.1.5)(vitest@4.1.5)':
+    dependencies:
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 4.20260701.0
+      vitest: 4.1.5(@types/node@25.9.2)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      wrangler: 4.107.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    optional: true
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/color-helpers@5.1.0': {}
 
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
@@ -7625,6 +7964,102 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
 
   '@inquirer/ansi@2.0.5': {}
 
@@ -7910,6 +8345,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@juggle/resize-observer@3.4.0': {}
 
   '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
@@ -8126,6 +8566,18 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -8860,6 +9312,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sinonjs/commons@3.0.1':
@@ -8869,6 +9323,8 @@ snapshots:
   '@sinonjs/fake-timers@15.4.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -9679,7 +10135,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.9.2)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -10096,6 +10552,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
   bluebird@3.7.2: {}
 
   body-parser@2.2.2:
@@ -10229,6 +10687,8 @@ snapshots:
   chownr@1.1.4: {}
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@1.2.3: {}
 
   cjs-module-lexer@2.2.0: {}
 
@@ -10732,6 +11192,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -12196,6 +12658,18 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  miniflare@4.20260701.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260701.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -13043,6 +13517,37 @@ snapshots:
       - supports-color
       - typescript
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -13300,6 +13805,8 @@ snapshots:
     dependencies:
       copy-anything: 4.0.5
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -13464,6 +13971,12 @@ snapshots:
   undici-types@7.19.2: {}
 
   undici-types@7.24.6: {}
+
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicorn-magic@0.3.0: {}
 
@@ -13861,6 +14374,30 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  workerd@1.20260701.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260701.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260701.1
+      '@cloudflare/workerd-linux-64': 1.20260701.1
+      '@cloudflare/workerd-linux-arm64': 1.20260701.1
+      '@cloudflare/workerd-windows-64': 1.20260701.1
+
+  wrangler@4.107.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260701.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260701.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -13956,6 +14493,19 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
## Summary

- add same-origin Cloudflare Workers for demo consent, initialization health, typed product telemetry, and hourly retention
- store non-linkable consent/init counters separately from consented pseudonymous events in D1
- issue versioned first-party consent plus HttpOnly visitor/session cookies only after confirmed grant; decline creates no analytics identity
- enforce closed event/attribute schemas, same-origin metadata, bounded bodies, D1 and edge rate limits, 24-hour dedupe/rate expiry, and 90-day data expiry
- include aggregate-only reports while keeping operational and consented populations separate
- keep generated Wrangler runtime bindings out of source control through a minimal four-binding environment contract

Post-accept withdrawal and current-visitor erasure remain explicitly deferred.

## Validation

- `corepack pnpm demo-edge:check`
- `corepack pnpm demo-edge:test` — 26 Worker behavior tests and 4 config/privacy tests
- `corepack pnpm demo-edge:migrate:local` — both migrations applied
- `corepack pnpm demo-edge:dry-run` — API and retention Worker bundles pass
- `corepack pnpm check`
- `corepack pnpm docs:build`
- `python3 scripts/release_check.py`
- `git diff --check`

## Stack

Base: #412 (`feat/demo-p3b-scenarios`).

The checked-in zero D1 UUID is intentionally a provisioning placeholder and must be replaced before deployment.