### PR TITLE
build(release): publish artifacts directly to R2

### DIFF
--- a/.github/workflows/release-distribution.yml
+++ b/.github/workflows/release-distribution.yml
@@ -764,12 +764,20 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
-      - name: Publish checksum-checked immutable candidate assets
+      - name: Publish checksum-checked immutable candidate assets to R2
         env:
-          RELEASE_UPLOAD_BASE_URL: ${{ secrets.JOBCTRL_RELEASE_UPLOAD_BASE_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.JOBCTRL_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.JOBCTRL_R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.JOBCTRL_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.JOBCTRL_R2_BUCKET }}
         run: |
           set -euo pipefail
-          test -n "$RELEASE_UPLOAD_BASE_URL"
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          [[ "$R2_ACCOUNT_ID" =~ ^[a-f0-9]{32}$ ]]
+          [[ "$R2_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           release="$RUNNER_TEMP/release"
           upload_immutable() {
             local source="$1" destination="$2" expected actual existing status
@@ -785,7 +793,13 @@ jobs:
               echo "failed to read immutable release path $destination (HTTP $status)" >&2
               exit 1
             fi
-            if ! curl --fail --silent --show-error --proto '=https' --tlsv1.2 -H 'If-None-Match: *' --upload-file "$source" "$RELEASE_UPLOAD_BASE_URL/$destination"; then
+            if ! aws s3api put-object \
+              --endpoint-url "$r2_endpoint" \
+              --bucket "$R2_BUCKET" \
+              --key "$destination" \
+              --body "$source" \
+              --if-none-match '*' \
+              --no-cli-pager >/dev/null; then
               actual="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 "https://releases.jobctrl.dev/$destination" | shasum -a 256 | awk '{print $1}')"
               test "$actual" = "$expected"
               return
@@ -1034,22 +1048,37 @@ jobs:
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')" = "$RELEASE_REF"
           test "$(gh api "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" --jq '.sha')" = "$RELEASE_REF"
 
-      - name: Atomically promote one channel pointer with compare-and-swap
+      - name: Atomically promote one R2 channel pointer with compare-and-swap
         if: ${{ steps.cas-state.outputs.requires_write == 'true' }}
         env:
-          RELEASE_UPLOAD_BASE_URL: ${{ secrets.JOBCTRL_RELEASE_UPLOAD_BASE_URL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.JOBCTRL_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.JOBCTRL_R2_SECRET_ACCESS_KEY }}
+          AWS_REGION: auto
+          R2_ACCOUNT_ID: ${{ vars.JOBCTRL_R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.JOBCTRL_R2_BUCKET }}
         run: |
           set -euo pipefail
-          test -n "$RELEASE_UPLOAD_BASE_URL"
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          [[ "$R2_ACCOUNT_ID" =~ ^[a-f0-9]{32}$ ]]
+          [[ "$R2_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]]
+          r2_endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           pointer="$RUNNER_TEMP/release/channel-pointer.json"
           destination="v1/$RELEASE_CHANNEL/darwin-arm64.json"
           mode="$(<"$RUNNER_TEMP/channel-mode")"
+          put_args=(
+            --endpoint-url "$r2_endpoint"
+            --bucket "$R2_BUCKET"
+            --key "$destination"
+            --body "$pointer"
+            --no-cli-pager
+          )
           if [[ "$mode" = replace ]]; then
             etag="$(<"$RUNNER_TEMP/channel-etag")"
             case "$etag" in ""|*$'\r'*|*$'\n'*) echo "invalid prevalidated ETag" >&2; exit 1 ;; esac
-            curl --fail --silent --show-error --proto '=https' --tlsv1.2 -H "If-Match: $etag" --upload-file "$pointer" "$RELEASE_UPLOAD_BASE_URL/$destination"
+            aws s3api put-object "${put_args[@]}" --if-match "$etag" >/dev/null
           elif [[ "$mode" = create ]]; then
-            curl --fail --silent --show-error --proto '=https' --tlsv1.2 -H 'If-None-Match: *' --upload-file "$pointer" "$RELEASE_UPLOAD_BASE_URL/$destination"
+            aws s3api put-object "${put_args[@]}" --if-none-match '*' >/dev/null
           else
             echo "invalid prevalidated promotion mode" >&2
             exit 1

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -1,0 +1,11 @@
+# JobCtrl Launch Checklist
+
+Keep every item unchecked until it is reverified during launch. Detailed release procedure remains in [`docs/publish-checklist.md`](docs/publish-checklist.md).
+
+- [ ] Restore the GitHub billing/plan state and prove Actions jobs can start.
+- [ ] Require owner approval and allow only `v*` tags (no branches) for `release-signing`, `release-publication`, `release-verification`, and `pypi`.
+- [ ] Reverify the protected environment secret and variable names, token expiry, and PyPI Trusted Publisher configuration without exposing values.
+- [ ] Finish the Homebrew key rotation: remove the old `JobCtrl Homebrew tap sync` deploy key and repository-level `HOMEBREW_TAP_DEPLOY_KEY` after confirming the environment-scoped key.
+- [ ] Merge the native R2 publication workflow after its hosted checks can run and pass.
+- [ ] Cut the audited `v*` tag from current `main`, dispatch the first signed release, and verify notarization, immutable R2 assets, channel compare-and-swap, immutable GitHub Release, Homebrew tap, and PyPI publication.
+- [ ] Publish user-facing curl and Homebrew install instructions only after the hosted release path passes end to end.

--- a/LAUNCH_CHECKLIST.md
+++ b/LAUNCH_CHECKLIST.md
@@ -5,7 +5,7 @@ Keep every item unchecked until it is reverified during launch. Detailed release
 - [ ] Restore the GitHub billing/plan state and prove Actions jobs can start.
 - [ ] Require owner approval and allow only `v*` tags (no branches) for `release-signing`, `release-publication`, `release-verification`, and `pypi`.
 - [ ] Reverify the protected environment secret and variable names, token expiry, and PyPI Trusted Publisher configuration without exposing values.
-- [ ] Finish the Homebrew key rotation: remove the old `JobCtrl Homebrew tap sync` deploy key and repository-level `HOMEBREW_TAP_DEPLOY_KEY` after confirming the environment-scoped key.
+- [ ] Confirm the retired Homebrew deploy key and repository-level secret remain absent, and the environment-scoped replacement is still limited to `ebarti/homebrew-tap`.
 - [ ] Merge the native R2 publication workflow after its hosted checks can run and pass.
 - [ ] Cut the audited `v*` tag from current `main`, dispatch the first signed release, and verify notarization, immutable R2 assets, channel compare-and-swap, immutable GitHub Release, Homebrew tap, and PyPI publication.
 - [ ] Publish user-facing curl and Homebrew install instructions only after the hosted release path passes end to end.

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -274,12 +274,14 @@ lane.
 
 **Current hosted-release status.** The `jobctrl-releases` R2 bucket,
 `https://releases.jobctrl.dev` custom domain, and repository immutable Releases
-are provisioned. The protected `release-publication` environment still needs
-bucket-scoped R2 credentials and `JOBCTRL_RELEASE_ADMIN_READ_TOKEN`, followed
-by the first live signed-release verification. GitHub Actions jobs are also
-currently zero-step blocked by the repository account billing/spending state.
-No user-facing curl or Homebrew stable-install claim may be made until those
-hosted gates have completed.
+are provisioned. The `release-publication` R2 credentials, administration-read
+token, Homebrew deploy key, account ID, and bucket are configured. GitHub
+currently rejects required-reviewer and tag-policy protection for this private
+repository under its billing/plan state, and Actions jobs are zero-step blocked
+by the same account state. Restore billing/plan access, configure the required
+owner approval plus `v*`-tag-only deployment policy, and complete the first
+live signed-release verification. No user-facing curl or Homebrew
+stable-install claim may be made until those hosted gates have completed.
 
 ### 9.5 — Homebrew tap publication (signed-release-gated)
 

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -276,8 +276,10 @@ lane.
 `https://releases.jobctrl.dev` custom domain, and repository immutable Releases
 are provisioned. The protected `release-publication` environment still needs
 bucket-scoped R2 credentials and `JOBCTRL_RELEASE_ADMIN_READ_TOKEN`, followed
-by the first live signed-release verification. No user-facing curl or Homebrew
-stable-install claim may be made until that hosted path has completed.
+by the first live signed-release verification. GitHub Actions jobs are also
+currently zero-step blocked by the repository account billing/spending state.
+No user-facing curl or Homebrew stable-install claim may be made until those
+hosted gates have completed.
 
 ### 9.5 — Homebrew tap publication (signed-release-gated)
 

--- a/docs/publish-checklist.md
+++ b/docs/publish-checklist.md
@@ -229,14 +229,18 @@ exactly matches the independently protected verification value.
   dependencies and both unsigned comparison builds have passed; it performs no
   package installation and runs only the sealed finalizer plus system signing
   and notarization tools.
-- `release-publication`: `JOBCTRL_RELEASE_UPLOAD_BASE_URL`,
-  `JOBCTRL_RELEASE_ADMIN_READ_TOKEN` (a fine-grained token with repository
-  Administration read access), and `HOMEBREW_TAP_DEPLOY_KEY`. Keep all three
-  as environment secrets; the reusable Homebrew workflow resolves the tap key
-  only inside its `publish` job after the environment approval, rather than
-  accepting it through `workflow_call`. Require a separate owner approval. Its release origin
-  must support TLS, read-after-write verification, and conditional `PUT`
-  (`If-Match` / `If-None-Match: *`) for the one channel-pointer object.
+- `release-publication`: environment secrets `JOBCTRL_R2_ACCESS_KEY_ID`,
+  `JOBCTRL_R2_SECRET_ACCESS_KEY`, `JOBCTRL_RELEASE_ADMIN_READ_TOKEN` (a
+  fine-grained token with repository Administration read access), and
+  `HOMEBREW_TAP_DEPLOY_KEY`; plus protected environment variables
+  `JOBCTRL_R2_ACCOUNT_ID` and `JOBCTRL_R2_BUCKET`. The R2 access key must have
+  Object Read & Write permission scoped only to the release bucket. Keep the
+  credentials as environment secrets; the reusable Homebrew workflow resolves
+  the tap key only inside its `publish` job after the environment approval,
+  rather than accepting it through `workflow_call`. Require a separate owner
+  approval. Publication writes directly to the configured R2 S3 endpoint with
+  conditional `PutObject` (`If-Match` / `If-None-Match: *`), then verifies the
+  resulting bytes through `https://releases.jobctrl.dev`.
 - `release-verification`: protected environment variables
   `JOBCTRL_RELEASE_PUBLIC_KEY` and `JOBCTRL_RELEASE_KEY_ID`, the non-secret but
   integrity-sensitive release trust anchor. Require an owner approval. The
@@ -268,16 +272,12 @@ post-lock verifies the immutable GitHub Release after pointer and tap
 publication; only the stable channel can then enter the clean two-builder PyPI
 lane.
 
-**Current external blockers.** No protected Apple signing/notarization
-credentials or release-publication origin are configured, and the canonical
-origin currently fails its TLS handshake. The repository immutable-Releases
-API currently reports `enabled=false`; the owner must enable immutable
-Releases and provision `JOBCTRL_RELEASE_ADMIN_READ_TOKEN` before the workflow
-can create or publish a draft. GitHub Actions jobs are also zero-step blocked
-by the repository account billing/spending state. Therefore this workflow is
-prepared but cannot produce a signed, notarized, published candidate yet; no
-user-facing curl or Homebrew stable-install claim may be made until the hosted
-path has completed.
+**Current hosted-release status.** The `jobctrl-releases` R2 bucket,
+`https://releases.jobctrl.dev` custom domain, and repository immutable Releases
+are provisioned. The protected `release-publication` environment still needs
+bucket-scoped R2 credentials and `JOBCTRL_RELEASE_ADMIN_READ_TOKEN`, followed
+by the first live signed-release verification. No user-facing curl or Homebrew
+stable-install claim may be made until that hosted path has completed.
 
 ### 9.5 — Homebrew tap publication (signed-release-gated)
 

--- a/packaging/distribution/README.md
+++ b/packaging/distribution/README.md
@@ -120,8 +120,8 @@ SHA equal to that audited tag's current-main commit; every release environment
 admits protected `v*` tags and no branches. The path separates
 `release-signing` (the Ed25519 private key, Developer
 ID certificate, and notary credentials) from `release-publication`
-(release-origin upload and GitHub/tap side effects). It builds the full release
-ID from the exact 40-character audited commit,
+(bucket-scoped Cloudflare R2 upload and GitHub/tap side effects). It builds the
+full release ID from the exact 40-character audited commit,
 uploads ZIP, native installer, pinned `install.sh`, signed descriptor, and
 signature under `v1/artifacts/<build-id>/`, then runs the native lifecycle and
 Homebrew audit/install/test from those immutable URLs. A formula therefore pins
@@ -133,8 +133,9 @@ the paired immutable descriptor and signature URLs/digests plus the signed
 descriptor's channel, platform, source commit, build ID, and sequence. The
 native installer must fetch the pair, verify both digests, then verify the
 descriptor with its compiled Ed25519 key; it must reject a pointer whose fields
-do not exactly match the fetched signed descriptor. The release origin must
-honour HTTP `If-Match` and `If-None-Match: *` on this pointer path. A rerun
+do not exactly match the fetched signed descriptor. The publication jobs write
+through the R2 S3 API with `If-Match` and `If-None-Match: *`, while public
+readback and checksum verification use `https://releases.jobctrl.dev`. A rerun
 accepts an exact pointer already present, otherwise rejects a changed pointer
 instead of overwriting it. Rollback is a new explicitly revoking release, not
 an untracked pointer overwrite. Release runs are serialized per

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -701,12 +701,18 @@ test("release workflows use protected manual signing, artifact handoff, candidat
     "gh release create \"$RELEASE_TAG\"",
     "gh release edit \"$RELEASE_TAG\" --draft=false",
     "channel-pointer.json",
-    "If-Match:",
-    "If-None-Match: *",
+    "aws s3api put-object",
+    "--if-match \"$etag\"",
+    "--if-none-match '*'",
+    "JOBCTRL_R2_ACCESS_KEY_ID",
+    "JOBCTRL_R2_SECRET_ACCESS_KEY",
+    "JOBCTRL_R2_ACCOUNT_ID",
+    "JOBCTRL_R2_BUCKET",
     "channel-promotion-evidence.json",
     "immutableDescriptorUrl",
     "brew audit --strict --formula \"$release/jobctrl.rb\"",
   ]) assert.ok(releaseWorkflow.includes(marker), `missing release workflow marker ${marker}`);
+  assert.doesNotMatch(releaseWorkflow, /JOBCTRL_RELEASE_UPLOAD_BASE_URL/);
   assert.doesNotMatch(homebrewWorkflow, /workflow_dispatch:/);
   assert.match(homebrewWorkflow, /actions\/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093/);
   assert.match(homebrewWorkflow, /--trust "\$TRUST_PATH"/);

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -10,6 +10,7 @@ import argparse
 import hashlib
 import json
 import re
+import shlex
 import subprocess
 import sys
 import tarfile
@@ -924,6 +925,42 @@ def _workflow_executable_text(body: str) -> str:
     )
 
 
+def _workflow_shell_commands(body: str) -> tuple[str, ...]:
+    commands: list[str] = []
+    continuation = ""
+    for raw_line in _workflow_executable_text(body).splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        continuation = f"{continuation} {line}".strip()
+        if continuation.endswith("\\"):
+            continuation = continuation[:-1].rstrip()
+            continue
+        commands.append(continuation)
+        continuation = ""
+    if continuation:
+        commands.append(continuation)
+    return tuple(commands)
+
+
+def _workflow_has_conditional_put(body: str, flag: str, value: str) -> bool:
+    for command in _workflow_shell_commands(body):
+        try:
+            tokens = shlex.split(command, comments=True, posix=True)
+        except ValueError:
+            continue
+        for index in range(len(tokens) - 2):
+            if tokens[index : index + 3] != ["aws", "s3api", "put-object"]:
+                continue
+            arguments = tokens[index + 3 :]
+            if any(
+                arguments[position : position + 2] == [flag, value]
+                for position in range(len(arguments) - 1)
+            ):
+                return True
+    return False
+
+
 def _release_distribution_findings(root: Path) -> list[str]:
     try:
         workflow = (root / RELEASE_DISTRIBUTION_WORKFLOW_PATH).read_text(encoding="utf-8")
@@ -1169,13 +1206,20 @@ def _release_distribution_findings(root: Path) -> list[str]:
                 )
                 break
     publish_immutable = jobs.get("publish-immutable")
-    if publish_immutable is not None and "--if-none-match '*'" not in publish_immutable:
+    if publish_immutable is not None and not _workflow_has_conditional_put(
+        publish_immutable, "--if-none-match", "*"
+    ):
         findings.append(
             f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publish-immutable must protect immutable R2 object creation"
         )
     promote = jobs.get("promote-channel-pointer")
     if promote is not None and (
-        "--if-none-match '*'" not in promote or '--if-match "$etag"' not in promote
+        not _workflow_has_conditional_put(
+            promote, "--if-none-match", "*"
+        )
+        or not _workflow_has_conditional_put(
+            promote, "--if-match", "$etag"
+        )
     ):
         findings.append(
             f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: promote-channel-pointer must compare-and-swap an existing R2 channel pointer and protect first creation"

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -962,8 +962,14 @@ def _release_distribution_findings(root: Path) -> list[str]:
         "channel-pointer.json": "does not carry one finalized atomic channel-pointer object through publication",
         "https://releases.jobctrl.dev/$destination": "does not checksum-read canonical published assets",
         "v1/$RELEASE_CHANNEL/darwin-arm64.json": "does not promote the compiled canonical channel path",
-        "If-Match:": "does not compare-and-swap an existing channel pointer",
-        "If-None-Match: *": "does not protect first channel-pointer creation",
+        "aws s3api put-object": "does not publish directly through the authenticated R2 S3 API",
+        'https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com': "does not bind writes to the configured R2 account endpoint",
+        "AWS_ACCESS_KEY_ID: ${{ secrets.JOBCTRL_R2_ACCESS_KEY_ID }}": "does not use protected bucket-scoped R2 access-key identity",
+        "AWS_SECRET_ACCESS_KEY: ${{ secrets.JOBCTRL_R2_SECRET_ACCESS_KEY }}": "does not use protected bucket-scoped R2 secret authority",
+        "R2_ACCOUNT_ID: ${{ vars.JOBCTRL_R2_ACCOUNT_ID }}": "does not use protected R2 account configuration",
+        "R2_BUCKET: ${{ vars.JOBCTRL_R2_BUCKET }}": "does not use protected R2 bucket configuration",
+        '--if-match "$etag"': "does not compare-and-swap an existing R2 channel pointer",
+        "--if-none-match '*'": "does not protect immutable R2 object creation",
         "channel-promotion-evidence.json": "does not retain channel-promotion recovery evidence",
         "immutableDescriptorUrl": "does not smoke the immutable candidate descriptor before promotion",
         "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02": "does not hand signed assets across clean jobs as artifacts",
@@ -1112,7 +1118,7 @@ def _release_distribution_findings(root: Path) -> list[str]:
                 f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {job_name} checkout must set persist-credentials false"
             )
         if re.search(
-            r"secrets\.(?:JOBCTRL_RELEASE_SIGNING_KEY|JOBCTRL_APPLE_[A-Z0-9_]+|JOBCTRL_RELEASE_UPLOAD_BASE_URL|HOMEBREW_TAP_DEPLOY_KEY)",
+            r"secrets\.(?:JOBCTRL_RELEASE_SIGNING_KEY|JOBCTRL_APPLE_[A-Z0-9_]+|JOBCTRL_R2_(?:ACCESS_KEY_ID|SECRET_ACCESS_KEY)|HOMEBREW_TAP_DEPLOY_KEY)",
             body,
         ) or "environment: release-signing" in body or "environment: release-publication" in body:
             findings.append(
@@ -1137,12 +1143,43 @@ def _release_distribution_findings(root: Path) -> list[str]:
                 f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publication job {job_name} executes repository or dependency code"
             )
         job_header = body.partition("\n    steps:")[0]
-        for credential in ("GH_TOKEN:", "JOBCTRL_RELEASE_UPLOAD_BASE_URL"):
+        for credential in ("GH_TOKEN:", "AWS_ACCESS_KEY_ID:", "AWS_SECRET_ACCESS_KEY:"):
             if credential in job_header:
                 findings.append(
                     f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {job_name} exposes {credential.rstrip(':')} at job scope"
                 )
+    if "JOBCTRL_RELEASE_UPLOAD_BASE_URL" in workflow:
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publication must use bucket-scoped native R2 credentials instead of a generic upload URL"
+        )
+    for job_name in ("publish-immutable", "promote-channel-pointer"):
+        body = jobs.get(job_name)
+        if body is None:
+            continue
+        for marker in (
+            "AWS_ACCESS_KEY_ID: ${{ secrets.JOBCTRL_R2_ACCESS_KEY_ID }}",
+            "AWS_SECRET_ACCESS_KEY: ${{ secrets.JOBCTRL_R2_SECRET_ACCESS_KEY }}",
+            "R2_ACCOUNT_ID: ${{ vars.JOBCTRL_R2_ACCOUNT_ID }}",
+            "R2_BUCKET: ${{ vars.JOBCTRL_R2_BUCKET }}",
+            "aws s3api put-object",
+        ):
+            if marker not in body:
+                findings.append(
+                    f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: {job_name} must publish with protected bucket-scoped R2 S3 authority"
+                )
+                break
+    publish_immutable = jobs.get("publish-immutable")
+    if publish_immutable is not None and "--if-none-match '*'" not in publish_immutable:
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: publish-immutable must protect immutable R2 object creation"
+        )
     promote = jobs.get("promote-channel-pointer")
+    if promote is not None and (
+        "--if-none-match '*'" not in promote or '--if-match "$etag"' not in promote
+    ):
+        findings.append(
+            f"{RELEASE_DISTRIBUTION_WORKFLOW_PATH}: promote-channel-pointer must compare-and-swap an existing R2 channel pointer and protect first creation"
+        )
     if promote is not None and (
         "needs: [resolve, sign, package-signed-candidate, smoke-and-verify]" not in promote
         or "EXPECTED_SIGNER_POINTER_SHA256: ${{ needs.sign.outputs.channel_pointer_sha256 }}" not in promote

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -806,6 +806,31 @@ def test_distribution_requires_native_conditional_r2_publication(
     assert any("protect immutable R2 object creation" in item for item in findings)
     assert any("compare-and-swap an existing R2 channel pointer" in item for item in findings)
 
+    comment_spoofed = workflow.replace("--if-none-match '*'", "").replace(
+        '--if-match "$etag"', ""
+    )
+    comment_spoofed = comment_spoofed.replace(
+        "  publish-immutable:\n",
+        "  publish-immutable:\n    # aws s3api put-object --if-none-match '*'\n",
+        1,
+    ).replace(
+        "  promote-channel-pointer:\n",
+        "  promote-channel-pointer:\n"
+        "    # aws s3api put-object --if-match \"$etag\"\n"
+        "    # aws s3api put-object --if-none-match '*'\n",
+        1,
+    )
+    spoof_root = tmp_path / "comment-spoof"
+    _write(spoof_root / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH, comment_spoofed)
+    _write(spoof_root / release_check.SIGNING_POLICY_PATH, policy)
+
+    spoof_findings = release_check._release_distribution_findings(spoof_root)
+    assert any("protect immutable R2 object creation" in item for item in spoof_findings)
+    assert any(
+        "compare-and-swap an existing R2 channel pointer" in item
+        for item in spoof_findings
+    )
+
 
 def test_distribution_dispatch_must_execute_from_the_audited_release_tag(
     tmp_path: Path,

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -781,6 +781,32 @@ def test_distribution_privileged_jobs_reject_dependency_or_repo_execution(
     )
 
 
+def test_distribution_requires_native_conditional_r2_publication(
+    tmp_path: Path,
+) -> None:
+    workflow = (
+        release_check.ROOT / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH
+    ).read_text(encoding="utf-8")
+    policy = (release_check.ROOT / release_check.SIGNING_POLICY_PATH).read_text(
+        encoding="utf-8"
+    )
+    assert "JOBCTRL_RELEASE_UPLOAD_BASE_URL" not in workflow
+    assert "secrets.JOBCTRL_R2_ACCESS_KEY_ID" in workflow
+    assert "secrets.JOBCTRL_R2_SECRET_ACCESS_KEY" in workflow
+    assert "vars.JOBCTRL_R2_ACCOUNT_ID" in workflow
+    assert "vars.JOBCTRL_R2_BUCKET" in workflow
+
+    insecure = workflow.replace("--if-none-match '*'", "").replace(
+        '--if-match "$etag"', ""
+    )
+    _write(tmp_path / release_check.RELEASE_DISTRIBUTION_WORKFLOW_PATH, insecure)
+    _write(tmp_path / release_check.SIGNING_POLICY_PATH, policy)
+
+    findings = release_check._release_distribution_findings(tmp_path)
+    assert any("protect immutable R2 object creation" in item for item in findings)
+    assert any("compare-and-swap an existing R2 channel pointer" in item for item in findings)
+
+
 def test_distribution_dispatch_must_execute_from_the_audited_release_tag(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- replace the generic release upload URL with bucket-scoped Cloudflare R2 S3 credentials
- publish immutable artifacts with conditional `PutObject` and promote channel pointers with compare-and-swap semantics
- keep checksum verification on the public `releases.jobctrl.dev` read path
- extend the release policy scanner and regressions to require native conditional R2 publication
- document the protected environment secret and variable contract
- add an intentionally unchecked root launch checklist for the remaining hosted gates

## Why

The release workflow previously assumed a separate HTTP upload service implementing authenticated conditional writes. R2 already exposes those semantics through its S3-compatible API, so the workflow can upload directly with the AWS CLI while preserving immutable paths, channel-pointer conflict detection, credential isolation, and public readback verification.

## Validation

- `node --test scripts/distribution-release.test.mjs` — 22 passed
- `uv --project workers/automation run --extra dev pytest -q workers/automation/tests/test_release_check.py` — 42 passed
- `corepack pnpm scripts:test` — 107 passed
- `python3 scripts/release_check.py` — passed
- `uv --project workers/automation run --extra dev ruff check scripts/release_check.py workers/automation/tests/test_release_check.py` — passed
- `corepack pnpm docs:build` — passed; 5,837 emitted references resolved
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-distribution.yml` — passed

## Hosted setup

The `jobctrl-releases` R2 bucket and `releases.jobctrl.dev` custom domain are provisioned. The `release-publication` environment has the R2 access keys, administration-read token, Homebrew deploy key, account ID, and bucket configuration.

GitHub currently rejects required-reviewer and `v*`-tag environment protection for this private repository under its billing/plan state. Actions is also preventing jobs from starting for the same billing/spending reason, so no workflow steps execute until that external blocker is cleared and the documented protection is enabled.
