### PR TITLE
feat(web): redesign detail workspaces

### DIFF
--- a/apps/web/src/routes/jobs.$jobId.run.$runId.test.tsx
+++ b/apps/web/src/routes/jobs.$jobId.run.$runId.test.tsx
@@ -1,0 +1,103 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import { makeWorkflowRunDetail } from "../test/fixtures/projections.js";
+import { server } from "../test/msw/server.js";
+import { buildProviderHarness } from "../test/render.js";
+import { JobRunTimelineWorkspace } from "./jobs.$jobId.run.$runId.js";
+
+function buildRouter() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const jobsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/jobs",
+    component: () => <Outlet />,
+  });
+  const jobRoute = createRoute({
+    getParentRoute: () => jobsRoute,
+    path: "/$jobId",
+    component: () => <Outlet />,
+  });
+  const runRoute = createRoute({
+    getParentRoute: () => jobRoute,
+    path: "/run/$runId",
+    component: () => <JobRunTimelineWorkspace jobId="job-1" runId="run-1" />,
+  });
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([
+      jobsRoute.addChildren([jobRoute.addChildren([runRoute])]),
+    ]),
+    history: createMemoryHistory({ initialEntries: ["/jobs/job-1/run/run-1"] }),
+  });
+}
+
+describe("<JobRunTimelineWorkspace>", () => {
+  it("renders the nested timeline as a complete route workspace", async () => {
+    server.use(
+      http.get("*/v1/workflow-runs/:runId", () =>
+        HttpResponse.json(
+          makeWorkflowRunDetail({
+            workflowId: "run-1",
+            runId: "run-1",
+            workflowType: "ApplyWorkflow",
+            status: "in_progress",
+            jobKey: "job-1",
+            title: "Staff Software Engineer",
+            company: "Acme",
+            dryRun: true,
+            errorCode: null,
+            errorMessage: null,
+            retryable: false,
+            temporalRunId: "temporal-apply-1",
+            events: [
+              {
+                eventType: "WorkflowStarted",
+                occurredAt: "2026-05-06T07:45:00Z",
+                status: "in_progress",
+                message: "Apply agent acquired job",
+              },
+            ],
+          }),
+        ),
+      ),
+    );
+    const harness = buildProviderHarness();
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const workspace = await screen.findByRole("article", {
+      name: "Apply run details",
+    });
+
+    expect(
+      within(workspace).getByRole("heading", {
+        level: 1,
+        name: "Apply run timeline",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(workspace).getByRole("link", { name: "Back to job details" }),
+    ).toHaveAttribute("href", "/jobs/job-1");
+    expect(within(workspace).getByText("in progress")).toBeInTheDocument();
+    expect(
+      within(workspace).getByText("Staff Software Engineer"),
+    ).toBeInTheDocument();
+    expect(within(workspace).getAllByText("run-1").length).toBeGreaterThan(0);
+    expect(within(workspace).getByText("temporal-apply-1")).toBeInTheDocument();
+    expect(within(workspace).getByText("Workflow Started")).toBeInTheDocument();
+    expect(
+      within(workspace).getByText("Apply agent acquired job"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/jobs.$jobId.run.$runId.tsx
+++ b/apps/web/src/routes/jobs.$jobId.run.$runId.tsx
@@ -1,12 +1,164 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { ApplyRunTimeline } from "../contexts/apply/components/ApplyRunTimeline.js";
+import { RunStatusBadge } from "../contexts/apply/components/RunStatusBadge.js";
+import { useWorkflowRunDetailQuery } from "../contexts/operations/hooks/useWorkflowRunDetailQuery.js";
+import { formatDateTime } from "../shared/lib/formatters.js";
+import { Button } from "../shared/ui/button.js";
+import { RouteWorkspace } from "../shared/ui/route-workspace.js";
+import { Section } from "../shared/ui/section.js";
 
 export const Route = createFileRoute("/jobs/$jobId/run/$runId")({
   component: JobRunTimelineRoute,
 });
 
 function JobRunTimelineRoute() {
-  const { runId } = Route.useParams();
-  return <ApplyRunTimeline runId={runId} />;
+  const { jobId, runId } = Route.useParams();
+  return <JobRunTimelineWorkspace jobId={jobId} runId={runId} />;
+}
+
+export interface JobRunTimelineWorkspaceProps {
+  readonly jobId: string;
+  readonly runId: string;
+}
+
+export function JobRunTimelineWorkspace({
+  jobId,
+  runId,
+}: JobRunTimelineWorkspaceProps) {
+  const { data: run, isLoading, error } = useWorkflowRunDetailQuery(runId);
+  const message = error instanceof Error ? error.message : null;
+
+  return (
+    <div
+      className="route-page route-page--job-run-detail"
+      aria-label="Apply run details"
+    >
+      <RouteWorkspace
+        aria-label="Apply run details"
+        className="job-run-workspace"
+        contentLabel="Apply run timeline"
+        inspectorLabel="Apply run facts and failure details"
+        header={
+          <div className="job-run-workspace__header">
+            <Button asChild className="workspace-back" size="sm" variant="ghost">
+              <Link
+                aria-label="Back to job details"
+                params={{ jobId }}
+                search={(prev) => prev}
+                to="/jobs/$jobId"
+              >
+                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                Job details
+              </Link>
+            </Button>
+            {run ? (
+              <RunStatusBadge status={run.status} />
+            ) : (
+              <span className="tag muted">
+                {isLoading ? "loading" : "status unavailable"}
+              </span>
+            )}
+            <div className="job-run-workspace__title">
+              <small>{run?.workflowType || "apply workflow"}</small>
+              <h1>Apply run timeline</h1>
+              <p>
+                {run?.title ? `${run.title} · ` : ""}
+                <span className="mono">{runId}</span>
+              </p>
+            </div>
+          </div>
+        }
+        inspector={
+          <div className="job-run-workspace__inspector">
+            <Section title="Run details">
+              <dl className="detail-list">
+                <div>
+                  <dt>Run id</dt>
+                  <dd className="mono">{runId}</dd>
+                </div>
+                <div>
+                  <dt>Job</dt>
+                  <dd>
+                    <Link
+                      className="title-link"
+                      params={{ jobId }}
+                      search={(prev) => prev}
+                      to="/jobs/$jobId"
+                    >
+                      {run?.title || jobId}
+                    </Link>
+                  </dd>
+                </div>
+                {run ? (
+                  <>
+                    <div>
+                      <dt>Workflow id</dt>
+                      <dd className="mono">{run.workflowId}</dd>
+                    </div>
+                    <div>
+                      <dt>Type</dt>
+                      <dd>{run.workflowType || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{run.status}</dd>
+                    </div>
+                    <div>
+                      <dt>Started</dt>
+                      <dd>{formatDateTime(run.startedAt)}</dd>
+                    </div>
+                    <div>
+                      <dt>Finished</dt>
+                      <dd>
+                        {run.finishedAt ? formatDateTime(run.finishedAt) : "-"}
+                      </dd>
+                    </div>
+                    {run.temporalRunId ? (
+                      <div>
+                        <dt>Temporal run id</dt>
+                        <dd className="mono">{run.temporalRunId}</dd>
+                      </div>
+                    ) : null}
+                    <div>
+                      <dt>Mode</dt>
+                      <dd>{run.dryRun ? "dry-run" : "live"}</dd>
+                    </div>
+                  </>
+                ) : null}
+              </dl>
+              {message ? <div className="banner inline">{message}</div> : null}
+            </Section>
+            {run && (run.errorMessage || run.errorCode) ? (
+              <Section title="Failure">
+                <dl className="detail-list">
+                  {run.errorCode ? (
+                    <div>
+                      <dt>Error code</dt>
+                      <dd className="mono">{run.errorCode}</dd>
+                    </div>
+                  ) : null}
+                  {run.errorMessage ? (
+                    <div>
+                      <dt>Message</dt>
+                      <dd>{run.errorMessage}</dd>
+                    </div>
+                  ) : null}
+                  <div>
+                    <dt>Retryable</dt>
+                    <dd>{run.retryable ? "yes" : "no"}</dd>
+                  </div>
+                </dl>
+              </Section>
+            ) : null}
+          </div>
+        }
+      >
+        <Section className="job-run-workspace__timeline" title="Timeline">
+          <ApplyRunTimeline runId={runId} events={run?.events ?? []} />
+        </Section>
+      </RouteWorkspace>
+    </div>
+  );
 }

--- a/apps/web/src/routes/jobs.$jobId.tsx
+++ b/apps/web/src/routes/jobs.$jobId.tsx
@@ -1,4 +1,9 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Outlet,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { JobDetailDrawer } from "../views/jobs/JobDetailDrawer.js";
@@ -11,9 +16,19 @@ function JobDrawerRoute() {
   const { jobId } = Route.useParams();
   const search = Route.useSearch();
   const navigate = useNavigate();
+  const showingRunDetail = useRouterState({
+    select: (state) =>
+      state.matches.some(
+        (match) => match.routeId === "/jobs/$jobId/run/$runId",
+      ),
+  });
   const close = useCallback(() => {
     void navigate({ to: "/jobs", search });
   }, [navigate, search]);
+
+  if (showingRunDetail) {
+    return <Outlet />;
+  }
 
   return <JobDetailDrawer jobId={jobId} onClose={close} />;
 }

--- a/apps/web/src/shared/ui/route-workspace.tsx
+++ b/apps/web/src/shared/ui/route-workspace.tsx
@@ -26,7 +26,11 @@ export function RouteWorkspace({
   return (
     <article className={cn("route-workspace", className)} {...props}>
       {header ? <header className="route-workspace__header">{header}</header> : null}
-      <div className="route-workspace__grid">
+      <div
+        className="route-workspace__grid"
+        data-has-inspector={Boolean(inspector)}
+        data-has-navigation={Boolean(navigation)}
+      >
         {navigation ? (
           <aside className="route-workspace__navigation" aria-label={navigationLabel}>
             {navigation}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1125,6 +1125,18 @@ input[type="radio"] {
   min-width: 0;
 }
 
+.route-workspace__grid[data-has-navigation="false"][data-has-inspector="true"] {
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.34fr);
+}
+
+.route-workspace__grid[data-has-navigation="true"][data-has-inspector="false"] {
+  grid-template-columns: minmax(190px, 0.25fr) minmax(0, 1fr);
+}
+
+.route-workspace__grid[data-has-navigation="false"][data-has-inspector="false"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .route-workspace__navigation,
 .route-workspace__content,
 .route-workspace__inspector {
@@ -8714,6 +8726,385 @@ input[type="radio"] {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 164px), 1fr));
 }
 
+/* Route-level detail workspaces --------------------------------------------- */
+
+.workspace-back {
+  width: max-content;
+  color: var(--muted-foreground);
+}
+
+.workspace-back:hover {
+  color: var(--foreground);
+}
+
+.job-detail-workspace__header,
+.artifact-detail-workspace__header,
+.contact-detail-workspace__header,
+.activity-detail-workspace__header,
+.workflow-run-workspace__header,
+.job-run-workspace__header {
+  display: grid;
+  min-width: 0;
+  gap: 12px 16px;
+  align-items: start;
+}
+
+.job-detail-workspace__header {
+  grid-template-columns: minmax(300px, 1fr) minmax(320px, auto);
+}
+
+.job-detail-workspace__header > .workspace-back,
+.artifact-detail-workspace__header > .workspace-back,
+.contact-detail-workspace__header > .workspace-back,
+.activity-detail-workspace__header > .workspace-back,
+.workflow-run-workspace__header > .workspace-back,
+.job-run-workspace__header > .workspace-back {
+  grid-column: 1 / -1;
+}
+
+.job-overview {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.job-overview > span {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.job-overview h1,
+.artifact-detail-workspace__title h1,
+.contact-detail-workspace__title h1,
+.activity-detail-workspace__title h1,
+.workflow-run-workspace__title h1,
+.job-run-workspace__title h1 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: clamp(20px, 2vw, 27px);
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.job-overview p,
+.artifact-detail-workspace__title p,
+.contact-detail-workspace__title p,
+.activity-detail-workspace__title p,
+.workflow-run-workspace__title p,
+.job-run-workspace__title p {
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+.job-detail-top-actions {
+  align-self: end;
+  justify-content: flex-end;
+  border: 0;
+  padding: 0;
+}
+
+.job-detail-top-actions .action-panel {
+  flex: 1 1 100%;
+  margin: 0;
+}
+
+.job-detail-workspace > .route-workspace__grid,
+.artifact-detail-workspace > .route-workspace__grid,
+.contact-detail-workspace > .route-workspace__grid,
+.activity-detail-workspace > .route-workspace__grid,
+.workflow-run-workspace > .route-workspace__grid,
+.job-run-workspace > .route-workspace__grid {
+  align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+}
+
+.job-detail-workspace > .route-workspace__grid > .route-workspace__content,
+.job-detail-workspace > .route-workspace__grid > .route-workspace__inspector,
+.artifact-detail-workspace > .route-workspace__grid > .route-workspace__content,
+.artifact-detail-workspace > .route-workspace__grid > .route-workspace__inspector,
+.contact-detail-workspace > .route-workspace__grid > .route-workspace__content,
+.contact-detail-workspace > .route-workspace__grid > .route-workspace__inspector,
+.activity-detail-workspace > .route-workspace__grid > .route-workspace__content,
+.activity-detail-workspace > .route-workspace__grid > .route-workspace__inspector,
+.workflow-run-workspace > .route-workspace__grid > .route-workspace__content,
+.workflow-run-workspace > .route-workspace__grid > .route-workspace__inspector,
+.job-run-workspace > .route-workspace__grid > .route-workspace__content,
+.job-run-workspace > .route-workspace__grid > .route-workspace__inspector {
+  padding: 0;
+}
+
+.job-detail-workspace__content,
+.job-detail-workspace__inspector,
+.artifact-detail-workspace__inspector,
+.activity-detail-workspace__content,
+.activity-detail-workspace__inspector,
+.workflow-run-workspace__inspector,
+.job-run-workspace__inspector {
+  display: grid;
+  min-width: 0;
+}
+
+.job-detail-workspace__content > .section,
+.job-detail-workspace__inspector > .section,
+.job-detail-workspace__inspector > .job-contacts-panel,
+.artifact-detail-workspace__inspector > .section,
+.artifact-detail-workspace__inspector > .tailoring-explanation-section,
+.contact-detail-workspace .section,
+.activity-detail-workspace__content > .section {
+  padding: 16px 18px;
+}
+
+.job-detail-workspace__content > :last-child,
+.job-detail-workspace__inspector > :last-child,
+.artifact-detail-workspace__inspector > :last-child,
+.contact-detail-workspace .route-workspace__content > :last-child,
+.contact-detail-workspace .route-workspace__inspector > :last-child {
+  border-bottom: 0;
+}
+
+.job-detail-workspace__inspector .mini-row {
+  grid-template-columns: auto minmax(86px, 0.55fr) minmax(0, 1fr) auto;
+  padding-inline: 0;
+}
+
+.artifact-detail-workspace__header {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.artifact-detail-workspace__title,
+.contact-detail-workspace__title,
+.activity-detail-workspace__title,
+.workflow-run-workspace__title,
+.job-run-workspace__title {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.artifact-detail-workspace__actions,
+.contact-detail-actions,
+.activity-detail-workspace__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.artifact-detail-workspace .route-workspace__content {
+  min-height: min(76dvh, 900px);
+  background: #242424;
+}
+
+.artifact-detail-workspace .artifact-preview-panel,
+.artifact-detail-workspace .pdf-preview-viewer {
+  min-height: inherit;
+}
+
+.artifact-detail-workspace .empty {
+  background: var(--card);
+}
+
+.artifact-comparison-picker {
+  margin-bottom: 12px;
+}
+
+.contact-detail-workspace__header {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.contact-detail-workspace .route-workspace__content {
+  min-height: 460px;
+}
+
+.activity-detail-workspace__header {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.workflow-run-workspace__header,
+.job-run-workspace__header {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+}
+
+.workflow-run-workspace__inspector > .section,
+.job-run-workspace__inspector > .section,
+.workflow-run-workspace__timeline,
+.job-run-workspace__timeline {
+  padding: 16px 18px;
+}
+
+.workflow-run-workspace__timeline,
+.job-run-workspace__timeline {
+  border-bottom: 0;
+}
+
+.workflow-run-workspace__timeline .timeline,
+.job-run-workspace__timeline .timeline {
+  margin: 0;
+}
+
+.activity-detail-workspace__inspector {
+  gap: 12px;
+  padding: 16px;
+}
+
+.activity-detail-workspace__inspector h2 {
+  margin: 0;
+  font-size: 13px;
+}
+
+.activity-detail-workspace__payload {
+  max-width: 100%;
+  max-height: 52dvh;
+  margin: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-subtle);
+  padding: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-size: 11px;
+}
+
+.activity-detail-workspace__timeline-entry {
+  width: 100%;
+}
+
+.activity-detail-workspace__timeline-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.activity-detail-workspace__timeline-copy time {
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.evidence-map-workspace {
+  min-height: min(76dvh, 820px);
+}
+
+.evidence-map-workspace > .route-workspace__header {
+  padding: 0;
+}
+
+.evidence-map-workspace > .route-workspace__grid {
+  grid-template-columns: minmax(230px, 0.26fr) minmax(420px, 1fr) minmax(280px, 0.34fr);
+  min-height: min(70dvh, 760px);
+}
+
+.evidence-map-workspace__tools {
+  border: 0;
+  border-radius: 0;
+}
+
+.evidence-entry-list--workspace,
+.evidence-detail--workspace,
+.evidence-side-panel--workspace {
+  padding: 0;
+  border: 0;
+}
+
+.evidence-entry-list--workspace .evidence-entry-link {
+  border-width: 0 0 1px;
+  border-radius: 0;
+  background: transparent;
+}
+
+.evidence-entry-list--workspace,
+.evidence-detail--workspace,
+.evidence-side-panel--workspace {
+  max-height: min(70dvh, 760px);
+  overflow: auto;
+  scrollbar-gutter: stable;
+}
+
+.evidence-entry-link:hover,
+.evidence-entry-link.selected,
+.evidence-usage-link:hover {
+  border-color: color-mix(in oklch, var(--foreground) 24%, var(--border));
+  background: var(--surface-raised);
+  color: var(--foreground);
+}
+
+.evidence-entry-link.selected {
+  box-shadow: inset 3px 0 0 var(--foreground);
+}
+
+.apply-review-workspace-shell {
+  display: block;
+  min-height: min(78dvh, 840px);
+}
+
+.apply-review-workspace-shell > .route-workspace__grid {
+  grid-template-columns: minmax(260px, 310px) minmax(0, 1fr);
+  min-height: inherit;
+}
+
+.apply-review-workspace-shell > .route-workspace__grid > .route-workspace__navigation,
+.apply-review-workspace-shell > .route-workspace__grid > .route-workspace__content {
+  padding: 0;
+}
+
+.apply-review-workspace-shell .apply-review-queue {
+  border: 0;
+  background: var(--surface-subtle);
+}
+
+.apply-review-queue-list {
+  margin: 0;
+  list-style: none;
+}
+
+.apply-review-queue-list > li {
+  min-width: 0;
+}
+
+.apply-review-queue-item {
+  border-width: 0 0 1px;
+  border-radius: 0;
+  background: transparent;
+  padding: 12px;
+}
+
+.apply-review-queue-score {
+  min-width: 24px;
+  color: var(--foreground);
+  font-size: 15px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+}
+
+.apply-review-queue-item:hover,
+.apply-review-queue-item.selected {
+  border-color: color-mix(in oklch, var(--foreground) 24%, var(--border));
+  background: var(--surface-raised);
+}
+
+.apply-review-queue-item.selected {
+  box-shadow: inset 3px 0 0 var(--foreground);
+}
+
+.apply-review-selected-toolbar {
+  position: sticky;
+  z-index: 2;
+  top: 0;
+  background: var(--card);
+}
+
+.apply-review-pane--evidence,
+.apply-review-pane--materials {
+  min-height: min(62dvh, 720px);
+}
+
 .data-surface > .bulk-bar {
   background: var(--surface-raised);
 }
@@ -8730,6 +9121,32 @@ input[type="radio"] {
   .analytics-toolbar .analytics-dimension-control {
     display: none;
   }
+
+  .job-detail-workspace > .route-workspace__grid,
+  .artifact-detail-workspace > .route-workspace__grid,
+  .contact-detail-workspace > .route-workspace__grid,
+  .activity-detail-workspace > .route-workspace__grid,
+  .workflow-run-workspace > .route-workspace__grid,
+  .job-run-workspace > .route-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .evidence-map-workspace > .route-workspace__grid,
+  .apply-review-workspace-shell > .route-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apply-review-workspace-shell .apply-review-queue-list {
+    max-height: 320px;
+  }
+
+  .job-detail-workspace__header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .job-detail-top-actions {
+    justify-content: flex-start;
+  }
 }
 
 @media (max-width: 720px) {
@@ -8745,6 +9162,28 @@ input[type="radio"] {
     flex-basis: 100%;
   }
 
+  .artifact-detail-workspace__header,
+  .contact-detail-workspace__header,
+  .activity-detail-workspace__header {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .artifact-detail-workspace__header > .workspace-back,
+  .contact-detail-workspace__header > .workspace-back,
+  .activity-detail-workspace__header > .workspace-back {
+    grid-column: 1;
+  }
+
+  .artifact-detail-workspace__actions,
+  .contact-detail-actions,
+  .activity-detail-workspace__actions {
+    justify-content: flex-start;
+  }
+
+  .job-detail-workspace__inspector .mini-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .connection-pill {

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -13,6 +13,7 @@ import { LOCAL_TENANT } from "@jobctrl/domain-types";
 import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { applyReviewKeys } from "../../contexts/operations/applyReviewKeys.js";
@@ -28,12 +29,21 @@ import {
   sampleDraftResumeArtifact,
   sampleResumeTemplateListResponse,
 } from "../../test/fixtures/projections.js";
-import { buildProviderHarness, createTestQueryClient, renderWithProviders } from "../../test/render.js";
+import {
+  buildProviderHarness,
+  createTestQueryClient,
+  renderWithProviders as renderWithProviderHarness,
+  type RenderWithProvidersOptions,
+} from "../../test/render.js";
 import { buildTestPorts } from "../../test/testPorts.js";
 import { ApplyReviewView } from "./ApplyReviewView.js";
 
 let htmlPreviewResumeText = sampleApplyReviewQueue.items[0]!.materialsPreview.resumeText;
 let htmlPreviewOverride: string | null = null;
+
+function renderWithProviders(ui: ReactElement, opts: RenderWithProvidersOptions = {}) {
+  return renderWithProviderHarness(ui, { ...opts, withRouter: true });
+}
 
 const TEST_RESUME_SECTION_HEADINGS = new Set([
   "core skills",
@@ -594,22 +604,6 @@ vi.mock("../../shared/ui/PdfPreviewViewer.js", () => ({
   },
 }));
 
-vi.mock("../jobs/JobDetailDrawer.js", () => ({
-  JobDetailDrawer: ({
-    jobId,
-    onClose,
-  }: {
-    readonly jobId: string;
-    readonly onClose: () => void;
-  }) => (
-    <div aria-label={`Job details for ${jobId}`} role="dialog">
-      <button type="button" onClick={onClose}>
-        close details
-      </button>
-    </div>
-  ),
-}));
-
 const sampleTailoringExplanation: ArtifactTailoringExplanation = {
   targetSeniority: "principal",
   claimMode: "evidence_reframing",
@@ -852,6 +846,15 @@ describe("<ApplyReviewView>", () => {
     renderWithProviders(<ApplyReviewView />);
 
     expect(await screen.findByText("Principal Platform Engineer")).toBeInTheDocument();
+    const routeWorkspace = screen.getByRole("article", { name: "Application review workspace" });
+    expect(
+      within(routeWorkspace).getByRole("complementary", { name: "Application review queue" }),
+    ).toBeInTheDocument();
+    expect(
+      within(routeWorkspace).getByRole("region", {
+        name: "Selected application review for Principal Platform Engineer",
+      }),
+    ).toBeInTheDocument();
     const selectedHeader = document.querySelector(".apply-review-selected-head");
     expect(selectedHeader).toBeInstanceOf(HTMLElement);
     const header = within(selectedHeader as HTMLElement);
@@ -863,8 +866,12 @@ describe("<ApplyReviewView>", () => {
     expect(header.getByRole("region", { name: "Compensation" })).toBeInTheDocument();
     expect(header.getByLabelText("Resume template")).toBeInTheDocument();
     expect(header.queryByRole("button", { name: /Refresh resume materials/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Requirements and original post" })).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: "Tailored resume and cover" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("article", { name: "Requirements and original post" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("article", { name: "Tailored resume and cover" }),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("materials ready").length).toBeGreaterThan(0);
     expect(screen.getAllByText("platform reliability").length).toBeGreaterThan(0);
     expect(screen.getByText("public company scale")).toBeInTheDocument();
@@ -944,11 +951,13 @@ describe("<ApplyReviewView>", () => {
     expect(screen.getByText(/7 samples/i)).toBeInTheDocument();
     expect(screen.queryByText(/dry_run/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Globex needs a principal engineer/i)).toBeInTheDocument();
-    const detailButton = screen.getByRole("button", {
+    const detailLink = screen.getByRole("link", {
       name: /Open job detail for Principal Platform Engineer/i,
     });
-    expect(detailButton).toBeInTheDocument();
-    expect(screen.queryByRole("link", { name: /Open job detail/i })).not.toBeInTheDocument();
+    expect(detailLink).toHaveAttribute(
+      "href",
+      `/jobs/${sampleApplyReviewQueue.items[0]!.jobKey}`,
+    );
     expect(screen.queryByRole("img", { name: "Tailored resume preview" })).not.toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Tailored resume preview editor" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Bold" })).toBeInTheDocument();
@@ -2526,29 +2535,14 @@ describe("<ApplyReviewView>", () => {
     );
   });
 
-  it("opens job detail as an in-place overlay", async () => {
-    const user = userEvent.setup();
+  it("links to the route-level job detail workspace", async () => {
     renderWithProviders(<ApplyReviewView />);
 
-    await user.click(
-      await screen.findByRole("button", {
+    expect(
+      await screen.findByRole("link", {
         name: /Open job detail for Principal Platform Engineer/i,
       }),
-    );
-
-    expect(
-      screen.getByRole("dialog", {
-        name: `Job details for ${sampleApplyReviewQueue.items[0]!.jobKey}`,
-      }),
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "close details" }));
-
-    expect(
-      screen.queryByRole("dialog", {
-        name: `Job details for ${sampleApplyReviewQueue.items[0]!.jobKey}`,
-      }),
-    ).not.toBeInTheDocument();
+    ).toHaveAttribute("href", `/jobs/${sampleApplyReviewQueue.items[0]!.jobKey}`);
   });
 
   it("renders non-pending review decisions as user-facing copy", async () => {

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -8,6 +8,7 @@ import type {
   ResumeReviewDraftRenderResponse,
 } from "@jobctrl/contracts";
 import { IconExternalLink } from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ACTIVE_APPLY_RUN_STATUSES, CancelApplyButton } from "../../contexts/apply/components/CancelApplyButton.js";
@@ -36,11 +37,13 @@ import { useResumeReviewDraftQuery } from "../../contexts/operations/hooks/useRe
 import { useResumeTemplatesQuery } from "../../contexts/profile/hooks/useResumeTemplatesQuery.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { MarkdownDocument } from "../../shared/ui/MarkdownDocument.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 import type { PdfAuditLineSelection, PdfAuditLineTarget } from "../../shared/ui/PdfPreviewViewer.js";
-import { JobDetailDrawer } from "../jobs/JobDetailDrawer.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 
 type MaterialStatus = {
   readonly kind: ApplyReviewQueueItem["applyAudit"]["state"];
@@ -417,35 +420,36 @@ function ApplyReviewQueue({
   readonly onSelect: (jobKey: string) => void;
 }) {
   return (
-    <aside className="apply-review-queue" aria-label="Application review queue">
-      <div className="apply-review-queue-head">
+    <div className="apply-review-queue">
+      <header className="apply-review-queue-head">
         <span className="eyebrow">Queue</span>
         <b>{items.length} human decision{items.length === 1 ? "" : "s"}</b>
-      </div>
-      <div className="apply-review-queue-list">
+      </header>
+      <ul className="apply-review-queue-list">
         {items.map((item) => {
           const status = materialStatus(item);
           return (
-            <button
-              key={item.jobKey}
-              type="button"
-              className={`apply-review-queue-item${item.jobKey === selected.jobKey ? " selected" : ""}`}
-              aria-pressed={item.jobKey === selected.jobKey}
-              onClick={() => onSelect(item.jobKey)}
-            >
-              <span className="apply-review-queue-title">
-                <span className="tag ok">{item.fitScore ?? "-"}</span>
-                <b>{item.title}</b>
-              </span>
-              <span className="meta">
-                {item.company} · {item.source}
-              </span>
-              <span className={`tag ${status.tone}`}>{status.label}</span>
-            </button>
+            <li key={item.jobKey}>
+              <button
+                type="button"
+                className={`apply-review-queue-item${item.jobKey === selected.jobKey ? " selected" : ""}`}
+                aria-pressed={item.jobKey === selected.jobKey}
+                onClick={() => onSelect(item.jobKey)}
+              >
+                <span className="apply-review-queue-title">
+                  <span className="apply-review-queue-score">{item.fitScore ?? "-"}</span>
+                  <b>{item.title}</b>
+                </span>
+                <span className="meta">
+                  {item.company} · {item.source}
+                </span>
+                <span className={`tag ${status.tone}`}>{status.label}</span>
+              </button>
+            </li>
           );
         })}
-      </div>
-    </aside>
+      </ul>
+    </div>
   );
 }
 
@@ -1106,7 +1110,6 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
   const setJobTemplate = useSetJobResumeTemplateMutation();
   const ensureCurrentMaterials = useEnsureCurrentResumeMaterialsMutation();
   const prepareApprovalRef = useRef<(() => Promise<boolean>) | null>(null);
-  const [detailJobKey, setDetailJobKey] = useState<string | null>(null);
   const [comparisonDraft, setComparisonDraft] = useState<ArtifactComparisonDraftTarget | null>(null);
   const [draftGate, setDraftGate] = useState<ResumeDraftGateState>({
     draftId: null,
@@ -1141,7 +1144,6 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
     );
   }, []);
   useEffect(() => {
-    setDetailJobKey(null);
     setComparisonDraft(null);
     setDraftGate({
       draftId: null,
@@ -1179,68 +1181,80 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
   );
 
   return (
-    <main className="apply-review-selected">
-      <header className="apply-review-selected-head">
-        <div
-          className="apply-review-selected-context"
-          aria-label={`Review controls and material facts for ${item.title}`}
-        >
-          {reviewState ? <span className="tag muted">Current decision: {reviewState}.</span> : null}
-          <CompensationSummaryStrip
-            summary={item.compensationSummary}
-            label="Compensation"
-          />
-          <ApplyAuditFacts item={item} />
-          <JobResumeTemplateSelect
-            current={item.materialsPreview.resumeTemplate}
-            disabled={templatesQuery.isLoading || setJobTemplate.isPending || ensureCurrentMaterials.isPending}
-            onTemplateChange={handleTemplateChange}
-            refreshing={setJobTemplate.isPending || ensureCurrentMaterials.isPending}
-            templates={templatesQuery.data?.templates ?? []}
-          />
-          {templateMutationError ? <span className="tag warn">{templateMutationError}</span> : null}
-        </div>
-        <div className="apply-review-selected-actions">
-          <button
-            aria-label={`Open job detail for ${item.title}`}
-            className="tab"
-            type="button"
-            onClick={() => setDetailJobKey(item.jobKey)}
-          >
-            <IconExternalLink size={14} aria-hidden="true" />
-            open job detail
-          </button>
-          {activeRun ? (
-            <CancelApplyButton
-              jobId={item.jobKey}
-              runId={activeRun.runId}
-              className="tab danger-action"
-              label="stop apply"
-              ariaLabel={`Stop apply run for ${item.title}`}
-            />
-          ) : null}
-          <ApplyReviewDecisionControls
-            item={item}
-            approvalDisabledReason={draftGate.reason}
-            approvalNotice={draftGate.notice}
-            approvalPreparing={draftGate.preparing}
-            onPrepareApproval={draftGate.notice ? handlePrepareApproval : null}
-          />
-        </div>
+    <div className="apply-review-selected">
+      <header className="apply-review-selected-toolbar">
+        <ToolRow
+          className="apply-review-selected-head data-surface__tools"
+          primary={
+            <div
+              className="apply-review-selected-context"
+              aria-label={`Review controls and material facts for ${item.title}`}
+            >
+              {reviewState ? (
+                <span className="tag muted">Current decision: {reviewState}.</span>
+              ) : null}
+              <CompensationSummaryStrip
+                summary={item.compensationSummary}
+                label="Compensation"
+              />
+              <ApplyAuditFacts item={item} />
+              <JobResumeTemplateSelect
+                current={item.materialsPreview.resumeTemplate}
+                disabled={
+                  templatesQuery.isLoading ||
+                  setJobTemplate.isPending ||
+                  ensureCurrentMaterials.isPending
+                }
+                onTemplateChange={handleTemplateChange}
+                refreshing={setJobTemplate.isPending || ensureCurrentMaterials.isPending}
+                templates={templatesQuery.data?.templates ?? []}
+              />
+              {templateMutationError ? (
+                <span className="tag warn">{templateMutationError}</span>
+              ) : null}
+            </div>
+          }
+          secondary={
+            <div className="apply-review-selected-actions">
+              <Button asChild size="sm" variant="outline">
+                <Link
+                  aria-label={`Open job detail for ${item.title}`}
+                  params={{ jobId: item.jobKey }}
+                  to="/jobs/$jobId"
+                >
+                  <IconExternalLink size={14} aria-hidden="true" />
+                  open job detail
+                </Link>
+              </Button>
+              {activeRun ? (
+                <CancelApplyButton
+                  jobId={item.jobKey}
+                  runId={activeRun.runId}
+                  className="tab danger-action"
+                  label="stop apply"
+                  ariaLabel={`Stop apply run for ${item.title}`}
+                />
+              ) : null}
+              <ApplyReviewDecisionControls
+                item={item}
+                approvalDisabledReason={draftGate.reason}
+                approvalNotice={draftGate.notice}
+                approvalPreparing={draftGate.preparing}
+                onPrepareApproval={draftGate.notice ? handlePrepareApproval : null}
+              />
+            </div>
+          }
+        />
       </header>
 
-      {detailJobKey ? (
-        <JobDetailDrawer
-          jobId={detailJobKey}
-          onClose={() => setDetailJobKey(null)}
-        />
-      ) : null}
-
       <section className="apply-review-workspace" aria-label={`Review evidence for ${item.title}`}>
-        <article className="apply-review-pane">
+        <article
+          className="apply-review-pane apply-review-pane--evidence"
+          aria-labelledby="apply-review-evidence-heading"
+        >
           <header>
             <span className="eyebrow">Job Position</span>
-            <h2>Requirements and original post</h2>
+            <h2 id="apply-review-evidence-heading">Requirements and original post</h2>
           </header>
           <div className="apply-review-pane-scroll">
             <section className="apply-review-preview-block">
@@ -1263,10 +1277,13 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
           </div>
         </article>
 
-        <article className="apply-review-pane">
+        <article
+          className="apply-review-pane apply-review-pane--materials"
+          aria-labelledby="apply-review-materials-heading"
+        >
           <header>
             <span className="eyebrow">Application Materials</span>
-            <h2>Tailored resume and cover</h2>
+            <h2 id="apply-review-materials-heading">Tailored resume and cover</h2>
           </header>
           <div className="apply-review-pane-scroll apply-review-materials-scroll">
             {resumeAuditArtifactId ? <ArtifactGroundingRiskPanel artifactId={resumeAuditArtifactId} /> : null}
@@ -1293,7 +1310,7 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
           </div>
         </article>
       </section>
-    </main>
+    </div>
   );
 }
 
@@ -1338,26 +1355,33 @@ export function ApplyReviewView({
   const repairCount = statuses.filter((status) => status.kind === "repair" || status.kind === "blocked").length;
 
   return (
-    <div className="apply-review-layout">
+    <div className="route-page route-page--apply-review apply-review-layout">
       <PageHead
         eyebrow="Pipeline"
         title="Application review"
         subtitle={`${readyCount} ready · ${preparingCount} preparing · ${repairCount} need repair`}
       />
-      <section className="card full">
-        {queueError ? <div className="banner inline">{queueError}</div> : null}
-        {queue.isFetching && !queue.data ? <Empty title="Loading review queue." /> : null}
-        {queue.data && selected ? (
-          <div className="apply-review-shell">
+      {queueError ? <div className="banner inline">{queueError}</div> : null}
+      {queue.isFetching && !queue.data ? <Empty title="Loading review queue." /> : null}
+      {queue.data && selected ? (
+        <RouteWorkspace
+          aria-label="Application review workspace"
+          className="apply-review-workspace-shell"
+          contentLabel={`Selected application review for ${selected.title}`}
+          navigationLabel="Application review queue"
+          navigation={
             <ApplyReviewQueue items={items} selected={selected} onSelect={handleSelectJob} />
-            <SelectedReview item={selected} />
-          </div>
-        ) : null}
-        {queue.data && targetJobKey && !selected ? (
-          <Empty title="This job is not in the application review queue." />
-        ) : null}
-        {queue.data && !targetJobKey && !items.length ? <Empty title="No application review items." /> : null}
-      </section>
+          }
+        >
+          <SelectedReview item={selected} />
+        </RouteWorkspace>
+      ) : null}
+      {queue.data && targetJobKey && !selected ? (
+        <Empty title="This job is not in the application review queue." />
+      ) : null}
+      {queue.data && !targetJobKey && !items.length ? (
+        <Empty title="No application review items." />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
@@ -12,6 +12,7 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -95,7 +96,7 @@ function renderArtifactRoute(
   });
 
   render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
-  return { artifactPreviewPdfUrl };
+  return { artifactPreviewPdfUrl, router };
 }
 
 describe("<ArtifactDetailPanel>", () => {
@@ -150,6 +151,22 @@ describe("<ArtifactDetailPanel>", () => {
       "artifact-preview",
       expect.stringContaining("1234"),
     );
+  });
+
+  it("renders as a route workspace and returns to the artifacts list", async () => {
+    const user = userEvent.setup();
+    const { router } = renderArtifactRoute(
+      <ArtifactDetailPanel artifactId="artifact-preview" />,
+    );
+
+    expect(
+      await screen.findByRole("article", { name: "Artifact details" }),
+    ).toHaveClass("route-workspace", "artifact-detail-workspace");
+    expect(screen.queryByRole("dialog", { name: "Artifact details" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back to artifacts" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/artifacts"));
   });
 
   it("marks suppressed artifacts as historical audit material", async () => {
@@ -457,6 +474,7 @@ describe("<ArtifactDetailPanel>", () => {
   });
 
   it("offers same-job same-type artifacts for comparison", async () => {
+    const user = userEvent.setup();
     renderArtifactRoute(
       <ArtifactDetailPanel artifactId="artifact-preview" />,
       "approved",
@@ -474,7 +492,9 @@ describe("<ArtifactDetailPanel>", () => {
     );
 
     expect(await screen.findByText("Artifact comparison")).toBeInTheDocument();
-    expect(await screen.findByLabelText("Compare with")).toHaveValue("artifact-template-b");
+    const comparisonPicker = await screen.findByRole("combobox", { name: "Compare with" });
+    expect(comparisonPicker).toHaveTextContent(/candidate/i);
+    await user.click(comparisonPicker);
     expect(screen.getByRole("option", { name: /candidate/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -1,4 +1,5 @@
 import type { ArtifactSummary } from "@jobctrl/contracts";
+import { IconArrowLeft } from "@tabler/icons-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -10,12 +11,13 @@ import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status
 import { useArtifactDetailQuery } from "../../contexts/operations/hooks/useArtifactDetailQuery.js";
 import { useArtifactsListQuery } from "../../contexts/operations/hooks/useArtifactsListQuery.js";
 import type { ArtifactsListInput } from "../../contexts/operations/types.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { PdfPreviewViewer } from "../../shared/ui/PdfPreviewViewer.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
+import { SelectField } from "../../shared/ui/select-field.js";
 import { Section } from "../../shared/ui/section.js";
 
 export interface ArtifactDetailPanelProps {
@@ -60,7 +62,9 @@ function comparableArtifacts(
 }
 
 function artifactOptionLabel(artifact: ArtifactSummary): string {
-  const template = artifact.resumeTemplate?.effective.templateName ?? artifact.resumeTemplate?.effective.templateId;
+  const template =
+    artifact.resumeTemplate?.effective.templateName ??
+    artifact.resumeTemplate?.effective.templateId;
   const created = formatDateTime(artifact.createdAt);
   return [artifact.status, template, created].filter(Boolean).join(" / ");
 }
@@ -73,7 +77,6 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   const close = useCallback(() => {
     void navigate({ to: "/artifacts", search });
   }, [navigate, search]);
-  useEscapeKey(true, close);
 
   const { data: detail, error: queryError } = useArtifactDetailQuery(artifactId);
   const comparisonListInput = useMemo(
@@ -101,155 +104,155 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   }, [artifactId, comparisonCandidates]);
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer artifact-detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Artifact details"
-      >
-        <button
-          aria-label="Close artifact details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          x
-        </button>
-        {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
-        {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
-        {detail ? (
-          <>
-            <div className="drawer-head">
-              <span>
-                <span
-                  className={`tag ${artifactStatusTone(detail.artifact.status)}`}
-                  title={artifactStatusDescription(detail.artifact.status)}
-                >
-                  {detail.artifact.status}
-                </span>
+    <div className="route-page route-page--artifact-detail" aria-label="Artifact details">
+      {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
+      {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
+      {detail ? (
+        <RouteWorkspace
+          aria-label="Artifact details"
+          className="artifact-detail-workspace"
+          contentLabel="Artifact preview"
+          inspectorLabel="Artifact audit and comparison"
+          header={
+            <div className="artifact-detail-workspace__header">
+              <Button
+                aria-label="Back to artifacts"
+                className="workspace-back"
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={close}
+              >
+                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                Artifacts
+              </Button>
+              <span
+                className={`tag ${artifactStatusTone(detail.artifact.status)}`}
+                title={artifactStatusDescription(detail.artifact.status)}
+              >
+                {detail.artifact.status}
               </span>
-              <span>
+              <div className="artifact-detail-workspace__title">
                 <small>{detail.artifact.company}</small>
-                <h2>{detail.artifact.title || detail.artifact.type}</h2>
+                <h1>{detail.artifact.title || detail.artifact.type}</h1>
                 <p>
                   {detail.artifact.type} · created {formatDateTime(detail.artifact.createdAt)}
                 </p>
-              </span>
-            </div>
-            <div className="artifact-detail-layout">
-              <div className="artifact-detail-sidebar">
-                <Section title="Artifact details">
-                  {isSuppressed(detail.artifact.status) ? (
-                    <div className="banner inline">
-                      This artifact is historical audit material and is not active apply-ready material.
-                    </div>
-                  ) : null}
-                  <dl className="detail-list">
-                    <div>
-                      <dt>Status</dt>
-                      <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
-                    </div>
-                    <div>
-                      <dt>Artifact id</dt>
-                      <dd className="mono">{detail.artifact.artifactId}</dd>
-                    </div>
-                    <div>
-                      <dt>Job</dt>
-                      <dd>{detail.artifact.jobKey || "-"}</dd>
-                    </div>
-                    <div>
-                      <dt>Local path</dt>
-                      <dd className="mono">{detail.artifact.localPath || "-"}</dd>
-                    </div>
-                    <div>
-                      <dt>Size</dt>
-                      <dd>{detail.artifact.size}</dd>
-                    </div>
-                  </dl>
-                  <button
-                    className="tab on"
-                    type="button"
-                    disabled={openArtifact.isPending || detail.artifact.status === "missing"}
-                    onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
-                  >
-                    {openArtifact.isPending
-                      ? "opening"
-                      : isDemo
-                        ? "preview in browser"
-                        : "open"}
-                  </button>
-                  <button
-                    className="tab"
-                    type="button"
-                    disabled={!detail.artifact.jobKey}
-                    onClick={() =>
-                      void navigate({
-                        to: "/jobs/$jobId",
-                        params: { jobId: detail.artifact.jobKey },
-                      })
-                    }
-                  >
-                    open related job
-                  </button>
-                </Section>
-                <TailoringExplanationSection explanation={detail.tailoringExplanation} />
-                <Section title="Artifact comparison">
-                  {comparisonList.isFetching && !comparisonList.data ? (
-                    <p className="meta">Loading comparable artifacts.</p>
-                  ) : null}
-                  {comparisonCandidates.length ? (
-                    <>
-                      <label className="field compact artifact-comparison-picker">
-                        <span>Compare with</span>
-                        <select
-                          value={comparisonArtifactId}
-                          onChange={(event) => setComparisonArtifactId(event.currentTarget.value)}
-                        >
-                          {comparisonCandidates.map((candidate) => (
-                            <option key={candidate.artifactId} value={candidate.artifactId}>
-                              {artifactOptionLabel(candidate)}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <ArtifactComparison
-                        leftArtifactId={detail.artifact.artifactId}
-                        leftLabel="Selected"
-                        rightArtifactId={comparisonArtifactId || null}
-                        rightLabel="Comparison"
-                        showTitle={false}
-                      />
-                    </>
-                  ) : (
-                    <Empty title="No other artifact for this job and type was found in the current artifact list." />
-                  )}
-                </Section>
               </div>
-              {isPreviewablePdfArtifact(detail.artifact.type, detail.artifact.localPath) ? (
-                <section className="artifact-preview-panel" aria-label="Artifact PDF preview">
-                  <PdfPreviewViewer
-                    cacheKey={artifactPreviewCacheKey(
-                      detail.artifact.createdAt,
-                      detail.artifact.sizeBytes,
-                    )}
-                    loadingMessage="The artifact PDF is loading into the in-app preview."
-                    loadingTitle="Rendering artifact PDF."
-                    openLabel="open PDF"
-                    pageAltPrefix={detail.artifact.title || detail.artifact.type}
-                    title="Artifact preview"
-                    url={api.artifactPreviewPdfUrl(
-                      detail.artifact.artifactId,
-                      artifactPreviewCacheKey(detail.artifact.createdAt, detail.artifact.sizeBytes),
-                    )}
-                  />
-                </section>
-              ) : null}
+              <div className="artifact-detail-workspace__actions">
+                <Button
+                  size="sm"
+                  type="button"
+                  disabled={openArtifact.isPending || detail.artifact.status === "missing"}
+                  onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
+                >
+                  {openArtifact.isPending ? "opening" : isDemo ? "preview in browser" : "open"}
+                </Button>
+                <Button
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                  disabled={!detail.artifact.jobKey}
+                  onClick={() =>
+                    void navigate({
+                      to: "/jobs/$jobId",
+                      params: { jobId: detail.artifact.jobKey },
+                    })
+                  }
+                >
+                  open related job
+                </Button>
+              </div>
             </div>
-            {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+          }
+          inspector={
+            <div className="artifact-detail-workspace__inspector">
+              <Section title="Artifact details">
+                {isSuppressed(detail.artifact.status) ? (
+                  <div className="banner inline">
+                    This artifact is historical audit material and is not active apply-ready
+                    material.
+                  </div>
+                ) : null}
+                <dl className="detail-list">
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
+                  </div>
+                  <div>
+                    <dt>Artifact id</dt>
+                    <dd className="mono">{detail.artifact.artifactId}</dd>
+                  </div>
+                  <div>
+                    <dt>Job</dt>
+                    <dd>{detail.artifact.jobKey || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Local path</dt>
+                    <dd className="mono">{detail.artifact.localPath || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Size</dt>
+                    <dd>{detail.artifact.size}</dd>
+                  </div>
+                </dl>
+              </Section>
+              <TailoringExplanationSection explanation={detail.tailoringExplanation} />
+              <Section title="Artifact comparison">
+                {comparisonList.isFetching && !comparisonList.data ? (
+                  <p className="meta">Loading comparable artifacts.</p>
+                ) : null}
+                {comparisonCandidates.length ? (
+                  <>
+                    <SelectField
+                      className="artifact-comparison-picker"
+                      label="Compare with"
+                      value={comparisonArtifactId}
+                      onValueChange={setComparisonArtifactId}
+                      options={comparisonCandidates.map((candidate) => ({
+                        value: candidate.artifactId,
+                        label: artifactOptionLabel(candidate),
+                      }))}
+                    />
+                    <ArtifactComparison
+                      leftArtifactId={detail.artifact.artifactId}
+                      leftLabel="Selected"
+                      rightArtifactId={comparisonArtifactId || null}
+                      rightLabel="Comparison"
+                      showTitle={false}
+                    />
+                  </>
+                ) : (
+                  <Empty title="No other artifact for this job and type was found in the current artifact list." />
+                )}
+              </Section>
+            </div>
+          }
+        >
+          {isPreviewablePdfArtifact(detail.artifact.type, detail.artifact.localPath) ? (
+            <section className="artifact-preview-panel" aria-label="Artifact PDF preview">
+              <PdfPreviewViewer
+                cacheKey={artifactPreviewCacheKey(
+                  detail.artifact.createdAt,
+                  detail.artifact.sizeBytes,
+                )}
+                loadingMessage="The artifact PDF is loading into the in-app preview."
+                loadingTitle="Rendering artifact PDF."
+                openLabel="open PDF"
+                pageAltPrefix={detail.artifact.title || detail.artifact.type}
+                title="Artifact preview"
+                url={api.artifactPreviewPdfUrl(
+                  detail.artifact.artifactId,
+                  artifactPreviewCacheKey(detail.artifact.createdAt, detail.artifact.sizeBytes),
+                )}
+              />
+            </section>
+          ) : (
+            <Empty title="This artifact type does not have an in-app PDF preview." />
+          )}
+          {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+        </RouteWorkspace>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/views/artifacts/ArtifactsView.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.tsx
@@ -1,5 +1,5 @@
 import type { ArtifactSortField } from "@jobctrl/contracts";
-import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useEffect, useMemo, useState } from "react";
 
@@ -34,6 +34,10 @@ function artifactsListInput(search: ArtifactsSearch) {
 export function ArtifactsView() {
   const search = useSearch({ from: "/artifacts" });
   const navigate = useNavigate({ from: "/artifacts" });
+  const showingDetail = useRouterState({
+    select: (state) =>
+      state.location.pathname !== "/artifacts" && state.location.pathname !== "/artifacts/",
+  });
 
   const { data, isFetching, error } = useArtifactsListQuery(artifactsListInput(search));
   const message = error instanceof Error ? error.message : null;
@@ -67,30 +71,34 @@ export function ArtifactsView() {
 
   return (
     <div className="route-page route-page--artifacts">
-      <PageHead
-        eyebrow="Library"
-        title="Artifacts"
-        subtitle={data ? `${data.pagination.total} total` : "loading"}
-      />
-      <section className="card full data-surface">
-        {message ? <div className="banner inline">{message}</div> : null}
-        <ArtifactFilterBar search={search} />
-        <ArtifactsTable
-          data={data ?? null}
-          loading={isFetching}
-          sorting={sorting}
-          onSortingChange={handleSortingChange}
-          rowSelection={rowSelection}
-          onRowSelectionChange={setRowSelection}
-          page={search.page}
-          pageSize={search.pageSize}
-          onPageChange={(page) => setSearch({ page })}
-          onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
-          onOpenArtifact={(artifactId) =>
-            void navigate({ to: "/artifacts/$artifactId", params: { artifactId } })
-          }
-        />
-      </section>
+      {!showingDetail ? (
+        <>
+          <PageHead
+            eyebrow="Library"
+            title="Artifacts"
+            subtitle={data ? `${data.pagination.total} total` : "loading"}
+          />
+          <section className="card full data-surface">
+            {message ? <div className="banner inline">{message}</div> : null}
+            <ArtifactFilterBar search={search} />
+            <ArtifactsTable
+              data={data ?? null}
+              loading={isFetching}
+              sorting={sorting}
+              onSortingChange={handleSortingChange}
+              rowSelection={rowSelection}
+              onRowSelectionChange={setRowSelection}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(page) => setSearch({ page })}
+              onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
+              onOpenArtifact={(artifactId) =>
+                void navigate({ to: "/artifacts/$artifactId", params: { artifactId } })
+              }
+            />
+          </section>
+        </>
+      ) : null}
       <Outlet />
     </div>
   );

--- a/apps/web/src/views/debug/ActivityDetailDrawer.a11y.test.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.a11y.test.tsx
@@ -10,7 +10,7 @@ describe("<ActivityDetailDrawer> a11y", () => {
     const view = renderWithProviders(<ActivityDetailDrawer eventId="evt-1" />, {
       withRouter: true,
     });
-    await waitFor(() => expect(view.container.querySelector("h2")).not.toBeNull());
+    await waitFor(() => expect(view.container.querySelector("h1")).not.toBeNull());
     const results = await axe(view.container);
     expect(results).toHaveNoViolations();
   });

--- a/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
@@ -1,0 +1,60 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders } from "../../test/render.js";
+import { ActivityDetailDrawer } from "./ActivityDetailDrawer.js";
+
+describe("<ActivityDetailDrawer>", () => {
+  it("renders the selected event as a route workspace without losing activity facts", async () => {
+    renderWithProviders(<ActivityDetailDrawer eventId="evt-1" />, {
+      withRouter: true,
+    });
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Job scored 8/10" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to Debug" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open related job" })).toHaveAttribute(
+      "href",
+      "/jobs/job-1",
+    );
+
+    const inspector = screen.getByRole("complementary", {
+      name: "Activity event facts",
+    });
+    for (const fact of [
+      "evt-1",
+      "JobScored",
+      "score",
+      "info",
+      "job-1",
+      "Staff Software Engineer",
+      "Acme Corp",
+      "Not exposed by the activity projection",
+    ]) {
+      expect(within(inspector).getByText(fact)).toBeInTheDocument();
+    }
+
+    const payload = screen.getByRole("region", { name: "Projected event payload" });
+    expect(payload).toHaveTextContent('"eventId": "evt-1"');
+    expect(payload).toHaveTextContent('"message": "Job scored 8/10"');
+
+    const timeline = screen.getByRole("region", { name: "Activity event timeline" });
+    expect(within(timeline).getByText("JobScored")).toBeInTheDocument();
+    expect(within(timeline).getByText("Job scored 8/10")).toBeInTheDocument();
+  });
+
+  it("keeps the existing unavailable-event state", async () => {
+    renderWithProviders(<ActivityDetailDrawer eventId="missing" />, {
+      withRouter: true,
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Activity event missing is no longer in the recent list."),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/debug/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.tsx
@@ -1,11 +1,16 @@
-import { useNavigate } from "@tanstack/react-router";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { useActivityEventQuery } from "../../contexts/operations/hooks/useActivityEventQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import {
+  InspectorLedger,
+  InspectorLedgerItem,
+} from "../../shared/ui/inspector-ledger.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
 import { activityLevelTone } from "./activity-tone.js";
 
@@ -18,67 +23,141 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
   const close = useCallback(() => {
     void navigate({ to: "/debug" });
   }, [navigate]);
-  useEscapeKey(true, close);
 
-  const { data: activity } = useActivityEventQuery(eventId);
+  const { data: activity, error, isLoading } = useActivityEventQuery(eventId);
+  const errorMessage = error instanceof Error ? error.message : null;
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Activity details"
-      >
-        <button
-          aria-label="Close activity details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          x
-        </button>
-        {!activity ? (
-          <Empty title={`Activity event ${eventId} is no longer in the recent list.`} />
-        ) : (
-          <>
-            <div className="drawer-head">
+    <div className="route-page route-page--activity-detail">
+      {errorMessage ? <Empty title={errorMessage} /> : null}
+      {!errorMessage && isLoading ? <Empty title="Loading activity event." /> : null}
+      {!errorMessage && !isLoading && !activity ? (
+        <Empty title={`Activity event ${eventId} is no longer in the recent list.`} />
+      ) : null}
+      {activity ? (
+        <RouteWorkspace
+          aria-labelledby="activity-detail-heading"
+          className="activity-detail-workspace"
+          contentLabel="Activity payload and timeline"
+          inspectorLabel="Activity event facts"
+          header={
+            <div className="activity-detail-workspace__header">
+              <Button
+                aria-label="Back to Debug"
+                className="workspace-back"
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={close}
+              >
+                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                Debug
+              </Button>
               <span className={`tag ${activityLevelTone(activity.level)}`}>
                 {activity.level}
               </span>
-              <span>
-                <small>{activity.stage}</small>
-                <h2>{activity.message}</h2>
-                <p>{formatDateTime(activity.at)}</p>
-              </span>
+              <div className="activity-detail-workspace__title">
+                <small>
+                  {activity.stage} · {activity.eventType}
+                </small>
+                <h1 id="activity-detail-heading">{activity.message}</h1>
+                <p>
+                  <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
+                  {activity.title ? ` · ${activity.title}` : ""}
+                  {activity.company ? ` at ${activity.company}` : ""}
+                </p>
+              </div>
+              {activity.jobKey ? (
+                <div className="activity-detail-workspace__actions">
+                  <Button asChild size="sm" variant="outline">
+                    <Link to="/jobs/$jobId" params={{ jobId: activity.jobKey }}>
+                      Open related job
+                    </Link>
+                  </Button>
+                </div>
+              ) : null}
             </div>
-            <Section title="Event details">
-              <dl className="detail-list">
-                <div>
-                  <dt>Event id</dt>
-                  <dd className="mono">{activity.eventId}</dd>
-                </div>
-                <div>
-                  <dt>Stage</dt>
-                  <dd>{activity.stage}</dd>
-                </div>
-                <div>
-                  <dt>Level</dt>
-                  <dd>{activity.level}</dd>
-                </div>
-                <div>
-                  <dt>Timestamp</dt>
-                  <dd>{formatDateTime(activity.at)}</dd>
-                </div>
-                <div>
-                  <dt>Message</dt>
-                  <dd>{activity.message}</dd>
-                </div>
-              </dl>
+          }
+          inspector={
+            <div className="activity-detail-workspace__inspector">
+              <h2>Event facts</h2>
+              <InspectorLedger>
+                <InspectorLedgerItem
+                  label="Event id"
+                  value={<span className="mono">{activity.eventId}</span>}
+                  source="Activity projection"
+                />
+                <InspectorLedgerItem
+                  label="Event type"
+                  value={<span className="mono">{activity.eventType}</span>}
+                  source="Activity projection"
+                />
+                <InspectorLedgerItem label="Stage" value={activity.stage} />
+                <InspectorLedgerItem
+                  label="Level"
+                  value={
+                    <span className={`tag ${activityLevelTone(activity.level)}`}>
+                      {activity.level}
+                    </span>
+                  }
+                />
+                <InspectorLedgerItem
+                  label="Timestamp"
+                  value={
+                    <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
+                  }
+                />
+                <InspectorLedgerItem
+                  label="Job key"
+                  value={
+                    activity.jobKey ? <span className="mono">{activity.jobKey}</span> : undefined
+                  }
+                />
+                <InspectorLedgerItem label="Job title" value={activity.title ?? undefined} />
+                <InspectorLedgerItem label="Company" value={activity.company ?? undefined} />
+                <InspectorLedgerItem
+                  label="Run reference"
+                  source="Not exposed by the activity projection"
+                />
+              </InspectorLedger>
+            </div>
+          }
+        >
+          <div className="activity-detail-workspace__content">
+            <h2 className="sr-only">Activity event evidence</h2>
+            <Section
+              aria-label="Projected event payload"
+              title="Projected event payload"
+              description="The complete activity detail returned by the local read model."
+            >
+              <pre className="activity-detail-workspace__payload">
+                <code>{JSON.stringify(activity, null, 2)}</code>
+              </pre>
             </Section>
-          </>
-        )}
-      </div>
-    </DetailDrawerBackdrop>
+            <Section
+              aria-label="Activity event timeline"
+              title="Timeline"
+              description="The selected event at its recorded timestamp."
+            >
+              <ol className="timeline activity-detail-workspace__timeline">
+                <li className="timeline-row activity-detail-workspace__timeline-entry">
+                  <span className="timeline-row-head">
+                    <span className={`tag ${activityLevelTone(activity.level)}`}>
+                      {activity.level}
+                    </span>
+                    <span className="stage-pill">{activity.stage}</span>
+                  </span>
+                  <span className="activity-detail-workspace__timeline-copy">
+                    <strong className="mono">{activity.eventType}</strong>
+                    <span>{activity.message}</span>
+                    <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
+                  </span>
+                </li>
+              </ol>
+            </Section>
+          </div>
+        </RouteWorkspace>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/views/evidence-map/EvidenceMapView.test.tsx
+++ b/apps/web/src/views/evidence-map/EvidenceMapView.test.tsx
@@ -68,6 +68,18 @@ describe("<EvidenceMapView>", () => {
     expect(
       await screen.findByRole("heading", { name: "Career evidence map" }),
     ).toBeInTheDocument();
+    const workspace = screen.getByRole("article", { name: "Career evidence workspace" });
+    expect(
+      within(workspace).getByRole("complementary", { name: "Evidence library" }),
+    ).toBeInTheDocument();
+    expect(
+      within(workspace).getByRole("region", { name: "Selected evidence detail" }),
+    ).toBeInTheDocument();
+    expect(
+      within(workspace).getByRole("complementary", {
+        name: "Evidence gaps and reusable stories",
+      }),
+    ).toBeInTheDocument();
     expect(
       await screen.findAllByText("Reduced incident response time through platform automation"),
     ).not.toHaveLength(0);

--- a/apps/web/src/views/evidence-map/EvidenceMapView.tsx
+++ b/apps/web/src/views/evidence-map/EvidenceMapView.tsx
@@ -11,8 +11,13 @@ import type {
   EvidenceUsageRef,
 } from "../../contexts/operations/types.js";
 import type { EvidenceMapSearch } from "../../routes/-evidence-map.search.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { Field, FieldLabel } from "../../shared/ui/field.js";
+import { Input } from "../../shared/ui/input.js";
 import { PageHead } from "../../shared/ui/page-head.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
 
 function entryKindLabel(entry: EvidenceMapEntry): string {
   return entry.kind === "skill" ? "Skill" : "Achievement";
@@ -167,7 +172,7 @@ function EvidenceEntryButton({
           <span className={`tag ${tagTone(entry.freshness.evidenceStrength)}`}>
             {entry.freshness.evidenceStrength ?? "unrated"}
           </span>
-          <span className="tag muted">{usageCount} uses</span>
+          <span className="meta">{usageCount} uses</span>
         </span>
       </Link>
     </li>
@@ -180,7 +185,10 @@ function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) 
   }
   const freshness = entry.freshness;
   return (
-    <aside className="evidence-detail" aria-labelledby="evidence-detail-title">
+    <div
+      className="evidence-detail evidence-detail--workspace"
+      aria-labelledby="evidence-detail-title"
+    >
       <header>
         <p className="meta">{entryKindLabel(entry)}</p>
         <h2 id="evidence-detail-title">{entry.title}</h2>
@@ -234,7 +242,7 @@ function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) 
       <UsageGroup title="Used in resumes" usages={entry.resumeUsages} />
       <UsageGroup title="Requirement fit history" usages={entry.requirementUsages} />
       <UsageGroup title="Coverage history" usages={entry.coverageUsages} />
-    </aside>
+    </div>
   );
 }
 
@@ -312,31 +320,51 @@ export function EvidenceMapView() {
   };
 
   return (
-    <>
+    <div className="route-page route-page--evidence-map">
       <PageHead
         eyebrow="Library"
         title="Career evidence map"
         subtitle={evidenceMap.data ? `${filteredEntries.length} entries` : "loading"}
       />
-      <section className="card full evidence-map-view">
-        {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-        <div className="toolbar evidence-map-toolbar">
-          <label>
-            <span>Search evidence</span>
-            <input
-              value={search.q}
-              onChange={(event) => setSearch({ q: event.target.value, entry: "" })}
-              placeholder="Skill, story, metric..."
-            />
-          </label>
-          {search.job ? (
-            <Link className="tab" search={{ ...search, job: "", entry: "" }} to="/evidence-map">
-              Clear job filter
-            </Link>
-          ) : null}
-        </div>
-        <div className="evidence-map-shell">
-          <nav className="evidence-entry-list" aria-label="Evidence entries">
+      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+      <RouteWorkspace
+        aria-label="Career evidence workspace"
+        className="evidence-map-view evidence-map-workspace"
+        contentLabel="Selected evidence detail"
+        inspectorLabel="Evidence gaps and reusable stories"
+        navigationLabel="Evidence library"
+        header={
+          <ToolRow
+            aria-label="Evidence map search"
+            className="data-surface__tools evidence-map-workspace__tools"
+            role="search"
+            primary={
+              <Field className="tool-row__search">
+                <FieldLabel htmlFor="evidence-map-search">Search evidence</FieldLabel>
+                <Input
+                  id="evidence-map-search"
+                  value={search.q}
+                  onChange={(event) => setSearch({ q: event.target.value, entry: "" })}
+                  placeholder="Skill, story, metric..."
+                />
+              </Field>
+            }
+            secondary={
+              search.job ? (
+                <Button asChild size="sm" variant="outline">
+                  <Link search={{ ...search, job: "", entry: "" }} to="/evidence-map">
+                    Clear job filter
+                  </Link>
+                </Button>
+              ) : null
+            }
+          />
+        }
+        navigation={
+          <nav
+            className="evidence-entry-list evidence-entry-list--workspace"
+            aria-label="Evidence entries"
+          >
             {evidenceMap.isFetching && !evidenceMap.data ? (
               <Empty title="Loading evidence map." />
             ) : filteredEntries.length ? (
@@ -354,15 +382,21 @@ export function EvidenceMapView() {
               <Empty title="No evidence entries match." />
             )}
           </nav>
-          <EvidenceDetail entry={selected} />
-          <section className="evidence-side-panel" aria-labelledby="evidence-gaps-title">
+        }
+        inspector={
+          <section
+            className="evidence-side-panel evidence-side-panel--workspace"
+            aria-labelledby="evidence-gaps-title"
+          >
             <h2 id="evidence-gaps-title">Gaps</h2>
             <GapList gaps={filteredGaps} />
             <h2>Reusable stories</h2>
             <StoryList entries={filteredEntries} />
           </section>
-        </div>
-      </section>
-    </>
+        }
+      >
+        <EvidenceDetail entry={selected} />
+      </RouteWorkspace>
+    </div>
   );
 }

--- a/apps/web/src/views/jobs/JobDetailDrawer.a11y.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.a11y.test.tsx
@@ -46,7 +46,11 @@ describe("<JobDetailDrawer> a11y", () => {
       }),
     });
     const view = render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
-    await waitFor(() => expect(view.container.querySelector("[role='dialog'].drawer")).not.toBeNull());
+    await waitFor(() =>
+      expect(
+        view.container.querySelector("article.route-workspace[aria-label='Job details']"),
+      ).not.toBeNull(),
+    );
     const results = await axe(view.container);
     expect(results).toHaveNoViolations();
   });

--- a/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
@@ -180,7 +180,7 @@ describe("<JobDetailDrawer>", () => {
     ).toBeInTheDocument();
 
     const triage = screen.getByRole("region", { name: "Job audit triage" });
-    const drawer = screen.getByRole("dialog", { name: "Job details" });
+    const workspace = screen.getByRole("article", { name: "Job details" });
     for (const text of [
       "source_conflict_with_posted_salary",
       "Market estimate is above the posted range.",
@@ -193,10 +193,16 @@ describe("<JobDetailDrawer>", () => {
     expect(within(triage).getByText("Missing apply link: No application URL is recorded.")).toBeInTheDocument();
     expect(within(triage).getByText("Submit-ready PDF missing: A submit-ready PDF is still missing.")).toBeInTheDocument();
     expect(within(triage).getByText("Eligibility warning: Sponsorship requirements need review.")).toBeInTheDocument();
-    expect(within(drawer).getByLabelText("Apply readiness")).toHaveTextContent("missing apply link");
-    expect(within(drawer).getByLabelText("Apply readiness")).not.toHaveTextContent(/compensation|salary|source conflict/i);
+    expect(within(workspace).getByLabelText("Apply readiness")).toHaveTextContent(
+      "missing apply link",
+    );
+    expect(within(workspace).getByLabelText("Apply readiness")).not.toHaveTextContent(
+      /compensation|salary|source conflict/i,
+    );
     expect(
-      within(drawer).getByRole("link", { name: "Open Apply Review for Compensated Platform Role" }),
+      within(workspace).getByRole("link", {
+        name: "Open Apply Review for Compensated Platform Role",
+      }),
     ).not.toHaveTextContent(/compensation|salary|source conflict/i);
   });
 
@@ -296,13 +302,13 @@ describe("<JobDetailDrawer>", () => {
     renderJobDetailDrawer("https://example.com/jobs/1");
 
     const triage = await screen.findByRole("region", { name: "Job audit triage" });
-    const drawer = screen.getByRole("dialog", { name: "Job details" });
-    const toolbar = within(drawer).getByRole("toolbar", { name: "Job actions" });
-    expect(drawer).toHaveClass("job-detail-drawer");
-    expect(drawer.querySelector(".job-detail-drawer-content")).not.toBeNull();
-    expect(drawer.querySelector(".job-detail-drawer-main")).not.toBeNull();
-    expect(within(drawer).queryByText("Audit triage")).not.toBeInTheDocument();
-    expect(within(drawer).queryByText("Why this job is here")).not.toBeInTheDocument();
+    const workspace = screen.getByRole("article", { name: "Job details" });
+    const toolbar = within(workspace).getByRole("toolbar", { name: "Job actions" });
+    expect(workspace).toHaveClass("route-workspace", "job-detail-workspace");
+    expect(workspace.querySelector(".job-detail-workspace__content")).not.toBeNull();
+    expect(workspace.querySelector(".job-detail-workspace__inspector")).not.toBeNull();
+    expect(within(workspace).queryByText("Audit triage")).not.toBeInTheDocument();
+    expect(within(workspace).queryByText("Why this job is here")).not.toBeInTheDocument();
     expect(toolbar.compareDocumentPosition(triage) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(within(triage).getByText("8/10")).toBeInTheDocument();
     expect(within(triage).getByText("strong")).toBeInTheDocument();
@@ -317,7 +323,7 @@ describe("<JobDetailDrawer>", () => {
     expect(within(triage).getByText("Lead platform reliability programs across multiple teams")).toBeInTheDocument();
     expect(within(triage).getByText("Transferable requirements")).toBeInTheDocument();
     expect(within(triage).getByText("Experience with Kubernetes-based developer platforms")).toBeInTheDocument();
-    const readiness = within(drawer).getByLabelText("Apply readiness");
+    const readiness = within(workspace).getByLabelText("Apply readiness");
     expect(within(readiness).getByText("missing apply link")).toBeInTheDocument();
     expect(within(triage).getByText("Apply concerns")).toBeInTheDocument();
     expect(
@@ -326,7 +332,9 @@ describe("<JobDetailDrawer>", () => {
     expect(
       within(triage).getByText("Eligibility warning: Sponsorship requirements need review."),
     ).toBeInTheDocument();
-    const handoff = within(drawer).getByRole("link", { name: "Open Apply Review for Staff Software Engineer" });
+    const handoff = within(workspace).getByRole("link", {
+      name: "Open Apply Review for Staff Software Engineer",
+    });
     const handoffUrl = new URL(handoff.getAttribute("href") ?? "", "http://localhost");
     expect(handoffUrl.pathname).toBe("/apply-review");
     expect(handoffUrl.searchParams.get("jobKey")).toBe("https://example.com/jobs/1");
@@ -488,18 +496,18 @@ describe("<JobDetailDrawer>", () => {
     expect(within(requirement).queryByText("Matched score signal")).not.toBeInTheDocument();
   });
 
-  it("closes when clicking the backdrop without treating drawer content as backdrop", async () => {
+  it("returns to the jobs list from the route-level workspace", async () => {
     const user = userEvent.setup();
     const { container, router } = renderJobDetailDrawer("job-1");
 
-    await waitFor(() => expect(screen.getByLabelText("Job details")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole("article", { name: "Job details" })).toBeInTheDocument(),
+    );
 
-    await user.click(screen.getByLabelText("Job details"));
     expect(router.state.location.pathname).toBe("/jobs/job-1");
+    expect(container.querySelector(".drawer-backdrop")).toBeNull();
 
-    const backdrop = container.querySelector(".drawer-backdrop");
-    expect(backdrop).not.toBeNull();
-    await user.click(backdrop as HTMLElement);
+    await user.click(screen.getByRole("button", { name: "Back to jobs" }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe("/jobs"));
   });
@@ -513,8 +521,8 @@ describe("<JobDetailDrawer>", () => {
     expect(auditDisclosure).not.toBeNull();
     expect(auditDisclosure).not.toHaveAttribute("open");
 
-    const drawer = screen.getByLabelText("Job details");
-    const sections = Array.from(drawer.querySelectorAll("section.section"));
+    const workspace = screen.getByRole("article", { name: "Job details" });
+    const sections = Array.from(workspace.querySelectorAll("section.section"));
     expect(sections.at(-1)).toContainElement(auditDisclosure);
     expect(sections.at(-1)).toHaveTextContent("Audit history");
     expect(sections[1]).toHaveTextContent("Compensation");
@@ -570,8 +578,8 @@ describe("<JobDetailDrawer>", () => {
     renderJobDetailDrawer("https://example.com/jobs/1");
 
     await screen.findByText(sampleJob.title);
-    const drawer = screen.getByLabelText("Job details");
-    expect(drawer).not.toHaveTextContent("jobctrl retry enrich");
+    const workspace = screen.getByRole("article", { name: "Job details" });
+    expect(workspace).not.toHaveTextContent("jobctrl retry enrich");
     expect(screen.getByRole("button", { name: "retry" })).toBeInTheDocument();
   });
 

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
 import type { JobAuditEntry, StageSummary } from "@jobctrl/contracts";
+import { IconArrowLeft } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
 import { ApplyHistory } from "../../contexts/apply/components/ApplyHistory.js";
@@ -19,9 +20,9 @@ import { useJobDetailQuery } from "../../contexts/operations/hooks/useJobDetailQ
 import { JobActions } from "../../contexts/pipeline/components/JobActions.js";
 import { StageTimeline } from "../../contexts/pipeline/components/StageTimeline.js";
 import { RescoreJobButton } from "../../contexts/scoring/components/RescoreCurrentPolicyButton.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
 import { JobAuditTriage } from "./JobAuditTriage.js";
 import { JobDescription } from "./JobDescription.js";
@@ -86,8 +87,6 @@ function RequirementFitMissingCallout({ jobId }: { readonly jobId: string }) {
 }
 
 export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
-  useEscapeKey(true, onClose);
-
   const { data: detail, error: detailError } = useJobDetailQuery(jobId);
   const discoverySettingsQuery = useDiscoverySettingsQuery();
   const applyApprovalRequired =
@@ -98,22 +97,29 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
   );
 
   return (
-    <DetailDrawerBackdrop onDismiss={onClose}>
-      <div className="drawer job-detail-drawer" role="dialog" aria-modal="true" aria-label="Job details">
-        <button
-          aria-label="Close job details"
-          className="drawer-close"
-          type="button"
-          onClick={onClose}
-        >
-          x
-        </button>
-        {errorMessage ? <Empty title={errorMessage} /> : null}
-        {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
-        {detail ? (
-          <>
-            <JobOverview detail={detail} />
-            <div className="job-detail-drawer-content">
+    <div className="route-page route-page--job-detail" aria-label="Job details">
+      {errorMessage ? <Empty title={errorMessage} /> : null}
+      {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
+      {detail ? (
+        <RouteWorkspace
+          aria-label="Job details"
+          className="job-detail-workspace"
+          contentLabel="Job evidence and analysis"
+          inspectorLabel="Job progress, materials, and history"
+          header={
+            <div className="job-detail-workspace__header">
+              <Button
+                aria-label="Back to jobs"
+                className="workspace-back"
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+              >
+                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                Jobs
+              </Button>
+              <JobOverview detail={detail} />
               <div className="job-detail-top-actions">
                 <JobActions
                   jobId={detail.job.jobKey}
@@ -123,94 +129,100 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                   canRetailor={detail.artifacts.length > 0}
                   applyApprovalRequired={applyApprovalRequired}
                 />
-                <Link
-                  aria-label={`Open Apply Review for ${detail.job.title}`}
-                  className="tab"
-                  search={{ jobKey: detail.job.jobKey }}
-                  to="/apply-review"
-                >
-                  Open Apply Review
-                </Link>
-                <Link
-                  aria-label={`Open evidence map for ${detail.job.title}`}
-                  className="tab"
-                  search={{ q: "", entry: "", job: detail.job.jobKey }}
-                  to="/evidence-map"
-                >
-                  Evidence map
-                </Link>
-              </div>
-              <JobAuditTriage detail={detail} />
-              <CompensationAuditSection
-                jobId={detail.job.jobKey}
-                summary={detail.job.compensationSummary}
-                audit={detail.compensationAudit}
-                fallbackSalary={detail.job.salary}
-              />
-              <section className="section job-detail-description">
-                <h3>Description</h3>
-                <JobDescription text={detail.job.descriptionPreview} />
-              </section>
-              <div className="job-detail-drawer-main">
-                <Section title="Preparation diagnostics">
-                  <StageTimeline
-                    jobId={detail.job.jobKey}
-                    stages={preparationStages(detail.stages)}
-                  />
-                </Section>
-                <Section title="Active artifacts">
-                  {detail.artifacts.length ? (
-                    detail.artifacts.map((artifact) => (
-                      <div className="mini-row" key={artifact.artifactId}>
-                        <ArtifactStatusBadge status={artifact.status} />
-                        <span>{artifact.type}</span>
-                        <code>{artifact.localPath}</code>
-                        <OpenArtifactButton
-                          artifactId={artifact.artifactId}
-                          disabled={artifact.status === "missing"}
-                        />
-                      </div>
-                    ))
-                  ) : (
-                    <Empty title="No active apply-ready artifacts." />
-                  )}
-                </Section>
-                {detail.employerAnalysis && !detail.requirementFitReport ? (
-                  <RequirementFitMissingCallout jobId={detail.job.jobKey} />
-                ) : null}
-                <EmployerAnalysisPanel
-                  analysis={detail.employerAnalysis}
-                  className="section job-detail-role-analysis"
-                  requirementFitReport={detail.requirementFitReport}
-                />
-                <InterviewPrepPanel
-                  jobId={detail.job.jobKey}
-                  prep={detail.interviewPrep}
-                  reflectionContent={
-                    detail.interviewPrep ? (
-                      <InterviewReflectionPanel
-                        jobId={detail.job.jobKey}
-                        prepGeneration={detail.interviewPrep.generation}
-                      />
-                    ) : null
-                  }
-                />
-                <Section title="Apply history">
-                  <ApplyHistory jobId={detail.job.jobKey} />
-                </Section>
-                <Section title="Application outcomes">
-                  <JobOutcomePanel jobId={detail.job.jobKey} />
-                </Section>
-                <JobContactsPanel
-                  jobId={detail.job.jobKey}
-                  {...(detail.job.company ? { employer: detail.job.company } : {})}
-                />
-                <JobAuditHistorySection entries={detail.auditHistory} />
+                <Button asChild size="sm" variant="outline">
+                  <Link
+                    aria-label={`Open Apply Review for ${detail.job.title}`}
+                    search={{ jobKey: detail.job.jobKey }}
+                    to="/apply-review"
+                  >
+                    Open Apply Review
+                  </Link>
+                </Button>
+                <Button asChild size="sm" variant="outline">
+                  <Link
+                    aria-label={`Open evidence map for ${detail.job.title}`}
+                    search={{ q: "", entry: "", job: detail.job.jobKey }}
+                    to="/evidence-map"
+                  >
+                    Evidence map
+                  </Link>
+                </Button>
               </div>
             </div>
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+          }
+          inspector={
+            <div className="job-detail-workspace__inspector">
+              <Section title="Preparation diagnostics">
+                <StageTimeline
+                  jobId={detail.job.jobKey}
+                  stages={preparationStages(detail.stages)}
+                />
+              </Section>
+              <Section title="Active artifacts">
+                {detail.artifacts.length ? (
+                  detail.artifacts.map((artifact) => (
+                    <div className="mini-row" key={artifact.artifactId}>
+                      <ArtifactStatusBadge status={artifact.status} />
+                      <span>{artifact.type}</span>
+                      <code>{artifact.localPath}</code>
+                      <OpenArtifactButton
+                        artifactId={artifact.artifactId}
+                        disabled={artifact.status === "missing"}
+                      />
+                    </div>
+                  ))
+                ) : (
+                  <Empty title="No active apply-ready artifacts." />
+                )}
+              </Section>
+              <Section title="Apply history">
+                <ApplyHistory jobId={detail.job.jobKey} />
+              </Section>
+              <Section title="Application outcomes">
+                <JobOutcomePanel jobId={detail.job.jobKey} />
+              </Section>
+              <JobContactsPanel
+                jobId={detail.job.jobKey}
+                {...(detail.job.company ? { employer: detail.job.company } : {})}
+              />
+              <JobAuditHistorySection entries={detail.auditHistory} />
+            </div>
+          }
+        >
+          <div className="job-detail-workspace__content">
+            <JobAuditTriage detail={detail} />
+            <CompensationAuditSection
+              jobId={detail.job.jobKey}
+              summary={detail.job.compensationSummary}
+              audit={detail.compensationAudit}
+              fallbackSalary={detail.job.salary}
+            />
+            <Section title="Description" className="job-detail-description">
+              <JobDescription text={detail.job.descriptionPreview} />
+            </Section>
+            {detail.employerAnalysis && !detail.requirementFitReport ? (
+              <RequirementFitMissingCallout jobId={detail.job.jobKey} />
+            ) : null}
+            <EmployerAnalysisPanel
+              analysis={detail.employerAnalysis}
+              className="section job-detail-role-analysis"
+              requirementFitReport={detail.requirementFitReport}
+            />
+            <InterviewPrepPanel
+              jobId={detail.job.jobKey}
+              prep={detail.interviewPrep}
+              reflectionContent={
+                detail.interviewPrep ? (
+                  <InterviewReflectionPanel
+                    jobId={detail.job.jobKey}
+                    prepGeneration={detail.interviewPrep.generation}
+                  />
+                ) : null
+              }
+            />
+          </div>
+        </RouteWorkspace>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -14,7 +14,7 @@ function auditTone(state: JobDetail["applyAudit"]["state"]): "ok" | "info" | "wa
 export function JobOverview({ detail }: JobOverviewProps) {
   const { applyAudit, job } = detail;
   return (
-    <div className="drawer-head">
+    <div className="job-overview">
       <ScoreBadge score={job.fitScore} />
       <span>
         <small>
@@ -22,7 +22,7 @@ export function JobOverview({ detail }: JobOverviewProps) {
           {job.postingSource ? ` · posting: ${job.postingSource}` : ""}
           {job.discoverySource ? ` · discovered via: ${job.discoverySource}` : ""}
         </small>
-        <h2>{job.title}</h2>
+        <h1>{job.title}</h1>
         <p>
           {job.location || "-"} · {job.salary || "-"}
         </p>

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -9,7 +9,7 @@ import {
   type SavedTableView,
   STAGE_STATES,
 } from "@jobctrl/contracts";
-import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 import type { UseMutationResult } from "@tanstack/react-query";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -241,6 +241,9 @@ function sameKeys(
 export function JobsView() {
   const search = useSearch({ from: "/jobs" });
   const navigate = useNavigate({ from: "/jobs" });
+  const showingDetail = useRouterState({
+    select: (state) => state.location.pathname !== "/jobs" && state.location.pathname !== "/jobs/",
+  });
 
   const { data, isFetching, error } = useJobsListQuery(jobsListInput(search));
   const deleteJobs = useDeleteJobsBulkMutation();
@@ -667,64 +670,68 @@ export function JobsView() {
 
   return (
     <div className="route-page route-page--jobs">
-      <PageHead
-        eyebrow="Pipeline"
-        title="Jobs"
-        subtitle={data ? `${data.pagination.total} total` : "loading"}
-      />
-      <section className="card full data-surface">
-        {message ? <div className="banner inline">{message}</div> : null}
-        <JobBulkActions
-          search={search}
-          selectedCount={selectedCount}
-          selectedJobKeys={allMatchingSelected ? [] : selectedKeys}
-          staleCount={staleKeysOnPage.length}
-          selectedStaleKeys={selectedStaleKeys}
-          hasItems={visiblePageKeys.length > 0}
-          hasAnyMatching={Boolean(data?.pagination.total)}
-          hasLocalFilters={hasLocalFilters}
-          loading={selectionMutationBusy}
-          retryLoading={retryFailedJobs.isPending}
-          pendingPreparationLoading={runPendingPreparation.isPending}
-          onSetDeleted={(deleted) => setSearch({ deleted, page: 1 })}
-          onSelectPage={selectPage}
-          onSelectAllMatching={selectAllMatching}
-          onClearSelection={clearSelection}
-          onPrimaryAction={mutatePrimarySelected}
-          onHideSelected={hideSelected}
-          onPermanentlyDeleteSelected={permanentlyDeleteSelected}
-          onRetryFailedSelected={retryFailedSelected}
-          onRetryAllFailed={retryAllFailed}
-          onRunPendingPreparation={continuePendingPreparation}
-          onResetStaleSuccess={clearSelection}
-          onMaintenanceSuccess={clearSelection}
-        />
-        <JobsTable
-          data={data ?? null}
-          loading={isFetching}
-          sorting={sorting}
-          onSortingChange={handleSortingChange}
-          rowSelection={rowSelection}
-          onRowSelectionChange={handleRowSelectionChange}
-          allMatchingSelected={allMatchingSelected}
-          page={search.page}
-          pageSize={search.pageSize}
-          onPageChange={(page) => setSearch({ page })}
-          onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
-          onOpenJob={openJob}
-          filters={tableFilters}
-          onFiltersChange={handleTableFiltersChange}
-          onVisiblePageRowsChange={handleVisiblePageRowsChange}
-          columnOrder={savedPresentation.columns.order}
-          hiddenColumnIds={savedPresentation.columns.hidden}
-          columnWidths={savedPresentation.columns.widths}
-          onColumnWidthsChange={handleColumnWidthsChange}
-          density={savedPresentation.density}
-          grouping={savedPresentation.grouping}
-          colorRules={savedPresentation.colorRules}
-          toolbarActions={renderSavedTableActions}
-        />
-      </section>
+      {!showingDetail ? (
+        <>
+          <PageHead
+            eyebrow="Pipeline"
+            title="Jobs"
+            subtitle={data ? `${data.pagination.total} total` : "loading"}
+          />
+          <section className="card full data-surface">
+            {message ? <div className="banner inline">{message}</div> : null}
+            <JobBulkActions
+              search={search}
+              selectedCount={selectedCount}
+              selectedJobKeys={allMatchingSelected ? [] : selectedKeys}
+              staleCount={staleKeysOnPage.length}
+              selectedStaleKeys={selectedStaleKeys}
+              hasItems={visiblePageKeys.length > 0}
+              hasAnyMatching={Boolean(data?.pagination.total)}
+              hasLocalFilters={hasLocalFilters}
+              loading={selectionMutationBusy}
+              retryLoading={retryFailedJobs.isPending}
+              pendingPreparationLoading={runPendingPreparation.isPending}
+              onSetDeleted={(deleted) => setSearch({ deleted, page: 1 })}
+              onSelectPage={selectPage}
+              onSelectAllMatching={selectAllMatching}
+              onClearSelection={clearSelection}
+              onPrimaryAction={mutatePrimarySelected}
+              onHideSelected={hideSelected}
+              onPermanentlyDeleteSelected={permanentlyDeleteSelected}
+              onRetryFailedSelected={retryFailedSelected}
+              onRetryAllFailed={retryAllFailed}
+              onRunPendingPreparation={continuePendingPreparation}
+              onResetStaleSuccess={clearSelection}
+              onMaintenanceSuccess={clearSelection}
+            />
+            <JobsTable
+              data={data ?? null}
+              loading={isFetching}
+              sorting={sorting}
+              onSortingChange={handleSortingChange}
+              rowSelection={rowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
+              allMatchingSelected={allMatchingSelected}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(page) => setSearch({ page })}
+              onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
+              onOpenJob={openJob}
+              filters={tableFilters}
+              onFiltersChange={handleTableFiltersChange}
+              onVisiblePageRowsChange={handleVisiblePageRowsChange}
+              columnOrder={savedPresentation.columns.order}
+              hiddenColumnIds={savedPresentation.columns.hidden}
+              columnWidths={savedPresentation.columns.widths}
+              onColumnWidthsChange={handleColumnWidthsChange}
+              density={savedPresentation.density}
+              grouping={savedPresentation.grouping}
+              colorRules={savedPresentation.colorRules}
+              toolbarActions={renderSavedTableActions}
+            />
+          </section>
+        </>
+      ) : null}
       <Outlet />
     </div>
   );

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.test.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.test.tsx
@@ -1,13 +1,16 @@
+import { userEvent } from "@testing-library/user-event";
 import { waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders } from "../../test/render.js";
 import { OutreachDetailDrawer } from "./OutreachDetailDrawer.js";
 
 describe("<OutreachDetailDrawer>", () => {
   it("shows the contact's facts and composes the outreach draft review surface", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
     const view = renderWithProviders(
-      <OutreachDetailDrawer contactId="contact-1" onClose={() => {}} />,
+      <OutreachDetailDrawer contactId="contact-1" onClose={onClose} />,
     );
     await waitFor(() =>
       expect(view.getByRole("heading", { name: "Dana Reyes" })).toBeInTheDocument(),
@@ -19,5 +22,13 @@ describe("<OutreachDetailDrawer>", () => {
       expect(view.getByRole("heading", { name: "Outreach" })).toBeInTheDocument(),
     );
     expect(view.getByRole("heading", { name: "Approved message" })).toBeInTheDocument();
+    expect(view.getByRole("article", { name: "Contact details" })).toHaveClass(
+      "route-workspace",
+      "contact-detail-workspace",
+    );
+    expect(view.queryByRole("dialog", { name: "Contact details" })).not.toBeInTheDocument();
+
+    await user.click(view.getByRole("button", { name: "Back to contacts" }));
+    expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
@@ -1,4 +1,5 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
+import { IconArrowLeft } from "@tabler/icons-react";
 
 import { ContactDeleteButton } from "../../contexts/outreach/components/ContactDeleteButton.js";
 import { ContactEditButton } from "../../contexts/outreach/components/ContactEditButton.js";
@@ -6,10 +7,10 @@ import { ContactProvenanceList } from "../../contexts/outreach/components/Contac
 import { ContactRoleBadge } from "../../contexts/outreach/components/ContactRoleBadge.js";
 import { OutreachThreadPanel } from "../../contexts/outreach/components/OutreachThreadPanel.js";
 import { useContactDetailQuery } from "../../contexts/outreach/hooks/useContactDetailQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { Button, buttonVariants } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
 
 export interface OutreachDetailDrawerProps {
@@ -25,60 +26,67 @@ function detailErrorTitle(error: unknown): string {
 }
 
 export function OutreachDetailDrawer({ contactId, onClose }: OutreachDetailDrawerProps) {
-  useEscapeKey(true, onClose);
-
   const { data, error } = useContactDetailQuery(contactId);
   const errorMessage = detailErrorTitle(error);
   const contact = data?.contact;
 
   return (
-    <DetailDrawerBackdrop onDismiss={onClose}>
-      <div
-        className="drawer detail-drawer contact-detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Contact details"
-      >
-        <button
-          aria-label="Close contact details"
-          className="drawer-close"
-          type="button"
-          onClick={onClose}
-        >
-          x
-        </button>
-        {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
-        {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}
-        {contact ? (
-          <>
-            <div className="drawer-head">
+    <div className="route-page route-page--contact-detail" aria-label="Contact details">
+      {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
+      {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}
+      {contact ? (
+        <RouteWorkspace
+          aria-label="Contact details"
+          className="contact-detail-workspace"
+          contentLabel="Outreach thread"
+          inspectorLabel="Contact facts and provenance"
+          header={
+            <div className="contact-detail-workspace__header">
+              <Button
+                aria-label="Back to contacts"
+                className="workspace-back"
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+              >
+                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                Contacts
+              </Button>
               <span>
                 <ContactRoleBadge role={contact.role} />
               </span>
-              <span>
+              <div className="contact-detail-workspace__title">
                 <small>{contact.employer ?? "No employer"}</small>
-                <h2>{contact.displayName}</h2>
+                <h1>{contact.displayName}</h1>
                 <p>
                   {contact.jobId ? `Linked job ${contact.jobId}` : "Not linked to a job"} · updated{" "}
                   {formatDateTime(contact.updatedAt)}
                 </p>
-              </span>
+              </div>
+              <div className="contact-detail-actions">
+                <ContactEditButton
+                  contact={contact}
+                  className={buttonVariants({ size: "sm", variant: "outline" })}
+                />
+                <ContactDeleteButton
+                  className={buttonVariants({ size: "sm", variant: "destructive" })}
+                  contactId={contact.contactId}
+                  displayName={contact.displayName}
+                  onDeleted={onClose}
+                />
+              </div>
             </div>
-            <div className="contact-detail-actions">
-              <ContactEditButton contact={contact} />
-              <ContactDeleteButton
-                contactId={contact.contactId}
-                displayName={contact.displayName}
-                onDeleted={onClose}
-              />
-            </div>
+          }
+          inspector={
             <Section title="Facts and provenance">
               <ContactProvenanceList attributes={contact.attributes} />
             </Section>
-            <OutreachThreadPanel contactId={contact.contactId} />
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+          }
+        >
+          <OutreachThreadPanel contactId={contact.contactId} />
+        </RouteWorkspace>
+      ) : null}
+    </div>
   );
 }

--- a/apps/web/src/views/outreach/OutreachView.tsx
+++ b/apps/web/src/views/outreach/OutreachView.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
 
 import { ContactCreateButton } from "../../contexts/outreach/components/ContactCreateButton.js";
 import { ContactImportButton } from "../../contexts/outreach/components/ContactImportButton.js";
@@ -28,6 +28,10 @@ function listFilters(search: OutreachSearch): ContactsListFilters {
 export function OutreachView() {
   const search = useSearch({ from: "/outreach" });
   const navigate = useNavigate({ from: "/outreach" });
+  const showingDetail = useRouterState({
+    select: (state) =>
+      state.location.pathname !== "/outreach" && state.location.pathname !== "/outreach/",
+  });
 
   const { data, isFetching, error } = useContactsListQuery(listFilters(search));
   const message = error instanceof Error ? error.message : null;
@@ -38,56 +42,60 @@ export function OutreachView() {
 
   return (
     <div className="route-page route-page--outreach">
-      <PageHead
-        eyebrow="Library"
-        title="Contacts"
-        subtitle={data ? `${data.items.length} shown` : "loading"}
-        actions={<DueFollowUpsBadge />}
-      />
-      <DueFollowUpsPanel />
-      <section className="card full data-surface">
-        {message ? <div className="banner inline">{message}</div> : null}
-        <ToolRow
-          className="data-surface__tools"
-          primary={
-            <>
-              <label className="field compact tool-row__field">
-                <span>Employer</span>
-                <Input
-                  value={search.employer}
-                  placeholder="Filter by employer"
-                  onChange={(event) => setSearch({ employer: event.target.value })}
-                />
-              </label>
-              <label className="field compact tool-row__field">
-                <span>Job</span>
-                <Input
-                  value={search.jobId}
-                  placeholder="Filter by job id"
-                  onChange={(event) => setSearch({ jobId: event.target.value })}
-                />
-              </label>
-            </>
-          }
-          secondary={
-            <>
-              <ContactCreateButton />
-              <ContactImportButton />
-            </>
-          }
-        />
-        <OutreachTable
-          data={data ?? null}
-          loading={isFetching}
-          onOpenContact={(contactId) =>
-            void navigate({
-              to: "/outreach/$contactId",
-              params: { contactId },
-              search: (prev: OutreachSearch) => prev,
-            })
-          }
-        />
-      </section>
+      {!showingDetail ? (
+        <>
+          <PageHead
+            eyebrow="Library"
+            title="Contacts"
+            subtitle={data ? `${data.items.length} shown` : "loading"}
+            actions={<DueFollowUpsBadge />}
+          />
+          <DueFollowUpsPanel />
+          <section className="card full data-surface">
+            {message ? <div className="banner inline">{message}</div> : null}
+            <ToolRow
+              className="data-surface__tools"
+              primary={
+                <>
+                  <label className="field compact tool-row__field">
+                    <span>Employer</span>
+                    <Input
+                      value={search.employer}
+                      placeholder="Filter by employer"
+                      onChange={(event) => setSearch({ employer: event.target.value })}
+                    />
+                  </label>
+                  <label className="field compact tool-row__field">
+                    <span>Job</span>
+                    <Input
+                      value={search.jobId}
+                      placeholder="Filter by job id"
+                      onChange={(event) => setSearch({ jobId: event.target.value })}
+                    />
+                  </label>
+                </>
+              }
+              secondary={
+                <>
+                  <ContactCreateButton />
+                  <ContactImportButton />
+                </>
+              }
+            />
+            <OutreachTable
+              data={data ?? null}
+              loading={isFetching}
+              onOpenContact={(contactId) =>
+                void navigate({
+                  to: "/outreach/$contactId",
+                  params: { contactId },
+                  search: (prev: OutreachSearch) => prev,
+                })
+              }
+            />
+          </section>
+        </>
+      ) : null}
       <Outlet />
     </div>
   );

--- a/apps/web/src/views/runs/RunsView.test.tsx
+++ b/apps/web/src/views/runs/RunsView.test.tsx
@@ -15,7 +15,10 @@ import { server } from "../../test/msw/server.js";
 import { buildProviderHarness } from "../../test/render.js";
 import { RunsView } from "./RunsView.js";
 
-function buildRouter(harness: ReturnType<typeof buildProviderHarness>) {
+function buildRouter(
+  harness: ReturnType<typeof buildProviderHarness>,
+  initialEntries: readonly string[] = ["/runs"],
+) {
   const rootRoute = createRootRoute({ component: () => <Outlet /> });
   const runsRoute = createRoute({
     getParentRoute: () => rootRoute,
@@ -26,11 +29,11 @@ function buildRouter(harness: ReturnType<typeof buildProviderHarness>) {
   const detailRoute = createRoute({
     getParentRoute: () => runsRoute,
     path: "/$runId",
-    component: () => null,
+    component: () => <h1>Workflow run detail route</h1>,
   });
   const router = createRouter({
     routeTree: rootRoute.addChildren([runsRoute.addChildren([detailRoute])]),
-    history: createMemoryHistory({ initialEntries: ["/runs"] }),
+    history: createMemoryHistory({ initialEntries: [...initialEntries] }),
   });
   return { router, queryClient: harness.queryClient, Wrapper: harness.Wrapper };
 }
@@ -90,5 +93,24 @@ describe("<RunsView>", () => {
     await waitFor(() =>
       expect(screen.getByText(/JobCtrl API request failed: 500/i)).toBeInTheDocument(),
     );
+  });
+
+  it("hides the parent list while a route-level run workspace is open", async () => {
+    const harness = buildProviderHarness();
+    const { router, Wrapper } = buildRouter(harness, [
+      "/runs/run-pipeline-1?status=failed&page=2",
+    ]);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    expect(
+      await screen.findByRole("heading", {
+        level: 1,
+        name: "Workflow run detail route",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Workflow runs" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Runs table")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -2,7 +2,12 @@ import {
   WORKFLOW_RUN_SORT_FIELDS,
   type WorkflowRunSortField,
 } from "@jobctrl/contracts";
-import { Outlet, useNavigate, useSearch } from "@tanstack/react-router";
+import {
+  Outlet,
+  useNavigate,
+  useRouterState,
+  useSearch,
+} from "@tanstack/react-router";
 import type { SortingState } from "@tanstack/react-table";
 import { useMemo } from "react";
 
@@ -38,6 +43,10 @@ function isWorkflowRunSortField(value: string): value is WorkflowRunSortField {
 export function RunsView() {
   const search = useSearch({ from: "/runs" });
   const navigate = useNavigate({ from: "/runs" });
+  const showingDetail = useRouterState({
+    select: (state) =>
+      state.location.pathname !== "/runs" && state.location.pathname !== "/runs/",
+  });
   const { data, isFetching, error } = useWorkflowRunsListQuery(
     workflowRunsInput(search),
   );
@@ -66,34 +75,42 @@ export function RunsView() {
   // there. The table's `onRowActivate` already supplies the workflow id
   // (which equals `runId` for apply runs).
   const openRun = (workflowId: string) => {
-    void navigate({ to: "/runs/$runId", params: { runId: workflowId } });
+    void navigate({
+      to: "/runs/$runId",
+      params: { runId: workflowId },
+      search: (prev: RunsSearch) => prev,
+    });
   };
 
   return (
     <div className="route-page route-page--runs">
-      <PageHead
-        eyebrow="Activity"
-        title="Workflow runs"
-        subtitle={data ? `${data.pagination.total} total` : "loading"}
-      />
-      <section className="card full data-surface">
-        {message ? <div className="banner inline">{message}</div> : null}
-        <RunsFilterBar
-          status={search.status}
-          onStatusChange={(status) => setSearch({ status, page: 1 })}
-        />
-        <RunsTable
-          data={data ?? null}
-          loading={isFetching}
-          sorting={sorting}
-          onSortingChange={handleSortingChange}
-          page={search.page}
-          pageSize={search.pageSize}
-          onPageChange={(page) => setSearch({ page })}
-          onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
-          onOpenRun={openRun}
-        />
-      </section>
+      {!showingDetail ? (
+        <>
+          <PageHead
+            eyebrow="Activity"
+            title="Workflow runs"
+            subtitle={data ? `${data.pagination.total} total` : "loading"}
+          />
+          <section className="card full data-surface">
+            {message ? <div className="banner inline">{message}</div> : null}
+            <RunsFilterBar
+              status={search.status}
+              onStatusChange={(status) => setSearch({ status, page: 1 })}
+            />
+            <RunsTable
+              data={data ?? null}
+              loading={isFetching}
+              sorting={sorting}
+              onSortingChange={handleSortingChange}
+              page={search.page}
+              pageSize={search.pageSize}
+              onPageChange={(page) => setSearch({ page })}
+              onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
+              onOpenRun={openRun}
+            />
+          </section>
+        </>
+      ) : null}
       <Outlet />
     </div>
   );

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -1,0 +1,68 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from "@tanstack/react-router";
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { runsSearchSchema } from "../../routes/-runs.search.js";
+import { buildProviderHarness } from "../../test/render.js";
+import { WorkflowRunDrawer } from "./WorkflowRunDrawer.js";
+
+function buildRouter() {
+  const rootRoute = createRootRoute({ component: () => <Outlet /> });
+  const runsRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/runs",
+    validateSearch: runsSearchSchema,
+    component: () => <Outlet />,
+  });
+  const detailRoute = createRoute({
+    getParentRoute: () => runsRoute,
+    path: "/$runId",
+    component: () => <WorkflowRunDrawer runId="run-pipeline-1" />,
+  });
+
+  return createRouter({
+    routeTree: rootRoute.addChildren([runsRoute.addChildren([detailRoute])]),
+    history: createMemoryHistory({
+      initialEntries: ["/runs/run-pipeline-1?status=failed&page=2"],
+    }),
+  });
+}
+
+describe("<WorkflowRunDrawer>", () => {
+  it("renders the run as a route workspace without dropping detail or failure facts", async () => {
+    const harness = buildProviderHarness();
+    const router = buildRouter();
+    render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
+
+    const workspace = await screen.findByRole("article", {
+      name: "Workflow run details",
+    });
+
+    expect(
+      within(workspace).getByRole("heading", {
+        level: 1,
+        name: "JobPipelineWorkflow",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(workspace)
+        .getByRole("link", { name: "Back to workflow runs" })
+        .getAttribute("href"),
+    ).toContain("status=failed");
+    expect(within(workspace).getAllByText("failed").length).toBeGreaterThan(0);
+    expect(within(workspace).getByText("run-pipeline-1")).toBeInTheDocument();
+    expect(within(workspace).getByText("temporal-run-1")).toBeInTheDocument();
+    expect(within(workspace).getByText("activity_error")).toBeInTheDocument();
+    expect(within(workspace).getByText("yes")).toBeInTheDocument();
+    expect(within(workspace).getByText("WorkflowStarted")).toBeInTheDocument();
+    expect(within(workspace).getByText("WorkflowFailed")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -1,12 +1,12 @@
-import { useNavigate } from "@tanstack/react-router";
-import { useCallback } from "react";
+import { IconArrowLeft } from "@tabler/icons-react";
+import { Link } from "@tanstack/react-router";
 
 import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
 import { useWorkflowRunDetailQuery } from "../../contexts/operations/hooks/useWorkflowRunDetailQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
 
 export interface WorkflowRunDrawerProps {
@@ -14,130 +14,134 @@ export interface WorkflowRunDrawerProps {
 }
 
 /**
- * Detail drawer for the unified Workflow Runs view — renders any workflow
+ * Route workspace for the unified Workflow Runs view — renders any workflow
  * type from `GET /v1/workflow-runs/:runId`, including non-apply runs. The
  * folded lifecycle timeline gives a durable, at-a-glance record of the
  * start marker and terminal event (Temporal loop closure, P0).
  */
 export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
-  const navigate = useNavigate();
-  const close = useCallback(() => {
-    void navigate({ to: "/runs" });
-  }, [navigate]);
-  useEscapeKey(true, close);
-
   const { data: run, isLoading, error } = useWorkflowRunDetailQuery(runId);
   const message = error instanceof Error ? error.message : null;
   const notFound = !isLoading && !message && !run;
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Workflow run details"
-      >
-        <button
-          aria-label="Close workflow run details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          x
-        </button>
-        {message ? <Empty title={message} /> : null}
-        {!message && isLoading ? <Empty title="Loading workflow run." /> : null}
-        {notFound ? <Empty title="Workflow run not found." /> : null}
-        {run ? (
-          <>
-            <div className="drawer-head">
+    <div
+      className="route-page route-page--workflow-run-detail"
+      aria-label="Workflow run details"
+    >
+      {message ? <Empty title={message} /> : null}
+      {!message && isLoading ? <Empty title="Loading workflow run." /> : null}
+      {notFound ? <Empty title="Workflow run not found." /> : null}
+      {run ? (
+        <RouteWorkspace
+          aria-label="Workflow run details"
+          className="workflow-run-workspace"
+          contentLabel="Workflow run timeline"
+          inspectorLabel="Workflow run facts and failure details"
+          header={
+            <div className="workflow-run-workspace__header">
+              <Button asChild className="workspace-back" size="sm" variant="ghost">
+                <Link aria-label="Back to workflow runs" search={(prev) => prev} to="/runs">
+                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                  Runs
+                </Link>
+              </Button>
               <RunStatusBadge status={run.status} />
-              <span>
+              <div className="workflow-run-workspace__title">
                 <small>{run.workflowType || "workflow"}</small>
-                <h2>{run.title || run.workflowType || "Workflow run"}</h2>
+                <h1>{run.title || run.workflowType || "Workflow run"}</h1>
                 <p>
                   {run.status}
                   {run.dryRun ? " · dry-run" : ""}
                 </p>
-              </span>
+              </div>
             </div>
-            <Section title="Run details">
-              <dl className="detail-list">
-                <div>
-                  <dt>Workflow id</dt>
-                  <dd className="mono">{run.workflowId}</dd>
-                </div>
-                <div>
-                  <dt>Type</dt>
-                  <dd>{run.workflowType || "-"}</dd>
-                </div>
-                <div>
-                  <dt>Status</dt>
-                  <dd>{run.status}</dd>
-                </div>
-                {run.jobKey ? (
-                  <div>
-                    <dt>Job</dt>
-                    <dd>{run.title || run.jobKey}</dd>
-                  </div>
-                ) : null}
-                <div>
-                  <dt>Started</dt>
-                  <dd>{formatDateTime(run.startedAt)}</dd>
-                </div>
-                <div>
-                  <dt>Finished</dt>
-                  <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : "-"}</dd>
-                </div>
-                {run.temporalRunId ? (
-                  <div>
-                    <dt>Temporal run id</dt>
-                    <dd className="mono">{run.temporalRunId}</dd>
-                  </div>
-                ) : null}
-              </dl>
-            </Section>
-            {run.errorMessage || run.errorCode ? (
-              <Section title="Failure">
+          }
+          inspector={
+            <div className="workflow-run-workspace__inspector">
+              <Section title="Run details">
                 <dl className="detail-list">
-                  {run.errorCode ? (
+                  <div>
+                    <dt>Workflow id</dt>
+                    <dd className="mono">{run.workflowId}</dd>
+                  </div>
+                  <div>
+                    <dt>Type</dt>
+                    <dd>{run.workflowType || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{run.status}</dd>
+                  </div>
+                  {run.jobKey ? (
                     <div>
-                      <dt>Error code</dt>
-                      <dd className="mono">{run.errorCode}</dd>
-                    </div>
-                  ) : null}
-                  {run.errorMessage ? (
-                    <div>
-                      <dt>Message</dt>
-                      <dd>{run.errorMessage}</dd>
+                      <dt>Job</dt>
+                      <dd>{run.title || run.jobKey}</dd>
                     </div>
                   ) : null}
                   <div>
-                    <dt>Retryable</dt>
-                    <dd>{run.retryable ? "yes" : "no"}</dd>
+                    <dt>Started</dt>
+                    <dd>{formatDateTime(run.startedAt)}</dd>
                   </div>
+                  <div>
+                    <dt>Finished</dt>
+                    <dd>
+                      {run.finishedAt ? formatDateTime(run.finishedAt) : "-"}
+                    </dd>
+                  </div>
+                  {run.temporalRunId ? (
+                    <div>
+                      <dt>Temporal run id</dt>
+                      <dd className="mono">{run.temporalRunId}</dd>
+                    </div>
+                  ) : null}
                 </dl>
               </Section>
-            ) : null}
-            <Section title="Timeline">
-              {run.events.length === 0 ? (
-                <Empty title="No lifecycle events recorded yet." />
-              ) : (
-                <ol className="timeline">
-                  {run.events.map((event, index) => (
-                    <li key={`${event.eventType}-${index}`}>
-                      <span className="mono">{event.eventType}</span>
-                      <span className="muted"> {formatDateTime(event.occurredAt)}</span>
-                      {event.message ? <p>{event.message}</p> : null}
-                    </li>
-                  ))}
-                </ol>
-              )}
-            </Section>
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+              {run.errorMessage || run.errorCode ? (
+                <Section title="Failure">
+                  <dl className="detail-list">
+                    {run.errorCode ? (
+                      <div>
+                        <dt>Error code</dt>
+                        <dd className="mono">{run.errorCode}</dd>
+                      </div>
+                    ) : null}
+                    {run.errorMessage ? (
+                      <div>
+                        <dt>Message</dt>
+                        <dd>{run.errorMessage}</dd>
+                      </div>
+                    ) : null}
+                    <div>
+                      <dt>Retryable</dt>
+                      <dd>{run.retryable ? "yes" : "no"}</dd>
+                    </div>
+                  </dl>
+                </Section>
+              ) : null}
+            </div>
+          }
+        >
+          <Section className="workflow-run-workspace__timeline" title="Timeline">
+            {run.events.length === 0 ? (
+              <Empty title="No lifecycle events recorded yet." />
+            ) : (
+              <ol className="timeline">
+                {run.events.map((event, index) => (
+                  <li key={`${event.eventType}-${index}`}>
+                    <span className="mono">{event.eventType}</span>
+                    <span className="muted">
+                      {" "}
+                      {formatDateTime(event.occurredAt)}
+                    </span>
+                    {event.message ? <p>{event.message}</p> : null}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </Section>
+        </RouteWorkspace>
+      ) : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- replace oversized detail overlays with route-level workspaces for jobs, artifacts, contacts, workflow runs, job run timelines, and activity events
- recompose Evidence Map and Apply Review as explicit navigation, working-content, and audit-inspector regions
- preserve existing controls, evidence, provenance, timelines, comparison, materials, review decisions, and URL state while standardizing responsive layout and navigation
- add focused regression coverage for the route-workspace contract and parent-list hiding behavior

## Why

The previous detail surfaces behaved like disconnected oversized modals, mixed dense audit data with primary tasks, and left inconsistent spacing and navigation across routes. The redesigned workspaces make the active task and its supporting evidence legible without dropping any of the original application data.

## Stack

- depends on #443
- plan: #440
- foundation: #442

## Validation

- `git diff --check` passed
- unit, type, build, browser, accessibility, and product-path QA are intentionally deferred until the complete redesign and final documentation layer are integrated, per the stack delivery sequence

## Documentation

Product documentation and screenshots are intentionally deferred to the final integration PR so they describe the complete redesign once.