### PR TITLE
fix(codex): reuse existing CLI authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,10 +332,10 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 - `chrome-workers/`, `apply-workers/` — local browser/apply worker state.
 - `codex_home/` — JobCtrl-owned Codex home for local analysis. Setup and the
   first generation retain one-time reuse of a valid regular Codex CLI login;
-  Settings verification invokes the same safe reuse path. A candidate is
-  verified in private staging before publication, never overwrites existing
-  isolated auth, and never changes the normal Codex home. Prompt-driven
-  commands run from `codex_home/workspace/` only.
+  Settings verification invokes the same copy-once behavior before checking
+  the isolated login. Existing isolated auth is not overwritten, and the normal
+  Codex home is not changed. Prompt-driven commands run from
+  `codex_home/workspace/` only.
 - `backups/` — source-mode `jobctrl backup` snapshots and, once the P6-signed
   bundled channel is public, verified paired lifecycle snapshots.
 
@@ -539,9 +539,8 @@ Keychain output.
 - `JOBCTRL_DIR` — override the local app directory.
 - `ANTHROPIC_API_KEY` or a supported Claude cloud-provider route — Claude.
 - `$JOBCTRL_DIR/codex_home/auth.json` — Codex; setup, first generation, or the
-  Settings verify action can safely reuse an existing normal Codex CLI login
-  once. Failed or expired candidates are not published, and existing isolated
-  auth is never overwritten. If there is no reusable login, authenticate this
+  Settings verify action can copy an existing valid normal Codex CLI login
+  once. Existing isolated auth is not overwritten. If there is no reusable login, authenticate this
   isolated home with a ChatGPT subscription or enroll an API key through
   `codex login --with-api-key`. Raw OpenAI keys are not used directly.
 - `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or Vertex AI ADC — Google.

--- a/README.md
+++ b/README.md
@@ -330,9 +330,12 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 - `tailored_resumes/`, `cover_letters/`, `logs/` — generated artifacts and
   logs.
 - `chrome-workers/`, `apply-workers/` — local browser/apply worker state.
-- `codex_home/` — JobCtrl-owned Codex home for local analysis. The adapter
-  copies Codex auth here from the user's regular Codex home and runs
-  prompt-driven commands from `codex_home/workspace/` only.
+- `codex_home/` — JobCtrl-owned Codex home for local analysis. Setup and the
+  first generation retain one-time reuse of a valid regular Codex CLI login;
+  Settings verification invokes the same safe reuse path. A candidate is
+  verified in private staging before publication, never overwrites existing
+  isolated auth, and never changes the normal Codex home. Prompt-driven
+  commands run from `codex_home/workspace/` only.
 - `backups/` — source-mode `jobctrl backup` snapshots and, once the P6-signed
   bundled channel is public, verified paired lifecycle snapshots.
 
@@ -506,7 +509,8 @@ locally. Start with [.env.example](.env.example); full reference:
 
 The cross-platform provider-credential path is the plaintext
 `~/.jobctrl/.env` file or the process environment. On macOS, **Settings →
-Credentials** guides one of three providers: authenticated Codex CLI, Claude
+Credentials** guides one of three providers: an existing authenticated Codex
+CLI reused into JobCtrl's isolated home (or fallback target-home login), Claude
 Agent SDK (Anthropic API key or supported cloud-provider credentials), or
 Google (Gemini key or Vertex AI ADC). One ready provider is sufficient for all
 core AI stages; a second provider is optional. After a provider is ready,
@@ -534,9 +538,12 @@ Keychain output.
 
 - `JOBCTRL_DIR` — override the local app directory.
 - `ANTHROPIC_API_KEY` or a supported Claude cloud-provider route — Claude.
-- `$JOBCTRL_DIR/codex_home/auth.json` — Codex; authenticate it with a ChatGPT
-  subscription or enroll an API key through `codex login --with-api-key`.
-  Raw OpenAI keys are not used directly.
+- `$JOBCTRL_DIR/codex_home/auth.json` — Codex; setup, first generation, or the
+  Settings verify action can safely reuse an existing normal Codex CLI login
+  once. Failed or expired candidates are not published, and existing isolated
+  auth is never overwritten. If there is no reusable login, authenticate this
+  isolated home with a ChatGPT subscription or enroll an API key through
+  `codex login --with-api-key`. Raw OpenAI keys are not used directly.
 - `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or Vertex AI ADC — Google.
 - `JOBCTRL_ANALYSIS_LEGS` — comma-separated enabled analysis legs when setup
   intentionally skips an unauthenticated leg.

--- a/apps/api/test/credential-docs-contract.test.ts
+++ b/apps/api/test/credential-docs-contract.test.ts
@@ -44,7 +44,9 @@ describe("credential and browser privacy documentation contract", () => {
     expect(runtime).toContain("A batch either applies completely or restores its pre-change Keychain state");
     expect(runtime).toContain("`configured` state is `true`, `false`, or `null`");
     expect(runtime).toContain("Secret values used internally for rollback are never returned, logged, persisted in SQLite, or passed to Python by the API");
-    expect(runtime).toContain("`POST /v1/providers/codex/verify` runs `codex login status`");
+    expect(runtime).toContain("then runs `codex login status` without generating model output");
+    expect(runtime).toContain("same safe one-time importer used by setup and generation");
+    expect(runtime).toContain("It is read-only and never copies ambient Codex auth");
     expect(runtime).toContain("performs a non-interactive Keychain lookup only for a missing or empty value");
     expect(runtime).toContain("copied only into that process's environment");
     expect(runtime).toContain("There is no hot reload");
@@ -54,6 +56,8 @@ describe("credential and browser privacy documentation contract", () => {
     expect(completeApi).toContain("private batch snapshots are used only for compensating rollback, not provider runtime");
     expect(completeApi).toContain("`unavailableReason` as `unsupported_platform`, `inspection_failed`, or `null`");
     expect(completeApi).toContain("`503 credential_store_unavailable` with a sanitized operational or rollback failure reason");
+    expect(completeApi).toContain("is the explicit mutation that may validate and copy a reusable normal Codex CLI `auth.json` once");
+    expect(completeApi).toContain("It is read-only and never copies ambient Codex auth");
   });
 
   it("preserves owner-signoff state for credential claims", () => {

--- a/apps/api/test/credential-docs-contract.test.ts
+++ b/apps/api/test/credential-docs-contract.test.ts
@@ -45,7 +45,7 @@ describe("credential and browser privacy documentation contract", () => {
     expect(runtime).toContain("`configured` state is `true`, `false`, or `null`");
     expect(runtime).toContain("Secret values used internally for rollback are never returned, logged, persisted in SQLite, or passed to Python by the API");
     expect(runtime).toContain("then runs `codex login status` without generating model output");
-    expect(runtime).toContain("same safe one-time importer used by setup and generation");
+    expect(runtime).toContain("same copy-once behavior used by setup");
     expect(runtime).toContain("It is read-only and never copies ambient Codex auth");
     expect(runtime).toContain("performs a non-interactive Keychain lookup only for a missing or empty value");
     expect(runtime).toContain("copied only into that process's environment");
@@ -56,7 +56,7 @@ describe("credential and browser privacy documentation contract", () => {
     expect(completeApi).toContain("private batch snapshots are used only for compensating rollback, not provider runtime");
     expect(completeApi).toContain("`unavailableReason` as `unsupported_platform`, `inspection_failed`, or `null`");
     expect(completeApi).toContain("`503 credential_store_unavailable` with a sanitized operational or rollback failure reason");
-    expect(completeApi).toContain("is the explicit mutation that may validate and copy a reusable normal Codex CLI `auth.json` once");
+    expect(completeApi).toContain("is the explicit mutation that may validate");
     expect(completeApi).toContain("It is read-only and never copies ambient Codex auth");
   });
 

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
@@ -3,6 +3,7 @@ import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import type { ApiClientPort } from "../../../shared/ports/ApiClientPort.js";
+import type { FeatureFlagPort } from "../../../shared/ports/index.js";
 
 import {
   sampleCredentialsResponse,
@@ -147,7 +148,7 @@ describe("<CredentialsPanel>", () => {
       .mockRejectedValueOnce(new Error("private-token-must-not-render"));
     renderPanel({ verifyCodexProvider });
     const card = await providerCard("Codex");
-    const button = within(card).getByRole("button", { name: "Verify connection" });
+    const button = within(card).getByRole("button", { name: "Reuse existing login or verify" });
 
     await user.click(button);
     expect(await within(card).findByText("Codex CLI authentication is ready.")).toBeInTheDocument();
@@ -216,44 +217,116 @@ describe("<CredentialsPanel>", () => {
     expect(updateCredentialsBatch).toHaveBeenCalledWith(removeGoogleProviderBatch());
   });
 
-  it("renders guidance without secret inputs when Keychain is unavailable", async () => {
+  it.each([
+    ["unsupported_platform", /available only with macOS Keychain/i],
+    ["inspection_failed", /could not safely inspect Keychain/i],
+  ] as const)("keeps Codex actionable when Keychain reports %s", async (reason, notice) => {
+    const verifyCodexProvider = vi.fn(async () => ({
+      ok: true as const,
+      verification: {
+        provider: "codex" as const,
+        ok: false,
+        status: "not_configured" as const,
+        message: "Codex CLI is not authenticated.",
+      },
+    }));
     renderPanel({
       credentials: vi.fn(async () => ({
         ...sampleCredentialsResponse,
         store: {
           ...sampleCredentialsResponse.store,
           available: false,
-          unavailableReason: "unsupported_platform" as const,
+          unavailableReason: reason,
         },
+        credentials: sampleCredentialsResponse.credentials.map((credential) => ({
+          ...credential,
+          configured: null,
+        })),
+      })),
+      verifyCodexProvider,
+    });
+
+    expect(await screen.findByText(notice)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/API key/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Set GEMINI_API_KEY/i)).toBeInTheDocument();
+    const codex = await providerCard("Codex");
+    await userEvent.setup().click(
+      within(codex).getByRole("button", { name: "Reuse existing login or verify" }),
+    );
+    expect(verifyCodexProvider).toHaveBeenCalledOnce();
+    const privacy = within(screen.getByRole("region", { name: "Credential privacy" }));
+    if (reason === "inspection_failed") {
+      expect(screen.getByText(/guided Claude and Google editing/i)).toBeInTheDocument();
+      expect(screen.getByText(/Codex verification remains available/i)).toBeInTheDocument();
+      expect(privacy.getByText("Keychain status unavailable")).toBeInTheDocument();
+    } else {
+      expect(privacy.getByText("Process environment")).toBeInTheDocument();
+      expect(privacy.queryByText(/macOS Keychain/i)).not.toBeInTheDocument();
+    }
+  });
+
+  it("labels isolated auth accurately when the managed SDK is unavailable", async () => {
+    renderPanel({
+      providerStatus: vi.fn(async () => ({
+        ok: true as const,
+        providers: [
+          {
+            provider: "codex" as const,
+            configured: true,
+            ready: false,
+            mode: "cli_auth",
+            message: "Codex CLI auth is configured but the managed SDK runtime is unavailable",
+          },
+        ],
       })),
     });
 
-    expect(await screen.findByText(/available only with macOS Keychain/i)).toBeInTheDocument();
-    expect(screen.queryByLabelText(/API key/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/Set GEMINI_API_KEY/i)).toBeInTheDocument();
-    expect(screen.getByText(/jobctrl doctor/i)).toBeInTheDocument();
+    const codex = await providerCard("Codex");
+    expect(within(codex).getByText("Authenticated · runtime unavailable")).toBeInTheDocument();
+    expect(within(codex).getByRole("button", { name: "Verify isolated login" })).toBeEnabled();
+    expect(within(codex).queryByRole("button", { name: /Use existing login/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps the public demo read-only with no host verification action", async () => {
+    renderPanel({}, { demo: true });
+
+    expect(await screen.findByText(/public demo never accepts/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Codex" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /login|verify/i })).not.toBeInTheDocument();
   });
 });
 
-function renderPanel(api: Partial<ApiClientPort> = {}) {
+class DemoFeatureFlags implements FeatureFlagPort {
+  get<T extends boolean | number | string>(key: string, defaultValue: T): T {
+    return (key === "demoMode" ? true : defaultValue) as T;
+  }
+}
+
+function renderPanel(
+  api: Partial<ApiClientPort> = {},
+  options: { demo?: boolean } = {},
+) {
+  const ports = buildTestPorts({
+    api: {
+      credentials: vi.fn(async () => sampleCredentialsResponse),
+      providerStatus: vi.fn(async () => sampleProviderStatusResponse),
+      updateCredentialsBatch: vi.fn(async () => sampleCredentialsResponse),
+      verifyCodexProvider: vi.fn(async () => ({
+        ok: true as const,
+        verification: {
+          provider: "codex" as const,
+          ok: true,
+          status: "connected" as const,
+          message: "Codex CLI authentication is ready.",
+        },
+      })),
+      ...api,
+    },
+  });
   return renderWithProviders(<CredentialsPanel />, {
-    ports: buildTestPorts({
-      api: {
-        credentials: vi.fn(async () => sampleCredentialsResponse),
-        providerStatus: vi.fn(async () => sampleProviderStatusResponse),
-        updateCredentialsBatch: vi.fn(async () => sampleCredentialsResponse),
-        verifyCodexProvider: vi.fn(async () => ({
-          ok: true as const,
-          verification: {
-            provider: "codex" as const,
-            ok: true,
-            status: "connected" as const,
-            message: "Codex CLI authentication is ready.",
-          },
-        })),
-        ...api,
-      },
-    }),
+    ports: options.demo
+      ? { ...ports, featureFlags: new DemoFeatureFlags() }
+      : ports,
   });
 }
 

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
@@ -42,6 +42,7 @@ export function CredentialsPanel() {
     keys.some((key) => credentials.find((entry) => entry.key === key)?.configured === true);
   const claudeConfigured = configured(CLAUDE_KEYS);
   const googleConfigured = configured(GOOGLE_KEYS);
+  const codexStatus = findStatus(statuses, "codex");
   const claudeStatus = findStatus(statuses, "claude");
   const googleStatus = findStatus(statuses, "google");
   const claudeCurrentMode = inferConfiguredMode(
@@ -73,46 +74,56 @@ export function CredentialsPanel() {
         />
         {!store ? (
           <div className="empty" role="status">Checking provider setup.</div>
-        ) : store.available ? (
+        ) : (
           <div className="provider-card-list">
             <ProviderCard
-              description="Uses the authenticated Codex CLI in JobCtrl's isolated Codex home. JobCtrl does not accept a raw OpenAI key."
+              description="Reuses an already authenticated normal Codex CLI first, then verifies it in JobCtrl's isolated Codex home. JobCtrl does not accept a raw OpenAI key."
               provider="codex"
-              status={findStatus(statuses, "codex")}
+              status={codexStatus}
               title="Codex"
             >
               <CodexProviderSetup
-                legacyOpenAiKeyConfigured={configured(["OPENAI_API_KEY"])}
+                isolatedAuthDetected={codexStatus?.mode === "cli_auth"}
+                legacyOpenAiKeyConfigured={
+                  store.available && configured(["OPENAI_API_KEY"])
+                }
               />
             </ProviderCard>
-            <ProviderCard
-              description="Choose one direct or third-party Claude Agent SDK authentication route."
-              provider="claude"
-              status={mergeConfiguredStatus("claude", claudeStatus, claudeConfigured)}
-              title="Claude"
-            >
-              <ClaudeProviderForm
-                configured={claudeConfigured}
-                currentMode={claudeCurrentMode}
+            {store.available ? (
+              <>
+                <ProviderCard
+                  description="Choose one direct or third-party Claude Agent SDK authentication route."
+                  provider="claude"
+                  status={mergeConfiguredStatus("claude", claudeStatus, claudeConfigured)}
+                  title="Claude"
+                >
+                  <ClaudeProviderForm
+                    configured={claudeConfigured}
+                    currentMode={claudeCurrentMode}
+                  />
+                </ProviderCard>
+                <ProviderCard
+                  description="Use a Gemini API key or Google Vertex AI with Application Default Credentials."
+                  provider="google"
+                  status={mergeConfiguredStatus("google", googleStatus, googleConfigured)}
+                  title="Google"
+                >
+                  <GoogleProviderForm
+                    configured={googleConfigured}
+                    currentMode={googleCurrentMode}
+                  />
+                </ProviderCard>
+              </>
+            ) : (
+              <ReadOnlyProviderGuidance
+                includeCodex={false}
+                reason={store.unavailableReason}
               />
-            </ProviderCard>
-            <ProviderCard
-              description="Use a Gemini API key or Google Vertex AI with Application Default Credentials."
-              provider="google"
-              status={mergeConfiguredStatus("google", googleStatus, googleConfigured)}
-              title="Google"
-            >
-              <GoogleProviderForm
-                configured={googleConfigured}
-                currentMode={googleCurrentMode}
-              />
-            </ProviderCard>
+            )}
           </div>
-        ) : (
-          <ReadOnlyProviderGuidance reason={store.unavailableReason} />
         )}
       </section>
-      <CredentialPrivacyNotice />
+      <CredentialPrivacyNotice store={store} />
     </>
   );
 }
@@ -142,14 +153,14 @@ function ProviderSetupNotice({
   if (store.unavailableReason === "inspection_failed") {
     return (
       <div className="banner credential-store-notice credential-store-notice--failure" role="alert">
-        JobCtrl could not safely inspect Keychain. Unlock Keychain Access, then reload this page before changing provider setup.
+        JobCtrl could not safely inspect Keychain. Unlock Keychain Access, then reload before changing Claude or Google setup. Codex verification remains available.
       </div>
     );
   }
   return (
     <div className="banner credential-store-notice credential-store-notice--guidance">
       <span>
-        Provider settings saved here stay in macOS Keychain. Restart JobCtrl after a change so its API provider process and worker reload Keychain values.
+        Claude and Google settings saved here stay in macOS Keychain. Restart JobCtrl after a change so its API provider process and worker reload Keychain values.
       </span>
       {providerStatusError ? (
         <span className="provider-status-warning" role="status">
@@ -175,9 +186,11 @@ function ProviderCard({
 }) {
   const statusLabel = status?.ready
     ? "Ready"
-    : status?.configured
-      ? "Configured · restart or verify"
-      : "Not configured";
+    : provider === "codex" && status?.mode === "cli_auth"
+      ? "Authenticated · runtime unavailable"
+      : status?.configured
+        ? "Configured · restart or verify"
+        : "Not configured";
   return (
     <article className="provider-card" data-provider={provider}>
       <header className="provider-card-header">
@@ -194,7 +207,13 @@ function ProviderCard({
   );
 }
 
-function CodexProviderSetup({ legacyOpenAiKeyConfigured }: { legacyOpenAiKeyConfigured: boolean }) {
+function CodexProviderSetup({
+  isolatedAuthDetected,
+  legacyOpenAiKeyConfigured,
+}: {
+  isolatedAuthDetected: boolean;
+  legacyOpenAiKeyConfigured: boolean;
+}) {
   const verify = useVerifyCodexProviderMutation();
   const removeLegacyKey = useUpdateCredentialsBatchMutation();
   const [legacyMessage, setLegacyMessage] = useState("");
@@ -217,13 +236,27 @@ function CodexProviderSetup({ legacyOpenAiKeyConfigured }: { legacyOpenAiKeyConf
     <div className="provider-form codex-provider-setup">
       <div className="codex-auth-options">
         <section>
-          <h4>ChatGPT subscription or device login</h4>
-          <p>Authenticate the Codex CLI into JobCtrl's stable, isolated Codex home.</p>
+          <h4>Use an existing Codex CLI login first</h4>
+          <p>
+            Click the action below to validate an already authenticated normal
+            Codex CLI login and import it once into JobCtrl's stable, isolated
+            home. It does not change your normal Codex home.
+          </p>
+        </section>
+        <section>
+          <h4>Fallback: ChatGPT subscription or device login</h4>
+          <p>
+            If there is no existing login to reuse, authenticate the Codex CLI
+            into JobCtrl's stable, isolated Codex home.
+          </p>
           <code>{CODEX_LOGIN_COMMANDS.subscription}</code>
         </section>
         <section>
-          <h4>OpenAI API key enrollment</h4>
-          <p>Pipe your existing shell key directly into Codex. JobCtrl never receives or stores the raw key.</p>
+          <h4>Fallback: OpenAI API key enrollment</h4>
+          <p>
+            If there is no existing login to reuse, pipe your existing shell key
+            directly into Codex. JobCtrl never receives or stores the raw key.
+          </p>
           <code>{CODEX_LOGIN_COMMANDS.apiKey}</code>
         </section>
       </div>
@@ -252,7 +285,11 @@ function CodexProviderSetup({ legacyOpenAiKeyConfigured }: { legacyOpenAiKeyConf
           type="button"
           onClick={() => verify.mutate()}
         >
-          {verify.isPending ? "Verifying…" : "Verify connection"}
+          {verify.isPending
+            ? "Verifying…"
+            : isolatedAuthDetected
+              ? "Verify isolated login"
+              : "Reuse existing login or verify"}
         </button>
         <div
           aria-live="polite"
@@ -267,23 +304,30 @@ function CodexProviderSetup({ legacyOpenAiKeyConfigured }: { legacyOpenAiKeyConf
   );
 }
 
-function ReadOnlyProviderGuidance({ reason }: { reason: "inspection_failed" | "unsupported_platform" | null }) {
+function ReadOnlyProviderGuidance({
+  includeCodex = true,
+  reason,
+}: {
+  includeCodex?: boolean;
+  reason: "inspection_failed" | "unsupported_platform" | null;
+}) {
+  const providers = [
+    ["Codex", "Authenticate the isolated Codex CLI home from a terminal, then verify it with jobctrl doctor or the Codex CLI status command."],
+    ["Claude", "Set one supported Claude SDK authentication route in the worker environment."],
+    ["Google", "Set GEMINI_API_KEY or configure Vertex AI Application Default Credentials in the worker environment."],
+  ].filter(([title]) => includeCodex || title !== "Codex");
   return (
-    <div className="provider-card-list">
-      {[
-        ["Codex", "Authenticate the isolated Codex CLI home from a terminal, then verify it with jobctrl doctor or the Codex CLI status command."],
-        ["Claude", "Set one supported Claude SDK authentication route in the worker environment."],
-        ["Google", "Set GEMINI_API_KEY or configure Vertex AI Application Default Credentials in the worker environment."],
-      ].map(([title, copy]) => (
+    <>
+      {providers.map(([title, copy]) => (
         <article className="provider-card provider-card--readonly" key={title}>
           <h3>{title}</h3>
           <p>{copy}</p>
         </article>
       ))}
       {reason === "inspection_failed" ? (
-        <p className="provider-readonly-summary" role="alert">Keychain inspection must succeed before guided editing is restored.</p>
+        <p className="provider-readonly-summary" role="alert">Keychain inspection must succeed before guided Claude and Google editing is restored.</p>
       ) : null}
-    </div>
+    </>
   );
 }
 
@@ -294,21 +338,41 @@ function DemoProviderSetup() {
       <div className="banner credential-store-notice credential-store-notice--guidance">
         The public demo never accepts, checks, or stores provider secrets. Configure providers only in a local JobCtrl installation.
       </div>
-      <ReadOnlyProviderGuidance reason={null} />
+      <div className="provider-card-list">
+        <ReadOnlyProviderGuidance reason={null} />
+      </div>
     </section>
   );
 }
 
-function CredentialPrivacyNotice() {
+function CredentialPrivacyNotice({
+  store,
+}: {
+  store?: CredentialsResponse["store"] | undefined;
+}) {
+  const boundaryCopy = store?.available
+    ? "Claude and Google values saved here stay on this Mac in Keychain."
+    : store?.unavailableReason === "unsupported_platform"
+      ? "Claude and Google credentials are configured through the worker environment on this platform."
+      : store?.unavailableReason === "inspection_failed"
+        ? "Claude and Google Keychain state is unavailable until inspection succeeds."
+        : "Provider credential storage status is loading.";
+  const boundaryBadge = store?.available
+    ? "macOS Keychain"
+    : store?.unavailableReason === "unsupported_platform"
+      ? "Process environment"
+      : store?.unavailableReason === "inspection_failed"
+        ? "Keychain status unavailable"
+        : "Storage status loading";
   return (
     <section aria-label="Credential privacy" className="privacy-box">
       <h2>Your provider data stays private</h2>
       <p className="privacy-box-copy">
-        Values saved here stay on this Mac in Keychain. They are never returned by the API, stored in SQLite, placed in URLs, or written to logs, traces, and generated artifacts. Cloud credential files remain managed by their vendor CLIs.
+        {boundaryCopy} Codex authentication stays in JobCtrl's isolated filesystem home. Credentials are never returned by the API, stored in SQLite, placed in URLs, or written to logs, traces, and generated artifacts. Cloud credential files remain managed by their vendor CLIs.
       </p>
       <div className="privacy-box-tags">
         <Badge>Local only</Badge>
-        <Badge>macOS Keychain</Badge>
+        <Badge>{boundaryBadge}</Badge>
         <Badge>Never in logs</Badge>
         <Badge>Worker restart required</Badge>
       </div>

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1147,10 +1147,16 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   the change.
 - `GET /v1/providers/status` returns sanitized status for exactly Codex,
   Claude, and Google: `configured`, `ready`, detected `mode`, and a bounded
-  secret-free message. `POST /v1/providers/codex/verify` runs the isolated
-  Codex CLI's `login status` command without making a generation request and
-  returns `connected`, `not_configured`, or `failed`. RPC errors and malformed
-  provider responses become sanitized `502`/`503` provider-operation errors.
+  secret-free message. It is read-only and never copies ambient Codex auth.
+  `POST /v1/providers/codex/verify` is the explicit mutation that may validate
+  and copy a reusable normal Codex CLI `auth.json` once when isolated auth is
+  absent, then runs the isolated Codex CLI's `login status` command without
+  making a generation request. This is the same staged, no-replace importer
+  retained by setup and generation: failed candidates are not published,
+  existing isolated auth is never overwritten, and the normal Codex home is
+  unchanged. The response contains only secret-free `connected`,
+  `not_configured`, or `failed` results. RPC errors and malformed provider
+  responses become sanitized `502`/`503` provider-operation errors.
 - `GET /v1/providers/models` returns `{ok: true, providers}` in stable Codex,
   Claude, Google order. Each item includes `provider`, `configured`, `ready`,
   `source`, `models`, and an optional bounded status message. Unready providers
@@ -1158,9 +1164,10 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   (`source: "live"`); ready Claude returns `sonnet`, `opus`, and `haiku` with
   `source: "provider_aliases"`. Model entries expose only `id`, `displayName`,
   and optional `isDefault`; account, auth, path, and secret metadata never
-  cross the JSON-RPC/API boundary. A preferred-model patch returns `409` when
-  its provider is not ready, `400` when the ID is not offered, and sanitized
-  `503` when validation cannot obtain a live catalog.
+  cross the JSON-RPC/API boundary. It is read-only and never copies ambient
+  Codex auth. A preferred-model patch returns `409` when its provider is not
+  ready, `400` when the ID is not offered, and sanitized `503` when validation
+  cannot obtain a live catalog.
 - `GET /v1/extension/pairing-token` returns the local browser-extension
   capability token for the Settings pairing surface; `POST
   /v1/extension/pairing-token/rotate` replaces it. The token is generated under

--- a/docs/api/complete-contract.md
+++ b/docs/api/complete-contract.md
@@ -1151,10 +1151,9 @@ table; this keeps Dashboard lightweight without imposing an event-history cap.
   `POST /v1/providers/codex/verify` is the explicit mutation that may validate
   and copy a reusable normal Codex CLI `auth.json` once when isolated auth is
   absent, then runs the isolated Codex CLI's `login status` command without
-  making a generation request. This is the same staged, no-replace importer
-  retained by setup and generation: failed candidates are not published,
-  existing isolated auth is never overwritten, and the normal Codex home is
-  unchanged. The response contains only secret-free `connected`,
+  making a generation request. This is the same copy-once behavior retained by
+  setup and generation: existing isolated auth is not overwritten, and the
+  normal Codex home is unchanged. The response contains only secret-free `connected`,
   `not_configured`, or `failed` results. RPC errors and malformed provider
   responses become sanitized `502`/`503` provider-operation errors.
 - `GET /v1/providers/models` returns `{ok: true, providers}` in stable Codex,

--- a/docs/api/profile-and-settings.md
+++ b/docs/api/profile-and-settings.md
@@ -42,9 +42,9 @@ enter the system. They do not hold provider credentials or raw feed contents.
 | `PATCH /v1/credentials` | Store or replace a credential through the local credential adapter. |
 | `PATCH /v1/credentials/batch` | Atomically replace or remove one guided provider configuration. |
 | `DELETE /v1/credentials/:key` | Remove a stored credential. |
-| `GET /v1/providers/status` | Sanitized Codex/Claude/Google configuration and readiness. |
-| `GET /v1/providers/models` | Sanitized model choices in stable Codex/Claude/Google order. Codex and Google are live; Claude is explicitly provider aliases. |
-| `POST /v1/providers/codex/verify` | Verify isolated Codex CLI auth without a model call. |
+| `GET /v1/providers/status` | Read-only sanitized Codex/Claude/Google configuration and readiness; never copies ambient Codex auth. |
+| `GET /v1/providers/models` | Read-only sanitized model choices in stable Codex/Claude/Google order; never copies ambient Codex auth. Codex and Google are live; Claude is explicitly provider aliases. |
+| `POST /v1/providers/codex/verify` | Explicitly validate and import a reusable normal Codex CLI `auth.json` once when isolated auth is absent, then verify isolated auth without a model call. |
 | `GET /v1/extension/pairing-token` | Read the local extension pairing state. |
 
 Credential responses expose enough state for the UI to show whether a provider
@@ -52,6 +52,12 @@ is configured, but do not return stored secret material. Guided provider
 replacement rolls back on failure; an unrecoverable rollback is reported as an
 explicit sanitized store failure. See the
 [Security guide](../user/security.md) for the user-facing trust boundary.
+
+The Codex verify response remains secret-free: it reports only provider,
+boolean result, bounded status, and a bounded message. The explicit import
+never overwrites JobCtrl's existing isolated auth or changes the normal Codex
+home. It invokes the same staged, no-replace importer retained by setup and
+generation; a failed candidate is not published.
 
 `PATCH /v1/settings` stores provider-scoped model choices as
 `preferred_models` in `dashboard.json` and returns them as `preferredModels`.

--- a/docs/api/profile-and-settings.md
+++ b/docs/api/profile-and-settings.md
@@ -56,8 +56,7 @@ explicit sanitized store failure. See the
 The Codex verify response remains secret-free: it reports only provider,
 boolean result, bounded status, and a bounded message. The explicit import
 never overwrites JobCtrl's existing isolated auth or changes the normal Codex
-home. It invokes the same staged, no-replace importer retained by setup and
-generation; a failed candidate is not published.
+home. It invokes the same copy-once behavior retained by setup and generation.
 
 `PATCH /v1/settings` stores provider-scoped model choices as
 `preferred_models` in `dashboard.json` and returns them as `preferredModels`.

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -59,9 +59,13 @@ bundled mode Claude accepts API/cloud authentication only, launches with
 credentials. Codex uses persisted CLI authentication in the stable
 `$JOBCTRL_DIR/codex_home`; raw OpenAI keys are accepted only as stdin enrollment
 input to `codex login --with-api-key`, never as a direct runtime credential.
-When isolated auth is absent, setup may copy a regular Codex CLI `auth.json`
-once without overwriting later JobCtrl-owned state. Structured Claude
-analysis/voice calls expose no built-in tools.
+When isolated auth is absent, setup and generation retain safe one-time reuse
+of a regular Codex CLI `auth.json`; the explicit Codex provider verify action
+uses the same importer. It validates the candidate against the pinned Codex
+runtime in private staging before atomic no-replace publication. A failed
+candidate is not published, existing JobCtrl-owned auth is never overwritten,
+and the normal Codex home is unchanged. Structured Claude analysis/voice calls
+expose no built-in tools.
 Codex analysis disables its shell, denies approvals, and gives any command
 child an empty inherited environment, so provider API keys authenticate the SDK
 transport without becoming model-readable tool input.
@@ -374,15 +378,19 @@ is not a runtime secret read performed by the API:
   credential_store_unavailable`. Secret values used internally for rollback are
   never returned, logged, persisted in SQLite, or passed to Python by the API.
 - `GET /v1/providers/status` asks the long-lived JSON-RPC process for sanitized
-  Codex/Claude/Google configuration and readiness. `POST
-  /v1/providers/codex/verify` runs `codex login status` against the isolated
-  home without generating model output. Because Python environment/Keychain
-  loading is process-start scoped, Settings combines fresh presence with the
-  last runtime status and requires a JobCtrl restart before new values become
-  ready.
-- `GET /v1/providers/models` uses the same JSON-RPC boundary. Ready Codex uses
-  the isolated JobCtrl-owned Codex App Server SDK's live `model/list` without
-  shelling out, copying ambient auth, or returning account data. Ready Google
+  Codex/Claude/Google configuration and readiness. It is read-only and never
+  copies ambient Codex auth. `POST /v1/providers/codex/verify` is the explicit
+  Settings action that invokes the same safe one-time importer used by setup
+  and generation, then runs `codex login status` without generating model
+  output. A failed candidate is not published; it never overwrites isolated
+  auth or changes the normal Codex home.
+  Because Python environment/Keychain loading is process-start scoped, Settings
+  combines fresh presence with the last runtime status and requires a JobCtrl
+  restart before new values become ready.
+- `GET /v1/providers/models` uses the same JSON-RPC boundary. It is read-only
+  and never copies ambient Codex auth. Ready Codex uses the isolated
+  JobCtrl-owned Codex App Server SDK's live `model/list` without shelling out
+  or returning account data. Ready Google
   uses the authenticated `google-genai` live model list for Gemini-key or
   Vertex/ADC configuration. Claude returns the SDK's provider-safe `sonnet`,
   `opus`, and `haiku` aliases with `source=provider_aliases`; it does not claim

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -59,13 +59,11 @@ bundled mode Claude accepts API/cloud authentication only, launches with
 credentials. Codex uses persisted CLI authentication in the stable
 `$JOBCTRL_DIR/codex_home`; raw OpenAI keys are accepted only as stdin enrollment
 input to `codex login --with-api-key`, never as a direct runtime credential.
-When isolated auth is absent, setup and generation retain safe one-time reuse
+When isolated auth is absent, setup and generation retain one-time reuse
 of a regular Codex CLI `auth.json`; the explicit Codex provider verify action
-uses the same importer. It validates the candidate against the pinned Codex
-runtime in private staging before atomic no-replace publication. A failed
-candidate is not published, existing JobCtrl-owned auth is never overwritten,
-and the normal Codex home is unchanged. Structured Claude analysis/voice calls
-expose no built-in tools.
+uses the same copy-once behavior before checking the isolated login. Existing
+JobCtrl-owned auth is not overwritten, and the normal Codex home is unchanged.
+Structured Claude analysis/voice calls expose no built-in tools.
 Codex analysis disables its shell, denies approvals, and gives any command
 child an empty inherited environment, so provider API keys authenticate the SDK
 transport without becoming model-readable tool input.
@@ -380,10 +378,9 @@ is not a runtime secret read performed by the API:
 - `GET /v1/providers/status` asks the long-lived JSON-RPC process for sanitized
   Codex/Claude/Google configuration and readiness. It is read-only and never
   copies ambient Codex auth. `POST /v1/providers/codex/verify` is the explicit
-  Settings action that invokes the same safe one-time importer used by setup
+  Settings action that invokes the same copy-once behavior used by setup
   and generation, then runs `codex login status` without generating model
-  output. A failed candidate is not published; it never overwrites isolated
-  auth or changes the normal Codex home.
+  output. It never overwrites isolated auth or changes the normal Codex home.
   Because Python environment/Keychain loading is process-start scoped, Settings
   combines fresh presence with the last runtime status and requires a JobCtrl
   restart before new values become ready.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -150,9 +150,8 @@ JobCtrl uses persisted Codex CLI authentication only. A raw
 route and does not satisfy readiness. If your normal Codex CLI is already
 authenticated, click **Reuse existing login or verify** in **Settings →
 Credentials**. Setup and the first generation retain the same one-time reuse
-behavior. Each path validates the regular CLI `auth.json` against the pinned
-Codex runtime in private staging before publishing it to JobCtrl's stable
-isolated home, without changing the normal Codex home.
+behavior. Each path validates the regular CLI `auth.json` before copying it to
+JobCtrl's stable isolated home, without changing the normal Codex home.
 
 If there is no reusable normal Codex CLI login, fall back to authenticating the
 stable JobCtrl-owned home with a ChatGPT subscription or an API key enrolled
@@ -176,11 +175,10 @@ and [state-location reference](https://learn.chatgpt.com/docs/config-file/config
 
 JobCtrl keeps authentication outside the model-readable
 `codex_home/workspace/` directory. If isolated auth is absent, setup,
-generation, and the Settings verify action use one shared safe importer. It
-publishes only a candidate that passes staged live verification; a failed or
-expired candidate leaves no isolated auth and can be retried after the source
-login is refreshed. It never overwrites an existing isolated login, changes
-the normal Codex home, or creates a transient per-run runtime home.
+generation, and the Settings verify action use one shared copy-once path. It
+never overwrites an existing isolated login, changes the normal Codex home, or
+creates a transient per-run runtime home. Settings then checks the isolated
+login with `codex login status`.
 
 ### Claude
 

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -147,8 +147,16 @@ restart requirement (or require an explicit adapter reset).
 
 JobCtrl uses persisted Codex CLI authentication only. A raw
 `OPENAI_API_KEY` in JobCtrl's environment or Keychain is not a direct model
-route and does not satisfy readiness. Authenticate the stable JobCtrl-owned
-home with either a ChatGPT subscription or an API key enrolled through Codex:
+route and does not satisfy readiness. If your normal Codex CLI is already
+authenticated, click **Reuse existing login or verify** in **Settings →
+Credentials**. Setup and the first generation retain the same one-time reuse
+behavior. Each path validates the regular CLI `auth.json` against the pinned
+Codex runtime in private staging before publishing it to JobCtrl's stable
+isolated home, without changing the normal Codex home.
+
+If there is no reusable normal Codex CLI login, fall back to authenticating the
+stable JobCtrl-owned home with a ChatGPT subscription or an API key enrolled
+through Codex:
 
 ```bash
 CODEX_HOME="${JOBCTRL_DIR:-$HOME/.jobctrl}/codex_home" codex login
@@ -158,17 +166,21 @@ printenv OPENAI_API_KEY | \
   codex login --with-api-key
 ```
 
-`jobctrl setup --launch-logins` uses the bundled Codex runtime for the same
-flow. The Settings card can verify the resulting login without making a model
-call. Codex stores local state under `CODEX_HOME`, and `codex login status`
+`jobctrl setup --launch-logins` uses the bundled Codex runtime for the fallback
+flow. The Settings card can invoke the same reusable-login importer and verify
+the resulting isolated login without making a model call. Codex stores local
+state under `CODEX_HOME`, and `codex login status`
 exits successfully when credentials are present. See the official
 [Codex login command](https://learn.chatgpt.com/docs/developer-commands#codex-login)
 and [state-location reference](https://learn.chatgpt.com/docs/config-file/config-advanced#config-and-state-locations).
 
 JobCtrl keeps authentication outside the model-readable
-`codex_home/workspace/` directory. If isolated auth is absent, setup may copy a
-regular Codex CLI `auth.json` into the stable JobCtrl home once; it never
-overwrites an existing isolated login or creates a transient per-run home.
+`codex_home/workspace/` directory. If isolated auth is absent, setup,
+generation, and the Settings verify action use one shared safe importer. It
+publishes only a candidate that passes staged live verification; a failed or
+expired candidate leaves no isolated auth and can be retried after the source
+login is refreshed. It never overwrites an existing isolated login, changes
+the normal Codex home, or creates a transient per-run runtime home.
 
 ### Claude
 

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -107,9 +107,13 @@ not recorded there.
 
 Open **Settings → Credentials** and configure one provider:
 
-- **Codex:** authenticate JobCtrl's isolated Codex CLI with a ChatGPT
-  subscription or enroll an OpenAI API key through `codex login`. A raw
-  `OPENAI_API_KEY` is not used directly by JobCtrl.
+- **Codex:** setup and first generation safely reuse a valid normal Codex CLI
+  login once, and **Reuse existing login or verify** invokes the same path from
+  Settings. Failed candidates are not published, existing isolated auth is not
+  overwritten, and the normal home is unchanged. If there is no login to reuse,
+  authenticate the isolated home with a ChatGPT subscription or enroll an
+  OpenAI API key through `codex login`. A raw `OPENAI_API_KEY` is not used
+  directly by JobCtrl.
 - **Claude:** use an Anthropic API key or one of the guided Google Vertex,
   Amazon Bedrock, Claude Platform on AWS, or Microsoft Foundry routes.
 - **Google:** use a Gemini API key or Vertex AI Application Default

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -107,9 +107,9 @@ not recorded there.
 
 Open **Settings → Credentials** and configure one provider:
 
-- **Codex:** setup and first generation safely reuse a valid normal Codex CLI
+- **Codex:** setup and first generation copy a valid normal Codex CLI
   login once, and **Reuse existing login or verify** invokes the same path from
-  Settings. Failed candidates are not published, existing isolated auth is not
+  Settings before checking the isolated login. Existing isolated auth is not
   overwritten, and the normal home is unchanged. If there is no login to reuse,
   authenticate the isolated home with a ChatGPT subscription or enroll an
   OpenAI API key through `codex login`. A raw `OPENAI_API_KEY` is not used

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -172,7 +172,7 @@ browser session but remains rate/budget limited. See
 | Secret | Boundary |
 | --- | --- |
 | Provider/runtime keys | Shell, plaintext `~/.jobctrl/.env`, or the guided macOS Keychain boundary; never SQLite. |
-| Codex login | Persisted under JobCtrl's isolated `codex_home`; raw OpenAI keys are enrollment input only. |
+| Codex login | Persisted under JobCtrl's isolated `codex_home`; setup, first generation, and Settings verification share staged validation plus atomic one-time publication from an existing normal login. Failed candidates are not published, existing isolated auth is not overwritten, and the normal home is unchanged. Raw OpenAI keys are enrollment input only. |
 | Claude/Google web entries | Keychain for API keys plus cloud activation flags/non-secret identifiers; AWS, Google, and Azure credential files remain in their vendor stores. Status only is returned. |
 | CAPTCHA key | `CAPSOLVER_API_KEY` read by the owned local solver, not the model. |
 | Job-site passwords | Optional local profile value typed through a focused-field credential tool, never returned to the model. |

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -172,7 +172,7 @@ browser session but remains rate/budget limited. See
 | Secret | Boundary |
 | --- | --- |
 | Provider/runtime keys | Shell, plaintext `~/.jobctrl/.env`, or the guided macOS Keychain boundary; never SQLite. |
-| Codex login | Persisted under JobCtrl's isolated `codex_home`; setup, first generation, and Settings verification share staged validation plus atomic one-time publication from an existing normal login. Failed candidates are not published, existing isolated auth is not overwritten, and the normal home is unchanged. Raw OpenAI keys are enrollment input only. |
+| Codex login | Persisted under JobCtrl's isolated `codex_home`; setup, first generation, and Settings verification can copy valid authentication once from an existing normal login. Existing isolated auth is not overwritten, and the normal home is unchanged. Raw OpenAI keys are enrollment input only. |
 | Claude/Google web entries | Keychain for API keys plus cloud activation flags/non-secret identifiers; AWS, Google, and Azure credential files remain in their vendor stores. Status only is returned. |
 | CAPTCHA key | `CAPSOLVER_API_KEY` read by the owned local solver, not the model. |
 | Job-site passwords | Optional local profile value typed through a focused-field credential tool, never returned to the model. |

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -74,6 +74,8 @@ test("launch provider guidance requires one of Codex, Claude, or Google", async 
   assert.match(configuration, /^### Codex$/m);
   assert.match(configuration, /^### Claude$/m);
   assert.match(configuration, /^### Google$/m);
+  assert.match(gettingStarted, /Reuse existing login or verify/);
+  assert.match(configuration, /validates the regular CLI `auth\.json`.*pinned\s+Codex runtime/s);
   assert.match(configuration, /codex login --with-api-key/);
   assert.match(configuration, /CLAUDE_CODE_USE_BEDROCK/);
   assert.match(configuration, /CLAUDE_CODE_USE_ANTHROPIC_AWS/);

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -75,7 +75,7 @@ test("launch provider guidance requires one of Codex, Claude, or Google", async 
   assert.match(configuration, /^### Claude$/m);
   assert.match(configuration, /^### Google$/m);
   assert.match(gettingStarted, /Reuse existing login or verify/);
-  assert.match(configuration, /validates the regular CLI `auth\.json`.*pinned\s+Codex runtime/s);
+  assert.match(configuration, /validates the regular CLI `auth\.json` before copying it/);
   assert.match(configuration, /codex login --with-api-key/);
   assert.match(configuration, /CLAUDE_CODE_USE_BEDROCK/);
   assert.match(configuration, /CLAUDE_CODE_USE_ANTHROPIC_AWS/);

--- a/workers/automation/src/jobctrl/cli.py
+++ b/workers/automation/src/jobctrl/cli.py
@@ -940,11 +940,13 @@ def setup(
     from jobctrl.config import ensure_dirs, get_env_path, load_env
     from jobctrl.infrastructure.setup_probes import (
         ANALYSIS_LEGS_ENV,
+        CODEX_NEUTRALIZED_AUTH_ENV,
         antigravity_auth_kwargs,
         codex_auth_path,
         enabled_analysis_legs,
         ensure_jobctrl_codex_auth,
         jobctrl_codex_home,
+        prepare_jobctrl_codex_home,
         probe_analysis_setup,
         probe_antigravity_auth,
         probe_claude_auth,
@@ -1080,10 +1082,15 @@ def setup(
                 if dry_run:
                     authenticated_legs.append("codex")
                 else:
+                    try:
+                        prepare_jobctrl_codex_home()
+                    except RuntimeError as exc:
+                        console.print(f"[red]Unsafe JobCtrl Codex home:[/red] {exc}")
+                        raise typer.Exit(code=1) from exc
                     login_env = dict(os.environ)
                     login_env["CODEX_HOME"] = str(jobctrl_codex_home())
-                    login_env.pop("OPENAI_API_KEY", None)
-                    login_env.pop("CODEX_API_KEY", None)
+                    for auth_key in CODEX_NEUTRALIZED_AUTH_ENV:
+                        login_env.pop(auth_key, None)
                     proc = subprocess.run(
                         command,
                         input=stdin,

--- a/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
@@ -37,8 +37,10 @@ from jobctrl.domain.materials.analysis import (
 from jobctrl.infrastructure.analysis.strict_schema import strict_json_schema
 from jobctrl.infrastructure.observability.llm_spans import llm_generation_span
 from jobctrl.infrastructure.setup_probes import (
-    jobctrl_codex_home,
+    CODEX_NEUTRALIZED_AUTH_ENV,
     ensure_jobctrl_codex_auth,
+    ensure_private_directory,
+    jobctrl_codex_home,
     resolve_codex_binary,
 )
 from jobctrl.runtime import is_bundled_runtime
@@ -76,15 +78,6 @@ _CODEX_CONFIG_OVERRIDES = (
     f'default_permissions="{_CODEX_PERMISSION_PROFILE}"',
     _CODEX_PERMISSION_PROFILE_OVERRIDE,
 )
-_CODEX_BUNDLED_NEUTRALIZED_AUTH_ENV = (
-    "OPENAI_API_KEY",
-    "CODEX_ACCESS_TOKEN",
-    "CODEX_AGENT_IDENTITY_AUTH",
-    "CODEX_API_KEY",
-    "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
-    "CODEX_REVOKE_TOKEN_URL_OVERRIDE",
-)
-_CODEX_HOME_DIRNAME = "codex_home"
 _CODEX_WORKSPACE_DIRNAME = "workspace"
 _CODEX_PROCESS_HOME_DIRNAME = "home"
 
@@ -110,15 +103,14 @@ def _prepare_isolated_codex_home(*, ensure_auth: bool = True) -> _CodexHomeDirs:
     """
 
     codex_home = _isolated_codex_home()
-    codex_home.mkdir(mode=0o700, parents=True, exist_ok=True)
-    codex_home.chmod(0o700)
+    if ensure_auth:
+        ensure_jobctrl_codex_auth()
+    ensure_private_directory(codex_home.parent)
+    ensure_private_directory(codex_home, parent=codex_home.parent)
     workdir = codex_home / _CODEX_WORKSPACE_DIRNAME
     process_home = codex_home / _CODEX_PROCESS_HOME_DIRNAME
     for directory in (workdir, process_home):
-        directory.mkdir(mode=0o700, exist_ok=True)
-        directory.chmod(0o700)
-    if ensure_auth:
-        ensure_jobctrl_codex_auth()
+        ensure_private_directory(directory, parent=codex_home)
     return _CodexHomeDirs(
         codex_home=codex_home,
         workdir=workdir,
@@ -132,7 +124,7 @@ def _isolated_codex_env(codex_home: Path, process_home: Path) -> dict[str, str]:
     env = {
         "CODEX_HOME": str(codex_home),
         "HOME": str(process_home),
-        **{key: "" for key in _CODEX_BUNDLED_NEUTRALIZED_AUTH_ENV},
+        **{key: "" for key in CODEX_NEUTRALIZED_AUTH_ENV},
     }
     if os.name == "nt":
         env["USERPROFILE"] = str(process_home)

--- a/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
+++ b/workers/automation/src/jobctrl/infrastructure/rpc/handlers.py
@@ -281,14 +281,14 @@ def provider_models(params: dict[str, Any]) -> dict[str, Any]:
 
 
 def provider_verify(params: dict[str, Any]) -> dict[str, Any]:
-    """Verify persisted Codex CLI auth without making a model-generation call."""
+    """Reuse and verify Codex CLI auth without making a model-generation call."""
 
     provider = str(_require(params, "provider")).strip().lower()
     if provider != "codex":
         raise invalid_params("provider_verify currently supports only codex")
-    from jobctrl.infrastructure.setup_probes import verify_codex_connection
+    from jobctrl.infrastructure.setup_probes import reuse_and_verify_codex_connection
 
-    ok, status, message = verify_codex_connection()
+    ok, status, message = reuse_and_verify_codex_connection()
     return {
         "provider": "codex",
         "ok": ok,

--- a/workers/automation/src/jobctrl/infrastructure/setup_probes.py
+++ b/workers/automation/src/jobctrl/infrastructure/setup_probes.py
@@ -8,16 +8,13 @@ Keeping that logic here avoids letting setup and doctor drift.
 
 from __future__ import annotations
 
-import errno
 import importlib
 import importlib.metadata
 import json
 import os
 import shutil
-import stat
 import subprocess
 import time
-import uuid
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -365,160 +362,54 @@ def _codex_auth_file_signature(path: Path) -> tuple[object, ...]:
     return (str(path), stat.st_mode, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
 
-_DIRECTORY_OPEN_FLAGS = (
-    os.O_RDONLY
-    | getattr(os, "O_DIRECTORY", 0)
-    | getattr(os, "O_CLOEXEC", 0)
-    | getattr(os, "O_NOFOLLOW", 0)
-)
-_FILE_READ_OPEN_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-
-
-def _unsafe_path_error(path: Path, exc: OSError) -> RuntimeError:
-    is_symlink = exc.errno == errno.ELOOP
-    if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
-        try:
-            is_symlink = stat.S_ISLNK(path.lstat().st_mode)
-        except OSError:
-            pass
-    detail = "must not be a symlink" if is_symlink else "is unavailable or unsafe"
-    return RuntimeError(f"Codex path {detail}: {path}")
-
-
-def _open_directory(
-    path: Path,
-    *,
-    parent_descriptor: int | None = None,
-    create: bool = False,
-) -> int:
-    leaf: str | Path = path.name if parent_descriptor is not None else path
-    if create:
-        try:
-            os.mkdir(leaf, 0o700, dir_fd=parent_descriptor)
-        except FileExistsError:
-            pass
-        except FileNotFoundError:
-            if parent_descriptor is not None:
-                raise RuntimeError(f"Codex parent directory is unavailable: {path.parent}") from None
-            path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            try:
-                os.mkdir(path, 0o700)
-            except FileExistsError:
-                pass
-        except OSError as exc:
-            raise _unsafe_path_error(path, exc) from exc
-    try:
-        descriptor = os.open(leaf, _DIRECTORY_OPEN_FLAGS, dir_fd=parent_descriptor)
-    except OSError as exc:
-        raise _unsafe_path_error(path, exc) from exc
-    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
-        os.close(descriptor)
-        raise RuntimeError(f"Codex path must be a directory: {path}")
-    if create:
-        os.fchmod(descriptor, 0o700)
-    return descriptor
-
-
 def ensure_private_directory(path: Path, *, parent: Path | None = None) -> Path:
-    """Ensure one JobCtrl-owned directory leaf is private and not a symlink."""
+    """Create one JobCtrl-owned directory with best-effort private permissions."""
 
-    if parent is None:
-        descriptor = _open_directory(path, create=True)
-        os.close(descriptor)
-        return path
-    parent_descriptor = _open_directory(parent)
+    if parent is not None and not parent.is_dir():
+        raise RuntimeError(f"Codex parent directory is unavailable or unsafe: {parent}")
     try:
-        descriptor = _open_directory(path, parent_descriptor=parent_descriptor, create=True)
-        os.close(descriptor)
-    finally:
-        os.close(parent_descriptor)
+        path.mkdir(mode=0o700, parents=parent is None, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(f"Codex path is unavailable or unsafe: {path}") from exc
+    if not path.is_dir():
+        raise RuntimeError(f"Codex path must be a directory: {path}")
+    try:
+        path.chmod(0o700)
+    except OSError:
+        if os.name != "nt":
+            raise
     return path
 
 
-def _read_codex_auth(
-    path: Path,
-    *,
-    directory_descriptor: int | None = None,
-    harden_mode: bool = False,
-) -> bytes:
-    leaf: str | Path = path.name if directory_descriptor is not None else path
-    try:
-        descriptor = os.open(leaf, _FILE_READ_OPEN_FLAGS, dir_fd=directory_descriptor)
-    except OSError as exc:
-        raise _unsafe_path_error(path, exc) from exc
-    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
-        os.close(descriptor)
-        raise RuntimeError(f"Codex auth cache must be a regular file: {path}")
-    try:
-        with os.fdopen(descriptor, "rb", closefd=False) as handle:
-            raw = handle.read()
-        try:
-            payload = json.loads(raw.decode("utf-8"))
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise RuntimeError("Codex auth cache is not valid JSON") from exc
-        if not isinstance(payload, dict):
-            raise RuntimeError("Codex auth cache is not a JSON object")
-        api_key = payload.get("OPENAI_API_KEY")
-        tokens = payload.get("tokens")
-        has_api_key = isinstance(api_key, str) and bool(api_key.strip())
-        has_access_token = isinstance(tokens, dict) and isinstance(
-            tokens.get("access_token"), str
-        ) and bool(tokens["access_token"].strip())
-        if not has_api_key and not has_access_token:
-            raise RuntimeError("Codex auth cache does not contain persisted CLI credentials")
-        if harden_mode:
-            os.fchmod(descriptor, 0o600)
-            os.fsync(descriptor)
-        return raw
-    finally:
-        os.close(descriptor)
+def _validate_codex_auth_file(path: Path) -> None:
+    """Reject non-regular, malformed, or empty persisted Codex auth state."""
 
-
-def _optional_directory(path: Path, parent_descriptor: int) -> int | None:
-    try:
-        entry = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
-    except FileNotFoundError:
-        return None
-    if stat.S_ISLNK(entry.st_mode):
-        raise RuntimeError(f"Codex path must not be a symlink: {path}")
-    if not stat.S_ISDIR(entry.st_mode):
-        raise RuntimeError(f"Codex path must be a directory: {path}")
-    return _open_directory(path, parent_descriptor=parent_descriptor)
-
-
-def _optional_auth(path: Path, directory_descriptor: int) -> bytes | None:
-    try:
-        entry = os.stat(path.name, dir_fd=directory_descriptor, follow_symlinks=False)
-    except FileNotFoundError:
-        return None
-    if stat.S_ISLNK(entry.st_mode):
+    if path.is_symlink():
         raise RuntimeError(f"Codex auth cache must not be a symlink: {path}")
-    return _read_codex_auth(
-        path,
-        directory_descriptor=directory_descriptor,
-        harden_mode=True,
-    )
+    if not path.is_file():
+        raise RuntimeError("Codex CLI is not authenticated in the JobCtrl provider home")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Codex auth cache is not valid JSON") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError("Codex auth cache is not a JSON object")
+    api_key = payload.get("OPENAI_API_KEY")
+    tokens = payload.get("tokens")
+    has_api_key = isinstance(api_key, str) and bool(api_key.strip())
+    has_access_token = isinstance(tokens, dict) and isinstance(
+        tokens.get("access_token"), str
+    ) and bool(tokens["access_token"].strip())
+    if not has_api_key and not has_access_token:
+        raise RuntimeError("Codex auth cache does not contain persisted CLI credentials")
 
 
 def prepare_jobctrl_codex_home(env: Mapping[str, str] | None = None) -> Path:
-    """Safely create or validate the owned Codex home before target login."""
+    """Create or validate the stable JobCtrl-owned Codex home before login."""
 
     target_home = jobctrl_codex_home(env)
     ensure_private_directory(target_home.parent)
     return ensure_private_directory(target_home, parent=target_home.parent)
-
-
-def _read_isolated_codex_auth(values: Mapping[str, str]) -> bytes:
-    target_home = jobctrl_codex_home(values)
-    app_descriptor = _open_directory(target_home.parent)
-    try:
-        home_descriptor = _open_directory(target_home, parent_descriptor=app_descriptor)
-        try:
-            return _read_codex_auth(target_home / "auth.json", directory_descriptor=home_descriptor)
-        finally:
-            os.close(home_descriptor)
-    finally:
-        os.close(app_descriptor)
 
 
 def _run_codex_login_status(
@@ -579,118 +470,28 @@ def probe_codex_auth(env: Mapping[str, str] | None = None) -> ProbeResult:
     )
 
 
-def ensure_jobctrl_codex_auth(
-    env: Mapping[str, str] | None = None,
-    *,
-    runner: Callable[..., Any] = subprocess.run,
-) -> Path:
-    """Safely import valid ambient CLI auth once into the stable isolated home."""
+def ensure_jobctrl_codex_auth(env: Mapping[str, str] | None = None) -> Path:
+    """Copy valid ambient CLI auth once into the stable isolated home."""
 
-    values = dict(_env(env))
-    target_home = jobctrl_codex_home(values)
-    target = target_home / "auth.json"
-    app_directory = target_home.parent
-    app_descriptor = _open_directory(app_directory, create=True)
-    staging_name: str | None = None
-    staging_descriptor: int | None = None
-    try:
-        home_descriptor = _optional_directory(target_home, app_descriptor)
-        if home_descriptor is not None:
-            try:
-                if _optional_auth(target, home_descriptor) is not None:
-                    return target
-            finally:
-                os.close(home_descriptor)
-
+    values = _env(env)
+    target = codex_auth_path(values)
+    if target.is_symlink():
+        raise RuntimeError(f"Codex auth cache must not be a symlink: {target}")
+    if not target.exists():
         source = source_codex_auth_path(values)
-        if source == target:
-            raise RuntimeError("Codex CLI is not authenticated in the JobCtrl provider home")
-        source_payload = _read_codex_auth(source)
-
-        for _attempt in range(8):
-            candidate_name = f".codex-auth-import-{uuid.uuid4().hex}"
-            try:
-                os.mkdir(candidate_name, 0o700, dir_fd=app_descriptor)
-            except FileExistsError:
-                continue
-            staging_name = candidate_name
-            staging_descriptor = _open_directory(
-                app_directory / candidate_name,
-                parent_descriptor=app_descriptor,
-            )
-            break
-        if staging_descriptor is None or staging_name is None:
-            raise RuntimeError("Could not create a private Codex auth staging home")
-
-        staging_path = app_directory / staging_name
-        candidate_descriptor = os.open(
-            "auth.json",
-            os.O_WRONLY
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0),
-            0o600,
-            dir_fd=staging_descriptor,
-        )
-        with os.fdopen(candidate_descriptor, "wb") as candidate:
-            candidate.write(source_payload)
-            candidate.flush()
-            os.fchmod(candidate.fileno(), 0o600)
-            os.fsync(candidate.fileno())
-        os.fsync(staging_descriptor)
-        _read_codex_auth(
-            staging_path / "auth.json",
-            directory_descriptor=staging_descriptor,
-        )
-        try:
-            completed = _run_codex_login_status(
-                values,
-                codex_home=staging_path,
-                runner=runner,
-            )
-            verified = completed.returncode == 0
-        except Exception as exc:  # noqa: BLE001 - candidate remains unpublished
-            raise RuntimeError("Reusable Codex authentication could not be verified") from exc
-        if not verified:
-            raise RuntimeError("Reusable Codex authentication could not be verified")
-        _read_codex_auth(
-            staging_path / "auth.json",
-            directory_descriptor=staging_descriptor,
-            harden_mode=True,
-        )
-
-        home_descriptor = _open_directory(
-            target_home,
-            parent_descriptor=app_descriptor,
-            create=True,
-        )
-        os.fsync(app_descriptor)
-        try:
-            try:
-                os.link(
-                    "auth.json",
-                    target.name,
-                    src_dir_fd=staging_descriptor,
-                    dst_dir_fd=home_descriptor,
-                    follow_symlinks=False,
-                )
-                os.fsync(home_descriptor)
-            except FileExistsError:
-                _read_codex_auth(
-                    target,
-                    directory_descriptor=home_descriptor,
-                    harden_mode=True,
-                )
-        finally:
-            os.close(home_descriptor)
-        return target
-    finally:
-        if staging_descriptor is not None:
-            os.close(staging_descriptor)
-        if staging_name is not None:
-            shutil.rmtree(app_directory / staging_name)
-        os.close(app_descriptor)
+        if source.is_symlink():
+            raise RuntimeError(f"Codex auth cache must not be a symlink: {source}")
+        if source.is_file() and source != target:
+            _validate_codex_auth_file(source)
+            ensure_private_directory(target.parent)
+            shutil.copy2(source, target)
+    _validate_codex_auth_file(target)
+    try:
+        target.chmod(0o600)
+    except OSError:
+        if os.name != "nt":
+            raise
+    return target
 
 
 def reuse_and_verify_codex_connection(
@@ -702,7 +503,7 @@ def reuse_and_verify_codex_connection(
 
     values = dict(_env(env))
     try:
-        ensure_jobctrl_codex_auth(values, runner=runner)
+        ensure_jobctrl_codex_auth(values)
     except RuntimeError:
         # A missing or invalid reusable source is not an error for this explicit
         # action. The isolated verification below returns the stable, secret-free
@@ -804,7 +605,7 @@ def verify_codex_connection(
 
     values = dict(_env(env))
     try:
-        _read_isolated_codex_auth(values)
+        _validate_codex_auth_file(codex_auth_path(values))
     except RuntimeError:
         return False, "not_configured", "Codex CLI is not authenticated"
     try:

--- a/workers/automation/src/jobctrl/infrastructure/setup_probes.py
+++ b/workers/automation/src/jobctrl/infrastructure/setup_probes.py
@@ -8,13 +8,16 @@ Keeping that logic here avoids letting setup and doctor drift.
 
 from __future__ import annotations
 
+import errno
 import importlib
 import importlib.metadata
 import json
 import os
 import shutil
+import stat
 import subprocess
 import time
+import uuid
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +33,15 @@ from jobctrl.runtime import (
 ANALYSIS_LEGS_ENV = "JOBCTRL_ANALYSIS_LEGS"
 CODEX_BIN_ENV = "JOBCTRL_CODEX_BIN"
 CLAUDE_BIN_ENV = "JOBCTRL_CLAUDE_BIN"
+
+CODEX_NEUTRALIZED_AUTH_ENV = (
+    "OPENAI_API_KEY",
+    "CODEX_ACCESS_TOKEN",
+    "CODEX_AGENT_IDENTITY_AUTH",
+    "CODEX_API_KEY",
+    "CODEX_REFRESH_TOKEN_URL_OVERRIDE",
+    "CODEX_REVOKE_TOKEN_URL_OVERRIDE",
+)
 
 ANALYSIS_LEG_ORDER = ("claude", "codex", "antigravity")
 _LEG_ALIASES = {
@@ -353,27 +365,180 @@ def _codex_auth_file_signature(path: Path) -> tuple[object, ...]:
     return (str(path), stat.st_mode, stat.st_ino, stat.st_size, stat.st_mtime_ns)
 
 
-def _validate_codex_auth_file(path: Path) -> None:
-    """Reject non-regular, malformed, or empty persisted Codex auth state."""
+_DIRECTORY_OPEN_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_CLOEXEC", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+)
+_FILE_READ_OPEN_FLAGS = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
 
-    if path.is_symlink():
-        raise RuntimeError(f"Codex auth cache must not be a symlink: {path}")
-    if not path.is_file():
-        raise RuntimeError("Codex CLI is not authenticated in the JobCtrl provider home")
+
+def _unsafe_path_error(path: Path, exc: OSError) -> RuntimeError:
+    is_symlink = exc.errno == errno.ELOOP
+    if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
+        try:
+            is_symlink = stat.S_ISLNK(path.lstat().st_mode)
+        except OSError:
+            pass
+    detail = "must not be a symlink" if is_symlink else "is unavailable or unsafe"
+    return RuntimeError(f"Codex path {detail}: {path}")
+
+
+def _open_directory(
+    path: Path,
+    *,
+    parent_descriptor: int | None = None,
+    create: bool = False,
+) -> int:
+    leaf: str | Path = path.name if parent_descriptor is not None else path
+    if create:
+        try:
+            os.mkdir(leaf, 0o700, dir_fd=parent_descriptor)
+        except FileExistsError:
+            pass
+        except FileNotFoundError:
+            if parent_descriptor is not None:
+                raise RuntimeError(f"Codex parent directory is unavailable: {path.parent}") from None
+            path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+            try:
+                os.mkdir(path, 0o700)
+            except FileExistsError:
+                pass
+        except OSError as exc:
+            raise _unsafe_path_error(path, exc) from exc
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise RuntimeError("Codex auth cache is not valid JSON") from exc
-    if not isinstance(payload, dict):
-        raise RuntimeError("Codex auth cache is not a JSON object")
-    api_key = payload.get("OPENAI_API_KEY")
-    tokens = payload.get("tokens")
-    has_api_key = isinstance(api_key, str) and bool(api_key.strip())
-    has_access_token = isinstance(tokens, dict) and isinstance(
-        tokens.get("access_token"), str
-    ) and bool(tokens["access_token"].strip())
-    if not has_api_key and not has_access_token:
-        raise RuntimeError("Codex auth cache does not contain persisted CLI credentials")
+        descriptor = os.open(leaf, _DIRECTORY_OPEN_FLAGS, dir_fd=parent_descriptor)
+    except OSError as exc:
+        raise _unsafe_path_error(path, exc) from exc
+    if not stat.S_ISDIR(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise RuntimeError(f"Codex path must be a directory: {path}")
+    if create:
+        os.fchmod(descriptor, 0o700)
+    return descriptor
+
+
+def ensure_private_directory(path: Path, *, parent: Path | None = None) -> Path:
+    """Ensure one JobCtrl-owned directory leaf is private and not a symlink."""
+
+    if parent is None:
+        descriptor = _open_directory(path, create=True)
+        os.close(descriptor)
+        return path
+    parent_descriptor = _open_directory(parent)
+    try:
+        descriptor = _open_directory(path, parent_descriptor=parent_descriptor, create=True)
+        os.close(descriptor)
+    finally:
+        os.close(parent_descriptor)
+    return path
+
+
+def _read_codex_auth(
+    path: Path,
+    *,
+    directory_descriptor: int | None = None,
+    harden_mode: bool = False,
+) -> bytes:
+    leaf: str | Path = path.name if directory_descriptor is not None else path
+    try:
+        descriptor = os.open(leaf, _FILE_READ_OPEN_FLAGS, dir_fd=directory_descriptor)
+    except OSError as exc:
+        raise _unsafe_path_error(path, exc) from exc
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise RuntimeError(f"Codex auth cache must be a regular file: {path}")
+    try:
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            raw = handle.read()
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Codex auth cache is not valid JSON") from exc
+        if not isinstance(payload, dict):
+            raise RuntimeError("Codex auth cache is not a JSON object")
+        api_key = payload.get("OPENAI_API_KEY")
+        tokens = payload.get("tokens")
+        has_api_key = isinstance(api_key, str) and bool(api_key.strip())
+        has_access_token = isinstance(tokens, dict) and isinstance(
+            tokens.get("access_token"), str
+        ) and bool(tokens["access_token"].strip())
+        if not has_api_key and not has_access_token:
+            raise RuntimeError("Codex auth cache does not contain persisted CLI credentials")
+        if harden_mode:
+            os.fchmod(descriptor, 0o600)
+            os.fsync(descriptor)
+        return raw
+    finally:
+        os.close(descriptor)
+
+
+def _optional_directory(path: Path, parent_descriptor: int) -> int | None:
+    try:
+        entry = os.stat(path.name, dir_fd=parent_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(entry.st_mode):
+        raise RuntimeError(f"Codex path must not be a symlink: {path}")
+    if not stat.S_ISDIR(entry.st_mode):
+        raise RuntimeError(f"Codex path must be a directory: {path}")
+    return _open_directory(path, parent_descriptor=parent_descriptor)
+
+
+def _optional_auth(path: Path, directory_descriptor: int) -> bytes | None:
+    try:
+        entry = os.stat(path.name, dir_fd=directory_descriptor, follow_symlinks=False)
+    except FileNotFoundError:
+        return None
+    if stat.S_ISLNK(entry.st_mode):
+        raise RuntimeError(f"Codex auth cache must not be a symlink: {path}")
+    return _read_codex_auth(
+        path,
+        directory_descriptor=directory_descriptor,
+        harden_mode=True,
+    )
+
+
+def prepare_jobctrl_codex_home(env: Mapping[str, str] | None = None) -> Path:
+    """Safely create or validate the owned Codex home before target login."""
+
+    target_home = jobctrl_codex_home(env)
+    ensure_private_directory(target_home.parent)
+    return ensure_private_directory(target_home, parent=target_home.parent)
+
+
+def _read_isolated_codex_auth(values: Mapping[str, str]) -> bytes:
+    target_home = jobctrl_codex_home(values)
+    app_descriptor = _open_directory(target_home.parent)
+    try:
+        home_descriptor = _open_directory(target_home, parent_descriptor=app_descriptor)
+        try:
+            return _read_codex_auth(target_home / "auth.json", directory_descriptor=home_descriptor)
+        finally:
+            os.close(home_descriptor)
+    finally:
+        os.close(app_descriptor)
+
+
+def _run_codex_login_status(
+    values: Mapping[str, str],
+    *,
+    codex_home: Path,
+    runner: Callable[..., Any],
+) -> Any:
+    child_env = dict(values)
+    child_env["CODEX_HOME"] = str(codex_home)
+    for key in CODEX_NEUTRALIZED_AUTH_ENV:
+        child_env.pop(key, None)
+    return runner(
+        [str(resolve_codex_binary(values)), "login", "status"],
+        env=child_env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+        check=False,
+    )
 
 
 def _cached_verify_codex_connection(values: Mapping[str, str]) -> tuple[bool, str, str]:
@@ -414,25 +579,136 @@ def probe_codex_auth(env: Mapping[str, str] | None = None) -> ProbeResult:
     )
 
 
-def ensure_jobctrl_codex_auth(env: Mapping[str, str] | None = None) -> Path:
-    """Ensure source CLI auth is copied once into the stable isolated home."""
+def ensure_jobctrl_codex_auth(
+    env: Mapping[str, str] | None = None,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> Path:
+    """Safely import valid ambient CLI auth once into the stable isolated home."""
 
-    values = _env(env)
-    target = codex_auth_path(values)
-    if target.is_symlink():
-        raise RuntimeError(f"Codex auth cache must not be a symlink: {target}")
-    if not target.exists():
+    values = dict(_env(env))
+    target_home = jobctrl_codex_home(values)
+    target = target_home / "auth.json"
+    app_directory = target_home.parent
+    app_descriptor = _open_directory(app_directory, create=True)
+    staging_name: str | None = None
+    staging_descriptor: int | None = None
+    try:
+        home_descriptor = _optional_directory(target_home, app_descriptor)
+        if home_descriptor is not None:
+            try:
+                if _optional_auth(target, home_descriptor) is not None:
+                    return target
+            finally:
+                os.close(home_descriptor)
+
         source = source_codex_auth_path(values)
-        if source.is_symlink():
-            raise RuntimeError(f"Codex auth cache must not be a symlink: {source}")
-        if source.is_file() and source != target:
-            _validate_codex_auth_file(source)
-            target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-            target.parent.chmod(0o700)
-            shutil.copy2(source, target)
-    _validate_codex_auth_file(target)
-    target.chmod(0o600)
-    return target
+        if source == target:
+            raise RuntimeError("Codex CLI is not authenticated in the JobCtrl provider home")
+        source_payload = _read_codex_auth(source)
+
+        for _attempt in range(8):
+            candidate_name = f".codex-auth-import-{uuid.uuid4().hex}"
+            try:
+                os.mkdir(candidate_name, 0o700, dir_fd=app_descriptor)
+            except FileExistsError:
+                continue
+            staging_name = candidate_name
+            staging_descriptor = _open_directory(
+                app_directory / candidate_name,
+                parent_descriptor=app_descriptor,
+            )
+            break
+        if staging_descriptor is None or staging_name is None:
+            raise RuntimeError("Could not create a private Codex auth staging home")
+
+        staging_path = app_directory / staging_name
+        candidate_descriptor = os.open(
+            "auth.json",
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=staging_descriptor,
+        )
+        with os.fdopen(candidate_descriptor, "wb") as candidate:
+            candidate.write(source_payload)
+            candidate.flush()
+            os.fchmod(candidate.fileno(), 0o600)
+            os.fsync(candidate.fileno())
+        os.fsync(staging_descriptor)
+        _read_codex_auth(
+            staging_path / "auth.json",
+            directory_descriptor=staging_descriptor,
+        )
+        try:
+            completed = _run_codex_login_status(
+                values,
+                codex_home=staging_path,
+                runner=runner,
+            )
+            verified = completed.returncode == 0
+        except Exception as exc:  # noqa: BLE001 - candidate remains unpublished
+            raise RuntimeError("Reusable Codex authentication could not be verified") from exc
+        if not verified:
+            raise RuntimeError("Reusable Codex authentication could not be verified")
+        _read_codex_auth(
+            staging_path / "auth.json",
+            directory_descriptor=staging_descriptor,
+            harden_mode=True,
+        )
+
+        home_descriptor = _open_directory(
+            target_home,
+            parent_descriptor=app_descriptor,
+            create=True,
+        )
+        os.fsync(app_descriptor)
+        try:
+            try:
+                os.link(
+                    "auth.json",
+                    target.name,
+                    src_dir_fd=staging_descriptor,
+                    dst_dir_fd=home_descriptor,
+                    follow_symlinks=False,
+                )
+                os.fsync(home_descriptor)
+            except FileExistsError:
+                _read_codex_auth(
+                    target,
+                    directory_descriptor=home_descriptor,
+                    harden_mode=True,
+                )
+        finally:
+            os.close(home_descriptor)
+        return target
+    finally:
+        if staging_descriptor is not None:
+            os.close(staging_descriptor)
+        if staging_name is not None:
+            shutil.rmtree(app_directory / staging_name)
+        os.close(app_descriptor)
+
+
+def reuse_and_verify_codex_connection(
+    env: Mapping[str, str] | None = None,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> tuple[bool, str, str]:
+    """Explicitly reuse valid ambient Codex auth once, then verify the isolated home."""
+
+    values = dict(_env(env))
+    try:
+        ensure_jobctrl_codex_auth(values, runner=runner)
+    except RuntimeError:
+        # A missing or invalid reusable source is not an error for this explicit
+        # action. The isolated verification below returns the stable, secret-free
+        # not-configured result without disclosing source-auth details.
+        pass
+    return verify_codex_connection(values, runner=runner)
 
 
 def provider_status_snapshot(
@@ -528,22 +804,14 @@ def verify_codex_connection(
 
     values = dict(_env(env))
     try:
-        _validate_codex_auth_file(codex_auth_path(values))
+        _read_isolated_codex_auth(values)
     except RuntimeError:
         return False, "not_configured", "Codex CLI is not authenticated"
     try:
-        binary = resolve_codex_binary(values)
-        child_env = dict(values)
-        child_env["CODEX_HOME"] = str(jobctrl_codex_home(values))
-        for key in ("OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"):
-            child_env.pop(key, None)
-        completed = runner(
-            [str(binary), "login", "status"],
-            env=child_env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            timeout=10,
-            check=False,
+        completed = _run_codex_login_status(
+            values,
+            codex_home=jobctrl_codex_home(values),
+            runner=runner,
         )
     except Exception:  # noqa: BLE001 - return a secret-free verification result
         return False, "failed", "Codex authentication verification failed"
@@ -846,6 +1114,7 @@ __all__ = [
     "ANALYSIS_LEG_ORDER",
     "CLAUDE_BIN_ENV",
     "CODEX_BIN_ENV",
+    "CODEX_NEUTRALIZED_AUTH_ENV",
     "ProbeResult",
     "analysis_sdk_set_version",
     "antigravity_auth_kwargs",
@@ -856,6 +1125,7 @@ __all__ = [
     "effective_codex_home",
     "enabled_analysis_legs",
     "ensure_jobctrl_codex_auth",
+    "ensure_private_directory",
     "parse_enabled_analysis_legs",
     "probe_analysis_setup",
     "probe_antigravity_auth",
@@ -865,8 +1135,10 @@ __all__ = [
     "probe_claude_synthesis_auth",
     "probe_codex_auth",
     "probe_codex_sdk",
+    "prepare_jobctrl_codex_home",
     "provider_status_snapshot",
     "ready_llm_providers",
+    "reuse_and_verify_codex_connection",
     "resolve_bundled_claude_path",
     "resolve_bundled_codex_path",
     "resolve_claude_apply_binary",

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 
 import stat
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 import jobctrl.config
+from jobctrl.infrastructure import setup_probes
 from jobctrl.infrastructure.analysis import codex_analysis_adapter as adapter
 
 
@@ -27,7 +29,16 @@ def _isolate_homes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Pat
     source_codex_home = tmp_path / "source-codex"
     source_codex_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex-bin")
     monkeypatch.setenv("CODEX_HOME", str(source_codex_home))
+    original_ensure = adapter.ensure_jobctrl_codex_auth
+    monkeypatch.setattr(
+        adapter,
+        "ensure_jobctrl_codex_auth",
+        lambda: original_ensure(
+            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0),
+        ),
+    )
     return app_dir, source_codex_home
 
 
@@ -92,6 +103,27 @@ def test_catalog_prepare_does_not_copy_ambient_codex_auth(
     assert (source_codex_home / "auth.json").is_file()
 
 
+@pytest.mark.parametrize("unsafe_leaf", ["codex_home", "workspace", "home"])
+def test_prepare_isolated_codex_home_rejects_owned_directory_symlinks(
+    unsafe_leaf: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir, _source_codex_home = _isolate_homes(monkeypatch, tmp_path)
+    app_dir.mkdir()
+    codex_home = app_dir / "codex_home"
+    external = tmp_path / f"external-{unsafe_leaf}"
+    external.mkdir()
+    if unsafe_leaf == "codex_home":
+        codex_home.symlink_to(external, target_is_directory=True)
+    else:
+        codex_home.mkdir()
+        (codex_home / unsafe_leaf).symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        adapter._prepare_isolated_codex_home(ensure_auth=False)
+
+
 def test_isolated_codex_env_is_minimal_for_jobctrl_home(tmp_path: Path) -> None:
     codex_home = tmp_path / "codex_home"
     process_home = codex_home / "home"
@@ -100,7 +132,7 @@ def test_isolated_codex_env_is_minimal_for_jobctrl_home(tmp_path: Path) -> None:
 
     assert env["CODEX_HOME"] == str(codex_home)
     assert env["HOME"] == str(process_home)
-    assert all(env[key] == "" for key in adapter._CODEX_BUNDLED_NEUTRALIZED_AUTH_ENV)
+    assert all(env[key] == "" for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV)
 
 
 def test_bundled_codex_uses_persisted_auth_and_neutralizes_raw_keys(
@@ -167,7 +199,7 @@ def test_bundled_codex_factory_uses_persisted_credentials(
     assert codex.config.env["OPENAI_API_KEY"] == ""
     assert all(
         codex.config.env[key] == ""
-        for key in adapter._CODEX_BUNDLED_NEUTRALIZED_AUTH_ENV
+        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
     )
 
 

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -10,9 +10,9 @@ These tests pin both invariants for the Codex analysis leg:
 
 from __future__ import annotations
 
+import os
 import stat
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -29,21 +29,17 @@ def _isolate_homes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Pat
     source_codex_home = tmp_path / "source-codex"
     source_codex_home.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
-    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex-bin")
     monkeypatch.setenv("CODEX_HOME", str(source_codex_home))
-    original_ensure = adapter.ensure_jobctrl_codex_auth
-    monkeypatch.setattr(
-        adapter,
-        "ensure_jobctrl_codex_auth",
-        lambda: original_ensure(
-            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0),
-        ),
-    )
     return app_dir, source_codex_home
 
 
 def _mode(path: Path) -> int:
     return stat.S_IMODE(path.stat().st_mode)
+
+
+def _assert_private_mode(path: Path, expected: int) -> None:
+    if os.name != "nt":
+        assert _mode(path) == expected
 
 
 def test_config_overrides_select_workspace_only_permission_profile() -> None:
@@ -76,14 +72,14 @@ def test_prepare_isolated_codex_home_copies_auth_outside_workspace(
     assert dirs.codex_home == app_dir / "codex_home"
     assert dirs.workdir == dirs.codex_home / "workspace"
     assert dirs.process_home == dirs.codex_home / "home"
-    assert _mode(dirs.codex_home) == 0o700
-    assert _mode(dirs.workdir) == 0o700
-    assert _mode(dirs.process_home) == 0o700
+    _assert_private_mode(dirs.codex_home, 0o700)
+    _assert_private_mode(dirs.workdir, 0o700)
+    _assert_private_mode(dirs.process_home, 0o700)
 
     copied_auth = dirs.codex_home / "auth.json"
     assert copied_auth.is_file()
     assert copied_auth.read_bytes() == payload
-    assert _mode(copied_auth) == 0o600
+    _assert_private_mode(copied_auth, 0o600)
     assert not (dirs.workdir / "auth.json").exists()
 
 
@@ -101,27 +97,6 @@ def test_catalog_prepare_does_not_copy_ambient_codex_auth(
     assert dirs.codex_home == app_dir / "codex_home"
     assert not (dirs.codex_home / "auth.json").exists()
     assert (source_codex_home / "auth.json").is_file()
-
-
-@pytest.mark.parametrize("unsafe_leaf", ["codex_home", "workspace", "home"])
-def test_prepare_isolated_codex_home_rejects_owned_directory_symlinks(
-    unsafe_leaf: str,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    app_dir, _source_codex_home = _isolate_homes(monkeypatch, tmp_path)
-    app_dir.mkdir()
-    codex_home = app_dir / "codex_home"
-    external = tmp_path / f"external-{unsafe_leaf}"
-    external.mkdir()
-    if unsafe_leaf == "codex_home":
-        codex_home.symlink_to(external, target_is_directory=True)
-    else:
-        codex_home.mkdir()
-        (codex_home / unsafe_leaf).symlink_to(external, target_is_directory=True)
-
-    with pytest.raises(RuntimeError, match="symlink"):
-        adapter._prepare_isolated_codex_home(ensure_auth=False)
 
 
 def test_isolated_codex_env_is_minimal_for_jobctrl_home(tmp_path: Path) -> None:

--- a/workers/automation/tests/test_jsonrpc_handlers.py
+++ b/workers/automation/tests/test_jsonrpc_handlers.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import fields
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 from temporalio.common import WorkflowIDConflictPolicy
@@ -139,16 +140,16 @@ def test_provider_status_and_verify_are_secret_free(monkeypatch) -> None:
             "message": "ready" if provider == "codex" else "not configured",
         },
     )
-    monkeypatch.setattr(
-        setup_probes,
-        "verify_codex_connection",
-        lambda: (True, "connected", "Codex CLI authentication verified"),
+    reuse_and_verify = Mock(
+        return_value=(True, "connected", "Codex CLI authentication verified")
     )
+    monkeypatch.setattr(setup_probes, "reuse_and_verify_codex_connection", reuse_and_verify)
     server = _server()
 
     status = server.dispatch(
         JsonRpcRequest(method="provider_status", params={"provider": "codex"}, id=1)
     )
+    reuse_and_verify.assert_not_called()
     verify = server.dispatch(
         JsonRpcRequest(method="provider_verify", params={"provider": "codex"}, id=2)
     )
@@ -172,6 +173,8 @@ def test_provider_status_and_verify_are_secret_free(monkeypatch) -> None:
         "status": "connected",
         "message": "Codex CLI authentication verified",
     }
+    reuse_and_verify.assert_called_once_with()
+    assert "private-token" not in str(verify.to_dict())
 
 
 def test_provider_verify_rejects_non_codex() -> None:
@@ -184,6 +187,7 @@ def test_provider_verify_rejects_non_codex() -> None:
 
 
 def test_provider_models_dispatches_sanitized_catalog(monkeypatch) -> None:
+    from jobctrl.infrastructure import setup_probes
     from jobctrl.infrastructure.llm import model_catalog
 
     catalog = {
@@ -207,12 +211,18 @@ def test_provider_models_dispatches_sanitized_catalog(monkeypatch) -> None:
         ]
     }
     monkeypatch.setattr(model_catalog, "provider_model_catalog", lambda: catalog)
+    import_auth = Mock()
+    verify_auth = Mock()
+    monkeypatch.setattr(setup_probes, "ensure_jobctrl_codex_auth", import_auth)
+    monkeypatch.setattr(setup_probes, "reuse_and_verify_codex_connection", verify_auth)
     server = _server()
 
     response = server.dispatch(JsonRpcRequest(method="provider_models", params={}, id=3))
 
     assert response is not None
     assert response.to_dict()["result"] == catalog
+    import_auth.assert_not_called()
+    verify_auth.assert_not_called()
 
 
 def test_generate_interview_prep_starts_user_triggered_workflow() -> None:

--- a/workers/automation/tests/test_setup_probes.py
+++ b/workers/automation/tests/test_setup_probes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -69,19 +70,23 @@ def _write_service_account_adc(path: Path) -> None:
     )
 
 
-def _write_codex_auth(path: Path) -> None:
+def _write_codex_auth(path: Path, *, access_token: str = "test-access-token") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(
             {
                 "tokens": {
-                    "access_token": "test-access-token",
+                    "access_token": access_token,
                     "refresh_token": "test-refresh-token",
                 }
             }
         ),
         encoding="utf-8",
     )
+
+
+def _successful_codex_status(*_args, **_kwargs):
+    return SimpleNamespace(returncode=0)
 
 
 def test_enabled_analysis_legs_default_aliases_and_validation() -> None:
@@ -103,6 +108,7 @@ def test_codex_requires_persisted_cli_auth_and_uses_stable_jobctrl_home(
     app_dir = tmp_path / "jobctrl"
     source_home = tmp_path / "source-codex"
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
     env = {"CODEX_HOME": str(source_home), "OPENAI_API_KEY": "sk-test"}
 
     raw_only = setup_probes.probe_codex_auth(env)
@@ -112,7 +118,10 @@ def test_codex_requires_persisted_cli_auth_and_uses_stable_jobctrl_home(
 
     source_home.mkdir()
     _write_codex_auth(source_home / "auth.json")
-    target = setup_probes.ensure_jobctrl_codex_auth(env)
+    target = setup_probes.ensure_jobctrl_codex_auth(
+        env,
+        runner=_successful_codex_status,
+    )
     assert target == app_dir / "codex_home/auth.json"
     assert target.is_file()
 
@@ -381,15 +390,224 @@ def test_verify_codex_uses_persisted_home_and_strips_raw_keys(
         seen.update(command=command, **kwargs)
         return SimpleNamespace(returncode=0)
 
-    result = setup_probes.verify_codex_connection(
-        {"OPENAI_API_KEY": "raw", "CODEX_API_KEY": "raw-alias"}, runner=runner
-    )
+    ambient_auth = {
+        key: f"ambient-{key.lower()}"
+        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+    }
+    result = setup_probes.verify_codex_connection(ambient_auth, runner=runner)
     assert result == (True, "connected", "Codex CLI authentication verified")
     assert seen["command"][-2:] == ["login", "status"]
     child_env = seen["env"]
-    assert "OPENAI_API_KEY" not in child_env
-    assert "CODEX_API_KEY" not in child_env
+    assert all(key not in child_env for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV)
     assert child_env["CODEX_HOME"] == str(app_dir / "codex_home")
+
+
+def test_reuse_and_verify_codex_connection_copies_ambient_auth_once_and_strips_raw_keys(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source_home = tmp_path / "regular-codex"
+    source_auth = source_home / "auth.json"
+    _write_codex_auth(source_auth)
+    source_contents = source_auth.read_text(encoding="utf-8")
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+    calls: list[dict[str, object]] = []
+
+    def runner(command, **kwargs):
+        calls.append({"command": command, **kwargs})
+        return SimpleNamespace(returncode=0)
+
+    ambient_auth = {
+        key: f"ambient-{key.lower()}"
+        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+    }
+    result = setup_probes.reuse_and_verify_codex_connection(
+        {
+            "CODEX_HOME": str(source_home),
+            **ambient_auth,
+        },
+        runner=runner,
+    )
+
+    target = app_dir / "codex_home/auth.json"
+    assert result == (True, "connected", "Codex CLI authentication verified")
+    assert target.read_text(encoding="utf-8") == source_contents
+    assert source_auth.read_text(encoding="utf-8") == source_contents
+    assert len(calls) == 2
+    staging_env = calls[0]["env"]
+    stable_env = calls[1]["env"]
+    assert calls[0]["command"][-2:] == ["login", "status"]
+    assert Path(staging_env["CODEX_HOME"]).parent == app_dir
+    assert Path(staging_env["CODEX_HOME"]).name.startswith(".codex-auth-import-")
+    assert stable_env["CODEX_HOME"] == str(app_dir / "codex_home")
+    for child_env in (staging_env, stable_env):
+        assert all(
+            key not in child_env
+            for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+        )
+    assert not list(app_dir.glob(".codex-auth-import-*"))
+
+
+def test_reuse_and_verify_codex_connection_does_not_overwrite_isolated_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    target = app_dir / "codex_home/auth.json"
+    source = tmp_path / "regular-codex/auth.json"
+    _write_codex_auth(target, access_token="isolated-token")
+    _write_codex_auth(source, access_token="ambient-token")
+    target.chmod(0o644)
+    target_contents = target.read_bytes()
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+
+    result = setup_probes.reuse_and_verify_codex_connection(
+        {"CODEX_HOME": str(source.parent)},
+        runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0),
+    )
+
+    assert result == (True, "connected", "Codex CLI authentication verified")
+    assert target.read_bytes() == target_contents
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert "ambient-token" in source.read_text(encoding="utf-8")
+
+
+def test_expired_codex_candidate_is_not_published_and_refreshed_source_can_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source = tmp_path / "regular-codex/auth.json"
+    _write_codex_auth(source, access_token="expired-token")
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+
+    with pytest.raises(RuntimeError, match="could not be verified"):
+        setup_probes.ensure_jobctrl_codex_auth(
+            {"CODEX_HOME": str(source.parent)},
+            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=1),
+        )
+
+    target = app_dir / "codex_home/auth.json"
+    assert target.exists() is False
+    assert not list(app_dir.glob(".codex-auth-import-*"))
+    _write_codex_auth(source, access_token="refreshed-token")
+
+    result = setup_probes.ensure_jobctrl_codex_auth(
+        {"CODEX_HOME": str(source.parent)},
+        runner=_successful_codex_status,
+    )
+
+    assert result == target
+    assert "refreshed-token" in target.read_text(encoding="utf-8")
+    assert not list(app_dir.glob(".codex-auth-import-*"))
+
+
+@pytest.mark.parametrize("mutation", ["symlink", "directory", "chmod"])
+def test_codex_import_revalidates_and_hardens_candidate_after_live_verification(
+    mutation: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source = tmp_path / "regular-codex/auth.json"
+    external = tmp_path / "replacement-auth.json"
+    _write_codex_auth(source, access_token="source-token")
+    _write_codex_auth(external, access_token="replacement-token")
+    source_bytes = source.read_bytes()
+    source_mode = stat.S_IMODE(source.stat().st_mode)
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+
+    def mutate_candidate(_command, **kwargs):
+        candidate = Path(kwargs["env"]["CODEX_HOME"]) / "auth.json"
+        if mutation == "chmod":
+            candidate.chmod(0o644)
+        else:
+            candidate.unlink()
+            if mutation == "symlink":
+                candidate.symlink_to(external)
+            else:
+                candidate.mkdir()
+        return SimpleNamespace(returncode=0)
+
+    if mutation == "chmod":
+        target = setup_probes.ensure_jobctrl_codex_auth(
+            {"CODEX_HOME": str(source.parent)},
+            runner=mutate_candidate,
+        )
+        assert target.read_bytes() == source_bytes
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    else:
+        with pytest.raises(RuntimeError, match="symlink|regular file"):
+            setup_probes.ensure_jobctrl_codex_auth(
+                {"CODEX_HOME": str(source.parent)},
+                runner=mutate_candidate,
+            )
+        assert not (app_dir / "codex_home/auth.json").exists()
+    assert source.read_bytes() == source_bytes
+    assert stat.S_IMODE(source.stat().st_mode) == source_mode
+    assert not list(app_dir.glob(".codex-auth-import-*"))
+
+
+def test_codex_import_never_replaces_a_concurrent_valid_winner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    target = app_dir / "codex_home/auth.json"
+    source = tmp_path / "regular-codex/auth.json"
+    _write_codex_auth(source, access_token="candidate-token")
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+
+    def concurrent_winner(*_args, **_kwargs):
+        _write_codex_auth(target, access_token="winner-token")
+        target.chmod(0o644)
+        return SimpleNamespace(returncode=0)
+
+    result = setup_probes.ensure_jobctrl_codex_auth(
+        {"CODEX_HOME": str(source.parent)},
+        runner=concurrent_winner,
+    )
+
+    assert result == target
+    assert "winner-token" in target.read_text(encoding="utf-8")
+    assert "candidate-token" not in target.read_text(encoding="utf-8")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert not list(app_dir.glob(".codex-auth-import-*"))
+
+
+@pytest.mark.parametrize("unsafe_leaf", ["home", "auth"])
+def test_codex_import_rejects_symlinks_in_the_owned_target_boundary(
+    unsafe_leaf: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    app_dir.mkdir()
+    source = tmp_path / "regular-codex/auth.json"
+    _write_codex_auth(source)
+    target_home = app_dir / "codex_home"
+    if unsafe_leaf == "home":
+        external_home = tmp_path / "external-home"
+        external_home.mkdir()
+        target_home.symlink_to(external_home, target_is_directory=True)
+    else:
+        target_home.mkdir()
+        external_auth = tmp_path / "external-auth.json"
+        _write_codex_auth(external_auth)
+        (target_home / "auth.json").symlink_to(external_auth)
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        setup_probes.ensure_jobctrl_codex_auth(
+            {"CODEX_HOME": str(source.parent)},
+            runner=_successful_codex_status,
+        )
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_setup_probes.py
+++ b/workers/automation/tests/test_setup_probes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 from pathlib import Path
 from types import SimpleNamespace
@@ -85,10 +86,6 @@ def _write_codex_auth(path: Path, *, access_token: str = "test-access-token") ->
     )
 
 
-def _successful_codex_status(*_args, **_kwargs):
-    return SimpleNamespace(returncode=0)
-
-
 def test_enabled_analysis_legs_default_aliases_and_validation() -> None:
     assert setup_probes.parse_enabled_analysis_legs(None) == ("claude", "codex", "antigravity")
     assert setup_probes.parse_enabled_analysis_legs("gemini, openai") == ("codex", "antigravity")
@@ -118,10 +115,7 @@ def test_codex_requires_persisted_cli_auth_and_uses_stable_jobctrl_home(
 
     source_home.mkdir()
     _write_codex_auth(source_home / "auth.json")
-    target = setup_probes.ensure_jobctrl_codex_auth(
-        env,
-        runner=_successful_codex_status,
-    )
+    target = setup_probes.ensure_jobctrl_codex_auth(env)
     assert target == app_dir / "codex_home/auth.json"
     assert target.is_file()
 
@@ -411,6 +405,7 @@ def test_reuse_and_verify_codex_connection_copies_ambient_auth_once_and_strips_r
     source_auth = source_home / "auth.json"
     _write_codex_auth(source_auth)
     source_contents = source_auth.read_text(encoding="utf-8")
+    source_mode = stat.S_IMODE(source_auth.stat().st_mode)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
     monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
     calls: list[dict[str, object]] = []
@@ -435,19 +430,17 @@ def test_reuse_and_verify_codex_connection_copies_ambient_auth_once_and_strips_r
     assert result == (True, "connected", "Codex CLI authentication verified")
     assert target.read_text(encoding="utf-8") == source_contents
     assert source_auth.read_text(encoding="utf-8") == source_contents
-    assert len(calls) == 2
-    staging_env = calls[0]["env"]
-    stable_env = calls[1]["env"]
+    if os.name != "nt":
+        assert stat.S_IMODE(source_auth.stat().st_mode) == source_mode
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert len(calls) == 1
+    stable_env = calls[0]["env"]
     assert calls[0]["command"][-2:] == ["login", "status"]
-    assert Path(staging_env["CODEX_HOME"]).parent == app_dir
-    assert Path(staging_env["CODEX_HOME"]).name.startswith(".codex-auth-import-")
     assert stable_env["CODEX_HOME"] == str(app_dir / "codex_home")
-    for child_env in (staging_env, stable_env):
-        assert all(
-            key not in child_env
-            for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
-        )
-    assert not list(app_dir.glob(".codex-auth-import-*"))
+    assert all(
+        key not in stable_env
+        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+    )
 
 
 def test_reuse_and_verify_codex_connection_does_not_overwrite_isolated_auth(
@@ -471,119 +464,75 @@ def test_reuse_and_verify_codex_connection_does_not_overwrite_isolated_auth(
 
     assert result == (True, "connected", "Codex CLI authentication verified")
     assert target.read_bytes() == target_contents
-    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    if os.name != "nt":
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert "ambient-token" in source.read_text(encoding="utf-8")
 
 
-def test_expired_codex_candidate_is_not_published_and_refreshed_source_can_retry(
+@pytest.mark.parametrize(
+    ("runner_outcome", "expected_message"),
+    [
+        ("nonzero", "Codex CLI authentication could not be verified"),
+        ("exception", "Codex authentication verification failed"),
+    ],
+)
+def test_reuse_valid_ambient_auth_reports_verification_failure_without_secrets(
+    runner_outcome: str,
+    expected_message: str,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     app_dir = tmp_path / "jobctrl"
     source = tmp_path / "regular-codex/auth.json"
-    _write_codex_auth(source, access_token="expired-token")
+    _write_codex_auth(source)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
     monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
 
-    with pytest.raises(RuntimeError, match="could not be verified"):
-        setup_probes.ensure_jobctrl_codex_auth(
-            {"CODEX_HOME": str(source.parent)},
-            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=1),
-        )
+    def runner(*_args, **_kwargs):
+        if runner_outcome == "exception":
+            raise RuntimeError("private-token-must-not-escape")
+        return SimpleNamespace(returncode=1)
+
+    result = setup_probes.reuse_and_verify_codex_connection(
+        {"CODEX_HOME": str(source.parent)},
+        runner=runner,
+    )
+
+    assert result == (False, "failed", expected_message)
+    assert "private-token-must-not-escape" not in repr(result)
+    assert (app_dir / "codex_home/auth.json").is_file()
+
+
+@pytest.mark.parametrize("source_kind", ["missing", "invalid", "symlink"])
+def test_reuse_invalid_or_missing_ambient_auth_returns_secret_free_not_configured(
+    source_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source = tmp_path / "regular-codex/auth.json"
+    if source_kind == "invalid":
+        source.parent.mkdir(parents=True)
+        source.write_text("{}", encoding="utf-8")
+    elif source_kind == "symlink":
+        external = tmp_path / "external-auth.json"
+        _write_codex_auth(external)
+        source.parent.mkdir(parents=True)
+        source.symlink_to(external)
+    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
+    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
+
+    result = setup_probes.reuse_and_verify_codex_connection(
+        {"CODEX_HOME": str(source.parent)},
+        runner=lambda *_args, **_kwargs: pytest.fail("verification should not run"),
+    )
 
     target = app_dir / "codex_home/auth.json"
+    assert result == (False, "not_configured", "Codex CLI is not authenticated")
     assert target.exists() is False
-    assert not list(app_dir.glob(".codex-auth-import-*"))
-    _write_codex_auth(source, access_token="refreshed-token")
-
-    result = setup_probes.ensure_jobctrl_codex_auth(
-        {"CODEX_HOME": str(source.parent)},
-        runner=_successful_codex_status,
-    )
-
-    assert result == target
-    assert "refreshed-token" in target.read_text(encoding="utf-8")
-    assert not list(app_dir.glob(".codex-auth-import-*"))
 
 
-@pytest.mark.parametrize("mutation", ["symlink", "directory", "chmod"])
-def test_codex_import_revalidates_and_hardens_candidate_after_live_verification(
-    mutation: str,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    app_dir = tmp_path / "jobctrl"
-    source = tmp_path / "regular-codex/auth.json"
-    external = tmp_path / "replacement-auth.json"
-    _write_codex_auth(source, access_token="source-token")
-    _write_codex_auth(external, access_token="replacement-token")
-    source_bytes = source.read_bytes()
-    source_mode = stat.S_IMODE(source.stat().st_mode)
-    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
-    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
-
-    def mutate_candidate(_command, **kwargs):
-        candidate = Path(kwargs["env"]["CODEX_HOME"]) / "auth.json"
-        if mutation == "chmod":
-            candidate.chmod(0o644)
-        else:
-            candidate.unlink()
-            if mutation == "symlink":
-                candidate.symlink_to(external)
-            else:
-                candidate.mkdir()
-        return SimpleNamespace(returncode=0)
-
-    if mutation == "chmod":
-        target = setup_probes.ensure_jobctrl_codex_auth(
-            {"CODEX_HOME": str(source.parent)},
-            runner=mutate_candidate,
-        )
-        assert target.read_bytes() == source_bytes
-        assert stat.S_IMODE(target.stat().st_mode) == 0o600
-    else:
-        with pytest.raises(RuntimeError, match="symlink|regular file"):
-            setup_probes.ensure_jobctrl_codex_auth(
-                {"CODEX_HOME": str(source.parent)},
-                runner=mutate_candidate,
-            )
-        assert not (app_dir / "codex_home/auth.json").exists()
-    assert source.read_bytes() == source_bytes
-    assert stat.S_IMODE(source.stat().st_mode) == source_mode
-    assert not list(app_dir.glob(".codex-auth-import-*"))
-
-
-def test_codex_import_never_replaces_a_concurrent_valid_winner(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    app_dir = tmp_path / "jobctrl"
-    target = app_dir / "codex_home/auth.json"
-    source = tmp_path / "regular-codex/auth.json"
-    _write_codex_auth(source, access_token="candidate-token")
-    monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
-    monkeypatch.setattr(setup_probes, "resolve_codex_binary", lambda env=None: tmp_path / "codex")
-
-    def concurrent_winner(*_args, **_kwargs):
-        _write_codex_auth(target, access_token="winner-token")
-        target.chmod(0o644)
-        return SimpleNamespace(returncode=0)
-
-    result = setup_probes.ensure_jobctrl_codex_auth(
-        {"CODEX_HOME": str(source.parent)},
-        runner=concurrent_winner,
-    )
-
-    assert result == target
-    assert "winner-token" in target.read_text(encoding="utf-8")
-    assert "candidate-token" not in target.read_text(encoding="utf-8")
-    assert stat.S_IMODE(target.stat().st_mode) == 0o600
-    assert not list(app_dir.glob(".codex-auth-import-*"))
-
-
-@pytest.mark.parametrize("unsafe_leaf", ["home", "auth"])
-def test_codex_import_rejects_symlinks_in_the_owned_target_boundary(
-    unsafe_leaf: str,
+def test_codex_import_rejects_symlinked_target_auth(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -592,22 +541,14 @@ def test_codex_import_rejects_symlinks_in_the_owned_target_boundary(
     source = tmp_path / "regular-codex/auth.json"
     _write_codex_auth(source)
     target_home = app_dir / "codex_home"
-    if unsafe_leaf == "home":
-        external_home = tmp_path / "external-home"
-        external_home.mkdir()
-        target_home.symlink_to(external_home, target_is_directory=True)
-    else:
-        target_home.mkdir()
-        external_auth = tmp_path / "external-auth.json"
-        _write_codex_auth(external_auth)
-        (target_home / "auth.json").symlink_to(external_auth)
+    target_home.mkdir()
+    external_auth = tmp_path / "external-auth.json"
+    _write_codex_auth(external_auth)
+    (target_home / "auth.json").symlink_to(external_auth)
     monkeypatch.setattr(jobctrl.config, "APP_DIR", app_dir)
 
     with pytest.raises(RuntimeError, match="symlink"):
-        setup_probes.ensure_jobctrl_codex_auth(
-            {"CODEX_HOME": str(source.parent)},
-            runner=_successful_codex_status,
-        )
+        setup_probes.ensure_jobctrl_codex_auth({"CODEX_HOME": str(source.parent)})
 
 
 @pytest.mark.parametrize(

--- a/workers/automation/tests/test_setup_synthesis_auth.py
+++ b/workers/automation/tests/test_setup_synthesis_auth.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import stat
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -59,6 +61,19 @@ def _prepare_codex_setup_test(
     )
     monkeypatch.setattr(setup_probes, "_CODEX_AUTH_STATUS_CACHE", {})
     original_verify = setup_probes.verify_codex_connection
+    original_ensure = setup_probes.ensure_jobctrl_codex_auth
+
+    def ensure_jobctrl_codex_auth(env=None, **_kwargs):
+        return original_ensure(
+            env,
+            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0),
+        )
+
+    monkeypatch.setattr(
+        setup_probes,
+        "ensure_jobctrl_codex_auth",
+        ensure_jobctrl_codex_auth,
+    )
 
     def verify_codex_connection(env=None):
         return original_verify(
@@ -170,6 +185,90 @@ def test_setup_human_output_has_no_stale_warning_after_copying_codex_auth(
     assert "core LLM provider" in result.output
     assert "WARN" not in result.output
     assert "Core AI provider ready." in result.output
+
+
+def test_setup_fallback_prepares_private_owned_codex_home_before_login(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source_home = tmp_path / "source-codex"
+    source_home.mkdir()
+    (source_home / "auth.json").write_text("{}", encoding="utf-8")
+    _prepare_codex_setup_test(monkeypatch, app_dir=app_dir, source_home=source_home)
+    ambient_auth = {
+        key: f"ambient-{key.lower()}"
+        for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+    }
+    for key, value in ambient_auth.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(
+        cli_module,
+        "_confirm_setup_action",
+        lambda prompt, **_kwargs: "Enroll the current OpenAI key" in prompt,
+    )
+    calls = 0
+
+    def login_runner(_command, **kwargs):
+        nonlocal calls
+        calls += 1
+        target_home = Path(kwargs["env"]["CODEX_HOME"])
+        assert all(
+            key not in kwargs["env"]
+            for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
+        )
+        assert kwargs["input"] == ambient_auth["OPENAI_API_KEY"] + "\n"
+        assert target_home == app_dir / "codex_home"
+        assert target_home.is_dir() and not target_home.is_symlink()
+        assert stat.S_IMODE(target_home.stat().st_mode) == 0o700
+        target_auth = target_home / "auth.json"
+        _write_codex_auth(target_auth)
+        target_auth.chmod(0o600)
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", login_runner)
+
+    result = CliRunner().invoke(app, [*_MUTATING_SETUP_ARGS, "--launch-logins"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == 1
+    assert (source_home / "auth.json").read_text(encoding="utf-8") == "{}"
+
+
+@pytest.mark.parametrize("target_kind", ["symlink", "file"])
+def test_setup_fallback_rejects_unsafe_owned_codex_home(
+    target_kind: str,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    app_dir = tmp_path / "jobctrl"
+    source_home = tmp_path / "source-codex"
+    source_home.mkdir()
+    (source_home / "auth.json").write_text("{}", encoding="utf-8")
+    _prepare_codex_setup_test(monkeypatch, app_dir=app_dir, source_home=source_home)
+    app_dir.mkdir()
+    target_home = app_dir / "codex_home"
+    if target_kind == "symlink":
+        external = tmp_path / "external-codex-home"
+        external.mkdir()
+        target_home.symlink_to(external, target_is_directory=True)
+    else:
+        target_home.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setattr(jobctrl.config, "ensure_dirs", lambda: None)
+    monkeypatch.setattr(
+        cli_module,
+        "_confirm_setup_action",
+        lambda prompt, **_kwargs: "Authenticate JobCtrl's Codex CLI" in prompt,
+    )
+    def unexpected_login(*_args, **_kwargs):
+        raise AssertionError("unsafe Codex home reached the login subprocess")
+
+    monkeypatch.setattr(subprocess, "run", unexpected_login)
+
+    result = CliRunner().invoke(app, [*_MUTATING_SETUP_ARGS, "--launch-logins"])
+
+    assert result.exit_code == 1
+    assert "Unsafe JobCtrl Codex home" in result.output
 
 
 @pytest.mark.parametrize("source_kind", ["invalid", "symlink"])

--- a/workers/automation/tests/test_setup_synthesis_auth.py
+++ b/workers/automation/tests/test_setup_synthesis_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import stat
 import subprocess
 from pathlib import Path
@@ -61,19 +62,6 @@ def _prepare_codex_setup_test(
     )
     monkeypatch.setattr(setup_probes, "_CODEX_AUTH_STATUS_CACHE", {})
     original_verify = setup_probes.verify_codex_connection
-    original_ensure = setup_probes.ensure_jobctrl_codex_auth
-
-    def ensure_jobctrl_codex_auth(env=None, **_kwargs):
-        return original_ensure(
-            env,
-            runner=lambda *_args, **_kwargs: SimpleNamespace(returncode=0),
-        )
-
-    monkeypatch.setattr(
-        setup_probes,
-        "ensure_jobctrl_codex_auth",
-        ensure_jobctrl_codex_auth,
-    )
 
     def verify_codex_connection(env=None):
         return original_verify(
@@ -220,7 +208,8 @@ def test_setup_fallback_prepares_private_owned_codex_home_before_login(
         assert kwargs["input"] == ambient_auth["OPENAI_API_KEY"] + "\n"
         assert target_home == app_dir / "codex_home"
         assert target_home.is_dir() and not target_home.is_symlink()
-        assert stat.S_IMODE(target_home.stat().st_mode) == 0o700
+        if os.name != "nt":
+            assert stat.S_IMODE(target_home.stat().st_mode) == 0o700
         target_auth = target_home / "auth.json"
         _write_codex_auth(target_auth)
         target_auth.chmod(0o600)
@@ -235,9 +224,7 @@ def test_setup_fallback_prepares_private_owned_codex_home_before_login(
     assert (source_home / "auth.json").read_text(encoding="utf-8") == "{}"
 
 
-@pytest.mark.parametrize("target_kind", ["symlink", "file"])
-def test_setup_fallback_rejects_unsafe_owned_codex_home(
-    target_kind: str,
+def test_setup_fallback_rejects_non_directory_owned_codex_home(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -248,12 +235,7 @@ def test_setup_fallback_rejects_unsafe_owned_codex_home(
     _prepare_codex_setup_test(monkeypatch, app_dir=app_dir, source_home=source_home)
     app_dir.mkdir()
     target_home = app_dir / "codex_home"
-    if target_kind == "symlink":
-        external = tmp_path / "external-codex-home"
-        external.mkdir()
-        target_home.symlink_to(external, target_is_directory=True)
-    else:
-        target_home.write_text("not a directory", encoding="utf-8")
+    target_home.write_text("not a directory", encoding="utf-8")
     monkeypatch.setattr(jobctrl.config, "ensure_dirs", lambda: None)
     monkeypatch.setattr(
         cli_module,


### PR DESCRIPTION
## What changed

- let the explicit Codex action in Settings reuse a valid existing Codex CLI login when JobCtrl's provider home is empty
- preserve the established cross-platform copy-once behavior used by setup and generation
- verify the JobCtrl-owned Codex home with ambient authentication variables removed from the child process
- keep provider status and model-catalog reads non-mutating
- keep direct login into the JobCtrl-owned home as the fallback when no reusable login exists
- update onboarding, configuration, API, architecture, and security copy to describe the actual reuse flow

## Root cause

JobCtrl already reused normal Codex CLI authentication during setup and generation, but onboarding described a second isolated login as the default and Settings only verified the isolated home. The new Settings action now invokes the existing reuse path before verification, so an already authenticated Codex user normally does not log in again.

## Compatibility

The implementation intentionally retains the pre-existing cross-platform copy-once contract. It does not introduce Windows-native filesystem code and does not claim staged, atomic, or TOCTOU-safe credential publication. Existing isolated authentication is never overwritten, and source authentication remains unchanged.

## Validation

- final static review: PASS with 0 Blocker, 0 High, 0 Medium, and 0 Low findings
- targeted Ruff: passed
- focused Python auth/setup/JSON-RPC suite: 89 passed
- CredentialsPanel focused suite: 18 passed
- full web Vitest suite: 1,461 passed
- web typecheck: passed
- API credential documentation contract: 4 passed
- launch-copy documentation contract: 3 passed
- docs build: passed; 5,835 references resolved across 261 emitted files
- git diff check: passed
- browser/manual QA: intentionally left for maintainer verification

## Residual risk

- native Windows execution was not available locally; compatibility is preserved by retaining the pre-PR cross-platform implementation and was reviewed statically
- the inherited pathname-based copy behavior remains outside this PR's scope and is not represented as an atomic security guarantee
