### PR TITLE
docs: add comparison screenshot carousel

### DIFF
--- a/docs/.vitepress/theme/ComparisonScreenshotCarousel.vue
+++ b/docs/.vitepress/theme/ComparisonScreenshotCarousel.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import applyReviewScreenshot from "../../assets/screenshots/apply-review.png";
+import jobsScreenshot from "../../assets/screenshots/jobs.png";
+
+const screenshots = [
+  {
+    alt: "Jobs table with fit scores, stages, and filters",
+    caption: "scored and filterable, with every score inspectable",
+    image: jobsScreenshot,
+    title: "Jobs",
+  },
+  {
+    alt: "Apply Review editing a tailored resume with audit evidence",
+    caption: "edit and approve the exact resume that ships",
+    image: applyReviewScreenshot,
+    title: "Apply Review",
+  },
+] as const;
+
+const activeIndex = ref(0);
+const activeScreenshot = computed(() => screenshots[activeIndex.value] ?? screenshots[0]);
+
+function showPrevious(): void {
+  activeIndex.value = Math.max(0, activeIndex.value - 1);
+}
+
+function showNext(): void {
+  activeIndex.value = Math.min(screenshots.length - 1, activeIndex.value + 1);
+}
+</script>
+
+<template>
+  <section
+    class="jh-comparison-screenshot-carousel"
+    data-jh-comparison-carousel
+    role="group"
+    aria-roledescription="carousel"
+    aria-label="JobCtrl product screenshots"
+  >
+    <figure class="jh-comparison-screenshot-carousel__figure">
+      <img
+        :key="activeScreenshot.image"
+        class="jh-comparison-screenshot-carousel__image"
+        :src="activeScreenshot.image"
+        :alt="activeScreenshot.alt"
+      />
+      <figcaption class="jh-comparison-screenshot-carousel__caption">
+        <strong>{{ activeScreenshot.title }}</strong> — {{ activeScreenshot.caption }}
+      </figcaption>
+    </figure>
+
+    <div class="jh-comparison-screenshot-carousel__controls">
+      <button
+        type="button"
+        class="jh-comparison-screenshot-carousel__button"
+        :disabled="activeIndex === 0"
+        @click="showPrevious"
+      >
+        Previous
+      </button>
+      <p
+        class="jh-comparison-screenshot-carousel__status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {{ activeIndex + 1 }} of {{ screenshots.length }}
+      </p>
+      <button
+        type="button"
+        class="jh-comparison-screenshot-carousel__button"
+        :disabled="activeIndex === screenshots.length - 1"
+        @click="showNext"
+      >
+        Next
+      </button>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -733,12 +733,14 @@ html[data-jh-workflow-surface="cli"] .jh-channel-panel[data-jh-channel-panel="cl
     .jh-compare-grid,
     .jh-compare-table-wrap,
     .jh-compare-fit-grid,
+    .jh-comparison-screenshot-carousel,
     table
   ),
 .Layout.jh-comparison-page .vp-doc > div > :is(
     .jh-compare-grid,
     .jh-compare-table-wrap,
     .jh-compare-fit-grid,
+    .jh-comparison-screenshot-carousel,
     table
   ) {
   width: 100%;
@@ -750,16 +752,10 @@ html[data-jh-workflow-surface="cli"] .jh-channel-panel[data-jh-channel-panel="cl
     .jh-compare-grid,
     .jh-compare-table-wrap,
     .jh-compare-fit-grid,
+    .jh-comparison-screenshot-carousel,
     table
   ) {
   max-width: 1040px;
-}
-
-.jh-compare-eyebrow {
-  color: var(--vp-c-brand-1);
-  font-size: 0.82rem;
-  font-weight: 750;
-  letter-spacing: 0.015em;
 }
 
 .jh-compare-grid {
@@ -918,6 +914,106 @@ html[data-jh-workflow-surface="cli"] .jh-channel-panel[data-jh-channel-panel="cl
   border-radius: 6px;
 }
 
+.jh-comparison-screenshot-carousel {
+  display: grid;
+  width: 100%;
+  max-width: 960px;
+  gap: 14px;
+  margin: 28px auto 34px;
+  padding: 12px;
+  border: 1px solid var(--jh-doc-frame);
+  border-radius: 10px;
+  background: var(--jh-doc-surface);
+}
+
+.jh-comparison-screenshot-carousel__figure {
+  display: grid;
+  min-width: 0;
+  place-items: center;
+  gap: 10px;
+  margin: 0;
+}
+
+.jh-comparison-screenshot-carousel__image {
+  display: block;
+  width: auto;
+  max-width: 100%;
+  height: auto;
+  max-height: 46rem;
+  max-block-size: min(72dvh, 46rem);
+  border: 1px solid var(--jh-doc-frame);
+  border-radius: 6px;
+  object-fit: contain;
+}
+
+.jh-comparison-screenshot-carousel__caption {
+  max-width: 70ch;
+  margin: 0;
+  color: var(--vp-c-text-2);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.jh-comparison-screenshot-carousel__controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.jh-comparison-screenshot-carousel__button {
+  min-inline-size: 5.75rem;
+  min-block-size: 2.5rem;
+  padding: 0.45rem 0.85rem;
+  border: 1px solid var(--vp-c-brand-1);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.jh-comparison-screenshot-carousel__button:not(:disabled):hover {
+  background: var(--vp-c-brand-soft);
+}
+
+.jh-comparison-screenshot-carousel__button:disabled {
+  border-color: var(--vp-c-divider);
+  color: var(--vp-c-text-3);
+  cursor: not-allowed;
+}
+
+.jh-comparison-screenshot-carousel__button:focus-visible {
+  outline: 3px solid var(--vp-c-brand-1);
+  outline-offset: 3px;
+}
+
+.jh-comparison-screenshot-carousel__status {
+  min-inline-size: 4.5rem;
+  margin: 0;
+  color: var(--vp-c-text-2);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+@media (max-width: 767px) {
+  .jh-comparison-screenshot-carousel {
+    margin-inline: 0;
+    padding: 8px;
+  }
+
+  .jh-comparison-screenshot-carousel__controls {
+    justify-content: space-between;
+    gap: 8px;
+  }
+
+  .jh-comparison-screenshot-carousel__button {
+    flex: 1 1 0;
+    min-inline-size: 0;
+  }
+}
+
 .jh-compare-fit-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -948,6 +1044,10 @@ html[data-jh-workflow-surface="cli"] .jh-channel-panel[data-jh-channel-panel="cl
   .jh-compare-card--featured,
   .jh-compare-fit-grid > div {
     border-color: Highlight;
+  }
+
+  .jh-comparison-screenshot-carousel__button {
+    border-color: ButtonText;
   }
 }
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "vitepress";
 import { inBrowser } from "vitepress";
 import DefaultTheme from "vitepress/theme";
+import ComparisonScreenshotCarousel from "./ComparisonScreenshotCarousel.vue";
 import JobCtrlLayout from "./JobCtrlLayout.vue";
 import MermaidRenderer from "./MermaidRenderer.vue";
 import WorkflowSurfacePanel from "./WorkflowSurfacePanel.vue";
@@ -22,6 +23,7 @@ export default {
   extends: DefaultTheme,
   Layout: JobCtrlLayout,
   enhanceApp({ app, router }) {
+    app.component("ComparisonScreenshotCarousel", ComparisonScreenshotCarousel);
     app.component("Mermaid", MermaidRenderer);
     app.component("WorkflowSurfacePanel", WorkflowSurfacePanel);
     app.component("WorkflowSurfaceSelector", WorkflowSurfaceSelector);

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -9,8 +9,6 @@ JobCtrl, [Career-Ops](https://github.com/santifer/career-ops), and
 broad problem through three different operating models. This is an
 evidence-backed capability comparison, not a quality ranking.
 
-<p class="jh-compare-eyebrow">Pinned snapshots · issue threads checked · no marketing claims taken at face value</p>
-
 ## Three operating models
 
 <div class="jh-compare-grid" role="list">
@@ -129,9 +127,7 @@ and follow durable runs as server-side changes arrive.
 
 [![JobCtrl dashboard showing pipeline progress, job counts, source health, and apply runs](assets/screenshots/dashboard.png)](user/screenshots.md)
 
-| [![Jobs table with fit scores, stages, and filters](assets/screenshots/jobs.png)](user/screenshots.md) | [![Apply Review editing a tailored resume with audit evidence](assets/screenshots/apply-review.png)](user/screenshots.md) |
-| --- | --- |
-| **Jobs** — scored and filterable, with every score inspectable | **Apply Review** — edit and approve the exact resume that ships |
+<ComparisonScreenshotCarousel />
 
 All screenshots use synthetic sample data. Open the [Product Tour](user/screenshots.md)
 for the complete Profile → Discovery → Pipeline → Jobs → Apply Review → Runs

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -439,8 +439,9 @@ pull requests after review.
 (`.github/workflows/docs-site.yml`). Mermaid diagrams render client-side in
 the browser, so a build that passes can still contain a diagram that fails to
 parse. `pnpm docs:check:runtime` starts a fresh preview and checks hydration,
-images, navigation, responsive diagrams, search, and the desktop/mobile
-comparison layout (including keyboard access to its wide table) in Chromium;
+images, navigation, responsive diagrams, search, the comparison screenshot-carousel
+interaction, and the desktop/mobile comparison layout (including keyboard access to
+its wide table) in Chromium;
 run it after `pnpm docs:build` for public-doc changes. Note that
 `pnpm docs:preview` snapshots the built file list at startup: after any
 rebuild, restart the preview server or hashed assets will 404. Deploys to

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -626,6 +626,115 @@ try {
     console.log("ok    /comparison desktop visual hierarchy");
   }
 
+  const comparisonEyebrow =
+    "Pinned snapshots · issue threads checked · no marketing claims taken at face value";
+  const comparisonCarousel = page.locator("[data-jh-comparison-carousel]");
+  const comparisonCarouselCount = await comparisonCarousel.count();
+  if (comparisonCarouselCount !== 1) {
+    fail(`/comparison desktop: expected one screenshot carousel, found ${comparisonCarouselCount}`);
+  } else {
+    const carouselState = async () =>
+      comparisonCarousel.evaluate((carousel) => {
+        const images = [...carousel.querySelectorAll("img")];
+        const visibleImages = images.filter((image) => {
+          const box = image.getBoundingClientRect();
+          const style = getComputedStyle(image);
+          return box.width > 0 && box.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+        });
+        return {
+          caption: carousel.querySelector("figcaption")?.textContent?.trim() ?? "",
+          imageCount: images.length,
+          imageAlt: visibleImages[0]?.alt ?? "",
+          status:
+            carousel.querySelector(".jh-comparison-screenshot-carousel__status")?.textContent?.trim() ?? "",
+          visibleImageCount: visibleImages.length,
+        };
+      });
+    const previous = comparisonCarousel.getByRole("button", { name: "Previous", exact: true });
+    const next = comparisonCarousel.getByRole("button", { name: "Next", exact: true });
+    const initialCarousel = await carouselState();
+    const initialPreviousDisabled = await previous.isDisabled();
+    const initialNextDisabled = await next.isDisabled();
+
+    await next.click();
+    await page.waitForFunction(
+      () =>
+        document
+          .querySelector("[data-jh-comparison-carousel] .jh-comparison-screenshot-carousel__status")
+          ?.textContent?.trim() === "2 of 2",
+    );
+    await page.waitForFunction(
+      () =>
+        document
+          .querySelector("[data-jh-comparison-carousel] img")
+          ?.getAttribute("aria-label") === "Expand image: Apply Review editing a tailored resume with audit evidence",
+    );
+    const applyReviewImage = comparisonCarousel.locator("img");
+    const applyReviewZoomLabel = await applyReviewImage.getAttribute("aria-label");
+    await applyReviewImage.click();
+    await page.waitForSelector(".jh-lightbox", { state: "visible", timeout: 5000 });
+    const expandedApplyReviewAlt = await page.locator(".jh-lightbox__content img").getAttribute("alt");
+    await page.locator('.jh-lightbox button[aria-label="Close"]').click();
+    const nextCarousel = await carouselState();
+    const nextPreviousDisabled = await previous.isDisabled();
+    const nextNextDisabled = await next.isDisabled();
+
+    await previous.click();
+    await page.waitForFunction(
+      () =>
+        document
+          .querySelector("[data-jh-comparison-carousel] .jh-comparison-screenshot-carousel__status")
+          ?.textContent?.trim() === "1 of 2",
+    );
+    const restoredCarousel = await carouselState();
+    const restoredPreviousDisabled = await previous.isDisabled();
+    const restoredNextDisabled = await next.isDisabled();
+    const eyebrowPresent = (await page.locator(".vp-doc").innerText()).includes(comparisonEyebrow);
+
+    if (
+      eyebrowPresent
+      || initialCarousel.imageCount !== 1
+      || initialCarousel.visibleImageCount !== 1
+      || initialCarousel.imageAlt !== "Jobs table with fit scores, stages, and filters"
+      || initialCarousel.caption !== "Jobs — scored and filterable, with every score inspectable"
+      || initialCarousel.status !== "1 of 2"
+      || !initialPreviousDisabled
+      || initialNextDisabled
+      || nextCarousel.imageCount !== 1
+      || nextCarousel.visibleImageCount !== 1
+      || nextCarousel.imageAlt !== "Apply Review editing a tailored resume with audit evidence"
+      || nextCarousel.caption !== "Apply Review — edit and approve the exact resume that ships"
+      || nextCarousel.status !== "2 of 2"
+      || nextPreviousDisabled
+      || !nextNextDisabled
+      || applyReviewZoomLabel !== "Expand image: Apply Review editing a tailored resume with audit evidence"
+      || expandedApplyReviewAlt !== "Apply Review editing a tailored resume with audit evidence"
+      || restoredCarousel.imageCount !== 1
+      || restoredCarousel.visibleImageCount !== 1
+      || restoredCarousel.imageAlt !== "Jobs table with fit scores, stages, and filters"
+      || restoredCarousel.status !== "1 of 2"
+      || !restoredPreviousDisabled
+      || restoredNextDisabled
+    ) {
+      fail(`/comparison desktop: screenshot carousel state regressed (${JSON.stringify({
+        eyebrowPresent,
+        initialCarousel,
+        initialPreviousDisabled,
+        initialNextDisabled,
+        nextCarousel,
+        nextPreviousDisabled,
+        nextNextDisabled,
+        applyReviewZoomLabel,
+        expandedApplyReviewAlt,
+        restoredCarousel,
+        restoredPreviousDisabled,
+        restoredNextDisabled,
+      })})`);
+    } else {
+      console.log("ok    /comparison desktop screenshot carousel");
+    }
+  }
+
   await page.goto(`http://127.0.0.1:${port}/user/normal-flows`, { waitUntil: "networkidle" });
   await page.waitForFunction(() => document.querySelectorAll(".mermaid svg").length >= 1, { timeout: 15000 });
   const desktopLoopDiagram = await page.locator(".vp-doc .mermaid").first().boundingBox();
@@ -715,17 +824,42 @@ try {
   await page.locator('.jh-lightbox button[aria-label="Close"]').click();
 
   await page.goto(`http://127.0.0.1:${port}/comparison`, { waitUntil: "networkidle" });
+  const comparisonCarouselMobile = page.locator("[data-jh-comparison-carousel]");
+  await comparisonCarouselMobile.scrollIntoViewIfNeeded();
+  await comparisonCarouselMobile.getByRole("button", { name: "Next", exact: true }).click();
+  await page.waitForFunction(
+    () =>
+      document
+        .querySelector("[data-jh-comparison-carousel] .jh-comparison-screenshot-carousel__status")
+        ?.textContent?.trim() === "2 of 2",
+  );
   const comparisonMobile = await page.evaluate(() => {
     const cards = [...document.querySelectorAll(".jh-compare-card")].map((card) => {
       const box = card.getBoundingClientRect();
       return { x: box.x, y: box.y, width: box.width };
     });
     const summary = document.querySelector(".jh-compare-table-wrap");
+    const carousel = document.querySelector("[data-jh-comparison-carousel]");
+    const carouselImage = carousel?.querySelector("img");
+    const carouselImageBox = carouselImage?.getBoundingClientRect();
     return {
       cards,
+      carouselImage: carouselImageBox
+        ? {
+            height: carouselImageBox.height,
+            left: carouselImageBox.left,
+            right: carouselImageBox.right,
+            width: carouselImageBox.width,
+          }
+        : null,
+      carouselImageCount: carousel?.querySelectorAll("img").length ?? 0,
+      carouselStatus:
+        carousel?.querySelector(".jh-comparison-screenshot-carousel__status")?.textContent?.trim() ?? "",
       pageOverflows: document.documentElement.scrollWidth > window.innerWidth,
       summaryClientWidth: summary?.clientWidth ?? 0,
       summaryScrollWidth: summary?.scrollWidth ?? 0,
+      viewportHeight: window.innerHeight,
+      viewportWidth: window.innerWidth,
     };
   });
   const cardsStack = comparisonMobile.cards.length === 3
@@ -744,16 +878,23 @@ try {
     || comparisonMobile.pageOverflows
     || comparisonMobile.summaryScrollWidth <= comparisonMobile.summaryClientWidth + 80
     || afterArrow <= beforeArrow
+    || comparisonMobile.carouselImageCount !== 1
+    || comparisonMobile.carouselStatus !== "2 of 2"
+    || !comparisonMobile.carouselImage
+    || comparisonMobile.carouselImage.left < -1
+    || comparisonMobile.carouselImage.right > comparisonMobile.viewportWidth + 1
+    || comparisonMobile.carouselImage.width < 220
+    || comparisonMobile.carouselImage.height > comparisonMobile.viewportHeight * 0.8
   ) {
     fail(
-      `/comparison mobile: cards or keyboard-scroll table regressed (${JSON.stringify({
+      `/comparison mobile: cards, carousel, or keyboard-scroll table regressed (${JSON.stringify({
         ...comparisonMobile,
         beforeArrow,
         afterArrow,
       })})`,
     );
   } else {
-    console.log("ok    /comparison mobile layout and keyboard table scroll");
+    console.log("ok    /comparison mobile layout, screenshot carousel, and keyboard table scroll");
   }
 
   await page.goto(`http://127.0.0.1:${port}/user/data-and-safety`, { waitUntil: "networkidle" });


### PR DESCRIPTION
## What changed

- remove the internal evidence-review eyebrow from the public comparison page
- replace the two-column Jobs and Apply Review screenshot table with a responsive, one-image-at-a-time carousel
- add native Previous and Next controls, position feedback, zoom-compatible keyed images, and mobile-safe sizing
- extend the existing docs runtime regression gate for carousel state, lightbox semantics, and responsive containment

## Why

The side-by-side screenshot layout made both product surfaces difficult to inspect. Showing one image at a time gives each screenshot useful space while preserving the surrounding comparison narrative.

## Validation

- static review gate: PASS with no findings
- `corepack pnpm docs:build` — passed; 5,835 emitted references resolved
- `git diff --check` — passed
- interactive runtime and manual browser QA — intentionally left for maintainer verification