### PR TITLE
fix(demo): clarify browser-profile isolation

### DIFF
--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -213,7 +213,7 @@ test("consent grant precedes IndexedDB, health, telemetry, and populated demo en
   )).toBe(false);
 
   await page.getByRole("button", { name: "Accept cookies and enter demo" }).click();
-  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  await expect(page.getByText("Demo mode — browser-local workspace")).toBeVisible();
   await expect.poll(async () => page.evaluate(async () =>
     (await indexedDB.databases()).some((database) => database.name === "jobctrl-demo"),
   )).toBe(true);
@@ -352,13 +352,13 @@ test("a fresh grant wins over a stale denied consent read", async ({ page, conte
 
   await page.goto("/");
   await page.getByRole("button", { name: "Accept cookies and enter demo" }).click();
-  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  await expect(page.getByText("Demo mode — browser-local workspace")).toBeVisible();
   releaseRead?.();
   await readResponseSent;
   await page.evaluate(() => new Promise<void>((resolve) =>
     requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
   ));
-  await expect(page.getByText("Demo mode — shared browser profile")).toBeVisible();
+  await expect(page.getByText("Demo mode — browser-local workspace")).toBeVisible();
   await expect(page.getByRole("heading", { name: /Explore JobCtrl/i })).toHaveCount(0);
 });
 
@@ -549,7 +549,7 @@ scenarioTest(
   },
 );
 
-scenarioTest("demo shell renders the shared-profile and personal-data boundary without product network", async ({
+scenarioTest("demo shell renders the browser-profile isolation and personal-data boundary without product network", async ({
   page,
   context,
 }) => {
@@ -565,12 +565,14 @@ scenarioTest("demo shell renders the shared-profile and personal-data boundary w
   const notice = page.getByRole("status", {
     name: "Public demo data boundary",
   });
+  await expect(notice).toContainText("not shared across browser profiles");
+  await expect(notice).toContainText("common demo environment");
   await expect(notice).toContainText(
-    "shared with other tabs and people using this browser profile",
+    "Other tabs and anyone using this profile can see the same data",
   );
   await expect(notice).toContainText("Do not enter personal data or secrets");
   await expect(
-    page.getByText("Demo mode — shared browser profile"),
+    page.getByText("Demo mode — browser-local workspace"),
   ).toBeVisible();
   expect(productRequests).toEqual([]);
 });

--- a/apps/web/src/demo/workspace/DemoWorkspaceNotice.test.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceNotice.test.tsx
@@ -47,7 +47,7 @@ class QuotaStore implements DemoWorkspaceStore {
 }
 
 describe("<DemoWorkspaceNotice>", () => {
-  it("always explains browser-profile sharing and personal-data boundaries in demo mode", async () => {
+  it("explains browser-profile isolation, tab sharing, and personal-data boundaries in demo mode", async () => {
     const workspace = new DemoWorkspaceRepository({
       store: new QuotaStore(),
       createWorkspaceId: () => "notice-workspace",
@@ -60,16 +60,17 @@ describe("<DemoWorkspaceNotice>", () => {
       </DemoWorkspaceProvider>,
     );
 
-    expect(
-      screen.getByRole("status", { name: "Public demo data boundary" }),
-    ).toHaveTextContent(
-      "shared with other tabs and people using this browser profile",
+    const notice = screen.getByRole("status", {
+      name: "Public demo data boundary",
+    });
+    expect(notice).toHaveTextContent("not shared across browser profiles");
+    expect(notice).toHaveTextContent("common demo environment");
+    expect(notice).toHaveTextContent(
+      "Other tabs and anyone using this profile can see the same data",
     );
-    expect(screen.getByRole("status")).toHaveTextContent(
-      "Do not enter personal data or secrets",
-    );
+    expect(notice).toHaveTextContent("Do not enter personal data or secrets");
     expect(
-      screen.getByText("Demo mode — shared browser profile"),
+      screen.getByText("Demo mode — browser-local workspace"),
     ).toBeInTheDocument();
     expect(await axe(view.container)).toHaveNoViolations();
   });

--- a/apps/web/src/demo/workspace/DemoWorkspaceNotice.tsx
+++ b/apps/web/src/demo/workspace/DemoWorkspaceNotice.tsx
@@ -18,8 +18,10 @@ export function DemoWorkspaceNotice() {
       <strong>Public demo · synthetic browser-local data</strong>
       {runtime.storageMode === "indexeddb" ? (
         <span>
-          This workspace is shared with other tabs and people using this browser
-          profile. Do not enter personal data or secrets.
+          This workspace stays in this browser profile; it is not shared across
+          browser profiles or through a common demo environment. Other tabs and
+          anyone using this profile can see the same data. Do not enter personal
+          data or secrets.
         </span>
       ) : (
         <span>

--- a/apps/web/src/shared/layout/SideRail.tsx
+++ b/apps/web/src/shared/layout/SideRail.tsx
@@ -127,7 +127,7 @@ export function LocalModeCard() {
   const text =
     workspace.mode === "demo"
       ? workspace.runtime.storageMode === "indexeddb"
-        ? "Demo mode — shared browser profile"
+        ? "Demo mode — browser-local workspace"
         : "Demo mode — this tab only"
       : "Local mode — all data stays on device";
   return (

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -154,8 +154,9 @@ workspace does not initialize. The dedicated Playwright lane stubs the exact
 Worker contract for browser-local development; use a Cloudflare preview when
 manually testing real cookie persistence across reloads.
 
-The demo workspace persists in IndexedDB and is shared by tabs and people using
-the same browser profile. Separate browser profiles and private/incognito
+Each browser/storage profile has its own IndexedDB demo workspace. It is not
+shared across browser profiles or through a common demo environment, but tabs
+and anyone using the same profile can see the same data. Private/incognito
 contexts are isolated. Reset rotates the workspace identity, clears pending
 demo actions, and deletes generated demo blobs in the same transaction. If
 IndexedDB is unavailable or full, the page warns that it has switched to


### PR DESCRIPTION
## Summary

- clarify that the public demo has no common shared workspace and keeps IndexedDB state per browser profile
- explicitly warn that tabs and anyone using the same browser profile can see the same demo data
- rename the rail status to “Demo mode — browser-local workspace”
- preserve the personal-data warning and tab-only memory fallback
- update the owning documentation, unit/a11y coverage, and no-product-network Playwright assertion

## Why

The previous phrase “shared with other tabs and people using this browser profile” was technically correct but sounded like all public visitors used one common environment. An intermediate rewrite overcorrected by promising visitor isolation even when two people share one browser profile. This copy now states the exact storage boundary without changing any storage, API, consent, or telemetry behavior.

## User impact

Each browser/storage profile has its own demo workspace. There is no global demo workspace or cross-profile sharing. Tabs and anyone with access to the same profile intentionally see the same IndexedDB state. Visitors are still told not to enter personal data or secrets.

## Validation

Static review completed before testing:

- initial review caught and rejected an overbroad human-isolation promise
- repaired rereview: PASS — Blocker 0, High 0, Medium 0, Low 0

Automated:

- focused notice unit/a11y tests — 3 passed
- complete demo Playwright suite — 23 passed
- focused product-network boundary Playwright — 1 passed
- web typecheck — PASS
- docs build/link check — 5,841 references across 262 emitted files
- git diff --check — PASS

Independent QA: PASS — Blocker 0, High 0, Medium 0, Low 0.

QA verified consent through /settings/models, the corrected notice and footer, absence of the old copy, no product API/SSE/external-origin requests, zero console warnings/errors, and clean desktop plus 390×844 rendering without horizontal overflow.