### PR TITLE
docs: link homepage to live demo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,9 @@ hero:
     alt: JobCtrl dashboard showing pipeline progress, job counts, and apply runs
   actions:
     - theme: brand
+      text: Try the Live Demo
+      link: https://demo.jobctrl.dev/
+    - theme: alt
       text: Product Tour
       link: /user/screenshots
     - theme: alt

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -169,6 +169,21 @@ try {
     console.log("ok    / hero image");
   }
 
+  const heroBrandActions = await page.locator(".VPHome .VPHero .actions .VPButton.brand").evaluateAll((actions) =>
+    actions
+      .filter((action) => action.getClientRects().length > 0)
+      .map((action) => ({ text: action.textContent?.trim(), href: action.href })),
+  );
+  if (
+    heroBrandActions.length !== 1 ||
+    heroBrandActions[0]?.text !== "Try the Live Demo" ||
+    heroBrandActions[0]?.href !== "https://demo.jobctrl.dev/"
+  ) {
+    fail(`/: expected one visible brand action for Try the Live Demo, found ${JSON.stringify(heroBrandActions)}`);
+  } else {
+    console.log("ok    / live demo hero action");
+  }
+
   await page.goto(`http://127.0.0.1:${port}/user/screenshots`, { waitUntil: "networkidle" });
   const tourSidebar = await page.locator(".VPSidebar").innerText();
   if (/Developer Guide|System Architecture|API|Reference/.test(tourSidebar)) {


### PR DESCRIPTION
## What changed

- add a primary `Try the Live Demo` hero action that opens `https://demo.jobctrl.dev/`
- keep Product Tour, source/release status, and Developer Guide as secondary actions
- extend the existing docs runtime gate to protect the exact prominent demo action

## Why

The documentation homepage did not give visitors a prominent path into the interactive demo.

## Validation

- static review gate: PASS with no findings
- `corepack pnpm docs:build` — passed; 5,835 emitted references resolved
- `git diff --check` — passed
- interactive runtime and manual browser QA — intentionally left for maintainer verification