### PR TITLE
fix(web): restore redesign visual fidelity

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,83 +1,62 @@
 ---
 version: alpha
 name: JobCtrl
-description: Local-first, AI-assisted job application pipeline with a calm operational UI.
+description: Local-first job operations with an editorial, evidence-led interface.
 
 colors:
-  background: "oklch(0.967 0.003 264.542)"
-  foreground: "oklch(0.145 0 0)"
-  card: "oklch(1 0 0)"
-  card-foreground: "oklch(0.145 0 0)"
-  popover: "oklch(1 0 0)"
-  popover-foreground: "oklch(0.145 0 0)"
-  primary: "oklch(0.541 0.281 293.009)"
-  primary-foreground: "oklch(0.985 0.006 293)"
-  secondary: "oklch(0.967 0.001 286.375)"
-  secondary-foreground: "oklch(0.21 0.006 285.885)"
-  muted: "oklch(0.97 0 0)"
-  muted-foreground: "oklch(0.535 0 0)"
-  accent: "oklch(0.943 0.029 294.588)"
-  accent-foreground: "oklch(0.541 0.281 293.009)"
-  destructive: "oklch(0.577 0.245 27.325)"
-  border: "oklch(0.928 0.006 264.531)"
-  input: "oklch(0.928 0.006 264.531)"
-  ring: "oklch(0.541 0.281 293.009 / 0.36)"
-  success: "oklch(0.54 0.13 145)"
-  success-foreground: "oklch(0.985 0 0)"
-  warning: "oklch(0.72 0.15 72)"
-  warning-foreground: "oklch(0.145 0 0)"
-  status-info: "oklch(0.56 0.11 242)"
-  status-info-foreground: "oklch(0.985 0 0)"
-  chart-1: "oklch(0.541 0.281 293.009)"
-  chart-2: "oklch(0.606 0.25 292.717)"
-  chart-3: "oklch(0.702 0.183 293.541)"
-  chart-4: "oklch(0.811 0.111 293.571)"
-  chart-5: "oklch(0.894 0.057 293.283)"
-  sidebar: "oklch(1 0 0 / 0.84)"
-  sidebar-foreground: "oklch(0.145 0 0)"
-  sidebar-primary: "oklch(0.541 0.281 293.009)"
-  sidebar-primary-foreground: "oklch(0.985 0.006 293)"
-  sidebar-accent: "oklch(0.943 0.029 294.588)"
-  sidebar-accent-foreground: "oklch(0.541 0.281 293.009)"
-  sidebar-border: "oklch(0.928 0.006 264.531)"
-  brand-navy: "#1F2937"
-  brand-violet: "#7C3AED"
-  brand-violet-start: "#8B5CF6"
-  brand-violet-end: "#6D28D9"
-  brand-violet-layer: "#DDD6FE"
-  brand-violet-layer-deep: "#C4B5FD"
-  brand-amber: "#F59E0B"
-  brand-green: "#10B981"
-  brand-surface: "#F3F4F6"
+  background: "#f5f5f3"
+  foreground: "#181817"
+  card: "#ffffff"
+  card-foreground: "#181817"
+  popover: "#ffffff"
+  popover-foreground: "#181817"
+  primary: "#6d28d9"
+  primary-foreground: "#ffffff"
+  secondary: "#fafaf8"
+  secondary-foreground: "#181817"
+  muted: "#fafaf8"
+  muted-foreground: "#686865"
+  accent: "#eee7ff"
+  accent-foreground: "#181817"
+  destructive: "#c9362b"
+  border: "#deded9"
+  input: "#c8c8c1"
+  ring: "#6d28d9"
+  success: "#2f7d44"
+  warning: "#8a4c00"
+  status-info: "#3269c8"
+  sidebar: "#ffffff"
+  sidebar-foreground: "#181817"
+  sidebar-primary: "#6d28d9"
+  sidebar-primary-foreground: "#ffffff"
+  sidebar-accent: "#fafaf8"
+  sidebar-accent-foreground: "#181817"
+  sidebar-border: "#deded9"
+  brand-navy: "#181817"
+  brand-violet: "#6d28d9"
 
 typography:
   display:
     fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 48px
-    fontWeight: 800
-    lineHeight: "1.05"
-    letterSpacing: "0em"
+    fontSize: 30px
+    fontWeight: 820
+    lineHeight: "1.08"
+    letterSpacing: "-0.045em"
   h1:
     fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 32px
-    fontWeight: 800
-    lineHeight: "1.15"
-    letterSpacing: "0em"
+    fontSize: 28px
+    fontWeight: 820
+    lineHeight: "1.08"
+    letterSpacing: "-0.045em"
   h2:
     fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 22px
-    fontWeight: 700
-    lineHeight: "1.2"
-    letterSpacing: "0em"
-  card-title:
-    fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 15px
-    fontWeight: 700
+    fontSize: 14px
+    fontWeight: 760
     lineHeight: "1.25"
-    letterSpacing: "0em"
+    letterSpacing: "-0.015em"
   body:
     fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 13px
+    fontSize: 14px
     fontWeight: 500
     lineHeight: "1.5"
     letterSpacing: "0em"
@@ -90,13 +69,13 @@ typography:
   label:
     fontFamily: "Plus Jakarta Sans Variable"
     fontSize: 11px
-    fontWeight: 800
-    lineHeight: "1"
-    letterSpacing: "0.01em"
+    fontWeight: 700
+    lineHeight: "1.2"
+    letterSpacing: "0em"
   button:
     fontFamily: "Plus Jakarta Sans Variable"
-    fontSize: 13px
-    fontWeight: 750
+    fontSize: 12px
+    fontWeight: 680
     lineHeight: "1"
     letterSpacing: "0em"
   mono:
@@ -107,11 +86,9 @@ typography:
     letterSpacing: "0em"
 
 rounded:
-  xs: 3px
-  sm: 5px
-  md: 6px
-  lg: 8px
-  xl: 11px
+  none: 0px
+  xs: 2px
+  sm: 3px
   full: 999px
 
 spacing:
@@ -130,318 +107,186 @@ components:
   side-rail:
     backgroundColor: "{colors.sidebar}"
     textColor: "{colors.sidebar-foreground}"
-    rounded: "{rounded.lg}"
+    rounded: "{rounded.none}"
     padding: 12px
   side-rail-active-item:
-    backgroundColor: "{colors.sidebar-accent}"
-    textColor: "{colors.sidebar-accent-foreground}"
-    rounded: "{rounded.md}"
-    padding: 8px
-  brand-lockup:
-    backgroundColor: "{colors.card}"
-    textColor: "{colors.brand-navy}"
-    typography: "{typography.h1}"
-  brand-glyph:
-    backgroundColor: "{colors.brand-violet-layer}"
-    textColor: "{colors.brand-violet-end}"
-    rounded: "{rounded.lg}"
-    size: 32px
-  card:
+    backgroundColor: transparent
+    textColor: "{colors.foreground}"
+    indicatorColor: "{colors.primary}"
+    rounded: "{rounded.none}"
+  rule-section:
     backgroundColor: "{colors.card}"
     textColor: "{colors.card-foreground}"
-    rounded: "{rounded.lg}"
-    padding: 16px
-  card-header:
-    backgroundColor: "{colors.muted}"
-    textColor: "{colors.foreground}"
-    typography: "{typography.card-title}"
-    padding: 16px
+    rounded: "{rounded.none}"
+    dividerColor: "{colors.border}"
   button-primary:
-    backgroundColor: "{colors.primary}"
-    textColor: "{colors.primary-foreground}"
+    backgroundColor: "{colors.foreground}"
+    textColor: "{colors.card}"
     typography: "{typography.button}"
-    rounded: "{rounded.md}"
-    padding: 10px
+    rounded: "{rounded.xs}"
     height: 36px
   button-secondary:
-    backgroundColor: "{colors.secondary}"
-    textColor: "{colors.secondary-foreground}"
+    backgroundColor: "{colors.card}"
+    textColor: "{colors.foreground}"
+    borderColor: "{colors.border}"
     typography: "{typography.button}"
-    rounded: "{rounded.md}"
-    padding: 10px
+    rounded: "{rounded.xs}"
     height: 36px
-  button-quiet:
-    backgroundColor: "{colors.accent}"
-    textColor: "{colors.accent-foreground}"
-    typography: "{typography.button}"
-    rounded: "{rounded.md}"
-    padding: 8px
-    height: 32px
   input:
     backgroundColor: "{colors.card}"
     textColor: "{colors.foreground}"
-    rounded: "{rounded.md}"
-    padding: 10px
-    height: 36px
-  focus-ring:
-    backgroundColor: "{colors.ring}"
-  badge-success:
-    backgroundColor: "{colors.success}"
-    textColor: "{colors.success-foreground}"
-    typography: "{typography.label}"
-    rounded: "{rounded.full}"
-    padding: 8px
-  badge-warning:
-    backgroundColor: "{colors.warning}"
-    textColor: "{colors.warning-foreground}"
-    typography: "{typography.label}"
-    rounded: "{rounded.full}"
-    padding: 8px
-  badge-info:
-    backgroundColor: "{colors.card}"
-    textColor: "{colors.status-info}"
-    typography: "{typography.label}"
-    rounded: "{rounded.full}"
-    padding: 8px
-  badge-danger:
-    backgroundColor: "{colors.destructive}"
-    textColor: "{colors.primary-foreground}"
-    typography: "{typography.label}"
-    rounded: "{rounded.full}"
-    padding: 8px
-  chart-series-1:
-    backgroundColor: "{colors.chart-1}"
-  chart-series-2:
-    backgroundColor: "{colors.chart-2}"
-  chart-series-3:
-    backgroundColor: "{colors.chart-3}"
-  chart-series-4:
-    backgroundColor: "{colors.chart-4}"
-  chart-series-5:
-    backgroundColor: "{colors.chart-5}"
-  popover:
-    backgroundColor: "{colors.popover}"
-    textColor: "{colors.popover-foreground}"
-    rounded: "{rounded.lg}"
-    padding: 8px
-  muted-copy:
+    borderColor: "{colors.input}"
+    rounded: "{rounded.xs}"
+    height: 38px
+  tab:
+    backgroundColor: transparent
     textColor: "{colors.muted-foreground}"
-    typography: "{typography.body-sm}"
+    activeTextColor: "{colors.foreground}"
+    activeRuleColor: "{colors.primary}"
+    rounded: "{rounded.none}"
+  status:
+    backgroundColor: transparent
+    textColor: "{colors.muted-foreground}"
+    rounded: "{rounded.none}"
   divider:
     backgroundColor: "{colors.border}"
     height: 1px
-  input-border:
-    backgroundColor: "{colors.input}"
-    height: 1px
-  side-rail-primary-action:
-    backgroundColor: "{colors.sidebar-primary}"
-    textColor: "{colors.sidebar-primary-foreground}"
-    rounded: "{rounded.md}"
-    padding: 8px
-  side-rail-divider:
-    backgroundColor: "{colors.sidebar-border}"
-    height: 1px
-  brand-violet-swatch:
-    backgroundColor: "{colors.brand-violet}"
-  brand-violet-gradient-start:
-    backgroundColor: "{colors.brand-violet-start}"
-  brand-violet-layer-deep:
-    backgroundColor: "{colors.brand-violet-layer-deep}"
-  brand-stage-amber:
-    backgroundColor: "{colors.brand-amber}"
-  brand-stage-green:
-    backgroundColor: "{colors.brand-green}"
-  brand-surface-panel:
-    backgroundColor: "{colors.brand-surface}"
-    textColor: "{colors.brand-navy}"
-    rounded: "{rounded.lg}"
-    padding: 16px
-  status-info-solid-swatch:
-    backgroundColor: "{colors.status-info-foreground}"
-  chart-label:
-    textColor: "{colors.foreground}"
-    typography: "{typography.label}"
+  overlay:
+    backgroundColor: "{colors.popover}"
+    textColor: "{colors.popover-foreground}"
+    rounded: "{rounded.xs}"
 ---
 
-## Overview
+# JobCtrl Interface Standard
 
-JobCtrl is a local-first operations console for finding jobs, judging fit,
-generating audited application materials, and applying only behind explicit
-approval gates. The design system should feel focused, private, reliable, and
-slightly optimistic. It is a productivity surface, not a marketing splash:
-prioritize scanability, evidence, workflow status, and controls that stay calm
-under dense data.
+The design system is the contract that makes every JobCtrl screen feel like one product. It is not a bag of components. Tokens own values, shared primitives own appearance and interaction, domain components own meaning, and route composers use a small set of recurring structures.
 
-The brand expression is a layered violet checkmark over stacked planes. The
-checkmark means progress and completion; the layers mean organized stages and
-traceable workflow. Use the tagline exactly as:
+## Product character
 
-Plan. Apply. Track. Succeed.
+JobCtrl is a local-first control plane for consequential work. Its interface is editorial, calm, dense without being cramped, and explicit about evidence and lifecycle.
 
-Brand assets in this repository:
+Non-negotiables:
 
-- `docs/assets/brand/lockup-primary.png` - full-color lockup with icon,
-  wordmark, and tagline for large brand moments.
-- `docs/assets/brand/lockup-horizontal.png` - wide horizontal lockup with
-  divider and tagline for broad headers, docs, and presentation contexts.
-- `docs/assets/brand/app-icon.png` - square app icon artwork for docs, launch
-  surfaces, social previews, and compact empty states.
-- `docs/assets/brand/lockup-mono.png` - single-color lockup for print,
-  embossing, reduced-color contexts, and high-contrast fallback.
-- `apps/web/public/favicon.svg` and `apps/web/public/apple-touch-icon.png` -
-  runtime browser icons derived from the brand mark. Keep runtime icons in the
-  web public directory rather than using documentation lockups directly.
+- Type before containers.
+- One-pixel rules before cards.
+- Large surfaces stay neutral.
+- Purple marks focus, selection, links, and the active rule; it is not a generic fill color.
+- Semantic color appears on small glyphs and text, never large status backgrounds.
+- Status is dot or icon + label + optional detail, never a colored capsule.
+- Structural radius is 0–3px. `rounded-full` is reserved for intrinsically round controls.
+- Shadows belong only to true overlays. Route-backed detail is a full workspace, not a floating card.
+- Missing, unknown, blocked, residual-warning, and failed-refresh states remain visible.
+- Retrying or re-tailoring never hides the last accepted artifact.
 
-## Colors
+## Foundations
 
-The implemented app uses semantic CSS tokens in `apps/web/src/styles/tokens.css`.
-The front matter above mirrors those values so generation tools can use the
-same decisions. Use semantic tokens first; use brand hex tokens only when
-creating brand artwork, illustrations, docs visuals, or marketing lockups.
+| Foundation | Contract |
+| --- | --- |
+| Base rhythm | 4px; primary steps 8, 12, 16, 24, 32 |
+| Product type | Plus Jakarta Sans Variable |
+| Technical type | JetBrains Mono Variable |
+| Page title | 25–30px, 800–820 weight, tight optical spacing |
+| Body | 14px / 21px |
+| Label/meta | 10–12px, stronger weight or mono where appropriate |
+| Table density | 32px compact, 40px regular, 48px comfy |
+| Canvas | warm neutral `#f5f5f3` |
+| Surface | white `#ffffff` |
+| Ink | near-black `#181817` |
+| Focus | purple `#6d28d9` |
+| Semantic signals | green `#2f7d44`, amber `#8a4c00`, red `#c9362b`, blue `#3269c8` on glyph/text only |
+| Icon family | Tabler, consistent 1.5–2px stroke |
+| Shape | square/2px structural corners; no capsule taxonomy |
 
-- `primary` / `brand-violet` drives key actions, active navigation, focus
-  affordances, and the accented `Ctrl` in the wordmark.
-- `brand-navy` is the wordmark and headline anchor. It should feel precise and
-  operational.
-- `background`, `card`, `muted`, `border`, and `input` create the light,
-  off-white product shell. Avoid pure gray slabs unless they are semantic
-  disabled states.
-- `success`, `warning`, `status-info`, and `destructive` communicate workflow
-  state. Do not reuse them as decorative accents.
-- `brand-amber` and `brand-green` come from the proposal board and may support
-  job-stage counters or diagrams, but production UI should prefer the semantic
-  status tokens.
+Dark mode remaps the same semantic tokens. It does not invent a second component language.
 
-Dark mode follows the same semantic names with darker values in
-`tokens.css`. Do not invent separate component behavior for dark mode; switch
-the token values and keep spacing, typography, and hierarchy stable.
+## Ownership layers
 
-## Typography
+1. **Tokens** — color, spacing, typography, rule, radius, elevation, density, and motion values.
+2. **Primitives** — button, icon button, field, checkbox, tabs, status, ledger, rule section, table, empty state, and detail workspace.
+3. **Domain components** — score, stage, run, source, evidence, artifact, apply decision, and lifecycle displays.
+4. **Page archetypes** — the six recurring compositions below.
+5. **Route composers** — real application pages combine domain components without redefining their appearance.
 
-Use Plus Jakarta Sans Variable for the entire product interface and brand
-wordmark. It gives JobCtrl a modern, technical, and approachable tone without
-looking like a consumer social app. Use JetBrains Mono Variable only for code,
-IDs, file paths, JSON, logs, and other developer-facing literals.
+## Page archetypes
 
-Headings should be confident but compact. Inside dashboards, cards, drawers,
-and tables, avoid oversized display type; reserve display scale for onboarding,
-docs hero graphics, or one-off brand surfaces. Letter spacing is `0em` for new
-UI unless matching the existing CSS wordmark or a tested component contract.
+| Archetype | Routes |
+| --- | --- |
+| Overview / insight | `/dashboard`, `/analytics` |
+| Data index | `/jobs`, `/artifacts`, `/outreach`, `/runs`, `/debug` |
+| Inspector / decision | `/apply-review`, `/evidence-map` |
+| Operations | `/pipelines`, `/discovery` |
+| Configuration / form | `/profile`, `/profile/import/*`, `/preferences`, `/settings/*` |
+| Route-backed detail workspace | `/jobs/$jobId`, `/jobs/$jobId/run/$runId`, `/artifacts/$artifactId`, `/outreach/$contactId`, `/runs/$runId`, `/activity/$eventId` |
 
-## Layout
+## Composition rules
 
-JobCtrl is a repeated-use work tool. Build layouts as dense, organized
-operational surfaces:
+- Overview pages use a ruled metric ledger followed by a small number of continuous insight bands.
+- Data indexes use one tool row and one dense table sheet. Saved views and filters are controls, not content cards.
+- Inspector pages use stable master-detail geometry with evidence and the decision action visible together.
+- Operations pages use ledgers, stage rows, timelines, and disclosures; each datum does not get its own tile.
+- Configuration pages use collapsible rule sections and adaptive field grids. The resume preview is a full-width workbench.
+- Detail routes use a full workspace with a clear return action, identity header, tab rule, and persistent audit inspector.
 
-- Keep the left rail persistent for primary navigation.
-- Use full-width work areas with constrained content only where readability
-  needs it.
-- Put evidence, audit trails, status, and next actions near the data they
-  explain.
-- Prefer tables, drawers, split panes, timelines, and compact panels over
-  oversized cards.
-- Use 8px as the default spacing rhythm, with 12px and 16px for card internals
-  and toolbars.
-- Keep row heights stable: regular 40px, compact 32px, comfy 48px.
-
-Never nest decorative cards inside other cards. A repeated item may be a card;
-a page section should be an unframed layout or a full-width band.
-
-## Elevation & Depth
-
-Depth is quiet and functional. Use one soft panel shadow for cards and floating
-surfaces:
-
-`0 12px 34px rgb(31 41 55 / 0.08)`
-
-Use borders more often than shadows. Shadows should indicate a real surface
-relationship: panels, drawers, menus, popovers, previews, and modal surfaces.
-Do not use glow effects or decorative gradient blobs.
-
-The brand glyph can retain its layered translucent violet planes in brand
-artwork. In the product UI, keep those layers small and symbolic rather than
-turning them into page backgrounds.
-
-## Shapes
-
-The base radius is 8px (`0.5rem`). Most product UI should use 5px, 6px, or 8px.
-Use full pills only for compact badges, status tags, and count chips. Large
-rounded rectangles should be rare; the app should feel precise, not bubbly.
-
-Icon buttons and compact controls should have stable square dimensions so hover
-states and label changes never shift layout. Inputs and buttons should align to
-the same height within a toolbar.
+Never nest decorative cards inside another card. A container exists only when it expresses structure, grouping, scroll ownership, selection, or an overlay relationship.
 
 ## Components
 
 Buttons:
 
-- Primary buttons use `primary` on `primary-foreground` and are reserved for
-  committing the main action in the current workflow.
-- Secondary buttons use `secondary` on `secondary-foreground`.
-- Quiet buttons use `accent` on `accent-foreground` for local controls,
-  filters, low-risk actions, and active affordances.
-- Dangerous actions use `destructive`; never make destructive actions visually
-  equivalent to primary actions.
+- One dominant action per page uses near-black on the neutral surface.
+- Secondary actions use neutral borders and surfaces.
+- Destructive actions use red text/glyph and a neutral surface until confirmation.
+- Purple belongs to focus and selection, not every primary button fill.
 
-Cards and panels:
+Tabs and selection:
 
-- Cards use `card`, `card-foreground`, `border`, `radius.lg`, and the panel
-  shadow.
-- Card headers may use `muted` to separate controls from content.
-- Drawers and detail panels should keep audit evidence visible with the action
-  that depends on it.
-
-Navigation:
-
-- The side rail uses `sidebar` tokens, compact Tabler icons, and a small
-  lockup.
-- Active navigation uses the violet `accent` family, not green or amber.
-- Keep labels short. Tooltips may clarify icon-only collapsed states.
+- Tabs are labels on a one-pixel rule; the active tab uses a 2px purple underline.
+- Row and navigation selection use a thin purple rule or an explicit checked state.
+- Segmented choices remain square and use a rule/underline; they do not become capsule groups.
 
 Status:
 
-- Success means completed, accepted, validated, or safe.
-- Warning means needs review, policy concern, budget risk, or residual issue.
-- Info means queued, running, neutral progress, or inspected evidence.
-- Destructive means failed, blocked, exhausted, deleted, or unsafe.
+- Render a small semantic dot or icon, a readable label, and optional muted detail.
+- Green means complete/accepted/validated; amber means review/risk/residual warning; blue means queued/running/inspected; red means failed/blocked/unsafe.
+- Never use background color alone, and never wrap status in a tinted rounded rectangle.
+
+Forms:
+
+- Inputs, selects, textareas, and checkboxes share 2px corners, a neutral one-pixel border, and no resting shadow.
+- Labels explain meaning; optional documentation links sit beside the label rather than inside helper-card chrome.
+- Adaptive grids use available width and collapse by their own container, not only the viewport.
 
 Data grids:
 
-- Keep columns scannable and avoid inline prose.
-- Use badges for stage/state/status, not color-only text.
-- Filters and saved views should look like controls, not content cards.
+- Keep columns scannable, ruled, and compact; allow horizontal scrolling only inside the table.
+- Filters and saved views live in the tool row or an overlay, never as a wall of mini-cards.
+- Semantic row/cell rules are thin markers. Do not flood a cell or row with status color.
 
-Brand:
+Elevation:
 
-- Use `docs/assets/brand/app-icon.png` for compact icon contexts outside the
-  running web app.
-- Use `apps/web/public/favicon.svg` and `apps/web/public/apple-touch-icon.png`
-  only for browser/runtime icon delivery.
-- Use the wordmark with `Job` in navy and `Ctrl` in violet.
-- Do not recolor the full-color brand mark outside the approved violet range.
-- Use the monochrome mark only when the medium cannot support color or contrast
-  requires it.
+- Normal route content has no shadow.
+- Menus, dialogs, popovers, and mobile sheets may use one quiet shadow because they truly overlay content.
+- Large previews may use a dark neutral stage only when it clarifies the physical page boundary.
 
-## Do's and Don'ts
+## State contract
 
-Do:
+Every asynchronous composite defines loading, empty, error, populated, refreshing, and disabled states. Loading preserves final geometry. Refreshing keeps reviewable truth in place. Disabled controls explain the missing prerequisite. Consequential states show their source, lifecycle, and timestamp when the data exists.
 
-- Use semantic tokens from `tokens.css` for implementation.
-- Keep pages quiet, dense, and built for repeated operational use.
-- Keep audit evidence, source context, and approval controls visible together.
-- Use Tabler icons for product UI controls.
-- Use violet for brand and primary workflow emphasis.
-- Use green, amber, blue, and red only for status semantics.
-- Preserve the local-first and safety-first tone in empty states and warnings.
+## Interaction and accessibility
 
-Don't:
+- URL state owns navigation and filters that users may revisit, share, or traverse with browser history.
+- Focus remains visible with the focus token.
+- Interactive targets are at least 24px, with 32–40px preferred for primary controls.
+- State never relies on color alone and remains legible in forced-colors mode.
+- Mobile reflow favors readable stacking over compressed desktop columns.
+- The page itself never overflows horizontally; only intrinsically wide tabs, tables, and editors may scroll.
 
-- Do not create marketing-style hero pages inside the app shell.
-- Do not use decorative violet gradients as page backgrounds.
-- Do not make broad beige, dark-slate, or one-note purple screens.
-- Do not hide failed, blocked, or residual-warning states behind neutral labels.
-- Do not use color alone to communicate status.
-- Do not stretch the icon, alter the checkmark angle, or rebuild the logo from
-  unrelated iconography.
-- Do not replace product evidence with generic motivational copy.
+## Acceptance bar
+
+- No unexplained one-off spacing, radius, color, or control treatment.
+- No rounded-rectangle proliferation and no capsule status taxonomy.
+- No P0/P1/P2 visual mismatch against the approved draft direction.
+- Zero page-level horizontal overflow at supported widths.
+- All original data, controls, audit fields, filters, and route transitions remain available.
+- All core actions work and all consequential claims expose source and lifecycle when data exists.
+- Zero critical or serious accessibility violations in supported stories.

--- a/apps/web/src/contexts/apply/components/ApplicationOutcomes.test.tsx
+++ b/apps/web/src/contexts/apply/components/ApplicationOutcomes.test.tsx
@@ -17,6 +17,7 @@ describe("application outcome components", () => {
     renderWithProviders(<JobOutcomePanel jobId="job-2" />);
 
     const timeline = await screen.findByLabelText("Application outcome timeline");
+    expect(timeline).toHaveClass("editorial-timeline");
     expect(within(timeline).getByText("Applied confirmation")).toBeInTheDocument();
     expect(screen.getByText("Confirmed in the ATS portal.")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /record outcome/i })).toBeInTheDocument();

--- a/apps/web/src/contexts/apply/components/ApplicationOutcomes.tsx
+++ b/apps/web/src/contexts/apply/components/ApplicationOutcomes.tsx
@@ -387,7 +387,10 @@ export function OutcomeTimeline({ outcomes }: OutcomeTimelineProps) {
     return <Empty title="No reviewed outcomes yet." />;
   }
   return (
-    <ol className="outcome-timeline" aria-label="Application outcome timeline">
+    <ol
+      className="outcome-timeline timeline editorial-timeline"
+      aria-label="Application outcome timeline"
+    >
       {sorted.map((outcome) => (
         <li className="timeline-row" key={outcome.outcomeId}>
           <span className="timeline-row-head">

--- a/apps/web/src/contexts/apply/components/ApplyRunBadge.test.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyRunBadge.test.tsx
@@ -9,7 +9,7 @@ describe("<ApplyRunBadge>", () => {
     it(`renders the ${status} status with a non-default tone`, () => {
       const { container } = render(<ApplyRunBadge result={status} />);
       const span = container.querySelector("span");
-      expect(span?.className).toMatch(/tag (ok|info|warn|danger|muted)/);
+      expect(span?.className).toMatch(/editorial-status (ok|info|warn|danger|muted)/);
       expect(screen.getByText(status)).toBeInTheDocument();
     });
   }

--- a/apps/web/src/contexts/apply/components/ApplyRunBadge.tsx
+++ b/apps/web/src/contexts/apply/components/ApplyRunBadge.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { applyRunResultTone, type ApplyRunResult, type ApplyRunTone } from "../lib/apply-run-tone.js";
 
 export interface ApplyRunBadgeProps {
@@ -8,5 +9,5 @@ export interface ApplyRunBadgeProps {
 
 export function ApplyRunBadge({ result }: ApplyRunBadgeProps): JSX.Element {
   const tone: ApplyRunTone = applyRunResultTone(result);
-  return <span className={`tag ${tone}`}>{result}</span>;
+  return <StatusLabel tone={tone}>{result}</StatusLabel>;
 }

--- a/apps/web/src/contexts/apply/components/RunStatusBadge.test.tsx
+++ b/apps/web/src/contexts/apply/components/RunStatusBadge.test.tsx
@@ -9,7 +9,7 @@ describe("<RunStatusBadge>", () => {
     it(`renders the ${status} workflow-run status with a non-default tone`, () => {
       const { container } = render(<RunStatusBadge status={status} />);
       const span = container.querySelector("span");
-      expect(span?.className).toMatch(/tag (ok|info|warn|danger|muted)/);
+      expect(span?.className).toMatch(/editorial-status (ok|info|warn|danger|muted)/);
       expect(span?.textContent ?? "").not.toBe("");
     });
   }

--- a/apps/web/src/contexts/apply/components/RunStatusBadge.tsx
+++ b/apps/web/src/contexts/apply/components/RunStatusBadge.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "react";
 import type { WorkflowRunStatus } from "@jobctrl/contracts";
 
 import { assertNever } from "../../../shared/lib/exhaustive.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import type { ApplyRunTone } from "../lib/apply-run-tone.js";
 
 export interface RunStatusBadgeProps {
@@ -18,7 +19,7 @@ export interface RunStatusBadgeProps {
  */
 export function RunStatusBadge({ status }: RunStatusBadgeProps): JSX.Element {
   const tone: ApplyRunTone = workflowRunStatusTone(status);
-  return <span className={`tag ${tone}`}>{statusLabel(status)}</span>;
+  return <StatusLabel tone={tone}>{statusLabel(status)}</StatusLabel>;
 }
 
 function workflowRunStatusTone(status: WorkflowRunStatus): ApplyRunTone {

--- a/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
+++ b/apps/web/src/contexts/enrichment/components/CompensationEvidence.tsx
@@ -17,6 +17,7 @@ import type {
 
 import { Empty } from "../../../shared/ui/empty.js";
 import { Input } from "../../../shared/ui/input.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { useRefreshCompensationMutation } from "../hooks/useRefreshCompensationMutation.js";
 
 type TagTone = "ok" | "info" | "warn" | "muted";
@@ -247,8 +248,10 @@ export function CompensationSummaryCell({
     >
       <b>{primary.range}</b>
       <span>{primary.source}</span>
-      <span className={`tag ${primary.tone}`}>{primary.confidence}</span>
-      {primary.warningCount ? <span className="tag warn">{plural(primary.warningCount, "warning")}</span> : null}
+      <StatusLabel tone={primary.tone}>{primary.confidence}</StatusLabel>
+      {primary.warningCount ? (
+        <StatusLabel tone="warn">{plural(primary.warningCount, "warning")}</StatusLabel>
+      ) : null}
     </div>
   );
 }
@@ -264,8 +267,10 @@ export function CompensationSummaryStrip({
       <span className="compensation-strip-label">{label}</span>
       <b>{primary.range}</b>
       <span>{primary.source}</span>
-      <span className={`tag ${primary.tone}`}>{primary.confidence}</span>
-      {primary.warningCount ? <span className="tag warn">{plural(primary.warningCount, "warning")}</span> : null}
+      <StatusLabel tone={primary.tone}>{primary.confidence}</StatusLabel>
+      {primary.warningCount ? (
+        <StatusLabel tone="warn">{plural(primary.warningCount, "warning")}</StatusLabel>
+      ) : null}
     </section>
   );
 }
@@ -407,9 +412,9 @@ function FactorList({ factors }: { readonly factors: readonly MarketCompensation
         {factors.map((factor) => (
           <li key={factor.name}>
             <span>{formatToken(factor.name)}</span>
-            <b className={`tag ${confidenceTone(factor.band)}`}>
+            <StatusLabel tone={confidenceTone(factor.band)}>
               {formatToken(factor.band)} {formatPercent(factor.score)}
-            </b>
+            </StatusLabel>
             <p>{factor.reason}</p>
           </li>
         ))}
@@ -471,7 +476,7 @@ function PostedPanel({
       <header>
         <span className="eyebrow">Posted Salary</span>
         <b>{posted.displayRange || formatToken(posted.parseState) || "not recorded"}</b>
-        <span className={`tag ${confidenceTone(posted.confidence)}`}>{postedConfidenceText(posted)}</span>
+        <StatusLabel tone={confidenceTone(posted.confidence)}>{postedConfidenceText(posted)}</StatusLabel>
       </header>
       <dl className="compensation-detail-grid">
         <DetailRow label="State" value={posted.recordStatus === "recorded" ? formatToken(posted.parseState) : "not recorded"} />
@@ -501,7 +506,9 @@ function MarketPanel({
       <header>
         <span className="eyebrow">Reported Company-Role Market</span>
         <b>{market.displayRange || formatToken(market.estimateState) || "not requested"}</b>
-        <span className={`tag ${confidenceTone(market.confidenceBand)}`}>{marketConfidenceText(market)}</span>
+        <StatusLabel tone={confidenceTone(market.confidenceBand)}>
+          {marketConfidenceText(market)}
+        </StatusLabel>
       </header>
       <dl className="compensation-detail-grid">
         <DetailRow label="State" value={formatToken(market.estimateState)} />

--- a/apps/web/src/contexts/materials/components/AiExecutionPolicyPanel.tsx
+++ b/apps/web/src/contexts/materials/components/AiExecutionPolicyPanel.tsx
@@ -21,6 +21,10 @@ import {
 import { Input } from "../../../shared/ui/input.js";
 import { SelectField } from "../../../shared/ui/select-field.js";
 import {
+  StatusLabel,
+  type StatusLabelTone,
+} from "../../../shared/ui/status-label.js";
+import {
   useProviderModelCatalogQuery,
   useSettingsPolicyQuery,
 } from "../../operations/hooks/useSettingsPolicyQueries.js";
@@ -125,11 +129,28 @@ export function AiExecutionPolicyPanel() {
       : editableFieldCount === 0
         ? "Read only"
         : "Partially editable";
-  const collapsedSummary = settingsQuery.error
+  const summaryStatus = settingsQuery.error
     ? "Policy unavailable"
     : response
-      ? `${editStatus} · Primary generator: ${generators[0] ?? "Provider/default policy"}`
+      ? editStatus
       : "Loading policy and saved choices";
+  const statusTone: StatusLabelTone = settingsQuery.error
+    ? "danger"
+    : !response
+      ? "info"
+      : editableFieldCount === 4
+        ? "ok"
+        : editableFieldCount === 0
+          ? "muted"
+          : "warn";
+  const collapsedSummary = (
+    <span className="provider-disclosure__summary">
+      <StatusLabel tone={statusTone}>{summaryStatus}</StatusLabel>
+      {response ? (
+        <span>Primary generator: {generators[0] ?? "Provider/default policy"}</span>
+      ) : null}
+    </span>
+  );
 
   return (
     <DisclosureSection
@@ -161,9 +182,7 @@ export function AiExecutionPolicyPanel() {
             }}
           >
             <div className="ai-execution-policy-status grid gap-2">
-              <p className="m-0 text-[12px] leading-5 text-muted-foreground">
-                Configuration status: {editStatus}.
-              </p>
+              <StatusLabel tone={statusTone}>Configuration status: {editStatus}</StatusLabel>
               {status ? (
                 <p className="m-0 text-[12px] leading-5 text-muted-foreground" role="status">
                   {status}

--- a/apps/web/src/contexts/materials/components/ArtifactComparison.tsx
+++ b/apps/web/src/contexts/materials/components/ArtifactComparison.tsx
@@ -6,6 +6,7 @@ import type {
 import { useMemo } from "react";
 
 import { Empty } from "../../../shared/ui/empty.js";
+import { StatusLabel, type StatusLabelTone } from "../../../shared/ui/status-label.js";
 import { useArtifactDetailQuery } from "../../operations/hooks/useArtifactDetailQuery.js";
 import { compareArtifactCoverage } from "../selectors/compareCoverage.js";
 
@@ -97,7 +98,9 @@ function ArtifactComparisonSideSummary({ side }: { readonly side: ArtifactCompar
       <dl className="detail-list compact">
         <div>
           <dt>Status</dt>
-          <dd>{side.status}</dd>
+          <dd>
+            <StatusLabel tone={artifactStatusTone(side.status)}>{side.status}</StatusLabel>
+          </dd>
         </div>
         <div>
           <dt>Template</dt>
@@ -119,6 +122,15 @@ function ArtifactComparisonSideSummary({ side }: { readonly side: ArtifactCompar
       <TagGroup label="Risk labels" values={side.riskLabels} tone="warn" empty="none recorded" />
     </section>
   );
+}
+
+function artifactStatusTone(status: string): StatusLabelTone {
+  const normalized = status.toLowerCase();
+  if (/fail|reject|block|invalid|not[\s_-]*(accept|approv|valid)/.test(normalized)) return "danger";
+  if (/ready|accept|complete|generated|valid/.test(normalized)) return "ok";
+  if (/warn|review|stale/.test(normalized)) return "warn";
+  if (/pending|missing|unknown/.test(normalized)) return "muted";
+  return "info";
 }
 
 function CoverageDeltaPanel({ delta }: { readonly delta: CoverageDelta }) {
@@ -163,17 +175,17 @@ function TagGroup({
   return (
     <div className="artifact-comparison-tag-group">
       <span>{label}</span>
-      <div>
+      <ul className="audit-value-list">
         {values.length ? (
           values.map((value) => (
-            <span className={`tag ${tone}`} key={`${label}:${value}`}>
+            <li className={`audit-value audit-value--${tone}`} key={`${label}:${value}`}>
               {value}
-            </span>
+            </li>
           ))
         ) : (
-          <span className="meta">{empty}</span>
+          <li className="audit-value audit-value--empty">{empty}</li>
         )}
-      </div>
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/contexts/materials/components/ArtifactStatusBadge.test.tsx
+++ b/apps/web/src/contexts/materials/components/ArtifactStatusBadge.test.tsx
@@ -15,7 +15,7 @@ describe("<ArtifactStatusBadge>", () => {
     const { container } = render(<ArtifactStatusBadge status="approved" />);
     const badge = container.querySelector("span");
 
-    expect(badge?.className).toBe("tag ok");
+    expect(badge?.className).toBe("tag editorial-status ok");
     expect(badge).toHaveAttribute(
       "aria-label",
       "approved: Approved means this generated material passed validation and is the accepted version for this job.",
@@ -35,6 +35,6 @@ describe("<ArtifactStatusBadge>", () => {
   it("renders rejected artifacts with destructive status tone", () => {
     const { container } = render(<ArtifactStatusBadge status="rejected" />);
 
-    expect(container.querySelector("span")?.className).toBe("tag danger");
+    expect(container.querySelector("span")?.className).toBe("tag editorial-status danger");
   });
 });

--- a/apps/web/src/contexts/materials/components/ArtifactStatusBadge.tsx
+++ b/apps/web/src/contexts/materials/components/ArtifactStatusBadge.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { artifactStatusDescription } from "../lib/artifact-status-copy.js";
 import { artifactStatusTone } from "../lib/artifact-status-tone.js";
 
@@ -10,12 +11,8 @@ export interface ArtifactStatusBadgeProps {
 export function ArtifactStatusBadge({ status }: ArtifactStatusBadgeProps): JSX.Element {
   const description = artifactStatusDescription(status);
   return (
-    <span
-      aria-label={`${status}: ${description}`}
-      className={`tag ${artifactStatusTone(status)}`}
-      title={description}
-    >
+    <StatusLabel ariaLabel={`${status}: ${description}`} title={description} tone={artifactStatusTone(status)}>
       {status}
-    </span>
+    </StatusLabel>
   );
 }

--- a/apps/web/src/contexts/materials/components/BulletProvenanceList.tsx
+++ b/apps/web/src/contexts/materials/components/BulletProvenanceList.tsx
@@ -48,11 +48,13 @@ function TagList({
       <dt>{label}</dt>
       <dd>
         {items.length ? (
-          items.map((item) => (
-            <span className={`tag ${tone}`} key={item}>
-              {item}
-            </span>
-          ))
+          <ul className="audit-value-list">
+            {items.map((item) => (
+              <li className={`audit-value audit-value--${tone}`} key={item}>
+                {item}
+              </li>
+            ))}
+          </ul>
         ) : (
           <span className="muted">none recorded</span>
         )}
@@ -105,13 +107,13 @@ function BulletProvenanceCard({
 }): JSX.Element {
   return (
     <article className="bullet-provenance">
-      <header>
-        <span className="stage-pill">{formatToken(entry.section)}</span>
-        <span className="tag muted" title="Transform applied">
+      <header className="audit-record-head">
+        <span className="audit-kicker">{formatToken(entry.section)}</span>
+        <span className="audit-inline-meta" title="Transform applied">
           {formatToken(entry.transformType)}
         </span>
         {entry.control ? (
-          <span className="tag muted" title="Governing control rule">
+          <span className="audit-inline-meta" title="Governing control rule">
             {formatToken(entry.control)}
           </span>
         ) : null}

--- a/apps/web/src/contexts/materials/components/EmployerAnalysisPanel.tsx
+++ b/apps/web/src/contexts/materials/components/EmployerAnalysisPanel.tsx
@@ -9,6 +9,7 @@ import type {
 } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { formatToken, scorePercent, weightPercent } from "../lib/audit-format.js";
 
 export interface EmployerAnalysisPanelProps {
@@ -250,21 +251,23 @@ function RequirementItem({
   return (
     <article className="employer-analysis-requirement" aria-label={`Requirement: ${requirement.text}`}>
       <div className="employer-analysis-requirement-side">
-        <header>
-          <span className={`tag ${tier}`}>{formatToken(requirement.tier)}</span>
+        <header className="audit-record-head">
+          <span className={`audit-kicker audit-kicker--${tier}`}>
+            {formatToken(requirement.tier)}
+          </span>
           <span
-            className="tag muted"
+            className="audit-inline-meta"
             title="Relative priority from job-post analysis, not a match score"
           >
             importance {weightPercent(requirement.weight)}
           </span>
           {flagged ? (
-            <span
-              className="tag warn"
+            <StatusLabel
+              tone="warn"
               title="The ensemble agreement marked this requirement as non-unanimous across model legs."
             >
               ensemble divergence
-            </span>
+            </StatusLabel>
           ) : null}
         </header>
         <p className="employer-analysis-requirement-text">{requirement.text}</p>
@@ -277,21 +280,24 @@ function RequirementItem({
       <div className="employer-analysis-match-side">
         <header>
           <span>Requirement fit</span>
-          <span className={`tag ${assessment.tone}`} title={assessment.title}>
+          <StatusLabel tone={assessment.tone} title={assessment.title}>
             {assessment.label}
-          </span>
+          </StatusLabel>
         </header>
         <p className="employer-analysis-rationale">{assessment.explanation}</p>
         {assessment.rows.map((row) => (
           <div className="employer-analysis-signal-row" key={`${requirement.id}:${row.label}`}>
             <span>{row.label}</span>
-            <span>
+            <ul className="audit-value-list">
               {row.values.map((value) => (
-                <span className={`tag ${row.tone ?? assessment.tone}`} key={`${row.label}:${value}`}>
+                <li
+                  className={`audit-value audit-value--${row.tone ?? assessment.tone}`}
+                  key={`${row.label}:${value}`}
+                >
                   {value}
-                </span>
+                </li>
               ))}
-            </span>
+            </ul>
           </div>
         ))}
       </div>
@@ -305,14 +311,14 @@ function KeywordItem({ keyword }: { readonly keyword: EmployerAnalysisKeyword })
       <header>
         <b>{keyword.keyword}</b>
         {keyword.requirement_ref ? (
-          <span className="tag muted" title="Serves requirement">
+          <span className="audit-inline-meta" title="Serves requirement">
             {keyword.requirement_ref}
           </span>
         ) : null}
         {keyword.is_orphan ? (
-          <span className="tag warn" title="Not tied to a specific requirement">
+          <StatusLabel tone="warn" title="Not tied to a specific requirement">
             orphan
-          </span>
+          </StatusLabel>
         ) : null}
       </header>
       {keyword.evidence_span ? (
@@ -343,7 +349,7 @@ function SubAnalysisDetails({
           <article className="employer-analysis-sub" key={sub.model_id}>
             <header>
               <b>{sub.model_id}</b>
-              <span className="tag muted">{formatToken(sub.inferred_seniority)}</span>
+              <span className="audit-inline-meta">{formatToken(sub.inferred_seniority)}</span>
             </header>
             {sub.role_framing ? <p>{sub.role_framing}</p> : null}
             <span className="muted">
@@ -412,11 +418,16 @@ export function EmployerAnalysisPanel({
             <dt>Ensemble</dt>
             <dd>
               {analysis.is_degraded ? (
-                <span className="tag warn" title={`${analysis.legs_succeeded}/${analysis.legs_attempted} models succeeded`}>
+                <StatusLabel
+                  tone="warn"
+                  title={`${analysis.legs_succeeded}/${analysis.legs_attempted} models succeeded`}
+                >
                   degraded ({analysis.legs_succeeded}/{analysis.legs_attempted})
-                </span>
+                </StatusLabel>
               ) : (
-                <span className="tag ok">{formatToken(analysis.ensemble_completeness) || "complete"}</span>
+                <StatusLabel tone="ok">
+                  {formatToken(analysis.ensemble_completeness) || "complete"}
+                </StatusLabel>
               )}
             </dd>
           </div>

--- a/apps/web/src/contexts/materials/components/InterviewPrepPanel.tsx
+++ b/apps/web/src/contexts/materials/components/InterviewPrepPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 
 import { Empty } from "../../../shared/ui/empty.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { GenerateInterviewPrepButton } from "./GenerateInterviewPrepButton.js";
 
 export interface InterviewPrepPanelProps {
@@ -28,7 +29,9 @@ function PrepItemCard({ item, jobId }: { readonly item: InterviewPrepItem; reado
   return (
     <article className="interview-prep-item">
       <div className="interview-prep-item-head">
-        <span className={`tag ${kindTone(item.kind)}`}>{KIND_LABELS[item.kind]}</span>
+        <span className={`audit-kicker audit-kicker--${kindTone(item.kind)}`}>
+          {KIND_LABELS[item.kind]}
+        </span>
         <h4>{item.title}</h4>
       </div>
       <p>{item.generatedText}</p>
@@ -40,7 +43,7 @@ function PrepItemCard({ item, jobId }: { readonly item: InterviewPrepItem; reado
               <dd>
                 {item.evidenceIds.map((evidenceId) => (
                   <Link
-                    className="tag info"
+                    className="audit-link"
                     key={evidenceId}
                     search={{ q: "", entry: evidenceId, job: jobId }}
                     to="/evidence-map"
@@ -55,11 +58,13 @@ function PrepItemCard({ item, jobId }: { readonly item: InterviewPrepItem; reado
             <>
               <dt>{item.kind === "gap_drill" ? "Gap requirements" : "Requirements"}</dt>
               <dd>
-                {item.requirementIds.map((requirementId) => (
-                  <span className="tag muted" key={requirementId}>
-                    {requirementId}
-                  </span>
-                ))}
+                <ul className="audit-value-list">
+                  {item.requirementIds.map((requirementId) => (
+                    <li className="audit-value audit-value--muted" key={requirementId}>
+                      {requirementId}
+                    </li>
+                  ))}
+                </ul>
               </dd>
             </>
           ) : null}
@@ -77,7 +82,7 @@ function PrepItemCard({ item, jobId }: { readonly item: InterviewPrepItem; reado
       ) : null}
       {item.warnings.length ? (
         <div className="interview-prep-warning-group">
-          <span className="tag warn">accepted residual warnings</span>
+          <StatusLabel tone="warn">accepted residual warnings</StatusLabel>
           <ul>
             {item.warnings.map((warning) => (
               <li key={warning}>{warning}</li>
@@ -93,15 +98,17 @@ function GateAudit({ prep }: { readonly prep: InterviewPrep }) {
   const warnings = prep.gateAudit.warnings;
   return (
     <div className="interview-prep-gate">
-      <span className={prep.gateAudit.status === "passed" ? "tag ok" : "tag danger"}>
+      <StatusLabel tone={prep.gateAudit.status === "passed" ? "ok" : "danger"}>
         gate {prep.gateAudit.status}
-      </span>
-      {prep.gateAudit.judgeVerdict ? <span className="tag muted">{prep.gateAudit.judgeVerdict}</span> : null}
-      <span className="tag muted">generation {prep.generation}</span>
-      {prep.model ? <span className="tag muted">{prep.model}</span> : null}
+      </StatusLabel>
+      {prep.gateAudit.judgeVerdict ? (
+        <span className="audit-inline-meta">{prep.gateAudit.judgeVerdict}</span>
+      ) : null}
+      <span className="audit-inline-meta">generation {prep.generation}</span>
+      {prep.model ? <span className="audit-inline-meta">{prep.model}</span> : null}
       {warnings.length ? (
         <div className="interview-prep-warning-group">
-          <span className="tag warn">accepted residual warnings</span>
+          <StatusLabel tone="warn">accepted residual warnings</StatusLabel>
           <ul>
             {warnings.map((warning) => (
               <li key={warning}>{warning}</li>

--- a/apps/web/src/contexts/materials/components/JobResumeTemplateSelect.tsx
+++ b/apps/web/src/contexts/materials/components/JobResumeTemplateSelect.tsx
@@ -2,6 +2,7 @@ import type { ResumeTemplateSummary, ResumeTemplateState } from "@jobctrl/contra
 import type { JSX } from "react";
 import { useId } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { ResumeTemplateStatusBadge } from "./ResumeTemplateStatusBadge.js";
 
 export interface JobResumeTemplateSelectProps {
@@ -54,9 +55,9 @@ export function JobResumeTemplateSelect({
       <div className="resume-template-job-select-status" aria-live="polite">
         <ResumeTemplateStatusBadge state={current} />
         {refreshing ? (
-          <span className="tag info" id={refreshStatusId}>
+          <StatusLabel id={refreshStatusId} tone="info">
             updating materials
-          </span>
+          </StatusLabel>
         ) : null}
       </div>
     </div>

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -54,6 +54,7 @@ import {
 
 import { Empty } from "../../../shared/ui/empty.js";
 import type { PdfAuditLineSelection, PdfAuditLineTarget } from "../../../shared/ui/PdfPreviewViewer.js";
+import { StatusLabel, type StatusLabelTone } from "../../../shared/ui/status-label.js";
 import { useArtifactDetailQuery } from "../../operations/hooks/useArtifactDetailQuery.js";
 import { formatToken, scorePercent } from "../lib/audit-format.js";
 
@@ -1475,11 +1476,13 @@ function OptionalTagRow({
     <div>
       <dt>{label}</dt>
       <dd>
-        {values.map((value) => (
-          <span className={`tag ${tone}`} key={value}>
-            {value}
-          </span>
-        ))}
+        <ul className="audit-value-list">
+          {values.map((value) => (
+            <li className={`audit-value audit-value--${tone}`} key={value}>
+              {value}
+            </li>
+          ))}
+        </ul>
       </dd>
     </div>
   );
@@ -1505,8 +1508,8 @@ function CompactFindingList({
       <summary>
         <span className="artifact-risk-finding-label">
           <b>{label}</b>
-          <span className="tag muted">{items.length}</span>
-          {sourceLabel ? <span className="tag muted">{sourceLabel}</span> : null}
+          <span className="audit-inline-meta">{items.length}</span>
+          {sourceLabel ? <span className="audit-inline-meta">{sourceLabel}</span> : null}
         </span>
         <span className="artifact-risk-finding-preview">{items[0]}</span>
       </summary>
@@ -1645,6 +1648,13 @@ function commentThreadStateLabel(thread: ResumeCommentThread): string {
   return formatToken(thread.state.replaceAll("_", " "));
 }
 
+function commentThreadTone(thread: ResumeCommentThread): StatusLabelTone {
+  if (/resolved|accepted|closed/.test(thread.state)) return "ok";
+  if (/blocked|rejected|failed/.test(thread.state)) return "danger";
+  if (/review|rewrite|open/.test(thread.state)) return "warn";
+  return "info";
+}
+
 function ResumeCommentReplyForm({
   disabled,
   thread,
@@ -1722,10 +1732,10 @@ function ResumeCommentThreadPanel({
       {threads.map((thread) => (
         <article className={`resume-comment-thread ${thread.state}`} key={thread.threadId}>
           <div className="resume-comment-thread-meta">
-            <span className="tag info">{commentThreadStateLabel(thread)}</span>
-            {thread.riskLabel ? <span className="tag warn">{thread.riskLabel}</span> : null}
+            <StatusLabel tone={commentThreadTone(thread)}>{commentThreadStateLabel(thread)}</StatusLabel>
+            {thread.riskLabel ? <StatusLabel tone="warn">{thread.riskLabel}</StatusLabel> : null}
             {thread.lineAnchor?.lineNumber ? <span className="mono">line {thread.lineAnchor.lineNumber}</span> : null}
-            {!thread.anchorResolved ? <span className="tag warn">anchor unresolved</span> : null}
+            {!thread.anchorResolved ? <StatusLabel tone="warn">anchor unresolved</StatusLabel> : null}
           </div>
           <p>{thread.commentBody}</p>
           <div className="resume-comment-thread-source">
@@ -3281,7 +3291,7 @@ function SelectedPinInspector({
           <span className="eyebrow">{formatToken(pin.section)}</span>
           <h4>{pin.title}</h4>
         </div>
-        <span className={`tag ${tone}`}>{pinStatus(pin, risk)}</span>
+        <StatusLabel tone={tone}>{pinStatus(pin, risk)}</StatusLabel>
       </header>
       <LineJustification pin={pin} />
       <details className="resume-pin-source-check">

--- a/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeAuditPins.tsx
@@ -3066,11 +3066,13 @@ export function ResumePlateEditor({
         </div>
       ) : null}
       {renderResult?.validation.warnings.length ? (
-        <div className="resume-render-warnings" role="status">
+        <ul className="resume-render-warnings" role="status">
           {renderResult.validation.warnings.map((warning) => (
-            <span key={warning}>{warning}</span>
+            <li key={warning}>
+              <StatusLabel tone="warn">{warning}</StatusLabel>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : null}
       <div className="resume-plate-scroll" tabIndex={0}>
         {htmlState.status === "ready" && initialPlateValue && currentPlateValue ? (

--- a/apps/web/src/contexts/materials/components/ResumeTemplateStatusBadge.tsx
+++ b/apps/web/src/contexts/materials/components/ResumeTemplateStatusBadge.tsx
@@ -1,6 +1,8 @@
 import type { ResumeTemplateState, ResumeTemplateStaleState } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
+
 export interface ResumeTemplateStatusBadgeProps {
   readonly state?: ResumeTemplateState | null | undefined;
 }
@@ -16,9 +18,9 @@ const STATUS_LABELS: Record<ResumeTemplateStaleState, string> = {
 export function ResumeTemplateStatusBadge({ state }: ResumeTemplateStatusBadgeProps): JSX.Element | null {
   if (!state) return null;
   return (
-    <span className={`tag ${toneForState(state.state)}`} title={templateTitle(state)}>
+    <StatusLabel title={templateTitle(state)} tone={toneForState(state.state)}>
       {STATUS_LABELS[state.state]}
-    </span>
+    </StatusLabel>
   );
 }
 

--- a/apps/web/src/contexts/materials/components/TailoringExplanationSection.tsx
+++ b/apps/web/src/contexts/materials/components/TailoringExplanationSection.tsx
@@ -1,6 +1,7 @@
 import type { ArtifactTailoringExplanation } from "@jobctrl/contracts";
 import type { ReactNode } from "react";
 
+import { StatusLabel, type StatusLabelTone } from "../../../shared/ui/status-label.js";
 import { BulletProvenanceList } from "./BulletProvenanceList.js";
 
 export interface TailoringExplanationSectionProps {
@@ -70,9 +71,11 @@ function hasItems(items: readonly string[]): boolean {
 
 function EvidenceList({ items }: { readonly items: readonly string[] }) {
   return (
-    <ul className="compact-list">
+    <ul className="audit-value-list">
       {items.map((item) => (
-        <li key={item}>{item}</li>
+        <li className="audit-value" key={item}>
+          {item}
+        </li>
       ))}
     </ul>
   );
@@ -130,10 +133,20 @@ function AuditStatus({
 }) {
   return (
     <span className="audit-status">
-      <span>{verdict ?? "-"}</span>
-      {score === null ? null : <span>{scoreText(score)}</span>}
+      <StatusLabel tone={auditStatusTone(verdict)}>{verdict ?? "not recorded"}</StatusLabel>
+      {score === null ? null : <span className="audit-status__score">{scoreText(score)}</span>}
     </span>
   );
+}
+
+function auditStatusTone(verdict: string | null): StatusLabelTone {
+  const normalized = verdict?.toLowerCase() ?? "";
+  if (/fail|reject|block|unsafe|invalid|not[\s_-]*(pass|accept|approv|valid)/.test(normalized)) {
+    return "danger";
+  }
+  if (/pass|accept|approv|complete|valid/.test(normalized)) return "ok";
+  if (/warn|review|risk|residual/.test(normalized)) return "warn";
+  return verdict ? "info" : "muted";
 }
 
 function AuditResponseList({
@@ -287,9 +300,9 @@ function VoicePassBlock({
           <dt>Outcome</dt>
           <dd>
             {voicePass.accepted ? (
-              <span className="tag ok">accepted</span>
+              <StatusLabel tone="ok">accepted</StatusLabel>
             ) : (
-              <span className="tag warn">not accepted</span>
+              <StatusLabel tone="warn">not accepted</StatusLabel>
             )}
           </dd>
         </div>

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.a11y.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.a11y.test.tsx
@@ -12,13 +12,8 @@ describe("Browser capabilities a11y", () => {
     const user = userEvent.setup();
     const view = renderWithProviders(<BrowserCapabilitiesPanel />);
 
-    await user.click(
-      await screen.findByRole("button", { name: /^Core managed browser/ }),
-    );
-    await user.click(screen.getByRole("button", { name: /^Auto-apply browser/ }));
-    await user.click(
-      screen.getByRole("button", { name: /^Authenticated LinkedIn browser/ }),
-    );
+    const configurations = await screen.findAllByText("Configure executable path");
+    await user.click(configurations[0]!);
 
     expect(await axe(view.container)).toHaveNoViolations();
   });

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.test.tsx
@@ -3,7 +3,7 @@ import type {
   BrowserCapabilityId,
   BrowserCapabilityItem,
 } from "@jobctrl/contracts";
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -57,7 +57,7 @@ function updateCapability(
 }
 
 describe("<BrowserCapabilitiesPanel>", () => {
-  it("keeps every capability, status, detail, and control reachable through disclosures", async () => {
+  it("keeps every capability, status, detail, and primary action visible in direct rows", async () => {
     const user = userEvent.setup();
     const ports = buildTestPorts({
       api: { browserCapabilities: vi.fn(async () => disabledCapabilities) },
@@ -70,34 +70,66 @@ describe("<BrowserCapabilitiesPanel>", () => {
     expect(panelTrigger).toHaveAccessibleName(/Explicit adoption/i);
     expect(screen.getByText(/never auto-detects or adopts Chrome/i)).toBeInTheDocument();
 
-    const coreTrigger = screen.getByRole("button", { name: /^Core managed browser/ });
-    const autoApplyTrigger = screen.getByRole("button", { name: /^Auto-apply browser/ });
-    const linkedInTrigger = screen.getByRole("button", {
-      name: /^Authenticated LinkedIn browser/,
+    const coreRow = (await screen.findByRole("heading", {
+      name: "Core managed browser",
+    })).closest("section");
+    const autoApplyRow = screen.getByRole("heading", { name: "Auto-apply browser" }).closest("section");
+    const linkedInRow = screen.getByRole("heading", {
+      name: "Authenticated LinkedIn browser",
+    }).closest("section");
+    if (!coreRow || !autoApplyRow || !linkedInRow) throw new Error("Missing capability row");
+
+    expect(within(coreRow).getByText("Current status: ready")).toBeInTheDocument();
+    expect(within(coreRow).getByText("Managed by JobCtrl and read-only.")).toBeInTheDocument();
+    expect(within(autoApplyRow).getByText("Current status: disabled")).toBeInTheDocument();
+    expect(within(linkedInRow).getByText("Current status: disabled")).toBeInTheDocument();
+    expect(within(autoApplyRow).getByRole("button", { name: "Enable browser" })).toBeDisabled();
+    expect(within(linkedInRow).getByRole("button", { name: "Enable browser" })).toBeDisabled();
+    expect(within(autoApplyRow).getByText("Configure executable path")).toBeVisible();
+    expect(within(linkedInRow).getByText("Configure executable path")).toBeVisible();
+
+    expect(within(autoApplyRow).getByRole("textbox", {
+      name: "Chrome or Chromium executable path",
+    }).closest("details")).not.toHaveAttribute("open");
+    await user.click(within(autoApplyRow).getByText("Configure executable path"));
+    expect(within(autoApplyRow).getByRole("textbox", {
+      name: "Chrome or Chromium executable path",
+    })).toBeInTheDocument();
+    expect(within(autoApplyRow).getByRole("button", { name: "Enable browser" })).toBeDisabled();
+    expect(within(autoApplyRow).queryByRole("button", { name: "Disable now" })).not.toBeInTheDocument();
+    expect(within(autoApplyRow).getByText(/status API does not echo local paths/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /download/i })).not.toBeInTheDocument();
+  });
+
+  it("keeps profile-copy consent subordinate to its visible LinkedIn capability row", async () => {
+    const user = userEvent.setup();
+    const current = updateCapability(disabledCapabilities, "authenticated-linkedin-browser", {
+      enabled: true,
+      status: "ready",
+      detail: "Explicit LinkedIn browser ready.",
+    });
+    const ports = buildTestPorts({
+      api: { browserCapabilities: vi.fn(async () => current) },
     });
 
-    expect(coreTrigger).toHaveAccessibleName(/Managed browser ready.*Status: ready/i);
-    expect(autoApplyTrigger).toHaveAccessibleName(/Disabled.*Status: disabled/i);
-    expect(linkedInTrigger).toHaveAccessibleName(/Disabled.*Status: disabled/i);
-    expect(coreTrigger).toHaveAttribute("aria-expanded", "false");
-    expect(autoApplyTrigger).toHaveAttribute("aria-expanded", "false");
-    expect(linkedInTrigger).toHaveAttribute("aria-expanded", "false");
+    renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
 
-    await user.click(coreTrigger);
-    expect(screen.getByText("Current status: ready")).toBeInTheDocument();
-    expect(screen.getByText("Managed by JobCtrl and read-only.")).toBeInTheDocument();
+    const linkedInRow = (await screen.findByRole("heading", {
+      name: "Authenticated LinkedIn browser",
+    })).closest("section");
+    if (!linkedInRow) throw new Error("Missing LinkedIn capability row");
 
+    expect(within(linkedInRow).getByText("Current status: ready")).toBeInTheDocument();
+    expect(within(linkedInRow).getByRole("button", { name: "Disable now" })).toBeEnabled();
+    expect(within(linkedInRow).getByText("Configure authenticated profile copy")).toBeVisible();
     expect(
-      screen.queryByRole("button", { name: "Enable selected browser" }),
-    ).not.toBeInTheDocument();
-    await user.click(autoApplyTrigger);
-    expect(
-      screen.getByRole("textbox", { name: "Chrome or Chromium executable path" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Enable selected browser" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Disable now" })).toBeDisabled();
-    expect(screen.getAllByText(/status API does not echo local paths/i)).toHaveLength(2);
-    expect(screen.queryByRole("button", { name: /download/i })).not.toBeInTheDocument();
+      within(linkedInRow)
+        .getByLabelText("Existing browser profile directory")
+        .closest("details"),
+    ).not.toHaveAttribute("open");
+
+    await user.click(within(linkedInRow).getByText("Configure authenticated profile copy"));
+    expect(within(linkedInRow).getByLabelText("Existing browser profile directory")).toBeInTheDocument();
   });
 
   it("enables and hot-disables an optional browser from the explicit executable path", async () => {
@@ -132,14 +164,14 @@ describe("<BrowserCapabilitiesPanel>", () => {
 
     renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
 
-    await user.click(
-      await screen.findByRole("button", { name: /^Auto-apply browser/ }),
-    );
-    const executablePath = screen.getByRole("textbox", {
+    const autoApplyRow = (await screen.findByRole("heading", { name: "Auto-apply browser" })).closest("section");
+    if (!autoApplyRow) throw new Error("Missing auto-apply capability row");
+    await user.click(within(autoApplyRow).getByText("Configure executable path"));
+    const executablePath = within(autoApplyRow).getByRole("textbox", {
       name: "Chrome or Chromium executable path",
     });
     await user.type(executablePath, "  /Applications/Chromium.app/Contents/MacOS/Chromium  ");
-    await user.click(screen.getByRole("button", { name: "Enable selected browser" }));
+    await user.click(within(autoApplyRow).getByRole("button", { name: "Enable browser" }));
 
     await waitFor(() =>
       expect(enableBrowserCapability).toHaveBeenCalledWith("auto-apply-browser", {
@@ -151,7 +183,7 @@ describe("<BrowserCapabilitiesPanel>", () => {
     );
     expect(executablePath).toHaveValue("");
 
-    const disableButton = screen.getByRole("button", { name: "Disable now" });
+    const disableButton = within(autoApplyRow).getByRole("button", { name: "Disable now" });
     await waitFor(() => expect(disableButton).toBeEnabled());
     await user.click(disableButton);
 
@@ -192,14 +224,16 @@ describe("<BrowserCapabilitiesPanel>", () => {
 
     renderWithProviders(<BrowserCapabilitiesPanel />, { ports });
 
-    await user.click(
-      await screen.findByRole("button", { name: /^Authenticated LinkedIn browser/ }),
-    );
-    const sourcePath = screen.getByLabelText("Existing browser profile directory");
-    const consent = screen.getByRole("checkbox", {
+    const linkedInRow = (await screen.findByRole("heading", {
+      name: "Authenticated LinkedIn browser",
+    })).closest("section");
+    if (!linkedInRow) throw new Error("Missing LinkedIn capability row");
+    await user.click(within(linkedInRow).getByText("Configure authenticated profile copy"));
+    const sourcePath = within(linkedInRow).getByLabelText("Existing browser profile directory");
+    const consent = within(linkedInRow).getByRole("checkbox", {
       name: "I explicitly consent to copy this profile into JobCtrl-owned storage.",
     });
-    const copyButton = screen.getByRole("button", { name: "Copy selected profile" });
+    const copyButton = within(linkedInRow).getByRole("button", { name: "Copy selected profile" });
 
     expect(sourcePath).toHaveAttribute("type", "password");
     expect(copyButton).toBeDisabled();

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
@@ -13,6 +13,10 @@ import {
 } from "../../../shared/ui/field.js";
 import { Input } from "../../../shared/ui/input.js";
 import {
+  StatusLabel,
+  type StatusLabelTone,
+} from "../../../shared/ui/status-label.js";
+import {
   useCopyLinkedInBrowserProfileMutation,
   useDisableBrowserCapabilityMutation,
   useEnableBrowserCapabilityMutation,
@@ -23,6 +27,14 @@ const LABELS: Record<BrowserCapabilityId, string> = {
   "core-browser": "Core managed browser",
   "auto-apply-browser": "Auto-apply browser",
   "authenticated-linkedin-browser": "Authenticated LinkedIn browser",
+};
+
+const STATUS_TONES: Record<BrowserCapabilityItem["status"], StatusLabelTone> = {
+  ready: "ok",
+  failed: "danger",
+  unavailable: "danger",
+  missing: "warn",
+  disabled: "muted",
 };
 
 export function BrowserCapabilitiesPanel() {
@@ -178,10 +190,19 @@ export function BrowserCapabilitiesPanel() {
             key={capability.id}
             title={LABELS[capability.id]}
             description={capability.detail}
-            collapsedSummary={`Status: ${capability.status}`}
+            collapsedSummary={(
+              <StatusLabel tone={browserCapabilityTone(capability.status)}>
+                Status: {capability.status}
+              </StatusLabel>
+            )}
             defaultOpen={false}
           >
-            <p className="browser-capability-status">Current status: {capability.status}</p>
+            <StatusLabel
+              className="browser-capability-status"
+              tone={browserCapabilityTone(capability.status)}
+            >
+              Current status: {capability.status}
+            </StatusLabel>
             {renderCapabilityControls(capability)}
           </DisclosureSection>
         ))}
@@ -189,4 +210,10 @@ export function BrowserCapabilitiesPanel() {
       {message ? <div className="status-line" role="status">{message}</div> : null}
     </DisclosureSection>
   );
+}
+
+function browserCapabilityTone(
+  status: BrowserCapabilityItem["status"],
+): StatusLabelTone {
+  return STATUS_TONES[status];
 }

--- a/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
+++ b/apps/web/src/contexts/operations/components/BrowserCapabilitiesPanel.tsx
@@ -2,7 +2,6 @@ import type { BrowserCapabilityId, BrowserCapabilityItem } from "@jobctrl/contra
 import { useState } from "react";
 
 import { usePorts } from "../../../shared/providers/PortsProvider.js";
-import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
 import { Button } from "../../../shared/ui/button.js";
 import { ChoiceControl } from "../../../shared/ui/choice-control.js";
 import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
@@ -76,95 +75,108 @@ export function BrowserCapabilitiesPanel() {
 
   function renderCapabilityControls(capability: BrowserCapabilityItem) {
     if (capability.id === "core-browser") {
-      return <p className="provider-copy">Managed by JobCtrl and read-only.</p>;
+      return <p className="browser-capability-row__managed">Managed by JobCtrl and read-only.</p>;
     }
 
     const capabilityId = capability.id;
     return (
-      <div className="browser-capability-controls">
-        <AdaptiveFieldGrid columns={2} minColumnWidth={280} density="compact">
-          <Field data-disabled={demo || capability.enabled || undefined}>
-            <FieldLabel htmlFor={`browser-executable-${capabilityId}`}>
-              Chrome or Chromium executable path
-            </FieldLabel>
-            <Input
-              id={`browser-executable-${capabilityId}`}
-              name={`browser-executable-${capabilityId}`}
-              type="text"
-              autoComplete="off"
-              disabled={demo || capability.enabled}
-              value={executablePaths[capabilityId] ?? ""}
-              onChange={(event) =>
-                setExecutablePaths((current) => ({
-                  ...current,
-                  [capabilityId]: event.target.value,
-                }))
-              }
-            />
-            <FieldDescription>
-              Saved as non-secret browser configuration in config.json. The status API does not
-              echo local paths.
-            </FieldDescription>
-          </Field>
-        </AdaptiveFieldGrid>
-        <div className="form-actions browser-capability-actions">
-          <Button
-            type="button"
-            disabled={demo || capability.enabled || enable.isPending}
-            onClick={() => void enableCapability(capabilityId)}
-          >
-            Enable selected browser
-          </Button>
-          <Button
-            variant="outline"
-            type="button"
-            disabled={demo || !capability.enabled || disable.isPending}
-            onClick={() =>
-              void disable
-                .mutateAsync(capabilityId)
-                .then(() => setMessage(`${LABELS[capabilityId]} disabled immediately.`))
-                .catch(() => setMessage("Capability disable failed."))
-            }
-          >
-            Disable now
-          </Button>
-        </div>
-        {capabilityId === "authenticated-linkedin-browser" && capability.enabled ? (
-          <fieldset className="provider-choice-fieldset browser-profile-copy">
-            <legend>Separate authenticated profile copy</legend>
-            <Field>
-              <FieldLabel htmlFor="linkedin-profile-source">
-                Existing browser profile directory
-              </FieldLabel>
-              <Input
-                id="linkedin-profile-source"
-                name="linkedin-profile-source"
-                type="password"
-                autoComplete="off"
-                value={sourceProfilePath}
-                onChange={(event) => setSourceProfilePath(event.target.value)}
-              />
-              <FieldDescription>
-                Request-only. Cleared after submission and never returned or logged.
-              </FieldDescription>
-            </Field>
-            <ChoiceControl
-              id="linkedin-profile-consent"
-              name="linkedin-profile-consent"
-              label="I explicitly consent to copy this profile into JobCtrl-owned storage."
-              checked={profileConsent}
-              onCheckedChange={(checked) => setProfileConsent(checked === true)}
-            />
+      <>
+        {capability.enabled ? (
+          <div className="browser-capability-row__actions">
             <Button
+              variant="outline"
               type="button"
-              disabled={copyProfile.isPending || !profileConsent || !sourceProfilePath.trim()}
-              onClick={() => void copyLinkedInProfile()}
+              disabled={demo || disable.isPending}
+              onClick={() =>
+                void disable
+                  .mutateAsync(capabilityId)
+                  .then(() => setMessage(`${LABELS[capabilityId]} disabled immediately.`))
+                  .catch(() => setMessage("Capability disable failed."))
+              }
             >
-              Copy selected profile
+              Disable now
             </Button>
-          </fieldset>
+          </div>
+        ) : (
+          <>
+            <div className="browser-capability-row__actions">
+              <Button
+                type="button"
+                disabled={demo || enable.isPending || !executablePaths[capabilityId]?.trim()}
+                onClick={() => void enableCapability(capabilityId)}
+              >
+                Enable browser
+              </Button>
+            </div>
+            <details className="browser-capability-configuration">
+              <summary>Configure executable path</summary>
+              <div className="browser-capability-configuration__body">
+                <Field data-disabled={demo || undefined}>
+                  <FieldLabel htmlFor={`browser-executable-${capabilityId}`}>
+                    Chrome or Chromium executable path
+                  </FieldLabel>
+                  <Input
+                    id={`browser-executable-${capabilityId}`}
+                    name={`browser-executable-${capabilityId}`}
+                    type="text"
+                    autoComplete="off"
+                    disabled={demo}
+                    value={executablePaths[capabilityId] ?? ""}
+                    onChange={(event) =>
+                      setExecutablePaths((current) => ({
+                        ...current,
+                        [capabilityId]: event.target.value,
+                      }))
+                    }
+                  />
+                  <FieldDescription>
+                    Saved as non-secret browser configuration in config.json. The status API does
+                    not echo local paths.
+                  </FieldDescription>
+                </Field>
+              </div>
+            </details>
+          </>
+        )}
+        {capabilityId === "authenticated-linkedin-browser" && capability.enabled ? (
+          <details className="browser-capability-profile-copy">
+            <summary>Configure authenticated profile copy</summary>
+            <fieldset className="provider-choice-fieldset browser-profile-copy">
+              <legend>Separate authenticated profile copy</legend>
+              <Field>
+                <FieldLabel htmlFor="linkedin-profile-source">
+                  Existing browser profile directory
+                </FieldLabel>
+                <Input
+                  id="linkedin-profile-source"
+                  name="linkedin-profile-source"
+                  type="password"
+                  autoComplete="off"
+                  value={sourceProfilePath}
+                  onChange={(event) => setSourceProfilePath(event.target.value)}
+                />
+                <FieldDescription>
+                  Request-only. Cleared after submission and never returned or logged.
+                </FieldDescription>
+              </Field>
+              <ChoiceControl
+                id="linkedin-profile-consent"
+                name="linkedin-profile-consent"
+                label="I explicitly consent to copy this profile into JobCtrl-owned storage."
+                checked={profileConsent}
+                onCheckedChange={(checked) => setProfileConsent(checked === true)}
+              />
+              <Button
+                type="button"
+                disabled={copyProfile.isPending || !profileConsent || !sourceProfilePath.trim()}
+                onClick={() => void copyLinkedInProfile()}
+              >
+                Copy selected profile
+              </Button>
+            </fieldset>
+          </details>
         ) : null}
-      </div>
+      </>
     );
   }
 
@@ -185,26 +197,22 @@ export function BrowserCapabilitiesPanel() {
       {query.error ? <div className="banner inline" role="alert">Browser capability status is unavailable.</div> : null}
       <div className="browser-capability-list" aria-busy={query.isPending}>
         {(query.data?.capabilities ?? []).map((capability) => (
-          <DisclosureSection
-            className="browser-capability-section"
+          <section
+            className="browser-capability-row"
             key={capability.id}
-            title={LABELS[capability.id]}
-            description={capability.detail}
-            collapsedSummary={(
-              <StatusLabel tone={browserCapabilityTone(capability.status)}>
-                Status: {capability.status}
-              </StatusLabel>
-            )}
-            defaultOpen={false}
+            aria-labelledby={`browser-capability-${capability.id}`}
           >
-            <StatusLabel
-              className="browser-capability-status"
-              tone={browserCapabilityTone(capability.status)}
-            >
-              Current status: {capability.status}
-            </StatusLabel>
+            <div className="browser-capability-row__overview">
+              <div>
+                <h3 id={`browser-capability-${capability.id}`}>{LABELS[capability.id]}</h3>
+                <p>{capability.detail}</p>
+              </div>
+              <StatusLabel tone={browserCapabilityTone(capability.status)}>
+                Current status: {capability.status}
+              </StatusLabel>
+            </div>
             {renderCapabilityControls(capability)}
-          </DisclosureSection>
+          </section>
         ))}
       </div>
       {message ? <div className="status-line" role="status">{message}</div> : null}

--- a/apps/web/src/contexts/outreach/components/ContactRoleBadge.tsx
+++ b/apps/web/src/contexts/outreach/components/ContactRoleBadge.tsx
@@ -1,6 +1,7 @@
 import type { ContactRole } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { contactRoleLabel } from "../lib/contact-copy.js";
 
 export interface ContactRoleBadgeProps {
@@ -10,8 +11,8 @@ export interface ContactRoleBadgeProps {
 export function ContactRoleBadge({ role }: ContactRoleBadgeProps): JSX.Element {
   const label = contactRoleLabel(role);
   return (
-    <span className={`tag contact-role-${role}`} title={`Contact role: ${label}`}>
+    <StatusLabel className={`contact-role-${role}`} title={`Contact role: ${label}`} tone="muted">
       {label}
-    </span>
+    </StatusLabel>
   );
 }

--- a/apps/web/src/contexts/outreach/components/DraftGateResultsPanel.tsx
+++ b/apps/web/src/contexts/outreach/components/DraftGateResultsPanel.tsx
@@ -1,6 +1,8 @@
 import type { OutreachDraftGateResults } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
+
 export interface DraftGateResultsPanelProps {
   gateResults: OutreachDraftGateResults;
 }
@@ -13,21 +15,36 @@ function formatScore(score: number): string {
 // is rendered and a failing field is NEVER hidden (CLAUDE.md auditability
 // discipline). Blocks are labelled by what they prove: deterministic
 // never-fabricate findings, validator errors/warnings, and the persona judge.
-export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProps): JSX.Element {
-  const { passed, computedAgainst, fabrications, validation, judge } = gateResults;
+export function DraftGateResultsPanel({
+  gateResults,
+}: DraftGateResultsPanelProps): JSX.Element {
+  const { passed, computedAgainst, fabrications, validation, judge } =
+    gateResults;
   return (
-    <div className="draft-gate-results" role="group" aria-label="Truthfulness gate results">
-      <p className={`tag ${passed ? "ok" : "danger"}`} role="status">
-        {passed ? "Truthfulness gates passed" : "Truthfulness gates blocked this draft"}
+    <div
+      className="draft-gate-results"
+      role="group"
+      aria-label="Truthfulness gate results"
+    >
+      <p className="draft-gate-overall-status" role="status">
+        <StatusLabel tone={passed ? "ok" : "danger"}>
+          {passed
+            ? "Truthfulness gates passed"
+            : "Truthfulness gates blocked this draft"}
+        </StatusLabel>
       </p>
       <p className="draft-gate-computed-against">
         Computed against <span className="mono">{computedAgainst}</span>
       </p>
 
       <div className="draft-gate-block">
-        <p className="draft-gate-block-title">Deterministic never-fabricate findings</p>
+        <p className="draft-gate-block-title">
+          Deterministic never-fabricate findings
+        </p>
         {fabrications.length === 0 ? (
-          <p className="muted">No fabricated claims detected in the generated text.</p>
+          <p className="muted">
+            No fabricated claims detected in the generated text.
+          </p>
         ) : (
           <ul className="draft-gate-fabrication-list">
             {fabrications.map((fabrication, index) => (
@@ -35,7 +52,10 @@ export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProp
                 key={`${fabrication.section}:${fabrication.token}:${index}`}
                 className="draft-gate-fabrication"
               >
-                <dl className="detail-list" aria-label={`Fabrication finding ${index + 1}`}>
+                <dl
+                  className="detail-list"
+                  aria-label={`Fabrication finding ${index + 1}`}
+                >
                   <div>
                     <dt>Kind</dt>
                     <dd>{fabrication.kind}</dd>
@@ -65,11 +85,9 @@ export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProp
 
       <div className="draft-gate-block">
         <p className="draft-gate-block-title">Validation</p>
-        <p>
-          <span className={`tag ${validation.passed ? "ok" : "danger"}`}>
-            {validation.passed ? "Passed" : "Failed"}
-          </span>
-        </p>
+        <StatusLabel tone={validation.passed ? "ok" : "danger"}>
+          {validation.passed ? "Passed" : "Failed"}
+        </StatusLabel>
         {validation.errors.length > 0 ? (
           <>
             <p className="draft-gate-list-label">Errors</p>
@@ -103,9 +121,9 @@ export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProp
               <div>
                 <dt>Verdict</dt>
                 <dd>
-                  <span className={`tag ${judge.approved ? "ok" : "danger"}`}>
+                  <StatusLabel tone={judge.approved ? "ok" : "danger"}>
                     {judge.approved ? "Approved" : "Blocked"}
-                  </span>
+                  </StatusLabel>
                 </dd>
               </div>
               <div>
@@ -117,12 +135,14 @@ export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProp
               <>
                 <p className="draft-gate-list-label">Criterion scores</p>
                 <dl className="detail-list" aria-label="Judge criterion scores">
-                  {Object.entries(judge.criterionScores).map(([criterion, score]) => (
-                    <div key={criterion}>
-                      <dt>{criterion}</dt>
-                      <dd>{formatScore(score)}</dd>
-                    </div>
-                  ))}
+                  {Object.entries(judge.criterionScores).map(
+                    ([criterion, score]) => (
+                      <div key={criterion}>
+                        <dt>{criterion}</dt>
+                        <dd>{formatScore(score)}</dd>
+                      </div>
+                    ),
+                  )}
                 </dl>
               </>
             ) : null}
@@ -136,7 +156,9 @@ export function DraftGateResultsPanel({ gateResults }: DraftGateResultsPanelProp
                 </ul>
               </>
             ) : null}
-            {judge.notes ? <p className="draft-gate-judge-notes">{judge.notes}</p> : null}
+            {judge.notes ? (
+              <p className="draft-gate-judge-notes">{judge.notes}</p>
+            ) : null}
           </>
         ) : (
           <p className="muted">No judge review was recorded for this draft.</p>

--- a/apps/web/src/contexts/outreach/components/DraftStatusBadge.tsx
+++ b/apps/web/src/contexts/outreach/components/DraftStatusBadge.tsx
@@ -1,9 +1,10 @@
 import type { OutreachDraftStatus } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel, type StatusLabelTone } from "../../../shared/ui/status-label.js";
 import { outreachDraftStatusLabel } from "../lib/draft-copy.js";
 
-const STATUS_TONE: Record<OutreachDraftStatus, string> = {
+const STATUS_TONE: Record<OutreachDraftStatus, StatusLabelTone> = {
   candidate: "info",
   approved: "ok",
   rejected: "danger",
@@ -17,8 +18,12 @@ export interface DraftStatusBadgeProps {
 export function DraftStatusBadge({ status }: DraftStatusBadgeProps): JSX.Element {
   const label = outreachDraftStatusLabel(status);
   return (
-    <span className={`tag ${STATUS_TONE[status]} outreach-draft-status-${status}`} title={`Draft status: ${label}`}>
+    <StatusLabel
+      className={`outreach-draft-status-${status}`}
+      title={`Draft status: ${label}`}
+      tone={STATUS_TONE[status]}
+    >
       {label}
-    </span>
+    </StatusLabel>
   );
 }

--- a/apps/web/src/contexts/outreach/components/DueFollowUpsBadge.tsx
+++ b/apps/web/src/contexts/outreach/components/DueFollowUpsBadge.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { useDueFollowUpsQuery } from "../hooks/useDueFollowUpsQuery.js";
 
 // Compact count of follow-ups that are due right now, for surfacing next to the
@@ -12,8 +13,12 @@ export function DueFollowUpsBadge(): JSX.Element | null {
     return null;
   }
   return (
-    <span className="tag outreach-due-badge" aria-label={`${dueCount} follow-ups due`}>
+    <StatusLabel
+      ariaLabel={`${dueCount} follow-ups due`}
+      className="outreach-due-badge"
+      tone="warn"
+    >
       {dueCount} due
-    </span>
+    </StatusLabel>
   );
 }

--- a/apps/web/src/contexts/outreach/components/DueFollowUpsPanel.tsx
+++ b/apps/web/src/contexts/outreach/components/DueFollowUpsPanel.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 
 import { formatDateTime } from "../../../shared/lib/formatters.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { useDueFollowUpsQuery } from "../hooks/useDueFollowUpsQuery.js";
 
 // Context-owned surface listing the outreach follow-ups that are due. These are
@@ -13,14 +14,25 @@ export function DueFollowUpsPanel(): JSX.Element {
   const errorMessage = query.error instanceof Error ? query.error.message : "";
 
   return (
-    <section className="card full outreach-due-follow-ups" aria-label="Follow-ups due">
+    <section
+      className="card full outreach-due-follow-ups"
+      aria-label="Follow-ups due"
+    >
       <header className="card-hd">
         <h2>Follow-ups due</h2>
-        <span className="meta">{query.isPending ? "loading" : `${followUps.length} shown`}</span>
+        <span className="meta">
+          {query.isPending ? "loading" : `${followUps.length} shown`}
+        </span>
       </header>
-      <p className="muted">Reminders surfaced for you to act on. JobCtrl never sends them.</p>
-      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-      {query.isPending && !errorMessage ? <Empty title="Loading follow-ups." /> : null}
+      <p className="muted">
+        Reminders surfaced for you to act on. JobCtrl never sends them.
+      </p>
+      {errorMessage ? (
+        <div className="banner inline">{errorMessage}</div>
+      ) : null}
+      {query.isPending && !errorMessage ? (
+        <Empty title="Loading follow-ups." />
+      ) : null}
       {!query.isPending && followUps.length === 0 && !errorMessage ? (
         <Empty title="No follow-ups due." />
       ) : null}
@@ -28,7 +40,9 @@ export function DueFollowUpsPanel(): JSX.Element {
         <ul className="outreach-due-follow-ups-list">
           {followUps.map((item) => (
             <li key={item.threadId} className="outreach-due-follow-up-item">
-              <span className="tag">{item.isDue ? "due" : "scheduled"}</span>
+              <StatusLabel tone={item.isDue ? "warn" : "info"}>
+                {item.isDue ? "due" : "scheduled"}
+              </StatusLabel>
               <span>due {formatDateTime(item.dueAt)}</span>
               {item.basis ? <span className="muted">{item.basis}</span> : null}
               <span className="mono">{item.jobId ?? item.contactId}</span>

--- a/apps/web/src/contexts/outreach/components/FollowUpPanel.tsx
+++ b/apps/web/src/contexts/outreach/components/FollowUpPanel.tsx
@@ -2,6 +2,7 @@ import type { OutreachFollowUp } from "@jobctrl/contracts";
 import { useState, type JSX } from "react";
 
 import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import { useCompleteFollowUpMutation } from "../hooks/useCompleteFollowUpMutation.js";
 import { useDismissFollowUpMutation } from "../hooks/useDismissFollowUpMutation.js";
 import { useScheduleFollowUpMutation } from "../hooks/useScheduleFollowUpMutation.js";
@@ -39,14 +40,18 @@ export function FollowUpPanel({
     <div className="outreach-follow-up" aria-label="Follow-up">
       <h4>Follow-up</h4>
       <p className="muted">
-        A follow-up is a reminder surfaced for you. JobCtrl never sends it or acts on it.
+        A follow-up is a reminder surfaced for you. JobCtrl never sends it or
+        acts on it.
       </p>
       {error ? <div className="banner inline">{error}</div> : null}
       {isScheduled && followUp ? (
         <div className="outreach-follow-up-scheduled">
           <p>
-            <span className="tag">scheduled</span> due {formatDateTime(followUp.dueAt)}
-            {followUp.basis ? <span className="muted"> · {followUp.basis}</span> : null}
+            <StatusLabel tone="info">scheduled</StatusLabel> due{" "}
+            {formatDateTime(followUp.dueAt)}
+            {followUp.basis ? (
+              <span className="muted"> · {followUp.basis}</span>
+            ) : null}
           </p>
           <div className="form-actions">
             <button
@@ -70,7 +75,9 @@ export function FollowUpPanel({
       ) : (
         <div className="outreach-follow-up-schedule">
           {followUp && followUp.state !== "none" ? (
-            <p className="muted">Last follow-up {followUp.state}. Schedule a new reminder:</p>
+            <p className="muted">
+              Last follow-up {followUp.state}. Schedule a new reminder:
+            </p>
           ) : null}
           <label className="field compact">
             <span>Remind me on</span>

--- a/apps/web/src/contexts/pipeline/components/JobActions.tsx
+++ b/apps/web/src/contexts/pipeline/components/JobActions.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "react";
 import type { Stage } from "@jobctrl/contracts";
-import { Link } from "@tanstack/react-router";
+import { IconDots } from "@tabler/icons-react";
 
 import { ApplyButton } from "../../apply/components/ApplyButton.js";
 import { CancelApplyButton } from "../../apply/components/CancelApplyButton.js";
@@ -8,6 +8,12 @@ import { DryRunButton } from "../../apply/components/DryRunButton.js";
 import { GenerateMaterialsButton } from "../../materials/components/GenerateMaterialsButton.js";
 import { RetailorJobButton } from "../../materials/components/RetailorCurrentPolicyButton.js";
 import { RescoreJobButton } from "../../scoring/components/RescoreCurrentPolicyButton.js";
+import { Button } from "../../../shared/ui/button.js";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "../../../shared/ui/popover.js";
 import { CancelStageButton } from "./CancelStageButton.js";
 import { MarkAppliedButton } from "./MarkAppliedButton.js";
 import { MarkSkippedButton } from "./MarkSkippedButton.js";
@@ -39,27 +45,44 @@ export function JobActions({
           stage={currentStage}
           runAfter={shouldRunAfterRetry(currentStage)}
         />
-      ) : null}
-      <RunJobStageButton
-        disabled={!canRunCurrentStage}
-        jobId={jobId}
-        stage={currentStage}
-      />
-      <CancelStageButton jobId={jobId} stage={currentStage} />
-      <RescoreJobButton jobId={jobId} />
-      <GenerateMaterialsButton jobId={jobId} />
-      {canRetailor ? <RetailorJobButton jobId={jobId} /> : null}
-      <DryRunButton jobId={jobId} />
-      {applyApprovalRequired ? (
-        <Link className="tab on" search={{ jobKey: jobId }} to="/apply-review">
-          apply review
-        </Link>
       ) : (
-        <ApplyButton jobId={jobId} />
+        <RunJobStageButton
+          disabled={!canRunCurrentStage}
+          jobId={jobId}
+          stage={currentStage}
+        />
       )}
-      <CancelApplyButton jobId={jobId} />
-      <MarkAppliedButton jobId={jobId} />
-      <MarkSkippedButton jobId={jobId} />
+      <GenerateMaterialsButton jobId={jobId} />
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button aria-label="More job actions" size="icon" type="button" variant="outline">
+            <IconDots aria-hidden="true" size={16} stroke={1.9} />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          aria-label="Additional job actions"
+          className="job-actions-overflow"
+        >
+          <div className="job-actions-overflow__list">
+            {canRetryStage ? (
+              <RunJobStageButton
+                disabled={!canRunCurrentStage}
+                jobId={jobId}
+                stage={currentStage}
+              />
+            ) : null}
+            <CancelStageButton jobId={jobId} stage={currentStage} />
+            <RescoreJobButton jobId={jobId} />
+            {canRetailor ? <RetailorJobButton jobId={jobId} /> : null}
+            <DryRunButton jobId={jobId} />
+            {!applyApprovalRequired ? <ApplyButton jobId={jobId} /> : null}
+            <CancelApplyButton jobId={jobId} />
+            <MarkAppliedButton jobId={jobId} />
+            <MarkSkippedButton jobId={jobId} />
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }

--- a/apps/web/src/contexts/pipeline/components/StageBadge.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageBadge.test.tsx
@@ -5,10 +5,10 @@ import { describe, expect, it } from "vitest";
 import { StageBadge } from "./StageBadge.js";
 
 describe("<StageBadge>", () => {
-  it("renders a stage pill when given a `stage`", () => {
+  it("renders a plain stage label when given a `stage`", () => {
     const { container } = render(<StageBadge stage="apply" />);
     const span = container.querySelector("span");
-    expect(span?.className).toMatch(/stage-pill/);
+    expect(span?.className).toMatch(/stage-label/);
     expect(screen.getByText("apply")).toBeInTheDocument();
   });
 
@@ -16,13 +16,14 @@ describe("<StageBadge>", () => {
     it(`assigns a non-default tone to stage="${stage}"`, () => {
       const { container } = render(<StageBadge stage={stage} />);
       const span = container.querySelector("span");
-      expect(span?.className).toMatch(/stage-pill/);
+      expect(span?.className).toMatch(/stage-label/);
       expect(span?.className.split(" ").length).toBeGreaterThan(1);
     });
   }
 
-  it("renders a tag with state text when given a `state`", () => {
-    render(<StageBadge state="failed" />);
+  it("renders a dot-led status label when given a `state`", () => {
+    const { container } = render(<StageBadge state="failed" />);
     expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(container.querySelector(".editorial-status .status-dot")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/contexts/pipeline/components/StageBadge.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageBadge.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import type { Stage, StageState } from "../../operations/types.js";
 import { stageStateTone, type StageStateTone } from "../lib/stage-state-tone.js";
 import { stageTone, type StageTone } from "../lib/stage-tone.js";
@@ -9,8 +10,8 @@ export type StageBadgeProps = { stage: Stage } | { state: StageState };
 export function StageBadge(props: StageBadgeProps): JSX.Element {
   if ("stage" in props) {
     const tone: StageTone = stageTone(props.stage);
-    return <span className={`stage-pill ${tone}`}>{props.stage}</span>;
+    return <span className={`stage-pill stage-label ${tone}`}>{props.stage}</span>;
   }
   const tone: StageStateTone = stageStateTone(props.state);
-  return <span className={`tag ${tone}`}>{props.state}</span>;
+  return <StatusLabel tone={tone}>{props.state}</StatusLabel>;
 }

--- a/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTimeline.tsx
@@ -1,7 +1,6 @@
 import type { JSX } from "react";
 import type { StageSummary } from "@jobctrl/contracts";
 
-import { StatusDot } from "../../../shared/ui/status-dot.js";
 import { TailorJobButton } from "../../materials/components/RetailorCurrentPolicyButton.js";
 import { StageBadge } from "./StageBadge.js";
 
@@ -12,16 +11,15 @@ export interface StageTimelineProps {
 
 export function StageTimeline({ stages, jobId }: StageTimelineProps): JSX.Element {
   return (
-    <ol className="timeline">
+    <ol className="timeline editorial-timeline">
       {stages.map((stage) => {
         const diagnostics = stageDiagnostics(stage);
         return (
           <li key={stage.stage} className="timeline-row">
-            <span className="timeline-row-head">
-              <StatusDot state={stage.state} />
+            <div className="timeline-row-summary">
               <StageBadge stage={stage.stage} />
-            </span>
-            <StageBadge state={stage.state} />
+              <StageBadge state={stage.state} />
+            </div>
             {diagnostics.length ? (
               <dl className="timeline-diagnostics" aria-label={`${stage.stage} diagnostics`}>
                 {diagnostics.map(([label, value]) => (

--- a/apps/web/src/contexts/pipeline/components/UserFacingStageBadge.tsx
+++ b/apps/web/src/contexts/pipeline/components/UserFacingStageBadge.tsx
@@ -17,7 +17,7 @@ export function UserFacingStageBadge({ stage }: UserFacingStageBadgeProps): JSX.
   const visibleStage = userFacingStage(stage);
 
   return (
-    <span aria-label={visibleStage} className={`stage-pill ${stageTone(visibleStage)}`}>
+    <span aria-label={visibleStage} className={`stage-pill stage-label ${stageTone(visibleStage)}`}>
       {visibleStage}
     </span>
   );

--- a/apps/web/src/contexts/pipeline/components/every-stage-state-has-badge.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/every-stage-state-has-badge.test.tsx
@@ -37,7 +37,7 @@ describe("stage-state parity (the second-most important test in the app)", () =>
       const { container } = render(<StageBadge state={state} />);
       const span = container.querySelector("span");
       expect(span, `expected a <span> in <StageBadge state="${state}">`).toBeTruthy();
-      expect(span?.className).toMatch(/tag /);
+      expect(span?.className).toMatch(/editorial-status/);
       expect(span?.className).toMatch(TONE_PATTERN);
       expect(screen.getByText(state)).toBeInTheDocument();
     });

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.test.tsx
@@ -48,6 +48,29 @@ describe("<CredentialsPanel>", () => {
     expect(trigger).toHaveTextContent(/Ownership:/i);
   });
 
+  it("keeps every provider authentication route and description visible as semantic radios", async () => {
+    renderPanel();
+
+    const claude = await providerCard("Claude");
+    const google = await providerCard("Google");
+    const claudeModes = within(claude).getByRole("group", {
+      name: "Choose how Claude authenticates",
+    });
+    const googleModes = within(google).getByRole("group", {
+      name: "Choose how Google authenticates",
+    });
+
+    expect(within(claudeModes).getByRole("radio", { name: "Anthropic API key" })).toBeChecked();
+    expect(within(claudeModes).getByRole("radio", { name: "Google Cloud Agent Platform" })).toBeInTheDocument();
+    expect(within(claudeModes).getByRole("radio", { name: "Amazon Bedrock" })).toBeInTheDocument();
+    expect(within(claudeModes).getByRole("radio", { name: "Claude Platform on AWS" })).toBeInTheDocument();
+    expect(within(claudeModes).getByRole("radio", { name: "Microsoft Foundry" })).toBeInTheDocument();
+    expect(within(claudeModes).getByText("Claude through Azure default credentials.")).toBeVisible();
+    expect(within(googleModes).getByRole("radio", { name: "Gemini API key" })).toBeChecked();
+    expect(within(googleModes).getByRole("radio", { name: "Vertex AI" })).toBeInTheDocument();
+    expect(within(googleModes).getByText("Gemini through Google Application Default Credentials.")).toBeVisible();
+  });
+
   it("exposes provider privacy boundaries through the final disclosure ledger", async () => {
     const user = userEvent.setup();
     renderPanel();
@@ -76,7 +99,7 @@ describe("<CredentialsPanel>", () => {
     renderPanel();
     const card = await providerCard("Claude");
 
-    await selectProviderMode(user, card, "Choose how Claude authenticates", choice);
+    await selectProviderMode(user, card, choice);
 
     expect(within(card).getByLabelText(expectedField)).toBeInTheDocument();
   });
@@ -89,7 +112,7 @@ describe("<CredentialsPanel>", () => {
     renderPanel();
     const card = await providerCard("Google");
 
-    await selectProviderMode(user, card, "Choose how Google authenticates", choice);
+    await selectProviderMode(user, card, choice);
 
     expect(within(card).getByLabelText(expectedField)).toBeInTheDocument();
   });
@@ -115,12 +138,10 @@ describe("<CredentialsPanel>", () => {
 
     const claude = await providerCard("Claude");
     const google = await providerCard("Google");
-    await waitFor(() => expect(
-      within(claude).getByRole("combobox", { name: /Choose how Claude authenticates/i }),
-    ).toHaveTextContent("Amazon Bedrock"));
-    expect(
-      within(google).getByRole("combobox", { name: /Choose how Google authenticates/i }),
-    ).toHaveTextContent("Vertex AI");
+    await waitFor(() =>
+      expect(within(claude).getByRole("radio", { name: "Amazon Bedrock" })).toBeChecked(),
+    );
+    expect(within(google).getByRole("radio", { name: "Vertex AI" })).toBeChecked();
     expect(screen.queryByDisplayValue(/secret/i)).not.toBeInTheDocument();
   });
 
@@ -153,12 +174,10 @@ describe("<CredentialsPanel>", () => {
     const google = await providerCard("Google");
     await waitFor(() =>
       expect(
-        within(claude).getByRole("combobox", { name: /Choose how Claude authenticates/i }),
-      ).toHaveTextContent("Google Cloud Agent Platform"),
+        within(claude).getByRole("radio", { name: "Google Cloud Agent Platform" }),
+      ).toBeChecked(),
     );
-    expect(
-      within(google).getByRole("combobox", { name: /Choose how Google authenticates/i }),
-    ).toHaveTextContent("Vertex AI");
+    expect(within(google).getByRole("radio", { name: "Vertex AI" })).toBeChecked();
     expect(within(claude).getAllByText("Configured · restart or verify").length).toBeGreaterThan(0);
     expect(within(google).getAllByText("Configured · restart or verify").length).toBeGreaterThan(0);
     expect(within(claude).queryByText("Ready")).not.toBeInTheDocument();
@@ -266,9 +285,7 @@ describe("<CredentialsPanel>", () => {
     expect(within(card).getByText(/effective mode is owned by the launch environment/i)).toBeInTheDocument();
     expect(within(card).getByRole("button", { name: "Save Google setup" })).toBeDisabled();
     expect(within(card).queryByRole("button", { name: "Remove Google setup" })).not.toBeInTheDocument();
-    expect(
-      within(card).getByRole("combobox", { name: /Choose how Google authenticates/i }),
-    ).toBeDisabled();
+    expect(within(card).getByRole("radio", { name: "Vertex AI" })).toBeDisabled();
     expect(updateCredentialsBatch).not.toHaveBeenCalled();
     expect(card).not.toHaveTextContent(/provider settings removed/i);
   });
@@ -352,22 +369,18 @@ describe("<CredentialsPanel>", () => {
     expect(await screen.findByText(/Non-secret provider settings remain editable in config\.json/i)).toBeInTheDocument();
     const claude = await providerCard("Claude");
     const google = await providerCard("Google");
-    const claudeMode = within(claude).getByRole("combobox", {
-      name: /Choose how Claude authenticates/i,
-    });
-    await user.click(claudeMode);
-    expect(screen.getByRole("option", { name: /Anthropic API key/i })).toHaveAttribute("data-disabled");
-    await user.keyboard("{Escape}");
-    const googleMode = within(google).getByRole("combobox", {
-      name: /Choose how Google authenticates/i,
-    });
-    await user.click(googleMode);
-    expect(screen.getByRole("option", { name: /Gemini API key/i })).toHaveAttribute("data-disabled");
-    expect(screen.getByRole("option", { name: /Vertex AI/i })).not.toHaveAttribute("data-disabled");
-    await user.click(screen.getByRole("option", { name: /Vertex AI/i }));
+    const claudeApiKey = within(claude).getByRole("radio", { name: "Anthropic API key" });
+    const claudeVertex = within(claude).getByRole("radio", { name: "Google Cloud Agent Platform" });
+    const googleApiKey = within(google).getByRole("radio", { name: "Gemini API key" });
+    const googleVertex = within(google).getByRole("radio", { name: "Vertex AI" });
+    expect(claudeApiKey).toBeDisabled();
+    expect(claudeVertex).toBeEnabled();
+    expect(googleApiKey).toBeDisabled();
+    expect(googleVertex).toBeEnabled();
+    await user.click(googleVertex);
     expect(within(claude).queryByLabelText(/Anthropic API key \(required\)/i)).not.toBeInTheDocument();
     expect(within(google).queryByLabelText(/Gemini API key \(required\)/i)).not.toBeInTheDocument();
-    expect(claudeMode).toHaveTextContent("Google Cloud Agent Platform");
+    expect(claudeVertex).toBeChecked();
 
     await user.type(within(google).getByLabelText(/Google Cloud project ID/i), "jobctrl-test-project");
     await user.click(within(google).getByRole("button", { name: "Save Google setup" }));
@@ -423,7 +436,7 @@ describe("<CredentialsPanel>", () => {
     const privacy = within(screen.getByRole("region", { name: "Credential privacy" }));
     expect(screen.getByText(/guided Claude and Google editing/i)).toBeInTheDocument();
     expect(screen.getByText(/Codex verification remains available/i)).toBeInTheDocument();
-    expect(privacy.getByText("Keychain status unavailable")).toBeInTheDocument();
+    expect(privacy.getAllByText("Keychain status unavailable").length).toBeGreaterThan(0);
   });
 
   it("labels isolated auth accurately when the managed SDK is unavailable", async () => {
@@ -530,13 +543,9 @@ async function providerCard(name: string): Promise<HTMLElement> {
 async function selectProviderMode(
   user: ReturnType<typeof userEvent.setup>,
   card: HTMLElement,
-  selectLabel: string,
   optionLabel: string,
 ) {
-  await user.click(within(card).getByRole("combobox", {
-    name: new RegExp(escapeRegExp(selectLabel), "i"),
-  }));
-  await user.click(screen.getByRole("option", {
+  await user.click(within(card).getByRole("radio", {
     name: new RegExp(`^${escapeRegExp(optionLabel)}$`, "i"),
   }));
 }

--- a/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/CredentialsPanel.tsx
@@ -14,6 +14,10 @@ import {
   InspectorLedgerItem,
 } from "../../../shared/ui/inspector-ledger.js";
 import {
+  StatusLabel,
+  type StatusLabelTone,
+} from "../../../shared/ui/status-label.js";
+import {
   ClaudeProviderForm,
   GoogleProviderForm,
 } from "../forms/provider-setup-forms.js";
@@ -144,7 +148,14 @@ export function CredentialsPanel() {
         {store && capSolver ? (
           <DisclosureSection
             className="provider-disclosure provider-disclosure--capsolver"
-            collapsedSummary={`${credentialStatusLabel(capSolver)} · Optional · restart required`}
+            collapsedSummary={(
+              <span className="provider-disclosure__summary">
+                <StatusLabel tone={credentialStatusTone(capSolver)}>
+                  {credentialStatusLabel(capSolver)}
+                </StatusLabel>
+                <span>Optional · restart required</span>
+              </span>
+            )}
             defaultOpen={false}
             description="A CapSolver key only enables JobCtrl's owned solver tool during a user-started Apply. Unsupported or unconfigured CAPTCHA always fails closed."
             title="Apply CAPTCHA solver"
@@ -238,7 +249,7 @@ function ProviderDisclosure({
       className="provider-disclosure"
       collapsedSummary={(
         <span className="provider-disclosure__summary">
-          <span>{statusLabel}</span>
+          <StatusLabel tone={providerStatusTone(status)}>{statusLabel}</StatusLabel>
           <span>Ownership: {ownership}</span>
         </span>
       )}
@@ -248,7 +259,10 @@ function ProviderDisclosure({
       title={title}
     >
       <InspectorLedger className="provider-status-ledger">
-        <InspectorLedgerItem label="Status" value={statusLabel} />
+        <InspectorLedgerItem
+          label="Status"
+          value={<StatusLabel tone={providerStatusTone(status)}>{statusLabel}</StatusLabel>}
+        />
         <InspectorLedgerItem label="Effective ownership" value={ownership} />
         {status?.mode ? (
           <InspectorLedgerItem label="Detected mode" value={status.mode} />
@@ -379,7 +393,7 @@ function ReadOnlyProviderGuidance({
           className="provider-disclosure provider-disclosure--readonly"
           collapsedSummary={(
             <span className="provider-disclosure__summary">
-              <span>Read only</span>
+              <StatusLabel tone="muted">Read only</StatusLabel>
               <span>Ownership: external provider environment</span>
             </span>
           )}
@@ -504,6 +518,22 @@ function credentialStatusLabel(
   if (credential.effectiveSource === "environment") return "Environment-managed";
   if (credential.effectiveSource === "inspection_unknown") return "Status unavailable";
   return credential.configured ? "Configured" : "Not configured";
+}
+
+function credentialStatusTone(
+  credential: CredentialsResponse["credentials"][number],
+): StatusLabelTone {
+  if (credential.effectiveSource === "inspection_unknown") return "warn";
+  if (credential.effectiveSource === "environment" || credential.configured) return "ok";
+  return "muted";
+}
+
+function providerStatusTone(
+  status: ProviderStatusItem | undefined,
+): StatusLabelTone {
+  if (status?.ready) return "ok";
+  if (status?.configured) return "warn";
+  return "muted";
 }
 
 function findStatus(

--- a/apps/web/src/contexts/profile/components/ModelSelectionPanel.tsx
+++ b/apps/web/src/contexts/profile/components/ModelSelectionPanel.tsx
@@ -12,6 +12,10 @@ import { AdaptiveFieldGrid } from "../../../shared/ui/adaptive-field-grid.js";
 import { Button } from "../../../shared/ui/button.js";
 import { DisclosureSection } from "../../../shared/ui/disclosure-section.js";
 import { SelectField } from "../../../shared/ui/select-field.js";
+import {
+  StatusLabel,
+  type StatusLabelTone,
+} from "../../../shared/ui/status-label.js";
 import { useProviderModelsQuery } from "../hooks/useProviderModelsQuery.js";
 import { useSettingsQuery } from "../hooks/useSettingsQuery.js";
 import { useUpdateSettingsMutation } from "../hooks/useUpdateSettingsMutation.js";
@@ -177,6 +181,15 @@ function ProviderModelPreference({
         : catalog?.configured
           ? "Needs attention"
           : "Configure first";
+  const statusTone: StatusLabelTone = isDemo
+    ? "neutral"
+    : catalogPending
+      ? "info"
+      : catalog?.ready && models.length > 0
+        ? "ok"
+        : catalog?.ready || catalog?.configured
+          ? "warn"
+          : "muted";
   const savedChoiceLabel = settingsReady
     ? savedModel || "Provider default"
     : settingsPending
@@ -229,11 +242,16 @@ function ProviderModelPreference({
         className="provider-preference-disclosure"
         title={providerCopy.title}
         description={providerCopy.description}
-        collapsedSummary={`Status: ${statusLabel} · Saved: ${savedChoiceLabel}`}
+        collapsedSummary={(
+          <span className="provider-disclosure__summary">
+            <StatusLabel tone={statusTone}>Status: {statusLabel}</StatusLabel>
+            <span>Saved: {savedChoiceLabel}</span>
+          </span>
+        )}
       >
         <div className="provider-preference-content grid gap-4">
           <div className="provider-preference-status grid gap-1 text-[12px] leading-5 text-muted-foreground">
-            <p className="m-0">Status: {statusLabel}</p>
+            <StatusLabel tone={statusTone}>Status: {statusLabel}</StatusLabel>
             <p className="m-0">Saved choice: {savedChoiceLabel}</p>
             <p className="m-0">Live availability from the authenticated provider runtime.</p>
             {catalog?.message ? <p className="m-0">{catalog.message}</p> : null}

--- a/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
@@ -44,8 +44,7 @@ describe("<ProfileEditor>", () => {
       withRouter: true,
     });
 
-    expect(await screen.findByRole("heading", { name: "Resume data" })).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Resume preview" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Baseline resume" })).toBeInTheDocument();
     expect(await screen.findByText("Baseline resume editor")).toBeInTheDocument();
     expect(await screen.findByText("Plate HTML/CSS editor")).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Bold" })).toBeInTheDocument();

--- a/apps/web/src/contexts/profile/components/ProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.tsx
@@ -10,7 +10,7 @@ import { useProfileQuery } from "../hooks/useProfileQuery.js";
 import { ResumeTemplatePanel } from "./ResumeTemplatePanel.js";
 
 const SPLIT_STORAGE_KEY = "profile-preview-split-width";
-const DEFAULT_EDITOR_WIDTH = 62;
+const DEFAULT_EDITOR_WIDTH = 48;
 const MIN_EDITOR_WIDTH = 38;
 const MAX_EDITOR_WIDTH = 76;
 
@@ -73,15 +73,6 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
     >
       <section className="profile-editor-panel">
         {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-        {section === "profile" ? (
-          <header className="profile-editor-panel__header">
-            <div>
-              <span className="eyebrow">Canonical source</span>
-              <h2>Resume data</h2>
-              <p>Maintain the evidence-backed baseline used for every tailored resume.</p>
-            </div>
-          </header>
-        ) : null}
         {profileQuery.data ? (
           section === "preferences" ? (
             <>
@@ -119,8 +110,8 @@ export function ProfileEditor({ section = "profile" }: ProfileEditorProps) {
           <aside className="profile-preview-pane">
             <PreviewWorkbench
               className="profile-preview-workbench"
-              title="Resume preview"
-              description="The live baseline generated from the profile data."
+              title="Baseline resume"
+              description="Current local HTML"
               previewLabel="Baseline resume preview"
             >
               <ResumeStandalonePlateEditor

--- a/apps/web/src/contexts/profile/components/ResumeImportWizard.stories.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeImportWizard.stories.tsx
@@ -56,6 +56,10 @@ export const StepUpload: Story = {
   render: () => <WizardHost initialPath="/profile/import/upload" />,
 };
 
+export const Start: Story = {
+  render: () => <WizardHost initialPath="/profile/import" />,
+};
+
 export const StepPreview: Story = {
   render: () => <WizardHost initialPath="/profile/import/preview" />,
 };

--- a/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
@@ -73,7 +73,7 @@ export function ResumeImportWizard() {
                           String(index + 1).padStart(2, "0")
                         )}
                       </span>
-                      <span>{step.label}</span>
+                      <span className="resume-import-wizard__step-label">{step.label}</span>
                     </Link>
                   </TabsTrigger>
                 );

--- a/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
@@ -1,5 +1,11 @@
+import {
+  IconArrowLeft,
+  IconCheck,
+  IconFileTypePdf,
+} from "@tabler/icons-react";
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 
+import { Button } from "../../../shared/ui/button.js";
 import { Card } from "../../../shared/ui/card.js";
 import { PageHead } from "../../../shared/ui/page-head.js";
 import { SectionTabs, SectionTabsList } from "../../../shared/ui/section-tabs.js";
@@ -10,40 +16,64 @@ const STEPS: ReadonlyArray<{
   readonly label: string;
   readonly to: "/profile/import/upload" | "/profile/import/preview" | "/profile/import/confirm";
 }> = [
-  { key: "upload", label: "1 · Upload PDF", to: "/profile/import/upload" },
-  { key: "preview", label: "2 · Preview options", to: "/profile/import/preview" },
-  { key: "confirm", label: "3 · Confirm import", to: "/profile/import/confirm" },
+  { key: "upload", label: "Upload PDF", to: "/profile/import/upload" },
+  { key: "preview", label: "Preview options", to: "/profile/import/preview" },
+  { key: "confirm", label: "Confirm import", to: "/profile/import/confirm" },
 ];
 
 export function ResumeImportWizard() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const atStart = pathname === "/profile/import";
   const activeStep = STEPS.find((step) => step.to === pathname)?.to ?? "/profile/import/upload";
+  const activeStepIndex = Math.max(0, STEPS.findIndex((step) => step.to === activeStep));
 
   return (
-    <div className="route-page resume-import-wizard">
+    <div className="route-page route-page--profile-import resume-import-wizard">
       <PageHead
-        eyebrow="Profile"
-        title="Resume import"
-        subtitle="Upload a PDF, choose the sections to import, then confirm."
+        eyebrow="Profile import"
+        title="Import resume"
+        subtitle={(
+          <>
+            <span>Read a local PDF, choose what to import, then confirm the change.</span>
+            <small>The source file never leaves this device.</small>
+          </>
+        )}
+        actions={(
+          <Button asChild size="sm" variant="ghost">
+            <Link to="/profile">
+              <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+              Back to profile
+            </Link>
+          </Button>
+        )}
       />
       <Card className="resume-import-wizard__card overflow-hidden shadow-none">
         <SectionTabs className="resume-import-wizard__tabs" value={activeStep}>
-          <nav className="resume-import-wizard__steps px-4 pt-2" aria-label="Wizard steps">
+          <nav className="resume-import-wizard__steps" aria-label="Wizard steps">
             <SectionTabsList>
-              {STEPS.map((step) => {
+              {STEPS.map((step, index) => {
                 const active = activeStep === step.to;
+                const complete = index < activeStepIndex;
                 return (
                   <TabsTrigger
                     key={step.key}
                     value={step.to}
-                    className="data-[state=active]:border-foreground"
+                    className="resume-import-wizard__step"
+                    data-step-state={active ? "active" : complete ? "complete" : "upcoming"}
                     asChild
                   >
                     <Link
                       to={step.to}
                       aria-current={active ? "step" : undefined}
                     >
-                      {step.label}
+                      <span className="resume-import-wizard__step-number" aria-hidden="true">
+                        {complete ? (
+                          <IconCheck size={15} stroke={2} />
+                        ) : (
+                          String(index + 1).padStart(2, "0")
+                        )}
+                      </span>
+                      <span>{step.label}</span>
                     </Link>
                   </TabsTrigger>
                 );
@@ -51,14 +81,32 @@ export function ResumeImportWizard() {
             </SectionTabsList>
           </nav>
           <TabsContent
-            className="resume-import-wizard__content m-0 p-4"
+            className="resume-import-wizard__content m-0 p-0"
             value={activeStep}
             forceMount
           >
-            <Outlet />
+            {atStart ? <ResumeImportStart /> : <Outlet />}
           </TabsContent>
         </SectionTabs>
       </Card>
     </div>
+  );
+}
+
+function ResumeImportStart() {
+  return (
+    <section className="resume-import-start" aria-labelledby="resume-import-start-title">
+      <IconFileTypePdf aria-hidden="true" size={28} stroke={1.6} />
+      <div className="resume-import-start__copy">
+        <h2 id="resume-import-start-title">Start with the source file</h2>
+        <p>
+          Choose a local PDF. JobCtrl separates canonical profile evidence from presentation
+          style, and nothing is imported until the final confirmation.
+        </p>
+      </div>
+      <Button asChild>
+        <Link to="/profile/import/upload">Choose PDF</Link>
+      </Button>
+    </section>
   );
 }

--- a/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
@@ -21,6 +21,7 @@ import { Input } from "../../../shared/ui/input.js";
 import { PreviewWorkbench } from "../../../shared/ui/preview-workbench.js";
 import { SegmentedField } from "../../../shared/ui/segmented-field.js";
 import { SelectField } from "../../../shared/ui/select-field.js";
+import { StatusLabel } from "../../../shared/ui/status-label.js";
 import {
   useSaveResumeTemplateMutation,
   useSetDefaultResumeTemplateMutation,
@@ -225,7 +226,9 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
       title="Resume templates"
       status={
         selectedTemplateIsDefault ? (
-          <span className="resume-template-default-state">Default template</span>
+          <StatusLabel className="resume-template-default-state" tone="ok">
+            Default template
+          </StatusLabel>
         ) : undefined
       }
       primaryControls={

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
@@ -175,6 +175,18 @@ describe("<StructuredProfileEditor>", () => {
     expect(screen.getByRole("heading", { name: "Application configurations", level: 2 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Tailoring controls", level: 2 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Resume style", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Application configurations/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.getByRole("button", { name: /^Tailoring controls/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /^Resume style/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
 
     const tabs = screen.getByRole("tablist", { name: "Tailoring control sections" });
     expect(tabs).toBeInTheDocument();
@@ -244,15 +256,16 @@ describe("<StructuredProfileEditor>", () => {
     render(<StatefulEditor onLatestProfile={(value) => { latestProfile = value; }} />);
 
     expect(screen.getByRole("heading", { name: "Experience entries" })).toBeInTheDocument();
-    expect(screen.getAllByText("must appear in final resume").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /^Experience entries/ }));
+    expect(screen.getAllByText(/must appear in final resume/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText("Required").length).toBeGreaterThan(0);
 
-    fireEvent.click(screen.getByRole("checkbox", { name: "must appear in final resume" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /must appear in final resume/i }));
     expect(
       JSON.parse(latestProfile).resume.tailoring_rules.required_experience_entry_ids,
     ).toEqual(["exp-1"]);
 
-    fireEvent.click(screen.getByRole("button", { name: "add bullet" }));
+    fireEvent.click(screen.getByRole("button", { name: /add bullet/i }));
     expect(screen.getByLabelText("Bullet 3")).toBeInTheDocument();
     expect(JSON.parse(latestProfile).resume.experience_entries[0].bullets).toHaveLength(3);
 
@@ -297,7 +310,7 @@ describe("<StructuredProfileEditor>", () => {
 
     expect(personalTrigger).toHaveAttribute("aria-expanded", "true");
     expect(baselineTrigger).toHaveAttribute("aria-expanded", "true");
-    expect(experienceTrigger).toHaveAttribute("aria-expanded", "true");
+    expect(experienceTrigger).toHaveAttribute("aria-expanded", "false");
     expect(educationTrigger).toHaveAttribute("aria-expanded", "false");
     expect(skillsTrigger).toHaveAttribute("aria-expanded", "false");
     expect(eeoTrigger).toHaveAttribute("aria-expanded", "false");

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1158,7 +1158,7 @@ export function StructuredProfileEditor({
             collapsedSummary={`${experienceEntries.length} ${
               experienceEntries.length === 1 ? "entry" : "entries"
             }`}
-            defaultOpen
+            defaultOpen={false}
           >
             <div className="profile-repeat-editor profile-repeat-editor--experience">
               {experienceEntries.map((entry, index) => {
@@ -1514,6 +1514,7 @@ export function StructuredProfileEditor({
             title="Application configurations"
             description="Work authorization, availability, and compensation defaults"
             collapsedSummary="Authorization · availability · compensation"
+            defaultOpen={false}
           >
             <AdaptiveFieldGrid
               className="preferences-field-grid preferences-field-grid--application"
@@ -1557,6 +1558,7 @@ export function StructuredProfileEditor({
             title="Tailoring controls"
             description="Control what JobCtrl may change and how generated resumes are evaluated"
             collapsedSummary="Content rules · writing style · quality gates"
+            defaultOpen
             helpHref={TAILORING_INPUTS_DOCS_URL}
             helpLabel="Tailoring inputs"
           >
@@ -1583,6 +1585,7 @@ export function StructuredProfileEditor({
             title="Resume style"
             description="Profile-level typography, template, and page defaults"
             collapsedSummary="Typography · template · page layout"
+            defaultOpen={false}
           >
             <AdaptiveFieldGrid
               className="preferences-field-grid preferences-field-grid--resume-style"

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1015,8 +1015,7 @@ export function StructuredProfileEditor({
   );
 
   const targetSearchSection = () => (
-    <section className="form-section">
-      <h3>Target search</h3>
+    <section className="form-section" aria-label="Target search fields">
       <div className="target-preferences-grid">
         {targetSearchCheckboxGroup("experience.target_track", "Target tracks", TARGET_TRACK_GROUPS)}
         {targetSearchCheckboxGroup(

--- a/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
@@ -9,9 +9,9 @@ export function TargetSearchSettingsPanel() {
   return (
     <DisclosureSection
       className="target-search-settings"
-      title="Discovery settings"
+      title="Target search"
       description="Roles, locations, work models, and target search defaults"
-      collapsedSummary="Target search profile"
+      collapsedSummary="Roles, locations, seniority, and work models"
     >
       {profileQuery.error ? <div className="banner inline">{profileQuery.error.message}</div> : null}
       {profileQuery.data ? (

--- a/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
@@ -80,19 +80,28 @@ export function ImportConfirmForm() {
     >
       {errorMessage ? <div className="banner inline" role="alert">{errorMessage}</div> : null}
       {statusMessage ? <div className="status-line" role="status">{statusMessage}</div> : null}
-      <div
-        className="resume-import-confirmation flex items-center gap-3 border-y border-border py-3"
-      >
+      <section className="resume-import-confirmation" aria-label="Import summary">
         <IconFileTypePdf
-          className="shrink-0 text-muted-foreground"
+          className="resume-import-confirmation__icon"
           aria-hidden="true"
           size={24}
           stroke={1.7}
         />
-        <p className="m-0 min-w-0 break-words text-[12px] leading-relaxed">
-          Importing <b className="break-all">{filename}</b> with {summary}.
-        </p>
-      </div>
+        <div className="resume-import-confirmation__file">
+          <span>Source PDF</span>
+          <strong className="break-all">{filename}</strong>
+        </div>
+        <dl className="resume-import-confirmation__ledger">
+          <div>
+            <dt>Import scope</dt>
+            <dd>{summary}</dd>
+          </div>
+          <div>
+            <dt>Current state</dt>
+            <dd>Nothing has changed yet</dd>
+          </div>
+        </dl>
+      </section>
       <form.Subscribe selector={(state) => state.errors}>
         {(errors) => {
           const message = errors
@@ -106,7 +115,7 @@ export function ImportConfirmForm() {
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions resume-import-actions justify-end">
+          <div className="form-actions resume-import-actions">
             <Button asChild variant="outline">
               <Link to="/profile/import/preview">Back</Link>
             </Button>

--- a/apps/web/src/contexts/profile/forms/import-preview-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-preview-form.tsx
@@ -94,6 +94,7 @@ export function ImportPreviewForm() {
             <ChoiceControl
               name="importProfile"
               label="Profile data"
+              description="Personal details, experience, education, skills, and profile evidence."
               checked={field.state.value}
               onBlur={field.handleBlur}
               onCheckedChange={(checked) => field.handleChange(checked === true)}
@@ -105,6 +106,7 @@ export function ImportPreviewForm() {
             <ChoiceControl
               name="importStyle"
               label="Style data"
+              description="Type scale, spacing, section order, and emphasis from the source resume."
               checked={field.state.value}
               onBlur={field.handleBlur}
               onCheckedChange={(checked) => field.handleChange(checked === true)}
@@ -125,7 +127,7 @@ export function ImportPreviewForm() {
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions resume-import-actions justify-end">
+          <div className="form-actions resume-import-actions">
             <Button asChild variant="outline">
               <Link to="/profile/import/upload">Back</Link>
             </Button>

--- a/apps/web/src/contexts/profile/forms/import-upload-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-upload-form.tsx
@@ -84,6 +84,11 @@ export function ImportUploadForm() {
             <span className="min-w-0">
               <b>Resume PDF</b>
               <small className="break-all">{field.state.value || "No file selected"}</small>
+              <small>
+                {field.state.value
+                  ? "Selected file will be read locally."
+                  : "PDF only · processed on this device"}
+              </small>
             </span>
             <Input
               className="resume-import-upload__input"
@@ -113,7 +118,7 @@ export function ImportUploadForm() {
         })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions resume-import-actions justify-end">
+          <div className="form-actions resume-import-actions">
             <Button asChild variant="outline">
               <Link to="/profile">Cancel</Link>
             </Button>

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -61,6 +61,7 @@ describe("<ProfileForm>", () => {
       withRouter: true,
     });
 
+    await user.click(await screen.findByRole("button", { name: /^Experience entries/ }));
     await user.click(await screen.findByRole("button", { name: /add bullet/i }));
 
     expect(screen.getByLabelText("Bullet 3")).toBeInTheDocument();
@@ -72,6 +73,7 @@ describe("<ProfileForm>", () => {
       withRouter: true,
     });
 
+    await user.click(await screen.findByRole("button", { name: /^Experience entries/ }));
     await user.click(await screen.findByLabelText("Present"));
 
     expect(screen.queryByLabelText("End month")).not.toBeInTheDocument();
@@ -86,6 +88,7 @@ describe("<ProfileForm>", () => {
       withRouter: true,
     });
 
+    await user.click(await screen.findByRole("button", { name: /^Experience entries/ }));
     await user.selectOptions(await screen.findByLabelText("End year"), "2021");
     await user.click(screen.getByRole("button", { name: /^save all$/i }));
 
@@ -124,7 +127,7 @@ describe("<ProfileForm>", () => {
   it("renders target search as a discovery settings section", async () => {
     renderWithProviders(<ProfileForm initial={sampleProfileResponse} section="target-search" />);
 
-    expect(screen.getByRole("heading", { name: "Target search" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Target search fields" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Target tracks" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Individual Contributor" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Management" })).toBeInTheDocument();

--- a/apps/web/src/contexts/profile/forms/profile-form.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.tsx
@@ -4,7 +4,6 @@ import {
   type ProfileUpdateRequest,
 } from "@jobctrl/contracts";
 import { useForm } from "@tanstack/react-form";
-import { Link } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 
 import type { ProfileConfigResponse } from "../../operations/types.js";
@@ -98,7 +97,6 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
   const [statusMessage, setStatusMessage] = useState("");
   const [resetToken, setResetToken] = useState(0);
   const formRef = useRef<HTMLFormElement>(null);
-  const isProfileSection = section === "profile";
   const saveLabel = section === "target-search" ? "Save discovery settings" : "Save all";
   const discardLabel = section === "target-search" ? "Discard changes" : "Discard all";
   const savedMessage =
@@ -177,11 +175,6 @@ export function ProfileForm({ initial, section = "profile" }: ProfileFormProps) 
       <form.Subscribe selector={(state) => ({ isDirty: state.isDirty, isSubmitting: state.isSubmitting })}>
         {({ isDirty, isSubmitting }) => (
           <div className="editor-bulk-actions">
-            {isProfileSection ? (
-              <Button asChild size="sm" variant="outline">
-                <Link to="/profile/import/upload">Import resume</Link>
-              </Button>
-            ) : null}
             <Button
               size="sm"
               type="submit"

--- a/apps/web/src/contexts/profile/forms/provider-setup-forms.tsx
+++ b/apps/web/src/contexts/profile/forms/provider-setup-forms.tsx
@@ -29,7 +29,6 @@ import {
   FieldLabel,
 } from "../../../shared/ui/field.js";
 import { Input } from "../../../shared/ui/input.js";
-import { SelectField } from "../../../shared/ui/select-field.js";
 import { useUpdateCredentialsBatchMutation } from "../hooks/useUpdateCredentialsBatchMutation.js";
 import {
   buildClaudeCredentialBatch,
@@ -589,32 +588,57 @@ function ProviderModeSelect<T extends string>({
   disabled?: boolean;
   disabledValues?: readonly T[];
 }) {
-  const selected = options.find((option) => option.value === value);
-  const description = [
-    selected?.description,
-    disabled ? "The active mode is owned by the launch environment and is read-only here." : null,
-    disabledValues.length > 0
-      ? "Direct API-key modes require a supported secure-storage adapter."
-      : null,
-  ].filter(Boolean).join(" ");
-
   return (
-    <SelectField
-      className="provider-mode-select"
-      description={description}
-      disabled={disabled}
-      id={name}
-      label={legend}
-      name={name}
-      options={options.map((option) => ({
-        disabled: disabledValues.includes(option.value),
-        label: option.label,
-        value: option.value,
-      }))}
-      required
-      value={value}
-      onValueChange={(nextValue) => onChange(nextValue as T)}
-    />
+    <fieldset className="provider-mode-choice-fieldset" disabled={disabled}>
+      <legend>{legend}</legend>
+      <div className="provider-mode-choice-list">
+        {options.map((option) => {
+          const optionId = `${name}-${option.value}`;
+          const optionDisabled = disabled || disabledValues.includes(option.value);
+          return (
+            <div
+              className="provider-mode-choice"
+              data-disabled={optionDisabled || undefined}
+              key={option.value}
+            >
+              <input
+                aria-describedby={`${optionId}-description`}
+                checked={value === option.value}
+                disabled={optionDisabled}
+                id={optionId}
+                name={name}
+                type="radio"
+                value={option.value}
+                onChange={(event) => {
+                  if (event.target.checked) onChange(option.value);
+                }}
+              />
+              <span className="provider-mode-choice__copy">
+                <label className="provider-mode-choice__label" htmlFor={optionId}>
+                  {option.label}
+                </label>
+                <span
+                  className="provider-mode-choice__description"
+                  id={`${optionId}-description`}
+                >
+                  {option.description}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {disabled ? (
+        <p className="provider-mode-choice-fieldset__notice">
+          The active mode is owned by the launch environment and is read-only here.
+        </p>
+      ) : null}
+      {disabledValues.length > 0 ? (
+        <p className="provider-mode-choice-fieldset__notice">
+          Direct API-key modes require a supported secure-storage adapter.
+        </p>
+      ) : null}
+    </fieldset>
   );
 }
 

--- a/apps/web/src/contexts/scoring/components/ScoreBadge.test.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBadge.test.tsx
@@ -36,22 +36,20 @@ describe("<ScoreBadge>", () => {
     expect(badge).toHaveTextContent("7");
   });
 
-  it("maps 10 to green, 5 to neutral gray, and 0 to red", () => {
+  it("maps 10, 5, and 0 to semantic text tones without status-card styles", () => {
     const { container, rerender } = render(<ScoreBadge score={10} />);
     const badge = () => container.querySelector("span");
 
     expect(badge()).toHaveAttribute("data-score-tone", "positive");
-    expect(badge()?.style.getPropertyValue("--fit-score-bg")).toContain("var(--success) 52%");
-    expect(badge()?.style.getPropertyValue("--fit-score-border")).toContain("var(--success) 66%");
+    expect(badge()).toHaveAttribute("aria-label", "Fit score 10 out of 10");
+    expect(badge()).not.toHaveAttribute("style");
 
     rerender(<ScoreBadge score={5} />);
     expect(badge()).toHaveAttribute("data-score-tone", "neutral");
-    expect(badge()?.style.getPropertyValue("--fit-score-bg")).toBe("var(--muted)");
-    expect(badge()?.style.getPropertyValue("--fit-score-fg")).toBe("var(--muted-foreground)");
+    expect(badge()).not.toHaveAttribute("style");
 
     rerender(<ScoreBadge score={0} />);
     expect(badge()).toHaveAttribute("data-score-tone", "negative");
-    expect(badge()?.style.getPropertyValue("--fit-score-bg")).toContain("var(--destructive) 52%");
-    expect(badge()?.style.getPropertyValue("--fit-score-border")).toContain("var(--destructive) 66%");
+    expect(badge()).not.toHaveAttribute("style");
   });
 });

--- a/apps/web/src/contexts/scoring/components/ScoreBadge.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBadge.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, JSX } from "react";
+import type { JSX } from "react";
 
 import { scoreTier } from "../lib/score-tier.js";
 
@@ -7,13 +7,6 @@ export interface ScoreBadgeProps {
 }
 
 type ScoreTone = "negative" | "neutral" | "positive" | "unknown";
-type ScoreBadgeStyle = CSSProperties & {
-  "--fit-score-bg"?: string;
-  "--fit-score-border"?: string;
-  "--fit-score-fg"?: string;
-  "--fit-score-shadow"?: string;
-};
-
 function clampScore(score: number): number {
   return Math.min(10, Math.max(0, score));
 }
@@ -26,37 +19,12 @@ function scoreTone(score: number | null): ScoreTone {
   return "neutral";
 }
 
-function scoreBadgeStyle(score: number | null): ScoreBadgeStyle | undefined {
-  if (score === null) return undefined;
-  const clamped = clampScore(score);
-  if (clamped === 5) {
-    return {
-      "--fit-score-bg": "var(--muted)",
-      "--fit-score-border": "var(--border)",
-      "--fit-score-fg": "var(--muted-foreground)",
-      "--fit-score-shadow": "none",
-    };
-  }
-
-  const token = clamped > 5 ? "var(--success)" : "var(--destructive)";
-  const distance = Math.abs(clamped - 5) / 5;
-  const fill = Math.round(12 + distance * 40);
-  const border = Math.round(24 + distance * 42);
-
-  return {
-    "--fit-score-bg": `color-mix(in oklab, ${token} ${fill}%, var(--card))`,
-    "--fit-score-border": `color-mix(in oklab, ${token} ${border}%, var(--border))`,
-    "--fit-score-fg": "var(--foreground)",
-    "--fit-score-shadow": `inset 0 0 0 1px color-mix(in oklab, ${token} ${Math.min(border, 64)}%, transparent)`,
-  };
-}
-
 export function ScoreBadge({ score }: ScoreBadgeProps): JSX.Element {
   return (
     <span
       className={`fit ${scoreTier(score)}`}
       data-score-tone={scoreTone(score)}
-      style={scoreBadgeStyle(score)}
+      aria-label={score === null ? "Fit score unavailable" : `Fit score ${score} out of 10`}
     >
       {score ?? "-"}
     </span>

--- a/apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreBreakdown.tsx
@@ -85,13 +85,13 @@ export function ScoreBreakdown({
         </div>
       </div>
       {scoreKeywords.length ? (
-        <div className="keyword-list" aria-label="Matched keywords">
+        <ul className="audit-value-list keyword-list" aria-label="Matched keywords">
           {scoreKeywords.map((keyword) => (
-            <span className="tag info" key={keyword}>
+            <li className="audit-value audit-value--info" key={keyword}>
               {keyword}
-            </span>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : null}
       <SignalList label="Matched signals" values={scoreBreakdown.matchedSignals} />
       <SignalList label="Missing signals" values={scoreBreakdown.missingSignals} />
@@ -140,12 +140,15 @@ function SignalList({
 }) {
   if (!values?.length) return null;
   return (
-    <div className="keyword-list" aria-label={label}>
-      {values.map((value) => (
-        <span className={`tag ${tone}`} key={value}>
-          {value}
-        </span>
-      ))}
+    <div className="score-signal-row">
+      <span>{label}</span>
+      <ul className="audit-value-list keyword-list" aria-label={label}>
+        {values.map((value) => (
+          <li className={`audit-value audit-value--${tone}`} key={value}>
+            {value}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/contexts/scoring/components/ScoreReasoning.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreReasoning.tsx
@@ -33,13 +33,13 @@ export function ScoreReasoning({ text, fitScore }: ScoreReasoningProps) {
         </p>
       )}
       {parsed.keywords.length ? (
-        <div className="keyword-list" aria-label="Tracked keywords">
+        <ul className="audit-value-list keyword-list" aria-label="Tracked keywords">
           {parsed.keywords.map((keyword) => (
-            <span className="tag info" key={keyword}>
+            <li className="audit-value audit-value--info" key={keyword}>
               {keyword}
-            </span>
+            </li>
           ))}
-        </div>
+        </ul>
       ) : null}
     </div>
   );

--- a/apps/web/src/contexts/scoring/components/ScoreStalenessBadge.tsx
+++ b/apps/web/src/contexts/scoring/components/ScoreStalenessBadge.tsx
@@ -1,6 +1,8 @@
 import type { ScoreStaleness } from "@jobctrl/contracts";
 import type { JSX } from "react";
 
+import { StatusLabel } from "../../../shared/ui/status-label.js";
+
 export interface ScoreStalenessBadgeProps {
   readonly staleness: ScoreStaleness;
 }
@@ -14,11 +16,12 @@ export function ScoreStalenessBadge({ staleness }: ScoreStalenessBadgeProps): JS
       ? `v${staleness.currentPolicyVersion} -> v${staleness.targetPolicyVersion}`
       : "policy updated";
   return (
-    <span
-      className="tag score-stale-tag"
+    <StatusLabel
+      className="score-stale-tag"
       title={staleness.staleReason ?? "Score stale after scoring policy update"}
+      tone="warn"
     >
       stale score {versionLabel}
-    </span>
+    </StatusLabel>
   );
 }

--- a/apps/web/src/demo/consent/DemoConsentGate.css
+++ b/apps/web/src/demo/consent/DemoConsentGate.css
@@ -3,89 +3,90 @@
   display: grid;
   place-items: center;
   padding: clamp(1.25rem, 4vw, 3rem);
-  color: #18231f;
-  background:
-    radial-gradient(circle at 14% 8%, rgb(235 118 65 / 18%), transparent 32rem),
-    radial-gradient(circle at 88% 86%, rgb(44 99 79 / 18%), transparent 34rem),
-    #f5f1e8;
+  color: #181817;
+  background: #f5f5f3;
 }
 
 .demo-consent-card {
-  width: min(100%, 42rem);
+  width: min(100%, 44rem);
   padding: clamp(1.5rem, 4vw, 3rem);
-  border: 1px solid rgb(24 35 31 / 14%);
-  border-radius: 1.5rem;
-  background: rgb(255 253 247 / 94%);
-  box-shadow: 0 1.5rem 4rem rgb(24 35 31 / 12%);
+  border: 1px solid #deded9;
+  border-radius: 0;
+  background: #fff;
 }
 
 .demo-consent-mark {
-  display: grid;
-  place-items: center;
-  width: 2.75rem;
-  height: 2.75rem;
-  border-radius: 0.8rem;
-  color: #fffaf1;
-  background: #234c3e;
+  display: inline-block;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #6d28d9;
+  color: #181817;
+  font-size: 0.75rem;
   font-weight: 800;
-  letter-spacing: -0.04em;
+  letter-spacing: 0.08em;
 }
 
 .demo-consent-kicker {
-  margin: 1.35rem 0 0.4rem;
-  color: #b24e28;
-  font-size: 0.78rem;
-  font-weight: 800;
+  margin: 1.5rem 0 0.5rem;
+  color: #686865;
+  font-size: 0.6875rem;
+  font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
 .demo-consent-card h1 {
   margin: 0;
-  font-size: clamp(2rem, 6vw, 3.6rem);
-  line-height: 1.02;
+  max-width: 18ch;
+  font-size: clamp(1.875rem, 5vw, 2rem);
+  font-weight: 820;
+  line-height: 1.08;
   letter-spacing: -0.055em;
 }
 
 .demo-consent-card p {
-  line-height: 1.65;
+  line-height: 1.5;
 }
 
 .demo-consent-requirement {
-  margin-top: 1.4rem;
-  font-size: 1.08rem;
-  font-weight: 750;
+  margin-top: 1.5rem;
+  font-size: 0.9375rem;
+  font-weight: 700;
 }
 
 .demo-consent-return-note,
 .demo-consent-error {
-  padding: 0.8rem 1rem;
-  border-radius: 0.8rem;
-  background: #f8e8dc;
+  padding: 0.75rem 0 0.75rem 1rem;
+  border-left: 2px solid #deded9;
+  background: transparent;
 }
 
 .demo-consent-error {
-  color: #842f22;
-  border: 1px solid rgb(132 47 34 / 22%);
+  color: #c9362b;
+  border-color: #c9362b;
 }
 
 .demo-consent-links a {
-  color: #234c3e;
+  color: #6d28d9;
   font-weight: 700;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
 }
 
 .demo-consent-actions {
   display: grid;
-  gap: 0.75rem;
-  margin-top: 1.6rem;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid #deded9;
 }
 
 .demo-consent-actions button {
-  min-height: 3rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.8rem;
+  min-height: 2.25rem;
+  padding: 0.625rem 0.875rem;
+  border-radius: 2px;
   font: inherit;
-  font-weight: 800;
+  font-size: 0.75rem;
+  font-weight: 680;
   cursor: pointer;
 }
 
@@ -95,15 +96,28 @@
 }
 
 .demo-consent-accept {
-  border: 1px solid #234c3e;
-  color: #fffaf1;
-  background: #234c3e;
+  border: 1px solid #181817;
+  color: #fff;
+  background: #181817;
 }
 
 .demo-consent-decline {
-  border: 1px solid rgb(24 35 31 / 24%);
-  color: #26352f;
-  background: transparent;
+  border: 1px solid #deded9;
+  color: #181817;
+  background: #fff;
+}
+
+.demo-consent-actions button:not(:disabled):hover {
+  background: #fafaf8;
+}
+
+.demo-consent-actions .demo-consent-accept:not(:disabled):hover {
+  background: #302f2d;
+}
+
+.demo-consent-card :is(a, button):focus-visible {
+  outline: 2px solid #6d28d9;
+  outline-offset: 3px;
 }
 
 @media (min-width: 38rem) {

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -121,7 +121,7 @@ export function DemoGuide() {
 
   return (
     <aside
-      className="fixed bottom-4 right-4 z-40 grid w-[min(22rem,calc(100vw-2rem))] gap-3 rounded-xl border border-border bg-card p-4 text-card-foreground shadow-[var(--shadow-panel)] motion-reduce:transition-none"
+      className="fixed bottom-4 right-4 z-40 grid w-[min(22rem,calc(100vw-2rem))] gap-3 rounded-[2px] border border-border bg-card p-4 text-card-foreground shadow-[var(--shadow-float)] motion-reduce:transition-none"
       aria-labelledby="demo-guide-title"
     >
       <div className="flex items-start justify-between gap-3">

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,6 +21,16 @@ import { ThemeProvider } from "./shared/providers/ThemeProvider.js";
 import { ToasterProvider } from "./shared/providers/ToasterProvider.js";
 import { TooltipProvider } from "./shared/ui/tooltip.js";
 import "./styles/globals.css";
+import "./styles/editorial-foundation.css";
+import "./styles/editorial-status.css";
+import "./styles/editorial-library.css";
+import "./styles/editorial-job-detail.css";
+import "./styles/editorial-jobs-index.css";
+import "./styles/editorial-setup.css";
+import "./styles/editorial-apply-review.css";
+import "./styles/editorial-audit.css";
+import "./styles/editorial-operations.css";
+import "./styles/editorial-shell.css";
 
 const queryClient = createQueryClient();
 const root = createRoot(document.getElementById("root")!);

--- a/apps/web/src/qa/semantic-parity-manifest.test.ts
+++ b/apps/web/src/qa/semantic-parity-manifest.test.ts
@@ -1,0 +1,56 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  PRODUCTION_SURFACE_ROUTE_PATHS,
+  SEMANTIC_PARITY_MANIFEST,
+  routeCoverageFromManifest,
+  type SemanticCategory,
+} from "./semantic-parity-manifest.js";
+
+const WEB_ROOT = process.cwd();
+const REQUIRED_CATEGORIES: readonly SemanticCategory[] = [
+  "visibleData",
+  "controls",
+  "unavailableStates",
+  "auditProvenance",
+];
+
+describe("semantic parity manifest", () => {
+  it("covers every rendered production route exactly once", () => {
+    const routes = routeCoverageFromManifest();
+
+    expect([...routes].sort()).toEqual([...PRODUCTION_SURFACE_ROUTE_PATHS].sort());
+    expect(new Set(routes)).toHaveLength(routes.length);
+  });
+
+  it("keeps each surface reviewable through concrete categories, states, and locations", () => {
+    expect(new Set(SEMANTIC_PARITY_MANIFEST.map((surface) => surface.id))).toHaveLength(
+      SEMANTIC_PARITY_MANIFEST.length,
+    );
+
+    for (const surface of SEMANTIC_PARITY_MANIFEST) {
+      expect(Object.keys(surface.categories).sort()).toEqual([...REQUIRED_CATEGORIES].sort());
+      for (const category of REQUIRED_CATEGORIES) {
+        expect(surface.categories[category].every((entry) => entry.trim().length > 0)).toBe(true);
+      }
+
+      expect(surface.locations.every((location) => location.keyboardReachable)).toBe(true);
+      expect(surface.locations.every((location) => location.label.trim().length > 0)).toBe(true);
+      expect(surface.proof.fixture.trim().length).toBeGreaterThan(0);
+      expect(surface.proof.values.every((value) => value.trim().length > 0)).toBe(true);
+      expect(surface.proof.roles.every((role) => role.trim().length > 0)).toBe(true);
+      expect(surface.proof.labels.every((label) => label.trim().length > 0)).toBe(true);
+      expect(surface.proof.statusDiscriminants.every((status) => status.trim().length > 0)).toBe(true);
+    }
+  });
+
+  it("points to current route and component owners rather than an abstract checklist", () => {
+    for (const surface of SEMANTIC_PARITY_MANIFEST) {
+      for (const owner of [...surface.owners.routeModules, ...surface.owners.components]) {
+        expect(existsSync(resolve(WEB_ROOT, owner))).toBe(true);
+      }
+    }
+  });
+});

--- a/apps/web/src/qa/semantic-parity-manifest.ts
+++ b/apps/web/src/qa/semantic-parity-manifest.ts
@@ -1,0 +1,740 @@
+import type { FileRoutesByFullPath } from "../routeTree.gen.js";
+
+/**
+ * The redesign may change composition, but these facts may not disappear. Keep
+ * this inventory alongside the route tree so a new route or a removed semantic
+ * category is a deliberate, reviewed change rather than a visual regression.
+ */
+type NonEmpty<T> = readonly [T, ...T[]];
+type RouterRoutePath = keyof FileRoutesByFullPath;
+
+export const NON_SURFACE_ROUTE_PATHS = [
+  "/",
+  "/spikes/table-filters",
+] as const satisfies readonly RouterRoutePath[];
+
+export type ProductionSurfaceRoutePath = Exclude<
+  RouterRoutePath,
+  (typeof NON_SURFACE_ROUTE_PATHS)[number]
+>;
+
+export const PRODUCTION_SURFACE_ROUTE_PATHS = [
+  "/activity/$eventId",
+  "/analytics",
+  "/apply-review",
+  "/artifacts",
+  "/artifacts/",
+  "/artifacts/$artifactId",
+  "/dashboard",
+  "/debug",
+  "/discovery",
+  "/evidence-map",
+  "/jobs",
+  "/jobs/",
+  "/jobs/$jobId",
+  "/jobs/$jobId/run/$runId",
+  "/outreach",
+  "/outreach/",
+  "/outreach/$contactId",
+  "/pipelines",
+  "/preferences",
+  "/profile",
+  "/profile/",
+  "/profile/import",
+  "/profile/import/confirm",
+  "/profile/import/preview",
+  "/profile/import/upload",
+  "/runs",
+  "/runs/",
+  "/runs/$runId",
+  "/settings",
+  "/settings/",
+  "/settings/browser",
+  "/settings/credentials",
+  "/settings/models",
+] as const satisfies readonly ProductionSurfaceRoutePath[];
+
+type Exact<Left, Right> = (<Value>() => Value extends Left ? 1 : 2) extends <
+  Value,
+>() => Value extends Right ? 1 : 2
+  ? (<Value>() => Value extends Right ? 1 : 2) extends <Value>() => Value extends Left ? 1 : 2
+    ? true
+    : false
+  : false;
+type Assert<T extends true> = T;
+
+// `routeTree.gen.ts` is the source of truth. A new rendered route must be
+// added to the manifest inventory before the web typecheck can pass.
+export type ProductionSurfaceRoutesMatchRouter = Assert<
+  Exact<ProductionSurfaceRoutePath, (typeof PRODUCTION_SURFACE_ROUTE_PATHS)[number]>
+>;
+
+export type SemanticCategory =
+  | "visibleData"
+  | "controls"
+  | "unavailableStates"
+  | "auditProvenance";
+
+export type SemanticLocationKind =
+  | "persistent-shell"
+  | "primary-workspace"
+  | "tool-row"
+  | "tab"
+  | "disclosure"
+  | "inspector"
+  | "detail-route"
+  | "wizard-step";
+
+export interface SemanticLocation {
+  readonly kind: SemanticLocationKind;
+  readonly label: string;
+  readonly keyboardReachable: true;
+}
+
+export interface SemanticParityProof {
+  /** The canonical production-shaped fixture used by a future rendered check. */
+  readonly fixture: string;
+  /** Concrete values from that fixture; never a generic "data is shown" claim. */
+  readonly values: NonEmpty<string>;
+  readonly roles: NonEmpty<string>;
+  readonly labels: NonEmpty<string>;
+  readonly statusDiscriminants: NonEmpty<string>;
+}
+
+interface SharedSurface {
+  readonly id: string;
+  readonly title: string;
+  /** Existing route and component modules that own this surface today. */
+  readonly owners: {
+    readonly routeModules: NonEmpty<string>;
+    readonly components: NonEmpty<string>;
+  };
+  readonly categories: Readonly<Record<SemanticCategory, NonEmpty<string>>>;
+  readonly locations: NonEmpty<SemanticLocation>;
+  readonly proof: SemanticParityProof;
+}
+
+export interface GlobalSemanticParitySurface extends SharedSurface {
+  readonly kind: "global";
+  readonly routes: readonly [];
+}
+
+export interface RouteSemanticParitySurface extends SharedSurface {
+  readonly kind: "route";
+  readonly routes: NonEmpty<ProductionSurfaceRoutePath>;
+}
+
+export type SemanticParitySurface =
+  | GlobalSemanticParitySurface
+  | RouteSemanticParitySurface;
+
+export const SEMANTIC_PARITY_MANIFEST = [
+  {
+    id: "global-shell",
+    kind: "global",
+    title: "Global shell",
+    routes: [],
+    owners: {
+      routeModules: ["src/routes/__root.tsx"],
+      components: ["src/shared/layout/SideRail.tsx", "src/shared/layout/Topbar.tsx"],
+    },
+    categories: {
+      visibleData: ["14 labelled destinations", "connection state", "local-mode privacy notice", "runtime and spend facts"],
+      controls: ["global search", "density selector", "theme control", "demo guide and receipt controls"],
+      unavailableStates: ["offline connection", "stale runtime", "absent demo notices"],
+      auditProvenance: ["local-first mode", "runtime source", "LLM spend basis"],
+    },
+    locations: [
+      { kind: "persistent-shell", label: "grouped side rail", keyboardReachable: true },
+      { kind: "persistent-shell", label: "slim top bar", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "shell-health fixture",
+      values: ["Dashboard", "Jobs", "Preferences", "Local mode"],
+      roles: ["navigation", "searchbox", "button"],
+      labels: ["Primary navigation", "Filter jobs, errors, companies", "Theme"],
+      statusDiscriminants: ["live", "stale", "offline"],
+    },
+  },
+  {
+    id: "dashboard",
+    kind: "route",
+    title: "Dashboard",
+    routes: ["/dashboard"],
+    owners: { routeModules: ["src/routes/dashboard.tsx"], components: ["src/views/dashboard/DashboardView.tsx"] },
+    categories: {
+      visibleData: ["KPI values", "funnel", "digest", "source health", "workflow and apply runs", "conversion and outcome facts"],
+      controls: ["digest links", "run links", "source and workflow handoffs"],
+      unavailableStates: ["summary loading", "digest unavailable", "empty activity", "source health error"],
+      auditProvenance: ["outcome totals", "source health observations", "workflow run timestamps"],
+    },
+    locations: [{ kind: "primary-workspace", label: "operational ledger", keyboardReachable: true }],
+    proof: {
+      fixture: "dashboard operations fixture",
+      values: ["8 discovered jobs", "6 replies", "1 offer", "Greenhouse"],
+      roles: ["heading", "link", "list"],
+      labels: ["Application funnel", "Active workflow runs", "Source health"],
+      statusDiscriminants: ["loading", "empty", "error", "healthy"],
+    },
+  },
+  {
+    id: "analytics",
+    kind: "route",
+    title: "Analytics",
+    routes: ["/analytics"],
+    owners: { routeModules: ["src/routes/analytics.tsx"], components: ["src/views/analytics/AnalyticsView.tsx"] },
+    categories: {
+      visibleData: ["outcome counts", "rates", "confidence and sample warnings", "dimension group rows", "totals"],
+      controls: ["date window", "outcome dimension selector"],
+      unavailableStates: ["loading analytics", "no outcomes", "analytics request error"],
+      auditProvenance: ["window basis", "sample size", "suppressed rate reason"],
+    },
+    locations: [{ kind: "primary-workspace", label: "comparative outcome table", keyboardReachable: true }],
+    proof: {
+      fixture: "outcome analytics fixture",
+      values: ["Greenhouse", "LinkedIn", "6 replies", "3 interviews"],
+      roles: ["combobox", "table", "columnheader"],
+      labels: ["Outcome analytics dimension", "Application outcome rates"],
+      statusDiscriminants: ["loading", "empty", "error", "suppressed"],
+    },
+  },
+  {
+    id: "jobs-list",
+    kind: "route",
+    title: "Jobs list",
+    routes: ["/jobs", "/jobs/"],
+    owners: { routeModules: ["src/routes/jobs.tsx", "src/routes/jobs.index.tsx"], components: ["src/views/jobs/JobsView.tsx", "src/views/jobs/JobsTable.tsx"] },
+    categories: {
+      visibleData: ["all job columns", "stage and state badges", "apply state", "totals", "saved views"],
+      controls: ["query", "stage", "state", "apply status", "deleted scope", "sort", "direction", "page", "page size", "bulk actions"],
+      unavailableStates: ["loading jobs", "no matching jobs", "list error", "empty selection"],
+      auditProvenance: ["discovered timestamp", "source", "score and apply state basis"],
+    },
+    locations: [
+      { kind: "tool-row", label: "URL-backed jobs filters", keyboardReachable: true },
+      { kind: "primary-workspace", label: "filterable jobs data grid", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "job list fixture",
+      values: ["Staff Platform Engineer", "Northstar", "discovered", "85%"],
+      roles: ["searchbox", "combobox", "table", "checkbox"],
+      labels: ["Filter jobs", "Stage", "Apply status", "Select all rows"],
+      statusDiscriminants: ["loading", "empty", "error", "selected", "deleted"],
+    },
+  },
+  {
+    id: "job-detail",
+    kind: "route",
+    title: "Job detail",
+    routes: ["/jobs/$jobId"],
+    owners: { routeModules: ["src/routes/jobs.$jobId.tsx"], components: ["src/views/jobs/JobDetailDrawer.tsx", "src/views/jobs/JobAuditTriage.tsx"] },
+    categories: {
+      visibleData: ["identity, employer, location, source, timestamps", "stage, score, apply and materials state", "compensation and description", "requirements, evidence, employer analysis", "materials and accepted-artifact history"],
+      controls: ["stage actions", "material actions", "related run links", "audit triage actions"],
+      unavailableStates: ["job loading", "job not found", "description unavailable", "blocked material actions"],
+      auditProvenance: ["source and timestamp", "score rationale", "requirement evidence", "warnings and blockers", "accepted artifact history"],
+    },
+    locations: [
+      { kind: "detail-route", label: "job header ledger", keyboardReachable: true },
+      { kind: "tab", label: "job detail panels", keyboardReachable: true },
+      { kind: "inspector", label: "audit triage", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "job detail fixture",
+      values: ["Staff Platform Engineer", "Barcelona", "EUR 105000", "Score rationale"],
+      roles: ["heading", "tablist", "button", "link"],
+      labels: ["Job summary", "Apply readiness", "Job audit triage"],
+      statusDiscriminants: ["loading", "not-found", "scored", "blocked", "accepted"],
+    },
+  },
+  {
+    id: "job-run-timeline",
+    kind: "route",
+    title: "Job run timeline",
+    routes: ["/jobs/$jobId/run/$runId"],
+    owners: { routeModules: ["src/routes/jobs.$jobId.run.$runId.tsx"], components: ["src/contexts/apply/components/ApplyRunTimeline.tsx"] },
+    categories: {
+      visibleData: ["run identity", "job relationship", "stage events", "timestamps", "retries", "error details"],
+      controls: ["back to job", "summary and timeline tabs"],
+      unavailableStates: ["run loading", "run unavailable", "no stage events", "failed stage"],
+      auditProvenance: ["workflow id", "run id", "event timestamps", "retry attempt"],
+    },
+    locations: [{ kind: "detail-route", label: "job run workspace", keyboardReachable: true }],
+    proof: {
+      fixture: "apply run timeline fixture",
+      values: ["run-001", "score job", "attempt 2", "activity_error"],
+      roles: ["heading", "tab", "link", "list"],
+      labels: ["Run timeline", "Back to job", "Run status"],
+      statusDiscriminants: ["queued", "running", "succeeded", "failed", "retrying"],
+    },
+  },
+  {
+    id: "apply-review",
+    kind: "route",
+    title: "Apply review",
+    routes: ["/apply-review"],
+    owners: { routeModules: ["src/routes/apply-review.tsx"], components: ["src/views/apply-review/ApplyReviewView.tsx"] },
+    categories: {
+      visibleData: ["queue and selected job", "compensation and score basis", "requirement evidence", "tailoring coverage", "accepted and current artifacts", "resume, cover letter and email", "judge and persona audit"],
+      controls: ["approve", "defer", "decline", "stop", "reset", "artifact comparison", "resume comments"],
+      unavailableStates: ["empty queue", "job post unavailable", "no accepted artifact", "cover letter unavailable", "approval blocked"],
+      auditProvenance: ["grounding and fabrication results", "bullet provenance", "warning lifecycle", "revision and persona responses", "dry-run evidence"],
+    },
+    locations: [
+      { kind: "primary-workspace", label: "review queue and workspace", keyboardReachable: true },
+      { kind: "tab", label: "evidence and material panels", keyboardReachable: true },
+      { kind: "inspector", label: "requirement-led tailoring audit", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "apply review canonical fixture",
+      values: ["Minimum score 8", "Evidence rules remain enforced", "accepted resume", "dry run"],
+      roles: ["listbox", "button", "tablist", "textbox"],
+      labels: ["Application review workspace", "Requirement-led tailoring audit", "Resume audit"],
+      statusDiscriminants: ["empty", "blocked", "draft", "accepted", "approval-ready"],
+    },
+  },
+  {
+    id: "pipelines",
+    kind: "route",
+    title: "Pipelines",
+    routes: ["/pipelines"],
+    owners: { routeModules: ["src/routes/pipelines.tsx"], components: ["src/views/pipelines/PipelinesView.tsx"] },
+    categories: {
+      visibleData: ["pipeline and stage status", "progress", "worker capacity", "task queues", "current and historical outcomes"],
+      controls: ["run stage", "retry", "stop", "concurrency", "source and dry-run controls"],
+      unavailableStates: ["telemetry unavailable", "stale worker", "empty scoped outcomes", "unsupported queue observation"],
+      auditProvenance: ["workflow and Temporal run ids", "observation time", "capacity reason", "activity attempt"],
+    },
+    locations: [
+      { kind: "primary-workspace", label: "operational stage ledger", keyboardReachable: true },
+      { kind: "disclosure", label: "execution and cohort diagnostics", keyboardReachable: true },
+      { kind: "inspector", label: "execution inspector", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "pipeline operations fixture",
+      values: ["Current execution", "3/3", "9 total", "activity-opaque-17"],
+      roles: ["tab", "table", "button", "checkbox"],
+      labels: ["Pipeline actions", "Worker capacity", "Task queue telemetry"],
+      statusDiscriminants: ["calibrating", "paused", "stale", "unavailable", "succeeded"],
+    },
+  },
+  {
+    id: "discovery",
+    kind: "route",
+    title: "Discovery",
+    routes: ["/discovery"],
+    owners: { routeModules: ["src/routes/discovery.tsx"], components: ["src/views/discovery/DiscoveryView.tsx"] },
+    categories: {
+      visibleData: ["target-search preferences", "sources and source health", "schedules", "crawl policy", "runtime diagnostics"],
+      controls: ["manual capture", "source actions", "automation and runtime controls"],
+      unavailableStates: ["source quarantined", "runtime unavailable", "manual capture error", "empty source list"],
+      auditProvenance: ["source health observation", "schedule", "crawl-policy reason", "capture diagnostic"],
+    },
+    locations: [
+      { kind: "primary-workspace", label: "target and source sections", keyboardReachable: true },
+      { kind: "disclosure", label: "runtime diagnostics", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "discovery source fixture",
+      values: ["Northstar", "Orbit", "quarantined", "schedule"],
+      roles: ["heading", "button", "switch", "table"],
+      labels: ["Discovery sources", "Manual capture", "Discovery runtime"],
+      statusDiscriminants: ["healthy", "quarantined", "unavailable", "error"],
+    },
+  },
+  {
+    id: "artifacts-list",
+    kind: "route",
+    title: "Artifacts list",
+    routes: ["/artifacts", "/artifacts/"],
+    owners: { routeModules: ["src/routes/artifacts.tsx", "src/routes/artifacts.index.tsx"], components: ["src/views/artifacts/ArtifactsView.tsx"] },
+    categories: {
+      visibleData: ["type", "version", "status", "job", "company", "created time", "local path", "size"],
+      controls: ["search", "filter", "sort", "page controls", "open artifact", "related job"],
+      unavailableStates: ["loading artifacts", "no matching artifacts", "list error", "unavailable file"],
+      auditProvenance: ["artifact id", "generation time", "local path", "related job"],
+    },
+    locations: [
+      { kind: "tool-row", label: "artifact filters", keyboardReachable: true },
+      { kind: "primary-workspace", label: "artifact data grid", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "artifact list fixture",
+      values: ["resume", "v2", "accepted", "tailored-resume.pdf"],
+      roles: ["searchbox", "combobox", "table", "link"],
+      labels: ["Filter artifacts", "Artifact status", "Open artifact"],
+      statusDiscriminants: ["loading", "empty", "error", "accepted", "unavailable"],
+    },
+  },
+  {
+    id: "artifact-detail",
+    kind: "route",
+    title: "Artifact detail",
+    routes: ["/artifacts/$artifactId"],
+    owners: { routeModules: ["src/routes/artifacts.$artifactId.tsx"], components: ["src/views/artifacts/ArtifactDetailPanel.tsx"] },
+    categories: {
+      visibleData: ["status and id", "job and local path", "size and created time", "preview", "tailoring explanation", "annotations and coverage", "comparison delta"],
+      controls: ["open preview", "open related job", "comparison controls"],
+      unavailableStates: ["artifact loading", "preview unavailable", "artifact not found", "missing comparison baseline"],
+      auditProvenance: ["keyword and evidence coverage", "bullet provenance", "safety and warning lifecycle", "judge prompts and responses", "generation models"],
+    },
+    locations: [
+      { kind: "detail-route", label: "artifact workspace", keyboardReachable: true },
+      { kind: "inspector", label: "artifact audit inspector", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "artifact detail fixture",
+      values: ["artifact-001", "resume.pdf", "keyword coverage", "generation model"],
+      roles: ["heading", "button", "tablist", "document"],
+      labels: ["Artifact details", "Artifact preview", "Tailoring explanation"],
+      statusDiscriminants: ["loading", "not-found", "preview-unavailable", "accepted", "warning"],
+    },
+  },
+  {
+    id: "evidence-map",
+    kind: "route",
+    title: "Evidence map",
+    routes: ["/evidence-map"],
+    owners: { routeModules: ["src/routes/evidence-map.tsx"], components: ["src/views/evidence-map/EvidenceMapView.tsx"] },
+    categories: {
+      visibleData: ["evidence entries", "canonical story", "source pin", "skills", "freshness", "requirement and artifact uses", "evidence gaps"],
+      controls: ["search", "filters", "open linked artifact", "open linked job"],
+      unavailableStates: ["loading evidence", "no entries", "search error", "no linked uses"],
+      auditProvenance: ["source pin", "freshness", "artifact use", "requirement use"],
+    },
+    locations: [
+      { kind: "primary-workspace", label: "career evidence workspace", keyboardReachable: true },
+      { kind: "inspector", label: "evidence detail", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "evidence map fixture",
+      values: ["Reusable story", "Story metrics", "resume bullet", "requirement fit"],
+      roles: ["searchbox", "list", "heading", "link"],
+      labels: ["Career evidence workspace", "Evidence entries", "Evidence map search"],
+      statusDiscriminants: ["loading", "empty", "error", "fresh", "stale"],
+    },
+  },
+  {
+    id: "contacts-list",
+    kind: "route",
+    title: "Contacts",
+    routes: ["/outreach", "/outreach/"],
+    owners: { routeModules: ["src/routes/outreach.tsx", "src/routes/outreach.index.tsx"], components: ["src/views/outreach/OutreachView.tsx"] },
+    categories: {
+      visibleData: ["contact, employer and role", "relationship", "follow-up state", "research tasks", "draft and send counts"],
+      controls: ["search and filters", "import contact", "create contact", "due follow-up actions"],
+      unavailableStates: ["loading contacts", "no matches", "list error", "no due follow-ups"],
+      auditProvenance: ["contact source", "research provenance", "user-attested send summary"],
+    },
+    locations: [
+      { kind: "tool-row", label: "contact filters and actions", keyboardReachable: true },
+      { kind: "primary-workspace", label: "contacts data grid", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "outreach contact fixture",
+      values: ["Alex Morgan", "Q&A Systems", "follow-up due", "public web page"],
+      roles: ["searchbox", "table", "button", "link"],
+      labels: ["Contacts", "Import contacts", "Create contact"],
+      statusDiscriminants: ["loading", "empty", "error", "due", "dismissed"],
+    },
+  },
+  {
+    id: "contact-detail",
+    kind: "route",
+    title: "Contact detail",
+    routes: ["/outreach/$contactId"],
+    owners: { routeModules: ["src/routes/outreach.$contactId.tsx"], components: ["src/views/outreach/OutreachDetailDrawer.tsx"] },
+    categories: {
+      visibleData: ["detail thread", "draft generations and revisions", "approval and rejection", "send log", "follow-up schedule", "research tasks"],
+      controls: ["generate", "revise", "approve", "reject", "log send", "schedule and dismiss follow-up"],
+      unavailableStates: ["loading contact", "not found", "no draft", "send log unavailable"],
+      auditProvenance: ["contact attributes", "research source", "draft gate result", "user-attested send log"],
+    },
+    locations: [
+      { kind: "detail-route", label: "contact workspace", keyboardReachable: true },
+      { kind: "tab", label: "outreach and provenance panels", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "outreach thread fixture",
+      values: ["approved draft", "revision 2", "send log", "public_web_page"],
+      roles: ["heading", "tab", "button", "form"],
+      labels: ["Contact details", "Contact detail panels", "Facts and provenance"],
+      statusDiscriminants: ["loading", "not-found", "draft", "approved", "rejected", "sent"],
+    },
+  },
+  {
+    id: "runs-list",
+    kind: "route",
+    title: "Runs",
+    routes: ["/runs", "/runs/"],
+    owners: { routeModules: ["src/routes/runs.tsx", "src/routes/runs.index.tsx"], components: ["src/views/runs/RunsView.tsx"] },
+    categories: {
+      visibleData: ["workflow and run identity", "type", "status", "start, update and end", "progress", "errors"],
+      controls: ["filters", "pagination", "cancel", "open related record"],
+      unavailableStates: ["loading runs", "no workflow runs", "list error", "cancel unavailable"],
+      auditProvenance: ["workflow id", "run id", "timestamps", "error code"],
+    },
+    locations: [
+      { kind: "tool-row", label: "run filters", keyboardReachable: true },
+      { kind: "primary-workspace", label: "workflow run grid", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "workflow run list fixture",
+      values: ["discover", "run-001", "in progress", "activity_error"],
+      roles: ["combobox", "table", "button", "link"],
+      labels: ["Workflow runs", "Run status", "Cancel workflow run"],
+      statusDiscriminants: ["loading", "empty", "error", "running", "failed", "cancelled"],
+    },
+  },
+  {
+    id: "run-detail",
+    kind: "route",
+    title: "Run detail",
+    routes: ["/runs/$runId"],
+    owners: { routeModules: ["src/routes/runs.$runId.tsx"], components: ["src/views/runs/WorkflowRunDrawer.tsx"] },
+    categories: {
+      visibleData: ["run identity", "workflow type", "status", "timeline", "progress", "diagnostics and errors", "related records"],
+      controls: ["back to runs", "summary", "timeline", "diagnostics", "related links"],
+      unavailableStates: ["loading run", "run unavailable", "no diagnostics", "missing related record"],
+      auditProvenance: ["run id", "workflow id", "event timestamps", "error code and message"],
+    },
+    locations: [
+      { kind: "detail-route", label: "workflow run workspace", keyboardReachable: true },
+      { kind: "tab", label: "workflow run detail panels", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "workflow run detail fixture",
+      values: ["run-001", "activity_error", "Summary", "Diagnostics"],
+      roles: ["heading", "tablist", "link", "list"],
+      labels: ["Workflow run details", "Workflow run detail panels", "Back to workflow runs"],
+      statusDiscriminants: ["loading", "not-found", "running", "failed", "succeeded"],
+    },
+  },
+  {
+    id: "debug",
+    kind: "route",
+    title: "Debug activity",
+    routes: ["/debug"],
+    owners: { routeModules: ["src/routes/debug.tsx"], components: ["src/views/debug/DebugView.tsx"] },
+    categories: {
+      visibleData: ["time", "event", "level", "stage", "job and run references", "payload summary"],
+      controls: ["query", "level", "stage", "event type", "sort", "pagination", "open event"],
+      unavailableStates: ["loading activity", "no matching events", "activity error"],
+      auditProvenance: ["event id", "payload", "job handoff", "run reference"],
+    },
+    locations: [
+      { kind: "tool-row", label: "debug filters", keyboardReachable: true },
+      { kind: "primary-workspace", label: "debug activity grid", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "debug activity fixture",
+      values: ["error", "score_job", "job-001", "run-001"],
+      roles: ["searchbox", "combobox", "table", "link"],
+      labels: ["Activity search", "Activity stage", "Activity event type"],
+      statusDiscriminants: ["loading", "empty", "error", "info", "warning"],
+    },
+  },
+  {
+    id: "activity-detail",
+    kind: "route",
+    title: "Activity detail",
+    routes: ["/activity/$eventId"],
+    owners: { routeModules: ["src/routes/activity.$eventId.tsx"], components: ["src/views/debug/ActivityDetailDrawer.tsx"] },
+    categories: {
+      visibleData: ["time", "event", "level", "stage", "job and run references", "payload", "timeline"],
+      controls: ["back to debug", "payload and timeline tabs", "job handoff"],
+      unavailableStates: ["loading event", "event unavailable", "payload absent", "direct detail disabled redirect"],
+      auditProvenance: ["event id", "projected payload", "event timeline", "job and run links"],
+    },
+    locations: [
+      { kind: "detail-route", label: "activity workspace", keyboardReachable: true },
+      { kind: "tab", label: "activity detail panels", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "activity detail fixture",
+      values: ["activity-001", "score_job", "payload", "timeline"],
+      roles: ["heading", "tablist", "link", "region"],
+      labels: ["Activity event state", "Projected event payload", "Activity event timeline"],
+      statusDiscriminants: ["loading", "not-found", "error", "redirected"],
+    },
+  },
+  {
+    id: "profile",
+    kind: "route",
+    title: "Profile",
+    routes: ["/profile", "/profile/"],
+    owners: { routeModules: ["src/routes/profile.tsx", "src/routes/profile.index.tsx"], components: ["src/contexts/profile/components/ProfileEditor.tsx"] },
+    categories: {
+      visibleData: ["personal, contact and address fields", "work authorization and attestations", "executive baseline", "experience, education, skills and verified metrics", "search targets, EEO and evidence pins"],
+      controls: ["add, remove and reorder", "save", "discard", "import resume", "open evidence map", "preview resizer"],
+      unavailableStates: ["profile loading", "empty evidence", "validation error", "resume preview unavailable"],
+      auditProvenance: ["canonical candidate source", "verified metrics", "evidence and source pins", "import version"],
+    },
+    locations: [
+      { kind: "primary-workspace", label: "structured profile editor", keyboardReachable: true },
+      { kind: "inspector", label: "full-height editable resume preview", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "canonical profile fixture",
+      values: ["Alex Morgan", "EU citizen", "Platform Engineering", "verified metric"],
+      roles: ["form", "textbox", "button", "region"],
+      labels: ["Profile", "Import resume", "Open evidence map"],
+      statusDiscriminants: ["loading", "dirty", "saved", "validation-error", "preview-unavailable"],
+    },
+  },
+  {
+    id: "resume-import",
+    kind: "route",
+    title: "Resume import",
+    routes: ["/profile/import", "/profile/import/upload", "/profile/import/preview", "/profile/import/confirm"],
+    owners: {
+      routeModules: ["src/routes/profile.import.tsx", "src/routes/profile.import.upload.tsx", "src/routes/profile.import.preview.tsx", "src/routes/profile.import.confirm.tsx"],
+      components: ["src/contexts/profile/components/ResumeImportWizard.tsx", "src/contexts/profile/forms/import-upload-form.tsx", "src/contexts/profile/forms/import-preview-form.tsx", "src/contexts/profile/forms/import-confirm-form.tsx"],
+    },
+    categories: {
+      visibleData: ["upload source", "include and exclude choices", "parse diagnostics", "conflicts", "backup and version facts", "success summary"],
+      controls: ["upload", "next", "back", "confirm", "cancel", "include profile", "include style"],
+      unavailableStates: ["no file", "parse error", "conflict", "import failure"],
+      auditProvenance: ["source filename", "parse diagnostic", "backup id", "import version"],
+    },
+    locations: [
+      { kind: "wizard-step", label: "upload step", keyboardReachable: true },
+      { kind: "wizard-step", label: "preview step", keyboardReachable: true },
+      { kind: "wizard-step", label: "confirm step", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "resume import fixture",
+      values: ["synthetic-platform-resume.pdf", "Parse diagnostics", "backup", "version"],
+      roles: ["form", "checkbox", "button", "alert"],
+      labels: ["Upload resume", "Include profile", "Include style", "Confirm import"],
+      statusDiscriminants: ["upload", "preview", "conflict", "error", "success"],
+    },
+  },
+  {
+    id: "preferences",
+    kind: "route",
+    title: "Preferences",
+    routes: ["/preferences"],
+    owners: { routeModules: ["src/routes/preferences.tsx"], components: ["src/contexts/profile/components/ProfileEditor.tsx"] },
+    categories: {
+      visibleData: ["generation permissions", "writing style", "revision policy", "additional guidance", "resume style", "template versions and defaults"],
+      controls: ["autosave", "undo", "save", "discard", "template save and set default", "real resume editor"],
+      unavailableStates: ["template preview unavailable", "save error", "undo unavailable", "no default template"],
+      auditProvenance: ["evidence rules", "template version", "default template marker", "resume style origin"],
+    },
+    locations: [
+      { kind: "disclosure", label: "tailoring controls", keyboardReachable: true },
+      { kind: "tab", label: "writing and resume style controls", keyboardReachable: true },
+      { kind: "primary-workspace", label: "full-width resume template preview", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "preferences fixture",
+      values: ["Rewrite executive summary", "Executive", "A4", "Modern editorial"],
+      roles: ["checkbox", "combobox", "button", "tabpanel"],
+      labels: ["Tailoring controls", "Resume style", "Resume template preview"],
+      statusDiscriminants: ["autosaving", "saved", "dirty", "error", "default"],
+    },
+  },
+  {
+    id: "settings-general",
+    kind: "route",
+    title: "Settings — General",
+    routes: ["/settings", "/settings/"],
+    owners: { routeModules: ["src/routes/settings.tsx", "src/routes/settings.index.tsx"], components: ["src/contexts/profile/components/SettingsPanel.tsx", "src/contexts/apply/components/ApplyRuntimeSettingsPanel.tsx"] },
+    categories: {
+      visibleData: ["current settings", "apply runtime controls", "scoring guidance", "compensation source policy", "effective, default, override and source facts"],
+      controls: ["autosave", "undo", "reset", "apply runtime controls"],
+      unavailableStates: ["validation error", "save error", "default unavailable", "override unavailable"],
+      auditProvenance: ["effective value", "default value", "override source", "compensation policy source"],
+    },
+    locations: [
+      { kind: "tab", label: "settings sections", keyboardReachable: true },
+      { kind: "disclosure", label: "general settings panels", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "general settings fixture",
+      values: ["Minimum score", "Compensation source", "effective", "override"],
+      roles: ["tablist", "form", "button", "textbox"],
+      labels: ["Settings sections", "General", "Apply runtime settings"],
+      statusDiscriminants: ["default", "effective", "override", "invalid", "saved"],
+    },
+  },
+  {
+    id: "settings-credentials",
+    kind: "route",
+    title: "Settings — Credentials",
+    routes: ["/settings/credentials"],
+    owners: { routeModules: ["src/routes/settings.credentials.tsx"], components: ["src/contexts/profile/components/CredentialsPanel.tsx"] },
+    categories: {
+      visibleData: ["provider states", "supported auth modes", "secret-presence metadata", "readiness and errors"],
+      controls: ["add", "update", "delete", "verify provider"],
+      unavailableStates: ["provider unconfigured", "verification failure", "unsupported auth mode", "secret absent"],
+      auditProvenance: ["local secret boundary", "provider readiness result", "verification timestamp"],
+    },
+    locations: [
+      { kind: "tab", label: "Credentials settings section", keyboardReachable: true },
+      { kind: "primary-workspace", label: "provider ledger and setup forms", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "credentials fixture",
+      values: ["OpenAI", "configured", "API key present", "verify"],
+      roles: ["tab", "table", "button", "form"],
+      labels: ["Credentials", "Provider status", "Verify provider"],
+      statusDiscriminants: ["unconfigured", "configured", "ready", "invalid", "error"],
+    },
+  },
+  {
+    id: "settings-models",
+    kind: "route",
+    title: "Settings — Models",
+    routes: ["/settings/models"],
+    owners: { routeModules: ["src/routes/settings.models.tsx"], components: ["src/contexts/profile/components/ModelSelectionPanel.tsx", "src/contexts/materials/components/AiExecutionPolicyPanel.tsx"] },
+    categories: {
+      visibleData: ["provider and model catalogs", "generator and judge selections", "analysis legs", "execution policy", "cost and concurrency controls"],
+      controls: ["select provider", "select model", "set generator and judge", "set policy and concurrency"],
+      unavailableStates: ["provider unready", "model invalid", "catalog unavailable", "execution blocked"],
+      auditProvenance: ["selected model", "provider readiness", "policy source", "cost limit"],
+    },
+    locations: [
+      { kind: "tab", label: "Model selection settings section", keyboardReachable: true },
+      { kind: "inspector", label: "model matrix and policy inspector", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "model selection fixture",
+      values: ["generator", "judge", "analysis leg", "concurrency 3"],
+      roles: ["tab", "combobox", "button", "table"],
+      labels: ["Model selection", "AI execution policy", "Generator model"],
+      statusDiscriminants: ["ready", "unready", "invalid", "blocked"],
+    },
+  },
+  {
+    id: "settings-browser",
+    kind: "route",
+    title: "Settings — Browser",
+    routes: ["/settings/browser"],
+    owners: { routeModules: ["src/routes/settings.browser.tsx"], components: ["src/contexts/operations/components/BrowserCapabilitiesPanel.tsx", "src/contexts/operations/components/ExtensionPairingPanel.tsx"] },
+    categories: {
+      visibleData: ["browser capabilities", "pairing state", "expiry", "token metadata", "capability restrictions and reasons"],
+      controls: ["create", "revoke", "rotate", "pair extension", "refresh capability state"],
+      unavailableStates: ["unpaired", "expired", "capability restricted", "extension unavailable"],
+      auditProvenance: ["pairing metadata", "capability reason", "expiry", "local browser boundary"],
+    },
+    locations: [
+      { kind: "tab", label: "Browser and extension settings section", keyboardReachable: true },
+      { kind: "primary-workspace", label: "capability ledger and pairing workbench", keyboardReachable: true },
+    ],
+    proof: {
+      fixture: "browser pairing fixture",
+      values: ["paired", "expired", "rotate token", "restriction reason"],
+      roles: ["tab", "table", "button", "status"],
+      labels: ["Browser and extension", "Browser capabilities", "Extension pairing"],
+      statusDiscriminants: ["unpaired", "paired", "expired", "restricted", "unavailable"],
+    },
+  },
+] as const satisfies readonly SemanticParitySurface[];
+
+export function routeCoverageFromManifest(
+  manifest: readonly SemanticParitySurface[] = SEMANTIC_PARITY_MANIFEST,
+): readonly ProductionSurfaceRoutePath[] {
+  return manifest.flatMap((surface) => surface.routes);
+}

--- a/apps/web/src/routes/jobs.$jobId.run.$runId.test.tsx
+++ b/apps/web/src/routes/jobs.$jobId.run.$runId.test.tsx
@@ -7,6 +7,7 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 import { render, screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -43,6 +44,7 @@ function buildRouter() {
 
 describe("<JobRunTimelineWorkspace>", () => {
   it("renders the nested timeline as a complete route workspace", async () => {
+    const user = userEvent.setup();
     server.use(
       http.get("*/v1/workflow-runs/:runId", () =>
         HttpResponse.json(
@@ -94,6 +96,7 @@ describe("<JobRunTimelineWorkspace>", () => {
     ).toBeInTheDocument();
     expect(within(workspace).getAllByText("run-1").length).toBeGreaterThan(0);
     expect(within(workspace).getByText("temporal-apply-1")).toBeInTheDocument();
+    await user.click(within(workspace).getByRole("tab", { name: "Timeline" }));
     expect(within(workspace).getByText("Workflow Started")).toBeInTheDocument();
     expect(
       within(workspace).getByText("Apply agent acquired job"),

--- a/apps/web/src/routes/jobs.$jobId.run.$runId.tsx
+++ b/apps/web/src/routes/jobs.$jobId.run.$runId.tsx
@@ -8,6 +8,9 @@ import { formatDateTime } from "../shared/lib/formatters.js";
 import { Button } from "../shared/ui/button.js";
 import { RouteWorkspace } from "../shared/ui/route-workspace.js";
 import { Section } from "../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../shared/ui/section-tabs.js";
+import { StatusLabel } from "../shared/ui/status-label.js";
+import { TabsContent, TabsTrigger } from "../shared/ui/tabs.js";
 
 export const Route = createFileRoute("/jobs/$jobId/run/$runId")({
   component: JobRunTimelineRoute,
@@ -35,44 +38,101 @@ export function JobRunTimelineWorkspace({
       className="route-page route-page--job-run-detail"
       aria-label="Apply run details"
     >
-      <RouteWorkspace
-        aria-label="Apply run details"
-        className="job-run-workspace"
-        contentLabel="Apply run timeline"
-        inspectorLabel="Apply run facts and failure details"
-        header={
-          <div className="job-run-workspace__header">
-            <Button asChild className="workspace-back" size="sm" variant="ghost">
-              <Link
-                aria-label="Back to job details"
-                params={{ jobId }}
-                search={(prev) => prev}
-                to="/jobs/$jobId"
-              >
-                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                Job details
-              </Link>
-            </Button>
-            {run ? (
-              <RunStatusBadge status={run.status} />
-            ) : (
-              <span className="tag muted">
-                {isLoading ? "loading" : "status unavailable"}
-              </span>
-            )}
-            <div className="job-run-workspace__title">
-              <small>{run?.workflowType || "apply workflow"}</small>
-              <h1>Apply run timeline</h1>
-              <p>
-                {run?.title ? `${run.title} · ` : ""}
-                <span className="mono">{runId}</span>
-              </p>
+      <SectionTabs className="job-run-tabs" defaultValue="summary">
+        <RouteWorkspace
+          aria-label="Apply run details"
+          className="job-run-workspace"
+          contentLabel="Apply run workspace panels"
+          inspectorLabel="Apply run identity"
+          tabs={
+            <nav aria-label="Apply run detail panels">
+              <SectionTabsList>
+                <TabsTrigger value="summary">Summary</TabsTrigger>
+                <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+              </SectionTabsList>
+            </nav>
+          }
+          header={
+            <div className="job-run-workspace__header">
+              <Button asChild className="workspace-back" size="sm" variant="ghost">
+                <Link
+                  aria-label="Back to job details"
+                  params={{ jobId }}
+                  search={(prev) => prev}
+                  to="/jobs/$jobId"
+                >
+                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                  Job details
+                </Link>
+              </Button>
+              <div className="job-run-workspace__title">
+                <small>{run?.workflowType || "apply workflow"}</small>
+                <h1>Apply run timeline</h1>
+                <p>
+                  {run?.title ? `${run.title} · ` : ""}
+                  <span className="mono">{runId}</span>
+                </p>
+              </div>
+              <div className="job-run-workspace__status">
+                {run ? (
+                  <RunStatusBadge status={run.status} />
+                ) : (
+                  <StatusLabel tone="neutral">
+                    {isLoading ? "loading" : "status unavailable"}
+                  </StatusLabel>
+                )}
+              </div>
             </div>
-          </div>
-        }
-        inspector={
-          <div className="job-run-workspace__inspector">
-            <Section title="Run details">
+          }
+          inspector={
+            <div className="job-run-workspace__inspector">
+              <Section title="Run identity">
+                <dl className="detail-list">
+                  <div>
+                    <dt>Run id</dt>
+                    <dd className="mono">{runId}</dd>
+                  </div>
+                  <div>
+                    <dt>Job</dt>
+                    <dd>
+                      <Link
+                        className="title-link"
+                        params={{ jobId }}
+                        search={(prev) => prev}
+                        to="/jobs/$jobId"
+                      >
+                        {run?.title || jobId}
+                      </Link>
+                    </dd>
+                  </div>
+                  {run ? (
+                    <>
+                      <div>
+                        <dt>Workflow id</dt>
+                        <dd className="mono">{run.workflowId}</dd>
+                      </div>
+                      <div>
+                        <dt>Status</dt>
+                        <dd>{run.status}</dd>
+                      </div>
+                    </>
+                  ) : null}
+                </dl>
+              </Section>
+              {message ? <div className="banner inline">{message}</div> : null}
+            </div>
+          }
+        >
+          <TabsContent
+            className="job-run-workspace__panel"
+            forceMount
+            value="summary"
+          >
+            <Section
+              title="Run details"
+              description="Workflow identity and execution boundary"
+            >
               <dl className="detail-list">
                 <div>
                   <dt>Run id</dt>
@@ -128,10 +188,28 @@ export function JobRunTimelineWorkspace({
                   </>
                 ) : null}
               </dl>
-              {message ? <div className="banner inline">{message}</div> : null}
             </Section>
+          </TabsContent>
+          <TabsContent
+            className="job-run-workspace__panel"
+            forceMount
+            value="timeline"
+          >
+            <Section
+              className="job-run-workspace__timeline"
+              title="Timeline"
+              description="Immutable workflow and domain events"
+            >
+              <ApplyRunTimeline runId={runId} events={run?.events ?? []} />
+            </Section>
+          </TabsContent>
+          <TabsContent
+            className="job-run-workspace__panel"
+            forceMount
+            value="diagnostics"
+          >
             {run && (run.errorMessage || run.errorCode) ? (
-              <Section title="Failure">
+              <Section className="job-run-workspace__failure" title="Failure">
                 <dl className="detail-list">
                   {run.errorCode ? (
                     <div>
@@ -151,14 +229,14 @@ export function JobRunTimelineWorkspace({
                   </div>
                 </dl>
               </Section>
-            ) : null}
-          </div>
-        }
-      >
-        <Section className="job-run-workspace__timeline" title="Timeline">
-          <ApplyRunTimeline runId={runId} events={run?.events ?? []} />
-        </Section>
-      </RouteWorkspace>
+            ) : (
+              <Section title="Diagnostics">
+                <p className="muted">No failure diagnostics recorded.</p>
+              </Section>
+            )}
+          </TabsContent>
+        </RouteWorkspace>
+      </SectionTabs>
     </div>
   );
 }

--- a/apps/web/src/routes/profile.index.tsx
+++ b/apps/web/src/routes/profile.index.tsx
@@ -26,11 +26,16 @@ function ProfilePage() {
       <PageHead
         eyebrow="Setup"
         title="Profile"
-        subtitle="Baseline resume, evidence, and personal details"
+        subtitle="Canonical candidate evidence and the baseline resume that every generated artifact starts from."
         actions={
-          <Button asChild size="sm" variant="outline">
-            <Link to="/evidence-map">Open evidence map</Link>
-          </Button>
+          <>
+            <Button asChild size="sm" variant="outline">
+              <Link to="/evidence-map">Open evidence map</Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link to="/profile/import/upload">Import resume</Link>
+            </Button>
+          </>
         }
       />
       <ProfileEditor />

--- a/apps/web/src/routes/settings.browser.tsx
+++ b/apps/web/src/routes/settings.browser.tsx
@@ -10,6 +10,10 @@ export const Route = createFileRoute("/settings/browser")({
 function BrowserSettingsRoute() {
   return (
     <div className="settings-browser-sections">
+      <header className="settings-browser-intro">
+        <h2>Browser and extension</h2>
+        <p>Optional capabilities are explicit, revocable, and scoped to local JobCtrl workflows.</p>
+      </header>
       <BrowserCapabilitiesPanel />
       <ExtensionPairingPanel />
     </div>

--- a/apps/web/src/routes/settings.credentials.tsx
+++ b/apps/web/src/routes/settings.credentials.tsx
@@ -3,5 +3,17 @@ import { createFileRoute } from "@tanstack/react-router";
 import { CredentialsPanel } from "../contexts/profile/components/CredentialsPanel.js";
 
 export const Route = createFileRoute("/settings/credentials")({
-  component: CredentialsPanel,
+  component: CredentialsSettingsRoute,
 });
+
+function CredentialsSettingsRoute() {
+  return (
+    <div className="settings-credentials-sections">
+      <header className="settings-subroute-head">
+        <h2>Credentials</h2>
+        <p>Verify provider readiness without exposing the underlying secret.</p>
+      </header>
+      <CredentialsPanel />
+    </div>
+  );
+}

--- a/apps/web/src/routes/settings.models.tsx
+++ b/apps/web/src/routes/settings.models.tsx
@@ -10,6 +10,10 @@ export const Route = createFileRoute("/settings/models")({
 function ModelsSettingsRoute() {
   return (
     <div className="models-settings-sections grid gap-[18px]">
+      <header className="settings-subroute-head">
+        <h2>Models and execution policy</h2>
+        <p>Choose explicit providers for analysis, generation, fallback, and judging.</p>
+      </header>
       <ModelSelectionPanel />
       <AiExecutionPolicyPanel />
     </div>

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -24,7 +24,11 @@ function SettingsLayout() {
 
   return (
     <div className="route-page route-page--settings">
-      <PageHead eyebrow="Setup" title="Settings" />
+      <PageHead
+        eyebrow="Setup"
+        title="Settings"
+        subtitle="Runtime policy, providers, model choices, and optional local capabilities."
+      />
       <div className="config-layout">
         <SectionTabs className="settings-route-tabs grid gap-[18px]" value={activeTab}>
           <nav className="settings-section-navigation" aria-label="Settings sections">

--- a/apps/web/src/shared/layout/ConnectionStatusPill.test.tsx
+++ b/apps/web/src/shared/layout/ConnectionStatusPill.test.tsx
@@ -33,6 +33,8 @@ describe("<ConnectionStatusPill>", () => {
     const pill = screen.getByText("live");
     expect(pill).toHaveAttribute("aria-live", "polite");
     expect(pill).toHaveAttribute("data-status", "open");
+    expect(pill).toHaveClass("connection-status__state");
+    expect(pill.querySelector(".connection-status__dot")).toHaveAttribute("aria-hidden", "true");
     expect(await screen.findByText("LLM $0.12 / $25.00")).toHaveAttribute("data-status", "ok");
   });
 

--- a/apps/web/src/shared/layout/ConnectionStatusPill.tsx
+++ b/apps/web/src/shared/layout/ConnectionStatusPill.tsx
@@ -21,17 +21,18 @@ export function ConnectionStatusPill() {
   const label = workerUnhealthy ? "worker" : lostForLong ? "offline" : STATUS_LABEL[status];
   const spend = health.data?.llmSpend;
   return (
-    <div className="connection-pill-group">
+    <div className="connection-status">
       <span
-        className="connection-pill"
+        className="connection-status__state"
         data-status={workerUnhealthy ? "lost" : lostForLong ? "lost" : status}
         aria-live="polite"
       >
+        <span className="connection-status__dot" aria-hidden="true" />
         {label}
       </span>
       {spend ? (
         <span
-          className="connection-spend"
+          className="connection-status__spend"
           data-status={spend.status}
           aria-live="polite"
         >
@@ -39,11 +40,11 @@ export function ConnectionStatusPill() {
         </span>
       ) : null}
       {workerUnhealthy ? (
-        <div className="connection-banner" role="alert" aria-live="assertive">
+        <div className="connection-status__banner" role="alert" aria-live="assertive">
           {health.data?.worker.message ?? "JobCtrl automation worker health is unavailable."}
         </div>
       ) : lostForLong ? (
-        <div className="connection-banner" role="status" aria-live="polite">
+        <div className="connection-status__banner" role="status" aria-live="polite">
           Connection lost — events paused; data will refresh when reconnected.
         </div>
       ) : null}

--- a/apps/web/src/shared/layout/SideRail.test.tsx
+++ b/apps/web/src/shared/layout/SideRail.test.tsx
@@ -62,7 +62,10 @@ describe("<SideRail>", () => {
     renderRail();
 
     expect(await screen.findByRole("link", { name: "JobCtrl" })).toHaveAttribute("href", "/dashboard");
-    expect(screen.getByText("Local mode — all data stays on device")).toBeInTheDocument();
+    const localMode = screen.getByText("Local mode — all data stays on device").parentElement;
+    expect(localMode).toHaveAttribute("role", "note");
+    expect(localMode).toHaveAttribute("aria-label", "Local mode — all data stays on device");
+    expect(localMode).toHaveAttribute("title", "Local mode — all data stays on device");
     expect(screen.getByText("Copyright © 2026 Eloi Barti")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "AGPL-3.0-only" })).toHaveAttribute(
       "href",

--- a/apps/web/src/shared/layout/SideRail.tsx
+++ b/apps/web/src/shared/layout/SideRail.tsx
@@ -122,7 +122,7 @@ export function RailNav({ className, onNavigate }: RailNavProps) {
   );
 }
 
-export function LocalModeCard() {
+export function LocalModeStatus() {
   const workspace = useDemoWorkspace();
   const text =
     workspace.mode === "demo"
@@ -131,7 +131,7 @@ export function LocalModeCard() {
         : "Demo mode — this tab only"
       : "Local mode — all data stays on device";
   return (
-    <div className="side-rail__footer">
+    <div className="side-rail__footer" role="note" aria-label={text} title={text}>
       <span className="side-rail__status-dot" aria-hidden="true" />
       <span className="side-rail__footer-text">{text}</span>
     </div>
@@ -146,7 +146,7 @@ export function SideRail() {
       </Link>
       <RailNav />
       <span className="side-rail__spacer" />
-      <LocalModeCard />
+      <LocalModeStatus />
       <LegalNotice className="legal-notice legal-notice--rail" />
     </aside>
   );

--- a/apps/web/src/shared/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/layout/Topbar.test.tsx
@@ -103,6 +103,12 @@ describe("<Topbar>", () => {
       "href",
       "https://github.com/ebarti/JobCtrl",
     );
+    expect(within(dialog).getByRole("combobox", { name: "Row density" })).toHaveTextContent(
+      "Regular",
+    );
+    expect(within(dialog).getByRole("button", { name: "Switch to dark theme" })).toBeInTheDocument();
+    expect(await within(dialog).findByText("LLM $0.12 / $25.00")).toBeInTheDocument();
+    expect(within(dialog).getByText("Local mode — all data stays on device")).toBeInTheDocument();
     expect(nav).toBeInTheDocument();
   });
 

--- a/apps/web/src/shared/layout/Topbar.tsx
+++ b/apps/web/src/shared/layout/Topbar.tsx
@@ -15,10 +15,33 @@ import {
 import { BrandMark } from "./BrandMark.js";
 import { ConnectionStatusPill } from "./ConnectionStatusPill.js";
 import { LegalNotice } from "./LegalNotice.js";
-import { RailNav } from "./SideRail.js";
+import { LocalModeStatus, RailNav } from "./SideRail.js";
 import { ThemeToggle } from "./ThemeToggle.js";
 
 const DENSITY_OPTIONS: ReadonlyArray<Density> = ["compact", "regular", "comfy"];
+
+interface DensityControlProps {
+  readonly className: string;
+  readonly density: Density;
+  readonly onDensityChange: (density: Density) => void;
+}
+
+function DensityControl({ className, density, onDensityChange }: DensityControlProps) {
+  return (
+    <Select value={density} onValueChange={(value) => onDensityChange(value as Density)}>
+      <SelectTrigger className={className} aria-label="Row density">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent align="end">
+        {DENSITY_OPTIONS.map((option) => (
+          <SelectItem key={option} value={option}>
+            {option[0]?.toUpperCase()}{option.slice(1)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
 
 export function Topbar() {
   const { density, setDensity } = useDensity();
@@ -33,13 +56,34 @@ export function Topbar() {
             <IconMenu2 aria-hidden="true" size={18} />
           </button>
         </SheetTrigger>
-        <SheetContent side="left" aria-describedby={undefined}>
-          <SheetHeader>
-            <SheetTitle>
+        <SheetContent
+          side="left"
+          className="mobile-navigation-sheet"
+          aria-describedby={undefined}
+        >
+          <SheetHeader className="mobile-navigation-sheet__header">
+            <SheetTitle className="mobile-navigation-sheet__title">
               <BrandMark showTagline />
             </SheetTitle>
           </SheetHeader>
           <RailNav className="sheet-nav" onNavigate={() => setNavOpen(false)} />
+          <section
+            className="mobile-navigation-sheet__utilities"
+            aria-labelledby="mobile-navigation-utilities-title"
+          >
+            <h2 id="mobile-navigation-utilities-title">Interface controls</h2>
+            <div className="mobile-navigation-sheet__density-row">
+              <span>Row density</span>
+              <DensityControl
+                className="mobile-navigation-sheet__density"
+                density={density}
+                onDensityChange={setDensity}
+              />
+            </div>
+            <ThemeToggle />
+            <ConnectionStatusPill />
+          </section>
+          <LocalModeStatus />
           <LegalNotice className="legal-notice legal-notice--sheet" />
         </SheetContent>
       </Sheet>
@@ -58,19 +102,14 @@ export function Topbar() {
           }}
         />
       </label>
-      <Select value={density} onValueChange={(value) => setDensity(value as Density)}>
-        <SelectTrigger className="topbar__density" aria-label="Row density">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent align="end">
-          {DENSITY_OPTIONS.map((option) => (
-            <SelectItem key={option} value={option}>
-              {option[0]?.toUpperCase()}{option.slice(1)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <ThemeToggle />
+      <DensityControl
+        className="topbar__density"
+        density={density}
+        onDensityChange={setDensity}
+      />
+      <span className="topbar__theme-control">
+        <ThemeToggle />
+      </span>
       <ConnectionStatusPill />
       <LegalNotice className="legal-notice legal-notice--topbar" />
     </header>

--- a/apps/web/src/shared/ui/badge.tsx
+++ b/apps/web/src/shared/ui/badge.tsx
@@ -4,14 +4,13 @@ import type { HTMLAttributes, JSX } from "react";
 import { cn } from "../lib/cn.js";
 
 const badgeVariants = cva(
-  "inline-flex min-h-[22px] items-center rounded-full border px-2.5 text-[11px] font-[850] leading-none tracking-[0.01em] transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex min-h-[22px] items-center rounded-none border-0 border-l-2 bg-transparent px-2 text-[11px] font-bold leading-none tracking-0 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-accent text-accent-foreground",
-        secondary: "border-transparent bg-muted text-muted-foreground",
-        destructive:
-          "border-transparent bg-[color-mix(in_oklab,var(--destructive)_14%,var(--card))] text-destructive",
+        default: "border-primary text-foreground",
+        secondary: "border-border text-muted-foreground",
+        destructive: "border-destructive text-destructive",
         outline: "border-border text-muted-foreground",
       },
     },

--- a/apps/web/src/shared/ui/button.tsx
+++ b/apps/web/src/shared/ui/button.tsx
@@ -5,23 +5,23 @@ import { forwardRef, type ButtonHTMLAttributes } from "react";
 import { cn } from "../lib/cn.js";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[6px] text-[12px] font-extrabold transition-[background-color,border-color,color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[2px] text-[12px] font-bold transition-[background-color,border-color,color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[0_1px_2px_rgb(15_23_42/0.12)] hover:bg-primary/90",
-        destructive: "bg-destructive text-white hover:bg-destructive/90",
-        outline: "border border-border bg-card text-foreground shadow-[0_1px_2px_rgb(15_23_42/0.04)] hover:border-foreground/25 hover:bg-muted",
+          "border border-foreground bg-foreground text-card shadow-none hover:bg-foreground/90",
+        destructive: "border border-destructive/45 bg-card text-destructive hover:border-destructive hover:bg-destructive/5",
+        outline: "border border-border bg-card text-foreground shadow-none hover:border-foreground/35 hover:bg-muted/45",
         secondary:
-          "border border-border bg-secondary text-secondary-foreground hover:border-foreground/20 hover:bg-muted",
+          "border border-border bg-card text-foreground hover:border-foreground/35 hover:bg-muted/45",
         ghost: "text-muted-foreground hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-[5px] px-3 text-xs",
-        lg: "h-10 rounded-[6px] px-6",
+        sm: "h-8 rounded-[2px] px-3 text-xs",
+        lg: "h-10 rounded-[2px] px-6",
         icon: "h-9 w-9",
       },
     },

--- a/apps/web/src/shared/ui/card.tsx
+++ b/apps/web/src/shared/ui/card.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type HTMLAttributes } from "react";
 import { cn } from "../lib/cn.js";
 
 export const cardClassName =
-  "rounded-lg border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]";
+  "rounded-none border border-border bg-card text-card-foreground shadow-none";
 
 export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (

--- a/apps/web/src/shared/ui/checkbox.tsx
+++ b/apps/web/src/shared/ui/checkbox.tsx
@@ -11,13 +11,13 @@ export const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer grid size-[18px] shrink-0 place-items-center rounded-[4px] border border-input bg-card text-primary-foreground shadow-[0_1px_1px_rgb(15_23_42/0.04)] transition-[border-color,background-color,box-shadow] hover:border-foreground/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary",
+      "peer grid size-4 shrink-0 place-items-center rounded-[2px] border border-input bg-card text-primary-foreground shadow-none transition-[border-color,background-color] hover:border-foreground/45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=indeterminate]:border-primary data-[state=indeterminate]:bg-primary",
       className,
     )}
     {...props}
   >
     <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
-      <IconCheck className="size-[14px]" stroke={2.7} />
+      <IconCheck className="size-3" stroke={2.7} />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/apps/web/src/shared/ui/command.tsx
+++ b/apps/web/src/shared/ui/command.tsx
@@ -71,7 +71,7 @@ export const Command = forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden rounded-[2px] bg-popover text-popover-foreground",
       className,
     )}
     {...props}
@@ -103,7 +103,7 @@ export const CommandInput = forwardRef<
       <CommandPrimitive.Input
         ref={ref}
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-[2px] bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}
@@ -177,7 +177,7 @@ export const CommandItem = forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-[2px] px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/copyable-command.tsx
+++ b/apps/web/src/shared/ui/copyable-command.tsx
@@ -25,7 +25,7 @@ export function CopyableCommand({ command, className, label = "Copy command" }: 
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-2 rounded-md border border-border bg-muted px-3 py-2 font-mono text-xs",
+        "flex items-center justify-between gap-2 rounded-[2px] border border-border bg-muted px-3 py-2 font-mono text-xs",
         className,
       )}
     >

--- a/apps/web/src/shared/ui/dialog.tsx
+++ b/apps/web/src/shared/ui/dialog.tsx
@@ -38,13 +38,13 @@ export const DialogContent = forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-popover p-6 text-popover-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-[2px] border border-border bg-popover p-6 text-popover-foreground shadow-[var(--shadow-float)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-[2px] opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <IconX className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/web/src/shared/ui/dropdown-menu.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu.tsx
@@ -23,7 +23,7 @@ export const DropdownMenuSubTrigger = forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      "flex cursor-default select-none items-center rounded-[2px] px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
       inset && "pl-8",
       className,
     )}
@@ -42,7 +42,7 @@ export const DropdownMenuSubContent = forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-panel)]",
+      "z-50 min-w-[8rem] overflow-hidden rounded-[2px] border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-float)]",
       className,
     )}
     {...props}
@@ -59,7 +59,7 @@ export const DropdownMenuContent = forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-panel)]",
+        "z-50 min-w-[8rem] overflow-hidden rounded-[2px] border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-float)]",
         className,
       )}
       {...props}
@@ -75,7 +75,7 @@ export const DropdownMenuItem = forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center gap-2 rounded-[2px] px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -91,7 +91,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-[2px] py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
@@ -113,7 +113,7 @@ export const DropdownMenuRadioItem = forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-[2px] py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/field.tsx
+++ b/apps/web/src/shared/ui/field.tsx
@@ -115,7 +115,7 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 text-[11px] font-bold leading-snug tracking-[0.005em] group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-[6px] has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
+        "group/field-label peer/field-label flex w-fit gap-2 text-[11px] font-bold leading-snug tracking-[0.005em] group-data-[disabled=true]/field:opacity-50 has-[>[data-slot=field]]:rounded-[2px] has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className,
       )}

--- a/apps/web/src/shared/ui/input.tsx
+++ b/apps/web/src/shared/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     <input
       type={type}
       className={cn(
-        "flex h-[38px] w-full rounded-[6px] border border-input bg-card px-3 py-1 text-[13px] font-medium shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/25 focus-visible:border-primary/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
+        "flex h-[38px] w-full rounded-[2px] border border-input bg-card px-3 py-1 text-[13px] font-medium shadow-none transition-[border-color,background-color] file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/35 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/inspector-ledger.tsx
+++ b/apps/web/src/shared/ui/inspector-ledger.tsx
@@ -33,8 +33,8 @@ export function InspectorLedgerItem({
     <div className={cn("inspector-ledger__item", className)} {...props}>
       <dt>{label}</dt>
       <dd>{value ?? <span className="inspector-ledger__missing">Not available</span>}</dd>
-      {source ? <span className="inspector-ledger__source">{source}</span> : null}
-      {status ? <span className="inspector-ledger__status">{status}</span> : null}
+      {source ? <dd className="inspector-ledger__source">{source}</dd> : null}
+      {status ? <dd className="inspector-ledger__status">{status}</dd> : null}
     </div>
   );
 }

--- a/apps/web/src/shared/ui/popover.tsx
+++ b/apps/web/src/shared/ui/popover.tsx
@@ -17,7 +17,7 @@ export const PopoverContent = forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-panel)] outline-none",
+        "z-50 w-72 rounded-[2px] border border-border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-float)] outline-none",
         className,
       )}
       {...props}

--- a/apps/web/src/shared/ui/route-workspace.tsx
+++ b/apps/web/src/shared/ui/route-workspace.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/cn.js";
 
 export interface RouteWorkspaceProps extends HTMLAttributes<HTMLElement> {
   readonly header?: ReactNode;
+  readonly tabs?: ReactNode;
   readonly navigation?: ReactNode;
   readonly inspector?: ReactNode;
   readonly children: ReactNode;
@@ -14,6 +15,7 @@ export interface RouteWorkspaceProps extends HTMLAttributes<HTMLElement> {
 
 export function RouteWorkspace({
   header,
+  tabs,
   navigation,
   inspector,
   children,
@@ -26,6 +28,7 @@ export function RouteWorkspace({
   return (
     <article className={cn("route-workspace", className)} {...props}>
       {header ? <header className="route-workspace__header">{header}</header> : null}
+      {tabs ? <div className="route-workspace__tabs">{tabs}</div> : null}
       <div
         className="route-workspace__grid"
         data-has-inspector={Boolean(inspector)}

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -19,7 +19,7 @@ export const SelectTrigger = forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-[38px] w-full items-center justify-between gap-3 whitespace-nowrap rounded-[6px] border border-input bg-card px-3 py-2 text-left text-[13px] font-medium shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] placeholder:text-muted-foreground hover:border-foreground/25 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 data-[placeholder]:text-muted-foreground disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 [&>span]:line-clamp-1",
+      "flex h-[38px] w-full items-center justify-between gap-3 whitespace-nowrap rounded-[2px] border border-input bg-card px-3 py-2 text-left text-[13px] font-medium shadow-none transition-[border-color,background-color] placeholder:text-muted-foreground hover:border-foreground/35 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1 data-[placeholder]:text-muted-foreground disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
@@ -68,7 +68,7 @@ export const SelectContent = forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[10rem] origin-[var(--radix-select-content-transform-origin)] overflow-hidden rounded-[7px] border border-border bg-popover text-popover-foreground shadow-[0_18px_46px_rgb(15_23_42/0.16)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "relative z-50 max-h-96 min-w-[10rem] origin-[var(--radix-select-content-transform-origin)] overflow-hidden rounded-[2px] border border-border bg-popover text-popover-foreground shadow-[0_18px_46px_rgb(15_23_42/0.16)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -114,7 +114,7 @@ export const SelectItem = forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex min-h-9 w-full cursor-default select-none items-center rounded-[4px] py-2 pl-2.5 pr-9 text-[13px] outline-none focus:bg-muted focus:text-foreground data-[state=checked]:font-semibold data-[disabled]:pointer-events-none data-[disabled]:opacity-45",
+      "relative flex min-h-9 w-full cursor-default select-none items-center rounded-none py-2 pl-2.5 pr-9 text-[13px] outline-none focus:bg-muted focus:text-foreground data-[state=checked]:font-semibold data-[disabled]:pointer-events-none data-[disabled]:opacity-45",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/sheet.tsx
+++ b/apps/web/src/shared/ui/sheet.tsx
@@ -61,7 +61,7 @@ export const SheetContent = forwardRef<
     <SheetOverlay />
     <DialogPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-[2px] opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <IconX className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/apps/web/src/shared/ui/skeleton.tsx
+++ b/apps/web/src/shared/ui/skeleton.tsx
@@ -3,5 +3,5 @@ import type { HTMLAttributes, JSX } from "react";
 import { cn } from "../lib/cn.js";
 
 export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>): JSX.Element {
-  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+  return <div className={cn("animate-pulse rounded-[2px] bg-muted", className)} {...props} />;
 }

--- a/apps/web/src/shared/ui/status-label.tsx
+++ b/apps/web/src/shared/ui/status-label.tsx
@@ -1,0 +1,50 @@
+import type { JSX, ReactNode } from "react";
+
+import { StatusDot } from "./status-dot.js";
+import type { StatusDotState, StatusTagTone } from "./status-tokens.js";
+
+export type StatusLabelTone = StatusTagTone | "neutral";
+
+const DOT_STATE_BY_TONE: Record<StatusLabelTone, StatusDotState> = {
+  danger: "failed",
+  info: "running",
+  muted: "pending",
+  neutral: "pending",
+  ok: "succeeded",
+  warn: "needs_verification",
+};
+
+export interface StatusLabelProps {
+  readonly ariaLabel?: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly id?: string;
+  readonly title?: string;
+  readonly tone: StatusLabelTone;
+}
+
+/**
+ * Compact status treatment for lists and ledgers. The tone stays in the class
+ * list so callers retain their semantic styling hooks while the visible state
+ * is communicated by a dot and plain language.
+ */
+export function StatusLabel({
+  ariaLabel,
+  children,
+  className,
+  id,
+  title,
+  tone,
+}: StatusLabelProps): JSX.Element {
+  return (
+    <span
+      aria-label={ariaLabel}
+      className={["tag", "editorial-status", tone, className].filter(Boolean).join(" ")}
+      id={id}
+      title={title}
+    >
+      <StatusDot state={DOT_STATE_BY_TONE[tone]} />
+      <span className="editorial-status__label">{children}</span>
+    </span>
+  );
+}

--- a/apps/web/src/shared/ui/table.tsx
+++ b/apps/web/src/shared/ui/table.tsx
@@ -42,7 +42,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, HTMLAttributes<HTMLTable
     <tr
       ref={ref}
       className={cn(
-        "border-b border-border transition-colors hover:bg-[color-mix(in_oklch,var(--primary)_4%,var(--card))] data-[state=selected]:bg-[color-mix(in_oklch,var(--primary)_8%,var(--card))]",
+        "border-b border-border transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_3.5%,var(--card))] data-[state=selected]:bg-transparent data-[state=selected]:shadow-[inset_2px_0_0_var(--primary)]",
         className,
       )}
       {...props}

--- a/apps/web/src/shared/ui/textarea.tsx
+++ b/apps/web/src/shared/ui/textarea.tsx
@@ -8,7 +8,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => (
     <textarea
       className={cn(
-        "flex min-h-[88px] w-full rounded-[6px] border border-input bg-card px-3 py-2.5 text-[13px] font-medium leading-relaxed shadow-[0_1px_2px_rgb(15_23_42/0.04)] transition-[border-color,box-shadow,background-color] placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/25 focus-visible:border-primary/70 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
+        "flex min-h-[88px] w-full rounded-[2px] border border-input bg-card px-3 py-2.5 text-[13px] font-medium leading-relaxed shadow-none transition-[border-color,background-color] placeholder:font-normal placeholder:text-muted-foreground hover:border-foreground/35 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:bg-muted disabled:opacity-55",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/toast.tsx
+++ b/apps/web/src/shared/ui/toast.tsx
@@ -28,12 +28,13 @@ export const ToastViewport = forwardRef<
 ToastViewport.displayName = ToastPrimitive.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-lg border p-4 pr-6 shadow-lg transition-all",
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-[2px] border p-4 pr-6 shadow-[var(--shadow-float)] transition-all",
   {
     variants: {
       variant: {
         default: "border-border bg-popover text-popover-foreground",
-        destructive: "destructive group border-destructive bg-destructive text-white",
+        destructive:
+          "destructive group border-border border-l-2 border-l-destructive bg-popover text-destructive",
       },
     },
     defaultVariants: {
@@ -57,7 +58,7 @@ export const ToastAction = forwardRef<
   <ToastPrimitive.Action
     ref={ref}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-[2px] border border-border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}
@@ -73,7 +74,7 @@ export const ToastClose = forwardRef<
     ref={ref}
     aria-label="Close"
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring group-hover:opacity-100",
+      "absolute right-1 top-1 rounded-[2px] p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring group-hover:opacity-100",
       className,
     )}
     toast-close=""

--- a/apps/web/src/shared/ui/toggle-group.tsx
+++ b/apps/web/src/shared/ui/toggle-group.tsx
@@ -41,7 +41,7 @@ function ToggleGroup({
       data-orientation={orientation}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(
-        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-3xl data-vertical:flex-col data-vertical:items-stretch",
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-[2px] data-vertical:flex-col data-vertical:items-stretch",
         className,
       )}
       {...props}
@@ -72,7 +72,7 @@ function ToggleGroupItem({
       data-size={context.size || size}
       data-spacing={context.spacing}
       className={cn(
-        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-3xl group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-3xl group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-3xl group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-3xl data-[state=on]:bg-muted group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-[2px] group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-[2px] group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-[2px] group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-[2px] data-[state=on]:bg-muted group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
         toggleVariants({
           variant: context.variant || variant,
           size: context.size || size,

--- a/apps/web/src/shared/ui/toggle.tsx
+++ b/apps/web/src/shared/ui/toggle.tsx
@@ -5,7 +5,7 @@ import * as React from "react";
 import { cn } from "../lib/cn.js";
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-3xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-[2px] text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {

--- a/apps/web/src/shared/ui/tooltip.tsx
+++ b/apps/web/src/shared/ui/tooltip.tsx
@@ -15,7 +15,7 @@ export const TooltipContent = forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md",
+      "z-50 overflow-hidden rounded-[2px] border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-[var(--shadow-float)]",
       className,
     )}
     {...props}

--- a/apps/web/src/styles/editorial-apply-review.css
+++ b/apps/web/src/styles/editorial-apply-review.css
@@ -1,0 +1,563 @@
+/*
+ * Editorial application-review workspace
+ *
+ * This route is a continuous decision surface: the queue, evidence, and
+ * current material share one ruled sheet. Keep status information legible,
+ * but do not turn its audit evidence into a second layer of rounded cards.
+ */
+
+.route-page--apply-review {
+  container: apply-review / inline-size;
+  gap: 0.875rem;
+}
+
+.route-page--apply-review .page-head {
+  padding-block: 0.25rem 0.375rem;
+}
+
+.route-page--apply-review .page-head h1 {
+  font-size: clamp(1.7rem, 2.4cqi, 2.15rem);
+  letter-spacing: -0.055em;
+}
+
+.route-page--apply-review .apply-review-workspace-shell {
+  overflow: visible;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.route-page--apply-review .route-workspace__grid[data-has-navigation="true"][data-has-inspector="false"] {
+  grid-template-columns: minmax(14.5rem, 0.28fr) minmax(0, 1fr);
+}
+
+.route-page--apply-review .route-workspace__navigation,
+.route-page--apply-review .route-workspace__content {
+  padding: 0;
+}
+
+/* Queue: a compact, ordered decision list rather than a stack of cards. */
+.route-page--apply-review .apply-review-queue {
+  background: var(--card);
+}
+
+.route-page--apply-review .apply-review-queue-head {
+  display: flex;
+  min-block-size: 2.55rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.625rem 0.875rem;
+}
+
+.route-page--apply-review .apply-review-queue-head .eyebrow {
+  color: var(--foreground);
+  font-size: 0.6875rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.route-page--apply-review .apply-review-queue-head b {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 650;
+}
+
+.route-page--apply-review .apply-review-queue-list {
+  gap: 0;
+  max-block-size: min(72dvh, 56rem);
+  margin: 0;
+  padding: 0;
+  background: var(--card);
+}
+
+.route-page--apply-review .apply-review-queue-list > li {
+  border-bottom: 1px solid var(--border);
+}
+
+.route-page--apply-review .apply-review-queue-item {
+  position: relative;
+  gap: 0.35rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.875rem 0.875rem 0.9rem;
+}
+
+.route-page--apply-review .apply-review-queue-item::before {
+  position: absolute;
+  inset-block: 0.7rem;
+  inset-inline-start: 0;
+  inline-size: 2px;
+  background: transparent;
+  content: "";
+}
+
+.route-page--apply-review .apply-review-queue-item:hover {
+  border-color: transparent;
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+
+.route-page--apply-review .apply-review-queue-item.selected {
+  border-color: transparent;
+  background: transparent;
+  box-shadow: none;
+}
+
+.route-page--apply-review .apply-review-queue-item.selected::before {
+  background: var(--primary);
+}
+
+.route-page--apply-review .apply-review-queue-title {
+  gap: 0.625rem;
+}
+
+.route-page--apply-review .apply-review-queue-title b {
+  font-size: 0.9rem;
+  line-height: 1.22;
+  white-space: normal;
+}
+
+.route-page--apply-review .apply-review-queue-score {
+  display: inline-grid;
+  flex: 0 0 1.75rem;
+  inline-size: 1.75rem;
+  block-size: 1.75rem;
+  place-items: center;
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  font-size: 0.7rem;
+  font-weight: 750;
+  line-height: 1;
+}
+
+.route-page--apply-review .apply-review-queue-item .meta {
+  padding-inline-start: 2.375rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+}
+
+.route-page--apply-review .apply-review-queue-item > .tag {
+  width: fit-content;
+  margin-inline-start: 2.375rem;
+}
+
+/* The selected job and human decision are deliberately kept above the audit. */
+.route-page--apply-review .apply-review-selected-toolbar,
+.route-page--apply-review .apply-review-selected-head {
+  margin: 0;
+}
+
+.route-page--apply-review .apply-review-selected-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.86fr);
+  gap: 1rem;
+  align-items: start;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  padding: 0.875rem 1rem;
+}
+
+.route-page--apply-review .apply-review-selected-head .tool-row__primary {
+  align-items: flex-start;
+}
+
+.route-page--apply-review .apply-review-selected-context {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem 0.75rem;
+}
+
+.route-page--apply-review .apply-review-selected-title {
+  display: grid;
+  min-inline-size: min(100%, 15rem);
+  gap: 0.15rem;
+  margin-inline-end: auto;
+}
+
+.route-page--apply-review .apply-review-selected-title h2 {
+  margin: 0;
+  font-size: clamp(1rem, 1.65cqi, 1.2rem);
+  font-weight: 780;
+  letter-spacing: -0.035em;
+  line-height: 1.15;
+}
+
+.route-page--apply-review .apply-review-selected-title p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.route-page--apply-review .apply-review-selected-status {
+  margin-inline-start: auto;
+}
+
+.route-page--apply-review .apply-review-selected-context .compensation-strip,
+.route-page--apply-review .apply-review-selected-context .resume-template-job-select,
+.route-page--apply-review .apply-review-audit-facts {
+  flex: 1 1 100%;
+}
+
+.route-page--apply-review .compensation-strip {
+  gap: 0.3rem 0.55rem;
+  font-size: 0.72rem;
+}
+
+.route-page--apply-review .compensation-strip-label,
+.route-page--apply-review .apply-review-audit-facts dt {
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.route-page--apply-review .resume-template-job-select {
+  grid-template-columns: minmax(10rem, 1fr) auto;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.4rem 0;
+}
+
+.route-page--apply-review .apply-review-audit-facts {
+  gap: 0;
+  margin: 0.15rem 0 0;
+  border-top: 1px solid var(--border);
+}
+
+.route-page--apply-review .apply-review-audit-facts > div {
+  grid-template-columns: minmax(5.25rem, 0.28fr) minmax(0, 1fr);
+  gap: 0.625rem;
+  padding-block: 0.45rem;
+}
+
+.route-page--apply-review .apply-review-audit-facts > div + div {
+  border-top: 1px solid var(--border);
+}
+
+.route-page--apply-review .apply-review-audit-facts dd {
+  gap: 0.35rem 0.625rem;
+}
+
+.route-page--apply-review .apply-review-selected-actions {
+  display: grid;
+  justify-self: stretch;
+  justify-content: end;
+  gap: 0.5rem;
+}
+
+.route-page--apply-review .apply-review-selected-actions > .button,
+.route-page--apply-review .apply-review-selected-actions > a,
+.route-page--apply-review .apply-review-selected-actions .tab,
+.route-page--apply-review .apply-review-selected-actions .button {
+  border-radius: 0;
+}
+
+.route-page--apply-review .apply-review-selected-actions .apply-review-actions {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.route-page--apply-review .apply-review-approval-binding {
+  flex-basis: 100%;
+  justify-content: flex-end;
+  gap: 0.25rem 0.75rem;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.45rem;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+}
+
+.route-page--apply-review .apply-review-approval-block {
+  flex-basis: 100%;
+  font-size: 0.6875rem;
+  line-height: 1.4;
+}
+
+/* Evidence and material are adjacent columns on one flat, scrollable sheet. */
+.route-page--apply-review .apply-review-workspace {
+  grid-template-columns: minmax(19rem, 0.9fr) minmax(0, 1.1fr);
+  gap: 0;
+  padding: 0;
+  background: var(--card);
+}
+
+.route-page--apply-review .apply-review-pane {
+  min-block-size: min(57dvh, 44rem);
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-page--apply-review .apply-review-pane + .apply-review-pane {
+  border-inline-start: 1px solid var(--border);
+}
+
+.route-page--apply-review .apply-review-pane > header {
+  gap: 0.25rem;
+  background: transparent;
+  padding: 1rem 1rem 0.8rem;
+}
+
+.route-page--apply-review .apply-review-pane > header .eyebrow {
+  font-size: 0.625rem;
+}
+
+.route-page--apply-review .apply-review-pane > header h2 {
+  font-size: 0.95rem;
+  font-weight: 750;
+  letter-spacing: -0.025em;
+}
+
+.route-page--apply-review .apply-review-pane-scroll {
+  padding: 0 1rem 1rem;
+}
+
+.route-page--apply-review .apply-review-materials-scroll {
+  gap: 0;
+}
+
+.route-page--apply-review .apply-review-preview-block {
+  gap: 0.625rem;
+  padding-block: 0.875rem;
+}
+
+.route-page--apply-review .apply-review-preview-block:first-child {
+  padding-top: 0;
+}
+
+.route-page--apply-review .apply-review-preview-block + .apply-review-preview-block {
+  padding-top: 0.875rem;
+}
+
+.route-page--apply-review .apply-review-preview-block h3 {
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.route-page--apply-review .apply-review-document {
+  border-radius: 0;
+  background: color-mix(in oklch, var(--background) 55%, var(--card));
+  padding: 0.75rem;
+}
+
+.route-page--apply-review .apply-review-html-line-review,
+.route-page--apply-review .apply-review-pdf-line-review {
+  background: transparent;
+  padding: 0;
+}
+
+.route-page--apply-review .resume-plate-editor,
+.route-page--apply-review .pdf-preview-viewer {
+  border-radius: 0;
+}
+
+/* Audit language is a ledger: a label, direct text, and hairline separation. */
+.route-page--apply-review .tag {
+  min-block-size: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.route-page--apply-review .tag:not(.muted) {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.route-page--apply-review .tag:not(.muted)::before {
+  inline-size: 0.375rem;
+  block-size: 0.375rem;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.route-page--apply-review .tag.muted {
+  color: var(--muted-foreground);
+}
+
+.route-page--apply-review .tag.ok {
+  color: var(--success);
+}
+
+.route-page--apply-review .tag.warn {
+  color: var(--warning);
+}
+
+.route-page--apply-review .tag.info {
+  color: var(--status-info);
+}
+
+.route-page--apply-review .tag.danger {
+  color: var(--destructive);
+}
+
+.route-page--apply-review .apply-review-ideal-profile,
+.route-page--apply-review .apply-review-score-evidence,
+.route-page--apply-review .apply-review-audit-section,
+.route-page--apply-review .artifact-comparison,
+.route-page--apply-review .apply-review-artifact-risk {
+  border-top: 1px solid var(--border);
+  padding-top: 0.875rem;
+}
+
+.route-page--apply-review .apply-review-ideal-profile > section + section,
+.route-page--apply-review .apply-review-score-evidence,
+.route-page--apply-review .apply-review-audit-section + .apply-review-audit-section {
+  margin-top: 0.875rem;
+}
+
+.route-page--apply-review .apply-review-ideal-profile h4,
+.route-page--apply-review .apply-review-score-evidence h4,
+.route-page--apply-review .apply-review-audit-section h4 {
+  font-size: 0.75rem;
+  text-transform: none;
+}
+
+.route-page--apply-review .apply-review-ideal-requirements {
+  gap: 0;
+  margin-top: 0.625rem;
+}
+
+.route-page--apply-review .apply-review-ideal-requirements > li {
+  padding-block: 0.75rem;
+}
+
+.route-page--apply-review .apply-review-requirement-fit-grid {
+  gap: 0;
+  background: transparent;
+}
+
+.route-page--apply-review .apply-review-requirement-fit-grid > div {
+  gap: 0.325rem;
+  border-block: 1px solid var(--border);
+  background: transparent;
+  padding: 0.55rem;
+}
+
+.route-page--apply-review .apply-review-requirement-fit-grid > div + div {
+  border-inline-start: 1px solid var(--border);
+}
+
+.route-page--apply-review .apply-review-evidence-list {
+  gap: 0;
+}
+
+.route-page--apply-review .apply-review-evidence-list > div {
+  grid-template-columns: minmax(7rem, 0.4fr) minmax(0, 1fr);
+  gap: 0.625rem;
+  border-top: 1px solid var(--border);
+  padding-block: 0.5rem;
+}
+
+.route-page--apply-review .apply-review-evidence-list dd,
+.route-page--apply-review .apply-review-audit-summary,
+.route-page--apply-review .apply-review-audit-tags > span:last-child,
+.route-page--apply-review .apply-review-audit-revision {
+  gap: 0.35rem 0.625rem;
+}
+
+.route-page--apply-review .apply-review-audit-tags {
+  grid-template-columns: minmax(6.5rem, 0.38fr) minmax(0, 1fr);
+  gap: 0.625rem;
+  margin-top: 0.25rem;
+}
+
+.route-page--apply-review .artifact-comparison {
+  gap: 0.625rem;
+}
+
+.route-page--apply-review .artifact-comparison-sides {
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.route-page--apply-review .artifact-comparison-side,
+.route-page--apply-review .artifact-comparison-delta {
+  border: 0;
+  border-radius: 0;
+  padding: 0.625rem;
+}
+
+.route-page--apply-review .artifact-comparison-side + .artifact-comparison-side {
+  border-inline-start: 1px solid var(--border);
+}
+
+.route-page--apply-review .artifact-comparison-delta {
+  border: 1px solid var(--border);
+}
+
+@container apply-review (max-width: 62rem) {
+  .route-page--apply-review .route-workspace__grid[data-has-navigation="true"][data-has-inspector="false"],
+  .route-page--apply-review .apply-review-selected-head,
+  .route-page--apply-review .apply-review-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--apply-review .route-workspace__navigation {
+    border-inline: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .route-page--apply-review .apply-review-pane + .apply-review-pane {
+    border-inline: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .route-page--apply-review .apply-review-selected-actions,
+  .route-page--apply-review .apply-review-selected-actions .apply-review-actions,
+  .route-page--apply-review .apply-review-approval-binding {
+    justify-content: flex-start;
+  }
+}
+
+@container apply-review (max-width: 38rem) {
+  .route-page--apply-review .apply-review-queue-head,
+  .route-page--apply-review .apply-review-selected-head,
+  .route-page--apply-review .apply-review-pane > header,
+  .route-page--apply-review .apply-review-pane-scroll {
+    padding-inline: 0.75rem;
+  }
+
+  .route-page--apply-review .apply-review-requirement-fit-grid,
+  .route-page--apply-review .artifact-comparison-sides {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--apply-review .apply-review-requirement-fit-grid > div + div,
+  .route-page--apply-review .artifact-comparison-side + .artifact-comparison-side {
+    border-inline-start: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .route-page--apply-review .apply-review-audit-facts > div,
+  .route-page--apply-review .apply-review-evidence-list > div,
+  .route-page--apply-review .apply-review-audit-tags {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.3rem;
+  }
+}
+
+@media (forced-colors: active) {
+  .route-page--apply-review .apply-review-queue-item.selected::before {
+    background: Highlight;
+  }
+
+  .route-page--apply-review .tag:not(.muted)::before {
+    border: 1px solid currentColor;
+  }
+}

--- a/apps/web/src/styles/editorial-audit.css
+++ b/apps/web/src/styles/editorial-audit.css
@@ -1,0 +1,919 @@
+/*
+ * Editorial audit and evidence language
+ *
+ * Consequential data reads as a ruled ledger. Evidence values remain visible
+ * without becoming a collection of badges, and lifecycle state is delegated to
+ * the shared dot + text status treatment.
+ */
+
+.audit-value-list,
+.audit-status-list {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.8rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.audit-status-list {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.route-page--apply-review .tag.editorial-status::before {
+  display: none;
+  content: none;
+}
+
+.audit-value {
+  position: relative;
+  min-width: 0;
+  padding-inline-start: 0.65rem;
+  color: var(--foreground);
+  font-size: 0.75rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.audit-value::before {
+  position: absolute;
+  inset-block-start: 0.58em;
+  inset-inline-start: 0;
+  inline-size: 0.25rem;
+  block-size: 0.25rem;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+  content: "";
+}
+
+.audit-value--ok::before {
+  background: var(--success);
+}
+
+.audit-value--info::before {
+  background: var(--status-info);
+}
+
+.audit-value--warn::before,
+.audit-value--warning::before {
+  background: var(--warning);
+}
+
+.audit-value--danger::before {
+  background: var(--destructive);
+}
+
+.audit-value--empty {
+  color: var(--muted-foreground);
+  font-style: italic;
+}
+
+.audit-value--empty::before {
+  display: none;
+}
+
+.audit-link {
+  color: var(--primary);
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-decoration: underline;
+  text-decoration-thickness: 0.0625rem;
+  text-underline-offset: 0.18em;
+}
+
+.audit-link:focus-visible,
+:where(
+    .persona-audit-disclosure,
+    .employer-analysis-ensemble,
+    .interview-prep-sources,
+    .compensation-evidence-rows,
+    .artifact-risk-finding,
+    .resume-pin-source-check,
+    .resume-pin-source-span-details
+  ) > summary:focus-visible {
+  outline: 0.125rem solid var(--ring);
+  outline-offset: 0.125rem;
+}
+
+.audit-kicker {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 760;
+  line-height: 1.25;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.audit-kicker--ok {
+  color: var(--success);
+}
+
+.audit-kicker--info {
+  color: var(--status-info);
+}
+
+.audit-kicker--warn {
+  color: var(--warning);
+}
+
+.audit-inline-meta {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+}
+
+.audit-record-head {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.35rem 0.75rem;
+}
+
+/* Shared summary and detail ledgers -------------------------------------- */
+
+:where(
+    .tailoring-evidence,
+    .employer-analysis,
+    .artifact-comparison,
+    .artifact-risk-summary,
+    .job-audit-triage
+  ) .evidence-summary-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+:where(
+    .tailoring-evidence,
+    .employer-analysis,
+    .artifact-comparison,
+    .artifact-risk-summary,
+    .job-audit-triage
+  ) .evidence-summary-grid > div {
+  min-width: 0;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.7rem 0.75rem;
+  box-shadow: none;
+}
+
+:where(
+    .tailoring-evidence,
+    .bullet-provenance,
+    .employer-analysis,
+    .compensation-panel,
+    .resume-pin-detail,
+    .artifact-comparison-side
+  ) .detail-list.compact {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+:where(
+    .tailoring-evidence,
+    .bullet-provenance,
+    .employer-analysis,
+    .compensation-panel,
+    .resume-pin-detail,
+    .artifact-comparison-side
+  ) .detail-list.compact > div {
+  grid-template-columns: minmax(7rem, 0.34fr) minmax(0, 0.66fr);
+  gap: 0.75rem;
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.55rem;
+}
+
+:where(
+    .tailoring-evidence,
+    .bullet-provenance,
+    .employer-analysis,
+    .compensation-panel,
+    .resume-pin-detail,
+    .artifact-comparison-side
+  ) .detail-list.compact :where(dt, dd) {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+:where(
+    .tailoring-evidence,
+    .bullet-provenance,
+    .employer-analysis,
+    .compensation-panel,
+    .resume-pin-detail,
+    .artifact-comparison-side
+  ) .detail-list.compact dt {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* Tailoring and provenance ---------------------------------------------- */
+
+.tailoring-evidence {
+  gap: 0;
+}
+
+.tailoring-evidence > :where(.evidence-block, .artifact-comparison) {
+  gap: 0.75rem;
+  border-block-start: 1px solid var(--border);
+  padding-block: 1rem;
+}
+
+.tailoring-evidence > .evidence-summary-grid + .evidence-block {
+  border-block-start: 0;
+}
+
+.tailoring-evidence .evidence-block h4 {
+  font-size: 0.8125rem;
+  font-weight: 780;
+  letter-spacing: -0.01em;
+}
+
+.tailoring-change-list,
+.bullet-provenance-list,
+.persona-audit-list,
+.prompt-audit-list {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+:where(.tailoring-change, .bullet-provenance, .persona-audit, .prompt-audit, .audit-response) {
+  min-width: 0;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.8rem 0;
+  box-shadow: none;
+}
+
+.tailoring-change header {
+  margin-block-end: 0.65rem;
+}
+
+.bullet-provenance header {
+  margin-block-end: 0.65rem;
+}
+
+.bullet-provenance-diff {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.bullet-provenance-diff-side {
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem;
+}
+
+.bullet-provenance-diff-side + .bullet-provenance-diff-side {
+  border-inline-start: 1px solid var(--border);
+}
+
+.bullet-provenance-tags dd {
+  display: block;
+}
+
+.finding-list {
+  border: 0;
+  border-inline-start: 0.125rem solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.25rem 0 0.25rem 0.75rem;
+}
+
+.finding-list.danger {
+  border-inline-start-color: var(--destructive);
+}
+
+.finding-list.warning {
+  border-inline-start-color: var(--warning);
+}
+
+:where(.tailoring-evidence, .employer-analysis, .artifact-risk-finding, .resume-pin-detail)
+  .compact-list {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+:where(.tailoring-evidence, .employer-analysis, .artifact-risk-finding, .resume-pin-detail)
+  .compact-list li {
+  position: relative;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0 0 0 0.65rem;
+  color: var(--foreground);
+  font-size: 0.75rem;
+}
+
+:where(.tailoring-evidence, .employer-analysis, .artifact-risk-finding, .resume-pin-detail)
+  .compact-list li::before {
+  position: absolute;
+  inset-block-start: 0.6em;
+  inset-inline-start: 0;
+  inline-size: 0.2rem;
+  block-size: 0.2rem;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+  content: "";
+}
+
+.audit-text-block {
+  gap: 0.5rem;
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.75rem;
+}
+
+.audit-status {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.6rem;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.audit-status .audit-status__score::before {
+  margin-inline-end: 0.6rem;
+  color: var(--border-strong, var(--border));
+  content: "·";
+}
+
+.audit-status .editorial-status__label::before {
+  margin: 0;
+  content: none;
+}
+
+.persona-audit header {
+  align-items: center;
+}
+
+.persona-audit-disclosure,
+.employer-analysis-ensemble,
+.interview-prep-sources,
+.compensation-evidence-rows,
+.resume-pin-source-check,
+.resume-pin-source-span-details {
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.65rem;
+}
+
+:where(
+    .persona-audit-disclosure,
+    .employer-analysis-ensemble,
+    .interview-prep-sources,
+    .compensation-evidence-rows,
+    .resume-pin-source-check,
+    .resume-pin-source-span-details
+  ) > summary {
+  min-block-size: 1.5rem;
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.prompt-audit pre {
+  border-inline-start: 1px solid var(--border);
+  background: var(--muted);
+  padding: 0.75rem;
+}
+
+/* Artifact comparison ---------------------------------------------------- */
+
+.artifact-comparison-sides {
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.artifact-comparison-side,
+.artifact-comparison-delta {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem;
+  box-shadow: none;
+}
+
+.artifact-comparison-side + .artifact-comparison-side {
+  border-inline-start: 1px solid var(--border);
+}
+
+.artifact-comparison-delta {
+  border: 1px solid var(--border);
+}
+
+.artifact-comparison-delta-grid {
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+.artifact-comparison-tag-group {
+  gap: 0.4rem;
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  padding: 0.65rem;
+}
+
+.artifact-comparison-tag-group > span {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+/* Employer analysis ------------------------------------------------------ */
+
+.employer-analysis {
+  gap: 0;
+}
+
+.employer-analysis > .evidence-block {
+  gap: 0.75rem;
+  border-block-start: 1px solid var(--border);
+  padding-block: 1rem;
+}
+
+.employer-analysis-requirement-list,
+.employer-analysis-keyword-list,
+.employer-analysis-ensemble-body {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+:where(.employer-analysis-requirement, .employer-analysis-keyword, .employer-analysis-sub) {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.8rem 0;
+  box-shadow: none;
+}
+
+.employer-analysis-requirement {
+  gap: 0;
+}
+
+.employer-analysis-match-side {
+  gap: 0.55rem;
+  border: 0;
+  border-inline-start: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0 0 0 0.9rem;
+}
+
+.employer-analysis-signal-row {
+  gap: 0.35rem;
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.5rem;
+}
+
+.employer-analysis-signal-row > .audit-value-list {
+  display: flex;
+}
+
+.employer-analysis-evidence {
+  border-inline-start-width: 0.125rem;
+  font-style: normal;
+}
+
+/* Interview preparation ------------------------------------------------- */
+
+.interview-prep-gate {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  border-block: 1px solid var(--border);
+  padding-block: 0.7rem;
+}
+
+.interview-prep-gate > .interview-prep-warning-group {
+  flex: 1 1 100%;
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.65rem;
+}
+
+.interview-prep-items {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.interview-prep-item {
+  gap: 0.7rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.85rem 0;
+  box-shadow: none;
+}
+
+.interview-prep-item-head {
+  align-items: baseline;
+}
+
+.interview-prep-provenance {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.interview-prep-provenance :where(dt, dd) {
+  min-width: 0;
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.5rem;
+}
+
+.interview-prep-provenance dd {
+  gap: 0.35rem 0.75rem;
+}
+
+.interview-prep-warning-group {
+  border-inline-start: 0.125rem solid var(--warning);
+  padding-inline-start: 0.75rem;
+}
+
+/* Compensation evidence ------------------------------------------------- */
+
+.compensation-strip {
+  border-block: 1px solid var(--border);
+  padding-block: 0.65rem;
+}
+
+.compensation-cell > .editorial-status,
+.compensation-strip > .editorial-status {
+  font-size: 0.6875rem;
+}
+
+.compensation-cell .editorial-status :where(.status-dot, .editorial-status__label),
+.compensation-strip .editorial-status :where(.status-dot, .editorial-status__label) {
+  color: inherit;
+}
+
+.compensation-panels {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.compensation-panel {
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.85rem;
+  box-shadow: none;
+}
+
+.compensation-panel + .compensation-panel {
+  border-inline-start: 1px solid var(--border);
+}
+
+.compensation-detail-grid {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+.compensation-detail-grid > div {
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  padding: 0.55rem;
+}
+
+.compensation-evidence-row-list {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.compensation-evidence-rows > summary b {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+
+.compensation-evidence-row {
+  gap: 0.6rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem 0;
+  box-shadow: none;
+}
+
+.compensation-evidence-row dl {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+.compensation-evidence-row dl > div {
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  padding: 0.45rem;
+}
+
+.compensation-factor-list > ul,
+.compensation-source-trail > ul {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  border-block-start: 1px solid var(--border);
+  padding: 0;
+  list-style: none;
+}
+
+.compensation-factor-list > ul > li,
+.compensation-source-trail > ul > li {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.38fr) minmax(0, 0.62fr);
+  gap: 0.25rem 0.75rem;
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.55rem;
+}
+
+.compensation-factor-list > ul > li > p {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--muted-foreground);
+}
+
+/* Score and job audit ledgers ------------------------------------------- */
+
+.score-dimensions,
+.job-audit-metrics {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+.score-dimension,
+.job-audit-metrics > div {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.65rem;
+  box-shadow: none;
+}
+
+.score-signal-row,
+.job-audit-tag-group,
+.job-audit-fact-list > div {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.3fr) minmax(0, 0.7fr);
+  gap: 0.75rem;
+  border-block-start: 1px solid var(--border);
+  padding-block: 0.55rem;
+}
+
+.score-signal-row > span,
+.job-audit-tag-group > span,
+.job-audit-fact-list dt {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.job-audit-fact-list dd {
+  display: block;
+  margin: 0;
+}
+
+.job-audit-concerns {
+  gap: 0.5rem;
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.75rem;
+}
+
+/* Artifact risk and resume line audit ----------------------------------- */
+
+.artifact-risk-summary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.artifact-risk-summary h4 {
+  margin: 0;
+}
+
+.artifact-risk-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+  border-inline-start: 1px solid var(--border);
+}
+
+.artifact-risk-metrics > div {
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.42fr) minmax(0, 0.58fr);
+  gap: 0.6rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-inline-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.6rem;
+}
+
+.artifact-risk-findings {
+  display: grid;
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.artifact-risk-finding {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+}
+
+.artifact-risk-finding:is(.danger, .warning) {
+  border-color: var(--border);
+}
+
+.artifact-risk-finding-label::before {
+  flex: 0 0 auto;
+  inline-size: 0.4rem;
+  block-size: 0.4rem;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
+.artifact-risk-finding.danger .artifact-risk-finding-label {
+  color: var(--destructive);
+}
+
+.artifact-risk-finding.warning .artifact-risk-finding-label {
+  color: var(--warning);
+}
+
+.artifact-risk-finding :where(summary, .compact-list, .meta) {
+  padding-inline: 0;
+}
+
+.artifact-risk-finding .compact-list {
+  display: grid;
+  gap: 0.35rem;
+  padding-block-end: 0.75rem;
+}
+
+.artifact-risk-finding .compact-list li {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0 0 0 0.65rem;
+}
+
+.resume-pin-detail,
+.resume-comment-thread {
+  border: 0;
+  border-block-start: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.8rem 0;
+  box-shadow: none;
+}
+
+.resume-pin-risk {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+}
+
+.resume-pin-justification,
+.resume-pin-source-check-body > section {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.resume-pin-source-check {
+  border: 0;
+  border-block-start: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.resume-pin-source-check > summary {
+  padding: 0.65rem 0;
+}
+
+.resume-pin-source-check-body {
+  gap: 0.75rem;
+  border-block-start: 1px solid var(--border);
+  background: transparent;
+  padding: 0.75rem 0 0;
+}
+
+.resume-pin-source-evidence,
+.resume-pin-source-evidence.muted,
+.resume-pin-source-evidence.missing,
+.resume-pin-source-span-details summary {
+  border-radius: 0;
+  background: transparent;
+}
+
+.resume-pin-source-span-details summary {
+  padding-inline: 0;
+}
+
+.resume-comment-thread-meta {
+  gap: 0.4rem 0.8rem;
+}
+
+@container (max-width: 42rem) {
+  .bullet-provenance-diff,
+  .artifact-comparison-sides,
+  .compensation-panels,
+  .employer-analysis-requirement {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bullet-provenance-diff-side + .bullet-provenance-diff-side,
+  .artifact-comparison-side + .artifact-comparison-side,
+  .compensation-panel + .compensation-panel,
+  .employer-analysis-match-side {
+    border-inline-start: 0;
+    border-block-start: 1px solid var(--border);
+    padding-inline-start: 0;
+    padding-block-start: 0.75rem;
+  }
+
+  .score-signal-row,
+  .job-audit-tag-group,
+  .job-audit-fact-list > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.35rem;
+  }
+}
+
+@media (max-width: 42rem) {
+  .compensation-panels,
+  .artifact-comparison-sides,
+  .bullet-provenance-diff {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .compensation-panel + .compensation-panel,
+  .artifact-comparison-side + .artifact-comparison-side,
+  .bullet-provenance-diff-side + .bullet-provenance-diff-side {
+    border-inline-start: 0;
+    border-block-start: 1px solid var(--border);
+  }
+
+  .artifact-risk-metrics,
+  :where(
+      .tailoring-evidence,
+      .employer-analysis,
+      .artifact-comparison,
+      .artifact-risk-summary,
+      .job-audit-triage
+    ) .evidence-summary-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (forced-colors: active) {
+  .audit-value::before {
+    border: 1px solid currentColor;
+    background: currentColor;
+  }
+
+  .finding-list,
+  .interview-prep-warning-group {
+    border-inline-start-color: CanvasText;
+  }
+}

--- a/apps/web/src/styles/editorial-foundation.css
+++ b/apps/web/src/styles/editorial-foundation.css
@@ -1,0 +1,475 @@
+/*
+ * Editorial product surface
+ *
+ * The approved redesign uses continuous workspaces, hairline rules, and
+ * typography for hierarchy. Radius remains available for controls and true
+ * circular indicators; it must not turn every data group into a card.
+ */
+
+:root {
+  --radius: 0.125rem;
+  --shadow-panel: none;
+  --shadow-control: none;
+  --surface-raised: var(--card);
+}
+
+:where(
+  .card,
+  .data-surface,
+  .route-workspace,
+  .disclosure-section,
+  .profile-editor-panel,
+  .tool-row,
+  .provider-card,
+  .action-panel,
+  .stage-trigger-panel,
+  .resume-template-panel,
+  .preview-workbench,
+  .editor-bulk-actions
+) {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+:where(button, input, select, textarea, [data-slot="select-trigger"]) {
+  border-radius: 0.125rem;
+}
+
+.side-rail__brand,
+.side-rail__link,
+.side-rail__footer {
+  border-radius: 0;
+}
+
+.side-rail__link.on {
+  background: transparent;
+}
+
+.side-rail__link:hover {
+  background: color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.side-rail__footer {
+  border-inline: 0;
+  border-bottom: 0;
+  padding-inline: 2px;
+}
+
+.page-head {
+  align-items: flex-start;
+  padding-block: 2px 4px;
+}
+
+.page-head h1 {
+  font-size: clamp(1.7rem, 2.25vw, 2rem);
+  line-height: 1.05;
+}
+
+.page-head-subtitle {
+  max-width: 78ch;
+}
+
+.route-page {
+  gap: clamp(0.875rem, 1.35vw, 1.125rem);
+}
+
+.route-workspace__header {
+  padding: 1rem 1.125rem;
+}
+
+.route-workspace__inspector {
+  background: color-mix(in oklch, var(--background) 58%, var(--card));
+}
+
+.disclosure-section__header {
+  min-height: 3.25rem;
+  background: transparent;
+}
+
+.disclosure-section__trigger {
+  border-radius: 0;
+}
+
+.tool-row {
+  border-inline: 0;
+  padding-inline: 0;
+}
+
+/* The dashboard is one operational sheet, not a collection of floating cards. */
+.route-page--dashboard .kpis {
+  gap: 0;
+  border-block: 1px solid var(--border);
+}
+
+.route-page--dashboard .kpis > * {
+  border-width: 0 1px 0 0;
+  padding: 0.875rem 1rem;
+}
+
+.route-page--dashboard .kpis > :last-child {
+  border-right: 0;
+}
+
+.route-page--dashboard [data-slot="stat-label"] {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.route-page--dashboard [data-slot="stat-value"] {
+  font-size: 1.375rem;
+}
+
+.route-page--dashboard .dashboard-ops,
+.route-page--dashboard .dashboard-tail {
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.route-page--dashboard .dashboard-ops > .card,
+.route-page--dashboard .dashboard-tail > .card {
+  border-width: 0 1px 0 0;
+}
+
+.route-page--dashboard .dashboard-ops > .card:last-child,
+.route-page--dashboard .dashboard-tail > .card:last-child {
+  border-right: 0;
+}
+
+.route-page--dashboard .card-hd {
+  min-height: 3rem;
+  padding: 0.75rem 0.875rem;
+}
+
+.route-page--dashboard .card-hd h2 {
+  font-size: 0.875rem;
+}
+
+.card-hd {
+  background: transparent;
+}
+
+/* Tabs carry navigation through type and a rule, never through a capsule. */
+.tab {
+  position: relative;
+  min-height: 40px;
+  border-radius: 0;
+  padding: 8px 2px;
+}
+
+.tab:hover,
+.tab.on {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.tab.on {
+  box-shadow: inset 0 -2px 0 var(--primary);
+}
+
+.topbar__hamburger.tab {
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  padding: 0;
+}
+
+.section-tabs [role="tablist"] {
+  gap: 20px;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-workspace__tabs {
+  min-inline-size: 0;
+  padding-inline: clamp(1rem, 2.5vw, 1.5rem);
+  border-block-end: 1px solid var(--border);
+  background: var(--card);
+}
+
+.route-workspace__tabs .section-tabs__list {
+  inline-size: 100%;
+  border-block-end: 0;
+}
+
+/* Segmented choices use the same ruled grammar as tabs. */
+.segmented-field {
+  overflow: visible;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.segmented-field [data-slot="toggle-group-item"] {
+  position: relative;
+  min-height: 36px;
+  border-radius: 0;
+}
+
+.segmented-field [data-slot="toggle-group-item"][data-state="on"] {
+  background: transparent;
+  box-shadow: inset 0 -2px 0 var(--primary);
+}
+
+.segmented {
+  border-radius: 0;
+}
+
+.segmented.active {
+  border-color: var(--foreground);
+  background: transparent;
+  color: var(--foreground);
+}
+
+/* The shared data index is a ruled sheet, not a toolbar card followed by rows. */
+.filterable-data-grid {
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.data-grid-toolbar {
+  min-height: 48px;
+  padding-inline: 10px;
+}
+
+.data-grid-tools :where(button, select),
+.saved-table-views-control button,
+.saved-table-view-form button,
+.saved-table-density,
+.saved-table-column-row button,
+.saved-table-views-select select,
+.saved-table-rule-field select,
+.saved-table-rule-editor select,
+.saved-table-rule-editor input {
+  border-radius: 2px;
+  box-shadow: none;
+}
+
+.saved-table-rule-list,
+.saved-table-column-list {
+  gap: 0;
+}
+
+.saved-table-rule-list div,
+.saved-table-column-row {
+  border-width: 0 0 1px;
+  border-radius: 0;
+}
+
+.data-grid-filter-list {
+  gap: 0;
+}
+
+.data-grid-filter-condition {
+  gap: 10px;
+  border-width: 0 1px 0 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 10px 12px;
+}
+
+.data-grid-filter-condition:last-child {
+  border-right: 0;
+}
+
+.data-grid-filter-operator,
+.data-grid-value-list {
+  border-radius: 2px;
+}
+
+.data-grid-value-option {
+  border-radius: 0;
+}
+
+.data-grid-filter-chips {
+  gap: 12px;
+}
+
+.data-grid-filter-chips button {
+  border-width: 0 0 0 2px;
+  border-color: var(--primary);
+  border-radius: 0;
+  background: transparent;
+  padding: 3px 6px;
+}
+
+.filterable-data-grid-table thead th {
+  background: var(--card);
+  letter-spacing: 0.035em;
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-success,
+.filterable-data-grid-table .data-grid-cell-tone-warning,
+.filterable-data-grid-table .data-grid-cell-tone-danger,
+.filterable-data-grid-table .data-grid-cell-tone-info {
+  background: transparent;
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-success {
+  box-shadow: inset 2px 0 0 var(--success);
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-warning {
+  box-shadow: inset 2px 0 0 var(--warning);
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-danger {
+  box-shadow: inset 2px 0 0 var(--destructive);
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-info {
+  box-shadow: inset 2px 0 0 var(--status-info);
+}
+
+.filterable-data-grid-table tbody tr[aria-selected="true"] {
+  background: color-mix(in oklch, var(--primary) 2%, var(--card));
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.data-grid-column-filter-button,
+.data-grid-row-activation-button,
+.table-row-activation-button {
+  border-radius: 2px;
+}
+
+/* Fit is a value with semantic text, not a miniature colored card. */
+.fit,
+.fit.good,
+.fit.mid,
+.fit.none {
+  width: auto;
+  height: auto;
+  min-width: 1.5rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--muted-foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.fit[data-score-tone="positive"] {
+  color: var(--success);
+}
+
+.fit[data-score-tone="negative"] {
+  color: var(--destructive);
+}
+
+.connection-pill {
+  min-height: 24px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 2px 0;
+  font-weight: 650;
+}
+
+.connection-banner {
+  border-width: 1px 0 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-inline: 0;
+}
+
+/* Legacy metadata hooks remain for compatibility, but lose badge chrome. */
+.tag,
+.stage-pill,
+.tag.muted,
+.stage-pill.neutral,
+.stage-pill.info,
+.stage-pill.ok,
+.tag.ok,
+.tag.warn,
+.tag.danger,
+.tag.info {
+  min-height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.tag.muted,
+.stage-pill.neutral {
+  color: var(--muted-foreground);
+}
+
+.stage-pill.info,
+.tag.info {
+  color: var(--status-info);
+}
+
+.stage-pill.ok,
+.tag.ok {
+  color: var(--success);
+}
+
+.tag.warn {
+  color: var(--warning);
+}
+
+.tag.danger {
+  color: var(--destructive);
+}
+
+.compact-list li {
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+}
+
+.mini-row,
+.digest-row,
+.data-row,
+.conversion-row,
+.inspector-ledger__item {
+  border-radius: 0;
+}
+
+@media (max-width: 900px) {
+  .route-page--dashboard .kpis > *:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .route-page--dashboard .dashboard-ops,
+  .route-page--dashboard .dashboard-tail {
+    border-bottom: 0;
+  }
+
+  .route-page--dashboard .dashboard-ops > .card,
+  .route-page--dashboard .dashboard-tail > .card {
+    border-width: 0 0 1px;
+  }
+}
+
+@media (max-width: 620px) {
+  .route-page--dashboard .kpis > * {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .kpis > *:nth-child(3n) {
+    border-right: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .kpis > *:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .route-page--dashboard .kpis > :nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+}
+
+@media (forced-colors: active) {
+  .side-rail__link.on {
+    border-left: 3px solid Highlight;
+  }
+}

--- a/apps/web/src/styles/editorial-job-detail.css
+++ b/apps/web/src/styles/editorial-job-detail.css
@@ -1,0 +1,468 @@
+/*
+ * Editorial job-detail workspace
+ *
+ * This route intentionally uses a flat, ruled workspace. The scope keeps the
+ * editorial treatment from changing shared detail views or badge components.
+ */
+
+.route-page--job-detail {
+  container: job-detail / inline-size;
+  gap: 0;
+}
+
+.route-page--job-detail .route-workspace {
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.route-page--job-detail .route-workspace__header {
+  padding: 0;
+}
+
+.job-detail-route-controls {
+  display: flex;
+  align-items: center;
+  min-height: 2.75rem;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.job-detail-route-controls .workspace-back {
+  min-height: 2.75rem;
+  padding: 0.75rem 1.5rem;
+  color: var(--primary);
+  font-weight: 750;
+}
+
+.job-detail-workspace__header {
+  display: grid;
+  grid-template-areas:
+    "overview actions"
+    "ledger ledger";
+  grid-template-columns: minmax(0, 1fr) minmax(19rem, 0.78fr);
+  gap: 0;
+  align-items: stretch;
+}
+
+.job-overview {
+  grid-area: overview;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 1.1rem;
+  align-items: start;
+  min-width: 0;
+  padding: 1.25rem 1.5rem 1.4rem;
+}
+
+.job-overview__fit {
+  display: grid;
+  justify-items: center;
+  gap: 0.3rem;
+  color: var(--muted-foreground);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.job-overview__fit .fit {
+  width: auto;
+  height: auto;
+  min-width: 2.5rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+  font-size: clamp(1.65rem, 2.6cqi, 2.2rem);
+  line-height: 1;
+}
+
+.job-overview__identity {
+  display: grid;
+  min-width: 0;
+  gap: 0.2rem;
+}
+
+.job-overview__company,
+.job-overview__metadata,
+.job-overview .external-link {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.job-overview__company,
+.job-overview__metadata {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.job-overview h1 {
+  margin: 0.05rem 0 0.15rem;
+  font-size: clamp(1.35rem, 2.4cqi, 2rem);
+  font-weight: 790;
+  line-height: 1.08;
+  letter-spacing: -0.045em;
+}
+
+.job-overview__metadata {
+  margin: 0;
+}
+
+.job-overview .external-link {
+  width: fit-content;
+  margin-top: 0.35rem;
+  color: var(--primary);
+  font-size: 0.76rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.job-overview .external-link:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.job-overview-readiness {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: baseline;
+  margin-top: 0.3rem;
+}
+
+.job-overview-readiness-label,
+.job-summary-ledger dt {
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.job-overview-readiness-value,
+.job-summary-ledger__status {
+  font-weight: 800;
+}
+
+.job-overview-readiness-value--ok,
+.job-summary-ledger__status--ok {
+  color: var(--success);
+}
+
+.job-overview-readiness-value--info,
+.job-summary-ledger__status--info {
+  color: var(--status-info);
+}
+
+.job-overview-readiness-value--warn,
+.job-summary-ledger__status--warn {
+  color: var(--warning);
+}
+
+.job-detail-top-actions {
+  grid-area: actions;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-content: start;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
+  padding: 1.25rem 1.5rem 1.4rem 0;
+}
+
+.job-detail-top-actions .action-panel {
+  display: flex;
+  flex: 1 1 100%;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.4rem;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.job-detail-top-actions .action-panel :is(button, a),
+.job-detail-top-actions > a {
+  border-radius: 0 !important;
+}
+
+.job-detail-top-actions > a {
+  flex: 0 1 auto;
+  border-color: var(--border);
+}
+
+.job-actions-overflow {
+  inline-size: min(17rem, calc(100vw - 2rem));
+  border-radius: 0;
+  padding: 0.5rem;
+}
+
+.job-actions-overflow__list {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.job-actions-overflow__list :is(button, a) {
+  inline-size: 100%;
+  justify-content: flex-start;
+  border-radius: 0 !important;
+}
+
+.job-summary-ledger {
+  grid-area: ledger;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  border-block: 1px solid var(--border);
+}
+
+.job-summary-ledger > div {
+  display: grid;
+  min-width: 0;
+  gap: 0.38rem;
+  padding: 1rem 1.5rem 1.1rem;
+}
+
+.job-summary-ledger > div + div {
+  border-inline-start: 1px solid var(--border);
+}
+
+.job-summary-ledger dd {
+  display: grid;
+  min-width: 0;
+  gap: 0.14rem;
+  margin: 0;
+}
+
+.job-summary-ledger dd > b {
+  overflow-wrap: anywhere;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.job-summary-ledger dd > span {
+  color: var(--muted-foreground);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.job-detail-workspace > .route-workspace__grid[data-has-inspector="true"] {
+  grid-template-columns: minmax(0, 1.58fr) minmax(18rem, 0.82fr);
+  align-items: start;
+}
+
+.job-detail-workspace > .route-workspace__grid > .route-workspace__content,
+.job-detail-workspace > .route-workspace__grid > .route-workspace__inspector {
+  padding: 0;
+  background: var(--card);
+}
+
+.job-detail-workspace > .route-workspace__grid > .route-workspace__inspector {
+  border-inline-start: 1px solid var(--border);
+}
+
+.job-detail-workspace__content,
+.job-detail-workspace__inspector {
+  display: grid;
+  min-width: 0;
+}
+
+.job-detail-workspace__tab-panel {
+  min-width: 0;
+  margin: 0;
+}
+
+.job-detail-workspace__content > .section,
+.job-detail-workspace__content > .job-contacts-panel,
+.job-detail-workspace__inspector > .section,
+.job-detail-workspace__inspector > .job-contacts-panel {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.job-detail-workspace__content > :last-child,
+.job-detail-workspace__inspector > :last-child {
+  border-bottom: 0;
+}
+
+.job-detail-workspace .section__header {
+  margin-bottom: 0.8rem;
+}
+
+.job-detail-workspace .section__heading h3,
+.job-detail-workspace .interview-prep-heading h3 {
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.job-detail-workspace .section__heading p {
+  max-width: 62ch;
+  font-size: 0.72rem;
+}
+
+.job-detail-description .description-text {
+  max-width: 74ch;
+  gap: 0.75rem;
+}
+
+.job-detail-description .description-text :is(p, li) {
+  line-height: 1.55;
+}
+
+.job-detail-workspace .job-audit-triage {
+  gap: 1rem;
+}
+
+.job-detail-workspace .job-audit-metrics {
+  gap: 0;
+  border: 1px solid var(--border);
+}
+
+.job-detail-workspace .job-audit-metrics > div {
+  padding: 0.7rem;
+  border-inline-end: 1px solid var(--border);
+  border-block-end: 1px solid var(--border);
+}
+
+.job-detail-workspace .job-audit-metrics > div:nth-child(2n) {
+  border-inline-end: 0;
+}
+
+.job-detail-workspace .job-audit-metrics > div:nth-last-child(-n + 2) {
+  border-block-end: 0;
+}
+
+.job-detail-workspace :is(
+  .section,
+  .requirement-fit-missing,
+  .interview-prep-item,
+  .employer-analysis-requirement,
+  .employer-analysis-keyword,
+  .employer-analysis-sub,
+  .compensation-evidence-row,
+  .outcome-suggestion-card,
+  .outcome-form,
+  .job-contacts-panel
+) {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.job-detail-workspace .interview-prep-item,
+.job-detail-workspace .employer-analysis-requirement,
+.job-detail-workspace .employer-analysis-keyword,
+.job-detail-workspace .employer-analysis-sub,
+.job-detail-workspace .compensation-evidence-row {
+  background: transparent;
+}
+
+.job-detail-before-apply .mini-row {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.job-detail-before-apply .mini-row:last-child {
+  border-bottom: 0;
+}
+
+.job-detail-before-apply .mini-row > code {
+  grid-column: 2;
+  color: var(--muted-foreground);
+  font-size: 0.68rem;
+}
+
+.job-detail-before-apply .mini-row > :last-child {
+  grid-column: 3;
+  grid-row: 1 / span 2;
+}
+
+.job-detail-before-apply .empty {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+@container job-detail (max-width: 52rem) {
+  .job-detail-workspace__header {
+    grid-template-areas:
+      "overview"
+      "actions"
+      "ledger";
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .job-detail-top-actions {
+    justify-content: flex-start;
+    border-top: 1px solid var(--border);
+    padding: 0.85rem 1.5rem;
+  }
+
+  .job-detail-top-actions .action-panel {
+    justify-content: flex-start;
+  }
+
+  .job-detail-workspace > .route-workspace__grid[data-has-inspector="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .job-detail-workspace > .route-workspace__grid > .route-workspace__inspector {
+    border-top: 1px solid var(--border);
+    border-inline-start: 0;
+  }
+}
+
+@container job-detail (max-width: 43rem) {
+  .job-overview {
+    padding-inline: 1rem;
+  }
+
+  .job-detail-workspace__header > .workspace-back,
+  .job-detail-top-actions,
+  .job-summary-ledger > div,
+  .job-detail-workspace__content > .section,
+  .job-detail-workspace__content > .job-contacts-panel,
+  .job-detail-workspace__inspector > .section,
+  .job-detail-workspace__inspector > .job-contacts-panel {
+    padding-inline: 1rem;
+  }
+
+  .job-summary-ledger {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .job-summary-ledger > div:nth-child(odd) {
+    border-inline-start: 0;
+  }
+
+  .job-summary-ledger > div:nth-child(n + 3) {
+    border-top: 1px solid var(--border);
+  }
+}
+
+@container job-detail (max-width: 28rem) {
+  .job-overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .job-overview__fit {
+    justify-items: start;
+    grid-template-columns: auto auto;
+    align-items: center;
+  }
+
+  .job-detail-top-actions .action-panel {
+    gap: 0.3rem;
+  }
+}

--- a/apps/web/src/styles/editorial-jobs-index.css
+++ b/apps/web/src/styles/editorial-jobs-index.css
@@ -1,0 +1,404 @@
+/*
+ * Jobs data index
+ *
+ * The queue is one continuous editorial sheet. Views, preparation controls,
+ * selection controls, saved views, filters, rows, and paging are separated by
+ * rules and type hierarchy instead of a stack of rounded action capsules.
+ */
+
+.route-page--jobs {
+  container: jobs-index / inline-size;
+}
+
+.route-page--jobs > .page-head {
+  padding-block-end: 0.25rem;
+}
+
+.route-page--jobs .page-head-subtitle {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.jobs-index-sheet {
+  container: jobs-grid / inline-size;
+  overflow: hidden;
+  border-inline: 0;
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.jobs-index-controls.bulk-bar {
+  display: block;
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+  padding: 0;
+}
+
+.jobs-index-view-row {
+  display: flex;
+  min-width: 0;
+  min-height: 2.875rem;
+  align-items: center;
+  gap: 0.875rem;
+  border-bottom: 1px solid var(--border);
+  padding-inline: 0.75rem;
+}
+
+.jobs-index-control-label {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 800;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.jobs-index-controls .job-view-switcher {
+  min-width: 0;
+  align-self: stretch;
+  gap: 1.25rem;
+}
+
+.jobs-index-controls .job-view-switcher [data-slot="toggle-group-item"] {
+  position: relative;
+  min-height: 2.875rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--muted-foreground);
+  padding: 0 0.125rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.jobs-index-controls .job-view-switcher [data-slot="toggle-group-item"]:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.jobs-index-controls
+  .job-view-switcher
+  [data-slot="toggle-group-item"][data-state="on"] {
+  background: transparent;
+  box-shadow: inset 0 -2px 0 var(--primary);
+  color: var(--foreground);
+  font-weight: 760;
+}
+
+.jobs-index-controls
+  .job-view-switcher
+  [data-slot="toggle-group-item"]:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.jobs-index-selection-count {
+  margin-inline-start: auto;
+  border-inline-start: 2px solid var(--primary);
+  padding-inline-start: 0.5rem;
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  white-space: nowrap;
+}
+
+.jobs-index-selection-count:empty {
+  display: none;
+}
+
+.jobs-index-action-row {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.jobs-index-action-group {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(5.5rem, auto) minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem 0.875rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.jobs-index-action-group + .jobs-index-action-group {
+  border-top: 1px solid var(--border);
+}
+
+.jobs-index-action-list {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.125rem 0.875rem;
+}
+
+.jobs-index-action {
+  display: inline-flex;
+  min-height: 2rem;
+  align-items: center;
+  gap: 0.375rem;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  padding: 0.25rem 0.125rem;
+  font: inherit;
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1.2;
+  text-align: start;
+  cursor: pointer;
+}
+
+.jobs-index-action:hover {
+  border-bottom-color: var(--border);
+  color: var(--foreground);
+}
+
+.jobs-index-action:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.jobs-index-action:disabled {
+  border-bottom-color: transparent;
+  color: var(--muted-foreground);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.jobs-index-action svg {
+  flex: 0 0 auto;
+}
+
+.jobs-index-action--emphasis {
+  color: var(--foreground);
+  font-weight: 760;
+}
+
+.jobs-index-action--danger {
+  color: var(--destructive);
+}
+
+.jobs-index-sheet {
+  min-width: 0;
+  container: jobs-grid / inline-size;
+}
+
+.jobs-index-sheet .filterable-data-grid {
+  border-top: 0;
+  border-bottom: 0;
+}
+
+.jobs-index-sheet .data-grid-toolbar {
+  min-height: 3rem;
+  background: var(--card);
+  padding-inline: 0.75rem;
+}
+
+.jobs-index-sheet .data-grid-view-title {
+  gap: 0.5rem;
+}
+
+.jobs-index-sheet .data-grid-view-title strong {
+  font-size: 0.8125rem;
+  letter-spacing: -0.01em;
+}
+
+.jobs-index-sheet .data-grid-view-title .meta {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+}
+
+.jobs-index-sheet .data-grid-tools {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.jobs-index-sheet .saved-table-views-control button {
+  min-width: 1.75rem;
+  min-height: 1.75rem;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  padding-inline: 0.375rem;
+}
+
+.jobs-index-sheet .saved-table-views-control button:hover {
+  border-bottom-color: var(--border);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.jobs-index-sheet .saved-table-views-select select {
+  min-height: 1.75rem;
+  border-radius: 2px;
+  padding-inline: 0.375rem;
+}
+
+.jobs-index-sheet .filterable-data-grid-scroll {
+  scrollbar-gutter: stable;
+}
+
+.jobs-index-sheet .filterable-data-grid-table thead th {
+  background: var(--card);
+  font-weight: 780;
+  letter-spacing: 0.035em;
+}
+
+.jobs-index-sheet .filterable-data-grid-table tbody tr {
+  background: transparent;
+}
+
+.jobs-index-sheet .filterable-data-grid-table tbody tr:hover {
+  background: color-mix(in oklch, var(--primary) 3%, var(--card));
+}
+
+.jobs-index-sheet .filterable-data-grid-table tbody tr[aria-selected="true"] {
+  background: color-mix(in oklch, var(--primary) 2%, var(--card));
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.jobs-index-sheet .jobs-data-grid-table .fit {
+  width: auto;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+  padding: 0;
+  font-size: 0.9375rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.jobs-index-sheet .job-compensation-confidence {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.jobs-index-sheet .pager {
+  min-height: 3rem;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.jobs-index-sheet .pager .tab {
+  min-height: 2rem;
+  border: 0;
+  border-bottom: 1px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.25rem 0.125rem;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.jobs-index-sheet .pager .tab:hover:not(:disabled) {
+  border-bottom-color: var(--border);
+  color: var(--foreground);
+}
+
+.jobs-index-sheet .pager select {
+  min-height: 2rem;
+  border-radius: 2px;
+  background: var(--card);
+  font-size: 0.6875rem;
+}
+
+@container jobs-index (min-width: 52rem) {
+  .jobs-index-action-row {
+    grid-template-columns: minmax(17rem, 0.75fr) minmax(30rem, 1.4fr);
+  }
+
+  .jobs-index-action-group--preparation {
+    border-top: 0;
+    border-inline-start: 1px solid var(--border);
+  }
+
+  .jobs-index-action-group--selected {
+    grid-column: 1 / -1;
+  }
+}
+
+@container jobs-index (min-width: 76rem) {
+  .jobs-index-action-row {
+    grid-template-columns:
+      minmax(17rem, 0.7fr)
+      minmax(30rem, 1.55fr)
+      minmax(18rem, 0.85fr);
+  }
+
+  .jobs-index-action-group--selected {
+    grid-column: auto;
+    border-top: 0;
+    border-inline-start: 1px solid var(--border);
+  }
+}
+
+@container jobs-grid (max-width: 44rem) {
+  .jobs-index-sheet .data-grid-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .jobs-index-sheet .data-grid-tools {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .jobs-index-sheet .pager {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 620px) {
+  .jobs-index-view-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding-block: 0.5rem 0;
+  }
+
+  .jobs-index-controls .job-view-switcher {
+    width: 100%;
+    align-self: auto;
+    overflow-x: auto;
+  }
+
+  .jobs-index-selection-count {
+    margin: 0 0 0.5rem;
+  }
+
+  .jobs-index-action-group {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (forced-colors: active) {
+  .jobs-index-controls
+    .job-view-switcher
+    [data-slot="toggle-group-item"][data-state="on"] {
+    border-bottom: 2px solid Highlight;
+  }
+
+  .jobs-index-selection-count {
+    border-inline-start-color: Highlight;
+  }
+
+  .jobs-index-sheet .filterable-data-grid-table tbody tr[aria-selected="true"] {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}

--- a/apps/web/src/styles/editorial-library.css
+++ b/apps/web/src/styles/editorial-library.css
@@ -1,0 +1,1212 @@
+/*
+ * Editorial library and activity surfaces
+ *
+ * Indexes are dense ruled sheets; details are continuous workspaces with one
+ * quiet inspector. Data remains complete, but hierarchy comes from type and
+ * hairlines rather than a card or capsule around every value.
+ */
+
+.editorial-index-page {
+  --editorial-row-block-size: 2.5rem;
+  gap: 0.875rem;
+}
+
+.editorial-page-head {
+  margin-block-end: 0;
+  padding-block-end: 0.25rem;
+}
+
+.editorial-page-head .page-head-subtitle {
+  display: flex;
+  max-inline-size: none;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem 1rem;
+}
+
+.editorial-page-head .page-head-count {
+  color: var(--foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
+
+.editorial-data-surface {
+  container: editorial-data-surface / inline-size;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.editorial-data-surface > .data-surface__tools,
+.editorial-data-surface > .debug-filter-form .data-surface__tools {
+  min-block-size: 3.25rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  padding: 0.625rem 0.75rem;
+}
+
+.editorial-data-surface .filterable-data-grid {
+  border-block-start: 0;
+  border-radius: 0;
+  background: var(--card);
+}
+
+.editorial-data-surface .data-grid-toolbar {
+  min-block-size: 2.625rem;
+  background: var(--surface-subtle);
+  padding: 0.5rem 0.75rem;
+}
+
+.editorial-data-surface .data-grid-view-title {
+  gap: 0.5rem;
+  font-size: 0.75rem;
+}
+
+.editorial-data-surface .data-grid-view-title > svg {
+  color: var(--muted-foreground);
+}
+
+.editorial-data-surface .data-grid-filter-chips {
+  gap: 0.5rem 0.875rem;
+  background: var(--surface-subtle);
+  padding: 0.5rem 0.75rem;
+}
+
+.editorial-data-surface .data-grid-filter-chips button {
+  min-block-size: 1.75rem;
+  gap: 0.35rem;
+  border: 0;
+  border-block-end: 1px solid var(--primary);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.125rem 0;
+}
+
+.editorial-data-surface .filterable-data-grid-table th,
+.editorial-data-surface .filterable-data-grid-table td {
+  block-size: var(--editorial-row-block-size);
+  border-block-end-color: var(--border);
+  padding: 0.5rem 0.625rem;
+}
+
+.editorial-data-surface .filterable-data-grid-table thead th {
+  background: var(--surface-subtle);
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+}
+
+.editorial-data-surface .filterable-data-grid-table tbody th {
+  font-weight: 600;
+}
+
+.editorial-data-surface
+  .filterable-data-grid-table
+  tbody
+  tr.data-grid-row-activatable:hover {
+  background: color-mix(in oklch, var(--foreground) 3.5%, var(--card));
+}
+
+.editorial-data-surface
+  .filterable-data-grid-table
+  tbody
+  tr[aria-selected="true"] {
+  background: transparent;
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.editorial-data-surface .data-grid-row-activation-button {
+  min-inline-size: 0;
+  min-block-size: 1.5rem;
+  border: 0;
+  border-radius: 0;
+  color: var(--primary);
+  padding: 0 0.125rem;
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.editorial-data-surface .data-grid-row-activation-button:hover {
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+}
+
+.editorial-data-surface .row-check input {
+  border-radius: 1px;
+  accent-color: var(--primary);
+}
+
+.editorial-data-surface .artifact-type {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+}
+
+.editorial-data-surface .artifact-type > .tag,
+.editorial-data-surface .contact-provenance-summary > .tag {
+  min-block-size: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.editorial-data-surface .contact-provenance-summary {
+  display: flex;
+  max-inline-size: 22rem;
+  flex-wrap: wrap;
+  gap: 0.15rem 0.5rem;
+}
+
+.editorial-data-surface .contact-confirmed {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.editorial-data-surface .run-mode-label,
+.editorial-data-surface .activity-stage-label {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.editorial-data-surface .activity-stage-label {
+  font-family: var(--font-mono);
+}
+
+/* Route-backed details ----------------------------------------------------- */
+
+:is(
+  .route-page--artifact-detail,
+  .route-page--contact-detail,
+  .route-page--workflow-run-detail,
+  .route-page--activity-detail
+) {
+  gap: 0;
+}
+
+:is(
+  .artifact-detail-workspace,
+  .contact-detail-workspace,
+  .workflow-run-workspace,
+  .activity-detail-workspace
+) {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__header {
+  background: var(--card);
+  padding: 0.875rem 1rem 1rem;
+}
+
+:is(
+  .artifact-detail-workspace__header,
+  .contact-detail-workspace__header,
+  .workflow-run-workspace__header,
+  .activity-detail-workspace__header
+) {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+}
+
+:is(
+    .artifact-detail-workspace__header,
+    .contact-detail-workspace__header,
+    .workflow-run-workspace__header,
+    .activity-detail-workspace__header
+  )
+  > .workspace-back {
+  grid-column: 1 / -1;
+  inline-size: fit-content;
+  block-size: auto;
+  min-block-size: 1.75rem;
+  justify-content: flex-start;
+  border: 0;
+  background: transparent;
+  padding-inline: 0;
+  color: var(--muted-foreground);
+}
+
+:is(
+    .artifact-detail-workspace__header,
+    .contact-detail-workspace__header,
+    .workflow-run-workspace__header,
+    .activity-detail-workspace__header
+  )
+  > .workspace-back:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+:is(
+  .artifact-detail-workspace__status,
+  .contact-detail-workspace__status,
+  .workflow-run-workspace__status,
+  .activity-detail-workspace__status
+) {
+  align-self: start;
+  padding-block-start: 0.25rem;
+}
+
+:is(
+    .artifact-detail-workspace__title,
+    .contact-detail-workspace__title,
+    .workflow-run-workspace__title,
+    .activity-detail-workspace__title
+  )
+  small {
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+:is(
+    .artifact-detail-workspace__title,
+    .contact-detail-workspace__title,
+    .workflow-run-workspace__title,
+    .activity-detail-workspace__title
+  )
+  h1 {
+  font-size: clamp(1.4rem, 2.2vw, 1.8rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+}
+
+:is(
+  .artifact-detail-workspace__actions,
+  .contact-detail-actions,
+  .workflow-run-workspace__actions,
+  .activity-detail-workspace__actions
+) {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid[data-has-inspector="true"] {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid
+  > .route-workspace__content,
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid
+  > .route-workspace__inspector {
+  min-inline-size: 0;
+  padding: 0;
+}
+
+:is(
+  .artifact-detail-tabs,
+  .contact-detail-tabs,
+  .workflow-run-tabs,
+  .activity-detail-tabs
+) {
+  display: block;
+  min-inline-size: 0;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid
+  > .route-workspace__content
+  > [data-state="inactive"] {
+  display: none;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid
+  > .route-workspace__content
+  > [role="tabpanel"] {
+  margin-block-start: 0;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  > .route-workspace__grid
+  > .route-workspace__inspector {
+  border-inline-start: 1px solid var(--border);
+  background: var(--surface-subtle);
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  .section {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 1rem 1.125rem;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  .section__header {
+  margin-block-end: 0.75rem;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  .detail-list {
+  gap: 0;
+  margin: 0;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  .detail-list
+  > div {
+  grid-template-columns: minmax(6.75rem, 0.4fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.5rem;
+}
+
+:is(
+    .artifact-detail-workspace,
+    .contact-detail-workspace,
+    .workflow-run-workspace,
+    .activity-detail-workspace
+  )
+  .detail-list
+  > div:last-child {
+  border-block-end: 0;
+}
+
+.detail-route-state {
+  display: grid;
+  gap: 0.75rem;
+  min-block-size: min(70dvh, 42rem);
+  align-content: start;
+  border: 1px solid var(--border);
+  background: var(--card);
+  padding: 0.875rem 1rem;
+}
+
+.detail-route-state > .workspace-back {
+  inline-size: fit-content;
+  border: 0;
+  background: transparent;
+  padding-inline: 0;
+}
+
+.detail-route-state > .empty {
+  align-self: center;
+  border: 0;
+  background: transparent;
+}
+
+/* Artifact detail --------------------------------------------------------- */
+
+.artifact-detail-workspace .route-workspace__content {
+  min-block-size: 0;
+  background: var(--card);
+}
+
+.artifact-detail-workspace__panel--preview {
+  min-block-size: min(76dvh, 56rem);
+}
+
+.artifact-detail-workspace .artifact-preview-panel,
+.artifact-detail-workspace .pdf-preview-viewer {
+  min-block-size: inherit;
+}
+
+.artifact-detail-workspace .artifact-preview-panel {
+  background: #242424;
+}
+
+.artifact-detail-workspace__audit {
+  border-block-end: 1px solid var(--border);
+  padding: 1rem 1.125rem;
+}
+
+.artifact-detail-workspace :where(.tag:not(.editorial-status)) {
+  min-block-size: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+  font-size: 0.6875rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.artifact-detail-workspace
+  :where(
+    .evidence-summary-grid,
+    .artifact-comparison-sides,
+    .artifact-comparison-delta-grid
+  ) {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.artifact-detail-workspace
+  :where(
+    .evidence-summary-grid > div,
+    .artifact-comparison-side,
+    .artifact-comparison-delta,
+    .tailoring-change,
+    .evidence-block,
+    .persona-audit,
+    .prompt-audit
+  ) {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.artifact-detail-workspace
+  .artifact-comparison-side
+  + .artifact-comparison-side {
+  border-inline-start: 1px solid var(--border);
+}
+
+.artifact-detail-workspace .compact-list {
+  gap: 0.25rem 0.75rem;
+}
+
+.artifact-detail-workspace .compact-list li {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+/* Evidence map ------------------------------------------------------------ */
+
+.evidence-map-workspace {
+  container: evidence-workspace / inline-size;
+  min-block-size: min(76dvh, 51rem);
+  border: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.evidence-map-workspace > .route-workspace__header {
+  border-block-end: 1px solid var(--border);
+  padding: 0;
+}
+
+.evidence-map-workspace__tools {
+  border: 0;
+  background: var(--card);
+  padding: 0.625rem 0.75rem;
+}
+
+.evidence-map-workspace > .route-workspace__grid {
+  grid-template-columns: minmax(15rem, 0.3fr) minmax(22rem, 1fr) minmax(
+      20rem,
+      0.42fr
+    );
+  min-block-size: min(70dvh, 47rem);
+}
+
+.evidence-map-workspace .route-workspace__navigation,
+.evidence-map-workspace .route-workspace__content,
+.evidence-map-workspace .route-workspace__inspector {
+  max-block-size: min(70dvh, 47rem);
+  overflow: auto;
+  padding: 0;
+  scrollbar-gutter: stable;
+}
+
+.evidence-map-workspace .route-workspace__navigation {
+  border-inline-end: 1px solid var(--border);
+}
+
+.evidence-map-workspace .route-workspace__inspector {
+  border-inline-start: 1px solid var(--border);
+  background: var(--surface-subtle);
+}
+
+.evidence-entry-list ul,
+.evidence-usage-list,
+.evidence-gap-list,
+.evidence-story-list,
+.evidence-inline-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.evidence-entry-link,
+.evidence-usage-link {
+  min-block-size: 3.5rem;
+  gap: 0.625rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.625rem 0.75rem;
+}
+
+.evidence-entry-link {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+
+.evidence-entry-link .evidence-entry-meta {
+  justify-content: space-between;
+}
+
+.evidence-entry-link:hover,
+.evidence-entry-link.selected,
+.evidence-usage-link:hover {
+  border-color: var(--border);
+  background: color-mix(in oklch, var(--foreground) 3.5%, var(--card));
+  color: var(--foreground);
+}
+
+.evidence-entry-link.selected {
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.evidence-entry-link .muted,
+.evidence-entry-meta .meta,
+.evidence-usage-kind,
+.evidence-date {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.evidence-entry-meta,
+.evidence-tags {
+  gap: 0.35rem 0.75rem;
+}
+
+.evidence-detail--workspace {
+  display: grid;
+  align-content: start;
+  gap: 0;
+}
+
+.evidence-detail--workspace > header,
+.evidence-detail--workspace > .evidence-detail-group,
+.evidence-detail--workspace > .evidence-story {
+  border-block-end: 1px solid var(--border);
+  padding: 1rem 1.125rem;
+}
+
+.evidence-detail--workspace > header {
+  gap: 0.4rem;
+}
+
+.evidence-detail--workspace h2 {
+  font-size: 1.25rem;
+  letter-spacing: -0.025em;
+}
+
+.evidence-detail--workspace h3,
+.evidence-side-panel--workspace h2 {
+  font-size: 0.75rem;
+  font-weight: 750;
+  letter-spacing: 0.02em;
+}
+
+.evidence-story dl {
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.evidence-story dl > div {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.625rem 0;
+}
+
+.evidence-inline-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.evidence-inline-list > li {
+  overflow-wrap: anywhere;
+}
+
+.evidence-usage-list {
+  border-block-start: 1px solid var(--border);
+}
+
+.evidence-side-panel--workspace {
+  display: grid;
+  align-content: start;
+  gap: 0;
+}
+
+.evidence-side-panel--workspace > h2 {
+  margin: 0;
+  border-block-end: 1px solid var(--border);
+  padding: 0.75rem;
+}
+
+.evidence-gap-list > li,
+.evidence-story-list > li {
+  gap: 0.45rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem;
+}
+
+.evidence-gap-list > li > div:first-child {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.evidence-gap-links {
+  gap: 0;
+}
+
+.evidence-gap-links .evidence-usage-link {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: start;
+  padding-inline: 0;
+}
+
+/* Outreach --------------------------------------------------------------- */
+
+.route-page--outreach .outreach-due-follow-ups {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+  padding: 0;
+}
+
+.route-page--outreach .outreach-due-follow-ups > .card-hd {
+  min-block-size: 2.75rem;
+  border-block-end: 1px solid var(--border);
+  background: var(--surface-subtle);
+  padding: 0.625rem 0.75rem;
+}
+
+.route-page--outreach .outreach-due-follow-ups > p {
+  margin: 0;
+  border-block-end: 1px solid var(--border);
+  padding: 0.625rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.outreach-due-follow-ups-list,
+.outreach-draft-history-list,
+.outreach-send-log-list,
+.contact-provenance-list,
+.draft-gate-fabrication-list,
+.draft-gate-message-list,
+.draft-claim-provenance-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.outreach-due-follow-up-item {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  border-block-end: 1px solid var(--border);
+  padding: 0.625rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.outreach-due-follow-up-item:last-child {
+  border-block-end: 0;
+}
+
+.contact-detail-workspace .route-workspace__content {
+  background: var(--card);
+}
+
+.contact-detail-workspace .outreach-thread-panel {
+  padding: 0;
+}
+
+.contact-detail-workspace
+  :where(
+    .outreach-thread-head,
+    .outreach-approved-draft,
+    .outreach-send-log,
+    .outreach-follow-up,
+    .outreach-candidate-draft,
+    .outreach-generation-history
+  ) {
+  border-block-end: 1px solid var(--border);
+  padding: 1rem 1.125rem;
+}
+
+.contact-detail-workspace .outreach-thread-head {
+  display: flex;
+  min-block-size: 3rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: var(--surface-subtle);
+}
+
+.contact-detail-workspace
+  :where(
+    .outreach-thread-head h3,
+    .outreach-approved-draft h4,
+    .outreach-send-log h4,
+    .outreach-follow-up h4,
+    .outreach-candidate-draft h4,
+    .outreach-generation-history h4
+  ) {
+  margin-block: 0;
+  font-size: 0.8125rem;
+}
+
+.contact-detail-workspace
+  :where(.outreach-approved-draft, .outreach-candidate-draft) {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.contact-detail-workspace .outreach-draft-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem 0.75rem;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.contact-detail-workspace :where(.tag:not(.editorial-status)) {
+  min-block-size: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  box-shadow: none;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.contact-detail-workspace .outreach-draft-body {
+  margin: 0;
+  border-inline-start: 2px solid var(--border-strong, var(--border));
+  background: var(--surface-subtle);
+  padding: 0.875rem 1rem;
+  line-height: 1.65;
+}
+
+.contact-detail-workspace
+  :where(.outreach-draft-actions, .outreach-send-log-actions, .form-actions) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.contact-detail-workspace
+  :where(.outreach-draft-actions, .outreach-send-log-actions)
+  .tab {
+  min-block-size: 1.75rem;
+  border-radius: 0;
+  background: transparent;
+  padding-inline: 0;
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+
+.contact-detail-workspace
+  :where(.outreach-draft-actions, .outreach-send-log-actions)
+  .tab
+  + .tab,
+.contact-detail-workspace
+  :where(.outreach-draft-actions, .outreach-send-log-actions)
+  > *
+  + * {
+  margin-inline-start: 0.75rem;
+}
+
+.contact-detail-workspace .outreach-draft-audit {
+  border-block-start: 1px solid var(--border);
+  padding-block-start: 0.625rem;
+}
+
+.contact-detail-workspace .outreach-draft-audit > summary {
+  color: var(--foreground);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.contact-detail-workspace .outreach-draft-audit[open] > summary {
+  margin-block-end: 0.75rem;
+}
+
+.contact-detail-workspace .draft-gate-results {
+  display: grid;
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.contact-detail-workspace .draft-gate-overall-status,
+.contact-detail-workspace .draft-gate-computed-against {
+  margin: 0;
+  border-block-end: 1px solid var(--border);
+  padding: 0.625rem 0;
+}
+
+.contact-detail-workspace .draft-gate-block {
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.75rem;
+}
+
+.contact-detail-workspace .draft-gate-block:last-child {
+  border-block-end: 0;
+}
+
+.contact-detail-workspace .draft-gate-block-title,
+.contact-detail-workspace .draft-gate-list-label {
+  margin-block: 0 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 750;
+}
+
+.contact-detail-workspace .draft-gate-message-list > li,
+.contact-detail-workspace .draft-gate-fabrication-list > li,
+.contact-detail-workspace .draft-claim-provenance-list > li {
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.5rem;
+}
+
+.contact-detail-workspace .outreach-send-log-list,
+.contact-detail-workspace .outreach-draft-history-list {
+  border-block-start: 1px solid var(--border);
+}
+
+.contact-detail-workspace .outreach-send-log-item,
+.contact-detail-workspace .outreach-draft-history-item {
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.625rem;
+}
+
+.contact-detail-workspace .outreach-send-log-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.contact-detail-workspace .contact-provenance-item {
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.75rem;
+}
+
+.contact-detail-workspace .contact-provenance-item:last-child {
+  border-block-end: 0;
+}
+
+.contact-detail-workspace .contact-provenance-fact {
+  display: grid;
+  gap: 0.2rem;
+  margin-block-end: 0.5rem;
+}
+
+.contact-detail-workspace .contact-attribute-kind {
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.contact-detail-workspace .contact-attribute-value {
+  font-weight: 650;
+}
+
+/* Workflow runs and activity --------------------------------------------- */
+
+.workflow-run-workspace__header {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+}
+
+.workflow-run-workspace__timeline .timeline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.workflow-run-workspace__timeline .timeline > li {
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.32fr) minmax(0, 1fr);
+  gap: 0.25rem 1rem;
+  border-block-end: 1px solid var(--border);
+  padding-block: 0.75rem;
+}
+
+.workflow-run-workspace__timeline .timeline > li:last-child {
+  border-block-end: 0;
+}
+
+.workflow-run-workspace__timeline .timeline > li > p {
+  grid-column: 2;
+  margin: 0;
+}
+
+.activity-data-grid-table .activity-main {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.activity-data-grid-table .activity-main > span {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.activity-detail-workspace__inspector {
+  gap: 0;
+  padding: 1rem 1.125rem;
+}
+
+.activity-detail-workspace__payload {
+  max-block-size: 52dvh;
+  border: 0;
+  border-block: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--surface-subtle);
+  padding: 0.875rem;
+}
+
+.activity-detail-workspace .timeline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.activity-detail-workspace .timeline-row {
+  display: grid;
+  grid-template-columns: minmax(7rem, auto) minmax(0, 1fr);
+  gap: 0.75rem 1rem;
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem 0;
+}
+
+.activity-detail-workspace .activity-stage-label {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+}
+
+@container editorial-data-surface (max-width: 45rem) {
+  .data-surface__tools .tool-row__primary,
+  .data-surface__tools .tool-row__secondary {
+    inline-size: 100%;
+  }
+
+  .data-surface__tools .tool-row__field,
+  .data-surface__tools .tool-row__search,
+  .data-surface__tools .tool-row__compact-input {
+    inline-size: 100%;
+    flex-basis: 100%;
+  }
+}
+
+@container evidence-workspace (max-width: 60rem) {
+  .evidence-map-workspace > .route-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .evidence-map-workspace .route-workspace__navigation,
+  .evidence-map-workspace .route-workspace__content,
+  .evidence-map-workspace .route-workspace__inspector {
+    max-block-size: none;
+    border-inline: 0;
+    border-block-end: 1px solid var(--border);
+  }
+
+  .evidence-map-workspace .route-workspace__navigation {
+    max-block-size: 18rem;
+  }
+}
+
+@media (max-width: 62.5rem) {
+  :is(
+      .artifact-detail-workspace,
+      .contact-detail-workspace,
+      .workflow-run-workspace,
+      .activity-detail-workspace
+    )
+    > .route-workspace__grid[data-has-inspector="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  :is(
+      .artifact-detail-workspace,
+      .contact-detail-workspace,
+      .workflow-run-workspace,
+      .activity-detail-workspace
+    )
+    > .route-workspace__grid
+    > .route-workspace__inspector {
+    border-block-start: 1px solid var(--border);
+    border-inline-start: 0;
+  }
+}
+
+@media (max-width: 45rem) {
+  .editorial-page-head .page-head-subtitle {
+    display: grid;
+  }
+
+  :is(
+    .artifact-detail-workspace__header,
+    .contact-detail-workspace__header,
+    .workflow-run-workspace__header,
+    .activity-detail-workspace__header
+  ) {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+  }
+
+  :is(
+      .artifact-detail-workspace__header,
+      .contact-detail-workspace__header,
+      .workflow-run-workspace__header,
+      .activity-detail-workspace__header
+    )
+    > .workspace-back,
+  :is(
+    .artifact-detail-workspace__status,
+    .contact-detail-workspace__status,
+    .workflow-run-workspace__status,
+    .activity-detail-workspace__status
+  ),
+  :is(
+    .artifact-detail-workspace__actions,
+    .contact-detail-actions,
+    .workflow-run-workspace__actions,
+    .activity-detail-workspace__actions
+  ) {
+    grid-column: 1;
+  }
+
+  :is(
+    .artifact-detail-workspace__actions,
+    .contact-detail-actions,
+    .workflow-run-workspace__actions,
+    .activity-detail-workspace__actions
+  ) {
+    justify-content: flex-start;
+  }
+
+  .outreach-due-follow-up-item,
+  .contact-detail-workspace .outreach-send-log-item,
+  .workflow-run-workspace__timeline .timeline > li,
+  .activity-detail-workspace .timeline-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .workflow-run-workspace__timeline .timeline > li > p {
+    grid-column: 1;
+  }
+}
+
+@media (forced-colors: active) {
+  .editorial-data-surface
+    .filterable-data-grid-table
+    tbody
+    tr[aria-selected="true"],
+  .evidence-entry-link.selected {
+    border-inline-start: 2px solid Highlight;
+    box-shadow: none;
+  }
+}

--- a/apps/web/src/styles/editorial-operations.css
+++ b/apps/web/src/styles/editorial-operations.css
@@ -1,0 +1,1007 @@
+/*
+ * Editorial operations surfaces
+ *
+ * Dashboard, analytics, discovery, and pipeline operations share one visual
+ * grammar: continuous ruled sheets, compact ledgers, and type-led hierarchy.
+ * Data density is preserved without turning each datum into a rounded tile.
+ */
+
+.route-page--dashboard,
+.route-page--analytics,
+.route-page--discovery,
+.route-page--pipelines {
+  container-type: inline-size;
+}
+
+:where(
+  .route-page--dashboard,
+  .route-page--analytics,
+  .route-page--discovery,
+  .route-page--pipelines
+) :is(.tag, .stage-pill) {
+  min-height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+}
+
+:where(
+  .route-page--dashboard,
+  .route-page--analytics,
+  .route-page--discovery,
+  .route-page--pipelines
+) .banner {
+  border: 1px solid var(--border);
+  border-inline-start: 2px solid var(--destructive);
+  background: var(--surface-subtle);
+}
+
+:where(.route-page--discovery, .route-page--pipelines) .status-line.warning {
+  background: var(--surface-subtle);
+  color: var(--warning);
+}
+
+/* Dashboard ---------------------------------------------------------------- */
+
+.dashboard-generated-at {
+  margin: -0.65rem 0 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.route-page--dashboard .kpis {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0;
+  overflow: clip;
+  border: 1px solid var(--border);
+  background: var(--card);
+}
+
+.route-page--dashboard .kpis > * {
+  min-height: 5.5rem;
+  justify-content: space-between;
+  border: 0;
+  border-inline-end: 1px solid var(--border);
+  background: transparent;
+  box-shadow: none;
+}
+
+.route-page--dashboard .kpis > :last-child {
+  border-inline-end: 0;
+}
+
+.route-page--dashboard .kpis > a:hover {
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+
+.route-page--dashboard .dashboard-stack {
+  gap: 1rem;
+}
+
+.route-page--dashboard .dashboard-ops {
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1.12fr) minmax(0, 0.9fr);
+}
+
+.route-page--dashboard .dashboard-tail {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.route-page--dashboard .dashboard-ops,
+.route-page--dashboard .dashboard-tail {
+  gap: 0;
+  overflow: clip;
+  border: 1px solid var(--border);
+  background: var(--border);
+}
+
+.route-page--dashboard .dashboard-ops > .card,
+.route-page--dashboard .dashboard-tail > .card {
+  height: auto;
+  border: 0;
+  border-inline-end: 1px solid var(--border);
+  background: var(--card);
+}
+
+.route-page--dashboard .dashboard-ops > .card:last-child,
+.route-page--dashboard .dashboard-tail > .card:nth-child(2n),
+.route-page--dashboard .dashboard-tail > .card:last-child {
+  border-inline-end: 0;
+}
+
+.route-page--dashboard .dashboard-tail > .card:nth-child(n + 3) {
+  border-block-start: 1px solid var(--border);
+}
+
+.route-page--dashboard .dashboard-stack > .card {
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.route-page--dashboard .card-hd {
+  min-height: 3.3rem;
+  border-block-end: 1px solid var(--border);
+  padding: 0.75rem 0.875rem;
+  background: transparent;
+}
+
+.route-page--dashboard .card-hd h2 {
+  font-size: 0.875rem;
+  font-weight: 760;
+  letter-spacing: -0.015em;
+}
+
+.route-page--dashboard .card-hd .meta {
+  font-size: 0.6875rem;
+}
+
+.route-page--dashboard .rows,
+.route-page--dashboard .digest-list,
+.route-page--dashboard .conversion-rows {
+  padding-inline: 0.875rem;
+}
+
+.route-page--dashboard .mini-row,
+.route-page--dashboard .digest-row,
+.route-page--dashboard .conversion-row {
+  min-height: 2.8rem;
+  border-radius: 0;
+  padding-inline: 0;
+}
+
+.route-page--dashboard .mini-row:hover,
+.route-page--dashboard .digest-row:hover,
+.route-page--dashboard .funnel-row:hover {
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+
+.dashboard-signal {
+  display: inline-flex;
+  min-height: 1.25rem;
+  align-items: center;
+  padding: 0;
+  background: transparent;
+  font-size: 0.6875rem;
+  font-weight: 720;
+  line-height: 1.2;
+  text-transform: lowercase;
+}
+
+.dashboard-signal--danger { color: var(--destructive); }
+.dashboard-signal--warn { color: var(--warning); }
+.dashboard-signal--info { color: var(--status-info); }
+.dashboard-signal--muted { color: var(--muted-foreground); }
+
+.route-page--dashboard .source-politeness-badge {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.route-page--dashboard .source-politeness-badge-count {
+  color: inherit;
+  font-weight: 750;
+}
+
+.route-page--dashboard .conversion-body {
+  gap: 0;
+  padding: 0;
+}
+
+.route-page--dashboard .conversion-funnel {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+}
+
+.route-page--dashboard .conversion-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.35rem;
+  align-content: start;
+  border-inline-end: 1px solid var(--border);
+  padding: 0.9rem 0.75rem;
+}
+
+.route-page--dashboard .conversion-stage:nth-child(4) {
+  border-inline-end: 0;
+}
+
+.route-page--dashboard .conversion-stage-val {
+  align-items: baseline;
+  flex-direction: row;
+}
+
+.route-page--dashboard .conversion-stage-val b {
+  font-size: 1.45rem;
+  letter-spacing: -0.03em;
+}
+
+.route-page--dashboard .conversion-stage .bar {
+  order: 3;
+  block-size: 0.3rem;
+}
+
+.route-page--dashboard .conversion-note {
+  grid-column: 1 / -1;
+  border-block-start: 1px solid var(--border);
+  padding: 0.6rem 0.875rem;
+}
+
+.route-page--dashboard .conversion-breakdowns {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-block-start: 1px solid var(--border);
+}
+
+.route-page--dashboard .conversion-breakdown {
+  min-width: 0;
+  padding: 0.8rem 0.875rem;
+}
+
+.route-page--dashboard .conversion-breakdown + .conversion-breakdown {
+  border-inline-start: 1px solid var(--border);
+}
+
+.route-page--dashboard .funnel {
+  gap: 0;
+  padding: 0;
+}
+
+.route-page--dashboard .funnel-row {
+  grid-template-columns: minmax(7.5rem, max-content) minmax(8rem, 1fr) minmax(12rem, auto);
+  gap: 0.75rem 1rem;
+  min-height: 3.7rem;
+  border-radius: 0;
+  border-block-end: 1px solid var(--border);
+  padding: 0.75rem 0.875rem;
+}
+
+.route-page--dashboard .funnel-row:last-child {
+  border-block-end: 0;
+}
+
+.route-page--dashboard .funnel-row .legend {
+  grid-column: auto;
+  justify-content: flex-end;
+}
+
+.route-page--dashboard .bar,
+.route-page--pipelines .stage-progress-meter {
+  overflow: clip;
+  border-radius: 0;
+}
+
+.route-page--dashboard .bar {
+  block-size: 0.375rem;
+  border: 0;
+  background: var(--border);
+}
+
+.route-page--dashboard .bar > span {
+  background: var(--foreground);
+}
+
+.route-page--dashboard .bar > .seg-done {
+  opacity: 1;
+}
+
+.route-page--dashboard .bar > .seg-failed {
+  opacity: 0.82;
+}
+
+.route-page--dashboard .bar > .seg-blocked {
+  opacity: 0.64;
+}
+
+.route-page--dashboard .bar > .seg-running {
+  opacity: 0.46;
+}
+
+.route-page--dashboard .bar > .seg-pending {
+  opacity: 0.26;
+}
+
+.route-page--pipelines .stage-progress-meter {
+  block-size: 0.375rem;
+  border: 0;
+  appearance: none;
+  accent-color: var(--foreground);
+  background: var(--border);
+}
+
+.route-page--pipelines .stage-progress-meter::-webkit-progress-bar {
+  border-radius: 0;
+  background: var(--border);
+}
+
+.route-page--pipelines .stage-progress-meter::-webkit-progress-value,
+.route-page--pipelines .stage-progress-meter::-moz-progress-bar {
+  border-radius: 0;
+  background: var(--foreground);
+}
+
+.route-page--dashboard .work-status-ledger {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+  border-block-end: 1px solid var(--border);
+  padding: 0;
+}
+
+.route-page--dashboard .work-status-ledger__cell {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 0.4rem;
+  padding: 0.875rem;
+}
+
+.route-page--dashboard .work-status-ledger__cell + .work-status-ledger__cell {
+  border-inline-start: 1px solid var(--border);
+}
+
+.route-page--dashboard .work-status-ledger__cell :is(dt, dd) {
+  min-width: 0;
+  margin: 0;
+}
+
+.route-page--dashboard .work-status-ledger__cell dd {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.route-page--dashboard .work-status-ledger [data-slot="stat-delta"] {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.route-page--dashboard .outcome-suggestion-card {
+  border: 0;
+  border-block-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.route-page--dashboard .digest-actions .tab.on {
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding-inline: 0;
+  color: var(--primary);
+}
+
+/* Analytics ---------------------------------------------------------------- */
+
+.route-page--analytics .analytics-view {
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.route-page--analytics .analytics-toolbar {
+  min-height: 3rem;
+  border-block-end: 1px solid var(--border);
+  padding: 0 1rem;
+}
+
+.route-page--analytics .analytics-dimension-control {
+  gap: 1.25rem;
+  border-block-end: 0;
+}
+
+.route-page--analytics .analytics-dimension-control [data-slot="toggle-group-item"] {
+  min-height: 3rem;
+  border-radius: 0;
+  padding-inline: 0;
+}
+
+.route-page--analytics .analytics-summary-strip {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.route-page--analytics .analytics-summary-strip > div {
+  min-height: 5rem;
+  padding: 0.85rem 1rem;
+}
+
+.route-page--analytics .analytics-summary-strip span {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.route-page--analytics .analytics-summary-strip b {
+  font-size: 1.45rem;
+}
+
+.route-page--analytics .analytics-caption {
+  border-block-end: 1px solid var(--border);
+  background: transparent;
+  padding: 0.75rem 1rem;
+  line-height: 1.55;
+}
+
+.analytics-dimension-label {
+  margin-inline-end: 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 720;
+}
+
+.analytics-dimension-label.info { color: var(--status-info); }
+.analytics-dimension-label.ok { color: var(--success); }
+.analytics-dimension-label.warn { color: var(--warning); }
+.analytics-dimension-label.muted { color: var(--muted-foreground); }
+
+.route-page--analytics .filterable-data-grid,
+.route-page--analytics .data-surface {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* Discovery ---------------------------------------------------------------- */
+
+.route-page--discovery .discovery-view-stack {
+  gap: 0.875rem;
+}
+
+.route-page--discovery .disclosure-section,
+.route-page--discovery .discovery-controls {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.route-page--discovery .disclosure-section__header,
+.route-page--discovery .card-hd,
+.route-page--discovery .discovery-panel-head {
+  min-height: 3.25rem;
+  border-block-end: 1px solid var(--border);
+  background: transparent;
+}
+
+.route-page--discovery .disclosure-section__body {
+  padding: 1rem;
+}
+
+.route-page--discovery .discovery-runtime-settings .disclosure-section__body {
+  padding: 0;
+}
+
+.route-page--discovery .discovery-runtime-settings .field-grid {
+  padding: 1rem;
+}
+
+.route-page--discovery .target-search-settings .form-section {
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-page--discovery .target-search-settings .form-section > h3 {
+  display: none;
+}
+
+.route-page--discovery .target-search-settings .target-preferences-grid {
+  gap: 0.875rem 1rem;
+  padding: 0;
+}
+
+.route-page--discovery .discovery-tabs {
+  padding: 0 1rem 1rem;
+  background: transparent;
+}
+
+.route-page--discovery .discovery-tab-list {
+  width: 100%;
+  margin: 0;
+  gap: 1.25rem;
+}
+
+.route-page--discovery .discovery-tab-panel {
+  margin: 0;
+}
+
+.route-page--discovery .discovery-tab-panel .discovery-control-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-page--discovery .discovery-source-summary {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  padding: 0;
+}
+
+.route-page--discovery .discovery-source-summary span {
+  min-height: 3.5rem;
+  border: 0;
+  border-inline-end: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem;
+  font-size: 0.6875rem;
+}
+
+.route-page--discovery .discovery-source-summary span:last-child {
+  border-inline-end: 0;
+}
+
+.route-page--discovery .discovery-source-summary strong {
+  display: block;
+  margin-block-end: 0.2rem;
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.route-page--discovery :is(.source-table-tone, .source-table-metric) {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  font-weight: 680;
+}
+
+.route-page--discovery .source-politeness-badges {
+  gap: 0.45rem;
+}
+
+.route-page--discovery .source-politeness-badge {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+}
+
+.route-page--discovery .source-politeness-badge-count {
+  color: inherit;
+  font-weight: 760;
+}
+
+.route-page--discovery .discovery-review-row,
+.route-page--discovery .discovery-preview-row {
+  border-radius: 0;
+  padding-block: 0.75rem;
+}
+
+.route-page--discovery .source-upsert-form {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+  align-items: end;
+}
+
+.route-page--discovery .source-upsert-form .wide {
+  grid-column: auto;
+}
+
+.route-page--discovery .source-upsert-form button {
+  grid-column: auto;
+  justify-self: start;
+}
+
+.route-page--discovery :is(.form-actions, .editor-bulk-actions) .tab {
+  border: 1px solid var(--border);
+  border-radius: 0.125rem;
+  background: transparent;
+  box-shadow: none;
+}
+
+.route-page--discovery :is(.form-actions, .editor-bulk-actions) .tab.on {
+  border-color: var(--foreground);
+  background: var(--foreground);
+  color: var(--card);
+}
+
+/* Pipeline operations ------------------------------------------------------- */
+
+.route-page--pipelines .pipelines-workspace {
+  overflow: clip;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--card);
+  box-shadow: none;
+}
+
+.route-page--pipelines .route-workspace__header {
+  border-block-end: 1px solid var(--border);
+  padding: 0;
+}
+
+.pipelines-workspace__live-header {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0;
+  border: 0;
+  padding: 0;
+}
+
+.pipelines-workspace__live-header > * {
+  min-height: 4.4rem;
+  align-content: center;
+  border-inline-end: 1px solid var(--border);
+  padding: 0.75rem 0.875rem;
+}
+
+.pipelines-workspace__live-header > :last-child {
+  border-inline-end: 0;
+}
+
+.pipelines-workspace > .route-workspace__grid[data-has-inspector="true"] {
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 0.36fr);
+  align-items: start;
+  gap: 0;
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__content,
+.pipelines-workspace > .route-workspace__grid > .route-workspace__inspector {
+  gap: 0;
+  padding: 0;
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__content {
+  display: grid;
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__content > * + * {
+  border-block-start: 1px solid var(--border);
+}
+
+.pipelines-workspace > .route-workspace__grid > .route-workspace__inspector {
+  border-inline-start: 1px solid var(--border);
+  background: color-mix(in oklch, var(--background) 58%, var(--card));
+}
+
+.pipelines-workspace__ledger,
+.pipeline-operations-inspector {
+  border: 0;
+}
+
+.pipelines-workspace__ledger,
+.pipeline-operations-inspector,
+.pipelines-workspace > .route-workspace__grid > .route-workspace__content > .disclosure-section {
+  padding: 0.875rem 1rem;
+}
+
+.pipelines-workspace__ledger > h2,
+.pipeline-operations-inspector > h2 {
+  padding: 0 0 0.75rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.07em;
+}
+
+.pipeline-stage-ledger {
+  padding-block: 0.75rem;
+}
+
+.pipeline-stage-ledger + .pipeline-stage-ledger {
+  border-block-start: 1px solid var(--border);
+}
+
+.pipeline-stage-ledger__table {
+  min-width: 62rem;
+}
+
+.pipeline-stage-ledger__table :is(th, td) {
+  padding: 0.65rem 0.7rem;
+}
+
+.pipeline-stage-ledger__table thead th {
+  background: color-mix(in oklch, var(--background) 62%, var(--card));
+}
+
+.pipeline-stage-ledger__table tbody th :is(strong, small) {
+  display: block;
+}
+
+.pipeline-stage-ledger__table tbody th small {
+  margin-block-start: 0.2rem;
+}
+
+.pipeline-stage-ledger__counts,
+.pipeline-stage-ledger__backlog,
+.pipeline-operations-eta,
+.pipeline-operations-capacity {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 5.5rem), 1fr));
+  gap: 0.35rem 0.65rem;
+}
+
+.pipeline-stage-ledger__counts,
+.pipeline-stage-ledger__backlog {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.7rem;
+}
+
+.pipeline-stage-ledger__counts > *,
+.pipeline-stage-ledger__backlog > * {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.pipeline-stage-ledger__counts dt,
+.pipeline-stage-ledger__backlog dt,
+.pipeline-operations-eta dt,
+.pipeline-operations-capacity dt {
+  font-size: 0.625rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.pipeline-stage-ledger__table details {
+  margin-block-start: 0.45rem;
+}
+
+.pipeline-stage-ledger__table summary {
+  color: var(--primary);
+  cursor: pointer;
+  font-size: 0.6875rem;
+  font-weight: 700;
+}
+
+.pipelines-workspace .disclosure-section {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.pipelines-workspace .disclosure-section__header {
+  min-height: 2.8rem;
+  border-block: 0 1px solid var(--border);
+  padding: 0.35rem 0;
+}
+
+.pipelines-workspace .disclosure-section__body {
+  padding: 0.75rem 0 0.25rem;
+}
+
+.pipeline-source-reconciliation {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+}
+
+.pipeline-source-reconciliation > section {
+  padding-inline-end: 1rem;
+}
+
+.pipeline-source-reconciliation > section + section {
+  border-block-start: 0;
+  border-inline-start: 1px solid var(--border);
+  padding-block-start: 0;
+  padding-inline: 1rem 0;
+}
+
+.pipeline-operations-inspector > * + * {
+  border-block-start: 1px solid var(--border);
+}
+
+.pipeline-operations-inspector .inspector-ledger__item {
+  border-radius: 0;
+}
+
+.pipelines-workspace__controls.tool-row {
+  border: 0;
+  padding: 0;
+}
+
+.pipelines-workspace__controls .stage-trigger-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-page--pipelines .stage-trigger-panel .card-hd {
+  min-height: 3.25rem;
+  border-block-end: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  background: transparent;
+}
+
+.route-page--pipelines .stage-trigger-tabs {
+  padding: 0 1rem;
+  background: transparent;
+}
+
+.route-page--pipelines .stage-trigger-tab-list {
+  gap: 1.25rem;
+}
+
+.route-page--pipelines .stage-trigger-tab-panel .stage-trigger-form {
+  padding: 1rem 0;
+}
+
+.route-page--pipelines .stage-trigger-grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 10rem), 1fr));
+}
+
+.route-page--pipelines .stage-trigger-options {
+  border-block: 1px solid var(--border);
+  padding-block: 0.75rem;
+}
+
+.route-page--pipelines .stage-trigger-active {
+  gap: 0.5rem;
+  border-block-end: 1px solid var(--border);
+  padding-block-end: 0.75rem;
+}
+
+@container (max-width: 64rem) {
+  .route-page--analytics .analytics-summary-strip,
+  .pipelines-workspace__live-header {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .route-page--analytics .analytics-summary-strip > :nth-child(3n),
+  .pipelines-workspace__live-header > :nth-child(3n) {
+    border-inline-end: 0;
+  }
+
+  .route-page--analytics .analytics-summary-strip > :nth-child(n + 4),
+  .pipelines-workspace__live-header > :nth-child(n + 4) {
+    border-block-start: 1px solid var(--border);
+  }
+
+  .pipelines-workspace > .route-workspace__grid[data-has-inspector="true"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pipelines-workspace > .route-workspace__grid > .route-workspace__inspector {
+    border-block-start: 1px solid var(--border);
+    border-inline-start: 0;
+  }
+}
+
+@container (max-width: 52rem) {
+  .route-page--dashboard .kpis {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .route-page--dashboard .kpis > :nth-child(3n) {
+    border-inline-end: 0;
+  }
+
+  .route-page--dashboard .kpis > :nth-child(n + 4) {
+    border-block-start: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .dashboard-ops {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .route-page--dashboard .dashboard-ops > .card:nth-child(2) {
+    border-inline-end: 0;
+  }
+
+  .route-page--dashboard .dashboard-ops > .card:nth-child(3) {
+    grid-column: 1 / -1;
+    border-block-start: 1px solid var(--border);
+    border-inline-end: 0;
+  }
+}
+
+@container (max-width: 44rem) {
+  .route-page--dashboard .kpis,
+  .route-page--analytics .analytics-summary-strip,
+  .pipelines-workspace__live-header {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .route-page--dashboard .kpis > :nth-child(3n),
+  .route-page--analytics .analytics-summary-strip > :nth-child(3n),
+  .pipelines-workspace__live-header > :nth-child(3n) {
+    border-inline-end: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .kpis > :nth-child(2n),
+  .route-page--analytics .analytics-summary-strip > :nth-child(2n),
+  .pipelines-workspace__live-header > :nth-child(2n) {
+    border-inline-end: 0;
+  }
+
+  .route-page--dashboard .kpis > :nth-child(n + 3),
+  .route-page--analytics .analytics-summary-strip > :nth-child(n + 3),
+  .pipelines-workspace__live-header > :nth-child(n + 3) {
+    border-block-start: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .dashboard-ops,
+  .route-page--dashboard .dashboard-tail,
+  .route-page--dashboard .conversion-breakdowns,
+  .pipeline-source-reconciliation {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--dashboard .dashboard-ops > .card,
+  .route-page--dashboard .dashboard-tail > .card {
+    grid-column: auto;
+    border-block-start: 1px solid var(--border);
+    border-inline-end: 0;
+  }
+
+  .route-page--dashboard .dashboard-ops > .card:first-child,
+  .route-page--dashboard .dashboard-tail > .card:first-child {
+    border-block-start: 0;
+  }
+
+  .route-page--dashboard .conversion-funnel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .route-page--dashboard .conversion-stage:nth-child(2n) {
+    border-inline-end: 0;
+  }
+
+  .route-page--dashboard .conversion-stage:nth-child(n + 3) {
+    border-block-start: 1px solid var(--border);
+  }
+
+  .route-page--dashboard .conversion-breakdown + .conversion-breakdown,
+  .pipeline-source-reconciliation > section + section {
+    border-block-start: 1px solid var(--border);
+    border-inline-start: 0;
+    padding-block-start: 1rem;
+    padding-inline: 0;
+  }
+
+  .route-page--dashboard .funnel-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--dashboard .funnel-row .legend {
+    justify-content: flex-start;
+  }
+
+  .route-page--discovery .discovery-source-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .route-page--discovery .discovery-source-summary span:nth-child(2n) {
+    border-inline-end: 0;
+  }
+
+  .route-page--discovery .discovery-source-summary span:nth-child(n + 3) {
+    border-block-start: 1px solid var(--border);
+  }
+
+  .route-page--pipelines .pipeline-stage-ledger__table {
+    min-width: 42rem;
+  }
+}
+
+@container (max-width: 28rem) {
+  .route-page--discovery .discovery-source-summary {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--discovery .discovery-source-summary span {
+    border-inline-end: 0;
+    border-block-start: 1px solid var(--border);
+  }
+
+  .route-page--discovery .discovery-source-summary span:first-child {
+    border-block-start: 0;
+  }
+}
+
+@media (forced-colors: active) {
+  .route-page--analytics .analytics-dimension-control [data-state="on"],
+  .route-page--discovery [role="tab"][data-state="active"],
+  .route-page--pipelines [role="tab"][data-state="active"] {
+    border-block-end-color: Highlight;
+  }
+}

--- a/apps/web/src/styles/editorial-operations.css
+++ b/apps/web/src/styles/editorial-operations.css
@@ -692,7 +692,9 @@
 }
 
 .pipeline-stage-ledger__table {
-  min-width: 62rem;
+  width: 100%;
+  min-width: 50rem;
+  table-layout: fixed;
 }
 
 .pipeline-stage-ledger__table :is(th, td) {
@@ -711,23 +713,30 @@
   margin-block-start: 0.2rem;
 }
 
+.pipeline-stage-ledger__table :is(td, th) {
+  overflow-wrap: anywhere;
+}
+
 .pipeline-stage-ledger__counts,
 .pipeline-stage-ledger__backlog,
 .pipeline-operations-eta,
-.pipeline-operations-capacity {
+.pipeline-stage-ledger__summary {
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 5.5rem), 1fr));
   gap: 0.35rem 0.65rem;
 }
 
 .pipeline-stage-ledger__counts,
-.pipeline-stage-ledger__backlog {
+.pipeline-stage-ledger__backlog,
+.pipeline-stage-ledger__summary {
   display: flex;
   flex-wrap: wrap;
   gap: 0.3rem 0.7rem;
+  margin: 0;
 }
 
 .pipeline-stage-ledger__counts > *,
-.pipeline-stage-ledger__backlog > * {
+.pipeline-stage-ledger__backlog > *,
+.pipeline-stage-ledger__summary > * {
   display: inline-flex;
   align-items: baseline;
   gap: 0.25rem;
@@ -735,6 +744,7 @@
 
 .pipeline-stage-ledger__counts dt,
 .pipeline-stage-ledger__backlog dt,
+.pipeline-stage-ledger__summary dt,
 .pipeline-operations-eta dt,
 .pipeline-operations-capacity dt {
   font-size: 0.625rem;
@@ -751,6 +761,11 @@
   cursor: pointer;
   font-size: 0.6875rem;
   font-weight: 700;
+}
+
+.pipeline-stage-ledger__empty-summary {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
 }
 
 .pipelines-workspace .disclosure-section {
@@ -790,8 +805,48 @@
   border-block-start: 1px solid var(--border);
 }
 
+.pipeline-operations-inspector {
+  container: pipeline-inspector / inline-size;
+}
+
 .pipeline-operations-inspector .inspector-ledger__item {
   border-radius: 0;
+}
+
+.pipeline-operations-capacity {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+}
+
+.pipeline-operations-capacity > section {
+  padding-block: 0.75rem;
+}
+
+.pipeline-operations-capacity > section + section {
+  border-block-start: 1px solid var(--border);
+}
+
+.pipeline-operations-capacity h3 {
+  margin: 0 0 0.45rem;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@container pipeline-inspector (max-width: 28rem) {
+  .pipeline-operations-inspector .inspector-ledger__item {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 0.2rem;
+  }
+
+  .pipeline-operations-inspector .inspector-ledger__item :is(dd, .inspector-ledger__source, .inspector-ledger__status) {
+    grid-column: 1;
+    grid-row: auto;
+  }
 }
 
 .pipelines-workspace__controls.tool-row {

--- a/apps/web/src/styles/editorial-setup.css
+++ b/apps/web/src/styles/editorial-setup.css
@@ -754,20 +754,158 @@
   border-top: 1px solid var(--setup-rule);
 }
 
-.route-page--settings .browser-capability-section {
+.route-page--settings .browser-capability-row {
+  display: grid;
+  gap: 0.75rem;
   border: 0;
   border-bottom: 1px solid var(--setup-rule);
   background: transparent;
+  padding: 1rem 0;
 }
 
-.route-page--settings .browser-capability-section > .disclosure-section__header {
-  min-height: 3.75rem;
-  padding-inline: 0;
-  background: transparent;
+.route-page--settings .browser-capability-row__overview {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.625rem 1rem;
+  align-items: start;
 }
 
-.route-page--settings .browser-capability-section > .disclosure-section__body {
-  padding: 0.875rem 0 1rem;
+.route-page--settings .browser-capability-row__overview h3,
+.route-page--settings .browser-capability-row__overview p {
+  margin: 0;
+}
+
+.route-page--settings .browser-capability-row__overview h3 {
+  font-size: 0.875rem;
+}
+
+.route-page--settings .browser-capability-row__overview p,
+.route-page--settings .browser-capability-row__managed {
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.route-page--settings .browser-capability-row__managed {
+  margin: 0;
+}
+
+.route-page--settings .browser-capability-row__actions,
+.route-page--settings .browser-capability-configuration__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.route-page--settings .browser-capability-configuration,
+.route-page--settings .browser-capability-profile-copy {
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .browser-capability-configuration > summary,
+.route-page--settings .browser-capability-profile-copy > summary {
+  cursor: pointer;
+  padding-block: 0.625rem;
+  color: var(--foreground);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.route-page--settings .browser-capability-configuration > summary::marker,
+.route-page--settings .browser-capability-profile-copy > summary::marker {
+  color: var(--muted-foreground);
+}
+
+.route-page--settings .browser-capability-configuration > summary:focus-visible,
+.route-page--settings .browser-capability-profile-copy > summary:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.route-page--settings .browser-capability-configuration__body {
+  display: grid;
+  gap: 0.75rem;
+  max-width: 46rem;
+  padding: 0.25rem 0 0.875rem;
+}
+
+.route-page--settings .browser-capability-profile-copy > .browser-profile-copy {
+  margin-top: 0;
+  padding-bottom: 0.875rem;
+}
+
+.route-page--settings .provider-mode-choice-fieldset {
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.route-page--settings .provider-mode-choice-fieldset > legend {
+  margin-bottom: 0.5rem;
+  padding: 0;
+  color: var(--foreground);
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.route-page--settings .provider-mode-choice-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr));
+  border-block: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .provider-mode-choice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.5rem;
+  align-items: start;
+  min-height: 4.5rem;
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  padding: 0.75rem 0.875rem;
+  cursor: pointer;
+}
+
+.route-page--settings .provider-mode-choice:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.route-page--settings .provider-mode-choice:has(input:checked) {
+  box-shadow: inset 2px 0 0 var(--primary);
+}
+
+.route-page--settings .provider-mode-choice[data-disabled] {
+  cursor: not-allowed;
+  color: var(--muted-foreground);
+}
+
+.route-page--settings .provider-mode-choice input {
+  width: 1rem;
+  height: 1rem;
+  margin: 0.125rem 0 0;
+  accent-color: var(--primary);
+}
+
+.route-page--settings .provider-mode-choice__copy {
+  display: grid;
+  gap: 0.1875rem;
+}
+
+.route-page--settings .provider-mode-choice__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.route-page--settings .provider-mode-choice__description,
+.route-page--settings .provider-mode-choice-fieldset__notice {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  line-height: 1.45;
+}
+
+.route-page--settings .provider-mode-choice-fieldset__notice {
+  margin: 0.5rem 0 0;
 }
 
 .route-page--settings .extension-pairing-controls {
@@ -979,12 +1117,18 @@
   }
 
   .route-page--profile-import .resume-import-wizard__step {
-    justify-content: center;
-    padding-inline: 0.5rem;
+    min-height: 4.375rem;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 0.25rem;
+    padding: 0.5rem 0.375rem;
   }
 
-  .route-page--profile-import .resume-import-wizard__step > span:last-child {
-    display: none;
+  .route-page--profile-import .resume-import-wizard__step-label {
+    display: block;
+    overflow-wrap: anywhere;
+    font-size: 0.625rem;
+    line-height: 1.2;
   }
 
   .route-page--profile-import .resume-import-start,

--- a/apps/web/src/styles/editorial-setup.css
+++ b/apps/web/src/styles/editorial-setup.css
@@ -1,0 +1,1016 @@
+/*
+ * Setup surfaces: Profile, Preferences, and Settings
+ *
+ * These routes are long-lived workspaces. Keep their hierarchy in typography,
+ * spacing, and rules instead of nesting framed cards around every form group.
+ */
+
+.route-page--profile,
+.route-page--preferences,
+.route-page--settings,
+.route-page--profile-import {
+  --setup-rule: color-mix(in oklch, var(--border) 88%, transparent);
+}
+
+.route-page--profile :is(input, select, textarea),
+.route-page--preferences :is(input, select, textarea),
+.route-page--settings :is(input, select, textarea),
+.route-page--profile-import :is(input, select, textarea) {
+  min-height: 2.25rem;
+  border-color: var(--border);
+  box-shadow: none;
+}
+
+.route-page--profile textarea,
+.route-page--preferences textarea,
+.route-page--settings textarea,
+.route-page--profile-import textarea {
+  min-height: 5.5rem;
+  resize: vertical;
+}
+
+.route-page--profile .adaptive-field-grid,
+.route-page--preferences .adaptive-field-grid,
+.route-page--settings .adaptive-field-grid,
+.route-page--profile-import .adaptive-field-grid {
+  gap: 0.75rem 0.875rem;
+}
+
+.route-page--profile .field > span,
+.route-page--preferences .field > span,
+.route-page--settings .field > span,
+.route-page--profile .field > legend,
+.route-page--preferences .field > legend,
+.route-page--settings .field > legend,
+.route-page--profile-import .field > legend {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+/* Profile ------------------------------------------------------------------ */
+
+.route-page--profile .page-head-actions {
+  gap: 0.5rem;
+}
+
+.route-page--profile .profile-layout {
+  align-items: start;
+  gap: 1rem;
+}
+
+.route-page--profile .profile-editor-panel {
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.route-page--profile .profile-editor-panel > form {
+  display: grid;
+  gap: 1rem;
+}
+
+.route-page--profile .editor-bulk-actions {
+  position: static;
+  justify-content: flex-end;
+  margin: 0;
+  border-block: 1px solid var(--setup-rule);
+  border-inline: 0;
+  padding: 0.625rem 0;
+  background: transparent;
+  backdrop-filter: none;
+}
+
+.route-page--profile .profile-sections {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--profile .profile-disclosure {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--profile .profile-disclosure > .disclosure-section__header {
+  min-height: 3.5rem;
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--profile .profile-disclosure > .disclosure-section__body {
+  padding: 1rem 0 1.25rem;
+}
+
+.route-page--profile .profile-disclosure .disclosure-section__title {
+  font-size: 0.875rem;
+}
+
+.route-page--profile .profile-resizer {
+  width: 1rem;
+  border-inline: 0;
+  background: transparent;
+}
+
+.route-page--profile .profile-resizer span {
+  width: 1px;
+  height: 100%;
+  border-radius: 0;
+  background: var(--setup-rule);
+}
+
+.route-page--profile .profile-resizer:hover span,
+.route-page--profile .profile-resizer:focus-visible span {
+  background: var(--foreground);
+}
+
+.route-page--profile .profile-preview-pane {
+  top: calc(var(--app-header-height, 60px) + 0.75rem);
+}
+
+.route-page--profile .profile-preview-workbench {
+  min-height: min(78dvh, 58rem);
+  border: 1px solid color-mix(in oklch, var(--foreground) 58%, transparent);
+  border-radius: 2px;
+  background: #1b1b1b;
+  color: #f6f6f5;
+}
+
+.route-page--profile .form-section {
+  overflow: visible;
+  border-width: 1px 0 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.route-page--profile .form-section > h3 {
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+  padding-inline: 0;
+}
+
+.route-page--profile .repeat-list {
+  gap: 0;
+  padding: 0;
+}
+
+.route-page--profile :is(
+  .repeat-card,
+  .achievement-evidence-card,
+  .bullet-row,
+  .skill-row
+) {
+  border-width: 0 0 1px;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.875rem 0;
+}
+
+.route-page--profile .advanced-policy-group {
+  border-width: 1px 0 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem 0 0;
+}
+
+.route-page--profile .target-work-model-option {
+  border-width: 0 0 1px;
+  border-radius: 0;
+  background: transparent;
+  padding-inline: 0;
+}
+
+.route-page--profile .profile-preview-workbench .preview-workbench__header {
+  min-height: 3.875rem;
+  border: 0;
+  padding: 0.75rem 0.875rem;
+  background: transparent;
+}
+
+.route-page--profile .profile-preview-workbench .preview-workbench__heading {
+  gap: 0.125rem;
+}
+
+.route-page--profile .profile-preview-workbench .preview-workbench__heading h2 {
+  color: inherit;
+  font-size: 1rem;
+}
+
+.route-page--profile .profile-preview-workbench .preview-workbench__heading p {
+  color: color-mix(in srgb, #fff 62%, transparent);
+}
+
+.route-page--profile .profile-preview-workbench .preview-workbench__document,
+.route-page--profile .profile-preview-workbench .resume-plate-editor,
+.route-page--profile .profile-preview-workbench .resume-plate-scroll {
+  border: 0;
+  background: #1b1b1b;
+}
+
+.route-page--profile .profile-preview-workbench .resume-plate-toolbar {
+  min-height: 2.75rem;
+  border-block: 1px solid color-mix(in srgb, #fff 20%, transparent);
+  background: #1b1b1b;
+  color: #f6f6f5;
+}
+
+.route-page--profile .profile-preview-workbench .resume-plate-scroll {
+  padding: 1rem;
+}
+
+.route-page--profile .profile-preview-workbench .resume-plate-page {
+  border-radius: 0;
+  box-shadow: 0 0.25rem 1.25rem rgb(0 0 0 / 30%);
+}
+
+/* Profile import ----------------------------------------------------------- */
+
+.route-page--profile-import .page-head-subtitle {
+  display: grid;
+  gap: 0.125rem;
+}
+
+.route-page--profile-import .page-head-subtitle small {
+  font-size: 0.6875rem;
+}
+
+.route-page--profile-import .page-head-actions {
+  align-self: start;
+}
+
+.route-page--profile-import .resume-import-wizard__card {
+  width: 100%;
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.route-page--profile-import .resume-import-wizard__steps {
+  border-block: 1px solid var(--setup-rule);
+  background: var(--card);
+}
+
+.route-page--profile-import .resume-import-wizard__steps .section-tabs__list {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.route-page--profile-import .resume-import-wizard__step {
+  min-height: 3.625rem;
+  justify-content: flex-start;
+  gap: 0.625rem;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  padding: 0.625rem 1rem;
+  color: var(--muted-foreground);
+  text-align: left;
+}
+
+.route-page--profile-import .resume-import-wizard__step + .resume-import-wizard__step {
+  border-inline-start: 1px solid var(--setup-rule);
+}
+
+.route-page--profile-import .resume-import-wizard__step[data-step-state="active"] {
+  background: transparent;
+  box-shadow: inset 0 -2px 0 var(--primary);
+  color: var(--foreground);
+}
+
+.route-page--profile-import .resume-import-wizard__step[data-step-state="complete"] {
+  color: var(--success);
+}
+
+.route-page--profile-import .resume-import-wizard__step-number {
+  display: inline-flex;
+  min-width: 1.125rem;
+  align-items: center;
+  justify-content: flex-start;
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 650;
+}
+
+.route-page--profile-import .resume-import-wizard__content {
+  width: min(52.5rem, 100%);
+  margin-inline: auto;
+  padding-block: 1.5rem 0.5rem;
+}
+
+.route-page--profile-import .resume-import-start {
+  display: grid;
+  min-height: 14rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 1rem;
+  border-block: 1px solid var(--setup-rule);
+  padding: 2rem;
+}
+
+.route-page--profile-import .resume-import-start > svg {
+  color: var(--muted-foreground);
+}
+
+.route-page--profile-import .resume-import-start__copy {
+  display: grid;
+  gap: 0.375rem;
+}
+
+.route-page--profile-import .resume-import-start__copy h2,
+.route-page--profile-import .resume-import-start__copy p {
+  margin: 0;
+}
+
+.route-page--profile-import .resume-import-start__copy h2 {
+  font-size: 1rem;
+  letter-spacing: -0.015em;
+}
+
+.route-page--profile-import .resume-import-start__copy p {
+  max-width: 60ch;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.route-page--profile-import .resume-import-step {
+  gap: 1rem;
+}
+
+.route-page--profile-import .resume-import-upload__target {
+  display: grid;
+  min-height: 13rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-content: center;
+  align-items: center;
+  gap: 1rem;
+  border-color: var(--input);
+  border-radius: 0;
+  background: transparent;
+  padding: 2rem;
+}
+
+.route-page--profile-import .resume-import-upload__target .import-icon {
+  width: auto;
+  height: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.route-page--profile-import .resume-import-upload__target > .min-w-0 {
+  display: grid;
+  gap: 0.1875rem;
+}
+
+.route-page--profile-import .resume-import-upload__target small {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-style: normal;
+  line-height: 1.4;
+}
+
+.route-page--profile-import .resume-import-upload__target em {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 0.125rem;
+  background: var(--card);
+  padding: 0.625rem 0.75rem;
+  color: var(--foreground);
+  font-size: 0.75rem;
+  font-weight: 680;
+}
+
+.route-page--profile-import .resume-import-upload__input {
+  position: absolute;
+  width: 1px;
+  min-width: 1px;
+  height: 1px;
+  min-height: 1px;
+  clip-path: inset(50%);
+  overflow: hidden;
+  border: 0;
+  margin: -1px;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.route-page--profile-import .resume-import-upload__target:has(input:focus-visible) {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.route-page--profile-import .resume-import-file-summary {
+  border-color: var(--setup-rule);
+}
+
+.route-page--profile-import .resume-import-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border-width: 1px 0;
+  border-radius: 0;
+  border-color: var(--setup-rule);
+  padding: 0;
+}
+
+.route-page--profile-import .resume-import-options > legend {
+  width: 100%;
+  grid-column: 1 / -1;
+  margin-block-end: 0.5rem;
+  padding: 0;
+}
+
+.route-page--profile-import .resume-import-options .choice-control {
+  min-height: 5.75rem;
+  border: 0;
+  padding: 1rem;
+}
+
+.route-page--profile-import .resume-import-options .choice-control + .choice-control {
+  border-inline-start: 1px solid var(--setup-rule);
+}
+
+.route-page--profile-import .resume-import-confirmation {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem 1rem;
+  align-items: center;
+  border-block: 1px solid var(--setup-rule);
+  padding-block: 1rem;
+}
+
+.route-page--profile-import .resume-import-confirmation__icon {
+  color: var(--muted-foreground);
+}
+
+.route-page--profile-import .resume-import-confirmation__file {
+  display: grid;
+  gap: 0.1875rem;
+}
+
+.route-page--profile-import .resume-import-confirmation__file span,
+.route-page--profile-import .resume-import-confirmation__ledger dt {
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 650;
+}
+
+.route-page--profile-import .resume-import-confirmation__file strong {
+  font-size: 0.8125rem;
+}
+
+.route-page--profile-import .resume-import-confirmation__ledger {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--profile-import .resume-import-confirmation__ledger > div {
+  display: grid;
+  gap: 0.1875rem;
+  padding: 0.875rem 0;
+}
+
+.route-page--profile-import .resume-import-confirmation__ledger > div + div {
+  border-inline-start: 1px solid var(--setup-rule);
+  padding-inline-start: 1rem;
+}
+
+.route-page--profile-import .resume-import-confirmation__ledger dd {
+  margin: 0;
+  font-size: 0.75rem;
+}
+
+.route-page--profile-import .resume-import-actions {
+  justify-content: space-between;
+  gap: 0.5rem;
+  border-top: 1px solid var(--setup-rule);
+  padding-top: 0.875rem;
+}
+
+.route-page--profile-import :is(.banner.inline, .status-line, .empty) {
+  border-width: 1px 0;
+  border-radius: 0;
+  background: transparent;
+  padding-inline: 0;
+  text-align: start;
+}
+
+/* Preferences -------------------------------------------------------------- */
+
+.route-page--preferences .profile-layout-single {
+  display: block;
+}
+
+.route-page--preferences .profile-editor-panel {
+  border: 0;
+  background: transparent;
+}
+
+.route-page--preferences .profile-editor-panel > form {
+  display: grid;
+  gap: 1rem;
+}
+
+.route-page--preferences .editor-bulk-actions {
+  justify-content: flex-end;
+  margin: 0;
+  border-block: 1px solid var(--setup-rule);
+  border-inline: 0;
+  padding: 0.625rem 0;
+  background: transparent;
+}
+
+.route-page--preferences .profile-sections {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--preferences .preferences-disclosure {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--preferences .preferences-disclosure > .disclosure-section__header {
+  min-height: 3.5rem;
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--preferences .preferences-disclosure > .disclosure-section__body {
+  padding: 1rem 0 1.25rem;
+}
+
+.route-page--preferences .preferences-disclosure--tailoring .disclosure-section__body {
+  padding-top: 0.75rem;
+}
+
+.route-page--preferences .resume-template-panel {
+  margin: 0;
+  border-block: 1px solid var(--setup-rule);
+  border-inline: 0;
+  background: transparent;
+}
+
+.route-page--preferences .resume-template-panel .preview-workbench__header,
+.route-page--preferences .resume-template-panel .preview-workbench__control-row {
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--preferences .resume-template-panel .preview-workbench__document {
+  border-inline: 0;
+}
+
+.route-page--preferences .resume-template-panel .resume-plate-editor {
+  border-radius: 0;
+}
+
+/* Settings ----------------------------------------------------------------- */
+
+.route-page--settings .config-layout {
+  gap: 0;
+}
+
+.route-page--settings .settings-route-tabs {
+  gap: 0;
+}
+
+.route-page--settings .settings-section-navigation {
+  border-bottom: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .section-tabs__list {
+  width: max-content;
+  min-width: 100%;
+  gap: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.route-page--settings .section-tabs__list > * {
+  min-height: 2.625rem;
+  border-radius: 0;
+  padding-inline: 0.875rem;
+}
+
+.route-page--settings .section-tabs__list > :first-child {
+  padding-left: 0;
+}
+
+.route-page--settings .section-tabs__list [data-state="active"] {
+  border-bottom-color: var(--primary);
+  background: transparent;
+  box-shadow: none;
+  color: var(--foreground);
+}
+
+.route-page--settings .settings-route-tabs__content,
+.route-page--settings .settings-general-sections,
+.route-page--settings .settings-credentials-sections,
+.route-page--settings .models-settings-sections,
+.route-page--settings .settings-browser-sections {
+  gap: 0;
+}
+
+.route-page--settings :is(
+  .settings-general-sections,
+  .settings-credentials-sections,
+  .models-settings-sections,
+  .settings-browser-sections,
+  .settings-route-tabs__content
+) > .disclosure-section {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--settings :is(
+  .settings-general-sections,
+  .settings-credentials-sections,
+  .models-settings-sections,
+  .settings-browser-sections,
+  .settings-route-tabs__content
+) > .disclosure-section > .disclosure-section__header {
+  min-height: 3.5rem;
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--settings :is(
+  .settings-general-sections,
+  .settings-credentials-sections,
+  .models-settings-sections,
+  .settings-browser-sections,
+  .settings-route-tabs__content
+) > .disclosure-section > .disclosure-section__body {
+  padding: 1rem 0 1.25rem;
+}
+
+.route-page--settings :is(.settings-browser-intro, .settings-subroute-head) {
+  display: grid;
+  gap: 0.25rem;
+  padding: 1.5rem 0 1rem;
+}
+
+.route-page--settings :is(.settings-browser-intro, .settings-subroute-head) h2,
+.route-page--settings :is(.settings-browser-intro, .settings-subroute-head) p {
+  margin: 0;
+}
+
+.route-page--settings :is(.settings-browser-intro, .settings-subroute-head) h2 {
+  font-size: 1.125rem;
+  letter-spacing: -0.02em;
+}
+
+.route-page--settings :is(.settings-browser-intro, .settings-subroute-head) p {
+  max-width: 70ch;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+  line-height: 1.45;
+}
+
+.route-page--settings :is(
+  .settings-credentials-sections,
+  .models-settings-sections,
+  .settings-browser-sections
+) {
+  display: grid;
+}
+
+.route-page--settings :is(
+  .settings-credentials-sections,
+  .models-settings-sections,
+  .settings-browser-sections
+) > .disclosure-section {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--settings .settings-subroute-head + .disclosure-section {
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--settings :is(.banner, .credential-store-notice) {
+  border-width: 1px 0;
+  border-radius: 0;
+  border-color: var(--setup-rule);
+  background: transparent;
+  box-shadow: none;
+  padding: 0.75rem 0;
+  text-align: start;
+}
+
+.route-page--settings .provider-removal-error {
+  border: 0;
+  border-inline-start: 2px solid var(--warning);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.625rem 0 0.625rem 0.75rem;
+  color: var(--warning);
+}
+
+.route-page--settings .provider-disclosure__summary {
+  align-items: center;
+}
+
+.route-page--settings .provider-status-ledger,
+.route-page--settings .provider-preference-status {
+  border-color: var(--setup-rule);
+}
+
+.route-page--settings .model-selection-guidance {
+  max-width: 76ch;
+  border-bottom: 1px solid var(--setup-rule);
+  padding-bottom: 0.875rem;
+}
+
+.route-page--settings .ai-execution-policy-analysis__choices {
+  border-block: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .ai-execution-policy-analysis__choices .choice-control {
+  border-bottom: 0;
+}
+
+.route-page--settings .browser-capability-list {
+  gap: 0;
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .browser-capability-section {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--settings .browser-capability-section > .disclosure-section__header {
+  min-height: 3.75rem;
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--settings .browser-capability-section > .disclosure-section__body {
+  padding: 0.875rem 0 1rem;
+}
+
+.route-page--settings .extension-pairing-controls {
+  gap: 0.875rem;
+}
+
+.route-page--settings .provider-disclosure-list,
+.route-page--settings .model-provider-preferences {
+  gap: 0;
+  border-top: 1px solid var(--setup-rule);
+}
+
+.route-page--settings .provider-disclosure,
+.route-page--settings .provider-preference-disclosure {
+  border: 0;
+  border-bottom: 1px solid var(--setup-rule);
+  background: transparent;
+}
+
+.route-page--settings .provider-disclosure > .disclosure-section__header,
+.route-page--settings .provider-preference-disclosure > .disclosure-section__header {
+  padding-inline: 0;
+  background: transparent;
+}
+
+.route-page--settings .provider-disclosure > .disclosure-section__body,
+.route-page--settings .provider-preference-disclosure > .disclosure-section__body {
+  padding-inline: 0;
+}
+
+/* Nested job run ----------------------------------------------------------- */
+
+.route-page--job-run-detail {
+  --job-run-rule: color-mix(in oklch, var(--border) 88%, transparent);
+}
+
+.route-page--job-run-detail .job-run-workspace {
+  overflow: visible;
+  border: 0;
+  background: transparent;
+}
+
+.route-page--job-run-detail .job-run-workspace > .route-workspace__header {
+  border-bottom: 1px solid var(--job-run-rule);
+  padding: 0 0 1rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__header {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.625rem 1rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__header > .workspace-back {
+  grid-column: 1 / -1;
+}
+
+.route-page--job-run-detail .job-run-workspace__status {
+  align-self: end;
+  justify-self: end;
+  padding-bottom: 0.25rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__title {
+  gap: 0.1875rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__title small {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 650;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.route-page--job-run-detail .job-run-workspace > .route-workspace__grid {
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 22.5rem);
+  border-bottom: 1px solid var(--job-run-rule);
+}
+
+.route-page--job-run-detail .job-run-tabs {
+  display: block;
+  min-inline-size: 0;
+}
+
+.route-page--job-run-detail
+  .job-run-workspace
+  > .route-workspace__grid
+  > .route-workspace__content
+  > [data-state="inactive"] {
+  display: none;
+}
+
+.route-page--job-run-detail
+  .job-run-workspace
+  > .route-workspace__grid
+  > .route-workspace__content
+  > [role="tabpanel"] {
+  margin-block-start: 0;
+}
+
+.route-page--job-run-detail .job-run-workspace > .route-workspace__grid > :is(
+  .route-workspace__content,
+  .route-workspace__inspector
+) {
+  padding: 0;
+}
+
+.route-page--job-run-detail .job-run-workspace__inspector {
+  border-inline-start: 1px solid var(--job-run-rule);
+  background: color-mix(in oklch, var(--background) 58%, var(--card));
+}
+
+.route-page--job-run-detail :is(
+  .job-run-workspace__timeline,
+  .job-run-workspace__inspector > .section
+) {
+  border: 0;
+  border-bottom: 1px solid var(--job-run-rule);
+  background: transparent;
+  padding: 1rem 1.125rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__inspector > .section:last-child {
+  border-bottom: 0;
+}
+
+.route-page--job-run-detail .job-run-workspace__timeline {
+  min-height: min(60dvh, 42rem);
+}
+
+.route-page--job-run-detail .job-run-workspace__timeline .section__header {
+  margin-bottom: 0.875rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__inspector .detail-list {
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--job-run-rule);
+}
+
+.route-page--job-run-detail .job-run-workspace__inspector .detail-list > div {
+  grid-template-columns: minmax(6.5rem, 0.42fr) minmax(0, 1fr);
+  border-bottom: 1px solid var(--job-run-rule);
+  padding-block: 0.625rem;
+}
+
+.route-page--job-run-detail .job-run-workspace__failure .section__heading h3 {
+  color: var(--destructive);
+}
+
+@media (max-width: 1024px) {
+  .route-page--profile .profile-layout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+
+  .route-page--profile .profile-resizer {
+    display: none;
+  }
+
+  .route-page--profile .profile-preview-pane {
+    position: static;
+  }
+
+  .route-page--job-run-detail .job-run-workspace > .route-workspace__grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--job-run-detail .job-run-workspace__inspector {
+    border-block-start: 1px solid var(--job-run-rule);
+    border-inline-start: 0;
+  }
+}
+
+@media (max-width: 640px) {
+  .route-page--profile .page-head-actions {
+    width: 100%;
+  }
+
+  .route-page--profile .page-head-actions > * {
+    flex: 1 1 auto;
+  }
+
+  .route-page--profile .page-head-actions :is(a, button) {
+    width: 100%;
+  }
+
+  .route-page--profile .editor-bulk-actions,
+  .route-page--preferences .editor-bulk-actions {
+    justify-content: stretch;
+  }
+
+  .route-page--profile .editor-bulk-actions > *,
+  .route-page--preferences .editor-bulk-actions > * {
+    flex: 1 1 auto;
+  }
+
+  .route-page--settings .section-tabs__list > * {
+    padding-inline: 0.625rem;
+  }
+
+  .route-page--profile-import .page-head-actions {
+    width: 100%;
+  }
+
+  .route-page--profile-import .page-head-actions > * {
+    width: 100%;
+  }
+
+  .route-page--profile-import .resume-import-wizard__step {
+    justify-content: center;
+    padding-inline: 0.5rem;
+  }
+
+  .route-page--profile-import .resume-import-wizard__step > span:last-child {
+    display: none;
+  }
+
+  .route-page--profile-import .resume-import-start,
+  .route-page--profile-import .resume-import-upload__target {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: start;
+    padding: 1.25rem;
+  }
+
+  .route-page--profile-import .resume-import-options,
+  .route-page--profile-import .resume-import-confirmation__ledger {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--profile-import .resume-import-options .choice-control + .choice-control,
+  .route-page--profile-import .resume-import-confirmation__ledger > div + div {
+    border-inline-start: 0;
+    border-top: 1px solid var(--setup-rule);
+    padding-inline-start: 0;
+  }
+
+  .route-page--job-run-detail .job-run-workspace__header {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .route-page--job-run-detail .job-run-workspace__status {
+    justify-self: start;
+  }
+}

--- a/apps/web/src/styles/editorial-shell.css
+++ b/apps/web/src/styles/editorial-shell.css
@@ -1,0 +1,553 @@
+/*
+ * Editorial application shell
+ *
+ * The shell follows the approved type-and-rule grammar: a neutral rail, an
+ * underlined search surface, and compact dot-plus-label runtime state. Shell
+ * utilities move into the mobile navigation sheet instead of disappearing.
+ */
+
+.app-shell {
+  grid-template-columns: var(--rail-width) minmax(0, 1fr);
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
+  background: var(--background);
+}
+
+.main-shell {
+  min-block-size: 100vh;
+  min-block-size: 100dvh;
+}
+
+.side-rail {
+  position: sticky;
+  inset-block-start: 0;
+  align-self: start;
+  inline-size: var(--rail-width);
+  block-size: 100vh;
+  block-size: 100dvh;
+  gap: 0;
+  padding: 0;
+  border-inline-end: 1px solid var(--sidebar-border);
+  background: var(--sidebar);
+  backdrop-filter: none;
+}
+
+.side-rail__brand {
+  min-block-size: 64px;
+  padding: 0 20px;
+  border-radius: 0;
+}
+
+.side-rail__brand:hover {
+  background: transparent;
+  color: var(--sidebar-foreground);
+}
+
+.brand-lockup {
+  gap: 10px;
+}
+
+.brand-mark-svg {
+  inline-size: 26px;
+  block-size: 26px;
+}
+
+.side-rail__wordmark {
+  font-size: 1.125rem;
+  font-weight: 850;
+  letter-spacing: -0.04em;
+}
+
+.side-rail__nav {
+  display: grid;
+  gap: 17px;
+  margin-block-start: 4px;
+  padding: 4px 12px 24px;
+}
+
+.side-rail__group {
+  display: grid;
+  gap: 2px;
+}
+
+.side-rail__group + .side-rail__group {
+  margin-block-start: 0;
+}
+
+.side-rail__group-label {
+  margin: 0 8px 5px;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+}
+
+.side-rail__link {
+  min-block-size: 34px;
+  gap: 10px;
+  padding: 7px 8px 7px 10px;
+  border-radius: 0;
+  color: var(--muted-foreground);
+  font-size: 0.8125rem;
+  font-weight: 560;
+}
+
+.side-rail__link:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.side-rail__link.on {
+  background: transparent;
+  color: var(--foreground);
+  font-weight: 780;
+}
+
+.side-rail__link.on::before {
+  inset-block: 7px;
+  inset-inline-start: -12px;
+  inline-size: 2px;
+  border-radius: 0;
+  background: var(--primary);
+}
+
+.side-rail__spacer {
+  min-block-size: 12px;
+}
+
+.side-rail__footer {
+  gap: 8px;
+  margin: 0 16px;
+  padding: 10px 0;
+  border: 0;
+  border-block-start: 1px solid var(--sidebar-border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  line-height: 1.45;
+}
+
+.side-rail__status-dot {
+  inline-size: 7px;
+  block-size: 7px;
+  background: var(--success);
+  box-shadow: none;
+}
+
+.legal-notice--rail {
+  padding: 2px 16px 16px;
+}
+
+.topbar {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 20;
+  flex-wrap: nowrap;
+  block-size: var(--topbar-height);
+  min-block-size: var(--topbar-height);
+  gap: 12px;
+  padding: 0 24px;
+  border-block-end: 1px solid var(--border);
+  background: color-mix(in oklch, var(--card) 96%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.topbar__search {
+  inline-size: min(560px, 48vw);
+  min-inline-size: 220px;
+  max-inline-size: 560px;
+  block-size: 34px;
+  flex: 1 1 440px;
+  gap: 8px;
+  border-block-end: 1px solid var(--input);
+  color: var(--muted-foreground);
+}
+
+.topbar__search:focus-within {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.topbar__search .global-search {
+  min-block-size: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  font-size: 0.8125rem;
+}
+
+.topbar__search .global-search:hover,
+.topbar__search .global-search:focus-visible {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.topbar__density {
+  inline-size: 124px;
+  min-block-size: 32px;
+  block-size: 32px;
+  flex: 0 0 124px;
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+
+.topbar__theme-control {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.topbar__theme-control > .tab {
+  min-block-size: 32px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.topbar__theme-control > .tab:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.connection-status {
+  position: relative;
+  display: inline-flex;
+  min-inline-size: 0;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-inline-start: auto;
+}
+
+.connection-status__state {
+  display: inline-flex;
+  min-block-size: 24px;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.connection-status__dot {
+  inline-size: 6px;
+  block-size: 6px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+}
+
+.connection-status__state[data-status="open"] {
+  color: var(--success);
+}
+
+.connection-status__state[data-status="open"] .connection-status__dot {
+  background: var(--success);
+}
+
+.connection-status__state:is([data-status="connecting"], [data-status="closed"]) {
+  color: var(--warning);
+}
+
+.connection-status__state:is([data-status="connecting"], [data-status="closed"])
+  .connection-status__dot {
+  background: var(--warning);
+}
+
+.connection-status__state[data-status="lost"] {
+  color: var(--destructive);
+}
+
+.connection-status__state[data-status="lost"] .connection-status__dot {
+  background: var(--destructive);
+}
+
+.connection-status__spend {
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  white-space: nowrap;
+}
+
+.connection-status__spend[data-status="over_budget"] {
+  color: var(--destructive);
+}
+
+.connection-status__banner {
+  position: absolute;
+  inset-block-start: calc(100% + 12px);
+  inset-inline-end: 0;
+  inline-size: min(420px, calc(100vw - var(--rail-width) - 48px));
+  max-inline-size: calc(100vw - var(--rail-width) - 48px);
+  padding: 9px 12px;
+  border: 1px solid var(--destructive);
+  border-radius: 2px;
+  background: var(--popover);
+  color: var(--destructive);
+  box-shadow: var(--shadow-float);
+  font-size: 0.75rem;
+  line-height: 1.45;
+}
+
+.main {
+  padding: 24px 32px 48px;
+}
+
+.mobile-navigation-sheet {
+  display: flex;
+  inline-size: min(320px, calc(100dvw - 44px));
+  max-inline-size: none;
+  flex-direction: column;
+  gap: 0;
+  overflow-y: auto;
+  padding: 0;
+  border-radius: 0;
+  background: var(--sidebar);
+  color: var(--sidebar-foreground);
+  box-shadow: var(--shadow-float);
+}
+
+.mobile-navigation-sheet__header {
+  min-block-size: 64px;
+  justify-content: center;
+  padding: 0 52px 0 16px;
+  text-align: start;
+}
+
+.mobile-navigation-sheet__title {
+  color: var(--sidebar-foreground);
+}
+
+.mobile-navigation-sheet .sheet-nav {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 17px;
+  margin: 0;
+  padding: 8px 12px 24px;
+}
+
+.mobile-navigation-sheet .side-rail__group {
+  display: grid;
+}
+
+.mobile-navigation-sheet .side-rail__group-label,
+.mobile-navigation-sheet .side-rail__label,
+.mobile-navigation-sheet .side-rail__footer-text {
+  display: initial;
+}
+
+.mobile-navigation-sheet .side-rail__link {
+  justify-content: flex-start;
+  padding: 7px 8px 7px 10px;
+}
+
+.mobile-navigation-sheet__utilities {
+  display: grid;
+  gap: 12px;
+  margin: 0 16px;
+  padding: 16px 0;
+  border-block: 1px solid var(--sidebar-border);
+}
+
+.mobile-navigation-sheet__utilities > h2 {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 0.625rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mobile-navigation-sheet__density-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 124px;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted-foreground);
+  font-size: 0.75rem;
+}
+
+.mobile-navigation-sheet__density {
+  min-block-size: 32px;
+  block-size: 32px;
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+
+.mobile-navigation-sheet__utilities > .tab {
+  inline-size: fit-content;
+  min-block-size: 32px;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.mobile-navigation-sheet__utilities .connection-status {
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 6px 12px;
+  margin-inline-start: 0;
+}
+
+.mobile-navigation-sheet__utilities .connection-status__banner {
+  position: static;
+  inline-size: 100%;
+  max-inline-size: none;
+  box-shadow: none;
+}
+
+.mobile-navigation-sheet > .side-rail__footer {
+  justify-content: flex-start;
+  margin-block-start: 0;
+}
+
+.mobile-navigation-sheet .legal-notice--sheet {
+  margin-block-start: 0;
+  padding: 12px 16px 20px;
+}
+
+@media (max-width: 1180px) {
+  .app-shell {
+    grid-template-columns: var(--rail-width-collapsed) minmax(0, 1fr);
+  }
+
+  .side-rail {
+    inline-size: var(--rail-width-collapsed);
+  }
+
+  .side-rail__brand {
+    justify-content: center;
+    padding: 0;
+  }
+
+  .side-rail__nav {
+    padding-inline: 12px;
+  }
+
+  .side-rail__link {
+    justify-content: center;
+    padding-inline: 0;
+  }
+
+  .side-rail__group-label,
+  .side-rail__label,
+  .side-rail__wordmark,
+  .side-rail__footer-text,
+  .legal-notice--rail {
+    display: none;
+  }
+
+  .side-rail__footer {
+    justify-content: center;
+    margin-inline: 16px;
+    padding: 12px 0;
+  }
+
+  .connection-status__banner {
+    inline-size: min(420px, calc(100vw - var(--rail-width-collapsed) - 32px));
+    max-inline-size: calc(100vw - var(--rail-width-collapsed) - 32px);
+  }
+}
+
+@media (min-width: 821px) and (max-width: 980px) {
+  .topbar {
+    gap: 10px;
+    padding-inline: 16px;
+  }
+
+  .topbar__search {
+    min-inline-size: 180px;
+  }
+
+  .topbar__density {
+    inline-size: 104px;
+    flex-basis: 104px;
+  }
+
+  .legal-notice--topbar > span:first-child {
+    display: none;
+  }
+}
+
+@media (max-width: 820px) {
+  .app-shell {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .side-rail {
+    display: none;
+  }
+
+  .topbar {
+    block-size: var(--topbar-height);
+    min-block-size: var(--topbar-height);
+    gap: 10px;
+    padding: 0 14px;
+  }
+
+  .topbar .topbar__hamburger {
+    display: inline-flex;
+    inline-size: 34px;
+    block-size: 34px;
+    flex: 0 0 34px;
+  }
+
+  .topbar__search {
+    order: initial;
+    inline-size: auto;
+    min-inline-size: 0;
+    max-inline-size: none;
+    flex: 1 1 auto;
+  }
+
+  .topbar__density,
+  .topbar__theme-control,
+  .topbar > .connection-status,
+  .legal-notice--topbar {
+    display: none;
+  }
+
+  .connection-status__banner {
+    max-inline-size: calc(100dvw - 32px);
+  }
+
+  .main {
+    padding: 24px 16px 32px;
+  }
+}
+
+@media (pointer: coarse) {
+  .side-rail__link,
+  .mobile-navigation-sheet__utilities > .tab {
+    min-block-size: 44px;
+  }
+}
+
+@media (forced-colors: active) {
+  .side-rail__link.on::before,
+  .connection-status__dot,
+  .side-rail__status-dot {
+    background: Highlight;
+  }
+
+  .connection-status__banner {
+    border-color: CanvasText;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-navigation-sheet {
+    scroll-behavior: auto;
+  }
+}

--- a/apps/web/src/styles/editorial-status.css
+++ b/apps/web/src/styles/editorial-status.css
@@ -1,0 +1,143 @@
+/*
+ * Editorial status language
+ *
+ * Statuses read as evidence in a ledger: a small semantic dot followed by
+ * direct language. The retained tone classes remain a stable hook for callers
+ * while this layer intentionally removes the legacy rounded-tag treatment.
+ */
+
+.editorial-status {
+  display: inline-flex;
+  align-items: center;
+  min-block-size: 0;
+  gap: 0.375rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 650;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.editorial-status .status-dot {
+  flex: 0 0 auto;
+  inline-size: 0.4375rem;
+  block-size: 0.4375rem;
+  border: 0;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.editorial-status.ok {
+  color: var(--success);
+}
+
+.editorial-status.warn {
+  color: var(--warning);
+}
+
+.editorial-status.danger {
+  color: var(--destructive);
+}
+
+.editorial-status.info {
+  color: var(--status-info);
+}
+
+.editorial-status.muted,
+.editorial-status.neutral {
+  color: var(--muted-foreground);
+}
+
+.stage-label {
+  display: inline-flex;
+  align-items: center;
+  min-block-size: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+.stage-label.neutral {
+  color: var(--muted-foreground);
+}
+
+.stage-label.info {
+  color: var(--status-info);
+}
+
+.stage-label.ok {
+  color: var(--success);
+}
+
+.editorial-timeline {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+
+.editorial-timeline > .timeline-row {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.5rem;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0.75rem 0;
+}
+
+.editorial-timeline .timeline-row-summary {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.375rem 1rem;
+}
+
+.editorial-timeline .timeline-diagnostics {
+  width: auto;
+  gap: 0.25rem;
+  padding-inline-start: 0.875rem;
+}
+
+.editorial-timeline .timeline-diagnostics div {
+  grid-template-columns: minmax(4.5rem, max-content) minmax(0, 1fr);
+}
+
+.editorial-timeline .timeline-action {
+  width: fit-content;
+}
+
+.apply-run-timeline-list {
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.apply-run-timeline-event {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+@media (forced-colors: active) {
+  .editorial-status .status-dot {
+    border: 1px solid currentColor;
+  }
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -78,24 +78,26 @@ code,
   gap: 6px 12px;
   margin: 12px 16px 0;
   padding: 10px 12px;
-  border: 1px solid var(--warning);
-  border-radius: calc(var(--radius) * 0.8);
-  background: color-mix(in oklch, var(--warning) 10%, var(--card));
+  border: 1px solid var(--border);
+  border-inline-start: 2px solid var(--warning);
+  border-radius: 0.125rem;
+  background: var(--surface-subtle);
   color: var(--foreground);
   font-size: 12px;
   line-height: 1.45;
 }
 
 .demo-workspace-notice strong {
-  color: var(--warning-foreground);
+  color: var(--warning);
 }
 
 .demo-receipt-history {
   margin: 8px 16px 0;
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: calc(var(--radius) * 0.8);
-  background: var(--card);
+  border-inline-start: 2px solid var(--success);
+  border-radius: 0.125rem;
+  background: var(--surface-subtle);
   font-size: 12px;
   line-height: 1.45;
 }
@@ -570,7 +572,7 @@ select,
 input,
 textarea {
   border: 1px solid var(--input);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: var(--foreground);
   padding: 8px 10px;
@@ -597,7 +599,7 @@ input[type="radio"] {
   flex: 0 0 auto;
   margin: 0;
   padding: 0;
-  border-radius: 4px;
+  border-radius: var(--radius);
   box-shadow: none;
   accent-color: var(--primary);
 }
@@ -802,7 +804,7 @@ input[type="radio"] {
   min-width: 0;
   overflow: clip;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -828,7 +830,7 @@ input[type="radio"] {
   align-items: center;
   gap: 10px;
   border: 0;
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: transparent;
   padding: 4px;
   color: var(--foreground);
@@ -955,7 +957,7 @@ input[type="radio"] {
   gap: 0;
   overflow: hidden;
   border: 1px solid var(--input);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--surface-subtle);
   padding: 2px;
 }
@@ -963,7 +965,7 @@ input[type="radio"] {
 .segmented-field [data-slot="toggle-group-item"] {
   min-width: 0;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--muted-foreground);
   padding-inline: 10px;
@@ -1039,7 +1041,7 @@ input[type="radio"] {
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -1110,7 +1112,7 @@ input[type="radio"] {
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -1161,7 +1163,7 @@ input[type="radio"] {
   gap: 10px 14px;
   padding: 10px 12px;
   border: 1px solid var(--border);
-  border-radius: 7px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -2001,8 +2003,9 @@ input[type="radio"] {
 }
 
 .banner.credential-store-notice--guidance {
-  background: var(--status-info-muted);
-  color: var(--foreground);
+  border-inline-start-color: var(--status-info);
+  background: var(--surface-subtle);
+  color: var(--status-info);
 }
 
 .banner.credential-store-notice.credential-store-recovery {
@@ -2113,7 +2116,7 @@ input[type="radio"] {
   width: 100%;
   min-height: var(--jh-row-height);
   border: 0;
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: transparent;
   padding: 8px 10px;
   text-align: left;
@@ -2516,7 +2519,7 @@ input[type="radio"] {
   min-width: 0;
   gap: 7px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: inherit;
   cursor: pointer;
@@ -2664,7 +2667,7 @@ input[type="radio"] {
   min-height: min(54dvh, 640px);
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -2707,7 +2710,7 @@ input[type="radio"] {
   max-height: 34dvh;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 12px;
   scrollbar-gutter: stable;
@@ -2722,7 +2725,7 @@ input[type="radio"] {
   height: min(66dvh, 720px);
   min-height: 520px;
   overflow: hidden;
-  border-radius: 6px;
+  border-radius: var(--radius);
 }
 
 .apply-review-materials-scroll {
@@ -2883,7 +2886,7 @@ input[type="radio"] {
   min-width: 0;
   flex-direction: column;
   overflow: hidden;
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: #242424;
 }
 
@@ -2922,7 +2925,7 @@ input[type="radio"] {
   display: inline-flex;
   overflow: hidden;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: rgb(255 255 255 / 5%);
 }
 
@@ -2977,7 +2980,7 @@ input[type="radio"] {
 .resume-format-select input {
   min-block-size: 30px;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: #242424;
   color: #f5f5f5;
   font: inherit;
@@ -2998,7 +3001,7 @@ input[type="radio"] {
   gap: 7px;
   padding: 8px;
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: #242424;
   box-shadow: 0 12px 28px rgb(0 0 0 / 35%);
 }
@@ -3017,7 +3020,7 @@ input[type="radio"] {
   grid-column: 1 / -1;
   max-inline-size: 280px;
   border: 1px solid rgb(248 113 113 / 50%);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: #301616;
   color: #fecaca;
   font-size: 11px;
@@ -3351,7 +3354,7 @@ input[type="radio"] {
   inline-size: 204px;
   gap: 4px;
   border: 1px solid #111;
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: #fff;
   box-shadow: 0 8px 22px rgb(0 0 0 / 14%);
   color: #111;
@@ -3402,7 +3405,7 @@ input[type="radio"] {
 
 .resume-render-warnings span {
   border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 4px 6px;
 }
 
@@ -3442,7 +3445,7 @@ input[type="radio"] {
   display: grid;
   gap: 8px;
   border: 1px solid rgb(255 255 255 / 16%);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
   background: rgb(255 255 255 / 5%);
 }
@@ -3482,7 +3485,7 @@ input[type="radio"] {
 .resume-comment-reply-form select {
   min-width: 0;
   border: 1px solid rgb(255 255 255 / 22%);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: #1f1f1f;
   color: #f5f5f5;
 }
@@ -3504,7 +3507,7 @@ input[type="radio"] {
   margin: 40px auto;
   padding: 18px;
   border: 1px solid color-mix(in oklab, var(--warning) 60%, var(--border));
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: #fff;
   color: #202124;
 }
@@ -3615,7 +3618,7 @@ input[type="radio"] {
 .resume-pin-risk {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -3660,7 +3663,7 @@ input[type="radio"] {
   gap: 6px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 10px;
 }
@@ -3792,7 +3795,7 @@ input[type="radio"] {
   gap: 8px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -3863,7 +3866,7 @@ input[type="radio"] {
   gap: 8px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 5px 7px;
 }
@@ -3897,7 +3900,7 @@ input[type="radio"] {
   flex: 1 1 220px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: color-mix(in oklch, var(--muted) 62%, var(--card));
 }
 
@@ -4115,7 +4118,7 @@ input[type="radio"] {
 .outcome-correction-form {
   grid-template-columns: repeat(3, minmax(0, 1fr));
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 10px;
 }
@@ -4176,7 +4179,7 @@ input[type="radio"] {
   display: grid;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 12px;
 }
@@ -4228,7 +4231,7 @@ input[type="radio"] {
 
 .discovery-tab-panel .discovery-control-panel {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -4271,7 +4274,7 @@ input[type="radio"] {
 .discovery-source-summary span {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 7px 8px;
   color: var(--muted-foreground);
@@ -4348,7 +4351,7 @@ input[type="radio"] {
   width: 100%;
   min-width: 72px;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 5px 6px;
   color: var(--foreground);
@@ -4417,7 +4420,7 @@ input[type="radio"] {
   min-width: 28px;
   min-height: 28px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: var(--foreground);
   font: inherit;
@@ -4454,7 +4457,7 @@ input[type="radio"] {
   max-width: 180px;
   min-height: 28px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: var(--foreground);
   font: inherit;
@@ -4477,7 +4480,7 @@ input[type="radio"] {
   grid-template-columns: repeat(4, minmax(0, 1fr));
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
 }
 
 .saved-table-density button {
@@ -4516,7 +4519,7 @@ input[type="radio"] {
 .saved-table-rule-editor input {
   min-height: 30px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: var(--foreground);
   font: inherit;
@@ -4547,7 +4550,7 @@ input[type="radio"] {
   align-items: center;
   gap: 8px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 4px 6px;
   color: var(--foreground);
   font-size: 12px;
@@ -4575,7 +4578,7 @@ input[type="radio"] {
   gap: 8px;
   min-height: 34px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 4px 6px;
 }
 
@@ -4652,7 +4655,7 @@ input[type="radio"] {
   gap: 8px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 10px;
 }
@@ -4716,7 +4719,7 @@ input[type="radio"] {
   max-height: 148px;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 6px;
 }
@@ -4727,7 +4730,7 @@ input[type="radio"] {
   align-items: center;
   gap: 8px;
   min-height: 26px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 2px 4px;
   color: var(--foreground);
   font-size: 12px;
@@ -4935,7 +4938,7 @@ input[type="radio"] {
   width: 24px;
   height: 24px;
   border: 1px solid transparent;
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--muted-foreground);
   padding: 0;
@@ -4983,7 +4986,7 @@ input[type="radio"] {
   min-height: 24px;
   margin-left: 8px;
   border: 1px solid transparent;
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--muted-foreground);
   font: inherit;
@@ -5105,7 +5108,7 @@ input[type="radio"] {
   width: fit-content;
   max-width: 100%;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 2px 6px;
   font-size: 11px;
   font-weight: 650;
@@ -5287,7 +5290,7 @@ input[type="radio"] {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  border-radius: 4px;
+  border-radius: var(--radius);
   padding: 1px 6px;
   font-size: 0.75rem;
   background: color-mix(in oklch, var(--muted-foreground) 12%, var(--muted));
@@ -5880,7 +5883,7 @@ input[type="radio"] {
   align-items: center;
   gap: 8px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 6px 8px;
   text-align: left;
@@ -5903,8 +5906,9 @@ input[type="radio"] {
 }
 
 .status-line.warning {
-  background: color-mix(in oklch, var(--warning) 12%, var(--card));
-  color: var(--warning-foreground);
+  border-inline-start: 2px solid var(--warning);
+  background: var(--surface-subtle);
+  color: var(--warning);
 }
 
 .empty,
@@ -5916,7 +5920,8 @@ input[type="radio"] {
 
 .banner {
   border-bottom: 1px solid var(--border);
-  background: color-mix(in oklch, var(--destructive) 10%, var(--card));
+  border-inline-start: 2px solid var(--destructive);
+  background: var(--surface-subtle);
   color: var(--destructive);
 }
 
@@ -5946,7 +5951,7 @@ input[type="radio"] {
   block-size: calc(100dvh - 32px);
   margin: 16px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   scrollbar-gutter: stable;
 }
@@ -6091,7 +6096,7 @@ input[type="radio"] {
   gap: 10px;
   padding: 12px;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
 }
 
 .interview-prep-item-head {
@@ -6287,7 +6292,7 @@ input[type="radio"] {
 .finding-list {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -6323,7 +6328,7 @@ input[type="radio"] {
 .tailoring-change {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -6370,7 +6375,7 @@ input[type="radio"] {
 .audit-response {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 8px;
 }
 
@@ -6543,7 +6548,7 @@ input[type="radio"] {
 .employer-analysis-sub {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -6577,7 +6582,7 @@ input[type="radio"] {
   display: grid;
   gap: 8px;
   min-width: 0;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: color-mix(in oklch, var(--muted) 42%, transparent);
   padding: 8px;
 }
@@ -6659,7 +6664,7 @@ input[type="radio"] {
 .bullet-provenance-diff-side {
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 8px;
 }
 
@@ -6727,7 +6732,7 @@ input[type="radio"] {
   flex-direction: column;
   gap: 3px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 8px;
 }
 
@@ -6752,7 +6757,7 @@ input[type="radio"] {
   gap: 8px;
   margin: 16px 28px;
   border: 1px solid rgba(199, 103, 69, 0.24);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: rgba(199, 103, 69, 0.1);
   padding: 12px;
 }
@@ -6764,7 +6769,7 @@ input[type="radio"] {
   align-items: center;
   margin: 16px 28px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 12px;
 }
@@ -6804,7 +6809,7 @@ input[type="radio"] {
   align-items: flex-start;
   gap: 6px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 10px;
 }
@@ -6981,7 +6986,7 @@ input[type="radio"] {
   min-width: 0;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 12px;
 }
 
@@ -7049,7 +7054,7 @@ input[type="radio"] {
 }
 
 .compensation-evidence-rows > summary b {
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--muted);
   color: var(--foreground);
   padding: 1px 4px;
@@ -7069,7 +7074,7 @@ input[type="radio"] {
   gap: 6px;
   min-width: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 8px;
 }
 
@@ -7141,7 +7146,7 @@ input[type="radio"] {
 .compensation-warning-list code {
   width: fit-content;
   max-width: 100%;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--muted);
   color: var(--foreground);
   padding: 1px 4px;
@@ -7407,7 +7412,7 @@ input[type="radio"] {
 
 .description-text code {
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 0 4px;
   font-size: 0.92em;
@@ -7523,7 +7528,7 @@ input[type="radio"] {
   justify-content: space-between;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--popover);
   color: inherit;
   padding: 10px;
@@ -7618,7 +7623,7 @@ input[type="radio"] {
   display: grid;
   gap: 8px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--popover);
   padding: 10px;
 }
@@ -7649,7 +7654,7 @@ input[type="radio"] {
   gap: 14px;
   min-height: 116px;
   border: 1px dashed var(--input);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 14px;
 }
@@ -7682,7 +7687,7 @@ input[type="radio"] {
   align-items: center;
   justify-content: center;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   color: var(--muted-foreground);
   font-size: 11px;
@@ -7693,7 +7698,7 @@ input[type="radio"] {
   flex-direction: column;
   gap: 8px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px;
 }
 
@@ -7784,7 +7789,7 @@ input[type="radio"] {
   align-items: end;
   padding: 8px 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: color-mix(in srgb, var(--muted) 72%, var(--card));
 }
 
@@ -7800,7 +7805,7 @@ input[type="radio"] {
 .form-section {
   overflow: hidden;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -7825,7 +7830,7 @@ input[type="radio"] {
   flex-direction: column;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 10px;
 }
@@ -7881,7 +7886,7 @@ input[type="radio"] {
   flex-direction: column;
   gap: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 10px;
 }
@@ -7911,7 +7916,7 @@ input[type="radio"] {
 
 .advanced-policy-group {
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 10px;
 }
@@ -7937,7 +7942,7 @@ input[type="radio"] {
   gap: 8px 10px;
   padding: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -8039,7 +8044,7 @@ input[type="radio"] {
   align-items: center;
   gap: 6px;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 6px 9px;
   color: var(--muted-foreground);
@@ -8056,7 +8061,7 @@ input[type="radio"] {
   align-items: end;
   padding: 10px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -8080,7 +8085,7 @@ input[type="radio"] {
   align-items: stretch;
   flex-wrap: wrap;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--card);
   padding: 8px;
 }
@@ -8101,7 +8106,7 @@ input[type="radio"] {
   flex-direction: column;
   gap: 4px;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 8px;
 }
@@ -8128,7 +8133,7 @@ input[type="radio"] {
   align-self: center;
   min-height: 32px;
   border: 1px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: var(--muted);
   padding: 8px 10px;
 }
@@ -8141,7 +8146,7 @@ input[type="radio"] {
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 5px;
+  border-radius: var(--radius);
   background: transparent;
   color: var(--muted-foreground);
 }
@@ -8188,7 +8193,7 @@ input[type="radio"] {
   top: 78px;
   align-self: start;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: var(--card);
 }
 
@@ -8286,7 +8291,7 @@ input[type="radio"] {
 .pdf-audit-line-target {
   position: absolute;
   border: 0;
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: transparent;
   cursor: pointer;
   padding: 0;
@@ -9817,7 +9822,7 @@ input[type="radio"] {
   margin: 0;
   overflow: auto;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--surface-subtle);
   padding: 12px;
   white-space: pre-wrap;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3394,19 +3394,23 @@ input[type="radio"] {
 }
 
 .resume-render-warnings {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  display: grid;
+  gap: 4px;
+  margin: 0;
   padding: 8px 12px;
   background: #303030;
   color: #f5f5f5;
   font-size: 12px;
+  list-style: none;
 }
 
-.resume-render-warnings span {
-  border: 1px solid rgb(255 255 255 / 18%);
-  border-radius: var(--radius);
-  padding: 4px 6px;
+.resume-render-warnings li {
+  margin: 0;
+  padding: 0;
+}
+
+.resume-render-warnings .editorial-status.warn {
+  color: var(--warning);
 }
 
 .resume-comment-thread-panel {

--- a/apps/web/src/styles/token-contract.test.ts
+++ b/apps/web/src/styles/token-contract.test.ts
@@ -12,6 +12,8 @@ const readJson = <T>(path: string): T => JSON.parse(readText(path)) as T;
 
 const tokensCss = readText("apps/web/src/styles/tokens.css");
 const globalsCss = readText("apps/web/src/styles/globals.css");
+const editorialFoundationCss = readText("apps/web/src/styles/editorial-foundation.css");
+const editorialStatusCss = readText("apps/web/src/styles/editorial-status.css");
 const componentsJson = readJson<{
   style: string;
   tailwind: { config: string; css: string; baseColor: string; cssVariables: boolean };
@@ -83,11 +85,6 @@ const requiredThemeMappings = [
 ] as const;
 
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-const cssRuleContaining = (selector: string): string => {
-  const pattern = new RegExp(`[^{}]*${escapeRegExp(selector)}[^{}]*\\{(?<body>[^}]*)\\}`, "m");
-  const match = globalsCss.match(pattern);
-  return match?.groups?.body?.trim() ?? "";
-};
 const absentPattern = (prefix: string, parts: readonly string[], joiner = "") =>
   new RegExp(`${escapeRegExp(prefix)}${parts.map(escapeRegExp).join(escapeRegExp(joiner))}(?![a-z0-9-])`, "i");
 
@@ -122,9 +119,9 @@ describe("shadcn token contract", () => {
       expect(matches.length, `expected light and dark definitions for token ${token}`).toBeGreaterThanOrEqual(2);
     }
 
-    expect(tokensCss, "expected the mock-up 8px radius token").toContain("--radius: 0.5rem;");
-    expect(tokensCss, "expected light violet primary value").toContain("--primary: oklch(0.541 0.281 293.009);");
-    expect(tokensCss, "expected dark violet primary value").toContain("--primary: oklch(0.702 0.183 293.541);");
+    expect(tokensCss, "expected the editorial 2px radius token").toContain("--radius: 0.125rem;");
+    expect(tokensCss, "expected light violet focus value").toContain("--primary: #6d28d9;");
+    expect(tokensCss, "expected dark violet focus value").toContain("--primary: #a78bfa;");
     expect(tokensCss, "expected violet-ramp chart token").toContain("--chart-1: oklch(0.541 0.281 293.009);");
   });
 
@@ -152,27 +149,28 @@ describe("shadcn token contract", () => {
       "background: color-mix(in oklch, var(--card) 96%, transparent);",
     );
     expect(globalsCss, "expected brand mark to use the primary token").toContain("background: var(--primary);");
-    expect(globalsCss, "expected active shell tabs to use accent token").toContain("background: var(--accent);");
+    expect(editorialFoundationCss, "expected active shell navigation to remain unfilled").toContain(
+      ".side-rail__link.on {\n  background: transparent;",
+    );
     expect(globalsCss, "expected shell controls to use the popover token").toContain("background: var(--popover);");
     expect(globalsCss, "expected connection banners to use destructive token").toContain(
       "border: 1px solid var(--destructive);",
     );
   });
 
-  it("keeps success badges visibly green", () => {
-    const tagOkRule = cssRuleContaining(".tag.ok");
-    const stagePillOkRule = cssRuleContaining(".stage-pill.ok");
-
-    expect(tagOkRule, "expected a shared success badge rule").toContain(
-      "background: color-mix(in oklab, var(--success) 32%, var(--card));",
+  it("keeps semantic status visible without capsule chrome", () => {
+    expect(editorialStatusCss, "expected the shared editorial status primitive").toContain(
+      ".editorial-status {",
     );
-    expect(tagOkRule, "expected success badge border to stay green").toContain(
-      "box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--success) 52%, transparent);",
+    expect(editorialStatusCss, "expected status backgrounds to remain neutral").toContain(
+      "background: transparent;",
     );
-    expect(tagOkRule, "expected success badge text to stay green").toContain(
-      "color: color-mix(in oklab, var(--success) 78%, var(--foreground));",
+    expect(editorialStatusCss, "expected success status text to use the semantic token").toContain(
+      ".editorial-status.ok {\n  color: var(--success);",
     );
-    expect(stagePillOkRule, "stage pills should use the same success rule as tags").toBe(tagOkRule);
+    expect(editorialStatusCss, "expected status to avoid rounded badge chrome").toContain(
+      "border-radius: 0;",
+    );
   });
 
   it("keeps shadcn preset config and packages wired", () => {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,25 +1,25 @@
 :root {
   color-scheme: light;
-  --radius: 0.5rem;
+  --radius: 0.125rem;
 
-  --background: oklch(0.967 0.003 264.542);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.541 0.281 293.009);
-  --primary-foreground: oklch(0.985 0.006 293);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.535 0 0);
-  --accent: oklch(0.943 0.029 294.588);
-  --accent-foreground: oklch(0.541 0.281 293.009);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.928 0.006 264.531);
-  --input: oklch(0.928 0.006 264.531);
-  --ring: oklch(0.541 0.281 293.009 / 0.36);
+  --background: #f5f5f3;
+  --foreground: #181817;
+  --card: #ffffff;
+  --card-foreground: #181817;
+  --popover: #ffffff;
+  --popover-foreground: #181817;
+  --primary: #6d28d9;
+  --primary-foreground: #ffffff;
+  --secondary: #fafaf8;
+  --secondary-foreground: #181817;
+  --muted: #fafaf8;
+  --muted-foreground: #686865;
+  --accent: #eee7ff;
+  --accent-foreground: #6d28d9;
+  --destructive: #c9362b;
+  --border: #deded9;
+  --input: #c8c8c1;
+  --ring: #6d28d9;
 
   --chart-1: oklch(0.541 0.281 293.009);
   --chart-2: oklch(0.606 0.25 292.717);
@@ -27,36 +27,36 @@
   --chart-4: oklch(0.811 0.111 293.571);
   --chart-5: oklch(0.894 0.057 293.283);
 
-  --sidebar: oklch(1 0 0 / 0.84);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.541 0.281 293.009);
-  --sidebar-primary-foreground: oklch(0.985 0.006 293);
-  --sidebar-accent: oklch(0.943 0.029 294.588);
-  --sidebar-accent-foreground: oklch(0.541 0.281 293.009);
-  --sidebar-border: oklch(0.928 0.006 264.531);
-  --sidebar-ring: oklch(0.541 0.281 293.009 / 0.36);
+  --sidebar: #ffffff;
+  --sidebar-foreground: #181817;
+  --sidebar-primary: #6d28d9;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #fafaf8;
+  --sidebar-accent-foreground: #181817;
+  --sidebar-border: #deded9;
+  --sidebar-ring: #6d28d9;
 
-  --success: oklch(0.54 0.13 145);
-  --success-foreground: oklch(0.985 0 0);
+  --success: #2f7d44;
+  --success-foreground: #ffffff;
   --success-muted: color-mix(in oklch, var(--success) 14%, var(--card));
-  --warning: oklch(0.72 0.15 72);
-  --warning-foreground: oklch(0.145 0 0);
+  --warning: #8a4c00;
+  --warning-foreground: #8a4c00;
   --warning-muted: color-mix(in oklch, var(--warning) 16%, var(--card));
-  --status-info: oklch(0.56 0.11 242);
-  --status-info-foreground: oklch(0.985 0 0);
+  --status-info: #3269c8;
+  --status-info-foreground: #ffffff;
   --status-info-muted: color-mix(in oklch, var(--status-info) 14%, var(--card));
 
-  --shadow-panel: 0 12px 34px rgb(31 41 55 / 0.08);
-  --shadow-control: 0 1px 2px rgb(15 23 42 / 0.05);
+  --shadow-panel: none;
+  --shadow-control: none;
   --shadow-float: 0 18px 46px rgb(15 23 42 / 0.16);
   --surface-subtle: color-mix(in oklch, var(--muted) 72%, var(--card));
   --surface-raised: color-mix(in oklch, var(--card) 96%, var(--background));
   --content-gutter: clamp(16px, 2.1vw, 32px);
   --section-gap: clamp(14px, 1.6vw, 20px);
   --control-height: 38px;
-  --rail-width: 236px;
+  --rail-width: 210px;
   --rail-width-collapsed: 72px;
-  --topbar-height: 60px;
+  --topbar-height: 56px;
 
   --jh-font-sans:
     "Plus Jakarta Sans Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
@@ -70,24 +70,24 @@
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.702 0.183 293.541);
-  --primary-foreground: oklch(0.21 0.03 293.5);
-  --secondary: oklch(0.274 0.006 286.033);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.32 0.075 293.5);
-  --accent-foreground: oklch(0.87 0.08 293.5);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.702 0.183 293.541 / 0.4);
+  --background: #171716;
+  --foreground: #f5f5f2;
+  --card: #1f1f1e;
+  --card-foreground: #f5f5f2;
+  --popover: #1f1f1e;
+  --popover-foreground: #f5f5f2;
+  --primary: #a78bfa;
+  --primary-foreground: #171716;
+  --secondary: #242422;
+  --secondary-foreground: #f5f5f2;
+  --muted: #242422;
+  --muted-foreground: #b4b4ad;
+  --accent: #2b2142;
+  --accent-foreground: #a78bfa;
+  --destructive: #f07065;
+  --border: #383835;
+  --input: #50504b;
+  --ring: #a78bfa;
 
   --chart-1: oklch(0.702 0.183 293.541);
   --chart-2: oklch(0.606 0.25 292.717);
@@ -95,27 +95,27 @@
   --chart-4: oklch(0.811 0.111 293.571);
   --chart-5: oklch(0.894 0.057 293.283);
 
-  --sidebar: oklch(0.205 0 0 / 0.86);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.702 0.183 293.541);
-  --sidebar-primary-foreground: oklch(0.21 0.03 293.5);
-  --sidebar-accent: oklch(0.32 0.075 293.5);
-  --sidebar-accent-foreground: oklch(0.87 0.08 293.5);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.702 0.183 293.541 / 0.4);
+  --sidebar: #1f1f1e;
+  --sidebar-foreground: #f5f5f2;
+  --sidebar-primary: #a78bfa;
+  --sidebar-primary-foreground: #171716;
+  --sidebar-accent: #242422;
+  --sidebar-accent-foreground: #f5f5f2;
+  --sidebar-border: #383835;
+  --sidebar-ring: #a78bfa;
 
-  --success: oklch(0.66 0.14 145);
-  --success-foreground: oklch(0.145 0 0);
+  --success: #6dbf79;
+  --success-foreground: #171716;
   --success-muted: color-mix(in oklch, var(--success) 18%, var(--card));
-  --warning: oklch(0.8 0.15 76);
-  --warning-foreground: oklch(0.145 0 0);
+  --warning: #e3a33c;
+  --warning-foreground: #e3a33c;
   --warning-muted: color-mix(in oklch, var(--warning) 20%, var(--card));
-  --status-info: oklch(0.72 0.13 242);
-  --status-info-foreground: oklch(0.145 0 0);
+  --status-info: #76a8f5;
+  --status-info-foreground: #171716;
   --status-info-muted: color-mix(in oklch, var(--status-info) 18%, var(--card));
 
-  --shadow-panel: 0 12px 34px rgb(0 0 0 / 0.45);
-  --shadow-control: 0 1px 2px rgb(0 0 0 / 0.28);
+  --shadow-panel: none;
+  --shadow-control: none;
   --shadow-float: 0 20px 50px rgb(0 0 0 / 0.52);
 }
 

--- a/apps/web/src/views/analytics/AnalyticsView.tsx
+++ b/apps/web/src/views/analytics/AnalyticsView.tsx
@@ -67,7 +67,11 @@ export function AnalyticsView() {
       <PageHead
         eyebrow="Overview"
         title="Outcome analytics"
-        subtitle={analytics ? `${applied} applied` : "loading"}
+        subtitle={
+          analytics
+            ? `${applied} applied · descriptive associations from recorded outcomes`
+            : "Loading recorded outcomes"
+        }
       />
       <section className="card full analytics-view">
         {message ? <div className="banner inline">{message}</div> : null}

--- a/apps/web/src/views/analytics/OutcomeRateTable.tsx
+++ b/apps/web/src/views/analytics/OutcomeRateTable.tsx
@@ -62,7 +62,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
       <span className="title-stack">
         <b>{row.label}</b>
         <span>
-          <span className={`tag ${row.badgeTone}`}>{row.dimension}</span> {countLabel(row)}
+          <span className={`analytics-dimension-label ${row.badgeTone}`}>{row.dimension}</span>{" "}
+          {countLabel(row)}
         </span>
       </span>
     ),

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -859,9 +859,9 @@ describe("<ApplyReviewView>", () => {
     expect(selectedHeader).toBeInstanceOf(HTMLElement);
     const header = within(selectedHeader as HTMLElement);
     expect(header.queryByText("Selected application")).not.toBeInTheDocument();
-    expect(header.queryByText("Principal Platform Engineer")).not.toBeInTheDocument();
-    expect(header.queryByText(/Globex · score 9/i)).not.toBeInTheDocument();
-    expect(header.queryByText("materials ready")).not.toBeInTheDocument();
+    expect(header.getByRole("heading", { name: "Principal Platform Engineer" })).toBeInTheDocument();
+    expect(header.getByText(/Globex · Lever/i)).toBeInTheDocument();
+    expect(header.getByText("materials ready")).toBeInTheDocument();
     expect(document.querySelector(".apply-review-status-note")).not.toBeInTheDocument();
     expect(header.getByRole("region", { name: "Compensation" })).toBeInTheDocument();
     expect(header.getByLabelText("Resume template")).toBeInTheDocument();

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1104,6 +1104,7 @@ function ResumeReviewSurface({
 
 function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
   const reviewState = reviewStateLabel(item);
+  const status = materialStatus(item);
   const activeRun = activeApplyRun(item);
   const resumeAuditArtifactId = item.materialsPreview.resumeTextArtifactId ?? item.materialsPreview.resumePdfArtifactId;
   const templatesQuery = useResumeTemplatesQuery();
@@ -1190,6 +1191,13 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
               className="apply-review-selected-context"
               aria-label={`Review controls and material facts for ${item.title}`}
             >
+              <div className="apply-review-selected-title">
+                <h2>{item.title}</h2>
+                <p>
+                  {item.company} · {item.source}
+                </p>
+              </div>
+              <span className={`apply-review-selected-status tag ${status.tone}`}>{status.label}</span>
               {reviewState ? (
                 <span className="tag muted">Current decision: {reviewState}.</span>
               ) : null}

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.test.tsx
@@ -180,6 +180,7 @@ describe("<ArtifactDetailPanel>", () => {
   });
 
   it("renders tailoring rationale from artifact detail evidence", async () => {
+    const user = userEvent.setup();
     renderArtifactRoute(<ArtifactDetailPanel artifactId="artifact-preview" />, "approved", {
       targetSeniority: "senior",
       claimMode: "evidence_reframing",
@@ -336,6 +337,7 @@ describe("<ArtifactDetailPanel>", () => {
       },
     });
 
+    await user.click(await screen.findByRole("tab", { name: "Audit" }));
     expect(await screen.findByText("Tailoring rationale")).toBeInTheDocument();
     expect(screen.getByText("Senior")).toBeInTheDocument();
     expect(screen.getByText("Evidence Reframing")).toBeInTheDocument();
@@ -385,6 +387,7 @@ describe("<ArtifactDetailPanel>", () => {
   });
 
   it("does not show missing resume keyword matches when coverage was not recorded", async () => {
+    const user = userEvent.setup();
     renderArtifactRoute(<ArtifactDetailPanel artifactId="artifact-preview" />, "approved", {
       targetSeniority: null,
       claimMode: null,
@@ -464,6 +467,7 @@ describe("<ArtifactDetailPanel>", () => {
       },
     });
 
+    await user.click(await screen.findByRole("tab", { name: "Audit" }));
     expect(await screen.findByText("Resume match audit")).toBeInTheDocument();
     expect(screen.getByText("not recorded for this artifact")).toBeInTheDocument();
     expect(screen.getByText("Target job keywords")).toBeInTheDocument();
@@ -491,6 +495,7 @@ describe("<ArtifactDetailPanel>", () => {
       ],
     );
 
+    await user.click(await screen.findByRole("tab", { name: "Compare" }));
     expect(await screen.findByText("Artifact comparison")).toBeInTheDocument();
     const comparisonPicker = await screen.findByRole("combobox", { name: "Compare with" });
     expect(comparisonPicker).toHaveTextContent(/candidate/i);

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -4,10 +4,10 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { ArtifactComparison } from "../../contexts/materials/components/ArtifactComparison.js";
+import { ArtifactStatusBadge } from "../../contexts/materials/components/ArtifactStatusBadge.js";
 import { useOpenArtifactMutation } from "../../contexts/materials/hooks/useOpenArtifactMutation.js";
 import { TailoringExplanationSection } from "../../contexts/materials/components/TailoringExplanationSection.js";
 import { artifactStatusDescription } from "../../contexts/materials/lib/artifact-status-copy.js";
-import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status-tone.js";
 import { useArtifactDetailQuery } from "../../contexts/operations/hooks/useArtifactDetailQuery.js";
 import { useArtifactsListQuery } from "../../contexts/operations/hooks/useArtifactsListQuery.js";
 import type { ArtifactsListInput } from "../../contexts/operations/types.js";
@@ -19,16 +19,24 @@ import { PdfPreviewViewer } from "../../shared/ui/PdfPreviewViewer.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { SelectField } from "../../shared/ui/select-field.js";
 import { Section } from "../../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../../shared/ui/tabs.js";
 
 export interface ArtifactDetailPanelProps {
   artifactId: string;
 }
 
 function isPreviewablePdfArtifact(type: string, localPath: string): boolean {
-  return type.toLowerCase().endsWith("_pdf") || localPath.toLowerCase().endsWith(".pdf");
+  return (
+    type.toLowerCase().endsWith("_pdf") ||
+    localPath.toLowerCase().endsWith(".pdf")
+  );
 }
 
-function artifactPreviewCacheKey(createdAt: string | null, sizeBytes: number | null): string {
+function artifactPreviewCacheKey(
+  createdAt: string | null,
+  sizeBytes: number | null,
+): string {
   return `${createdAt ?? "unknown"}:${sizeBytes ?? "unknown"}`;
 }
 
@@ -36,7 +44,9 @@ function isSuppressed(status: string): boolean {
   return status.toLowerCase() === "suppressed";
 }
 
-function artifactComparisonListInput(type: string | null | undefined): ArtifactsListInput {
+function artifactComparisonListInput(
+  type: string | null | undefined,
+): ArtifactsListInput {
   const input: ArtifactsListInput = {
     pageSize: 200,
     sort: "created_at",
@@ -78,14 +88,20 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
     void navigate({ to: "/artifacts", search });
   }, [navigate, search]);
 
-  const { data: detail, error: queryError } = useArtifactDetailQuery(artifactId);
+  const { data: detail, error: queryError } =
+    useArtifactDetailQuery(artifactId);
   const comparisonListInput = useMemo(
     () => artifactComparisonListInput(detail?.artifact.type),
     [detail?.artifact.type],
   );
-  const comparisonList = useArtifactsListQuery(comparisonListInput, { enabled: Boolean(detail) });
+  const comparisonList = useArtifactsListQuery(comparisonListInput, {
+    enabled: Boolean(detail),
+  });
   const comparisonCandidates = useMemo(
-    () => (detail ? comparableArtifacts(detail.artifact, comparisonList.data?.items ?? []) : []),
+    () =>
+      detail
+        ? comparableArtifacts(detail.artifact, comparisonList.data?.items ?? [])
+        : [],
     [comparisonList.data?.items, detail],
   );
   const [comparisonArtifactId, setComparisonArtifactId] = useState<string>("");
@@ -93,111 +109,209 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   const errorMessage =
     queryError instanceof Error
       ? queryError.message
-      : openArtifact.error?.message ?? "";
+      : (openArtifact.error?.message ?? "");
+  const hasPdfPreview = detail
+    ? isPreviewablePdfArtifact(
+        detail.artifact.type,
+        detail.artifact.localPath,
+      )
+    : false;
+  const stateTitle = errorMessage || "Loading artifact.";
 
   useEffect(() => {
     setComparisonArtifactId((current) =>
       comparisonCandidates.some((candidate) => candidate.artifactId === current)
         ? current
-        : comparisonCandidates[0]?.artifactId ?? "",
+        : (comparisonCandidates[0]?.artifactId ?? ""),
     );
   }, [artifactId, comparisonCandidates]);
 
   return (
-    <div className="route-page route-page--artifact-detail" aria-label="Artifact details">
-      {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
-      {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
+    <div
+      className="route-page route-page--artifact-detail"
+      aria-label="Artifact details"
+    >
+      {!detail ? (
+        <section className="detail-route-state" aria-label="Artifact state">
+          <Button
+            aria-label="Back to artifacts"
+            className="workspace-back"
+            size="sm"
+            type="button"
+            variant="ghost"
+            onClick={close}
+          >
+            <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+            Artifacts
+          </Button>
+          <Empty title={stateTitle} />
+        </section>
+      ) : null}
       {detail ? (
-        <RouteWorkspace
-          aria-label="Artifact details"
-          className="artifact-detail-workspace"
-          contentLabel="Artifact preview"
-          inspectorLabel="Artifact audit and comparison"
-          header={
-            <div className="artifact-detail-workspace__header">
-              <Button
-                aria-label="Back to artifacts"
-                className="workspace-back"
-                size="sm"
-                type="button"
-                variant="ghost"
-                onClick={close}
-              >
-                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                Artifacts
-              </Button>
-              <span
-                className={`tag ${artifactStatusTone(detail.artifact.status)}`}
-                title={artifactStatusDescription(detail.artifact.status)}
-              >
-                {detail.artifact.status}
-              </span>
-              <div className="artifact-detail-workspace__title">
-                <small>{detail.artifact.company}</small>
-                <h1>{detail.artifact.title || detail.artifact.type}</h1>
-                <p>
-                  {detail.artifact.type} · created {formatDateTime(detail.artifact.createdAt)}
-                </p>
-              </div>
-              <div className="artifact-detail-workspace__actions">
+        <SectionTabs className="artifact-detail-tabs" defaultValue="preview">
+          <RouteWorkspace
+            aria-label="Artifact details"
+            className="artifact-detail-workspace"
+            contentLabel="Artifact workspace panels"
+            inspectorLabel="Artifact details"
+            tabs={
+              <nav aria-label="Artifact detail panels">
+                <SectionTabsList>
+                  <TabsTrigger value="preview">Preview</TabsTrigger>
+                  <TabsTrigger value="audit">Audit</TabsTrigger>
+                  <TabsTrigger value="compare">Compare</TabsTrigger>
+                </SectionTabsList>
+              </nav>
+            }
+            header={
+              <div className="artifact-detail-workspace__header">
                 <Button
+                  aria-label="Back to artifacts"
+                  className="workspace-back"
                   size="sm"
                   type="button"
-                  disabled={openArtifact.isPending || detail.artifact.status === "missing"}
-                  onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
+                  variant="ghost"
+                  onClick={close}
                 >
-                  {openArtifact.isPending ? "opening" : isDemo ? "preview in browser" : "open"}
+                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                  Artifacts
                 </Button>
-                <Button
-                  size="sm"
-                  type="button"
-                  variant="outline"
-                  disabled={!detail.artifact.jobKey}
-                  onClick={() =>
-                    void navigate({
-                      to: "/jobs/$jobId",
-                      params: { jobId: detail.artifact.jobKey },
-                    })
-                  }
-                >
-                  open related job
-                </Button>
+                <span className="artifact-detail-workspace__status">
+                  <ArtifactStatusBadge status={detail.artifact.status} />
+                </span>
+                <div className="artifact-detail-workspace__title">
+                  <small>{detail.artifact.company}</small>
+                  <h1>{detail.artifact.title || detail.artifact.type}</h1>
+                  <p>
+                    {detail.artifact.type} · created{" "}
+                    {formatDateTime(detail.artifact.createdAt)}
+                  </p>
+                </div>
+                <div className="artifact-detail-workspace__actions">
+                  <Button
+                    size="sm"
+                    type="button"
+                    disabled={
+                      openArtifact.isPending ||
+                      detail.artifact.status === "missing"
+                    }
+                    onClick={() =>
+                      openArtifact.mutate({
+                        artifactId: detail.artifact.artifactId,
+                      })
+                    }
+                  >
+                    {openArtifact.isPending
+                      ? "opening"
+                      : isDemo
+                        ? "preview in browser"
+                        : "open"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    type="button"
+                    variant="outline"
+                    disabled={!detail.artifact.jobKey}
+                    onClick={() =>
+                      void navigate({
+                        to: "/jobs/$jobId",
+                        params: { jobId: detail.artifact.jobKey },
+                      })
+                    }
+                  >
+                    open related job
+                  </Button>
+                </div>
               </div>
-            </div>
-          }
-          inspector={
-            <div className="artifact-detail-workspace__inspector">
-              <Section title="Artifact details">
-                {isSuppressed(detail.artifact.status) ? (
-                  <div className="banner inline">
-                    This artifact is historical audit material and is not active apply-ready
-                    material.
-                  </div>
-                ) : null}
-                <dl className="detail-list">
-                  <div>
-                    <dt>Status</dt>
-                    <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
-                  </div>
-                  <div>
-                    <dt>Artifact id</dt>
-                    <dd className="mono">{detail.artifact.artifactId}</dd>
-                  </div>
-                  <div>
-                    <dt>Job</dt>
-                    <dd>{detail.artifact.jobKey || "-"}</dd>
-                  </div>
-                  <div>
-                    <dt>Local path</dt>
-                    <dd className="mono">{detail.artifact.localPath || "-"}</dd>
-                  </div>
-                  <div>
-                    <dt>Size</dt>
-                    <dd>{detail.artifact.size}</dd>
-                  </div>
-                </dl>
-              </Section>
-              <TailoringExplanationSection explanation={detail.tailoringExplanation} />
+            }
+            inspector={
+              <div className="artifact-detail-workspace__inspector">
+                <Section title="Artifact details">
+                  {isSuppressed(detail.artifact.status) ? (
+                    <div className="banner inline">
+                      This artifact is historical audit material and is not active
+                      apply-ready material.
+                    </div>
+                  ) : null}
+                  <dl className="detail-list">
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
+                    </div>
+                    <div>
+                      <dt>Artifact id</dt>
+                      <dd className="mono">{detail.artifact.artifactId}</dd>
+                    </div>
+                    <div>
+                      <dt>Job</dt>
+                      <dd>{detail.artifact.jobKey || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Local path</dt>
+                      <dd className="mono">{detail.artifact.localPath || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Size</dt>
+                      <dd>{detail.artifact.size}</dd>
+                    </div>
+                  </dl>
+                </Section>
+              </div>
+            }
+          >
+            {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+            <TabsContent
+              className={
+                hasPdfPreview
+                  ? "artifact-detail-workspace__panel artifact-detail-workspace__panel--preview"
+                  : "artifact-detail-workspace__panel"
+              }
+              forceMount
+              value="preview"
+            >
+              {hasPdfPreview ? (
+                <section
+                  className="artifact-preview-panel"
+                  aria-label="Artifact PDF preview"
+                >
+                  <PdfPreviewViewer
+                    cacheKey={artifactPreviewCacheKey(
+                      detail.artifact.createdAt,
+                      detail.artifact.sizeBytes,
+                    )}
+                    loadingMessage="The artifact PDF is loading into the in-app preview."
+                    loadingTitle="Rendering artifact PDF."
+                    openLabel="open PDF"
+                    pageAltPrefix={detail.artifact.title || detail.artifact.type}
+                    title="Artifact preview"
+                    url={api.artifactPreviewPdfUrl(
+                      detail.artifact.artifactId,
+                      artifactPreviewCacheKey(
+                        detail.artifact.createdAt,
+                        detail.artifact.sizeBytes,
+                      ),
+                    )}
+                  />
+                </section>
+              ) : (
+                <Empty title="This artifact type does not have an in-app PDF preview." />
+              )}
+            </TabsContent>
+            <TabsContent
+              className="artifact-detail-workspace__panel"
+              forceMount
+              value="audit"
+            >
+              <TailoringExplanationSection
+                className="section artifact-detail-workspace__audit"
+                explanation={detail.tailoringExplanation}
+              />
+            </TabsContent>
+            <TabsContent
+              className="artifact-detail-workspace__panel"
+              forceMount
+              value="compare"
+            >
               <Section title="Artifact comparison">
                 {comparisonList.isFetching && !comparisonList.data ? (
                   <p className="meta">Loading comparable artifacts.</p>
@@ -226,32 +340,9 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
                   <Empty title="No other artifact for this job and type was found in the current artifact list." />
                 )}
               </Section>
-            </div>
-          }
-        >
-          {isPreviewablePdfArtifact(detail.artifact.type, detail.artifact.localPath) ? (
-            <section className="artifact-preview-panel" aria-label="Artifact PDF preview">
-              <PdfPreviewViewer
-                cacheKey={artifactPreviewCacheKey(
-                  detail.artifact.createdAt,
-                  detail.artifact.sizeBytes,
-                )}
-                loadingMessage="The artifact PDF is loading into the in-app preview."
-                loadingTitle="Rendering artifact PDF."
-                openLabel="open PDF"
-                pageAltPrefix={detail.artifact.title || detail.artifact.type}
-                title="Artifact preview"
-                url={api.artifactPreviewPdfUrl(
-                  detail.artifact.artifactId,
-                  artifactPreviewCacheKey(detail.artifact.createdAt, detail.artifact.sizeBytes),
-                )}
-              />
-            </section>
-          ) : (
-            <Empty title="This artifact type does not have an in-app PDF preview." />
-          )}
-          {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-        </RouteWorkspace>
+            </TabsContent>
+          </RouteWorkspace>
+        </SectionTabs>
       ) : null}
     </div>
   );

--- a/apps/web/src/views/artifacts/ArtifactsView.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.tsx
@@ -1,5 +1,10 @@
 import type { ArtifactSortField } from "@jobctrl/contracts";
-import { Outlet, useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import {
+  Outlet,
+  useNavigate,
+  useRouterState,
+  useSearch,
+} from "@tanstack/react-router";
 import type { RowSelectionState, SortingState } from "@tanstack/react-table";
 import { useEffect, useMemo, useState } from "react";
 
@@ -36,20 +41,32 @@ export function ArtifactsView() {
   const navigate = useNavigate({ from: "/artifacts" });
   const showingDetail = useRouterState({
     select: (state) =>
-      state.location.pathname !== "/artifacts" && state.location.pathname !== "/artifacts/",
+      state.location.pathname !== "/artifacts" &&
+      state.location.pathname !== "/artifacts/",
   });
 
-  const { data, isFetching, error } = useArtifactsListQuery(artifactsListInput(search));
+  const { data, isFetching, error } = useArtifactsListQuery(
+    artifactsListInput(search),
+  );
   const message = error instanceof Error ? error.message : null;
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   useEffect(() => {
     setRowSelection({});
-  }, [search.dir, search.page, search.pageSize, search.q, search.sort, search.status]);
+  }, [
+    search.dir,
+    search.page,
+    search.pageSize,
+    search.q,
+    search.sort,
+    search.status,
+  ]);
 
   const setSearch = (next: Partial<ArtifactsSearch>) => {
-    void navigate({ search: (prev: ArtifactsSearch) => ({ ...prev, ...next }) });
+    void navigate({
+      search: (prev: ArtifactsSearch) => ({ ...prev, ...next }),
+    });
   };
 
   const sorting = useMemo<SortingState>(
@@ -70,15 +87,26 @@ export function ArtifactsView() {
   };
 
   return (
-    <div className="route-page route-page--artifacts">
+    <div className="route-page route-page--artifacts editorial-index-page">
       {!showingDetail ? (
         <>
           <PageHead
+            className="editorial-page-head"
             eyebrow="Library"
             title="Artifacts"
-            subtitle={data ? `${data.pagination.total} total` : "loading"}
+            subtitle={
+              <>
+                <span>
+                  Generated materials, their lifecycle, and the last accepted
+                  truth.
+                </span>
+                <span className="page-head-count">
+                  {data ? `${data.pagination.total} total` : "loading"}
+                </span>
+              </>
+            }
           />
-          <section className="card full data-surface">
+          <section className="card full data-surface editorial-data-surface">
             {message ? <div className="banner inline">{message}</div> : null}
             <ArtifactFilterBar search={search} />
             <ArtifactsTable
@@ -93,7 +121,10 @@ export function ArtifactsView() {
               onPageChange={(page) => setSearch({ page })}
               onPageSizeChange={(pageSize) => setSearch({ pageSize, page: 1 })}
               onOpenArtifact={(artifactId) =>
-                void navigate({ to: "/artifacts/$artifactId", params: { artifactId } })
+                void navigate({
+                  to: "/artifacts/$artifactId",
+                  params: { artifactId },
+                })
               }
             />
           </section>

--- a/apps/web/src/views/dashboard/ApplyRunsCard.tsx
+++ b/apps/web/src/views/dashboard/ApplyRunsCard.tsx
@@ -34,7 +34,9 @@ export function ApplyRunsCard({ summary }: ApplyRunsCardProps) {
                   {run.company} · {formatDateTime(run.startedAt)}
                 </span>
               </span>
-              {run.dryRun ? <span className="tag info">dry-run</span> : null}
+              {run.dryRun ? (
+                <span className="dashboard-signal dashboard-signal--info">dry-run</span>
+              ) : null}
             </button>
           ))
         ) : (

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -38,7 +38,14 @@ export function DashboardView() {
   );
   return (
     <div className="route-page route-page--dashboard">
-      <PageHead eyebrow="Overview" title="Dashboard" />
+      <PageHead
+        eyebrow="Overview"
+        title="Dashboard"
+        subtitle="What needs a decision, what is moving, and what is stuck."
+      />
+      {summary ? (
+        <p className="dashboard-generated-at">Generated {new Date(summary.generatedAt).toLocaleString()}</p>
+      ) : null}
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
       {message ? <div className="banner">{message}</div> : null}
       {outcomesError ? <div className="banner">{outcomesError}</div> : null}

--- a/apps/web/src/views/dashboard/KpiGrid.tsx
+++ b/apps/web/src/views/dashboard/KpiGrid.tsx
@@ -2,19 +2,9 @@ import { useNavigate } from "@tanstack/react-router";
 
 import type { DashboardSummary } from "../../contexts/operations/types.js";
 import type { JobsSearch } from "../../routes/-jobs.search.js";
-import { StatCard, type StatTone } from "../../shared/ui/stat-card.js";
+import { StatCard } from "../../shared/ui/stat-card.js";
 
 export type KpiTarget = "all" | "failed" | "blocked" | "ready" | "applied";
-type KpiTone = "alert" | "warn" | "ok";
-
-const VALUE_TONE: Record<KpiTone, StatTone> = {
-  alert: "down",
-  warn: "warn",
-  ok: "up",
-};
-
-const KPI_HOVER =
-  "transition-colors hover:border-[color-mix(in_oklch,var(--primary)_45%,var(--border))]";
 
 const KPI_BASE: JobsSearch = {
   q: "",
@@ -64,49 +54,42 @@ const ITEMS: ReadonlyArray<{
   readonly key: keyof DashboardSummary["totals"];
   readonly caption: (summary: DashboardSummary) => string;
   readonly target: KpiTarget;
-  readonly tone: KpiTone | null;
 }> = [
   {
     label: "Jobs",
     key: "jobs",
     caption: (summary) => `+${summary.totals.jobsToday} today`,
     target: "all",
-    tone: null,
   },
   {
     label: "Failures",
     key: "failures",
     caption: () => "needs retry",
     target: "failed",
-    tone: "alert",
   },
   {
     label: "Blocked",
     key: "blocked",
     caption: () => "needs review",
     target: "blocked",
-    tone: "warn",
   },
   {
     label: "Ready",
     key: "ready",
     caption: () => "ready queue",
     target: "ready",
-    tone: "ok",
   },
   {
     label: "Applied",
     key: "applied",
     caption: (summary) => `+${summary.totals.appliedToday} today`,
     target: "applied",
-    tone: null,
   },
   {
     label: "Dry runs",
     key: "dryRuns",
     caption: () => "today excluded",
     target: "all",
-    tone: null,
   },
 ];
 
@@ -118,16 +101,14 @@ export function KpiGrid({ summary }: KpiGridProps) {
   const navigate = useNavigate();
   return (
     <section className="kpis">
-      {ITEMS.map(({ label, key, caption, target, tone }) => {
+      {ITEMS.map(({ label, key, caption, target }) => {
         const search = kpiSearchFor(target);
         return (
           <StatCard
             key={label}
             asChild
-            className={KPI_HOVER}
             label={label}
             value={summary.totals[key]}
-            valueTone={tone ? VALUE_TONE[tone] : undefined}
             delta={caption(summary)}
           >
             <a

--- a/apps/web/src/views/dashboard/RecentActivityCard.tsx
+++ b/apps/web/src/views/dashboard/RecentActivityCard.tsx
@@ -46,7 +46,7 @@ export function RecentActivityCard({ summary }: { summary: DashboardSummary }) {
                 })
               }
             >
-              <span className={`tag ${activityTone(entry)}`}>
+              <span className={`dashboard-signal dashboard-signal--${activityTone(entry)}`}>
                 {entry.level}
               </span>
               <span className="title-stack">

--- a/apps/web/src/views/dashboard/SourceHealthCard.tsx
+++ b/apps/web/src/views/dashboard/SourceHealthCard.tsx
@@ -48,7 +48,9 @@ export function SourceHealthCard({ summary }: SourceHealthCardProps) {
                 />
               </span>
               {source.consecutiveFailures ? (
-                <span className="tag danger">{source.consecutiveFailures} fails</span>
+                <span className="dashboard-signal dashboard-signal--danger">
+                  {source.consecutiveFailures} fails
+                </span>
               ) : null}
             </div>
           ))

--- a/apps/web/src/views/dashboard/WorkStatusCard.test.tsx
+++ b/apps/web/src/views/dashboard/WorkStatusCard.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { sampleDashboardSummary } from "../../test/fixtures/projections.js";
+import { renderWithProviders } from "../../test/render.js";
+import { WorkStatusCard } from "./WorkStatusCard.js";
+
+describe("<WorkStatusCard>", () => {
+  it("renders active and stuck work as one continuous two-cell ledger", () => {
+    const { container } = renderWithProviders(
+      <WorkStatusCard summary={sampleDashboardSummary} />,
+    );
+
+    const ledger = container.querySelector(".work-status-ledger");
+    expect(ledger).toBeInTheDocument();
+    expect(
+      ledger?.querySelectorAll(":scope > .work-status-ledger__cell"),
+    ).toHaveLength(2);
+    expect(ledger?.querySelector(".card")).not.toBeInTheDocument();
+    expect(screen.getByText("Active work")).toBeInTheDocument();
+    expect(screen.getByText("Stuck work")).toBeInTheDocument();
+    expect(
+      screen.getByText("worker unavailable · stale over 2m 30s"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/views/dashboard/WorkStatusCard.tsx
+++ b/apps/web/src/views/dashboard/WorkStatusCard.tsx
@@ -4,7 +4,6 @@ import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
-import { StatCard } from "../../shared/ui/stat-card.js";
 import { kpiSearchFor } from "./KpiGrid.js";
 
 function formatThreshold(seconds: number): string {
@@ -23,23 +22,26 @@ export function WorkStatusCard({ summary }: { summary: DashboardSummary }) {
         title="Work status"
         meta={`${work.active} active · ${work.stuck} stuck`}
       />
-      <div className="grid grid-cols-2 gap-3 p-4">
-        <StatCard
-          label="Active work"
-          value={work.active}
-          delta="queued or moving"
-        />
-        <StatCard
-          label="Stuck work"
-          value={work.stuck}
-          valueTone={work.stuck ? "down" : undefined}
-          delta={
-            work.stuck
-              ? `worker unavailable · stale over ${formatThreshold(work.stuckAfterSeconds)}`
-              : `no stuck work over ${formatThreshold(work.stuckAfterSeconds)}`
-          }
-        />
-      </div>
+      <dl className="work-status-ledger" aria-label="Work status summary">
+        <div className="work-status-ledger__cell">
+          <dt data-slot="stat-label">Active work</dt>
+          <dd>
+            <span data-slot="stat-value">{work.active}</span>
+            <span data-slot="stat-delta">queued or moving</span>
+          </dd>
+        </div>
+        <div className="work-status-ledger__cell">
+          <dt data-slot="stat-label">Stuck work</dt>
+          <dd>
+            <span data-slot="stat-value">{work.stuck}</span>
+            <span data-slot="stat-delta">
+              {work.stuck
+                ? `worker unavailable · stale over ${formatThreshold(work.stuckAfterSeconds)}`
+                : `no stuck work over ${formatThreshold(work.stuckAfterSeconds)}`}
+            </span>
+          </dd>
+        </div>
+      </dl>
       <div className="rows">
         {work.stuckItems.length ? (
           work.stuckItems.map((item) => (
@@ -55,7 +57,7 @@ export function WorkStatusCard({ summary }: { summary: DashboardSummary }) {
                 })
               }
             >
-              <span className="tag danger">stuck</span>
+              <span className="dashboard-signal dashboard-signal--danger">stuck</span>
               <span className="title-stack">
                 <b>{item.title}</b>
                 <span>

--- a/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { renderWithProviders } from "../../test/render.js";
@@ -6,6 +7,7 @@ import { ActivityDetailDrawer } from "./ActivityDetailDrawer.js";
 
 describe("<ActivityDetailDrawer>", () => {
   it("renders the selected event as a route workspace without losing activity facts", async () => {
+    const user = userEvent.setup();
     renderWithProviders(<ActivityDetailDrawer eventId="evt-1" />, {
       withRouter: true,
     });
@@ -40,6 +42,7 @@ describe("<ActivityDetailDrawer>", () => {
     expect(payload).toHaveTextContent('"eventId": "evt-1"');
     expect(payload).toHaveTextContent('"message": "Job scored 8/10"');
 
+    await user.click(screen.getByRole("tab", { name: "Timeline" }));
     const timeline = screen.getByRole("region", { name: "Activity event timeline" });
     expect(within(timeline).getByText("JobScored")).toBeInTheDocument();
     expect(within(timeline).getByText("Job scored 8/10")).toBeInTheDocument();

--- a/apps/web/src/views/debug/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.tsx
@@ -12,6 +12,9 @@ import {
 } from "../../shared/ui/inspector-ledger.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../../shared/ui/section-tabs.js";
+import { StatusLabel } from "../../shared/ui/status-label.js";
+import { TabsContent, TabsTrigger } from "../../shared/ui/tabs.js";
 import { activityLevelTone } from "./activity-tone.js";
 
 export interface ActivityDetailDrawerProps {
@@ -26,137 +29,193 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
 
   const { data: activity, error, isLoading } = useActivityEventQuery(eventId);
   const errorMessage = error instanceof Error ? error.message : null;
+  const stateTitle = errorMessage
+    ? errorMessage
+    : isLoading
+      ? "Loading activity event."
+      : `Activity event ${eventId} is no longer in the recent list.`;
 
   return (
     <div className="route-page route-page--activity-detail">
-      {errorMessage ? <Empty title={errorMessage} /> : null}
-      {!errorMessage && isLoading ? <Empty title="Loading activity event." /> : null}
-      {!errorMessage && !isLoading && !activity ? (
-        <Empty title={`Activity event ${eventId} is no longer in the recent list.`} />
+      {!activity ? (
+        <section
+          className="detail-route-state"
+          aria-label="Activity event state"
+        >
+          <Button
+            aria-label="Back to Debug"
+            className="workspace-back"
+            size="sm"
+            type="button"
+            variant="ghost"
+            onClick={close}
+          >
+            <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+            Debug
+          </Button>
+          <Empty title={stateTitle} />
+        </section>
       ) : null}
       {activity ? (
-        <RouteWorkspace
-          aria-labelledby="activity-detail-heading"
-          className="activity-detail-workspace"
-          contentLabel="Activity payload and timeline"
-          inspectorLabel="Activity event facts"
-          header={
-            <div className="activity-detail-workspace__header">
-              <Button
-                aria-label="Back to Debug"
-                className="workspace-back"
-                size="sm"
-                type="button"
-                variant="ghost"
-                onClick={close}
-              >
-                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                Debug
-              </Button>
-              <span className={`tag ${activityLevelTone(activity.level)}`}>
-                {activity.level}
-              </span>
-              <div className="activity-detail-workspace__title">
-                <small>
-                  {activity.stage} · {activity.eventType}
-                </small>
-                <h1 id="activity-detail-heading">{activity.message}</h1>
-                <p>
-                  <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
-                  {activity.title ? ` · ${activity.title}` : ""}
-                  {activity.company ? ` at ${activity.company}` : ""}
-                </p>
-              </div>
-              {activity.jobKey ? (
-                <div className="activity-detail-workspace__actions">
-                  <Button asChild size="sm" variant="outline">
-                    <Link to="/jobs/$jobId" params={{ jobId: activity.jobKey }}>
-                      Open related job
-                    </Link>
-                  </Button>
+        <SectionTabs className="activity-detail-tabs" defaultValue="payload">
+          <RouteWorkspace
+            aria-labelledby="activity-detail-heading"
+            className="activity-detail-workspace"
+            contentLabel="Activity workspace panels"
+            inspectorLabel="Activity event facts"
+            tabs={
+              <nav aria-label="Activity detail panels">
+                <SectionTabsList>
+                  <TabsTrigger value="payload">Payload</TabsTrigger>
+                  <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                </SectionTabsList>
+              </nav>
+            }
+            header={
+              <div className="activity-detail-workspace__header">
+                <Button
+                  aria-label="Back to Debug"
+                  className="workspace-back"
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={close}
+                >
+                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                  Debug
+                </Button>
+                <span className="activity-detail-workspace__status">
+                  <StatusLabel tone={activityLevelTone(activity.level)}>
+                    {activity.level}
+                  </StatusLabel>
+                </span>
+                <div className="activity-detail-workspace__title">
+                  <small>
+                    {activity.stage} · {activity.eventType}
+                  </small>
+                  <h1 id="activity-detail-heading">{activity.message}</h1>
+                  <p>
+                    <time dateTime={activity.at ?? undefined}>
+                      {formatDateTime(activity.at)}
+                    </time>
+                    {activity.title ? ` · ${activity.title}` : ""}
+                    {activity.company ? ` at ${activity.company}` : ""}
+                  </p>
                 </div>
-              ) : null}
-            </div>
-          }
-          inspector={
-            <div className="activity-detail-workspace__inspector">
-              <h2>Event facts</h2>
-              <InspectorLedger>
-                <InspectorLedgerItem
-                  label="Event id"
-                  value={<span className="mono">{activity.eventId}</span>}
-                  source="Activity projection"
-                />
-                <InspectorLedgerItem
-                  label="Event type"
-                  value={<span className="mono">{activity.eventType}</span>}
-                  source="Activity projection"
-                />
-                <InspectorLedgerItem label="Stage" value={activity.stage} />
-                <InspectorLedgerItem
-                  label="Level"
-                  value={
-                    <span className={`tag ${activityLevelTone(activity.level)}`}>
-                      {activity.level}
-                    </span>
-                  }
-                />
-                <InspectorLedgerItem
-                  label="Timestamp"
-                  value={
-                    <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
-                  }
-                />
-                <InspectorLedgerItem
-                  label="Job key"
-                  value={
-                    activity.jobKey ? <span className="mono">{activity.jobKey}</span> : undefined
-                  }
-                />
-                <InspectorLedgerItem label="Job title" value={activity.title ?? undefined} />
-                <InspectorLedgerItem label="Company" value={activity.company ?? undefined} />
-                <InspectorLedgerItem
-                  label="Run reference"
-                  source="Not exposed by the activity projection"
-                />
-              </InspectorLedger>
-            </div>
-          }
-        >
-          <div className="activity-detail-workspace__content">
-            <h2 className="sr-only">Activity event evidence</h2>
-            <Section
-              aria-label="Projected event payload"
-              title="Projected event payload"
-              description="The complete activity detail returned by the local read model."
+                {activity.jobKey ? (
+                  <div className="activity-detail-workspace__actions">
+                    <Button asChild size="sm" variant="outline">
+                      <Link to="/jobs/$jobId" params={{ jobId: activity.jobKey }}>
+                        Open related job
+                      </Link>
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            }
+            inspector={
+              <div className="activity-detail-workspace__inspector">
+                <h2>Event facts</h2>
+                <InspectorLedger>
+                  <InspectorLedgerItem
+                    label="Event id"
+                    value={<span className="mono">{activity.eventId}</span>}
+                    source="Activity projection"
+                  />
+                  <InspectorLedgerItem
+                    label="Event type"
+                    value={<span className="mono">{activity.eventType}</span>}
+                    source="Activity projection"
+                  />
+                  <InspectorLedgerItem label="Stage" value={activity.stage} />
+                  <InspectorLedgerItem
+                    label="Level"
+                    value={
+                      <StatusLabel tone={activityLevelTone(activity.level)}>
+                        {activity.level}
+                      </StatusLabel>
+                    }
+                  />
+                  <InspectorLedgerItem
+                    label="Timestamp"
+                    value={
+                      <time dateTime={activity.at ?? undefined}>
+                        {formatDateTime(activity.at)}
+                      </time>
+                    }
+                  />
+                  <InspectorLedgerItem
+                    label="Job key"
+                    value={
+                      activity.jobKey ? (
+                        <span className="mono">{activity.jobKey}</span>
+                      ) : undefined
+                    }
+                  />
+                  <InspectorLedgerItem
+                    label="Job title"
+                    value={activity.title ?? undefined}
+                  />
+                  <InspectorLedgerItem
+                    label="Company"
+                    value={activity.company ?? undefined}
+                  />
+                  <InspectorLedgerItem
+                    label="Run reference"
+                    source="Not exposed by the activity projection"
+                  />
+                </InspectorLedger>
+              </div>
+            }
+          >
+            <TabsContent
+              className="activity-detail-workspace__panel"
+              forceMount
+              value="payload"
             >
-              <pre className="activity-detail-workspace__payload">
-                <code>{JSON.stringify(activity, null, 2)}</code>
-              </pre>
-            </Section>
-            <Section
-              aria-label="Activity event timeline"
-              title="Timeline"
-              description="The selected event at its recorded timestamp."
+              <Section
+                aria-label="Projected event payload"
+                title="Projected event payload"
+                description="The complete activity detail returned by the local read model."
+              >
+                <pre className="activity-detail-workspace__payload">
+                  <code>{JSON.stringify(activity, null, 2)}</code>
+                </pre>
+              </Section>
+            </TabsContent>
+            <TabsContent
+              className="activity-detail-workspace__panel"
+              forceMount
+              value="timeline"
             >
-              <ol className="timeline activity-detail-workspace__timeline">
-                <li className="timeline-row activity-detail-workspace__timeline-entry">
-                  <span className="timeline-row-head">
-                    <span className={`tag ${activityLevelTone(activity.level)}`}>
-                      {activity.level}
+              <Section
+                aria-label="Activity event timeline"
+                title="Timeline"
+                description="The selected event at its recorded timestamp."
+              >
+                <ol className="timeline activity-detail-workspace__timeline">
+                  <li className="timeline-row activity-detail-workspace__timeline-entry">
+                    <span className="timeline-row-head">
+                      <StatusLabel tone={activityLevelTone(activity.level)}>
+                        {activity.level}
+                      </StatusLabel>
+                      <span className="activity-stage-label">
+                        {activity.stage}
+                      </span>
                     </span>
-                    <span className="stage-pill">{activity.stage}</span>
-                  </span>
-                  <span className="activity-detail-workspace__timeline-copy">
-                    <strong className="mono">{activity.eventType}</strong>
-                    <span>{activity.message}</span>
-                    <time dateTime={activity.at ?? undefined}>{formatDateTime(activity.at)}</time>
-                  </span>
-                </li>
-              </ol>
-            </Section>
-          </div>
-        </RouteWorkspace>
+                    <span className="activity-detail-workspace__timeline-copy">
+                      <strong className="mono">{activity.eventType}</strong>
+                      <span>{activity.message}</span>
+                      <time dateTime={activity.at ?? undefined}>
+                        {formatDateTime(activity.at)}
+                      </time>
+                    </span>
+                  </li>
+                </ol>
+              </Section>
+            </TabsContent>
+          </RouteWorkspace>
+        </SectionTabs>
       ) : null}
     </div>
   );

--- a/apps/web/src/views/debug/DebugView.tsx
+++ b/apps/web/src/views/debug/DebugView.tsx
@@ -37,7 +37,9 @@ function isActivitySortField(value: string): value is ActivitySortField {
 export function DebugView() {
   const search = useSearch({ from: "/debug" });
   const navigate = useNavigate({ from: "/debug" });
-  const { data, isFetching, error } = useActivityListQuery(activityInput(search));
+  const { data, isFetching, error } = useActivityListQuery(
+    activityInput(search),
+  );
   const message = error instanceof Error ? error.message : null;
 
   const setSearch = (next: Partial<DebugSearch>) => {
@@ -63,13 +65,24 @@ export function DebugView() {
   };
 
   return (
-    <div className="route-page route-page--debug">
+    <div className="route-page route-page--debug editorial-index-page">
       <PageHead
+        className="editorial-page-head"
         eyebrow="Activity"
         title="Debug"
-        subtitle={data ? `${data.pagination.total} activity events` : "loading"}
+        subtitle={
+          <>
+            <span>
+              Search event history without losing the object and workflow
+              context.
+            </span>
+            <span className="page-head-count">
+              {data ? `${data.pagination.total} activity events` : "loading"}
+            </span>
+          </>
+        }
       />
-      <section className="card full data-surface">
+      <section className="card full data-surface editorial-data-surface">
         {message ? <div className="banner inline">{message}</div> : null}
         <DebugFilterBar search={search} onChange={setSearch} />
         <DebugActivityTable

--- a/apps/web/src/views/debug/activity-columns.tsx
+++ b/apps/web/src/views/debug/activity-columns.tsx
@@ -1,6 +1,7 @@
 import type { ActivityEventSummary } from "../../contexts/operations/types.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import type { DataGridColumn } from "../../shared/ui/filterable-data-grid.js";
+import { StatusLabel } from "../../shared/ui/status-label.js";
 import { activityLevelTone } from "./activity-tone.js";
 
 function activityContext(activity: ActivityEventSummary): string {
@@ -20,9 +21,9 @@ export const activityColumns: Array<DataGridColumn<ActivityEventSummary>> = [
     minWidth: 62,
     sortable: true,
     render: (activity) => (
-      <span className={`tag ${activityLevelTone(activity.level)}`}>
+      <StatusLabel tone={activityLevelTone(activity.level)}>
         {activity.level}
-      </span>
+      </StatusLabel>
     ),
   },
   {
@@ -33,7 +34,9 @@ export const activityColumns: Array<DataGridColumn<ActivityEventSummary>> = [
     width: 74,
     minWidth: 62,
     sortable: true,
-    render: (activity) => <span className="stage-pill">{activity.stage}</span>,
+    render: (activity) => (
+      <span className="activity-stage-label">{activity.stage}</span>
+    ),
   },
   {
     id: "message",

--- a/apps/web/src/views/discovery/DiscoveryView.test.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.test.tsx
@@ -9,7 +9,6 @@ describe("DiscoveryView", () => {
   it("renders discovery controls as tabs with a source registry table", async () => {
     renderWithProviders(<DiscoveryView />);
 
-    expect(await screen.findByRole("heading", { name: "Discovery settings" })).toBeInTheDocument();
     expect(await screen.findByRole("heading", { name: "Target search" })).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Target tracks" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Management" })).toBeInTheDocument();

--- a/apps/web/src/views/discovery/DiscoveryView.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.tsx
@@ -7,7 +7,11 @@ import { PageHead } from "../../shared/ui/page-head.js";
 export function DiscoveryView() {
   return (
     <div className="route-page route-page--discovery">
-      <PageHead eyebrow="Pipeline" title="Discovery" />
+      <PageHead
+        eyebrow="Pipeline"
+        title="Discovery"
+        subtitle="Search defaults, source execution, supervision, and intake controls."
+      />
       <div className="discovery-view-stack">
         <TargetSearchSettingsPanel />
         <DiscoveryAutomationSettingsPanel />

--- a/apps/web/src/views/evidence-map/EvidenceMapView.tsx
+++ b/apps/web/src/views/evidence-map/EvidenceMapView.tsx
@@ -17,6 +17,7 @@ import { Field, FieldLabel } from "../../shared/ui/field.js";
 import { Input } from "../../shared/ui/input.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
+import { StatusLabel } from "../../shared/ui/status-label.js";
 import { ToolRow } from "../../shared/ui/tool-row.js";
 
 function entryKindLabel(entry: EvidenceMapEntry): string {
@@ -37,10 +38,14 @@ function gapKindLabel(gap: EvidenceGap): string {
   }
 }
 
-function tagTone(value: string | null | undefined): "danger" | "info" | "muted" | "ok" | "warn" {
+function tagTone(
+  value: string | null | undefined,
+): "danger" | "info" | "muted" | "ok" | "warn" {
   if (!value) return "muted";
-  if (["covered", "matched", "verified", "declared"].includes(value)) return "ok";
-  if (["missing", "missing_from_profile", "blocked"].includes(value)) return "danger";
+  if (["covered", "matched", "verified", "declared"].includes(value))
+    return "ok";
+  if (["missing", "missing_from_profile", "blocked"].includes(value))
+    return "danger";
   if (["transferable", "declared_only"].includes(value)) return "warn";
   return "info";
 }
@@ -49,7 +54,10 @@ function compactDate(value: string | null): string {
   return value || "No date range";
 }
 
-function includesText(value: string | null | undefined, needle: string): boolean {
+function includesText(
+  value: string | null | undefined,
+  needle: string,
+): boolean {
   return Boolean(value && value.toLowerCase().includes(needle));
 }
 
@@ -84,18 +92,18 @@ function entryMatchesQuery(entry: EvidenceMapEntry, q: string): boolean {
 }
 
 function requirementLinkLabel(usage: EvidenceUsageRef): string {
-  return [
-    usage.jobTitle || usage.jobKey,
-    usage.requirementText,
-    usage.requirementFitKind,
-  ].filter(Boolean).join(" · ");
+  return [usage.jobTitle || usage.jobKey, usage.requirementText]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function resumeLinkLabel(usage: EvidenceUsageRef): string {
   return [
     usage.jobTitle || usage.jobKey,
     usage.generatedTextPreview || usage.bulletId,
-  ].filter(Boolean).join(" · ");
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function UsageLink({ usage }: { readonly usage: EvidenceUsageRef }) {
@@ -107,16 +115,22 @@ function UsageLink({ usage }: { readonly usage: EvidenceUsageRef }) {
         to="/artifacts/$artifactId"
       >
         <span>{resumeLinkLabel(usage)}</span>
-        <span className="tag muted">artifact</span>
+        <span className="evidence-usage-kind mono">artifact</span>
       </Link>
     );
   }
   return (
-    <Link className="evidence-usage-link" params={{ jobId: usage.jobKey }} to="/jobs/$jobId">
+    <Link
+      className="evidence-usage-link"
+      params={{ jobId: usage.jobKey }}
+      to="/jobs/$jobId"
+    >
       <span>{requirementLinkLabel(usage) || usage.jobKey}</span>
-      <span className={`tag ${tagTone(usage.requirementFitKind ?? usage.coverageState)}`}>
+      <StatusLabel
+        tone={tagTone(usage.requirementFitKind ?? usage.coverageState)}
+      >
         {usage.requirementFitKind ?? usage.coverageState ?? "job"}
-      </span>
+      </StatusLabel>
     </Link>
   );
 }
@@ -136,7 +150,9 @@ function UsageGroup({
       <h3>{title}</h3>
       <ul className="evidence-usage-list">
         {usages.map((usage, index) => (
-          <li key={`${usage.kind}:${usage.jobKey}:${usage.artifactId ?? ""}:${usage.requirementId ?? ""}:${index}`}>
+          <li
+            key={`${usage.kind}:${usage.jobKey}:${usage.artifactId ?? ""}:${usage.requirementId ?? ""}:${index}`}
+          >
             <UsageLink usage={usage} />
           </li>
         ))}
@@ -155,7 +171,9 @@ function EvidenceEntryButton({
   readonly selected: boolean;
 }) {
   const usageCount =
-    entry.resumeUsages.length + entry.requirementUsages.length + entry.coverageUsages.length;
+    entry.resumeUsages.length +
+    entry.requirementUsages.length +
+    entry.coverageUsages.length;
   return (
     <li>
       <Link
@@ -169,9 +187,9 @@ function EvidenceEntryButton({
           <span className="muted">{entryKindLabel(entry)}</span>
         </span>
         <span className="evidence-entry-meta">
-          <span className={`tag ${tagTone(entry.freshness.evidenceStrength)}`}>
+          <StatusLabel tone={tagTone(entry.freshness.evidenceStrength)}>
             {entry.freshness.evidenceStrength ?? "unrated"}
-          </span>
+          </StatusLabel>
           <span className="meta">{usageCount} uses</span>
         </span>
       </Link>
@@ -179,7 +197,11 @@ function EvidenceEntryButton({
   );
 }
 
-function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) {
+function EvidenceDetail({
+  entry,
+}: {
+  readonly entry: EvidenceMapEntry | null;
+}) {
   if (!entry) {
     return <Empty title="Select evidence to inspect usage." />;
   }
@@ -193,13 +215,15 @@ function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) 
         <p className="meta">{entryKindLabel(entry)}</p>
         <h2 id="evidence-detail-title">{entry.title}</h2>
         <div className="evidence-tags">
-          <span className={`tag ${tagTone(freshness.evidenceStrength)}`}>
+          <StatusLabel tone={tagTone(freshness.evidenceStrength)}>
             {freshness.evidenceStrength ?? "unrated"}
-          </span>
-          <span className={freshness.userConfirmed ? "tag ok" : "tag warn"}>
+          </StatusLabel>
+          <StatusLabel tone={freshness.userConfirmed ? "ok" : "warn"}>
             {freshness.userConfirmed ? "confirmed" : "unconfirmed"}
+          </StatusLabel>
+          <span className="evidence-date mono">
+            {compactDate(freshness.evidenceDateRange)}
           </span>
-          <span className="tag muted">{compactDate(freshness.evidenceDateRange)}</span>
         </div>
       </header>
 
@@ -221,9 +245,9 @@ function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) 
             </div>
           </dl>
           {entry.story.metrics.length ? (
-            <ul className="evidence-chip-list" aria-label="Story metrics">
+            <ul className="evidence-inline-list" aria-label="Story metrics">
               {entry.story.metrics.map((metric) => (
-                <li className="tag info" key={metric}>{metric}</li>
+                <li key={metric}>{metric}</li>
               ))}
             </ul>
           ) : null}
@@ -232,15 +256,18 @@ function EvidenceDetail({ entry }: { readonly entry: EvidenceMapEntry | null }) 
 
       <section className="evidence-detail-group">
         <h3>Skills and tags</h3>
-        <ul className="evidence-chip-list">
+        <ul className="evidence-inline-list">
           {[...entry.skills, ...entry.tags].map((value) => (
-            <li className="tag muted" key={value}>{value}</li>
+            <li key={value}>{value}</li>
           ))}
         </ul>
       </section>
 
       <UsageGroup title="Used in resumes" usages={entry.resumeUsages} />
-      <UsageGroup title="Requirement fit history" usages={entry.requirementUsages} />
+      <UsageGroup
+        title="Requirement fit history"
+        usages={entry.requirementUsages}
+      />
       <UsageGroup title="Coverage history" usages={entry.coverageUsages} />
     </div>
   );
@@ -255,7 +282,9 @@ function GapList({ gaps }: { readonly gaps: readonly EvidenceGap[] }) {
       {gaps.map((gap) => (
         <li key={gap.gapId}>
           <div>
-            <span className={`tag ${tagTone(gap.fitKind ?? gap.kind)}`}>{gapKindLabel(gap)}</span>
+            <StatusLabel tone={tagTone(gap.fitKind ?? gap.kind)}>
+              {gapKindLabel(gap)}
+            </StatusLabel>
             <strong>{gap.requirementText}</strong>
             <p className="muted">{gap.reason}</p>
           </div>
@@ -273,7 +302,11 @@ function GapList({ gaps }: { readonly gaps: readonly EvidenceGap[] }) {
   );
 }
 
-function StoryList({ entries }: { readonly entries: readonly EvidenceMapEntry[] }) {
+function StoryList({
+  entries,
+}: {
+  readonly entries: readonly EvidenceMapEntry[];
+}) {
   const stories = entries.filter((entry) => entry.story);
   if (!stories.length) {
     return <Empty title="No reusable stories match this view." />;
@@ -313,20 +346,38 @@ export function EvidenceMapView() {
     selectedEntry.data ??
     filteredEntries.find((entry) => entry.entryId === selectedEntryId) ??
     null;
-  const errorMessage = evidenceMap.error instanceof Error ? evidenceMap.error.message : null;
+  const errorMessage =
+    evidenceMap.error instanceof Error ? evidenceMap.error.message : null;
 
   const setSearch = (next: Partial<EvidenceMapSearch>) => {
-    void navigate({ search: (prev: EvidenceMapSearch) => ({ ...prev, ...next }) });
+    void navigate({
+      search: (prev: EvidenceMapSearch) => ({ ...prev, ...next }),
+    });
   };
 
   return (
     <div className="route-page route-page--evidence-map">
       <PageHead
+        className="editorial-page-head"
         eyebrow="Library"
         title="Career evidence map"
-        subtitle={evidenceMap.data ? `${filteredEntries.length} entries` : "loading"}
+        subtitle={
+          <>
+            <span>
+              Trace canonical evidence through requirements, artifacts, and
+              visible gaps.
+            </span>
+            <span className="page-head-count">
+              {evidenceMap.data
+                ? `${filteredEntries.length} entries`
+                : "loading"}
+            </span>
+          </>
+        }
       />
-      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
+      {errorMessage ? (
+        <div className="banner inline">{errorMessage}</div>
+      ) : null}
       <RouteWorkspace
         aria-label="Career evidence workspace"
         className="evidence-map-view evidence-map-workspace"
@@ -340,11 +391,15 @@ export function EvidenceMapView() {
             role="search"
             primary={
               <Field className="tool-row__search">
-                <FieldLabel htmlFor="evidence-map-search">Search evidence</FieldLabel>
+                <FieldLabel htmlFor="evidence-map-search">
+                  Search evidence
+                </FieldLabel>
                 <Input
                   id="evidence-map-search"
                   value={search.q}
-                  onChange={(event) => setSearch({ q: event.target.value, entry: "" })}
+                  onChange={(event) =>
+                    setSearch({ q: event.target.value, entry: "" })
+                  }
                   placeholder="Skill, story, metric..."
                 />
               </Field>
@@ -352,7 +407,10 @@ export function EvidenceMapView() {
             secondary={
               search.job ? (
                 <Button asChild size="sm" variant="outline">
-                  <Link search={{ ...search, job: "", entry: "" }} to="/evidence-map">
+                  <Link
+                    search={{ ...search, job: "", entry: "" }}
+                    to="/evidence-map"
+                  >
                     Clear job filter
                   </Link>
                 </Button>

--- a/apps/web/src/views/jobs/JobAuditTriage.tsx
+++ b/apps/web/src/views/jobs/JobAuditTriage.tsx
@@ -4,6 +4,7 @@ import type { JobDetail } from "../../contexts/operations/types.js";
 import { ResetStaleScoresButton } from "../../contexts/scoring/components/ResetStaleScoresButton.js";
 import { ScoreCorrectionControl } from "../../contexts/scoring/components/ScoreCorrectionControl.js";
 import { ScoreStalenessBadge } from "../../contexts/scoring/components/ScoreStalenessBadge.js";
+import { StatusLabel } from "../../shared/ui/status-label.js";
 
 export interface JobAuditTriageProps {
   detail: JobDetail;
@@ -70,14 +71,15 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
                   <div key={group.label}>
                     <dt>{group.label}</dt>
                     <dd>
-                      {group.facts.map((fact) => (
-                        <span
-                          className={`tag ${factTone(fact)}`}
-                          key={`${group.label}:${fact.code}:${fact.detail ?? ""}`}
-                        >
-                          {fact.detail ? `${fact.label}: ${fact.detail}` : fact.label}
-                        </span>
-                      ))}
+                      <ul className="audit-status-list">
+                        {group.facts.map((fact) => (
+                          <li key={`${group.label}:${fact.code}:${fact.detail ?? ""}`}>
+                            <StatusLabel tone={factTone(fact)}>
+                              {fact.detail ? `${fact.label}: ${fact.detail}` : fact.label}
+                            </StatusLabel>
+                          </li>
+                        ))}
+                      </ul>
                     </dd>
                   </div>
                 ))}
@@ -153,13 +155,13 @@ function TagGroup({
   return (
     <div className="job-audit-tag-group">
       <span>{label}</span>
-      <div>
+      <ul className="audit-value-list">
         {values.map((value) => (
-          <span className={`tag ${tone}`} key={value}>
+          <li className={`audit-value audit-value--${tone}`} key={value}>
             {value}
-          </span>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   );
 }

--- a/apps/web/src/views/jobs/JobBulkActions.test.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.test.tsx
@@ -62,7 +62,7 @@ describe("<JobBulkActions>", () => {
       />,
     );
 
-    const viewSwitcher = screen.getByRole("radiogroup", { name: "Job views" });
+    const viewSwitcher = screen.getByRole("radiogroup", { name: "Queue" });
     expect(viewSwitcher).toHaveClass("job-view-switcher");
     expect(viewSwitcher).toHaveAttribute("data-variant", "outline");
     expect(within(viewSwitcher).getByRole("radio", { name: "deleted" })).toHaveAttribute(
@@ -73,13 +73,36 @@ describe("<JobBulkActions>", () => {
       "aria-checked",
       "false",
     );
-    expect(screen.getByRole("button", { name: "hide selected" })).toHaveTextContent(/^hide$/);
+    const selectionControls = screen.getByRole("group", {
+      name: "Selection",
+    });
+    const preparationControls = screen.getByRole("group", {
+      name: "Preparation",
+    });
+    const selectedJobControls = screen.getByRole("group", {
+      name: "Selected jobs",
+    });
     expect(
-      screen.getByRole("button", { name: "permanently delete selected" }),
+      within(selectionControls).getByRole("button", { name: "select page" }),
+    ).toBeInTheDocument();
+    expect(
+      within(preparationControls).getByRole("button", {
+        name: "refresh compensation",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(selectedJobControls).getByRole("button", { name: "hide selected" }),
+    ).toHaveTextContent(/^hide$/);
+    expect(
+      within(selectedJobControls).getByRole("button", {
+        name: "permanently delete selected",
+      }),
     ).toHaveTextContent(/^permanently delete$/);
-    expect(screen.getByRole("button", { name: "restore selected" })).toHaveTextContent(
-      /^restore$/,
-    );
+    expect(
+      within(selectedJobControls).getByRole("button", {
+        name: "restore selected",
+      }),
+    ).toHaveTextContent(/^restore$/);
   });
 
   it("omits the redundant selection instruction when nothing is selected", () => {

--- a/apps/web/src/views/jobs/JobBulkActions.tsx
+++ b/apps/web/src/views/jobs/JobBulkActions.tsx
@@ -77,148 +77,219 @@ export function JobBulkActions({
       ? "restore"
       : "delete selected";
   return (
-    <div className="bulk-bar">
-      <ToggleGroup
-        aria-label="Job views"
-        className="job-view-switcher max-w-full flex-wrap"
-        size="sm"
-        spacing={1}
-        type="single"
-        value={search.deleted}
-        variant="outline"
-        onValueChange={(value) => {
-          if (value) {
-            onSetDeleted(value as JobsSearch["deleted"]);
-          }
-        }}
-      >
-        {JOB_VIEWS.map((view) => (
-          <ToggleGroupItem key={view.value} value={view.value}>
-            {view.label}
-          </ToggleGroupItem>
-        ))}
-      </ToggleGroup>
-      {selectedCount ? (
-        <span className="meta">{selectedCount} selected</span>
-      ) : null}
-      <button
-        className="tab"
-        type="button"
-        disabled={!hasItems}
-        onClick={onSelectPage}
-      >
-        select page
-      </button>
-      <button
-        className="tab"
-        type="button"
-        disabled={!hasAnyMatching || hasLocalFilters}
-        onClick={onSelectAllMatching}
-      >
-        select all matching
-      </button>
-      <button
-        className="tab"
-        type="button"
-        disabled={!selectedCount}
-        onClick={onClearSelection}
-      >
-        clear selected
-      </button>
-      <RefreshAllCompensationButton onSuccess={onMaintenanceSuccess} />
-      {staleCount || selectedStaleKeys.length ? (
-        <ResetStaleScoresButton
-          jobKeys={selectedStaleKeys}
-          staleCount={selectedStaleKeys.length || staleCount}
-          label={
-            selectedStaleKeys.length
-              ? "reset stale selected"
-              : "reset all stale scores"
-          }
-          onSuccess={onResetStaleSuccess}
-        />
-      ) : null}
-      {!restoring && !hidden && !closed ? (
-        <>
-          <RescoreCurrentPolicyButton onSuccess={onMaintenanceSuccess} />
-          <RetailorCurrentPolicyButton onSuccess={onMaintenanceSuccess} />
-          {selectedJobKeys.length ? (
-            <>
-              <RescoreCurrentPolicyButton
-                jobKeys={selectedJobKeys}
-                label="rescore selected"
-                onSuccess={onMaintenanceSuccess}
-              />
-              <RetailorCurrentPolicyButton
-                jobKeys={selectedJobKeys}
-                label="re-tailor selected"
-                onSuccess={onMaintenanceSuccess}
-              />
-            </>
-          ) : null}
-        </>
-      ) : null}
-      {retrySelectedFailures ? (
-          <button
-            className="tab on"
-            type="button"
-            disabled={!selectedCount || retryLoading}
-            onClick={onRetryFailedSelected}
-          >
-            retry selected
-          </button>
-      ) : null}
-      {retryAllFailures ? (
-        <>
-          <button
-            className="tab"
-            type="button"
-            disabled={hasLocalFilters || pendingPreparationLoading}
-            onClick={onRunPendingPreparation}
-          >
-            continue pending prep
-          </button>
-          <button
-            className="tab"
-            type="button"
-            disabled={hasLocalFilters || retryLoading}
-            onClick={onRetryAllFailed}
-          >
-            retry all failed
-          </button>
-        </>
-      ) : null}
-      {!hidden ? (
-        <button
-          aria-label="hide selected"
-          className="tab danger-action"
-          type="button"
-          disabled={!selectedCount || loading}
-          onClick={onHideSelected}
+    <div className="bulk-bar jobs-index-controls">
+      <div className="jobs-index-view-row">
+        <span
+          className="jobs-index-control-label"
+          id="jobs-index-queue-label"
         >
-          hide
-        </button>
-      ) : null}
-      {restoring || hidden ? (
-        <button
-          aria-label="permanently delete selected"
-          className="tab danger-action"
-          type="button"
-          disabled={!selectedCount || loading}
-          onClick={onPermanentlyDeleteSelected}
+          Queue
+        </span>
+        <ToggleGroup
+          aria-labelledby="jobs-index-queue-label"
+          className="job-view-switcher max-w-full flex-wrap"
+          size="sm"
+          spacing={1}
+          type="single"
+          value={search.deleted}
+          variant="outline"
+          onValueChange={(value) => {
+            if (value) {
+              onSetDeleted(value as JobsSearch["deleted"]);
+            }
+          }}
         >
-          permanently delete
-        </button>
-      ) : null}
-      <button
-        aria-label={restoring ? "restore selected" : undefined}
-        className={`tab ${restoring || hidden ? "on" : "danger-action"}`}
-        type="button"
-        disabled={!selectedCount || loading}
-        onClick={onPrimaryAction}
-      >
-        {primaryLabel}
-      </button>
+          {JOB_VIEWS.map((view) => (
+            <ToggleGroupItem key={view.value} value={view.value}>
+              {view.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+        <span className="jobs-index-selection-count" aria-live="polite">
+          {selectedCount ? `${selectedCount} selected` : null}
+        </span>
+      </div>
+
+      <div className="jobs-index-action-row">
+        <div
+          aria-labelledby="jobs-index-selection-label"
+          className="jobs-index-action-group jobs-index-action-group--selection"
+          role="group"
+        >
+          <span
+            className="jobs-index-control-label"
+            id="jobs-index-selection-label"
+          >
+            Selection
+          </span>
+          <div className="jobs-index-action-list">
+            <button
+              className="jobs-index-action"
+              type="button"
+              disabled={!hasItems}
+              onClick={onSelectPage}
+            >
+              select page
+            </button>
+            <button
+              className="jobs-index-action"
+              type="button"
+              disabled={!hasAnyMatching || hasLocalFilters}
+              onClick={onSelectAllMatching}
+            >
+              select all matching
+            </button>
+            <button
+              className="jobs-index-action"
+              type="button"
+              disabled={!selectedCount}
+              onClick={onClearSelection}
+            >
+              clear selected
+            </button>
+          </div>
+        </div>
+
+        <div
+          aria-labelledby="jobs-index-preparation-label"
+          className="jobs-index-action-group jobs-index-action-group--preparation"
+          role="group"
+        >
+          <span
+            className="jobs-index-control-label"
+            id="jobs-index-preparation-label"
+          >
+            Preparation
+          </span>
+          <div className="jobs-index-action-list">
+            <RefreshAllCompensationButton
+              className="jobs-index-action"
+              onSuccess={onMaintenanceSuccess}
+            />
+            {staleCount || selectedStaleKeys.length ? (
+              <ResetStaleScoresButton
+                className="jobs-index-action"
+                jobKeys={selectedStaleKeys}
+                staleCount={selectedStaleKeys.length || staleCount}
+                label={
+                  selectedStaleKeys.length
+                    ? "reset stale selected"
+                    : "reset all stale scores"
+                }
+                onSuccess={onResetStaleSuccess}
+              />
+            ) : null}
+            {!restoring && !hidden && !closed ? (
+              <>
+                <RescoreCurrentPolicyButton
+                  className="jobs-index-action"
+                  onSuccess={onMaintenanceSuccess}
+                />
+                <RetailorCurrentPolicyButton
+                  className="jobs-index-action"
+                  onSuccess={onMaintenanceSuccess}
+                />
+              </>
+            ) : null}
+            {retryAllFailures ? (
+              <>
+                <button
+                  className="jobs-index-action"
+                  type="button"
+                  disabled={hasLocalFilters || pendingPreparationLoading}
+                  onClick={onRunPendingPreparation}
+                >
+                  continue pending prep
+                </button>
+                <button
+                  className="jobs-index-action"
+                  type="button"
+                  disabled={hasLocalFilters || retryLoading}
+                  onClick={onRetryAllFailed}
+                >
+                  retry all failed
+                </button>
+              </>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          aria-labelledby="jobs-index-selected-label"
+          className="jobs-index-action-group jobs-index-action-group--selected"
+          role="group"
+        >
+          <span
+            className="jobs-index-control-label"
+            id="jobs-index-selected-label"
+          >
+            Selected jobs
+          </span>
+          <div className="jobs-index-action-list">
+            {!restoring && !hidden && !closed && selectedJobKeys.length ? (
+              <>
+                <RescoreCurrentPolicyButton
+                  className="jobs-index-action"
+                  jobKeys={selectedJobKeys}
+                  label="rescore selected"
+                  onSuccess={onMaintenanceSuccess}
+                />
+                <RetailorCurrentPolicyButton
+                  className="jobs-index-action"
+                  jobKeys={selectedJobKeys}
+                  label="re-tailor selected"
+                  onSuccess={onMaintenanceSuccess}
+                />
+              </>
+            ) : null}
+            {retrySelectedFailures ? (
+              <button
+                className="jobs-index-action jobs-index-action--emphasis"
+                type="button"
+                disabled={!selectedCount || retryLoading}
+                onClick={onRetryFailedSelected}
+              >
+                retry selected
+              </button>
+            ) : null}
+            {!hidden ? (
+              <button
+                aria-label="hide selected"
+                className="jobs-index-action jobs-index-action--danger"
+                type="button"
+                disabled={!selectedCount || loading}
+                onClick={onHideSelected}
+              >
+                hide
+              </button>
+            ) : null}
+            {restoring || hidden ? (
+              <button
+                aria-label="permanently delete selected"
+                className="jobs-index-action jobs-index-action--danger"
+                type="button"
+                disabled={!selectedCount || loading}
+                onClick={onPermanentlyDeleteSelected}
+              >
+                permanently delete
+              </button>
+            ) : null}
+            <button
+              aria-label={restoring ? "restore selected" : undefined}
+              className={`jobs-index-action ${
+                restoring || hidden
+                  ? "jobs-index-action--emphasis"
+                  : "jobs-index-action--danger"
+              }`}
+              type="button"
+              disabled={!selectedCount || loading}
+              onClick={onPrimaryAction}
+            >
+              {primaryLabel}
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.test.tsx
@@ -71,7 +71,58 @@ function renderJobDetailDrawer(jobId: string) {
   };
 }
 
+async function selectJobDetailTab(label: string) {
+  await userEvent.setup().click(await screen.findByRole("tab", { name: label }));
+}
+
 describe("<JobDetailDrawer>", () => {
+  it("keeps the jobs return control available while detail data is loading", async () => {
+    const user = userEvent.setup();
+    const { router } = renderJobDetailDrawer("job-1");
+
+    expect(screen.getByText("Loading job.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back to jobs" }));
+
+    await waitFor(() => expect(router.state.location.pathname).toBe("/jobs"));
+  });
+
+  it("uses accessible detail tabs while keeping the progress and audit inspector persistent", async () => {
+    const user = userEvent.setup();
+    renderJobDetailDrawer("job-1");
+
+    const tabList = await screen.findByRole("tablist", { name: "Job detail sections" });
+    const overviewTab = within(tabList).getByRole("tab", { name: "Overview" });
+    const fitEvidenceTab = within(tabList).getByRole("tab", { name: "Fit & evidence" });
+    const materialsTab = within(tabList).getByRole("tab", { name: "Materials" });
+    const activityTab = within(tabList).getByRole("tab", { name: "Activity" });
+    const inspector = screen.getByLabelText("Job progress and audit history");
+
+    expect(overviewTab).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel", { name: "Overview" })).toHaveTextContent("About the role");
+    expect(within(inspector).getByText("Preparation diagnostics")).toBeInTheDocument();
+    expect(within(inspector).getByText("Audit history")).toBeInTheDocument();
+
+    await user.click(overviewTab);
+    await user.keyboard("{ArrowRight}");
+
+    expect(fitEvidenceTab).toHaveAttribute("aria-selected", "true");
+    expect(
+      within(screen.getByRole("tabpanel", { name: "Fit & evidence" })).getByRole("region", {
+        name: "Job audit triage",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(materialsTab);
+    expect(screen.getByRole("tabpanel", { name: "Materials" })).toHaveTextContent(
+      "Before you apply",
+    );
+
+    await user.click(activityTab);
+    expect(screen.getByRole("tabpanel", { name: "Activity" })).toHaveTextContent("Apply history");
+    expect(within(inspector).getByText("Preparation diagnostics")).toBeInTheDocument();
+    expect(within(inspector).getByText("Audit history")).toBeInTheDocument();
+  });
+
   it("renders source-conflict compensation warnings only inside compensation evidence", async () => {
     if (sampleCompensationAudit.market.recordStatus !== "recorded") {
       throw new Error("sample compensation audit must include recorded market evidence");
@@ -170,6 +221,7 @@ describe("<JobDetailDrawer>", () => {
     );
 
     renderJobDetailDrawer("job-source-conflict");
+    await selectJobDetailTab("Fit & evidence");
 
     const compensation = await screen.findByRole("region", { name: "Compensation evidence" });
     expect(within(compensation).getByText("source_conflict_with_posted_salary")).toBeInTheDocument();
@@ -236,12 +288,14 @@ describe("<JobDetailDrawer>", () => {
 
     renderJobDetailDrawer("https://example.com/jobs/1");
 
+    await user.click(await screen.findByRole("tab", { name: "Fit & evidence" }));
     await user.click(await screen.findByRole("button", { name: "refresh compensation" }));
 
     await waitFor(() => expect(calls).toEqual([{}]));
   });
 
   it("summarizes ranking, readiness, blockers, eligibility, and Apply Review handoff", async () => {
+    const user = userEvent.setup();
     server.use(
       http.get("*/v1/jobs/:jobKey", ({ params }) => {
         return HttpResponse.json(
@@ -301,6 +355,9 @@ describe("<JobDetailDrawer>", () => {
 
     renderJobDetailDrawer("https://example.com/jobs/1");
 
+    const overview = await screen.findByRole("tabpanel", { name: "Overview" });
+    expect(within(overview).getByText("About the role")).toBeInTheDocument();
+    await user.click(screen.getByRole("tab", { name: "Fit & evidence" }));
     const triage = await screen.findByRole("region", { name: "Job audit triage" });
     const workspace = screen.getByRole("article", { name: "Job details" });
     const toolbar = within(workspace).getByRole("toolbar", { name: "Job actions" });
@@ -342,10 +399,7 @@ describe("<JobDetailDrawer>", () => {
     expect(screen.queryByText("Score breakdown")).not.toBeInTheDocument();
     expect(screen.queryByText("Tailoring rationale")).not.toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Role Analysis" })).toHaveClass("job-detail-role-analysis");
-    const description = screen.getByText("Description").closest("section");
-    expect(description).not.toBeNull();
-    expect(description).toHaveClass("job-detail-description");
-    expect(triage.compareDocumentPosition(description as HTMLElement) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.queryByRole("tabpanel", { name: "Overview" })).not.toBeInTheDocument();
   });
 
   it("shows a not-found state instead of the raw API 404 for missing jobs", async () => {
@@ -359,6 +413,7 @@ describe("<JobDetailDrawer>", () => {
 
     await waitFor(() => expect(screen.getByText("Job not found.")).toBeInTheDocument());
     expect(screen.queryByText(/JobCtrl API request failed: 404/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Back to jobs" })).toBeInTheDocument();
   });
 
   it("renders compensation audit range, statistical confidence, and reported sources", async () => {
@@ -381,6 +436,7 @@ describe("<JobDetailDrawer>", () => {
     );
 
     renderJobDetailDrawer("https://example.com/jobs/compensation");
+    await selectJobDetailTab("Fit & evidence");
 
     const compensation = await screen.findByRole("region", { name: "Compensation evidence" });
     expect(within(compensation).getByText("Compensation")).toBeInTheDocument();
@@ -435,6 +491,7 @@ describe("<JobDetailDrawer>", () => {
     );
 
     renderJobDetailDrawer("https://example.com/jobs/1");
+    await selectJobDetailTab("Fit & evidence");
 
     const requirement = await screen.findByRole("article", {
       name: "Requirement: Lead platform reliability programs across multiple teams",
@@ -476,6 +533,7 @@ describe("<JobDetailDrawer>", () => {
     );
 
     renderJobDetailDrawer("https://example.com/jobs/legacy-fit");
+    await selectJobDetailTab("Fit & evidence");
 
     const callout = await screen.findByRole("region", { name: "Requirement fit not assessed" });
     expect(within(callout).getByText("Requirement fit not assessed")).toBeInTheDocument();
@@ -512,7 +570,7 @@ describe("<JobDetailDrawer>", () => {
     await waitFor(() => expect(router.state.location.pathname).toBe("/jobs"));
   });
 
-  it("renders user-facing audit history as the collapsed final drawer section", async () => {
+  it("keeps user-facing audit history persistent as the collapsed final inspector section", async () => {
     const user = userEvent.setup();
     renderJobDetailDrawer("job-1");
 
@@ -522,11 +580,11 @@ describe("<JobDetailDrawer>", () => {
     expect(auditDisclosure).not.toHaveAttribute("open");
 
     const workspace = screen.getByRole("article", { name: "Job details" });
-    const sections = Array.from(workspace.querySelectorAll("section.section"));
+    const inspector = within(workspace).getByLabelText("Job progress and audit history");
+    const sections = Array.from(inspector.querySelectorAll("section.section"));
     expect(sections.at(-1)).toContainElement(auditDisclosure);
     expect(sections.at(-1)).toHaveTextContent("Audit history");
-    expect(sections[1]).toHaveTextContent("Compensation");
-    expect(sections[2]).toHaveTextContent("Description");
+    expect(sections[0]).toHaveTextContent("Preparation diagnostics");
 
     await user.click(auditSummary);
     expect(auditDisclosure).toHaveAttribute("open");

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -24,9 +24,11 @@ import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../../shared/ui/tabs.js";
 import { JobAuditTriage } from "./JobAuditTriage.js";
 import { JobDescription } from "./JobDescription.js";
-import { JobOverview } from "./JobOverview.js";
+import { JobOverview, JobSummaryLedger } from "./JobOverview.js";
 
 export interface JobDetailDrawerProps {
   jobId: string;
@@ -98,130 +100,165 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
 
   return (
     <div className="route-page route-page--job-detail" aria-label="Job details">
+      <div className="job-detail-route-controls">
+        <Button
+          aria-label="Back to jobs"
+          className="workspace-back"
+          size="sm"
+          type="button"
+          variant="ghost"
+          onClick={onClose}
+        >
+          <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+          Jobs
+        </Button>
+      </div>
       {errorMessage ? <Empty title={errorMessage} /> : null}
       {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
       {detail ? (
-        <RouteWorkspace
-          aria-label="Job details"
-          className="job-detail-workspace"
-          contentLabel="Job evidence and analysis"
-          inspectorLabel="Job progress, materials, and history"
-          header={
-            <div className="job-detail-workspace__header">
-              <Button
-                aria-label="Back to jobs"
-                className="workspace-back"
-                size="sm"
-                type="button"
-                variant="ghost"
-                onClick={onClose}
-              >
-                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                Jobs
-              </Button>
-              <JobOverview detail={detail} />
-              <div className="job-detail-top-actions">
-                <JobActions
-                  jobId={detail.job.jobKey}
-                  currentStage={detail.job.currentSubstage}
-                  canRetryStage={canRetryStage(currentSubstage)}
-                  canRunCurrentStage={canRunCurrentStage(currentSubstage)}
-                  canRetailor={detail.artifacts.length > 0}
-                  applyApprovalRequired={applyApprovalRequired}
-                />
-                <Button asChild size="sm" variant="outline">
-                  <Link
-                    aria-label={`Open Apply Review for ${detail.job.title}`}
-                    search={{ jobKey: detail.job.jobKey }}
-                    to="/apply-review"
-                  >
-                    Open Apply Review
-                  </Link>
-                </Button>
-                <Button asChild size="sm" variant="outline">
-                  <Link
-                    aria-label={`Open evidence map for ${detail.job.title}`}
-                    search={{ q: "", entry: "", job: detail.job.jobKey }}
-                    to="/evidence-map"
-                  >
-                    Evidence map
-                  </Link>
-                </Button>
-              </div>
-            </div>
-          }
-          inspector={
-            <div className="job-detail-workspace__inspector">
-              <Section title="Preparation diagnostics">
-                <StageTimeline
-                  jobId={detail.job.jobKey}
-                  stages={preparationStages(detail.stages)}
-                />
-              </Section>
-              <Section title="Active artifacts">
-                {detail.artifacts.length ? (
-                  detail.artifacts.map((artifact) => (
-                    <div className="mini-row" key={artifact.artifactId}>
-                      <ArtifactStatusBadge status={artifact.status} />
-                      <span>{artifact.type}</span>
-                      <code>{artifact.localPath}</code>
-                      <OpenArtifactButton
-                        artifactId={artifact.artifactId}
-                        disabled={artifact.status === "missing"}
-                      />
-                    </div>
-                  ))
-                ) : (
-                  <Empty title="No active apply-ready artifacts." />
-                )}
-              </Section>
-              <Section title="Apply history">
-                <ApplyHistory jobId={detail.job.jobKey} />
-              </Section>
-              <Section title="Application outcomes">
-                <JobOutcomePanel jobId={detail.job.jobKey} />
-              </Section>
-              <JobContactsPanel
-                jobId={detail.job.jobKey}
-                {...(detail.job.company ? { employer: detail.job.company } : {})}
-              />
-              <JobAuditHistorySection entries={detail.auditHistory} />
-            </div>
-          }
-        >
-          <div className="job-detail-workspace__content">
-            <JobAuditTriage detail={detail} />
-            <CompensationAuditSection
-              jobId={detail.job.jobKey}
-              summary={detail.job.compensationSummary}
-              audit={detail.compensationAudit}
-              fallbackSalary={detail.job.salary}
-            />
-            <Section title="Description" className="job-detail-description">
-              <JobDescription text={detail.job.descriptionPreview} />
-            </Section>
-            {detail.employerAnalysis && !detail.requirementFitReport ? (
-              <RequirementFitMissingCallout jobId={detail.job.jobKey} />
-            ) : null}
-            <EmployerAnalysisPanel
-              analysis={detail.employerAnalysis}
-              className="section job-detail-role-analysis"
-              requirementFitReport={detail.requirementFitReport}
-            />
-            <InterviewPrepPanel
-              jobId={detail.job.jobKey}
-              prep={detail.interviewPrep}
-              reflectionContent={
-                detail.interviewPrep ? (
-                  <InterviewReflectionPanel
+        <SectionTabs defaultValue="overview" className="job-detail-tabs">
+          <RouteWorkspace
+            aria-label="Job details"
+            className="job-detail-workspace"
+            contentLabel="Job evidence and analysis"
+            inspectorLabel="Job progress and audit history"
+            header={
+              <div className="job-detail-workspace__header">
+                <JobOverview detail={detail} />
+                <div className="job-detail-top-actions">
+                  <JobActions
                     jobId={detail.job.jobKey}
-                    prepGeneration={detail.interviewPrep.generation}
+                    currentStage={detail.job.currentSubstage}
+                    canRetryStage={canRetryStage(currentSubstage)}
+                    canRunCurrentStage={canRunCurrentStage(currentSubstage)}
+                    canRetailor={detail.artifacts.length > 0}
+                    applyApprovalRequired={applyApprovalRequired}
                   />
-                ) : null
-              }
-            />
-          </div>
-        </RouteWorkspace>
+                  <Button asChild size="sm" variant="outline">
+                    <Link
+                      aria-label={`Open Apply Review for ${detail.job.title}`}
+                      search={{ jobKey: detail.job.jobKey }}
+                      to="/apply-review"
+                    >
+                      Open Apply Review
+                    </Link>
+                  </Button>
+                  <Button asChild size="sm" variant="outline">
+                    <Link
+                      aria-label={`Open evidence map for ${detail.job.title}`}
+                      search={{ q: "", entry: "", job: detail.job.jobKey }}
+                      to="/evidence-map"
+                    >
+                      Evidence map
+                    </Link>
+                  </Button>
+                </div>
+                <JobSummaryLedger detail={detail} />
+              </div>
+            }
+            tabs={
+              <SectionTabsList aria-label="Job detail sections">
+                <TabsTrigger value="overview">Overview</TabsTrigger>
+                <TabsTrigger value="fit-evidence">Fit &amp; evidence</TabsTrigger>
+                <TabsTrigger value="materials">Materials</TabsTrigger>
+                <TabsTrigger value="activity">Activity</TabsTrigger>
+              </SectionTabsList>
+            }
+            inspector={
+              <div className="job-detail-workspace__inspector">
+                <Section title="Preparation diagnostics">
+                  <StageTimeline
+                    jobId={detail.job.jobKey}
+                    stages={preparationStages(detail.stages)}
+                  />
+                </Section>
+                <JobAuditHistorySection entries={detail.auditHistory} />
+              </div>
+            }
+          >
+            <TabsContent value="overview" className="job-detail-workspace__tab-panel">
+              <div className="job-detail-workspace__content">
+                <Section
+                  title="About the role"
+                  description="Original job description"
+                  className="job-detail-description"
+                >
+                  <JobDescription text={detail.job.descriptionPreview} />
+                </Section>
+              </div>
+            </TabsContent>
+            <TabsContent value="fit-evidence" className="job-detail-workspace__tab-panel">
+              <div className="job-detail-workspace__content">
+                <JobAuditTriage detail={detail} />
+                <CompensationAuditSection
+                  jobId={detail.job.jobKey}
+                  summary={detail.job.compensationSummary}
+                  audit={detail.compensationAudit}
+                  fallbackSalary={detail.job.salary}
+                />
+                {detail.employerAnalysis && !detail.requirementFitReport ? (
+                  <RequirementFitMissingCallout jobId={detail.job.jobKey} />
+                ) : null}
+                <EmployerAnalysisPanel
+                  analysis={detail.employerAnalysis}
+                  className="section job-detail-role-analysis"
+                  requirementFitReport={detail.requirementFitReport}
+                />
+              </div>
+            </TabsContent>
+            <TabsContent value="materials" className="job-detail-workspace__tab-panel">
+              <div className="job-detail-workspace__content">
+                <Section
+                  title="Before you apply"
+                  description="Active artifacts and required material"
+                  className="job-detail-before-apply"
+                >
+                  {detail.artifacts.length ? (
+                    detail.artifacts.map((artifact) => (
+                      <div className="mini-row" key={artifact.artifactId}>
+                        <ArtifactStatusBadge status={artifact.status} />
+                        <span>{artifact.type}</span>
+                        <code>{artifact.localPath}</code>
+                        <OpenArtifactButton
+                          artifactId={artifact.artifactId}
+                          disabled={artifact.status === "missing"}
+                        />
+                      </div>
+                    ))
+                  ) : (
+                    <Empty title="No active apply-ready artifacts." />
+                  )}
+                </Section>
+                <InterviewPrepPanel
+                  jobId={detail.job.jobKey}
+                  prep={detail.interviewPrep}
+                  reflectionContent={
+                    detail.interviewPrep ? (
+                      <InterviewReflectionPanel
+                        jobId={detail.job.jobKey}
+                        prepGeneration={detail.interviewPrep.generation}
+                      />
+                    ) : null
+                  }
+                />
+              </div>
+            </TabsContent>
+            <TabsContent value="activity" className="job-detail-workspace__tab-panel">
+              <div className="job-detail-workspace__content">
+                <Section title="Apply history">
+                  <ApplyHistory jobId={detail.job.jobKey} />
+                </Section>
+                <Section title="Application outcomes">
+                  <JobOutcomePanel jobId={detail.job.jobKey} />
+                </Section>
+                <JobContactsPanel
+                  jobId={detail.job.jobKey}
+                  {...(detail.job.company ? { employer: detail.job.company } : {})}
+                />
+              </div>
+            </TabsContent>
+          </RouteWorkspace>
+        </SectionTabs>
       ) : null}
     </div>
   );

--- a/apps/web/src/views/jobs/JobOverview.test.tsx
+++ b/apps/web/src/views/jobs/JobOverview.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { makeJobDetail, sampleJob } from "../../test/fixtures/projections.js";
-import { JobOverview } from "./JobOverview.js";
+import { JobOverview, JobSummaryLedger } from "./JobOverview.js";
 
 describe("<JobOverview>", () => {
   it("shows separate discovery and posting owner provenance", () => {
@@ -21,5 +21,29 @@ describe("<JobOverview>", () => {
     expect(
       screen.getByText("Acme Corp · posting: greenhouse:acme · discovered via: jobspy:linkedin"),
     ).toBeInTheDocument();
+  });
+
+  it("keeps fit, readiness, compensation, and stage in the summary ledger", () => {
+    render(
+      <JobSummaryLedger
+        detail={makeJobDetail({
+          ...sampleJob,
+          fitScore: 8,
+          salary: "EUR 110,000-140,000/year",
+          currentStage: "discover",
+          currentSubstage: "enrich",
+          postingSource: "greenhouse:acme",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Fit")).toBeInTheDocument();
+    expect(screen.getByText("8/10")).toBeInTheDocument();
+    expect(screen.getByText("Readiness")).toBeInTheDocument();
+    expect(screen.getByText("Compensation")).toBeInTheDocument();
+    expect(screen.getByText("EUR 110,000-140,000/year")).toBeInTheDocument();
+    expect(screen.getByText("Current stage")).toBeInTheDocument();
+    expect(screen.getByText("enrich")).toBeInTheDocument();
+    expect(screen.getByText("via greenhouse:acme")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -11,19 +11,29 @@ function auditTone(state: JobDetail["applyAudit"]["state"]): "ok" | "info" | "wa
   return "warn";
 }
 
+function formatStage(stage: string): string {
+  return stage.replaceAll("_", " ");
+}
+
 export function JobOverview({ detail }: JobOverviewProps) {
   const { applyAudit, job } = detail;
   return (
     <div className="job-overview">
-      <ScoreBadge score={job.fitScore} />
-      <span>
-        <small>
+      <div
+        className="job-overview__fit"
+        aria-label={`Fit score ${job.fitScore ?? "not scored"} out of 10`}
+      >
+        <ScoreBadge score={job.fitScore} />
+        <span>Fit</span>
+      </div>
+      <div className="job-overview__identity">
+        <small className="job-overview__company">
           {job.company}
           {job.postingSource ? ` · posting: ${job.postingSource}` : ""}
           {job.discoverySource ? ` · discovered via: ${job.discoverySource}` : ""}
         </small>
         <h1>{job.title}</h1>
-        <p>
+        <p className="job-overview__metadata">
           {job.location || "-"} · {job.salary || "-"}
         </p>
         <a className="external-link" href={job.url} rel="noreferrer" target="_blank">
@@ -31,11 +41,58 @@ export function JobOverview({ detail }: JobOverviewProps) {
         </a>
         <div className="job-overview-readiness" aria-label="Apply readiness">
           <span className="job-overview-readiness-label">Apply readiness</span>
-          <span className={`tag ${auditTone(applyAudit.state)}`} title={applyAudit.summary}>
+          <span
+            className={`job-overview-readiness-value job-overview-readiness-value--${auditTone(
+              applyAudit.state,
+            )}`}
+            title={applyAudit.summary}
+          >
             {applyAudit.label}
           </span>
         </div>
-      </span>
+      </div>
     </div>
+  );
+}
+
+export function JobSummaryLedger({ detail }: JobOverviewProps) {
+  const { applyAudit, job } = detail;
+  const readinessTone = auditTone(applyAudit.state);
+  const currentStage = formatStage(job.currentSubstage || job.currentStage);
+  const source = job.postingSource || job.discoverySource;
+
+  return (
+    <dl className="job-summary-ledger" aria-label="Job summary">
+      <div>
+        <dt>Fit</dt>
+        <dd>
+          <b>{job.fitScore === null ? "Not scored" : `${job.fitScore}/10`}</b>
+          <span>{job.scoreBreakdown?.fitBand || "Current score"}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Readiness</dt>
+        <dd>
+          <b className={`job-summary-ledger__status job-summary-ledger__status--${readinessTone}`}>
+            {applyAudit.label}
+          </b>
+          <span>{applyAudit.summary}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Compensation</dt>
+        <dd>
+          <b>{job.salary || "Not published"}</b>
+          <span>{job.salary ? "Published range" : "No published range"}</span>
+        </dd>
+      </div>
+      <div>
+        <dt>Current stage</dt>
+        <dd>
+          <b>{currentStage}</b>
+          <span>{source ? `via ${source}` : "Source not recorded"}</span>
+        </dd>
+      </div>
+    </dl>
   );
 }

--- a/apps/web/src/views/jobs/JobsView.test.tsx
+++ b/apps/web/src/views/jobs/JobsView.test.tsx
@@ -138,6 +138,9 @@ describe("<JobsRoute> loader reliability", () => {
 
     expect(await screen.findByText("api offline")).toBeInTheDocument();
     expect(screen.getByText("Jobs table")).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Jobs data index" }),
+    ).toHaveClass("jobs-index-sheet");
     expect(screen.queryByText("Something went wrong!")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -675,9 +675,17 @@ export function JobsView() {
           <PageHead
             eyebrow="Pipeline"
             title="Jobs"
-            subtitle={data ? `${data.pagination.total} total` : "loading"}
+            subtitle={
+              data
+                ? `${data.pagination.total} total · Triage the queue, then open a job for evidence-level review.`
+                : "Loading the current queue."
+            }
           />
-          <section className="card full data-surface">
+          <section
+            aria-busy={isFetching}
+            aria-label="Jobs data index"
+            className="card full data-surface jobs-index-sheet"
+          >
             {message ? <div className="banner inline">{message}</div> : null}
             <JobBulkActions
               search={search}

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.test.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.test.tsx
@@ -15,8 +15,9 @@ describe("<OutreachDetailDrawer>", () => {
     await waitFor(() =>
       expect(view.getByRole("heading", { name: "Dana Reyes" })).toBeInTheDocument(),
     );
-    // Phase 1 facts + provenance remain.
+    await user.click(view.getByRole("tab", { name: "Provenance" }));
     expect(view.getByText("dana.reyes@acme.example")).toBeInTheDocument();
+    await user.click(view.getByRole("tab", { name: "Outreach" }));
     // Phase 3 outreach thread panel is composed into the drawer (contact-only thread).
     await waitFor(() =>
       expect(view.getByRole("heading", { name: "Outreach" })).toBeInTheDocument(),

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
@@ -12,6 +12,8 @@ import { Button, buttonVariants } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../../shared/ui/tabs.js";
 
 export interface OutreachDetailDrawerProps {
   contactId: string;
@@ -25,67 +27,137 @@ function detailErrorTitle(error: unknown): string {
   return error instanceof Error ? error.message : "";
 }
 
-export function OutreachDetailDrawer({ contactId, onClose }: OutreachDetailDrawerProps) {
+export function OutreachDetailDrawer({
+  contactId,
+  onClose,
+}: OutreachDetailDrawerProps) {
   const { data, error } = useContactDetailQuery(contactId);
   const errorMessage = detailErrorTitle(error);
   const contact = data?.contact;
+  const stateTitle = errorMessage || "Loading contact.";
 
   return (
-    <div className="route-page route-page--contact-detail" aria-label="Contact details">
-      {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
-      {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}
+    <div
+      className="route-page route-page--contact-detail"
+      aria-label="Contact details"
+    >
+      {!contact ? (
+        <section className="detail-route-state" aria-label="Contact state">
+          <Button
+            aria-label="Back to contacts"
+            className="workspace-back"
+            size="sm"
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+          >
+            <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+            Contacts
+          </Button>
+          <Empty title={stateTitle} />
+        </section>
+      ) : null}
       {contact ? (
-        <RouteWorkspace
-          aria-label="Contact details"
-          className="contact-detail-workspace"
-          contentLabel="Outreach thread"
-          inspectorLabel="Contact facts and provenance"
-          header={
-            <div className="contact-detail-workspace__header">
-              <Button
-                aria-label="Back to contacts"
-                className="workspace-back"
-                size="sm"
-                type="button"
-                variant="ghost"
-                onClick={onClose}
-              >
-                <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                Contacts
-              </Button>
-              <span>
-                <ContactRoleBadge role={contact.role} />
-              </span>
-              <div className="contact-detail-workspace__title">
-                <small>{contact.employer ?? "No employer"}</small>
-                <h1>{contact.displayName}</h1>
-                <p>
-                  {contact.jobId ? `Linked job ${contact.jobId}` : "Not linked to a job"} · updated{" "}
-                  {formatDateTime(contact.updatedAt)}
-                </p>
+        <SectionTabs className="contact-detail-tabs" defaultValue="outreach">
+          <RouteWorkspace
+            aria-label="Contact details"
+            className="contact-detail-workspace"
+            contentLabel="Contact workspace panels"
+            inspectorLabel="Contact summary"
+            tabs={
+              <nav aria-label="Contact detail panels">
+                <SectionTabsList>
+                  <TabsTrigger value="outreach">Outreach</TabsTrigger>
+                  <TabsTrigger value="provenance">Provenance</TabsTrigger>
+                </SectionTabsList>
+              </nav>
+            }
+            header={
+              <div className="contact-detail-workspace__header">
+                <Button
+                  aria-label="Back to contacts"
+                  className="workspace-back"
+                  size="sm"
+                  type="button"
+                  variant="ghost"
+                  onClick={onClose}
+                >
+                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                  Contacts
+                </Button>
+                <span className="contact-detail-workspace__status">
+                  <ContactRoleBadge role={contact.role} />
+                </span>
+                <div className="contact-detail-workspace__title">
+                  <small>{contact.employer ?? "No employer"}</small>
+                  <h1>{contact.displayName}</h1>
+                  <p>
+                    {contact.jobId
+                      ? `Linked job ${contact.jobId}`
+                      : "Not linked to a job"}{" "}
+                    · updated {formatDateTime(contact.updatedAt)}
+                  </p>
+                </div>
+                <div className="contact-detail-actions">
+                  <ContactEditButton
+                    contact={contact}
+                    className={buttonVariants({ size: "sm", variant: "outline" })}
+                  />
+                  <ContactDeleteButton
+                    className={buttonVariants({
+                      size: "sm",
+                      variant: "destructive",
+                    })}
+                    contactId={contact.contactId}
+                    displayName={contact.displayName}
+                    onDeleted={onClose}
+                  />
+                </div>
               </div>
-              <div className="contact-detail-actions">
-                <ContactEditButton
-                  contact={contact}
-                  className={buttonVariants({ size: "sm", variant: "outline" })}
-                />
-                <ContactDeleteButton
-                  className={buttonVariants({ size: "sm", variant: "destructive" })}
-                  contactId={contact.contactId}
-                  displayName={contact.displayName}
-                  onDeleted={onClose}
-                />
+            }
+            inspector={
+              <div className="contact-detail-workspace__inspector">
+                <Section title="Contact summary">
+                  <dl className="detail-list">
+                    <div>
+                      <dt>Role</dt>
+                      <dd>{contact.role || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Employer</dt>
+                      <dd>{contact.employer || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Job</dt>
+                      <dd>{contact.jobId || "-"}</dd>
+                    </div>
+                    <div>
+                      <dt>Updated</dt>
+                      <dd>{formatDateTime(contact.updatedAt)}</dd>
+                    </div>
+                  </dl>
+                </Section>
               </div>
-            </div>
-          }
-          inspector={
-            <Section title="Facts and provenance">
-              <ContactProvenanceList attributes={contact.attributes} />
-            </Section>
-          }
-        >
-          <OutreachThreadPanel contactId={contact.contactId} />
-        </RouteWorkspace>
+            }
+          >
+            <TabsContent
+              className="contact-detail-workspace__panel"
+              forceMount
+              value="outreach"
+            >
+              <OutreachThreadPanel contactId={contact.contactId} />
+            </TabsContent>
+            <TabsContent
+              className="contact-detail-workspace__panel"
+              forceMount
+              value="provenance"
+            >
+              <Section title="Facts and provenance">
+                <ContactProvenanceList attributes={contact.attributes} />
+              </Section>
+            </TabsContent>
+          </RouteWorkspace>
+        </SectionTabs>
       ) : null}
     </div>
   );

--- a/apps/web/src/views/outreach/OutreachView.tsx
+++ b/apps/web/src/views/outreach/OutreachView.tsx
@@ -1,4 +1,9 @@
-import { Outlet, useNavigate, useRouterState, useSearch } from "@tanstack/react-router";
+import {
+  Outlet,
+  useNavigate,
+  useRouterState,
+  useSearch,
+} from "@tanstack/react-router";
 
 import { ContactCreateButton } from "../../contexts/outreach/components/ContactCreateButton.js";
 import { ContactImportButton } from "../../contexts/outreach/components/ContactImportButton.js";
@@ -9,6 +14,7 @@ import {
   type ContactsListFilters,
 } from "../../contexts/outreach/hooks/useContactsListQuery.js";
 import type { OutreachSearch } from "../../routes/-outreach.search.js";
+import { buttonVariants } from "../../shared/ui/button.js";
 import { Input } from "../../shared/ui/input.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 import { ToolRow } from "../../shared/ui/tool-row.js";
@@ -30,7 +36,8 @@ export function OutreachView() {
   const navigate = useNavigate({ from: "/outreach" });
   const showingDetail = useRouterState({
     select: (state) =>
-      state.location.pathname !== "/outreach" && state.location.pathname !== "/outreach/",
+      state.location.pathname !== "/outreach" &&
+      state.location.pathname !== "/outreach/",
   });
 
   const { data, isFetching, error } = useContactsListQuery(listFilters(search));
@@ -41,17 +48,40 @@ export function OutreachView() {
   };
 
   return (
-    <div className="route-page route-page--outreach">
+    <div className="route-page route-page--outreach editorial-index-page">
       {!showingDetail ? (
         <>
           <PageHead
+            className="editorial-page-head"
             eyebrow="Library"
             title="Contacts"
-            subtitle={data ? `${data.items.length} shown` : "loading"}
-            actions={<DueFollowUpsBadge />}
+            subtitle={
+              <>
+                <span>
+                  Grounded relationship context and user-sent outreach—never an
+                  autonomous messaging queue.
+                </span>
+                <span className="page-head-count">
+                  {data ? `${data.items.length} shown` : "loading"}
+                </span>
+              </>
+            }
+            actions={
+              <>
+                <DueFollowUpsBadge />
+                <ContactImportButton
+                  className={buttonVariants({ size: "sm", variant: "outline" })}
+                  label="Import"
+                />
+                <ContactCreateButton
+                  className={buttonVariants({ size: "sm", variant: "default" })}
+                  label="New contact"
+                />
+              </>
+            }
           />
           <DueFollowUpsPanel />
-          <section className="card full data-surface">
+          <section className="card full data-surface editorial-data-surface">
             {message ? <div className="banner inline">{message}</div> : null}
             <ToolRow
               className="data-surface__tools"
@@ -62,7 +92,9 @@ export function OutreachView() {
                     <Input
                       value={search.employer}
                       placeholder="Filter by employer"
-                      onChange={(event) => setSearch({ employer: event.target.value })}
+                      onChange={(event) =>
+                        setSearch({ employer: event.target.value })
+                      }
                     />
                   </label>
                   <label className="field compact tool-row__field">
@@ -70,15 +102,11 @@ export function OutreachView() {
                     <Input
                       value={search.jobId}
                       placeholder="Filter by job id"
-                      onChange={(event) => setSearch({ jobId: event.target.value })}
+                      onChange={(event) =>
+                        setSearch({ jobId: event.target.value })
+                      }
                     />
                   </label>
-                </>
-              }
-              secondary={
-                <>
-                  <ContactCreateButton />
-                  <ContactImportButton />
                 </>
               }
             />

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -63,6 +63,27 @@ describe("PipelinesView", () => {
     expect(screen.getAllByRole("table")).toHaveLength(3);
   });
 
+  it("keeps table rows scannable while preserving the complete operational basis in disclosures", async () => {
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
+
+    const currentExecution = screen.getByRole("heading", { name: "Current execution" }).closest("section");
+    if (!currentExecution) {
+      throw new Error("Expected current execution stage ledger.");
+    }
+
+    const planSources = within(currentExecution).getByRole("row", { name: /Plan sources/i });
+    const scopedSummary = within(planSources).getByLabelText("Plan sources scoped outcomes summary");
+
+    expect(scopedSummary).toHaveTextContent("Eligible");
+    expect(scopedSummary).toHaveTextContent("Succeeded");
+    expect(scopedSummary).not.toHaveTextContent("Blocked");
+    expect(within(planSources).getByText("All 12 outcomes")).toBeInTheDocument();
+    expect(within(planSources).getByText("Estimate basis")).toBeInTheDocument();
+    expect(within(planSources).getAllByText("Needs verification")).toHaveLength(2);
+    expect(within(planSources).getByText("Caveat")).toBeInTheDocument();
+    expect(within(planSources).getByText("Capacity details")).toBeInTheDocument();
+  });
+
   it("keeps the three source families separate from the two reconciliation steps", async () => {
     await renderPipelineOperations(pipelinesThreeSourceSixStepSnapshot);
 
@@ -104,7 +125,7 @@ describe("PipelinesView", () => {
   it("reports active inventory truth and multi-worker internal concurrency", async () => {
     await renderPipelineOperations(pipelinesMultiWorkerCapacitySnapshot);
 
-    const activeWork = screen.getByText("Active work").closest(".disclosure-section");
+    const activeWork = screen.getByText("Active work").closest<HTMLElement>(".disclosure-section");
     if (!activeWork) {
       throw new Error("Expected the active-work disclosure.");
     }
@@ -119,6 +140,8 @@ describe("PipelinesView", () => {
     }
     expect(within(capacity).getByText("Internal concurrency")).toBeInTheDocument();
     expect(capacity).toHaveTextContent("3");
+    expect(within(capacity).getByRole("heading", { name: "Worker capacity" })).toBeInTheDocument();
+    expect(within(capacity).getByRole("heading", { name: "Task queue telemetry" })).toBeInTheDocument();
   });
 
   it("withholds URL-shaped job keys from the operations inspector", async () => {

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -107,6 +107,30 @@ function CountsFacts({ counts, className = "pipeline-stage-ledger__counts" }: {
   );
 }
 
+function StageStateSummary({
+  counts,
+  label,
+  emptyLabel,
+}: {
+  readonly counts: PipelineStageCounts;
+  readonly label: string;
+  readonly emptyLabel: string;
+}) {
+  const nonZeroFields = COUNT_FIELDS.filter(([field]) => counts[field] > 0);
+  return nonZeroFields.length > 0 ? (
+    <dl aria-label={label} className="pipeline-stage-ledger__summary">
+      {nonZeroFields.map(([field, fieldLabel]) => (
+        <div key={field}>
+          <dt>{fieldLabel}</dt>
+          <dd>{counts[field]}</dd>
+        </div>
+      ))}
+    </dl>
+  ) : (
+    <span className="pipeline-stage-ledger__empty-summary">{emptyLabel}</span>
+  );
+}
+
 function CohortFacts({ cohort }: { readonly cohort: PipelineExecutionCohortSummary }) {
   return (
     <InspectorLedger>
@@ -183,34 +207,40 @@ function TaskQueueFacts({ queue }: { readonly queue: PipelineApproximateTaskQueu
 function CapacityFacts({ capacity }: { readonly capacity: PipelineCapacity }) {
   return (
     <div className="pipeline-operations-capacity">
-      <InspectorLedger>
-        <InspectorLedgerItem label="Status" value={sentenceCase(capacity.status)} />
-        <InspectorLedgerItem label="Observed" value={formatDateTime(capacity.asOf)} />
-        <InspectorLedgerItem label="Stale after" value={`${capacity.staleAfterSeconds} sec`} />
-        <InspectorLedgerItem label="Task queue" value={capacity.taskQueue ?? "Not reported"} />
-        {capacity.status === "available" ? (
-          <>
-            <InspectorLedgerItem label="Pool" value={sentenceCase(capacity.kind)} />
-            <InspectorLedgerItem label="Fresh workers" value={capacity.freshWorkerCount} />
-            <InspectorLedgerItem label="Stale workers" value={capacity.staleWorkerCount} />
-            <InspectorLedgerItem label="Invalid workers" value={capacity.invalidWorkerCount} />
-            <InspectorLedgerItem label="Configured slots" value={capacity.configuredSlots} />
-            <InspectorLedgerItem label="Active slots" value={capacity.activeSlots} />
-            <InspectorLedgerItem label="Available slots" value={capacity.availableSlots} />
-            <InspectorLedgerItem label="Executor threads" value={capacity.executorThreads} />
-            <InspectorLedgerItem
-              label="Slot saturation"
-              value={capacity.slotSaturation === null ? "Not available" : `${Math.round(capacity.slotSaturation * 100)}%`}
-            />
-            {capacity.kind === "shared_activity_pool_with_internal_parallelism" ? (
-              <InspectorLedgerItem label="Internal concurrency" value={capacity.internalParallelism} />
-            ) : null}
-          </>
-        ) : (
-          <InspectorLedgerItem label="Reason" value={capacity.reason} />
-        )}
-      </InspectorLedger>
-      <TaskQueueFacts queue={capacity.approximateTaskQueue} />
+      <section aria-label="Worker capacity">
+        <h3>Worker capacity</h3>
+        <InspectorLedger>
+          <InspectorLedgerItem label="Status" value={sentenceCase(capacity.status)} />
+          <InspectorLedgerItem label="Observed" value={formatDateTime(capacity.asOf)} />
+          <InspectorLedgerItem label="Stale after" value={`${capacity.staleAfterSeconds} sec`} />
+          <InspectorLedgerItem label="Task queue" value={capacity.taskQueue ?? "Not reported"} />
+          {capacity.status === "available" ? (
+            <>
+              <InspectorLedgerItem label="Pool" value={sentenceCase(capacity.kind)} />
+              <InspectorLedgerItem label="Fresh workers" value={capacity.freshWorkerCount} />
+              <InspectorLedgerItem label="Stale workers" value={capacity.staleWorkerCount} />
+              <InspectorLedgerItem label="Invalid workers" value={capacity.invalidWorkerCount} />
+              <InspectorLedgerItem label="Configured slots" value={capacity.configuredSlots} />
+              <InspectorLedgerItem label="Active slots" value={capacity.activeSlots} />
+              <InspectorLedgerItem label="Available slots" value={capacity.availableSlots} />
+              <InspectorLedgerItem label="Executor threads" value={capacity.executorThreads} />
+              <InspectorLedgerItem
+                label="Slot saturation"
+                value={capacity.slotSaturation === null ? "Not available" : `${Math.round(capacity.slotSaturation * 100)}%`}
+              />
+              {capacity.kind === "shared_activity_pool_with_internal_parallelism" ? (
+                <InspectorLedgerItem label="Internal concurrency" value={capacity.internalParallelism} />
+              ) : null}
+            </>
+          ) : (
+            <InspectorLedgerItem label="Reason" value={capacity.reason} />
+          )}
+        </InspectorLedger>
+      </section>
+      <section aria-label="Task queue telemetry">
+        <h3>Task queue telemetry</h3>
+        <TaskQueueFacts queue={capacity.approximateTaskQueue} />
+      </section>
     </div>
   );
 }
@@ -295,10 +325,33 @@ function PipelineStageLedger({ snapshot }: { readonly snapshot: PipelineOperatio
                       <strong>{stage.label}</strong>
                       <small>{stage.stage}</small>
                     </th>
-                    <td><CountsFacts counts={stage.currentExecution} /></td>
+                    <td>
+                      <StageStateSummary
+                        counts={stage.currentExecution}
+                        emptyLabel="No scoped outcomes"
+                        label={`${stage.label} scoped outcomes summary`}
+                      />
+                      <details>
+                        <summary>All 12 outcomes</summary>
+                        <CountsFacts counts={stage.currentExecution} />
+                      </details>
+                    </td>
                     <td>
                       {stage.existingBacklog.kind === "domain_jobs" ? (
-                        <CountsFacts counts={stage.existingBacklog.counts} className="pipeline-stage-ledger__backlog" />
+                        <>
+                          <StageStateSummary
+                            counts={stage.existingBacklog.counts}
+                            emptyLabel="No existing backlog"
+                            label={`${stage.label} existing backlog summary`}
+                          />
+                          <details>
+                            <summary>All backlog states</summary>
+                            <CountsFacts
+                              counts={stage.existingBacklog.counts}
+                              className="pipeline-stage-ledger__backlog"
+                            />
+                          </details>
+                        </>
                       ) : (
                         <span>{sentenceCase(stage.existingBacklog.reason)}</span>
                       )}
@@ -312,7 +365,10 @@ function PipelineStageLedger({ snapshot }: { readonly snapshot: PipelineOperatio
                     </td>
                     <td>
                       <strong>{etaLabel(stage.eta)}</strong>
-                      <EtaFacts eta={stage.eta} label={`${stage.label} ETA details`} />
+                      <details>
+                        <summary>Estimate basis</summary>
+                        <EtaFacts eta={stage.eta} label={`${stage.label} ETA details`} />
+                      </details>
                     </td>
                     <td>{formatDateTime(stage.asOf)}</td>
                   </tr>

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -474,7 +474,11 @@ export function PipelinesView() {
   const message = operations.error instanceof Error ? operations.error.message : null;
   return (
     <div className="route-page route-page--pipelines">
-      <PageHead eyebrow="Pipeline" title="Pipelines" />
+      <PageHead
+        eyebrow="Pipeline"
+        title="Pipelines"
+        subtitle="Execution cohorts, stage backlogs, worker capacity, and completion estimates."
+      />
       {message ? <div className="banner" role="alert">Pipeline operations are unavailable: {message}</div> : null}
       {operations.data ? (
         <PipelineWorkspace snapshot={operations.data} />

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -45,7 +45,8 @@ export function RunsView() {
   const navigate = useNavigate({ from: "/runs" });
   const showingDetail = useRouterState({
     select: (state) =>
-      state.location.pathname !== "/runs" && state.location.pathname !== "/runs/",
+      state.location.pathname !== "/runs" &&
+      state.location.pathname !== "/runs/",
   });
   const { data, isFetching, error } = useWorkflowRunsListQuery(
     workflowRunsInput(search),
@@ -83,15 +84,26 @@ export function RunsView() {
   };
 
   return (
-    <div className="route-page route-page--runs">
+    <div className="route-page route-page--runs editorial-index-page">
       {!showingDetail ? (
         <>
           <PageHead
+            className="editorial-page-head"
             eyebrow="Activity"
             title="Workflow runs"
-            subtitle={data ? `${data.pagination.total} total` : "loading"}
+            subtitle={
+              <>
+                <span>
+                  Every workflow execution, its lifecycle, and the product
+                  object it changed.
+                </span>
+                <span className="page-head-count">
+                  {data ? `${data.pagination.total} total` : "loading"}
+                </span>
+              </>
+            }
           />
-          <section className="card full data-surface">
+          <section className="card full data-surface editorial-data-surface">
             {message ? <div className="banner inline">{message}</div> : null}
             <RunsFilterBar
               status={search.status}

--- a/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.test.tsx
@@ -7,6 +7,7 @@ import {
   RouterProvider,
 } from "@tanstack/react-router";
 import { render, screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { runsSearchSchema } from "../../routes/-runs.search.js";
@@ -37,6 +38,7 @@ function buildRouter() {
 
 describe("<WorkflowRunDrawer>", () => {
   it("renders the run as a route workspace without dropping detail or failure facts", async () => {
+    const user = userEvent.setup();
     const harness = buildProviderHarness();
     const router = buildRouter();
     render(<RouterProvider router={router} />, { wrapper: harness.Wrapper });
@@ -59,8 +61,10 @@ describe("<WorkflowRunDrawer>", () => {
     expect(within(workspace).getAllByText("failed").length).toBeGreaterThan(0);
     expect(within(workspace).getByText("run-pipeline-1")).toBeInTheDocument();
     expect(within(workspace).getByText("temporal-run-1")).toBeInTheDocument();
+    await user.click(within(workspace).getByRole("tab", { name: "Diagnostics" }));
     expect(within(workspace).getByText("activity_error")).toBeInTheDocument();
     expect(within(workspace).getByText("yes")).toBeInTheDocument();
+    await user.click(within(workspace).getByRole("tab", { name: "Timeline" }));
     expect(within(workspace).getByText("WorkflowStarted")).toBeInTheDocument();
     expect(within(workspace).getByText("WorkflowFailed")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -1,4 +1,4 @@
-import { IconArrowLeft } from "@tabler/icons-react";
+import { IconArrowLeft, IconExternalLink } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
 import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
@@ -8,6 +8,9 @@ import { Button } from "../../shared/ui/button.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RouteWorkspace } from "../../shared/ui/route-workspace.js";
 import { Section } from "../../shared/ui/section.js";
+import { SectionTabs, SectionTabsList } from "../../shared/ui/section-tabs.js";
+import { TabsContent, TabsTrigger } from "../../shared/ui/tabs.js";
+import { temporalWebUiWorkflowUrl } from "./temporal-web-ui.js";
 
 export interface WorkflowRunDrawerProps {
   runId: string;
@@ -22,43 +25,122 @@ export interface WorkflowRunDrawerProps {
 export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
   const { data: run, isLoading, error } = useWorkflowRunDetailQuery(runId);
   const message = error instanceof Error ? error.message : null;
-  const notFound = !isLoading && !message && !run;
+  const stateTitle = message
+    ? message
+    : isLoading
+      ? "Loading workflow run."
+      : "Workflow run not found.";
 
   return (
     <div
       className="route-page route-page--workflow-run-detail"
       aria-label="Workflow run details"
     >
-      {message ? <Empty title={message} /> : null}
-      {!message && isLoading ? <Empty title="Loading workflow run." /> : null}
-      {notFound ? <Empty title="Workflow run not found." /> : null}
+      {!run ? (
+        <section className="detail-route-state" aria-label="Workflow run state">
+          <Button asChild className="workspace-back" size="sm" variant="ghost">
+            <Link
+              aria-label="Back to workflow runs"
+              search={(prev) => prev}
+              to="/runs"
+            >
+              <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+              Runs
+            </Link>
+          </Button>
+          <Empty title={stateTitle} />
+        </section>
+      ) : null}
       {run ? (
-        <RouteWorkspace
-          aria-label="Workflow run details"
-          className="workflow-run-workspace"
-          contentLabel="Workflow run timeline"
-          inspectorLabel="Workflow run facts and failure details"
-          header={
-            <div className="workflow-run-workspace__header">
-              <Button asChild className="workspace-back" size="sm" variant="ghost">
-                <Link aria-label="Back to workflow runs" search={(prev) => prev} to="/runs">
-                  <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
-                  Runs
-                </Link>
-              </Button>
-              <RunStatusBadge status={run.status} />
-              <div className="workflow-run-workspace__title">
-                <small>{run.workflowType || "workflow"}</small>
-                <h1>{run.title || run.workflowType || "Workflow run"}</h1>
-                <p>
-                  {run.status}
-                  {run.dryRun ? " · dry-run" : ""}
-                </p>
+        <SectionTabs className="workflow-run-tabs" defaultValue="summary">
+          <RouteWorkspace
+            aria-label="Workflow run details"
+            className="workflow-run-workspace"
+            contentLabel="Workflow run workspace panels"
+            inspectorLabel="Workflow run identity"
+            tabs={
+              <nav aria-label="Workflow run detail panels">
+                <SectionTabsList>
+                  <TabsTrigger value="summary">Summary</TabsTrigger>
+                  <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                  <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
+                </SectionTabsList>
+              </nav>
+            }
+            header={
+              <div className="workflow-run-workspace__header">
+                <Button
+                  asChild
+                  className="workspace-back"
+                  size="sm"
+                  variant="ghost"
+                >
+                  <Link
+                    aria-label="Back to workflow runs"
+                    search={(prev) => prev}
+                    to="/runs"
+                  >
+                    <IconArrowLeft aria-hidden="true" size={16} stroke={1.9} />
+                    Runs
+                  </Link>
+                </Button>
+                <span className="workflow-run-workspace__status">
+                  <RunStatusBadge status={run.status} />
+                </span>
+                <div className="workflow-run-workspace__title">
+                  <small>{run.workflowType || "workflow"}</small>
+                  <h1>{run.title || run.workflowType || "Workflow run"}</h1>
+                  <p>
+                    {run.status}
+                    {run.dryRun ? " · dry-run" : ""}
+                  </p>
+                </div>
+                <div className="workflow-run-workspace__actions">
+                  <Button asChild size="sm" variant="outline">
+                    <a
+                      href={temporalWebUiWorkflowUrl(run.workflowId)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <IconExternalLink
+                        aria-hidden="true"
+                        size={15}
+                        stroke={1.8}
+                      />
+                      Open in Temporal
+                    </a>
+                  </Button>
+                </div>
               </div>
-            </div>
-          }
-          inspector={
-            <div className="workflow-run-workspace__inspector">
+            }
+            inspector={
+              <div className="workflow-run-workspace__inspector">
+                <Section title="Run identity">
+                  <dl className="detail-list">
+                    <div>
+                      <dt>Workflow id</dt>
+                      <dd className="mono">{run.workflowId}</dd>
+                    </div>
+                    <div>
+                      <dt>Status</dt>
+                      <dd>{run.status}</dd>
+                    </div>
+                    {run.temporalRunId ? (
+                      <div>
+                        <dt>Temporal run id</dt>
+                        <dd className="mono">{run.temporalRunId}</dd>
+                      </div>
+                    ) : null}
+                  </dl>
+                </Section>
+              </div>
+            }
+          >
+            <TabsContent
+              className="workflow-run-workspace__panel"
+              forceMount
+              value="summary"
+            >
               <Section title="Run details">
                 <dl className="detail-list">
                   <div>
@@ -97,6 +179,39 @@ export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
                   ) : null}
                 </dl>
               </Section>
+            </TabsContent>
+            <TabsContent
+              className="workflow-run-workspace__panel"
+              forceMount
+              value="timeline"
+            >
+              <Section
+                className="workflow-run-workspace__timeline"
+                title="Timeline"
+              >
+                {run.events.length === 0 ? (
+                  <Empty title="No lifecycle events recorded yet." />
+                ) : (
+                  <ol className="timeline">
+                    {run.events.map((event, index) => (
+                      <li key={`${event.eventType}-${index}`}>
+                        <span className="mono">{event.eventType}</span>
+                        <span className="muted">
+                          {" "}
+                          {formatDateTime(event.occurredAt)}
+                        </span>
+                        {event.message ? <p>{event.message}</p> : null}
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </Section>
+            </TabsContent>
+            <TabsContent
+              className="workflow-run-workspace__panel"
+              forceMount
+              value="diagnostics"
+            >
               {run.errorMessage || run.errorCode ? (
                 <Section title="Failure">
                   <dl className="detail-list">
@@ -118,29 +233,12 @@ export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
                     </div>
                   </dl>
                 </Section>
-              ) : null}
-            </div>
-          }
-        >
-          <Section className="workflow-run-workspace__timeline" title="Timeline">
-            {run.events.length === 0 ? (
-              <Empty title="No lifecycle events recorded yet." />
-            ) : (
-              <ol className="timeline">
-                {run.events.map((event, index) => (
-                  <li key={`${event.eventType}-${index}`}>
-                    <span className="mono">{event.eventType}</span>
-                    <span className="muted">
-                      {" "}
-                      {formatDateTime(event.occurredAt)}
-                    </span>
-                    {event.message ? <p>{event.message}</p> : null}
-                  </li>
-                ))}
-              </ol>
-            )}
-          </Section>
-        </RouteWorkspace>
+              ) : (
+                <Empty title="No failure diagnostics recorded." />
+              )}
+            </TabsContent>
+          </RouteWorkspace>
+        </SectionTabs>
       ) : null}
     </div>
   );

--- a/apps/web/src/views/runs/columns.tsx
+++ b/apps/web/src/views/runs/columns.tsx
@@ -62,12 +62,11 @@ export const workflowRunColumns: Array<DataGridColumn<WorkflowRunSummary>> = [
     label: "Mode",
     sortable: true,
     getFilterValue: (row) => (row.dryRun ? "dry-run" : "live"),
-    render: (row) =>
-      row.dryRun ? (
-        <span className="tag info">dry-run</span>
-      ) : (
-        <span>live</span>
-      ),
+    render: (row) => (
+      <span className="run-mode-label mono">
+        {row.dryRun ? "dry-run" : "live"}
+      </span>
+    ),
   },
   {
     id: "started_at",
@@ -81,9 +80,7 @@ export const workflowRunColumns: Array<DataGridColumn<WorkflowRunSummary>> = [
     label: "Duration",
     sortable: true,
     getFilterValue: (row) => formatDurationMs(row.durationMs),
-    render: (row) => (
-      <span>{formatDurationMs(row.durationMs)}</span>
-    ),
+    render: (row) => <span>{formatDurationMs(row.durationMs)}</span>,
   },
   {
     id: "finished_at",

--- a/apps/web/test/types/semantic-parity-manifest.test-d.ts
+++ b/apps/web/test/types/semantic-parity-manifest.test-d.ts
@@ -1,0 +1,18 @@
+import type { FileRoutesByFullPath } from "../../src/routeTree.gen.js";
+import {
+  PRODUCTION_SURFACE_ROUTE_PATHS,
+  type ProductionSurfaceRoutePath,
+} from "../../src/qa/semantic-parity-manifest.js";
+import { expectTypeOf, test } from "vitest";
+
+type RenderedProductionRoute = Exclude<
+  keyof FileRoutesByFullPath,
+  "/" | "/spikes/table-filters"
+>;
+
+test("semantic parity inventory remains exhaustive for the generated production router", () => {
+  expectTypeOf<ProductionSurfaceRoutePath>().toEqualTypeOf<RenderedProductionRoute>();
+  expectTypeOf<(typeof PRODUCTION_SURFACE_ROUTE_PATHS)[number]>().toEqualTypeOf<
+    RenderedProductionRoute
+  >();
+});


### PR DESCRIPTION
## Summary

- restores the approved editorial design language across shared primitives and every application archetype
- replaces rounded status capsules, nested datum cards, and broad semantic fills with ruled ledgers, tabs, disclosures, and dot-plus-text status labels
- turns job, artifact, contact, workflow, activity, profile, preference, discovery, and pipeline details into coherent full workspaces while retaining their complete data and control inventory
- improves responsive behavior for profile, evidence, discovery, and intrinsically wide pipeline tables
- records the production interface contract in `DESIGN.md`

## Why

The production-data parity pass preserved the right information but allowed the old card-and-pill grammar to reappear around it. That made the implementation diverge from the approved drafts even though the data was present. This change makes the drafts the visual contract and the existing application the semantic inventory: all fields and actions remain, but they are composed through the new system.

## Impact

The application now uses one consistent editorial hierarchy: neutral surfaces, one-pixel rules, square controls, underlined tabs, restrained semantic color, and persistent audit context. Existing controls remain reachable through visible primary actions, tabs, disclosures, or explicit overflow menus.

## Validation

- `git diff --check`
- inspected representative production-backed routes in the in-app browser, including Dashboard, Jobs, Job Detail, Artifacts, Evidence, Contacts, Runs, Debug, Discovery, Pipelines, Profile, Preferences, and Settings
- completed a static semantic-parity audit against the parent branch with no missing data points or actions found

The full automated, documentation, accessibility, and end-to-end QA matrix is intentionally deferred until the documentation PR at the end of this stack, as planned.