### PR TITLE
feat(demo): require telemetry consent before entry

### DIFF
--- a/apps/demo-edge/src/contracts.ts
+++ b/apps/demo-edge/src/contracts.ts
@@ -39,13 +39,23 @@ export type TelemetryEventName = (typeof telemetryEventNames)[number];
 
 export const routeNames = [
   "dashboard",
+  "discovery",
   "jobs",
   "job_detail",
   "evidence",
   "tailor",
+  "artifacts",
+  "artifact_detail",
   "apply_review",
   "apply_dry_run",
   "runs",
+  "pipelines",
+  "analytics",
+  "profile",
+  "preferences",
+  "outreach",
+  "contact_detail",
+  "activity",
   "settings",
   "docs",
 ] as const;
@@ -54,8 +64,10 @@ export type RouteName = (typeof routeNames)[number];
 export const featureNames = [
   "discovery",
   "scoring",
+  "pipeline",
   "evidence",
   "materials",
+  "artifacts",
   "apply_review",
   "apply",
   "outreach",
@@ -73,6 +85,13 @@ export const actionNames = [
   "reset",
   "install_cta",
   "docs_cta",
+  "rescore",
+  "retailor",
+  "retry_stage",
+  "run_stage",
+  "open_artifact",
+  "apply_dry_run",
+  "mark_applied",
 ] as const;
 export type ActionName = (typeof actionNames)[number];
 

--- a/apps/demo-edge/test/demo-edge.test.ts
+++ b/apps/demo-edge/test/demo-edge.test.ts
@@ -14,6 +14,8 @@ import {
   RETENTION_SAFETY_MARGIN_SECONDS,
   TELEMETRY_GLOBAL_RATE_LIMIT_PER_MINUTE,
   TELEMETRY_RATE_LIMIT_PER_MINUTE,
+  actionNames,
+  routeNames,
   timingMetrics,
 } from "../src/contracts.js";
 import {
@@ -30,6 +32,7 @@ import {
   handleTelemetryPost,
 } from "../src/handlers.js";
 import { readStrictJson } from "../src/http.js";
+import { parseTelemetryEvent } from "../src/schema.js";
 import type { DemoRequestContext } from "../src/context.js";
 import { runRetention } from "../workers/retention.js";
 
@@ -170,6 +173,21 @@ beforeEach(async () => {
 });
 
 describe("API Worker consent and telemetry boundaries", () => {
+  it("accepts every closed browser route and action dimension", () => {
+    for (const route of routeNames) {
+      expect(parseTelemetryEvent({
+        name: "demo_route_viewed",
+        attributes: { route },
+      }), route).toBeDefined();
+    }
+    for (const action of actionNames) {
+      expect(parseTelemetryEvent({
+        name: "demo_action_started",
+        attributes: { action },
+      }), action).toBeDefined();
+    }
+  });
+
   it("exercises every routed endpoint and permits browser-equivalent safe GETs without Origin", async () => {
     expect((await dispatchDemoApi(context("/api/demo-consent", { method: "GET" }, testEnv, false).request, testEnv)).status).toBe(200);
     expect((await dispatchDemoApi(context("/api/demo-consent", {

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -272,6 +272,35 @@ test("a denied revisit reopens the acceptance-required gate", async ({ page, con
   )).toBe(false);
 });
 
+test("a stalled consent read still renders the static gate without creating a workspace", async ({
+  page,
+  context,
+}) => {
+  let releaseRequest: (() => void) | undefined;
+  const stalled = new Promise<void>((resolve) => {
+    releaseRequest = resolve;
+  });
+  await context.route("**/api/demo-consent", async (route) => {
+    await stalled;
+    await route.abort("failed");
+  });
+
+  try {
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toBeVisible({
+      timeout: 1_000,
+    });
+    await expect(
+      page.getByRole("button", { name: "Accept cookies and enter demo" }),
+    ).toBeEnabled();
+    expect(await page.evaluate(async () =>
+      (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
+    )).toBe(false);
+  } finally {
+    releaseRequest?.();
+  }
+});
+
 scenarioTest(
   "J1 run-current-stage shows durable queued, running, and terminal state across tabs",
   async ({ page, context }) => {

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -27,6 +27,21 @@ const scenarioTest = test.extend<{ demoNetworkBoundary: void }>({
       const forbiddenRequests: string[] = [];
       const guard = async (route: Route) => {
         const requestUrl = new URL(route.request().url());
+        if (requestUrl.origin === demoOrigin && requestUrl.pathname === "/api/demo-consent") {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ choice: "granted", version: "v1" }),
+          });
+          return;
+        }
+        if (
+          requestUrl.origin === demoOrigin &&
+          (requestUrl.pathname === "/api/demo-health" ||
+            requestUrl.pathname === "/api/demo-telemetry")
+        ) {
+          await route.fulfill({ status: 204, body: "" });
+          return;
+        }
         const forbidden =
           requestUrl.pathname === "/v1" ||
           requestUrl.pathname === "/v1/events/stream" ||
@@ -134,6 +149,127 @@ function acceptNextConfirmation(page: Page): void {
 
 test.beforeEach(async ({ page }) => {
   await page.goto(STATIC_HOST);
+});
+
+test("consent grant precedes IndexedDB, health, telemetry, and populated demo entry", async ({
+  page,
+  context,
+}) => {
+  const requests: Array<{ path: string; method: string; body: unknown }> = [];
+  await context.route("**/api/demo-consent", async (route) => {
+    const request = route.request();
+    requests.push({
+      path: "/api/demo-consent",
+      method: request.method(),
+      body: request.postData() ? (request.postDataJSON() as unknown) : null,
+    });
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        choice: request.method() === "POST" ? "granted" : "unknown",
+        version: "v1",
+      }),
+    });
+  });
+  for (const path of ["/api/demo-health", "/api/demo-telemetry"] as const) {
+    await context.route(`**${path}`, async (route) => {
+      requests.push({
+        path,
+        method: route.request().method(),
+        body: route.request().postDataJSON() as unknown,
+      });
+      await route.fulfill({ status: 204, body: "" });
+    });
+  }
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toBeVisible();
+  await expect(page.getByText(/demo can only be used after accepting.*analytics cookies/i)).toBeVisible();
+  expect(requests.map(({ path }) => path)).toEqual(["/api/demo-consent"]);
+  expect(await page.evaluate(async () =>
+    (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
+  )).toBe(false);
+
+  await page.getByRole("button", { name: "Accept cookies and enter demo" }).click();
+  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  await expect.poll(async () => page.evaluate(async () =>
+    (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
+  )).toBe(true);
+  await expect.poll(() => requests.some(({ path }) => path === "/api/demo-health")).toBe(true);
+  await expect.poll(() => requests.some(({ path }) => path === "/api/demo-telemetry")).toBe(true);
+
+  const grantIndex = requests.findIndex(({ path, method }) =>
+    path === "/api/demo-consent" && method === "POST");
+  const healthIndex = requests.findIndex(({ path }) => path === "/api/demo-health");
+  const telemetryIndex = requests.findIndex(({ path }) => path === "/api/demo-telemetry");
+  expect(grantIndex).toBeGreaterThan(0);
+  expect(healthIndex).toBeGreaterThan(grantIndex);
+  expect(telemetryIndex).toBeGreaterThan(grantIndex);
+  expect(requests[grantIndex]?.body).toMatchObject({ choice: "granted" });
+});
+
+test("decline stays anonymous and redirects even when consent measurement fails", async ({
+  page,
+  context,
+}) => {
+  const requests: Array<{ path: string; body: unknown }> = [];
+  await context.route("**/api/demo-consent", async (route) => {
+    const request = route.request();
+    requests.push({
+      path: "/api/demo-consent",
+      body: request.postData() ? (request.postDataJSON() as unknown) : null,
+    });
+    if (request.method() === "POST") {
+      await route.abort("failed");
+      return;
+    }
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ choice: "unknown", version: "v1" }),
+    });
+  });
+  await context.route("https://jobctrl.dev/**", (route) =>
+    route.fulfill({ contentType: "text/html", body: "<h1>JobCtrl</h1>" }),
+  );
+  await context.route("**/api/demo-health", (route) => route.abort("blockedbyclient"));
+  await context.route("**/api/demo-telemetry", (route) => route.abort("blockedbyclient"));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Decline and return to jobctrl.dev" }).click();
+  await expect(page).toHaveURL("https://jobctrl.dev/");
+  expect(requests).toHaveLength(2);
+  expect(requests[1]?.body).toEqual({
+    choice: "denied",
+    operationKey: expect.stringMatching(/^[A-Za-z0-9_-]{32,128}$/),
+  });
+  expect(await page.evaluate(async () =>
+    (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
+  )).toBe(false);
+});
+
+test("a denied revisit reopens the acceptance-required gate", async ({ page, context }) => {
+  const optionalRequests: string[] = [];
+  await context.route("**/api/demo-consent", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ choice: "denied", version: "v1" }),
+    }),
+  );
+  for (const path of ["/api/demo-health", "/api/demo-telemetry"] as const) {
+    await context.route(`**${path}`, (route) => {
+      optionalRequests.push(path);
+      return route.abort("blockedbyclient");
+    });
+  }
+
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toBeVisible();
+  await expect(page.getByText(/previously declined/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Accept cookies and enter demo" })).toBeVisible();
+  expect(optionalRequests).toEqual([]);
+  expect(await page.evaluate(async () =>
+    (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
+  )).toBe(false);
 });
 
 scenarioTest(
@@ -295,7 +431,7 @@ scenarioTest(
   },
 );
 
-test("demo shell renders the shared-profile and personal-data boundary without product network", async ({
+scenarioTest("demo shell renders the shared-profile and personal-data boundary without product network", async ({
   page,
   context,
 }) => {
@@ -321,7 +457,7 @@ test("demo shell renders the shared-profile and personal-data boundary without p
   expect(productRequests).toEqual([]);
 });
 
-test("every P2 product route and seeded deep link renders populated across direct refreshes", async ({
+scenarioTest("every P2 product route and seeded deep link renders populated across direct refreshes", async ({
   page,
   context,
 }) => {
@@ -403,7 +539,7 @@ test("every P2 product route and seeded deep link renders populated across direc
   expect(externalRequests).toEqual([]);
 });
 
-test("same-context tabs share, serialize concurrent writes, and survive reload without product network", async ({
+scenarioTest("same-context tabs share, serialize concurrent writes, and survive reload without product network", async ({
   page,
   context,
 }) => {
@@ -466,7 +602,7 @@ test("same-context tabs share, serialize concurrent writes, and survive reload w
   expect(productRequests).toEqual([]);
 });
 
-test("eventless discovery and settings writes resync across tabs and survive reload", async ({
+scenarioTest("eventless discovery and settings writes resync across tabs and survive reload", async ({
   page,
   context,
 }) => {
@@ -504,7 +640,7 @@ test("eventless discovery and settings writes resync across tabs and survive rel
   expect(externalRequests).toEqual([]);
 });
 
-test("discovery promotes a source and imports a manual capture through the real browser-local UI", async ({
+scenarioTest("discovery promotes a source and imports a manual capture through the real browser-local UI", async ({
   page,
   context,
 }) => {
@@ -541,7 +677,7 @@ test("discovery promotes a source and imports a manual capture through the real 
   expect(externalRequests).toEqual([]);
 });
 
-test("score correction is browser-local, cross-tab visible, reload durable, and network-free", async ({
+scenarioTest("score correction is browser-local, cross-tab visible, reload durable, and network-free", async ({
   page,
   context,
 }) => {
@@ -574,7 +710,7 @@ test("score correction is browser-local, cross-tab visible, reload durable, and 
   expect(externalRequests).toEqual([]);
 });
 
-test("separate browser contexts isolate workspaces", async ({
+scenarioTest("separate browser contexts isolate workspaces", async ({
   page,
   browser,
 }) => {
@@ -593,7 +729,7 @@ test("separate browser contexts isolate workspaces", async ({
   }
 });
 
-test("reset rotates identity, fences state, and deletes generated blobs", async ({
+scenarioTest("reset rotates identity, fences state, and deletes generated blobs", async ({
   page,
 }) => {
   const initialized = await initializeWorkspace(page);
@@ -631,7 +767,7 @@ test("reset rotates identity, fences state, and deletes generated blobs", async 
   ).toBe(true);
 });
 
-test("future native database version is upgrade-required without downgrade", async ({
+scenarioTest("future native database version is upgrade-required without downgrade", async ({
   page,
 }) => {
   await page.evaluate(async () => {
@@ -670,7 +806,7 @@ test("future native database version is upgrade-required without downgrade", asy
   ).toBe(2);
 });
 
-test("postcommit event adapter emits only valid ordered domain events", async ({
+scenarioTest("postcommit event adapter emits only valid ordered domain events", async ({
   page,
 }) => {
   const result = await page.evaluate(async (moduleUrls) => {

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -301,6 +301,45 @@ test("a stalled consent read still renders the static gate without creating a wo
   }
 });
 
+test("a fresh grant wins over a stale denied consent read", async ({ page, context }) => {
+  let releaseRead: (() => void) | undefined;
+  let confirmReadResponse: (() => void) | undefined;
+  const stalledRead = new Promise<void>((resolve) => {
+    releaseRead = resolve;
+  });
+  const readResponseSent = new Promise<void>((resolve) => {
+    confirmReadResponse = resolve;
+  });
+  await context.route("**/api/demo-consent", async (route) => {
+    if (route.request().method() === "POST") {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ choice: "granted", version: "v1" }),
+      });
+      return;
+    }
+    await stalledRead;
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ choice: "denied", version: "v1" }),
+    });
+    confirmReadResponse?.();
+  });
+  await context.route("**/api/demo-health", (route) => route.fulfill({ status: 204 }));
+  await context.route("**/api/demo-telemetry", (route) => route.fulfill({ status: 204 }));
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Accept cookies and enter demo" }).click();
+  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  releaseRead?.();
+  await readResponseSent;
+  await page.evaluate(() => new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  ));
+  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toHaveCount(0);
+});
+
 scenarioTest(
   "J1 run-current-stage shows durable queued, running, and terminal state across tabs",
   async ({ page, context }) => {

--- a/apps/web/src/demo/DemoApiClientAdapter.test.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.test.ts
@@ -9,6 +9,7 @@ import {
 } from "@jobctrl/contracts";
 
 import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
+import { FakeTelemetryPort } from "../test/testPorts.js";
 import { DEMO_CAPABILITY_MANIFEST } from "./capabilities.js";
 import {
   DemoApiClientAdapter,
@@ -825,5 +826,34 @@ describe("DemoApiClientAdapter", () => {
       name: "DemoCapabilityError",
       code: "demo_capability_not_implemented",
     });
+  });
+
+  it("emits only closed action telemetry without affecting scenario results", async () => {
+    const telemetry = new FakeTelemetryPort();
+    const { adapter } = await createAdapter({ telemetry });
+
+    await expect(adapter.rescoreJob("job-fabrikam-systems", {})).resolves.toMatchObject({
+      status: "queued",
+    });
+    expect(telemetry.event).toHaveBeenNthCalledWith(1, "demo_action_started", {
+      feature: "scoring",
+      action: "rescore",
+      scenario: "success",
+    });
+    expect(telemetry.event).toHaveBeenCalledTimes(1);
+
+    telemetry.event.mockClear();
+    await expect(adapter.retailorJob("job-fabrikam-systems", {})).resolves.toMatchObject({
+      status: "blocked",
+    });
+    expect(telemetry.event).toHaveBeenNthCalledWith(2, "demo_action_failed", {
+      feature: "materials",
+      action: "retailor",
+      scenario: "retry",
+      result: "failed",
+      errorCode: "validation_rejected",
+      durationBucket: expect.stringMatching(/ms|s/),
+    });
+    adapter.dispose();
   });
 });

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -15,6 +15,7 @@ import {
 } from "@jobctrl/contracts";
 
 import type { ApiClientPort } from "../shared/ports/ApiClientPort.js";
+import type { TelemetryPort } from "../shared/ports/TelemetryPort.js";
 import { isDemoArtifactUrl } from "./artifacts.js";
 import type { ApiClientResponse, DemoReadModel } from "./contracts.js";
 import {
@@ -84,6 +85,7 @@ export interface DemoApiClientAdapterOptions
   extends DemoLocalCommandExecutorOptions {
   readonly scenario?: DemoScenarioEngineOptions;
   readonly external?: DemoExternalRehearsalExecutorOptions;
+  readonly telemetry?: TelemetryPort;
 }
 
 /** Browser-local adapter for reads, local commands, and deterministic scenarios. */
@@ -91,12 +93,14 @@ export class DemoApiClientAdapter implements ApiClientPort {
   private readonly localCommands: DemoLocalCommandExecutor;
   private readonly scenarios: DemoScenarioEngine;
   private readonly externalRehearsals: DemoExternalRehearsalExecutor;
+  private readonly telemetry: TelemetryPort | undefined;
 
   constructor(
     private readonly workspace: DemoWorkspaceRepository,
     options: DemoApiClientAdapterOptions = {},
   ) {
     this.localCommands = new DemoLocalCommandExecutor(workspace, options);
+    this.telemetry = options.telemetry;
     this.scenarios = new DemoScenarioEngine(workspace, options.scenario ?? {
       ...(options.clock ? { clock: options.clock } : {}),
       ...(options.createId ? { createId: options.createId } : {}),
@@ -649,15 +653,102 @@ export class DemoApiClientAdapter implements ApiClientPort {
     method: TMethod,
   ): ApiClientPort[TMethod] {
     return ((...args: Parameters<ApiClientPort[TMethod]>) =>
-      this.scenarios.execute(method, args)) as ApiClientPort[TMethod];
+      this.trackDemoAction(method, () => this.scenarios.execute(method, args))) as ApiClientPort[TMethod];
   }
 
   private rehearsed<TMethod extends DemoInitialExternalRehearsalOperation>(
     method: TMethod,
   ): ApiClientPort[TMethod] {
     return ((...args: Parameters<ApiClientPort[TMethod]>) =>
-      this.externalRehearsals.execute(method, args)) as ApiClientPort[TMethod];
+      this.trackDemoAction(method, () => this.externalRehearsals.execute(method, args))) as ApiClientPort[TMethod];
   }
+
+  private async trackDemoAction<TResult>(
+    method: string,
+    execute: () => Promise<TResult>,
+  ): Promise<TResult> {
+    const metadata = DEMO_ACTION_TELEMETRY[method];
+    if (!metadata || !this.telemetry) return execute();
+    const startedAt = monotonicNow();
+    this.emitTelemetry("demo_action_started", metadata);
+    try {
+      const result = await execute();
+      const status = actionStatus(result);
+      const durationBucket = telemetryDurationBucket(monotonicNow() - startedAt);
+      if (status === "queued" || status === "starting" || status === "in_progress") {
+        return result;
+      }
+      if (status === "failed" || status === "blocked") {
+        this.emitTelemetry("demo_action_failed", {
+          ...metadata,
+          result: "failed",
+          errorCode: status === "blocked" ? "validation_rejected" : "scenario_failed",
+          durationBucket,
+        });
+      } else if (status === "canceled" || status === "cancelled") {
+        this.emitTelemetry("demo_action_cancelled", {
+          ...metadata,
+          result: "cancelled",
+          durationBucket,
+        });
+      } else {
+        this.emitTelemetry("demo_action_completed", {
+          ...metadata,
+          result: "succeeded",
+          durationBucket,
+        });
+      }
+      return result;
+    } catch (error) {
+      this.emitTelemetry("demo_action_failed", {
+        ...metadata,
+        result: "failed",
+        errorCode: "client_unexpected",
+        durationBucket: telemetryDurationBucket(monotonicNow() - startedAt),
+      });
+      throw error;
+    }
+  }
+
+  private emitTelemetry(
+    name: string,
+    attributes: Record<string, string>,
+  ): void {
+    try {
+      this.telemetry?.event(name, attributes);
+    } catch {
+      // Optional analytics never changes browser-local product behavior.
+    }
+  }
+}
+
+const DEMO_ACTION_TELEMETRY: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  rescoreJob: { feature: "scoring", action: "rescore", scenario: "success" },
+  retailorJob: { feature: "materials", action: "retailor", scenario: "retry" },
+  retryStage: { feature: "pipeline", action: "retry_stage", scenario: "retry" },
+  runJobStage: { feature: "pipeline", action: "run_stage", scenario: "success" },
+  openArtifact: { feature: "artifacts", action: "open_artifact", scenario: "success" },
+  applyJob: { feature: "apply", action: "apply_dry_run", scenario: "success" },
+  markApplied: { feature: "apply", action: "mark_applied", scenario: "success" },
+};
+
+function actionStatus(result: unknown): string | undefined {
+  if (typeof result !== "object" || result === null || !("status" in result)) return undefined;
+  return typeof result.status === "string" ? result.status : undefined;
+}
+
+function monotonicNow(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+function telemetryDurationBucket(milliseconds: number): string {
+  if (milliseconds < 100) return "under_100ms";
+  if (milliseconds < 500) return "100ms_to_499ms";
+  if (milliseconds < 1_000) return "500ms_to_999ms";
+  if (milliseconds < 2_000) return "1s_to_2s";
+  if (milliseconds < 5_000) return "2s_to_5s";
+  if (milliseconds < 10_000) return "5s_to_10s";
+  return "over_10s";
 }
 
 function artifactPreviewUrl(

--- a/apps/web/src/demo/consent/DemoConsentClient.test.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  DemoConsentClient,
+  DemoConsentUnavailableError,
+} from "./DemoConsentClient.js";
+
+const KEY = "k".repeat(32);
+
+describe("DemoConsentClient", () => {
+  it("reads the versioned same-origin consent choice", async () => {
+    const fetcher = vi.fn(async () => json({ choice: "denied", version: "v1" }));
+    const client = new DemoConsentClient({ fetcher: fetcher as typeof fetch });
+
+    await expect(client.getChoice()).resolves.toEqual({ choice: "denied", version: "v1" });
+    expect(fetcher).toHaveBeenCalledWith("/api/demo-consent", expect.objectContaining({
+      method: "GET",
+      credentials: "same-origin",
+    }));
+  });
+
+  it("retains one operation key across a failed grant retry", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+    const client = new DemoConsentClient({
+      fetcher: fetcher as typeof fetch,
+      createOperationKey: () => KEY,
+    });
+
+    await expect(client.submitChoice("granted")).rejects.toBeInstanceOf(DemoConsentUnavailableError);
+    await expect(client.submitChoice("granted")).resolves.toMatchObject({ choice: "granted" });
+    const bodies = fetcher.mock.calls.map((call) => JSON.parse(String(call[1]?.body)) as unknown);
+    expect(bodies).toEqual([
+      { choice: "granted", operationKey: KEY },
+      { choice: "granted", operationKey: KEY },
+    ]);
+  });
+
+  it("uses a stable health key and rejects malformed consent responses", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v2" }));
+    const client = new DemoConsentClient({
+      fetcher: fetcher as typeof fetch,
+      createOperationKey: () => KEY,
+    });
+
+    await expect(client.recordHealth("success", "persistent")).rejects.toBeInstanceOf(DemoConsentUnavailableError);
+    await expect(client.recordHealth("success", "persistent")).resolves.toBeUndefined();
+    expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual(
+      JSON.parse(String(fetcher.mock.calls[1]?.[1]?.body)),
+    );
+    await expect(client.getChoice()).rejects.toBeInstanceOf(DemoConsentUnavailableError);
+  });
+});
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/apps/web/src/demo/consent/DemoConsentClient.test.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.test.ts
@@ -54,6 +54,38 @@ describe("DemoConsentClient", () => {
     );
     await expect(client.getChoice()).rejects.toBeInstanceOf(DemoConsentUnavailableError);
   });
+
+  it("bounds a never-settling consent read", async () => {
+    const fetcher = vi.fn(
+      (_input: RequestInfo | URL, _init?: RequestInit) => new Promise<Response>(() => undefined),
+    );
+    const client = new DemoConsentClient({
+      fetcher: fetcher as typeof fetch,
+      requestTimeoutMs: 5,
+    });
+
+    await expect(client.getChoice()).rejects.toBeInstanceOf(DemoConsentUnavailableError);
+    expect(fetcher.mock.calls[0]?.[1]?.signal).toMatchObject({ aborted: true });
+  });
+
+  it("bounds a never-settling grant and retains its operation key for retry", async () => {
+    const fetcher = vi.fn()
+      .mockImplementationOnce(() => new Promise<Response>(() => undefined))
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+    const client = new DemoConsentClient({
+      fetcher: fetcher as typeof fetch,
+      createOperationKey: () => KEY,
+      requestTimeoutMs: 5,
+    });
+
+    await expect(client.submitChoice("granted")).rejects.toBeInstanceOf(DemoConsentUnavailableError);
+    await expect(client.submitChoice("granted")).resolves.toMatchObject({ choice: "granted" });
+    const bodies = fetcher.mock.calls.map((call) => JSON.parse(String(call[1]?.body)) as unknown);
+    expect(bodies).toEqual([
+      { choice: "granted", operationKey: KEY },
+      { choice: "granted", operationKey: KEY },
+    ]);
+  });
 });
 
 function json(value: unknown): Response {

--- a/apps/web/src/demo/consent/DemoConsentClient.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.ts
@@ -1,0 +1,109 @@
+export const DEMO_CONSENT_VERSION = "v1" as const;
+
+export type DemoConsentChoice = "unknown" | "granted" | "denied";
+export type DemoConsentDecision = Exclude<DemoConsentChoice, "unknown">;
+export type DemoHealthResult = "success" | "failure";
+export type DemoHealthStorageMode = "persistent" | "memory";
+
+export interface DemoConsentState {
+  readonly choice: DemoConsentChoice;
+  readonly version: typeof DEMO_CONSENT_VERSION;
+}
+
+export interface DemoConsentClientOptions {
+  readonly fetcher?: typeof fetch;
+  readonly createOperationKey?: () => string;
+}
+
+export class DemoConsentUnavailableError extends Error {
+  constructor() {
+    super("The demo consent service is temporarily unavailable.");
+    this.name = "DemoConsentUnavailableError";
+  }
+}
+
+/** The only browser client allowed to contact consent/health before app mount. */
+export class DemoConsentClient {
+  private readonly fetcher: typeof fetch;
+  private readonly createOperationKey: () => string;
+  private readonly choiceKeys = new Map<DemoConsentDecision, string>();
+  private healthKey: string | undefined;
+
+  constructor(options: DemoConsentClientOptions = {}) {
+    this.fetcher = options.fetcher ?? ((input, init) => globalThis.fetch(input, init));
+    this.createOperationKey = options.createOperationKey ?? randomOperationKey;
+  }
+
+  async getChoice(): Promise<DemoConsentState> {
+    const response = await this.fetcher("/api/demo-consent", {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { accept: "application/json" },
+    });
+    return readConsentState(response);
+  }
+
+  async submitChoice(choice: DemoConsentDecision): Promise<DemoConsentState> {
+    const operationKey = this.choiceKeys.get(choice) ?? this.createOperationKey();
+    this.choiceKeys.set(choice, operationKey);
+    const response = await this.fetcher("/api/demo-consent", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { accept: "application/json", "content-type": "application/json" },
+      body: JSON.stringify({ choice, operationKey }),
+    });
+    const state = await readConsentState(response);
+    if (state.choice !== choice) throw new DemoConsentUnavailableError();
+    this.choiceKeys.delete(choice);
+    return state;
+  }
+
+  async recordHealth(
+    result: DemoHealthResult,
+    storageMode: DemoHealthStorageMode,
+  ): Promise<void> {
+    const operationKey = this.healthKey ?? this.createOperationKey();
+    this.healthKey = operationKey;
+    const response = await this.fetcher("/api/demo-health", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        choice: "granted",
+        result,
+        storageMode,
+        operationKey,
+      }),
+    });
+    if (!response.ok) throw new DemoConsentUnavailableError();
+    this.healthKey = undefined;
+  }
+}
+
+async function readConsentState(response: Response): Promise<DemoConsentState> {
+  if (!response.ok) throw new DemoConsentUnavailableError();
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new DemoConsentUnavailableError();
+  }
+  if (!isRecord(value)) throw new DemoConsentUnavailableError();
+  if (
+    value.version !== DEMO_CONSENT_VERSION ||
+    (value.choice !== "unknown" && value.choice !== "granted" && value.choice !== "denied")
+  ) {
+    throw new DemoConsentUnavailableError();
+  }
+  return { choice: value.choice, version: value.version };
+}
+
+function randomOperationKey(): string {
+  if (typeof crypto.randomUUID === "function") return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/web/src/demo/consent/DemoConsentClient.ts
+++ b/apps/web/src/demo/consent/DemoConsentClient.ts
@@ -1,4 +1,5 @@
 export const DEMO_CONSENT_VERSION = "v1" as const;
+export const DEMO_CONSENT_REQUEST_TIMEOUT_MS = 3_000;
 
 export type DemoConsentChoice = "unknown" | "granted" | "denied";
 export type DemoConsentDecision = Exclude<DemoConsentChoice, "unknown">;
@@ -13,6 +14,7 @@ export interface DemoConsentState {
 export interface DemoConsentClientOptions {
   readonly fetcher?: typeof fetch;
   readonly createOperationKey?: () => string;
+  readonly requestTimeoutMs?: number;
 }
 
 export class DemoConsentUnavailableError extends Error {
@@ -26,33 +28,41 @@ export class DemoConsentUnavailableError extends Error {
 export class DemoConsentClient {
   private readonly fetcher: typeof fetch;
   private readonly createOperationKey: () => string;
+  private readonly requestTimeoutMs: number;
   private readonly choiceKeys = new Map<DemoConsentDecision, string>();
   private healthKey: string | undefined;
 
   constructor(options: DemoConsentClientOptions = {}) {
     this.fetcher = options.fetcher ?? ((input, init) => globalThis.fetch(input, init));
     this.createOperationKey = options.createOperationKey ?? randomOperationKey;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEMO_CONSENT_REQUEST_TIMEOUT_MS;
   }
 
   async getChoice(): Promise<DemoConsentState> {
-    const response = await this.fetcher("/api/demo-consent", {
-      method: "GET",
-      credentials: "same-origin",
-      headers: { accept: "application/json" },
+    return this.withRequestTimeout(async (signal) => {
+      const response = await this.fetcher("/api/demo-consent", {
+        method: "GET",
+        credentials: "same-origin",
+        headers: { accept: "application/json" },
+        signal,
+      });
+      return readConsentState(response);
     });
-    return readConsentState(response);
   }
 
   async submitChoice(choice: DemoConsentDecision): Promise<DemoConsentState> {
     const operationKey = this.choiceKeys.get(choice) ?? this.createOperationKey();
     this.choiceKeys.set(choice, operationKey);
-    const response = await this.fetcher("/api/demo-consent", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { accept: "application/json", "content-type": "application/json" },
-      body: JSON.stringify({ choice, operationKey }),
+    const state = await this.withRequestTimeout(async (signal) => {
+      const response = await this.fetcher("/api/demo-consent", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { accept: "application/json", "content-type": "application/json" },
+        body: JSON.stringify({ choice, operationKey }),
+        signal,
+      });
+      return readConsentState(response);
     });
-    const state = await readConsentState(response);
     if (state.choice !== choice) throw new DemoConsentUnavailableError();
     this.choiceKeys.delete(choice);
     return state;
@@ -64,19 +74,44 @@ export class DemoConsentClient {
   ): Promise<void> {
     const operationKey = this.healthKey ?? this.createOperationKey();
     this.healthKey = operationKey;
-    const response = await this.fetcher("/api/demo-health", {
-      method: "POST",
-      credentials: "same-origin",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        choice: "granted",
-        result,
-        storageMode,
-        operationKey,
-      }),
+    await this.withRequestTimeout(async (signal) => {
+      const response = await this.fetcher("/api/demo-health", {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          choice: "granted",
+          result,
+          storageMode,
+          operationKey,
+        }),
+        signal,
+      });
+      if (!response.ok) throw new DemoConsentUnavailableError();
     });
-    if (!response.ok) throw new DemoConsentUnavailableError();
     this.healthKey = undefined;
+  }
+
+  private async withRequestTimeout<T>(
+    operation: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T> {
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timeoutId = setTimeout(() => {
+        controller.abort();
+        reject(new DemoConsentUnavailableError());
+      }, this.requestTimeoutMs);
+    });
+
+    try {
+      return await Promise.race([operation(controller.signal), timeout]);
+    } catch (error) {
+      if (error instanceof DemoConsentUnavailableError) throw error;
+      throw new DemoConsentUnavailableError();
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/apps/web/src/demo/consent/DemoConsentGate.a11y.test.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.a11y.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { expect, it, vi } from "vitest";
+
+import { DemoConsentClient } from "./DemoConsentClient.js";
+import { DemoConsentGate } from "./DemoConsentGate.js";
+
+it("has no automated accessibility violations", async () => {
+  const view = render(
+    <DemoConsentGate
+      client={new DemoConsentClient({
+        fetcher: vi.fn() as unknown as typeof fetch,
+        createOperationKey: () => "a".repeat(32),
+      })}
+      initialChoice="denied"
+      onDeclined={vi.fn()}
+      onGranted={vi.fn()}
+    />,
+  );
+
+  expect(await axe(view.container)).toHaveNoViolations();
+});

--- a/apps/web/src/demo/consent/DemoConsentGate.css
+++ b/apps/web/src/demo/consent/DemoConsentGate.css
@@ -1,0 +1,113 @@
+.demo-consent-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: clamp(1.25rem, 4vw, 3rem);
+  color: #18231f;
+  background:
+    radial-gradient(circle at 14% 8%, rgb(235 118 65 / 18%), transparent 32rem),
+    radial-gradient(circle at 88% 86%, rgb(44 99 79 / 18%), transparent 34rem),
+    #f5f1e8;
+}
+
+.demo-consent-card {
+  width: min(100%, 42rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  border: 1px solid rgb(24 35 31 / 14%);
+  border-radius: 1.5rem;
+  background: rgb(255 253 247 / 94%);
+  box-shadow: 0 1.5rem 4rem rgb(24 35 31 / 12%);
+}
+
+.demo-consent-mark {
+  display: grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.8rem;
+  color: #fffaf1;
+  background: #234c3e;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+.demo-consent-kicker {
+  margin: 1.35rem 0 0.4rem;
+  color: #b24e28;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.demo-consent-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 6vw, 3.6rem);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+}
+
+.demo-consent-card p {
+  line-height: 1.65;
+}
+
+.demo-consent-requirement {
+  margin-top: 1.4rem;
+  font-size: 1.08rem;
+  font-weight: 750;
+}
+
+.demo-consent-return-note,
+.demo-consent-error {
+  padding: 0.8rem 1rem;
+  border-radius: 0.8rem;
+  background: #f8e8dc;
+}
+
+.demo-consent-error {
+  color: #842f22;
+  border: 1px solid rgb(132 47 34 / 22%);
+}
+
+.demo-consent-links a {
+  color: #234c3e;
+  font-weight: 700;
+}
+
+.demo-consent-actions {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.6rem;
+}
+
+.demo-consent-actions button {
+  min-height: 3rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.8rem;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.demo-consent-actions button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.demo-consent-accept {
+  border: 1px solid #234c3e;
+  color: #fffaf1;
+  background: #234c3e;
+}
+
+.demo-consent-decline {
+  border: 1px solid rgb(24 35 31 / 24%);
+  color: #26352f;
+  background: transparent;
+}
+
+@media (min-width: 38rem) {
+  .demo-consent-actions {
+    grid-template-columns: 1.25fr 1fr;
+  }
+}

--- a/apps/web/src/demo/consent/DemoConsentGate.test.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DemoConsentClient } from "./DemoConsentClient.js";
+import { DemoConsentGate } from "./DemoConsentGate.js";
+
+const KEY = "g".repeat(32);
+
+describe("DemoConsentGate", () => {
+  it("discloses the hard gate and retries a failed acceptance without entering", async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(json({ choice: "granted", version: "v1" }));
+    const onGranted = vi.fn();
+    render(
+      <DemoConsentGate
+        client={new DemoConsentClient({ fetcher: fetcher as typeof fetch, createOperationKey: () => KEY })}
+        initialChoice="unknown"
+        onDeclined={vi.fn()}
+        onGranted={onGranted}
+      />,
+    );
+    const user = userEvent.setup();
+
+    expect(screen.getByText(/demo can only be used after accepting first-party analytics cookies/i)).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Accept cookies and enter demo" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/try again/i);
+    expect(onGranted).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Accept cookies and enter demo" }));
+    await waitFor(() => expect(onGranted).toHaveBeenCalledTimes(1));
+  });
+
+  it("reopens after denial and leaves even when anonymous measurement fails", async () => {
+    const onDeclined = vi.fn();
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.reject(new TypeError("offline")));
+    render(
+      <DemoConsentGate
+        client={new DemoConsentClient({ fetcher: fetcher as typeof fetch, createOperationKey: () => KEY })}
+        initialChoice="denied"
+        onDeclined={onDeclined}
+        onGranted={vi.fn()}
+      />,
+    );
+    const user = userEvent.setup();
+
+    expect(screen.getByText(/previously declined/i)).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Decline and return to jobctrl.dev" }));
+    await waitFor(() => expect(onDeclined).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual({
+      choice: "denied",
+      operationKey: KEY,
+    });
+  });
+});
+
+function json(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/apps/web/src/demo/consent/DemoConsentGate.test.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.test.tsx
@@ -54,6 +54,25 @@ describe("DemoConsentGate", () => {
       operationKey: KEY,
     });
   });
+
+  it("recovers the accept controls when the consent service never settles", async () => {
+    const fetcher = vi.fn(
+      (_input: RequestInfo | URL, _init?: RequestInit) => new Promise<Response>(() => undefined),
+    );
+    render(
+      <DemoConsentGate
+        client={new DemoConsentClient({ fetcher: fetcher as typeof fetch, requestTimeoutMs: 5 })}
+        initialChoice="unknown"
+        onDeclined={vi.fn()}
+        onGranted={vi.fn()}
+      />,
+    );
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole("button", { name: "Accept cookies and enter demo" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/try again/i);
+    expect(screen.getByRole("button", { name: "Accept cookies and enter demo" })).toBeEnabled();
+  });
 });
 
 function json(value: unknown): Response {

--- a/apps/web/src/demo/consent/DemoConsentGate.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.tsx
@@ -1,11 +1,16 @@
 import { useState, type JSX } from "react";
 
-import type { DemoConsentChoice, DemoConsentClient } from "./DemoConsentClient.js";
+import type {
+  DemoConsentChoice,
+  DemoConsentClient,
+  DemoConsentDecision,
+} from "./DemoConsentClient.js";
 import "./DemoConsentGate.css";
 
 export interface DemoConsentGateProps {
   readonly client: DemoConsentClient;
   readonly initialChoice: DemoConsentChoice;
+  readonly onDecisionStarted?: (choice: DemoConsentDecision) => void;
   readonly onGranted: () => void | Promise<void>;
   readonly onDeclined: () => void;
 }
@@ -13,6 +18,7 @@ export interface DemoConsentGateProps {
 export function DemoConsentGate({
   client,
   initialChoice,
+  onDecisionStarted,
   onGranted,
   onDeclined,
 }: DemoConsentGateProps): JSX.Element {
@@ -20,6 +26,7 @@ export function DemoConsentGate({
   const [error, setError] = useState<string | null>(null);
 
   const accept = async (): Promise<void> => {
+    onDecisionStarted?.("granted");
     setPending("granted");
     setError(null);
     try {
@@ -32,6 +39,7 @@ export function DemoConsentGate({
   };
 
   const decline = async (): Promise<void> => {
+    onDecisionStarted?.("denied");
     setPending("denied");
     setError(null);
     await Promise.race([

--- a/apps/web/src/demo/consent/DemoConsentGate.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.tsx
@@ -1,0 +1,91 @@
+import { useState, type JSX } from "react";
+
+import type { DemoConsentChoice, DemoConsentClient } from "./DemoConsentClient.js";
+import "./DemoConsentGate.css";
+
+export interface DemoConsentGateProps {
+  readonly client: DemoConsentClient;
+  readonly initialChoice: DemoConsentChoice;
+  readonly onGranted: () => void | Promise<void>;
+  readonly onDeclined: () => void;
+}
+
+export function DemoConsentGate({
+  client,
+  initialChoice,
+  onGranted,
+  onDeclined,
+}: DemoConsentGateProps): JSX.Element {
+  const [pending, setPending] = useState<"granted" | "denied" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const accept = async (): Promise<void> => {
+    setPending("granted");
+    setError(null);
+    try {
+      await client.submitChoice("granted");
+      await onGranted();
+    } catch {
+      setError("The consent service is unavailable. Please try again to enter the demo.");
+      setPending(null);
+    }
+  };
+
+  const decline = async (): Promise<void> => {
+    setPending("denied");
+    setError(null);
+    await Promise.race([
+      client.submitChoice("denied").catch(() => undefined),
+      new Promise<void>((resolve) => setTimeout(resolve, 500)),
+    ]);
+    onDeclined();
+  };
+
+  return (
+    <main className="demo-consent-shell">
+      <section className="demo-consent-card" aria-labelledby="demo-consent-title">
+        <div className="demo-consent-mark" aria-hidden="true">JC</div>
+        <p className="demo-consent-kicker">JobCtrl public demo</p>
+        <h1 id="demo-consent-title">Explore JobCtrl with synthetic data</h1>
+        <p className="demo-consent-requirement">
+          The live demo can only be used after accepting first-party analytics cookies.
+        </p>
+        <p>
+          Acceptance lets us measure coarse routes and demo actions so we can improve the
+          experience. The demo uses synthetic jobs and stays in this browser; do not enter
+          personal data, credentials, or secrets.
+        </p>
+        {initialChoice === "denied" ? (
+          <p className="demo-consent-return-note">
+            You previously declined. Accept now to enter, or decline again to return to
+            jobctrl.dev.
+          </p>
+        ) : null}
+        <p className="demo-consent-links">
+          Read the <a href="https://jobctrl.dev/user/data-and-safety#public-demo">demo data notice</a>
+          {" and "}
+          <a href="https://jobctrl.dev/user/security#public-demo-boundary">security boundary</a>.
+        </p>
+        {error ? <p className="demo-consent-error" role="alert">{error}</p> : null}
+        <div className="demo-consent-actions">
+          <button
+            className="demo-consent-accept"
+            disabled={pending !== null}
+            onClick={() => void accept()}
+            type="button"
+          >
+            {pending === "granted" ? "Confirming…" : "Accept cookies and enter demo"}
+          </button>
+          <button
+            className="demo-consent-decline"
+            disabled={pending !== null}
+            onClick={() => void decline()}
+            type="button"
+          >
+            {pending === "denied" ? "Leaving…" : "Decline and return to jobctrl.dev"}
+          </button>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/demo/consent/DemoTelemetryAdapter.test.ts
+++ b/apps/web/src/demo/consent/DemoTelemetryAdapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DemoTelemetryAdapter, classifyDemoRoute } from "./DemoTelemetryAdapter.js";
+
+describe("DemoTelemetryAdapter", () => {
+  it("sends only closed event names, attributes, and values", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(null, { status: 204 }));
+    const adapter = new DemoTelemetryAdapter({ fetcher: fetcher as typeof fetch });
+
+    adapter.event("demo_action_completed", {
+      feature: "pipeline",
+      action: "run_stage",
+      scenario: "success",
+      result: "succeeded",
+      durationBucket: "under_100ms",
+    });
+    adapter.event("arbitrary_event", { route: "dashboard" });
+    adapter.event("demo_route_viewed", { route: "dashboard", search: "private value" });
+    adapter.event("demo_route_viewed", { route: "private/company/name" });
+    await Promise.resolve();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetcher.mock.calls[0]?.[1]?.body))).toEqual({
+      name: "demo_action_completed",
+      attributes: {
+        feature: "pipeline",
+        action: "run_stage",
+        scenario: "success",
+        result: "succeeded",
+        durationBucket: "under_100ms",
+      },
+    });
+  });
+
+  it("never serializes raw errors and remains fail-open", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Promise.reject(new TypeError("network secret")));
+    const adapter = new DemoTelemetryAdapter({ fetcher: fetcher as typeof fetch });
+
+    expect(() => adapter.error(new Error("resume text"), { errorCode: "raw stack" })).not.toThrow();
+    await Promise.resolve();
+    const body = String(fetcher.mock.calls[0]?.[1]?.body);
+    expect(body).toContain("client_unexpected");
+    expect(body).not.toMatch(/resume text|raw stack|network secret/);
+  });
+
+  it("classifies route, viewport, and referrer without sending raw URLs", async () => {
+    const fetcher = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      new Response(null, { status: 204 }));
+    const adapter = new DemoTelemetryAdapter({
+      fetcher: fetcher as typeof fetch,
+      viewportWidth: () => 640,
+      referrer: () => "https://jobctrl.dev/private?query=value",
+    });
+
+    adapter.sessionStarted("/jobs/job-northwind-platform?secret=value");
+    adapter.routeViewed("/artifacts/artifact-tailored-resume");
+    await Promise.resolve();
+    const bodies = fetcher.mock.calls.map((call) => String(call[1]?.body));
+    expect(bodies.map((body) => JSON.parse(body))).toEqual([
+      {
+        name: "demo_session_started",
+        attributes: { route: "job_detail", viewportBucket: "compact", referrerClass: "jobctrl_docs" },
+      },
+      {
+        name: "demo_route_viewed",
+        attributes: { route: "artifact_detail", viewportBucket: "compact", referrerClass: "jobctrl_docs" },
+      },
+    ]);
+    expect(bodies.join(" ")).not.toMatch(/northwind|secret|private|query/);
+    expect(classifyDemoRoute("/discovery")).toBe("discovery");
+  });
+});

--- a/apps/web/src/demo/consent/DemoTelemetryAdapter.ts
+++ b/apps/web/src/demo/consent/DemoTelemetryAdapter.ts
@@ -1,0 +1,234 @@
+import type {
+  TelemetryAttributes as PortTelemetryAttributes,
+  TelemetryPort,
+} from "../../shared/ports/TelemetryPort.js";
+
+const EVENT_NAMES = [
+  "demo_session_started",
+  "demo_route_viewed",
+  "demo_tour_started",
+  "demo_tour_step_completed",
+  "demo_tour_completed",
+  "demo_feature_opened",
+  "demo_action_started",
+  "demo_action_completed",
+  "demo_action_failed",
+  "demo_action_cancelled",
+  "demo_workspace_reset",
+  "demo_install_cta_clicked",
+  "demo_docs_cta_clicked",
+  "demo_client_error",
+  "demo_timing",
+] as const;
+
+const ROUTES = [
+  "dashboard", "discovery", "jobs", "job_detail", "evidence", "tailor",
+  "artifacts", "artifact_detail", "apply_review", "apply_dry_run", "runs",
+  "pipelines", "analytics", "profile", "preferences", "outreach",
+  "contact_detail", "activity", "settings", "docs",
+] as const;
+const FEATURES = [
+  "discovery", "scoring", "pipeline", "evidence", "materials", "artifacts",
+  "apply_review", "apply", "outreach", "demo_tour",
+] as const;
+const ACTIONS = [
+  "open", "start", "complete", "fail", "cancel", "retry", "reset",
+  "install_cta", "docs_cta", "rescore", "retailor", "retry_stage",
+  "run_stage", "open_artifact", "apply_dry_run", "mark_applied",
+] as const;
+const SCENARIOS = ["success", "failure", "cancellation", "retry"] as const;
+const RESULTS = ["succeeded", "failed", "cancelled"] as const;
+const ERRORS = [
+  "network_unavailable", "telemetry_unavailable", "validation_rejected",
+  "scenario_failed", "client_unexpected",
+] as const;
+const DURATIONS = [
+  "under_100ms", "100ms_to_499ms", "500ms_to_999ms", "1s_to_2s",
+  "2s_to_5s", "5s_to_10s", "over_10s",
+] as const;
+const TIMINGS = ["lcp", "inp", "cls", "ttfb", "route_transition"] as const;
+const METRICS = ["good", "needs_improvement", "poor"] as const;
+const VIEWPORTS = ["compact", "standard", "wide"] as const;
+const TOUR_STEPS = ["welcome", "jobs", "evidence", "tailor", "apply", "install"] as const;
+const REFERRERS = ["direct", "jobctrl_docs", "github", "search", "other"] as const;
+
+export type DemoRouteName = (typeof ROUTES)[number];
+
+interface DemoTelemetryAdapterOptions {
+  readonly fetcher?: typeof fetch;
+  readonly viewportWidth?: () => number;
+  readonly referrer?: () => string;
+}
+
+const ALLOWED_ATTRIBUTES: Readonly<Record<(typeof EVENT_NAMES)[number], readonly string[]>> = {
+  demo_session_started: ["route", "viewportBucket", "referrerClass"],
+  demo_route_viewed: ["route", "viewportBucket", "referrerClass"],
+  demo_tour_started: ["route", "tourStep"],
+  demo_tour_step_completed: ["route", "tourStep"],
+  demo_tour_completed: ["route"],
+  demo_feature_opened: ["route", "feature"],
+  demo_action_started: ["route", "feature", "action", "scenario"],
+  demo_action_completed: ["route", "feature", "action", "scenario", "result", "durationBucket"],
+  demo_action_failed: ["route", "feature", "action", "scenario", "result", "errorCode", "durationBucket"],
+  demo_action_cancelled: ["route", "feature", "action", "scenario", "result", "durationBucket"],
+  demo_workspace_reset: ["route"],
+  demo_install_cta_clicked: ["route"],
+  demo_docs_cta_clicked: ["route"],
+  demo_client_error: ["route", "errorCode"],
+  demo_timing: ["route", "timingMetric", "metricBucket", "viewportBucket"],
+};
+
+const ATTRIBUTE_VALUES: Readonly<Record<string, readonly string[]>> = {
+  route: ROUTES,
+  feature: FEATURES,
+  action: ACTIONS,
+  scenario: SCENARIOS,
+  result: RESULTS,
+  errorCode: ERRORS,
+  durationBucket: DURATIONS,
+  timingMetric: TIMINGS,
+  metricBucket: METRICS,
+  viewportBucket: VIEWPORTS,
+  tourStep: TOUR_STEPS,
+  referrerClass: REFERRERS,
+};
+
+/** Consent-gated, fail-open telemetry with a closed payload vocabulary. */
+export class DemoTelemetryAdapter implements TelemetryPort {
+  private readonly fetcher: typeof fetch;
+  private readonly viewportWidth: () => number;
+  private readonly referrer: () => string;
+
+  constructor(options: DemoTelemetryAdapterOptions = {}) {
+    this.fetcher = options.fetcher ?? ((input, init) => globalThis.fetch(input, init));
+    this.viewportWidth = options.viewportWidth ?? (() => window.innerWidth);
+    this.referrer = options.referrer ?? (() => document.referrer);
+  }
+
+  event(name: string, attributes: PortTelemetryAttributes = {}): void {
+    const event = validatedEvent(name, attributes);
+    if (!event) return;
+    this.send(event);
+  }
+
+  error(_error: unknown, attributes: PortTelemetryAttributes = {}): void {
+    const route = isFrom(attributes.route, ROUTES) ? attributes.route : undefined;
+    const errorCode = isFrom(attributes.errorCode, ERRORS)
+      ? attributes.errorCode
+      : "client_unexpected";
+    this.event("demo_client_error", { ...(route ? { route } : {}), errorCode });
+  }
+
+  timing(name: string, milliseconds: number, attributes: PortTelemetryAttributes = {}): void {
+    if (!Number.isFinite(milliseconds) || milliseconds < 0) return;
+    const route = isFrom(attributes.route, ROUTES) ? attributes.route : undefined;
+    const timingMetric = isFrom(name, TIMINGS) ? name : "route_transition";
+    this.event("demo_timing", {
+      ...(route ? { route } : {}),
+      timingMetric,
+      metricBucket: metricBucket(milliseconds),
+      viewportBucket: viewportBucket(this.viewportWidth()),
+    });
+  }
+
+  sessionStarted(pathname: string): void {
+    this.event("demo_session_started", this.navigationAttributes(pathname));
+  }
+
+  routeViewed(pathname: string): void {
+    this.event("demo_route_viewed", this.navigationAttributes(pathname));
+  }
+
+  private navigationAttributes(pathname: string): PortTelemetryAttributes {
+    return {
+      route: classifyDemoRoute(pathname),
+      viewportBucket: viewportBucket(this.viewportWidth()),
+      referrerClass: classifyReferrer(this.referrer()),
+    };
+  }
+
+  private send(event: { name: string; attributes: Record<string, string> }): void {
+    try {
+      void this.fetcher("/api/demo-telemetry", {
+        method: "POST",
+        credentials: "same-origin",
+        keepalive: true,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(event),
+      }).catch(() => undefined);
+    } catch {
+      // Optional analytics never changes product behavior.
+    }
+  }
+}
+
+export function classifyDemoRoute(pathname: string): DemoRouteName {
+  const parts = pathname.split("/").filter(Boolean);
+  const root = parts[0] ?? "dashboard";
+  if (root === "jobs") return parts.length > 1 ? "job_detail" : "jobs";
+  if (root === "artifacts") return parts.length > 1 ? "artifact_detail" : "artifacts";
+  if (root === "outreach") return parts.length > 1 ? "contact_detail" : "outreach";
+  const direct: Readonly<Record<string, DemoRouteName>> = {
+    dashboard: "dashboard",
+    discovery: "discovery",
+    "evidence-map": "evidence",
+    "apply-review": "apply_review",
+    runs: "runs",
+    pipelines: "pipelines",
+    analytics: "analytics",
+    profile: "profile",
+    preferences: "preferences",
+    activity: "activity",
+    settings: "settings",
+  };
+  return direct[root] ?? "dashboard";
+}
+
+function validatedEvent(
+  name: string,
+  attributes: PortTelemetryAttributes,
+): { name: string; attributes: Record<string, string> } | undefined {
+  if (!isFrom(name, EVENT_NAMES)) return undefined;
+  const allowed = ALLOWED_ATTRIBUTES[name];
+  const entries = Object.entries(attributes);
+  if (entries.some(([key]) => !allowed.includes(key))) return undefined;
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of entries) {
+    const values = ATTRIBUTE_VALUES[key];
+    if (!values || typeof value !== "string" || !values.includes(value)) return undefined;
+    normalized[key] = value;
+  }
+  if (name === "demo_timing" && (!normalized.timingMetric || !normalized.metricBucket)) {
+    return undefined;
+  }
+  return { name, attributes: normalized };
+}
+
+function isFrom<T extends string>(value: unknown, values: readonly T[]): value is T {
+  return typeof value === "string" && values.includes(value as T);
+}
+
+function viewportBucket(width: number): (typeof VIEWPORTS)[number] {
+  if (width < 720) return "compact";
+  if (width < 1280) return "standard";
+  return "wide";
+}
+
+function classifyReferrer(referrer: string): (typeof REFERRERS)[number] {
+  if (!referrer) return "direct";
+  try {
+    const host = new URL(referrer).hostname.toLowerCase();
+    if (host === "jobctrl.dev" || host.endsWith(".jobctrl.dev")) return "jobctrl_docs";
+    if (host === "github.com" || host.endsWith(".github.com")) return "github";
+    if (/^(www\.)?(google|bing|duckduckgo|ecosia)\./.test(host)) return "search";
+    return "other";
+  } catch {
+    return "other";
+  }
+}
+
+function metricBucket(milliseconds: number): (typeof METRICS)[number] {
+  if (milliseconds < 2_500) return "good";
+  if (milliseconds < 4_000) return "needs_improvement";
+  return "poor";
+}

--- a/apps/web/src/demo/consent/index.ts
+++ b/apps/web/src/demo/consent/index.ts
@@ -1,0 +1,3 @@
+export * from "./DemoConsentClient.js";
+export * from "./DemoConsentGate.js";
+export * from "./DemoTelemetryAdapter.js";

--- a/apps/web/src/demo/portFactory.test.ts
+++ b/apps/web/src/demo/portFactory.test.ts
@@ -8,6 +8,7 @@ import { NavigatorClipboardAdapter } from "../shared/adapters/local/NavigatorCli
 import { OpenArtifactAdapter } from "../shared/adapters/local/OpenArtifactAdapter.js";
 import { SseEventStreamAdapter } from "../shared/adapters/local/SseEventStreamAdapter.js";
 import { StaticFeatureFlagAdapter } from "../shared/adapters/local/StaticFeatureFlagAdapter.js";
+import { FakeTelemetryPort } from "../test/testPorts.js";
 import type {
   DemoWorkspaceSnapshot,
   DemoWorkspaceStore,
@@ -87,11 +88,13 @@ describe("port factory", () => {
   it("selects demo only explicitly and constructs no product-network, SSE, or host-OS adapter", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const previewOpener = vi.fn(() => ({ close: vi.fn() }));
+    const telemetry = new FakeTelemetryPort();
     try {
       expect(resolveAppMode("demo")).toBe("demo");
       const composition = await createAppComposition({
         mode: "demo",
         demoPreviewOpener: previewOpener,
+        demoTelemetry: telemetry,
         demoWorkspace: { store: new InMemoryDemoWorkspaceStore() },
       });
 
@@ -117,6 +120,7 @@ describe("port factory", () => {
         composition.ports.featureFlags.get("activityDetailDirectLoad", false),
       ).toBe(true);
       expect(composition.ports.featureFlags.get("demoMode", false)).toBe(true);
+      expect(composition.ports.telemetry).toBe(telemetry);
       expect(composition.ports.api).toBeInstanceOf(DemoApiClientAdapter);
       await expect(composition.ports.api.health()).resolves.toMatchObject({
         ok: true,

--- a/apps/web/src/demo/portFactory.ts
+++ b/apps/web/src/demo/portFactory.ts
@@ -28,6 +28,7 @@ export interface PortFactoryOptions {
   readonly mode: AppMode;
   readonly apiBaseUrl?: string;
   readonly demoPreviewOpener?: DemoArtifactPreviewOpener;
+  readonly demoTelemetry?: Ports["telemetry"];
   readonly demoWorkspace?: Omit<DemoWorkspaceRepositoryOptions, "store"> & {
     readonly store?: DemoWorkspaceRepositoryOptions["store"];
   };
@@ -83,6 +84,7 @@ export async function createAppComposition(
   });
   const initialization = await workspace.initialize();
   const api = new DemoApiClientAdapter(workspace, {
+    ...(options.demoTelemetry ? { telemetry: options.demoTelemetry } : {}),
     external: {
       opener: options.demoPreviewOpener ?? browserDemoArtifactPreviewOpener,
     },
@@ -99,7 +101,7 @@ export async function createAppComposition(
       session: new DemoSessionAdapter(),
       clipboard: new NavigatorClipboardAdapter(),
       openInOs: new DemoOpenInOsAdapter(api),
-      telemetry: new ConsoleTelemetryAdapter(),
+      telemetry: options.demoTelemetry ?? new ConsoleTelemetryAdapter(),
       featureFlags: new DemoFeatureFlagAdapter(),
     },
     workspace,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -26,6 +26,7 @@ const queryClient = createQueryClient();
 const root = createRoot(document.getElementById("root")!);
 let disposeComposition: () => void = () => undefined;
 let demoAdmission: Promise<void> | undefined;
+let demoChoiceStarted = false;
 
 window.addEventListener("pagehide", () => disposeComposition(), { once: true });
 if (import.meta.hot) {
@@ -45,6 +46,7 @@ async function bootstrap(): Promise<void> {
   renderConsentGate(client, "unknown");
   try {
     const state = await client.getChoice();
+    if (demoChoiceStarted) return;
     if (state.choice === "granted") {
       await enterDemo(client);
       return;
@@ -61,6 +63,7 @@ function renderConsentGate(client: DemoConsentClient, initialChoice: DemoConsent
       <DemoConsentGate
         client={client}
         initialChoice={initialChoice}
+        onDecisionStarted={() => { demoChoiceStarted = true; }}
         onDeclined={() => window.location.assign("https://jobctrl.dev")}
         onGranted={() => enterDemo(client)}
       />

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,8 +3,15 @@ import { createRoot } from "react-dom/client";
 
 import { App } from "./App.js";
 import { EventStreamProvider } from "./contexts/operations/providers/EventStreamProvider.js";
+import {
+  DemoConsentClient,
+  DemoConsentGate,
+  DemoTelemetryAdapter,
+  type DemoConsentChoice,
+} from "./demo/consent/index.js";
 import { createAppComposition, resolveAppMode } from "./demo/portFactory.js";
 import { DemoWorkspaceProvider } from "./demo/workspace/DemoWorkspaceProvider.js";
+import { router } from "./router.js";
 import { createQueryClient } from "./shared/lib/queryClient.js";
 import { DensityProvider } from "./shared/providers/DensityProvider.js";
 import { PortsProvider } from "./shared/providers/PortsProvider.js";
@@ -24,19 +31,79 @@ if (import.meta.hot) {
   import.meta.hot.dispose(() => disposeComposition());
 }
 
-void mount();
+const appMode = resolveAppMode(import.meta.env.VITE_JOBCTRL_APP_MODE);
+void bootstrap();
 
-async function mount(): Promise<void> {
-  const composition = await createAppComposition({
-    mode: resolveAppMode(import.meta.env.VITE_JOBCTRL_APP_MODE),
-    apiBaseUrl: import.meta.env.VITE_JOBCTRL_API_BASE_URL ?? "",
-  });
+async function bootstrap(): Promise<void> {
+  if (appMode !== "demo") {
+    await mountApplication();
+    return;
+  }
+
+  const client = new DemoConsentClient();
+  let initialChoice: DemoConsentChoice = "unknown";
+  try {
+    const state = await client.getChoice();
+    initialChoice = state.choice;
+    if (state.choice === "granted") {
+      await mountApplication(client);
+      return;
+    }
+  } catch {
+    // The static gate remains usable and acceptance stays retryable.
+  }
+
+  root.render(
+    <React.StrictMode>
+      <DemoConsentGate
+        client={client}
+        initialChoice={initialChoice}
+        onDeclined={() => window.location.assign("https://jobctrl.dev")}
+        onGranted={() => mountApplication(client)}
+      />
+    </React.StrictMode>,
+  );
+}
+
+async function mountApplication(consentClient?: DemoConsentClient): Promise<void> {
+  const demoTelemetry = appMode === "demo" ? new DemoTelemetryAdapter() : undefined;
+  let composition: Awaited<ReturnType<typeof createAppComposition>>;
+  try {
+    composition = await createAppComposition({
+      mode: appMode,
+      apiBaseUrl: import.meta.env.VITE_JOBCTRL_API_BASE_URL ?? "",
+      ...(demoTelemetry ? { demoTelemetry } : {}),
+    });
+  } catch {
+    if (consentClient) {
+      void consentClient.recordHealth("failure", "persistent").catch(() => undefined);
+    }
+    demoTelemetry?.error(undefined, { errorCode: "client_unexpected" });
+    root.render(
+      <main role="alert">
+        <h1>Demo temporarily unavailable</h1>
+        <p>Reload to try the browser-local demo again.</p>
+      </main>,
+    );
+    return;
+  }
   disposeComposition();
-  disposeComposition = composition.dispose;
+  const stopRouteTelemetry = demoTelemetry
+    ? router.subscribe("onResolved", ({ pathChanged, toLocation }) => {
+        if (pathChanged) demoTelemetry.routeViewed(toLocation.pathname);
+      })
+    : () => undefined;
+  disposeComposition = () => {
+    stopRouteTelemetry();
+    composition.dispose();
+  };
   if (
     composition.kind === "demo" &&
     composition.initialization.kind === "upgrade_required"
   ) {
+    if (consentClient) {
+      void consentClient.recordHealth("failure", "persistent").catch(() => undefined);
+    }
     root.render(
       <main role="alert">
         <h1>Demo update required</h1>
@@ -44,6 +111,17 @@ async function mount(): Promise<void> {
       </main>,
     );
     return;
+  }
+  if (
+    composition.kind === "demo" &&
+    composition.initialization.kind === "ready" &&
+    consentClient
+  ) {
+    const storageMode = composition.initialization.storageMode === "indexeddb"
+      ? "persistent"
+      : "memory";
+    void consentClient.recordHealth("success", storageMode).catch(() => undefined);
+    demoTelemetry?.sessionStarted(window.location.pathname);
   }
   const workspace = composition.kind === "demo" ? composition.workspace : null;
   root.render(

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,6 +25,7 @@ import "./styles/globals.css";
 const queryClient = createQueryClient();
 const root = createRoot(document.getElementById("root")!);
 let disposeComposition: () => void = () => undefined;
+let demoAdmission: Promise<void> | undefined;
 
 window.addEventListener("pagehide", () => disposeComposition(), { once: true });
 if (import.meta.hot) {
@@ -41,28 +42,35 @@ async function bootstrap(): Promise<void> {
   }
 
   const client = new DemoConsentClient();
-  let initialChoice: DemoConsentChoice = "unknown";
+  renderConsentGate(client, "unknown");
   try {
     const state = await client.getChoice();
-    initialChoice = state.choice;
     if (state.choice === "granted") {
-      await mountApplication(client);
+      await enterDemo(client);
       return;
     }
+    if (state.choice === "denied") renderConsentGate(client, "denied");
   } catch {
-    // The static gate remains usable and acceptance stays retryable.
+    // The already-rendered static gate remains usable and acceptance stays retryable.
   }
+}
 
+function renderConsentGate(client: DemoConsentClient, initialChoice: DemoConsentChoice): void {
   root.render(
     <React.StrictMode>
       <DemoConsentGate
         client={client}
         initialChoice={initialChoice}
         onDeclined={() => window.location.assign("https://jobctrl.dev")}
-        onGranted={() => mountApplication(client)}
+        onGranted={() => enterDemo(client)}
       />
     </React.StrictMode>,
   );
+}
+
+function enterDemo(client: DemoConsentClient): Promise<void> {
+  demoAdmission ??= mountApplication(client);
+  return demoAdmission;
 }
 
 async function mountApplication(consentClient?: DemoConsentClient): Promise<void> {

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -150,6 +150,12 @@ Only the exact value `demo` selects this composition. A missing or invalid
 `VITE_JOBCTRL_APP_MODE` keeps the normal local composition, so a mistyped value
 cannot produce a partially mounted app.
 
+Demo mode now renders the static acceptance gate before creating IndexedDB.
+Without the same-origin consent Worker, acceptance remains fail-closed and the
+workspace does not initialize. The dedicated Playwright lane stubs the exact
+Worker contract for browser-local development; use a Cloudflare preview when
+manually testing real cookie persistence across reloads.
+
 The demo workspace persists in IndexedDB and is shared by tabs and people using
 the same browser profile. Separate browser profiles and private/incognito
 contexts are isolated. Reset rotates the workspace identity, clears pending

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -102,6 +102,12 @@ warning, and the unchanged canonical event provider/invalidation router.
 Playwright artifacts are written outside the repository under the system
 temporary directory.
 
+The same lane begins with three consent regressions: no IndexedDB, health, or
+product telemetry before a confirmed grant; anonymous decline redirects even
+when measurement fails; and a denied revisit renders the acceptance-required
+gate again. Existing product journeys use a granted same-origin API stub, so
+the full suite also proves the gate does not regress admitted sessions.
+
 <a id="token-foundation-qa-gate"></a>
 <a id="shared-primitive-qa-gate"></a>
 <a id="route-visual-qa-gate"></a>

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -29,6 +29,29 @@ settings, read [Configuration](configuration.md).
 Local-first does not mean offline. Discovery fetches sources, generation calls
 models, and live apply contacts an employer only when you use those features.
 
+## Public Demo
+
+The hosted synthetic demo is separate from the local product described above.
+It can only be used after accepting first-party analytics cookies. Declining
+returns to `https://jobctrl.dev`; opening the demo again shows the choice again.
+The demo does not initialize its browser-local workspace until the consent
+service confirms acceptance.
+
+After acceptance, Cloudflare sets a versioned consent cookie plus random
+HttpOnly visitor and session identifiers. The persistent cookies expire within
+six months, the session cookie at the end of the browser session, and raw demo
+events and non-linkable operational counters expire within 90 days. Events use
+closed route/action/result categories: they exclude names, contact details,
+profile or resume text, job/company content, URLs, searches, comments, local
+paths, raw errors, and demo entity/workspace identifiers. IP addresses may be
+used transiently by Cloudflare rate limiting but are not written to D1 or
+application logs.
+
+The demo contains synthetic data. Do not enter personal data, credentials, or
+secrets. Post-accept withdrawal and immediate visitor-event deletion are not
+yet available in this MVP; retained data expires on the schedules above. The
+consent screen links to this disclosure before entry.
+
 ## Local Data
 
 Default workspace:

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -26,6 +26,28 @@ in [Configuration](configuration.md); the repo threat model is in
 - Live apply is approval-gated by default, dry-run is blocked at the browser
   network layer, and ambiguous post-submit recovery parks for verification.
 
+## Public Demo Boundary
+
+The public synthetic demo never connects to the local JobCtrl API, worker,
+browser extension, model providers, job boards, Gmail, or application
+submission transports. Its product state stays in the visitor's browser. A
+same-origin Cloudflare Worker handles only consent, aggregate initialization
+health, allowlisted analytics, and retention.
+
+The demo is unavailable until the visitor accepts first-party analytics
+cookies. A decline creates no visitor or session identifier and redirects to
+`https://jobctrl.dev`; returning shows the consent screen again. Before a
+confirmed grant, the app creates no demo IndexedDB workspace and sends no
+health or product-telemetry event. Post-accept analytics failures never block
+browser-local product interaction.
+
+Telemetry schemas reject free-form content and product identifiers at both the
+browser and Worker boundaries. Cloudflare automatic invocation logs and traces
+are disabled for the demo Workers; only closed lifecycle outcomes may be
+logged. Post-accept withdrawal and immediate visitor-event deletion are
+deferred from this MVP, so the notice relies on the documented cookie and
+90-day raw-data expiry instead of claiming an unavailable control.
+
 ## What Leaves Your Machine
 
 | Outbound call | When | What can be sent |


### PR DESCRIPTION
## Summary

- render a static, accessible acceptance-required consent screen before the demo creates IndexedDB or mounts product composition
- enter only after the same-origin Worker confirms `granted`; failed or stalled consent requests remain bounded, retryable, and fail-closed
- make a fresh visitor choice win over a stale initial read, including delayed-denied-read/fast-grant races
- make decline best-effort and anonymous, redirect to `https://jobctrl.dev` even on measurement failure, and show the gate again for a denied revisit
- send initialization health, coarse session/route events, and seven allowlisted demo-action categories only after grant
- reject unknown event names, fields, values, raw errors, URLs, queries, and product identifiers at the browser boundary; delivery failures never affect the demo
- document cookie/data expiry and explicitly state that post-accept withdrawal/current-visitor deletion is deferred

## Validation

- `corepack pnpm check`
- `corepack pnpm --filter @jobctrl/web test` — 242 files, 1,397 tests
- `corepack pnpm --filter @jobctrl/web test-d` — 13 tests, no type errors
- `corepack pnpm --filter @jobctrl/web e2e:demo-workspace` — 19 Chromium journeys
- `corepack pnpm demo-edge:test` — 27 Worker behavior tests and 4 config/privacy tests
- `corepack pnpm web:build`
- `corepack pnpm docs:build`
- `python3 scripts/release_check.py`
- `git diff --check`
- desktop/mobile visual inspection; consent component axe check passes
- final independent review: PASS, zero findings
- QA: PASS; stalled-read, stalled-grant, consent-ordering, and pre-grant isolation paths verified

## Stack

Base: #413 (`feat/demo-p4a-telemetry-edge`).