### PR TITLE
docs(workflow): scale validation effort by risk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,23 +40,11 @@ Do not run auto-apply, browser submission, destructive profile/database actions,
 
 ## Build, Test, And Lint Commands
 
-Use the smallest command set that proves the touched behavior. Run the
-cross-stack aggregates only for cross-stack changes, release/high-risk work, or
-when an active plan explicitly requires them:
-
-- Cross-stack typecheck + lint aggregate: `pnpm check` (contracts, api-client, API, and web typechecks plus Python ruff).
-- Cross-stack test aggregate: `pnpm test` (API Vitest + web build + Python pytest). It does NOT run the web unit/hook/component suite, the type-level tests, or the Playwright e2e specs — run those explicitly for frontend changes.
-- TypeScript API typecheck: `pnpm api:check`.
-- TypeScript API tests: `pnpm api:test`.
-- Web typecheck: `pnpm web:check`.
-- Web build: `pnpm web:build`.
-- Web Vitest unit + hook + component tests: `pnpm --filter @jobctrl/web test` (watch: `:watch`; coverage: `:coverage`).
-- Web type-level tests: `pnpm --filter @jobctrl/web test-d`.
-- Web Playwright end-to-end specs: `pnpm --filter @jobctrl/web e2e` (headed: `e2e:headed`).
-- Web Storybook: `pnpm web:storybook` (build: `pnpm web:storybook:build`; test runner with a11y addon: `pnpm web:storybook:test`).
-- Python tests: `uv --project workers/automation run --extra dev pytest -q`.
-- Python lint: `uv --project workers/automation run --extra dev ruff check .`.
-- Python package build: `uv --project workers/automation run --extra dev python -m build workers/automation`.
+Choose the smallest command set from `docs/local-reliability-qa.md` that proves
+the touched behavior. Reserve `pnpm check` and `pnpm test` for cross-stack,
+release/high-risk, or explicitly plan-required work. Frontend changes must run
+their separate web unit/type/E2E/Storybook checks when the touched risk calls
+for them; the aggregate does not include those suites.
 
 When changing behavior, add or update unit tests for the changed logic. When changing user-facing behavior, local API behavior, browser flows, or UI/UX, include a QA stage that exercises the product path, not only unit tests.
 
@@ -64,7 +52,12 @@ Any major UI/UX regression found by the human must become a QA regression test o
 
 ## Documentation Requirements
 
-**PRs that add meaningful new capabilities MUST include documentation updates.** Do not add doc bloat: internal refactors, test-only changes, bug fixes that do not change public behavior, and renaming without functional change do NOT need doc updates.
+Standalone PRs that add meaningful capabilities must update their owning docs.
+For an approved feature stack that is not released between phases, defer
+canonical product docs to the final PR; intermediate PRs update only plan or
+contract material needed for review. Phases released independently or changing
+active high-risk paths document immediately. Internal refactors, tests, and
+behavior-neutral fixes do not need doc churn.
 
 When a doc update is warranted:
 
@@ -84,7 +77,8 @@ When a doc update is warranted:
 | Python package metadata, CLI entry point, Python version, optional dev dependencies, or Ruff config | `workers/automation/pyproject.toml` |
 | Agent workflow rules, PR expectations, repo-specific constraints, or automation guidance | `AGENTS.md` |
 
-If multiple surfaces changed, update every relevant document. If no documentation update is warranted for a meaningful-looking change, explain why in the PR description. Keep documentation edits narrow: update the existing owning document, remove stale instructions, and avoid creating new docs unless no listed document owns the behavior.
+If multiple surfaces changed, update every owning document. Keep edits narrow
+and explain any intentional stacked deferral in the PR body.
 
 ## Agent Behavior
 
@@ -149,7 +143,8 @@ When a new worktree is actually needed:
   verify the selected base first.
 - Never mark work complete while Blocker or High PR review findings remain.
 - Never mark work complete while Blocker or High QA findings remain.
-- Never skip the QA stage for user-facing UI/API/product-flow changes.
+- Never skip required QA. For an approved unreleased stack, run it once on the
+  cumulative final branch after canonical docs are complete.
 - Never broaden scope silently. If the correct fix exceeds the assigned scope, stop and raise the scope issue.
 - Never commit local secrets, generated user data, resumes, cover letters, PDFs, browser profiles, worker directories, logs, or SQLite databases.
 
@@ -172,6 +167,12 @@ If Tier 3 groundwork changes only contracts or fixtures and no executable
 product/operational path exists yet, do not fabricate product QA. Require one
 independent review plus the focused safety checks, record why QA is deferred,
 and make QA mandatory in the first phase that exposes the executable path.
+
+For an approved stack whose intermediate phases are not released independently,
+each intermediate PR runs focused checks and one review. The final PR updates
+canonical docs first, then runs cumulative product QA and any final high-risk
+gate across the whole stack. A phase that changes an active high-risk path or is
+released independently follows its normal tier immediately.
 
 Run independent gates once after implementation and focused verification. Rerun
 a failed gate after addressing its Blocker/High findings; do not repeat passing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,25 +1,24 @@
-## Reference Index
+## Reference Routing
 
-Use these repository documents before making architectural, workflow, or QA decisions:
+Start with `docs/README.md`, the canonical documentation map, then read only the
+documents that own the behavior being changed. Do not scan the entire reference
+tree by default.
 
-- `docs/README.md`: canonical map of every public, user, and developer document (GitHub renders it when browsing `docs/`; unpublished on the docs site, whose homepage is the hero page `docs/index.md`).
-- `README.md`: user-facing product behavior, CLI commands, runtime requirements, generated local artifacts, and safety notes.
-- `docs/user/` (`getting-started.md`, `screenshots.md`, `normal-flows.md`, `configuration.md`, `data-and-safety.md`, `security.md`): end-user setup, the visual product tour (screenshots), expected product flows, the configuration/env-var reference, data and safety boundaries, and the user-facing security model.
-- `docs/developer/README.md`: contributor entry point and architecture/QA reading path.
-- `docs/local-development.md`: install, run, verify, and frontend development commands, plus the synthetic documentation-screenshot workflow.
-- `docs/local-reliability-qa.md`: local QA checklist, regression matrix, known high-risk workflows that need test coverage, and the frontend test pyramid + a11y bar.
-- `docs/local-ts-api.md`: local TypeScript API routes, JSON-RPC dispatch, web app development notes, and the `GET /v1/events/stream` SSE contract.
-- `docs/architecture/`: the System Architecture section — `index.md` (system shape, eight bounded contexts, core data flow, local commands), `runtime.md` (runtime boundaries of the TypeScript app/API plus Python worker, Temporal-native orchestration, JSON-RPC TS↔Python protocol, local-first boundaries), `observability.md` (OpenTelemetry → Langfuse export of LLM, workflow, and JSON-RPC spans), `storage.md` (SQLite and generated files), `scoring.md`, `materials.md`, and `read-model.md` (projection-backed read model).
-- `docs/architecture/pipeline/`: workflow-by-workflow pipeline execution on Temporal — `index.md` (execution surfaces, workflow catalog, source files), `envelope.md` (universal envelope, activities, error taxonomy), `concurrency.md` (worker capacity, fan-out topology, throughput bounds), `stages.md` (per-stage call paths and sequence diagrams), `operations.md` (spend ceiling, discovery schedule, persistence map, events, projection recovery, failure behavior).
-- `docs/architecture/tailoring.md`: resume tailoring prompt contract, generated JSON shape, validation/judge/fabrication gates, provenance, audit metadata, and safe change points.
-- `docs/requirements.md`: product and technical requirements that must stay true as implementation changes.
-- `docs/architecture/domain-model/`: canonical DDD + hexagonal target architecture (§1–§11 numbering preserved across subpages), including bounded-context language, aggregates, ports, domain events, projection strategy, and hosted-future seams. The implementation in this codebase realises this target — see `docs/plans/implemented/2026-05-06-ddd-migration.md`.
-- `docs/architecture/frontend/`: canonical frontend architecture (§1–§15 numbering preserved across subpages) — three-layer state (server / URL / client), eight bounded contexts mirrored 1:1 from the backend, view-vs-context dichotomy, hexagonal frontend ports, SSE realtime + invalidation router, testing pyramid. The implementation in this codebase realises this target — see `docs/plans/implemented/2026-05-06-frontend-tanstack-migration.md`.
-- `docs/decisions.md`: architectural decision records — DDD adoption, per-aggregate repositories, in-process EventPublisher + projections, JSON-RPC for TS↔Python, TanStack family adopted for the frontend, frontend hexagonal ports with local + hosted adapters named, SSE realtime via `GET /v1/events/stream` + invalidation router, view-vs-context dichotomy, and the Temporal-native orchestration ADRs.
-- `ROADMAP.md`: public roadmap; `docs/backlog.md`: detailed engineering backlog, frontend a11y deferrals, and the known-failing web e2e baseline.
-- `docs/plans/`: active plans at the top level, historical records under `implemented/`; `docs/incidents/`: incident reports.
-- `package.json`: current TypeScript/API/web scripts.
-- `workers/automation/pyproject.toml`: Python package metadata, CLI entry point, Python version, optional dev dependencies, and Ruff config.
+- Product behavior, commands, runtime requirements, artifacts, or safety:
+  `README.md` and the relevant page under `docs/user/`.
+- Contributor workflow and validation: `docs/developer/README.md`,
+  `docs/local-development.md`, and `docs/local-reliability-qa.md`.
+- API routes, JSON-RPC, or SSE: `docs/local-ts-api.md`.
+- Architecture: the relevant page under `docs/architecture/`, plus
+  `docs/requirements.md` and `docs/decisions.md` when the contract or decision
+  itself changes.
+- Plans and status: the relevant active file under `docs/plans/`; use
+  `implemented/` only for historical context.
+- TypeScript scripts/dependencies: `package.json`; Python package metadata and
+  tooling: `workers/automation/pyproject.toml`.
+
+Follow links beyond the owning document only when they are needed to resolve a
+specific contract, dependency, or QA risk.
 
 ## How To Run The Project
 
@@ -41,7 +40,9 @@ Do not run auto-apply, browser submission, destructive profile/database actions,
 
 ## Build, Test, And Lint Commands
 
-The unit-test and QA command set must be made explicit as the project evolves. Until a stronger command matrix exists, use the following defaults and narrow them to the touched surface when appropriate:
+Use the smallest command set that proves the touched behavior. Run the
+cross-stack aggregates only for cross-stack changes, release/high-risk work, or
+when an active plan explicitly requires them:
 
 - Cross-stack typecheck + lint aggregate: `pnpm check` (contracts, api-client, API, and web typechecks plus Python ruff).
 - Cross-stack test aggregate: `pnpm test` (API Vitest + web build + Python pytest). It does NOT run the web unit/hook/component suite, the type-level tests, or the Playwright e2e specs — run those explicitly for frontend changes.
@@ -91,7 +92,9 @@ If multiple surfaces changed, update every relevant document. If no documentatio
 - If a reasonable assumption is low-risk and needed to make progress, state it explicitly before acting.
 - Treat payloads, local generated artifacts, and job/application data as sensitive. Do not expose secrets, profile data, API keys, resumes, cover letters, generated PDFs, browser profiles, SQLite databases, or application logs unless the user explicitly requests them.
 - Prefer repo-grounded answers and edits over generic advice. Check the referenced docs and current code before making architectural claims.
-- **Subagent spawning:** You may spawn as many subagents as you need for parallel or complex work. Do not artificially limit concurrency — if a task naturally decomposes into independent subtasks, run them in parallel.
+- **Subagent spawning:** Use subagents only for genuinely independent work or
+  for the review/QA gates required by the validation tiers below. Do not add
+  coordination overhead to work that is faster to complete directly.
 
 ### Root-Cause And Auditability Discipline
 
@@ -115,25 +118,35 @@ Before claiming "fixed" on these surfaces, add or update a regression fixture th
 - PR descriptions must clearly and unambiguously explain what changed, why it changed, and how it was validated.
 - Keep changes as small as possible while still fully satisfying the goal.
 - Use stacked PRs when functionality builds on prior functionality or when a large change should be broken into reviewable steps.
-- Every implementation task must be developed in its own worktree on the relevant branch.
+- Every implementation task must run off `main` in a dedicated worktree or
+  task branch. If the current task already has a dedicated worktree, use it;
+  do not create a nested/replacement worktree or refresh `main` solely for
+  compliance.
 - Never edit code on `main` or leave `main` dirty.
-- Always ensure `main` is fetched and pulled before creating a worktree.
-- Before coding, confirm the current branch/worktree. If you are on `main`, stop and create or switch to the correct worktree first.
+- Resolve the base before creating a worktree: use updated `main` for standalone
+  work, or the explicit parent branch/commit for an approved stacked change.
+  Fetch the relevant remote ref and verify that chosen base is current.
+- Before coding, confirm the current branch/worktree. If you are on `main`, stop
+  and create or switch to the correct worktree first.
 - Do not remove existing compatibility behavior unless the assigned goal explicitly authorizes that breaking change.
 
-Recommended worktree setup:
+When a new worktree is actually needed:
 
-1. From the main checkout, ensure no unrelated dirty changes block setup.
-2. Run `git fetch origin main`.
-3. Update main with `git switch main` and `git pull --ff-only origin main`.
-4. Create a task branch and worktree with `git worktree add <worktree-path> -b <branch-name> main`.
+1. Ensure no unrelated dirty changes block setup.
+2. Choose `<base-ref>`: updated `main` for standalone work, or the explicit
+   parent branch/commit for an approved stack.
+3. Fetch the relevant remote ref. If `<base-ref>` is `main`, fast-forward the
+   main checkout with `git pull --ff-only origin main`.
+4. Create the task worktree with
+   `git worktree add <worktree-path> -b <branch-name> <base-ref>`.
 5. Do all coding, testing, commits, and PR work from that task worktree.
 
 ## Constraints And Do-Not Rules
 
 - Never edit code in the main branch.
 - Never leave `main` dirty.
-- Never create a worktree from stale `main`; fetch and pull first.
+- Never create a worktree from stale `main` or a stale stack parent; fetch and
+  verify the selected base first.
 - Never mark work complete while Blocker or High PR review findings remain.
 - Never mark work complete while Blocker or High QA findings remain.
 - Never skip the QA stage for user-facing UI/API/product-flow changes.
@@ -142,84 +155,42 @@ Recommended worktree setup:
 
 ## What Done Means And How To Verify Work
 
-Done means the user's instruction or goal has been fully achieved, the changeset is as small as practical, and the work has passed the required implementation, review, and QA gates.
+Done means the user's instruction or goal has been fully achieved, the changeset
+is as small as practical, and verification is proportional to its actual risk.
+Use the lowest tier that fully covers the change; an active plan or explicit user
+instruction may raise the tier. Never lower the tier for security, privacy, data
+integrity, destructive actions, migrations, releases, or application submission.
+
+| Tier | Applies to | Minimum verification | Independent gates |
+| --- | --- | --- | --- |
+| 0 — Editorial | Prose/typo/comment/format-only changes with no workflow, contract, test, or runtime effect | `git diff --check`; build docs only when site content, links, navigation, or rendering changed | None unless explicitly requested |
+| 1 — Scoped | Internal refactors, tests, developer workflow/tooling, or contained behavior with no user-facing/high-risk boundary | Touched-surface lint/typecheck/unit tests plus `git diff --check` | One final `reviewer` pass; use `pr-reviewer` when a PR already exists |
+| 2 — Product | User-facing UI, CLI, API, browser flow, integration, or workflow behavior | Tier 1 plus the smallest product-path QA that proves the change | `reviewer`/`pr-reviewer` and `qa` must return `Gate: PASS` |
+| 3 — High risk | Security/privacy controls, credentials, user data, apply/submission, destructive actions, migrations, release/distribution, or cross-stack critical invariants | Relevant full matrix, regression fixture, and product/operational proof | `reviewer`/`pr-reviewer` and `qa` must return `Gate: PASS`; fix and rerun until no Blocker/High remains |
+
+If Tier 3 groundwork changes only contracts or fixtures and no executable
+product/operational path exists yet, do not fabricate product QA. Require one
+independent review plus the focused safety checks, record why QA is deferred,
+and make QA mandatory in the first phase that exposes the executable path.
+
+Run independent gates once after implementation and focused verification. Rerun
+a failed gate after addressing its Blocker/High findings; do not repeat passing
+gates for cosmetic edits or unresolved Medium/Low observations unless the edit
+could affect the verified behavior.
 
 Before calling work done:
 
 1. Confirm the work happened in a dedicated worktree and not on `main`.
 2. Confirm the goal and acceptance criteria are satisfied.
-3. Run the relevant build, lint, unit-test, and QA commands for the touched surfaces.
-4. Run the PR review/fix loop until `pr-reviewer` returns `Gate: PASS` or the workflow is explicitly blocked.
-5. Run the QA loop until `qa` returns `Gate: PASS` or the workflow is explicitly blocked.
-6. Report exact commands, exact results, PR number, unresolved Medium/Low risks, and any skipped verification with a concrete reason.
+3. Classify the validation tier and run its focused commands.
+4. Run only the independent gates required by that tier.
+5. Report exact commands and results, the tier, unresolved Medium/Low risks, any
+   skipped verification with a concrete reason, and the PR number when a PR
+   exists or was requested.
 
 If any required verification cannot be run, the final status is not done. Report it as blocked or partially verified and explain what remains.
 
-## Frontend Conventions
+## Scoped Instructions
 
-The `apps/web` frontend follows the architecture documented in `docs/architecture/frontend/` and the four ADRs landed on 2026-05-06 in `docs/decisions.md` (TanStack family adopted, frontend hexagonal ports, SSE realtime + invalidation router, view-vs-context dichotomy). Follow these conventions on every frontend change; they exist so the architecture stays the architecture.
-
-### Folder structure
-
-- **Bounded-context folders mirror the backend 1:1.** Eight folders under `apps/web/src/contexts/`: `discovery/`, `enrichment/`, `profile/`, `scoring/`, `materials/`, `apply/`, `pipeline/`, `operations/`. A context may own any of `components/`, `hooks/`, `handlers.ts` (invalidation handlers registered with `operations/`), `queryKeys.ts` (re-exported through `contexts/operations/queryKeys.ts`), `selectors/`, `lib/`, `forms/`, `stores/`, and `index.ts` — only as needed; thin contexts (Discovery, Enrichment) keep their folder so future hooks land without restructure. **`operations/` is the special case:** it has no `handlers.ts` of its own (it hosts `invalidation-router.ts` which loads the seven aggregate contexts' handlers) and it owns the read-side hooks the other contexts do not.
-- **Views are composers, not contexts.** `apps/web/src/views/dashboard/`, `views/jobs/`, `views/artifacts/` import components and hooks from contexts and assemble them into a layout. Views never own query keys, mutations, or persistent state stores; they only own layout and view-local ephemeral UI (e.g., bulk-selection sets).
-- **Dependency direction.** Views depend on contexts; contexts never depend on views. A view never depends on another view (cross-view navigation goes through the URL). A context never imports another context's hooks or stores; cross-context coordination happens in (a) the view that composes them or (b) the invalidation router for cache fan-out. The only exception is `operations/` — every other context depends on it for read access and for the query-key registry.
-
-### View composer rules
-
-- View files (`views/<view>/<View>.tsx`, `<View>Table.tsx`, `<View>FilterBar.tsx`, `<View>DetailDrawer.tsx`, …) compose context components.
-- Views never call `useQuery` / `useMutation` / `apiClient.*` / `queryClient.*` directly. Read data comes through Operations hooks (`useJobsListQuery`, `useJobDetailQuery`, …). Writes come through context-owned mutation hooks composed inside context-owned button components.
-
-### Query keys
-
-- Per-context factory living in `contexts/<context>/queryKeys.ts` (or for read keys, `contexts/operations/queryKeys.ts`); re-exported through `contexts/operations/queryKeys.ts` so the invalidation router has a single import surface.
-- Shape: `["tenant", tenantId, <context>, <subset>, ...args] as const`. `tenantId` is the first segment for every key, today resolving to `LOCAL_TENANT` and tomorrow to the JWT-derived tenant — the hook signature does not change.
-- Hierarchical scopes: `<context>Keys.all(tenantId)`, `.lists(tenantId)`, `.list(tenantId, filters)`, `.details(tenantId)`, `.detail(tenantId, id)` so invalidation can target the right scope.
-
-### Mutation invalidation
-
-- Per-aggregate `useMutation` hook in the owning context (e.g., `useApplyJobMutation` in `contexts/apply/hooks/`).
-- Each mutation declares its own `onSettled` `invalidateQueries` set per `docs/architecture/frontend/integration.md` §8.2. Default mutation options do **not** invalidate broadly.
-- Synchronous mutations: optimistic update + invalidate on settle. Async (202) mutations: small immediate "queued" invalidation; the real result arrives via the SSE invalidation router.
-
-### Optimistic mutations
-
-- Use `createOptimisticMutation` from `apps/web/src/shared/lib/createOptimisticMutation.ts` for any mutation that needs an optimistic patch.
-- **Always supply a real patcher.** The helper is dead code without one — calling it with an empty / no-op patcher is a Phase 3 reviewer Major; the QA gate fails any PR that wires `createOptimisticMutation` without a patch + rollback.
-
-### SSE + invalidation router
-
-- The real SSE adapter lives in `apps/web/src/shared/adapters/local/SseEventStreamAdapter.ts` and reads `EventStreamPort` from `apps/web/src/shared/ports/`. Feature code consumes events through the invalidation router, never by reading `EventSource` directly.
-- The invalidation router is `apps/web/src/contexts/operations/invalidation-router.ts`. It maps `DomainEvent.eventType` to the right query-key set via the per-context handlers (`contexts/<context>/handlers.ts`).
-- `Record<DomainEvent["eventType"], InvalidationHandler>` typing makes a missing handler a TypeScript compile error; the `every-event-has-handler.test.ts` parity test catches obvious empty-stub bodies at runtime.
-
-### Forms
-
-- TanStack Form + Zod `safeParse`. Do **not** use the deprecated `zod-form-adapter`; call `safeParse` in the field validators directly.
-- Multi-step or wizard state that needs to survive navigation lives in a Zustand store with `persist` middleware (e.g., `contexts/profile/stores/profile-import-store.ts`). Single-step transient form state stays inside TanStack Form.
-
-### Tables
-
-- Column models live in `views/<view>/columns.tsx` as `DataGridColumn<T>[]` for the shared grid (`apps/web/src/shared/ui/filterable-data-grid.tsx`); `@tanstack/react-table` supplies row-selection/sorting types only, not the table engine.
-- Cell renderers compose context-owned components (`<ScoreBadge>` from `contexts/scoring/`, `<StageBadge>` from `contexts/pipeline/`, `<ApplyRunBadge>` from `contexts/apply/`, …) — never inline JSX duplicating what a context already exports.
-
-### Anti-patterns (forbidden in feature code)
-
-- `useState<DataShape>` for server data — server data lives in TanStack Query.
-- `useEffect(() => fetch(...))` for data loading — use a `useQuery` hook from `contexts/operations/`.
-- `useRef(0)` for stale-response dedup — TanStack Query handles this via the cache key.
-- `window.dispatchEvent` / `addEventListener` for cross-component coordination — use the URL (`navigate`), Zustand stores, or the query cache + invalidation router.
-- Direct `apiClient.*`, `navigator.clipboard.*`, `localStorage.*`, `new EventSource(...)` calls — go through the corresponding port (`usePorts()`).
-
-### Tests
-
-- Colocated `*.test.ts(x)` next to source. Type-level tests live under `apps/web/test/types/<name>.test-d.ts` (separate config: `vitest.types.config.ts`, runs Vitest's `typecheck` mode — invoked via `pnpm --filter @jobctrl/web test-d`). Accessibility tests are colocated `*.a11y.test.tsx`. Storybook stories are colocated `*.stories.tsx`.
-- MSW handlers live in `apps/web/src/test/msw/handlers.ts` (REST) and `apps/web/src/test/msw/sse-handlers.ts` (SSE). Add to the existing handler file rather than creating new MSW setups.
-- One test per query hook and per mutation hook covering the success path AND the rollback path.
-- The two parity tests are non-negotiable: `every-event-has-handler.test.ts` (`apps/web/src/contexts/operations/`) for `DomainEventUnion`, `every-stage-state-has-badge.test.tsx` (`apps/web/src/contexts/pipeline/components/`) for `STAGE_STATE_KINDS`.
-- E2E specs live under `apps/web/e2e/tests/<flow>.spec.ts`.
-
-### Stories
-
-- Colocated `*.stories.tsx`. Per-state stories (loading / populated / empty / error) for view composers and forms via the MSW addon. Per-variant stories for primitives. Per-discriminant-arm stories for components rendering discriminated unions (`<StageBadge>` per `STAGE_STATE_KINDS`).
-- The a11y addon enforces zero **critical** and **serious** axe violations. If a story exercises a pre-existing production a11y defect, set `parameters.a11y.test = "off"` AND record the deferral in `docs/backlog.md` "Frontend Accessibility Backlog" with the production file and defect type. Never silence the bar without filing the backlog entry.
+Changes under `apps/web/` must also follow `apps/web/AGENTS.md`. Read those
+frontend-specific rules only for work that touches the web application.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ JOBCTRL_DIR=/tmp/jobctrl-qa corepack pnpm dev
 - Use Conventional Commits for commit messages and PR titles.
 - External contributors should sign off every commit with the Developer
   Certificate of Origin trailer.
-- Update documentation when public behavior, commands, runtime requirements,
-  configuration, architecture, or QA expectations change.
+- For standalone changes, update docs with public behavior. For an approved
+  unreleased stack, update canonical docs in the final PR and run QA afterward.
 - Do not commit local user data, `.env` files, resumes, PDFs, logs, browser
   profiles, SQLite databases, or generated application materials.
 - Heavy CI workflows do not run automatically on public pull requests. Run the
@@ -73,17 +73,10 @@ git rebase --signoff origin/main
 
 ## Validation
 
-Run the narrowest useful checks while iterating and before opening a PR. Use the
-touched-surface commands in
-[Reliability & QA](docs/local-reliability-qa.md), then always run:
-
-```bash
-git diff --check
-```
-
-Add `corepack pnpm check` and `corepack pnpm test` for cross-stack changes,
-release/high-risk work, or when an active plan requires the aggregate. Build the
-Python package only when package or distribution behavior changes.
+Run the touched-surface commands in
+[Reliability & QA](docs/local-reliability-qa.md) plus `git diff --check`. Add the
+cross-stack aggregates only for cross-stack, release/high-risk, or plan-required
+work; build the Python package only when package/distribution behavior changes.
 
 For user-facing UI/API/product-flow changes, include a product-path QA step, not
 only unit tests. See [docs/local-reliability-qa.md](docs/local-reliability-qa.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,14 +73,17 @@ git rebase --signoff origin/main
 
 ## Validation
 
-Run the narrowest useful checks while iterating. Before opening a PR, prefer:
+Run the narrowest useful checks while iterating and before opening a PR. Use the
+touched-surface commands in
+[Reliability & QA](docs/local-reliability-qa.md), then always run:
 
 ```bash
-corepack pnpm check
-corepack pnpm test
-uv --project workers/automation run --extra dev python -m build workers/automation
 git diff --check
 ```
+
+Add `corepack pnpm check` and `corepack pnpm test` for cross-stack changes,
+release/high-risk work, or when an active plan requires the aggregate. Build the
+Python package only when package or distribution behavior changes.
 
 For user-facing UI/API/product-flow changes, include a product-path QA step, not
 only unit tests. See [docs/local-reliability-qa.md](docs/local-reliability-qa.md)

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,110 @@
+# Web Frontend Instructions
+
+These instructions apply to changes under `apps/web/` in addition to the
+repository-wide `AGENTS.md`.
+
+The frontend follows the architecture documented in
+`docs/architecture/frontend/` and the four ADRs landed on 2026-05-06 in
+`docs/decisions.md` (TanStack family adopted, frontend hexagonal ports, SSE
+realtime + invalidation router, and view-vs-context dichotomy).
+
+## Folder structure
+
+- **Bounded-context folders mirror the backend 1:1.** Eight folders under
+  `src/contexts/`: `discovery/`, `enrichment/`, `profile/`, `scoring/`,
+  `materials/`, `apply/`, `pipeline/`, and `operations/`. A context may own any
+  of `components/`, `hooks/`, `handlers.ts`, `queryKeys.ts`, `selectors/`,
+  `lib/`, `forms/`, `stores/`, and `index.ts` only as needed. `operations/` is
+  the special case: it hosts the invalidation router and owns read-side hooks.
+- **Views are composers, not contexts.** `src/views/` imports components and
+  hooks from contexts and owns only layout plus view-local ephemeral UI.
+- **Dependency direction.** Views depend on contexts; contexts never depend on
+  views. Views do not depend on other views. Contexts do not import other
+  contexts' hooks or stores. Cross-context coordination happens in the composing
+  view or the invalidation router. `operations/` is the exception every other
+  context may use for read access and the query-key registry.
+
+## View composer rules
+
+- View files compose context components.
+- Views never call `useQuery`, `useMutation`, `apiClient.*`, or
+  `queryClient.*` directly. Reads come through Operations hooks; writes come
+  through context-owned mutation hooks composed inside context-owned controls.
+
+## Query keys
+
+- Keep per-context factories in `contexts/<context>/queryKeys.ts` (or
+  `contexts/operations/queryKeys.ts` for read keys) and re-export them through
+  `contexts/operations/queryKeys.ts`.
+- Shape every key as
+  `["tenant", tenantId, <context>, <subset>, ...args] as const`.
+- Keep hierarchical scopes: `.all`, `.lists`, `.list`, `.details`, `.detail`.
+
+## Mutation invalidation
+
+- Put each `useMutation` hook in the owning aggregate context.
+- Each mutation declares its own `onSettled` invalidation set per
+  `docs/architecture/frontend/integration.md` §8.2. Default mutation options do
+  not invalidate broadly.
+- Synchronous mutations use optimistic update plus settle invalidation. Async
+  (202) mutations use a small immediate queued invalidation; the final result
+  arrives through the SSE invalidation router.
+
+## Optimistic mutations
+
+- Use `createOptimisticMutation` from
+  `src/shared/lib/createOptimisticMutation.ts` when an optimistic patch is
+  needed.
+- Always supply a real patcher and rollback. A no-op patcher fails review and
+  QA.
+
+## SSE and invalidation router
+
+- The real SSE adapter is
+  `src/shared/adapters/local/SseEventStreamAdapter.ts`. Feature code consumes
+  events through the invalidation router, never through `EventSource` directly.
+- The router is `src/contexts/operations/invalidation-router.ts`; per-context
+  handlers map domain events to query-key sets.
+- Preserve exhaustive `DomainEvent["eventType"]` typing and the
+  `every-event-has-handler.test.ts` parity test.
+
+## Forms
+
+- Use TanStack Form with Zod `safeParse`; do not use `zod-form-adapter`.
+- Persist multi-step state that must survive navigation in a Zustand store.
+  Keep single-step transient state inside TanStack Form.
+
+## Tables
+
+- Keep `DataGridColumn<T>[]` column models in `views/<view>/columns.tsx` for the
+  shared grid. Use `@tanstack/react-table` only for row-selection/sorting types.
+- Cell renderers compose context-owned components instead of duplicating them
+  inline.
+
+## Forbidden feature-code patterns
+
+- `useState<DataShape>` for server data.
+- `useEffect(() => fetch(...))` for data loading.
+- `useRef(0)` for stale-response deduplication.
+- `window.dispatchEvent` / `addEventListener` for cross-component coordination.
+- Direct `apiClient.*`, `navigator.clipboard.*`, `localStorage.*`, or
+  `new EventSource(...)` calls; use the corresponding port from `usePorts()`.
+
+## Tests
+
+- Colocate `*.test.ts(x)`, `*.a11y.test.tsx`, and `*.stories.tsx`. Keep
+  type-level tests under `test/types/` and E2E specs under `e2e/tests/`.
+- Add REST handlers to `src/test/msw/handlers.ts` and SSE handlers to
+  `src/test/msw/sse-handlers.ts`; do not create separate MSW setups.
+- Cover success and rollback for every query or mutation hook whose behavior
+  changes.
+- Preserve the non-negotiable event-handler and stage-badge parity tests.
+
+## Stories and accessibility
+
+- Add per-state stories for view composers/forms, per-variant stories for
+  primitives, and per-discriminant stories for discriminated unions.
+- The a11y addon allows zero critical or serious axe violations. If a story
+  exposes a pre-existing production defect, disable that story's a11y test only
+  after recording the production file and defect in the Frontend Accessibility
+  Backlog in `docs/backlog.md`.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,110 +1,24 @@
 # Web Frontend Instructions
 
-These instructions apply to changes under `apps/web/` in addition to the
-repository-wide `AGENTS.md`.
+Also follow the root `AGENTS.md`. The canonical frontend contract lives in
+`docs/architecture/frontend/` and `docs/decisions.md`; do not duplicate it here.
 
-The frontend follows the architecture documented in
-`docs/architecture/frontend/` and the four ADRs landed on 2026-05-06 in
-`docs/decisions.md` (TanStack family adopted, frontend hexagonal ports, SSE
-realtime + invalidation router, and view-vs-context dichotomy).
+Non-negotiable implementation rules:
 
-## Folder structure
+- Preserve the documented context/view dependency direction. Views compose
+  context components and never call query, mutation, API-client, or query-client
+  APIs directly.
+- Keep tenant-first hierarchical query keys, context-owned mutations with
+  targeted invalidation, real optimistic patch/rollback behavior, and exhaustive
+  SSE invalidation handlers.
+- Access browser and local capabilities through ports; do not call clipboard,
+  storage, `EventSource`, or other adapters directly from feature code.
+- Use TanStack Form with Zod `safeParse`; persist only navigation-surviving
+  multi-step state in Zustand.
+- Colocate focused tests/stories, reuse the shared MSW handlers, cover changed
+  query/mutation success and rollback, and preserve the event/stage parity tests.
+- Keep Storybook free of critical/serious axe violations. Any pre-existing
+  production deferral must be recorded in `docs/backlog.md`.
 
-- **Bounded-context folders mirror the backend 1:1.** Eight folders under
-  `src/contexts/`: `discovery/`, `enrichment/`, `profile/`, `scoring/`,
-  `materials/`, `apply/`, `pipeline/`, and `operations/`. A context may own any
-  of `components/`, `hooks/`, `handlers.ts`, `queryKeys.ts`, `selectors/`,
-  `lib/`, `forms/`, `stores/`, and `index.ts` only as needed. `operations/` is
-  the special case: it hosts the invalidation router and owns read-side hooks.
-- **Views are composers, not contexts.** `src/views/` imports components and
-  hooks from contexts and owns only layout plus view-local ephemeral UI.
-- **Dependency direction.** Views depend on contexts; contexts never depend on
-  views. Views do not depend on other views. Contexts do not import other
-  contexts' hooks or stores. Cross-context coordination happens in the composing
-  view or the invalidation router. `operations/` is the exception every other
-  context may use for read access and the query-key registry.
-
-## View composer rules
-
-- View files compose context components.
-- Views never call `useQuery`, `useMutation`, `apiClient.*`, or
-  `queryClient.*` directly. Reads come through Operations hooks; writes come
-  through context-owned mutation hooks composed inside context-owned controls.
-
-## Query keys
-
-- Keep per-context factories in `contexts/<context>/queryKeys.ts` (or
-  `contexts/operations/queryKeys.ts` for read keys) and re-export them through
-  `contexts/operations/queryKeys.ts`.
-- Shape every key as
-  `["tenant", tenantId, <context>, <subset>, ...args] as const`.
-- Keep hierarchical scopes: `.all`, `.lists`, `.list`, `.details`, `.detail`.
-
-## Mutation invalidation
-
-- Put each `useMutation` hook in the owning aggregate context.
-- Each mutation declares its own `onSettled` invalidation set per
-  `docs/architecture/frontend/integration.md` §8.2. Default mutation options do
-  not invalidate broadly.
-- Synchronous mutations use optimistic update plus settle invalidation. Async
-  (202) mutations use a small immediate queued invalidation; the final result
-  arrives through the SSE invalidation router.
-
-## Optimistic mutations
-
-- Use `createOptimisticMutation` from
-  `src/shared/lib/createOptimisticMutation.ts` when an optimistic patch is
-  needed.
-- Always supply a real patcher and rollback. A no-op patcher fails review and
-  QA.
-
-## SSE and invalidation router
-
-- The real SSE adapter is
-  `src/shared/adapters/local/SseEventStreamAdapter.ts`. Feature code consumes
-  events through the invalidation router, never through `EventSource` directly.
-- The router is `src/contexts/operations/invalidation-router.ts`; per-context
-  handlers map domain events to query-key sets.
-- Preserve exhaustive `DomainEvent["eventType"]` typing and the
-  `every-event-has-handler.test.ts` parity test.
-
-## Forms
-
-- Use TanStack Form with Zod `safeParse`; do not use `zod-form-adapter`.
-- Persist multi-step state that must survive navigation in a Zustand store.
-  Keep single-step transient state inside TanStack Form.
-
-## Tables
-
-- Keep `DataGridColumn<T>[]` column models in `views/<view>/columns.tsx` for the
-  shared grid. Use `@tanstack/react-table` only for row-selection/sorting types.
-- Cell renderers compose context-owned components instead of duplicating them
-  inline.
-
-## Forbidden feature-code patterns
-
-- `useState<DataShape>` for server data.
-- `useEffect(() => fetch(...))` for data loading.
-- `useRef(0)` for stale-response deduplication.
-- `window.dispatchEvent` / `addEventListener` for cross-component coordination.
-- Direct `apiClient.*`, `navigator.clipboard.*`, `localStorage.*`, or
-  `new EventSource(...)` calls; use the corresponding port from `usePorts()`.
-
-## Tests
-
-- Colocate `*.test.ts(x)`, `*.a11y.test.tsx`, and `*.stories.tsx`. Keep
-  type-level tests under `test/types/` and E2E specs under `e2e/tests/`.
-- Add REST handlers to `src/test/msw/handlers.ts` and SSE handlers to
-  `src/test/msw/sse-handlers.ts`; do not create separate MSW setups.
-- Cover success and rollback for every query or mutation hook whose behavior
-  changes.
-- Preserve the non-negotiable event-handler and stage-badge parity tests.
-
-## Stories and accessibility
-
-- Add per-state stories for view composers/forms, per-variant stories for
-  primitives, and per-discriminant stories for discriminated unions.
-- The a11y addon allows zero critical or serious axe violations. If a story
-  exposes a pre-existing production defect, disable that story's a11y test only
-  after recording the production file and defect in the Frontend Accessibility
-  Backlog in `docs/backlog.md`.
+Choose verification through the root risk tiers and
+`docs/local-reliability-qa.md`.

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -4,11 +4,10 @@ Use this page to choose the smallest QA surface that proves a change. The
 complete risk matrix still exists, but the common commands and browser paths
 come first.
 
-**No single aggregate covers every layer.** Match the commands to the code you
-changed, then add a browser/product-path check for user-visible behavior.
-Do not add cross-stack aggregates to a scoped change "just in case"; escalate
-only when the changed contract crosses boundaries, the risk tier requires it,
-or an active plan names the aggregate.
+**No single aggregate covers every layer.** Match commands to the changed
+contract; do not add cross-stack checks "just in case." For an approved
+unreleased stack, run focused checks per phase, finish canonical docs in the
+final PR, then run product QA on the cumulative stack.
 
 ## Required Commands
 

--- a/docs/local-reliability-qa.md
+++ b/docs/local-reliability-qa.md
@@ -6,6 +6,9 @@ come first.
 
 **No single aggregate covers every layer.** Match the commands to the code you
 changed, then add a browser/product-path check for user-visible behavior.
+Do not add cross-stack aggregates to a scoped change "just in case"; escalate
+only when the changed contract crosses boundaries, the risk tier requires it,
+or an active plan names the aggregate.
 
 ## Required Commands
 

--- a/docs/plans/2026-07-11-public-live-demo-plan.md
+++ b/docs/plans/2026-07-11-public-live-demo-plan.md
@@ -316,10 +316,9 @@ and rollback. Cloudflare supports custom subdomains on Pages projects:
 ### D8. Stacked delivery
 
 **Decision:** This plan PR is the base. Implementation is delivered as the
-stack in §10, one coherent concern per PR, with the repository's tier-required
-independent gates at every layer. P0 defers product QA to P1 because P0 has no
-executable product path; P1–P6 require review and QA. User-facing claims remain
-“planned” until the production deployment and live QA PR lands.
+stack in §10, one coherent concern per PR. P0–P5 get focused checks and review;
+P6 completes canonical docs, then runs cumulative review and product QA before
+launch. User-facing claims remain “planned” until that final gate passes.
 
 ---
 
@@ -1101,13 +1100,12 @@ Rules:
 - Validate every cited path/symbol against that phase's base; update this plan
   PR rather than guessing when anchors drift.
 - Do not claim the demo is shipped before P6 production verification.
-- Apply the repository validation tiers to each stack PR. P0 requires one
-  independent review plus its focused contract/privacy checks. Because P0 has
-  no executable product path, product QA is explicitly deferred to P1, whose
-  browser-local boot and persistence coverage must exercise the P0 seed. P1–P6
-  are product/high-risk changes and require `pr-reviewer` and `qa` to return
-  `Gate: PASS`. Run the gates once on the final phase diff and rerun only after
-  changes that address a blocking finding or affect verified behavior.
+- P0–P5 run focused phase checks and `pr-reviewer`; canonical product docs and
+  product QA are deferred because the demo is not released between phases.
+- P6 updates canonical docs first, then runs the full cumulative matrix,
+  `pr-reviewer`, and `qa` across P0–P6. If any earlier phase is released or
+  changes an active high-risk path, it exits this deferral and uses its normal
+  repository tier immediately.
 
 ---
 
@@ -1254,5 +1252,5 @@ This plan is complete only when:
     preview, production smoke, and rollback all pass.
 11. The local JobCtrl application retains its current security and behavior.
 12. Canonical docs describe the shipped boundary and synthetic-data policy.
-13. Every stack PR has passed its tier-required checks and independent gates;
-    P1–P6 have no unresolved Blocker or High `pr-reviewer` or `qa` findings.
+13. P0–P5 passed focused checks and review; after canonical docs landed, P6
+    passed cumulative `pr-reviewer` and `qa` with no Blocker or High findings.

--- a/docs/plans/2026-07-11-public-live-demo-plan.md
+++ b/docs/plans/2026-07-11-public-live-demo-plan.md
@@ -316,9 +316,10 @@ and rollback. Cloudflare supports custom subdomains on Pages projects:
 ### D8. Stacked delivery
 
 **Decision:** This plan PR is the base. Implementation is delivered as the
-stack in §10, one coherent concern per PR, with review and QA gates at every
-layer. User-facing claims remain “planned” until the production deployment and
-live QA PR lands.
+stack in §10, one coherent concern per PR, with the repository's tier-required
+independent gates at every layer. P0 defers product QA to P1 because P0 has no
+executable product path; P1–P6 require review and QA. User-facing claims remain
+“planned” until the production deployment and live QA PR lands.
 
 ---
 
@@ -1100,8 +1101,13 @@ Rules:
 - Validate every cited path/symbol against that phase's base; update this plan
   PR rather than guessing when anchors drift.
 - Do not claim the demo is shipped before P6 production verification.
-- P0–P6 each require the repository's `pr-reviewer` and `qa` loops to
-  `Gate: PASS` before completion.
+- Apply the repository validation tiers to each stack PR. P0 requires one
+  independent review plus its focused contract/privacy checks. Because P0 has
+  no executable product path, product QA is explicitly deferred to P1, whose
+  browser-local boot and persistence coverage must exercise the P0 seed. P1–P6
+  are product/high-risk changes and require `pr-reviewer` and `qa` to return
+  `Gate: PASS`. Run the gates once on the final phase diff and rerun only after
+  changes that address a blocking finding or affect verified behavior.
 
 ---
 
@@ -1248,5 +1254,5 @@ This plan is complete only when:
     preview, production smoke, and rollback all pass.
 11. The local JobCtrl application retains its current security and behavior.
 12. Canonical docs describe the shipped boundary and synthetic-data policy.
-13. Every stack PR has passed its required checks, `pr-reviewer`, and `qa` gates,
-    with no Blocker or High findings left unresolved.
+13. Every stack PR has passed its tier-required checks and independent gates;
+    P1–P6 have no unresolved Blocker or High `pr-reviewer` or `qa` findings.


### PR DESCRIPTION
## Summary

- route contributors to the owning documentation instead of requiring a full reference-tree scan
- replace blanket verification with four risk tiers and touched-surface commands
- reuse existing task worktrees and reserve subagents for independent work or required gates
- define stacked delivery for approved unreleased features: intermediate PRs run focused checks and one review; the final PR updates canonical docs first, then runs cumulative product QA
- require independently released or active-high-risk phases to document immediately and follow their normal validation tier
- align `CONTRIBUTING.md`, the reliability guide, the scoped web instructions, and the public demo delivery plan

The cumulative patch is a true reduction: 139 insertions and 141 deletions. Root plus scoped agent instructions fall from 3,236 to 2,391 words.

## Why

The previous policy applied broad reading, worktree setup, cross-stack validation, PR review, and QA too uniformly. That created repeat work for low-risk or incremental changes without improving evidence. The revised workflow keeps the hard safety boundaries while scaling effort to the changed surface and deferring cumulative documentation/QA to the end of an approved unreleased stack.

## Validation

- `git diff --check`
- `corepack pnpm docs:build`
  - install asset matches
  - VitePress build succeeds
  - 8,221 documentation references resolve across 316 emitted files
- policy sequencing and reduction assertions
- independent review gate: PASS, zero findings
- independent QA gate: PASS, zero findings

## Hosted check note

The Demo Site workflow currently stops before checkout with zero executed steps because the private repository is behind the documented GitHub billing gate. It provides no executable validation evidence; the equivalent local documentation build and link checks pass.