### PR TITLE
docs: simplify launch setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,8 @@
 # Configure at least one provider. Settings -> Credentials is preferred on macOS.
 # One ready provider is sufficient; a second is optional.
 
-# Codex: authenticate the stable JobCtrl-owned CLI home. Do not put an OpenAI
-# key here for direct runtime use. Run `jobctrl setup --launch-logins`, or:
-# CODEX_HOME="${JOBCTRL_DIR:-$HOME/.jobctrl}/codex_home" codex login
-# printenv OPENAI_API_KEY | CODEX_HOME="${JOBCTRL_DIR:-$HOME/.jobctrl}/codex_home" codex login --with-api-key
+# Codex: use an authenticated Codex CLI. API-key users may authenticate through
+# Codex's `codex login --with-api-key` flow.
 
 # Claude: choose exactly one route.
 # ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Or acquire the same signed build with Homebrew:
 brew install ebarti/tap/jobctrl
 ```
 
+These public acquisition paths currently target Apple-silicon macOS. Native
+Windows is not yet a supported public installation path.
+
 Both methods install one native `jobctrl` command plus its managed private
 runtime. Start the complete local product from any directory:
 
@@ -330,12 +333,6 @@ By default, JobCtrl writes local data under `~/.jobctrl/`:
 - `tailored_resumes/`, `cover_letters/`, `logs/` — generated artifacts and
   logs.
 - `chrome-workers/`, `apply-workers/` — local browser/apply worker state.
-- `codex_home/` — JobCtrl-owned Codex home for local analysis. Setup and the
-  first generation retain one-time reuse of a valid regular Codex CLI login;
-  Settings verification invokes the same copy-once behavior before checking
-  the isolated login. Existing isolated auth is not overwritten, and the normal
-  Codex home is not changed. Prompt-driven commands run from
-  `codex_home/workspace/` only.
 - `backups/` — source-mode `jobctrl backup` snapshots and, once the P6-signed
   bundled channel is public, verified paired lifecycle snapshots.
 
@@ -507,13 +504,12 @@ registries. Compensation-source opt-ins are managed from Settings and stored
 locally. Start with [.env.example](.env.example); full reference:
 [Configuration](https://jobctrl.dev/user/configuration).
 
-The cross-platform provider-credential path is the plaintext
+Providers that accept environment credentials can use the plaintext
 `~/.jobctrl/.env` file or the process environment. On macOS, **Settings →
-Credentials** guides one of three providers: an existing authenticated Codex
-CLI reused into JobCtrl's isolated home (or fallback target-home login), Claude
-Agent SDK (Anthropic API key or supported cloud-provider credentials), or
-Google (Gemini key or Vertex AI ADC). One ready provider is sufficient for all
-core AI stages; a second provider is optional. After a provider is ready,
+Credentials** guides one of three providers: an authenticated Codex CLI,
+Claude Agent SDK (Anthropic API key or supported cloud-provider credentials),
+or Google (Gemini key or Vertex AI ADC). One ready provider is sufficient for
+all core AI stages; a second provider is optional. After a provider is ready,
 Settings can save a preferred model for that provider. Codex and Google choices
 come from live provider catalogs; Claude exposes the provider-safe `sonnet`,
 `opus`, and `haiku` aliases rather than claiming live enumeration. A saved model
@@ -538,11 +534,6 @@ Keychain output.
 
 - `JOBCTRL_DIR` — override the local app directory.
 - `ANTHROPIC_API_KEY` or a supported Claude cloud-provider route — Claude.
-- `$JOBCTRL_DIR/codex_home/auth.json` — Codex; setup, first generation, or the
-  Settings verify action can copy an existing valid normal Codex CLI login
-  once. Existing isolated auth is not overwritten. If there is no reusable login, authenticate this
-  isolated home with a ChatGPT subscription or enroll an API key through
-  `codex login --with-api-key`. Raw OpenAI keys are not used directly.
 - `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or Vertex AI ADC — Google.
 - `JOBCTRL_ANALYSIS_LEGS` — comma-separated enabled analysis legs when setup
   intentionally skips an unauthenticated leg.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,10 @@
 
 - [`user/getting-started.md`](user/getting-started.md): install, configure, run,
   and seed a disposable workspace.
-- [`user/configuration.md`](user/configuration.md): runtime variables,
-  provider keys, local data paths, telemetry, browser automation, Gmail, and
-  screenshot/test workspaces.
+- [`user/configuration.md`](user/configuration.md): user-facing profile and
+  provider choices, local data, spend controls, discovery, browser automation,
+  Gmail, compensation sources, observability, and test/documentation
+  workspaces.
 - [`user/normal-flows.md`](user/normal-flows.md): expected product flows from
   setup through review and apply.
 - [`user/data-and-safety.md`](user/data-and-safety.md): local data boundaries,
@@ -70,8 +71,9 @@
 - [`architecture/tailoring.md`](architecture/tailoring.md): resume tailoring
   prompt contract, generated JSON shape, validation/judge/fabrication gates,
   provenance, audit metadata, and safe change points.
-- [`local-development.md`](local-development.md): setup, run, build, test, lint
-  commands, and the synthetic documentation-screenshot workflow.
+- [`local-development.md`](local-development.md): setup, run, runtime
+  overrides, build, test, lint commands, and the synthetic
+  documentation-screenshot workflow.
 - [`developer/first-run-ttfv.md`](developer/first-run-ttfv.md): owner-run
   real-path first-run time-to-value measurement protocol and generated record
   commands.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -94,6 +94,30 @@ defaults to:
 - Temporal persistence: `.dev/temporal/temporal.db`
   (`JOBCTRL_TEMPORAL_DB` can override it)
 
+### Runtime Overrides
+
+Use these source-development overrides when troubleshooting a component or
+running isolated or multi-worktree stacks. Most contributors can keep the
+launcher defaults above.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `JOBCTRL_DIR` | `~/.jobctrl` | Local app directory for database, settings, artifacts, logs, browser worker state, and `.env`. |
+| `JOBCTRL_DB_PATH` | `$JOBCTRL_DIR/jobctrl.db` | TypeScript API database path. The Python worker ignores it and always uses `$JOBCTRL_DIR/jobctrl.db`, so overriding it desynchronizes the API from the worker — prefer `JOBCTRL_DIR` to move both. |
+| `JOBCTRL_DASHBOARD_CONFIG_PATH` | `$JOBCTRL_DIR/dashboard.json` | Non-secret settings file written by the TypeScript API and read by both API and worker (preferences, provider-scoped model IDs, apply approval gate, spend budget). |
+| `JOBCTRL_API_HOST` | `127.0.0.1` | Local API bind host. Non-loopback hosts require explicit opt-in. |
+| `JOBCTRL_API_PORT` / `PORT` | `8766` | Local API port. |
+| `JOBCTRL_API_ALLOW_REMOTE_BIND` | unset | Set to `1`, `true`, or `yes` to allow non-loopback API binding. This can expose private local data. |
+| `JOBCTRL_WEB_PORT` | `5173` | Requested Vite development port. |
+| `VITE_JOBCTRL_API_BASE_URL` | proxied `/v1` | Browser API origin when not using the default Vite proxy. |
+| `JOBCTRL_TEMPORAL_DB` | `.dev/temporal/temporal.db` | Temporal (the workflow engine) dev-server SQLite history store. |
+| `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal server address used by the worker, CLI, and workflow-starting RPC. |
+| `TEMPORAL_NAMESPACE` | `default` | Temporal namespace. |
+| `JOBCTRL_MAX_CONCURRENT_ACTIVITIES` | `4` | Maximum Temporal activities the local worker runs at once (shown on the Settings page). Set in the worker environment and restart the worker to apply. |
+| `JOBCTRL_API_SSE_POLL_MS` | `250` | API event-stream database poll interval in milliseconds. |
+| `VITE_DEV_API_PROXY_TARGET` | `http://127.0.0.1:8766` | Vite dev-server `/v1` proxy target; override it for isolated or multi-worktree stacks. |
+| `VITE_GOOGLE_MAPS_API_KEY` | unset | Enables Google Maps address search in the Profile form. |
+
 Inspect the foreground stack from another terminal:
 
 ```bash

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -33,7 +33,6 @@ Contributors running from source can use the checkout-prefixed commands in
 | Discovery sources, schedules, quarantine, or manual capture | Discovery in the web app |
 | Approval, spend, worker, or provider behavior | Settings in the web app |
 | Provider secret used by the Python runtime | `~/.jobctrl/.env`, shell environment, or the macOS credential panel |
-| One isolated development/QA stack | `JOBCTRL_DIR`, API/web ports, and [Test And Documentation Workspaces](#test-and-documentation-workspaces) |
 
 The rest of this page is a lookup table. [Data, Privacy & Safety](data-and-safety.md)
 explains what is stored or sent; [Security](security.md) explains the controls
@@ -54,10 +53,9 @@ The development launcher loads `~/.jobctrl/.env`, repo `.env`, and the optional
 
 On macOS, **Settings → Credentials** is the preferred guided provider setup. It
 stores Anthropic or Gemini API keys and the selected provider-mode settings in
-macOS Keychain. Codex credentials stay in JobCtrl's isolated Codex home, and
-AWS, Google, and Azure credentials stay in their native CLI-managed stores;
-JobCtrl records only the activation flags and non-secret identifiers needed to
-select those routes.
+macOS Keychain. Codex uses an authenticated Codex CLI, and AWS, Google, and
+Azure credentials stay in their native CLI-managed stores; JobCtrl records only
+the activation flags and non-secret identifiers needed to select those routes.
 
 At Python process startup, after env-file loading, JobCtrl uses a Keychain value
 only when the corresponding environment value is missing or empty; any
@@ -90,25 +88,17 @@ The profile also supports `application_preferences.how_heard` for common
 "How did you hear about us?" questions. It is a preference, not a legal
 attestation; leave it empty when there is no truthful answer.
 
-## Core Runtime
+## Local Data
 
-| Variable | Default | What it does |
-| --- | --- | --- |
-| `JOBCTRL_DIR` | `~/.jobctrl` | Local app directory for database, settings, artifacts, logs, browser worker state, and `.env`. |
-| `JOBCTRL_DB_PATH` | `$JOBCTRL_DIR/jobctrl.db` | TypeScript API database path. The Python worker ignores it and always uses `$JOBCTRL_DIR/jobctrl.db`, so overriding it desynchronizes the API from the worker — prefer `JOBCTRL_DIR` to move both. |
-| `JOBCTRL_DASHBOARD_CONFIG_PATH` | `$JOBCTRL_DIR/dashboard.json` | Non-secret settings file written by the TypeScript API and read by both API and worker (preferences, provider-scoped model IDs, apply approval gate, spend budget). |
-| `JOBCTRL_API_HOST` | `127.0.0.1` | Local API bind host. Non-loopback hosts require explicit opt-in. |
-| `JOBCTRL_API_PORT` / `PORT` | `8766` | Local API port. |
-| `JOBCTRL_API_ALLOW_REMOTE_BIND` | unset | Set to `1`, `true`, or `yes` to allow non-loopback API binding. This can expose private local data. |
-| `JOBCTRL_WEB_PORT` | `5173` | Requested Vite development port. |
-| `VITE_JOBCTRL_API_BASE_URL` | proxied `/v1` | Browser API origin when not using the default Vite proxy. |
-| `JOBCTRL_TEMPORAL_DB` | `.dev/temporal/temporal.db` | Temporal (the workflow engine) dev-server SQLite history store. |
-| `TEMPORAL_ADDRESS` | `localhost:7233` | Temporal server address used by the worker, CLI, and workflow-starting RPC. |
-| `TEMPORAL_NAMESPACE` | `default` | Temporal namespace. |
-| `JOBCTRL_MAX_CONCURRENT_ACTIVITIES` | `4` | Maximum Temporal activities the local worker runs at once (shown on the Settings page). Set in the worker environment and restart the worker to apply. |
-| `JOBCTRL_API_SSE_POLL_MS` | `250` | API event-stream database poll interval in milliseconds. |
-| `VITE_DEV_API_PROXY_TARGET` | `http://127.0.0.1:8766` | Vite dev-server `/v1` proxy target; override it for isolated or multi-worktree stacks. |
-| `VITE_GOOGLE_MAPS_API_KEY` | unset | Enables Google Maps address search in the Profile form. |
+JobCtrl stores its local database, settings, provider environment file,
+generated artifacts, logs, and browser state under `~/.jobctrl` by default.
+Most users should leave this location unchanged. Advanced users can set
+`JOBCTRL_DIR` before starting JobCtrl to relocate the entire local data
+directory. See
+[Data, Privacy & Safety](data-and-safety.md) for what stays local and what may
+leave the machine. Contributors who need custom data paths, ports, Temporal
+settings, API/Vite proxy targets, or isolated stacks should use
+[Local Development → Runtime Overrides](../local-development.md#runtime-overrides).
 
 ## LLM Providers
 
@@ -145,40 +135,9 @@ restart requirement (or require an explicit adapter reset).
 
 ### Codex
 
-JobCtrl uses persisted Codex CLI authentication only. A raw
-`OPENAI_API_KEY` in JobCtrl's environment or Keychain is not a direct model
-route and does not satisfy readiness. If your normal Codex CLI is already
-authenticated, click **Reuse existing login or verify** in **Settings →
-Credentials**. Setup and the first generation retain the same one-time reuse
-behavior. Each path validates the regular CLI `auth.json` before copying it to
-JobCtrl's stable isolated home, without changing the normal Codex home.
-
-If there is no reusable normal Codex CLI login, fall back to authenticating the
-stable JobCtrl-owned home with a ChatGPT subscription or an API key enrolled
-through Codex:
-
-```bash
-CODEX_HOME="${JOBCTRL_DIR:-$HOME/.jobctrl}/codex_home" codex login
-
-printenv OPENAI_API_KEY | \
-  CODEX_HOME="${JOBCTRL_DIR:-$HOME/.jobctrl}/codex_home" \
-  codex login --with-api-key
-```
-
-`jobctrl setup --launch-logins` uses the bundled Codex runtime for the fallback
-flow. The Settings card can invoke the same reusable-login importer and verify
-the resulting isolated login without making a model call. Codex stores local
-state under `CODEX_HOME`, and `codex login status`
-exits successfully when credentials are present. See the official
-[Codex login command](https://learn.chatgpt.com/docs/developer-commands#codex-login)
-and [state-location reference](https://learn.chatgpt.com/docs/config-file/config-advanced#config-and-state-locations).
-
-JobCtrl keeps authentication outside the model-readable
-`codex_home/workspace/` directory. If isolated auth is absent, setup,
-generation, and the Settings verify action use one shared copy-once path. It
-never overwrites an existing isolated login, changes the normal Codex home, or
-creates a transient per-run runtime home. Settings then checks the isolated
-login with `codex login status`.
+JobCtrl requires an authenticated Codex CLI and reuses that authentication.
+API-key users may authenticate through Codex's `codex login --with-api-key`
+flow.
 
 ### Claude
 

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -81,7 +81,6 @@ Unless a row says otherwise, every path below is relative to JOBCTRL_DIR
 | `.env` | Plaintext provider credentials and runtime settings. Not encrypted at rest. |
 | `tailored_resumes/`, `cover_letters/` | Generated text, HTML, and PDF artifacts. |
 | `logs/`, `apply-workers/`, `chrome-workers/` | Logs and local browser/apply state. |
-| `codex_home/` | JobCtrl-owned integration state, isolated from the normal Codex app home. |
 | `backups/` | Timestamped SQLite snapshots created by `jobctrl backup`. |
 | `gmail/` | Gmail OAuth client and token files. |
 | Baseline/legacy resume files | `resume.txt`, `resume.pdf`, and older local style/template files. |
@@ -91,13 +90,15 @@ directory; treat those logs as sensitive too.
 
 ### Credentials Outside The Workspace
 
-The macOS credential panel guides Codex, Claude, and Google setup. Anthropic and
-Gemini API keys plus cloud activation flags/non-secret identifiers can live in
-Keychain. Codex auth lives under the isolated `codex_home`; AWS, Google, and
-Azure credential files remain in their vendor stores. After environment-file
-loading, Python loads a Keychain entry at startup only when that environment
-value is missing or empty. Any non-empty environment value already present
-wins. Restart JobCtrl after saving or removing a value.
+The macOS credential panel guides Codex, Claude, and Google setup. Codex
+requires an authenticated Codex CLI. Reused authentication stays in sensitive
+local provider state outside SQLite and the prompt-readable workspace.
+Anthropic and Gemini API keys plus cloud activation flags/non-secret identifiers
+can live in Keychain; AWS, Google, and Azure credential files remain in their
+vendor stores. After environment-file loading, Python loads a Keychain entry at
+startup only when that environment value is missing or empty. Any non-empty
+environment value already present wins. Restart JobCtrl after saving or removing
+a value.
 
 Windows Credential Manager and Linux Secret Service/keyring adapters are
 planned; those platforms use `.env` or shell variables today. The panel returns

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -5,7 +5,7 @@ pageClass: jh-user-guide-page
 # Getting Started
 
 JobCtrl is a local application: the app, database, settings, and generated
-files stay on your Mac unless you explicitly connect an external provider.
+files stay on your computer unless you explicitly connect an external provider.
 Install it once, then use the same `jobctrl` command from any directory.
 
 ::: tip Want to explore before installing?
@@ -16,22 +16,24 @@ for a screen-by-screen walkthrough.
 
 ## What You Need
 
-- An Apple-silicon Mac running macOS 15 or newer.
+- For the bundled installer or Homebrew: an Apple-silicon Mac running macOS 15
+  or newer.
 - Internet access for installation, updates, and any hosted providers you
   choose to connect.
 - One supported LLM provider before you run scoring or material generation:
   Codex, Claude, or Google.
 
 The bundled install includes JobCtrl's application runtimes, workflow engine,
-PDF tooling, and managed headless browser. You do **not** need to install Git,
-Node.js, pnpm, Corepack, uv, Python, Temporal, Poppler, Playwright, or Chrome
-for the core product. A system Chrome or Chromium installation is optional and
-used only by capabilities that explicitly adopt an authenticated browser.
+PDF tooling, and managed headless browser. A system Chrome or Chromium
+installation is optional and used only by capabilities that explicitly adopt
+an authenticated browser.
 
 ## 1. Install JobCtrl
 
 Choose one acquisition method. The installer and Homebrew formula resolve the
-same signed JobCtrl release and provide the same `jobctrl` command.
+same signed JobCtrl release and provide the same `jobctrl` command. These public
+acquisition paths currently target Apple-silicon macOS. Native Windows is not
+yet a supported public installation path.
 
 ### Recommended: bundled installer
 
@@ -107,13 +109,8 @@ not recorded there.
 
 Open **Settings → Credentials** and configure one provider:
 
-- **Codex:** setup and first generation copy a valid normal Codex CLI
-  login once, and **Reuse existing login or verify** invokes the same path from
-  Settings before checking the isolated login. Existing isolated auth is not
-  overwritten, and the normal home is unchanged. If there is no login to reuse,
-  authenticate the isolated home with a ChatGPT subscription or enroll an
-  OpenAI API key through `codex login`. A raw `OPENAI_API_KEY` is not used
-  directly by JobCtrl.
+- **Codex:** have an authenticated Codex CLI. JobCtrl reuses that authentication;
+  API-key users may use Codex's `codex login --with-api-key` flow.
 - **Claude:** use an Anthropic API key or one of the guided Google Vertex,
   Amazon Bedrock, Claude Platform on AWS, or Microsoft Foundry routes.
 - **Google:** use a Gemini API key or Vertex AI Application Default

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -172,7 +172,7 @@ browser session but remains rate/budget limited. See
 | Secret | Boundary |
 | --- | --- |
 | Provider/runtime keys | Shell, plaintext `~/.jobctrl/.env`, or the guided macOS Keychain boundary; never SQLite. |
-| Codex login | Persisted under JobCtrl's isolated `codex_home`; setup, first generation, and Settings verification can copy valid authentication once from an existing normal login. Existing isolated auth is not overwritten, and the normal home is unchanged. Raw OpenAI keys are enrollment input only. |
+| Codex login | JobCtrl requires an authenticated Codex CLI. Reused authentication stays in sensitive local provider state outside SQLite and the prompt-readable workspace. |
 | Claude/Google web entries | Keychain for API keys plus cloud activation flags/non-secret identifiers; AWS, Google, and Azure credential files remain in their vendor stores. Status only is returned. |
 | CAPTCHA key | `CAPSOLVER_API_KEY` read by the owned local solver, not the model. |
 | Job-site passwords | Optional local profile value typed through a focused-field credential tool, never returned to the model. |

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -21,6 +21,26 @@ test("public onboarding leads with bundled acquisition and keeps source advanced
   assert.ok(installer >= 0 && installer < homebrew && homebrew < source);
   assert.match(gettingStarted, /Only this option requires Git/);
   assert.doesNotMatch(gettingStarted, /^## \d+\. Source-Checkout Requirements$/m);
+  assert.match(
+    gettingStarted,
+    /For the bundled installer or Homebrew: an Apple-silicon Mac running macOS 15\s+or newer\./,
+  );
+  const normalizedOnboarding = [gettingStarted, readme].map((document) =>
+    document.replace(/\s+/g, " "),
+  );
+  for (const document of normalizedOnboarding) {
+    assert.match(
+      document,
+      /Native Windows is not yet a supported public installation path\./i,
+    );
+    assert.doesNotMatch(
+      document,
+      /Windows compatibility currently uses this source-development path until a signed Windows bundle is published\./i,
+    );
+  }
+  assert.match(gettingStarted, /stay on your computer/);
+  assert.doesNotMatch(gettingStarted, /stay on your Mac/);
+  assert.doesNotMatch(gettingStarted, /You do \*\*not\*\* need to install Git/);
 
   const publicCopy = [
     readme,
@@ -59,24 +79,77 @@ test("launch provider guidance requires one of Codex, Claude, or Google", async 
   const gettingStarted = await read("docs/user/getting-started.md");
   const configuration = await read("docs/user/configuration.md");
   const envExample = await read(".env.example");
+  const security = await read("docs/user/security.md");
+  const dataAndSafety = await read("docs/user/data-and-safety.md");
   const publicProviderCopy = [
     readme,
     gettingStarted,
     configuration,
     envExample,
-    await read("docs/user/security.md"),
-    await read("docs/user/data-and-safety.md"),
+    security,
+    dataAndSafety,
     await read("docs/architecture/runtime.md"),
     await read("docs/api/complete-contract.md"),
+  ].join("\n");
+  const publicCodexCopy = [
+    readme,
+    gettingStarted,
+    configuration,
+    envExample,
+    security,
+    dataAndSafety,
   ].join("\n");
 
   assert.match(gettingStarted, /One ready provider is sufficient/);
   assert.match(configuration, /^### Codex$/m);
   assert.match(configuration, /^### Claude$/m);
   assert.match(configuration, /^### Google$/m);
-  assert.match(gettingStarted, /Reuse existing login or verify/);
-  assert.match(configuration, /validates the regular CLI `auth\.json` before copying it/);
-  assert.match(configuration, /codex login --with-api-key/);
+  for (const document of [
+    readme,
+    gettingStarted,
+    configuration,
+    envExample,
+    security,
+    dataAndSafety,
+  ]) {
+    assert.match(document, /authenticated Codex CLI/i);
+  }
+
+  const readmeConfigurationStart = readme.indexOf("## Configuration");
+  const readmeDevelopmentStart = readme.indexOf(
+    "## Development",
+    readmeConfigurationStart,
+  );
+  assert.ok(
+    readmeConfigurationStart >= 0 &&
+      readmeDevelopmentStart > readmeConfigurationStart,
+  );
+  const readmeConfiguration = readme.slice(
+    readmeConfigurationStart,
+    readmeDevelopmentStart,
+  );
+  assert.doesNotMatch(
+    `${readmeConfiguration}\n${gettingStarted}`,
+    /auth\.json|setup --launch-logins|isolated (?:Codex )?home|copy-once|fallback target-home/i,
+  );
+
+  const codexStart = configuration.indexOf("### Codex");
+  const claudeStart = configuration.indexOf("### Claude", codexStart);
+  assert.ok(codexStart >= 0 && claudeStart > codexStart);
+  const codexSection = configuration.slice(codexStart, claudeStart);
+  assert.match(codexSection, /codex login --with-api-key/);
+  assert.doesNotMatch(
+    codexSection,
+    /CODEX_HOME|codex_home|auth\.json|setup --launch-logins|isolated (?:Codex )?home|fallback target-home/i,
+  );
+  assert.doesNotMatch(
+    publicCodexCopy,
+    /CODEX_HOME|codex_home|auth\.json|setup --launch-logins|isolated (?:Codex )?home|fallback target-home/i,
+  );
+  assert.doesNotMatch(
+    publicCodexCopy,
+    /\b(?:Codex (?:CLI )?login|credentials?|authentication) (?:copy|copying|import|importing|staging)\b|\b(?:copy|copying|import|importing) (?:an? )?(?:existing |valid |normal )*(?:Codex (?:CLI )?login|credentials?|authentication)\b|\b(?:copy-once|reusable-login importer)\b/i,
+  );
   assert.match(configuration, /CLAUDE_CODE_USE_BEDROCK/);
   assert.match(configuration, /CLAUDE_CODE_USE_ANTHROPIC_AWS/);
   assert.match(configuration, /CLAUDE_CODE_USE_VERTEX/);
@@ -85,4 +158,115 @@ test("launch provider guidance requires one of Codex, Claude, or Google", async 
   assert.doesNotMatch(publicProviderCopy, /LLM_URL|LLM_API_KEY/);
   assert.doesNotMatch(gettingStarted, /local OpenAI-compatible/i);
   assert.doesNotMatch(readme, /OpenAI-backed scoring|general LLM access.*OPENAI_API_KEY/i);
+});
+
+test("runtime overrides stay in contributor documentation", async () => {
+  const configuration = await read("docs/user/configuration.md");
+  const localDevelopment = await read("docs/local-development.md");
+  const expectedRuntimeOverrides = [
+    ["`JOBCTRL_DIR`", "`~/.jobctrl`"],
+    ["`JOBCTRL_DB_PATH`", "`$JOBCTRL_DIR/jobctrl.db`"],
+    ["`JOBCTRL_DASHBOARD_CONFIG_PATH`", "`$JOBCTRL_DIR/dashboard.json`"],
+    ["`JOBCTRL_API_HOST`", "`127.0.0.1`"],
+    ["`JOBCTRL_API_PORT` / `PORT`", "`8766`"],
+    ["`JOBCTRL_API_ALLOW_REMOTE_BIND`", "unset"],
+    ["`JOBCTRL_WEB_PORT`", "`5173`"],
+    ["`VITE_JOBCTRL_API_BASE_URL`", "proxied `/v1`"],
+    ["`JOBCTRL_TEMPORAL_DB`", "`.dev/temporal/temporal.db`"],
+    ["`TEMPORAL_ADDRESS`", "`localhost:7233`"],
+    ["`TEMPORAL_NAMESPACE`", "`default`"],
+    ["`JOBCTRL_MAX_CONCURRENT_ACTIVITIES`", "`4`"],
+    ["`JOBCTRL_API_SSE_POLL_MS`", "`250`"],
+    ["`VITE_DEV_API_PROXY_TARGET`", "`http://127.0.0.1:8766`"],
+    ["`VITE_GOOGLE_MAPS_API_KEY`", "unset"],
+  ];
+  const developerOnlyLocalDataVariables = [
+    "JOBCTRL_DB_PATH",
+    "JOBCTRL_DASHBOARD_CONFIG_PATH",
+    "JOBCTRL_API_HOST",
+    "JOBCTRL_API_PORT",
+    "JOBCTRL_API_ALLOW_REMOTE_BIND",
+    "JOBCTRL_WEB_PORT",
+    "VITE_JOBCTRL_API_BASE_URL",
+    "JOBCTRL_TEMPORAL_DB",
+    "TEMPORAL_ADDRESS",
+    "TEMPORAL_NAMESPACE",
+    "JOBCTRL_API_SSE_POLL_MS",
+    "VITE_DEV_API_PROXY_TARGET",
+  ];
+
+  assert.doesNotMatch(configuration, /^## Core Runtime$/m);
+  assert.doesNotMatch(configuration, /One isolated development\/QA stack/);
+
+  const localDataStart = configuration.indexOf("## Local Data");
+  const nextSection = configuration.indexOf("\n## ", localDataStart + 1);
+  assert.ok(localDataStart >= 0 && nextSection > localDataStart);
+  const localData = configuration.slice(localDataStart, nextSection);
+  for (const variable of developerOnlyLocalDataVariables) {
+    assert.ok(!localData.includes(`\`${variable}\``));
+  }
+  assert.match(localData, /`~\/.jobctrl`/);
+  assert.match(localData, /set\s+`JOBCTRL_DIR`\s+before starting JobCtrl/i);
+  assert.match(localData, /\[Data, Privacy & Safety\]\(data-and-safety\.md\)/);
+  assert.match(
+    localData,
+    /\[Local Development → Runtime Overrides\]\(\.\.\/local-development\.md#runtime-overrides\)/,
+  );
+  assert.doesNotMatch(localData, /^\| Variable \|/m);
+  assert.match(localDevelopment, /^### Runtime Overrides$/m);
+
+  const runtimeOverridesStart = localDevelopment.indexOf(
+    "### Runtime Overrides",
+  );
+  const nextRuntimeSubsection = localDevelopment.indexOf(
+    "\n### ",
+    runtimeOverridesStart + 1,
+  );
+  assert.ok(
+    runtimeOverridesStart >= 0 &&
+      nextRuntimeSubsection > runtimeOverridesStart,
+  );
+  const runtimeOverrides = localDevelopment.slice(
+    runtimeOverridesStart,
+    nextRuntimeSubsection,
+  );
+  const tableLines = runtimeOverrides
+    .split(/\r?\n/)
+    .filter((line) => /^\s*\|/.test(line));
+  const parseTableRow = (line) =>
+    line
+      .trim()
+      .replace(/^\|/, "")
+      .replace(/\|$/, "")
+      .split("|")
+      .map((cell) => cell.trim());
+
+  assert.equal(tableLines.length, expectedRuntimeOverrides.length + 2);
+  assert.deepEqual(parseTableRow(tableLines[0]), [
+    "Variable",
+    "Default",
+    "What it does",
+  ]);
+  assert.deepEqual(parseTableRow(tableLines[1]), ["---", "---", "---"]);
+  const runtimeRows = tableLines.slice(2).map(parseTableRow);
+  assert.deepEqual(
+    runtimeRows.map(([variable, defaultValue]) => [variable, defaultValue]),
+    expectedRuntimeOverrides,
+  );
+
+  const descriptions = new Map(
+    runtimeRows.map(([variable, , description]) => [variable, description]),
+  );
+  assert.match(
+    descriptions.get("`JOBCTRL_DB_PATH`"),
+    /Python worker ignores it.*desynchronizes the API from the worker.*prefer `JOBCTRL_DIR`/i,
+  );
+  assert.match(
+    descriptions.get("`JOBCTRL_API_HOST`"),
+    /Non-loopback hosts require explicit opt-in/i,
+  );
+  assert.match(
+    descriptions.get("`JOBCTRL_API_ALLOW_REMOTE_BIND`"),
+    /Set to `1`, `true`, or `yes` to allow non-loopback API binding.*expose private local data/i,
+  );
 });


### PR DESCRIPTION
## What changed

- simplify Codex setup guidance to require an authenticated Codex CLI, with only the optional API-key login flow mentioned
- scope the signed bundled installer and Homebrew requirement to Apple-silicon macOS 15 or newer
- state that native Windows is not yet a supported public installation path
- remove the negative bundled-tool inventory from Getting Started
- replace the end-user Core Runtime table with concise Local Data guidance
- move the complete 15-row runtime override reference, defaults, and safety warnings to Local Development
- retain path-free security guidance for sensitive local provider state
- strengthen launch-copy contracts across public onboarding and the user/developer documentation boundary

## Why

Public onboarding leaked internal Codex and runtime implementation details into end-user instructions. The user guide should explain choices users can act on, while API ports, Temporal, Vite proxying, SSE polling, concurrency, and isolated-stack controls belong in contributor documentation.

The platform wording also must not imply native Windows support before a public installation path is verified.

## Validation

- git diff --check
- node --test scripts/docs-launch-copy.test.mjs (4 passed)
- corepack pnpm --filter @jobctrl/api exec vitest run test/credential-docs-contract.test.ts (4 passed)
- corepack pnpm docs:build (5,837 links resolved across 261 emitted files)

## QA

Manual browser QA is intentionally left to the maintainer.