### PR TITLE
feat(pipeline): persist discovery execution lineage

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 2;
+export const SUPPORTED_SCHEMA_VERSION = 3;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -26,7 +26,9 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # ``job_events`` so contact-only events carry honest identity without
 # overloading ``job_url`` (outreach planner plan §10.1, owner decision 2b), plus
 # the ninth-context canonical tables (``ensure_contact_tables``).
-SCHEMA_VERSION = 2
+# v3 (Discovery execution lineage): immutable Temporal execution/job membership
+# and the idempotently filled preparation work plan used by Operations.
+SCHEMA_VERSION = 3
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -284,6 +286,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_discovery_run_tables(conn)
     ensure_operational_metric_tables(conn)
     ensure_source_observation_tables(conn)
+    ensure_discovery_execution_tables(conn)
     ensure_discovery_control_tables(conn)
     ensure_discovery_settings_tables(conn)
     ensure_contact_tables(conn)
@@ -3014,6 +3017,66 @@ def ensure_source_observation_tables(conn: sqlite3.Connection | None = None) -> 
         "job_duplicate_links",
         "job_rejected_duplicate_links",
     ]
+
+
+def ensure_discovery_execution_tables(conn: sqlite3.Connection | None = None) -> list[str]:
+    """Create the immutable Discover execution/job membership table.
+
+    ``job_source_observations.run_id`` intentionally remains outside the key:
+    repeated observations update that mutable source metadata, whereas this
+    table preserves one row for every Temporal Discover execution that saw or
+    selected the job.
+    """
+
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS discovery_execution_jobs (
+            tenant_id                TEXT NOT NULL,
+            discover_workflow_id     TEXT NOT NULL,
+            discover_run_id          TEXT NOT NULL,
+            job_url                  TEXT NOT NULL,
+            cohort_kind              TEXT NOT NULL
+                CHECK (cohort_kind IN ('observed_this_run', 'existing_backlog')),
+            source_family            TEXT,
+            source_run_id            TEXT,
+            preparation_workflow_id  TEXT,
+            work_plan_state          TEXT NOT NULL DEFAULT 'pending'
+                CHECK (work_plan_state IN ('pending', 'planned', 'not_eligible', 'failed')),
+            required_steps_json      TEXT,
+            work_plan_reason         TEXT,
+            linked_at                TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, discover_workflow_id, discover_run_id, job_url),
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_cohort
+        ON discovery_execution_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, cohort_kind
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_plan
+        ON discovery_execution_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, work_plan_state
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_execution_jobs_job
+        ON discovery_execution_jobs(tenant_id, job_url, linked_at)
+        """
+    )
+    conn.commit()
+    return ["discovery_execution_jobs"]
 
 
 def _backfill_one_observation_row(

--- a/workers/automation/src/jobctrl/discovery/activities.py
+++ b/workers/automation/src/jobctrl/discovery/activities.py
@@ -10,6 +10,10 @@ from typing import Any
 from temporalio import activity
 from temporalio.exceptions import ApplicationError
 
+from jobctrl.domain.discovery.execution import (
+    DiscoveryExecutionCohortKind,
+    DiscoveryExecutionRef,
+)
 from jobctrl.domain.errors import JobCtrlError, to_application_error
 from jobctrl.model_defaults import DEFAULT_PIPELINE_LLM_MODEL_SPEC
 
@@ -46,6 +50,7 @@ class DiscoverySourceActivityInput:
     progress_completed: int = 0
     progress_total: int = 0
     next_run_settings: dict[str, Any] = field(default_factory=dict)
+    discovery_execution: DiscoveryExecutionRef | None = None
 
 
 @dataclass(frozen=True)
@@ -78,6 +83,7 @@ class DiscoveryEnrichmentActivityInput:
     tailor_models: tuple[str, ...] = ()
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
+    discovery_execution: DiscoveryExecutionRef | None = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +116,9 @@ class DiscoveryPreparationFanoutInput:
     # (R9 Phase 1) sweeps stragglers on the first fan-out only, then derives
     # score-only, so a fresh job never gets a duplicate TAILOR_RESUME workflow.
     include_pending_tailor: bool = True
+    discovery_execution: DiscoveryExecutionRef | None = None
+    cohort_kind: DiscoveryExecutionCohortKind = "observed_this_run"
+    finalize_observed_work_plans: bool = False
 
 
 @dataclass(frozen=True)
@@ -167,6 +176,7 @@ async def discovery_source_family_activity(
                 progress_total=payload.progress_total,
                 cancel_event=cancel_event,
                 next_run_settings=payload.next_run_settings,
+                discovery_execution=payload.discovery_execution,
             ),
             starting_message=f"discover {payload.family} starting",
             progress_message=f"discover {payload.family} still running",
@@ -277,6 +287,8 @@ def _build_per_job_handoff(
                 tailor_judge_model=payload.tailor_judge_model,
                 tailor_judge_min_score=payload.tailor_judge_min_score,
                 tenant_id=TenantId(payload.tenant_id),
+                discovery_execution=payload.discovery_execution,
+                discovery_cohort_kind="observed_this_run",
             )
 
     return _handoff
@@ -327,6 +339,9 @@ async def discovery_preparation_fanout_activity(
                 tailor_judge_min_score=payload.tailor_judge_min_score,
                 tenant_id=TenantId(payload.tenant_id),
                 include_pending_tailor=payload.include_pending_tailor,
+                discovery_execution=payload.discovery_execution,
+                discovery_cohort_kind=payload.cohort_kind,
+                finalize_observed_work_plans=payload.finalize_observed_work_plans,
             )
         except Exception as exc:
             _record_preparation_progress(

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -17,9 +17,10 @@ from datetime import datetime, timezone
 from typing import Any, Callable
 
 from jobctrl import config
-from jobctrl.database import ensure_source_observation_tables, get_connection, init_db, resurface_deleted_job
+from jobctrl.database import get_connection, init_db, resurface_deleted_job
 from jobctrl.domain.discovery import JobMetadata, PostingUrl, SearchStrategy, Source
-from jobctrl.domain.discovery.identity import normalize_observed_url
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.identity import JobSourceObservation, normalize_observed_url
 from jobctrl.domain.discovery.source_registry import BROAD_BOARD_LEAD_POLICY
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
 from jobctrl.domain.ports.politeness import PolitenessDecision, PolitenessOutcome
@@ -29,6 +30,7 @@ from jobctrl.domain.job_content_identity import (
     job_content_fingerprint,
     normalize_identity_text,
 )
+from jobctrl.domain.identifiers import JobId
 
 # Phase 7 (S-27 round-1 review M1): ``parse_proxy`` lives under
 # ``jobctrl.infrastructure.network`` so the Enrichment context's
@@ -194,6 +196,7 @@ def store_jobspy_results(
     limit: int = 0,
     run_id: str = "jobspy",
     search_cfg: dict | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> tuple[int, int]:
     """Store JobSpy DataFrame results into the DB. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
@@ -201,7 +204,11 @@ def store_jobspy_results(
     existing = 0
     active_search_cfg = search_cfg if search_cfg is not None else _fallback_store_search_cfg(df, source_label)
     acceptance_policy = _posting_acceptance_policy(active_search_cfg)
-    repository = SqliteJobRepository(conn)
+    repository = SqliteJobRepository(
+        conn,
+        discovery_execution=discovery_execution,
+        source_family="jobspy" if discovery_execution is not None else None,
+    )
     use_case = DiscoverJobsUseCase(
         repository=repository,
         publisher=DurableJobEventPublisher(conn, stage="discover"),
@@ -292,6 +299,7 @@ def store_jobspy_results(
                 source_id=source_id,
                 run_id=run_id,
                 observed_at=now,
+                discovery_execution=discovery_execution,
             )
             _learn_posting_source(
                 conn,
@@ -336,6 +344,7 @@ def store_jobspy_results(
                 source_id=source_id,
                 run_id=run_id,
                 observed_at=now,
+                discovery_execution=discovery_execution,
             )
             _learn_posting_source(
                 conn,
@@ -564,52 +573,29 @@ def _record_jobspy_source_observation(
     source_id: str,
     run_id: str,
     observed_at: str,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> None:
-    ensure_source_observation_tables(conn)
     normalized = normalize_observed_url(observed_url)
     source_native_id = normalized or observed_url
     observation_id = "jobspy:" + hashlib.sha256(
         f"{source_id}:{source_native_id}".encode("utf-8")
     ).hexdigest()[:24]
-    updated = conn.execute(
-        """
-        UPDATE job_source_observations SET
-            source_observation_id = ?,
-            job_url = ?,
-            observed_url = ?,
-            normalized_observed_url = ?,
-            run_id = ?,
-            observed_at = ?
-        WHERE tenant_id = 'local' AND source_id = ? AND source_native_id = ?
-        """,
-        (observation_id, job_url, observed_url, normalized, run_id, observed_at, source_id, source_native_id),
+    SqliteJobRepository(
+        conn,
+        discovery_execution=discovery_execution,
+        source_family="jobspy" if discovery_execution is not None else None,
+    ).attach_source_observation(
+        LOCAL_TENANT,
+        JobId(job_url),
+        JobSourceObservation(
+            source_observation_id=observation_id,
+            source_id=source_id,
+            source_native_id=source_native_id,
+            observed_url=observed_url,
+            run_id=run_id,
+            observed_at=observed_at,
+        ),
     )
-    if updated.rowcount == 0:
-        updated = conn.execute(
-            """
-            UPDATE job_source_observations SET
-                source_observation_id = ?,
-                job_url = ?,
-                source_id = ?,
-                source_native_id = ?,
-                observed_url = ?,
-                run_id = ?,
-                observed_at = ?
-            WHERE tenant_id = 'local' AND normalized_observed_url = ?
-            """,
-            (observation_id, job_url, source_id, source_native_id, observed_url, run_id, observed_at, normalized),
-        )
-    if updated.rowcount == 0:
-        conn.execute(
-            """
-            INSERT INTO job_source_observations (
-                tenant_id, source_observation_id, job_url, source_id,
-                source_native_id, observed_url, normalized_observed_url,
-                run_id, observed_at
-            ) VALUES ('local', ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (observation_id, job_url, source_id, source_native_id, observed_url, normalized, run_id, observed_at),
-        )
     from jobctrl.state import record_job_event
 
     record_job_event(
@@ -871,6 +857,7 @@ def _run_one_search(
     limit: int = 0,
     run_id: str = "jobspy",
     search_cfg: dict | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Run a single search query and store results in DB."""
     s = search
@@ -986,6 +973,8 @@ def _run_one_search(
     store_kwargs: dict[str, object] = {"limit": limit, "run_id": run_id}
     if search_cfg is not None:
         store_kwargs["search_cfg"] = search_cfg
+    if discovery_execution is not None:
+        store_kwargs["discovery_execution"] = discovery_execution
     new, existing = store_jobspy_results(conn, df, s["query"], **store_kwargs)
 
     msg = f"[{label}] {before} results -> {new} new, {existing} dupes"
@@ -1090,6 +1079,7 @@ def _full_crawl(
     run_id: str = "jobspy",
     progress_callback: Callable[[dict[str, Any]], None] | None = None,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Run all search queries from search config across all locations."""
     if sites is None:
@@ -1224,6 +1214,7 @@ def _full_crawl(
                 limit=remaining if limit > 0 else 0,
                 run_id=run_id,
                 search_cfg=search_cfg,
+                discovery_execution=discovery_execution,
             )
         completed += 1
         total_new += result["new"]
@@ -1280,6 +1271,7 @@ def run_discovery(
     run_id: str | None = None,
     progress_callback: Callable[[dict[str, Any]], None] | None = None,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Main entry point for JobSpy-based job discovery.
 
@@ -1320,4 +1312,5 @@ def run_discovery(
         run_id=run_id or "jobspy",
         progress_callback=progress_callback,
         cancel_event=cancel_event,
+        discovery_execution=discovery_execution,
     )

--- a/workers/automation/src/jobctrl/discovery/smartextract.py
+++ b/workers/automation/src/jobctrl/discovery/smartextract.py
@@ -33,11 +33,13 @@ from jobctrl import config
 from jobctrl.config import CONFIG_DIR
 from jobctrl.database import get_stats, init_db, resurface_deleted_job
 from jobctrl.domain.discovery.identity import DuplicateJobLink, JobSourceObservation
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.use_cases import (
     CONTENT_MATCH_CONFIDENCE,
     CONTENT_SHINGLE_MATCH_CONFIDENCE,
 )
 from jobctrl.domain.errors import TransientNetworkError
+from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.events import (
     DuplicateJobLinkedPayload,
     create_duplicate_job_linked,
@@ -136,6 +138,7 @@ def _merge_smart_extract_content_duplicate(
     url: str,
     site: str,
     observed_at: str,
+    run_id: str,
 ) -> None:
     """Attach a content-matched Smart Extract posting to its existing owner.
 
@@ -173,7 +176,7 @@ def _merge_smart_extract_content_duplicate(
             source_id=f"smartextract:{site}",
             source_native_id=url,
             observed_url=url,
-            run_id="smartextract",
+            run_id=run_id,
             observed_at=observed_at,
         ),
     )
@@ -202,6 +205,8 @@ def _store_jobs_filtered(
     query: object | None = None,
     limit: int = 0,
     source_url: str | None = None,
+    run_id: str = "smartextract",
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> tuple[int, int]:
     """Store usable jobs with title, location, and description filtering."""
     now = datetime.now(timezone.utc).isoformat()
@@ -209,7 +214,11 @@ def _store_jobs_filtered(
     existing = 0
     filtered = 0
     missing_description = 0
-    repository = SqliteJobRepository(conn)
+    repository = SqliteJobRepository(
+        conn,
+        discovery_execution=discovery_execution,
+        source_family="smartextract" if discovery_execution is not None else None,
+    )
     publisher = DurableJobEventPublisher(conn, stage="discover")
 
     for job in jobs:
@@ -243,6 +252,7 @@ def _store_jobs_filtered(
                 url=url,
                 site=site,
                 observed_at=now,
+                run_id=run_id,
             )
             existing += 1
             continue
@@ -331,6 +341,19 @@ def _store_jobs_filtered(
                     )
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
+
+        repository.attach_source_observation(
+            LOCAL_TENANT,
+            JobId(url),
+            JobSourceObservation(
+                source_observation_id=f"obs:{uuid.uuid4().hex}",
+                source_id=f"smartextract:{site}",
+                source_native_id=url,
+                observed_url=url,
+                run_id=run_id,
+                observed_at=now,
+            ),
+        )
 
     if filtered:
         log.info("Filtered %d jobs (wrong title/location)", filtered)
@@ -1451,6 +1474,8 @@ def _run_all(
     workers: int = 1,
     limit: int = 0,
     cancel_event: threading.Event | None = None,
+    run_id: str = "smartextract",
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Run smart extract on all targets.
 
@@ -1484,6 +1509,8 @@ def _run_all(
                 query=target.get("query_spec") or target.get("queries") or target.get("query"),
                 limit=remaining if limit > 0 else 0,
                 source_url=target.get("url"),
+                run_id=run_id,
+                discovery_execution=discovery_execution,
             )
             total_new += new
             total_existing += existing
@@ -1580,6 +1607,8 @@ def run_smart_extract(
     workers: int = 1,
     limit: int = 0,
     cancel_event: threading.Event | None = None,
+    run_id: str | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Main entry point for AI-powered smart extraction.
 
@@ -1619,4 +1648,6 @@ def run_smart_extract(
         workers=workers,
         limit=limit,
         cancel_event=cancel_event,
+        run_id=run_id or "smartextract",
+        discovery_execution=discovery_execution,
     )

--- a/workers/automation/src/jobctrl/discovery/workday.py
+++ b/workers/automation/src/jobctrl/discovery/workday.py
@@ -22,6 +22,7 @@ from jobctrl import config
 from jobctrl.config import CONFIG_DIR
 from jobctrl.database import get_connection, init_db
 from jobctrl.domain.discovery.identity import AtsKind
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import WORKDAY_API_POLICY
 from jobctrl.domain.discovery.use_cases import DiscoverJobsUseCase
 from jobctrl.domain.discovery.value_objects import JobMetadata, PostingUrl, SearchStrategy, Source
@@ -488,11 +489,16 @@ def store_results(
     employers: dict,
     limit: int = 0,
     run_id: str | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> tuple[int, int]:
     """Store corporate jobs through the Discovery write boundary."""
     now = datetime.now(timezone.utc).isoformat()
     use_case = DiscoverJobsUseCase(
-        repository=SqliteJobRepository(conn),
+        repository=SqliteJobRepository(
+            conn,
+            discovery_execution=discovery_execution,
+            source_family="workday" if discovery_execution is not None else None,
+        ),
         publisher=_DiscoveryEventPublisher(conn),
     )
     if limit > 0:
@@ -553,6 +559,7 @@ def _process_one(
     run_id: str | None = None,
     query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Search one employer, fetch details, store results."""
     result = _search_and_fetch_one(
@@ -572,7 +579,14 @@ def _process_one(
         return result
 
     conn = get_connection()
-    new, existing = store_results(conn, jobs, employers, limit=limit, run_id=run_id)
+    new, existing = store_results(
+        conn,
+        jobs,
+        employers,
+        limit=limit,
+        run_id=run_id,
+        discovery_execution=discovery_execution,
+    )
     log.info("%s: %d new, %d already in DB", result["employer"], new, existing)
 
     return {**result, "new": new, "existing": existing}
@@ -645,6 +659,7 @@ def scrape_employers(
     run_id: str | None = None,
     query_specs: list[dict[str, object]] | tuple[dict[str, object], ...] | None = None,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Run full scrape: search -> filter -> detail -> store.
 
@@ -706,6 +721,7 @@ def scrape_employers(
                         0,
                         max_pages_per_employer,
                         run_id,
+                        discovery_execution=discovery_execution,
                         **cancel_kwargs,
                         **query_kwargs,
                     ): key
@@ -729,6 +745,7 @@ def scrape_employers(
                             employers,
                             limit=remaining if limit > 0 else 0,
                             run_id=run_id,
+                            discovery_execution=discovery_execution,
                         )
                         result = {**result, "found": len(jobs), "new": new, "existing": existing}
                 total_new += result["new"]
@@ -773,6 +790,7 @@ def scrape_employers(
                 remaining if limit > 0 else 0,
                 max_pages_per_employer,
                 run_id,
+                discovery_execution=discovery_execution,
                 **cancel_kwargs,
                 **query_kwargs,
             )
@@ -813,6 +831,7 @@ def run_workday_discovery(
     limit: int = 0,
     run_id: str | None = None,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict:
     """Main entry point for Workday-based corporate job discovery.
 
@@ -877,6 +896,7 @@ def run_workday_discovery(
         limit=limit,
         max_pages_per_employer=max_pages_per_employer,
         run_id=run_id,
+        discovery_execution=discovery_execution,
         query_specs=query_specs,
         cancel_event=cancel_event,
     )

--- a/workers/automation/src/jobctrl/discovery/workflow.py
+++ b/workers/automation/src/jobctrl/discovery/workflow.py
@@ -12,6 +12,10 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
 
 with workflow.unsafe.imports_passed_through():
+    from jobctrl.domain.discovery.execution import (
+        DiscoveryExecutionCohortKind,
+        DiscoveryExecutionRef,
+    )
     from jobctrl.discovery.activities import (
         DiscoveryEnrichmentActivityInput,
         DiscoveryEnrichmentActivityOutput,
@@ -89,6 +93,12 @@ class DiscoverWorkflow:
 
     @workflow.run
     async def run(self, payload: DiscoverWorkflowInput) -> DiscoverWorkflowResult:
+        execution_info = workflow.info()
+        discovery_execution = DiscoveryExecutionRef(
+            tenant_id=payload.tenant_id,
+            workflow_id=execution_info.workflow_id,
+            temporal_run_id=execution_info.run_id,
+        )
         started_at = workflow.now()
         await emit_workflow_started(
             tenant_id=payload.tenant_id,
@@ -100,7 +110,7 @@ class DiscoverWorkflow:
         )
         try:
             await _check_spend(payload)
-            result = await self._execute(payload)
+            result = await self._execute(payload, discovery_execution)
         except CancelledError:
             await emit_workflow_outcome(
                 tenant_id=payload.tenant_id,
@@ -152,7 +162,11 @@ class DiscoverWorkflow:
         )
         return result
 
-    async def _execute(self, payload: DiscoverWorkflowInput) -> DiscoverWorkflowResult:
+    async def _execute(
+        self,
+        payload: DiscoverWorkflowInput,
+        discovery_execution: DiscoveryExecutionRef,
+    ) -> DiscoverWorkflowResult:
         plan = await workflow.execute_activity(
             plan_discovery_sources,
             PlanDiscoverySourcesInput(
@@ -185,7 +199,7 @@ class DiscoverWorkflow:
         # ``pending_tailor`` mid-tailor is never double-fanned (I1/I4). Doing the
         # sweep here also keeps it correct when families run concurrently
         # (Phase 3).
-        await self._sweep_preexisting_preparation(payload)
+        await self._sweep_preexisting_preparation(payload, discovery_execution)
         # R9 Phase 3 — optional parallel source families, GATED. Families are
         # processed in batches of ``plan.max_parallel_families`` (env
         # ``max_parallel_families`` in SQLite, default 1 = sequential =
@@ -200,7 +214,16 @@ class DiscoverWorkflow:
         batch_size = max(1, plan.max_parallel_families)
         for batch in _chunk(indexed_families, batch_size):
             results = await asyncio.gather(
-                *(self._run_family_source(payload, index, family, plan) for index, family in batch)
+                *(
+                    self._run_family_source(
+                        payload,
+                        index,
+                        family,
+                        plan,
+                        discovery_execution,
+                    )
+                    for index, family in batch
+                )
             )
             if any(status == "canceled" for _family, status, _failure in results):
                 raise CancelledError()
@@ -214,7 +237,7 @@ class DiscoverWorkflow:
                     if failure is not None:
                         failures.append(failure)
             if batch_completed:
-                await self._stream_family_preparation(payload)
+                await self._stream_family_preparation(payload, discovery_execution)
 
         # Legacy semantics: per-source failures are tolerated. The TERMINAL
         # reconcile enrichment + preparation below ALWAYS run so the healthy
@@ -230,6 +253,7 @@ class DiscoverWorkflow:
         try:
             enrichment_result = await _run_enrichment_activity(
                 payload,
+                discovery_execution,
                 progress_completed=len(plan.families),
                 progress_total=plan.progress_total,
             )
@@ -251,7 +275,9 @@ class DiscoverWorkflow:
             # mid-tailor right now.
             preparation_started = await _start_preparation_workflows(
                 payload,
+                discovery_execution,
                 include_pending_tailor=False,
+                finalize_observed_work_plans=True,
                 progress_completed=len(plan.families) + 1,
                 progress_total=plan.progress_total,
             )
@@ -305,6 +331,7 @@ class DiscoverWorkflow:
         index: int,
         family: str,
         plan: PlanDiscoverySourcesOutput,
+        discovery_execution: DiscoveryExecutionRef,
     ) -> tuple[str, str, str | None]:
         """Run one family's source crawl; return ``(family, status, failure)``.
 
@@ -330,6 +357,7 @@ class DiscoverWorkflow:
                     progress_completed=index,
                     progress_total=plan.progress_total,
                     next_run_settings=plan.next_run_settings,
+                    discovery_execution=discovery_execution,
                 ),
                 start_to_close_timeout=_DISCOVERY_TIMEOUT,
                 heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -341,7 +369,11 @@ class DiscoverWorkflow:
             return (family, "failed", f"{family}: {exc.cause if exc.cause else exc}")
         return (family, "ok", None)
 
-    async def _sweep_preexisting_preparation(self, payload: DiscoverWorkflowInput) -> None:
+    async def _sweep_preexisting_preparation(
+        self,
+        payload: DiscoverWorkflowInput,
+        discovery_execution: DiscoveryExecutionRef,
+    ) -> None:
         """One-time full-derive fan-out for work left over from a PRIOR run.
 
         Runs before the family loop, when nothing this run has been enriched, so
@@ -356,7 +388,9 @@ class DiscoverWorkflow:
         try:
             await _start_preparation_workflows(
                 payload,
+                discovery_execution,
                 include_pending_tailor=True,
+                cohort_kind="existing_backlog",
                 progress_completed=0,
                 progress_total=0,
             )
@@ -364,7 +398,11 @@ class DiscoverWorkflow:
             if _activity_error_was_cancelled(exc):
                 raise CancelledError() from exc
 
-    async def _stream_family_preparation(self, payload: DiscoverWorkflowInput) -> None:
+    async def _stream_family_preparation(
+        self,
+        payload: DiscoverWorkflowInput,
+        discovery_execution: DiscoveryExecutionRef,
+    ) -> None:
         """Drain + fan out the just-completed family's jobs now (R9 Phase 1/2).
 
         Progress-silent (``progress_total=0``) so the Runs bar stays monotonic
@@ -379,7 +417,11 @@ class DiscoverWorkflow:
         """
         try:
             await _run_enrichment_activity(
-                payload, progress_completed=0, progress_total=0, per_job_handoff=True
+                payload,
+                discovery_execution,
+                progress_completed=0,
+                progress_total=0,
+                per_job_handoff=True,
             )
         except ActivityError as exc:
             if _activity_error_was_cancelled(exc):
@@ -388,6 +430,7 @@ class DiscoverWorkflow:
         try:
             await _start_preparation_workflows(
                 payload,
+                discovery_execution,
                 include_pending_tailor=False,
                 progress_completed=0,
                 progress_total=0,
@@ -399,6 +442,7 @@ class DiscoverWorkflow:
 
 async def _run_enrichment_activity(
     payload: DiscoverWorkflowInput,
+    discovery_execution: DiscoveryExecutionRef,
     *,
     progress_completed: int,
     progress_total: int,
@@ -421,6 +465,7 @@ async def _run_enrichment_activity(
             tailor_models=payload.tailor_models,
             tailor_judge_model=payload.tailor_judge_model,
             tailor_judge_min_score=payload.tailor_judge_min_score,
+            discovery_execution=discovery_execution,
         ),
         start_to_close_timeout=_DISCOVERY_TIMEOUT,
         heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,
@@ -430,8 +475,11 @@ async def _run_enrichment_activity(
 
 async def _start_preparation_workflows(
     payload: DiscoverWorkflowInput,
+    discovery_execution: DiscoveryExecutionRef,
     *,
     include_pending_tailor: bool = True,
+    cohort_kind: DiscoveryExecutionCohortKind = "observed_this_run",
+    finalize_observed_work_plans: bool = False,
     progress_completed: int = 0,
     progress_total: int = 0,
 ) -> int:
@@ -452,6 +500,9 @@ async def _start_preparation_workflows(
             progress_completed=progress_completed,
             progress_total=progress_total,
             include_pending_tailor=include_pending_tailor,
+            discovery_execution=discovery_execution,
+            cohort_kind=cohort_kind,
+            finalize_observed_work_plans=finalize_observed_work_plans,
         ),
         start_to_close_timeout=_DEFAULT_TIMEOUT,
         heartbeat_timeout=_DEFAULT_HEARTBEAT_TIMEOUT,

--- a/workers/automation/src/jobctrl/domain/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/domain/discovery/__init__.py
@@ -15,6 +15,16 @@ from jobctrl.domain.discovery.identity import (
     JobSourceObservation,
     normalize_observed_url,
 )
+from jobctrl.domain.discovery.execution import (
+    DISCOVERY_EXECUTION_COHORT_KINDS,
+    DISCOVERY_EXECUTION_WORK_PLAN_STATES,
+    DISCOVERY_PREPARATION_STEPS,
+    DiscoveryExecutionCohortKind,
+    DiscoveryExecutionJob,
+    DiscoveryExecutionRef,
+    DiscoveryExecutionWorkPlanState,
+    DiscoveryPreparationStep,
+)
 from jobctrl.domain.discovery.value_objects import (
     Employer,
     JobMetadata,
@@ -64,6 +74,14 @@ __all__ = [
     "DuplicateJobLink",
     "JobSourceObservation",
     "normalize_observed_url",
+    "DISCOVERY_EXECUTION_COHORT_KINDS",
+    "DISCOVERY_EXECUTION_WORK_PLAN_STATES",
+    "DISCOVERY_PREPARATION_STEPS",
+    "DiscoveryExecutionCohortKind",
+    "DiscoveryExecutionJob",
+    "DiscoveryExecutionRef",
+    "DiscoveryExecutionWorkPlanState",
+    "DiscoveryPreparationStep",
     "Employer",
     "JobMetadata",
     "PostingUrl",

--- a/workers/automation/src/jobctrl/domain/discovery/execution.py
+++ b/workers/automation/src/jobctrl/domain/discovery/execution.py
@@ -1,0 +1,130 @@
+"""Discovery execution identity and cohort membership value objects.
+
+One ``DiscoverWorkflow`` execution is identified by its Temporal workflow ID
+and Temporal run ID.  Source-family run IDs are deliberately excluded: their
+observation rows are mutable and therefore cannot be the authority for
+historical execution membership.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+
+DiscoveryExecutionCohortKind = Literal["observed_this_run", "existing_backlog"]
+DiscoveryExecutionWorkPlanState = Literal["pending", "planned", "not_eligible", "failed"]
+DiscoveryPreparationStep = Literal["score", "tailor", "cover", "pdf"]
+
+DISCOVERY_EXECUTION_COHORT_KINDS: tuple[DiscoveryExecutionCohortKind, ...] = (
+    "observed_this_run",
+    "existing_backlog",
+)
+DISCOVERY_EXECUTION_WORK_PLAN_STATES: tuple[DiscoveryExecutionWorkPlanState, ...] = (
+    "pending",
+    "planned",
+    "not_eligible",
+    "failed",
+)
+DISCOVERY_PREPARATION_STEPS: tuple[DiscoveryPreparationStep, ...] = (
+    "score",
+    "tailor",
+    "cover",
+    "pdf",
+)
+
+_SAFE_REASON_CODE = re.compile(r"^[a-z0-9][a-z0-9_.:-]{0,79}$")
+
+
+@dataclass(frozen=True)
+class DiscoveryExecutionRef:
+    """Serializable immutable identity for one ``DiscoverWorkflow`` run."""
+
+    tenant_id: str
+    workflow_id: str
+    temporal_run_id: str
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("tenant_id", self.tenant_id),
+            ("workflow_id", self.workflow_id),
+            ("temporal_run_id", self.temporal_run_id),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field_name} must be a non-empty string")
+
+    def safe_summary(self) -> dict[str, str]:
+        """Return the bounded identifiers safe for workflow input summaries."""
+
+        return {
+            "tenantId": self.tenant_id,
+            "workflowId": self.workflow_id,
+            "temporalRunId": self.temporal_run_id,
+        }
+
+
+@dataclass(frozen=True)
+class DiscoveryExecutionJob:
+    """One job's immutable membership and decided work plan in an execution."""
+
+    execution: DiscoveryExecutionRef
+    job_url: str
+    cohort_kind: DiscoveryExecutionCohortKind
+    source_family: str | None
+    source_run_id: str | None
+    preparation_workflow_id: str | None
+    work_plan_state: DiscoveryExecutionWorkPlanState
+    required_steps: tuple[DiscoveryPreparationStep, ...] | None
+    work_plan_reason: str | None
+    linked_at: str
+
+    @property
+    def required_work_decided(self) -> bool:
+        """Whether completion may interpret this row's required-work decision."""
+
+        return self.work_plan_state in {"planned", "not_eligible"}
+
+    @property
+    def has_required_work(self) -> bool | None:
+        """Return ``None`` while work is undecided or planning failed.
+
+        In particular, a NULL ``required_steps_json`` on ``pending`` or
+        ``failed`` is never collapsed into ``False`` / no work.
+        """
+
+        if self.work_plan_state == "planned":
+            return True
+        if self.work_plan_state == "not_eligible":
+            return False
+        return None
+
+
+def validate_cohort_kind(value: str) -> DiscoveryExecutionCohortKind:
+    if value not in DISCOVERY_EXECUTION_COHORT_KINDS:
+        raise ValueError(f"Unknown discovery execution cohort kind: {value}")
+    return value  # type: ignore[return-value]
+
+
+def validate_work_plan_state(value: str) -> DiscoveryExecutionWorkPlanState:
+    if value not in DISCOVERY_EXECUTION_WORK_PLAN_STATES:
+        raise ValueError(f"Unknown discovery execution work-plan state: {value}")
+    return value  # type: ignore[return-value]
+
+
+def validate_required_steps(steps: list[str] | tuple[str, ...]) -> tuple[DiscoveryPreparationStep, ...]:
+    """Return a unique, canonical preparation-step sequence."""
+
+    requested = {str(step) for step in steps}
+    invalid = requested.difference(DISCOVERY_PREPARATION_STEPS)
+    if invalid:
+        raise ValueError(f"Unknown preparation step(s): {', '.join(sorted(invalid))}")
+    return tuple(step for step in DISCOVERY_PREPARATION_STEPS if step in requested)
+
+
+def validate_safe_reason_code(reason: str | None) -> str | None:
+    if reason is None:
+        return None
+    if not _SAFE_REASON_CODE.fullmatch(reason):
+        raise ValueError("work_plan_reason must be a bounded safe code")
+    return reason

--- a/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
@@ -24,6 +24,9 @@ from jobctrl.infrastructure.discovery.ats_adapters import (
 from jobctrl.infrastructure.discovery.sqlite_repository import (
     SqliteJobRepository,
 )
+from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+    SqliteDiscoveryExecutionRepository,
+)
 from jobctrl.infrastructure.discovery.sqlite_run_repository import (
     SqliteDiscoveryRunRepository,
 )
@@ -50,6 +53,7 @@ __all__ = [
     "ManualCaptureImportOutcome",
     "SourceControlSeedSummary",
     "SqliteDiscoveryRunRepository",
+    "SqliteDiscoveryExecutionRepository",
     "SqliteJobRepository",
     "WorkdayBoardAdapter",
     "WorkdayEmployer",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -27,6 +27,7 @@ from jobctrl.database import (
     ensure_source_observation_tables,
 )
 from jobctrl.domain.discovery.identity import AtsKind, CanonicalJobIdentity
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import (
     ATS_API_POLICY,
     LocatorPolicy,
@@ -483,6 +484,7 @@ def run_scheduled_ats_sources(
     gateway: PolitenessGateway | None = None,
     limit: int = 0,
     cancel_event: threading.Event | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict[str, Any]:
     """Run Greenhouse, Lever, and Ashby through the Discovery use case.
 
@@ -511,7 +513,11 @@ def run_scheduled_ats_sources(
     if not adapters:
         return ScheduledAtsSummary().to_result_dict()
 
-    job_repository = SqliteJobRepository(conn)
+    job_repository = SqliteJobRepository(
+        conn,
+        discovery_execution=discovery_execution,
+        source_family="ats_api" if discovery_execution is not None else None,
+    )
     enrichment_repository = SqliteEnrichmentRepository(conn)
     use_case = DiscoverJobsUseCase(
         repository=job_repository,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_execution_repository.py
@@ -1,0 +1,298 @@
+"""SQLite adapter for durable Discover execution/job lineage."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from jobctrl.database import ensure_discovery_execution_tables
+from jobctrl.domain.discovery.execution import (
+    DiscoveryExecutionCohortKind,
+    DiscoveryExecutionJob,
+    DiscoveryExecutionRef,
+    DiscoveryExecutionWorkPlanState,
+    DiscoveryPreparationStep,
+    validate_cohort_kind,
+    validate_required_steps,
+    validate_safe_reason_code,
+    validate_work_plan_state,
+)
+
+
+_SELECT_COLUMNS = """
+    tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
+    source_family, source_run_id, preparation_workflow_id, work_plan_state,
+    required_steps_json, work_plan_reason, linked_at
+"""
+
+
+class SqliteDiscoveryExecutionRepository:
+    """Persist execution membership independently of mutable source rows."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_discovery_execution_tables(conn)
+
+    def link_job(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_url: str,
+        *,
+        cohort_kind: DiscoveryExecutionCohortKind,
+        source_family: str | None = None,
+        source_run_id: str | None = None,
+        linked_at: str | None = None,
+    ) -> DiscoveryExecutionJob:
+        """Idempotently link a job, allowing only backlog-to-observed promotion.
+
+        ``linked_at`` and the first observed source metadata never change after
+        their initial write. A backlog row may fill its previously NULL source
+        metadata exactly once when promoted to ``observed_this_run``.
+        """
+
+        resolved_cohort = validate_cohort_kind(cohort_kind)
+        normalized_job_url = _required_text(job_url, "job_url")
+        normalized_family = _optional_text(source_family)
+        normalized_source_run_id = _optional_text(source_run_id)
+        if resolved_cohort == "observed_this_run" and normalized_family is None:
+            raise ValueError("source_family is required for an observed execution job")
+        linked = linked_at or datetime.now(timezone.utc).isoformat()
+
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO discovery_execution_jobs (
+                    tenant_id, discover_workflow_id, discover_run_id, job_url,
+                    cohort_kind, source_family, source_run_id, work_plan_state,
+                    linked_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+                ON CONFLICT (tenant_id, discover_workflow_id, discover_run_id, job_url)
+                DO UPDATE SET
+                    cohort_kind = CASE
+                        WHEN excluded.cohort_kind = 'observed_this_run'
+                            THEN 'observed_this_run'
+                        ELSE discovery_execution_jobs.cohort_kind
+                    END,
+                    source_family = CASE
+                        WHEN discovery_execution_jobs.cohort_kind = 'existing_backlog'
+                         AND excluded.cohort_kind = 'observed_this_run'
+                         AND discovery_execution_jobs.source_family IS NULL
+                            THEN excluded.source_family
+                        ELSE discovery_execution_jobs.source_family
+                    END,
+                    source_run_id = CASE
+                        WHEN discovery_execution_jobs.cohort_kind = 'existing_backlog'
+                         AND excluded.cohort_kind = 'observed_this_run'
+                         AND discovery_execution_jobs.source_run_id IS NULL
+                            THEN excluded.source_run_id
+                        ELSE discovery_execution_jobs.source_run_id
+                    END
+                """,
+                (
+                    execution.tenant_id,
+                    execution.workflow_id,
+                    execution.temporal_run_id,
+                    normalized_job_url,
+                    resolved_cohort,
+                    normalized_family,
+                    normalized_source_run_id,
+                    linked,
+                ),
+            )
+
+        result = self.get(execution, normalized_job_url)
+        if result is None:  # pragma: no cover - defensive database invariant
+            raise RuntimeError("discovery execution job link was not persisted")
+        return result
+
+    def set_work_plan(
+        self,
+        execution: DiscoveryExecutionRef,
+        job_url: str,
+        *,
+        state: DiscoveryExecutionWorkPlanState,
+        required_steps: list[str] | tuple[str, ...] | None = None,
+        preparation_workflow_id: str | None = None,
+        reason: str | None = None,
+    ) -> DiscoveryExecutionJob:
+        """Fill a membership row's work plan without rewriting its decision.
+
+        ``pending`` and ``failed`` deliberately retain ``required_steps=NULL``;
+        consumers must not interpret either as no work. Failed planning may be
+        retried and advanced to a decided state. Once ``planned`` or
+        ``not_eligible`` is recorded, only an exact retry is accepted.
+        """
+
+        resolved_state = validate_work_plan_state(state)
+        resolved_reason = validate_safe_reason_code(reason)
+        normalized_workflow_id = _optional_text(preparation_workflow_id)
+        normalized_steps: tuple[DiscoveryPreparationStep, ...] | None = None
+        if required_steps is not None:
+            normalized_steps = validate_required_steps(required_steps)
+
+        if resolved_state == "planned":
+            if not normalized_steps:
+                raise ValueError("planned work requires at least one preparation step")
+            if normalized_workflow_id is None:
+                raise ValueError("planned work requires a preparation_workflow_id")
+        elif normalized_steps is not None:
+            raise ValueError(f"{resolved_state} work must keep required_steps undecided")
+
+        if resolved_state in {"not_eligible", "failed"} and resolved_reason is None:
+            raise ValueError(f"{resolved_state} work requires a safe reason code")
+        if resolved_state in {"pending", "not_eligible"} and normalized_workflow_id is not None:
+            raise ValueError(f"{resolved_state} work cannot name a preparation workflow")
+
+        normalized_job_url = _required_text(job_url, "job_url")
+        existing = self.get(execution, normalized_job_url)
+        if existing is None:
+            raise KeyError(f"Job is not linked to discovery execution: {normalized_job_url}")
+
+        desired_steps_json = (
+            json.dumps(list(normalized_steps), separators=(",", ":"))
+            if normalized_steps is not None
+            else None
+        )
+        if existing.work_plan_state in {"planned", "not_eligible"}:
+            desired = (
+                resolved_state,
+                normalized_steps,
+                normalized_workflow_id,
+                resolved_reason,
+            )
+            current = (
+                existing.work_plan_state,
+                existing.required_steps,
+                existing.preparation_workflow_id,
+                existing.work_plan_reason,
+            )
+            if desired != current:
+                raise ValueError("A decided discovery execution work plan is immutable")
+            return existing
+
+        if (
+            existing.preparation_workflow_id is not None
+            and normalized_workflow_id != existing.preparation_workflow_id
+        ):
+            raise ValueError("preparation_workflow_id is immutable once assigned")
+
+        with self._conn:
+            updated = self._conn.execute(
+                """
+                UPDATE discovery_execution_jobs
+                   SET preparation_workflow_id = COALESCE(preparation_workflow_id, ?),
+                       work_plan_state = ?,
+                       required_steps_json = ?,
+                       work_plan_reason = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND job_url = ?
+                   AND work_plan_state IN ('pending', 'failed')
+                """,
+                (
+                    normalized_workflow_id,
+                    resolved_state,
+                    desired_steps_json,
+                    resolved_reason,
+                    execution.tenant_id,
+                    execution.workflow_id,
+                    execution.temporal_run_id,
+                    normalized_job_url,
+                ),
+            )
+            if updated.rowcount != 1:
+                concurrent = self.get(execution, normalized_job_url)
+                if concurrent is not None and (
+                    concurrent.work_plan_state,
+                    concurrent.required_steps,
+                    concurrent.preparation_workflow_id,
+                    concurrent.work_plan_reason,
+                ) == (
+                    resolved_state,
+                    normalized_steps,
+                    normalized_workflow_id,
+                    resolved_reason,
+                ):
+                    return concurrent
+                raise RuntimeError("discovery execution work plan changed concurrently")
+
+        result = self.get(execution, normalized_job_url)
+        if result is None:  # pragma: no cover - defensive database invariant
+            raise RuntimeError("discovery execution work plan was not persisted")
+        return result
+
+    def get(self, execution: DiscoveryExecutionRef, job_url: str) -> DiscoveryExecutionJob | None:
+        row = self._conn.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+              FROM discovery_execution_jobs
+             WHERE tenant_id = ?
+               AND discover_workflow_id = ?
+               AND discover_run_id = ?
+               AND job_url = ?
+            """,
+            (
+                execution.tenant_id,
+                execution.workflow_id,
+                execution.temporal_run_id,
+                job_url,
+            ),
+        ).fetchone()
+        return _row_to_execution_job(row) if row is not None else None
+
+    def list_for_execution(self, execution: DiscoveryExecutionRef) -> list[DiscoveryExecutionJob]:
+        rows = self._conn.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+              FROM discovery_execution_jobs
+             WHERE tenant_id = ?
+               AND discover_workflow_id = ?
+               AND discover_run_id = ?
+             ORDER BY job_url
+            """,
+            (execution.tenant_id, execution.workflow_id, execution.temporal_run_id),
+        ).fetchall()
+        return [_row_to_execution_job(row) for row in rows]
+
+
+def _row_to_execution_job(row: sqlite3.Row | tuple[object, ...]) -> DiscoveryExecutionJob:
+    raw_steps = row[9]
+    steps: tuple[DiscoveryPreparationStep, ...] | None = None
+    if raw_steps is not None:
+        decoded = json.loads(str(raw_steps))
+        if not isinstance(decoded, list):
+            raise ValueError("required_steps_json must contain a list")
+        steps = validate_required_steps([str(step) for step in decoded])
+
+    return DiscoveryExecutionJob(
+        execution=DiscoveryExecutionRef(
+            tenant_id=str(row[0]),
+            workflow_id=str(row[1]),
+            temporal_run_id=str(row[2]),
+        ),
+        job_url=str(row[3]),
+        cohort_kind=validate_cohort_kind(str(row[4])),
+        source_family=_optional_text(row[5]),
+        source_run_id=_optional_text(row[6]),
+        preparation_workflow_id=_optional_text(row[7]),
+        work_plan_state=validate_work_plan_state(str(row[8])),
+        required_steps=steps,
+        work_plan_reason=validate_safe_reason_code(_optional_text(row[10])),
+        linked_at=str(row[11]),
+    )
+
+
+def _required_text(value: object, field_name: str) -> str:
+    normalized = _optional_text(value)
+    if normalized is None:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return normalized
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -37,6 +37,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from jobctrl.domain.discovery.aggregate import Job
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.identity import (
     AtsKind,
     CanonicalJobIdentity,
@@ -86,9 +87,29 @@ class SqliteJobRepository:
     when the API hasn't run yet.
     """
 
-    def __init__(self, conn: sqlite3.Connection) -> None:
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        discovery_execution: DiscoveryExecutionRef | None = None,
+        source_family: str | None = None,
+    ) -> None:
         self._conn = conn
+        self._discovery_execution = discovery_execution
+        self._source_family = source_family.strip() if source_family else None
+        if discovery_execution is not None and self._source_family is None:
+            raise ValueError("source_family is required with discovery_execution")
         self._ensure_deleted_jobs_table()
+        if discovery_execution is not None:
+            # Imported lazily to keep the aggregate repository's ordinary path
+            # independent from the execution-lineage adapter.
+            from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+                SqliteDiscoveryExecutionRepository,
+            )
+
+            self._execution_repository = SqliteDiscoveryExecutionRepository(conn)
+        else:
+            self._execution_repository = None
 
     # ------------------------------------------------------------------
     # Schema bootstrapping
@@ -602,6 +623,21 @@ class SqliteJobRepository:
                     observation.run_id,
                     observation.observed_at,
                 ),
+            )
+        if self._execution_repository is not None:
+            assert self._discovery_execution is not None
+            if str(tenant_id) != self._discovery_execution.tenant_id:
+                raise ValueError("source observation tenant does not match discovery execution")
+            # The Temporal execution ref is the authority. ``observation.run_id``
+            # is retained only as first-observation source metadata and may be
+            # updated independently in ``job_source_observations`` on retries.
+            self._execution_repository.link_job(
+                self._discovery_execution,
+                str(job_id),
+                cohort_kind="observed_this_run",
+                source_family=self._source_family,
+                source_run_id=observation.run_id,
+                linked_at=observation.observed_at,
             )
         self._conn.commit()
 

--- a/workers/automation/src/jobctrl/pipeline/preparation.py
+++ b/workers/automation/src/jobctrl/pipeline/preparation.py
@@ -19,12 +19,21 @@ from temporalio.common import WorkflowIDConflictPolicy
 
 from jobctrl import database as db_module
 from jobctrl.database import get_connection, get_jobs_by_stage
+from jobctrl.domain.discovery.execution import (
+    DiscoveryExecutionCohortKind,
+    DiscoveryExecutionRef,
+    DiscoveryExecutionWorkPlanState,
+    validate_required_steps,
+)
 from jobctrl.domain.identifiers import JobId
 from jobctrl.domain.materials.use_cases import SuppressTailoredArtifactsUseCase
 from jobctrl.domain.preparation import PreparationWorkItemKind, make_preparation_idempotency_key
 from jobctrl.domain.rpc.messages import WorkflowStartSpec
 from jobctrl.domain.tenant import LOCAL_TENANT, TenantId
 from jobctrl.infrastructure.materials import SqliteMaterialsRepository, SqliteTailoringPolicyRepository
+from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+    SqliteDiscoveryExecutionRepository,
+)
 from jobctrl.infrastructure.rpc.workflow_starter import (
     WorkflowStarter,
     default_workflow_starter,
@@ -96,30 +105,73 @@ def start_discovery_preparation_workflows(
     tenant_id: TenantId = LOCAL_TENANT,
     workflow_starter: WorkflowStarter | None = None,
     include_pending_tailor: bool = True,
+    discovery_execution: DiscoveryExecutionRef | None = None,
+    discovery_cohort_kind: DiscoveryExecutionCohortKind = "observed_this_run",
+    finalize_observed_work_plans: bool = False,
 ) -> dict[str, Any]:
     """Derive targets and start per-job preparation workflows in batches."""
-    targets = derive_preparation_targets(
-        DerivePreparationTargetsInput(
-            tenant_id=str(tenant_id),
-            min_score=min_score,
-            limit=limit,
-            include_pending_tailor=include_pending_tailor,
+    try:
+        targets = derive_preparation_targets(
+            DerivePreparationTargetsInput(
+                tenant_id=str(tenant_id),
+                min_score=min_score,
+                limit=limit,
+                include_pending_tailor=include_pending_tailor,
+            )
         )
-    )
-    specs = [
-        _workflow_spec_for_target(
-            target,
-            tenant_id=tenant_id,
-            min_score=min_score,
-            workers=workers,
-            validation_mode=validation_mode,
-            llm_model=llm_model,
-            tailor_models=tailor_models,
-            tailor_judge_model=tailor_judge_model,
-            tailor_judge_min_score=tailor_judge_min_score,
-        )
-        for target in targets
-    ]
+    except Exception:
+        if discovery_execution is not None:
+            _mark_pending_work_plans_failed(
+                discovery_execution,
+                reason="target_derivation_failed",
+            )
+        raise
+
+    try:
+        target_specs = [
+            (
+                target,
+                _workflow_spec_for_target(
+                    target,
+                    tenant_id=tenant_id,
+                    min_score=min_score,
+                    workers=workers,
+                    validation_mode=validation_mode,
+                    llm_model=llm_model,
+                    tailor_models=tailor_models,
+                    tailor_judge_model=tailor_judge_model,
+                    tailor_judge_min_score=tailor_judge_min_score,
+                    discovery_execution=discovery_execution,
+                    discovery_cohort_kind=discovery_cohort_kind,
+                ),
+            )
+            for target in targets
+        ]
+        specs = [spec for _target, spec in target_specs]
+        if discovery_execution is not None:
+            workflow_ids_to_start = _record_preparation_work_plans(
+                targets,
+                tenant_id=tenant_id,
+                discovery_execution=discovery_execution,
+                discovery_cohort_kind=discovery_cohort_kind,
+            )
+            specs = [
+                spec
+                for _target, spec in target_specs
+                if spec.workflow_id in workflow_ids_to_start
+            ]
+            if finalize_observed_work_plans:
+                _finalize_unplanned_observed_work_plans(
+                    discovery_execution,
+                    min_score=db_module.effective_tailoring_min_score(min_score),
+                )
+    except Exception:
+        if discovery_execution is not None:
+            _mark_pending_work_plans_failed(
+                discovery_execution,
+                reason="work_plan_persistence_failed",
+            )
+        raise
     starter = workflow_starter or default_workflow_starter
     started = 0
     for batch in _batches(specs, PREPARATION_CHILD_BATCH_SIZE):
@@ -147,6 +199,8 @@ def start_job_preparation_workflow(
     tailor_judge_min_score: float | None = None,
     tenant_id: TenantId = LOCAL_TENANT,
     workflow_starter: WorkflowStarter | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
+    discovery_cohort_kind: DiscoveryExecutionCohortKind = "observed_this_run",
 ) -> bool:
     """Start ONE job's ``SCORE_JOB`` preparation workflow (R9 Phase 2 handoff).
 
@@ -158,22 +212,52 @@ def start_job_preparation_workflow(
     version, latest source event), so `USE_EXISTING` makes the per-job handoff
     and the reconciling fan-outs converge on exactly one execution per job (I1).
     """
-    conn = get_connection()
-    target_version = current_scoring_policy_version(conn, tenant_id)
-    spec = build_preparation_workflow_spec(
-        tenant_id=tenant_id,
-        job_url=job_url,
-        steps=["score", "tailor", "cover", "pdf"],
-        kind=PreparationWorkItemKind.SCORE_JOB,
-        target_version=target_version,
-        min_score=min_score,
-        workers=workers,
-        validation_mode=validation_mode,
-        llm_model=llm_model,
-        tailor_models=tailor_models,
-        tailor_judge_model=tailor_judge_model,
-        tailor_judge_min_score=tailor_judge_min_score,
-    )
+    try:
+        conn = get_connection()
+        target_version = current_scoring_policy_version(conn, tenant_id)
+        spec = build_preparation_workflow_spec(
+            tenant_id=tenant_id,
+            job_url=job_url,
+            steps=["score", "tailor", "cover", "pdf"],
+            kind=PreparationWorkItemKind.SCORE_JOB,
+            target_version=target_version,
+            min_score=min_score,
+            workers=workers,
+            validation_mode=validation_mode,
+            llm_model=llm_model,
+            tailor_models=tailor_models,
+            tailor_judge_model=tailor_judge_model,
+            tailor_judge_min_score=tailor_judge_min_score,
+            discovery_execution=discovery_execution,
+            discovery_cohort_kind=discovery_cohort_kind,
+        )
+        if discovery_execution is not None:
+            preparation_payload = spec.args[0]
+            if not isinstance(preparation_payload, JobPreparationInput):
+                raise TypeError("preparation workflow spec has an unexpected input")
+            workflow_ids_to_start = _record_preparation_work_plans(
+                [
+                    PreparationTarget(
+                        job_url=job_url,
+                        idempotency_key=preparation_payload.idempotency_key,
+                        target_version=preparation_payload.target_version,
+                        steps=list(preparation_payload.steps),
+                    )
+                ],
+                tenant_id=tenant_id,
+                discovery_execution=discovery_execution,
+                discovery_cohort_kind=discovery_cohort_kind,
+            )
+            if spec.workflow_id not in workflow_ids_to_start:
+                return False
+    except Exception:
+        if discovery_execution is not None:
+            _mark_job_work_plan_failed(
+                discovery_execution,
+                job_url=job_url,
+                reason="work_plan_persistence_failed",
+            )
+        raise
     starter = workflow_starter or default_workflow_starter
     _run_start_batch([spec], starter)
     return True
@@ -200,6 +284,8 @@ def build_preparation_workflow_spec(
     source_event_id: str | None = None,
     expected_app_dir: str | None = None,
     expected_db_path: str | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
+    discovery_cohort_kind: DiscoveryExecutionCohortKind | None = None,
 ) -> WorkflowStartSpec:
     source_event = source_event_id if source_event_id is not None else _latest_source_event_id(get_connection(), job_url)
     idempotency_key = make_preparation_idempotency_key(
@@ -228,6 +314,8 @@ def build_preparation_workflow_spec(
         llm_model=llm_model or DEFAULT_PIPELINE_LLM_MODEL_SPEC,
         expected_app_dir=expected_app_dir,
         expected_db_path=expected_db_path,
+        discovery_execution=discovery_execution,
+        discovery_cohort_kind=discovery_cohort_kind,
     )
     return WorkflowStartSpec(
         workflow=JobPreparationWorkflow,
@@ -332,6 +420,8 @@ def _workflow_spec_for_target(
     tailor_models: tuple[str, ...],
     tailor_judge_model: str | None,
     tailor_judge_min_score: float | None,
+    discovery_execution: DiscoveryExecutionRef | None,
+    discovery_cohort_kind: DiscoveryExecutionCohortKind,
 ) -> WorkflowStartSpec:
     payload = JobPreparationInput(
         tenant_id=str(tenant_id),
@@ -346,6 +436,10 @@ def _workflow_spec_for_target(
         tailor_models=tailor_models,
         tailor_judge_model=tailor_judge_model,
         tailor_judge_min_score=tailor_judge_min_score,
+        discovery_execution=discovery_execution,
+        discovery_cohort_kind=(
+            discovery_cohort_kind if discovery_execution is not None else None
+        ),
     )
     return WorkflowStartSpec(
         workflow=JobPreparationWorkflow,
@@ -353,6 +447,197 @@ def _workflow_spec_for_target(
         workflow_id=preparation_workflow_id(target.idempotency_key),
         id_conflict_policy=WorkflowIDConflictPolicy.USE_EXISTING,
     )
+
+
+def _record_preparation_work_plans(
+    targets: list[PreparationTarget],
+    *,
+    tenant_id: TenantId,
+    discovery_execution: DiscoveryExecutionRef,
+    discovery_cohort_kind: DiscoveryExecutionCohortKind,
+) -> set[str]:
+    """Persist selected work before asking Temporal to start it.
+
+    Existing-backlog rows are created here because selection by the pre-run
+    sweep defines membership. Current-run rows must already exist from the
+    source-observation boundary; silently inventing those rows here would lose
+    their first source metadata and make the mutable source run authoritative.
+    """
+
+    if str(tenant_id) != discovery_execution.tenant_id:
+        raise ValueError("preparation tenant does not match discovery execution")
+    repository = SqliteDiscoveryExecutionRepository(get_connection())
+    workflow_ids_to_start: set[str] = set()
+    for target in targets:
+        if discovery_cohort_kind == "existing_backlog":
+            membership = repository.link_job(
+                discovery_execution,
+                target.job_url,
+                cohort_kind="existing_backlog",
+            )
+        else:
+            membership = repository.get(discovery_execution, target.job_url)
+            if membership is None:
+                raise RuntimeError(
+                    "Observed preparation target is missing discovery execution membership"
+                )
+        workflow_id = preparation_workflow_id(target.idempotency_key)
+        canonical_steps = validate_required_steps(target.steps)
+        if membership.work_plan_state in {"planned", "not_eligible"}:
+            # A pre-run plan remains authoritative after backlog-to-observed
+            # promotion. A later source event may derive a different idempotency
+            # key, but it must neither rewrite nor start parallel work.
+            if (
+                membership.work_plan_state == "planned"
+                and membership.preparation_workflow_id == workflow_id
+                and membership.required_steps == canonical_steps
+            ):
+                workflow_ids_to_start.add(workflow_id)
+            continue
+        repository.set_work_plan(
+            discovery_execution,
+            target.job_url,
+            state="planned",
+            required_steps=target.steps,
+            preparation_workflow_id=workflow_id,
+        )
+        workflow_ids_to_start.add(workflow_id)
+    return workflow_ids_to_start
+
+
+def _mark_pending_work_plans_failed(
+    discovery_execution: DiscoveryExecutionRef,
+    *,
+    reason: str,
+) -> None:
+    repository = SqliteDiscoveryExecutionRepository(get_connection())
+    for membership in repository.list_for_execution(discovery_execution):
+        if membership.work_plan_state != "pending":
+            continue
+        repository.set_work_plan(
+            discovery_execution,
+            membership.job_url,
+            state="failed",
+            reason=reason,
+        )
+
+
+def _mark_job_work_plan_failed(
+    discovery_execution: DiscoveryExecutionRef,
+    *,
+    job_url: str,
+    reason: str,
+) -> None:
+    repository = SqliteDiscoveryExecutionRepository(get_connection())
+    membership = repository.get(discovery_execution, job_url)
+    if membership is None or membership.work_plan_state != "pending":
+        return
+    repository.set_work_plan(
+        discovery_execution,
+        job_url,
+        state="failed",
+        reason=reason,
+    )
+
+
+def _finalize_unplanned_observed_work_plans(
+    discovery_execution: DiscoveryExecutionRef,
+    *,
+    min_score: int,
+) -> None:
+    """Close every unresolved current-cohort work-plan decision.
+
+    Only canonical evidence can produce ``not_eligible``. Any unselected job
+    whose lack of work cannot be proved becomes ``failed``; leaving it pending
+    would make the execution drain forever and treating it as no-work would
+    inflate completion.
+    """
+
+    conn = get_connection()
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    for membership in repository.list_for_execution(discovery_execution):
+        if membership.cohort_kind != "observed_this_run":
+            continue
+        if membership.work_plan_state not in {"pending", "failed"}:
+            continue
+        state, reason = _unselected_work_plan_outcome(
+            conn,
+            job_url=membership.job_url,
+            min_score=min_score,
+        )
+        repository.set_work_plan(
+            discovery_execution,
+            membership.job_url,
+            state=state,
+            reason=reason,
+        )
+
+
+def _unselected_work_plan_outcome(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    min_score: int,
+) -> tuple[DiscoveryExecutionWorkPlanState, str]:
+    row = conn.execute(
+        f"""
+        SELECT {db_module._EFFECTIVE_FIT_SCORE} AS effective_score,
+               CASE WHEN {db_module._SCORE_ELIGIBLE_FOR_DOWNSTREAM}
+                    THEN 1 ELSE 0 END AS score_eligible,
+               pss.latest_active_state AS active_state,
+               jm.jm_resume_pdf_path AS resume_pdf_path,
+               jm.jm_cover_pdf_path AS cover_pdf_path,
+               CASE WHEN EXISTS (
+                   SELECT 1
+                     FROM jobctrl_deleted_jobs deleted
+                    WHERE deleted.job_url = jobs.url
+                      AND (
+                          deleted.restored_at IS NULL
+                          OR julianday(deleted.restored_at) <= julianday(deleted.deleted_at)
+                      )
+               ) THEN 1 ELSE 0 END AS is_deleted
+          FROM jobs
+          {db_module._LATEST_SCORE_JOIN}
+          {db_module._LATEST_MATERIALS_JOIN}
+          {db_module._ACTIVE_STATE_JOIN}
+         WHERE jobs.url = ?
+        """,
+        (job_url,),
+    ).fetchone()
+    if row is None:
+        return ("failed", "canonical_job_missing")
+
+    effective_score = row["effective_score"]
+    if effective_score is not None and float(effective_score) < int(min_score):
+        return ("not_eligible", "score_below_threshold")
+    if effective_score is not None and not bool(row["score_eligible"]):
+        return ("not_eligible", "score_eligibility_blocked")
+    if bool(row["is_deleted"]):
+        return ("not_eligible", "job_not_actionable")
+    if str(row["active_state"] or "") in {"closed", "expired", "removed", "location_incompatible"}:
+        return ("not_eligible", "posting_not_actionable")
+    if row["resume_pdf_path"] and row["cover_pdf_path"]:
+        return ("not_eligible", "preparation_already_accounted")
+
+    stage_rows = conn.execute(
+        """
+        SELECT stage, state
+          FROM job_stage_states
+         WHERE job_url = ?
+           AND stage IN ('score', 'tailor', 'cover', 'apply')
+        """,
+        (job_url,),
+    ).fetchall()
+    stage_states = {str(stage_row["stage"]): str(stage_row["state"]) for stage_row in stage_rows}
+    if stage_states.get("apply") == "succeeded":
+        return ("not_eligible", "preparation_already_accounted")
+    if (
+        stage_states.get("score") == "succeeded"
+        and stage_states.get("tailor") == "skipped"
+        and stage_states.get("cover") == "skipped"
+    ):
+        return ("not_eligible", "preparation_explicitly_skipped")
+    return ("failed", "preparation_target_not_selected")
 
 
 def _run_start_batch(specs: list[WorkflowStartSpec], starter: WorkflowStarter) -> list[WorkflowHandle]:

--- a/workers/automation/src/jobctrl/pipeline/runner.py
+++ b/workers/automation/src/jobctrl/pipeline/runner.py
@@ -28,6 +28,7 @@ from jobctrl.domain.discovery.scheduler import (
     ScheduledSource,
     SourceQualitySnapshot,
 )
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
 from jobctrl.domain.discovery.source_registry import SourceKind, SourcePriority, SourceState
 from jobctrl.domain.errors import LlmTransientError, SourceUnavailableError, TransientNetworkError
 from jobctrl.domain.tenant import LOCAL_TENANT
@@ -1384,6 +1385,7 @@ def run_discovery_source_family(
     progress_total: int = 0,
     cancel_event: threading.Event | None = None,
     next_run_settings: dict[str, Any] | None = None,
+    discovery_execution: DiscoveryExecutionRef | None = None,
 ) -> dict[str, Any]:
     """Run one discovery source family and persist its lifecycle events."""
     selected_source_ids = tuple(dict.fromkeys(source_id.strip() for source_id in source_ids if source_id.strip()))
@@ -1448,6 +1450,8 @@ def run_discovery_source_family(
                 "cfg": jobspy_cfg,
                 "limit": _scheduled_limit(schedule, "jobspy", limit),
             }
+            if discovery_execution is not None:
+                run_kwargs["discovery_execution"] = discovery_execution
             _add_supported_discovery_kwargs(
                 run_discovery,
                 run_kwargs,
@@ -1486,6 +1490,11 @@ def run_discovery_source_family(
                 limit=_scheduled_limit_for_sources(
                     ats_sources,
                     _discover_remaining_limit(start_count, limit),
+                ),
+                **(
+                    {"discovery_execution": discovery_execution}
+                    if discovery_execution is not None
+                    else {}
                 ),
                 **({"cancel_event": cancel_event} if provided_cancel_event is not None else {}),
             )
@@ -1530,6 +1539,8 @@ def run_discovery_source_family(
                 ),
                 "run_id": run_id,
             }
+            if discovery_execution is not None:
+                workday_kwargs["discovery_execution"] = discovery_execution
             if provided_cancel_event is not None:
                 workday_kwargs["cancel_event"] = cancel_event
             return run_workday_discovery(**workday_kwargs)
@@ -1559,7 +1570,7 @@ def run_discovery_source_family(
         if source_filter_active and not smart_extract_sources:
             return {"family": family, "status": "skipped", "result": {}, "source_ids": []}
 
-        def run_smart_extract_source() -> dict:
+        def run_smart_extract_source(run_id: str | None = None) -> dict:
             console.print("  [cyan]Smart extract (AI-powered scraping)...[/cyan]")
             enqueue_manual_action_for_sources(conn, smart_extract_sources)
             from jobctrl.discovery.smartextract import run_smart_extract
@@ -1571,15 +1582,18 @@ def run_discovery_source_family(
                     smart_extract_sources,
                     _discover_remaining_limit(start_count, limit),
                 ),
+                "run_id": run_id,
             }
+            if discovery_execution is not None:
+                smart_kwargs["discovery_execution"] = discovery_execution
             if provided_cancel_event is not None:
                 smart_kwargs["cancel_event"] = cancel_event
             return run_smart_extract(**smart_kwargs)
 
         result_holder: dict[str, Any] = {}
 
-        def capture_smart_extract() -> dict:
-            result_holder.update(run_smart_extract_source())
+        def capture_smart_extract(run_id: str | None = None) -> dict:
+            result_holder.update(run_smart_extract_source(run_id))
             return result_holder
 
         status = _run_discovery_source(

--- a/workers/automation/src/jobctrl/preparation/workflow.py
+++ b/workers/automation/src/jobctrl/preparation/workflow.py
@@ -11,6 +11,10 @@ from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
 
 with workflow.unsafe.imports_passed_through():
+    from jobctrl.domain.discovery.execution import (
+        DiscoveryExecutionCohortKind,
+        DiscoveryExecutionRef,
+    )
     from jobctrl.infrastructure.temporal.finalize import (
         emit_workflow_outcome,
         emit_workflow_started,
@@ -58,6 +62,19 @@ class JobPreparationInput:
     tailor_judge_model: str | None = None
     tailor_judge_min_score: float | None = None
     llm_model: str = DEFAULT_PIPELINE_LLM_MODEL_SPEC
+    discovery_execution: DiscoveryExecutionRef | None = None
+    discovery_cohort_kind: DiscoveryExecutionCohortKind | None = None
+
+    def __post_init__(self) -> None:
+        if (self.discovery_execution is None) != (self.discovery_cohort_kind is None):
+            raise ValueError(
+                "discovery_execution and discovery_cohort_kind must be supplied together"
+            )
+        if (
+            self.discovery_execution is not None
+            and self.discovery_execution.tenant_id != self.tenant_id
+        ):
+            raise ValueError("preparation tenant does not match discovery execution")
 
 
 @dataclass(frozen=True)
@@ -247,12 +264,16 @@ def _ordered_steps(steps: list[str]) -> list[str]:
 
 
 def _input_summary(payload: JobPreparationInput) -> dict[str, Any]:
-    return {
+    summary: dict[str, Any] = {
         "jobUrl": payload.job_url,
         "steps": list(payload.steps),
         "targetVersion": payload.target_version,
         "idempotencyKey": payload.idempotency_key,
     }
+    if payload.discovery_execution is not None:
+        summary["discoveryExecution"] = payload.discovery_execution.safe_summary()
+        summary["discoveryCohortKind"] = payload.discovery_cohort_kind
+    return summary
 
 
 def _activity_error_code(exc: ActivityError) -> str | None:

--- a/workers/automation/tests/test_discovery_execution_lineage.py
+++ b/workers/automation/tests/test_discovery_execution_lineage.py
@@ -1,0 +1,538 @@
+"""Regression fixtures for immutable Discover execution/job lineage."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from jobctrl.database import init_db
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.identity import JobSourceObservation
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.discovery.activities import (
+    DiscoveryEnrichmentActivityInput,
+    DiscoveryPreparationFanoutInput,
+    DiscoverySourceActivityInput,
+)
+from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
+    SqliteDiscoveryExecutionRepository,
+)
+from jobctrl.infrastructure.discovery.sqlite_repository import SqliteJobRepository
+from jobctrl.pipeline import preparation as preparation_pipeline
+from jobctrl.preparation.workflow import JobPreparationInput, _input_summary
+
+
+@pytest.fixture()
+def conn(tmp_path: Path) -> sqlite3.Connection:
+    return init_db(tmp_path / "jobctrl.db")
+
+
+def _execution(run_id: str, *, workflow_id: str = "discover-local") -> DiscoveryExecutionRef:
+    return DiscoveryExecutionRef(
+        tenant_id=str(LOCAL_TENANT),
+        workflow_id=workflow_id,
+        temporal_run_id=run_id,
+    )
+
+
+def _insert_job(conn: sqlite3.Connection, suffix: str) -> str:
+    job_url = f"https://example.com/jobs/{suffix}"
+    conn.execute(
+        "INSERT INTO jobs (url, title, discovered_at) VALUES (?, ?, ?)",
+        (job_url, f"Job {suffix}", "2026-07-14T08:00:00+00:00"),
+    )
+    conn.commit()
+    return job_url
+
+
+def test_execution_ref_is_serializable_across_every_discovery_handoff() -> None:
+    execution = _execution("temporal-run-serialized")
+    source = DiscoverySourceActivityInput(
+        tenant_id=str(LOCAL_TENANT),
+        family="jobspy",
+        discovery_execution=execution,
+    )
+    enrichment = DiscoveryEnrichmentActivityInput(
+        tenant_id=str(LOCAL_TENANT),
+        discovery_execution=execution,
+    )
+    fanout = DiscoveryPreparationFanoutInput(
+        tenant_id=str(LOCAL_TENANT),
+        discovery_execution=execution,
+        cohort_kind="existing_backlog",
+    )
+    preparation = JobPreparationInput(
+        tenant_id=str(LOCAL_TENANT),
+        job_url="https://example.com/jobs/serialized",
+        steps=["score"],
+        target_version="1",
+        idempotency_key="preparation:serialized",
+        discovery_execution=execution,
+        discovery_cohort_kind="existing_backlog",
+    )
+
+    expected = {
+        "tenant_id": "local",
+        "workflow_id": "discover-local",
+        "temporal_run_id": "temporal-run-serialized",
+    }
+    assert asdict(source)["discovery_execution"] == expected
+    assert asdict(enrichment)["discovery_execution"] == expected
+    assert asdict(fanout)["discovery_execution"] == expected
+    assert asdict(preparation)["discovery_execution"] == expected
+    assert _input_summary(preparation)["discoveryExecution"] == {
+        "tenantId": "local",
+        "workflowId": "discover-local",
+        "temporalRunId": "temporal-run-serialized",
+    }
+    assert _input_summary(preparation)["discoveryCohortKind"] == "existing_backlog"
+
+
+def test_source_observation_retry_links_once_without_rewriting_first_link(
+    conn: sqlite3.Connection,
+) -> None:
+    job_url = _insert_job(conn, "retry")
+    execution = _execution("temporal-run-1")
+    repository = SqliteJobRepository(
+        conn,
+        discovery_execution=execution,
+        source_family="jobspy",
+    )
+
+    repository.attach_source_observation(
+        LOCAL_TENANT,
+        JobId(job_url),
+        JobSourceObservation(
+            source_observation_id="observation-1",
+            source_id="jobspy:indeed",
+            source_native_id="native-1",
+            observed_url=job_url,
+            run_id="source-run-original",
+            observed_at="2026-07-14T09:00:00+00:00",
+        ),
+    )
+    repository.attach_source_observation(
+        LOCAL_TENANT,
+        JobId(job_url),
+        JobSourceObservation(
+            source_observation_id="observation-2",
+            source_id="jobspy:indeed",
+            source_native_id="native-1",
+            observed_url=job_url,
+            run_id="source-run-retry",
+            observed_at="2026-07-14T09:05:00+00:00",
+        ),
+    )
+
+    lineage = SqliteDiscoveryExecutionRepository(conn).get(execution, job_url)
+    assert lineage is not None
+    assert lineage.source_run_id == "source-run-original"
+    assert lineage.linked_at == "2026-07-14T09:00:00+00:00"
+    assert conn.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 1
+
+    # The source observation remains mutable metadata and is intentionally not
+    # the authority for the immutable execution link above.
+    source_row = conn.execute(
+        "SELECT run_id, observed_at FROM job_source_observations WHERE job_url = ?",
+        (job_url,),
+    ).fetchone()
+    assert tuple(source_row) == ("source-run-retry", "2026-07-14T09:05:00+00:00")
+
+
+def test_later_temporal_run_inserts_history_instead_of_reusing_membership(
+    conn: sqlite3.Connection,
+) -> None:
+    job_url = _insert_job(conn, "history")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    first = _execution("temporal-run-old")
+    second = _execution("temporal-run-new")
+
+    repository.link_job(
+        first,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="workday",
+        source_run_id="source-old",
+        linked_at="2026-07-13T09:00:00+00:00",
+    )
+    repository.link_job(
+        second,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="ats_api",
+        source_run_id="source-new",
+        linked_at="2026-07-14T09:00:00+00:00",
+    )
+
+    first_membership = repository.get(first, job_url)
+    second_membership = repository.get(second, job_url)
+    assert first_membership is not None
+    assert second_membership is not None
+    assert first_membership.source_run_id == "source-old"
+    assert second_membership.source_run_id == "source-new"
+    assert conn.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 2
+
+
+def test_observed_promotion_wins_transactionally_without_double_count(
+    conn: sqlite3.Connection,
+) -> None:
+    job_url = _insert_job(conn, "promotion")
+    execution = _execution("temporal-run-promotion")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+
+    repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="existing_backlog",
+        linked_at="2026-07-14T08:55:00+00:00",
+    )
+    repository.set_work_plan(
+        execution,
+        job_url,
+        state="planned",
+        required_steps=["tailor", "cover", "pdf"],
+        preparation_workflow_id="prep-backlog-job",
+    )
+    promoted = repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+        source_run_id="source-current",
+        linked_at="2026-07-14T09:00:00+00:00",
+    )
+    attempted_reverse = repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="existing_backlog",
+        linked_at="2026-07-14T09:10:00+00:00",
+    )
+
+    assert promoted.cohort_kind == "observed_this_run"
+    assert attempted_reverse.cohort_kind == "observed_this_run"
+    assert attempted_reverse.source_family == "jobspy"
+    assert attempted_reverse.source_run_id == "source-current"
+    assert attempted_reverse.linked_at == "2026-07-14T08:55:00+00:00"
+    assert attempted_reverse.preparation_workflow_id == "prep-backlog-job"
+    assert attempted_reverse.required_steps == ("tailor", "cover", "pdf")
+    assert conn.execute("SELECT COUNT(*) FROM discovery_execution_jobs").fetchone()[0] == 1
+
+
+def test_promoted_job_keeps_existing_plan_instead_of_starting_parallel_work(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_url = _insert_job(conn, "promoted-plan")
+    execution = _execution("temporal-run-promoted-plan")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    repository.link_job(execution, job_url, cohort_kind="existing_backlog")
+    repository.set_work_plan(
+        execution,
+        job_url,
+        state="planned",
+        required_steps=["tailor", "cover", "pdf"],
+        preparation_workflow_id="prep-existing-plan",
+    )
+    repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="jobspy",
+        source_run_id="source-current",
+    )
+    replacement = preparation_pipeline.PreparationTarget(
+        job_url=job_url,
+        idempotency_key="replacement-plan",
+        target_version="4",
+        steps=["score", "tailor", "cover", "pdf"],
+    )
+    started: list[str] = []
+
+    monkeypatch.setattr(preparation_pipeline, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "derive_preparation_targets",
+        lambda _payload: [replacement],
+    )
+
+    async def starter(spec):
+        started.append(spec.workflow_id)
+        return SimpleNamespace(id=spec.workflow_id)
+
+    result = preparation_pipeline.start_discovery_preparation_workflows(
+        tenant_id=LOCAL_TENANT,
+        workflow_starter=starter,
+        discovery_execution=execution,
+    )
+
+    membership = repository.get(execution, job_url)
+    assert membership is not None
+    assert membership.cohort_kind == "observed_this_run"
+    assert membership.preparation_workflow_id == "prep-existing-plan"
+    assert membership.required_steps == ("tailor", "cover", "pdf")
+    assert started == []
+    assert result["started"] == {"job_preparation": 0}
+
+
+def test_pre_run_selection_can_form_an_existing_backlog_only_cohort(
+    conn: sqlite3.Connection,
+) -> None:
+    execution = _execution("temporal-run-backlog-only")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    first_url = _insert_job(conn, "backlog-a")
+    second_url = _insert_job(conn, "backlog-b")
+
+    for job_url in (first_url, second_url):
+        repository.link_job(execution, job_url, cohort_kind="existing_backlog")
+
+    memberships = repository.list_for_execution(execution)
+    assert [membership.job_url for membership in memberships] == sorted(
+        [first_url, second_url]
+    )
+    assert {membership.cohort_kind for membership in memberships} == {"existing_backlog"}
+
+
+def test_pre_run_fanout_links_selected_target_and_propagates_lineage(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution = _execution("temporal-run-pre-run-sweep")
+    job_url = _insert_job(conn, "selected-backlog")
+    target = preparation_pipeline.PreparationTarget(
+        job_url=job_url,
+        idempotency_key="preparation:selected-backlog",
+        target_version="3",
+        steps=["tailor", "cover", "pdf"],
+    )
+    started_inputs: list[JobPreparationInput] = []
+
+    monkeypatch.setattr(preparation_pipeline, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "derive_preparation_targets",
+        lambda _payload: [target],
+    )
+
+    async def starter(spec):
+        started_inputs.append(spec.args[0])
+        return SimpleNamespace(id=spec.workflow_id)
+
+    preparation_pipeline.start_discovery_preparation_workflows(
+        tenant_id=LOCAL_TENANT,
+        workflow_starter=starter,
+        discovery_execution=execution,
+        discovery_cohort_kind="existing_backlog",
+    )
+
+    membership = SqliteDiscoveryExecutionRepository(conn).get(execution, job_url)
+    assert membership is not None
+    assert membership.cohort_kind == "existing_backlog"
+    assert membership.work_plan_state == "planned"
+    assert membership.required_steps == ("tailor", "cover", "pdf")
+    assert membership.preparation_workflow_id == "prep-preparation:selected-backlog"
+    assert started_inputs[0].discovery_execution == execution
+    assert started_inputs[0].discovery_cohort_kind == "existing_backlog"
+
+
+def test_terminal_fanout_decides_every_unselected_observed_membership(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution = _execution("temporal-run-terminal-decisions")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    below_threshold_url = _insert_job(conn, "below-threshold")
+    unresolved_url = _insert_job(conn, "unresolved")
+    conn.execute("UPDATE jobs SET fit_score = 4 WHERE url = ?", (below_threshold_url,))
+    conn.commit()
+    for job_url in (below_threshold_url, unresolved_url):
+        repository.link_job(
+            execution,
+            job_url,
+            cohort_kind="observed_this_run",
+            source_family="jobspy",
+            source_run_id="source-terminal",
+        )
+
+    monkeypatch.setattr(preparation_pipeline, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "derive_preparation_targets",
+        lambda _payload: [],
+    )
+
+    preparation_pipeline.start_discovery_preparation_workflows(
+        tenant_id=LOCAL_TENANT,
+        min_score=7,
+        discovery_execution=execution,
+        finalize_observed_work_plans=True,
+    )
+
+    below_threshold = repository.get(execution, below_threshold_url)
+    unresolved = repository.get(execution, unresolved_url)
+    assert below_threshold is not None
+    assert below_threshold.work_plan_state == "not_eligible"
+    assert below_threshold.work_plan_reason == "score_below_threshold"
+    assert unresolved is not None
+    assert unresolved.work_plan_state == "failed"
+    assert unresolved.work_plan_reason == "preparation_target_not_selected"
+    assert all(
+        membership.work_plan_state != "pending"
+        for membership in repository.list_for_execution(execution)
+        if membership.cohort_kind == "observed_this_run"
+    )
+
+
+def test_derivation_failure_marks_pending_observed_membership_failed(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution = _execution("temporal-run-derivation-failure")
+    job_url = _insert_job(conn, "derivation-failure")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="ats_api",
+        source_run_id="source-failure",
+    )
+    monkeypatch.setattr(preparation_pipeline, "get_connection", lambda: conn)
+
+    def fail_derivation(_payload):
+        raise RuntimeError("synthetic derivation failure")
+
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "derive_preparation_targets",
+        fail_derivation,
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic derivation failure"):
+        preparation_pipeline.start_discovery_preparation_workflows(
+            tenant_id=LOCAL_TENANT,
+            discovery_execution=execution,
+        )
+
+    membership = repository.get(execution, job_url)
+    assert membership is not None
+    assert membership.work_plan_state == "failed"
+    assert membership.work_plan_reason == "target_derivation_failed"
+    assert membership.has_required_work is None
+
+
+def test_planning_failure_marks_pending_observed_membership_failed(
+    conn: sqlite3.Connection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    execution = _execution("temporal-run-planning-failure")
+    job_url = _insert_job(conn, "planning-failure")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    repository.link_job(
+        execution,
+        job_url,
+        cohort_kind="observed_this_run",
+        source_family="workday",
+        source_run_id="source-planning-failure",
+    )
+    target = preparation_pipeline.PreparationTarget(
+        job_url=job_url,
+        idempotency_key="preparation:planning-failure",
+        target_version="2",
+        steps=["score", "tailor", "cover", "pdf"],
+    )
+    monkeypatch.setattr(preparation_pipeline, "get_connection", lambda: conn)
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "derive_preparation_targets",
+        lambda _payload: [target],
+    )
+
+    def fail_planning(*_args, **_kwargs):
+        raise RuntimeError("synthetic planning failure")
+
+    monkeypatch.setattr(
+        preparation_pipeline,
+        "_workflow_spec_for_target",
+        fail_planning,
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic planning failure"):
+        preparation_pipeline.start_discovery_preparation_workflows(
+            tenant_id=LOCAL_TENANT,
+            discovery_execution=execution,
+        )
+
+    membership = repository.get(execution, job_url)
+    assert membership is not None
+    assert membership.work_plan_state == "failed"
+    assert membership.work_plan_reason == "work_plan_persistence_failed"
+    assert membership.has_required_work is None
+
+
+def test_pending_and_failed_work_plans_are_never_reported_as_no_work(
+    conn: sqlite3.Connection,
+) -> None:
+    execution = _execution("temporal-run-plans")
+    repository = SqliteDiscoveryExecutionRepository(conn)
+    failed_url = _insert_job(conn, "failed-plan")
+    excluded_url = _insert_job(conn, "explicitly-excluded")
+
+    pending = repository.link_job(
+        execution,
+        failed_url,
+        cohort_kind="observed_this_run",
+        source_family="ats_api",
+        source_run_id="source-plan",
+    )
+    assert pending.required_steps is None
+    assert pending.required_work_decided is False
+    assert pending.has_required_work is None
+
+    failed = repository.set_work_plan(
+        execution,
+        failed_url,
+        state="failed",
+        reason="target_derivation_failed",
+    )
+    assert failed.required_steps is None
+    assert failed.required_work_decided is False
+    assert failed.has_required_work is None
+
+    planned = repository.set_work_plan(
+        execution,
+        failed_url,
+        state="planned",
+        required_steps=["pdf", "score", "tailor", "cover", "score"],
+        preparation_workflow_id="prep-recovered-plan",
+    )
+    retried = repository.set_work_plan(
+        execution,
+        failed_url,
+        state="planned",
+        required_steps=["score", "tailor", "cover", "pdf"],
+        preparation_workflow_id="prep-recovered-plan",
+    )
+    assert planned.required_steps == ("score", "tailor", "cover", "pdf")
+    assert retried == planned
+    assert planned.has_required_work is True
+
+    repository.link_job(
+        execution,
+        excluded_url,
+        cohort_kind="observed_this_run",
+        source_family="workday",
+        source_run_id="source-plan",
+    )
+    excluded = repository.set_work_plan(
+        execution,
+        excluded_url,
+        state="not_eligible",
+        reason="no_preparation_required",
+    )
+    assert excluded.required_work_decided is True
+    assert excluded.has_required_work is False

--- a/workers/automation/tests/test_workflow_discovery.py
+++ b/workers/automation/tests/test_workflow_discovery.py
@@ -6,6 +6,7 @@ import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import timedelta
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -33,6 +34,7 @@ from jobctrl.discovery.activities import (
 from jobctrl.discovery.workflow import (
     DiscoverWorkflow,
     DiscoverWorkflowInput,
+    DiscoverWorkflowResult,
     _activity_error_was_cancelled,
 )
 from jobctrl.infrastructure.temporal.finalize import WorkflowOutcomeInput, WorkflowStartedInput
@@ -93,7 +95,7 @@ async def test_discover_workflow_records_canceled_outcome(monkeypatch: pytest.Mo
     async def fake_outcome(**kwargs) -> None:
         _EVENTS.append(("workflow_outcome", kwargs["status"]))
 
-    async def fake_execute(_payload) -> None:
+    async def fake_execute(_payload, _discovery_execution) -> None:
         raise CancelledError("canceled by test")
 
     async def fake_check_spend(_payload) -> None:
@@ -104,6 +106,10 @@ async def test_discover_workflow_records_canceled_outcome(monkeypatch: pytest.Mo
     monkeypatch.setattr("jobctrl.discovery.workflow.emit_workflow_started", fake_started)
     monkeypatch.setattr("jobctrl.discovery.workflow.emit_workflow_outcome", fake_outcome)
     monkeypatch.setattr("jobctrl.discovery.workflow.workflow.now", lambda: "2026-01-01T00:00:00Z")
+    monkeypatch.setattr(
+        "jobctrl.discovery.workflow.workflow.info",
+        lambda: SimpleNamespace(workflow_id="discover-local", run_id="temporal-run-test"),
+    )
 
     with pytest.raises(CancelledError):
         await workflow_instance.run(DiscoverWorkflowInput(tenant_id="local"))
@@ -112,6 +118,46 @@ async def test_discover_workflow_records_canceled_outcome(monkeypatch: pytest.Mo
         ("workflow_started", "DiscoverWorkflow"),
         ("workflow_outcome", "canceled"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_discover_workflow_captures_temporal_execution_identity_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workflow_instance = DiscoverWorkflow()
+    captured: dict[str, Any] = {"info_calls": 0}
+
+    def fake_info():
+        captured["info_calls"] = int(captured["info_calls"]) + 1
+        return SimpleNamespace(
+            workflow_id="discover-local",
+            run_id="temporal-run-stable",
+        )
+
+    async def fake_execute(_payload, discovery_execution) -> DiscoverWorkflowResult:
+        captured["execution"] = discovery_execution
+        return DiscoverWorkflowResult()
+
+    async def no_op(**_kwargs) -> None:
+        return None
+
+    async def no_spend(_payload) -> None:
+        return None
+
+    monkeypatch.setattr(workflow_instance, "_execute", fake_execute)
+    monkeypatch.setattr("jobctrl.discovery.workflow._check_spend", no_spend)
+    monkeypatch.setattr("jobctrl.discovery.workflow.emit_workflow_started", no_op)
+    monkeypatch.setattr("jobctrl.discovery.workflow.emit_workflow_outcome", no_op)
+    monkeypatch.setattr("jobctrl.discovery.workflow.workflow.info", fake_info)
+    monkeypatch.setattr("jobctrl.discovery.workflow.workflow.now", lambda: "2026-01-01T00:00:00Z")
+
+    result = await workflow_instance.run(DiscoverWorkflowInput(tenant_id="local"))
+
+    assert result == DiscoverWorkflowResult()
+    assert captured["info_calls"] == 1
+    assert captured["execution"].tenant_id == "local"
+    assert captured["execution"].workflow_id == "discover-local"
+    assert captured["execution"].temporal_run_id == "temporal-run-stable"
 
 
 def _discovery_activities():
@@ -270,6 +316,9 @@ async def test_discovery_preparation_fanout_activity_uses_root_workflow_fanout(
         # R9 Phase 1: the fan-out activity forwards the score-only vs
         # full-derive selector; default preserves the pre-streaming behavior.
         "include_pending_tailor": True,
+        "discovery_execution": None,
+        "discovery_cohort_kind": "observed_this_run",
+        "finalize_observed_work_plans": False,
     }
     assert result == DiscoveryPreparationFanoutOutput(started=2, queued=1, targets=3)
 


### PR DESCRIPTION
## Summary

- add immutable `DiscoveryExecutionRef` identity for each Temporal Discover run
- persist execution-scoped current-run versus existing-backlog job membership
- record explicit preparation work-plan outcomes without treating missing plans as no work
- preserve idempotent backlog promotion and immutable first-link history across retries and workflow ID reuse
- thread lineage through discovery sources, reconciliation, fan-out, and per-job preparation inputs

## Why

This is PR 5 in the product-redesign stack and the lineage foundation for the pipeline-operations visibility adaptation from #439. Operations needs a durable execution key and truthful cohort membership before it can report draining work, backlog contention, or ETA.

## Stack

- base: `feat/redesign-setup` / PR #446
- successor: pipeline lifecycle and runtime telemetry

## Validation

- `git diff --check`
- static execution-authority, source-boundary, propagation, schema-version, and compatibility audit
- focused regression tests were authored for serialization, retry/history, promotion, work-plan outcomes, and terminal reconciliation

Full test, replay/determinism, documentation, and browser QA are intentionally deferred until the assembled redesign stack is complete, per the delivery plan.