### PR TITLE
feat(web): establish redesign foundation

### DIFF
--- a/apps/web/src/shared/layout/ThemeToggle.tsx
+++ b/apps/web/src/shared/layout/ThemeToggle.tsx
@@ -12,8 +12,8 @@ export function ThemeToggle() {
       aria-label={`Switch to ${next} theme`}
       onClick={() => setTheme(next)}
     >
-      {theme === "dark" ? <IconSun aria-hidden="true" size={14} /> : <IconMoon aria-hidden="true" size={14} />}
-      <span>theme</span>
+      {theme === "dark" ? <IconSun aria-hidden="true" size={15} /> : <IconMoon aria-hidden="true" size={15} />}
+      <span>{theme}</span>
     </button>
   );
 }

--- a/apps/web/src/shared/layout/Topbar.tsx
+++ b/apps/web/src/shared/layout/Topbar.tsx
@@ -1,10 +1,17 @@
-import { IconMenu2 } from "@tabler/icons-react";
+import { IconMenu2, IconSearch } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { useDensity } from "../hooks/useDensity.js";
 import type { Density } from "../stores/ui-preferences.js";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "../ui/sheet.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select.js";
 import { BrandMark } from "./BrandMark.js";
 import { ConnectionStatusPill } from "./ConnectionStatusPill.js";
 import { LegalNotice } from "./LegalNotice.js";
@@ -36,30 +43,33 @@ export function Topbar() {
           <LegalNotice className="legal-notice legal-notice--sheet" />
         </SheetContent>
       </Sheet>
-      <input
-        aria-label="Global search"
-        className="global-search"
-        placeholder="Filter jobs, errors, companies..."
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && query.trim()) {
-            void navigate({ to: "/jobs", search: { q: query.trim(), page: 1 } });
-          }
-        }}
-      />
-      <select
-        aria-label="Row density"
-        className="select"
-        value={density}
-        onChange={(event) => setDensity(event.target.value as Density)}
-      >
-        {DENSITY_OPTIONS.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
+      <label className="topbar__search">
+        <IconSearch aria-hidden="true" size={17} stroke={1.8} />
+        <input
+          aria-label="Global search"
+          className="global-search"
+          placeholder="Filter jobs, errors, companies..."
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && query.trim()) {
+              void navigate({ to: "/jobs", search: { q: query.trim(), page: 1 } });
+            }
+          }}
+        />
+      </label>
+      <Select value={density} onValueChange={(value) => setDensity(value as Density)}>
+        <SelectTrigger className="topbar__density" aria-label="Row density">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="end">
+          {DENSITY_OPTIONS.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option[0]?.toUpperCase()}{option.slice(1)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
       <ThemeToggle />
       <ConnectionStatusPill />
       <LegalNotice className="legal-notice legal-notice--topbar" />

--- a/apps/web/src/shared/ui/adaptive-field-grid.tsx
+++ b/apps/web/src/shared/ui/adaptive-field-grid.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface AdaptiveFieldGridProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+  readonly columns?: "auto" | 1 | 2 | 3 | 4;
+  readonly minColumnWidth?: number;
+  readonly density?: "compact" | "regular";
+}
+
+type AdaptiveGridStyle = CSSProperties & {
+  "--adaptive-field-min"?: string;
+};
+
+export function AdaptiveFieldGrid({
+  children,
+  className,
+  columns = "auto",
+  minColumnWidth = 220,
+  density = "regular",
+  style,
+  ...props
+}: AdaptiveFieldGridProps) {
+  const adaptiveStyle: AdaptiveGridStyle = {
+    ...style,
+    "--adaptive-field-min": `${minColumnWidth}px`,
+  };
+
+  return (
+    <div
+      className={cn("adaptive-field-grid-container", className)}
+      style={adaptiveStyle}
+      {...props}
+    >
+      <div
+        className="adaptive-field-grid"
+        data-columns={columns}
+        data-density={density}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export interface AdaptiveFieldSpanProps extends HTMLAttributes<HTMLDivElement> {
+  readonly children: ReactNode;
+  readonly span?: "wide" | "full";
+}
+
+export function AdaptiveFieldSpan({
+  children,
+  className,
+  span = "wide",
+  ...props
+}: AdaptiveFieldSpanProps) {
+  return (
+    <div className={cn("adaptive-field-span", className)} data-span={span} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/button.tsx
+++ b/apps/web/src/shared/ui/button.tsx
@@ -5,23 +5,23 @@ import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "../lib/cn.js";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-[12px] font-[800] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[6px] text-[12px] font-extrabold transition-[background-color,border-color,color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[0_10px_20px_color-mix(in_oklab,var(--primary)_22%,transparent)] hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-[0_1px_2px_rgb(15_23_42/0.12)] hover:bg-primary/90",
         destructive: "bg-destructive text-white hover:bg-destructive/90",
-        outline: "border border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        outline: "border border-border bg-card text-foreground shadow-[0_1px_2px_rgb(15_23_42/0.04)] hover:border-foreground/25 hover:bg-muted",
         secondary:
-          "border border-[color-mix(in_oklab,var(--primary)_40%,var(--border))] bg-card text-primary hover:bg-accent hover:text-accent-foreground",
-        ghost: "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+          "border border-border bg-secondary text-secondary-foreground hover:border-foreground/20 hover:bg-muted",
+        ghost: "text-muted-foreground hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-lg px-3 text-xs",
-        lg: "h-10 rounded-lg px-6",
+        sm: "h-8 rounded-[5px] px-3 text-xs",
+        lg: "h-10 rounded-[6px] px-6",
         icon: "h-9 w-9",
       },
     },

--- a/apps/web/src/shared/ui/checkbox.tsx
+++ b/apps/web/src/shared/ui/checkbox.tsx
@@ -11,13 +11,13 @@ export const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer grid size-[18px] shrink-0 place-items-center rounded-[4px] border border-input bg-card text-primary-foreground shadow-[0_1px_1px_rgb(15_23_42/0.04)] transition-[border-color,background-color,box-shadow] hover:border-foreground/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary",
       className,
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
-      <IconCheck className="h-4 w-4" />
+      <IconCheck className="size-[14px]" stroke={2.7} />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/apps/web/src/shared/ui/choice-control.tsx
+++ b/apps/web/src/shared/ui/choice-control.tsx
@@ -1,0 +1,55 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { useId } from "react";
+
+import { cn } from "../lib/cn.js";
+import { Checkbox } from "./checkbox.js";
+
+export interface ChoiceControlProps
+  extends Omit<ComponentPropsWithoutRef<typeof Checkbox>, "children"> {
+  readonly label: ReactNode;
+  readonly description?: ReactNode;
+  readonly disabledReason?: ReactNode;
+  readonly locked?: boolean;
+}
+
+export function ChoiceControl({
+  id,
+  label,
+  description,
+  disabledReason,
+  locked = false,
+  disabled,
+  className,
+  ...props
+}: ChoiceControlProps) {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+  const labelId = `${controlId}-label`;
+  const descriptionId = `${controlId}-description`;
+  const isDisabled = disabled || locked;
+
+  return (
+    <div
+      className={cn("choice-control", className)}
+      data-disabled={isDisabled || undefined}
+      data-locked={locked || undefined}
+    >
+      <Checkbox
+        id={controlId}
+        disabled={isDisabled}
+        aria-labelledby={labelId}
+        aria-describedby={description || disabledReason ? descriptionId : undefined}
+        {...props}
+      />
+      <label className="choice-control__copy" htmlFor={controlId}>
+        <span className="choice-control__label" id={labelId}>{label}</span>
+        {description || disabledReason ? (
+          <span className="choice-control__description" id={descriptionId}>
+            {disabledReason ?? description}
+          </span>
+        ) : null}
+      </label>
+      {locked ? <span className="choice-control__state">Required</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/disclosure-section.tsx
+++ b/apps/web/src/shared/ui/disclosure-section.tsx
@@ -1,0 +1,92 @@
+import { IconChevronRight } from "@tabler/icons-react";
+import { type HTMLAttributes, type ReactNode, useId, useState } from "react";
+
+import { cn } from "../lib/cn.js";
+import { HelpLink } from "./help-link.js";
+
+export interface DisclosureSectionProps
+  extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+  readonly collapsedSummary?: ReactNode;
+  readonly actions?: ReactNode;
+  readonly helpHref?: string;
+  readonly helpLabel?: string;
+  readonly defaultOpen?: boolean;
+  readonly open?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+  readonly children: ReactNode;
+}
+
+export function DisclosureSection({
+  title,
+  description,
+  collapsedSummary,
+  actions,
+  helpHref,
+  helpLabel = "Read documentation",
+  defaultOpen = true,
+  open,
+  onOpenChange,
+  children,
+  className,
+  ...props
+}: DisclosureSectionProps) {
+  const [localOpen, setLocalOpen] = useState(defaultOpen);
+  const bodyId = useId();
+  const expanded = open ?? localOpen;
+
+  function setExpanded(next: boolean) {
+    if (open === undefined) {
+      setLocalOpen(next);
+    }
+    onOpenChange?.(next);
+  }
+
+  return (
+    <section
+      className={cn("disclosure-section", className)}
+      data-state={expanded ? "open" : "closed"}
+      {...props}
+    >
+      <header className="disclosure-section__header">
+        <button
+          type="button"
+          className="disclosure-section__trigger"
+          aria-controls={bodyId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded(!expanded)}
+        >
+          <IconChevronRight
+            className="disclosure-section__chevron"
+            aria-hidden="true"
+            size={18}
+            stroke={1.9}
+          />
+          <span className="disclosure-section__heading">
+            <span className="disclosure-section__title">{title}</span>
+            {description ? (
+              <span className="disclosure-section__description">{description}</span>
+            ) : null}
+            {!expanded && collapsedSummary ? (
+              <span className="disclosure-section__summary">{collapsedSummary}</span>
+            ) : null}
+          </span>
+        </button>
+        {helpHref || actions ? (
+          <div className="disclosure-section__tools">
+            {helpHref ? (
+              <HelpLink href={helpHref} target="_blank">
+                {helpLabel}
+              </HelpLink>
+            ) : null}
+            {actions}
+          </div>
+        ) : null}
+      </header>
+      <div id={bodyId} className="disclosure-section__body" hidden={!expanded}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/shared/ui/field.tsx
+++ b/apps/web/src/shared/ui/field.tsx
@@ -13,7 +13,7 @@ function FieldSet({
     <fieldset
       data-slot="field-set"
       className={cn(
-        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        "flex flex-col gap-5 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
         className,
       )}
       {...props}
@@ -33,7 +33,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        "mb-3 font-bold tracking-[-0.01em] data-[variant=label]:text-[12px] data-[variant=legend]:text-[14px]",
         className,
       )}
       {...props}
@@ -49,7 +49,7 @@ function FieldGroup({
     <div
       data-slot="field-group"
       className={cn(
-        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-2 *:data-[slot=field-group]:gap-4",
         className,
       )}
       {...props}
@@ -58,7 +58,7 @@ function FieldGroup({
 }
 
 const fieldVariants = cva(
-  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  "group/field flex min-w-0 w-full gap-1.5 data-[invalid=true]:text-destructive",
   {
     variants: {
       orientation: {
@@ -115,7 +115,7 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:bg-input/30 has-[>[data-slot=field]]:rounded-2xl has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
+        "group/field-label peer/field-label flex w-fit gap-2 text-[11px] font-bold leading-snug tracking-[0.005em] group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-[6px] has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className,
       )}
@@ -132,7 +132,7 @@ function FieldTitle({
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        "flex w-fit items-center gap-2 text-[12px] font-bold group-data-[disabled=true]/field:opacity-50",
         className,
       )}
       {...props}
@@ -148,7 +148,7 @@ function FieldDescription({
     <p
       data-slot="field-description"
       className={cn(
-        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "text-left text-[11px] leading-[1.45] font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
         "last:mt-0 nth-last-2:-mt-1",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,

--- a/apps/web/src/shared/ui/help-link.tsx
+++ b/apps/web/src/shared/ui/help-link.tsx
@@ -1,0 +1,28 @@
+import { IconExternalLink } from "@tabler/icons-react";
+import type { AnchorHTMLAttributes } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface HelpLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  readonly href: string;
+}
+
+export function HelpLink({
+  children,
+  className,
+  target,
+  rel,
+  ...props
+}: HelpLinkProps) {
+  return (
+    <a
+      className={cn("help-link", className)}
+      target={target}
+      rel={target === "_blank" ? "noreferrer" : rel}
+      {...props}
+    >
+      <span>{children}</span>
+      <IconExternalLink aria-hidden="true" className="help-link__icon" size={14} stroke={1.8} />
+    </a>
+  );
+}

--- a/apps/web/src/shared/ui/input.tsx
+++ b/apps/web/src/shared/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     <input
       type={type}
       className={cn(
-        "flex h-[38px] w-full rounded-md border border-input bg-card px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-[38px] w-full rounded-[6px] border border-input bg-card px-3 py-1 text-[13px] font-medium shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/25 focus-visible:border-primary/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/inspector-ledger.tsx
+++ b/apps/web/src/shared/ui/inspector-ledger.tsx
@@ -1,0 +1,40 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface InspectorLedgerProps extends HTMLAttributes<HTMLDListElement> {
+  readonly children: ReactNode;
+}
+
+export function InspectorLedger({ children, className, ...props }: InspectorLedgerProps) {
+  return (
+    <dl className={cn("inspector-ledger", className)} {...props}>
+      {children}
+    </dl>
+  );
+}
+
+export interface InspectorLedgerItemProps extends HTMLAttributes<HTMLDivElement> {
+  readonly label: ReactNode;
+  readonly value?: ReactNode;
+  readonly source?: ReactNode;
+  readonly status?: ReactNode;
+}
+
+export function InspectorLedgerItem({
+  label,
+  value,
+  source,
+  status,
+  className,
+  ...props
+}: InspectorLedgerItemProps) {
+  return (
+    <div className={cn("inspector-ledger__item", className)} {...props}>
+      <dt>{label}</dt>
+      <dd>{value ?? <span className="inspector-ledger__missing">Not available</span>}</dd>
+      {source ? <span className="inspector-ledger__source">{source}</span> : null}
+      {status ? <span className="inspector-ledger__status">{status}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/preview-workbench.tsx
+++ b/apps/web/src/shared/ui/preview-workbench.tsx
@@ -1,0 +1,55 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface PreviewWorkbenchProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+  readonly status?: ReactNode;
+  readonly primaryControls?: ReactNode;
+  readonly secondaryControls?: ReactNode;
+  readonly actions?: ReactNode;
+  readonly previewLabel: string;
+  readonly children: ReactNode;
+}
+
+export function PreviewWorkbench({
+  title,
+  description,
+  status,
+  primaryControls,
+  secondaryControls,
+  actions,
+  previewLabel,
+  children,
+  className,
+  ...props
+}: PreviewWorkbenchProps) {
+  return (
+    <section className={cn("preview-workbench", className)} {...props}>
+      <header className="preview-workbench__header">
+        <div className="preview-workbench__heading">
+          <h2>{title}</h2>
+          {description ? <p>{description}</p> : null}
+        </div>
+        {status ? <div className="preview-workbench__status">{status}</div> : null}
+      </header>
+      {primaryControls || actions ? (
+        <div className="preview-workbench__control-row" data-row="primary">
+          {primaryControls ? (
+            <div className="preview-workbench__controls">{primaryControls}</div>
+          ) : null}
+          {actions ? <div className="preview-workbench__actions">{actions}</div> : null}
+        </div>
+      ) : null}
+      {secondaryControls ? (
+        <div className="preview-workbench__control-row" data-row="secondary">
+          <div className="preview-workbench__controls">{secondaryControls}</div>
+        </div>
+      ) : null}
+      <div className="preview-workbench__document" role="region" aria-label={previewLabel}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/shared/ui/redesign-compositions.stories.tsx
+++ b/apps/web/src/shared/ui/redesign-compositions.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { AdaptiveFieldGrid, AdaptiveFieldSpan } from "./adaptive-field-grid.js";
+import { Button } from "./button.js";
+import { ChoiceControl } from "./choice-control.js";
+import { DisclosureSection } from "./disclosure-section.js";
+import { Input } from "./input.js";
+import { PreviewWorkbench } from "./preview-workbench.js";
+import { SegmentedField } from "./segmented-field.js";
+import { SelectField } from "./select-field.js";
+import { TabsContent, TabsTrigger } from "./tabs.js";
+import { SectionTabs, SectionTabsList } from "./section-tabs.js";
+
+const meta = {
+  title: "Shared/Compositions/Redesign system",
+  component: DisclosureSection,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof DisclosureSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const sizeOptions = [
+  { value: "small", label: "Small" },
+  { value: "regular", label: "Regular" },
+  { value: "large", label: "Large" },
+] as const;
+
+export const PreferencesSections: Story = {
+  render: function PreferencesSectionsStory() {
+    const [size, setSize] = useState("regular");
+    const [tone, setTone] = useState("executive");
+    return (
+      <div className="grid gap-4">
+        <DisclosureSection
+          title="Tailoring controls"
+          description="Evidence rules remain enforced"
+          collapsedSummary="3 generation permissions · Executive voice · 85% coverage"
+          helpHref="https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring"
+          helpLabel="Tailoring guide"
+        >
+          <SectionTabs defaultValue="content">
+            <SectionTabsList>
+              <TabsTrigger value="content">Content rules</TabsTrigger>
+              <TabsTrigger value="voice">Voice & language</TabsTrigger>
+              <TabsTrigger value="quality">Quality gates</TabsTrigger>
+            </SectionTabsList>
+            <TabsContent value="content">
+              <AdaptiveFieldGrid columns={2} minColumnWidth={260}>
+                <div>
+                  <ChoiceControl label="Rewrite executive summary" defaultChecked />
+                  <ChoiceControl label="Rewrite achievement bullets" defaultChecked />
+                  <ChoiceControl
+                    label="Change experience titles"
+                    disabledReason="Titles stay grounded in profile evidence."
+                    disabled
+                  />
+                </div>
+                <div>
+                  <ChoiceControl label="Impact" defaultChecked locked />
+                  <ChoiceControl label="Technical depth" defaultChecked locked />
+                  <ChoiceControl label="Leadership" defaultChecked locked />
+                </div>
+              </AdaptiveFieldGrid>
+            </TabsContent>
+            <TabsContent value="voice">
+              <SelectField
+                label="Writing tone"
+                value={tone}
+                onValueChange={setTone}
+                options={[
+                  { value: "direct", label: "Direct" },
+                  { value: "executive", label: "Executive" },
+                  { value: "technical", label: "Technical" },
+                ]}
+              />
+            </TabsContent>
+            <TabsContent value="quality">Quality gate controls</TabsContent>
+          </SectionTabs>
+        </DisclosureSection>
+        <DisclosureSection title="Resume style" description="Profile-level defaults">
+          <AdaptiveFieldGrid columns={4} minColumnWidth={164}>
+            <SegmentedField
+              label="Text size"
+              value={size}
+              onValueChange={setSize}
+              options={sizeOptions}
+            />
+            <SelectField
+              label="Template style"
+              defaultValue="banking"
+              options={[
+                { value: "banking", label: "Banking" },
+                { value: "classic", label: "Classic" },
+                { value: "casual", label: "Casual" },
+              ]}
+            />
+            <AdaptiveFieldSpan span="full">
+              <label className="field">
+                Additional guidance
+                <Input defaultValue="Keep certification gaps explicit." />
+              </label>
+            </AdaptiveFieldSpan>
+          </AdaptiveFieldGrid>
+        </DisclosureSection>
+      </div>
+    );
+  },
+};
+
+export const FullWidthPreview: Story = {
+  render: () => (
+    <PreviewWorkbench
+      title="Resume template"
+      description="Current template · Modern editorial"
+      status="Default"
+      primaryControls={
+        <>
+          <SelectField
+            label="Template"
+            defaultValue="modern"
+            options={[{ value: "modern", label: "Modern editorial" }]}
+          />
+          <label className="field">
+            Name
+            <Input defaultValue="Modern editorial" />
+          </label>
+        </>
+      }
+      actions={
+        <>
+          <Button variant="outline" size="sm">Save version</Button>
+          <Button size="sm">Save default</Button>
+        </>
+      }
+      previewLabel="Resume template preview"
+    >
+      <div className="mx-auto my-6 min-h-[560px] max-w-[760px] bg-card p-12 shadow-sm">
+        Production resume editor region
+      </div>
+    </PreviewWorkbench>
+  ),
+};

--- a/apps/web/src/shared/ui/redesign-compositions.test.tsx
+++ b/apps/web/src/shared/ui/redesign-compositions.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AdaptiveFieldGrid, AdaptiveFieldSpan } from "./adaptive-field-grid.js";
+import { ChoiceControl } from "./choice-control.js";
+import { DisclosureSection } from "./disclosure-section.js";
+import { PreviewWorkbench } from "./preview-workbench.js";
+
+describe("redesign compositions", () => {
+  it("keeps disclosure content mounted while collapsed", () => {
+    render(
+      <DisclosureSection title="Tailoring controls" defaultOpen>
+        <input aria-label="Additional guidance" defaultValue="Keep evidence explicit" />
+      </DisclosureSection>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /tailoring controls/i });
+    const input = screen.getByRole("textbox", { name: "Additional guidance" });
+
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(input).toBeInTheDocument();
+    expect(input.closest("[hidden]")).not.toBeNull();
+  });
+
+  it("associates a choice label and disabled reason with its control", () => {
+    render(
+      <ChoiceControl
+        label="Change experience titles"
+        disabledReason="Titles stay grounded in source evidence."
+        disabled
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", { name: "Change experience titles" });
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toHaveAccessibleDescription("Titles stay grounded in source evidence.");
+  });
+
+  it("exposes adaptive spans without changing source order", () => {
+    const { container } = render(
+      <AdaptiveFieldGrid columns={4} minColumnWidth={180}>
+        <div>First</div>
+        <AdaptiveFieldSpan span="full">Second</AdaptiveFieldSpan>
+      </AdaptiveFieldGrid>,
+    );
+
+    const grid = container.querySelector(".adaptive-field-grid");
+    const gridContainer = container.querySelector(".adaptive-field-grid-container");
+    expect(grid).toHaveAttribute("data-columns", "4");
+    expect(gridContainer).toHaveStyle({ "--adaptive-field-min": "180px" });
+    expect(screen.getByText("First").compareDocumentPosition(screen.getByText("Second"))).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("names the real document preview region", () => {
+    const action = vi.fn();
+    render(
+      <PreviewWorkbench
+        title="Resume template"
+        previewLabel="Resume template preview"
+        actions={<button onClick={action}>Save version</button>}
+      >
+        <article>Resume content</article>
+      </PreviewWorkbench>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save version" }));
+    expect(action).toHaveBeenCalledOnce();
+    expect(screen.getByRole("region", { name: "Resume template preview" })).toHaveTextContent(
+      "Resume content",
+    );
+  });
+});

--- a/apps/web/src/shared/ui/route-workspace.tsx
+++ b/apps/web/src/shared/ui/route-workspace.tsx
@@ -1,0 +1,46 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface RouteWorkspaceProps extends HTMLAttributes<HTMLElement> {
+  readonly header?: ReactNode;
+  readonly navigation?: ReactNode;
+  readonly inspector?: ReactNode;
+  readonly children: ReactNode;
+  readonly contentLabel?: string;
+  readonly navigationLabel?: string;
+  readonly inspectorLabel?: string;
+}
+
+export function RouteWorkspace({
+  header,
+  navigation,
+  inspector,
+  children,
+  contentLabel = "Detail workspace",
+  navigationLabel = "Workspace navigation",
+  inspectorLabel = "Details and provenance",
+  className,
+  ...props
+}: RouteWorkspaceProps) {
+  return (
+    <article className={cn("route-workspace", className)} {...props}>
+      {header ? <header className="route-workspace__header">{header}</header> : null}
+      <div className="route-workspace__grid">
+        {navigation ? (
+          <aside className="route-workspace__navigation" aria-label={navigationLabel}>
+            {navigation}
+          </aside>
+        ) : null}
+        <section className="route-workspace__content" aria-label={contentLabel}>
+          {children}
+        </section>
+        {inspector ? (
+          <aside className="route-workspace__inspector" aria-label={inspectorLabel}>
+            {inspector}
+          </aside>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/shared/ui/section-tabs.tsx
+++ b/apps/web/src/shared/ui/section-tabs.tsx
@@ -1,0 +1,18 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+import { cn } from "../lib/cn.js";
+import { Tabs, TabsList } from "./tabs.js";
+
+export function SectionTabs({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<typeof Tabs>) {
+  return <Tabs className={cn("section-tabs", className)} {...props} />;
+}
+
+export function SectionTabsList({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<typeof TabsList>) {
+  return <TabsList className={cn("section-tabs__list", className)} {...props} />;
+}

--- a/apps/web/src/shared/ui/section.tsx
+++ b/apps/web/src/shared/ui/section.tsx
@@ -1,15 +1,32 @@
-import type { ReactNode } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
 
-export interface SectionProps {
-  title: string;
-  children: ReactNode;
+import { cn } from "../lib/cn.js";
+
+export interface SectionProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+  readonly actions?: ReactNode;
+  readonly children: ReactNode;
 }
 
-export function Section({ title, children }: SectionProps) {
+export function Section({
+  title,
+  description,
+  actions,
+  children,
+  className,
+  ...props
+}: SectionProps) {
   return (
-    <section className="section">
-      <h3>{title}</h3>
-      {children}
+    <section className={cn("section", className)} {...props}>
+      <header className="section__header">
+        <div className="section__heading">
+          <h3>{title}</h3>
+          {description ? <p>{description}</p> : null}
+        </div>
+        {actions ? <div className="section__actions">{actions}</div> : null}
+      </header>
+      <div className="section__body">{children}</div>
     </section>
   );
 }

--- a/apps/web/src/shared/ui/segmented-field.tsx
+++ b/apps/web/src/shared/ui/segmented-field.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+import { useId } from "react";
+
+import { Field, FieldDescription, FieldLabel } from "./field.js";
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group.js";
+
+export interface SegmentedFieldOption {
+  readonly value: string;
+  readonly label: ReactNode;
+  readonly disabled?: boolean;
+}
+
+export interface SegmentedFieldProps {
+  readonly label: ReactNode;
+  readonly description?: ReactNode;
+  readonly options: readonly SegmentedFieldOption[];
+  readonly value: string;
+  readonly onValueChange: (value: string) => void;
+  readonly disabled?: boolean;
+  readonly className?: string;
+  readonly ariaLabel?: string;
+}
+
+export function SegmentedField({
+  label,
+  description,
+  options,
+  value,
+  onValueChange,
+  disabled,
+  className,
+  ariaLabel,
+}: SegmentedFieldProps) {
+  const descriptionId = useId();
+
+  return (
+    <Field className={className}>
+      <FieldLabel>{label}</FieldLabel>
+      <ToggleGroup
+        type="single"
+        value={value}
+        variant="outline"
+        spacing={0}
+        disabled={disabled}
+        aria-label={ariaLabel ?? (typeof label === "string" ? label : "Select an option")}
+        aria-describedby={description ? descriptionId : undefined}
+        className="segmented-field"
+        onValueChange={(next) => {
+          if (next) onValueChange(next);
+        }}
+      >
+        {options.map((option) => (
+          <ToggleGroupItem
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+            aria-label={typeof option.label === "string" ? option.label : option.value}
+          >
+            {option.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+      {description ? (
+        <FieldDescription id={descriptionId}>{description}</FieldDescription>
+      ) : null}
+    </Field>
+  );
+}

--- a/apps/web/src/shared/ui/select-field.tsx
+++ b/apps/web/src/shared/ui/select-field.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import { useId } from "react";
+
+import { cn } from "../lib/cn.js";
+import { Field, FieldDescription, FieldError, FieldLabel } from "./field.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select.js";
+
+export interface SelectFieldOption {
+  readonly value: string;
+  readonly label: ReactNode;
+  readonly disabled?: boolean;
+}
+
+export interface SelectFieldProps {
+  readonly id?: string;
+  readonly name?: string;
+  readonly label: ReactNode;
+  readonly description?: ReactNode;
+  readonly error?: ReactNode;
+  readonly options: readonly SelectFieldOption[];
+  readonly value?: string;
+  readonly defaultValue?: string;
+  readonly placeholder?: string;
+  readonly disabled?: boolean;
+  readonly required?: boolean;
+  readonly className?: string;
+  readonly triggerClassName?: string;
+  readonly onValueChange?: (value: string) => void;
+}
+
+export function SelectField({
+  id,
+  name,
+  label,
+  description,
+  error,
+  options,
+  value,
+  defaultValue,
+  placeholder = "Select an option",
+  disabled,
+  required,
+  className,
+  triggerClassName,
+  onValueChange,
+}: SelectFieldProps) {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+  const descriptionId = description ? `${controlId}-description` : undefined;
+  const errorId = error ? `${controlId}-error` : undefined;
+  const describedBy = [descriptionId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <Field className={className} data-invalid={Boolean(error) || undefined}>
+      <FieldLabel htmlFor={controlId}>{label}</FieldLabel>
+      <Select
+        name={name}
+        value={value}
+        defaultValue={defaultValue}
+        disabled={disabled}
+        required={required}
+        onValueChange={onValueChange}
+      >
+        <SelectTrigger
+          id={controlId}
+          className={cn("select-field__trigger", triggerClassName)}
+          aria-describedby={describedBy}
+          aria-invalid={Boolean(error) || undefined}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value} disabled={option.disabled}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {description ? (
+        <FieldDescription id={descriptionId}>{description}</FieldDescription>
+      ) : null}
+      {error ? <FieldError id={errorId}>{error}</FieldError> : null}
+    </Field>
+  );
+}

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -19,14 +19,14 @@ export const SelectTrigger = forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-[38px] w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-[38px] w-full items-center justify-between gap-3 whitespace-nowrap rounded-[6px] border border-input bg-card px-3 py-2 text-left text-[13px] font-medium shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] placeholder:text-muted-foreground hover:border-foreground/25 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 data-[placeholder]:text-muted-foreground disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <IconChevronDown className="h-4 w-4 opacity-50" />
+      <IconChevronDown className="size-4 shrink-0 text-muted-foreground" stroke={1.9} />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -68,7 +68,7 @@ export const SelectContent = forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[var(--shadow-panel)]",
+        "relative z-50 max-h-96 min-w-[10rem] origin-[var(--radix-select-content-transform-origin)] overflow-hidden rounded-[7px] border border-border bg-popover text-popover-foreground shadow-[0_18px_46px_rgb(15_23_42/0.16)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -98,7 +98,10 @@ export const SelectLabel = forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn(
+      "px-2.5 py-2 text-[10px] font-extrabold uppercase tracking-[0.08em] text-muted-foreground",
+      className,
+    )}
     {...props}
   />
 ));
@@ -111,7 +114,7 @@ export const SelectItem = forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex min-h-9 w-full cursor-default select-none items-center rounded-[4px] py-2 pl-2.5 pr-9 text-[13px] outline-none focus:bg-muted focus:text-foreground data-[state=checked]:font-semibold data-[disabled]:pointer-events-none data-[disabled]:opacity-45",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/tabs.tsx
+++ b/apps/web/src/shared/ui/tabs.tsx
@@ -12,7 +12,7 @@ export const TabsList = forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-full border border-border bg-muted p-[3px] text-muted-foreground",
+      "inline-flex min-h-10 max-w-full items-end justify-start gap-5 overflow-x-auto border-b border-border bg-transparent px-0 text-muted-foreground",
       className,
     )}
     {...props}
@@ -27,7 +27,7 @@ export const TabsTrigger = forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-3.5 py-1 text-[11px] font-[850] tracking-[0.01em] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-primary data-[state=active]:shadow-[var(--shadow-panel)]",
+      "relative -mb-px inline-flex min-h-10 items-center justify-center whitespace-nowrap border-b-2 border-transparent px-0 py-2 text-[12px] font-bold tracking-[-0.01em] transition-[border-color,color] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 data-[state=active]:border-primary data-[state=active]:text-foreground",
       className,
     )}
     {...props}
@@ -42,7 +42,7 @@ export const TabsContent = forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-4 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/textarea.tsx
+++ b/apps/web/src/shared/ui/textarea.tsx
@@ -8,7 +8,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-[88px] w-full rounded-[6px] border border-input bg-card px-3 py-2.5 text-[13px] font-medium leading-relaxed shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/25 focus-visible:border-primary/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/tool-row.tsx
+++ b/apps/web/src/shared/ui/tool-row.tsx
@@ -1,0 +1,19 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import { cn } from "../lib/cn.js";
+
+export interface ToolRowProps extends HTMLAttributes<HTMLDivElement> {
+  readonly primary?: ReactNode;
+  readonly secondary?: ReactNode;
+  readonly status?: ReactNode;
+}
+
+export function ToolRow({ primary, secondary, status, className, ...props }: ToolRowProps) {
+  return (
+    <div className={cn("tool-row", className)} {...props}>
+      {primary ? <div className="tool-row__primary">{primary}</div> : null}
+      {secondary ? <div className="tool-row__secondary">{secondary}</div> : null}
+      {status ? <div className="tool-row__status">{status}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -246,13 +246,13 @@ code,
 }
 
 .side-rail__link:hover {
-  background: color-mix(in oklch, var(--accent) 55%, transparent);
-  color: var(--accent-foreground);
+  background: var(--muted);
+  color: var(--foreground);
 }
 
 .side-rail__link.on {
-  background: var(--accent);
-  color: var(--accent-foreground);
+  background: var(--muted);
+  color: var(--foreground);
   font-weight: 650;
 }
 
@@ -399,7 +399,7 @@ code,
   align-items: center;
   gap: 8px 12px;
   min-height: var(--topbar-height);
-  padding: 10px 24px;
+  padding: 10px var(--content-gutter);
   background: color-mix(in oklch, var(--card) 96%, transparent);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid var(--border);
@@ -411,8 +411,27 @@ code,
 }
 
 @media (max-width: 820px) {
+  .topbar {
+    gap: 8px;
+    padding: 8px 12px;
+  }
+
   .topbar .topbar__hamburger {
     display: inline-flex;
+  }
+
+  .topbar__search {
+    order: 10;
+    max-width: none;
+    flex-basis: 100%;
+  }
+
+  .topbar__density {
+    width: 110px;
+  }
+
+  .topbar .connection-pill-group {
+    margin-left: 0;
   }
 }
 
@@ -441,10 +460,41 @@ code,
 }
 
 .global-search {
-  min-width: 240px;
+  min-width: 0;
   max-width: 560px;
-  flex: 1 1 320px;
+  flex: 1 1 auto;
   min-height: 36px;
+  border: 0;
+  background: transparent;
+  padding-inline: 0;
+  box-shadow: none;
+}
+
+.global-search:hover,
+.global-search:focus-visible {
+  border: 0;
+  box-shadow: none;
+}
+
+.topbar__search {
+  display: flex;
+  min-width: min(240px, 100%);
+  max-width: 600px;
+  flex: 1 1 360px;
+  align-items: center;
+  gap: 9px;
+  border-bottom: 1px solid var(--input);
+  color: var(--muted-foreground);
+}
+
+.topbar__search:focus-within {
+  border-color: var(--primary);
+  color: var(--foreground);
+}
+
+.topbar__density {
+  width: 124px;
+  flex: 0 0 auto;
 }
 
 .connection-pill-group {
@@ -502,12 +552,12 @@ code,
 
 .tab:hover,
 .tab.on {
-  background: var(--accent);
-  color: var(--accent-foreground);
+  background: var(--muted);
+  color: var(--foreground);
 }
 
 .tab.on {
-  box-shadow: inset 0 0 0 1px var(--border);
+  box-shadow: inset 0 -2px 0 var(--primary);
 }
 
 .tab:disabled {
@@ -520,10 +570,18 @@ select,
 input,
 textarea {
   border: 1px solid var(--input);
-  border-radius: calc(var(--radius) * 0.8);
-  background: var(--popover);
+  border-radius: 6px;
+  background: var(--card);
   color: var(--foreground);
-  padding: 7px 9px;
+  padding: 8px 10px;
+  box-shadow: var(--shadow-control);
+  transition: border-color 140ms ease, box-shadow 140ms ease, background-color 140ms ease;
+}
+
+select:hover,
+input:hover,
+textarea:hover {
+  border-color: color-mix(in oklch, var(--foreground) 24%, var(--input));
 }
 
 select:focus-visible,
@@ -534,7 +592,18 @@ textarea:focus-visible {
 
 input[type="checkbox"],
 input[type="radio"] {
+  width: 17px;
+  height: 17px;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0;
+  border-radius: 4px;
+  box-shadow: none;
   accent-color: var(--primary);
+}
+
+input[type="radio"] {
+  border-radius: 50%;
 }
 
 .pulse {
@@ -582,7 +651,7 @@ input[type="radio"] {
 }
 
 .main {
-  padding: 18px 24px 80px;
+  padding: clamp(18px, 2vw, 28px) var(--content-gutter) 80px;
 }
 
 .eyebrow {
@@ -598,7 +667,7 @@ input[type="radio"] {
   align-items: flex-end;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 18px;
+  margin-bottom: var(--section-gap);
 }
 
 .page-head-text {
@@ -610,7 +679,7 @@ input[type="radio"] {
 .page-head h1 {
   margin: 0;
   font-family: var(--font-heading);
-  font-size: 26px;
+  font-size: clamp(24px, 2vw, 30px);
   font-weight: 800;
   letter-spacing: -0.03em;
   line-height: 1.1;
@@ -619,7 +688,9 @@ input[type="radio"] {
 .page-head-subtitle {
   margin: 0;
   color: var(--muted-foreground);
-  font-size: 12px;
+  max-width: 72ch;
+  font-size: 13px;
+  line-height: 1.45;
 }
 
 .page-head-actions {
@@ -638,6 +709,513 @@ input[type="radio"] {
 
   .page-head-actions {
     justify-content: flex-start;
+  }
+}
+
+/* Shared redesign compositions ------------------------------------------------ */
+
+.adaptive-field-grid-container {
+  container-type: inline-size;
+  min-width: 0;
+}
+
+.adaptive-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--adaptive-field-min, 220px)), 1fr));
+  gap: 16px 18px;
+  min-width: 0;
+}
+
+.adaptive-field-grid[data-density="compact"] {
+  gap: 10px 14px;
+}
+
+.adaptive-field-grid[data-columns="1"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.adaptive-field-grid[data-columns="2"] {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.adaptive-field-grid[data-columns="3"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.adaptive-field-grid[data-columns="4"] {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.adaptive-field-span {
+  min-width: 0;
+}
+
+.adaptive-field-span[data-span="wide"] {
+  grid-column: span 2;
+}
+
+.adaptive-field-span[data-span="full"] {
+  grid-column: 1 / -1;
+}
+
+@container (max-width: 560px) {
+  .adaptive-field-grid[data-columns="2"],
+  .adaptive-field-grid[data-columns="3"],
+  .adaptive-field-grid[data-columns="4"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .adaptive-field-span[data-span="wide"] {
+    grid-column: 1 / -1;
+  }
+}
+
+@container (min-width: 561px) and (max-width: 920px) {
+  .adaptive-field-grid[data-columns="3"],
+  .adaptive-field-grid[data-columns="4"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.help-link {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 700;
+  text-decoration: none;
+  text-underline-offset: 3px;
+}
+
+.help-link:hover {
+  color: var(--foreground);
+  text-decoration: underline;
+}
+
+.help-link__icon {
+  flex: 0 0 auto;
+}
+
+.disclosure-section {
+  min-width: 0;
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+}
+
+.disclosure-section__header {
+  display: flex;
+  min-height: 64px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-raised);
+}
+
+.disclosure-section[data-state="closed"] .disclosure-section__header {
+  border-bottom: 0;
+}
+
+.disclosure-section__trigger {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  padding: 4px;
+  color: var(--foreground);
+  text-align: left;
+}
+
+.disclosure-section__trigger:hover .disclosure-section__title {
+  color: var(--primary);
+}
+
+.disclosure-section__chevron {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  transition: transform 160ms ease;
+}
+
+.disclosure-section[data-state="open"] .disclosure-section__chevron {
+  transform: rotate(90deg);
+}
+
+.disclosure-section__heading {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.disclosure-section__title {
+  font-size: 14px;
+  font-weight: 750;
+  letter-spacing: -0.015em;
+}
+
+.disclosure-section__description,
+.disclosure-section__summary {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.disclosure-section__summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.disclosure-section__tools {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.disclosure-section__body {
+  min-width: 0;
+  padding: clamp(14px, 1.7vw, 22px);
+}
+
+.disclosure-section__body[hidden] {
+  display: none;
+}
+
+.choice-control {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  min-width: 0;
+  align-items: start;
+  gap: 9px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 72%, transparent);
+  padding: 10px 2px;
+}
+
+.choice-control:last-child {
+  border-bottom: 0;
+}
+
+.choice-control > [role="checkbox"] {
+  margin-top: 1px;
+}
+
+.choice-control__copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+  cursor: pointer;
+}
+
+.choice-control[data-disabled] .choice-control__copy {
+  cursor: default;
+}
+
+.choice-control__label {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
+.choice-control__description {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.choice-control__state {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.choice-control[data-disabled] {
+  opacity: 0.68;
+}
+
+.segmented-field {
+  display: grid;
+  width: 100%;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-auto-flow: column;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--input);
+  border-radius: 6px;
+  background: var(--surface-subtle);
+  padding: 2px;
+}
+
+.segmented-field [data-slot="toggle-group-item"] {
+  min-width: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground);
+  padding-inline: 10px;
+  box-shadow: none;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.segmented-field [data-slot="toggle-group-item"][data-state="on"] {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: var(--shadow-control), inset 0 -2px 0 var(--primary);
+}
+
+.section-tabs {
+  min-width: 0;
+}
+
+.section-tabs__list {
+  width: 100%;
+}
+
+.inspector-ledger {
+  display: grid;
+  min-width: 0;
+  margin: 0;
+}
+
+.inspector-ledger__item {
+  display: grid;
+  grid-template-columns: minmax(112px, 0.42fr) minmax(0, 1fr) auto;
+  gap: 4px 12px;
+  align-items: baseline;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.inspector-ledger__item:last-child {
+  border-bottom: 0;
+}
+
+.inspector-ledger__item dt {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.inspector-ledger__item dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+}
+
+.inspector-ledger__source {
+  grid-column: 2;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.inspector-ledger__status {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+}
+
+.inspector-ledger__missing {
+  color: var(--muted-foreground);
+  font-style: italic;
+}
+
+.preview-workbench {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+}
+
+.preview-workbench__header,
+.preview-workbench__control-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.preview-workbench__header {
+  background: var(--surface-raised);
+}
+
+.preview-workbench__heading {
+  min-width: 0;
+}
+
+.preview-workbench__heading h2,
+.preview-workbench__heading p {
+  margin: 0;
+}
+
+.preview-workbench__heading h2 {
+  font-size: 14px;
+}
+
+.preview-workbench__heading p,
+.preview-workbench__status {
+  margin-top: 2px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.preview-workbench__control-row[data-row="secondary"] {
+  background: var(--surface-subtle);
+}
+
+.preview-workbench__controls {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 148px), 1fr));
+  gap: 10px;
+}
+
+.preview-workbench__actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.preview-workbench__document {
+  min-width: 0;
+  min-height: 480px;
+  overflow: auto;
+  background: var(--background);
+}
+
+.route-workspace {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card);
+}
+
+.route-workspace__header {
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.route-workspace__grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.24fr) minmax(420px, 1fr) minmax(240px, 0.32fr);
+  min-width: 0;
+}
+
+.route-workspace__navigation,
+.route-workspace__content,
+.route-workspace__inspector {
+  min-width: 0;
+  padding: 16px;
+}
+
+.route-workspace__navigation {
+  border-right: 1px solid var(--border);
+}
+
+.route-workspace__inspector {
+  border-left: 1px solid var(--border);
+  background: var(--surface-subtle);
+}
+
+.tool-row {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--card);
+}
+
+.tool-row__primary,
+.tool-row__secondary {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-row__primary {
+  flex: 1 1 320px;
+}
+
+.tool-row__secondary {
+  flex: 0 1 auto;
+}
+
+.tool-row__status {
+  margin-left: auto;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+@media (max-width: 1000px) {
+  .route-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-workspace__navigation,
+  .route-workspace__inspector {
+    border: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .route-workspace__inspector {
+    border-top: 1px solid var(--border);
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .disclosure-section__header,
+  .preview-workbench__header,
+  .preview-workbench__control-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .disclosure-section__tools,
+  .preview-workbench__actions {
+    justify-content: flex-start;
+  }
+
+  .inspector-ledger__item {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .inspector-ledger__item dd,
+  .inspector-ledger__source {
+    grid-column: 1 / -1;
+  }
+
+  .inspector-ledger__status {
+    grid-column: 2;
   }
 }
 
@@ -666,7 +1244,7 @@ input[type="radio"] {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--card);
-  box-shadow: var(--shadow-panel);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 5%, transparent);
 }
 
 .card.full {
@@ -680,7 +1258,7 @@ input[type="radio"] {
   gap: 12px;
   padding: 14px 16px;
   border-bottom: 1px solid var(--border);
-  background: var(--muted);
+  background: var(--card);
 }
 
 .card-hd h2 {
@@ -710,26 +1288,26 @@ input[type="radio"] {
 }
 
 .settings-tabs {
-  display: inline-flex;
-  align-self: flex-start;
-  gap: 4px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--muted);
+  display: flex;
+  width: 100%;
+  align-self: stretch;
+  gap: 20px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
 }
 
 .settings-tabs .tab {
-  min-height: 30px;
-  border-radius: 999px;
-  padding: 6px 16px;
+  min-height: 40px;
+  border-radius: 0;
+  padding: 8px 0;
   text-transform: capitalize;
 }
 
 .settings-tabs .tab.on {
-  background: var(--card);
+  background: transparent;
   color: var(--foreground);
-  box-shadow: 0 1px 2px rgb(31 41 55 / 0.12);
+  box-shadow: inset 0 -2px 0 var(--primary);
 }
 
 .config-form,
@@ -738,6 +1316,10 @@ input[type="radio"] {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px 16px;
   padding: 14px 16px;
+}
+
+.field-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
 }
 
 .runtime-summary {
@@ -1199,13 +1781,12 @@ input[type="radio"] {
 @media (max-width: 720px) {
   .settings-tabs {
     width: 100%;
-    flex-wrap: wrap;
-    border-radius: var(--radius);
+    gap: 16px;
   }
 
   .settings-tabs .tab {
-    min-width: 0;
-    flex: 1 1 120px;
+    min-width: max-content;
+    flex: 0 0 auto;
     text-align: center;
   }
 
@@ -6298,9 +6879,41 @@ input[type="radio"] {
   border-bottom: 1px solid var(--border);
 }
 
-.section h3 {
-  margin: 0 0 10px;
+.section__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.section__heading {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.section__heading h3 {
+  margin: 0;
   font-size: 13px;
+}
+
+.section__heading p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.section__actions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.section__body {
+  min-width: 0;
 }
 
 .compensation-audit-section {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -47,6 +47,13 @@
   --status-info-muted: color-mix(in oklch, var(--status-info) 14%, var(--card));
 
   --shadow-panel: 0 12px 34px rgb(31 41 55 / 0.08);
+  --shadow-control: 0 1px 2px rgb(15 23 42 / 0.05);
+  --shadow-float: 0 18px 46px rgb(15 23 42 / 0.16);
+  --surface-subtle: color-mix(in oklch, var(--muted) 72%, var(--card));
+  --surface-raised: color-mix(in oklch, var(--card) 96%, var(--background));
+  --content-gutter: clamp(16px, 2.1vw, 32px);
+  --section-gap: clamp(14px, 1.6vw, 20px);
+  --control-height: 38px;
   --rail-width: 236px;
   --rail-width-collapsed: 72px;
   --topbar-height: 60px;
@@ -108,6 +115,8 @@
   --status-info-muted: color-mix(in oklch, var(--status-info) 18%, var(--card));
 
   --shadow-panel: 0 12px 34px rgb(0 0 0 / 0.45);
+  --shadow-control: 0 1px 2px rgb(0 0 0 / 0.28);
+  --shadow-float: 0 20px 50px rgb(0 0 0 / 0.52);
 }
 
 :where(.app-shell) {


### PR DESCRIPTION
## Summary

- introduces the shared responsive compositions defined by the redesign plan
- refines form controls, tabs, spacing, shell search, and density selection around the existing JobCtrl tokens
- adds component stories and semantic regression coverage for disclosure state, choices, adaptive grids, and document preview regions

## Stack

- Base: `docs/redesign-implementation-plan` (#440)
- Successor: operational lists and dashboards

## Validation

The component tests and stories are authored in this layer. Per the redesign delivery contract, the integrated build, browser, accessibility, visual, and product-flow QA gate will run only after the full implementation stack and final documentation pass are complete.