### PR TITLE
fix(release): accept standard Ed25519 signing keys

### DIFF
--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -161,6 +161,60 @@ branches. Dispatch the workflow at `refs/tags/<release_tag>` so its own
 the resolver. These environment rules are the server-side defense against a
 modified branch workflow removing the in-workflow identity check:
 
+Generate the JobCtrl Ed25519 release key pair once, outside the repository. This
+key signs JobCtrl manifests and release descriptors; it is separate from the
+Apple Developer ID certificate used to sign macOS executables:
+
+```bash
+release_key_dir="$HOME/.jobctrl-release-secrets"
+(
+  set -euo pipefail
+  umask 077
+  mkdir -p "$release_key_dir"
+  chmod 700 "$release_key_dir"
+  private_pem="$release_key_dir/jobctrl-release-v1.pem"
+  private_der="$release_key_dir/jobctrl-release-v1.pk8"
+  if [[ -e "$private_pem" || -e "$private_der" ]]; then
+    echo "release key already exists; refusing to overwrite it" >&2
+    exit 1
+  fi
+  openssl genpkey -algorithm ED25519 -out "$private_pem"
+  openssl pkey -in "$private_pem" -outform DER -out "$private_der"
+)
+```
+
+Back up both private-key files offline. Never commit them. Copy the canonical
+base64 PKCS#8 DER value for the `JOBCTRL_RELEASE_SIGNING_KEY` environment secret,
+then paste it into `release-signing` before running the next clipboard command:
+
+```bash
+base64 < "$release_key_dir/jobctrl-release-v1.pk8" | tr -d '\n' | pbcopy
+```
+
+Derive and copy the matching raw 32-byte public key for the
+`JOBCTRL_RELEASE_PUBLIC_KEY` environment variable in `release-verification`:
+
+```bash
+node --input-type=module - "$release_key_dir/jobctrl-release-v1.pk8" <<'NODE' | pbcopy
+import { readFileSync } from "node:fs";
+import { createPrivateKey, createPublicKey } from "node:crypto";
+
+const privateDer = readFileSync(process.argv[2]);
+const privateKey = createPrivateKey({ key: privateDer, format: "der", type: "pkcs8" });
+if (privateKey.asymmetricKeyType !== "ed25519") throw new Error("release key is not Ed25519");
+const spki = Buffer.from(createPublicKey(privateKey).export({ format: "der", type: "spki" }));
+const prefix = Buffer.from("302a300506032b6570032100", "hex");
+if (spki.length !== 44 || !spki.subarray(0, prefix.length).equals(prefix)) {
+  throw new Error("unexpected Ed25519 public-key encoding");
+}
+process.stdout.write(spki.subarray(prefix.length).toString("base64"));
+NODE
+```
+
+Set `JOBCTRL_RELEASE_KEY_ID` to `jobctrl-release-v1`. The signing workflow
+derives the public key from the protected private key and fails unless it
+exactly matches the independently protected verification value.
+
 - `release-signing`: `JOBCTRL_RELEASE_SIGNING_KEY`,
   `JOBCTRL_APPLE_DEVELOPER_ID_P12`,
   `JOBCTRL_APPLE_DEVELOPER_ID_PASSWORD`, `JOBCTRL_APPLE_SIGNING_IDENTITY`,

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -172,18 +172,23 @@ release_key_dir="$HOME/.jobctrl-release-secrets"
   umask 077
   mkdir -p "$release_key_dir"
   chmod 700 "$release_key_dir"
-  private_pem="$release_key_dir/jobctrl-release-v1.pem"
   private_der="$release_key_dir/jobctrl-release-v1.pk8"
-  if [[ -e "$private_pem" || -e "$private_der" ]]; then
+  if [[ -e "$private_der" ]]; then
     echo "release key already exists; refusing to overwrite it" >&2
     exit 1
   fi
-  openssl genpkey -algorithm ED25519 -out "$private_pem"
-  openssl pkey -in "$private_pem" -outform DER -out "$private_der"
+  node --input-type=module - "$private_der" <<'NODE'
+import { writeFileSync } from "node:fs";
+import { generateKeyPairSync } from "node:crypto";
+
+const { privateKey } = generateKeyPairSync("ed25519");
+const privateDer = Buffer.from(privateKey.export({ format: "der", type: "pkcs8" }));
+writeFileSync(process.argv[2], privateDer, { flag: "wx", mode: 0o600 });
+NODE
 )
 ```
 
-Back up both private-key files offline. Never commit them. Copy the canonical
+Back up the private-key file offline. Never commit it. Copy the canonical
 base64 PKCS#8 DER value for the `JOBCTRL_RELEASE_SIGNING_KEY` environment secret,
 then paste it into `release-signing` before running the next clipboard command:
 

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -12736,7 +12736,7 @@ function rawPublicKey(publicKey) {
 function privateKeyFromBase64(encoded) {
   invariant4(typeof encoded === "string" && encoded.length > 0 && !/\s/.test(encoded), "release signing key must be non-empty base64 PKCS#8 DER");
   const der = Buffer.from(encoded, "base64");
-  invariant4(der.length > 48 && der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
+  invariant4(der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
   let privateKey;
   try {
     privateKey = createPrivateKey({ key: der, format: "der", type: "pkcs8" });

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-86146e29073cf28703ca5fe07abbbd78668200f205be577b7db39ca9efb07c9a  distribution-homebrew.render.bundle.mjs
+8cc98f95ad62bb3effb4a7e0d3219caf4b34582f31ace87214ae4f6ea36a4e81  distribution-homebrew.render.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.finalizer.bundle.mjs
+++ b/scripts/distribution-release.finalizer.bundle.mjs
@@ -12711,7 +12711,7 @@ function rawPublicKey(publicKey) {
 function privateKeyFromBase64(encoded) {
   invariant4(typeof encoded === "string" && encoded.length > 0 && !/\s/.test(encoded), "release signing key must be non-empty base64 PKCS#8 DER");
   const der = Buffer.from(encoded, "base64");
-  invariant4(der.length > 48 && der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
+  invariant4(der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
   let privateKey;
   try {
     privateKey = createPrivateKey({ key: der, format: "der", type: "pkcs8" });

--- a/scripts/distribution-release.finalizer.bundle.mjs.sha256
+++ b/scripts/distribution-release.finalizer.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-b768f61abf4d28a0d9c8303f33a18b3d835635bc8bfb6a8b0dc2bb2cd1c29bf7  distribution-release.finalizer.bundle.mjs
+9d436a445647ebff5261a38c824b1984fb8e45ab3f70847188f98571388b8eb1  distribution-release.finalizer.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.mjs
+++ b/scripts/distribution-release.mjs
@@ -334,7 +334,7 @@ function rawPublicKey(publicKey) {
 export function privateKeyFromBase64(encoded) {
   invariant(typeof encoded === "string" && encoded.length > 0 && !/\s/.test(encoded), "release signing key must be non-empty base64 PKCS#8 DER");
   const der = Buffer.from(encoded, "base64");
-  invariant(der.length > 48 && der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
+  invariant(der.toString("base64") === encoded, "release signing key must be canonical base64 PKCS#8 DER");
   let privateKey;
   try {
     privateKey = createPrivateKey({ key: der, format: "der", type: "pkcs8" });

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -24,6 +24,7 @@ import {
   createAppleSigningPlan,
   notarizeAndStaplePayload,
   publishedCandidateSmokePlan,
+  privateKeyFromBase64,
   renderPinnedInstallScript,
   recordPublishedCandidateSmoke,
   releasePublicKeyBase64,
@@ -39,6 +40,28 @@ import {
 
 const sha256 = (value) => createHash("sha256").update(value).digest("hex");
 const execFileAsync = promisify(execFile);
+
+test("release signing accepts standard canonical Ed25519 PKCS#8 DER", () => {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const privateKeyDer = Buffer.from(privateKey.export({ format: "der", type: "pkcs8" }));
+  const publicKeyDer = Buffer.from(publicKey.export({ format: "der", type: "spki" }));
+  const encodedPrivateKey = privateKeyDer.toString("base64");
+
+  assert.equal(privateKeyDer.length, 48, "the standard Ed25519 PKCS#8 encoding is 48 bytes");
+  const importedPrivateKey = privateKeyFromBase64(encodedPrivateKey);
+  assert.equal(importedPrivateKey.asymmetricKeyType, "ed25519");
+  assert.equal(
+    releasePublicKeyBase64(importedPrivateKey),
+    publicKeyDer.subarray(12).toString("base64"),
+  );
+
+  assert.throws(() => privateKeyFromBase64(`${encodedPrivateKey}\n`), /non-empty base64 PKCS#8 DER/);
+  assert.throws(() => privateKeyFromBase64(`${encodedPrivateKey}=`), /canonical base64 PKCS#8 DER/);
+  assert.throws(() => privateKeyFromBase64(Buffer.from("not a DER key").toString("base64")), /Ed25519 PKCS#8 DER key/);
+  const { privateKey: ecPrivateKey } = generateKeyPairSync("ec", { namedCurve: "prime256v1" });
+  const ecPrivateKeyBase64 = Buffer.from(ecPrivateKey.export({ format: "der", type: "pkcs8" })).toString("base64");
+  assert.throws(() => privateKeyFromBase64(ecPrivateKeyBase64), /release signing key must be Ed25519/);
+});
 
 test("tracked release-authority bundles are byte-reproducible with pinned esbuild", async (context) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "jobctrl-finalizer-rebuild-"));
@@ -88,6 +111,14 @@ test("tracked release-authority bundles dispatch exactly one intended CLI", asyn
   );
   assert.equal(typeof importedFinalizer.privateKeyFromBase64, "function");
   assert.equal(typeof importedFinalizer.releasePublicKeyBase64, "function");
+  const bundledPrivateKeyDer = Buffer.from(
+    generateKeyPairSync("ed25519").privateKey.export({ format: "der", type: "pkcs8" }),
+  );
+  assert.equal(bundledPrivateKeyDer.length, 48);
+  assert.equal(
+    importedFinalizer.privateKeyFromBase64(bundledPrivateKeyDer.toString("base64")).asymmetricKeyType,
+    "ed25519",
+  );
   const pointerPath = path.join(root, "channel-pointer.json");
   const pointerRun = await execFileAsync(
     process.execPath,


### PR DESCRIPTION
## What changed

- accept canonical Ed25519 PKCS#8 DER private keys based on cryptographic parsing and key type instead of an invalid minimum-length heuristic
- add regression coverage for the standard 48-byte encoding on both the source module and the sealed finalizer used by the signing job
- regenerate both audited release-authority bundles and their checksums
- document fail-safe one-time key generation, private-secret encoding, and matching raw public-key derivation

## Root cause

Standard OpenSSL and Node Ed25519 PKCS#8 DER exports are 48 bytes. The release parser required the decoded key to be greater than 48 bytes before attempting PKCS#8 parsing, so a valid key generated by the documented toolchain could never reach the cryptographic validation. The owner checklist also named the private and public values without explaining how to generate a matching pair.

## Validation

- `node --test scripts/distribution-release.test.mjs` — 22 passed
- operator key-generation QA — 48-byte PKCS#8 accepted, matching 32-byte public key derived, second generation refused without overwrite
- `corepack pnpm scripts:test` — 102 passed
- `corepack pnpm distribution:audit` — passed
- `python3 scripts/release_check.py --strict-prompt` — passed
- `corepack pnpm docs:build` — passed
- `corepack pnpm docs:check:runtime` — passed
- `corepack pnpm check` — passed

No Apple, App Store Connect, or JobCtrl release credentials are included in this changeset.
