### PR TITLE
feat(pipeline): redesign operations workspace

### DIFF
--- a/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.test.ts
@@ -1,0 +1,63 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { pipelineKeys } from "../../pipeline/queryKeys.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { usePipelineOperationsQuery } from "./usePipelineOperationsQuery.js";
+
+const snapshot: PipelineOperationsSnapshot = {
+  generatedAt: "2026-07-14T10:00:00.000Z",
+  etaEstimatorVersion: "pipeline-eta-v1",
+  freshness: { status: "fresh", asOf: "2026-07-14T10:00:00.000Z", staleAfterSeconds: 45 },
+  execution: null,
+  capacity: {
+    status: "unavailable",
+    asOf: "2026-07-14T10:00:00.000Z",
+    staleAfterSeconds: 45,
+    taskQueue: null,
+    reason: "Worker runtime telemetry is unavailable.",
+    approximateTaskQueue: {
+      status: "unavailable",
+      observedAt: "2026-07-14T10:00:00.000Z",
+      reasonCode: "telemetry_unavailable",
+    },
+  },
+  sourceFamilies: null,
+  reconciliation: null,
+  stages: [],
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: "2026-07-14T10:00:00.000Z" },
+};
+
+describe("usePipelineOperationsQuery", () => {
+  it("reads the pipeline operations snapshot through the operations port", async () => {
+    const pipelineOperations = vi.fn(async () => snapshot);
+    const { result, queryClient } = renderHookWithProviders(() => usePipelineOperationsQuery(), {
+      ports: buildTestPorts({ api: { pipelineOperations } }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(pipelineOperations).toHaveBeenCalledOnce();
+    expect(result.current.data).toEqual(snapshot);
+    expect(queryClient.getQueryData(pipelineKeys.operations(LOCAL_TENANT))).toEqual(snapshot);
+  });
+
+  it("surfaces pipeline operations read errors", async () => {
+    const pipelineOperations = vi.fn(async () => {
+      throw new Error("operations unavailable");
+    });
+    const { result } = renderHookWithProviders(() => usePipelineOperationsQuery(), {
+      ports: buildTestPorts({ api: { pipelineOperations } }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe("operations unavailable");
+  });
+});

--- a/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.ts
@@ -1,0 +1,28 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { pipelineKeys } from "../../pipeline/queryKeys.js";
+
+const ACTIVE_POLL_INTERVAL_MS = 15_000;
+const IDLE_POLL_INTERVAL_MS = 60_000;
+const PIPELINE_OPERATIONS_STALE_TIME_MS = 10_000;
+
+function isActiveExecution(snapshot: PipelineOperationsSnapshot | undefined): boolean {
+  const phase = snapshot?.execution?.phase;
+  return phase === "discovering" || phase === "draining";
+}
+
+export function usePipelineOperationsQuery(): UseQueryResult<PipelineOperationsSnapshot> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: pipelineKeys.operations(tenantId),
+    queryFn: () => api.pipelineOperations(),
+    staleTime: PIPELINE_OPERATIONS_STALE_TIME_MS,
+    refetchInterval: (query) =>
+      isActiveExecution(query.state.data) ? ACTIVE_POLL_INTERVAL_MS : IDLE_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -129,6 +129,7 @@ export {
 export { useJobApplicationOutcomesQuery } from "./hooks/useJobApplicationOutcomesQuery.js";
 export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
 export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";
 
 export { EventStreamProvider, useEventStreamStatus } from "./providers/EventStreamProvider.js";

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -15,6 +15,7 @@ import { jobsKeys } from "./jobsKeys.js";
 import { outcomesKeys } from "./outcomesKeys.js";
 import { workflowRunsKeys } from "./workflowRunsKeys.js";
 import { discoveryKeys } from "../discovery/queryKeys.js";
+import { pipelineKeys } from "../pipeline/queryKeys.js";
 import { profileKeys } from "../profile/queryKeys.js";
 import { outreachKeys } from "../outreach/queryKeys.js";
 
@@ -272,38 +273,46 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemStarted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     artifactsKeys.lists(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemFailed: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepQueued: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepStarted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepCompleted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepFailed: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ApplyRunStarted: [
     applyRunsKeys.lists(LOCAL_TENANT),
@@ -372,27 +381,36 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageFailed: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageExhausted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
-  StageReset: [jobsKeys.lists(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
+  StageReset: [
+    jobsKeys.lists(LOCAL_TENANT),
+    jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
+  ],
   StageBlocked: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageSkipped: [
     jobsKeys.lists(LOCAL_TENANT),
@@ -400,6 +418,7 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
     digestKeys.all(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageCanceled: [
     jobsKeys.lists(LOCAL_TENANT),
@@ -407,34 +426,41 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
     digestKeys.all(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ProfileUpdated: [profileKeys.profile(LOCAL_TENANT)],
   ProfileImported: [profileKeys.profile(LOCAL_TENANT)],
   WorkflowStarted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCompleted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowFailed: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCanceled: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowTimedOut: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowTerminated: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ContactCreated: [outreachKeys.contactLists(LOCAL_TENANT)],
   ContactUpdated: [

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -110,7 +110,7 @@ describe("StageTriggerPanel", () => {
     const user = userEvent.setup();
     renderWithProviders(<StageTriggerPanel />);
 
-    expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
     expect(screen.getByLabelText("Limit")).toBeInTheDocument();
     expect(screen.getByLabelText("Dry run")).toBeInTheDocument();
     expect(screen.queryByLabelText("Minimum score")).not.toBeInTheDocument();
@@ -124,7 +124,7 @@ describe("StageTriggerPanel", () => {
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     expect(screen.getByLabelText("Limit")).toBeInTheDocument();
-    expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
     expect(screen.getByLabelText("Minimum score")).toBeInTheDocument();
     expect(screen.getByLabelText("Apply model")).toBeInTheDocument();
     expect(screen.getByLabelText("Apply model")).toHaveRole("combobox");
@@ -336,8 +336,8 @@ describe("StageTriggerPanel", () => {
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     await user.clear(screen.getByLabelText("Limit"));
     await user.type(screen.getByLabelText("Limit"), "12");
-    await user.clear(screen.getByLabelText("Workers"));
-    await user.type(screen.getByLabelText("Workers"), "3");
+    await user.clear(screen.getByLabelText("Internal concurrency"));
+    await user.type(screen.getByLabelText("Internal concurrency"), "3");
     await user.clear(screen.getByLabelText("Minimum score"));
     await user.type(screen.getByLabelText("Minimum score"), "8");
     await user.click(screen.getByLabelText("Headless browser"));
@@ -687,8 +687,8 @@ describe("StageTriggerPanel", () => {
     const { unmount } = renderWithProviders(<StageTriggerPanel />);
 
     expect(screen.getByRole("tab", { name: "Discover" })).toHaveAttribute("aria-selected", "true");
-    await user.clear(screen.getByLabelText("Workers"));
-    await user.type(screen.getByLabelText("Workers"), "5");
+    await user.clear(screen.getByLabelText("Internal concurrency"));
+    await user.type(screen.getByLabelText("Internal concurrency"), "5");
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     await user.clear(screen.getByLabelText("Limit"));
@@ -696,14 +696,14 @@ describe("StageTriggerPanel", () => {
     await user.click(screen.getByLabelText("Headless browser"));
 
     await user.click(screen.getByRole("tab", { name: "Discover" }));
-    expect(screen.getByLabelText("Workers")).toHaveValue(5);
+    expect(screen.getByLabelText("Internal concurrency")).toHaveValue(5);
     expect(screen.queryByLabelText("Re-tailor")).not.toBeInTheDocument();
 
     unmount();
     renderWithProviders(<StageTriggerPanel />);
 
     expect(screen.getByRole("tab", { name: "Discover" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByLabelText("Workers")).toHaveValue(5);
+    expect(screen.getByLabelText("Internal concurrency")).toHaveValue(5);
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     expect(screen.getByLabelText("Limit")).toHaveValue(13);

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -487,7 +487,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
         ) : null}
         {controls.workers ? (
           <label className="field">
-            <span>Workers</span>
+            <span>Internal concurrency</span>
             <input
               min={1}
               max={16}

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -15,6 +15,7 @@ import type {
   PipelineStepFailed,
   PipelineStepQueued,
   PipelineStepStarted,
+  TenantId,
   WorkflowStarted,
   WorkflowCompleted,
   WorkflowFailed,
@@ -30,11 +31,16 @@ import { digestKeys } from "../operations/digestKeys.js";
 import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
 import { workflowRunsKeys } from "../operations/workflowRunsKeys.js";
+import { pipelineKeys } from "./queryKeys.js";
+
+const pipelineOperationsInvalidation = (tenantId: TenantId): InvalidationItem =>
+  invalidate(pipelineKeys.operations(tenantId));
 
 export const stageStartedHandler = (event: StageStarted): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageCompletedHandler = (
@@ -43,12 +49,14 @@ export const stageCompletedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageFailedHandler = (event: StageFailed): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageExhaustedHandler = (
@@ -57,17 +65,20 @@ export const stageExhaustedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageResetHandler = (event: StageReset): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageBlockedHandler = (event: StageBlocked): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageSkippedHandler = (event: StageSkipped): readonly InvalidationItem[] => [
@@ -76,6 +87,7 @@ export const stageSkippedHandler = (event: StageSkipped): readonly InvalidationI
   invalidate(applyReviewKeys.queue(event.tenantId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(digestKeys.all(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageCanceledHandler = (
@@ -86,6 +98,7 @@ export const stageCanceledHandler = (
   invalidate(applyReviewKeys.queue(event.tenantId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(digestKeys.all(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 type PreparationWorkItemEvent =
@@ -100,6 +113,7 @@ const preparationWorkItemHandler = (
   const invalidations = [
     invalidate(jobsKeys.lists(event.tenantId)),
     invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+    pipelineOperationsInvalidation(event.tenantId),
   ];
   if (
     event.eventType === "PreparationWorkItemCompleted" &&
@@ -122,9 +136,7 @@ type PipelineStepLifecycleEvent =
   | PipelineStepCompleted
   | PipelineStepFailed;
 
-// The dedicated pipeline-operations query lands later. Until then, refresh the
-// narrowest existing execution-scoped read model that can expose lifecycle
-// diagnostics. The global activity list invalidation is appended by dispatch.
+// The global activity-list invalidation is appended by dispatch.
 const pipelineStepLifecycleHandler = (
   event: PipelineStepLifecycleEvent,
 ): readonly InvalidationItem[] => [
@@ -132,6 +144,7 @@ const pipelineStepLifecycleHandler = (
   invalidate(
     workflowRunsKeys.detail(event.tenantId, event.payload.execution.workflowId),
   ),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const pipelineStepQueuedHandler = pipelineStepLifecycleHandler;
@@ -157,6 +170,7 @@ const workflowLifecycleHandler = (
 ): readonly InvalidationItem[] => [
   invalidate(workflowRunsKeys.lists(event.tenantId)),
   invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.workflowId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const workflowStartedHandler = workflowLifecycleHandler;

--- a/apps/web/src/contexts/pipeline/queryKeys.ts
+++ b/apps/web/src/contexts/pipeline/queryKeys.ts
@@ -2,4 +2,5 @@ import type { TenantId } from "@jobctrl/domain-types";
 
 export const pipelineKeys = {
   all: (tenantId: TenantId) => ["tenant", tenantId, "pipeline"] as const,
+  operations: (tenantId: TenantId) => [...pipelineKeys.all(tenantId), "operations"] as const,
 };

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -9280,6 +9280,304 @@ input[type="radio"] {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 164px), 1fr));
 }
 
+/* Pipeline operations workspace ------------------------------------------------ */
+
+.route-page--pipelines {
+  container-type: inline-size;
+}
+
+.pipelines-workspace > .route-workspace__grid[data-has-inspector="true"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.pipelines-workspace__live-header {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 150px), 1fr));
+  gap: 8px 18px;
+  border-block: 1px solid var(--border);
+  padding-block: 10px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.pipelines-workspace__live-header > * {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pipelines-workspace__live-header strong,
+.pipelines-workspace__live-header time {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.pipelines-workspace__controls {
+  min-width: 0;
+}
+
+.pipelines-workspace__controls.tool-row {
+  border: 0;
+  border-block: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.pipelines-workspace__controls .tool-row__primary {
+  flex-basis: 100%;
+  width: 100%;
+}
+
+.pipelines-workspace__controls .stage-trigger-panel {
+  margin: 0;
+  box-shadow: none;
+}
+
+.pipelines-workspace__ledger,
+.pipeline-operations-inspector {
+  min-width: 0;
+  border-block: 1px solid var(--border);
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__content {
+  display: grid;
+  gap: 14px;
+  padding: 14px 16px;
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__inspector {
+  align-self: start;
+  padding: 14px 16px;
+  background: var(--surface-subtle);
+}
+
+.pipelines-workspace__ledger > h2,
+.pipeline-operations-inspector > h2 {
+  margin: 0;
+  padding: 10px 0;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.pipeline-stage-ledger + .pipeline-stage-ledger,
+.pipeline-operations-inspector > * + * {
+  border-top: 1px solid var(--border);
+}
+
+.pipelines-workspace .disclosure-section {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.pipelines-workspace .disclosure-section__header {
+  min-height: 40px;
+  padding: 6px 0;
+  border-block: 1px solid var(--border);
+  background: transparent;
+}
+
+.pipelines-workspace .disclosure-section[data-state="closed"] .disclosure-section__header {
+  border-bottom-color: var(--border);
+}
+
+.pipelines-workspace .disclosure-section__trigger {
+  min-height: 28px;
+}
+
+.pipelines-workspace .disclosure-section__body {
+  padding: 10px 0 14px;
+}
+
+.pipeline-stage-ledger {
+  min-width: 0;
+  overflow-x: auto;
+  padding-block: 10px;
+  scrollbar-gutter: stable;
+}
+
+.pipeline-stage-ledger > h3 {
+  margin: 0 0 8px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.pipeline-stage-ledger__table {
+  width: 100%;
+  min-width: 42rem;
+  border-collapse: collapse;
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.pipeline-stage-ledger__table :is(th, td) {
+  border-bottom: 1px solid var(--border);
+  padding: 8px 10px;
+  text-align: start;
+  vertical-align: top;
+}
+
+.pipeline-stage-ledger__table th {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pipeline-stage-ledger__table tbody tr:last-child :is(th, td) {
+  border-bottom: 0;
+}
+
+.pipeline-stage-ledger__table td:not(:first-child) {
+  font-variant-numeric: tabular-nums;
+}
+
+.pipeline-stage-ledger__counts,
+.pipeline-stage-ledger__backlog,
+.pipeline-operations-eta,
+.pipeline-operations-capacity {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 120px), 1fr));
+  gap: 4px 10px;
+  margin: 0;
+}
+
+.pipeline-stage-ledger__counts > *,
+.pipeline-stage-ledger__backlog > *,
+.pipeline-operations-eta > *,
+.pipeline-operations-capacity > * {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pipeline-stage-ledger__counts dt,
+.pipeline-stage-ledger__backlog dt,
+.pipeline-operations-eta dt,
+.pipeline-operations-capacity dt {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.pipeline-stage-ledger__counts dd,
+.pipeline-stage-ledger__backlog dd,
+.pipeline-operations-eta dd,
+.pipeline-operations-capacity dd {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;
+}
+
+.pipeline-source-reconciliation {
+  display: grid;
+  gap: 14px;
+}
+
+.pipeline-source-reconciliation > section {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.pipeline-source-reconciliation > section + section {
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.pipeline-source-reconciliation :is(h3, h4, p) {
+  margin: 0;
+}
+
+.pipeline-source-reconciliation h3 {
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.pipeline-source-reconciliation h4 {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pipeline-active-items {
+  display: grid;
+  gap: 0;
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+}
+
+.pipeline-active-item {
+  padding-block: 10px;
+}
+
+.pipeline-active-item + .pipeline-active-item {
+  border-top: 1px solid var(--border);
+}
+
+.pipeline-operations-inspector [data-status="warning"],
+.pipeline-operations-inspector [data-status="stale"] {
+  color: var(--warning-foreground);
+}
+
+.pipeline-operations-inspector [data-status="error"],
+.pipeline-operations-inspector [data-status="unavailable"] {
+  color: var(--destructive);
+}
+
+.pipeline-operations-inspector [data-status="success"] {
+  color: var(--success);
+}
+
+@container (min-width: 54rem) {
+  .pipelines-workspace > .route-workspace__grid[data-has-inspector="true"] {
+    grid-template-columns: minmax(0, 1fr) minmax(17rem, 0.38fr);
+    align-items: start;
+    column-gap: 20px;
+  }
+
+  .pipelines-workspace > .route-workspace__grid > .route-workspace__inspector {
+    border-left: 1px solid var(--border);
+    padding-left: 16px;
+  }
+
+  .pipeline-source-reconciliation {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+  }
+
+  .pipeline-source-reconciliation > section + section {
+    border-top: 0;
+    border-left: 1px solid var(--border);
+    padding-top: 0;
+    padding-left: 18px;
+  }
+}
+
+@container (max-width: 53.99rem) {
+  .pipeline-stage-ledger__table {
+    min-width: 34rem;
+  }
+}
+
 /* Route-level detail workspaces --------------------------------------------- */
 
 .workspace-back {

--- a/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
+++ b/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
@@ -1,0 +1,430 @@
+import type {
+  PipelineCapacity,
+  PipelineEta,
+  PipelineOperationalStage,
+  PipelineOperationsSnapshot,
+  PipelineStageCounts,
+} from "@jobctrl/contracts";
+
+const AS_OF = "2026-07-14T12:00:00.000Z";
+
+function counts(overrides: Partial<PipelineStageCounts> = {}): PipelineStageCounts {
+  return {
+    eligible: 0,
+    waiting: 0,
+    processing: 0,
+    succeeded: 0,
+    skipped: 0,
+    blocked: 0,
+    failed: 0,
+    exhausted: 0,
+    canceled: 0,
+    needsVerification: 0,
+    stale: 0,
+    unknown: 0,
+    ...overrides,
+  };
+}
+
+const etaAvailable: PipelineEta = {
+  status: "available",
+  lowSeconds: 480,
+  highSeconds: 720,
+  confidence: "medium",
+  basis: "stage_throughput",
+  sampleSize: 14,
+  asOf: AS_OF,
+  caveat: "Estimate excludes unrelated backlog outside this discovery run.",
+};
+
+const etaCalibrating: PipelineEta = {
+  status: "calibrating",
+  completedSamples: 2,
+  minimumSamples: 8,
+  asOf: AS_OF,
+  reason: "insufficient_samples",
+};
+
+const etaUnavailable: PipelineEta = {
+  status: "unavailable",
+  reason: "telemetry_stale",
+  asOf: AS_OF,
+};
+
+const availableCapacity: PipelineCapacity = {
+  status: "available",
+  kind: "shared_activity_pool_with_internal_parallelism",
+  asOf: AS_OF,
+  staleAfterSeconds: 45,
+  taskQueue: "jobctrl-default",
+  freshWorkerCount: 1,
+  staleWorkerCount: 0,
+  invalidWorkerCount: 0,
+  configuredSlots: 4,
+  activeSlots: 2,
+  availableSlots: 2,
+  executorThreads: 6,
+  internalParallelism: 2,
+  slotSaturation: 0.5,
+  approximateTaskQueue: {
+    status: "available",
+    observedAt: AS_OF,
+    workflow: {
+      pollerCount: 1,
+      approximateBacklogCount: 0,
+      approximateBacklogAgeSeconds: 0,
+      tasksAddRate: 0.1,
+      tasksDispatchRate: 0.1,
+    },
+    activity: {
+      pollerCount: 1,
+      approximateBacklogCount: 2,
+      approximateBacklogAgeSeconds: 18,
+      tasksAddRate: 0.4,
+      tasksDispatchRate: 0.5,
+    },
+  },
+};
+
+function stage(
+  stageName: string,
+  label: string,
+  scope: PipelineOperationalStage["scope"],
+  currentExecution: PipelineStageCounts,
+  eta: PipelineEta = etaAvailable,
+  existingBacklog: PipelineOperationalStage["existingBacklog"] = {
+    kind: "domain_jobs",
+    counts: counts(),
+  },
+): PipelineOperationalStage {
+  return {
+    stage: stageName,
+    label,
+    scope,
+    currentExecution,
+    existingBacklog,
+    capacity: availableCapacity,
+    eta,
+    asOf: AS_OF,
+  };
+}
+
+const discoveringStages: PipelineOperationalStage[] = [
+  stage("source_planning", "Plan sources", "current_execution", counts({ eligible: 1, succeeded: 1 })),
+  stage("source_family", "Crawl sources", "current_execution", counts({ eligible: 3, processing: 2, succeeded: 1 })),
+  stage("reconciliation", "Reconciliation", "current_execution", counts({ eligible: 2, waiting: 2 })),
+  stage("enrich", "Enrich", "execution_sweep", counts({ eligible: 9, waiting: 5, processing: 2, succeeded: 2 })),
+  stage("score", "Score", "execution_sweep", counts({ eligible: 7, waiting: 4, processing: 1, succeeded: 2 })),
+  stage("tailor", "Tailor", "execution_sweep", counts({ eligible: 4, waiting: 4 })),
+  stage(
+    "score",
+    "Score",
+    "global_outside_execution",
+    counts(),
+    etaUnavailable,
+    { kind: "domain_jobs", counts: counts({ eligible: 11, waiting: 8, failed: 1, stale: 2 }) },
+  ),
+  stage(
+    "tailor",
+    "Tailor",
+    "global_outside_execution",
+    counts(),
+    etaUnavailable,
+    { kind: "domain_jobs", counts: counts({ eligible: 6, waiting: 5, needsVerification: 1 }) },
+  ),
+];
+
+function snapshot(overrides: Partial<PipelineOperationsSnapshot> = {}): PipelineOperationsSnapshot {
+  return {
+    generatedAt: AS_OF,
+    etaEstimatorVersion: "pipeline-eta-v1",
+    freshness: { status: "fresh", asOf: AS_OF, staleAfterSeconds: 45 },
+    execution: {
+      discoverWorkflowId: "discover-local",
+      discoverRunId: "run-discover-20260714",
+      selectedAs: "active_or_draining",
+      workflowStatus: "in_progress",
+      phase: "discovering",
+      membershipClosed: false,
+      startedAt: "2026-07-14T11:48:00.000Z",
+      finishedAt: null,
+      errorCode: null,
+      currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 6, failedPlan: 0, terminal: 3, remaining: 6 },
+      sweptExistingBacklog: { members: 11, planned: 11, notEligible: 0, pending: 8, failedPlan: 0, terminal: 3, remaining: 8 },
+    },
+    capacity: availableCapacity,
+    sourceFamilies: {
+      planned: 3,
+      counts: counts({ eligible: 3, processing: 2, succeeded: 1 }),
+      eta: etaAvailable,
+      asOf: AS_OF,
+    },
+    reconciliation: {
+      enrichment: counts({ eligible: 1, waiting: 1 }),
+      preparationFanout: counts({ eligible: 1, waiting: 1 }),
+      asOf: AS_OF,
+    },
+    stages: discoveringStages,
+    activeItems: [
+      {
+        kind: "source_family",
+        activityType: "discovery_source_family",
+        workflowId: "discover-local",
+        executionId: "run-discover-20260714",
+        attempt: 1,
+        startedAt: "2026-07-14T11:50:00.000Z",
+        sourceFamily: "JobSpy / LinkedIn",
+      },
+      {
+        kind: "source_family",
+        activityType: "discovery_source_family",
+        workflowId: "discover-local",
+        executionId: "run-discover-20260714",
+        attempt: 1,
+        startedAt: "2026-07-14T11:51:00.000Z",
+        sourceFamily: "Workday careers",
+      },
+    ],
+    activeItemsTotal: 2,
+    activeItemsTruncated: false,
+    overallEta: etaAvailable,
+    ...overrides,
+  };
+}
+
+export const pipelinesDiscoveringSnapshot = snapshot();
+
+export const pipelinesDrainingSnapshot = snapshot({
+  execution: {
+    ...pipelinesDiscoveringSnapshot.execution!,
+    phase: "draining",
+    membershipClosed: true,
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 3, failedPlan: 0, terminal: 6, remaining: 3 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, processing: 1 }),
+    asOf: AS_OF,
+  },
+  activeItems: [
+    {
+      kind: "orchestration",
+      activityType: "discovery_preparation_fanout",
+      workflowId: "discover-local",
+      executionId: "run-discover-20260714",
+      attempt: 1,
+      startedAt: "2026-07-14T11:58:00.000Z",
+      operation: "Starting preparation workflows",
+    },
+  ],
+  activeItemsTotal: 1,
+  overallEta: {
+    status: "available",
+    lowSeconds: 120,
+    highSeconds: 180,
+    confidence: "high",
+    basis: "cohort_throughput",
+    sampleSize: 18,
+    asOf: AS_OF,
+    caveat: null,
+  },
+});
+
+export const pipelinesCompletedSnapshot = snapshot({
+  execution: {
+    ...pipelinesDiscoveringSnapshot.execution!,
+    selectedAs: "latest_terminal",
+    workflowStatus: "succeeded",
+    phase: "completed",
+    membershipClosed: true,
+    finishedAt: "2026-07-14T12:04:00.000Z",
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 0, failedPlan: 0, terminal: 9, remaining: 0 },
+    sweptExistingBacklog: { members: 11, planned: 11, notEligible: 0, pending: 0, failedPlan: 0, terminal: 11, remaining: 0 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, succeeded: 1 }),
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({
+    ...entry,
+    currentExecution: counts({ eligible: entry.currentExecution.eligible, succeeded: entry.currentExecution.eligible }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+  })),
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+});
+
+export const pipelinesCompletedWithIssuesSnapshot = snapshot({
+  freshness: {
+    status: "stale",
+    asOf: "2026-07-14T11:45:00.000Z",
+    staleAfterSeconds: 45,
+    reason: "Worker telemetry is older than the configured freshness threshold.",
+  },
+  execution: {
+    ...pipelinesCompletedSnapshot.execution!,
+    phase: "completed_with_issues",
+    errorCode: "source_retry_exhausted",
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 0, failedPlan: 0, terminal: 9, remaining: 0 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 2, exhausted: 1 }),
+    eta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, blocked: 1 }),
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({
+    ...entry,
+    eta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+  })),
+  activeItems: [],
+  activeItemsTotal: null,
+  activeItemsTruncated: null,
+  overallEta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+});
+
+export const pipelinesCalibratingSnapshot = snapshot({
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, processing: 1, succeeded: 2 }),
+    eta: etaCalibrating,
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, eta: etaCalibrating })),
+  overallEta: etaCalibrating,
+});
+
+export const pipelinesUnavailableTelemetrySnapshot = snapshot({
+  freshness: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+  },
+  capacity: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    taskQueue: "jobctrl-default",
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+    approximateTaskQueue: { status: "unavailable", observedAt: AS_OF, reasonCode: "runtime_telemetry_missing" },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, processing: 1, succeeded: 2 }),
+    eta: etaUnavailable,
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, capacity: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    taskQueue: "jobctrl-default",
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+    approximateTaskQueue: { status: "unavailable", observedAt: AS_OF, reasonCode: "runtime_telemetry_missing" },
+  }, eta: etaUnavailable })),
+  activeItems: [],
+  activeItemsTotal: null,
+  activeItemsTruncated: null,
+  overallEta: etaUnavailable,
+});
+
+export const pipelinesMultiWorkerCapacitySnapshot = snapshot({
+  capacity: {
+    ...availableCapacity,
+    freshWorkerCount: 3,
+    configuredSlots: 12,
+    activeSlots: 9,
+    availableSlots: 3,
+    executorThreads: 18,
+    internalParallelism: 3,
+    slotSaturation: 0.75,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, capacity: {
+    ...availableCapacity,
+    freshWorkerCount: 3,
+    configuredSlots: 12,
+    activeSlots: 9,
+    availableSlots: 3,
+    executorThreads: 18,
+    internalParallelism: 3,
+    slotSaturation: 0.75,
+  } })),
+  activeItems: [
+    ...pipelinesDiscoveringSnapshot.activeItems,
+    {
+      kind: "resolved_job",
+      activityType: "score_job",
+      workflowId: "prepare-job-8",
+      executionId: "run-prepare-job-8",
+      attempt: 2,
+      startedAt: "2026-07-14T11:56:00.000Z",
+      jobKey: "job-8",
+      title: "Staff Platform Engineer",
+      company: "Northstar",
+      stage: "score",
+    },
+    {
+      kind: "unresolved_runtime_activity",
+      activityType: "workflow_activity",
+      workflowId: "discover-local",
+      executionId: "run-discover-20260714",
+      attempt: 3,
+      startedAt: "2026-07-14T11:57:00.000Z",
+      opaqueId: "activity-opaque-17",
+    },
+  ],
+  activeItemsTotal: 9,
+  activeItemsTruncated: true,
+});
+
+/**
+ * Guards the original topology: three source-family activities are not the
+ * two one-off reconciliation activities.  The view must never total them as
+ * five source families or describe the reconciliation pair as a sixth source.
+ */
+export const pipelinesThreeSourceSixStepSnapshot = snapshot({
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, succeeded: 1 }),
+    asOf: AS_OF,
+  },
+  stages: [
+    stage("source_planning", "Plan sources", "current_execution", counts({ eligible: 1, succeeded: 1 })),
+    stage("source_family", "Crawl sources", "current_execution", counts({ eligible: 3, succeeded: 3 })),
+    stage("reconciliation", "Reconciliation", "current_execution", counts({ eligible: 2, succeeded: 2 })),
+    stage("enrich", "Enrich", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+    stage("score", "Score", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+    stage("tailor", "Tailor", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+  ],
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+});

--- a/apps/web/src/views/pipelines/PipelinesView.stories.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.stories.tsx
@@ -1,5 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
 
+import {
+  pipelinesCalibratingSnapshot,
+  pipelinesCompletedSnapshot,
+  pipelinesCompletedWithIssuesSnapshot,
+  pipelinesDiscoveringSnapshot,
+  pipelinesDrainingSnapshot,
+  pipelinesMultiWorkerCapacitySnapshot,
+  pipelinesThreeSourceSixStepSnapshot,
+  pipelinesUnavailableTelemetrySnapshot,
+} from "./PipelinesView.fixtures.js";
 import { PipelinesView } from "./PipelinesView.js";
 
 const meta = {
@@ -14,4 +25,67 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+function operationsSnapshot(snapshot: typeof pipelinesDiscoveringSnapshot) {
+  return http.get("*/v1/pipeline/operations", () => HttpResponse.json(snapshot));
+}
+
+export const Discovering: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesDiscoveringSnapshot)] },
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/pipeline/operations", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 60_000));
+          return HttpResponse.json(pipelinesDiscoveringSnapshot);
+        }),
+      ],
+    },
+  },
+};
+
+export const Draining: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesDrainingSnapshot)] },
+  },
+};
+
+export const Completed: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCompletedSnapshot)] },
+  },
+};
+
+export const CompletedWithIssuesAndStaleTelemetry: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCompletedWithIssuesSnapshot)] },
+  },
+};
+
+export const CalibratingEta: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCalibratingSnapshot)] },
+  },
+};
+
+export const UnavailableTelemetryAndEta: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesUnavailableTelemetrySnapshot)] },
+  },
+};
+
+export const MultiWorkerCapacity: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesMultiWorkerCapacitySnapshot)] },
+  },
+};
+
+export const ThreeSourceSixStepRegression: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesThreeSourceSixStepSnapshot)] },
+  },
+};

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -1,9 +1,29 @@
-import { screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
 import { renderWithProviders } from "../../test/render.js";
+import { buildTestPorts } from "../../test/testPorts.js";
+import {
+  pipelinesCalibratingSnapshot,
+  pipelinesDiscoveringSnapshot,
+  pipelinesMultiWorkerCapacitySnapshot,
+  pipelinesThreeSourceSixStepSnapshot,
+  pipelinesUnavailableTelemetrySnapshot,
+} from "./PipelinesView.fixtures.js";
 import { PipelinesView } from "./PipelinesView.js";
+
+async function renderPipelineOperations(snapshot: PipelineOperationsSnapshot) {
+  const pipelineOperations = vi.fn(async () => snapshot);
+  const view = renderWithProviders(<PipelinesView />, {
+    ports: buildTestPorts({ api: { pipelineOperations } }),
+  });
+
+  await screen.findByRole("heading", { name: "Operational stage ledger" });
+  return { ...view, pipelineOperations };
+}
 
 describe("PipelinesView", () => {
   beforeEach(() => {
@@ -11,17 +31,124 @@ describe("PipelinesView", () => {
     useStageTriggerStore.getState().reset();
   });
 
-  it("hosts the pipeline action controls", async () => {
-    renderWithProviders(<PipelinesView />);
+  it("keeps the original action controls aligned with the live operations workspace", async () => {
+    const user = userEvent.setup();
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
 
     expect(
       screen.getByRole("heading", { name: "Pipeline actions" }),
     ).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Run Discover" })).toBeEnabled();
+    expect(screen.getByLabelText("Limit")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
+    expect(screen.getByLabelText("Source")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dry run")).toBeChecked();
+
+    await user.click(screen.getByRole("tab", { name: "Apply" }));
+
+    expect(screen.getByLabelText("Minimum score")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
+    expect(screen.getByLabelText("Apply model")).toBeInTheDocument();
+    expect(screen.getByLabelText("Headless browser")).toBeInTheDocument();
+    expect(screen.getByLabelText("Continuous")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Source")).not.toBeInTheDocument();
   });
 
-  it("does not show secondary discovery navigation inside pipeline actions", () => {
-    renderWithProviders(<PipelinesView />);
+  it("keeps current execution, sweep, and global work as separate semantic ledgers", async () => {
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
+
+    expect(screen.getByRole("heading", { name: "Current execution" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Execution sweep" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Global outside execution" })).toBeInTheDocument();
+    expect(screen.getAllByRole("table")).toHaveLength(3);
+  });
+
+  it("keeps the three source families separate from the two reconciliation steps", async () => {
+    await renderPipelineOperations(pipelinesThreeSourceSixStepSnapshot);
+
+    const sourcePlan = screen.getByText("Source-family plan").closest(".pipeline-source-reconciliation");
+    const reconciliation = screen.getByText("Reconciliation · 2 steps").closest(".pipeline-source-reconciliation");
+
+    if (!sourcePlan || !reconciliation) {
+      throw new Error("Expected source planning and reconciliation inspectors.");
+    }
+
+    expect(sourcePlan).toHaveTextContent("3/3");
+    expect(reconciliation).toHaveTextContent("2 steps");
+    expect(reconciliation).toHaveTextContent("Enrichment pass");
+    expect(reconciliation).toHaveTextContent("Preparation fanout");
+  });
+
+  it("announces only the compact live summary and keeps calibration text inspectable", async () => {
+    const { container } = await renderPipelineOperations(pipelinesCalibratingSnapshot);
+
+    const liveHeader = container.querySelector(".pipelines-workspace__live-header");
+    if (!liveHeader) {
+      throw new Error("Expected the compact pipeline live header.");
+    }
+
+    expect(liveHeader).toHaveAttribute("aria-live", "polite");
+    expect(container.querySelectorAll("[aria-live='polite']")).toHaveLength(1);
+    expect(liveHeader).toHaveTextContent("Calibrating");
+    expect(liveHeader).toHaveTextContent("2/8");
+  });
+
+  it("labels unavailable telemetry without inventing an ETA", async () => {
+    await renderPipelineOperations(pipelinesUnavailableTelemetrySnapshot);
+
+    expect(screen.getByRole("heading", { name: "Execution inspector" })).toBeInTheDocument();
+    expect(screen.getAllByText(/unavailable/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/estimate:.*min/i)).not.toBeInTheDocument();
+  });
+
+  it("reports active inventory truth and multi-worker internal concurrency", async () => {
+    await renderPipelineOperations(pipelinesMultiWorkerCapacitySnapshot);
+
+    const activeWork = screen.getByText("Active work").closest(".disclosure-section");
+    if (!activeWork) {
+      throw new Error("Expected the active-work disclosure.");
+    }
+
+    expect(activeWork).toHaveTextContent("9 total");
+    expect(activeWork).toHaveTextContent("truncated");
+    expect(within(activeWork).getByText("Staff Platform Engineer")).toBeInTheDocument();
+    expect(within(activeWork).getByText("activity-opaque-17")).toBeInTheDocument();
+    const capacity = document.querySelector<HTMLElement>(".pipeline-operations-capacity");
+    if (!capacity) {
+      throw new Error("Expected the pipeline capacity inspector.");
+    }
+    expect(within(capacity).getByText("Internal concurrency")).toBeInTheDocument();
+    expect(capacity).toHaveTextContent("3");
+  });
+
+  it("withholds URL-shaped job keys from the operations inspector", async () => {
+    const sensitiveJobKey = "https://jobs.example.test/private/123";
+    await renderPipelineOperations({
+      ...pipelinesDiscoveringSnapshot,
+      activeItems: [
+        {
+          kind: "resolved_job",
+          activityType: "score_job",
+          workflowId: "prep-opaque",
+          executionId: "run-opaque",
+          attempt: 1,
+          startedAt: "2026-07-14T11:59:00.000Z",
+          jobKey: sensitiveJobKey,
+          title: "Private role",
+          company: "Private employer",
+          stage: "score",
+        },
+      ],
+      activeItemsTotal: 1,
+      activeItemsTruncated: false,
+    });
+
+    expect(screen.queryByText(sensitiveJobKey)).not.toBeInTheDocument();
+    expect(screen.getByText("Sensitive identifier withheld")).toBeInTheDocument();
+  });
+
+  it("does not show secondary discovery navigation inside pipeline actions", async () => {
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
 
     expect(
       screen.queryByRole("heading", { name: "Discovery" }),

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -1,11 +1,497 @@
+import type {
+  PipelineActiveItem,
+  PipelineApproximateTaskQueue,
+  PipelineCapacity,
+  PipelineEta,
+  PipelineExecutionCohortSummary,
+  PipelineOperationsFreshness,
+  PipelineOperationsSnapshot,
+  PipelineStageCounts,
+  PipelineTaskQueueStats,
+} from "@jobctrl/contracts";
+import type { ReactNode } from "react";
+
 import { StageTriggerPanel } from "../../contexts/pipeline/components/StageTriggerPanel.js";
+import { usePipelineOperationsQuery } from "../../contexts/operations/hooks/usePipelineOperationsQuery.js";
+import { formatDateTime } from "../../shared/lib/formatters.js";
+import { DisclosureSection } from "../../shared/ui/disclosure-section.js";
+import { Empty } from "../../shared/ui/empty.js";
+import {
+  InspectorLedger,
+  InspectorLedgerItem,
+} from "../../shared/ui/inspector-ledger.js";
 import { PageHead } from "../../shared/ui/page-head.js";
+import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
+import { ToolRow } from "../../shared/ui/tool-row.js";
+
+const COUNT_FIELDS = [
+  ["eligible", "Eligible"],
+  ["waiting", "Waiting"],
+  ["processing", "Processing"],
+  ["succeeded", "Succeeded"],
+  ["skipped", "Skipped"],
+  ["blocked", "Blocked"],
+  ["failed", "Failed"],
+  ["exhausted", "Exhausted"],
+  ["canceled", "Canceled"],
+  ["needsVerification", "Needs verification"],
+  ["stale", "Stale"],
+  ["unknown", "Unknown"],
+] as const;
+
+const COHORT_FIELDS = [
+  ["members", "Members"],
+  ["planned", "Planned"],
+  ["notEligible", "Not eligible"],
+  ["pending", "Pending plan"],
+  ["failedPlan", "Failed plan"],
+  ["terminal", "Terminal"],
+  ["remaining", "Remaining"],
+] as const;
+
+function sentenceCase(value: string): string {
+  return value.replaceAll("_", " ").replace(/^./, (character) => character.toUpperCase());
+}
+
+function safeOperationalIdentifier(value: string): string {
+  return /(?:https?:\/\/|www\.)/i.test(value) ? "Sensitive identifier withheld" : value;
+}
+
+function formatSeconds(value: number): string {
+  if (value < 60) return `${Math.round(value)} sec`;
+  if (value < 3_600) return `${Math.round(value / 60)} min`;
+  return `${(value / 3_600).toFixed(value < 36_000 ? 1 : 0)} hr`;
+}
+
+function etaLabel(eta: PipelineEta): string {
+  switch (eta.status) {
+    case "available":
+      return `${formatSeconds(eta.lowSeconds)}–${formatSeconds(eta.highSeconds)}`;
+    case "calibrating":
+      return `Calibrating · ${eta.completedSamples}/${eta.minimumSamples}`;
+    case "paused":
+      return `Paused · ${sentenceCase(eta.reason)}`;
+    case "stale":
+      return `Stale · ${sentenceCase(eta.reason)}`;
+    case "unavailable":
+      return eta.reason === "no_work" ? "No work remaining" : `Unavailable · ${sentenceCase(eta.reason)}`;
+  }
+}
+
+function scopeLabel(scope: string): string {
+  switch (scope) {
+    case "current_execution":
+      return "Current execution";
+    case "execution_sweep":
+      return "Execution sweep";
+    case "global_outside_execution":
+      return "Global outside execution";
+    default:
+      return sentenceCase(scope);
+  }
+}
+
+function CountsFacts({ counts, className = "pipeline-stage-ledger__counts" }: {
+  readonly counts: PipelineStageCounts;
+  readonly className?: string;
+}) {
+  return (
+    <dl className={className}>
+      {COUNT_FIELDS.map(([field, label]) => (
+        <div key={field}>
+          <dt>{label}</dt>
+          <dd>{counts[field]}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function CohortFacts({ cohort }: { readonly cohort: PipelineExecutionCohortSummary }) {
+  return (
+    <InspectorLedger>
+      {COHORT_FIELDS.map(([field, label]) => (
+        <InspectorLedgerItem key={field} label={label} value={cohort[field]} />
+      ))}
+    </InspectorLedger>
+  );
+}
+
+function EtaFacts({ eta, label = "ETA" }: { readonly eta: PipelineEta; readonly label?: string }) {
+  return (
+    <dl className="pipeline-operations-eta" aria-label={label}>
+      <div>
+        <dt>Status</dt>
+        <dd>{sentenceCase(eta.status)}</dd>
+      </div>
+      {eta.status === "available" ? (
+        <>
+          <div><dt>Low</dt><dd>{formatSeconds(eta.lowSeconds)}</dd></div>
+          <div><dt>High</dt><dd>{formatSeconds(eta.highSeconds)}</dd></div>
+          <div><dt>Confidence</dt><dd>{sentenceCase(eta.confidence)}</dd></div>
+          <div><dt>Basis</dt><dd>{sentenceCase(eta.basis)}</dd></div>
+          <div><dt>Samples</dt><dd>{eta.sampleSize}</dd></div>
+          <div><dt>Caveat</dt><dd>{eta.caveat ?? "None"}</dd></div>
+        </>
+      ) : null}
+      {eta.status === "calibrating" ? (
+        <>
+          <div><dt>Completed samples</dt><dd>{eta.completedSamples}</dd></div>
+          <div><dt>Minimum samples</dt><dd>{eta.minimumSamples}</dd></div>
+          <div><dt>Reason</dt><dd>{sentenceCase(eta.reason)}</dd></div>
+        </>
+      ) : null}
+      {eta.status === "paused" || eta.status === "stale" || eta.status === "unavailable" ? (
+        <div><dt>Reason</dt><dd>{sentenceCase(eta.reason)}</dd></div>
+      ) : null}
+      <div><dt>As of</dt><dd>{formatDateTime(eta.asOf)}</dd></div>
+    </dl>
+  );
+}
+
+function queueStats(prefix: string, stats: PipelineTaskQueueStats): ReactNode[] {
+  return [
+    <InspectorLedgerItem key={`${prefix}-pollers`} label={`${prefix} pollers`} value={stats.pollerCount} />,
+    <InspectorLedgerItem key={`${prefix}-backlog`} label={`${prefix} backlog`} value={stats.approximateBacklogCount} />,
+    <InspectorLedgerItem key={`${prefix}-age`} label={`${prefix} backlog age`} value={formatSeconds(stats.approximateBacklogAgeSeconds)} />,
+    <InspectorLedgerItem key={`${prefix}-add`} label={`${prefix} add rate`} value={`${stats.tasksAddRate}/sec`} />,
+    <InspectorLedgerItem key={`${prefix}-dispatch`} label={`${prefix} dispatch rate`} value={`${stats.tasksDispatchRate}/sec`} />,
+  ];
+}
+
+function TaskQueueFacts({ queue }: { readonly queue: PipelineApproximateTaskQueue }) {
+  return (
+    <InspectorLedger>
+      <InspectorLedgerItem label="Observation" value={sentenceCase(queue.status)} />
+      <InspectorLedgerItem label="Observed" value={formatDateTime(queue.observedAt)} />
+      {queue.status === "available" ? (
+        <>
+          {queueStats("Workflow", queue.workflow)}
+          {queueStats("Activity", queue.activity)}
+        </>
+      ) : null}
+      {queue.status === "stale" ? (
+        <InspectorLedgerItem label="Last known status" value={sentenceCase(queue.lastKnownStatus)} />
+      ) : null}
+      {queue.status === "unsupported" || queue.status === "unavailable" ? (
+        <InspectorLedgerItem label="Reason code" value={queue.reasonCode} />
+      ) : null}
+    </InspectorLedger>
+  );
+}
+
+function CapacityFacts({ capacity }: { readonly capacity: PipelineCapacity }) {
+  return (
+    <div className="pipeline-operations-capacity">
+      <InspectorLedger>
+        <InspectorLedgerItem label="Status" value={sentenceCase(capacity.status)} />
+        <InspectorLedgerItem label="Observed" value={formatDateTime(capacity.asOf)} />
+        <InspectorLedgerItem label="Stale after" value={`${capacity.staleAfterSeconds} sec`} />
+        <InspectorLedgerItem label="Task queue" value={capacity.taskQueue ?? "Not reported"} />
+        {capacity.status === "available" ? (
+          <>
+            <InspectorLedgerItem label="Pool" value={sentenceCase(capacity.kind)} />
+            <InspectorLedgerItem label="Fresh workers" value={capacity.freshWorkerCount} />
+            <InspectorLedgerItem label="Stale workers" value={capacity.staleWorkerCount} />
+            <InspectorLedgerItem label="Invalid workers" value={capacity.invalidWorkerCount} />
+            <InspectorLedgerItem label="Configured slots" value={capacity.configuredSlots} />
+            <InspectorLedgerItem label="Active slots" value={capacity.activeSlots} />
+            <InspectorLedgerItem label="Available slots" value={capacity.availableSlots} />
+            <InspectorLedgerItem label="Executor threads" value={capacity.executorThreads} />
+            <InspectorLedgerItem
+              label="Slot saturation"
+              value={capacity.slotSaturation === null ? "Not available" : `${Math.round(capacity.slotSaturation * 100)}%`}
+            />
+            {capacity.kind === "shared_activity_pool_with_internal_parallelism" ? (
+              <InspectorLedgerItem label="Internal concurrency" value={capacity.internalParallelism} />
+            ) : null}
+          </>
+        ) : (
+          <InspectorLedgerItem label="Reason" value={capacity.reason} />
+        )}
+      </InspectorLedger>
+      <TaskQueueFacts queue={capacity.approximateTaskQueue} />
+    </div>
+  );
+}
+
+function FreshnessFacts({ freshness }: { readonly freshness: PipelineOperationsFreshness }) {
+  return (
+    <InspectorLedger>
+      <InspectorLedgerItem label="Read-model status" value={sentenceCase(freshness.status)} />
+      <InspectorLedgerItem label="As of" value={formatDateTime(freshness.asOf)} />
+      <InspectorLedgerItem label="Stale after" value={`${freshness.staleAfterSeconds} sec`} />
+      {freshness.status === "fresh" ? null : (
+        <InspectorLedgerItem label="Freshness reason" value={freshness.reason} />
+      )}
+    </InspectorLedger>
+  );
+}
+
+function ActiveItemFacts({ item }: { readonly item: PipelineActiveItem }) {
+  return (
+    <li className="pipeline-active-item">
+      <InspectorLedger>
+        <InspectorLedgerItem label="Kind" value={sentenceCase(item.kind)} />
+        <InspectorLedgerItem label="Activity" value={item.activityType} />
+        <InspectorLedgerItem label="Workflow" value={item.workflowId ?? "Not reported"} />
+        <InspectorLedgerItem label="Execution" value={item.executionId ?? "Not reported"} />
+        <InspectorLedgerItem label="Attempt" value={item.attempt} />
+        <InspectorLedgerItem label="Started" value={formatDateTime(item.startedAt)} />
+        {item.kind === "resolved_job" ? (
+          <>
+            <InspectorLedgerItem label="Job key" value={safeOperationalIdentifier(item.jobKey)} />
+            <InspectorLedgerItem label="Title" value={item.title ?? "Not reported"} />
+            <InspectorLedgerItem label="Company" value={item.company ?? "Not reported"} />
+            <InspectorLedgerItem label="Stage" value={item.stage} />
+          </>
+        ) : null}
+        {item.kind === "source_family" ? (
+          <InspectorLedgerItem label="Source family" value={item.sourceFamily} />
+        ) : null}
+        {item.kind === "orchestration" ? (
+          <InspectorLedgerItem label="Operation" value={item.operation} />
+        ) : null}
+        {item.kind === "unresolved_runtime_activity" ? (
+          <InspectorLedgerItem label="Opaque activity id" value={item.opaqueId} />
+        ) : null}
+      </InspectorLedger>
+    </li>
+  );
+}
+
+function PipelineStageLedger({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const scopes = ["current_execution", "execution_sweep", "global_outside_execution"] as const;
+  return (
+    <section className="pipelines-workspace__ledger" aria-labelledby="pipeline-stage-ledger-title">
+      <h2 id="pipeline-stage-ledger-title">Operational stage ledger</h2>
+      {scopes.map((scope) => {
+        const rows = snapshot.stages.filter((stage) => stage.scope === scope);
+        if (rows.length === 0) return null;
+        return (
+          <section
+            aria-label={`${scopeLabel(scope)} ledger table`}
+            className="pipeline-stage-ledger"
+            key={scope}
+            tabIndex={0}
+          >
+            <h3>{scopeLabel(scope)}</h3>
+            <table className="pipeline-stage-ledger__table">
+              <caption className="visually-hidden">{scopeLabel(scope)} stage state, backlog, capacity, and ETA</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Stage</th>
+                  <th scope="col">Scoped outcomes</th>
+                  <th scope="col">Existing backlog</th>
+                  <th scope="col">Capacity</th>
+                  <th scope="col">ETA</th>
+                  <th scope="col">Observed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((stage) => (
+                  <tr key={`${stage.scope}-${stage.stage}`}>
+                    <th scope="row">
+                      <strong>{stage.label}</strong>
+                      <small>{stage.stage}</small>
+                    </th>
+                    <td><CountsFacts counts={stage.currentExecution} /></td>
+                    <td>
+                      {stage.existingBacklog.kind === "domain_jobs" ? (
+                        <CountsFacts counts={stage.existingBacklog.counts} className="pipeline-stage-ledger__backlog" />
+                      ) : (
+                        <span>{sentenceCase(stage.existingBacklog.reason)}</span>
+                      )}
+                    </td>
+                    <td>
+                      <strong>{capacityLabel(stage.capacity)}</strong>
+                      <details>
+                        <summary>Capacity details</summary>
+                        <CapacityFacts capacity={stage.capacity} />
+                      </details>
+                    </td>
+                    <td>
+                      <strong>{etaLabel(stage.eta)}</strong>
+                      <EtaFacts eta={stage.eta} label={`${stage.label} ETA details`} />
+                    </td>
+                    <td>{formatDateTime(stage.asOf)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        );
+      })}
+    </section>
+  );
+}
+
+function capacityLabel(capacity: PipelineCapacity): string {
+  if (capacity.status !== "available") return sentenceCase(capacity.status);
+  return `${capacity.activeSlots}/${capacity.configuredSlots} active`;
+}
+
+function PipelineInspector({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const execution = snapshot.execution;
+  return (
+    <div className="pipeline-operations-inspector">
+      <h2>Execution inspector</h2>
+      <DisclosureSection title="Execution and cohorts" defaultOpen>
+        <InspectorLedger>
+          <InspectorLedgerItem label="Workflow id" value={execution?.discoverWorkflowId} />
+          <InspectorLedgerItem label="Temporal run id" value={execution?.discoverRunId} />
+          <InspectorLedgerItem label="Selected as" value={execution ? sentenceCase(execution.selectedAs) : "No execution selected"} />
+          <InspectorLedgerItem label="Workflow status" value={execution ? sentenceCase(execution.workflowStatus) : "Not available"} />
+          <InspectorLedgerItem label="Phase" value={execution ? sentenceCase(execution.phase) : "Idle"} />
+          <InspectorLedgerItem label="Membership closed" value={execution ? (execution.membershipClosed ? "Yes" : "No") : "Not available"} />
+          <InspectorLedgerItem label="Started" value={execution ? formatDateTime(execution.startedAt) : "Not available"} />
+          <InspectorLedgerItem label="Finished" value={execution ? formatDateTime(execution.finishedAt) : "Not available"} />
+          <InspectorLedgerItem label="Error code" value={execution?.errorCode ?? "None"} />
+        </InspectorLedger>
+        {execution ? (
+          <>
+            <h3>Current execution cohort</h3>
+            <CohortFacts cohort={execution.currentExecution} />
+            <h3>Execution sweep cohort</h3>
+            <CohortFacts cohort={execution.sweptExistingBacklog} />
+          </>
+        ) : null}
+      </DisclosureSection>
+      <DisclosureSection title="Freshness and capacity" defaultOpen>
+        <FreshnessFacts freshness={snapshot.freshness} />
+        <CapacityFacts capacity={snapshot.capacity} />
+      </DisclosureSection>
+      <DisclosureSection
+        title="Active work"
+        description={`${snapshot.activeItemsTotal ?? "Unknown"} total${snapshot.activeItemsTruncated ? " · truncated" : ""}`}
+        defaultOpen
+      >
+        <InspectorLedger>
+          <InspectorLedgerItem label="Inventory total" value={snapshot.activeItemsTotal ?? "Unknown"} />
+          <InspectorLedgerItem
+            label="Inventory truncated"
+            value={snapshot.activeItemsTruncated === null ? "Unknown" : snapshot.activeItemsTruncated ? "Yes" : "No"}
+          />
+        </InspectorLedger>
+        {snapshot.activeItems.length > 0 ? (
+          <ol className="pipeline-active-items">
+            {snapshot.activeItems.map((item, index) => (
+              <ActiveItemFacts item={item} key={`${item.kind}-${item.activityType}-${item.startedAt}-${index}`} />
+            ))}
+          </ol>
+        ) : (
+          <Empty title="No active work is visible in the current runtime inventory." />
+        )}
+      </DisclosureSection>
+    </div>
+  );
+}
+
+function PipelineSources({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const sourceFamilies = snapshot.sourceFamilies;
+  const reconciliation = snapshot.reconciliation;
+  return (
+    <DisclosureSection
+      title="Source families and reconciliation"
+      description="Discovery intake and post-source execution are reported independently."
+      defaultOpen
+    >
+      <div className="pipeline-source-reconciliation">
+        {sourceFamilies ? (
+          <section aria-labelledby="source-family-title">
+            <h3 id="source-family-title">Source-family plan</h3>
+            <p><strong>{sourceFamilies.counts.succeeded}/{sourceFamilies.planned}</strong> source families succeeded</p>
+            <CountsFacts counts={sourceFamilies.counts} />
+            <EtaFacts eta={sourceFamilies.eta} label="Source-family ETA details" />
+            <p className="muted">Observed {formatDateTime(sourceFamilies.asOf)}</p>
+          </section>
+        ) : (
+          <section aria-labelledby="source-family-title">
+            <h3 id="source-family-title">Source-family plan</h3>
+            <Empty title="No source-family plan is available for the selected execution." />
+          </section>
+        )}
+        {reconciliation ? (
+          <section aria-labelledby="reconciliation-title">
+            <h3 id="reconciliation-title">Reconciliation · 2 steps</h3>
+            <h4>Enrichment pass</h4>
+            <CountsFacts counts={reconciliation.enrichment} />
+            <h4>Preparation fanout</h4>
+            <CountsFacts counts={reconciliation.preparationFanout} />
+            <p className="muted">Observed {formatDateTime(reconciliation.asOf)}</p>
+          </section>
+        ) : (
+          <section aria-labelledby="reconciliation-title">
+            <h3 id="reconciliation-title">Reconciliation</h3>
+            <Empty title="No reconciliation projection is available for the selected execution." />
+          </section>
+        )}
+      </div>
+    </DisclosureSection>
+  );
+}
+
+function PipelineHeader({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const execution = snapshot.execution;
+  const sourceLabel = snapshot.sourceFamilies
+    ? `${snapshot.sourceFamilies.counts.succeeded}/${snapshot.sourceFamilies.planned}`
+    : "Not available";
+  return (
+    <div className="pipelines-workspace__live-header" aria-live="polite" aria-atomic="true">
+      <div><span>Phase</span><strong>{execution ? sentenceCase(execution.phase) : "Idle"}</strong></div>
+      <div><span>Current cohort</span><strong>{execution ? `${execution.currentExecution.remaining} remaining` : "No selected execution"}</strong></div>
+      <div><span>Execution sweep</span><strong>{execution ? `${execution.sweptExistingBacklog.remaining} remaining` : "Not available"}</strong></div>
+      <div><span>Source families</span><strong>{sourceLabel}</strong></div>
+      <div><span>Overall ETA</span><strong>{etaLabel(snapshot.overallEta)}</strong></div>
+      <div><span>Snapshot</span><time dateTime={snapshot.generatedAt}>{formatDateTime(snapshot.generatedAt)}</time></div>
+    </div>
+  );
+}
+
+function PipelineWorkspace({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  return (
+    <RouteWorkspace
+      className="pipelines-workspace"
+      contentLabel="Pipeline operations ledger and controls"
+      inspectorLabel="Pipeline execution, capacity, and active work"
+      header={<PipelineHeader snapshot={snapshot} />}
+      inspector={<PipelineInspector snapshot={snapshot} />}
+    >
+      <PipelineStageLedger snapshot={snapshot} />
+      <PipelineSources snapshot={snapshot} />
+      <DisclosureSection title="Overall completion estimate" defaultOpen>
+        <strong>{etaLabel(snapshot.overallEta)}</strong>
+        <EtaFacts eta={snapshot.overallEta} label="Overall ETA details" />
+        <p className="muted">Estimator {snapshot.etaEstimatorVersion}</p>
+      </DisclosureSection>
+      <ToolRow className="pipelines-workspace__controls" primary={<StageTriggerPanel />} />
+    </RouteWorkspace>
+  );
+}
 
 export function PipelinesView() {
+  const operations = usePipelineOperationsQuery();
+  const message = operations.error instanceof Error ? operations.error.message : null;
   return (
     <div className="route-page route-page--pipelines">
       <PageHead eyebrow="Pipeline" title="Pipelines" />
-      <StageTriggerPanel />
+      {message ? <div className="banner" role="alert">Pipeline operations are unavailable: {message}</div> : null}
+      {operations.data ? (
+        <PipelineWorkspace snapshot={operations.data} />
+      ) : (
+        <RouteWorkspace
+          className="pipelines-workspace"
+          contentLabel="Pipeline controls"
+          header={
+            <div className="pipelines-workspace__live-header">
+              <div><span>Operations</span><strong>{operations.isLoading ? "Loading snapshot" : "Snapshot unavailable"}</strong></div>
+            </div>
+          }
+        >
+          <Empty title={operations.isLoading ? "Loading pipeline operations." : "No pipeline operations snapshot is available."} />
+          <ToolRow className="pipelines-workspace__controls" primary={<StageTriggerPanel />} />
+        </RouteWorkspace>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- replaces the sparse Pipelines route with a responsive operations workspace backed by the typed snapshot from #449
- keeps current execution, execution sweep, and global work in separate semantic ledgers, with source-family planning reported independently from reconciliation
- exposes execution lineage, every stage outcome bucket, freshness, worker capacity, task-queue observations, ETA evidence, and privacy-safe active-work inventory through the shared RouteWorkspace, DisclosureSection, InspectorLedger, and ToolRow system
- preserves the complete existing Discover/Apply trigger behavior, payloads, persisted settings, health checks, progress, and cancellation; only the visible `Workers` label becomes `Internal concurrency`
- adds the Operations-owned query hook, foreground polling backstop, and lifecycle-event invalidation
- adds realistic stories and regression fixtures for loading, discovering, draining, completed, issues/stale, calibrating, unavailable telemetry, multi-worker capacity, and the original source/reconciliation counting failure

## Stack

- base: #449 (`feat/pipeline-operations-read-model`)
- full documentation, screenshots, and end-to-end QA remain intentionally deferred to the final stack layers

## Validation

- `git diff --cached --check`
- independent static review gate: PASS (Blocker 0, High 0)
- exact trigger parity audit: PASS
- complete contract-field and privacy audit: PASS
- tests, typecheck, lint, builds, Storybook, accessibility runner, and browser QA not run yet by stack sequencing; they will run once implementation and documentation are complete
