### PR TITLE
feat(web): redesign operational surfaces

### DIFF
--- a/apps/web/src/contexts/discovery/components/DiscoveryAutomationSettingsPanel.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryAutomationSettingsPanel.tsx
@@ -7,7 +7,7 @@ import { useForm } from "@tanstack/react-form";
 import { useEffect, useRef, useState } from "react";
 
 import { AutosaveUndoController } from "../../../shared/ui/autosave-undo-controller.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useDiscoverySettingsQuery } from "../../operations/hooks/useDiscoverySettingsQuery.js";
 import { useUpdateDiscoverySettingsMutation } from "../hooks/useUpdateDiscoverySettingsMutation.js";
@@ -29,15 +29,19 @@ export function DiscoveryAutomationSettingsPanel() {
   const settingsQuery = useDiscoverySettingsQuery();
 
   return (
-    <section className="card full discovery-automation-settings">
-      <CardHeader title="Automation settings" meta="SQLite · scoring and apply" />
+    <DisclosureSection
+      className="discovery-automation-settings"
+      title="Automation settings"
+      description="Scoring threshold and supervised apply policy"
+      collapsedSummary="SQLite-backed scoring and apply controls"
+    >
       {settingsQuery.error ? <div className="banner inline">{settingsQuery.error.message}</div> : null}
       {settingsQuery.data ? (
         <DiscoveryAutomationSettingsForm initial={settingsQuery.data} />
       ) : (
         <Empty title="Loading automation settings." />
       )}
-    </section>
+    </DisclosureSection>
   );
 }
 

--- a/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.tsx
@@ -9,7 +9,7 @@ import {
 import { useForm } from "@tanstack/react-form";
 import { useCallback, useEffect, useState } from "react";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useDiscoverySettingsQuery } from "../../operations/hooks/useDiscoverySettingsQuery.js";
 import { useUpdateDiscoverySettingsMutation } from "../hooks/useUpdateDiscoverySettingsMutation.js";
@@ -58,15 +58,19 @@ export function DiscoveryRuntimeSettingsPanel() {
   const settingsQuery = useDiscoverySettingsQuery();
 
   return (
-    <section className="card full discovery-runtime-settings">
-      <CardHeader title="Runtime settings" meta="discovery config" />
+    <DisclosureSection
+      className="discovery-runtime-settings"
+      title="Runtime settings"
+      description="Source execution, lookback, filtering, and schedule"
+      collapsedSummary="Discovery runtime configuration"
+    >
       {settingsQuery.error ? <div className="banner inline">{settingsQuery.error.message}</div> : null}
       {settingsQuery.data ? (
         <DiscoveryRuntimeSettingsForm initial={settingsQuery.data} />
       ) : (
         <Empty title="Loading runtime settings." />
       )}
-    </section>
+    </DisclosureSection>
   );
 }
 

--- a/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { ProfileForm } from "../forms/profile-form.js";
 import { useProfileQuery } from "../hooks/useProfileQuery.js";
@@ -7,14 +7,18 @@ export function TargetSearchSettingsPanel() {
   const profileQuery = useProfileQuery();
 
   return (
-    <section className="card full target-search-settings">
-      <CardHeader title="Discovery settings" meta="target search" />
+    <DisclosureSection
+      className="target-search-settings"
+      title="Discovery settings"
+      description="Roles, locations, work models, and target search defaults"
+      collapsedSummary="Target search profile"
+    >
       {profileQuery.error ? <div className="banner inline">{profileQuery.error.message}</div> : null}
       {profileQuery.data ? (
         <ProfileForm initial={profileQuery.data} section="target-search" />
       ) : (
         <Empty title="Loading discovery settings." />
       )}
-    </section>
+    </DisclosureSection>
   );
 }

--- a/apps/web/src/shared/ui/disclosure-section.tsx
+++ b/apps/web/src/shared/ui/disclosure-section.tsx
@@ -64,7 +64,9 @@ export function DisclosureSection({
             stroke={1.9}
           />
           <span className="disclosure-section__heading">
-            <span className="disclosure-section__title">{title}</span>
+            <span className="disclosure-section__title" role="heading" aria-level={2}>
+              {title}
+            </span>
             {description ? (
               <span className="disclosure-section__description">{description}</span>
             ) : null}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -856,6 +856,7 @@ input[type="radio"] {
 }
 
 .disclosure-section__title {
+  margin: 0;
   font-size: 14px;
   font-weight: 750;
   letter-spacing: -0.015em;
@@ -8582,6 +8583,168 @@ input[type="radio"] {
   .profile-resizer {
     display: none;
   }
+}
+
+/* Operational route composition --------------------------------------------- */
+
+.route-page {
+  display: grid;
+  min-width: 0;
+  gap: var(--section-gap);
+}
+
+.route-page > .page-head {
+  margin-bottom: 0;
+}
+
+.data-surface {
+  box-shadow: none;
+}
+
+.data-surface__tools {
+  border-width: 0 0 1px;
+  border-radius: 0;
+  padding: 10px 12px;
+}
+
+.tool-row__field {
+  width: min(220px, 100%);
+  flex: 0 1 220px;
+}
+
+.tool-row__search {
+  min-width: min(280px, 100%);
+  flex: 1 1 320px;
+}
+
+.tool-row__compact-input {
+  width: min(180px, 100%);
+  flex: 0 1 180px;
+}
+
+.debug-filter-form {
+  display: contents;
+}
+
+.route-page--dashboard .kpis {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 138px), 1fr));
+  gap: 10px;
+  margin-bottom: 0;
+}
+
+.route-page--dashboard .dashboard-stack {
+  gap: 14px;
+}
+
+.route-page--dashboard .dashboard-ops,
+.route-page--dashboard .dashboard-tail {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
+  gap: 14px;
+  align-items: stretch;
+}
+
+.route-page--dashboard .dashboard-ops > .card,
+.route-page--dashboard .dashboard-tail > .card {
+  height: 100%;
+}
+
+.route-page--dashboard .card-hd {
+  min-height: 48px;
+  padding-block: 12px;
+}
+
+.analytics-toolbar {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.analytics-dimension-control {
+  display: flex;
+  max-width: 100%;
+  flex: 1 1 auto;
+  gap: 18px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border);
+}
+
+.analytics-dimension-control [data-slot="toggle-group-item"] {
+  min-height: 38px;
+  flex: 0 0 auto;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  padding: 8px 0;
+  color: var(--muted-foreground);
+  box-shadow: none;
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.analytics-dimension-control [data-slot="toggle-group-item"]:hover {
+  color: var(--foreground);
+}
+
+.analytics-dimension-control [data-slot="toggle-group-item"][data-state="on"] {
+  border-bottom-color: var(--primary);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.analytics-summary-strip > div {
+  min-height: 86px;
+}
+
+.route-page--discovery .discovery-view-stack {
+  gap: 14px;
+}
+
+.route-page--pipelines .stage-trigger-panel {
+  margin-bottom: 0;
+}
+
+.route-page--pipelines .stage-trigger-tab-list {
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  gap: 18px;
+  overflow-x: auto;
+}
+
+.route-page--pipelines .stage-trigger-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 164px), 1fr));
+}
+
+.data-surface > .bulk-bar {
+  background: var(--surface-raised);
+}
+
+.data-surface > .filterable-data-grid {
+  border-top-color: var(--border);
+}
+
+@media (max-width: 1000px) {
+  .route-page--dashboard .kpis {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+  }
+
+  .analytics-toolbar .analytics-dimension-control {
+    display: none;
+  }
+}
+
+@media (max-width: 720px) {
+  .data-surface__tools .tool-row__primary,
+  .data-surface__tools .tool-row__secondary {
+    width: 100%;
+  }
+
+  .tool-row__field,
+  .tool-row__search,
+  .tool-row__compact-input {
+    width: 100%;
+    flex-basis: 100%;
+  }
+
 }
 
 .connection-pill {

--- a/apps/web/src/views/analytics/AnalyticsView.tsx
+++ b/apps/web/src/views/analytics/AnalyticsView.tsx
@@ -7,6 +7,14 @@ import {
   type AnalyticsSearch,
 } from "../../routes/-analytics.search.js";
 import { PageHead } from "../../shared/ui/page-head.js";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../shared/ui/select.js";
+import { ToggleGroup, ToggleGroupItem } from "../../shared/ui/toggle-group.js";
 import { DimensionBreakdownPanel } from "./DimensionBreakdownPanel.js";
 import { SmallSampleNotice } from "./SmallSampleNotice.js";
 
@@ -55,7 +63,7 @@ export function AnalyticsView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--analytics">
       <PageHead
         eyebrow="Overview"
         title="Outcome analytics"
@@ -64,33 +72,40 @@ export function AnalyticsView() {
       <section className="card full analytics-view">
         {message ? <div className="banner inline">{message}</div> : null}
         <div className="analytics-toolbar" role="group" aria-label="Outcome analytics dimension">
-          {DIMENSION_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              className={option.value === dimension ? "segmented active" : "segmented"}
-              aria-pressed={option.value === dimension}
-              onClick={() => setDimension(option.value)}
-            >
-              {option.label}
-            </button>
-          ))}
+          <ToggleGroup
+            type="single"
+            value={dimension}
+            className="analytics-dimension-control"
+            aria-label="Outcome analytics dimension"
+            onValueChange={(value) => {
+              if (isAnalyticsDimension(value)) setDimension(value);
+            }}
+          >
+            {DIMENSION_OPTIONS.map((option) => (
+              <ToggleGroupItem key={option.value} value={option.value}>
+                {option.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
           <label className="analytics-select-label">
             <span>Dimension</span>
-            <select
-              className="select"
+            <Select
               value={dimension}
-              onChange={(event) => {
-                const next = event.target.value;
-                if (isAnalyticsDimension(next)) setDimension(next);
+              onValueChange={(value) => {
+                if (isAnalyticsDimension(value)) setDimension(value);
               }}
             >
-              {DIMENSION_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
+              <SelectTrigger aria-label="Outcome analytics dimension">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DIMENSION_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </label>
         </div>
         <div className="analytics-summary-strip">
@@ -142,6 +157,6 @@ export function AnalyticsView() {
           loading={analyticsQuery.isFetching}
         />
       </section>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactFilterBar.tsx
+++ b/apps/web/src/views/artifacts/ArtifactFilterBar.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from "@tanstack/react-router";
 
 import { ARTIFACT_STATUSES, type ArtifactsSearch } from "../../routes/-artifacts.search.js";
+import { SelectField } from "../../shared/ui/select-field.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 
 export interface ArtifactFilterBarProps {
   search: ArtifactsSearch;
@@ -14,20 +16,20 @@ export function ArtifactFilterBar({ search }: ArtifactFilterBarProps) {
     });
   };
   return (
-    <div className="toolbar">
-      <label className="field">
-        <span>Status</span>
-        <select
+    <ToolRow
+      className="data-surface__tools"
+      primary={
+        <SelectField
+          className="tool-row__field"
+          label="Status"
           value={search.status}
-          onChange={(event) => apply({ status: event.target.value as ArtifactsSearch["status"] })}
-        >
-          {ARTIFACT_STATUSES.map((item) => (
-            <option key={item} value={item}>
-              {item}
-            </option>
-          ))}
-        </select>
-      </label>
-    </div>
+          onValueChange={(value) => apply({ status: value as ArtifactsSearch["status"] })}
+          options={ARTIFACT_STATUSES.map((item) => ({
+            value: item,
+            label: item === "all" ? "All statuses" : item.replace(/_/g, " "),
+          }))}
+        />
+      }
+    />
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactsView.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.tsx
@@ -66,13 +66,13 @@ export function ArtifactsView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--artifacts">
       <PageHead
         eyebrow="Library"
         title="Artifacts"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
         <ArtifactFilterBar search={search} />
         <ArtifactsTable
@@ -92,6 +92,6 @@ export function ArtifactsView() {
         />
       </section>
       <Outlet />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -37,7 +37,7 @@ export function DashboardView() {
     (suggestion) => suggestion.status === "pending",
   );
   return (
-    <>
+    <div className="route-page route-page--dashboard">
       <PageHead eyebrow="Overview" title="Dashboard" />
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
       {message ? <div className="banner">{message}</div> : null}
@@ -74,6 +74,6 @@ export function DashboardView() {
       ) : (
         <Empty title={isLoading ? "Loading dashboard." : "No dashboard data."} />
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/debug/DebugFilterBar.tsx
+++ b/apps/web/src/views/debug/DebugFilterBar.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 
 import type { DebugSearch } from "../../routes/-debug.search.js";
+import { Button } from "../../shared/ui/button.js";
+import { Input } from "../../shared/ui/input.js";
+import { SelectField } from "../../shared/ui/select-field.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 
 export interface DebugFilterBarProps {
   search: DebugSearch;
@@ -16,52 +20,75 @@ export function DebugFilterBar({ search, onChange }: DebugFilterBarProps) {
 
   return (
     <form
-      className="toolbar"
+      className="debug-filter-form"
       onSubmit={(event) => {
         event.preventDefault();
         onChange({ q: query.trim(), page: 1 });
       }}
     >
-      <input
-        aria-label="Activity search"
-        placeholder="Filter events, jobs, companies..."
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
+      <ToolRow
+        className="data-surface__tools"
+        primary={
+          <>
+            <Input
+              className="tool-row__search"
+              aria-label="Activity search"
+              placeholder="Filter events, jobs, companies..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+            />
+            <SelectField
+              className="tool-row__field"
+              label="Level"
+              value={search.level || "all"}
+              onValueChange={(value) =>
+                onChange({
+                  level: (value === "all" ? "" : value) as DebugSearch["level"],
+                  page: 1,
+                })
+              }
+              options={[
+                { value: "all", label: "All levels" },
+                { value: "info", label: "Info" },
+                { value: "warn", label: "Warning" },
+                { value: "error", label: "Error" },
+              ]}
+            />
+            <Input
+              className="tool-row__compact-input"
+              aria-label="Activity stage"
+              placeholder="Stage"
+              value={search.stage}
+              onChange={(event) => onChange({ stage: event.target.value.trim(), page: 1 })}
+            />
+            <Input
+              className="tool-row__compact-input"
+              aria-label="Activity event type"
+              placeholder="Event type"
+              value={search.eventType}
+              onChange={(event) => onChange({ eventType: event.target.value.trim(), page: 1 })}
+            />
+          </>
+        }
+        secondary={
+          <>
+            <Button type="submit" size="sm">Search</Button>
+            {search.q || search.level || search.stage || search.eventType ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setQuery("");
+                  onChange({ q: "", level: "", stage: "", eventType: "", page: 1 });
+                }}
+              >
+                Clear
+              </Button>
+            ) : null}
+          </>
+        }
       />
-      <select
-        aria-label="Activity level"
-        value={search.level}
-        onChange={(event) => onChange({ level: event.target.value, page: 1 })}
-      >
-        <option value="">all levels</option>
-        <option value="info">info</option>
-        <option value="warn">warn</option>
-        <option value="error">error</option>
-      </select>
-      <input
-        aria-label="Activity stage"
-        placeholder="stage"
-        value={search.stage}
-        onChange={(event) => onChange({ stage: event.target.value.trim(), page: 1 })}
-      />
-      <input
-        aria-label="Activity event type"
-        placeholder="event type"
-        value={search.eventType}
-        onChange={(event) => onChange({ eventType: event.target.value.trim(), page: 1 })}
-      />
-      <button type="submit">search</button>
-      {search.q || search.level || search.stage || search.eventType ? (
-        <button
-          type="button"
-          onClick={() => {
-            setQuery("");
-            onChange({ q: "", level: "", stage: "", eventType: "", page: 1 });
-          }}
-        >
-          clear
-        </button>
-      ) : null}
     </form>
   );
 }

--- a/apps/web/src/views/debug/DebugView.tsx
+++ b/apps/web/src/views/debug/DebugView.tsx
@@ -63,13 +63,13 @@ export function DebugView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--debug">
       <PageHead
         eyebrow="Activity"
         title="Debug"
         subtitle={data ? `${data.pagination.total} activity events` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
         <DebugFilterBar search={search} onChange={setSearch} />
         <DebugActivityTable
@@ -85,6 +85,6 @@ export function DebugView() {
         />
       </section>
       <Outlet />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/discovery/DiscoveryView.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.tsx
@@ -6,7 +6,7 @@ import { PageHead } from "../../shared/ui/page-head.js";
 
 export function DiscoveryView() {
   return (
-    <>
+    <div className="route-page route-page--discovery">
       <PageHead eyebrow="Pipeline" title="Discovery" />
       <div className="discovery-view-stack">
         <TargetSearchSettingsPanel />
@@ -14,6 +14,6 @@ export function DiscoveryView() {
         <DiscoveryRuntimeSettingsPanel />
         <DiscoveryProductControls layout="tabs" />
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -666,13 +666,13 @@ export function JobsView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--jobs">
       <PageHead
         eyebrow="Pipeline"
         title="Jobs"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
         <JobBulkActions
           search={search}
@@ -726,6 +726,6 @@ export function JobsView() {
         />
       </section>
       <Outlet />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/outreach/OutreachView.tsx
+++ b/apps/web/src/views/outreach/OutreachView.tsx
@@ -9,7 +9,9 @@ import {
   type ContactsListFilters,
 } from "../../contexts/outreach/hooks/useContactsListQuery.js";
 import type { OutreachSearch } from "../../routes/-outreach.search.js";
+import { Input } from "../../shared/ui/input.js";
 import { PageHead } from "../../shared/ui/page-head.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 import { OutreachTable } from "./OutreachTable.js";
 
 function listFilters(search: OutreachSearch): ContactsListFilters {
@@ -35,7 +37,7 @@ export function OutreachView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--outreach">
       <PageHead
         eyebrow="Library"
         title="Contacts"
@@ -43,26 +45,37 @@ export function OutreachView() {
         actions={<DueFollowUpsBadge />}
       />
       <DueFollowUpsPanel />
-      <section className="card full">
+      <section className="card full data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
-        <div className="toolbar">
-          <label className="field compact">
-            <span>Employer</span>
-            <input
-              value={search.employer}
-              onChange={(event) => setSearch({ employer: event.target.value })}
-            />
-          </label>
-          <label className="field compact">
-            <span>Job</span>
-            <input
-              value={search.jobId}
-              onChange={(event) => setSearch({ jobId: event.target.value })}
-            />
-          </label>
-          <ContactCreateButton />
-          <ContactImportButton />
-        </div>
+        <ToolRow
+          className="data-surface__tools"
+          primary={
+            <>
+              <label className="field compact tool-row__field">
+                <span>Employer</span>
+                <Input
+                  value={search.employer}
+                  placeholder="Filter by employer"
+                  onChange={(event) => setSearch({ employer: event.target.value })}
+                />
+              </label>
+              <label className="field compact tool-row__field">
+                <span>Job</span>
+                <Input
+                  value={search.jobId}
+                  placeholder="Filter by job id"
+                  onChange={(event) => setSearch({ jobId: event.target.value })}
+                />
+              </label>
+            </>
+          }
+          secondary={
+            <>
+              <ContactCreateButton />
+              <ContactImportButton />
+            </>
+          }
+        />
         <OutreachTable
           data={data ?? null}
           loading={isFetching}
@@ -76,6 +89,6 @@ export function OutreachView() {
         />
       </section>
       <Outlet />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -3,9 +3,9 @@ import { PageHead } from "../../shared/ui/page-head.js";
 
 export function PipelinesView() {
   return (
-    <>
+    <div className="route-page route-page--pipelines">
       <PageHead eyebrow="Pipeline" title="Pipelines" />
       <StageTriggerPanel />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/runs/RunsFilterBar.tsx
+++ b/apps/web/src/views/runs/RunsFilterBar.tsx
@@ -1,5 +1,7 @@
 import { WORKFLOW_RUN_STATUS_FILTERS, type WorkflowRunStatusFilter } from "@jobctrl/contracts";
-import type { ChangeEvent } from "react";
+
+import { SelectField } from "../../shared/ui/select-field.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 
 export interface RunsFilterBarProps {
   status: WorkflowRunStatusFilter;
@@ -12,27 +14,21 @@ function statusLabel(value: WorkflowRunStatusFilter): string {
 }
 
 export function RunsFilterBar({ status, onStatusChange }: RunsFilterBarProps) {
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    const next = event.target.value as WorkflowRunStatusFilter;
-    onStatusChange(next);
-  };
   return (
-    <div className="filter-bar">
-      <label className="field">
-        <span>Status</span>
-        <select
-          aria-label="Filter workflow runs by status"
-          className="select"
+    <ToolRow
+      className="data-surface__tools"
+      primary={
+        <SelectField
+          className="tool-row__field"
+          label="Status"
           value={status}
-          onChange={handleChange}
-        >
-          {WORKFLOW_RUN_STATUS_FILTERS.map((value) => (
-            <option key={value} value={value}>
-              {statusLabel(value)}
-            </option>
-          ))}
-        </select>
-      </label>
-    </div>
+          onValueChange={(value) => onStatusChange(value as WorkflowRunStatusFilter)}
+          options={WORKFLOW_RUN_STATUS_FILTERS.map((value) => ({
+            value,
+            label: statusLabel(value),
+          }))}
+        />
+      }
+    />
   );
 }

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -70,13 +70,13 @@ export function RunsView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--runs">
       <PageHead
         eyebrow="Activity"
         title="Workflow runs"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
         <RunsFilterBar
           status={search.status}
@@ -95,6 +95,6 @@ export function RunsView() {
         />
       </section>
       <Outlet />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- brings Dashboard, Analytics, Jobs, Pipelines, Discovery, Artifacts, Contacts, Runs, and Debug onto one route-page and data-surface composition
- replaces ad-hoc operational filter controls with the shared select, input, toggle, and tool-row system
- makes dense dashboards and pipeline controls width-adaptive while preserving every existing query, status, action, table column, and URL-backed state
- turns Discovery configuration groups into state-preserving disclosures

## Stack

- Base: `feat/redesign-foundation` (#442)
- Successor: route workspaces and audit surfaces

## Validation

Existing production-shaped view, data-grid, interaction, and accessibility tests remain in place. Per the redesign delivery contract, the complete test, browser, visual, accessibility, and product-flow QA gate is deferred until the full stack and final documentation pass are complete.