### PR TITLE
docs: simplify site footer

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -244,7 +244,6 @@ export default withMermaid(
       sidebar: SIDEBAR,
       socialLinks: [{ icon: "github", link: REPO_URL }],
       footer: {
-        message: "Documentation screenshots and examples use synthetic data unless noted.",
         copyright: `Copyright © 2026 Eloi Barti and JobCtrl contributors. Licensed under <a href="${REPO_URL}/blob/main/LICENSE">AGPL-3.0-only</a>. <a href="${REPO_URL}">Source code</a>.`,
       },
       search: {

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -199,11 +199,12 @@ try {
     console.log("ok    /user/screenshots section outline");
   }
   const footerText = await page.locator(".VPFooter").innerText();
+  const obsoleteFooterMessage = "Documentation screenshots and examples use synthetic data unless noted.";
   if (
     !footerText.includes("Copyright © 2026 Eloi Barti")
     || !footerText.includes("AGPL-3.0-only")
     || !footerText.includes("Source code")
-    || !footerText.includes("synthetic data")
+    || footerText.includes(obsoleteFooterMessage)
   ) {
     fail("/user/screenshots: copyright/license footer is missing or incomplete");
   } else {


### PR DESCRIPTION
## What changed

- remove the redundant synthetic-data sentence from the documentation footer
- keep the copyright, license, and source-code links unchanged
- update the existing runtime assertion so the removed sentence cannot return

## Why

The synthetic-data footer message repeats context already established by the documentation and adds unnecessary visual noise.

## Validation

- static review gate: PASS with no findings
- `corepack pnpm docs:build` — passed; 5,835 emitted references resolved
- `git diff --check` — passed
- interactive runtime and manual browser QA — intentionally left for maintainer verification