### PR TITLE
feat(demo): refresh outdated browser seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ creates its browser-local workspace. Declining returns to `jobctrl.dev`; a
 later visit asks again. Read the
 [demo data notice](https://jobctrl.dev/user/data-and-safety#public-demo) before
 entering, and do not type personal data, credentials, or secrets.
+When a deployment updates the canonical synthetic examples, the next demo load
+refreshes that browser-local workspace once; cookie consent is unchanged.
 
 ## Get Started
 

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -18,6 +18,7 @@ const MODULE_URLS = {
   eventStream: "/src/demo/workspace/DemoWorkspaceEventStreamAdapter.ts",
 } as const;
 const STATIC_HOST = "/demo/source-preview.html";
+const CURRENT_DEMO_SEED_VERSION = "2026-07-12.1";
 
 const scenarioTest = test.extend<{ demoNetworkBoundary: void }>({
   demoNetworkBoundary: [
@@ -949,6 +950,73 @@ scenarioTest("reset rotates identity, fences state, and deletes generated blobs"
       );
     }),
   ).toBe(true);
+});
+
+scenarioTest("an older seed refreshes once and clears generated browser state", async ({
+  page,
+}) => {
+  const initialized = await initializeWorkspace(page);
+  expect(initialized.kind).toBe("ready");
+  if (initialized.kind !== "ready") return;
+  await page.evaluate(async () => {
+    const workspace = window.__jobctrlDemoWorkspace;
+    if (!workspace) throw new Error("workspace not initialized");
+    await workspace.putBlob(
+      "outdated-seed-preview",
+      new Blob(["outdated synthetic edit"], { type: "text/plain" }),
+    );
+    await workspace.mutate((draft) => {
+      (draft as unknown as { schemaVersion: number }).schemaVersion = 3;
+      (draft as unknown as { seedVersion: string }).seedVersion =
+        "2026-07-11.1";
+      (draft.state as { title: string }).title =
+        "Mutated previous synthetic seed";
+    });
+    workspace.dispose();
+    delete window.__jobctrlDemoWorkspace;
+  });
+  const stale = initialized.snapshot;
+
+  await page.goto("/dashboard");
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  const refreshed = await initializeWorkspace(page);
+
+  expect(refreshed.kind).toBe("ready");
+  if (refreshed.kind !== "ready") return;
+  expect(refreshed.snapshot).toMatchObject({
+    schemaVersion: 4,
+    seedVersion: CURRENT_DEMO_SEED_VERSION,
+    resetCount: stale.resetCount + 1,
+    resetEpoch: stale.resetEpoch + 1,
+    pendingScenarios: [],
+    blobIds: [],
+    state: { title: "JobCtrl product tour" },
+  });
+  expect(refreshed.snapshot.workspaceId).not.toBe(stale.workspaceId);
+  expect(
+    await page.evaluate(async () => {
+      if (!window.__jobctrlDemoWorkspace)
+        throw new Error("workspace not initialized");
+      return (
+        (await window.__jobctrlDemoWorkspace.blob(
+          "outdated-seed-preview",
+        )) === null
+      );
+    }),
+  ).toBe(true);
+
+  const refreshedWorkspaceId = refreshed.snapshot.workspaceId;
+  await page.reload();
+  const reloaded = await initializeWorkspace(page);
+  expect(reloaded).toMatchObject({
+    kind: "ready",
+    snapshot: {
+      seedVersion: CURRENT_DEMO_SEED_VERSION,
+      workspaceId: refreshedWorkspaceId,
+      resetCount: stale.resetCount + 1,
+      resetEpoch: stale.resetEpoch + 1,
+    },
+  });
 });
 
 scenarioTest("future native database version is upgrade-required without downgrade", async ({

--- a/apps/web/src/demo/contracts.ts
+++ b/apps/web/src/demo/contracts.ts
@@ -254,7 +254,7 @@ export interface DemoReadModel {
 
 export interface DemoSeedValue {
   readonly schemaVersion: 1;
-  readonly seedVersion: "2026-07-11.1";
+  readonly seedVersion: "2026-07-12.1";
   readonly title: string;
   readonly artifacts: DemoArtifacts;
   readonly readModel: DemoReadModel;

--- a/apps/web/src/demo/demo-seed.test.ts
+++ b/apps/web/src/demo/demo-seed.test.ts
@@ -24,7 +24,7 @@ describe("canonical public demo seed", () => {
 
   it("is deterministic, immutable by type, and covers the required lifecycle arms", () => {
     expect(() => assertDemoSeedInvariants(DEMO_SEED)).not.toThrow();
-    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-b819c053");
+    expect(demoSeedDigest(DEMO_SEED)).toBe("fnv1a-bbe10ce8");
     expect(demoSeedDigest({ b: 2, a: ["seed", true] })).toBe(demoSeedDigest({ a: ["seed", true], b: 2 }));
   });
 

--- a/apps/web/src/demo/seed.ts
+++ b/apps/web/src/demo/seed.ts
@@ -6,7 +6,7 @@ const minutes = (offsetMinutes: number) => ({ offsetMinutes }) as const;
 
 const demoSeed = {
   schemaVersion: 1,
-  seedVersion: "2026-07-11.1",
+  seedVersion: "2026-07-12.1",
   title: "JobCtrl product tour",
   artifacts: DEMO_ARTIFACTS,
   readModel: DEMO_READ_MODEL,

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createJobUpdated, LOCAL_TENANT } from "@jobctrl/domain-types";
 
+import { DEMO_SEED } from "../seed.js";
 import type {
   DemoWorkspaceChannel,
   DemoWorkspaceChannelFactory,
@@ -233,7 +234,9 @@ describe("DemoWorkspaceRepository", () => {
     const unsubscribe = repository.subscribeReceipts(listener);
 
     await repository.mutate((draft) => {
-      (draft.state.receipts as Array<(typeof draft.state.receipts)[number]>).push({
+      (
+        draft.state.receipts as Array<(typeof draft.state.receipts)[number]>
+      ).push({
         receiptId: "receipt-live-open",
         kind: "os_open",
         simulated: true,
@@ -312,7 +315,9 @@ describe("DemoWorkspaceRepository", () => {
       expect(await repository.snapshot()).toMatchObject({
         revision: 2,
         state: { title: "Discover running" },
-        pendingScenarios: [{ phase: "running", deadlineAt: new Date(50).toISOString() }],
+        pendingScenarios: [
+          { phase: "running", deadlineAt: new Date(50).toISOString() },
+        ],
       });
 
       now = 50;
@@ -351,8 +356,8 @@ describe("DemoWorkspaceRepository", () => {
     expect(initial.kind).toBe("ready");
     if (initial.kind !== "ready") return;
     expect(initial.snapshot).toMatchObject({
-      schemaVersion: 3,
-      seedVersion: "2026-07-11.1",
+      schemaVersion: 4,
+      seedVersion: DEMO_SEED.seedVersion,
       workspaceId: "workspace-1",
       resetCount: 0,
       revision: 0,
@@ -369,6 +374,374 @@ describe("DemoWorkspaceRepository", () => {
     expect(reloaded).toMatchObject({
       kind: "ready",
       snapshot: { workspaceId: "workspace-1", revision: 0 },
+    });
+  });
+
+  it("atomically refreshes an older synthetic seed once and clears generated workspace state", async () => {
+    const baselineRepository = buildRepository(
+      new InMemoryDemoWorkspaceStore(),
+    );
+    const baseline = await baselineRepository.initialize();
+    expect(baseline.kind).toBe("ready");
+    if (baseline.kind !== "ready") return;
+    const staleSnapshot: DemoWorkspaceSnapshot = {
+      ...baseline.snapshot,
+      schemaVersion: 3,
+      seedVersion: "2026-07-11.1",
+      workspaceId: "workspace-stale-seed",
+      resetCount: 2,
+      resetEpoch: 4,
+      revision: 7,
+      lastEventSequence: 9,
+      eventLog: [],
+      blobIds: ["generated-preview"],
+      state: {
+        ...baseline.snapshot.state,
+        title: "Mutated previous synthetic seed",
+      },
+      pendingScenarios: [queuedInvocation({ resetEpoch: 4 })],
+    };
+    const store = new InMemoryDemoWorkspaceStore(staleSnapshot);
+    await store.transact((_current, transaction) => {
+      transaction.putBlob("generated-preview", new Blob(["generated preview"]));
+    });
+    const repository = new DemoWorkspaceRepository({
+      store,
+      clock: fixedClock,
+      createWorkspaceId: () => "workspace-refreshed-seed",
+    });
+
+    const ready = await repository.initialize();
+
+    expect(ready).toMatchObject({
+      kind: "ready",
+      snapshot: {
+        schemaVersion: 4,
+        seedVersion: DEMO_SEED.seedVersion,
+        workspaceId: "workspace-refreshed-seed",
+        resetCount: 3,
+        resetEpoch: 5,
+        revision: 8,
+        lastEventSequence: 9,
+        eventLog: [],
+        blobIds: [],
+        pendingScenarios: [],
+        state: { title: "JobCtrl product tour" },
+      },
+    });
+    expect(
+      ready.kind === "ready"
+        ? ready.snapshot.state.readModel.jobs.list.items.find(
+            (job) => job.jobKey === "job-fabrikam-systems",
+          )
+        : null,
+    ).toMatchObject({ currentState: "failed" });
+    expect(await repository.blob("generated-preview")).toBeNull();
+
+    const reloaded = new DemoWorkspaceRepository({
+      store,
+      clock: fixedClock,
+      createWorkspaceId: () => "workspace-must-not-reseed",
+    });
+    await expect(reloaded.initialize()).resolves.toMatchObject({
+      kind: "ready",
+      snapshot: {
+        workspaceId: "workspace-refreshed-seed",
+        resetCount: 3,
+        resetEpoch: 5,
+        revision: 8,
+      },
+    });
+  });
+
+  it.each([
+    ["newer", "2026-07-13.1"],
+    ["unknown", "future-seed"],
+  ] as const)(
+    "preserves a %s seed and requires an upgrade",
+    async (_description, seedVersion) => {
+      const baselineRepository = buildRepository(
+        new InMemoryDemoWorkspaceStore(),
+      );
+      const baseline = await baselineRepository.initialize();
+      expect(baseline.kind).toBe("ready");
+      if (baseline.kind !== "ready") return;
+      const protectedSnapshot: DemoWorkspaceSnapshot = {
+        ...baseline.snapshot,
+        seedVersion,
+        workspaceId: `workspace-${seedVersion}-seed`,
+        blobIds: ["protected-preview"],
+        state: {
+          ...baseline.snapshot.state,
+          title: "Protected newer demo workspace",
+        },
+      };
+      const store = new InMemoryDemoWorkspaceStore(protectedSnapshot);
+      await store.transact((_current, transaction) => {
+        transaction.putBlob("protected-preview", new Blob(["protected"]));
+      });
+
+      const initialization = await buildRepository(store).initialize();
+
+      expect(initialization).toMatchObject({
+        kind: "upgrade_required",
+        scope: "seed_version",
+        foundSeedVersion: seedVersion,
+        supportedSeedVersion: DEMO_SEED.seedVersion,
+      });
+      expect(await store.readSnapshot()).toMatchObject({
+        seedVersion,
+        workspaceId: `workspace-${seedVersion}-seed`,
+        blobIds: ["protected-preview"],
+        state: { title: "Protected newer demo workspace" },
+      });
+      expect(await store.readBlob("protected-preview")).toEqual(
+        expect.objectContaining({ size: 9 }),
+      );
+    },
+  );
+
+  it("refuses a manual reset after a newer seed replaces the active snapshot", async () => {
+    const store = new SharedPersistentStore();
+    const repository = buildRepository(store);
+    await repository.initialize();
+    const current = await repository.snapshot();
+    await store.memory.transact((_stored, transaction) => {
+      transaction.putBlob("newer-preview", new Blob(["protected"]));
+      transaction.putSnapshot({
+        ...current,
+        seedVersion: "2026-07-13.1",
+        workspaceId: "workspace-newer-manual-reset",
+        revision: current.revision + 1,
+        blobIds: ["newer-preview"],
+        state: {
+          ...current.state,
+          title: "Newer durable workspace",
+        },
+      });
+    });
+
+    await expect(repository.reset()).rejects.toMatchObject({
+      name: "DemoWorkspaceUpgradeRequiredError",
+      upgrade: {
+        scope: "seed_version",
+        foundSeedVersion: "2026-07-13.1",
+      },
+    });
+    expect(await store.readSnapshot()).toMatchObject({
+      seedVersion: "2026-07-13.1",
+      workspaceId: "workspace-newer-manual-reset",
+      revision: current.revision + 1,
+      blobIds: ["newer-preview"],
+      state: { title: "Newer durable workspace" },
+    });
+    expect(await store.readBlob("newer-preview")).toEqual(
+      expect.objectContaining({ size: 9 }),
+    );
+  });
+
+  it("does not let a newer cross-tab reset downgrade the durable workspace", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const olderTab = buildRepository(store, hub.createFactory());
+    await olderTab.initialize();
+    const current = await olderTab.snapshot();
+    const newerSnapshot = {
+      ...current,
+      seedVersion: "2026-07-13.1",
+      workspaceId: "workspace-newer-cross-tab",
+      resetCount: current.resetCount + 1,
+      resetEpoch: current.resetEpoch + 1,
+      revision: current.revision + 1,
+      blobIds: ["newer-cross-tab-preview"],
+      state: {
+        ...current.state,
+        title: "Newer cross-tab workspace",
+      },
+    };
+    await store.memory.transact((_stored, transaction) => {
+      transaction.putBlob("newer-cross-tab-preview", new Blob(["protected"]));
+      transaction.putSnapshot(newerSnapshot);
+    });
+
+    hub.send({
+      source: "local",
+      kind: "reset",
+      workspaceId: newerSnapshot.workspaceId,
+      revision: newerSnapshot.revision,
+      resetEpoch: newerSnapshot.resetEpoch,
+      lastEventSequence: newerSnapshot.lastEventSequence,
+    });
+    await settleBroadcast();
+
+    expect(olderTab.getRuntimeSnapshot()).toMatchObject({
+      status: "upgrade_required",
+      upgrade: {
+        scope: "seed_version",
+        foundSeedVersion: "2026-07-13.1",
+      },
+    });
+    expect(await store.readSnapshot()).toMatchObject({
+      seedVersion: "2026-07-13.1",
+      workspaceId: "workspace-newer-cross-tab",
+      blobIds: ["newer-cross-tab-preview"],
+      state: { title: "Newer cross-tab workspace" },
+    });
+    expect(await store.readBlob("newer-cross-tab-preview")).toEqual(
+      expect.objectContaining({ size: 9 }),
+    );
+  });
+
+  it("fences a P6 reset before it can downgrade a P7 workspace", async () => {
+    const p6WorkspaceSchemaVersion = 3;
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const p7Tab = buildRepository(store, hub.createFactory());
+    await p7Tab.initialize();
+    await p7Tab.putBlob("p7-preview", new Blob(["P7 generated preview"]));
+    const p7Snapshot = await p7Tab.snapshot();
+    const notifications: DemoWorkspaceNotification[] = [];
+    p7Tab.subscribe((notification) => notifications.push(notification));
+    const p6Channel = hub.createFactory().create();
+    if (!p6Channel) throw new Error("missing P6 channel fixture");
+
+    const p6CompatibleReset = async (): Promise<DemoWorkspaceSnapshot> => {
+      const committed = await store.transact((stored, transaction) => {
+        if (!stored) {
+          throw new Error("Demo workspace disappeared during P6 reset.");
+        }
+        if (stored.schemaVersion > p6WorkspaceSchemaVersion) {
+          throw new Error(
+            "This demo workspace was created by a newer version. Reload after updating the demo.",
+          );
+        }
+        const downgraded: DemoWorkspaceSnapshot = {
+          ...stored,
+          schemaVersion: p6WorkspaceSchemaVersion,
+          seedVersion: "2026-07-11.1",
+          workspaceId: "workspace-p6-reset",
+          revision: stored.revision + 1,
+          resetEpoch: stored.resetEpoch + 1,
+          resetCount: stored.resetCount + 1,
+          blobIds: [],
+        };
+        transaction.clearBlobs();
+        transaction.putSnapshot(downgraded);
+        return downgraded;
+      });
+      p6Channel.postMessage({
+        source: "local",
+        kind: "reset",
+        workspaceId: committed.workspaceId,
+        revision: committed.revision,
+        resetEpoch: committed.resetEpoch,
+        lastEventSequence: committed.lastEventSequence,
+      });
+      return committed;
+    };
+
+    await expect(p6CompatibleReset()).rejects.toThrow(
+      "This demo workspace was created by a newer version.",
+    );
+    await settleBroadcast();
+
+    expect(notifications).toEqual([]);
+    expect(p7Tab.getRuntimeSnapshot()).toMatchObject({ status: "ready" });
+    expect(p7Tab.snapshotNow()).toEqual(p7Snapshot);
+    expect(await store.readSnapshot()).toEqual(p7Snapshot);
+    expect(await store.readBlob("p7-preview")).toEqual(
+      expect.objectContaining({ size: 20 }),
+    );
+    p6Channel.close();
+  });
+
+  it("loads the current seed in memory when durable seed refresh hits quota", async () => {
+    const builder = buildRepository(new InMemoryDemoWorkspaceStore());
+    await builder.initialize();
+    const staleSnapshot: DemoWorkspaceSnapshot = {
+      ...(await builder.snapshot()),
+      schemaVersion: 3,
+      seedVersion: "2026-07-11.1",
+      workspaceId: "workspace-stale-quota-seed",
+    };
+    const store = new SharedPersistentStore(
+      new InMemoryDemoWorkspaceStore(staleSnapshot),
+    );
+    store.failNext = new DemoWorkspaceStorageError("quota");
+    const repository = new DemoWorkspaceRepository({
+      store,
+      clock: fixedClock,
+      createWorkspaceId: () => "workspace-memory-seed",
+    });
+
+    await expect(repository.initialize()).resolves.toMatchObject({
+      kind: "ready",
+      storageMode: "memory",
+      warning: {
+        code: "quota_exceeded",
+        message: expect.stringContaining("current synthetic examples"),
+      },
+      snapshot: {
+        seedVersion: DEMO_SEED.seedVersion,
+        workspaceId: "workspace-memory-seed",
+        resetCount: 1,
+        resetEpoch: 1,
+        revision: 1,
+        state: { title: "JobCtrl product tour" },
+      },
+    });
+    expect((await store.readSnapshot())?.seedVersion).toBe("2026-07-11.1");
+  });
+
+  it("broadcasts an automatic seed refresh as a reset to existing tabs", async () => {
+    const hub = new ChannelHub();
+    const store = new SharedPersistentStore();
+    const first = buildRepository(store, hub.createFactory());
+    await first.initialize();
+    const current = await first.snapshot();
+    await store.memory.transact((_stored, transaction) => {
+      transaction.putSnapshot({
+        ...current,
+        schemaVersion: 3,
+        seedVersion: "2026-07-11.1",
+        state: {
+          ...current.state,
+          title: "Mutated previous synthetic seed",
+        },
+      });
+    });
+    const notifications: DemoWorkspaceNotification[] = [];
+    first.subscribe((notification) => notifications.push(notification));
+    const second = new DemoWorkspaceRepository({
+      store,
+      clock: fixedClock,
+      channelFactory: hub.createFactory(),
+      createWorkspaceId: () => "workspace-refreshed-broadcast",
+    });
+
+    await expect(second.initialize()).resolves.toMatchObject({
+      kind: "ready",
+      snapshot: {
+        seedVersion: DEMO_SEED.seedVersion,
+        workspaceId: "workspace-refreshed-broadcast",
+        resetEpoch: 1,
+      },
+    });
+    await settleBroadcast();
+
+    expect(notifications).toContainEqual(
+      expect.objectContaining({
+        source: "broadcast",
+        kind: "reset",
+        workspaceId: "workspace-refreshed-broadcast",
+        revision: 1,
+        resetEpoch: 1,
+      }),
+    );
+    expect(await first.snapshot()).toMatchObject({
+      seedVersion: DEMO_SEED.seedVersion,
+      workspaceId: "workspace-refreshed-broadcast",
+      state: { title: "JobCtrl product tour" },
     });
   });
 
@@ -855,7 +1228,7 @@ describe("DemoWorkspaceRepository", () => {
     await builder.initialize();
     const future = {
       ...(await builder.snapshot()),
-      schemaVersion: 4,
+      schemaVersion: 5,
       workspaceId: "future-workspace",
     };
     const store = new InMemoryDemoWorkspaceStore(future);
@@ -864,8 +1237,8 @@ describe("DemoWorkspaceRepository", () => {
     await expect(repository.initialize()).resolves.toMatchObject({
       kind: "upgrade_required",
       scope: "workspace_schema",
-      foundSchemaVersion: 4,
-      supportedSchemaVersion: 3,
+      foundSchemaVersion: 5,
+      supportedSchemaVersion: 4,
     });
     expect((await store.readSnapshot())?.workspaceId).toBe("future-workspace");
   });
@@ -879,7 +1252,7 @@ describe("DemoWorkspaceRepository", () => {
     await store.memory.transact((_stored, transaction) => {
       transaction.putSnapshot({
         ...current,
-        schemaVersion: 4,
+        schemaVersion: 5,
         revision: 1,
       });
     });
@@ -898,7 +1271,7 @@ describe("DemoWorkspaceRepository", () => {
       status: "upgrade_required",
       upgrade: {
         scope: "workspace_schema",
-        foundSchemaVersion: 4,
+        foundSchemaVersion: 5,
       },
     });
   });
@@ -924,7 +1297,7 @@ describe("DemoWorkspaceRepository", () => {
     expect(ready).toMatchObject({
       kind: "ready",
       snapshot: {
-        schemaVersion: 3,
+        schemaVersion: 4,
         workspaceId: "legacy-workspace",
         revision: 2,
         blobIds: ["legacy-preview"],
@@ -958,7 +1331,7 @@ describe("DemoWorkspaceRepository", () => {
       kind: "ready",
       storageMode: "memory",
       snapshot: {
-        schemaVersion: 3,
+        schemaVersion: 4,
         workspaceId: "legacy-quota-workspace",
         blobIds: ["legacy-quota-preview"],
       },

--- a/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
+++ b/apps/web/src/demo/workspace/DemoWorkspaceRepository.ts
@@ -146,6 +146,15 @@ export class DemoWorkspaceRepository {
       if (upgrade) {
         return this.setUpgrade(upgrade);
       }
+      if (classifyDemoSeedVersion(current.seedVersion) === "refreshable") {
+        const refreshed = await this.refreshSeed();
+        this.adoptAuthoritativeSnapshot(refreshed.snapshot, true);
+        const ready = this.setReady(refreshed.snapshot);
+        if (refreshed.didRefresh) {
+          this.publishLocal("reset", refreshed.snapshot);
+        }
+        return ready;
+      }
       const migrated =
         current.schemaVersion < DEMO_WORKSPACE_SCHEMA_VERSION
           ? await this.migrate(current)
@@ -378,14 +387,7 @@ export class DemoWorkspaceRepository {
           throw new Error("Demo workspace disappeared during reset.");
         }
         throwIfFutureWorkspace(stored);
-        const now = this.clock.now().toISOString();
-        const next = this.makeSeedSnapshot({
-          createdAt: now,
-          resetCount: stored.resetCount + 1,
-          resetEpoch: stored.resetEpoch + 1,
-          revision: stored.revision + 1,
-          lastEventSequence: stored.lastEventSequence,
-        });
+        const next = this.makeReplacementSeedSnapshot(stored);
         transaction.clearBlobs();
         transaction.putSnapshot(next);
         return next;
@@ -455,13 +457,7 @@ export class DemoWorkspaceRepository {
   }
 
   private async seed(): Promise<DemoWorkspaceSnapshot> {
-    const candidate = this.makeSeedSnapshot({
-      createdAt: this.clock.now().toISOString(),
-      resetCount: 0,
-      resetEpoch: 0,
-      revision: 0,
-      lastEventSequence: 0,
-    });
+    const candidate = this.makeReplacementSeedSnapshot(null);
     const committed = await this.store.transact((current, transaction) => {
       if (current) {
         throwIfFutureWorkspace(current);
@@ -475,6 +471,31 @@ export class DemoWorkspaceRepository {
       this.publishLocal("commit", committed);
     }
     return committed;
+  }
+
+  private async refreshSeed(): Promise<{
+    readonly snapshot: DemoWorkspaceSnapshot;
+    readonly didRefresh: boolean;
+  }> {
+    let didRefresh = false;
+    const snapshot = await this.store.transact((stored, transaction) => {
+      if (!stored) {
+        throw new Error("Demo workspace disappeared during seed refresh.");
+      }
+      throwIfFutureWorkspace(stored);
+      if (classifyDemoSeedVersion(stored.seedVersion) !== "refreshable") {
+        return stored;
+      }
+      const next = this.makeReplacementSeedSnapshot(stored);
+      transaction.clearBlobs();
+      transaction.putSnapshot(next);
+      didRefresh = true;
+      return next;
+    });
+    return {
+      snapshot,
+      didRefresh,
+    };
   }
 
   private async migrate(
@@ -576,20 +597,16 @@ export class DemoWorkspaceRepository {
   private async fallbackFromUnavailable(
     confirmed: DemoWorkspaceSnapshot | null,
   ): Promise<DemoWorkspaceReady> {
+    const seedRefreshRequired =
+      confirmed !== null &&
+      classifyDemoSeedVersion(confirmed.seedVersion) === "refreshable";
     const warning: DemoWorkspaceWarning = {
       code: "indexeddb_unavailable",
-      message:
-        "Browser storage is unavailable; this tab will not share or retain demo changes.",
+      message: seedRefreshRequired
+        ? "Browser storage is unavailable; this tab loaded the current synthetic examples in memory only."
+        : "Browser storage is unavailable; this tab will not share or retain demo changes.",
     };
-    const candidate =
-      confirmed ??
-      this.makeSeedSnapshot({
-        createdAt: this.clock.now().toISOString(),
-        resetCount: 0,
-        resetEpoch: 0,
-        revision: 0,
-        lastEventSequence: 0,
-      });
+    const candidate = this.fallbackCandidate(confirmed);
     const snapshot = await this.switchToMemory(candidate, warning, true);
     if (!confirmed) {
       this.publishLocal("commit", snapshot);
@@ -600,25 +617,45 @@ export class DemoWorkspaceRepository {
   private async fallbackFromQuota(
     confirmed: DemoWorkspaceSnapshot | null,
   ): Promise<DemoWorkspaceReady> {
+    const seedRefreshRequired =
+      confirmed !== null &&
+      classifyDemoSeedVersion(confirmed.seedVersion) === "refreshable";
     const warning: DemoWorkspaceWarning = {
       code: "quota_exceeded",
-      message:
-        "Browser storage is full; this tab preserved the last confirmed demo state in memory only.",
+      message: seedRefreshRequired
+        ? "Browser storage is full; this tab loaded the current synthetic examples in memory only."
+        : "Browser storage is full; this tab preserved the last confirmed demo state in memory only.",
     };
-    const candidate =
-      confirmed ??
-      this.makeSeedSnapshot({
-        createdAt: this.clock.now().toISOString(),
-        resetCount: 0,
-        resetEpoch: 0,
-        revision: 0,
-        lastEventSequence: 0,
-      });
+    const candidate = this.fallbackCandidate(confirmed);
     const snapshot = await this.switchToMemory(candidate, warning, true);
     if (!confirmed) {
       this.publishLocal("commit", snapshot);
     }
     return this.setReady(snapshot);
+  }
+
+  private fallbackCandidate(
+    confirmed: DemoWorkspaceSnapshot | null,
+  ): DemoWorkspaceSnapshot {
+    if (confirmed) {
+      throwIfFutureWorkspace(confirmed);
+      if (classifyDemoSeedVersion(confirmed.seedVersion) === "current") {
+        return confirmed;
+      }
+    }
+    return this.makeReplacementSeedSnapshot(confirmed);
+  }
+
+  private makeReplacementSeedSnapshot(
+    previous: DemoWorkspaceSnapshot | null,
+  ): DemoWorkspaceSnapshot {
+    return this.makeSeedSnapshot({
+      createdAt: this.clock.now().toISOString(),
+      resetCount: previous ? previous.resetCount + 1 : 0,
+      resetEpoch: previous ? previous.resetEpoch + 1 : 0,
+      revision: previous ? previous.revision + 1 : 0,
+      lastEventSequence: previous?.lastEventSequence ?? 0,
+    });
   }
 
   private async switchToMemory(
@@ -940,16 +977,43 @@ function defaultWorkspaceId(): string {
 function workspaceUpgrade(
   snapshot: DemoWorkspaceSnapshot,
 ): DemoWorkspaceUpgradeRequired | null {
-  return snapshot.schemaVersion > DEMO_WORKSPACE_SCHEMA_VERSION
-    ? {
-        kind: "upgrade_required",
-        scope: "workspace_schema",
-        foundSchemaVersion: snapshot.schemaVersion,
-        supportedSchemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
-        message:
-          "This demo workspace was created by a newer version. Reload after updating the demo.",
-      }
-    : null;
+  if (snapshot.schemaVersion > DEMO_WORKSPACE_SCHEMA_VERSION) {
+    return {
+      kind: "upgrade_required",
+      scope: "workspace_schema",
+      foundSchemaVersion: snapshot.schemaVersion,
+      supportedSchemaVersion: DEMO_WORKSPACE_SCHEMA_VERSION,
+      message:
+        "This demo workspace was created by a newer version. Reload after updating the demo.",
+    };
+  }
+
+  if (classifyDemoSeedVersion(snapshot.seedVersion) === "unsupported") {
+    return {
+      kind: "upgrade_required",
+      scope: "seed_version",
+      foundSeedVersion: snapshot.seedVersion,
+      supportedSeedVersion: DEMO_SEED.seedVersion,
+      message:
+        "This demo workspace seed is not supported by this version. Reload after updating the demo.",
+    };
+  }
+
+  return null;
+}
+
+const REFRESHABLE_DEMO_SEED_VERSIONS = new Set(["2026-07-11.1"]);
+
+/** Only reviewed legacy fixtures may be destructively replaced. */
+function classifyDemoSeedVersion(
+  seedVersion: string,
+): "current" | "refreshable" | "unsupported" {
+  if (seedVersion === DEMO_SEED.seedVersion) {
+    return "current";
+  }
+  return REFRESHABLE_DEMO_SEED_VERSIONS.has(seedVersion)
+    ? "refreshable"
+    : "unsupported";
 }
 
 function throwIfFutureWorkspace(snapshot: DemoWorkspaceSnapshot): void {

--- a/apps/web/src/demo/workspace/contracts.ts
+++ b/apps/web/src/demo/workspace/contracts.ts
@@ -13,7 +13,7 @@ export const DEMO_WORKSPACE_DATABASE = "jobctrl-demo";
 export const DEMO_WORKSPACE_DATABASE_VERSION = 1;
 export const DEMO_WORKSPACE_STORE = "workspace";
 export const DEMO_BLOBS_STORE = "blobs";
-export const DEMO_WORKSPACE_SCHEMA_VERSION = 3;
+export const DEMO_WORKSPACE_SCHEMA_VERSION = 4;
 export const DEMO_WORKSPACE_EVENT_LOG_LIMIT = 128;
 
 export interface DemoLegacyPendingScenario {
@@ -100,7 +100,9 @@ export interface DemoScenarioInvocation extends DemoLegacyPendingScenario {
   readonly recoveryInput: DemoScenarioRecoveryInput;
 }
 
-export type DemoPendingScenario = DemoLegacyPendingScenario | DemoScenarioInvocation;
+export type DemoPendingScenario =
+  | DemoLegacyPendingScenario
+  | DemoScenarioInvocation;
 
 export function isDemoScenarioInvocation(
   pending: DemoPendingScenario,
@@ -128,7 +130,13 @@ export interface DemoDynamicReceipt {
     | DemoSimulatedAsyncOperation;
   readonly scenarioId?: string;
   readonly runId?: string;
-  readonly entityType: "artifact" | "contact" | "job" | "outreach_thread" | "source" | "workspace";
+  readonly entityType:
+    | "artifact"
+    | "contact"
+    | "job"
+    | "outreach_thread"
+    | "source"
+    | "workspace";
   readonly entityId: string;
 }
 
@@ -181,11 +189,15 @@ export type DemoWorkspaceStorageMode = "indexeddb" | "memory";
 export type DemoWorkspaceWarning =
   | {
       readonly code: "indexeddb_unavailable";
-      readonly message: "Browser storage is unavailable; this tab will not share or retain demo changes.";
+      readonly message:
+        | "Browser storage is unavailable; this tab will not share or retain demo changes."
+        | "Browser storage is unavailable; this tab loaded the current synthetic examples in memory only.";
     }
   | {
       readonly code: "quota_exceeded";
-      readonly message: "Browser storage is full; this tab preserved the last confirmed demo state in memory only.";
+      readonly message:
+        | "Browser storage is full; this tab preserved the last confirmed demo state in memory only."
+        | "Browser storage is full; this tab loaded the current synthetic examples in memory only.";
     };
 
 export interface DemoWorkspaceReady {
@@ -209,6 +221,13 @@ export type DemoWorkspaceUpgradeRequired =
       readonly foundDatabaseVersion: number;
       readonly supportedDatabaseVersion: number;
       readonly message: "This browser database was created by a newer demo version. Reload after updating the demo.";
+    }
+  | {
+      readonly kind: "upgrade_required";
+      readonly scope: "seed_version";
+      readonly foundSeedVersion: string;
+      readonly supportedSeedVersion: string;
+      readonly message: "This demo workspace seed is not supported by this version. Reload after updating the demo.";
     };
 
 export type DemoWorkspaceInitialization =

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -176,6 +176,19 @@ in the MVP. The receipt history stays inspectable in the demo shell. The demo
 never falls back to the product API, SSE, an external origin, or a host-OS
 opener.
 
+`DemoSeedValue.seedVersion` is the fixture-revision boundary, separate from the
+IndexedDB/workspace schema versions. Changing the canonical seed must bump this
+value. When a seed refresh changes the destructive writer contract, also advance
+`DEMO_WORKSPACE_SCHEMA_VERSION` so an older bundle refuses the snapshot before
+writing or clearing blobs. Only explicitly reviewed older seed versions are
+refreshable: on the next initialization they are atomically reseeded with a new
+workspace identity and reset epoch, and pending scenarios and generated blobs
+are removed. A newer or unknown seed version instead requires an updated demo
+and leaves its durable snapshot and blobs untouched. If an allowed durable
+refresh cannot be written, the current seed is loaded into tab-local memory with
+the existing storage warning. Consent state is outside this workspace lifecycle
+and is not reset.
+
 ### Public demo edge workers
 
 The public demo uses Cloudflare Pages for the Vite SPA, a same-origin Worker at

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -83,6 +83,7 @@ The dedicated demo-workspace Playwright lane starts Vite only; it must not
 start or contact the product API or SSE endpoint. It proves same-profile tab
 sharing and concurrent writes, separate-context isolation, reload persistence,
 atomic reset/blob deletion, future IndexedDB-version refusal without downgrade,
+one-time seed-version refresh with generated-blob cleanup,
 post-commit domain-event delivery, and populated direct-refresh coverage for
 the demo's dashboard, product routes, and seeded detail deep links. It also
 exercises real source promotion, manual-capture import, and score correction
@@ -98,11 +99,12 @@ external effect. It also proves the admitted Demo guide reaches the seeded
 scoring, materials, Apply Review, and run-history shortcuts before a confirmed
 workspace reset. Every scenario test installs a strict
 request guard that rejects product API, SSE, and external-origin traffic. Unit
-and component tests cover injected quota/security fallbacks, schema revalidation,
-reset-epoch races, event-log loss, read-adapter query/404/capability parity,
-valid arguments for every browser-local command plus focused projection,
-replay, cascade, and quota-rollback invariants, the reactive data-boundary
-warning, and the unchanged canonical event provider/invalidation router.
+and component tests cover seed-refresh quota/memory fallback, other injected
+quota/security fallbacks, schema revalidation, reset-epoch races, event-log
+loss, read-adapter query/404/capability parity, valid arguments for every
+browser-local command plus focused projection, replay, cascade, and
+quota-rollback invariants, the reactive data-boundary warning, and the unchanged
+canonical event provider/invalidation router.
 Playwright artifacts are written outside the repository under the system
 temporary directory.
 

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -57,6 +57,11 @@ tailored-material review, Apply Review/dry-run, and run history. Every shortcut
 and action is simulated; it does not contact employers, send messages, or make
 external changes. **Reset synthetic demo data** asks for confirmation, then
 replaces the browser-local workspace with the original examples.
+When a deployment changes the versioned synthetic seed, the next demo load
+performs the same replacement automatically: it rotates the workspace identity,
+clears pending simulated actions, and deletes generated demo blobs. This seed
+refresh does not change the separate consent cookie or telemetry-retention
+schedule.
 
 ## Local Data
 


### PR DESCRIPTION
## Summary

- bump the synthetic demo seed to `2026-07-12.1`
- atomically replace explicitly allowlisted older browser workspaces on first load
- rotate workspace identity and reset epoch while clearing pending scenarios and generated blobs
- preserve same-version workspaces and fail closed on newer or unknown seeds
- advance the workspace writer fence to schema 4 so already-open P6 bundles cannot downgrade P7 state
- keep cookie consent and telemetry retention state outside the workspace refresh lifecycle

## Why

Existing visitors retain IndexedDB across deployments. Without a fixture revision policy, corrected synthetic data would not reach those browsers. The schema writer fence also prevents a cached older bundle from resetting a refreshed workspace with its legacy seed.

## Validation

- `corepack pnpm web:check`
- `corepack pnpm --filter @jobctrl/web test` — 244 files / 1,416 tests
- `corepack pnpm --filter @jobctrl/web test-d` — 11 files / 13 tests
- `corepack pnpm --filter @jobctrl/web e2e:demo-workspace` — 23/23
- regular Chromium web E2E — 30 passed / 1 skipped
- `corepack pnpm demo:build`
- `corepack pnpm docs:build`
- demo-edge consent and retention tests — 27/27 plus 4/4 configuration checks
- independent review: PASS, no Blocker or High findings
- independent QA: PASS, no findings

## Stack

Stacked on #416. This PR does not merge or modify #416. Cookie-consent withdrawal and identifier deletion remain deferred.

Known non-blocking risk: on a brand-new browser database, a precisely concurrent P6 insert can be adopted by P7 until the next reload; established workspaces are fenced before any downgrade or blob deletion.