### PR TITLE
feat(demo): add guided demo experience

### DIFF
--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -546,6 +546,8 @@ scenarioTest("Demo guide shortcuts navigate through seeded surfaces and confirm 
   const guide = page.getByRole("complementary", {
     name: "Try the synthetic workflow",
   });
+  const openGuide = page.getByRole("button", { name: "Open demo guide" });
+  await openGuide.click();
   await expect(guide).toContainText("Every record and action in this demo is simulated and synthetic");
 
   await guide.getByRole("link", { name: "Inspect synthetic scoring evidence" }).click();
@@ -554,27 +556,32 @@ scenarioTest("Demo guide shortcuts navigate through seeded surfaces and confirm 
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Job details" })).toBeHidden();
 
+  await openGuide.click();
   await guide.getByRole("link", { name: "Review synthetic tailored materials" }).click();
   await expect(page).toHaveURL(/\/artifacts\/artifact-tailored-resume(?:\?|$)/);
   await expect(page.getByRole("dialog", { name: "Artifact details" })).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("dialog", { name: "Artifact details" })).toBeHidden();
 
+  await openGuide.click();
   await guide.getByRole("link", { name: "Open simulated Apply Review and dry run" }).click();
   await expect(page).toHaveURL(/\/apply-review\?jobKey=job-northwind-platform(?:&|$)/);
   await expect(page.getByRole("heading", { name: "Application review" })).toBeVisible();
 
+  await openGuide.click();
   await guide.getByRole("link", { name: "See simulated run history" }).click();
   await expect(page).toHaveURL(/\/runs(?:\?|$)/);
   await expect(page.getByRole("heading", { name: "Workflow runs" })).toBeVisible();
 
   const before = await resetEpoch(page);
+  await openGuide.click();
   await guide.getByRole("button", { name: "Reset synthetic demo data" }).click();
   await expect(page.getByRole("dialog", { name: "Reset synthetic demo data?" })).toBeVisible();
   await page.getByRole("button", { name: "Reset demo data" }).click();
   await expect(guide.getByRole("status")).toContainText(
     "Synthetic demo data reset. The seeded examples are ready again.",
   );
+  await expect(page).toHaveURL(/\/dashboard(?:\?|$)/);
   await expect.poll(() => resetEpoch(page)).toBe(before + 1);
 
   await page.setViewportSize({ width: 390, height: 844 });

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -100,6 +100,22 @@ async function snapshot(page: Page): Promise<DemoWorkspaceSnapshot> {
   });
 }
 
+async function resetEpoch(page: Page): Promise<number> {
+  return page.evaluate(async (moduleUrls) => {
+    const [repositoryModule, storageModule] = await Promise.all([
+      import(moduleUrls.repository),
+      import(moduleUrls.storage),
+    ]);
+    const workspace = new repositoryModule.DemoWorkspaceRepository({
+      store: new storageModule.IndexedDbDemoWorkspaceStore(),
+    });
+    await workspace.initialize();
+    const value = (await workspace.snapshot()).resetEpoch;
+    workspace.dispose();
+    return value;
+  }, MODULE_URLS);
+}
+
 function jobRow(page: Page, title: string): Locator {
   return page.getByRole("row").filter({
     has: page.getByText(title, { exact: true }),
@@ -523,6 +539,51 @@ scenarioTest("demo shell renders the shared-profile and personal-data boundary w
     page.getByText("Demo mode — shared browser profile"),
   ).toBeVisible();
   expect(productRequests).toEqual([]);
+});
+
+scenarioTest("Demo guide shortcuts navigate through seeded surfaces and confirm reset", async ({ page }) => {
+  await page.goto("/dashboard");
+  const guide = page.getByRole("complementary", {
+    name: "Try the synthetic workflow",
+  });
+  await expect(guide).toContainText("Every record and action in this demo is simulated and synthetic");
+
+  await guide.getByRole("link", { name: "Inspect synthetic scoring evidence" }).click();
+  await expect(page).toHaveURL(/\/jobs\/job-northwind-platform(?:\?|$)/);
+  await expect(page.getByText("Preparation diagnostics", { exact: false })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "Job details" })).toBeHidden();
+
+  await guide.getByRole("link", { name: "Review synthetic tailored materials" }).click();
+  await expect(page).toHaveURL(/\/artifacts\/artifact-tailored-resume(?:\?|$)/);
+  await expect(page.getByRole("dialog", { name: "Artifact details" })).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("dialog", { name: "Artifact details" })).toBeHidden();
+
+  await guide.getByRole("link", { name: "Open simulated Apply Review and dry run" }).click();
+  await expect(page).toHaveURL(/\/apply-review\?jobKey=job-northwind-platform(?:&|$)/);
+  await expect(page.getByRole("heading", { name: "Application review" })).toBeVisible();
+
+  await guide.getByRole("link", { name: "See simulated run history" }).click();
+  await expect(page).toHaveURL(/\/runs(?:\?|$)/);
+  await expect(page.getByRole("heading", { name: "Workflow runs" })).toBeVisible();
+
+  const before = await resetEpoch(page);
+  await guide.getByRole("button", { name: "Reset synthetic demo data" }).click();
+  await expect(page.getByRole("dialog", { name: "Reset synthetic demo data?" })).toBeVisible();
+  await page.getByRole("button", { name: "Reset demo data" }).click();
+  await expect(guide.getByRole("status")).toContainText(
+    "Synthetic demo data reset. The seeded examples are ready again.",
+  );
+  await expect.poll(() => resetEpoch(page)).toBe(before + 1);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(guide).toBeVisible();
+  const guideBounds = await guide.boundingBox();
+  expect(guideBounds).not.toBeNull();
+  expect(guideBounds!.x).toBeGreaterThanOrEqual(0);
+  expect(guideBounds!.x + guideBounds!.width).toBeLessThanOrEqual(390);
+  expect(guideBounds!.y + guideBounds!.height).toBeLessThanOrEqual(844);
 });
 
 scenarioTest("every P2 product route and seeded deep link renders populated across direct refreshes", async ({

--- a/apps/web/src/demo/guide/DemoGuide.a11y.test.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.a11y.test.tsx
@@ -6,7 +6,8 @@ import {
   Outlet,
   RouterProvider,
 } from "@tanstack/react-router";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { expect, it } from "vitest";
 
@@ -76,6 +77,9 @@ it("has no automated accessibility violations", async () => {
     </PortsProvider>,
   );
   await router.load();
+  await userEvent.setup().click(
+    screen.getByRole("button", { name: "Open demo guide" }),
+  );
 
   expect(await axe(view.container)).toHaveNoViolations();
 });

--- a/apps/web/src/demo/guide/DemoGuide.a11y.test.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.a11y.test.tsx
@@ -1,0 +1,81 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
+import { expect, it } from "vitest";
+
+import { PortsProvider } from "../../shared/providers/PortsProvider.js";
+import { buildTestPorts } from "../../test/testPorts.js";
+import { DemoWorkspaceProvider } from "../workspace/DemoWorkspaceProvider.js";
+import { DemoWorkspaceRepository } from "../workspace/DemoWorkspaceRepository.js";
+import { InMemoryDemoWorkspaceStore } from "../workspace/storage.js";
+import { DemoGuide } from "./DemoGuide.js";
+
+function GuideShell() {
+  return (
+    <>
+      <DemoGuide />
+      <Outlet />
+    </>
+  );
+}
+
+it("has no automated accessibility violations", async () => {
+  const workspace = new DemoWorkspaceRepository({
+    store: new InMemoryDemoWorkspaceStore(),
+    createWorkspaceId: () => "guide-a11y-workspace",
+  });
+  await workspace.initialize();
+  const root = createRootRoute({ component: GuideShell });
+  const dashboard = createRoute({
+    getParentRoute: () => root,
+    path: "/dashboard",
+    component: () => <main>Dashboard</main>,
+  });
+  const jobs = createRoute({
+    getParentRoute: () => root,
+    path: "/jobs/$jobId",
+    component: () => <main>Job detail</main>,
+  });
+  const artifacts = createRoute({
+    getParentRoute: () => root,
+    path: "/artifacts/$artifactId",
+    component: () => <main>Artifact detail</main>,
+  });
+  const applyReview = createRoute({
+    getParentRoute: () => root,
+    path: "/apply-review",
+    component: () => <main>Apply review</main>,
+  });
+  const runs = createRoute({
+    getParentRoute: () => root,
+    path: "/runs",
+    component: () => <main>Runs</main>,
+  });
+  const router = createRouter({
+    routeTree: root.addChildren([
+      dashboard,
+      jobs,
+      artifacts,
+      applyReview,
+      runs,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/dashboard"] }),
+  });
+  const view = render(
+    <PortsProvider ports={buildTestPorts()}>
+      <DemoWorkspaceProvider workspace={workspace}>
+        <RouterProvider router={router} />
+      </DemoWorkspaceProvider>
+    </PortsProvider>,
+  );
+  await router.load();
+
+  expect(await axe(view.container)).toHaveNoViolations();
+});

--- a/apps/web/src/demo/guide/DemoGuide.test.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@tanstack/react-router";
 import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   PortsProvider,
@@ -111,6 +111,8 @@ describe("<DemoGuide>", () => {
   it("shows the seeded synthetic shortcuts and records a typed feature CTA", async () => {
     const { ports, router, user } = await renderGuide();
 
+    await user.click(screen.getByRole("button", { name: "Open demo guide" }));
+
     expect(screen.getByRole("complementary")).toHaveTextContent(
       "Every record and action in this demo is simulated and synthetic",
     );
@@ -141,15 +143,22 @@ describe("<DemoGuide>", () => {
       "demo_feature_opened",
       { route: "dashboard", feature: "scoring" },
     );
+    expect(screen.getByRole("button", { name: "Open demo guide" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open demo guide" })).toHaveFocus();
   });
 
   it("keeps the compact control available after the panel is dismissed", async () => {
     const { ports, user } = await renderGuide();
 
+    expect(screen.getByRole("button", { name: "Open demo guide" })).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Open demo guide" }));
+    expect(screen.getByRole("button", { name: "Hide demo guide" })).toHaveFocus();
+    expect(screen.getByRole("complementary")).toBeVisible();
     await user.click(screen.getByRole("button", { name: "Hide demo guide" }));
     expect(
       screen.getByRole("button", { name: "Open demo guide" }),
     ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Open demo guide" })).toHaveFocus();
     expect(ports.storage.get("demo.guide.state")).toEqual({ open: false });
 
     await user.click(screen.getByRole("button", { name: "Open demo guide" }));
@@ -158,11 +167,13 @@ describe("<DemoGuide>", () => {
   });
 
   it("confirms and visibly completes a reset through the workspace authority", async () => {
-    const { ports, user, workspace } = await renderGuide();
+    const { ports, router, user, workspace } = await renderGuide();
     if (!workspace)
       throw new Error("The demo workspace is required for this test.");
     const before = await workspace.snapshot();
+    await router.navigate({ to: "/runs" });
 
+    await user.click(screen.getByRole("button", { name: "Open demo guide" }));
     await user.click(
       screen.getByRole("button", { name: "Reset synthetic demo data" }),
     );
@@ -181,7 +192,29 @@ describe("<DemoGuide>", () => {
     });
     expect((ports.telemetry as FakeTelemetryPort).event).toHaveBeenCalledWith(
       "demo_workspace_reset",
-      { route: "dashboard" },
+      { route: "runs" },
     );
+    expect(router.state.location.pathname).toBe("/dashboard");
+  });
+
+  it("closes the modal and reports a reset failure without navigating", async () => {
+    const workspace = await createWorkspace();
+    vi.spyOn(workspace, "reset").mockRejectedValueOnce(new Error("quota"));
+    const { router, user } = await renderGuide({ workspace });
+    await router.navigate({ to: "/runs" });
+
+    await user.click(screen.getByRole("button", { name: "Open demo guide" }));
+    await user.click(
+      screen.getByRole("button", { name: "Reset synthetic demo data" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Reset demo data" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Demo data could not be reset. Try again.",
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Reset synthetic demo data?" }),
+    ).not.toBeInTheDocument();
+    expect(router.state.location.pathname).toBe("/runs");
   });
 });

--- a/apps/web/src/demo/guide/DemoGuide.test.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.test.tsx
@@ -1,0 +1,187 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import {
+  PortsProvider,
+  type Ports,
+} from "../../shared/providers/PortsProvider.js";
+import { FakeTelemetryPort, buildTestPorts } from "../../test/testPorts.js";
+import { DemoWorkspaceProvider } from "../workspace/DemoWorkspaceProvider.js";
+import { DemoWorkspaceRepository } from "../workspace/DemoWorkspaceRepository.js";
+import { InMemoryDemoWorkspaceStore } from "../workspace/storage.js";
+import { DemoGuide } from "./DemoGuide.js";
+
+function GuideShell() {
+  return (
+    <>
+      <DemoGuide />
+      <Outlet />
+    </>
+  );
+}
+
+function createGuideRouter() {
+  const root = createRootRoute({ component: GuideShell });
+  const dashboard = createRoute({
+    getParentRoute: () => root,
+    path: "/dashboard",
+    component: () => <main>Dashboard</main>,
+  });
+  const jobs = createRoute({
+    getParentRoute: () => root,
+    path: "/jobs/$jobId",
+    component: () => <main>Job detail</main>,
+  });
+  const artifacts = createRoute({
+    getParentRoute: () => root,
+    path: "/artifacts/$artifactId",
+    component: () => <main>Artifact detail</main>,
+  });
+  const applyReview = createRoute({
+    getParentRoute: () => root,
+    path: "/apply-review",
+    component: () => <main>Apply review</main>,
+  });
+  const runs = createRoute({
+    getParentRoute: () => root,
+    path: "/runs",
+    component: () => <main>Runs</main>,
+  });
+  return createRouter({
+    routeTree: root.addChildren([
+      dashboard,
+      jobs,
+      artifacts,
+      applyReview,
+      runs,
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/dashboard"] }),
+  });
+}
+
+async function createWorkspace() {
+  const workspace = new DemoWorkspaceRepository({
+    store: new InMemoryDemoWorkspaceStore(),
+    createWorkspaceId: () => "guide-workspace",
+  });
+  await workspace.initialize();
+  return workspace;
+}
+
+async function renderGuide(
+  options: {
+    workspace?: DemoWorkspaceRepository | null;
+    ports?: Ports;
+  } = {},
+) {
+  const workspace =
+    options.workspace === undefined
+      ? await createWorkspace()
+      : options.workspace;
+  const ports = options.ports ?? buildTestPorts();
+  const router = createGuideRouter();
+  const user = userEvent.setup();
+  const view = render(
+    <PortsProvider ports={ports}>
+      <DemoWorkspaceProvider workspace={workspace}>
+        <RouterProvider router={router} />
+      </DemoWorkspaceProvider>
+    </PortsProvider>,
+  );
+  await router.load();
+  return { ...view, ports, router, user, workspace };
+}
+
+describe("<DemoGuide>", () => {
+  it("renders only for the admitted demo workspace", async () => {
+    await renderGuide({ workspace: null });
+
+    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+  });
+
+  it("shows the seeded synthetic shortcuts and records a typed feature CTA", async () => {
+    const { ports, router, user } = await renderGuide();
+
+    expect(screen.getByRole("complementary")).toHaveTextContent(
+      "Every record and action in this demo is simulated and synthetic",
+    );
+    expect(
+      screen.getByRole("link", { name: "Inspect synthetic scoring evidence" }),
+    ).toHaveAttribute("href", "/jobs/job-northwind-platform");
+    expect(
+      screen.getByRole("link", { name: "Review synthetic tailored materials" }),
+    ).toHaveAttribute("href", "/artifacts/artifact-tailored-resume");
+    expect(
+      screen.getByRole("link", {
+        name: "Open simulated Apply Review and dry run",
+      }),
+    ).toHaveAttribute("href", "/apply-review?jobKey=job-northwind-platform");
+    expect(
+      screen.getByRole("link", { name: "See simulated run history" }),
+    ).toHaveAttribute("href", "/runs");
+
+    await user.click(
+      screen.getByRole("link", { name: "Inspect synthetic scoring evidence" }),
+    );
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe(
+        "/jobs/job-northwind-platform",
+      );
+    });
+    expect((ports.telemetry as FakeTelemetryPort).event).toHaveBeenCalledWith(
+      "demo_feature_opened",
+      { route: "dashboard", feature: "scoring" },
+    );
+  });
+
+  it("keeps the compact control available after the panel is dismissed", async () => {
+    const { ports, user } = await renderGuide();
+
+    await user.click(screen.getByRole("button", { name: "Hide demo guide" }));
+    expect(
+      screen.getByRole("button", { name: "Open demo guide" }),
+    ).toBeVisible();
+    expect(ports.storage.get("demo.guide.state")).toEqual({ open: false });
+
+    await user.click(screen.getByRole("button", { name: "Open demo guide" }));
+    expect(screen.getByRole("complementary")).toBeVisible();
+    expect(ports.storage.get("demo.guide.state")).toEqual({ open: true });
+  });
+
+  it("confirms and visibly completes a reset through the workspace authority", async () => {
+    const { ports, user, workspace } = await renderGuide();
+    if (!workspace)
+      throw new Error("The demo workspace is required for this test.");
+    const before = await workspace.snapshot();
+
+    await user.click(
+      screen.getByRole("button", { name: "Reset synthetic demo data" }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Reset synthetic demo data?" }),
+    ).toBeVisible();
+    await user.click(screen.getByRole("button", { name: "Reset demo data" }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Synthetic demo data reset. The seeded examples are ready again.",
+    );
+    await waitFor(async () => {
+      expect((await workspace.snapshot()).resetEpoch).toBe(
+        before.resetEpoch + 1,
+      );
+    });
+    expect((ports.telemetry as FakeTelemetryPort).event).toHaveBeenCalledWith(
+      "demo_workspace_reset",
+      { route: "dashboard" },
+    );
+  });
+});

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -5,8 +5,8 @@ import {
   IconSparkles,
   IconX,
 } from "@tabler/icons-react";
-import { Link, useLocation } from "@tanstack/react-router";
-import { useState } from "react";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { useEffect, useRef, useState } from "react";
 
 import { classifyDemoRoute } from "../consent/DemoTelemetryAdapter.js";
 import { useDemoWorkspace } from "../workspace/DemoWorkspaceProvider.js";
@@ -33,11 +33,11 @@ interface DemoGuideState {
 }
 
 function isGuideOpen(value: unknown): boolean {
-  return !(
+  return (
     typeof value === "object" &&
     value !== null &&
     "open" in value &&
-    (value as DemoGuideState).open === false
+    (value as DemoGuideState).open === true
   );
 }
 
@@ -50,6 +50,7 @@ export function DemoGuide() {
   const workspaceContext = useDemoWorkspace();
   const { storage, telemetry } = usePorts();
   const location = useLocation();
+  const navigate = useNavigate();
   const toast = useToastStore((state) => state.toast);
   const [open, setOpen] = useState(() =>
     isGuideOpen(storage.get(GUIDE_STATE_KEY)),
@@ -57,6 +58,15 @@ export function DemoGuide() {
   const [confirmResetOpen, setConfirmResetOpen] = useState(false);
   const [isResetting, setIsResetting] = useState(false);
   const [resetStatus, setResetStatus] = useState<string | null>(null);
+  const launcherRef = useRef<HTMLButtonElement>(null);
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const previousOpen = useRef(open);
+
+  useEffect(() => {
+    if (open && !previousOpen.current) closeRef.current?.focus();
+    if (!open && previousOpen.current) launcherRef.current?.focus();
+    previousOpen.current = open;
+  }, [open]);
 
   if (workspaceContext.mode === "local") return null;
 
@@ -67,6 +77,7 @@ export function DemoGuide() {
   };
   const recordFeatureShortcut = (feature: DemoGuideFeature) => {
     telemetry.event("demo_feature_opened", { route, feature });
+    setGuideOpen(false);
   };
   const resetWorkspace = async () => {
     setIsResetting(true);
@@ -79,10 +90,12 @@ export function DemoGuide() {
       setResetStatus(message);
       toast({ title: "Demo data reset", message, variant: "success" });
       setConfirmResetOpen(false);
+      await navigate({ to: "/dashboard" });
     } catch {
       const message = "Demo data could not be reset. Try again.";
       setResetStatus(message);
       toast({ title: "Demo reset unavailable", message, variant: "error" });
+      setConfirmResetOpen(false);
     } finally {
       setIsResetting(false);
     }
@@ -92,6 +105,7 @@ export function DemoGuide() {
     return (
       <div className="fixed bottom-4 right-4 z-40 motion-reduce:transition-none">
         <Button
+          ref={launcherRef}
           type="button"
           variant="secondary"
           onClick={() => setGuideOpen(true)}
@@ -121,6 +135,7 @@ export function DemoGuide() {
           </h2>
         </div>
         <Button
+          ref={closeRef}
           type="button"
           variant="ghost"
           size="icon"

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -1,0 +1,300 @@
+import {
+  IconArrowRight,
+  IconExternalLink,
+  IconRefresh,
+  IconSparkles,
+  IconX,
+} from "@tabler/icons-react";
+import { Link, useLocation } from "@tanstack/react-router";
+import { useState } from "react";
+
+import { classifyDemoRoute } from "../consent/DemoTelemetryAdapter.js";
+import { useDemoWorkspace } from "../workspace/DemoWorkspaceProvider.js";
+import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { useToastStore } from "../../shared/stores/toasts.js";
+import { Button } from "../../shared/ui/button.js";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../shared/ui/dialog.js";
+
+const GUIDE_STATE_KEY = "demo.guide.state";
+const DEMO_JOB_ID = "job-northwind-platform";
+const DEMO_ARTIFACT_ID = "artifact-tailored-resume";
+
+type DemoGuideFeature = "scoring" | "materials" | "apply_review" | "pipeline";
+
+interface DemoGuideState {
+  readonly open: boolean;
+}
+
+function isGuideOpen(value: unknown): boolean {
+  return !(
+    typeof value === "object" &&
+    value !== null &&
+    "open" in value &&
+    (value as DemoGuideState).open === false
+  );
+}
+
+/**
+ * A small, non-modal orientation control for the consented synthetic demo.
+ * Its only persisted state is whether this panel is expanded in the current
+ * browser session; the workspace remains the authority for all demo data.
+ */
+export function DemoGuide() {
+  const workspaceContext = useDemoWorkspace();
+  const { storage, telemetry } = usePorts();
+  const location = useLocation();
+  const toast = useToastStore((state) => state.toast);
+  const [open, setOpen] = useState(() =>
+    isGuideOpen(storage.get(GUIDE_STATE_KEY)),
+  );
+  const [confirmResetOpen, setConfirmResetOpen] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+  const [resetStatus, setResetStatus] = useState<string | null>(null);
+
+  if (workspaceContext.mode === "local") return null;
+
+  const route = classifyDemoRoute(location.pathname);
+  const setGuideOpen = (next: boolean) => {
+    storage.set<DemoGuideState>(GUIDE_STATE_KEY, { open: next });
+    setOpen(next);
+  };
+  const recordFeatureShortcut = (feature: DemoGuideFeature) => {
+    telemetry.event("demo_feature_opened", { route, feature });
+  };
+  const resetWorkspace = async () => {
+    setIsResetting(true);
+    setResetStatus("Resetting synthetic demo data…");
+    try {
+      await workspaceContext.workspace.reset();
+      telemetry.event("demo_workspace_reset", { route });
+      const message =
+        "Synthetic demo data reset. The seeded examples are ready again.";
+      setResetStatus(message);
+      toast({ title: "Demo data reset", message, variant: "success" });
+      setConfirmResetOpen(false);
+    } catch {
+      const message = "Demo data could not be reset. Try again.";
+      setResetStatus(message);
+      toast({ title: "Demo reset unavailable", message, variant: "error" });
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <div className="fixed bottom-4 right-4 z-40 motion-reduce:transition-none">
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => setGuideOpen(true)}
+          aria-expanded="false"
+          aria-label="Open demo guide"
+        >
+          <IconSparkles aria-hidden="true" size={16} />
+          Demo guide
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <aside
+      className="fixed bottom-4 right-4 z-40 grid w-[min(22rem,calc(100vw-2rem))] gap-3 rounded-xl border border-border bg-card p-4 text-card-foreground shadow-[var(--shadow-panel)] motion-reduce:transition-none"
+      aria-labelledby="demo-guide-title"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Demo mode</p>
+          <h2
+            id="demo-guide-title"
+            className="mt-1 text-base font-bold tracking-tight"
+          >
+            Try the synthetic workflow
+          </h2>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="-mr-2 -mt-1 shrink-0"
+          onClick={() => setGuideOpen(false)}
+          aria-label="Hide demo guide"
+        >
+          <IconX aria-hidden="true" size={16} />
+        </Button>
+      </div>
+
+      <p className="text-xs leading-5 text-muted-foreground">
+        Every record and action in this demo is simulated and synthetic. Nothing
+        is sent to an employer, mailbox, or external service.
+      </p>
+
+      <nav aria-label="Synthetic demo shortcuts">
+        <ul className="grid gap-1">
+          <li>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="h-auto w-full justify-between px-2 py-2 text-left"
+            >
+              <Link
+                to="/jobs/$jobId"
+                params={{ jobId: DEMO_JOB_ID }}
+                onClick={() => recordFeatureShortcut("scoring")}
+              >
+                <span>Inspect synthetic scoring evidence</span>
+                <IconArrowRight aria-hidden="true" size={15} />
+              </Link>
+            </Button>
+          </li>
+          <li>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="h-auto w-full justify-between px-2 py-2 text-left"
+            >
+              <Link
+                to="/artifacts/$artifactId"
+                params={{ artifactId: DEMO_ARTIFACT_ID }}
+                onClick={() => recordFeatureShortcut("materials")}
+              >
+                <span>Review synthetic tailored materials</span>
+                <IconArrowRight aria-hidden="true" size={15} />
+              </Link>
+            </Button>
+          </li>
+          <li>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="h-auto w-full justify-between px-2 py-2 text-left"
+            >
+              <Link
+                to="/apply-review"
+                search={{ jobKey: DEMO_JOB_ID }}
+                onClick={() => recordFeatureShortcut("apply_review")}
+              >
+                <span>Open simulated Apply Review and dry run</span>
+                <IconArrowRight aria-hidden="true" size={15} />
+              </Link>
+            </Button>
+          </li>
+          <li>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="h-auto w-full justify-between px-2 py-2 text-left"
+            >
+              <Link
+                to="/runs"
+                onClick={() => recordFeatureShortcut("pipeline")}
+              >
+                <span>See simulated run history</span>
+                <IconArrowRight aria-hidden="true" size={15} />
+              </Link>
+            </Button>
+          </li>
+        </ul>
+      </nav>
+
+      <div className="grid gap-2 border-t border-border pt-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="w-full justify-start"
+          onClick={() => setConfirmResetOpen(true)}
+        >
+          <IconRefresh aria-hidden="true" size={15} />
+          Reset synthetic demo data
+        </Button>
+        <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs">
+          <a
+            className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+            href="https://jobctrl.dev/user/getting-started"
+            target="_blank"
+            rel="noreferrer"
+            onClick={() =>
+              telemetry.event("demo_install_cta_clicked", { route })
+            }
+          >
+            Install & setup
+            <IconExternalLink aria-hidden="true" size={13} />
+          </a>
+          <a
+            className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+            href="https://jobctrl.dev/"
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => telemetry.event("demo_docs_cta_clicked", { route })}
+          >
+            Docs
+            <IconExternalLink aria-hidden="true" size={13} />
+          </a>
+          <a
+            className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+            href="https://jobctrl.dev/user/data-and-safety"
+            target="_blank"
+            rel="noreferrer"
+            onClick={() => telemetry.event("demo_docs_cta_clicked", { route })}
+          >
+            Privacy
+            <IconExternalLink aria-hidden="true" size={13} />
+          </a>
+        </div>
+        {resetStatus ? (
+          <p className="text-xs leading-5 text-muted-foreground" role="status">
+            {resetStatus}
+          </p>
+        ) : null}
+      </div>
+
+      <Dialog
+        open={confirmResetOpen}
+        onOpenChange={(next) => {
+          if (!isResetting) setConfirmResetOpen(next);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset synthetic demo data?</DialogTitle>
+            <DialogDescription>
+              This replaces the browser-local demo workspace with its original
+              seeded examples and removes simulated changes and receipts.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setConfirmResetOpen(false)}
+              disabled={isResetting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={() => void resetWorkspace()}
+              disabled={isResetting}
+            >
+              {isResetting ? "Resetting…" : "Reset demo data"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </aside>
+  );
+}

--- a/apps/web/src/demo/guide/index.ts
+++ b/apps/web/src/demo/guide/index.ts
@@ -1,0 +1,1 @@
+export { DemoGuide } from "./DemoGuide.js";

--- a/apps/web/src/shared/layout/AppShell.tsx
+++ b/apps/web/src/shared/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "@tanstack/react-router";
 
+import { DemoGuide } from "../../demo/guide/DemoGuide.js";
 import { DemoReceiptHistory } from "../../demo/workspace/DemoReceiptHistory.js";
 import { DemoWorkspaceNotice } from "../../demo/workspace/DemoWorkspaceNotice.js";
 import { useDensity } from "../hooks/useDensity.js";
@@ -15,6 +16,7 @@ export function AppShell() {
       <SideRail />
       <div className="main-shell">
         <DemoWorkspaceNotice />
+        <DemoGuide />
         <DemoReceiptHistory />
         <Topbar />
         <main className="main">

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -92,7 +92,9 @@ drives deterministic queued, running, and terminal stage scenarios through
 accessible product controls; covers the Contoso fail-first tailoring retry;
 checks receipt history across reload and same-profile tabs; and rehearses
 artifact preview, application dry-run, and mark-applied actions without an
-external effect. Every scenario test installs a strict
+external effect. It also proves the admitted Demo guide reaches the seeded
+scoring, materials, Apply Review, and run-history shortcuts before a confirmed
+workspace reset. Every scenario test installs a strict
 request guard that rejects product API, SSE, and external-origin traffic. Unit
 and component tests cover injected quota/security fallbacks, schema revalidation,
 reset-epoch races, event-log loss, read-adapter query/404/capability parity,

--- a/docs/plans/2026-07-11-public-live-demo-plan.md
+++ b/docs/plans/2026-07-11-public-live-demo-plan.md
@@ -1006,11 +1006,14 @@ later visit.
 **Scope**
 
 - Add persistent Demo Mode identity and simulated-action language.
-- Add a concise guided tour and scenario shortcuts.
+- Add a concise guide with scenario shortcuts. Keep the MVP stateless: no
+  step/progress engine or forced walkthrough.
 - Add reset, install, docs, and privacy-notice controls.
 - Cover desktop/mobile, light/dark, keyboard, reduced-motion, and screen-reader
   paths.
-- Add per-state Storybook stories and a11y coverage.
+- Add colocated component, keyboard-focus, browser, and a11y coverage. A
+  Storybook demo-workspace decorator and per-state stories are deferred until
+  after the MVP instead of adding a second workspace harness in this slice.
 
 **Exit criterion**
 

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -52,6 +52,12 @@ secrets. Post-accept withdrawal and immediate visitor-event deletion are not
 yet available in this MVP; retained data expires on the schedules above. The
 consent screen links to this disclosure before entry.
 
+After entry, the compact **Demo guide** links to seeded scoring evidence,
+tailored-material review, Apply Review/dry-run, and run history. Every shortcut
+and action is simulated; it does not contact employers, send messages, or make
+external changes. **Reset synthetic demo data** asks for confirmation, then
+replaces the browser-local workspace with the original examples.
+
 ## Local Data
 
 Default workspace:


### PR DESCRIPTION
## Summary

- add a compact demo-only guide that opens on demand and links directly to seeded scoring evidence, tailored materials, Apply Review, and run history
- keep every action explicitly synthetic/simulated and expose install, docs, privacy, and confirmed reset controls
- default to a non-obstructive launcher, auto-collapse after route shortcuts, and preserve keyboard focus across launcher/panel transitions
- reset through the existing browser-workspace authority, invalidate through the existing reconnect path, navigate to the seeded dashboard after commit, and report failures without leaving an inaccessible modal
- record only the existing closed CTA/reset telemetry categories after admission
- update the accepted MVP scope to a stateless guide rather than adding a tour framework or second Storybook workspace harness

## Validation

- `corepack pnpm check`
- web suite — 244 files, 1,402 tests
- web type-level suite — 13 tests, no type errors
- demo Playwright lane — 20/20 Chromium journeys
- focused guide component/a11y suite — 6/6 tests
- `corepack pnpm docs:build` — 5,842 references across 262 files
- `python3 scripts/release_check.py`
- independent review: PASS, zero findings
- independent QA: PASS; keyboard, mobile, reset, collision, consent, network, and guide-scoped axe paths verified
- `git diff --check`

## Stack

Base: #414 (`feat/demo-p4b-consent-client`).

Storybook state stories are explicitly deferred until a reusable demo-workspace decorator exists; runtime component, axe, keyboard-focus, mobile, and browser coverage are included in this MVP.

QA reproduced an existing Dashboard color-contrast issue on the P4 base. The P5 guide itself has zero critical/serious axe violations.