### PR TITLE
feat(web): redesign setup and document workspaces

### DIFF
--- a/apps/web/src/contexts/apply/components/ApplyRuntimeSettingsPanel.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyRuntimeSettingsPanel.tsx
@@ -2,9 +2,17 @@ import { SettingsUpdateRequestSchema } from "@jobctrl/contracts";
 import { useForm } from "@tanstack/react-form";
 import { useEffect, useState } from "react";
 
-import { useSettingsPolicyQuery } from "../../operations/hooks/useSettingsPolicyQueries.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
+import { useSettingsPolicyQuery } from "../../operations/hooks/useSettingsPolicyQueries.js";
 import { useUpdateApplyRuntimeSettingsMutation } from "../hooks/useUpdateApplyRuntimeSettingsMutation.js";
 
 export function ApplyRuntimeSettingsPanel() {
@@ -17,34 +25,124 @@ export function ApplyRuntimeSettingsPanel() {
       applyMaxBudgetUsd: response?.settings.applyMaxBudgetUsd ?? 5,
       applyTimeoutSeconds: response?.settings.applyTimeoutSeconds ?? 900,
     },
-    validators: { onSubmit: ({ value }) => SettingsUpdateRequestSchema.safeParse(value).success ? undefined : "Invalid Apply runtime settings" },
+    validators: {
+      onSubmit: ({ value }) =>
+        SettingsUpdateRequestSchema.safeParse(value).success
+          ? undefined
+          : "Invalid Apply runtime settings",
+    },
     onSubmit: async ({ value, formApi }) => {
       if (!response) return;
       const request = {
-        ...(response.effectiveSettings.applyMaxBudgetUsd.editable ? { applyMaxBudgetUsd: value.applyMaxBudgetUsd } : {}),
-        ...(response.effectiveSettings.applyTimeoutSeconds.editable ? { applyTimeoutSeconds: value.applyTimeoutSeconds } : {}),
+        ...(response.effectiveSettings.applyMaxBudgetUsd.editable
+          ? { applyMaxBudgetUsd: value.applyMaxBudgetUsd }
+          : {}),
+        ...(response.effectiveSettings.applyTimeoutSeconds.editable
+          ? { applyTimeoutSeconds: value.applyTimeoutSeconds }
+          : {}),
       };
       const saved = await updateSettings.mutateAsync(request);
-      formApi.reset({ applyMaxBudgetUsd: saved.settings.applyMaxBudgetUsd, applyTimeoutSeconds: saved.settings.applyTimeoutSeconds });
+      formApi.reset({
+        applyMaxBudgetUsd: saved.settings.applyMaxBudgetUsd,
+        applyTimeoutSeconds: saved.settings.applyTimeoutSeconds,
+      });
       setStatus("Apply runtime settings saved for newly started application jobs.");
     },
   });
+
   useEffect(() => {
-    if (response && !form.state.isDirty) form.reset({ applyMaxBudgetUsd: response.settings.applyMaxBudgetUsd, applyTimeoutSeconds: response.settings.applyTimeoutSeconds });
+    if (response && !form.state.isDirty) {
+      form.reset({
+        applyMaxBudgetUsd: response.settings.applyMaxBudgetUsd,
+        applyTimeoutSeconds: response.settings.applyTimeoutSeconds,
+      });
+    }
   }, [form, response]);
-  if (!response) return <section className="card full"><CardHeader title="Application runtime" meta="apply" /><Empty title="Loading Apply runtime settings." /></section>;
-  const budget = response.effectiveSettings.applyMaxBudgetUsd;
-  const timeout = response.effectiveSettings.applyTimeoutSeconds;
+
+  const budget = response?.effectiveSettings.applyMaxBudgetUsd;
+  const timeout = response?.effectiveSettings.applyTimeoutSeconds;
+
   return (
-    <section className="card full">
-      <CardHeader title="Application runtime" meta="apply" />
-      <form className="config-form" onSubmit={(event) => { event.preventDefault(); void form.handleSubmit(); }}>
-        {status ? <div className="status-line" role="status">{status}</div> : null}
-        <form.Field name="applyMaxBudgetUsd">{(field) => <div className="field"><label htmlFor="apply-max-budget">Maximum AI budget per application (USD)</label><input id="apply-max-budget" name="applyMaxBudgetUsd" type="number" min={0} step={0.01} readOnly={!budget.editable} aria-describedby="apply-max-budget-help" value={field.state.value} onChange={(event) => field.handleChange(Number(event.target.value))} /><small id="apply-max-budget-help">0 is a zero-dollar cap, not unlimited. {policyContext(budget.source)}</small></div>}</form.Field>
-        <form.Field name="applyTimeoutSeconds">{(field) => <div className="field"><label htmlFor="apply-timeout">Apply agent timeout (seconds)</label><input id="apply-timeout" name="applyTimeoutSeconds" type="number" min={60} max={3600} step={1} readOnly={!timeout.editable} aria-describedby="apply-timeout-help" value={field.state.value} onChange={(event) => field.handleChange(Number(event.target.value))} /><small id="apply-timeout-help">Per application agent; separate from Temporal activity timeouts. {policyContext(timeout.source)}</small></div>}</form.Field>
-        <button className="tab on" type="submit" disabled={updateSettings.isPending || (!budget.editable && !timeout.editable)}>{updateSettings.isPending ? "saving" : "save Apply runtime"}</button>
-      </form>
-    </section>
+    <DisclosureSection
+      className="apply-runtime-settings"
+      title="Application runtime"
+      description="Per-application AI budget and agent timeout"
+      collapsedSummary="Limits for newly started application jobs"
+    >
+      {!response || !budget || !timeout ? (
+        <Empty title="Loading Apply runtime settings." />
+      ) : (
+        <form
+          className="apply-runtime-settings-form grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void form.handleSubmit();
+          }}
+        >
+          {status ? <div className="status-line" role="status">{status}</div> : null}
+          <AdaptiveFieldGrid columns={2} minColumnWidth={260} density="compact">
+            <form.Field name="applyMaxBudgetUsd">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="apply-max-budget">
+                    Maximum AI budget per application (USD)
+                  </FieldLabel>
+                  <Input
+                    id="apply-max-budget"
+                    name="applyMaxBudgetUsd"
+                    type="number"
+                    min={0}
+                    step={0.01}
+                    readOnly={!budget.editable}
+                    aria-readonly={!budget.editable || undefined}
+                    aria-describedby="apply-max-budget-help"
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(Number(event.target.value))}
+                  />
+                  <FieldDescription id="apply-max-budget-help">
+                    0 is a zero-dollar cap, not unlimited. {policyContext(budget.source)}
+                  </FieldDescription>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="applyTimeoutSeconds">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="apply-timeout">
+                    Apply agent timeout (seconds)
+                  </FieldLabel>
+                  <Input
+                    id="apply-timeout"
+                    name="applyTimeoutSeconds"
+                    type="number"
+                    min={60}
+                    max={3600}
+                    step={1}
+                    readOnly={!timeout.editable}
+                    aria-readonly={!timeout.editable || undefined}
+                    aria-describedby="apply-timeout-help"
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(Number(event.target.value))}
+                  />
+                  <FieldDescription id="apply-timeout-help">
+                    Per application agent; separate from Temporal activity timeouts.{" "}
+                    {policyContext(timeout.source)}
+                  </FieldDescription>
+                </Field>
+              )}
+            </form.Field>
+          </AdaptiveFieldGrid>
+          <div className="form-actions apply-runtime-settings-form__actions">
+            <Button
+              type="submit"
+              disabled={updateSettings.isPending || (!budget.editable && !timeout.editable)}
+            >
+              {updateSettings.isPending ? "Saving…" : "Save Apply runtime"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </DisclosureSection>
   );
 }
 

--- a/apps/web/src/contexts/materials/components/AiExecutionPolicyPanel.tsx
+++ b/apps/web/src/contexts/materials/components/AiExecutionPolicyPanel.tsx
@@ -1,14 +1,32 @@
-import { SettingsUpdateRequestSchema, type ProviderId } from "@jobctrl/contracts";
+import {
+  SettingsUpdateRequestSchema,
+  type ProviderId,
+  type SettingsResponse,
+} from "@jobctrl/contracts";
 import { useForm } from "@tanstack/react-form";
 import { useEffect, useMemo, useState } from "react";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { ChoiceControl } from "../../../shared/ui/choice-control.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
+import { SelectField } from "../../../shared/ui/select-field.js";
 import {
   useProviderModelCatalogQuery,
   useSettingsPolicyQuery,
 } from "../../operations/hooks/useSettingsPolicyQueries.js";
 import { useUpdateAiExecutionPolicyMutation } from "../hooks/useUpdateAiExecutionPolicyMutation.js";
+
+const DEFAULT_POLICY_OPTION = "__jobctrl_provider_default_policy__";
 
 const LEG_OPTIONS: Array<{ value: ProviderId; label: string }> = [
   { value: "claude", label: "Claude" },
@@ -16,15 +34,34 @@ const LEG_OPTIONS: Array<{ value: ProviderId; label: string }> = [
   { value: "google", label: "Google" },
 ];
 
+interface AiPolicyFormValues {
+  analysisLegs: ProviderId[];
+  generatorPrimary: string;
+  generatorFallback: string;
+  tailoringJudgeModel: string;
+  tailoringJudgeMinScore: number;
+}
+
 export function AiExecutionPolicyPanel() {
   const settingsQuery = useSettingsPolicyQuery();
   const catalogQuery = useProviderModelCatalogQuery();
   const updateSettings = useUpdateAiExecutionPolicyMutation();
   const [status, setStatus] = useState("");
   const response = settingsQuery.data;
-  const models = useMemo(() => (catalogQuery.data?.providers ?? []).flatMap((provider) =>
-    provider.ready ? provider.models.map((model) => ({ value: model.id.includes(":") ? model.id : `${provider.provider}:${model.id}`, label: `${provider.provider === "google" ? "Google" : provider.provider === "claude" ? "Claude" : "Codex"} — ${model.displayName}` })) : []
-  ), [catalogQuery.data]);
+  const models = useMemo(
+    () =>
+      (catalogQuery.data?.providers ?? []).flatMap((provider) =>
+        provider.ready
+          ? provider.models.map((model) => ({
+              value: model.id.includes(":")
+                ? model.id
+                : `${provider.provider}:${model.id}`,
+              label: `${providerName(provider.provider)} — ${model.displayName}`,
+            }))
+          : [],
+      ),
+    [catalogQuery.data],
+  );
   const generators = response?.settings.tailoringGeneratorModels ?? [];
   const form = useForm({
     defaultValues: {
@@ -34,17 +71,20 @@ export function AiExecutionPolicyPanel() {
       tailoringJudgeModel: response?.settings.tailoringJudgeModel ?? "",
       tailoringJudgeMinScore: response?.settings.tailoringJudgeMinScore ?? 0.82,
     },
+    validators: {
+      onSubmit: ({ value }) => {
+        if (!response) return "AI execution policy is unavailable.";
+        const parsed = SettingsUpdateRequestSchema.safeParse(toSettingsRequest(response, value));
+        return parsed.success
+          ? undefined
+          : (parsed.error.issues[0]?.message ?? "Invalid AI execution policy.");
+      },
+    },
     onSubmit: async ({ value, formApi }) => {
       if (!response) return;
-      const generatorModels = [value.generatorPrimary, value.generatorFallback].filter((model, index, all) => model && all.indexOf(model) === index);
-      const request = {
-        ...(response.effectiveSettings.analysisLegs.editable ? { analysisLegs: value.analysisLegs } : {}),
-        ...(response.effectiveSettings.tailoringGeneratorModels.editable ? { tailoringGeneratorModels: generatorModels.length ? generatorModels : null } : {}),
-        ...(response.effectiveSettings.tailoringJudgeModel.editable ? { tailoringJudgeModel: value.tailoringJudgeModel || null } : {}),
-        ...(response.effectiveSettings.tailoringJudgeMinScore.editable ? { tailoringJudgeMinScore: value.tailoringJudgeMinScore } : {}),
-      };
-      const parsed = SettingsUpdateRequestSchema.safeParse(request);
+      const parsed = SettingsUpdateRequestSchema.safeParse(toSettingsRequest(response, value));
       if (!parsed.success) return;
+      setStatus("");
       const saved = await updateSettings.mutateAsync(parsed.data);
       const savedGenerators = saved.settings.tailoringGeneratorModels ?? [];
       formApi.reset({
@@ -57,33 +97,305 @@ export function AiExecutionPolicyPanel() {
       setStatus("AI execution policy saved for newly started work.");
     },
   });
+
   useEffect(() => {
     if (!response || form.state.isDirty) return;
     const savedGenerators = response.settings.tailoringGeneratorModels ?? [];
-    form.reset({ analysisLegs: response.settings.analysisLegs, generatorPrimary: savedGenerators[0] ?? "", generatorFallback: savedGenerators[1] ?? "", tailoringJudgeModel: response.settings.tailoringJudgeModel ?? "", tailoringJudgeMinScore: response.settings.tailoringJudgeMinScore });
+    form.reset({
+      analysisLegs: response.settings.analysisLegs,
+      generatorPrimary: savedGenerators[0] ?? "",
+      generatorFallback: savedGenerators[1] ?? "",
+      tailoringJudgeModel: response.settings.tailoringJudgeModel ?? "",
+      tailoringJudgeMinScore: response.settings.tailoringJudgeMinScore,
+    });
   }, [form, response]);
-  if (!response) return <section className="card full"><CardHeader title="AI execution policy" meta="materials" /><Empty title="Loading AI execution policy." /></section>;
-  const effective = response.effectiveSettings;
+
+  const effective = response?.effectiveSettings;
+  const editableFieldCount = effective
+    ? [
+        effective.analysisLegs,
+        effective.tailoringGeneratorModels,
+        effective.tailoringJudgeModel,
+        effective.tailoringJudgeMinScore,
+      ].filter((field) => field.editable).length
+    : 0;
+  const editStatus =
+    editableFieldCount === 4
+      ? "Editable"
+      : editableFieldCount === 0
+        ? "Read only"
+        : "Partially editable";
+  const collapsedSummary = settingsQuery.error
+    ? "Policy unavailable"
+    : response
+      ? `${editStatus} · Primary generator: ${generators[0] ?? "Provider/default policy"}`
+      : "Loading policy and saved choices";
+
   return (
-    <section className="card full">
-      <CardHeader title="AI execution policy" meta="materials" />
-      <form className="config-form" onSubmit={(event) => { event.preventDefault(); void form.handleSubmit(); }}>
-        {status ? <div className="status-line" role="status">{status}</div> : null}
-        <form.Field name="analysisLegs">{(field) => <fieldset className="field wide checkbox-group-field" aria-describedby="analysis-legs-help"><legend>Employer analysis perspectives</legend><div className="checkbox-options">{LEG_OPTIONS.map((option) => <label className="choice target-choice" key={option.value}><input name="analysisLegs" type="checkbox" disabled={!effective.analysisLegs.editable} checked={field.state.value.includes(option.value)} onChange={(event) => { const next = event.target.checked ? [...field.state.value, option.value] : field.state.value.filter((leg) => leg !== option.value); if (next.length) field.handleChange(next); }} /><span>{option.label}</span></label>)}</div><small id="analysis-legs-help">{context(effective.analysisLegs.source, "next analysis")}</small></fieldset>}</form.Field>
-        <form.Field name="generatorPrimary">{(field) => <ModelSelectControl name="generatorPrimary" label="Primary tailoring generator" models={models} value={field.state.value} readOnly={!effective.tailoringGeneratorModels.editable} help={context(effective.tailoringGeneratorModels.source, "next tailoring workflow")} onChange={field.handleChange} />}</form.Field>
-        <form.Field name="generatorFallback">{(field) => <ModelSelectControl name="generatorFallback" label="Fallback tailoring generator" models={models} value={field.state.value} readOnly={!effective.tailoringGeneratorModels.editable} help="Optional second choice; used after the primary." onChange={field.handleChange} />}</form.Field>
-        <form.Field name="tailoringJudgeModel">{(field) => <ModelSelectControl name="tailoringJudgeModel" label="Tailoring judge" models={models} value={field.state.value} readOnly={!effective.tailoringJudgeModel.editable} help={context(effective.tailoringJudgeModel.source, "next tailoring workflow")} onChange={field.handleChange} />}</form.Field>
-        <form.Field name="tailoringJudgeMinScore">{(field) => <div className="field"><label htmlFor="tailoring-judge-score">Minimum judge score</label><input id="tailoring-judge-score" name="tailoringJudgeMinScore" type="number" min={0} max={1} step={0.01} readOnly={!effective.tailoringJudgeMinScore.editable} aria-describedby="tailoring-judge-score-help" value={field.state.value} onChange={(event) => field.handleChange(Number(event.target.value))} /><small id="tailoring-judge-score-help">{context(effective.tailoringJudgeMinScore.source, "next tailoring workflow")}</small></div>}</form.Field>
-        <button className="tab on" type="submit" disabled={updateSettings.isPending || (!effective.analysisLegs.editable && !effective.tailoringGeneratorModels.editable && !effective.tailoringJudgeModel.editable && !effective.tailoringJudgeMinScore.editable)}>{updateSettings.isPending ? "saving" : "save AI policy"}</button>
-      </form>
-    </section>
+    <DisclosureSection
+      className="ai-execution-policy-settings"
+      title="AI execution policy"
+      description="Analysis perspectives, tailoring generators, and judge policy"
+      collapsedSummary={collapsedSummary}
+    >
+      <div className="ai-execution-policy-settings__content grid gap-4">
+        {settingsQuery.error ? (
+          <p className="m-0 text-[12px] leading-5 text-destructive" role="alert">
+            {settingsQuery.error.message}
+          </p>
+        ) : null}
+        {!response || !effective ? (
+          <Empty
+            title={
+              settingsQuery.error
+                ? "AI execution policy is unavailable."
+                : "Loading AI execution policy."
+            }
+          />
+        ) : (
+          <form
+            className="ai-execution-policy-form grid gap-5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void form.handleSubmit();
+            }}
+          >
+            <div className="ai-execution-policy-status grid gap-2">
+              <p className="m-0 text-[12px] leading-5 text-muted-foreground">
+                Configuration status: {editStatus}.
+              </p>
+              {status ? (
+                <p className="m-0 text-[12px] leading-5 text-muted-foreground" role="status">
+                  {status}
+                </p>
+              ) : null}
+              {catalogQuery.error ? (
+                <div className="ai-policy-catalog-error flex flex-wrap items-center justify-between gap-3">
+                  <p className="m-0 text-[12px] leading-5 text-destructive" role="alert">
+                    Available model choices could not be loaded. Saved choices remain visible.
+                  </p>
+                  <Button
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                    onClick={() => void catalogQuery.refetch()}
+                  >
+                    Retry catalog
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+
+            <form.Field name="analysisLegs">
+              {(field) => (
+                <FieldSet
+                  className="ai-execution-policy-analysis gap-2"
+                  aria-describedby="analysis-legs-help"
+                >
+                  <FieldLegend>Employer analysis perspectives</FieldLegend>
+                  <div className="ai-execution-policy-analysis__choices">
+                    {LEG_OPTIONS.map((option) => (
+                      <ChoiceControl
+                        key={option.value}
+                        id={`analysis-leg-${option.value}`}
+                        name="analysisLegs"
+                        label={option.label}
+                        disabled={!effective.analysisLegs.editable}
+                        checked={field.state.value.includes(option.value)}
+                        onCheckedChange={(checked) => {
+                          const next = checked === true
+                            ? [...field.state.value, option.value]
+                            : field.state.value.filter((leg) => leg !== option.value);
+                          if (next.length) field.handleChange(next);
+                        }}
+                      />
+                    ))}
+                  </div>
+                  <FieldDescription id="analysis-legs-help">
+                    {context(effective.analysisLegs.source, "next analysis")}
+                  </FieldDescription>
+                </FieldSet>
+              )}
+            </form.Field>
+
+            <AdaptiveFieldGrid columns={2} minColumnWidth={300} density="compact">
+              <form.Field name="generatorPrimary">
+                {(field) => (
+                  <ModelSelectControl
+                    name="generatorPrimary"
+                    label="Primary tailoring generator"
+                    models={models}
+                    value={field.state.value}
+                    readOnly={!effective.tailoringGeneratorModels.editable}
+                    help={context(
+                      effective.tailoringGeneratorModels.source,
+                      "next tailoring workflow",
+                    )}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.Field>
+              <form.Field name="generatorFallback">
+                {(field) => (
+                  <ModelSelectControl
+                    name="generatorFallback"
+                    label="Fallback tailoring generator"
+                    models={models}
+                    value={field.state.value}
+                    readOnly={!effective.tailoringGeneratorModels.editable}
+                    help={`Optional second choice; used after the primary. ${context(
+                      effective.tailoringGeneratorModels.source,
+                      "next tailoring workflow",
+                    )}`}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.Field>
+              <form.Field name="tailoringJudgeModel">
+                {(field) => (
+                  <ModelSelectControl
+                    name="tailoringJudgeModel"
+                    label="Tailoring judge"
+                    models={models}
+                    value={field.state.value}
+                    readOnly={!effective.tailoringJudgeModel.editable}
+                    help={context(
+                      effective.tailoringJudgeModel.source,
+                      "next tailoring workflow",
+                    )}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.Field>
+              <form.Field name="tailoringJudgeMinScore">
+                {(field) => (
+                  <Field data-disabled={!effective.tailoringJudgeMinScore.editable || undefined}>
+                    <FieldLabel htmlFor="tailoring-judge-score">Minimum judge score</FieldLabel>
+                    <Input
+                      id="tailoring-judge-score"
+                      name="tailoringJudgeMinScore"
+                      type="number"
+                      min={0}
+                      max={1}
+                      step={0.01}
+                      readOnly={!effective.tailoringJudgeMinScore.editable}
+                      aria-readonly={!effective.tailoringJudgeMinScore.editable || undefined}
+                      aria-describedby="tailoring-judge-score-help"
+                      value={field.state.value}
+                      onChange={(event) => field.handleChange(Number(event.target.value))}
+                    />
+                    <FieldDescription id="tailoring-judge-score-help">
+                      {context(
+                        effective.tailoringJudgeMinScore.source,
+                        "next tailoring workflow",
+                      )}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+            </AdaptiveFieldGrid>
+
+            <form.Subscribe selector={(state) => state.errors}>
+              {(errors) => {
+                const message = errors
+                  .flat()
+                  .filter((entry): entry is string => typeof entry === "string")
+                  .at(0);
+                return message ? (
+                  <p className="m-0 text-[12px] leading-5 text-destructive" role="alert">
+                    {message}
+                  </p>
+                ) : null;
+              }}
+            </form.Subscribe>
+            {updateSettings.error ? (
+              <p className="m-0 text-[12px] leading-5 text-destructive" role="alert">
+                {updateSettings.error.message}
+              </p>
+            ) : null}
+
+            <div className="form-actions ai-execution-policy-form__actions">
+              <Button
+                type="submit"
+                disabled={updateSettings.isPending || editableFieldCount === 0}
+              >
+                {updateSettings.isPending ? "Saving…" : "Save AI policy"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </DisclosureSection>
   );
 }
 
-function ModelSelectControl({ name, label, models, value, readOnly, help, onChange }: { name: "generatorPrimary" | "generatorFallback" | "tailoringJudgeModel"; label: string; models: Array<{ value: string; label: string }>; value: string; readOnly: boolean; help: string; onChange: (value: string) => void }) {
-  const options = value && !models.some((model) => model.value === value) ? [{ value, label: `${value} — saved` }, ...models] : models;
-  const helpId = `ai-policy-${name}-help`;
-  return <div className="field"><label htmlFor={`ai-policy-${name}`}>{label}</label><select id={`ai-policy-${name}`} name={name} disabled={readOnly} aria-describedby={helpId} value={value} onChange={(event) => onChange(event.target.value)}><option value="">Provider/default policy</option>{options.map((model) => <option key={model.value} value={model.value}>{model.label}</option>)}</select><small id={helpId}>{help}</small></div>;
+function ModelSelectControl({
+  name,
+  label,
+  models,
+  value,
+  readOnly,
+  help,
+  onChange,
+}: {
+  name: "generatorPrimary" | "generatorFallback" | "tailoringJudgeModel";
+  label: string;
+  models: Array<{ value: string; label: string }>;
+  value: string;
+  readOnly: boolean;
+  help: string;
+  onChange: (value: string) => void;
+}) {
+  const options = [
+    { value: DEFAULT_POLICY_OPTION, label: "Provider/default policy" },
+    ...(value && !models.some((model) => model.value === value)
+      ? [{ value, label: `${value} — saved` }]
+      : []),
+    ...models,
+  ];
+
+  return (
+    <SelectField
+      id={`ai-policy-${name}`}
+      name={name}
+      className="ai-execution-policy-model-field"
+      label={label}
+      description={help}
+      disabled={readOnly}
+      options={options}
+      value={value || DEFAULT_POLICY_OPTION}
+      onValueChange={(nextValue) =>
+        onChange(nextValue === DEFAULT_POLICY_OPTION ? "" : nextValue)
+      }
+    />
+  );
+}
+
+function toSettingsRequest(
+  response: SettingsResponse,
+  value: AiPolicyFormValues,
+): unknown {
+  const generatorModels = [value.generatorPrimary, value.generatorFallback].filter(
+    (model, index, all) => model && all.indexOf(model) === index,
+  );
+  return {
+    ...(response.effectiveSettings.analysisLegs.editable
+      ? { analysisLegs: value.analysisLegs }
+      : {}),
+    ...(response.effectiveSettings.tailoringGeneratorModels.editable
+      ? { tailoringGeneratorModels: generatorModels.length ? generatorModels : null }
+      : {}),
+    ...(response.effectiveSettings.tailoringJudgeModel.editable
+      ? { tailoringJudgeModel: value.tailoringJudgeModel || null }
+      : {}),
+    ...(response.effectiveSettings.tailoringJudgeMinScore.editable
+      ? { tailoringJudgeMinScore: value.tailoringJudgeMinScore }
+      : {}),
+  };
+}
+
+function providerName(provider: ProviderId): string {
+  return provider === "google" ? "Google" : provider === "claude" ? "Claude" : "Codex";
 }
 
 function context(source: "persisted" | "default", activation: string): string {

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.a11y.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.a11y.test.tsx
@@ -1,14 +1,38 @@
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { describe, expect, it } from "vitest";
 
 import { renderWithProviders } from "../../../test/render.js";
 import { BrowserCapabilitiesPanel } from "./BrowserCapabilitiesPanel.js";
+import { ExtensionPairingPanel } from "./ExtensionPairingPanel.js";
 
 describe("Browser capabilities a11y", () => {
   it("has no axe violations", async () => {
+    const user = userEvent.setup();
     const view = renderWithProviders(<BrowserCapabilitiesPanel />);
-    await screen.findByText("Core managed browser");
+
+    await user.click(
+      await screen.findByRole("button", { name: /^Core managed browser/ }),
+    );
+    await user.click(screen.getByRole("button", { name: /^Auto-apply browser/ }));
+    await user.click(
+      screen.getByRole("button", { name: /^Authenticated LinkedIn browser/ }),
+    );
+
+    expect(await axe(view.container)).toHaveNoViolations();
+  });
+
+  it("keeps the extension token disclosure accessible", async () => {
+    const view = renderWithProviders(<ExtensionPairingPanel />);
+
+    expect(
+      screen.getByRole("region", { name: "Browser extension pairing controls" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Copy token" })).toBeEnabled(),
+    );
+
     expect(await axe(view.container)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.stories.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.stories.tsx
@@ -1,8 +1,94 @@
+import type { BrowserCapabilitiesResponse } from "@jobctrl/contracts";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
 
 import { BrowserCapabilitiesPanel } from "./BrowserCapabilitiesPanel.js";
+import { ExtensionPairingPanel } from "./ExtensionPairingPanel.js";
 
-const meta = { title: "Contexts/Operations/BrowserCapabilitiesPanel", component: BrowserCapabilitiesPanel } satisfies Meta<typeof BrowserCapabilitiesPanel>;
+const disabledCapabilities: BrowserCapabilitiesResponse = {
+  ok: true,
+  capabilities: [
+    {
+      id: "core-browser",
+      status: "ready",
+      detail: "Managed browser ready.",
+      mutable: false,
+      enabled: true,
+      profileCopyReady: false,
+    },
+    {
+      id: "auto-apply-browser",
+      status: "disabled",
+      detail: "Disabled; select an executable to adopt this capability.",
+      mutable: true,
+      enabled: false,
+      profileCopyReady: false,
+    },
+    {
+      id: "authenticated-linkedin-browser",
+      status: "disabled",
+      detail: "Disabled; authenticated profile access has not been adopted.",
+      mutable: true,
+      enabled: false,
+      profileCopyReady: false,
+    },
+  ],
+};
+
+const authenticatedProfileReady: BrowserCapabilitiesResponse = {
+  ...disabledCapabilities,
+  capabilities: disabledCapabilities.capabilities.map((capability) =>
+    capability.id === "authenticated-linkedin-browser"
+      ? {
+          ...capability,
+          status: "ready" as const,
+          detail: "Explicit LinkedIn browser ready; profile copy requires separate consent.",
+          enabled: true,
+        }
+      : capability,
+  ),
+};
+
+function browserCapabilitiesHandler(response: BrowserCapabilitiesResponse) {
+  return http.get("*/v1/browser-capabilities", () => HttpResponse.json(response));
+}
+
+const meta = {
+  title: "Contexts/Operations/BrowserCapabilitiesPanel",
+  component: BrowserCapabilitiesPanel,
+} satisfies Meta<typeof BrowserCapabilitiesPanel>;
+
 export default meta;
 type Story = StoryObj<typeof meta>;
-export const Default: Story = {};
+
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: [browserCapabilitiesHandler(disabledCapabilities)] },
+  },
+};
+
+export const AuthenticatedProfileReady: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        browserCapabilitiesHandler(authenticatedProfileReady),
+        http.post(
+          "*/v1/browser-capabilities/authenticated-linkedin-browser/profile-copy",
+          () => HttpResponse.json(authenticatedProfileReady),
+        ),
+      ],
+    },
+  },
+};
+
+export const BrowserSettings: Story = {
+  render: () => (
+    <div className="settings-browser-sections">
+      <BrowserCapabilitiesPanel />
+      <ExtensionPairingPanel />
+    </div>
+  ),
+  parameters: {
+    msw: { handlers: [browserCapabilitiesHandler(disabledCapabilities)] },
+  },
+};

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
@@ -1,16 +1,293 @@
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import type {
+  BrowserCapabilitiesResponse,
+  BrowserCapabilityId,
+  BrowserCapabilityItem,
+} from "@jobctrl/contracts";
+import { screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
+import { sampleExtensionCapabilityTokenResponse } from "../../../test/fixtures/projections.js";
 import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
 import { BrowserCapabilitiesPanel } from "./BrowserCapabilitiesPanel.js";
+import { ExtensionPairingPanel } from "./ExtensionPairingPanel.js";
+
+const disabledCapabilities: BrowserCapabilitiesResponse = {
+  ok: true,
+  capabilities: [
+    {
+      id: "core-browser",
+      status: "ready",
+      detail: "Managed browser ready.",
+      mutable: false,
+      enabled: true,
+      profileCopyReady: false,
+    },
+    {
+      id: "auto-apply-browser",
+      status: "disabled",
+      detail: "Disabled.",
+      mutable: true,
+      enabled: false,
+      profileCopyReady: false,
+    },
+    {
+      id: "authenticated-linkedin-browser",
+      status: "disabled",
+      detail: "Disabled.",
+      mutable: true,
+      enabled: false,
+      profileCopyReady: false,
+    },
+  ],
+};
+
+function updateCapability(
+  response: BrowserCapabilitiesResponse,
+  capabilityId: BrowserCapabilityId,
+  patch: Partial<BrowserCapabilityItem>,
+): BrowserCapabilitiesResponse {
+  return {
+    ...response,
+    capabilities: response.capabilities.map((capability) =>
+      capability.id === capabilityId ? { ...capability, ...patch } : capability,
+    ),
+  };
+}
 
 describe("<BrowserCapabilitiesPanel>", () => {
-  it("offers only explicit adoption and keeps the managed browser read-only", async () => {
-    renderWithProviders(<BrowserCapabilitiesPanel />);
+  it("keeps every capability, status, detail, and control reachable through disclosures", async () => {
+    const user = userEvent.setup();
+    const ports = buildTestPorts({
+      api: { browserCapabilities: vi.fn(async () => disabledCapabilities) },
+    });
 
-    expect(await screen.findByText("Core managed browser")).toBeInTheDocument();
+    renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
+
+    const panelTrigger = await screen.findByRole("button", { name: /^Browser capabilities/ });
+    expect(panelTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(panelTrigger).toHaveAccessibleName(/Explicit adoption/i);
     expect(screen.getByText(/never auto-detects or adopts Chrome/i)).toBeInTheDocument();
+
+    const coreTrigger = screen.getByRole("button", { name: /^Core managed browser/ });
+    const autoApplyTrigger = screen.getByRole("button", { name: /^Auto-apply browser/ });
+    const linkedInTrigger = screen.getByRole("button", {
+      name: /^Authenticated LinkedIn browser/,
+    });
+
+    expect(coreTrigger).toHaveAccessibleName(/Managed browser ready.*Status: ready/i);
+    expect(autoApplyTrigger).toHaveAccessibleName(/Disabled.*Status: disabled/i);
+    expect(linkedInTrigger).toHaveAccessibleName(/Disabled.*Status: disabled/i);
+    expect(coreTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(autoApplyTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(linkedInTrigger).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(coreTrigger);
+    expect(screen.getByText("Current status: ready")).toBeInTheDocument();
+    expect(screen.getByText("Managed by JobCtrl and read-only.")).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Enable selected browser" }),
+    ).not.toBeInTheDocument();
+    await user.click(autoApplyTrigger);
+    expect(
+      screen.getByRole("textbox", { name: "Chrome or Chromium executable path" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Enable selected browser" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Disable now" })).toBeDisabled();
     expect(screen.getAllByText(/status API does not echo local paths/i)).toHaveLength(2);
     expect(screen.queryByRole("button", { name: /download/i })).not.toBeInTheDocument();
+  });
+
+  it("enables and hot-disables an optional browser from the explicit executable path", async () => {
+    const user = userEvent.setup();
+    let current = disabledCapabilities;
+    const browserCapabilities = vi.fn(async () => current);
+    const enableBrowserCapability = vi.fn(
+      async (capabilityId: BrowserCapabilityId, _body: { executablePath: string }) => {
+        current = updateCapability(current, capabilityId, {
+          enabled: true,
+          status: "ready",
+          detail: "Explicit browser ready.",
+        });
+        return current;
+      },
+    );
+    const disableBrowserCapability = vi.fn(async (capabilityId: BrowserCapabilityId) => {
+      current = updateCapability(current, capabilityId, {
+        enabled: false,
+        status: "disabled",
+        detail: "Disabled; browser access is revoked.",
+      });
+      return current;
+    });
+    const ports = buildTestPorts({
+      api: {
+        browserCapabilities,
+        enableBrowserCapability,
+        disableBrowserCapability,
+      },
+    });
+
+    renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
+
+    await user.click(
+      await screen.findByRole("button", { name: /^Auto-apply browser/ }),
+    );
+    const executablePath = screen.getByRole("textbox", {
+      name: "Chrome or Chromium executable path",
+    });
+    await user.type(executablePath, "  /Applications/Chromium.app/Contents/MacOS/Chromium  ");
+    await user.click(screen.getByRole("button", { name: "Enable selected browser" }));
+
+    await waitFor(() =>
+      expect(enableBrowserCapability).toHaveBeenCalledWith("auto-apply-browser", {
+        executablePath: "/Applications/Chromium.app/Contents/MacOS/Chromium",
+      }),
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Auto-apply browser enabled from the explicitly selected executable.",
+    );
+    expect(executablePath).toHaveValue("");
+
+    const disableButton = screen.getByRole("button", { name: "Disable now" });
+    await waitFor(() => expect(disableButton).toBeEnabled());
+    await user.click(disableButton);
+
+    expect(disableBrowserCapability).toHaveBeenCalledWith("auto-apply-browser");
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Auto-apply browser disabled immediately.",
+      ),
+    );
+  });
+
+  it("requires a source path and separate consent before copying a LinkedIn profile", async () => {
+    const user = userEvent.setup();
+    let current = updateCapability(disabledCapabilities, "authenticated-linkedin-browser", {
+      enabled: true,
+      status: "ready",
+      detail: "Explicit LinkedIn browser ready.",
+    });
+    const copyLinkedInBrowserProfile = vi.fn(
+      async (_request: {
+        sourceProfilePath: string;
+        consent: true;
+        consentMethod: "explicit-ui-v1";
+      }) => {
+        current = updateCapability(current, "authenticated-linkedin-browser", {
+          profileCopyReady: true,
+          detail: "Copied profile ready.",
+        });
+        return current;
+      },
+    );
+    const ports = buildTestPorts({
+      api: {
+        browserCapabilities: vi.fn(async () => current),
+        copyLinkedInBrowserProfile,
+      },
+    });
+
+    renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
+
+    await user.click(
+      await screen.findByRole("button", { name: /^Authenticated LinkedIn browser/ }),
+    );
+    const sourcePath = screen.getByLabelText("Existing browser profile directory");
+    const consent = screen.getByRole("checkbox", {
+      name: "I explicitly consent to copy this profile into JobCtrl-owned storage.",
+    });
+    const copyButton = screen.getByRole("button", { name: "Copy selected profile" });
+
+    expect(sourcePath).toHaveAttribute("type", "password");
+    expect(copyButton).toBeDisabled();
+    await user.type(sourcePath, "  /Users/example/Library/Chrome/Profile 1  ");
+    expect(copyButton).toBeDisabled();
+    await user.click(consent);
+    expect(copyButton).toBeEnabled();
+    await user.click(copyButton);
+
+    await waitFor(() =>
+      expect(copyLinkedInBrowserProfile).toHaveBeenCalledWith({
+        sourceProfilePath: "/Users/example/Library/Chrome/Profile 1",
+        consent: true,
+        consentMethod: "explicit-ui-v1",
+      }),
+    );
+    await waitFor(() => {
+      expect(sourcePath).toHaveValue("");
+      expect(consent).not.toBeChecked();
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "The selected profile was copied into JobCtrl-owned storage.",
+    );
+  });
+});
+
+describe("<ExtensionPairingPanel>", () => {
+  it("preserves the visible pairing data and the copy then confirm-rotation flow", async () => {
+    const user = userEvent.setup();
+    const rotated = {
+      ...sampleExtensionCapabilityTokenResponse,
+      token: "jh_ext_rotated_token_123456789012345678901234567",
+      created: true,
+    };
+    let currentToken = sampleExtensionCapabilityTokenResponse;
+    const rotateExtensionCapabilityToken = vi.fn(async () => {
+      currentToken = rotated;
+      return rotated;
+    });
+    const ports = buildTestPorts({
+      api: {
+        extensionCapabilityToken: vi.fn(async () => currentToken),
+        rotateExtensionCapabilityToken,
+      },
+    });
+
+    renderWithProviders(<ExtensionPairingPanel />, { ports });
+
+    expect(
+      screen.getByRole("heading", { name: "Browser extension pairing", level: 2 }),
+    ).toBeInTheDocument();
+    const panelTrigger = screen.getByRole("button", { name: /^Browser extension pairing/ });
+    const pairingRegion = screen.getByRole("region", {
+      name: "Browser extension pairing controls",
+    });
+    expect(pairingRegion).toBeInTheDocument();
+    expect(screen.getByText("Local capability token for extension API requests")).toBeInTheDocument();
+    expect(screen.getByText("capture, autofill read")).toBeInTheDocument();
+
+    await user.click(panelTrigger);
+    expect(panelTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(pairingRegion.closest("[hidden]")).toBeInTheDocument();
+    panelTrigger.focus();
+    expect(panelTrigger).toHaveFocus();
+    await user.click(panelTrigger);
+    expect(panelTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("region", { name: "Browser extension pairing controls" }),
+    ).toBe(pairingRegion);
+
+    const tokenField = screen.getByLabelText("Extension capability token");
+    await waitFor(() =>
+      expect(tokenField).toHaveValue(sampleExtensionCapabilityTokenResponse.token),
+    );
+    await user.click(screen.getByRole("button", { name: "Copy token" }));
+    expect(ports.clipboard.write).toHaveBeenCalledWith(sampleExtensionCapabilityTokenResponse.token);
+
+    await user.click(screen.getByRole("button", { name: "Rotate token" }));
+    expect(rotateExtensionCapabilityToken).not.toHaveBeenCalled();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Confirm rotation below; existing extension pairing will disconnect.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Confirm rotate and disconnect" }));
+    await waitFor(() => {
+      expect(rotateExtensionCapabilityToken).toHaveBeenCalledTimes(1);
+      expect(ports.clipboard.write).toHaveBeenLastCalledWith(rotated.token);
+      expect(screen.getByRole("status")).toHaveTextContent("token rotated");
+    });
   });
 });

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
@@ -2,7 +2,16 @@ import type { BrowserCapabilityId, BrowserCapabilityItem } from "@jobctrl/contra
 import { useState } from "react";
 
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { ChoiceControl } from "../../../shared/ui/choice-control.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
 import {
   useCopyLinkedInBrowserProfileMutation,
   useDisableBrowserCapabilityMutation,
@@ -60,29 +69,87 @@ export function BrowserCapabilitiesPanel() {
 
     const capabilityId = capability.id;
     return (
-      <div className="provider-form">
-        <label className="field" htmlFor={`browser-executable-${capabilityId}`}>
-          <span>Chrome or Chromium executable path</span>
-          <input id={`browser-executable-${capabilityId}`} name={`browser-executable-${capabilityId}`} type="text" autoComplete="off" disabled={demo || capability.enabled} value={executablePaths[capabilityId] ?? ""} onChange={(event) => setExecutablePaths((current) => ({ ...current, [capabilityId]: event.target.value }))} />
-          <small>Saved as non-secret browser configuration in config.json. The status API does not echo local paths.</small>
-        </label>
-        <div className="form-actions">
-          <button className="tab on" type="button" disabled={demo || capability.enabled || enable.isPending} onClick={() => void enableCapability(capabilityId)}>enable selected browser</button>
-          <button className="tab" type="button" disabled={demo || !capability.enabled || disable.isPending} onClick={() => void disable.mutateAsync(capabilityId).then(() => setMessage(`${LABELS[capabilityId]} disabled immediately.`)).catch(() => setMessage("Capability disable failed."))}>disable now</button>
+      <div className="browser-capability-controls">
+        <AdaptiveFieldGrid columns={2} minColumnWidth={280} density="compact">
+          <Field data-disabled={demo || capability.enabled || undefined}>
+            <FieldLabel htmlFor={`browser-executable-${capabilityId}`}>
+              Chrome or Chromium executable path
+            </FieldLabel>
+            <Input
+              id={`browser-executable-${capabilityId}`}
+              name={`browser-executable-${capabilityId}`}
+              type="text"
+              autoComplete="off"
+              disabled={demo || capability.enabled}
+              value={executablePaths[capabilityId] ?? ""}
+              onChange={(event) =>
+                setExecutablePaths((current) => ({
+                  ...current,
+                  [capabilityId]: event.target.value,
+                }))
+              }
+            />
+            <FieldDescription>
+              Saved as non-secret browser configuration in config.json. The status API does not
+              echo local paths.
+            </FieldDescription>
+          </Field>
+        </AdaptiveFieldGrid>
+        <div className="form-actions browser-capability-actions">
+          <Button
+            type="button"
+            disabled={demo || capability.enabled || enable.isPending}
+            onClick={() => void enableCapability(capabilityId)}
+          >
+            Enable selected browser
+          </Button>
+          <Button
+            variant="outline"
+            type="button"
+            disabled={demo || !capability.enabled || disable.isPending}
+            onClick={() =>
+              void disable
+                .mutateAsync(capabilityId)
+                .then(() => setMessage(`${LABELS[capabilityId]} disabled immediately.`))
+                .catch(() => setMessage("Capability disable failed."))
+            }
+          >
+            Disable now
+          </Button>
         </div>
         {capabilityId === "authenticated-linkedin-browser" && capability.enabled ? (
-          <fieldset className="provider-choice-fieldset">
+          <fieldset className="provider-choice-fieldset browser-profile-copy">
             <legend>Separate authenticated profile copy</legend>
-            <label className="field" htmlFor="linkedin-profile-source">
-              <span>Existing browser profile directory</span>
-              <input id="linkedin-profile-source" name="linkedin-profile-source" type="password" autoComplete="off" value={sourceProfilePath} onChange={(event) => setSourceProfilePath(event.target.value)} />
-              <small>Request-only. Cleared after submission and never returned or logged.</small>
-            </label>
-            <label className="provider-choice-option" htmlFor="linkedin-profile-consent">
-              <input id="linkedin-profile-consent" name="linkedin-profile-consent" type="checkbox" checked={profileConsent} onChange={(event) => setProfileConsent(event.target.checked)} />
-              <span>I explicitly consent to copy this profile into JobCtrl-owned storage.</span>
-            </label>
-            <button className="tab on" type="button" disabled={copyProfile.isPending || !profileConsent || !sourceProfilePath.trim()} onClick={() => void copyLinkedInProfile()}>copy selected profile</button>
+            <Field>
+              <FieldLabel htmlFor="linkedin-profile-source">
+                Existing browser profile directory
+              </FieldLabel>
+              <Input
+                id="linkedin-profile-source"
+                name="linkedin-profile-source"
+                type="password"
+                autoComplete="off"
+                value={sourceProfilePath}
+                onChange={(event) => setSourceProfilePath(event.target.value)}
+              />
+              <FieldDescription>
+                Request-only. Cleared after submission and never returned or logged.
+              </FieldDescription>
+            </Field>
+            <ChoiceControl
+              id="linkedin-profile-consent"
+              name="linkedin-profile-consent"
+              label="I explicitly consent to copy this profile into JobCtrl-owned storage."
+              checked={profileConsent}
+              onCheckedChange={(checked) => setProfileConsent(checked === true)}
+            />
+            <Button
+              type="button"
+              disabled={copyProfile.isPending || !profileConsent || !sourceProfilePath.trim()}
+              onClick={() => void copyLinkedInProfile()}
+            >
+              Copy selected profile
+            </Button>
           </fieldset>
         ) : null}
       </div>
@@ -90,24 +157,36 @@ export function BrowserCapabilitiesPanel() {
   }
 
   return (
-    <section className="card full provider-setup-shell">
-      <CardHeader title="Browser capabilities" meta={demo ? "demo · read only" : "explicit adoption"} />
+    <DisclosureSection
+      className="browser-capabilities-settings"
+      title="Browser capabilities"
+      description={
+        demo
+          ? "Demo · read only"
+          : "Explicit adoption · revocable managed browser capabilities"
+      }
+      collapsedSummary={demo ? "Demo · read only" : "Core and optional browser access"}
+    >
       <div className="banner credential-store-notice credential-store-notice--guidance">
         JobCtrl never auto-detects or adopts Chrome. Optional access is fail-closed and can be revoked immediately. Optional managed downloads are unavailable until a signed supply chain exists.
       </div>
       {query.error ? <div className="banner inline" role="alert">Browser capability status is unavailable.</div> : null}
-      <div className="provider-card-list" aria-busy={query.isPending}>
+      <div className="browser-capability-list" aria-busy={query.isPending}>
         {(query.data?.capabilities ?? []).map((capability) => (
-          <article className="provider-card" key={capability.id}>
-            <header className="provider-card-header">
-              <div><h3>{LABELS[capability.id]}</h3><p>{capability.detail}</p></div>
-              <span className={`tag ${capability.status === "ready" ? "ok" : "muted"}`}>{capability.status}</span>
-            </header>
+          <DisclosureSection
+            className="browser-capability-section"
+            key={capability.id}
+            title={LABELS[capability.id]}
+            description={capability.detail}
+            collapsedSummary={`Status: ${capability.status}`}
+            defaultOpen={false}
+          >
+            <p className="browser-capability-status">Current status: {capability.status}</p>
             {renderCapabilityControls(capability)}
-          </article>
+          </DisclosureSection>
         ))}
       </div>
       {message ? <div className="status-line" role="status">{message}</div> : null}
-    </section>
+    </DisclosureSection>
   );
 }

--- a/apps/web/src/contexts/operations/components/ExtensionPairingPanel.tsx
+++ b/apps/web/src/contexts/operations/components/ExtensionPairingPanel.tsx
@@ -4,7 +4,14 @@ import { useState } from "react";
 
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
 import { useTenantId } from "../../../shared/providers/TenantProvider.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Button } from "../../../shared/ui/button.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
+import { Field, FieldLabel } from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
+import {
+  InspectorLedger,
+  InspectorLedgerItem,
+} from "../../../shared/ui/inspector-ledger.js";
 import { browserCapabilityKeys } from "../browserCapabilityKeys.js";
 
 export function ExtensionPairingPanel() {
@@ -53,22 +60,58 @@ export function ExtensionPairingPanel() {
   }
 
   return (
-    <section className="card full">
-      <CardHeader title="Browser extension" meta="pairing" />
-      <div className="runtime-summary extension-pairing" aria-label="Browser extension pairing">
-        <div><h3>Browser extension pairing</h3><p>Local capability token for extension API requests.</p></div>
+    <DisclosureSection
+      className="extension-pairing-settings"
+      title="Browser extension pairing"
+      description="Local capability token for extension API requests"
+      collapsedSummary="Capture and autofill-read pairing"
+    >
+      <section className="extension-pairing" aria-label="Browser extension pairing controls">
         <div className="extension-pairing-controls">
-          {tokenQuery.error ? <div className="banner inline">Pairing token is unavailable.</div> : null}
-          <label className="field extension-token-field"><span>Capability token</span><input readOnly type="password" value={token} aria-label="Extension capability token" placeholder={tokenQuery.isPending ? "loading" : "unavailable"} /></label>
-          <dl><div><dt>Capabilities</dt><dd>capture, autofill read</dd></div></dl>
+          {tokenQuery.error ? (
+            <div className="banner inline" role="alert">
+              Pairing token is unavailable.
+            </div>
+          ) : null}
+          <Field className="extension-token-field">
+            <FieldLabel htmlFor="extension-capability-token">Capability token</FieldLabel>
+            <Input
+              id="extension-capability-token"
+              readOnly
+              type="password"
+              value={token}
+              aria-label="Extension capability token"
+              placeholder={tokenQuery.isPending ? "loading" : "unavailable"}
+            />
+          </Field>
+          <InspectorLedger>
+            <InspectorLedgerItem
+              label="Capabilities"
+              value="capture, autofill read"
+              source="Local extension API"
+            />
+          </InspectorLedger>
           <div className="form-actions extension-pairing-actions">
-            <button className="tab on" type="button" disabled={!token} onClick={() => void copyToken()}>copy token</button>
-            <button className="tab" type="button" disabled={rotateToken.isPending} onClick={() => void rotate()}>{rotateToken.isPending ? "rotating" : confirmRotation ? "confirm rotate and disconnect" : "rotate token"}</button>
+            <Button type="button" disabled={!token} onClick={() => void copyToken()}>
+              Copy token
+            </Button>
+            <Button
+              variant="outline"
+              type="button"
+              disabled={rotateToken.isPending}
+              onClick={() => void rotate()}
+            >
+              {rotateToken.isPending
+                ? "Rotating…"
+                : confirmRotation
+                  ? "Confirm rotate and disconnect"
+                  : "Rotate token"}
+            </Button>
           </div>
           {message ? <div className="status-line" role="status">{message}</div> : null}
           {copyWarning ? <div className="banner inline" role="alert">{copyWarning}</div> : null}
         </div>
-      </div>
-    </section>
+      </section>
+    </DisclosureSection>
   );
 }

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.a11y.test.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.a11y.test.tsx
@@ -1,5 +1,5 @@
 import type { CredentialsResponse } from "@jobctrl/contracts";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { describe, expect, it, vi } from "vitest";
@@ -78,8 +78,14 @@ describe("<CredentialsPanel> a11y", () => {
           },
         }),
       });
+      const heading = await screen.findByRole("heading", { name: provider });
+      const disclosure = heading.closest("section");
+      if (!disclosure) throw new Error(`Missing ${provider} disclosure`);
+      await user.click(within(disclosure).getByRole("button", {
+        name: new RegExp(provider, "i"),
+      }));
       await user.click(
-        await screen.findByRole("button", { name: `Remove ${provider} setup` }),
+        await within(disclosure).findByRole("button", { name: `Remove ${provider} setup` }),
       );
       await screen.findByRole("dialog", { name: `Remove ${provider} provider setup?` });
 

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
@@ -19,18 +19,50 @@ import {
 import { CredentialsPanel } from "./CredentialsPanel.js";
 
 describe("<CredentialsPanel>", () => {
-  it("renders three guided provider cards and no raw Codex secret field", async () => {
+  it("renders three guided provider disclosures and no raw Codex secret field", async () => {
     renderPanel();
 
-    expect(await screen.findByRole("heading", { name: "Codex" })).toBeInTheDocument();
+    const codex = await providerCard("Codex");
+    const solver = await providerCard("Apply CAPTCHA solver");
+    expect(within(codex).getByRole("heading", { name: "Codex" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Claude" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Google" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Apply CAPTCHA solver" })).toBeInTheDocument();
-    expect(screen.getByLabelText("CapSolver API key")).toBeEnabled();
-    expect(screen.getByText(CODEX_LOGIN_COMMANDS.subscription)).toBeInTheDocument();
-    expect(screen.getByText(CODEX_LOGIN_COMMANDS.apiKey)).toBeInTheDocument();
+    expect(within(solver).getByLabelText("CapSolver API key")).toBeEnabled();
+    expect(within(codex).getByText(CODEX_LOGIN_COMMANDS.subscription)).toBeInTheDocument();
+    expect(within(codex).getByText(CODEX_LOGIN_COMMANDS.apiKey)).toBeInTheDocument();
     expect(screen.queryByLabelText(/OpenAI API key/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Restart JobCtrl after a change/i)).toBeInTheDocument();
+  });
+
+  it("keeps provider status and ownership visible in each collapsed summary", async () => {
+    renderPanel();
+
+    const heading = await screen.findByRole("heading", { name: "Claude" });
+    const disclosure = heading.closest("section");
+    if (!disclosure) throw new Error("Missing Claude provider disclosure");
+    const trigger = within(disclosure).getByRole("button", { name: /Claude/i });
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveTextContent(/Ready|Configured|Not configured/i);
+    expect(trigger).toHaveTextContent(/Ownership:/i);
+  });
+
+  it("exposes provider privacy boundaries through the final disclosure ledger", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    const privacy = await screen.findByRole("region", { name: "Credential privacy" });
+    await user.click(within(privacy).getByRole("button", {
+      name: /Your provider data stays private/i,
+    }));
+
+    expect(within(privacy).getByText("Local only")).toBeInTheDocument();
+    expect(within(privacy).getByText("Claude and Google storage")).toBeInTheDocument();
+    expect(within(privacy).getByText("Codex authentication")).toBeInTheDocument();
+    expect(within(privacy).getByText("API and persistence")).toBeInTheDocument();
+    expect(within(privacy).getByText("URLs, logs, traces, and artifacts")).toBeInTheDocument();
+    expect(within(privacy).getByText("Worker restart required")).toBeInTheDocument();
   });
 
   it.each([
@@ -44,7 +76,7 @@ describe("<CredentialsPanel>", () => {
     renderPanel();
     const card = await providerCard("Claude");
 
-    await user.click(within(card).getByRole("radio", { name: new RegExp(choice, "i") }));
+    await selectProviderMode(user, card, "Choose how Claude authenticates", choice);
 
     expect(within(card).getByLabelText(expectedField)).toBeInTheDocument();
   });
@@ -57,7 +89,7 @@ describe("<CredentialsPanel>", () => {
     renderPanel();
     const card = await providerCard("Google");
 
-    await user.click(within(card).getByRole("radio", { name: new RegExp(choice, "i") }));
+    await selectProviderMode(user, card, "Choose how Google authenticates", choice);
 
     expect(within(card).getByLabelText(expectedField)).toBeInTheDocument();
   });
@@ -83,8 +115,12 @@ describe("<CredentialsPanel>", () => {
 
     const claude = await providerCard("Claude");
     const google = await providerCard("Google");
-    await waitFor(() => expect(within(claude).getByRole("radio", { name: /Amazon Bedrock/i })).toBeChecked());
-    expect(within(google).getByRole("radio", { name: /Vertex AI/i })).toBeChecked();
+    await waitFor(() => expect(
+      within(claude).getByRole("combobox", { name: /Choose how Claude authenticates/i }),
+    ).toHaveTextContent("Amazon Bedrock"));
+    expect(
+      within(google).getByRole("combobox", { name: /Choose how Google authenticates/i }),
+    ).toHaveTextContent("Vertex AI");
     expect(screen.queryByDisplayValue(/secret/i)).not.toBeInTheDocument();
   });
 
@@ -116,9 +152,13 @@ describe("<CredentialsPanel>", () => {
     const claude = await providerCard("Claude");
     const google = await providerCard("Google");
     await waitFor(() =>
-      expect(within(claude).getByRole("radio", { name: /Google Cloud Agent Platform/i })).toBeChecked(),
+      expect(
+        within(claude).getByRole("combobox", { name: /Choose how Claude authenticates/i }),
+      ).toHaveTextContent("Google Cloud Agent Platform"),
     );
-    expect(within(google).getByRole("radio", { name: /Vertex AI/i })).toBeChecked();
+    expect(
+      within(google).getByRole("combobox", { name: /Choose how Google authenticates/i }),
+    ).toHaveTextContent("Vertex AI");
     expect(within(claude).getAllByText("Configured · restart or verify").length).toBeGreaterThan(0);
     expect(within(google).getAllByText("Configured · restart or verify").length).toBeGreaterThan(0);
     expect(within(claude).queryByText("Ready")).not.toBeInTheDocument();
@@ -133,9 +173,10 @@ describe("<CredentialsPanel>", () => {
 
     await user.type(input, "sk-ant-test");
     expect(input).toHaveAttribute("type", "password");
-    await user.click(within(card).getByRole("button", { name: "Show" }));
+    const visibility = within(card).getByRole("checkbox", { name: /Show anthropic api key/i });
+    await user.click(visibility);
     expect(input).toHaveAttribute("type", "text");
-    await user.click(within(card).getByRole("button", { name: "Hide" }));
+    await user.click(visibility);
     expect(input).toHaveAttribute("type", "password");
   });
 
@@ -225,7 +266,9 @@ describe("<CredentialsPanel>", () => {
     expect(within(card).getByText(/effective mode is owned by the launch environment/i)).toBeInTheDocument();
     expect(within(card).getByRole("button", { name: "Save Google setup" })).toBeDisabled();
     expect(within(card).queryByRole("button", { name: "Remove Google setup" })).not.toBeInTheDocument();
-    expect(within(card).getAllByRole("radio").every((radio) => radio.hasAttribute("disabled"))).toBe(true);
+    expect(
+      within(card).getByRole("combobox", { name: /Choose how Google authenticates/i }),
+    ).toBeDisabled();
     expect(updateCredentialsBatch).not.toHaveBeenCalled();
     expect(card).not.toHaveTextContent(/provider settings removed/i);
   });
@@ -247,11 +290,9 @@ describe("<CredentialsPanel>", () => {
       })),
     });
 
-    const solver = await screen.findByRole("heading", { name: "Apply CAPTCHA solver" });
-    const panel = solver.closest("section");
-    expect(panel).not.toBeNull();
-    expect(within(panel!).getByLabelText("CapSolver API key")).toBeDisabled();
-    expect(within(panel!).getByText("managed by environment")).toBeInTheDocument();
+    const panel = await providerCard("Apply CAPTCHA solver");
+    expect(within(panel).getByLabelText("CapSolver API key")).toBeDisabled();
+    expect(within(panel).getByText(/managed by environment/i)).toBeInTheDocument();
   });
 
   it("keeps a sanitized Google removal error inside the confirmation dialog", async () => {
@@ -311,12 +352,22 @@ describe("<CredentialsPanel>", () => {
     expect(await screen.findByText(/Non-secret provider settings remain editable in config\.json/i)).toBeInTheDocument();
     const claude = await providerCard("Claude");
     const google = await providerCard("Google");
-    expect(within(claude).getByRole("radio", { name: /Anthropic API key/i })).toBeDisabled();
-    expect(within(google).getByRole("radio", { name: /Gemini API key/i })).toBeDisabled();
+    const claudeMode = within(claude).getByRole("combobox", {
+      name: /Choose how Claude authenticates/i,
+    });
+    await user.click(claudeMode);
+    expect(screen.getByRole("option", { name: /Anthropic API key/i })).toHaveAttribute("data-disabled");
+    await user.keyboard("{Escape}");
+    const googleMode = within(google).getByRole("combobox", {
+      name: /Choose how Google authenticates/i,
+    });
+    await user.click(googleMode);
+    expect(screen.getByRole("option", { name: /Gemini API key/i })).toHaveAttribute("data-disabled");
+    expect(screen.getByRole("option", { name: /Vertex AI/i })).not.toHaveAttribute("data-disabled");
+    await user.click(screen.getByRole("option", { name: /Vertex AI/i }));
     expect(within(claude).queryByLabelText(/Anthropic API key \(required\)/i)).not.toBeInTheDocument();
     expect(within(google).queryByLabelText(/Gemini API key \(required\)/i)).not.toBeInTheDocument();
-    expect(within(claude).getByRole("radio", { name: /Google Cloud Agent Platform/i })).toBeEnabled();
-    await user.click(within(google).getByRole("radio", { name: /Vertex AI/i }));
+    expect(claudeMode).toHaveTextContent("Google Cloud Agent Platform");
 
     await user.type(within(google).getByLabelText(/Google Cloud project ID/i), "jobctrl-test-project");
     await user.click(within(google).getByRole("button", { name: "Save Google setup" }));
@@ -359,7 +410,8 @@ describe("<CredentialsPanel>", () => {
     expect(await screen.findByText(/could not safely inspect Keychain/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/Anthropic API key \(required\)/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/Gemini API key \(required\)/i)).not.toBeInTheDocument();
-    expect(screen.getByLabelText("CapSolver API key")).toBeDisabled();
+    const capSolver = await providerCard("Apply CAPTCHA solver");
+    expect(within(capSolver).getByLabelText("CapSolver API key")).toBeDisabled();
     expect(screen.queryByRole("button", { name: "Save Claude setup" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Save Google setup" })).not.toBeInTheDocument();
     expect(screen.getByText(/Set GEMINI_API_KEY/i)).toBeInTheDocument();
@@ -401,7 +453,9 @@ describe("<CredentialsPanel>", () => {
 
     expect(await screen.findByText(/public demo never accepts/i)).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Codex" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /login|verify/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", {
+      name: /Reuse existing login or verify|Verify isolated login/i,
+    })).not.toBeInTheDocument();
   });
 });
 
@@ -462,7 +516,31 @@ function configuredProvidersResponse() {
 
 async function providerCard(name: string): Promise<HTMLElement> {
   const heading = await screen.findByRole("heading", { name });
-  const card = heading.closest("article");
+  const card = heading.closest("section");
   if (!card) throw new Error(`Missing ${name} provider card`);
+  const trigger = within(card).getByRole("button", {
+    name: new RegExp(escapeRegExp(name), "i"),
+  });
+  if (trigger.getAttribute("aria-expanded") === "false") {
+    await userEvent.setup().click(trigger);
+  }
   return card;
+}
+
+async function selectProviderMode(
+  user: ReturnType<typeof userEvent.setup>,
+  card: HTMLElement,
+  selectLabel: string,
+  optionLabel: string,
+) {
+  await user.click(within(card).getByRole("combobox", {
+    name: new RegExp(escapeRegExp(selectLabel), "i"),
+  }));
+  await user.click(screen.getByRole("option", {
+    name: new RegExp(`^${escapeRegExp(optionLabel)}$`, "i"),
+  }));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
@@ -7,8 +7,12 @@ import type {
 import { useState, type ReactNode } from "react";
 
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
-import { Badge } from "../../../shared/ui/badge.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Button } from "../../../shared/ui/button.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
+import {
+  InspectorLedger,
+  InspectorLedgerItem,
+} from "../../../shared/ui/inspector-ledger.js";
 import {
   ClaudeProviderForm,
   GoogleProviderForm,
@@ -68,11 +72,13 @@ export function CredentialsPanel() {
 
   return (
     <>
-      <section className="card full provider-setup-shell">
-        <CardHeader
-          title="LLM providers"
-          meta={store?.available ? "macOS Keychain" : "setup"}
-        />
+      <DisclosureSection
+        className="provider-setup-disclosure"
+        collapsedSummary={providerSetupSummary(store, statuses)}
+        defaultOpen
+        description="Provider authentication, ownership, and runtime readiness"
+        title="LLM providers"
+      >
         <ProviderSetupNotice
           credentialsError={credentialsQuery.error?.message}
           providerStatusError={providerStatusQuery.error?.message}
@@ -81,8 +87,8 @@ export function CredentialsPanel() {
         {!store ? (
           <div className="empty" role="status">Checking provider setup.</div>
         ) : (
-          <div className="provider-card-list">
-            <ProviderCard
+          <div className="provider-disclosure-list">
+            <ProviderDisclosure
               description="Reuses an already authenticated normal Codex CLI first, then verifies it in JobCtrl's isolated Codex home. JobCtrl does not accept a raw OpenAI key."
               provider="codex"
               status={codexStatus}
@@ -95,10 +101,10 @@ export function CredentialsPanel() {
                   store.available && configured(["OPENAI_API_KEY"])
                 }
               />
-            </ProviderCard>
+            </ProviderDisclosure>
             {store.available || store.unavailableReason === "unsupported_platform" ? (
               <>
-                <ProviderCard
+                <ProviderDisclosure
                   description="Choose one direct or third-party Claude Agent SDK authentication route."
                   provider="claude"
                   status={mergeConfiguredStatus("claude", claudeStatus, claudeConfigured)}
@@ -111,8 +117,8 @@ export function CredentialsPanel() {
                     environmentManagedKeys={environmentManagedKeys}
                     secretStorageAvailable={store.available}
                   />
-                </ProviderCard>
-                <ProviderCard
+                </ProviderDisclosure>
+                <ProviderDisclosure
                   description="Use a Gemini API key or Google Vertex AI with Application Default Credentials."
                   provider="google"
                   status={mergeConfiguredStatus("google", googleStatus, googleConfigured)}
@@ -125,7 +131,7 @@ export function CredentialsPanel() {
                     environmentManagedKeys={environmentManagedKeys}
                     secretStorageAvailable={store.available}
                   />
-                </ProviderCard>
+                </ProviderDisclosure>
               </>
             ) : (
               <ReadOnlyProviderGuidance
@@ -135,24 +141,28 @@ export function CredentialsPanel() {
             )}
           </div>
         )}
-      </section>
-      {store && capSolver ? (
-        <section className="card full provider-setup-shell">
-          <CardHeader title="Apply CAPTCHA solver" meta="optional · restart required" />
-          <p className="provider-copy">A CapSolver key only enables JobCtrl's owned solver tool during a user-started Apply. Unsupported or unconfigured CAPTCHA always fails closed.</p>
-          <CredentialForm
-            credentialKey="CAPSOLVER_API_KEY"
-            label="CapSolver API key"
-            configured={capSolver.configured}
-            effectiveSource={capSolver.effectiveSource}
-            editable={capSolver.editable}
-            available={store.available}
-            {...(store.unavailableReason !== null
-              ? { unavailableReason: store.unavailableReason }
-              : {})}
-          />
-        </section>
-      ) : null}
+        {store && capSolver ? (
+          <DisclosureSection
+            className="provider-disclosure provider-disclosure--capsolver"
+            collapsedSummary={`${credentialStatusLabel(capSolver)} · Optional · restart required`}
+            defaultOpen={false}
+            description="A CapSolver key only enables JobCtrl's owned solver tool during a user-started Apply. Unsupported or unconfigured CAPTCHA always fails closed."
+            title="Apply CAPTCHA solver"
+          >
+            <CredentialForm
+              credentialKey="CAPSOLVER_API_KEY"
+              label="CapSolver API key"
+              configured={capSolver.configured}
+              effectiveSource={capSolver.effectiveSource}
+              editable={capSolver.editable}
+              available={store.available}
+              {...(store.unavailableReason !== null
+                ? { unavailableReason: store.unavailableReason }
+                : {})}
+            />
+          </DisclosureSection>
+        ) : null}
+      </DisclosureSection>
       <CredentialPrivacyNotice store={store} />
     </>
   );
@@ -168,27 +178,27 @@ function ProviderSetupNotice({
   store?: CredentialsResponse["store"] | undefined;
 }) {
   if (credentialsError) {
-    return <div className="banner credential-store-notice credential-store-notice--failure" role="alert">{credentialsError}</div>;
+    return <div className="banner credential-store-notice credential-store-notice--failure provider-setup-notice" role="alert">{credentialsError}</div>;
   }
   if (!store) {
     return null;
   }
   if (store.unavailableReason === "unsupported_platform") {
     return (
-      <div className="banner credential-store-notice credential-store-notice--guidance">
+      <div className="banner credential-store-notice credential-store-notice--guidance provider-setup-notice">
         Non-secret provider settings remain editable in config.json. API-key entry is unavailable until this platform has a supported secure-storage adapter; externally authenticated cloud routes remain available.
       </div>
     );
   }
   if (store.unavailableReason === "inspection_failed") {
     return (
-      <div className="banner credential-store-notice credential-store-notice--failure" role="alert">
+      <div className="banner credential-store-notice credential-store-notice--failure provider-setup-notice" role="alert">
         JobCtrl could not safely inspect Keychain. Unlock Keychain Access, then reload before changing Claude or Google setup. Codex verification remains available.
       </div>
     );
   }
   return (
-    <div className="banner credential-store-notice credential-store-notice--guidance">
+    <div className="banner credential-store-notice credential-store-notice--guidance provider-setup-notice">
       <span>
         Provider modes and non-secret connection fields are saved in config.json. API keys stay in macOS Keychain. Restart JobCtrl after a change so provider processes reload both sources.
       </span>
@@ -201,7 +211,7 @@ function ProviderSetupNotice({
   );
 }
 
-function ProviderCard({
+function ProviderDisclosure({
   provider,
   title,
   description,
@@ -224,19 +234,31 @@ function ProviderCard({
         ? "Configured · restart or verify"
         : "Not configured";
   return (
-    <article className="provider-card" data-provider={provider}>
-      <header className="provider-card-header">
-        <div>
-          <h3>{title}</h3>
-          <p>{description}</p>
-        </div>
-        <span className={`tag ${status?.ready ? "ok" : "muted"}`}>{statusLabel}</span>
-      </header>
-      {status?.mode ? <p className="provider-current-mode">Detected mode: {status.mode}</p> : null}
-      <p className="provider-current-mode">Effective ownership: {ownership}</p>
-      {status?.message ? <p className="provider-status-message">{status.message}</p> : null}
+    <DisclosureSection
+      className="provider-disclosure"
+      collapsedSummary={(
+        <span className="provider-disclosure__summary">
+          <span>{statusLabel}</span>
+          <span>Ownership: {ownership}</span>
+        </span>
+      )}
+      defaultOpen={false}
+      data-provider={provider}
+      description={description}
+      title={title}
+    >
+      <InspectorLedger className="provider-status-ledger">
+        <InspectorLedgerItem label="Status" value={statusLabel} />
+        <InspectorLedgerItem label="Effective ownership" value={ownership} />
+        {status?.mode ? (
+          <InspectorLedgerItem label="Detected mode" value={status.mode} />
+        ) : null}
+        {status?.message ? (
+          <InspectorLedgerItem label="Provider report" value={status.message} />
+        ) : null}
+      </InspectorLedger>
       {children}
-    </article>
+    </DisclosureSection>
   );
 }
 
@@ -266,55 +288,56 @@ function CodexProviderSetup({
   }
 
   return (
-    <div className="provider-form codex-provider-setup">
-      <div className="codex-auth-options">
-        <section>
+    <div className="provider-setup-form codex-provider-setup">
+      <ol className="codex-auth-methods">
+        <li className="codex-auth-method">
           <h4>Use an existing Codex CLI login first</h4>
           <p>
             Click the action below to validate an already authenticated normal
             Codex CLI login and import it once into JobCtrl's stable, isolated
             home. It does not change your normal Codex home.
           </p>
-        </section>
-        <section>
+        </li>
+        <li className="codex-auth-method">
           <h4>Fallback: ChatGPT subscription or device login</h4>
           <p>
             If there is no existing login to reuse, authenticate the Codex CLI
             into JobCtrl's stable, isolated Codex home.
           </p>
           <code>{CODEX_LOGIN_COMMANDS.subscription}</code>
-        </section>
-        <section>
+        </li>
+        <li className="codex-auth-method">
           <h4>Fallback: OpenAI API key enrollment</h4>
           <p>
             If there is no existing login to reuse, pipe your existing shell key
             directly into Codex. JobCtrl never receives or stores the raw key.
           </p>
           <code>{CODEX_LOGIN_COMMANDS.apiKey}</code>
-        </section>
-      </div>
-      <p className="provider-copy">
+        </li>
+      </ol>
+      <p className="provider-setup-boundary-copy">
         Authentication is stored outside JobCtrl's prompt-readable <code>codex_home/workspace</code> boundary.
       </p>
       {legacyOpenAiKeyConfigured ? (
-        <div className="provider-legacy-warning">
+        <div className="provider-setup-warning">
           <p>
             A legacy <code>OPENAI_API_KEY</code> exists in JobCtrl Keychain. The Codex runtime does not use it directly; enroll it with the command above, then remove this unused copy.
           </p>
-          <button
-            className="tab"
+          <Button
             disabled={removeLegacyKey.isPending}
+            size="sm"
             type="button"
+            variant="outline"
             onClick={() => void removeLegacy()}
           >
             {removeLegacyKey.isPending ? "Removing…" : "Remove legacy key"}
-          </button>
+          </Button>
         </div>
       ) : null}
-      <div className="provider-form-footer">
-        <button
-          className="tab on"
+      <div className="provider-setup-form__footer">
+        <Button
           disabled={verify.isPending}
+          size="sm"
           type="button"
           onClick={() => verify.mutate()}
         >
@@ -323,15 +346,15 @@ function CodexProviderSetup({
             : isolatedAuthDetected
               ? "Verify isolated login"
               : "Reuse existing login or verify"}
-        </button>
+        </Button>
         <div
           aria-live="polite"
-          className={verification?.ok === false || verify.error ? "provider-form-message warning" : "provider-form-message"}
+          className={verification?.ok === false || verify.error ? "provider-setup-form__message provider-setup-form__message--warning" : "provider-setup-form__message"}
           role="status"
         >
           {verificationMessage}
         </div>
-        {legacyMessage ? <div aria-live="polite" className="provider-form-message" role="status">{legacyMessage}</div> : null}
+        {legacyMessage ? <div aria-live="polite" className="provider-setup-form__message" role="status">{legacyMessage}</div> : null}
       </div>
     </div>
   );
@@ -352,10 +375,24 @@ function ReadOnlyProviderGuidance({
   return (
     <>
       {providers.map(([title, copy]) => (
-        <article className="provider-card provider-card--readonly" key={title}>
-          <h3>{title}</h3>
-          <p>{copy}</p>
-        </article>
+        <DisclosureSection
+          className="provider-disclosure provider-disclosure--readonly"
+          collapsedSummary={(
+            <span className="provider-disclosure__summary">
+              <span>Read only</span>
+              <span>Ownership: external provider environment</span>
+            </span>
+          )}
+          defaultOpen={false}
+          description={copy}
+          key={title}
+          title={title}
+        >
+          <InspectorLedger className="provider-status-ledger">
+            <InspectorLedgerItem label="Status" value="Guided editing unavailable" />
+            <InspectorLedgerItem label="Effective ownership" value="External provider environment" />
+          </InspectorLedger>
+        </DisclosureSection>
       ))}
       {reason === "inspection_failed" ? (
         <p className="provider-readonly-summary" role="alert">Keychain inspection must succeed before guided Claude and Google editing is restored.</p>
@@ -366,15 +403,20 @@ function ReadOnlyProviderGuidance({
 
 function DemoProviderSetup() {
   return (
-    <section className="card full provider-setup-shell">
-      <CardHeader title="LLM providers" meta="public demo · read only" />
-      <div className="banner credential-store-notice credential-store-notice--guidance">
+    <DisclosureSection
+      className="provider-setup-disclosure"
+      collapsedSummary="Public demo · read only"
+      defaultOpen
+      description="Provider authentication, ownership, and runtime readiness"
+      title="LLM providers"
+    >
+      <div className="banner credential-store-notice credential-store-notice--guidance provider-setup-notice">
         The public demo never accepts, checks, or stores provider secrets. Configure providers only in a local JobCtrl installation.
       </div>
-      <div className="provider-card-list">
+      <div className="provider-disclosure-list">
         <ReadOnlyProviderGuidance reason={null} />
       </div>
-    </section>
+    </DisclosureSection>
   );
 }
 
@@ -398,19 +440,70 @@ function CredentialPrivacyNotice({
         ? "Keychain status unavailable"
         : "Storage status loading";
   return (
-    <section aria-label="Credential privacy" className="privacy-box">
-      <h2>Your provider data stays private</h2>
-      <p className="privacy-box-copy">
+    <DisclosureSection
+      aria-label="Credential privacy"
+      className="credential-privacy-disclosure"
+      collapsedSummary={boundaryBadge}
+      defaultOpen={false}
+      description="Storage boundaries and data-handling guarantees"
+      title="Your provider data stays private"
+    >
+      <p className="credential-privacy-disclosure__copy">
         {boundaryCopy} Codex authentication stays in JobCtrl's isolated filesystem home. Credentials are never returned by the API, stored in SQLite, placed in URLs, or written to logs, traces, and generated artifacts. Cloud credential files remain managed by their vendor CLIs.
       </p>
-      <div className="privacy-box-tags">
-        <Badge>Local only</Badge>
-        <Badge>{boundaryBadge}</Badge>
-        <Badge>Never in logs</Badge>
-        <Badge>Worker restart required</Badge>
-      </div>
-    </section>
+      <InspectorLedger className="credential-privacy-ledger">
+        <InspectorLedgerItem
+          label="Data boundary"
+          value="Local only"
+        />
+        <InspectorLedgerItem
+          label="Claude and Google storage"
+          source={boundaryCopy}
+          value={boundaryBadge}
+        />
+        <InspectorLedgerItem
+          label="Codex authentication"
+          source="Outside the prompt-readable codex_home/workspace boundary"
+          value="Isolated filesystem home"
+        />
+        <InspectorLedgerItem
+          label="API and persistence"
+          source="Credentials are never returned by the API or stored in SQLite"
+          value="Secret values excluded"
+        />
+        <InspectorLedgerItem
+          label="URLs, logs, traces, and artifacts"
+          value="Never in logs, traces, URLs, or generated artifacts"
+        />
+        <InspectorLedgerItem
+          label="Provider reload"
+          value="Worker restart required"
+        />
+      </InspectorLedger>
+    </DisclosureSection>
   );
+}
+
+function providerSetupSummary(
+  store: CredentialsResponse["store"] | undefined,
+  statuses: readonly ProviderStatusItem[],
+): string {
+  if (!store) return "Checking provider setup";
+  const readyCount = statuses.filter((status) => status.ready).length;
+  const storage = store.available
+    ? "macOS Keychain"
+    : store.unavailableReason === "unsupported_platform"
+      ? "Environment-managed secrets"
+      : "Storage inspection unavailable";
+  return `${readyCount} of 3 providers ready · ${storage}`;
+}
+
+function credentialStatusLabel(
+  credential: CredentialsResponse["credentials"][number],
+): string {
+  if (credential.effectiveSource === "environment") return "Environment-managed";
+  if (credential.effectiveSource === "inspection_unknown") return "Status unavailable";
+  return credential.configured ? "Configured" : "Not configured";
 }
 
 function findStatus(

--- a/apps/web/src/contexts/profile/components/ModelSelectionPanel.a11y.test.tsx
+++ b/apps/web/src/contexts/profile/components/ModelSelectionPanel.a11y.test.tsx
@@ -37,7 +37,7 @@ describe("<ModelSelectionPanel> a11y", () => {
       }),
     });
 
-    await screen.findByRole("button", { name: "retry catalog" });
+    await screen.findByRole("button", { name: "Retry catalog" });
     expect(await axe(view.container)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/contexts/profile/components/ModelSelectionPanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/ModelSelectionPanel.test.tsx
@@ -44,7 +44,7 @@ describe("<ModelSelectionPanel>", () => {
     const google = await providerCard("Google");
     expect(claude.getByText(/live availability/i)).toBeInTheDocument();
     expect(codex.getByText(/live availability/i)).toBeInTheDocument();
-    expect(google.getByRole("link", { name: "configure Google" })).toHaveAttribute(
+    expect(google.getByRole("link", { name: "Configure Google" })).toHaveAttribute(
       "href",
       "/settings/credentials",
     );
@@ -73,9 +73,10 @@ describe("<ModelSelectionPanel>", () => {
 
     const claude = await providerCard("Claude");
     const select = await claude.findByRole("combobox", { name: /Preferred model/ });
-    expect(select).toHaveValue("claude-sonnet-5");
-    await user.selectOptions(select, "claude-opus-4-8");
-    await user.click(claude.getByRole("button", { name: "save model" }));
+    expect(select).toHaveTextContent("Sonnet 5");
+    await user.click(select);
+    await user.click(await screen.findByRole("option", { name: /Opus 4\.8.*claude-opus-4-8/ }));
+    await user.click(claude.getByRole("button", { name: "Save model" }));
 
     expect(updateSettings).toHaveBeenCalledWith({ preferredModels: { claude: "claude-opus-4-8" } });
     expect(await claude.findByRole("status")).toHaveTextContent(
@@ -102,9 +103,9 @@ describe("<ModelSelectionPanel>", () => {
 
     const claude = await providerCard("Claude");
     const select = await claude.findByRole("combobox", { name: /Preferred model/ });
-    expect(select).toHaveValue("");
+    expect(select).toHaveTextContent("Provider default");
     await act(async () => resolveSettings(sampleSettingsResponse));
-    await waitFor(() => expect(select).toHaveValue("claude-sonnet-5"));
+    await waitFor(() => expect(select).toHaveTextContent("Sonnet 5"));
   });
 
   it("clears a saved choice back to the provider default", async () => {
@@ -125,8 +126,9 @@ describe("<ModelSelectionPanel>", () => {
     });
 
     const claude = await providerCard("Claude");
-    await user.selectOptions(await claude.findByRole("combobox", { name: /Preferred model/ }), "");
-    await user.click(claude.getByRole("button", { name: "save model" }));
+    await user.click(await claude.findByRole("combobox", { name: /Preferred model/ }));
+    await user.click(await screen.findByRole("option", { name: "Provider default" }));
+    await user.click(claude.getByRole("button", { name: "Save model" }));
 
     expect(updateSettings).toHaveBeenCalledWith({ preferredModels: { claude: null } });
   });
@@ -155,7 +157,7 @@ describe("<ModelSelectionPanel>", () => {
     });
 
     const google = await providerCard("Google");
-    await user.click(await google.findByRole("button", { name: "clear saved model" }));
+    await user.click(await google.findByRole("button", { name: "Clear saved model" }));
     expect(updateSettings).toHaveBeenCalledWith({ preferredModels: { google: null } });
   });
 
@@ -177,7 +179,7 @@ describe("<ModelSelectionPanel>", () => {
     });
 
     const claude = await providerCard("Claude");
-    await user.click(await claude.findByRole("button", { name: "clear saved model" }));
+    await user.click(await claude.findByRole("button", { name: "Clear saved model" }));
     expect(updateSettings).toHaveBeenCalledWith({ preferredModels: { claude: null } });
   });
 
@@ -198,11 +200,12 @@ describe("<ModelSelectionPanel>", () => {
     expect(await screen.findByText(/synthetic model catalog for preview only/i)).toBeInTheDocument();
     const claude = await providerCard("Claude");
     expect(claude.getByRole("combobox", { name: /Preferred model/ })).toBeDisabled();
-    expect(claude.getByRole("button", { name: "save model" })).toBeDisabled();
+    expect(claude.getByRole("button", { name: "Save model" })).toBeDisabled();
     expect(updateSettings).not.toHaveBeenCalled();
   });
 
   it("keeps a stale saved model visible until the user chooses a current option", async () => {
+    const user = userEvent.setup();
     renderWithProviders(<ModelSelectionPanel />, {
       withRouter: true,
       ports: buildTestPorts({
@@ -220,8 +223,9 @@ describe("<ModelSelectionPanel>", () => {
     });
 
     const codex = await providerCard("Codex");
-    expect(await codex.findByRole("option", {
+    await user.click(await codex.findByRole("combobox", { name: /Preferred model/ }));
+    expect(await screen.findByRole("option", {
       name: "retired-codex-model (no longer available)",
-    })).toBeDisabled();
+    })).toHaveAttribute("data-disabled");
   });
 });

--- a/apps/web/src/contexts/profile/components/ModelSelectionPanel.tsx
+++ b/apps/web/src/contexts/profile/components/ModelSelectionPanel.tsx
@@ -8,10 +8,15 @@ import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
+import { SelectField } from "../../../shared/ui/select-field.js";
 import { useProviderModelsQuery } from "../hooks/useProviderModelsQuery.js";
 import { useSettingsQuery } from "../hooks/useSettingsQuery.js";
 import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
+
+const PROVIDER_DEFAULT_OPTION = "__jobctrl_provider_default__";
 
 const PROVIDER_COPY: Readonly<Record<ProviderId, { title: string; description: string }>> = {
   codex: {
@@ -37,67 +42,97 @@ export function ModelSelectionPanel() {
   const providers = new Map(
     (catalogQuery.data?.providers ?? []).map((provider) => [provider.provider, provider]),
   );
+  const readyProviderCount = ProviderIds.filter((providerId) => {
+    const provider = providers.get(providerId);
+    return provider?.ready && provider.models.length > 0;
+  }).length;
+  const savedPreferenceCount = ProviderIds.filter(
+    (providerId) => settings?.preferredModels[providerId],
+  ).length;
+  const collapsedSummary = isDemo
+    ? `Preview only · ${savedChoiceCount(savedPreferenceCount)}`
+    : catalogQuery.error
+      ? `Catalog unavailable · ${savedChoiceCount(savedPreferenceCount)}`
+      : catalogQuery.isPending
+        ? `Checking provider catalog · ${savedChoiceCount(savedPreferenceCount)}`
+        : `${readyProviderCount} of ${ProviderIds.length} providers ready · ${savedChoiceCount(savedPreferenceCount)}`;
 
   return (
-    <section className="card full model-selection-shell">
-      <CardHeader title="Model selection" meta="new work" />
-      <div className="model-selection-intro">
-        <p>
-          Configure at least one provider before choosing its preferred model. One provider is enough;
-          a second is recommended for resilience, not required.
-        </p>
-        <p>
-          Saved choices in <code>config.json</code> apply to newly started work. An explicit
-          per-workflow model takes precedence when that workflow supports one.
-        </p>
+    <DisclosureSection
+      className="model-selection-settings"
+      title="Model selection"
+      description="Preferred provider models for newly started work"
+      collapsedSummary={collapsedSummary}
+    >
+      <div className="model-selection-settings__content grid gap-4">
+        <div className="model-selection-guidance grid max-w-[76ch] gap-1.5 text-[12px] leading-5 text-muted-foreground">
+          <p className="m-0">
+            Configure at least one provider before choosing its preferred model. One provider is
+            enough; a second is recommended for resilience, not required.
+          </p>
+          <p className="m-0">
+            Saved choices in <code className="font-mono text-foreground">config.json</code> apply
+            to newly started work. An explicit per-workflow model takes precedence when that
+            workflow supports one.
+          </p>
+        </div>
+
+        {isDemo ? (
+          <p className="model-selection-demo-status m-0 text-[12px] leading-5 text-muted-foreground" role="status">
+            This browser-local demo shows a synthetic model catalog for preview only. Provider
+            connections and model changes are unavailable here.
+          </p>
+        ) : null}
+
+        {settingsQuery.error ? (
+          <p className="model-selection-error m-0 text-[12px] leading-5 text-destructive" role="alert">
+            Current model preferences are unavailable. Reload this page before making a change.
+          </p>
+        ) : null}
+        {catalogQuery.error ? (
+          <div className="model-catalog-error flex flex-wrap items-center justify-between gap-3">
+            <p className="m-0 text-[12px] leading-5 text-destructive" role="alert">
+              Available models could not be loaded. Provider credentials were not changed.
+            </p>
+            <Button
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={() => void catalogQuery.refetch()}
+            >
+              Retry catalog
+            </Button>
+          </div>
+        ) : null}
+
+        <div
+          className="model-provider-preferences grid gap-3"
+          aria-busy={settingsQuery.isPending || catalogQuery.isPending}
+        >
+          {ProviderIds.map((providerId) => (
+            <ProviderModelPreference
+              key={providerId}
+              catalog={providers.get(providerId)}
+              catalogPending={catalogQuery.isPending}
+              isDemo={isDemo}
+              provider={providerId}
+              savedModel={settings?.preferredModels[providerId]}
+              settingsPending={settingsQuery.isPending}
+              settingsReady={Boolean(settings)}
+            />
+          ))}
+        </div>
       </div>
-
-      {isDemo ? (
-        <div className="banner credential-store-notice credential-store-notice--guidance" role="status">
-          This browser-local demo shows a synthetic model catalog for preview only. Provider
-          connections and model changes are unavailable here.
-        </div>
-      ) : null}
-
-      {settingsQuery.error ? (
-        <div className="banner inline" role="alert">
-          Current model preferences are unavailable. Reload this page before making a change.
-        </div>
-      ) : null}
-      {catalogQuery.error ? (
-        <div className="banner inline model-catalog-error" role="alert">
-          <span>Available models could not be loaded. Provider credentials were not changed.</span>
-          <button className="tab" type="button" onClick={() => void catalogQuery.refetch()}>
-            retry catalog
-          </button>
-        </div>
-      ) : null}
-
-      <div
-        className="provider-card-list model-selection-list"
-        aria-busy={settingsQuery.isPending || catalogQuery.isPending}
-      >
-        {ProviderIds.map((providerId) => (
-          <ProviderModelCard
-            key={providerId}
-            catalog={providers.get(providerId)}
-            catalogPending={catalogQuery.isPending}
-            isDemo={isDemo}
-            provider={providerId}
-            savedModel={settings?.preferredModels[providerId]}
-            settingsReady={Boolean(settings)}
-          />
-        ))}
-      </div>
-    </section>
+    </DisclosureSection>
   );
 }
 
-function ProviderModelCard({
+function ProviderModelPreference({
   provider,
   catalog,
   savedModel,
   settingsReady,
+  settingsPending,
   catalogPending,
   isDemo,
 }: {
@@ -105,6 +140,7 @@ function ProviderModelCard({
   catalog: ProviderModelCatalogItem | undefined;
   savedModel: string | undefined;
   settingsReady: boolean;
+  settingsPending: boolean;
   catalogPending: boolean;
   isDemo: boolean;
 }) {
@@ -116,7 +152,6 @@ function ProviderModelCard({
   }));
   const [statusMessage, setStatusMessage] = useState("");
   const providerCopy = PROVIDER_COPY[provider];
-  const modelHintId = `preferred-model-${provider}-hint`;
   const models = catalog?.models ?? [];
   const knownModelIds = new Set(models.map((model) => model.id));
   const draftModel =
@@ -142,6 +177,21 @@ function ProviderModelCard({
         : catalog?.configured
           ? "Needs attention"
           : "Configure first";
+  const savedChoiceLabel = settingsReady
+    ? savedModel || "Provider default"
+    : settingsPending
+      ? "Checking saved choice"
+      : "Saved choice unavailable";
+  const modelOptions = [
+    { value: PROVIDER_DEFAULT_OPTION, label: "Provider default" },
+    ...(savedModelUnavailable && savedModel
+      ? [{ value: savedModel, label: `${savedModel} (no longer available)`, disabled: true }]
+      : []),
+    ...models.map((model) => ({
+      value: model.id,
+      label: `${modelOptionLabel(model.displayName, model.id)}${model.isDefault ? " · provider default" : ""}`,
+    })),
+  ];
 
   async function persistPreference(nextModel: string | null) {
     setStatusMessage("");
@@ -174,88 +224,99 @@ function ProviderModelCard({
   }
 
   return (
-    <article className="provider-card model-selection-card" data-provider={provider}>
-      <header className="provider-card-header">
-        <div>
-          <h3>{providerCopy.title}</h3>
-          <p>{providerCopy.description}</p>
-        </div>
-        <span className={`tag ${catalogReady && !isDemo ? "ok" : "muted"}`}>{statusLabel}</span>
-      </header>
+    <article className="provider-model-preference" data-provider={provider}>
+      <DisclosureSection
+        className="provider-preference-disclosure"
+        title={providerCopy.title}
+        description={providerCopy.description}
+        collapsedSummary={`Status: ${statusLabel} · Saved: ${savedChoiceLabel}`}
+      >
+        <div className="provider-preference-content grid gap-4">
+          <div className="provider-preference-status grid gap-1 text-[12px] leading-5 text-muted-foreground">
+            <p className="m-0">Status: {statusLabel}</p>
+            <p className="m-0">Saved choice: {savedChoiceLabel}</p>
+            <p className="m-0">Live availability from the authenticated provider runtime.</p>
+            {catalog?.message ? <p className="m-0">{catalog.message}</p> : null}
+          </div>
 
-      <p className="provider-model-source">
-        Live availability from the authenticated provider runtime.
-      </p>
-      {catalog?.message ? <p className="provider-status-message">{catalog.message}</p> : null}
+          {!catalogPending && !catalog?.ready && !isDemo ? (
+            <div className="provider-preference-empty grid justify-items-start gap-3">
+              <p className="m-0 text-[12px] leading-5 text-muted-foreground">
+                Finish and verify this provider before selecting a model.
+              </p>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/settings/credentials">Configure {providerCopy.title}</Link>
+              </Button>
+            </div>
+          ) : (
+            <AdaptiveFieldGrid columns="auto" minColumnWidth={280} density="compact">
+              <SelectField
+                id={`preferred-model-${provider}`}
+                name={`preferred-model-${provider}`}
+                className="provider-preference-field"
+                label="Preferred model"
+                description={
+                  savedModelUnavailable
+                    ? `Saved: ${savedModel}. This model is no longer available in the provider catalog.`
+                    : savedModel
+                      ? `Saved: ${savedModel}`
+                      : "No saved preference; the provider chooses its default."
+                }
+                disabled={!canEdit}
+                options={modelOptions}
+                value={draftModel || PROVIDER_DEFAULT_OPTION}
+                onValueChange={(value) => {
+                  setDraftState({
+                    base: currentSavedModel,
+                    value: value === PROVIDER_DEFAULT_OPTION ? "" : value,
+                  });
+                  setStatusMessage("");
+                  updateSettings.reset();
+                }}
+              />
+              <div className="provider-preference-save-action flex items-end">
+                <Button
+                  size="sm"
+                  type="button"
+                  disabled={!canSave}
+                  onClick={() => void savePreference()}
+                >
+                  {updateSettings.isPending ? "Saving…" : "Save model"}
+                </Button>
+              </div>
+            </AdaptiveFieldGrid>
+          )}
 
-      {!catalogPending && !catalog?.ready && !isDemo ? (
-        <div className="provider-model-empty">
-          <p>Finish and verify this provider before selecting a model.</p>
-          <Link className="tab" to="/settings/credentials">
-            configure {providerCopy.title}
-          </Link>
-        </div>
-      ) : (
-        <div className="provider-model-form">
-          <label className="field" htmlFor={`preferred-model-${provider}`}>
-            <span>Preferred model</span>
-            <select
-              id={`preferred-model-${provider}`}
-              name={`preferred-model-${provider}`}
-              aria-describedby={modelHintId}
-              value={draftModel}
-              disabled={!canEdit}
-              onChange={(event) => {
-                setDraftState({ base: currentSavedModel, value: event.target.value });
-                setStatusMessage("");
-                updateSettings.reset();
-              }}
+          {savedModel && !isDemo ? (
+            <div className="provider-preference-clear-action">
+              <Button
+                size="sm"
+                type="button"
+                variant="ghost"
+                disabled={!settingsReady || updateSettings.isPending}
+                onClick={() => void clearPreference()}
+              >
+                Clear saved model
+              </Button>
+            </div>
+          ) : null}
+
+          {statusMessage ? (
+            <p
+              className="provider-preference-save-status m-0 text-[12px] leading-5 text-muted-foreground"
+              role={updateSettings.isError ? "alert" : "status"}
             >
-              <option value="">Provider default</option>
-              {savedModelUnavailable ? (
-                <option value={savedModel} disabled>{savedModel} (no longer available)</option>
-              ) : null}
-              {models.map((model) => (
-                <option key={model.id} value={model.id}>
-                  {modelOptionLabel(model.displayName, model.id)}{model.isDefault ? " · provider default" : ""}
-                </option>
-              ))}
-            </select>
-            <small className="field-hint" id={modelHintId}>
-              {savedModel
-                ? `Saved: ${savedModel}`
-                : "No saved preference; the provider chooses its default."}
-            </small>
-          </label>
-          <button
-            className="tab on"
-            type="button"
-            disabled={!canSave}
-            onClick={() => void savePreference()}
-          >
-            {updateSettings.isPending ? "saving" : "save model"}
-          </button>
+              {statusMessage}
+            </p>
+          ) : null}
         </div>
-      )}
-
-      {savedModel && !isDemo ? (
-        <button
-          className="tab provider-model-clear"
-          type="button"
-          disabled={!settingsReady || updateSettings.isPending}
-          onClick={() => void clearPreference()}
-        >
-          clear saved model
-        </button>
-      ) : null}
-
-      {statusMessage ? (
-        <p className="provider-model-save-status" role={updateSettings.isError ? "alert" : "status"}>
-          {statusMessage}
-        </p>
-      ) : null}
+      </DisclosureSection>
     </article>
   );
+}
+
+function savedChoiceCount(count: number): string {
+  return `${count} saved ${count === 1 ? "choice" : "choices"}`;
 }
 
 function modelOptionLabel(displayName: string, modelId: string): string {

--- a/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -44,6 +45,7 @@ describe("<ProfileEditor>", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Resume data" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Resume preview" })).toBeInTheDocument();
     expect(await screen.findByText("Baseline resume editor")).toBeInTheDocument();
     expect(await screen.findByText("Plate HTML/CSS editor")).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Bold" })).toBeInTheDocument();
@@ -54,6 +56,7 @@ describe("<ProfileEditor>", () => {
   });
 
   it("renders preferences without the PDF preview pane", async () => {
+    const user = userEvent.setup();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
@@ -80,33 +83,20 @@ describe("<ProfileEditor>", () => {
       }),
     });
 
-    expect(
-      await screen.findByRole("heading", { name: "Configuration & templates" }),
-    ).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Application configurations" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Location filter")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Target search" })).not.toBeInTheDocument();
-    expect(screen.getByRole("group", { name: "Revision policy" })).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Quality gates" }));
     expect(screen.getByLabelText("Minimum fit score")).toHaveValue(8);
     expect(screen.getByLabelText("Must-have coverage (%)")).toHaveValue(85);
     expect(screen.getByLabelText("Revision attempts")).toHaveValue(1);
     expect(screen.queryByText("Baseline resume editor")).not.toBeInTheDocument();
-    expect(await screen.findByText("Resume template preview")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Resume templates" })).toBeInTheDocument();
     const templatePreview = document.querySelector<HTMLElement>(".resume-template-plate-editor");
     expect(templatePreview).toBeTruthy();
-    fireEvent.change(screen.getByLabelText("Density"), { target: { value: "spacious" } });
-    expect(templatePreview?.style.getPropertyValue("--resume-template-line-height")).toBe("1.48");
-    expect(templatePreview?.style.getPropertyValue("--resume-template-section-gap")).toBe("7.2mm");
-    expect(templatePreview?.style.getPropertyValue("--resume-template-entry-gap")).toBe("5.8mm");
-    expect(templatePreview?.style.getPropertyValue("--resume-template-list-gap")).toBe("2.4mm");
-    fireEvent.change(screen.getByLabelText("Bullets"), { target: { value: "loose" } });
-    expect(templatePreview?.style.getPropertyValue("--resume-template-bullet-gap")).toBe("2.4mm");
-    const fontSelects = screen.getAllByLabelText("Font");
-    expect(fontSelects).toHaveLength(2);
-    expect(within(fontSelects[0]!).getByRole("option", { name: "Garamond" })).toHaveValue("garamond");
-    expect(within(fontSelects[1]!).getByRole("option", { name: "Garamond" })).toHaveValue("garamond");
-    expect(within(fontSelects[1]!).getByRole("option", { name: "Resume" })).toHaveValue("resume");
-    expect(screen.getByLabelText("Size")).toHaveAttribute("type", "number");
+    expect(screen.getByRole("region", { name: "Resume template preview" })).toContainElement(
+      templatePreview,
+    );
     expect(screen.queryByLabelText("Resize profile and resume editor panes")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/contexts/profile/components/ProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.tsx
@@ -1,8 +1,7 @@
 import { useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent } from "react";
-import { Link } from "@tanstack/react-router";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import { PreviewWorkbench } from "../../../shared/ui/preview-workbench.js";
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
 import { ResumeStandalonePlateEditor } from "../../materials/components/ResumeAuditPins.js";
 import { ProfileForm } from "../forms/profile-form.js";
@@ -33,8 +32,6 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
   const layoutStyle = {
     "--profile-editor-width": `${editorWidth}%`,
   } as CSSProperties;
-  const cardTitle =
-    section === "preferences" ? "Configuration & templates" : "Resume data";
 
   const setWidthFromClientX = (clientX: number, persist = false) => {
     const rect = layoutRef.current?.getBoundingClientRect();
@@ -74,18 +71,16 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
       ref={layoutRef}
       style={layoutStyle}
     >
-      <section className="card">
-        <CardHeader
-          title={cardTitle}
-          meta={profileQuery.data ? undefined : "loading"}
-        />
+      <section className="profile-editor-panel">
         {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
         {section === "profile" ? (
-          <div className="toolbar profile-evidence-toolbar">
-            <Link className="tab" to="/evidence-map">
-              Open evidence map
-            </Link>
-          </div>
+          <header className="profile-editor-panel__header">
+            <div>
+              <span className="eyebrow">Canonical source</span>
+              <h2>Resume data</h2>
+              <p>Maintain the evidence-backed baseline used for every tailored resume.</p>
+            </div>
+          </header>
         ) : null}
         {profileQuery.data ? (
           section === "preferences" ? (
@@ -121,12 +116,19 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
           >
             <span aria-hidden="true" />
           </button>
-          <aside className="preview resume-editor-preview">
-            <ResumeStandalonePlateEditor
-              className="profile-resume-plate-editor"
-              htmlUrl={profileHtmlPreviewUrl}
-              title="Baseline resume editor"
-            />
+          <aside className="profile-preview-pane">
+            <PreviewWorkbench
+              className="profile-preview-workbench"
+              title="Resume preview"
+              description="The live baseline generated from the profile data."
+              previewLabel="Baseline resume preview"
+            >
+              <ResumeStandalonePlateEditor
+                className="profile-resume-plate-editor"
+                htmlUrl={profileHtmlPreviewUrl}
+                title="Baseline resume editor"
+              />
+            </PreviewWorkbench>
           </aside>
         </>
       ) : null}

--- a/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
@@ -1,6 +1,9 @@
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { Card } from "../../../shared/ui/card.js";
+import { PageHead } from "../../../shared/ui/page-head.js";
+import { SectionTabs, SectionTabsList } from "../../../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../../../shared/ui/tabs.js";
 
 const STEPS: ReadonlyArray<{
   readonly key: string;
@@ -14,27 +17,48 @@ const STEPS: ReadonlyArray<{
 
 export function ResumeImportWizard() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const activeStep = STEPS.find((step) => step.to === pathname)?.to ?? "/profile/import/upload";
+
   return (
-    <section className="card full">
-      <CardHeader title="Resume import" meta="three-step wizard" />
-      <nav className="wizard-steps" aria-label="Wizard steps">
-        {STEPS.map((step) => {
-          const active = pathname === step.to;
-          return (
-            <Link
-              key={step.key}
-              to={step.to}
-              className={`tab ${active ? "on" : ""}`}
-              aria-current={active ? "step" : undefined}
-            >
-              {step.label}
-            </Link>
-          );
-        })}
-      </nav>
-      <div className="wizard-body">
-        <Outlet />
-      </div>
-    </section>
+    <div className="route-page resume-import-wizard">
+      <PageHead
+        eyebrow="Profile"
+        title="Resume import"
+        subtitle="Upload a PDF, choose the sections to import, then confirm."
+      />
+      <Card className="resume-import-wizard__card overflow-hidden shadow-none">
+        <SectionTabs className="resume-import-wizard__tabs" value={activeStep}>
+          <nav className="resume-import-wizard__steps px-4 pt-2" aria-label="Wizard steps">
+            <SectionTabsList>
+              {STEPS.map((step) => {
+                const active = activeStep === step.to;
+                return (
+                  <TabsTrigger
+                    key={step.key}
+                    value={step.to}
+                    className="data-[state=active]:border-foreground"
+                    asChild
+                  >
+                    <Link
+                      to={step.to}
+                      aria-current={active ? "step" : undefined}
+                    >
+                      {step.label}
+                    </Link>
+                  </TabsTrigger>
+                );
+              })}
+            </SectionTabsList>
+          </nav>
+          <TabsContent
+            className="resume-import-wizard__content m-0 p-4"
+            value={activeStep}
+            forceMount
+          >
+            <Outlet />
+          </TabsContent>
+        </SectionTabs>
+      </Card>
+    </div>
   );
 }

--- a/apps/web/src/contexts/profile/components/ResumeTemplatePanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeTemplatePanel.test.tsx
@@ -1,0 +1,124 @@
+import { screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { sampleResumeTemplateListResponse } from "../../../test/fixtures/projections.js";
+import { renderWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { ResumeTemplatePanel } from "./ResumeTemplatePanel.js";
+
+describe("<ResumeTemplatePanel>", () => {
+  it("keeps compact controls above the real full-width Plate preview", async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithProviders(
+      <ResumeTemplatePanel profileHtmlPreviewUrl={null} />,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Resume templates" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Template" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Font" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("Modern HTML"),
+    );
+
+    const workbench = container.querySelector<HTMLElement>(
+      ".preview-workbench.resume-template-panel",
+    );
+    const primaryGrid = container.querySelector<HTMLElement>(
+      ".resume-template-primary-controls .adaptive-field-grid",
+    );
+    const secondaryControls = container.querySelector<HTMLElement>(
+      ".resume-template-secondary-controls",
+    );
+    const previewRegion = container.querySelector<HTMLElement>(
+      ".preview-workbench__document",
+    );
+    const plateEditor = container.querySelector<HTMLElement>(
+      ".resume-template-plate-editor",
+    );
+
+    expect(workbench).toBeTruthy();
+    expect(primaryGrid).toHaveAttribute("data-columns", "3");
+    expect(secondaryControls).toBeTruthy();
+    expect(previewRegion).toContainElement(plateEditor);
+    expect(plateEditor?.parentElement).toBe(previewRegion);
+    expect(
+      secondaryControls!.compareDocumentPosition(previewRegion!),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    const density = screen.getByRole("group", { name: "Density" });
+    await user.click(within(density).getByRole("button", { name: "Spacious" }));
+    expect(plateEditor?.style.getPropertyValue("--resume-template-line-height")).toBe("1.48");
+    expect(plateEditor?.style.getPropertyValue("--resume-template-section-gap")).toBe("7.2mm");
+
+    const bullets = screen.getByRole("group", { name: "Bullets" });
+    await user.click(within(bullets).getByRole("button", { name: "Loose" }));
+    expect(plateEditor?.style.getPropertyValue("--resume-template-bullet-gap")).toBe("2.4mm");
+  });
+
+  it("clones a built-in theme before chaining save default to the new version", async () => {
+    const user = userEvent.setup();
+    const sourceTemplate = sampleResumeTemplateListResponse.templates[0]!;
+    const savedTemplate = {
+      ...sourceTemplate,
+      templateId: "custom:executive",
+      displayName: "Executive",
+      builtIn: false,
+      activeVersion: {
+        ...sourceTemplate.activeVersion,
+        templateId: "custom:executive",
+        versionId: "custom:executive:v1",
+        displayName: "Executive",
+      },
+    };
+    const saveResumeTemplate = vi.fn(async () => ({
+      ok: true as const,
+      template: savedTemplate,
+    }));
+    const setDefaultResumeTemplate = vi.fn(async () => ({
+      ok: true as const,
+      defaultTemplate: {
+        ...sampleResumeTemplateListResponse.builtInDefault,
+        templateId: savedTemplate.templateId,
+        templateVersionId: savedTemplate.activeVersion.versionId,
+        templateName: savedTemplate.displayName,
+        assignmentSource: "profile_default" as const,
+      },
+    }));
+
+    renderWithProviders(<ResumeTemplatePanel profileHtmlPreviewUrl={null} />, {
+      ports: buildTestPorts({
+        api: {
+          saveResumeTemplate,
+          setDefaultResumeTemplate,
+        },
+      }),
+    });
+
+    const name = await screen.findByRole("textbox", { name: "Name" });
+    await waitFor(() => expect(name).toHaveValue("Modern HTML"));
+    await user.clear(name);
+    await user.type(name, "Executive");
+    await user.click(screen.getByRole("button", { name: "Save default" }));
+
+    await waitFor(() =>
+      expect(saveResumeTemplate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          templateId: undefined,
+          displayName: "Executive",
+          layout: {},
+          theme: expect.objectContaining({
+            fontFamily: sourceTemplate.activeVersion.theme.fontFamily,
+            marginMm: { ...sourceTemplate.activeVersion.theme.marginMm },
+          }),
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(setDefaultResumeTemplate).toHaveBeenCalledWith({
+        templateId: savedTemplate.templateId,
+        versionId: savedTemplate.activeVersion.versionId,
+      }),
+    );
+  });
+});

--- a/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
@@ -4,9 +4,23 @@ import type {
   ResumeTemplateTheme,
 } from "@jobctrl/contracts";
 import { IconDeviceFloppy, IconStar } from "@tabler/icons-react";
-import { useEffect, useMemo, useState, type CSSProperties, type JSX } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type JSX,
+} from "react";
 
 import { ResumeStandalonePlateEditor } from "../../materials/components/ResumeAuditPins.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { Field, FieldLabel } from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
+import { PreviewWorkbench } from "../../../shared/ui/preview-workbench.js";
+import { SegmentedField } from "../../../shared/ui/segmented-field.js";
+import { SelectField } from "../../../shared/ui/select-field.js";
 import {
   useSaveResumeTemplateMutation,
   useSetDefaultResumeTemplateMutation,
@@ -55,7 +69,40 @@ const FONT_LABELS: Record<ResumeTemplateTheme["fontFamily"], string> = {
   cambria: "Cambria",
 };
 
-const FONT_OPTIONS = Object.entries(FONT_LABELS) as Array<[ResumeTemplateTheme["fontFamily"], string]>;
+const FONT_OPTIONS = Object.entries(FONT_LABELS) as Array<
+  [ResumeTemplateTheme["fontFamily"], string]
+>;
+
+const FONT_SELECT_OPTIONS = FONT_OPTIONS.map(([value, label]) => ({ value, label }));
+
+const DENSITY_OPTIONS = [
+  { value: "compact", label: "Compact" },
+  { value: "balanced", label: "Balanced" },
+  { value: "spacious", label: "Spacious" },
+] as const;
+
+const HEADER_LAYOUT_OPTIONS = [
+  { value: "centered", label: "Centered" },
+  { value: "left", label: "Left" },
+  { value: "split", label: "Split" },
+] as const;
+
+const HEADING_STYLE_OPTIONS = [
+  { value: "rule", label: "Rule" },
+  { value: "plain", label: "Plain" },
+  { value: "boxed", label: "Boxed" },
+] as const;
+
+const ALIGNMENT_OPTIONS = [
+  { value: "justified", label: "Justified" },
+  { value: "left", label: "Left" },
+] as const;
+
+const BULLET_SPACING_OPTIONS = [
+  { value: "tight", label: "Tight" },
+  { value: "normal", label: "Normal" },
+  { value: "loose", label: "Loose" },
+] as const;
 
 const DENSITY_TOKENS: Record<
   ResumeTemplateTheme["density"],
@@ -91,6 +138,7 @@ const DENSITY_TOKENS: Record<
 };
 
 export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePanelProps): JSX.Element {
+  const fieldIdPrefix = useId();
   const templatesQuery = useResumeTemplatesQuery();
   const saveTemplate = useSaveResumeTemplateMutation();
   const setDefaultTemplate = useSetDefaultResumeTemplateMutation();
@@ -171,115 +219,112 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
   };
 
   return (
-    <section className="form-section resume-template-panel" aria-label="Resume templates">
-      <h3>Resume templates</h3>
-      <div className="resume-template-shell">
-        <div className="resume-template-controls">
-          <div className="field-grid">
-            <label className="field">
-              <span>Template</span>
-              <select
-                disabled={!templates.length || isSaving}
-                value={activeTemplate?.templateId ?? ""}
-                onChange={(event) => setActiveTemplateId(event.target.value)}
-              >
-                {templates.map((template) => (
-                  <option key={template.templateId} value={template.templateId}>
-                    {template.displayName}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="field">
-              <span>Name</span>
-              <input
-                disabled={!theme || isSaving}
-                value={displayName}
-                onChange={(event) => setDisplayName(event.target.value)}
-              />
-            </label>
-            <label className="field">
-              <span>Font</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.fontFamily ?? "sans"}
-                onChange={(event) => updateTheme("fontFamily", event.target.value as ResumeTemplateTheme["fontFamily"])}
-              >
-                {FONT_OPTIONS.map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label className="field">
-              <span>Density</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.density ?? "balanced"}
-                onChange={(event) => updateTheme("density", event.target.value as ResumeTemplateTheme["density"])}
-              >
-                <option value="compact">Compact</option>
-                <option value="balanced">Balanced</option>
-                <option value="spacious">Spacious</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>Header</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.headerLayout ?? "centered"}
-                onChange={(event) =>
-                  updateTheme("headerLayout", event.target.value as ResumeTemplateTheme["headerLayout"])
-                }
-              >
-                <option value="centered">Centered</option>
-                <option value="left">Left</option>
-                <option value="split">Split</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>Headings</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.sectionHeadingStyle ?? "rule"}
-                onChange={(event) =>
-                  updateTheme("sectionHeadingStyle", event.target.value as ResumeTemplateTheme["sectionHeadingStyle"])
-                }
-              >
-                <option value="rule">Rule</option>
-                <option value="plain">Plain</option>
-                <option value="boxed">Boxed</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>Alignment</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.alignment ?? "justified"}
-                onChange={(event) => updateTheme("alignment", event.target.value as ResumeTemplateTheme["alignment"])}
-              >
-                <option value="justified">Justified</option>
-                <option value="left">Left</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>Bullets</span>
-              <select
-                disabled={!theme || isSaving}
-                value={theme?.bulletSpacing ?? "normal"}
-                onChange={(event) =>
-                  updateTheme("bulletSpacing", event.target.value as ResumeTemplateTheme["bulletSpacing"])
-                }
-              >
-                <option value="tight">Tight</option>
-                <option value="normal">Normal</option>
-                <option value="loose">Loose</option>
-              </select>
-            </label>
-            <label className="field">
-              <span>Font scale</span>
-              <input
+    <PreviewWorkbench
+      className="resume-template-panel"
+      aria-label="Resume templates"
+      title="Resume templates"
+      status={
+        selectedTemplateIsDefault ? (
+          <span className="resume-template-default-state">Default template</span>
+        ) : undefined
+      }
+      primaryControls={
+        <AdaptiveFieldGrid
+          className="resume-template-primary-controls"
+          columns={3}
+          density="compact"
+          minColumnWidth={168}
+        >
+          <SelectField
+            label="Template"
+            disabled={!templates.length || isSaving}
+            options={templates.map((template) => ({
+              value: template.templateId,
+              label: template.displayName,
+            }))}
+            value={activeTemplate?.templateId ?? ""}
+            onValueChange={setActiveTemplateId}
+          />
+          <Field data-disabled={!theme || isSaving}>
+            <FieldLabel htmlFor={`${fieldIdPrefix}-name`}>Name</FieldLabel>
+            <Input
+              id={`${fieldIdPrefix}-name`}
+              disabled={!theme || isSaving}
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+            />
+          </Field>
+          <SelectField
+            label="Font"
+            disabled={!theme || isSaving}
+            options={FONT_SELECT_OPTIONS}
+            value={theme?.fontFamily ?? "sans"}
+            onValueChange={(value) =>
+              updateTheme("fontFamily", value as ResumeTemplateTheme["fontFamily"])
+            }
+          />
+        </AdaptiveFieldGrid>
+      }
+      secondaryControls={
+        <div className="resume-template-secondary-controls">
+          <AdaptiveFieldGrid
+            className="resume-template-style-controls"
+            columns={3}
+            density="compact"
+            minColumnWidth={238}
+          >
+            <SegmentedField
+              label="Density"
+              disabled={!theme || isSaving}
+              options={DENSITY_OPTIONS}
+              value={theme?.density ?? "balanced"}
+              onValueChange={(value) =>
+                updateTheme("density", value as ResumeTemplateTheme["density"])
+              }
+            />
+            <SegmentedField
+              label="Header"
+              disabled={!theme || isSaving}
+              options={HEADER_LAYOUT_OPTIONS}
+              value={theme?.headerLayout ?? "centered"}
+              onValueChange={(value) =>
+                updateTheme("headerLayout", value as ResumeTemplateTheme["headerLayout"])
+              }
+            />
+            <SegmentedField
+              label="Headings"
+              disabled={!theme || isSaving}
+              options={HEADING_STYLE_OPTIONS}
+              value={theme?.sectionHeadingStyle ?? "rule"}
+              onValueChange={(value) =>
+                updateTheme(
+                  "sectionHeadingStyle",
+                  value as ResumeTemplateTheme["sectionHeadingStyle"],
+                )
+              }
+            />
+            <SegmentedField
+              label="Alignment"
+              disabled={!theme || isSaving}
+              options={ALIGNMENT_OPTIONS}
+              value={theme?.alignment ?? "justified"}
+              onValueChange={(value) =>
+                updateTheme("alignment", value as ResumeTemplateTheme["alignment"])
+              }
+            />
+            <SegmentedField
+              label="Bullets"
+              disabled={!theme || isSaving}
+              options={BULLET_SPACING_OPTIONS}
+              value={theme?.bulletSpacing ?? "normal"}
+              onValueChange={(value) =>
+                updateTheme("bulletSpacing", value as ResumeTemplateTheme["bulletSpacing"])
+              }
+            />
+            <Field data-disabled={!theme || isSaving}>
+              <FieldLabel htmlFor={`${fieldIdPrefix}-font-scale`}>Font scale</FieldLabel>
+              <Input
+                id={`${fieldIdPrefix}-font-scale`}
                 disabled={!theme || isSaving}
                 max={1.2}
                 min={0.85}
@@ -288,19 +333,22 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
                 value={theme?.fontScale ?? 1}
                 onChange={(event) => updateTheme("fontScale", Number(event.target.value))}
               />
-            </label>
-            <label className="field">
-              <span>Accent</span>
-              <input
+            </Field>
+            <Field data-disabled={!theme || isSaving}>
+              <FieldLabel htmlFor={`${fieldIdPrefix}-accent`}>Accent</FieldLabel>
+              <Input
+                id={`${fieldIdPrefix}-accent`}
+                className="resume-template-accent-input"
                 disabled={!theme || isSaving}
                 type="color"
                 value={theme?.accentColor ?? "#111111"}
                 onChange={(event) => updateTheme("accentColor", event.target.value)}
               />
-            </label>
-            <label className="field">
-              <span>Top margin</span>
-              <input
+            </Field>
+            <Field data-disabled={!theme || isSaving}>
+              <FieldLabel htmlFor={`${fieldIdPrefix}-top-margin`}>Top margin</FieldLabel>
+              <Input
+                id={`${fieldIdPrefix}-top-margin`}
                 disabled={!theme || isSaving}
                 max={28}
                 min={8}
@@ -309,10 +357,11 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
                 value={theme?.marginMm.top ?? 16.5}
                 onChange={(event) => updateMargin("top", Number(event.target.value))}
               />
-            </label>
-            <label className="field">
-              <span>Side margin</span>
-              <input
+            </Field>
+            <Field data-disabled={!theme || isSaving}>
+              <FieldLabel htmlFor={`${fieldIdPrefix}-side-margin`}>Side margin</FieldLabel>
+              <Input
+                id={`${fieldIdPrefix}-side-margin`}
                 disabled={!theme || isSaving}
                 max={28}
                 min={8}
@@ -325,48 +374,69 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
                   updateMargin("right", value);
                 }}
               />
-            </label>
-          </div>
-          <div className="resume-template-actions">
-            <button className="tab on" disabled={!theme || isSaving || !displayName.trim()} type="button" onClick={() => saveCurrent(false)}>
-              <IconDeviceFloppy size={14} aria-hidden="true" />
-              {saveTemplate.isPending ? "saving" : "save version"}
-            </button>
-            <button className="tab" disabled={!theme || isSaving || !displayName.trim()} type="button" onClick={() => saveCurrent(true)}>
-              <IconStar size={14} aria-hidden="true" />
-              save default
-            </button>
-            <button
-              className="tab"
-              disabled={!selectedTemplateCanBeDefault || Boolean(selectedTemplateIsDefault) || isSaving}
-              type="button"
-              onClick={() => {
-                if (!activeTemplate) return;
-                setDefaultTemplate.mutate({
-                  templateId: activeTemplate.templateId,
-                  versionId: activeTemplate.activeVersion.versionId,
-                });
-              }}
-            >
-              <IconStar size={14} aria-hidden="true" />
-              {setDefaultTemplate.isPending ? "setting" : "set default"}
-            </button>
-            {selectedTemplateIsDefault ? <span className="tag ok">default</span> : null}
-          </div>
-          {templatesQuery.isLoading ? <div className="banner inline">Loading resume templates.</div> : null}
-          {saveError || defaultError ? <div className="banner inline">{saveError ?? defaultError}</div> : null}
+            </Field>
+          </AdaptiveFieldGrid>
+          {templatesQuery.isLoading ? (
+            <div className="banner inline">Loading resume templates.</div>
+          ) : null}
+          {saveError || defaultError ? (
+            <div className="banner inline" role="alert">
+              {saveError ?? defaultError}
+            </div>
+          ) : null}
         </div>
-        <div className="resume-template-preview">
-          <ResumeStandalonePlateEditor
-            className="resume-template-plate-editor"
-            htmlUrl={profileHtmlPreviewUrl}
-            previewStyle={previewStyle}
-            title="Resume template preview"
-            transformKey={theme ? JSON.stringify(theme) : "loading"}
-          />
-        </div>
-      </div>
-    </section>
+      }
+      actions={
+        <>
+          <Button
+            disabled={!theme || isSaving || !displayName.trim()}
+            size="sm"
+            type="button"
+            onClick={() => saveCurrent(false)}
+          >
+            <IconDeviceFloppy aria-hidden="true" data-icon="inline-start" />
+            {saveTemplate.isPending ? "Saving…" : "Save version"}
+          </Button>
+          <Button
+            disabled={!theme || isSaving || !displayName.trim()}
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={() => saveCurrent(true)}
+          >
+            <IconStar aria-hidden="true" data-icon="inline-start" />
+            Save default
+          </Button>
+          <Button
+            disabled={
+              !selectedTemplateCanBeDefault || Boolean(selectedTemplateIsDefault) || isSaving
+            }
+            size="sm"
+            type="button"
+            variant="outline"
+            onClick={() => {
+              if (!activeTemplate) return;
+              setDefaultTemplate.mutate({
+                templateId: activeTemplate.templateId,
+                versionId: activeTemplate.activeVersion.versionId,
+              });
+            }}
+          >
+            <IconStar aria-hidden="true" data-icon="inline-start" />
+            {setDefaultTemplate.isPending ? "Setting…" : "Set default"}
+          </Button>
+        </>
+      }
+      previewLabel="Resume template preview"
+    >
+      <ResumeStandalonePlateEditor
+        className="resume-template-plate-editor"
+        htmlUrl={profileHtmlPreviewUrl}
+        previewStyle={previewStyle}
+        title="Resume template preview"
+        transformKey={theme ? JSON.stringify(theme) : "loading"}
+      />
+    </PreviewWorkbench>
   );
 }
 

--- a/apps/web/src/contexts/profile/components/SettingsPanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/SettingsPanel.test.tsx
@@ -62,12 +62,12 @@ describe("<SettingsPanel>", () => {
     renderWithProviders(<ExtensionPairingPanel />, { ports });
 
     expect(await screen.findByText("Browser extension pairing")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "copy token" }));
+    await user.click(screen.getByRole("button", { name: "Copy token" }));
     expect(ports.clipboard.write).toHaveBeenCalledWith(sampleExtensionCapabilityTokenResponse.token);
 
-    await user.click(screen.getByRole("button", { name: "rotate token" }));
+    await user.click(screen.getByRole("button", { name: "Rotate token" }));
     expect(rotateExtensionCapabilityToken).not.toHaveBeenCalled();
-    await user.click(screen.getByRole("button", { name: "confirm rotate and disconnect" }));
+    await user.click(screen.getByRole("button", { name: "Confirm rotate and disconnect" }));
     expect(rotateExtensionCapabilityToken).toHaveBeenCalledTimes(1);
     expect(ports.clipboard.write).toHaveBeenLastCalledWith(
       "jh_ext_rotated_token_123456789012345678901234567",
@@ -101,9 +101,9 @@ describe("<SettingsPanel>", () => {
     renderWithProviders(<ExtensionPairingPanel />, { ports });
 
     await user.click(
-      await screen.findByRole("button", { name: "rotate token" }),
+      await screen.findByRole("button", { name: "Rotate token" }),
     );
-    await user.click(screen.getByRole("button", { name: "confirm rotate and disconnect" }));
+    await user.click(screen.getByRole("button", { name: "Confirm rotate and disconnect" }));
 
     expect(await screen.findByRole("status")).toHaveTextContent("token rotated");
     expect(screen.getByRole("alert")).toHaveTextContent(

--- a/apps/web/src/contexts/profile/components/SettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useHealthQuery } from "../../operations/hooks/useHealthQuery.js";
 import { SettingsForm } from "../forms/settings-form.js";
@@ -11,9 +11,13 @@ export function SettingsPanel() {
   const settings = settingsQuery.data?.settings ?? null;
 
   return (
-    <section className="card full">
-      <CardHeader title="Cost and capacity" meta="general" />
-      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+    <DisclosureSection
+      className="general-cost-capacity-settings"
+      title="Cost and capacity"
+      description="Daily spend, application concurrency, and worker capacity"
+      collapsedSummary="Execution limits and worker restart state"
+    >
+      {errorMessage ? <div className="banner inline" role="alert">{errorMessage}</div> : null}
       {settings ? (
         <SettingsForm
           initial={settings}
@@ -31,6 +35,6 @@ export function SettingsPanel() {
       ) : (
         <Empty title="Loading config." />
       )}
-    </section>
+    </DisclosureSection>
   );
 }

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.stories.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.stories.tsx
@@ -18,11 +18,76 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function Stateful({ profileSeed, styleSeed }: { profileSeed: string; styleSeed: string }) {
+const completeProfileSeed = (() => {
+  const profile = JSON.parse(JSON.stringify(sampleProfileResponse.profile));
+  profile.personal = {
+    ...profile.personal,
+    preferred_name: "Jordan",
+    phone: "+34 600 000 000",
+    address: "Example address",
+    city: "Barcelona",
+    country: "Spain",
+    postal_code: "08001",
+    linkedin_url: "https://www.linkedin.com/in/jordan-candidate",
+  };
+  profile.experience = {
+    years_of_experience_total: "12",
+    education_level: "Bachelor's degree",
+    current_job_title: "Director of Platform",
+    current_company: "Initech",
+  };
+  profile.resume = {
+    ...profile.resume,
+    education_entries: [
+      {
+        id: "education-1",
+        date: "2014-06",
+        degree: "BSc Computer Science",
+        institution: "Example University",
+        location: "Barcelona",
+      },
+    ],
+    skill_categories: [
+      {
+        id: "skills-1",
+        label: "Platform engineering",
+        items: ["TypeScript", "Kubernetes", "Observability"],
+      },
+    ],
+    tailoring_rules: {
+      ...profile.resume.tailoring_rules,
+      required_experience_entry_ids: ["exp-1"],
+      required_education_entry_ids: ["education-1"],
+      required_skill_category_ids: ["skills-1"],
+      required_bullets_by_experience_id: { "exp-1": ["Scaled the platform 10x."] },
+      required_skills_by_category_id: { "skills-1": ["Kubernetes"] },
+    },
+  };
+  profile.resume_constraints = { real_metrics: ["10x platform scale"] };
+  profile.eeo_voluntary = {
+    gender: "Prefer not to say",
+    race_ethnicity: "Prefer not to say",
+    veteran_status: "Prefer not to say",
+    disability_status: "Prefer not to say",
+  };
+  return JSON.stringify(profile, null, 2);
+})();
+
+function Stateful({
+  profileSeed,
+  styleSeed,
+  mode,
+}: {
+  profileSeed: string;
+  styleSeed: string;
+  mode?: "profile" | "preferences" | "target-search";
+}) {
   const [profileText, setProfileText] = useState(profileSeed);
   const [styleText, setStyleText] = useState(styleSeed);
+  const modeProps = mode ? { mode } : {};
   return (
     <StructuredProfileEditor
+      {...modeProps}
       profileText={profileText}
       styleText={styleText}
       onProfileTextChange={setProfileText}
@@ -36,6 +101,86 @@ export const Populated: Story = {
     <Stateful
       profileSeed={JSON.stringify(sampleProfileResponse.profile, null, 2)}
       styleSeed={JSON.stringify(sampleProfileResponse.style, null, 2)}
+    />
+  ),
+};
+
+export const CompleteProfile: Story = {
+  render: () => (
+    <Stateful
+      profileSeed={completeProfileSeed}
+      styleSeed={JSON.stringify(sampleProfileResponse.style, null, 2)}
+    />
+  ),
+};
+
+export const Preferences: Story = {
+  render: () => (
+    <Stateful
+      mode="preferences"
+      profileSeed={JSON.stringify(
+        {
+          personal: { password: "" },
+          work_authorization: {
+            legally_authorized_to_work: "Yes",
+            require_sponsorship: "No",
+            work_permit_type: "EU citizen",
+          },
+          availability: {
+            earliest_start_date: "2026-08-01",
+            available_for_full_time: "Yes",
+            available_for_contract: "No",
+          },
+          compensation: {
+            salary_expectation: "150000",
+            salary_currency: "EUR",
+            salary_range_min: "140000",
+            salary_range_max: "165000",
+            currency_conversion_note: "Use the application currency when possible.",
+          },
+          resume: {
+            tailoring_rules: {
+              tailoring_policy: {
+                claim_mode: "adjacent_translation",
+                allow_minor_inference: true,
+                allow_adjacent_achievement_drafts: false,
+                auto_approvable_claim_modes: ["verified_only", "evidence_reframing"],
+                allow_summary_rewrite: true,
+                allow_achievement_rewriting: true,
+                allow_skill_reordering: true,
+              },
+              writing_style: {
+                tone: "executive",
+                verbosity: "balanced",
+                keyword_density: "natural",
+                avoid_first_person: true,
+              },
+              revision_gates: {
+                min_fit_score: 8,
+                must_have_coverage: 0.85,
+                max_revision_attempts: 1,
+              },
+              custom_tailoring_prompt: "Keep evidence gaps explicit.",
+            },
+          },
+        },
+        null,
+        2,
+      )}
+      styleSeed={JSON.stringify(
+        {
+          document_font_size: "11pt",
+          font_family: "sans",
+          body_alignment: "left",
+          moderncv_style: "banking",
+          moderncv_color: "blue",
+          paper_size: "a4paper",
+          page_scale: 0.9,
+          hints_column_width_cm: 3.1,
+        },
+        null,
+        2,
+      )}
     />
   ),
 };

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
@@ -163,6 +163,48 @@ describe("<StructuredProfileEditor>", () => {
 
     expect(screen.queryByLabelText("AI may reframe experience titles")).not.toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Change experience titles" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Change experience titles" })).toHaveAccessibleDescription(
+      "Experience titles stay grounded in profile evidence.",
+    );
+  });
+
+  it("uses disclosure sections and keeps tailoring controls mounted across tab changes", () => {
+    let latestProfile = JSON.stringify(sampleProfileResponse.profile, null, 2);
+    render(<StatefulEditor mode="preferences" onLatestProfile={(value) => { latestProfile = value; }} />);
+
+    expect(screen.getByRole("heading", { name: "Application configurations", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Tailoring controls", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Resume style", level: 2 })).toBeInTheDocument();
+
+    const tabs = screen.getByRole("tablist", { name: "Tailoring control sections" });
+    expect(tabs).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Content rules" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Writing style" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Quality gates" })).toBeInTheDocument();
+
+    const guidance = screen.getByLabelText("Additional guidance");
+    expect(guidance.closest('[role="tabpanel"]')).toHaveAttribute("data-state", "inactive");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Writing style" }));
+    expect(screen.getByLabelText("Additional guidance")).toBe(guidance);
+    fireEvent.change(guidance, { target: { value: "Keep outcomes specific." } });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Quality gates" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Writing style" }));
+
+    expect(screen.getByLabelText("Additional guidance")).toBe(guidance);
+    expect(screen.getByLabelText("Additional guidance")).toHaveValue("Keep outcomes specific.");
+    expect(JSON.parse(latestProfile).resume.tailoring_rules.custom_tailoring_prompt).toBe(
+      "Keep outcomes specific.",
+    );
+    expect(screen.getByText("Tailoring inputs").closest("a")).toHaveAttribute(
+      "href",
+      "https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring",
+    );
+    expect(screen.getByText("Post-generation fit gate").closest("a")).toHaveAttribute(
+      "href",
+      "https://jobctrl.dev/architecture/tailoring#6-post-generation-fit-gate",
+    );
   });
 
   it("labels keyword density as advisory emphasis and edits revision gates", () => {
@@ -198,11 +240,78 @@ describe("<StructuredProfileEditor>", () => {
   });
 
   it("keeps required content pins configurable from the Profile editor", () => {
-    render(<StatefulEditor />);
+    let latestProfile = JSON.stringify(sampleProfileResponse.profile, null, 2);
+    render(<StatefulEditor onLatestProfile={(value) => { latestProfile = value; }} />);
 
     expect(screen.getByRole("heading", { name: "Experience entries" })).toBeInTheDocument();
     expect(screen.getAllByText("must appear in final resume").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Required").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "must appear in final resume" }));
+    expect(
+      JSON.parse(latestProfile).resume.tailoring_rules.required_experience_entry_ids,
+    ).toEqual(["exp-1"]);
+
+    fireEvent.click(screen.getByRole("button", { name: "add bullet" }));
+    expect(screen.getByLabelText("Bullet 3")).toBeInTheDocument();
+    expect(JSON.parse(latestProfile).resume.experience_entries[0].bullets).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove bullet 3" }));
+    expect(screen.queryByLabelText("Bullet 3")).not.toBeInTheDocument();
+    expect(JSON.parse(latestProfile).resume.experience_entries[0].bullets).toHaveLength(2);
+  });
+
+  it("groups Profile fields in keyboard-operable disclosures without unmounting collapsed editors", () => {
+    const initialProfile = JSON.parse(JSON.stringify(sampleProfileResponse.profile));
+    initialProfile.resume.education_entries = [
+      {
+        id: "education-1",
+        date: "2020-06",
+        degree: "BSc Computer Science",
+        institution: "Example University",
+        location: "Barcelona",
+      },
+    ];
+    initialProfile.resume.skill_categories = [
+      {
+        id: "skills-1",
+        label: "Platform engineering",
+        items: ["TypeScript"],
+      },
+    ];
+    initialProfile.eeo_voluntary = {
+      gender: "Prefer not to say",
+      race_ethnicity: "Prefer not to say",
+      veteran_status: "Prefer not to say",
+      disability_status: "Prefer not to say",
+    };
+
+    render(<StatefulEditor initialProfile={initialProfile} />);
+
+    const personalTrigger = screen.getByRole("button", { name: /^Personal information/ });
+    const baselineTrigger = screen.getByRole("button", { name: /^Resume baseline/ });
+    const experienceTrigger = screen.getByRole("button", { name: /^Experience entries/ });
+    const educationTrigger = screen.getByRole("button", { name: /^Education/ });
+    const skillsTrigger = screen.getByRole("button", { name: /^Skill categories/ });
+    const eeoTrigger = screen.getByRole("button", { name: /^Voluntary EEO/ });
+
+    expect(personalTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(baselineTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(experienceTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(educationTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(skillsTrigger).toHaveAttribute("aria-expanded", "false");
+    expect(eeoTrigger).toHaveAttribute("aria-expanded", "false");
+
+    const degreeField = screen.getByLabelText("Degree");
+    expect(degreeField.closest("[hidden]")).toBeInTheDocument();
+
+    educationTrigger.focus();
+    expect(educationTrigger).toHaveFocus();
+    fireEvent.click(educationTrigger);
+
+    expect(educationTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByLabelText("Degree")).toBe(degreeField);
+    expect(degreeField.closest("[hidden]")).not.toBeInTheDocument();
   });
 
   it("renders bullet standards as a combined fixed set", () => {
@@ -213,6 +322,13 @@ describe("<StructuredProfileEditor>", () => {
     expect(screen.getByRole("checkbox", { name: "Impact" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Technical depth" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Leadership" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Impact" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Technical depth" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Leadership" })).toBeDisabled();
+    expect(screen.getByText("What these mean").closest("a")).toHaveAttribute(
+      "href",
+      "https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring",
+    );
   });
 
   it("preserves extracted achievement evidence without exposing it as profile input", () => {

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import { IconPlus, IconTrash } from "@tabler/icons-react";
 
+import { AdaptiveFieldGrid, AdaptiveFieldSpan } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { ChoiceControl } from "../../../shared/ui/choice-control.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
+import { HelpLink } from "../../../shared/ui/help-link.js";
+import { SectionTabs, SectionTabsList } from "../../../shared/ui/section-tabs.js";
+import { SegmentedField } from "../../../shared/ui/segmented-field.js";
+import { SelectField as SelectFieldControl } from "../../../shared/ui/select-field.js";
+import { TabsContent, TabsTrigger } from "../../../shared/ui/tabs.js";
 import {
   GoogleAddressSearchField,
   isUnitedStatesAddressCountry,
@@ -128,6 +137,10 @@ const ROLE_AREA_LABEL = "Role areas";
 const ROLE_AREA_PLACEHOLDER = "Engineering, security, platform";
 const TARGET_LOCATION_LABEL = "Locations and work models";
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY ?? "";
+const TAILORING_INPUTS_DOCS_URL =
+  "https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring";
+const POST_GENERATION_FIT_GATE_DOCS_URL =
+  "https://jobctrl.dev/architecture/tailoring#6-post-generation-fit-gate";
 
 export interface StructuredProfileEditorProps {
   applicationConfigurationFields?: ReactNode;
@@ -520,46 +533,31 @@ export function StructuredProfileEditor({
     label: string,
     options: Array<[string, string]> | string[],
   ) => (
-    <label className="field">
-      <span>{label}</span>
-      <select
-        aria-label={label}
-        value={textAt(profile, path)}
-        onChange={(event) => updateProfilePath(path, event.target.value)}
-      >
-        {options.map((option) => {
-          const value = Array.isArray(option) ? option[0] : option;
-          const text = Array.isArray(option) ? option[1] : option;
-          return (
-            <option key={value} value={value}>
-              {text}
-            </option>
-          );
-        })}
-      </select>
-    </label>
+    <SelectFieldControl
+      label={label}
+      value={textAt(profile, path)}
+      onValueChange={(value) => updateProfilePath(path, value)}
+      options={options.map((option) => ({
+        value: Array.isArray(option) ? option[0] : option,
+        label: Array.isArray(option) ? option[1] : option,
+      }))}
+    />
   );
 
   const inventedAdjacentExperienceField = () => (
-    <label className="field check">
-      <input
-        type="checkbox"
-        checked={allowsInventedAdjacentExperience()}
-        onChange={(event) => setInventedAdjacentExperienceAllowed(event.target.checked)}
-      />
-      <span>Enable profile enhancement</span>
-    </label>
+    <ChoiceControl
+      label="Enable profile enhancement"
+      checked={allowsInventedAdjacentExperience()}
+      onCheckedChange={(checked) => setInventedAdjacentExperienceAllowed(checked === true)}
+    />
   );
 
   const checkboxField = (path: string, label: string) => (
-    <label className="field check">
-      <input
-        type="checkbox"
-        checked={Boolean(getPathValue(profile, path))}
-        onChange={(event) => updateProfilePath(path, event.target.checked)}
-      />
-      <span>{label}</span>
-    </label>
+    <ChoiceControl
+      label={label}
+      checked={Boolean(getPathValue(profile, path))}
+      onCheckedChange={(checked) => updateProfilePath(path, checked === true)}
+    />
   );
 
   const numberField = (
@@ -612,13 +610,6 @@ export function StructuredProfileEditor({
       </label>
     );
   };
-
-  const disabledCheckboxField = (label: string) => (
-    <label className="field check disabled">
-      <input type="checkbox" checked={false} disabled />
-      <span>{label}</span>
-    </label>
-  );
 
   const textareaField = (
     path: string,
@@ -899,32 +890,37 @@ export function StructuredProfileEditor({
   };
 
   const bulletStandardsField = () => (
-    <fieldset className="field wide checkbox-group-field bullet-standards-group">
-      <legend>Bullet standards</legend>
-      <div className="checkbox-options">
+    <fieldset className="checkbox-group-field tailoring-control-group preference-choice-group bullet-standards-group">
+      <legend className="sr-only">Bullet standards</legend>
+      <div className="preference-choice-group__heading">
+        <span className="preference-choice-group__legend" aria-hidden="true">
+          Bullet standards
+        </span>
+        <HelpLink href={TAILORING_INPUTS_DOCS_URL} target="_blank">
+          What these mean
+        </HelpLink>
+      </div>
+      <div className="preference-choice-list preference-choice-list--bullet-standards">
         {BULLET_STANDARD_OPTIONS.map(([value, label]) => (
-          <label className="choice target-choice" key={value}>
-            <input type="checkbox" checked readOnly value={value} />
-            <span>{label}</span>
-          </label>
+          <ChoiceControl key={value} label={label} checked locked value={value} />
         ))}
       </div>
     </fieldset>
   );
 
   const adjacentExperienceClaimsGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Adjacent experience claims</legend>
-      <div className="field-grid one">
+    <fieldset className="checkbox-group-field tailoring-control-group preference-choice-group">
+      <legend className="preference-choice-group__legend">Adjacent experience claims</legend>
+      <div className="preference-choice-list">
         {inventedAdjacentExperienceField()}
       </div>
     </fieldset>
   );
 
   const generationPermissionsGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Generation permissions</legend>
-      <div className="checkbox-options vertical">
+    <fieldset className="checkbox-group-field tailoring-control-group preference-choice-group">
+      <legend className="preference-choice-group__legend">Generation permissions</legend>
+      <div className="preference-choice-list">
         {checkboxField(
           "resume.tailoring_rules.tailoring_policy.allow_summary_rewrite",
           "Rewrite executive summary",
@@ -937,15 +933,28 @@ export function StructuredProfileEditor({
           "resume.tailoring_rules.tailoring_policy.allow_skill_reordering",
           "Select and order existing skills",
         )}
-        {disabledCheckboxField("Change experience titles")}
+        <ChoiceControl
+          label="Change experience titles"
+          disabled
+          disabledReason="Experience titles stay grounded in profile evidence."
+        />
       </div>
     </fieldset>
   );
 
-  const writingStyleGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Writing style</legend>
-      <div className="field-grid">
+  const contentRulesPanel = () => (
+    <div className="tailoring-tab-panel tailoring-tab-panel--content-rules">
+      <AdaptiveFieldGrid columns={2} minColumnWidth={260}>
+        {adjacentExperienceClaimsGroup()}
+        {generationPermissionsGroup()}
+        <AdaptiveFieldSpan span="full">{bulletStandardsField()}</AdaptiveFieldSpan>
+      </AdaptiveFieldGrid>
+    </div>
+  );
+
+  const writingStylePanel = () => (
+    <div className="tailoring-tab-panel tailoring-tab-panel--writing-style">
+      <AdaptiveFieldGrid columns={3} minColumnWidth={190}>
         {selectField("resume.tailoring_rules.writing_style.tone", "Writing tone", [
           ["direct", "Direct"],
           ["executive", "Executive"],
@@ -963,15 +972,26 @@ export function StructuredProfileEditor({
           "resume.tailoring_rules.writing_style.avoid_first_person",
           "Avoid first-person language",
         )}
-        {bulletStandardsField()}
-      </div>
-    </fieldset>
+        <AdaptiveFieldSpan span="full">
+          {textareaField(
+            "resume.tailoring_rules.custom_tailoring_prompt",
+            "Additional guidance",
+            "Writing and positioning guidance; evidence rules still apply.",
+            { maxLength: 1200 },
+          )}
+        </AdaptiveFieldSpan>
+      </AdaptiveFieldGrid>
+    </div>
   );
 
-  const revisionPolicyGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group revision-policy-group">
-      <legend>Revision policy</legend>
-      <div className="field-grid">
+  const qualityGatesPanel = () => (
+    <div className="tailoring-tab-panel tailoring-tab-panel--quality-gates">
+      <div className="tailoring-tab-panel__help">
+        <HelpLink href={POST_GENERATION_FIT_GATE_DOCS_URL} target="_blank">
+          Post-generation fit gate
+        </HelpLink>
+      </div>
+      <AdaptiveFieldGrid columns={3} minColumnWidth={190}>
         {numberField("resume.tailoring_rules.revision_gates.min_fit_score", "Minimum fit score", {
           min: 1,
           max: 10,
@@ -990,18 +1010,7 @@ export function StructuredProfileEditor({
           step: 1,
           defaultValue: 1,
         })}
-      </div>
-    </fieldset>
-  );
-
-  const additionalGuidanceGroup = () => (
-    <div className="field-grid one">
-      {textareaField(
-        "resume.tailoring_rules.custom_tailoring_prompt",
-        "Additional guidance",
-        "Writing and positioning guidance; evidence rules still apply.",
-        { maxLength: 1200 },
-      )}
+      </AdaptiveFieldGrid>
     </div>
   );
 
@@ -1029,20 +1038,21 @@ export function StructuredProfileEditor({
   );
 
   const styleSelect = (path: string, label: string, options: Array<[string, string]>) => (
-    <label className="field">
-      <span>{label}</span>
-      <select
-        aria-label={label}
-        value={textAt(style, path)}
-        onChange={(event) => updateStylePath(path, event.target.value)}
-      >
-        {options.map(([value, text]) => (
-          <option key={value} value={value}>
-            {text}
-          </option>
-        ))}
-      </select>
-    </label>
+    <SelectFieldControl
+      label={label}
+      value={textAt(style, path)}
+      onValueChange={(value) => updateStylePath(path, value)}
+      options={options.map(([value, text]) => ({ value, label: text }))}
+    />
+  );
+
+  const styleSegmented = (path: string, label: string, options: Array<[string, string]>) => (
+    <SegmentedField
+      label={label}
+      value={textAt(style, path)}
+      onValueChange={(value) => updateStylePath(path, value)}
+      options={options.map(([value, text]) => ({ value, label: text }))}
+    />
   );
 
   const styleNumber = (path: string, label: string, min: number, max: number, step: number) => (
@@ -1077,9 +1087,17 @@ export function StructuredProfileEditor({
     <div className="profile-sections">
       {mode === "profile" ? (
         <>
-          <section className="form-section">
-            <h3>Personal information</h3>
-            <div className="field-grid">
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--personal"
+            title="Personal information"
+            description="Contact, address, and professional links"
+            collapsedSummary="Contact · address · professional links"
+            defaultOpen
+          >
+            <AdaptiveFieldGrid
+              className="profile-field-grid profile-field-grid--personal"
+              minColumnWidth={210}
+            >
               {textField("personal.full_name", "Full name", "text", { required: true })}
               {textField("personal.preferred_name", "Preferred name")}
               {textField("personal.email", "Email", "email", { required: true })}
@@ -1097,12 +1115,20 @@ export function StructuredProfileEditor({
               {textField("personal.github_url", "GitHub URL", "url")}
               {textField("personal.portfolio_url", "Portfolio URL", "url")}
               {textField("personal.website_url", "Website URL", "url")}
-            </div>
-          </section>
+            </AdaptiveFieldGrid>
+          </DisclosureSection>
 
-          <section className="form-section">
-            <h3>Resume baseline</h3>
-            <div className="field-grid">
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--baseline"
+            title="Resume baseline"
+            description="Default experience summary and verified evidence"
+            collapsedSummary="Experience · executive profile · verified metrics"
+            defaultOpen
+          >
+            <AdaptiveFieldGrid
+              className="profile-field-grid profile-field-grid--baseline"
+              minColumnWidth={210}
+            >
               {textField("experience.years_of_experience_total", "Total years of experience", "number", {
                 min: 0,
                 step: 1,
@@ -1117,283 +1143,383 @@ export function StructuredProfileEditor({
                 "number",
                 { min: 1, max: 99, step: 1 },
               )}
-            </div>
-            <div className="field-grid one">
-              {textareaField("resume.executive_profile.baseline_text", "Executive profile baseline")}
-              {listField("resume_constraints.real_metrics", "Verified resume metrics")}
-            </div>
-          </section>
+              <AdaptiveFieldSpan span="full">
+                {textareaField("resume.executive_profile.baseline_text", "Executive profile baseline")}
+              </AdaptiveFieldSpan>
+              <AdaptiveFieldSpan span="full">
+                {listField("resume_constraints.real_metrics", "Verified resume metrics")}
+              </AdaptiveFieldSpan>
+            </AdaptiveFieldGrid>
+          </DisclosureSection>
 
-          <section className="form-section">
-        <h3>Experience entries</h3>
-        <div className="repeat-list">
-          {experienceEntries.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
-            const requiredBullets = new Set(
-              asTextArray(
-                recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
-              ),
-            );
-            return (
-              <div className="repeat-card" key={`${entryId || "experience"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["title"]) || `Experience ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredExperienceIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_experience_entry_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.experience_entries", index)}
-                    >
-                      remove experience
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {dateRangeField(`resume.experience_entries.${index}.date_range`, "Date range")}
-                  {textField(`resume.experience_entries.${index}.title`, "Title")}
-                  {textField(`resume.experience_entries.${index}.company`, "Company")}
-                  {textField(`resume.experience_entries.${index}.location`, "Location")}
-                </div>
-                <div className="bullet-list">
-                  {bullets.map((bullet, bulletIndex) => (
-                    <div className="bullet-row" key={`${entryId}-${bulletIndex}`}>
-                      <div className="bullet-row-top">
-                        <span className="bullet-label">Bullet {bulletIndex + 1}</span>
-                        <label className="choice bullet-choice">
-                          <input
-                            type="checkbox"
-                            checked={requiredBullets.has(bullet)}
-                            disabled={!entryId || !bullet}
-                            onChange={(event) =>
-                              setRequiredBullet(entryId, bullet, event.target.checked)
-                            }
-                          />
-                          <span>Required</span>
-                        </label>
-                      </div>
-                      <textarea
-                        aria-label={`Bullet ${bulletIndex + 1}`}
-                        value={bullet}
-                        onChange={(event) =>
-                          updateProfilePath(
-                            `resume.experience_entries.${index}.bullets.${bulletIndex}`,
-                            event.target.value,
-                          )
-                        }
-                      />
-                      <button
-                        className="icon-button"
-                        type="button"
-                        aria-label={`Remove bullet ${bulletIndex + 1}`}
-                        title="Remove bullet"
-                        onClick={() => removeBullet(index, bulletIndex)}
-                      >
-                        <IconTrash size={14} aria-hidden="true" />
-                      </button>
-                    </div>
-                  ))}
-                  <button className="tab add-bullet" type="button" onClick={() => addBullet(index)}>
-                    <IconPlus size={14} aria-hidden="true" />
-                    add bullet
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.experience_entries")}
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--experience"
+            title="Experience entries"
+            description="Roles, dates, bullets, and required content"
+            collapsedSummary={`${experienceEntries.length} ${
+              experienceEntries.length === 1 ? "entry" : "entries"
+            }`}
+            defaultOpen
           >
-            add experience
-          </button>
-        </div>
-          </section>
-
-          <section className="form-section">
-        <h3>Education</h3>
-        <div className="repeat-list">
-          {educationEntries.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            return (
-              <div className="repeat-card" key={`${entryId || "education"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["degree"]) || `Education ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredEducationIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_education_entry_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.education_entries", index)}
-                    >
-                      remove education
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {monthField(`resume.education_entries.${index}.date`, "Completion month")}
-                  {textField(`resume.education_entries.${index}.degree`, "Degree")}
-                  {textField(`resume.education_entries.${index}.institution`, "Institution")}
-                  {textField(`resume.education_entries.${index}.location`, "Location")}
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.education_entries")}
-          >
-            add education
-          </button>
-        </div>
-          </section>
-
-          <section className="form-section">
-        <h3>Skill categories</h3>
-        <div className="repeat-list">
-          {skillCategories.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            const skills = editableTextArrayAt(profile, `resume.skill_categories.${index}.items`);
-            const requiredSkills = new Set(
-              asTextArray(
-                recordAt(profile, "resume.tailoring_rules.required_skills_by_category_id")[entryId],
-              ),
-            );
-            return (
-              <div className="repeat-card" key={`${entryId || "skills"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["label"]) || `Skill category ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredSkillIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_skill_category_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.skill_categories", index)}
-                    >
-                      remove skill category
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {textField(`resume.skill_categories.${index}.label`, "Label")}
-                </div>
-                <div className="skill-list">
-                  {skills.map((skill, skillIndex) => (
-                    <div className="skill-row" key={`${entryId}-${skillIndex}`}>
-                      <label className="skill-input field">
-                        <span>Skill {skillIndex + 1}</span>
-                        <input
-                          value={skill}
-                          onChange={(event) =>
-                            updateProfilePath(
-                              `resume.skill_categories.${index}.items.${skillIndex}`,
-                              event.target.value,
+            <div className="profile-repeat-editor profile-repeat-editor--experience">
+              {experienceEntries.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
+                const requiredBullets = new Set(
+                  asTextArray(
+                    recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
+                  ),
+                );
+                return (
+                  <div
+                    className="profile-repeat-entry profile-repeat-entry--experience"
+                    key={`${entryId || "experience"}-${index}`}
+                  >
+                    <div className="profile-repeat-entry__header">
+                      <strong className="profile-repeat-entry__title">
+                        {textFrom(entry["title"]) || `Experience ${index + 1}`}
+                      </strong>
+                      <div className="profile-repeat-entry__controls">
+                        <ChoiceControl
+                          className="profile-repeat-choice profile-repeat-choice--entry"
+                          label="Must appear in final resume"
+                          checked={requiredExperienceIds.has(entryId)}
+                          disabled={!entryId}
+                          onCheckedChange={(checked) =>
+                            setRequiredId(
+                              "resume.tailoring_rules.required_experience_entry_ids",
+                              entryId,
+                              checked === true,
                             )
                           }
                         />
-                      </label>
-                      <label className="choice skill-choice">
-                        <input
-                          type="checkbox"
-                          checked={requiredSkills.has(skill)}
-                          disabled={!entryId || !skill}
-                          onChange={(event) =>
-                            setRequiredSkill(entryId, skill, event.target.checked)
+                        <Button
+                          className="profile-repeat-entry__remove"
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.experience_entries", index)}
+                        >
+                          <IconTrash data-icon="inline-start" size={14} aria-hidden="true" />
+                          Remove experience
+                        </Button>
+                      </div>
+                    </div>
+                    <AdaptiveFieldGrid
+                      className="profile-repeat-entry__fields"
+                      minColumnWidth={190}
+                      density="compact"
+                    >
+                      <AdaptiveFieldSpan span="full">
+                        {dateRangeField(`resume.experience_entries.${index}.date_range`, "Date range")}
+                      </AdaptiveFieldSpan>
+                      {textField(`resume.experience_entries.${index}.title`, "Title")}
+                      {textField(`resume.experience_entries.${index}.company`, "Company")}
+                      {textField(`resume.experience_entries.${index}.location`, "Location")}
+                    </AdaptiveFieldGrid>
+                    <div className="profile-repeat-items profile-repeat-items--bullets">
+                      {bullets.map((bullet, bulletIndex) => (
+                        <div
+                          className="profile-repeat-item profile-repeat-item--bullet"
+                          key={`${entryId}-${bulletIndex}`}
+                        >
+                          <div className="profile-repeat-item__meta">
+                            <span className="profile-repeat-item__label">Bullet {bulletIndex + 1}</span>
+                            <ChoiceControl
+                              className="profile-repeat-choice profile-repeat-choice--compact"
+                              label="Required"
+                              checked={requiredBullets.has(bullet)}
+                              disabled={!entryId || !bullet}
+                              onCheckedChange={(checked) =>
+                                setRequiredBullet(entryId, bullet, checked === true)
+                              }
+                            />
+                          </div>
+                          <textarea
+                            aria-label={`Bullet ${bulletIndex + 1}`}
+                            value={bullet}
+                            onChange={(event) =>
+                              updateProfilePath(
+                                `resume.experience_entries.${index}.bullets.${bulletIndex}`,
+                                event.target.value,
+                              )
+                            }
+                          />
+                          <Button
+                            className="profile-repeat-item__remove"
+                            variant="ghost"
+                            size="icon"
+                            type="button"
+                            aria-label={`Remove bullet ${bulletIndex + 1}`}
+                            title="Remove bullet"
+                            onClick={() => removeBullet(index, bulletIndex)}
+                          >
+                            <IconTrash size={14} aria-hidden="true" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        className="profile-repeat-add profile-repeat-add--item"
+                        variant="outline"
+                        size="sm"
+                        type="button"
+                        onClick={() => addBullet(index)}
+                      >
+                        <IconPlus data-icon="inline-start" size={14} aria-hidden="true" />
+                        Add bullet
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+              <Button
+                className="profile-repeat-add profile-repeat-add--entry"
+                variant="outline"
+                size="sm"
+                type="button"
+                onClick={() => addRepeatItem("resume.experience_entries")}
+              >
+                <IconPlus data-icon="inline-start" size={14} aria-hidden="true" />
+                Add experience
+              </Button>
+            </div>
+          </DisclosureSection>
+
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--education"
+            title="Education"
+            description="Degrees, institutions, completion dates, and required content"
+            collapsedSummary={`${educationEntries.length} ${
+              educationEntries.length === 1 ? "entry" : "entries"
+            }`}
+            defaultOpen={false}
+          >
+            <div className="profile-repeat-editor profile-repeat-editor--education">
+              {educationEntries.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                return (
+                  <div
+                    className="profile-repeat-entry profile-repeat-entry--education"
+                    key={`${entryId || "education"}-${index}`}
+                  >
+                    <div className="profile-repeat-entry__header">
+                      <strong className="profile-repeat-entry__title">
+                        {textFrom(entry["degree"]) || `Education ${index + 1}`}
+                      </strong>
+                      <div className="profile-repeat-entry__controls">
+                        <ChoiceControl
+                          className="profile-repeat-choice profile-repeat-choice--entry"
+                          label="Must appear in final resume"
+                          checked={requiredEducationIds.has(entryId)}
+                          disabled={!entryId}
+                          onCheckedChange={(checked) =>
+                            setRequiredId(
+                              "resume.tailoring_rules.required_education_entry_ids",
+                              entryId,
+                              checked === true,
+                            )
                           }
                         />
-                        <span>Required</span>
-                      </label>
-                      <button
-                        className="icon-button"
-                        type="button"
-                        aria-label={`Remove skill ${skillIndex + 1}`}
-                        title="Remove skill"
-                        onClick={() => removeSkill(index, skillIndex)}
-                      >
-                        <IconTrash size={14} aria-hidden="true" />
-                      </button>
+                        <Button
+                          className="profile-repeat-entry__remove"
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.education_entries", index)}
+                        >
+                          <IconTrash data-icon="inline-start" size={14} aria-hidden="true" />
+                          Remove education
+                        </Button>
+                      </div>
                     </div>
-                  ))}
-                  <button className="tab add-bullet" type="button" onClick={() => addSkill(index)}>
-                    <IconPlus size={14} aria-hidden="true" />
-                    add skill
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.skill_categories")}
-          >
-            add skill category
-          </button>
-        </div>
-          </section>
+                    <AdaptiveFieldGrid
+                      className="profile-repeat-entry__fields"
+                      minColumnWidth={190}
+                      density="compact"
+                    >
+                      {monthField(`resume.education_entries.${index}.date`, "Completion month")}
+                      {textField(`resume.education_entries.${index}.degree`, "Degree")}
+                      {textField(`resume.education_entries.${index}.institution`, "Institution")}
+                      {textField(`resume.education_entries.${index}.location`, "Location")}
+                    </AdaptiveFieldGrid>
+                  </div>
+                );
+              })}
+              <Button
+                className="profile-repeat-add profile-repeat-add--entry"
+                variant="outline"
+                size="sm"
+                type="button"
+                onClick={() => addRepeatItem("resume.education_entries")}
+              >
+                <IconPlus data-icon="inline-start" size={14} aria-hidden="true" />
+                Add education
+              </Button>
+            </div>
+          </DisclosureSection>
 
-          <section className="form-section">
-        <h3>Voluntary EEO</h3>
-        <div className="field-grid">
-          {textField("eeo_voluntary.gender", "Gender")}
-          {textField("eeo_voluntary.race_ethnicity", "Race / ethnicity")}
-          {textField("eeo_voluntary.veteran_status", "Veteran status")}
-          {textField("eeo_voluntary.disability_status", "Disability status")}
-        </div>
-          </section>
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--skills"
+            title="Skill categories"
+            description="Skill groups, individual skills, and required content"
+            collapsedSummary={`${skillCategories.length} ${
+              skillCategories.length === 1 ? "category" : "categories"
+            }`}
+            defaultOpen={false}
+          >
+            <div className="profile-repeat-editor profile-repeat-editor--skills">
+              {skillCategories.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                const skills = editableTextArrayAt(
+                  profile,
+                  `resume.skill_categories.${index}.items`,
+                );
+                const requiredSkills = new Set(
+                  asTextArray(
+                    recordAt(profile, "resume.tailoring_rules.required_skills_by_category_id")[entryId],
+                  ),
+                );
+                return (
+                  <div
+                    className="profile-repeat-entry profile-repeat-entry--skills"
+                    key={`${entryId || "skills"}-${index}`}
+                  >
+                    <div className="profile-repeat-entry__header">
+                      <strong className="profile-repeat-entry__title">
+                        {textFrom(entry["label"]) || `Skill category ${index + 1}`}
+                      </strong>
+                      <div className="profile-repeat-entry__controls">
+                        <ChoiceControl
+                          className="profile-repeat-choice profile-repeat-choice--entry"
+                          label="Must appear in final resume"
+                          checked={requiredSkillIds.has(entryId)}
+                          disabled={!entryId}
+                          onCheckedChange={(checked) =>
+                            setRequiredId(
+                              "resume.tailoring_rules.required_skill_category_ids",
+                              entryId,
+                              checked === true,
+                            )
+                          }
+                        />
+                        <Button
+                          className="profile-repeat-entry__remove"
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.skill_categories", index)}
+                        >
+                          <IconTrash data-icon="inline-start" size={14} aria-hidden="true" />
+                          Remove skill category
+                        </Button>
+                      </div>
+                    </div>
+                    <AdaptiveFieldGrid
+                      className="profile-repeat-entry__fields"
+                      minColumnWidth={190}
+                      density="compact"
+                    >
+                      {textField(`resume.skill_categories.${index}.label`, "Label")}
+                    </AdaptiveFieldGrid>
+                    <div className="profile-repeat-items profile-repeat-items--skills">
+                      {skills.map((skill, skillIndex) => (
+                        <div
+                          className="profile-repeat-item profile-repeat-item--skill"
+                          key={`${entryId}-${skillIndex}`}
+                        >
+                          <label className="field profile-repeat-item__field">
+                            <span>Skill {skillIndex + 1}</span>
+                            <input
+                              value={skill}
+                              onChange={(event) =>
+                                updateProfilePath(
+                                  `resume.skill_categories.${index}.items.${skillIndex}`,
+                                  event.target.value,
+                                )
+                              }
+                            />
+                          </label>
+                          <ChoiceControl
+                            className="profile-repeat-choice profile-repeat-choice--compact"
+                            label="Required"
+                            checked={requiredSkills.has(skill)}
+                            disabled={!entryId || !skill}
+                            onCheckedChange={(checked) =>
+                              setRequiredSkill(entryId, skill, checked === true)
+                            }
+                          />
+                          <Button
+                            className="profile-repeat-item__remove"
+                            variant="ghost"
+                            size="icon"
+                            type="button"
+                            aria-label={`Remove skill ${skillIndex + 1}`}
+                            title="Remove skill"
+                            onClick={() => removeSkill(index, skillIndex)}
+                          >
+                            <IconTrash size={14} aria-hidden="true" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        className="profile-repeat-add profile-repeat-add--item"
+                        variant="outline"
+                        size="sm"
+                        type="button"
+                        onClick={() => addSkill(index)}
+                      >
+                        <IconPlus data-icon="inline-start" size={14} aria-hidden="true" />
+                        Add skill
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+              <Button
+                className="profile-repeat-add profile-repeat-add--entry"
+                variant="outline"
+                size="sm"
+                type="button"
+                onClick={() => addRepeatItem("resume.skill_categories")}
+              >
+                <IconPlus data-icon="inline-start" size={14} aria-hidden="true" />
+                Add skill category
+              </Button>
+            </div>
+          </DisclosureSection>
+
+          <DisclosureSection
+            className="profile-disclosure profile-disclosure--eeo"
+            title="Voluntary EEO"
+            description="Optional demographic information"
+            collapsedSummary="Gender · race or ethnicity · veteran status · disability status"
+            defaultOpen={false}
+          >
+            <AdaptiveFieldGrid
+              className="profile-field-grid profile-field-grid--eeo"
+              minColumnWidth={210}
+            >
+              {textField("eeo_voluntary.gender", "Gender")}
+              {textField("eeo_voluntary.race_ethnicity", "Race / ethnicity")}
+              {textField("eeo_voluntary.veteran_status", "Veteran status")}
+              {textField("eeo_voluntary.disability_status", "Disability status")}
+            </AdaptiveFieldGrid>
+          </DisclosureSection>
         </>
       ) : mode === "target-search" ? (
         targetSearchSection()
       ) : (
         <>
-          <section className="form-section">
-            <h3>Application configurations</h3>
-            <div className="field-grid">
+          <DisclosureSection
+            className="preferences-disclosure preferences-disclosure--application"
+            title="Application configurations"
+            description="Work authorization, availability, and compensation defaults"
+            collapsedSummary="Authorization · availability · compensation"
+          >
+            <AdaptiveFieldGrid
+              className="preferences-field-grid preferences-field-grid--application"
+              minColumnWidth={220}
+            >
               {applicationConfigurationFields}
               {selectField("work_authorization.legally_authorized_to_work", "Legally authorized to work", [
                 "Yes",
@@ -1424,33 +1550,56 @@ export function StructuredProfileEditor({
                 valueKind: "text",
               })}
               {textField("compensation.currency_conversion_note", "Currency note")}
-            </div>
-          </section>
+            </AdaptiveFieldGrid>
+          </DisclosureSection>
 
-          <section className="form-section">
-            <h3>Tailoring controls</h3>
-            <div className="tailoring-controls-grid">
-              {adjacentExperienceClaimsGroup()}
-              {generationPermissionsGroup()}
-              {writingStyleGroup()}
-              {revisionPolicyGroup()}
-              {additionalGuidanceGroup()}
-            </div>
-          </section>
+          <DisclosureSection
+            className="preferences-disclosure preferences-disclosure--tailoring"
+            title="Tailoring controls"
+            description="Control what JobCtrl may change and how generated resumes are evaluated"
+            collapsedSummary="Content rules · writing style · quality gates"
+            helpHref={TAILORING_INPUTS_DOCS_URL}
+            helpLabel="Tailoring inputs"
+          >
+            <SectionTabs defaultValue="content-rules">
+              <SectionTabsList aria-label="Tailoring control sections">
+                <TabsTrigger value="content-rules">Content rules</TabsTrigger>
+                <TabsTrigger value="writing-style">Writing style</TabsTrigger>
+                <TabsTrigger value="quality-gates">Quality gates</TabsTrigger>
+              </SectionTabsList>
+              <TabsContent forceMount value="content-rules">
+                {contentRulesPanel()}
+              </TabsContent>
+              <TabsContent forceMount value="writing-style">
+                {writingStylePanel()}
+              </TabsContent>
+              <TabsContent forceMount value="quality-gates">
+                {qualityGatesPanel()}
+              </TabsContent>
+            </SectionTabs>
+          </DisclosureSection>
 
-          <section className="form-section">
-            <h3>Resume style</h3>
-            <div className="field-grid">
-              {styleSelect("document_font_size", "Text size", [
+          <DisclosureSection
+            className="preferences-disclosure preferences-disclosure--resume-style"
+            title="Resume style"
+            description="Profile-level typography, template, and page defaults"
+            collapsedSummary="Typography · template · page layout"
+          >
+            <AdaptiveFieldGrid
+              className="preferences-field-grid preferences-field-grid--resume-style"
+              columns={4}
+              minColumnWidth={164}
+            >
+              {styleSegmented("document_font_size", "Text size", [
                 ["10pt", "Small"],
                 ["11pt", "Regular"],
                 ["12pt", "Large"],
               ])}
-              {styleSelect("font_family", "Text font", [
+              {styleSegmented("font_family", "Text font", [
                 ["sans", "Sans"],
                 ["roman", "Serif"],
               ])}
-              {styleSelect("body_alignment", "Body alignment", [
+              {styleSegmented("body_alignment", "Body alignment", [
                 ["justified", "Justified"],
                 ["left", "Left aligned"],
               ])}
@@ -1471,14 +1620,14 @@ export function StructuredProfileEditor({
                 ["purple", "Purple"],
                 ["red", "Red"],
               ])}
-              {styleSelect("paper_size", "Paper", [
+              {styleSegmented("paper_size", "Paper", [
                 ["a4paper", "A4"],
                 ["letterpaper", "Letter"],
               ])}
               {styleNumber("page_scale", "Page scale", 0.7, 1, 0.01)}
               {styleNumber("hints_column_width_cm", "Date column width (cm)", 1.5, 5, 0.1)}
-            </div>
-          </section>
+            </AdaptiveFieldGrid>
+          </DisclosureSection>
         </>
       )}
     </div>

--- a/apps/web/src/contexts/profile/forms/credential-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/credential-form.test.tsx
@@ -28,7 +28,7 @@ describe("<CredentialForm>", () => {
       screen.getByLabelText(/OpenAI API key/i),
       "synthetic-secret",
     );
-    await user.click(screen.getByRole("button", { name: "save" }));
+    await user.click(screen.getByRole("button", { name: /save/i }));
 
     expect(
       await screen.findByRole("alert", { name: /Keychain update failed/i }),

--- a/apps/web/src/contexts/profile/forms/credential-form.tsx
+++ b/apps/web/src/contexts/profile/forms/credential-form.tsx
@@ -8,6 +8,17 @@ import { JobCtrlApiError } from "@jobctrl/api-client";
 import { useForm } from "@tanstack/react-form";
 import { useEffect, useState } from "react";
 
+import {
+  AdaptiveFieldGrid,
+  AdaptiveFieldSpan,
+} from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
 import { useDeleteCredentialMutation } from "../hooks/useDeleteCredentialMutation.js";
 import { useUpdateCredentialMutation } from "../hooks/useUpdateCredentialMutation.js";
 
@@ -109,108 +120,133 @@ export function CredentialForm({
   const mutationErrorMessage = credentialMutationErrorMessage(mutationError);
   const inputId = `credential-${credentialKey.toLowerCase()}`;
   const credentialDescriptionId = `${inputId}-description`;
+  const credentialStatus = environmentManaged
+    ? "Managed by environment"
+    : unsupportedPlatform
+      ? "Environment only"
+      : inspectionUnknown
+        ? "Unable to check"
+        : configured === true
+          ? "Stored in Keychain"
+          : "Not in Keychain";
+  const disabledReason = environmentManaged
+    ? "Managed by the launch environment."
+    : unsupportedPlatform
+      ? "Use environment configuration on this platform."
+      : inspectionUnknown
+        ? "Keychain inspection is unavailable."
+        : !available
+          ? "Keychain edits are paused until inspection succeeds."
+          : editable === false
+            ? "This credential is read-only."
+            : null;
   const describedBy = [
     credentialDescriptionId,
     !canEditKeychain ? unavailableDescriptionId : undefined,
   ].filter((value): value is string => value !== undefined).join(" ");
   return (
     <form
-      className="credential-row-form"
+      className="credential-form"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      <span className={`tag ${configured === true ? "ok" : "muted"}`}>
-        {environmentManaged
-          ? "managed by environment"
-          : unsupportedPlatform
-          ? "environment only"
-          : inspectionUnknown
-            ? "unable to check"
-            : configured === true
-              ? "stored in Keychain"
-              : "not in Keychain"}
-      </span>
-      <label className="title-stack" htmlFor={inputId}>
-        <b>{label}</b>
-      </label>
-      <span id={credentialDescriptionId}>{credentialKey}</span>
-      <form.Field name="value">
-        {(field) => (
-          <input
-            id={inputId}
-            name={credentialKey}
-            aria-describedby={describedBy}
-            disabled={!canEditKeychain}
-            placeholder={
-              environmentManaged
-                ? "Managed by launch environment"
-                : unsupportedPlatform
-                ? "Use environment configuration on this platform"
-                : inspectionUnknown
-                  ? "Keychain inspection unavailable"
-                  : !available
-                    ? "Keychain edits paused until inspection succeeds"
-                    : configured === true
-                      ? "Stored in Keychain"
-                      : "Paste value to store in Keychain"
-            }
-            type="password"
-            value={field.state.value}
-            onBlur={field.handleBlur}
-            onChange={(event) => field.handleChange(event.target.value)}
-          />
-        )}
-      </form.Field>
-      <span className="row-actions">
-        <form.Subscribe
-          selector={(state) => ({
-            canSubmit: state.canSubmit,
-            isSubmitting: state.isSubmitting,
-            isDirty: state.isDirty,
-          })}
-        >
-          {({ canSubmit, isSubmitting, isDirty }) => (
-            <button
-              className="tab on"
-              type="submit"
-              disabled={
-                !canEditKeychain ||
-                !canSubmit ||
-                !isDirty ||
-                isSubmitting ||
-                removing
-              }
-            >
-              {isSubmitting ? "saving" : "save"}
-            </button>
+      <AdaptiveFieldGrid
+        className="credential-form__grid"
+        columns={2}
+        density="compact"
+        minColumnWidth={240}
+      >
+        <form.Field name="value">
+          {(field) => (
+            <Field className="credential-form__field" data-disabled={!canEditKeychain || undefined}>
+              <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
+              <Input
+                id={inputId}
+                name={credentialKey}
+                aria-describedby={describedBy}
+                disabled={!canEditKeychain}
+                placeholder={
+                  environmentManaged
+                    ? "Managed by launch environment"
+                    : unsupportedPlatform
+                      ? "Use environment configuration on this platform"
+                      : inspectionUnknown
+                        ? "Keychain inspection unavailable"
+                        : !available
+                          ? "Keychain edits paused until inspection succeeds"
+                          : configured === true
+                            ? "Stored in Keychain"
+                            : "Paste value to store in Keychain"
+                }
+                type="password"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(event.target.value)}
+              />
+              <FieldDescription id={credentialDescriptionId}>
+                <span className="credential-form__key">{credentialKey}</span>
+                <span className="credential-form__status">{credentialStatus}</span>
+                {disabledReason ? (
+                  <span className="credential-form__disabled-reason">{disabledReason}</span>
+                ) : null}
+              </FieldDescription>
+            </Field>
           )}
-        </form.Subscribe>
-        <button
-          className="tab"
-          type="button"
-          disabled={!canEditKeychain || configured !== true || removing}
-          onClick={removeCredential}
-        >
-          {removing ? "removing" : "remove"}
-        </button>
-      </span>
-      {statusMessage ? (
-        <span className="status-line" role="status">
-          {statusMessage}
-        </span>
-      ) : null}
-      {mutationErrorMessage ? (
-        <span
-          aria-label="Keychain update failed"
-          className="status-line warning"
-          role="alert"
-        >
-          {mutationErrorMessage}
-        </span>
-      ) : null}
+        </form.Field>
+        <AdaptiveFieldSpan className="credential-form__footer" span="full">
+          <div className="credential-form__actions">
+            <form.Subscribe
+              selector={(state) => ({
+                canSubmit: state.canSubmit,
+                isSubmitting: state.isSubmitting,
+                isDirty: state.isDirty,
+              })}
+            >
+              {({ canSubmit, isSubmitting, isDirty }) => (
+                <Button
+                  disabled={
+                    !canEditKeychain ||
+                    !canSubmit ||
+                    !isDirty ||
+                    isSubmitting ||
+                    removing
+                  }
+                  size="sm"
+                  type="submit"
+                >
+                  {isSubmitting ? "Saving…" : "Save"}
+                </Button>
+              )}
+            </form.Subscribe>
+            <Button
+              disabled={!canEditKeychain || configured !== true || removing}
+              size="sm"
+              type="button"
+              variant="outline"
+              onClick={removeCredential}
+            >
+              {removing ? "Removing…" : "Remove"}
+            </Button>
+          </div>
+          {statusMessage ? (
+            <span className="status-line" role="status">
+              {statusMessage}
+            </span>
+          ) : null}
+          {mutationErrorMessage ? (
+            <span
+              aria-label="Keychain update failed"
+              className="status-line warning"
+              role="alert"
+            >
+              {mutationErrorMessage}
+            </span>
+          ) : null}
+        </AdaptiveFieldSpan>
+      </AdaptiveFieldGrid>
     </form>
   );
 }

--- a/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
@@ -1,8 +1,10 @@
 import { ProfileImportRequestSchema, type ProfileImportRequest } from "@jobctrl/contracts";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconFileTypePdf } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
+import { Button } from "../../../shared/ui/button.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useImportResumeMutation } from "../hooks/useImportResumeMutation.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
@@ -46,12 +48,12 @@ export function ImportConfirmForm() {
 
   if (!filename || !pdfBase64) {
     return (
-      <div className="wizard-step">
+      <div className="wizard-step resume-import-step grid gap-4">
         <Empty title="No upload found. Start at step 1." />
-        <div className="form-actions">
-          <Link className="tab" to="/profile/import/upload">
-            back to upload
-          </Link>
+        <div className="form-actions resume-import-actions justify-end">
+          <Button asChild variant="outline">
+            <Link to="/profile/import/upload">Back to upload</Link>
+          </Button>
         </div>
       </div>
     );
@@ -69,33 +71,51 @@ export function ImportConfirmForm() {
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-confirm grid gap-4"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-      {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
-      <p>
-        Importing <b>{filename}</b> with {summary}.
-      </p>
+      {errorMessage ? <div className="banner inline" role="alert">{errorMessage}</div> : null}
+      {statusMessage ? <div className="status-line" role="status">{statusMessage}</div> : null}
+      <div
+        className="resume-import-confirmation flex items-center gap-3 border-y border-border py-3"
+      >
+        <IconFileTypePdf
+          className="shrink-0 text-muted-foreground"
+          aria-hidden="true"
+          size={24}
+          stroke={1.7}
+        />
+        <p className="m-0 min-w-0 break-words text-[12px] leading-relaxed">
+          Importing <b className="break-all">{filename}</b> with {summary}.
+        </p>
+      </div>
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .filter((entry): entry is string => typeof entry === "string")
+            .at(0);
+          return message ? <div className="banner inline" role="alert">{message}</div> : null;
+        }}
+      </form.Subscribe>
       <form.Subscribe
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions justify-end">
+            <Button asChild variant="outline">
+              <Link to="/profile/import/preview">Back</Link>
+            </Button>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting}
             >
-              {isSubmitting ? "importing..." : "confirm import"}
-            </button>
-            <Link className="tab" to="/profile/import/preview">
-              back
-            </Link>
+              {isSubmitting ? "Importing…" : "Confirm import"}
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-preview-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-preview-form.tsx
@@ -1,7 +1,10 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconFileTypePdf } from "@tabler/icons-react";
 import { z } from "zod";
 
+import { Button } from "../../../shared/ui/button.js";
+import { ChoiceControl } from "../../../shared/ui/choice-control.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
 
@@ -48,12 +51,12 @@ export function ImportPreviewForm() {
 
   if (!filename) {
     return (
-      <div className="wizard-step">
+      <div className="wizard-step resume-import-step grid gap-4">
         <Empty title="Pick a PDF on the previous step before continuing." />
-        <div className="form-actions">
-          <Link className="tab" to="/profile/import/upload">
-            back to upload
-          </Link>
+        <div className="form-actions resume-import-actions justify-end">
+          <Button asChild variant="outline">
+            <Link to="/profile/import/upload">Back to upload</Link>
+          </Button>
         </div>
       </div>
     );
@@ -61,59 +64,77 @@ export function ImportPreviewForm() {
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-preview grid gap-4"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      <p className="status-line">
-        Selected: <b>{filename}</b>
-      </p>
-      <div className="import-options">
+      <div
+        className="resume-import-file-summary flex items-center gap-3 border-y border-border py-3"
+      >
+        <IconFileTypePdf
+          className="shrink-0 text-muted-foreground"
+          aria-hidden="true"
+          size={24}
+          stroke={1.7}
+        />
+        <div className="resume-import-file-summary__copy grid min-w-0 gap-0.5">
+          <span className="text-[11px] font-medium text-muted-foreground">Selected PDF</span>
+          <strong className="break-all text-[12px]">{filename}</strong>
+        </div>
+      </div>
+      <fieldset className="import-options resume-import-options m-0 min-w-0">
+        <legend className="px-1 text-[11px] font-bold text-muted-foreground">
+          Sections to import
+        </legend>
         <form.Field name="importProfile">
           {(field) => (
-            <label>
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.checked)}
-              />
-              profile data
-            </label>
+            <ChoiceControl
+              name="importProfile"
+              label="Profile data"
+              checked={field.state.value}
+              onBlur={field.handleBlur}
+              onCheckedChange={(checked) => field.handleChange(checked === true)}
+            />
           )}
         </form.Field>
         <form.Field name="importStyle">
           {(field) => (
-            <label>
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.checked)}
-              />
-              style data
-            </label>
+            <ChoiceControl
+              name="importStyle"
+              label="Style data"
+              checked={field.state.value}
+              onBlur={field.handleBlur}
+              onCheckedChange={(checked) => field.handleChange(checked === true)}
+            />
           )}
         </form.Field>
-      </div>
+      </fieldset>
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .filter((entry): entry is string => typeof entry === "string")
+            .at(0);
+          return message ? <div className="banner inline" role="alert">{message}</div> : null;
+        }}
+      </form.Subscribe>
       <form.Subscribe
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions justify-end">
+            <Button asChild variant="outline">
+              <Link to="/profile/import/upload">Back</Link>
+            </Button>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting}
             >
-              next
-            </button>
-            <Link className="tab" to="/profile/import/upload">
-              back
-            </Link>
+              Next
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-upload-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-upload-form.tsx
@@ -1,9 +1,12 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconFileTypePdf } from "@tabler/icons-react";
 import { useState } from "react";
 import { z } from "zod";
 
 import { fileToBase64 } from "../../../shared/lib/file.js";
+import { Button } from "../../../shared/ui/button.js";
+import { Input } from "../../../shared/ui/input.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
 
 interface UploadFormValues {
@@ -63,32 +66,46 @@ export function ImportUploadForm() {
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-upload grid gap-4"
+      aria-busy={reading}
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      {readError ? <div className="banner inline">{readError}</div> : null}
+      {readError ? <div className="banner inline" role="alert">{readError}</div> : null}
       <form.Field name="filename">
         {(field) => (
-          <label className="import-target">
-            <span className="import-icon">PDF</span>
-            <span>
-              <b>Resume PDF</b>
-              <small>{field.state.value || "No file selected"}</small>
+          <label className="import-target resume-import-upload__target">
+            <span className="import-icon" aria-hidden="true">
+              <IconFileTypePdf size={24} stroke={1.7} />
             </span>
-            <input
+            <span className="min-w-0">
+              <b>Resume PDF</b>
+              <small className="break-all">{field.state.value || "No file selected"}</small>
+            </span>
+            <Input
+              className="resume-import-upload__input"
               aria-label="Resume PDF"
+              name="resumePdf"
               type="file"
               accept="application/pdf"
               onChange={(event) => void handleFile(event.target.files?.[0] ?? null)}
             />
-            <em>{reading ? "reading..." : "choose file"}</em>
+            <em>{reading ? "Reading…" : "Choose file"}</em>
           </label>
         )}
       </form.Field>
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .filter((entry): entry is string => typeof entry === "string")
+            .at(0);
+          return message ? <div className="banner inline" role="alert">{message}</div> : null;
+        }}
+      </form.Subscribe>
       <form.Subscribe
         selector={(state) => ({
           canSubmit: state.canSubmit,
@@ -96,17 +113,16 @@ export function ImportUploadForm() {
         })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions justify-end">
+            <Button asChild variant="outline">
+              <Link to="/profile">Cancel</Link>
+            </Button>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting || reading}
             >
-              next
-            </button>
-            <Link className="tab" to="/profile">
-              cancel
-            </Link>
+              Next
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/profile-form.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.tsx
@@ -8,6 +8,7 @@ import { Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
 import type { ProfileConfigResponse } from "../../operations/types.js";
+import { Button } from "../../../shared/ui/button.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { StructuredProfileEditor } from "../components/StructuredProfileEditor.js";
 import { useUpdateProfileMutation } from "../hooks/useUpdateProfileMutation.js";
@@ -98,8 +99,8 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
   const [resetToken, setResetToken] = useState(0);
   const formRef = useRef<HTMLFormElement>(null);
   const isProfileSection = section === "profile";
-  const saveLabel = section === "target-search" ? "save discovery settings" : "save all";
-  const discardLabel = section === "target-search" ? "discard changes" : "discard all";
+  const saveLabel = section === "target-search" ? "Save discovery settings" : "Save all";
+  const discardLabel = section === "target-search" ? "Discard changes" : "Discard all";
   const savedMessage =
     section === "profile" ? "profile saved" : section === "target-search" ? "discovery settings saved" : "preferences saved";
 
@@ -177,24 +178,25 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
         {({ isDirty, isSubmitting }) => (
           <div className="editor-bulk-actions">
             {isProfileSection ? (
-              <Link className="tab on" to="/profile/import/upload">
-                import resume
-              </Link>
+              <Button asChild size="sm" variant="outline">
+                <Link to="/profile/import/upload">Import resume</Link>
+              </Button>
             ) : null}
-            <button
-              className="tab on"
+            <Button
+              size="sm"
               type="submit"
               disabled={!isDirty || isSubmitting}
             >
-              {isSubmitting ? "saving" : saveLabel}
-            </button>
-            <button
-              className="tab"
+              {isSubmitting ? "Saving…" : saveLabel}
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
               type="reset"
               disabled={!isDirty || isSubmitting}
             >
               {discardLabel}
-            </button>
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/provider-setup-forms.tsx
+++ b/apps/web/src/contexts/profile/forms/provider-setup-forms.tsx
@@ -7,7 +7,12 @@ import {
   type CredentialKey,
 } from "@jobctrl/contracts";
 
+import {
+  AdaptiveFieldGrid,
+  AdaptiveFieldSpan,
+} from "../../../shared/ui/adaptive-field-grid.js";
 import { Button } from "../../../shared/ui/button.js";
+import { ChoiceControl } from "../../../shared/ui/choice-control.js";
 import {
   Dialog,
   DialogClose,
@@ -18,6 +23,13 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "../../../shared/ui/dialog.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
+import { SelectField } from "../../../shared/ui/select-field.js";
 import { useUpdateCredentialsBatchMutation } from "../hooks/useUpdateCredentialsBatchMutation.js";
 import {
   buildClaudeCredentialBatch,
@@ -195,10 +207,10 @@ export function ClaudeProviderForm({
   }
 
   return (
-    <form className="provider-form" onSubmit={(event) => submitForm(event, form.handleSubmit)}>
+    <form className="provider-setup-form" onSubmit={(event) => submitForm(event, form.handleSubmit)}>
       <form.Field name="mode">
         {(field) => (
-          <ProviderChoices
+          <ProviderModeSelect
             legend="Choose how Claude authenticates"
             name="claude-auth-mode"
             value={field.state.value}
@@ -211,7 +223,13 @@ export function ClaudeProviderForm({
       </form.Field>
       <form.Subscribe selector={(state) => state.values.mode}>
         {(mode) => (
-          <div className="provider-mode-fields" aria-live="polite">
+          <AdaptiveFieldGrid
+            aria-live="polite"
+            className="provider-field-grid"
+            columns={2}
+            density="compact"
+            minColumnWidth={240}
+          >
             {mode === "anthropic_api_key" ? (
               <form.Field name="apiKey">
                 {(field) => (
@@ -222,6 +240,11 @@ export function ClaudeProviderForm({
                     help="Stored only in macOS Keychain. JobCtrl never returns the value after saving."
                     required
                     disabled={!secretStorageAvailable}
+                    disabledReason={
+                      !secretStorageAvailable
+                        ? "Secure secret storage is unavailable on this platform."
+                        : undefined
+                    }
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
@@ -257,6 +280,11 @@ export function ClaudeProviderForm({
                       label="Existing service-account JSON path (optional)"
                       help="Write-only. Leave blank to use normal gcloud Application Default Credentials. JobCtrl never uploads or copies the file."
                       disabled={sharedAdcEnvironmentManaged}
+                      disabledReason={
+                        sharedAdcEnvironmentManaged
+                          ? "GOOGLE_APPLICATION_CREDENTIALS is owned by the launch environment."
+                          : undefined
+                      }
                       value={field.state.value}
                       onBlur={field.handleBlur}
                       onChange={field.handleChange}
@@ -312,11 +340,10 @@ export function ClaudeProviderForm({
                 </form.Field>
               </>
             )}
-          </div>
+          </AdaptiveFieldGrid>
         )}
       </form.Subscribe>
       <ProviderFormActions
-        configured={configured}
         pending={update.isPending}
         message={message}
         saveLabel="Save Claude setup"
@@ -338,7 +365,7 @@ export function ClaudeProviderForm({
         }
       />
       {environmentManaged ? (
-        <p className="provider-form-message" role="status">Claude's effective mode is owned by the launch environment; save and removal controls are read-only.</p>
+        <p className="provider-setup-form__message" role="status">Claude's effective mode is owned by the launch environment; save and removal controls are read-only.</p>
       ) : null}
     </form>
   );
@@ -432,10 +459,10 @@ export function GoogleProviderForm({
   }
 
   return (
-    <form className="provider-form" onSubmit={(event) => submitForm(event, form.handleSubmit)}>
+    <form className="provider-setup-form" onSubmit={(event) => submitForm(event, form.handleSubmit)}>
       <form.Field name="mode">
         {(field) => (
-          <ProviderChoices
+          <ProviderModeSelect
             legend="Choose how Google authenticates"
             name="google-auth-mode"
             value={field.state.value}
@@ -448,7 +475,13 @@ export function GoogleProviderForm({
       </form.Field>
       <form.Subscribe selector={(state) => state.values.mode}>
         {(mode) => (
-          <div className="provider-mode-fields" aria-live="polite">
+          <AdaptiveFieldGrid
+            aria-live="polite"
+            className="provider-field-grid"
+            columns={2}
+            density="compact"
+            minColumnWidth={240}
+          >
             {mode === "gemini_api_key" ? (
               <form.Field name="apiKey">
                 {(field) => (
@@ -459,6 +492,11 @@ export function GoogleProviderForm({
                     help="Stored only in macOS Keychain and never returned by the API."
                     required
                     disabled={!secretStorageAvailable}
+                    disabledReason={
+                      !secretStorageAvailable
+                        ? "Secure secret storage is unavailable on this platform."
+                        : undefined
+                    }
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
@@ -484,6 +522,11 @@ export function GoogleProviderForm({
                       label="Existing service-account JSON path (optional)"
                       help="Write-only. Leave blank to use normal gcloud Application Default Credentials. JobCtrl never uploads or copies the file."
                       disabled={sharedAdcEnvironmentManaged}
+                      disabledReason={
+                        sharedAdcEnvironmentManaged
+                          ? "GOOGLE_APPLICATION_CREDENTIALS is owned by the launch environment."
+                          : undefined
+                      }
                       value={field.state.value}
                       onBlur={field.handleBlur}
                       onChange={field.handleChange}
@@ -492,11 +535,10 @@ export function GoogleProviderForm({
                 </form.Field>
               </>
             )}
-          </div>
+          </AdaptiveFieldGrid>
         )}
       </form.Subscribe>
       <ProviderFormActions
-        configured={configured}
         pending={update.isPending}
         message={message}
         saveLabel="Save Google setup"
@@ -518,19 +560,19 @@ export function GoogleProviderForm({
         }
       />
       {environmentManaged ? (
-        <p className="provider-form-message" role="status">Google's effective mode is owned by the launch environment; save and removal controls are read-only.</p>
+        <p className="provider-setup-form__message" role="status">Google's effective mode is owned by the launch environment; save and removal controls are read-only.</p>
       ) : null}
     </form>
   );
 }
 
-interface ChoiceOption<T extends string> {
+interface ProviderModeOption<T extends string> {
   value: T;
   label: string;
   description: string;
 }
 
-function ProviderChoices<T extends string>({
+function ProviderModeSelect<T extends string>({
   legend,
   name,
   value,
@@ -543,36 +585,36 @@ function ProviderChoices<T extends string>({
   name: string;
   value: T;
   onChange: (value: T) => void;
-  options: readonly ChoiceOption<T>[];
+  options: readonly ProviderModeOption<T>[];
   disabled?: boolean;
   disabledValues?: readonly T[];
 }) {
+  const selected = options.find((option) => option.value === value);
+  const description = [
+    selected?.description,
+    disabled ? "The active mode is owned by the launch environment and is read-only here." : null,
+    disabledValues.length > 0
+      ? "Direct API-key modes require a supported secure-storage adapter."
+      : null,
+  ].filter(Boolean).join(" ");
+
   return (
-    <fieldset className="provider-choice-fieldset">
-      <legend>{legend}</legend>
-      <div className="provider-choice-list">
-        {options.map((option) => {
-          const id = `${name}-${option.value}`;
-          return (
-            <label className="provider-choice" htmlFor={id} key={option.value}>
-              <input
-                checked={value === option.value}
-                id={id}
-                name={name}
-                type="radio"
-                value={option.value}
-                disabled={disabled || disabledValues.includes(option.value)}
-                onChange={() => onChange(option.value)}
-              />
-              <span>
-                <b>{option.label}</b>
-                <small>{option.description}</small>
-              </span>
-            </label>
-          );
-        })}
-      </div>
-    </fieldset>
+    <SelectField
+      className="provider-mode-select"
+      description={description}
+      disabled={disabled}
+      id={name}
+      label={legend}
+      name={name}
+      options={options.map((option) => ({
+        disabled: disabledValues.includes(option.value),
+        label: option.label,
+        value: option.value,
+      }))}
+      required
+      value={value}
+      onValueChange={(nextValue) => onChange(nextValue as T)}
+    />
   );
 }
 
@@ -586,6 +628,7 @@ function SecretField({
   onBlur,
   onChange,
   disabled = false,
+  disabledReason,
 }: {
   id: string;
   name: string;
@@ -596,37 +639,40 @@ function SecretField({
   onBlur: () => void;
   onChange: (value: string) => void;
   disabled?: boolean;
+  disabledReason?: string | undefined;
 }) {
   const [revealed, setRevealed] = useState(false);
   const helpId = `${id}-help`;
+  const disabledReasonId = disabled && disabledReason ? `${id}-disabled-reason` : undefined;
+  const describedBy = [helpId, disabledReasonId].filter(Boolean).join(" ");
   return (
-    <div className="field provider-field">
-      <label htmlFor={id}>{label}{required ? " (required)" : ""}</label>
-      <div className="secret-input-row">
-        <input
-          aria-describedby={helpId}
-          autoComplete="off"
-          id={id}
-          name={name}
-          disabled={disabled}
-          required={required}
-          type={revealed ? "text" : "password"}
-          value={value}
-          onBlur={onBlur}
-          onChange={(event) => onChange(event.target.value)}
-        />
-        <button
-          aria-pressed={revealed}
-          className="tab secret-reveal"
-          type="button"
-          disabled={disabled}
-          onClick={() => setRevealed((current) => !current)}
-        >
-          {revealed ? "Hide" : "Show"}
-        </button>
-      </div>
-      <small className="field-hint" id={helpId}>{help}</small>
-    </div>
+    <Field className="provider-setup-field provider-secret-field" data-disabled={disabled || undefined}>
+      <FieldLabel htmlFor={id}>{label}{required ? " (required)" : ""}</FieldLabel>
+      <Input
+        aria-describedby={describedBy}
+        autoComplete="off"
+        id={id}
+        name={name}
+        disabled={disabled}
+        required={required}
+        type={revealed ? "text" : "password"}
+        value={value}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      <FieldDescription id={helpId}>{help}</FieldDescription>
+      {disabledReasonId ? (
+        <FieldDescription id={disabledReasonId}>{disabledReason}</FieldDescription>
+      ) : null}
+      <ChoiceControl
+        checked={revealed}
+        className="provider-secret-visibility"
+        disabled={disabled}
+        description="Only changes how this unsaved value appears in the current field."
+        label={`Show ${label.toLowerCase()}`}
+        onCheckedChange={(checked) => setRevealed(checked === true)}
+      />
+    </Field>
   );
 }
 
@@ -650,9 +696,9 @@ function TextField({
 }) {
   const helpId = help ? `${id}-help` : undefined;
   return (
-    <div className="field provider-field">
-      <label htmlFor={id}>{label}{required ? " (required)" : ""}</label>
-      <input
+    <Field className="provider-setup-field">
+      <FieldLabel htmlFor={id}>{label}{required ? " (required)" : ""}</FieldLabel>
+      <Input
         aria-describedby={helpId}
         id={id}
         name={field.name}
@@ -662,29 +708,27 @@ function TextField({
         onBlur={field.handleBlur}
         onChange={(event) => field.handleChange(event.target.value)}
       />
-      {help ? <small className="field-hint" id={helpId}>{help}</small> : null}
-    </div>
+      {help ? <FieldDescription id={helpId}>{help}</FieldDescription> : null}
+    </Field>
   );
 }
 
 function CloudGuidance({ command, children }: { command: string; children: ReactNode }) {
   return (
-    <div className="provider-cloud-guidance">
+    <AdaptiveFieldSpan className="provider-setup-guidance" span="full">
       <p>{children}</p>
       <code>{command}</code>
-    </div>
+    </AdaptiveFieldSpan>
   );
 }
 
 function ProviderFormActions({
-  configured,
   pending,
   message,
   saveLabel,
   removeAction,
   readOnly = false,
 }: {
-  configured: boolean;
   pending: boolean;
   message: string;
   saveLabel: string;
@@ -692,15 +736,12 @@ function ProviderFormActions({
   readOnly?: boolean;
 }) {
   return (
-    <div className="provider-form-footer">
-      <button className="tab on" disabled={pending || readOnly} type="submit">
+    <div className="provider-setup-form__footer">
+      <Button disabled={pending || readOnly} size="sm" type="submit">
         {pending ? "Saving…" : saveLabel}
-      </button>
+      </Button>
       {removeAction}
-      <span className={`tag ${configured ? "ok" : "muted"}`}>
-        {configured ? "Configured" : "Not configured"}
-      </span>
-      <div aria-live="polite" className="provider-form-message" role="status">
+      <div aria-live="polite" className="provider-setup-form__message" role="status">
         {message}
       </div>
     </div>
@@ -725,7 +766,7 @@ function ProviderRemovalDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
-        <Button disabled={pending} type="button" variant="outline">
+        <Button disabled={pending} size="sm" type="button" variant="outline">
           Remove {provider} setup
         </Button>
       </DialogTrigger>
@@ -745,12 +786,13 @@ function ProviderRemovalDialog({
         ) : null}
         <DialogFooter>
           <DialogClose asChild>
-            <Button disabled={pending} type="button" variant="ghost">
+            <Button disabled={pending} size="sm" type="button" variant="ghost">
               Cancel
             </Button>
           </DialogClose>
           <Button
             disabled={pending}
+            size="sm"
             type="button"
             variant="destructive"
             onClick={onConfirm}
@@ -846,7 +888,7 @@ const GOOGLE_MODE_CREDENTIAL_KEYS: Readonly<Record<GoogleMode, readonly Credenti
   vertex: ["GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"],
 };
 
-const CLAUDE_OPTIONS: readonly ChoiceOption<ClaudeMode>[] = [
+const CLAUDE_OPTIONS: readonly ProviderModeOption<ClaudeMode>[] = [
   {
     value: "anthropic_api_key",
     label: "Anthropic API key",
@@ -874,7 +916,7 @@ const CLAUDE_OPTIONS: readonly ChoiceOption<ClaudeMode>[] = [
   },
 ];
 
-const GOOGLE_OPTIONS: readonly ChoiceOption<GoogleMode>[] = [
+const GOOGLE_OPTIONS: readonly ProviderModeOption<GoogleMode>[] = [
   {
     value: "gemini_api_key",
     label: "Gemini API key",

--- a/apps/web/src/contexts/profile/forms/settings-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/settings-form.test.tsx
@@ -149,7 +149,7 @@ describe("<SettingsForm>", () => {
     expect(screen.getByText(/Saved in config.json; requires a worker restart/)).toBeInTheDocument();
     expect(screen.getByText(/Restart pending/)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Daily LLM budget (USD)"), { target: { value: "30" } });
-    fireEvent.click(screen.getByRole("button", { name: "save" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
     expect(updateSettings).toHaveBeenCalledWith(expect.objectContaining({ workerActivitySlots: 9 }));

--- a/apps/web/src/contexts/profile/forms/settings-form.tsx
+++ b/apps/web/src/contexts/profile/forms/settings-form.tsx
@@ -6,9 +6,17 @@ import {
 import { useForm } from "@tanstack/react-form";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { AutosaveUndoController } from "../../../shared/ui/autosave-undo-controller.js";
+import { Button } from "../../../shared/ui/button.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
 import type { JobCtrlSettings } from "../../operations/types.js";
 import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
-import { AutosaveUndoController } from "../../../shared/ui/autosave-undo-controller.js";
 
 interface SettingsInitialProps {
   initial: JobCtrlSettings;
@@ -88,7 +96,7 @@ export function SettingsForm({
 
   return (
     <form
-      className="config-form"
+      className="settings-general-form grid gap-4"
       ref={formRef}
       onSubmit={(event) => {
         event.preventDefault();
@@ -123,70 +131,76 @@ export function SettingsForm({
           />
         )}
       </form.Subscribe>
-      <form.Field name="dailyBudgetUsd">
-        {(field) => (
-          <div className="field">
-            <label htmlFor="settings-daily-budget-usd">Daily LLM budget (USD)</label>
-            <input
-              id="settings-daily-budget-usd"
-              name="dailyBudgetUsd"
-              type="number"
-              min={0}
-              step={0.01}
-              aria-describedby="settings-daily-budget-usd-help"
-              value={field.state.value ?? 0}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(Number(event.target.value))}
-            />
-            <small id="settings-daily-budget-usd-help">
-              Use 0 for unlimited. {settingContext(effectiveSettings.dailyBudgetUsd)}
-            </small>
-          </div>
-        )}
-      </form.Field>
-      <form.Field name="applyConcurrency">
-        {(field) => (
-          <div className="field">
-            <label htmlFor="settings-apply-concurrency">Concurrent applications</label>
-            <input
-              id="settings-apply-concurrency"
-              name="applyConcurrency"
-              type="number"
-              min={1}
-              max={16}
-              step={1}
-              aria-describedby="settings-apply-concurrency-help"
-              value={field.state.value ?? 1}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(Number(event.target.value))}
-            />
-            <small id="settings-apply-concurrency-help">
-              {settingContext(effectiveSettings.applyConcurrency)}
-            </small>
-          </div>
-        )}
-      </form.Field>
-      {effectiveSettings.workerActivitySlots.editable ? (
-        <form.Field name="workerActivitySlots">
+      <AdaptiveFieldGrid columns={3} minColumnWidth={220} density="compact">
+        <form.Field name="dailyBudgetUsd">
           {(field) => (
-            <WorkerActivitySlotsField
-              value={field.state.value ?? initial.workerActivitySlots}
-              onBlur={field.handleBlur}
-              onChange={field.handleChange}
-              metadata={effectiveSettings.workerActivitySlots}
-              activeValue={activeWorkerActivitySlots}
-              workerStatus={workerStatus}
-            />
+            <Field>
+              <FieldLabel htmlFor="settings-daily-budget-usd">
+                Daily LLM budget (USD)
+              </FieldLabel>
+              <Input
+                id="settings-daily-budget-usd"
+                name="dailyBudgetUsd"
+                type="number"
+                min={0}
+                step={0.01}
+                aria-describedby="settings-daily-budget-usd-help"
+                value={field.state.value ?? 0}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(Number(event.target.value))}
+              />
+              <FieldDescription id="settings-daily-budget-usd-help">
+                Use 0 for unlimited. {settingContext(effectiveSettings.dailyBudgetUsd)}
+              </FieldDescription>
+            </Field>
           )}
         </form.Field>
-      ) : (
-        <WorkerActivitySlotsField
-          value={effectiveSettings.workerActivitySlots.value}
-          metadata={effectiveSettings.workerActivitySlots}
-          activeValue={activeWorkerActivitySlots}
-          workerStatus={workerStatus}
-        />
-      )}
+        <form.Field name="applyConcurrency">
+          {(field) => (
+            <Field>
+              <FieldLabel htmlFor="settings-apply-concurrency">
+                Concurrent applications
+              </FieldLabel>
+              <Input
+                id="settings-apply-concurrency"
+                name="applyConcurrency"
+                type="number"
+                min={1}
+                max={16}
+                step={1}
+                aria-describedby="settings-apply-concurrency-help"
+                value={field.state.value ?? 1}
+                onBlur={field.handleBlur}
+                onChange={(event) => field.handleChange(Number(event.target.value))}
+              />
+              <FieldDescription id="settings-apply-concurrency-help">
+                {settingContext(effectiveSettings.applyConcurrency)}
+              </FieldDescription>
+            </Field>
+          )}
+        </form.Field>
+        {effectiveSettings.workerActivitySlots.editable ? (
+          <form.Field name="workerActivitySlots">
+            {(field) => (
+              <WorkerActivitySlotsField
+                value={field.state.value ?? initial.workerActivitySlots}
+                onBlur={field.handleBlur}
+                onChange={field.handleChange}
+                metadata={effectiveSettings.workerActivitySlots}
+                activeValue={activeWorkerActivitySlots}
+                workerStatus={workerStatus}
+              />
+            )}
+          </form.Field>
+        ) : (
+          <WorkerActivitySlotsField
+            value={effectiveSettings.workerActivitySlots.value}
+            metadata={effectiveSettings.workerActivitySlots}
+            activeValue={activeWorkerActivitySlots}
+            workerStatus={workerStatus}
+          />
+        )}
+      </AdaptiveFieldGrid>
       <form.Subscribe
         selector={(state) => ({
           canSubmit: state.canSubmit,
@@ -195,21 +209,20 @@ export function SettingsForm({
         })}
       >
         {({ canSubmit, isSubmitting, isDirty }) => (
-          <div className="form-actions">
-            <button
-              className="tab on"
+          <div className="form-actions settings-general-form__actions">
+            <Button
               type="submit"
               disabled={!canSubmit || !isDirty || isSubmitting}
             >
-              {isSubmitting ? "saving" : "save"}
-            </button>
-            <button
-              className="tab"
+              {isSubmitting ? "Saving…" : "Save"}
+            </Button>
+            <Button
+              variant="outline"
               type="reset"
               disabled={!isDirty || isSubmitting}
             >
-              reset
-            </button>
+              Reset
+            </Button>
           </div>
         )}
       </form.Subscribe>
@@ -234,9 +247,11 @@ function WorkerActivitySlotsField({
 }) {
   const pendingRestart = activeValue !== null && activeValue !== value;
   return (
-    <div className="field">
-      <label htmlFor="settings-worker-activity-slots">Worker activity slots</label>
-      <input
+    <Field className="settings-worker-capacity-field">
+      <FieldLabel htmlFor="settings-worker-activity-slots">
+        Worker activity slots
+      </FieldLabel>
+      <Input
         id="settings-worker-activity-slots"
         name={metadata.editable ? "workerActivitySlots" : undefined}
         type="number"
@@ -250,14 +265,19 @@ function WorkerActivitySlotsField({
         onBlur={onBlur}
         onChange={onChange ? (event) => onChange(Number(event.target.value)) : undefined}
       />
-      <small id="settings-worker-activity-slots-help">{settingContext(metadata)}</small>
-      <div id="settings-worker-activity-slots-state" className="status-line">
+      <FieldDescription id="settings-worker-activity-slots-help">
+        {settingContext(metadata)}
+      </FieldDescription>
+      <FieldDescription
+        id="settings-worker-activity-slots-state"
+        className="settings-worker-capacity-state"
+      >
         Desired: {value}. Active: {activeValue ?? "not reported"}.{" "}
         {pendingRestart
           ? "Restart pending: restart the worker to activate the desired slots."
           : friendlyWorkerState(workerStatus, activeValue)}
-      </div>
-    </div>
+      </FieldDescription>
+    </Field>
   );
 }
 

--- a/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx
+++ b/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx
@@ -8,7 +8,7 @@ import { useState } from "react";
 import type { CompensationSourcePolicySummary } from "../../operations/types.js";
 import { useCompensationSourcePolicyQuery } from "../../operations/hooks/useCompensationSourcePolicyQuery.js";
 import { useUpdateCompensationSourcePolicyMutation } from "../hooks/useUpdateCompensationSourcePolicyMutation.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import {
   Field,
@@ -19,14 +19,7 @@ import {
   FieldLegend,
   FieldSet,
 } from "../../../shared/ui/field.js";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../../../shared/ui/select.js";
+import { SelectField } from "../../../shared/ui/select-field.js";
 import { Switch } from "../../../shared/ui/switch.js";
 
 const NOT_CONFIGURED = "not_configured";
@@ -58,9 +51,13 @@ export function CompensationSourcePolicyPanel() {
   };
 
   return (
-    <section className="card full compensation-source-policy-panel">
-      <CardHeader title="Compensation sources" meta="editable source policy" />
-      {query.error ? <div className="banner inline">{query.error.message}</div> : null}
+    <DisclosureSection
+      className="compensation-source-policy-panel"
+      title="Compensation sources"
+      description="Editable source policy, access status, and attribution requirements"
+      collapsedSummary={`${sources.length} configured source policies`}
+    >
+      {query.error ? <div className="banner inline" role="alert">{query.error.message}</div> : null}
       {statusMessage ? (
         <div className="status-line" aria-live="polite">
           {statusMessage}
@@ -97,7 +94,7 @@ export function CompensationSourcePolicyPanel() {
           </table>
         </div>
       ) : null}
-    </section>
+    </DisclosureSection>
   );
 }
 
@@ -139,16 +136,26 @@ function CompensationSourcePolicyRow({
       </td>
       <td>
         <div>{formatLabel(source.sourceType)}</div>
-        <span className="tag muted">{formatLabel(source.accessMode)}</span>
+        <span className="source-policy-fact">{formatLabel(source.accessMode)}</span>
       </td>
       <td>
         <div>
-          <span className={availabilityClass(source.availability)}>
+          <span
+            className="source-policy-status"
+            data-tone={source.availability === "available" ? "positive" : "warning"}
+          >
             {formatLabel(source.availability)}
           </span>
         </div>
         <div>
-          <span className={licenseClass(source.licenseStatus)}>
+          <span
+            className="source-policy-status"
+            data-tone={
+              source.licenseStatus === "permitted" || source.licenseStatus === "not_required"
+                ? "positive"
+                : "warning"
+            }
+          >
             {formatLabel(source.licenseStatus)}
           </span>
         </div>
@@ -184,12 +191,11 @@ function CompensationSourceControls({
   source: CompensationSourcePolicySummary;
 }) {
   if (source.control.kind === "fixed") {
-    return <span className="tag muted">always enabled</span>;
+    return <span className="source-policy-fact">always enabled</span>;
   }
 
   const control = source.control;
   const accessModeId = `${source.sourceId}-access-mode`;
-  const accessModeLabelId = `${accessModeId}-label`;
   const coverageId = `${source.sourceId}-europe-coverage`;
   const coverageLabelId = `${coverageId}-label`;
   const enabledId = `${source.sourceId}-enabled`;
@@ -242,45 +248,33 @@ function CompensationSourceControls({
         {source.displayName} source settings
       </FieldLegend>
       <FieldGroup className="min-w-64 gap-3">
-        <Field data-disabled={busy}>
-          <FieldLabel id={accessModeLabelId} htmlFor={accessModeId}>
-            {source.displayName} access mode
-          </FieldLabel>
-          <Select
-            disabled={busy}
-            value={control.accessMode ?? NOT_CONFIGURED}
-            onValueChange={(value) =>
-              update({
-                accessMode:
-                  value === NOT_CONFIGURED
-                    ? null
-                    : (value as UserCompensationSourceControl["accessMode"]),
-              })
-            }
-          >
-            <SelectTrigger
-              id={accessModeId}
-              aria-labelledby={accessModeLabelId}
-            >
-              <SelectValue placeholder="Choose access basis" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectItem
-                  disabled={control.enabled}
-                  value={NOT_CONFIGURED}
-                >
-                  Not configured
-                </SelectItem>
-                {control.allowedAccessModes.map((mode) => (
-                  <SelectItem key={mode} value={mode}>
-                    {formatLabel(mode)}
-                  </SelectItem>
-                ))}
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </Field>
+        <SelectField
+          id={accessModeId}
+          name={`${source.sourceId}-access-mode`}
+          label={`${source.displayName} access mode`}
+          disabled={busy}
+          value={control.accessMode ?? NOT_CONFIGURED}
+          placeholder="Choose access basis"
+          options={[
+            {
+              value: NOT_CONFIGURED,
+              label: "Not configured",
+              disabled: control.enabled,
+            },
+            ...control.allowedAccessModes.map((mode) => ({
+              value: mode,
+              label: formatLabel(mode),
+            })),
+          ]}
+          onValueChange={(value) =>
+            update({
+              accessMode:
+                value === NOT_CONFIGURED
+                  ? null
+                  : (value as UserCompensationSourceControl["accessMode"]),
+            })
+          }
+        />
         {control.europeCoverageRequired ? (
           <Field orientation="horizontal" data-disabled={busy}>
             <FieldContent>
@@ -337,12 +331,12 @@ function CompensationSourceControls({
 
 function renderSupportedFields(source: CompensationSourcePolicySummary) {
   if (source.supportedFields.length === 0) {
-    return <span className="tag muted">none until permitted</span>;
+    return <span className="source-policy-fact">none until permitted</span>;
   }
   return (
-    <div className="job-audit-tag-group" aria-label={`${source.displayName} supported fields`}>
+    <div className="source-policy-field-list" aria-label={`${source.displayName} supported fields`}>
       {source.supportedFields.map((field) => (
-        <span key={field} className="tag info">
+        <span key={field}>
           {formatLabel(field)}
         </span>
       ))}
@@ -352,15 +346,4 @@ function renderSupportedFields(source: CompensationSourcePolicySummary) {
 
 function formatLabel(value: string): string {
   return value.replaceAll("_", " ");
-}
-
-function availabilityClass(availability: CompensationSourcePolicySummary["availability"]): string {
-  return availability === "available" ? "tag ok" : "tag warn";
-}
-
-function licenseClass(status: CompensationSourcePolicySummary["licenseStatus"]): string {
-  if (status === "permitted" || status === "not_required") {
-    return "tag ok";
-  }
-  return "tag warn";
 }

--- a/apps/web/src/contexts/scoring/components/ScoringGuidancePanel.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoringGuidancePanel.tsx
@@ -2,8 +2,16 @@ import { SettingsUpdateRequestSchema } from "@jobctrl/contracts";
 import { useForm } from "@tanstack/react-form";
 import { useEffect, useState } from "react";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
+import { Button } from "../../../shared/ui/button.js";
+import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import {
+  Field,
+  FieldDescription,
+  FieldLabel,
+} from "../../../shared/ui/field.js";
+import { Textarea } from "../../../shared/ui/textarea.js";
 import { useSettingsPolicyQuery } from "../../operations/hooks/useSettingsPolicyQueries.js";
 import { useUpdateScoringGuidanceMutation } from "../hooks/useUpdateScoringGuidanceMutation.js";
 
@@ -13,27 +21,98 @@ export function ScoringGuidancePanel() {
   const [status, setStatus] = useState("");
   const response = settingsQuery.data;
   const form = useForm({
-    defaultValues: { scoreCriteria: response?.settings.scoreCriteria ?? "", targetCriteria: response?.settings.targetCriteria ?? "" },
-    validators: { onSubmit: ({ value }) => SettingsUpdateRequestSchema.safeParse(value).success ? undefined : "Scoring guidance is too long" },
+    defaultValues: {
+      scoreCriteria: response?.settings.scoreCriteria ?? "",
+      targetCriteria: response?.settings.targetCriteria ?? "",
+    },
+    validators: {
+      onSubmit: ({ value }) =>
+        SettingsUpdateRequestSchema.safeParse(value).success
+          ? undefined
+          : "Scoring guidance is too long",
+    },
     onSubmit: async ({ value, formApi }) => {
       const saved = await updateSettings.mutateAsync(value);
-      formApi.reset({ scoreCriteria: saved.settings.scoreCriteria, targetCriteria: saved.settings.targetCriteria });
+      formApi.reset({
+        scoreCriteria: saved.settings.scoreCriteria,
+        targetCriteria: saved.settings.targetCriteria,
+      });
       setStatus("Scoring guidance saved for newly started scoring work.");
     },
   });
+
   useEffect(() => {
-    if (response && !form.state.isDirty) form.reset({ scoreCriteria: response.settings.scoreCriteria, targetCriteria: response.settings.targetCriteria });
+    if (response && !form.state.isDirty) {
+      form.reset({
+        scoreCriteria: response.settings.scoreCriteria,
+        targetCriteria: response.settings.targetCriteria,
+      });
+    }
   }, [form, response]);
-  if (!response) return <section className="card full"><CardHeader title="Scoring guidance" meta="scoring" /><Empty title="Loading scoring guidance." /></section>;
+
   return (
-    <section className="card full">
-      <CardHeader title="Scoring guidance" meta="scoring" />
-      <form className="config-form" onSubmit={(event) => { event.preventDefault(); void form.handleSubmit(); }}>
-        {status ? <div className="status-line" role="status">{status}</div> : null}
-        <form.Field name="scoreCriteria">{(field) => <div className="field"><label htmlFor="score-guidance">Scoring priorities</label><textarea id="score-guidance" name="scoreCriteria" maxLength={8000} aria-describedby="score-guidance-help" value={field.state.value} onChange={(event) => field.handleChange(event.target.value)} /><small id="score-guidance-help">What strong-fit jobs should demonstrate. Applies to new scoring work.</small></div>}</form.Field>
-        <form.Field name="targetCriteria">{(field) => <div className="field"><label htmlFor="target-guidance">Target role guidance</label><textarea id="target-guidance" name="targetCriteria" maxLength={8000} aria-describedby="target-guidance-help" value={field.state.value} onChange={(event) => field.handleChange(event.target.value)} /><small id="target-guidance-help">Additional role and company targeting guidance.</small></div>}</form.Field>
-        <button className="tab on" type="submit" disabled={updateSettings.isPending}>{updateSettings.isPending ? "saving" : "save scoring guidance"}</button>
-      </form>
-    </section>
+    <DisclosureSection
+      className="scoring-guidance-settings"
+      title="Scoring guidance"
+      description="Priorities and targeting context for newly started scoring work"
+      collapsedSummary="Scoring priorities and target role guidance"
+    >
+      {!response ? (
+        <Empty title="Loading scoring guidance." />
+      ) : (
+        <form
+          className="scoring-guidance-form grid gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void form.handleSubmit();
+          }}
+        >
+          {status ? <div className="status-line" role="status">{status}</div> : null}
+          <AdaptiveFieldGrid columns={2} minColumnWidth={320} density="compact">
+            <form.Field name="scoreCriteria">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="score-guidance">Scoring priorities</FieldLabel>
+                  <Textarea
+                    id="score-guidance"
+                    name="scoreCriteria"
+                    maxLength={8000}
+                    aria-describedby="score-guidance-help"
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                  />
+                  <FieldDescription id="score-guidance-help">
+                    What strong-fit jobs should demonstrate. Applies to new scoring work.
+                  </FieldDescription>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="targetCriteria">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="target-guidance">Target role guidance</FieldLabel>
+                  <Textarea
+                    id="target-guidance"
+                    name="targetCriteria"
+                    maxLength={8000}
+                    aria-describedby="target-guidance-help"
+                    value={field.state.value}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                  />
+                  <FieldDescription id="target-guidance-help">
+                    Additional role and company targeting guidance.
+                  </FieldDescription>
+                </Field>
+              )}
+            </form.Field>
+          </AdaptiveFieldGrid>
+          <div className="form-actions scoring-guidance-form__actions">
+            <Button type="submit" disabled={updateSettings.isPending}>
+              {updateSettings.isPending ? "Saving…" : "Save scoring guidance"}
+            </Button>
+          </div>
+        </form>
+      )}
+    </DisclosureSection>
   );
 }

--- a/apps/web/src/routes/preferences.tsx
+++ b/apps/web/src/routes/preferences.tsx
@@ -21,13 +21,13 @@ export const Route = createFileRoute("/preferences")({
 
 function PreferencesEditor() {
   return (
-    <>
+    <div className="route-page route-page--preferences">
       <PageHead
         eyebrow="Setup"
         title="Preferences"
         subtitle="Search targets, tailoring, and apply configuration"
       />
       <ProfileEditor section="preferences" />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/routes/profile.index.tsx
+++ b/apps/web/src/routes/profile.index.tsx
@@ -1,7 +1,8 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { ProfileEditor } from "../contexts/profile/components/ProfileEditor.js";
 import { profileKeys } from "../contexts/profile/queryKeys.js";
+import { Button } from "../shared/ui/button.js";
 import { PageHead } from "../shared/ui/page-head.js";
 
 export const Route = createFileRoute("/profile/")({
@@ -21,13 +22,18 @@ export const Route = createFileRoute("/profile/")({
 
 function ProfilePage() {
   return (
-    <>
+    <div className="route-page route-page--profile">
       <PageHead
         eyebrow="Setup"
         title="Profile"
         subtitle="Baseline resume, evidence, and personal details"
+        actions={
+          <Button asChild size="sm" variant="outline">
+            <Link to="/evidence-map">Open evidence map</Link>
+          </Button>
+        }
       />
       <ProfileEditor />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/routes/settings.browser.tsx
+++ b/apps/web/src/routes/settings.browser.tsx
@@ -9,9 +9,9 @@ export const Route = createFileRoute("/settings/browser")({
 
 function BrowserSettingsRoute() {
   return (
-    <>
+    <div className="settings-browser-sections">
       <BrowserCapabilitiesPanel />
       <ExtensionPairingPanel />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/routes/settings.index.tsx
+++ b/apps/web/src/routes/settings.index.tsx
@@ -11,11 +11,11 @@ export const Route = createFileRoute("/settings/")({
 
 function SettingsIndexRoute() {
   return (
-    <>
+    <div className="settings-general-sections grid gap-4">
       <SettingsPanel />
       <ApplyRuntimeSettingsPanel />
       <ScoringGuidancePanel />
       <CompensationSourcePolicyPanel />
-    </>
+    </div>
   );
 }

--- a/apps/web/src/routes/settings.models.tsx
+++ b/apps/web/src/routes/settings.models.tsx
@@ -8,5 +8,10 @@ export const Route = createFileRoute("/settings/models")({
 });
 
 function ModelsSettingsRoute() {
-  return <><ModelSelectionPanel /><AiExecutionPolicyPanel /></>;
+  return (
+    <div className="models-settings-sections grid gap-[18px]">
+      <ModelSelectionPanel />
+      <AiExecutionPolicyPanel />
+    </div>
+  );
 }

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -1,14 +1,16 @@
 import { Link, Outlet, createFileRoute, useRouterState } from "@tanstack/react-router";
 
 import { PageHead } from "../shared/ui/page-head.js";
+import { SectionTabs, SectionTabsList } from "../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../shared/ui/tabs.js";
 
 const TABS: ReadonlyArray<{
   readonly to: "/settings" | "/settings/credentials" | "/settings/models" | "/settings/browser";
   readonly label: string;
 }> = [
-  { to: "/settings", label: "general" },
-  { to: "/settings/credentials", label: "credentials" },
-  { to: "/settings/models", label: "model selection" },
+  { to: "/settings", label: "General" },
+  { to: "/settings/credentials", label: "Credentials" },
+  { to: "/settings/models", label: "Model selection" },
   { to: "/settings/browser", label: "Browser & extension" },
 ];
 
@@ -18,27 +20,40 @@ export const Route = createFileRoute("/settings")({
 
 function SettingsLayout() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const activeTab = TABS.find((tab) => tab.to === pathname)?.to ?? "/settings";
+
   return (
-    <>
+    <div className="route-page route-page--settings">
       <PageHead eyebrow="Setup" title="Settings" />
       <div className="config-layout">
-        <nav className="settings-tabs" aria-label="Settings sections">
-          {TABS.map((tab) => {
-            const active = pathname === tab.to;
-            return (
-              <Link
-                key={tab.to}
-                to={tab.to}
-                className={`tab ${active ? "on" : ""}`}
-                aria-current={active ? "page" : undefined}
-              >
-                {tab.label}
-              </Link>
-            );
-          })}
-        </nav>
-        <Outlet />
+        <SectionTabs className="settings-route-tabs grid gap-[18px]" value={activeTab}>
+          <nav className="settings-section-navigation" aria-label="Settings sections">
+            <SectionTabsList>
+              {TABS.map((tab) => {
+                const active = activeTab === tab.to;
+                return (
+                  <TabsTrigger
+                    key={tab.to}
+                    value={tab.to}
+                    className="data-[state=active]:border-foreground"
+                    asChild
+                  >
+                    <Link
+                      to={tab.to}
+                      aria-current={active ? "page" : undefined}
+                    >
+                      {tab.label}
+                    </Link>
+                  </TabsTrigger>
+                );
+              })}
+            </SectionTabsList>
+          </nav>
+          <TabsContent className="settings-route-tabs__content mt-0" value={activeTab} forceMount>
+            <Outlet />
+          </TabsContent>
+        </SectionTabs>
       </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -8609,6 +8609,560 @@ input[type="radio"] {
   margin-bottom: 0;
 }
 
+/* Setup route composition --------------------------------------------------- */
+
+.route-page--profile,
+.route-page--preferences,
+.route-page--settings {
+  min-width: 0;
+}
+
+.route-page--profile .profile-layout {
+  grid-template-columns:
+    minmax(460px, var(--profile-editor-width, 62%))
+    18px
+    minmax(360px, 1fr);
+  gap: 0;
+}
+
+.profile-editor-panel {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--card);
+}
+
+.profile-layout-single .profile-editor-panel {
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.profile-editor-panel__header {
+  display: flex;
+  min-height: 74px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.profile-editor-panel__header h2,
+.profile-editor-panel__header p {
+  margin: 0;
+}
+
+.profile-editor-panel__header h2 {
+  margin-top: 3px;
+  font-size: 16px;
+}
+
+.profile-editor-panel__header p {
+  margin-top: 4px;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.profile-editor-panel > form > .editor-bulk-actions {
+  position: sticky;
+  z-index: 3;
+  top: var(--app-header-height, 60px);
+  justify-content: flex-end;
+  background: color-mix(in oklch, var(--card) 94%, transparent);
+  backdrop-filter: blur(12px);
+}
+
+.route-page--profile .profile-sections {
+  gap: 12px;
+  padding: 12px;
+}
+
+.profile-disclosure > .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.profile-repeat-editor,
+.profile-repeat-entry,
+.profile-repeat-items {
+  display: grid;
+  min-width: 0;
+  gap: 12px;
+}
+
+.profile-repeat-entry {
+  padding: 14px 0;
+  border-top: 1px solid var(--border);
+}
+
+.profile-repeat-entry:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.profile-repeat-entry__header,
+.profile-repeat-entry__controls,
+.profile-repeat-item__meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+}
+
+.profile-repeat-entry__header {
+  justify-content: space-between;
+}
+
+.profile-repeat-entry__title {
+  min-width: 0;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.profile-repeat-choice {
+  border: 0;
+  padding: 0;
+}
+
+.profile-repeat-choice--compact .choice-control__label,
+.profile-repeat-choice--entry .choice-control__label {
+  font-size: 11px;
+}
+
+.profile-repeat-item {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(104px, 0.24fr) minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in oklch, var(--border) 72%, transparent);
+}
+
+.profile-repeat-item__meta {
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.profile-repeat-item__label {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.profile-repeat-item--skill {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: end;
+}
+
+.profile-repeat-item textarea {
+  min-height: 76px;
+}
+
+.profile-repeat-add {
+  justify-self: start;
+}
+
+.preference-choice-group__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.profile-preview-pane {
+  position: sticky;
+  top: calc(var(--app-header-height, 60px) + 12px);
+  min-width: 0;
+}
+
+.profile-preview-workbench {
+  min-height: min(78dvh, 920px);
+}
+
+.profile-preview-workbench .preview-workbench__document {
+  min-height: min(68dvh, 820px);
+}
+
+.profile-preview-workbench .resume-plate-editor {
+  min-height: inherit;
+  border: 0;
+  border-radius: 0;
+}
+
+.profile-preview-workbench .resume-plate-canvas {
+  min-height: min(68dvh, 820px);
+}
+
+.route-page--preferences .editor-bulk-actions {
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.resume-template-secondary-controls {
+  display: grid;
+  min-width: 0;
+  width: 100%;
+  gap: 10px;
+}
+
+.resume-template-accent-input {
+  padding: 3px;
+}
+
+.resume-template-default-state {
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 750;
+}
+
+.resume-template-panel .resume-template-plate-editor {
+  width: 100%;
+  min-height: min(76dvh, 980px);
+  border: 0;
+  border-radius: 0;
+}
+
+.resume-template-panel .preview-workbench__document {
+  min-height: min(76dvh, 980px);
+}
+
+.route-page--preferences .profile-sections {
+  gap: 12px;
+  padding: 0;
+}
+
+.route-page--preferences .resume-template-panel {
+  margin: 12px 0 0;
+}
+
+.preferences-disclosure .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.preferences-disclosure--tailoring .disclosure-section__body {
+  padding-top: 0;
+}
+
+.preferences-field-grid {
+  width: 100%;
+}
+
+.preference-choice-group {
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.preference-choice-group__legend {
+  margin-bottom: 8px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.preference-choice-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 8px 14px;
+}
+
+.preference-choice-list--bullet-standards {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+}
+
+.tailoring-tab-panel {
+  min-width: 0;
+  padding-top: 14px;
+}
+
+.tailoring-tab-panel__help {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+}
+
+.settings-route-tabs,
+.settings-route-tabs__content,
+.settings-general-sections {
+  min-width: 0;
+}
+
+.settings-section-navigation {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.settings-route-tabs__content,
+.settings-general-sections {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-general-sections .disclosure-section__body,
+.general-cost-capacity-settings .disclosure-section__body,
+.apply-runtime-settings .disclosure-section__body,
+.scoring-guidance-settings .disclosure-section__body,
+.compensation-source-policy-panel .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.settings-general-form__actions,
+.apply-runtime-settings-form__actions,
+.scoring-guidance-form__actions {
+  justify-content: flex-end;
+}
+
+.settings-worker-capacity-field .status-line {
+  margin-top: 2px;
+  border-left: 2px solid color-mix(in oklch, var(--foreground) 28%, var(--border));
+  padding: 6px 8px;
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.compensation-source-policy-panel .source-registry-table-wrap {
+  margin: 14px -16px -16px;
+  border-top: 1px solid var(--border);
+}
+
+.source-policy-fact,
+.source-policy-status {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.source-policy-status[data-tone="positive"] {
+  color: var(--success);
+}
+
+.source-policy-status[data-tone="warning"] {
+  color: var(--warning-foreground, var(--foreground));
+}
+
+.source-policy-field-list {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 3px 10px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.source-policy-field-list > span + span {
+  border-left: 1px solid var(--border);
+  padding-left: 10px;
+}
+
+.settings-browser-sections,
+.browser-capability-list,
+.browser-capability-controls,
+.extension-pairing-controls {
+  display: grid;
+  min-width: 0;
+  gap: 12px;
+}
+
+.browser-capabilities-settings > .disclosure-section__body,
+.extension-pairing-settings > .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.browser-capability-section > .disclosure-section__body {
+  padding: 12px 14px 14px;
+}
+
+.browser-capability-status {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.browser-capability-actions,
+.extension-pairing-actions {
+  justify-content: flex-end;
+}
+
+.browser-profile-copy {
+  display: grid;
+  gap: 12px;
+  margin: 2px 0 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  padding: 14px 0 0;
+}
+
+.browser-profile-copy > legend {
+  padding-right: 8px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.provider-setup-disclosure > .disclosure-section__body,
+.credential-privacy-disclosure > .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.provider-setup-disclosure .provider-disclosure-list {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.provider-disclosure > .disclosure-section__body {
+  display: grid;
+  gap: 14px;
+  padding: 12px 14px 14px;
+}
+
+.provider-disclosure__summary {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 3px 12px;
+}
+
+.provider-status-ledger {
+  border-bottom: 1px solid var(--border);
+}
+
+.credential-form,
+.credential-form__actions,
+.provider-setup-form,
+.provider-setup-form__footer {
+  min-width: 0;
+}
+
+.credential-form__actions,
+.provider-setup-form__footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.credential-form__key,
+.credential-form__status,
+.credential-form__disabled-reason {
+  display: block;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+
+.credential-privacy-ledger {
+  margin-top: 10px;
+}
+
+.provider-setup-form {
+  display: grid;
+  gap: 14px;
+}
+
+.provider-setup-form__message {
+  min-width: min(100%, 260px);
+  flex: 1 1 260px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.provider-setup-form__message--warning,
+.provider-setup-warning {
+  color: var(--warning-foreground);
+}
+
+.codex-auth-methods {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 220px), 1fr));
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style-position: inside;
+}
+
+.codex-auth-method {
+  min-width: 0;
+  padding: 10px 14px;
+  border-left: 1px solid var(--border);
+}
+
+.codex-auth-method:first-child {
+  padding-left: 0;
+  border-left: 0;
+}
+
+.codex-auth-method h4,
+.codex-auth-method p {
+  margin: 0;
+}
+
+.codex-auth-method h4 {
+  display: inline;
+  font-size: 12px;
+}
+
+.codex-auth-method p,
+.provider-setup-boundary-copy,
+.credential-privacy-disclosure__copy {
+  margin: 5px 0 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.provider-secret-visibility {
+  border-bottom: 0;
+  padding-block: 4px 0;
+}
+
+.models-settings-sections,
+.model-selection-settings__content,
+.model-provider-preferences,
+.provider-preference-content,
+.ai-execution-policy-settings__content {
+  min-width: 0;
+}
+
+.model-selection-settings > .disclosure-section__body,
+.ai-execution-policy-settings > .disclosure-section__body {
+  padding: 14px 16px 16px;
+}
+
+.provider-preference-disclosure > .disclosure-section__body {
+  padding: 12px 14px 14px;
+}
+
+.provider-preference-status {
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.provider-preference-save-action,
+.provider-preference-clear-action,
+.ai-execution-policy-form__actions {
+  justify-content: flex-end;
+}
+
+.ai-execution-policy-analysis__choices {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
+  gap: 0 14px;
+}
+
 .data-surface {
   box-shadow: none;
 }
@@ -9114,6 +9668,18 @@ input[type="radio"] {
 }
 
 @media (max-width: 1000px) {
+  .route-page--profile .profile-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--profile .profile-resizer {
+    display: none;
+  }
+
+  .profile-preview-pane {
+    position: static;
+  }
+
   .route-page--dashboard .kpis {
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
   }
@@ -9150,6 +9716,22 @@ input[type="radio"] {
 }
 
 @media (max-width: 720px) {
+  .profile-repeat-entry__header,
+  .profile-repeat-entry__controls {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .profile-repeat-item,
+  .profile-repeat-item--skill {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .profile-repeat-item__meta,
+  .profile-repeat-item__field {
+    grid-column: 1 / -1;
+  }
+
   .data-surface__tools .tool-row__primary,
   .data-surface__tools .tool-row__secondary {
     width: 100%;


### PR DESCRIPTION
## Stack

- Base: #444 (`feat/redesign-workspaces`)
- This is the setup/forms/document-workbench layer of the redesign stack.
- Successor: pipeline execution-lineage foundation.

## What changed

- recomposes Profile around collapsible personal, baseline, experience, education, skills, and voluntary-EEO sections while keeping the live real resume editor beside the form
- rebuilds Preferences with collapsible application, tailoring, and resume-style sections; content/writing/quality tabs; adaptive field grids; shared selects and choice controls; contextual documentation links; and every original field/control preserved
- turns Resume templates into a full-width real Plate workbench with compact controls above the document preview
- modernizes the three-step resume import flow with route-backed semantic tabs, shared controls, and the real PDF-file affordance
- standardizes General, Credentials, Model selection, AI execution policy, Browser capabilities, and extension pairing around the same disclosure, field, ledger, and action patterns
- removes colored card/badge clutter from the redesigned setup surfaces and keeps status/provenance as plain, inspectable text
- adds focused component, interaction, accessibility, and Storybook coverage for the new compositions

## Why

The setup surfaces mixed rigid two-column forms, native selects and checkboxes, dense provider cards, duplicated headings, and a squeezed resume preview. The redesign keeps every setting and mutation in its owning context while giving the routes one consistent hierarchy, spacing model, and responsive behavior.

## Data and behavior parity

The implementation preserves profile JSON paths, required-entry/bullet/skill controls, date handling, autosave/undo, save/discard/import actions, provider modes and credential ownership rules, model catalog states, AI policy fields, browser capability adoption and revocation, profile-copy consent, extension token rotation, template cloning/default mutations, errors, disabled reasons, and demo/read-only states.

## Validation

- `git diff --check` — passed
- scoped static path/action/mutation audits — passed during implementation
- focused tests, stories, and a11y cases were authored but intentionally not run

Per the delivery instruction, builds, typechecks, component suites, Storybook/a11y execution, and browser/product QA are deferred until the complete redesign, pipeline-operations implementation, final documentation, and screenshots are assembled.