### PR TITLE
refactor(web): migrate leaf controls to Base UI

### DIFF
--- a/.migration/button.md
+++ b/.migration/button.md
@@ -1,0 +1,26 @@
+# button
+
+2026-07-14 — engine, migrated the Button Slot wrapper to Base UI's real Button primitive while preserving its exported variants and class strings.
+
+## Changed
+
+- `apps/web/src/shared/ui/button.tsx`: replaced the Radix Slot implementation with `@base-ui/react/button`, retaining the `Button`, `ButtonProps`, and `buttonVariants` exports and all CVA classes.
+- `apps/web/src/shared/ui/button.stories.tsx` and `apps/web/src/shared/ui/button.test.tsx`: added rendered-link and native-button coverage for the Base UI composition contract.
+- `apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx` and `apps/web/src/demo/guide/DemoGuide.tsx`: converted Button-owned `asChild` links to `render` targets with `nativeButton={false}`.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed the migrated Button wrapper from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\\|@radix-ui" apps/web/src/shared/ui/button.tsx` returns no matches.
+
+## Left alone
+
+- Radix trigger `asChild` usage in dialogs, sheets, popovers, tooltips, and other primitives was intentionally not changed.
+- `components.json`, package metadata, and the remaining Radix wrappers stay on the progressive migration path.
+
+## Behavior changes
+
+- `Button` now uses Base UI's `render` prop instead of `asChild`. Non-native rendered targets require `nativeButton={false}`; rendered navigation targets also set `role="link"` to retain their link semantics over Base UI's default button role.
+
+## Verify by hand
+
+1. Open the Button stories and confirm each variant and size preserves its current visual treatment.
+2. Tab to the default Button, activate it with Enter and Space, and verify disabled buttons do not activate.
+3. Open the rendered-link story and the migrated external-link controls; confirm navigation still works and focus styling remains visible.

--- a/.migration/checkbox.md
+++ b/.migration/checkbox.md
@@ -1,0 +1,32 @@
+# checkbox
+
+2026-07-14, engine (base-luma golden pair consulted), migrated while retaining the wrapper's visual classes and boolean controlled/uncontrolled contract.
+
+## Changed
+
+- `apps/web/src/shared/ui/checkbox.tsx:18` swaps the Radix parts for Base UI, translates checked and disabled styling to Base data attributes, and establishes root-owned inline-flex centering so checked and unchecked controls remain 16×16.
+- `apps/web/src/shared/ui/checkbox.stories.tsx:42` adds a generated-CSS browser regression that measures both checked and unchecked geometry, alongside indeterminate, controlled, and disabled states.
+- `apps/web/src/shared/ui/checkbox.test.tsx:20` proves uncontrolled, controlled, disabled, and indeterminate state attributes and callbacks.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts:12` removes Checkbox from the Radix wrapper allowlist so future direct Radix imports fail the migration boundary.
+- `apps/web/src/test/setup.ts:109` supplies JSDOM's missing `PointerEvent` constructor with `MouseEvent`, because Base UI dispatches `PointerEvent` from controls. The existing Switch consumer test still passes with it.
+- `.migration/checkbox.md` records this focused migration.
+
+`grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/checkbox.tsx` returned no matches.
+
+## Left alone
+
+- `apps/web/components.json` remains `radix-luma`: this is a progressive migration, not the final registry flip.
+- No in-tree consumer imports `Checkbox`; no application call site required a prop change.
+
+## Behavior changes
+
+- Base UI renders the control as an ARIA checkbox span with a hidden input rather than Radix's button. Explicit inline-flex layout now preserves the original 16×16 geometry in both checked and unchecked states; no in-tree consumer ref depends on the old button element.
+- Radix's `checked="indeterminate"` / `defaultChecked="indeterminate"` union is represented by Base UI's separate `indeterminate` boolean. No in-tree consumer used the legacy union; the new story and test exercise the explicit prop.
+
+## Verify by hand
+
+1. Open `Shared/UI/Checkbox/Geometry` in Storybook and confirm checked and unchecked controls are the same 16×16 size.
+2. Toggle Default with click, Space, and keyboard focus.
+3. Toggle Controlled and confirm its checked styling follows state; confirm Disabled and DisabledChecked ignore input.
+4. Open Indeterminate and confirm assistive technology reports a mixed checkbox and the indicator remains visible.
+5. Click the label in WithLabel and confirm focus and toggle behavior remain intact.

--- a/.migration/label.md
+++ b/.migration/label.md
@@ -1,0 +1,24 @@
+# label
+
+2026-07-14 — golden pair via CLI, migrated the wrapper to a native semantic label while preserving the public `Label` export and CVA styling.
+
+## Changed
+
+- `apps/web/src/shared/ui/label.tsx`: replaced `@radix-ui/react-label` with a native `<label>` while retaining the existing CVA class list, prop forwarding, and ref support.
+- `apps/web/src/shared/ui/label.test.tsx`: added coverage for native label semantics, control association, and retained styling classes.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed the migrated Label wrapper from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\\|@radix-ui" apps/web/src/shared/ui/label.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/shared/ui/label.stories.tsx`: its existing stories still exercise the exported `Label` and its input association; no story change was required.
+- Other shared UI wrappers remain on their assigned migration paths and were not changed.
+
+## Behavior changes
+
+- A native label does not retain Radix's double-click text-selection prevention. The existing wrapper had no `select-none` class, so that behavior is deliberately not recreated.
+
+## Verify by hand
+
+1. Open the Label Storybook story and confirm its typography matches the current form labels.
+2. In the WithInput story, click the label and verify focus moves to the numeric input.

--- a/.migration/separator.md
+++ b/.migration/separator.md
@@ -1,0 +1,24 @@
+# separator
+
+2026-07-14 — golden pair via CLI, migrated the wrapper to the Base UI separator while preserving the public `Separator` export, orientation, and rule styling.
+
+## Changed
+
+- `apps/web/src/shared/ui/separator.tsx`: replaced `@radix-ui/react-separator` with `@base-ui/react/separator`, preserving orientation classes and ref support.
+- `apps/web/src/shared/ui/separator.test.tsx`: added semantic-role and horizontal/vertical orientation coverage.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed the migrated Separator wrapper from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\\|@radix-ui" apps/web/src/shared/ui/separator.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/shared/ui/separator.stories.tsx`: the existing horizontal and vertical stories remain valid against the unchanged public API.
+- Other shared UI wrappers remain on their assigned migration paths and were not changed.
+
+## Behavior changes
+
+- The Radix-only `decorative` prop is removed. Base UI separators are always semantic (`role="separator"`), while their visuals and orientation remain unchanged.
+
+## Verify by hand
+
+1. Open the Separator Storybook stories and confirm horizontal rules retain their full-width, one-pixel appearance.
+2. Confirm vertical separators in the Vertical and DenseToolbar stories retain their full-height, one-pixel appearance and appear between adjacent text.

--- a/.migration/stat-card.md
+++ b/.migration/stat-card.md
@@ -1,0 +1,26 @@
+# stat-card
+
+2026-07-14 — engine, migrated the StatCard Slot composition to Base UI `useRender` and `mergeProps` while preserving the card layout and tone variants.
+
+## Changed
+
+- `apps/web/src/shared/ui/stat-card.tsx`: replaced Radix Slot/Slottable with Base UI render composition, preserving the existing card, label, value, delta, and tone class strings.
+- `apps/web/src/shared/ui/stat-card.stories.tsx` and `apps/web/src/shared/ui/stat-card.test.tsx`: converted the link story to `render` and added composition coverage for content, classes, and click handlers.
+- `apps/web/src/views/dashboard/KpiGrid.tsx`: converted the interactive KPI StatCard from `asChild` to a childless `render` anchor.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed the migrated StatCard wrapper from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\\|@radix-ui" apps/web/src/shared/ui/stat-card.tsx` returns no matches.
+
+## Left alone
+
+- Non-interactive StatCard consumers retain their existing direct-div rendering.
+- Other Radix Slot wrappers and trigger `asChild` usages remain outside this component migration.
+
+## Behavior changes
+
+- The StatCard polymorphic API is now `render={<a ... />}` rather than `asChild` with a child anchor. The supplied render target must remain childless so StatCard can provide the full stat layout.
+
+## Verify by hand
+
+1. Open the StatCard stories and confirm tone, spacing, and card-surface visuals match the existing variants.
+2. Open a dashboard KPI card with keyboard focus and activate it; confirm it navigates to the same filtered jobs view.
+3. Confirm the rendered-link StatCard exposes the full label, value, and delta as one clickable anchor.

--- a/.migration/switch.md
+++ b/.migration/switch.md
@@ -1,0 +1,31 @@
+# switch
+
+2026-07-14, engine (base-luma golden pair consulted), migrated while retaining the wrapper's visual classes and boolean controlled/uncontrolled contract.
+
+## Changed
+
+- `apps/web/src/shared/ui/switch.tsx:1` swaps the Radix Root and Thumb for Base UI and translates checked, unchecked, and disabled styling to Base data attributes.
+- `apps/web/src/shared/ui/switch.stories.tsx:24` adds an interactive controlled story while preserving the existing on/off and disabled stories.
+- `apps/web/src/shared/ui/switch.test.tsx:20` proves uncontrolled, controlled, and disabled state attributes and callbacks.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts:12` removes Switch from the Radix wrapper allowlist so future direct Radix imports fail the migration boundary.
+- `apps/web/src/test/setup.ts:109` supplies JSDOM's missing `PointerEvent` constructor with `MouseEvent`, because Base UI dispatches `PointerEvent` from controls. `CompensationSourcePolicyPanel.test.tsx`, the sole Switch consumer test, passes unchanged.
+- `.migration/switch.md` records this focused migration.
+
+`grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/switch.tsx` returned no matches.
+
+## Left alone
+
+- `apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx` remains unchanged: its boolean `checked` and first `onCheckedChange` argument are compatible with Base UI.
+- `apps/web/components.json` remains `radix-luma`: this is a progressive migration, not the final registry flip.
+
+## Behavior changes
+
+- Base UI renders the control as an ARIA switch span with a hidden input rather than Radix's button. Its visible geometry, controlled/uncontrolled state, and first callback argument are retained; no in-tree consumer ref depends on the old button element.
+- Base UI provides event details as a second `onCheckedChange` argument. Existing one-argument consumers remain compatible.
+
+## Verify by hand
+
+1. Open `Shared/UI/Switch` in Storybook and toggle Off and On with click, Space, and keyboard focus.
+2. Toggle Controlled and confirm state drives the thumb and track position.
+3. Confirm Disabled and DisabledOff ignore click and keyboard input while retaining disabled opacity.
+4. Click the label in WithLabel and confirm it focuses and toggles the switch.

--- a/apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx
@@ -976,17 +976,19 @@ function SourceLocatorPanel({
               <Button
                 size="icon"
                 variant="ghost"
-                asChild
+                nativeButton={false}
+                render={
+                  <a
+                    aria-label={`Open ${candidate.candidateUrl}`}
+                    href={candidate.candidateUrl}
+                    role="link"
+                    target="_blank"
+                    rel="noreferrer"
+                  />
+                }
                 title="Open candidate"
               >
-                <a
-                  aria-label={`Open ${candidate.candidateUrl}`}
-                  href={candidate.candidateUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <IconExternalLink size={14} aria-hidden="true" />
-                </a>
+                <IconExternalLink size={14} aria-hidden="true" />
               </Button>
               <Button
                 type="button"
@@ -1422,15 +1424,22 @@ function ManualCaptureRow({
         </form>
       </span>
       <div className="row-actions">
-        <Button size="icon" variant="ghost" asChild title="Open page">
-          <a
-            aria-label={`Open ${item.originatingUrl}`}
-            href={item.originatingUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <IconExternalLink size={14} aria-hidden="true" />
-          </a>
+        <Button
+          size="icon"
+          variant="ghost"
+          nativeButton={false}
+          render={
+            <a
+              aria-label={`Open ${item.originatingUrl}`}
+              href={item.originatingUrl}
+              role="link"
+              target="_blank"
+              rel="noreferrer"
+            />
+          }
+          title="Open page"
+        >
+          <IconExternalLink size={14} aria-hidden="true" />
         </Button>
         <Button
           type="button"

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -156,69 +156,77 @@ export function DemoGuide() {
         <ul className="grid gap-1">
           <li>
             <Button
-              asChild
               variant="ghost"
               size="sm"
               className="h-auto w-full justify-between px-2 py-2 text-left"
+              nativeButton={false}
+              render={
+                <Link
+                  to="/jobs/$jobId"
+                  params={{ jobId: DEMO_JOB_ID }}
+                  onClick={() => recordFeatureShortcut("scoring")}
+                  role="link"
+                />
+              }
             >
-              <Link
-                to="/jobs/$jobId"
-                params={{ jobId: DEMO_JOB_ID }}
-                onClick={() => recordFeatureShortcut("scoring")}
-              >
-                <span>Inspect synthetic scoring evidence</span>
-                <IconArrowRight aria-hidden="true" size={15} />
-              </Link>
+              <span>Inspect synthetic scoring evidence</span>
+              <IconArrowRight aria-hidden="true" size={15} />
             </Button>
           </li>
           <li>
             <Button
-              asChild
               variant="ghost"
               size="sm"
               className="h-auto w-full justify-between px-2 py-2 text-left"
+              nativeButton={false}
+              render={
+                <Link
+                  to="/artifacts/$artifactId"
+                  params={{ artifactId: DEMO_ARTIFACT_ID }}
+                  onClick={() => recordFeatureShortcut("materials")}
+                  role="link"
+                />
+              }
             >
-              <Link
-                to="/artifacts/$artifactId"
-                params={{ artifactId: DEMO_ARTIFACT_ID }}
-                onClick={() => recordFeatureShortcut("materials")}
-              >
-                <span>Review synthetic tailored materials</span>
-                <IconArrowRight aria-hidden="true" size={15} />
-              </Link>
+              <span>Review synthetic tailored materials</span>
+              <IconArrowRight aria-hidden="true" size={15} />
             </Button>
           </li>
           <li>
             <Button
-              asChild
               variant="ghost"
               size="sm"
               className="h-auto w-full justify-between px-2 py-2 text-left"
+              nativeButton={false}
+              render={
+                <Link
+                  to="/apply-review"
+                  search={{ jobKey: DEMO_JOB_ID }}
+                  onClick={() => recordFeatureShortcut("apply_review")}
+                  role="link"
+                />
+              }
             >
-              <Link
-                to="/apply-review"
-                search={{ jobKey: DEMO_JOB_ID }}
-                onClick={() => recordFeatureShortcut("apply_review")}
-              >
-                <span>Open simulated Apply Review and dry run</span>
-                <IconArrowRight aria-hidden="true" size={15} />
-              </Link>
+              <span>Open simulated Apply Review and dry run</span>
+              <IconArrowRight aria-hidden="true" size={15} />
             </Button>
           </li>
           <li>
             <Button
-              asChild
               variant="ghost"
               size="sm"
               className="h-auto w-full justify-between px-2 py-2 text-left"
+              nativeButton={false}
+              render={
+                <Link
+                  to="/runs"
+                  onClick={() => recordFeatureShortcut("pipeline")}
+                  role="link"
+                />
+              }
             >
-              <Link
-                to="/runs"
-                onClick={() => recordFeatureShortcut("pipeline")}
-              >
-                <span>See simulated run history</span>
-                <IconArrowRight aria-hidden="true" size={15} />
-              </Link>
+              <span>See simulated run history</span>
+              <IconArrowRight aria-hidden="true" size={15} />
             </Button>
           </li>
         </ul>

--- a/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
+++ b/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
@@ -10,18 +10,12 @@ const sourceExtensions = new Set([".ts", ".tsx"]);
 
 // Remove entries from this list as their wrappers migrate to Base UI.
 const radixWrapperAllowlist = new Set([
-  "shared/ui/button.tsx",
-  "shared/ui/checkbox.tsx",
   "shared/ui/dialog.tsx",
   "shared/ui/dropdown-menu.tsx",
-  "shared/ui/label.tsx",
   "shared/ui/popover.tsx",
   "shared/ui/scroll-area.tsx",
   "shared/ui/select.tsx",
-  "shared/ui/separator.tsx",
   "shared/ui/sheet.tsx",
-  "shared/ui/stat-card.tsx",
-  "shared/ui/switch.tsx",
   "shared/ui/tabs.tsx",
   "shared/ui/toast.tsx",
   "shared/ui/toggle-group.tsx",

--- a/apps/web/src/shared/ui/button.stories.tsx
+++ b/apps/web/src/shared/ui/button.stories.tsx
@@ -73,3 +73,12 @@ export const FocusVisible: Story = {
     children: "Save changes",
   },
 };
+
+export const AsLink: Story = {
+  args: {
+    children: "Open jobs",
+    nativeButton: false,
+    render: <a href="#jobs" role="link" />,
+    variant: "outline",
+  },
+};

--- a/apps/web/src/shared/ui/button.test.tsx
+++ b/apps/web/src/shared/ui/button.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Button } from "./button.js";
+
+describe("<Button>", () => {
+  it("renders a native button with the default button type", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Save changes</Button>);
+
+    const button = screen.getByRole("button", { name: "Save changes" });
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button).toHaveAttribute("type", "button");
+
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("composes with a rendered non-native button target", () => {
+    render(
+      <Button nativeButton={false} render={<a href="/jobs" role="link" />}>
+        Open jobs
+      </Button>,
+    );
+
+    const linkButton = screen.getByRole("link", { name: "Open jobs" });
+    expect(linkButton.tagName).toBe("A");
+    expect(linkButton).toHaveAttribute("href", "/jobs");
+    expect(linkButton).toHaveClass("inline-flex", "rounded-lg");
+  });
+});

--- a/apps/web/src/shared/ui/button.tsx
+++ b/apps/web/src/shared/ui/button.tsx
@@ -1,6 +1,6 @@
-import { Slot } from "@radix-ui/react-slot";
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
 import { cva, type VariantProps } from "class-variance-authority";
-import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { forwardRef } from "react";
 
 import { cn } from "../lib/cn.js";
 
@@ -12,10 +12,12 @@ const buttonVariants = cva(
         default:
           "bg-primary text-primary-foreground shadow-[0_10px_20px_color-mix(in_oklab,var(--primary)_22%,transparent)] hover:bg-primary/90",
         destructive: "bg-destructive text-white hover:bg-destructive/90",
-        outline: "border border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        outline:
+          "border border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
         secondary:
           "border border-[color-mix(in_oklab,var(--primary)_40%,var(--border))] bg-card text-primary hover:bg-accent hover:text-accent-foreground",
-        ghost: "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+        ghost:
+          "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
@@ -33,18 +35,20 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    Omit<ButtonPrimitive.Props, "className">,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  className?: string;
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button";
-    return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    );
-  },
+  ({ className, variant, size, ...props }, ref) => (
+    <ButtonPrimitive
+      className={cn(buttonVariants({ variant, size, className }))}
+      ref={ref}
+      {...props}
+    />
+  ),
 );
 Button.displayName = "Button";
 

--- a/apps/web/src/shared/ui/checkbox.stories.tsx
+++ b/apps/web/src/shared/ui/checkbox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 
 import { Checkbox } from "./checkbox.js";
 import { Label } from "./label.js";
@@ -20,12 +21,65 @@ export const Checked: Story = {
   args: { defaultChecked: true },
 };
 
+export const Indeterminate: Story = {
+  args: { indeterminate: true, "aria-label": "Indeterminate checkbox" },
+};
+
+export const Controlled: Story = {
+  render: function ControlledCheckbox() {
+    const [checked, setChecked] = useState(false);
+
+    return (
+      <Checkbox
+        aria-label="Controlled checkbox"
+        checked={checked}
+        onCheckedChange={(nextChecked) => setChecked(nextChecked)}
+      />
+    );
+  },
+};
+
+export const Geometry: Story = {
+  tags: ["checkbox-geometry"],
+  render: () => (
+    <div>
+      <div>
+        <Checkbox aria-label="Unchecked geometry" />
+      </div>
+      <div>
+        <Checkbox aria-label="Checked geometry" defaultChecked />
+      </div>
+    </div>
+  ),
+  play: ({ canvasElement }) => {
+    for (const name of ["Unchecked geometry", "Checked geometry"]) {
+      const checkbox = canvasElement.querySelector<HTMLElement>(
+        `[role="checkbox"][aria-label="${name}"]`,
+      );
+      if (!checkbox) {
+        throw new Error(`Missing ${name} checkbox.`);
+      }
+
+      const { height, width } = checkbox.getBoundingClientRect();
+      if (height !== 16 || width !== 16) {
+        throw new Error(
+          `Expected fixed 16x16 checkbox geometry, received ${width}x${height}.`,
+        );
+      }
+    }
+  },
+};
+
 export const Disabled: Story = {
   args: { disabled: true },
 };
 
 export const DisabledChecked: Story = {
-  args: { defaultChecked: true, disabled: true, "aria-label": "Disabled checked checkbox" },
+  args: {
+    defaultChecked: true,
+    disabled: true,
+    "aria-label": "Disabled checked checkbox",
+  },
 };
 
 export const WithLabel: Story = {

--- a/apps/web/src/shared/ui/checkbox.test.tsx
+++ b/apps/web/src/shared/ui/checkbox.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Checkbox } from "./checkbox.js";
+
+function ControlledCheckbox() {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <Checkbox
+      aria-label="Controlled checkbox"
+      checked={checked}
+      onCheckedChange={(nextChecked) => setChecked(nextChecked)}
+    />
+  );
+}
+
+describe("Checkbox", () => {
+  it("updates unchecked Base UI state in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+
+    render(
+      <Checkbox
+        aria-label="Uncontrolled checkbox"
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Uncontrolled checkbox",
+    });
+    expect(checkbox).toHaveAttribute("data-unchecked");
+
+    await user.click(checkbox);
+
+    expect(checkbox).toHaveAttribute("data-checked");
+    expect(checkbox).toHaveAttribute("aria-checked", "true");
+    expect(onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  it("keeps controlled and disabled checkbox states observable", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+
+    const { rerender } = render(<ControlledCheckbox />);
+    const controlled = screen.getByRole("checkbox", {
+      name: "Controlled checkbox",
+    });
+    await user.click(controlled);
+    expect(controlled).toHaveAttribute("data-checked");
+
+    rerender(
+      <Checkbox
+        aria-label="Disabled checkbox"
+        disabled
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+    const disabled = screen.getByRole("checkbox", {
+      name: "Disabled checkbox",
+    });
+    await user.click(disabled);
+
+    expect(disabled).toHaveAttribute("data-disabled");
+    expect(disabled).toHaveAttribute("data-unchecked");
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+
+  it("renders indeterminate state through Base UI", () => {
+    render(<Checkbox aria-label="Indeterminate checkbox" indeterminate />);
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Indeterminate checkbox",
+    });
+    expect(checkbox).toHaveAttribute("aria-checked", "mixed");
+    expect(checkbox).toHaveAttribute("data-indeterminate");
+    expect(checkbox.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/apps/web/src/shared/ui/checkbox.tsx
+++ b/apps/web/src/shared/ui/checkbox.tsx
@@ -1,6 +1,10 @@
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
 import { IconCheck } from "@tabler/icons-react";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
@@ -11,12 +15,14 @@ export const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:bg-primary data-checked:text-primary-foreground",
       className,
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator className={cn("flex items-center justify-center text-current")}>
+    <CheckboxPrimitive.Indicator
+      className={cn("flex items-center justify-center text-current")}
+    >
       <IconCheck className="h-4 w-4" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>

--- a/apps/web/src/shared/ui/label.test.tsx
+++ b/apps/web/src/shared/ui/label.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Label } from "./label.js";
+
+describe("<Label>", () => {
+  it("uses a native label to associate its text with the control", () => {
+    render(
+      <>
+        <Label htmlFor="label-test-input">Minimum fit score</Label>
+        <input id="label-test-input" />
+      </>,
+    );
+
+    const label = screen.getByText("Minimum fit score");
+
+    expect(label.tagName).toBe("LABEL");
+    expect(label).toHaveClass("text-sm", "font-medium", "leading-none");
+    expect(screen.getByLabelText("Minimum fit score")).toHaveAttribute(
+      "id",
+      "label-test-input",
+    );
+  });
+});

--- a/apps/web/src/shared/ui/label.tsx
+++ b/apps/web/src/shared/ui/label.tsx
@@ -1,6 +1,9 @@
-import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
@@ -9,9 +12,9 @@ const labelVariants = cva(
 );
 
 export const Label = forwardRef<
-  ComponentRef<typeof LabelPrimitive.Root>,
-  ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
+  ComponentRef<"label">,
+  ComponentPropsWithoutRef<"label"> & VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
+  <label ref={ref} className={cn(labelVariants(), className)} {...props} />
 ));
-Label.displayName = LabelPrimitive.Root.displayName;
+Label.displayName = "Label";

--- a/apps/web/src/shared/ui/separator.test.tsx
+++ b/apps/web/src/shared/ui/separator.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Separator } from "./separator.js";
+
+describe("<Separator>", () => {
+  it("renders a semantic horizontal separator with the existing rule styling", () => {
+    render(<Separator />);
+
+    const separator = screen.getByRole("separator");
+
+    expect(separator).toHaveAttribute("data-orientation", "horizontal");
+    expect(separator).toHaveClass("shrink-0", "bg-border", "h-[1px]", "w-full");
+  });
+
+  it("preserves the vertical orientation and rule styling", () => {
+    render(<Separator orientation="vertical" />);
+
+    const separator = screen.getByRole("separator");
+
+    expect(separator).toHaveAttribute("data-orientation", "vertical");
+    expect(separator).toHaveClass("h-full", "w-[1px]");
+  });
+});

--- a/apps/web/src/shared/ui/separator.tsx
+++ b/apps/web/src/shared/ui/separator.tsx
@@ -1,15 +1,18 @@
-import * as SeparatorPrimitive from "@radix-ui/react-separator";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
 export const Separator = forwardRef<
-  ComponentRef<typeof SeparatorPrimitive.Root>,
-  ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
-  <SeparatorPrimitive.Root
+  ComponentRef<typeof SeparatorPrimitive>,
+  ComponentPropsWithoutRef<typeof SeparatorPrimitive>
+>(({ className, orientation = "horizontal", ...props }, ref) => (
+  <SeparatorPrimitive
     ref={ref}
-    decorative={decorative}
     orientation={orientation}
     className={cn(
       "shrink-0 bg-border",
@@ -19,4 +22,4 @@ export const Separator = forwardRef<
     {...props}
   />
 ));
-Separator.displayName = SeparatorPrimitive.Root.displayName;
+Separator.displayName = SeparatorPrimitive.displayName ?? "Separator";

--- a/apps/web/src/shared/ui/stat-card.stories.tsx
+++ b/apps/web/src/shared/ui/stat-card.stories.tsx
@@ -73,12 +73,11 @@ export const ValueTone: Story = {
 
 export const AsLink: Story = {
   args: {
-    asChild: true,
     label: "Ready",
     value: "12",
     valueTone: "up",
     delta: "ready queue",
     className: "w-[240px]",
-    children: <a href="#ready" />,
+    render: <a href="#ready" />,
   },
 };

--- a/apps/web/src/shared/ui/stat-card.test.tsx
+++ b/apps/web/src/shared/ui/stat-card.test.tsx
@@ -1,11 +1,14 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 import { StatCard } from "./stat-card.js";
 
 describe("<StatCard>", () => {
   it("renders label, value, and delta", () => {
-    render(<StatCard label="Applications sent" value="128" delta="+12 this week" />);
+    render(
+      <StatCard label="Applications sent" value="128" delta="+12 this week" />,
+    );
 
     expect(screen.getByText("Applications sent")).toBeInTheDocument();
     expect(screen.getByText("128")).toBeInTheDocument();
@@ -13,13 +16,21 @@ describe("<StatCard>", () => {
   });
 
   it("renders the tag slot", () => {
-    render(<StatCard label="Response rate" value="34%" tag={<span>on track</span>} />);
+    render(
+      <StatCard
+        label="Response rate"
+        value="34%"
+        tag={<span>on track</span>}
+      />,
+    );
 
     expect(screen.getByText("on track")).toBeInTheDocument();
   });
 
   it("applies the delta tone class", () => {
-    const { rerender } = render(<StatCard label="X" value="1" delta="up" deltaTone="up" />);
+    const { rerender } = render(
+      <StatCard label="X" value="1" delta="up" deltaTone="up" />,
+    );
     expect(screen.getByText("up")).toHaveClass("text-success");
 
     rerender(<StatCard label="X" value="1" delta="warn" deltaTone="warn" />);
@@ -39,7 +50,9 @@ describe("<StatCard>", () => {
   it("renders the delta muted when no delta tone is set", () => {
     render(<StatCard label="Ready" value="4" delta="ready queue" />);
 
-    expect(screen.getByText("ready queue")).toHaveClass("text-muted-foreground");
+    expect(screen.getByText("ready queue")).toHaveClass(
+      "text-muted-foreground",
+    );
   });
 
   it("applies the value tone class", () => {
@@ -48,16 +61,36 @@ describe("<StatCard>", () => {
     expect(screen.getByText("3")).toHaveClass("text-destructive");
   });
 
-  it("renders as the slotted element when asChild is set", () => {
+  it("composes the stat layout into the rendered element", () => {
+    const onCardClick = vi.fn();
+    const onLinkClick = vi.fn((event: ReactMouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+    });
     render(
-      <StatCard asChild label="Jobs" value="42" delta="+2 today">
-        <a href="/jobs" />
-      </StatCard>,
+      <StatCard
+        className="stat-card-target"
+        label="Jobs"
+        value="42"
+        delta="+2 today"
+        onClick={onCardClick}
+        render={
+          <a className="stat-card-link" href="/jobs" onClick={onLinkClick} />
+        }
+      />,
     );
 
     const link = screen.getByRole("link", { name: /^Jobs/i });
     expect(link).toHaveAttribute("href", "/jobs");
     expect(link).toHaveTextContent("42");
     expect(link).toHaveTextContent("+2 today");
+    expect(link).toHaveClass(
+      "rounded-lg",
+      "stat-card-target",
+      "stat-card-link",
+    );
+
+    fireEvent.click(link);
+    expect(onLinkClick).toHaveBeenCalledOnce();
+    expect(onCardClick).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/shared/ui/stat-card.tsx
+++ b/apps/web/src/shared/ui/stat-card.tsx
@@ -1,5 +1,6 @@
-import { Slot, Slottable } from "@radix-ui/react-slot";
-import { forwardRef, type HTMLAttributes, type ReactNode } from "react";
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { forwardRef, type ReactNode } from "react";
 
 import { cn } from "../lib/cn.js";
 import { cardClassName } from "./card.js";
@@ -12,65 +13,75 @@ const toneClass: Record<StatTone, string> = {
   down: "text-destructive",
 };
 
-export interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
+export interface StatCardProps extends Omit<
+  useRender.ComponentProps<"div">,
+  "children" | "className"
+> {
   label: string;
   value: ReactNode;
   tag?: ReactNode;
   delta?: ReactNode;
   deltaTone?: StatTone | undefined;
   valueTone?: StatTone | undefined;
-  /**
-   * Render the card as the single child element (e.g. an anchor) so the whole
-   * surface becomes interactive while keeping the stat layout. Uses the Radix
-   * Slot pattern; the child's own props (href, onClick) are preserved.
-   */
-  asChild?: boolean;
+  className?: string;
 }
 
 export const StatCard = forwardRef<HTMLDivElement, StatCardProps>(
   (
-    { label, value, tag, delta, deltaTone, valueTone, asChild = false, className, children, ...props },
+    {
+      label,
+      value,
+      tag,
+      delta,
+      deltaTone,
+      valueTone,
+      className,
+      render,
+      ...props
+    },
     ref,
   ) => {
-    const Comp = asChild ? Slot : "div";
-    return (
-      <Comp
-        ref={ref}
-        className={cn(cardClassName, "flex flex-col gap-2 p-4", className)}
-        {...props}
-      >
-        <div className="flex items-start justify-between gap-2">
-          <span
-            data-slot="stat-label"
-            className="text-[11px] font-extrabold uppercase tracking-[0.08em] text-muted-foreground"
-          >
-            {label}
-          </span>
-          {tag ? <span className="shrink-0">{tag}</span> : null}
-        </div>
-        <span
-          data-slot="stat-value"
-          className={cn(
-            "text-[28px] font-[900] leading-none tracking-[-0.02em]",
-            valueTone ? toneClass[valueTone] : "text-foreground",
-          )}
-        >
-          {value}
-        </span>
-        {delta ? (
-          <span
-            data-slot="stat-delta"
-            className={cn(
-              "text-[12px] font-semibold",
-              deltaTone ? toneClass[deltaTone] : "text-muted-foreground",
-            )}
-          >
-            {delta}
-          </span>
-        ) : null}
-        {asChild ? <Slottable>{children}</Slottable> : null}
-      </Comp>
-    );
+    return useRender({
+      defaultTagName: "div",
+      ref,
+      render,
+      props: mergeProps(props, {
+        className: cn(cardClassName, "flex flex-col gap-2 p-4", className),
+        children: (
+          <>
+            <div className="flex items-start justify-between gap-2">
+              <span
+                data-slot="stat-label"
+                className="text-[11px] font-extrabold uppercase tracking-[0.08em] text-muted-foreground"
+              >
+                {label}
+              </span>
+              {tag ? <span className="shrink-0">{tag}</span> : null}
+            </div>
+            <span
+              data-slot="stat-value"
+              className={cn(
+                "text-[28px] font-[900] leading-none tracking-[-0.02em]",
+                valueTone ? toneClass[valueTone] : "text-foreground",
+              )}
+            >
+              {value}
+            </span>
+            {delta ? (
+              <span
+                data-slot="stat-delta"
+                className={cn(
+                  "text-[12px] font-semibold",
+                  deltaTone ? toneClass[deltaTone] : "text-muted-foreground",
+                )}
+              >
+                {delta}
+              </span>
+            ) : null}
+          </>
+        ),
+      }),
+    });
   },
 );
 StatCard.displayName = "StatCard";

--- a/apps/web/src/shared/ui/switch.stories.tsx
+++ b/apps/web/src/shared/ui/switch.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 
 import { Label } from "./label.js";
 import { Switch } from "./switch.js";
@@ -18,6 +19,20 @@ export const Off: Story = {};
 
 export const On: Story = {
   args: { defaultChecked: true },
+};
+
+export const Controlled: Story = {
+  render: function ControlledSwitch() {
+    const [checked, setChecked] = useState(false);
+
+    return (
+      <Switch
+        aria-label="Controlled switch"
+        checked={checked}
+        onCheckedChange={(nextChecked) => setChecked(nextChecked)}
+      />
+    );
+  },
 };
 
 export const Disabled: Story = {

--- a/apps/web/src/shared/ui/switch.test.tsx
+++ b/apps/web/src/shared/ui/switch.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Switch } from "./switch.js";
+
+function ControlledSwitch() {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <Switch
+      aria-label="Controlled switch"
+      checked={checked}
+      onCheckedChange={(nextChecked) => setChecked(nextChecked)}
+    />
+  );
+}
+
+describe("Switch", () => {
+  it("updates unchecked Base UI state in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+
+    render(
+      <Switch
+        aria-label="Uncontrolled switch"
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+
+    const switchControl = screen.getByRole("switch", {
+      name: "Uncontrolled switch",
+    });
+    expect(switchControl).toHaveAttribute("data-unchecked");
+
+    await user.click(switchControl);
+
+    expect(switchControl).toHaveAttribute("data-checked");
+    expect(switchControl).toHaveAttribute("aria-checked", "true");
+    expect(onCheckedChange).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  it("keeps controlled and disabled switch states observable", async () => {
+    const user = userEvent.setup();
+    const onCheckedChange = vi.fn();
+
+    const { rerender } = render(<ControlledSwitch />);
+    const controlled = screen.getByRole("switch", {
+      name: "Controlled switch",
+    });
+    await user.click(controlled);
+    expect(controlled).toHaveAttribute("data-checked");
+
+    rerender(
+      <Switch
+        aria-label="Disabled switch"
+        disabled
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+    const disabled = screen.getByRole("switch", { name: "Disabled switch" });
+    await user.click(disabled);
+
+    expect(disabled).toHaveAttribute("data-disabled");
+    expect(disabled).toHaveAttribute("data-unchecked");
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/ui/switch.tsx
+++ b/apps/web/src/shared/ui/switch.tsx
@@ -1,5 +1,9 @@
-import * as SwitchPrimitive from "@radix-ui/react-switch";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
@@ -9,7 +13,7 @@ export const Switch = forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:bg-primary data-unchecked:bg-muted",
       className,
     )}
     {...props}
@@ -17,7 +21,7 @@ export const Switch = forwardRef<
   >
     <SwitchPrimitive.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0",
       )}
     />
   </SwitchPrimitive.Root>

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -85,16 +85,35 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   });
 }
 
-if (typeof window !== "undefined" && typeof window.ResizeObserver === "undefined") {
+if (
+  typeof window !== "undefined" &&
+  typeof window.ResizeObserver === "undefined"
+) {
   class MockResizeObserver {
     observe() {}
     unobserve() {}
     disconnect() {}
   }
-  (window as unknown as { ResizeObserver: typeof MockResizeObserver }).ResizeObserver =
-    MockResizeObserver;
+  (
+    window as unknown as { ResizeObserver: typeof MockResizeObserver }
+  ).ResizeObserver = MockResizeObserver;
 }
 
 if (typeof window !== "undefined") {
-  Object.defineProperty(window, "scrollTo", { writable: true, value: () => {} });
+  Object.defineProperty(window, "scrollTo", {
+    writable: true,
+    value: () => {},
+  });
+}
+
+if (
+  typeof window !== "undefined" &&
+  typeof window.PointerEvent === "undefined"
+) {
+  // Base UI controls dispatch PointerEvent; JSDOM only provides MouseEvent.
+  Object.defineProperty(window, "PointerEvent", {
+    configurable: true,
+    value: window.MouseEvent,
+    writable: true,
+  });
 }

--- a/apps/web/src/views/dashboard/KpiGrid.tsx
+++ b/apps/web/src/views/dashboard/KpiGrid.tsx
@@ -123,31 +123,31 @@ export function KpiGrid({ summary }: KpiGridProps) {
         return (
           <StatCard
             key={label}
-            asChild
             className={KPI_HOVER}
             label={label}
             value={summary.totals[key]}
             valueTone={tone ? VALUE_TONE[tone] : undefined}
             delta={caption(summary)}
-          >
-            <a
-              href={kpiHrefFor(target)}
-              onClick={(event) => {
-                if (
-                  event.defaultPrevented
-                  || event.button !== 0
-                  || event.metaKey
-                  || event.altKey
-                  || event.ctrlKey
-                  || event.shiftKey
-                ) {
-                  return;
-                }
-                event.preventDefault();
-                void navigate({ to: "/jobs", search });
-              }}
-            />
-          </StatCard>
+            render={
+              <a
+                href={kpiHrefFor(target)}
+                onClick={(event) => {
+                  if (
+                    event.defaultPrevented ||
+                    event.button !== 0 ||
+                    event.metaKey ||
+                    event.altKey ||
+                    event.ctrlKey ||
+                    event.shiftKey
+                  ) {
+                    return;
+                  }
+                  event.preventDefault();
+                  void navigate({ to: "/jobs", search });
+                }}
+              />
+            }
+          />
         );
       })}
     </section>


### PR DESCRIPTION
## What changed

- migrate Button and StatCard composition from Radix Slot to Base UI render primitives
- migrate Checkbox, Switch, and Separator to Base UI and Label to native semantics
- adapt direct Button and StatCard consumers without changing their visual variants
- add focused state, composition, semantic, and generated-CSS geometry regressions
- shrink the temporary direct-Radix import allowlist by six wrappers

## Why

This is the first behavior-preserving implementation slice in the progressive Radix-to-Base UI migration. Keeping the primitive migration separate from visual redesign makes behavior and accessibility regressions reviewable before styling changes begin.

## Validation

- web TypeScript check passed
- production web build passed
- 31 focused Vitest assertions passed across the migration boundary, six wrappers, and affected consumers
- targeted Storybook Chromium geometry test passed for checked and unchecked Checkbox states at 16x16
- Storybook accessibility check reported no serious or critical violations for the targeted story
- focused reviewer gate passed with 0 Blocker, High, Medium, or Low findings
- git diff check passed

## Documentation

No public behavior or operating command changes are introduced in this slice. Per-component migration reports are included under .migration; public documentation and the full product QA pass remain scheduled for the end of the migration/redesign stack.

## Stack

- base: #453
- this PR: leaf controls
- next: toggles, tabs, and scroll area