### PR TITLE
refactor(web): migrate tabs toggle and scroll area to Base UI

### DIFF
--- a/.migration/scroll-area.md
+++ b/.migration/scroll-area.md
@@ -1,0 +1,29 @@
+# scroll-area
+
+2026-07-14 — merge, migrated the customized wrapper to Base UI 1.6 with explicit Content composition and preserved visual classes.
+
+## Changed
+
+- `apps/web/src/shared/ui/scroll-area.tsx`: replaced the Radix parts with Base UI `Root`, `Viewport`, `Content`, `Scrollbar`, `Thumb`, and `Corner`; retained the public `ScrollArea` and `ScrollBar` exports, refs, orientations, and existing class strings. The current base-luma registry wrapper omits `Content`, so the Base 1.6 documented anatomy and migration contract were applied explicitly.
+- `apps/web/src/shared/ui/scroll-area.stories.tsx`: added a tagged Chromium geometry/focus assertion for generated scrollbar CSS and Base-managed viewport focusability.
+- `apps/web/src/shared/ui/scroll-area.test.tsx`: added focused composition, orientation, ref-forwarding, and overflow-dependent keyboard-focus coverage.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed ScrollArea from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\\|@radix-ui" apps/web/src/shared/ui/scroll-area.tsx apps/web/src/shared/ui/scroll-area.stories.tsx apps/web/src/shared/ui/scroll-area.test.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/styles/globals.css`, `components.json`, package metadata, and lockfiles were intentionally left unchanged.
+- Toggle, toggle-group, tabs, and unrelated shared UI wrappers remain owned by their separate migration tasks.
+
+## Behavior changes
+
+- The viewport is now in the tab order only while content overflows; Base UI computes `tabIndex` as `0` for scrollable content and `-1` otherwise instead of the wrapper forcing `0` for every instance.
+- Base UI scrollbars remain mounted and visible whenever their axis overflows. Radix's root-level `type`, `scrollHideDelay`, `dir`, and `nonce` props are no longer available; polymorphic `asChild` becomes `render`, and scrollbar `forceMount` becomes `keepMounted`. No in-repository consumers used the removed props.
+
+## Verify by hand
+
+1. Open the DenseList story, focus the overflowing viewport with Tab, and use Arrow/Page keys and the mouse wheel to scroll through the rows.
+2. Open HorizontalOverflow, focus the viewport, and confirm horizontal keyboard/trackpad scrolling reaches the last card.
+3. Open Geometry and confirm the vertical thumb is draggable, the custom track remains 10 px wide, and the story play assertion passes in Chromium.
+
+Derived summary: 8 shared UI wrappers remain on Radix.

--- a/.migration/tabs.md
+++ b/.migration/tabs.md
@@ -1,0 +1,35 @@
+# tabs
+
+2026-07-14 — engine, migrated the Tabs wrapper from Radix to Base UI while retaining the existing string-value API, automatic keyboard activation, and mounted-panel compatibility.
+
+## Changed
+
+- `apps/web/src/shared/ui/tabs.tsx`: replaced Radix Root/List/Trigger/Content with Base UI Root/List/Tab/Panel, translated active and disabled selectors, and retained the exported wrapper names.
+- The wrapper maps Radix `activationMode` to Base UI `activateOnFocus`, Radix List `loop` to `loopFocus`, Radix Content `forceMount` to `keepMounted`, and Radix `dir` to a scoped Base UI `DirectionProvider` while retaining the root DOM attribute; explicit Base UI props take precedence. Direct testing confirmed that Base UI 1.6 reads its direction context for composite keyboard navigation, so the DOM attribute alone does not reverse the arrow-key order.
+- `apps/web/src/shared/ui/tabs.stories.tsx`: added manual-activation and right-to-left stories for keyboard review.
+- `apps/web/src/shared/ui/tabs.test.tsx`: covers uncontrolled and controlled state, automatic and manual keyboard activation, right-to-left navigation, explicit List overrides, disabled tabs, and forced mounting.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed Tabs from the temporary direct-Radix allowlist.
+- `grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/tabs.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/contexts/discovery/components/DiscoveryProductControls.tsx` keeps its existing Tabs API because the wrapper preserves automatic activation.
+- `apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx` keeps `forceMount`; the compatibility wrapper maps it to Base UI `keepMounted`.
+- `apps/web/components.json`, package metadata, lockfiles, global CSS, and other shared UI wrappers remain on their separately owned migration paths.
+
+## Behavior changes
+
+- There is no activation-mode delta: arrow-key focus activates tabs by default, while `activationMode="manual"` and an explicit List `activateOnFocus={false}` retain manual activation.
+- Radix `asChild` composition on Root, List, Trigger, and Content is no longer accepted; Base UI uses `render` composition instead. No in-repository Tabs consumer uses `asChild`.
+- Explicit unmatched uncontrolled defaults retain Base UI's fallback behavior rather than Radix's: `<Tabs defaultValue="missing">` selects the first enabled Base tab and mounts its panel, while Radix leaves every tab unselected and mounts no panel. Base UI 1.6 initially honors an explicitly disabled default; after an uncontrolled selection has been valid, later disabling or removing that selected tab falls back to the first enabled tab, or to no selection when none remain. Controlled `value` roots keep the exact supplied value and do not apply these fallbacks. The wrapper intentionally does not recreate Radix's missing-selection behavior.
+- Radix Tabs 1.1.13 excludes disabled triggers from its roving-focus sequence (`focusable={!disabled}`), while Base UI 1.6 intentionally keeps disabled composite tabs focusable so their disabled state can be discovered. Base UI exposes no supported option to change that navigation policy without replacing its Tabs composite implementation. Disabled tabs expose `aria-disabled` plus `data-disabled`, accept focus, remain non-interactive, and do not activate their panel.
+- Inactive forced panels remain mounted with `hidden`, `data-hidden`, and `inert`, matching the existing StageTriggerPanel requirement without changing that consumer.
+
+## Verify by hand
+
+1. Open `Shared/UI/Tabs/StateTabs`, use Left/Right arrows, and confirm a disabled tab can receive focus but does not activate; the next arrow press continues to an enabled tab and activates it.
+2. Open `Shared/UI/Tabs/ManualActivation`, use Left/Right arrows, and confirm focus moves without changing panels until Enter or Space is pressed.
+3. Open `Shared/UI/Tabs/RightToLeft`, focus First, press Arrow Left, and confirm focus and selection move to Second rather than wrapping to Third.
+4. Open Pipeline actions, switch between Discover and Apply, and confirm both tabpanels remain in the DOM while only the active stage form is visible.
+
+Derived summary: 8 shared UI wrappers remain on Radix.

--- a/.migration/toggle-group.md
+++ b/.migration/toggle-group.md
@@ -1,0 +1,25 @@
+# toggle-group
+
+2026-07-14, engine (base-luma golden pair consulted), migration blocked on Base UI 1.6; the parent-branch Radix implementation is retained.
+
+## Decision
+
+- `apps/web/src/shared/ui/toggle-group.tsx` is restored exactly to the parent-branch `@radix-ui/react-toggle-group` wrapper. No Base compatibility regression is shipped.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts` keeps ToggleGroup in the temporary direct-Radix allowlist.
+- `apps/web/src/shared/ui/toggle-group.test.tsx` adds one focused regression for the production contract: when a mounted controlled single value changes from `active` to `deleted` without item focus, the next keyboard entry focuses the newly checked radio and makes it the sole `tabindex="0"` item.
+- The migration-only ToggleGroup stories and Base-specific adapter tests were removed. Toggle's separate Base UI migration remains unchanged.
+
+## Base UI blocker evidence
+
+- The installed Base UI version is 1.6.0. Its public ToggleGroup declaration at `apps/web/node_modules/@base-ui/react/toggle-group/ToggleGroup.d.ts` exposes value, default value, value change, disabled, orientation, loop focus, and multiple selection, but no highlighted-index or composite-control prop.
+- Base's internal `CompositeRoot` reads `data-composite-item-active` only during its first item-map initialization (`hasSetDefaultIndexRef` in `internals/composite/root/useCompositeRoot.mjs`). Its list observer watches child-list changes, not active-marker attribute changes.
+- A temporary same-mount rerender probe against the Base candidate changed the checked state from `active` to `deleted`, but unchecked `active` retained `tabindex="0"` and checked `deleted` retained `tabindex="-1"`. This is production-reachable when Job views change through browser history without focusing the switcher.
+- Base's `highlightedIndex` control exists only on the explicitly `@internal` Composite API and is not forwarded by ToggleGroup. Remount keys, direct DOM `tabIndex` mutation, synthetic focus, and internal-package composition were rejected because they would lose focus, diverge from Base keyboard state, create focus side effects, or depend on unsupported internals.
+
+## Verify by hand
+
+1. Open the Job list with the Active view selected, then change to Deleted through browser history without focusing the Job views switcher.
+2. Tab into the switcher. Confirm Deleted receives focus and becomes the sole `tabindex="0"` item; Active must be unchecked with `tabindex="-1"`.
+3. Use arrow keys within the switcher and confirm the Radix roving-focus behavior remains unchanged.
+
+Derived summary: 8 shared UI wrappers remain on Radix.

--- a/.migration/toggle.md
+++ b/.migration/toggle.md
@@ -1,0 +1,33 @@
+# toggle
+
+2026-07-14, engine (base-luma golden pair consulted), migrated to Base UI 1.6 while retaining the wrapper's visual variants and boolean pressed contract.
+
+## Changed
+
+- `apps/web/src/shared/ui/toggle.tsx` replaces the Radix root with Base UI's callable Toggle and uses Base `data-pressed` / `data-disabled` state selectors.
+- `apps/web/src/shared/ui/toggle.stories.tsx` covers default, pressed, controlled, disabled, outlined, sized, and focus-visible examples.
+- `apps/web/src/shared/ui/toggle.test.tsx` proves controlled, uncontrolled, disabled, callback, ARIA, and Base data-attribute behavior through the shared PointerEvent harness.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts` removes Toggle from the temporary direct-Radix allowlist.
+- `.migration/toggle.md` records this focused migration.
+
+`grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/toggle.tsx` returned no matches.
+
+## Left alone
+
+- `apps/web/components.json`, package metadata, the lockfile, and global CSS remain owned by the cumulative migration.
+- No production code imports the standalone `Toggle`, so no application call site needed a prop change.
+
+## Behavior changes
+
+- Base UI adds event details as the second `onPressedChange` argument. Existing one-argument handlers remain compatible.
+- Base UI composition uses `render` (and `nativeButton={false}` for non-buttons) instead of Radix `asChild`; there are no in-tree `Toggle` consumers using composition.
+- The default native button element, `aria-pressed` state, controlled/uncontrolled behavior, disabled interaction, variants, and sizes remain unchanged.
+
+## Verify by hand
+
+1. Open `Shared/UI/Toggle` in Storybook and activate Default and Outline with click, Enter, and Space.
+2. Confirm Pressed and Controlled expose the pressed visual state and `aria-pressed=true`.
+3. Confirm Disabled ignores pointer and keyboard input while retaining disabled opacity.
+4. Tab to FocusVisible and confirm the focus ring remains visible.
+
+Derived summary: 8 shared UI wrappers remain on Radix.

--- a/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
+++ b/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
@@ -13,13 +13,10 @@ const radixWrapperAllowlist = new Set([
   "shared/ui/dialog.tsx",
   "shared/ui/dropdown-menu.tsx",
   "shared/ui/popover.tsx",
-  "shared/ui/scroll-area.tsx",
   "shared/ui/select.tsx",
   "shared/ui/sheet.tsx",
-  "shared/ui/tabs.tsx",
   "shared/ui/toast.tsx",
   "shared/ui/toggle-group.tsx",
-  "shared/ui/toggle.tsx",
   "shared/ui/tooltip.tsx",
 ]);
 

--- a/apps/web/src/shared/ui/scroll-area.stories.tsx
+++ b/apps/web/src/shared/ui/scroll-area.stories.tsx
@@ -10,7 +10,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const ROWS = Array.from({ length: 40 }, (_, index) => `Activity event #${index + 1}`);
+const ROWS = Array.from(
+  { length: 40 },
+  (_, index) => `Activity event #${index + 1}`,
+);
 
 export const DenseList: Story = {
   render: () => (
@@ -31,11 +34,81 @@ export const HorizontalOverflow: Story = {
     <ScrollArea className="w-80 rounded-md border border-border">
       <div className="flex w-max gap-2 p-3">
         {Array.from({ length: 12 }, (_, index) => (
-          <div key={index} className="w-28 rounded-md border border-border bg-card p-3 text-sm">
+          <div
+            key={index}
+            className="w-28 rounded-md border border-border bg-card p-3 text-sm"
+          >
             Item {index + 1}
           </div>
         ))}
       </div>
     </ScrollArea>
   ),
+};
+
+export const Geometry: Story = {
+  tags: ["scroll-area-geometry"],
+  render: () => (
+    <ScrollArea className="h-48 w-72 rounded-md border border-border">
+      <div className="h-96 w-[36rem] p-3 text-sm">
+        Two-axis overflow geometry
+      </div>
+    </ScrollArea>
+  ),
+  play: async ({ canvasElement }) => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+
+    const root = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="scroll-area"]',
+    );
+    const viewport = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    const content = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-content"]',
+    );
+    const scrollbar = canvasElement.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-scrollbar"][data-orientation="vertical"]',
+    );
+
+    if (!root || !viewport || !content || !scrollbar) {
+      throw new Error("Missing ScrollArea geometry parts.");
+    }
+
+    const rootRect = root.getBoundingClientRect();
+    const scrollbarRect = scrollbar.getBoundingClientRect();
+    if (rootRect.width !== 288 || rootRect.height !== 192) {
+      throw new Error(
+        `Expected fixed 288x192 ScrollArea geometry, received ${rootRect.width}x${rootRect.height}.`,
+      );
+    }
+    if (scrollbarRect.width !== 10) {
+      throw new Error(
+        `Expected a 10px vertical scrollbar, received ${scrollbarRect.width}px.`,
+      );
+    }
+    if (viewport.firstElementChild !== content) {
+      throw new Error("Expected Content to be the direct child of Viewport.");
+    }
+    if (
+      viewport.scrollHeight <= viewport.clientHeight ||
+      viewport.scrollWidth <= viewport.clientWidth
+    ) {
+      throw new Error("Expected the geometry story to overflow on both axes.");
+    }
+    if (viewport.tabIndex !== 0) {
+      throw new Error(
+        `Expected Base UI to make the overflowing viewport focusable, received ${viewport.tabIndex}.`,
+      );
+    }
+
+    viewport.focus();
+    if (document.activeElement !== viewport) {
+      throw new Error(
+        "Expected the overflowing viewport to receive keyboard focus.",
+      );
+    }
+  },
 };

--- a/apps/web/src/shared/ui/scroll-area.test.tsx
+++ b/apps/web/src/shared/ui/scroll-area.test.tsx
@@ -1,0 +1,136 @@
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+import { render, screen, waitFor } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ScrollArea, ScrollBar } from "./scroll-area.js";
+
+if (typeof HTMLElement.prototype.getAnimations !== "function") {
+  Object.defineProperty(HTMLElement.prototype, "getAnimations", {
+    configurable: true,
+    value: () => [],
+  });
+}
+
+const metric = (
+  element: HTMLElement,
+  name: "clientHeight" | "clientWidth" | "scrollHeight" | "scrollWidth",
+) => {
+  if (element.dataset["slot"] !== "scroll-area-viewport") return 0;
+
+  return name.startsWith("client") ? 100 : 240;
+};
+
+const mockOverflowingViewport = () => {
+  for (const name of [
+    "clientHeight",
+    "clientWidth",
+    "scrollHeight",
+    "scrollWidth",
+  ] as const) {
+    vi.spyOn(HTMLElement.prototype, name, "get").mockImplementation(function (
+      this: HTMLElement,
+    ) {
+      return metric(this, name);
+    });
+  }
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("<ScrollArea>", () => {
+  it("composes the Base UI parts and makes an overflowing viewport keyboard focusable", async () => {
+    mockOverflowingViewport();
+    const rootRef = createRef<HTMLDivElement>();
+
+    render(
+      <ScrollArea ref={rootRef} data-testid="scroll-area-root">
+        <p>Scrollable content</p>
+      </ScrollArea>,
+    );
+
+    const root = screen.getByTestId("scroll-area-root");
+    const viewport = root.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-viewport"]',
+    );
+    const content = root.querySelector<HTMLElement>(
+      '[data-slot="scroll-area-content"]',
+    );
+
+    expect(rootRef.current).toBe(root);
+    expect(root).toHaveClass("relative", "overflow-hidden");
+    expect(viewport?.firstElementChild).toBe(content);
+    expect(content).toHaveTextContent("Scrollable content");
+    expect(content).toHaveStyle({ minWidth: "fit-content" });
+
+    await waitFor(() => {
+      const scrollbar = root.querySelector(
+        '[data-slot="scroll-area-scrollbar"]',
+      );
+
+      expect(viewport).toHaveAttribute("tabindex", "0");
+      expect(scrollbar).toHaveAttribute("data-orientation", "vertical");
+      expect(scrollbar).toHaveClass(
+        "h-full",
+        "w-2.5",
+        "border-l",
+        "border-l-transparent",
+        "p-[1px]",
+      );
+      expect(
+        root.querySelector('[data-slot="scroll-area-thumb"]'),
+      ).not.toBeNull();
+      expect(
+        root.querySelector('[data-slot="scroll-area-corner"]'),
+      ).not.toBeNull();
+    });
+
+    viewport?.focus();
+    expect(viewport).toHaveFocus();
+  });
+
+  it("leaves a non-overflowing viewport out of the tab order", () => {
+    render(<ScrollArea>Static content</ScrollArea>);
+
+    expect(
+      document.querySelector('[data-slot="scroll-area-viewport"]'),
+    ).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("preserves horizontal ScrollBar orientation, styling, and ref forwarding", () => {
+    const scrollbarRef = createRef<HTMLDivElement>();
+
+    render(
+      <ScrollAreaPrimitive.Root>
+        <ScrollAreaPrimitive.Viewport>
+          <ScrollAreaPrimitive.Content>
+            Scrollable content
+          </ScrollAreaPrimitive.Content>
+        </ScrollAreaPrimitive.Viewport>
+        <ScrollBar
+          ref={scrollbarRef}
+          data-testid="horizontal-scrollbar"
+          orientation="horizontal"
+          keepMounted
+        />
+      </ScrollAreaPrimitive.Root>,
+    );
+
+    const scrollbar = screen.getByTestId("horizontal-scrollbar");
+
+    expect(scrollbarRef.current).toBe(scrollbar);
+    expect(scrollbar).toHaveAttribute("data-orientation", "horizontal");
+    expect(scrollbar).toHaveClass(
+      "h-2.5",
+      "flex-col",
+      "border-t",
+      "border-t-transparent",
+      "p-[1px]",
+    );
+    expect(
+      scrollbar.querySelector('[data-slot="scroll-area-thumb"]'),
+    ).not.toBeNull();
+  });
+});

--- a/apps/web/src/shared/ui/scroll-area.tsx
+++ b/apps/web/src/shared/ui/scroll-area.tsx
@@ -1,5 +1,9 @@
-import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+import {
+  forwardRef,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
@@ -7,32 +11,49 @@ export const ScrollArea = forwardRef<
   ComponentRef<typeof ScrollAreaPrimitive.Root>,
   ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root ref={ref} className={cn("relative overflow-hidden", className)} {...props}>
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]" tabIndex={0}>
-      {children}
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    data-slot="scroll-area"
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport
+      data-slot="scroll-area-viewport"
+      className="h-full w-full rounded-[inherit]"
+    >
+      <ScrollAreaPrimitive.Content data-slot="scroll-area-content">
+        {children}
+      </ScrollAreaPrimitive.Content>
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
+    <ScrollAreaPrimitive.Corner data-slot="scroll-area-corner" />
   </ScrollAreaPrimitive.Root>
 ));
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
 
 export const ScrollBar = forwardRef<
-  ComponentRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+  ComponentRef<typeof ScrollAreaPrimitive.Scrollbar>,
+  ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
 >(({ className, orientation = "vertical", ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
+  <ScrollAreaPrimitive.Scrollbar
     ref={ref}
+    data-slot="scroll-area-scrollbar"
+    data-orientation={orientation}
     orientation={orientation}
     className={cn(
       "flex touch-none select-none transition-colors",
-      orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-[1px]",
-      orientation === "horizontal" && "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
       className,
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    <ScrollAreaPrimitive.Thumb
+      data-slot="scroll-area-thumb"
+      className="relative flex-1 rounded-full bg-border"
+    />
+  </ScrollAreaPrimitive.Scrollbar>
 ));
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+ScrollBar.displayName = ScrollAreaPrimitive.Scrollbar.displayName;

--- a/apps/web/src/shared/ui/tabs.stories.tsx
+++ b/apps/web/src/shared/ui/tabs.stories.tsx
@@ -52,3 +52,41 @@ export const FocusVisible: Story = {
     </Tabs>
   ),
 };
+
+export const ManualActivation: Story = {
+  render: () => (
+    <Tabs activationMode="manual" defaultValue="first" className="w-[360px]">
+      <TabsList aria-label="Manual activation example">
+        <TabsTrigger value="first">First</TabsTrigger>
+        <TabsTrigger value="second">Second</TabsTrigger>
+      </TabsList>
+      <TabsContent value="first" className="text-sm">
+        Arrow keys move focus; Enter or Space activates the focused tab.
+      </TabsContent>
+      <TabsContent value="second" className="text-sm">
+        The second manually activated panel.
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+export const RightToLeft: Story = {
+  render: () => (
+    <Tabs dir="rtl" defaultValue="first" className="w-[360px]">
+      <TabsList aria-label="Right-to-left example">
+        <TabsTrigger value="first">First</TabsTrigger>
+        <TabsTrigger value="second">Second</TabsTrigger>
+        <TabsTrigger value="third">Third</TabsTrigger>
+      </TabsList>
+      <TabsContent value="first" className="text-sm">
+        Arrow Left moves focus to the second tab in right-to-left order.
+      </TabsContent>
+      <TabsContent value="second" className="text-sm">
+        The second right-to-left panel.
+      </TabsContent>
+      <TabsContent value="third" className="text-sm">
+        The third right-to-left panel.
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/apps/web/src/shared/ui/tabs.test.tsx
+++ b/apps/web/src/shared/ui/tabs.test.tsx
@@ -1,0 +1,244 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs.js";
+
+function TestTabs({
+  activationMode,
+  activateOnFocus,
+  forceMount = false,
+}: {
+  activationMode?: "automatic" | "manual";
+  activateOnFocus?: boolean;
+  forceMount?: boolean;
+}) {
+  return (
+    <Tabs activationMode={activationMode} defaultValue="overview">
+      <TabsList activateOnFocus={activateOnFocus} aria-label="Account sections">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="details">Details</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">Overview panel</TabsContent>
+      <TabsContent value="details" forceMount={forceMount || undefined}>
+        Details panel
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+describe("<Tabs>", () => {
+  it("keeps an uncontrolled root inactive when no default value is supplied", () => {
+    render(
+      <Tabs>
+        <TabsList aria-label="Optional sections">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="details">Details</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">Overview panel</TabsContent>
+        <TabsContent value="details">Details panel</TabsContent>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
+    expect(screen.queryByRole("tabpanel")).not.toBeInTheDocument();
+  });
+
+  it("changes an uncontrolled value when a tab is clicked", async () => {
+    const user = userEvent.setup();
+    render(<TestTabs />);
+
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Overview panel");
+
+    await user.click(screen.getByRole("tab", { name: "Details" }));
+
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Details panel");
+  });
+
+  it("reports controlled changes without replacing the supplied value", () => {
+    const onValueChange = vi.fn();
+    const renderTabs = (value: string) => (
+      <Tabs value={value} onValueChange={onValueChange}>
+        <TabsList aria-label="Controlled sections">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="details">Details</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">Overview panel</TabsContent>
+        <TabsContent value="details">Details panel</TabsContent>
+      </Tabs>
+    );
+    const { rerender } = render(renderTabs("overview"));
+
+    fireEvent.click(screen.getByRole("tab", { name: "Details" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("details");
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    rerender(renderTabs("details"));
+    expect(screen.getByRole("tab", { name: "Details" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("activates focused tabs during arrow-key navigation by default", async () => {
+    const user = userEvent.setup();
+    render(<TestTabs />);
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+
+    overview.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(details).toHaveFocus();
+    expect(details).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Details panel");
+  });
+
+  it("uses right-to-left arrow navigation when dir is rtl", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs dir="rtl" defaultValue="first" data-testid="rtl-tabs">
+        <TabsList aria-label="Right-to-left sections">
+          <TabsTrigger value="first">First</TabsTrigger>
+          <TabsTrigger value="second">Second</TabsTrigger>
+          <TabsTrigger value="third">Third</TabsTrigger>
+        </TabsList>
+        <TabsContent value="first">First panel</TabsContent>
+        <TabsContent value="second">Second panel</TabsContent>
+        <TabsContent value="third">Third panel</TabsContent>
+      </Tabs>,
+    );
+    const first = screen.getByRole("tab", { name: "First" });
+    const second = screen.getByRole("tab", { name: "Second" });
+
+    expect(screen.getByTestId("rtl-tabs")).toHaveAttribute("dir", "rtl");
+    first.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(second).toHaveFocus();
+    expect(second).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("preserves manual activation configured on the Radix-compatible root prop", async () => {
+    const user = userEvent.setup();
+    render(<TestTabs activationMode="manual" />);
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+
+    overview.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(details).toHaveFocus();
+    expect(overview).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{Enter}");
+    expect(details).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("honors an explicit activateOnFocus override on the list", async () => {
+    const user = userEvent.setup();
+    render(<TestTabs activateOnFocus={false} />);
+    const overview = screen.getByRole("tab", { name: "Overview" });
+    const details = screen.getByRole("tab", { name: "Details" });
+
+    overview.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(details).toHaveFocus();
+    expect(overview).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("marks disabled tabs and does not activate them", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="overview">
+        <TabsList aria-label="Disabled sections">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="details" disabled>
+            Details
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">Overview panel</TabsContent>
+        <TabsContent value="details">Details panel</TabsContent>
+      </Tabs>,
+    );
+    const disabledTab = screen.getByRole("tab", { name: "Details" });
+
+    expect(disabledTab).toHaveAttribute("aria-disabled", "true");
+    expect(disabledTab).toHaveAttribute("data-disabled");
+    expect(disabledTab).toHaveClass("aria-disabled:pointer-events-none");
+
+    await user.click(disabledTab);
+    expect(screen.getByRole("tab", { name: "Overview" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("keeps disabled Base UI tabs focusable without activating them", async () => {
+    const user = userEvent.setup();
+    render(
+      <Tabs defaultValue="first">
+        <TabsList aria-label="Focusable disabled sections">
+          <TabsTrigger value="first">First</TabsTrigger>
+          <TabsTrigger value="second" disabled>
+            Second
+          </TabsTrigger>
+          <TabsTrigger value="third">Third</TabsTrigger>
+        </TabsList>
+        <TabsContent value="first">First panel</TabsContent>
+        <TabsContent value="second">Second panel</TabsContent>
+        <TabsContent value="third">Third panel</TabsContent>
+      </Tabs>,
+    );
+    const first = screen.getByRole("tab", { name: "First" });
+    const second = screen.getByRole("tab", { name: "Second" });
+    const third = screen.getByRole("tab", { name: "Third" });
+
+    first.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(second).toHaveFocus();
+    expect(first).toHaveAttribute("aria-selected", "true");
+    expect(second).toHaveAttribute("aria-selected", "false");
+
+    await user.keyboard("{ArrowRight}");
+    expect(third).toHaveFocus();
+    expect(third).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("maps forceMount to a kept, hidden Base UI panel", async () => {
+    const user = userEvent.setup();
+    render(<TestTabs forceMount />);
+    const hiddenPanel = screen
+      .getByText("Details panel")
+      .closest("[role=tabpanel]");
+
+    expect(hiddenPanel).toHaveAttribute("hidden");
+    expect(hiddenPanel).toHaveAttribute("data-hidden");
+
+    await user.click(screen.getByRole("tab", { name: "Details" }));
+    expect(hiddenPanel).not.toHaveAttribute("hidden");
+    expect(hiddenPanel).not.toHaveAttribute("data-hidden");
+  });
+});

--- a/apps/web/src/shared/ui/tabs.tsx
+++ b/apps/web/src/shared/ui/tabs.tsx
@@ -1,46 +1,146 @@
-import * as TabsPrimitive from "@radix-ui/react-tabs";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { DirectionProvider } from "@base-ui/react/direction-provider";
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
-export const Tabs = TabsPrimitive.Root;
+type TabsActivationMode = "automatic" | "manual";
+
+const TabsActivationModeContext =
+  createContext<TabsActivationMode>("automatic");
+
+export interface TabsProps extends Omit<
+  TabsPrimitive.Root.Props,
+  "defaultValue" | "dir" | "onValueChange" | "value"
+> {
+  activationMode?: TabsActivationMode | undefined;
+  defaultValue?: string | undefined;
+  dir?: "ltr" | "rtl" | undefined;
+  onValueChange?: ((value: string) => void) | undefined;
+  value?: string | undefined;
+}
+
+export const Tabs = forwardRef<
+  ComponentRef<typeof TabsPrimitive.Root>,
+  TabsProps
+>(
+  (
+    {
+      activationMode = "automatic",
+      defaultValue,
+      dir,
+      onValueChange,
+      value,
+      ...props
+    },
+    ref,
+  ) => {
+    const root = (
+      <TabsPrimitive.Root
+        ref={ref}
+        defaultValue={
+          value === undefined && defaultValue === undefined
+            ? null
+            : defaultValue
+        }
+        dir={dir}
+        onValueChange={
+          onValueChange === undefined
+            ? undefined
+            : (nextValue) => {
+                if (typeof nextValue === "string") {
+                  onValueChange(nextValue);
+                }
+              }
+        }
+        value={value}
+        {...props}
+      />
+    );
+
+    return (
+      <TabsActivationModeContext.Provider value={activationMode}>
+        {dir === undefined ? (
+          root
+        ) : (
+          <DirectionProvider direction={dir}>{root}</DirectionProvider>
+        )}
+      </TabsActivationModeContext.Provider>
+    );
+  },
+);
+Tabs.displayName = TabsPrimitive.Root.displayName;
+
+export interface TabsListProps extends ComponentPropsWithoutRef<
+  typeof TabsPrimitive.List
+> {
+  loop?: boolean | undefined;
+}
 
 export const TabsList = forwardRef<
   ComponentRef<typeof TabsPrimitive.List>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-9 items-center justify-center rounded-full border border-border bg-muted p-[3px] text-muted-foreground",
-      className,
-    )}
-    {...props}
-  />
-));
+  TabsListProps
+>(({ activateOnFocus, className, loop, loopFocus, ...props }, ref) => {
+  const activationMode = useContext(TabsActivationModeContext);
+
+  return (
+    <TabsPrimitive.List
+      ref={ref}
+      activateOnFocus={activateOnFocus ?? activationMode === "automatic"}
+      loopFocus={loopFocus ?? loop}
+      className={cn(
+        "inline-flex h-9 items-center justify-center rounded-full border border-border bg-muted p-[3px] text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
 TabsList.displayName = TabsPrimitive.List.displayName;
 
+export type TabsTriggerProps = Omit<
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Tab>,
+  "value"
+> & {
+  value: string;
+};
+
 export const TabsTrigger = forwardRef<
-  ComponentRef<typeof TabsPrimitive.Trigger>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+  ComponentRef<typeof TabsPrimitive.Tab>,
+  TabsTriggerProps
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
+  <TabsPrimitive.Tab
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-3.5 py-1 text-[11px] font-[850] tracking-[0.01em] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-card data-[state=active]:text-primary data-[state=active]:shadow-[var(--shadow-panel)]",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-3.5 py-1 text-[11px] font-[850] tracking-[0.01em] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-card data-active:text-primary data-active:shadow-[var(--shadow-panel)]",
       className,
     )}
     {...props}
   />
 ));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+TabsTrigger.displayName = TabsPrimitive.Tab.displayName;
+
+export type TabsContentProps = Omit<
+  ComponentPropsWithoutRef<typeof TabsPrimitive.Panel>,
+  "value"
+> & {
+  forceMount?: true | undefined;
+  value: string;
+};
 
 export const TabsContent = forwardRef<
-  ComponentRef<typeof TabsPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
+  ComponentRef<typeof TabsPrimitive.Panel>,
+  TabsContentProps
+>(({ className, forceMount, keepMounted, ...props }, ref) => (
+  <TabsPrimitive.Panel
     ref={ref}
+    keepMounted={keepMounted ?? forceMount}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className,
@@ -48,4 +148,4 @@ export const TabsContent = forwardRef<
     {...props}
   />
 ));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+TabsContent.displayName = TabsPrimitive.Panel.displayName;

--- a/apps/web/src/shared/ui/toggle-group.test.tsx
+++ b/apps/web/src/shared/ui/toggle-group.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group.js";
+
+function controlledJobViews(value: "active" | "deleted") {
+  return (
+    <>
+      <button type="button">Before views</button>
+      <ToggleGroup aria-label="Job views" type="single" value={value}>
+        <ToggleGroupItem value="active">Active</ToggleGroupItem>
+        <ToggleGroupItem value="deleted">Deleted</ToggleGroupItem>
+      </ToggleGroup>
+    </>
+  );
+}
+
+describe("ToggleGroup", () => {
+  it("enters a mounted controlled group at its newly selected value", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(controlledJobViews("active"));
+    const beforeViews = screen.getByRole("button", { name: "Before views" });
+    const active = screen.getByRole("radio", { name: "Active" });
+    const deleted = screen.getByRole("radio", { name: "Deleted" });
+
+    expect(active).toHaveAttribute("aria-checked", "true");
+    expect(deleted).toHaveAttribute("aria-checked", "false");
+    beforeViews.focus();
+
+    rerender(controlledJobViews("deleted"));
+
+    expect(active).toHaveAttribute("aria-checked", "false");
+    expect(deleted).toHaveAttribute("aria-checked", "true");
+
+    await user.tab();
+
+    expect(deleted).toHaveFocus();
+    expect(active).toHaveAttribute("tabindex", "-1");
+    expect(deleted).toHaveAttribute("tabindex", "0");
+  });
+});

--- a/apps/web/src/shared/ui/toggle.stories.tsx
+++ b/apps/web/src/shared/ui/toggle.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { Toggle } from "./toggle.js";
+
+const meta = {
+  title: "Shared/UI/Toggle",
+  component: Toggle,
+  args: {
+    children: "Pin",
+  },
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Pressed: Story = {
+  args: { defaultPressed: true },
+};
+
+export const Outline: Story = {
+  args: { variant: "outline" },
+};
+
+export const Controlled: Story = {
+  render: function ControlledToggle() {
+    const [pressed, setPressed] = useState(false);
+
+    return (
+      <Toggle pressed={pressed} onPressedChange={setPressed}>
+        {pressed ? "Pinned" : "Pin"}
+      </Toggle>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: { defaultPressed: true, disabled: true },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Toggle size="sm">Small</Toggle>
+      <Toggle>Default</Toggle>
+      <Toggle size="lg">Large</Toggle>
+    </div>
+  ),
+};
+
+export const FocusVisible: Story = {
+  args: { autoFocus: true },
+};

--- a/apps/web/src/shared/ui/toggle.test.tsx
+++ b/apps/web/src/shared/ui/toggle.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Toggle } from "./toggle.js";
+
+function ControlledToggle() {
+  const [pressed, setPressed] = useState(false);
+
+  return (
+    <Toggle
+      aria-label="Controlled toggle"
+      pressed={pressed}
+      onPressedChange={(nextPressed) => setPressed(nextPressed)}
+    />
+  );
+}
+
+describe("Toggle", () => {
+  it("updates Base UI pressed state in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onPressedChange = vi.fn();
+
+    render(
+      <Toggle
+        aria-label="Uncontrolled toggle"
+        onPressedChange={onPressedChange}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", {
+      name: "Uncontrolled toggle",
+    });
+    expect(toggle).not.toHaveAttribute("data-pressed");
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("data-pressed");
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+    expect(onPressedChange).toHaveBeenCalledWith(true, expect.anything());
+  });
+
+  it("keeps controlled pressed state observable", async () => {
+    const user = userEvent.setup();
+    render(<ControlledToggle />);
+
+    const toggle = screen.getByRole("button", { name: "Controlled toggle" });
+    await user.click(toggle);
+
+    expect(toggle).toHaveAttribute("data-pressed");
+    expect(toggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("exposes disabled state and ignores interaction", async () => {
+    const user = userEvent.setup();
+    const onPressedChange = vi.fn();
+    render(
+      <Toggle
+        aria-label="Disabled toggle"
+        disabled
+        onPressedChange={onPressedChange}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: "Disabled toggle" });
+    await user.click(toggle);
+
+    expect(toggle).toBeDisabled();
+    expect(toggle).toHaveAttribute("data-disabled");
+    expect(toggle).not.toHaveAttribute("data-pressed");
+    expect(onPressedChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/shared/ui/toggle.tsx
+++ b/apps/web/src/shared/ui/toggle.tsx
@@ -1,11 +1,13 @@
-import * as TogglePrimitive from "@radix-ui/react-toggle";
+"use client";
+
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "../lib/cn.js";
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-3xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-3xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 data-disabled:pointer-events-none data-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -26,15 +28,21 @@ const toggleVariants = cva(
   },
 );
 
+interface ToggleProps
+  extends
+    Omit<React.ComponentProps<typeof TogglePrimitive>, "className">,
+    VariantProps<typeof toggleVariants> {
+  className?: string;
+}
+
 function Toggle({
   className,
   variant = "default",
   size = "default",
   ...props
-}: React.ComponentProps<typeof TogglePrimitive.Root> &
-  VariantProps<typeof toggleVariants>) {
+}: ToggleProps) {
   return (
-    <TogglePrimitive.Root
+    <TogglePrimitive
       data-slot="toggle"
       className={cn(toggleVariants({ variant, size, className }))}
       {...props}
@@ -42,4 +50,4 @@ function Toggle({
   );
 }
 
-export { Toggle, toggleVariants };
+export { Toggle, toggleVariants, type ToggleProps };


### PR DESCRIPTION
## What changed

- migrate the shared Tabs, Toggle, and ScrollArea wrappers from Radix to Base UI
- preserve current string values, activation modes, RTL navigation, force-mounted tab panels, variants, and consumer APIs through focused adapters
- add focused component tests and Storybook states for the migrated primitives
- keep ToggleGroup on Radix after proving Base UI 1.6 cannot preserve the controlled roving-tab-stop contract used by Job views
- update the direct-Radix boundary and add per-component migration reports

## Why

This is the next compatibility-first slice of the Radix-to-Base migration. It removes three direct Radix wrapper imports without combining the dependency migration with the later visual redesign. ToggleGroup remains intentionally unmigrated rather than introducing a production-reachable keyboard regression when URL or history state changes the selected Job view.

## Validation

- 8 focused Vitest files, 65 tests passed
- corepack pnpm web:check
- corepack pnpm web:build
- git diff --check
- review gate: PASS with 0 Blocker, High, Medium, or Low findings

## Documentation

Public documentation is intentionally deferred to the final PR in this migration and redesign stack. Focused migration reports under .migration record the compatibility decisions in this slice.