### PR TITLE
refactor(web): prepare Base UI migration

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "storybook:test": "start-server-and-test \"http-server ../../dist/web-storybook -p 6006 --silent\" http://127.0.0.1:6006 \"test-storybook --url http://127.0.0.1:6006\""
   },
   "dependencies": {
+    "@base-ui/react": "^1.6.0",
     "@fontsource-variable/jetbrains-mono": "5.2.8",
     "@fontsource-variable/plus-jakarta-sans": "5.2.8",
     "@jobctrl/api-client": "workspace:*",

--- a/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
+++ b/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
@@ -1,0 +1,162 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const globalsCssPath = resolve(sourceRoot, "styles/globals.css");
+const sourceExtensions = new Set([".ts", ".tsx"]);
+
+// Remove entries from this list as their wrappers migrate to Base UI.
+const radixWrapperAllowlist = new Set([
+  "shared/ui/button.tsx",
+  "shared/ui/checkbox.tsx",
+  "shared/ui/dialog.tsx",
+  "shared/ui/dropdown-menu.tsx",
+  "shared/ui/label.tsx",
+  "shared/ui/popover.tsx",
+  "shared/ui/scroll-area.tsx",
+  "shared/ui/select.tsx",
+  "shared/ui/separator.tsx",
+  "shared/ui/sheet.tsx",
+  "shared/ui/stat-card.tsx",
+  "shared/ui/switch.tsx",
+  "shared/ui/tabs.tsx",
+  "shared/ui/toast.tsx",
+  "shared/ui/toggle-group.tsx",
+  "shared/ui/toggle.tsx",
+  "shared/ui/tooltip.tsx",
+]);
+
+const sourceFilesIn = (directory: string): string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = resolve(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      return sourceFilesIn(path);
+    }
+
+    return sourceExtensions.has(extname(entry.name)) ? [path] : [];
+  });
+
+const radixModuleSpecifiersInSource = (
+  path: string,
+  sourceText: string,
+): string[] => {
+  const source = ts.createSourceFile(
+    path,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    false,
+    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const moduleSpecifiers = new Set<string>();
+
+  const recordIfRadix = (value: ts.Expression | undefined) => {
+    if (
+      value &&
+      ts.isStringLiteralLike(value) &&
+      value.text.startsWith("@radix-ui/")
+    ) {
+      moduleSpecifiers.add(value.text);
+    }
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      recordIfRadix(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      recordIfRadix(node.moduleReference.expression);
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      recordIfRadix(node.arguments[0]);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(source);
+  return [...moduleSpecifiers].sort();
+};
+
+const radixModuleSpecifiersIn = (path: string): string[] =>
+  radixModuleSpecifiersInSource(path, readFileSync(path, "utf8"));
+
+describe("Base UI migration boundary", () => {
+  it("detects direct Radix import forms", () => {
+    const fixtures = [
+      [
+        "static import",
+        'import * as Dialog from "@radix-ui/react-dialog";',
+        ["@radix-ui/react-dialog"],
+      ],
+      [
+        "type import",
+        'import type { Root } from "@radix-ui/react-dialog";',
+        ["@radix-ui/react-dialog"],
+      ],
+      [
+        "re-export",
+        'export { Root } from "@radix-ui/react-dialog";',
+        ["@radix-ui/react-dialog"],
+      ],
+      [
+        "import equals",
+        'import Dialog = require("@radix-ui/react-dialog");',
+        ["@radix-ui/react-dialog"],
+      ],
+      [
+        "dynamic string import",
+        'import("@radix-ui/react-dialog");',
+        ["@radix-ui/react-dialog"],
+      ],
+      [
+        "dynamic template import",
+        "import(`@radix-ui/react-dialog`);",
+        ["@radix-ui/react-dialog"],
+      ],
+      ["non-Radix import", 'import("@base-ui/react");', []],
+    ] as const;
+
+    for (const [name, source, expectedModuleSpecifiers] of fixtures) {
+      expect(radixModuleSpecifiersInSource(`${name}.ts`, source), name).toEqual(
+        expectedModuleSpecifiers,
+      );
+    }
+  });
+
+  it("confines direct Radix imports to the remaining wrapper allowlist", () => {
+    const violations = sourceFilesIn(sourceRoot).flatMap((path) => {
+      const moduleSpecifiers = radixModuleSpecifiersIn(path);
+      if (moduleSpecifiers.length === 0) {
+        return [];
+      }
+
+      const sourcePath = relative(sourceRoot, path).replaceAll("\\", "/");
+      return radixWrapperAllowlist.has(sourcePath)
+        ? []
+        : [`${sourcePath}: ${moduleSpecifiers.join(", ")}`];
+    });
+
+    expect(
+      violations,
+      "Direct @radix-ui/* imports must remain in an explicitly allowlisted migration wrapper.",
+    ).toEqual([]);
+  });
+
+  it("preserves the isolated root stacking context for Base UI portals", () => {
+    const globalsCss = readFileSync(globalsCssPath, "utf8");
+    const rootRule = globalsCss.match(/#root\s*\{(?<body>[^}]*)\}/);
+
+    expect(
+      rootRule?.groups?.body,
+      "expected #root to isolate portaled overlay stacking",
+    ).toMatch(/\bisolation\s*:\s*isolate\s*;/);
+  });
+});

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -12,6 +12,10 @@
     box-sizing: border-box;
   }
 
+  #root {
+    isolation: isolate;
+  }
+
   body {
     margin: 0;
     background: var(--background);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@fontsource-variable/jetbrains-mono':
         specifier: 5.2.8
         version: 5.2.8
@@ -774,6 +777,33 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.6.0':
+    resolution: {integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.3.1':
+    resolution: {integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -6135,6 +6165,9 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
     engines: {node: '>=8'}
@@ -7682,6 +7715,29 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@base-ui/react@1.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.3.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@base-ui/utils@0.3.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -10158,7 +10214,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.6.0)(typescript@6.0.3))(vite@7.3.5(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
+      vitest: 4.1.5(@types/node@25.9.2)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(msw@2.14.3(@types/node@25.9.2)(typescript@6.0.3))(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -13326,6 +13382,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-cwd@3.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- add Base UI alongside the existing Radix dependencies so components can migrate progressively
- isolate the application root so Base UI portals stack above application content
- add an AST-based migration boundary test that keeps direct Radix imports confined to the explicit remaining-wrapper allowlist

## Why

The component layer needs to move from Radix to Base UI before the visual redesign. Establishing coexistence and a shrinking import boundary lets each wrapper migrate independently while the application stays buildable and visually unchanged.

## Impact

This PR intentionally changes no product visuals or component behavior. It only prepares the migration seam and its regression guard.

## Validation

- `corepack pnpm --filter @jobctrl/web exec vitest run src/shared/ui/base-ui-migration-boundary.test.ts` — 3 tests passed
- `corepack pnpm web:check` — passed
- `corepack pnpm web:build` — passed
- focused review gate — PASS, no remaining findings

## Documentation

No public documentation update is warranted for this internal migration foundation. User-facing documentation will be updated at the end of the complete migration and redesign stack.