### PR TITLE
refactor(web): migrate overlays and select to Base UI

### DIFF
--- a/.migration/popover.md
+++ b/.migration/popover.md
@@ -1,0 +1,37 @@
+# popover
+
+2026-07-15 — current radix-luma/base-luma golden pair plus the transformation engine, migrated the Popover wrapper to Base UI 1.6 and hardened its outside-interaction bridge against Base's native event timing.
+
+## Changed
+
+- `apps/web/src/shared/ui/popover.tsx`: replaced the direct Radix import with Base UI `Root`, `Trigger`, `Portal`, `Positioner`, `Popup`, `Arrow`, and `Close`. The original `Popover`, `PopoverTrigger`, `PopoverAnchor`, and `PopoverContent` exports remain, and the Base structural parts are also exported as `PopoverPortal`, `PopoverPositioner`, `PopoverPopup`, `PopoverArrow`, and `PopoverClose`.
+- The focused Content adapter keeps the existing `align="center"`, `side="bottom"`, `sideOffset={4}`, fixed positioning, zero collision/arrow padding, no perpendicular-axis fallback, `sticky="partial"`, portal container, forced mounting, detached-anchor hiding, and exact popup visual class list. Its stable empty collision-boundary array retains Radix's viewport/root-boundary default instead of inheriting Base's clipping-ancestor default when a custom portal container clips overflow. Radix `sticky="always"` maps to Base `sticky={true}`; `avoidCollisions={false}` maps to Base's all-`none` collision policy.
+- `PopoverAnchor` remains a real compatibility part. It registers its rendered element with Base Positioner, supports both Radix `asChild` and Base `render` composition without an extra DOM wrapper, and yields to an explicit Content `anchor` prop.
+- Autofocus and dismissal callbacks remain cancelable. Actual Base `pointerdown` and focus-out transitions receive cancelable Radix-shaped custom events with `detail.originalEvent`. Base outside presses reported from another native phase receive a truthful cancelable `popover.outsidePress` event through `onInteractOutside`; preventing any compatibility event cancels Base Root's close transition. Root open callbacks retain their first boolean argument and may also inspect Base's event details.
+- Modal content includes a screen-reader-only Base Close control so Base UI's modal and `trap-focus` modes retain an accessible escape path and actually enable focus trapping.
+- `apps/web/src/shared/ui/popover.stories.tsx`: migrated the existing stories to Base `render` composition and added a controlled modal/Close/positioning story.
+- `apps/web/src/shared/ui/popover.test.tsx`: covers custom-anchor geometry, fixed placement and offsets, viewport versus clipping-ancestor behavior in a custom portal container, portal structure, retained classes, old `asChild` composition, controlled callbacks, initial/final focus, Close, prevented Escape/focus-out/outside-press dismissal, real focusable outside-click ordering with and without cancellation, native pointerdown-versus-click event types, forced mounting, and the modal escape control.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removed Popover from the temporary direct-Radix allowlist. `grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/popover.tsx apps/web/src/shared/ui/popover.test.tsx apps/web/src/shared/ui/popover.stories.tsx` returns no matches.
+
+## Left alone
+
+- Repository-wide consumer inspection found no production import of the shared Popover and no production `PopoverAnchor` consumer; the pre-existing consumers are the shared stories. No application call site required migration.
+- `apps/web/components.json`, package metadata, lockfiles, global CSS, and other shared UI migrations remain on their separately owned slices.
+
+## Behavior changes
+
+- Base Portal renders an additional `<div data-base-ui-portal>` and Positioner DOM layer. Positioner and Popup expose Base `data-open`, `data-closed`, `data-side`, and `data-align` attributes instead of Radix Content's `data-state`; no repository consumer targets the removed DOM shape, attributes, or Radix Popper CSS variables.
+- Base UI's modal focus manager requires a Close part. Modal Content therefore gains a screen-reader-only `Close popover` button in addition to any visible close control supplied by a caller.
+- Base UI 1.6's public Popover Root API exposes no initiating pointerdown event or dismissal-timing option for the default nonmodal mouse path. A real click on a focusable outside target reports `focus-out` first and then `outside-press` from the final native `click`; a non-focus-moving target reports only the final click. The adapter therefore never relabels either event as Radix `onPointerDownOutside`: `onInteractOutside` receives a cancelable Radix-shaped focus event first, then a cancelable `popover.outsidePress` event whose `detail.originalEvent` truthfully contains Base's `MouseEvent | PointerEvent | TouchEvent`. Base also calls Root `onOpenChange(false, …)` for both uncanceled phases of that one focusable click. Preventing `onInteractOutside` cancels both phases, but a caller using only `onPointerDownOutside` cannot observe or cancel this default Base path. Caching the earlier DOM pointerdown was rejected because correctly identifying associated triggers, nested portals/branches, drag-outs, and Radix's deferred touch-click behavior would duplicate unsupported outside-detection internals. When Base itself reports an actual `pointerdown` (for example, trap-focus's sloppy mouse path), both Radix-shaped callbacks still run in Radix order and share the same cancelable event. This widens `onInteractOutside`'s event union; no repository consumer uses either callback.
+- `onOpenAutoFocus` and `onCloseAutoFocus` retain their cancelable focus-policy behavior, but the compatibility callback receives a synthetic `Event` whose `target`/`currentTarget` are `null` rather than Radix's event dispatched from Content. No repository consumer uses either callback.
+- Radix Anchor's unused `virtualRef` prop and Content's unused `onPlaced` and `updatePositionStrategy` props have no exact Base 1.6 adapter equivalent and are not exposed. Base's explicit Content `anchor`, `positionMethod`, and `disableAnchorTracking` props cover current positioning needs; no repository consumer used the removed props.
+- Base Root `onOpenChange` receives a second event-details argument. Existing one-argument callbacks remain compatible.
+
+## Verify by hand
+
+1. Open `Shared/UI/Popover/FilterPicker`; activate the trigger by pointer and keyboard, confirm the popup opens start-aligned below it, and dismiss it with Escape and clicks on both focusable and non-focusable outside content.
+2. Open `Shared/UI/Popover/OpenByDefault`; confirm the popup surface, border, foreground, width, and shadow match the existing visual treatment and focus enters the popup content.
+3. Open `Shared/UI/Popover/ControlledModal`; open and close it with the trigger, visible Close button, Escape, and keyboard focus. Confirm focus is trapped while open, returns to the trigger on close, and the state label follows the controlled Root.
+4. Inspect the controlled popup and confirm it is right-positioned with the requested offset, has `role="dialog"`, and exposes an accessible `Close popover` escape control.
+
+Derived summary: 5 shared UI wrappers currently retain direct Radix imports in the shared worktree (`dialog`, `dropdown-menu`, `sheet`, `toast`, and `toggle-group`).

--- a/.migration/select.md
+++ b/.migration/select.md
@@ -1,0 +1,40 @@
+# select
+
+2026-07-14 — engine with the current base-luma golden pair as the structural reference; migrated the customized Select wrapper from Radix to Base UI 1.6 while preserving its string-value API, formatted labels, popper defaults, styling, and production source-policy flow.
+
+## Changed
+
+- `apps/web/src/shared/ui/select.tsx:1`: replaced the direct Radix import with Base UI `Root`, `Trigger`, `Value`, `Icon`, `Portal`, `Positioner`, `Popup`, `List`, `Group`, `GroupLabel`, `Item`, `ItemText`, `ItemIndicator`, scroll-arrow, and `Separator` parts. Existing exported JobCtrl names and visual class lists remain intact; Base-only structural classes and CSS-variable names were changed only where the primitive anatomy requires them.
+- `apps/web/src/shared/ui/select.tsx:17`: added a Radix-compatible string Root adapter for controlled/uncontrolled values, one-argument `onValueChange`, and scoped `dir`. It derives and stabilizes `{ value, label }` items from direct `SelectItem` descendants so Base `SelectValue` renders display labels such as `public markdown`, not storage values such as `public_markdown`; callers can also provide Base's explicit `items` prop.
+- `apps/web/src/shared/ui/select.tsx:186`: split Content into `Portal > Positioner > Popup > List`, explicitly forwards every exposed positioning prop, preserves the wrapper's `position="popper"` default through `alignItemWithTrigger={false}`, and retains Radix defaults for fixed positioning, start alignment, offsets, viewport collision padding, arrow padding, and viewport-based collision bounds. `avoidCollisions={false}` maps to Base's all-`none` collision policy, `hideWhenDetached` uses `data-anchor-hidden`, and the Popup ref remains the public Content ref.
+- `apps/web/src/shared/ui/select.tsx:282`: maps public `SelectLabel` to Base `GroupLabel`, maps Item `textValue` to Base `label`, keeps string item values required, and changes the indicator and trigger icon from Radix `asChild` to Base `render` composition.
+- `apps/web/src/shared/ui/select.test.tsx`: adds focused regression coverage for inferred formatted labels, controlled and uncontrolled string values, callback arity, placeholder/disabled states, group labeling, popper positioning, right-to-left logical positioning, and a zero-critical/serious open-state axe check that includes the portaled popup anatomy.
+- `apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.test.tsx:166`: proves the real consumer shows `public markdown` and that choosing the formatted `partner api` option persists the canonical `partner_api` value through the API port.
+- `apps/web/src/shared/ui/select.stories.tsx`: expands stories across populated, open, placeholder, controlled, disabled, right-to-left, and long-scroll states, plus a tagged browser contract that checks label formatting, popup positioning mode, and group-label association.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts`: removes Select from the temporary direct-Radix allowlist. `grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/select.tsx apps/web/src/shared/ui/select.test.tsx apps/web/src/shared/ui/select.stories.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx` keeps its existing Select markup and string callback API because the compatibility adapter preserves both; only its regression test changed.
+- Native `<select>` elements in Runs filters, AI model policy controls, and the resume plate editor are unrelated to the shared Radix wrapper and remain untouched.
+- Dialog, dropdown-menu, sheet, toast, toggle-group, package metadata, and the direct-Radix dependency removal remain on separately owned migration slices.
+
+## Behavior changes
+
+- Radix `asChild` composition on Trigger, Value, Content, Label, Item, and Separator is replaced by Base UI `render` composition. No in-repository Select consumer uses `asChild`; the wrapper's own trigger icon and item indicator now use `render`.
+- Root `onOpenChange` now receives Base UI event details as its second argument. Existing zero- or one-argument handlers remain compatible, and no in-repository Select consumer reads the additional argument.
+- Base Portal adds a `<div data-base-ui-portal>` and Positioner DOM layer. Popup/List expose Base `data-open`, `data-closed`, `data-side`, and `data-align` attributes instead of Radix Content's `data-state`; no in-repository Select consumer targets the removed attributes.
+- Base ItemText renders a `<div>` rather than Radix's `<span>`. The wrapper keeps the same text and layout contract, and no repository selector depends on the old element name.
+- Base scroll arrows do not render for touch input. Pointer, keyboard, typeahead, selected-item, disabled-item, and scroll behavior otherwise remain owned by Base UI.
+- Radix Content `onCloseAutoFocus`, `onEscapeKeyDown`, and `onPointerDownOutside` are not accepted by the compatibility Content wrapper. Base exposes final focus on Popup and close interception through Root `onOpenChange` event details; no repository consumer uses the old callbacks.
+- Radix `sticky="partial" | "always"` has no exact Base equivalent. The wrapper maps the unused default `partial` to Base `false` and `always` to Base `true`; no repository consumer supplies `sticky`.
+- Automatic label inference can inspect direct/nested JSX `SelectItem` elements, including arrays and fragments, but cannot execute an arbitrary custom component that privately returns items. Such abstractions must pass Base's explicit `items` prop. All current repository consumers and stories use inspectable items and are covered.
+
+## Verify by hand
+
+1. Open `Shared/UI/Select/MigrationContract`; confirm the trigger says `Licensed API`, not `licensed_api`, and the popup is open below the trigger with the labeled option group.
+2. Open `Shared/UI/Select/Controlled`; choose Regular and Comfortable, then reopen the list and use Arrow Up/Down, Home/End, typeahead, Enter, and Escape.
+3. Open `Shared/UI/Select/LongScrollableList`; confirm the top and bottom scroll arrows appear only when their direction can scroll and that hovering them moves the list.
+4. Open Settings > Compensation sources; confirm Levels.fyi shows `public markdown`, open Glassdoor access mode, choose `partner api`, and verify the saved status appears without changing the displayed label to the underscore-delimited storage value.
+
+Derived summary: 5 shared UI wrappers currently retain direct Radix imports in the shared worktree (`dialog`, `dropdown-menu`, `sheet`, `toast`, and `toggle-group`).

--- a/.migration/tooltip.md
+++ b/.migration/tooltip.md
@@ -1,0 +1,34 @@
+# tooltip
+
+2026-07-14, review-corrected 2026-07-15 — base-luma golden pair via registry plus engine, migrated the Tooltip wrapper from Radix to Base UI 1.6 while preserving the existing delay, hover/focus, accessibility, positioning, and visual contracts.
+
+## Changed
+
+- `apps/web/src/shared/ui/tooltip.tsx`: replaced Radix Provider/Root/Trigger/Content with Base UI Provider/Root/Trigger and the required `Portal > Positioner > Popup` structure. The popup keeps the exact existing class list and intentionally remains arrowless; the Positioner adds only the structural `isolate z-50` classes from the current base-luma golden pair.
+- Provider compatibility maps `delayDuration` to `delay`, `skipDelayDuration` to `timeout`, and provider-wide `disableHoverableContent` to each Root's `disableHoverablePopup`. The existing Radix defaults remain 700 ms and 300 ms rather than changing to Base Trigger/Provider defaults of 600 ms and 400 ms. Root `delayDuration` moves to Trigger `delay`, and an explicit Base Trigger `delay` wins.
+- Content positioning props are explicitly forwarded to Positioner. Existing defaults remain `positionMethod="fixed"`, `side="top"`, `align="center"`, `sideOffset={4}`, `alignOffset={0}`, `collisionPadding={0}`, and `arrowPadding={0}`; the explicit fixed default preserves Radix Popper's strategy instead of inheriting Base's absolute default. Enabled collisions explicitly use `fallbackAxisSide: "none"` plus a module-stable empty `Element[]` boundary, preserving Radix's preferred-axis-only fallback and viewport boundary instead of Base's perpendicular-end and clipping-ancestor defaults. `avoidCollisions={false}` maps to Base's all-`none` collision policy, `forceMount` maps to Portal `keepMounted`, and `hideWhenDetached` uses the Positioner's `data-anchor-hidden` state.
+- Base UI 1.6 does not add Tooltip ARIA semantics itself, so the wrapper preserves Radix's accessible relationship with a stable popup ID, `role="tooltip"`, and open-only `aria-describedby` on the trigger. Existing caller-supplied `aria-describedby` values and Content IDs are retained. Consumer `onOpenChange` callbacks run before the wrapper commits its uncontrolled ARIA state, and canceled transitions do not commit.
+- `apps/web/src/shared/ui/tooltip.stories.tsx` replaces Radix `asChild` composition with Base `render` composition and adds positioned offset coverage. `apps/web/src/shared/ui/tooltip.test.tsx` covers portal structure, exact classes, fixed positioning and offsets, Radix-compatible collision defaults and stable boundary identity, hover/focus/Escape behavior, canceled open/close ARIA synchronization, ARIA linkage, provider/root delay compatibility, provider hoverability, and forced mounting.
+- `apps/web/src/shared/ui/base-ui-migration-boundary.test.ts` removes Tooltip from the temporary direct-Radix allowlist. `grep -n "radix-ui\|@radix-ui" apps/web/src/shared/ui/tooltip.tsx` returns no matches.
+
+## Left alone
+
+- `apps/web/src/main.tsx`, `apps/web/src/test/render.tsx`, and `apps/web/.storybook/preview.tsx` keep their existing `<TooltipProvider>` calls because the wrapper preserves that API.
+- No production feature component directly consumes Tooltip Root, Trigger, or Content; the three pre-existing consumers are the shared stories. Other shared UI migrations and package metadata remain on their separately owned paths.
+
+## Behavior changes
+
+- Radix `asChild` is no longer accepted on Trigger or Content; Base UI uses `render`. All in-repository Tooltip stories have been migrated, and there are no production `asChild` consumers.
+- Base Portal renders an additional `<div data-base-ui-portal>` wrapper. Positioner now owns placement styles and exposes Base's `data-side`, `data-align`, and `data-anchor-hidden` attributes; Popup exposes `data-open`/`data-closed` instead of Radix's `data-state` values. No repository consumer styles the removed Radix data attributes or tooltip CSS variables.
+- Radix Content `onEscapeKeyDown` and `onPointerDownOutside` are not exposed by the compatibility wrapper. Base reports those interactions through Root `onOpenChange` event details (`escape-key` and `outside-press`), where closing can be canceled. No repository consumer uses the Content callbacks.
+- Radix `sticky="partial" | "always"` is intentionally not copied to Base's unrelated boolean `sticky` prop. Base collision policy should be configured through `collisionAvoidance`; no repository consumer sets `sticky`.
+- Root `onOpenChange` receives Base's second event-details argument. Existing one-argument callbacks remain valid JavaScript/TypeScript callbacks.
+
+## Verify by hand
+
+1. Open `Shared/UI/Tooltip/Hint`, hover and keyboard-focus the trigger, and confirm the tooltip opens immediately, remains reachable while moving the pointer toward it, and closes with Escape.
+2. Open `Shared/UI/Tooltip/DisabledControl` and confirm the open tooltip remains anchored to the wrapper around the disabled button.
+3. Open `Shared/UI/Tooltip/Positioned` and confirm the popup is below and start-aligned with the trigger using the visibly larger side/alignment offsets.
+4. Inspect the open Hint trigger and confirm `aria-describedby` references the element with `role="tooltip"`; close it and confirm the relationship is removed.
+
+Derived summary: 5 shared UI wrappers currently retain direct Radix imports in the shared worktree (`dialog`, `dropdown-menu`, `sheet`, `toast`, and `toggle-group`).

--- a/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.test.tsx
+++ b/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.test.tsx
@@ -175,7 +175,7 @@ describe("<CompensationSourcePolicyPanel>", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("combobox", { name: "Levels.fyi access mode" }),
-    ).toBeInTheDocument();
+    ).toHaveTextContent("public markdown");
     expect(
       screen.queryByRole("switch", { name: "Confirm Levels.fyi Europe coverage" }),
     ).not.toBeInTheDocument();
@@ -209,6 +209,36 @@ describe("<CompensationSourcePolicyPanel>", () => {
         enabled: true,
         accessMode: "public_markdown",
         europeCoverageConfirmed: false,
+      }),
+    );
+  });
+
+  it("saves the formatted access-mode selection through the API port", async () => {
+    const user = userEvent.setup();
+    const updateCompensationSourcePolicy = vi.fn(async () => policyResponse());
+    renderWithProviders(<CompensationSourcePolicyPanel />, {
+      ports: buildTestPorts({
+        api: {
+          compensationSources: vi.fn(async () => policyResponse()),
+          updateCompensationSourcePolicy,
+        },
+      }),
+    });
+
+    await user.click(
+      await screen.findByRole("combobox", {
+        name: "Glassdoor access mode",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("option", { name: "partner api" }),
+    );
+
+    await waitFor(() =>
+      expect(updateCompensationSourcePolicy).toHaveBeenCalledWith({
+        sourceId: "glassdoor",
+        enabled: false,
+        accessMode: "partner_api",
       }),
     );
   });

--- a/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
+++ b/apps/web/src/shared/ui/base-ui-migration-boundary.test.ts
@@ -12,12 +12,9 @@ const sourceExtensions = new Set([".ts", ".tsx"]);
 const radixWrapperAllowlist = new Set([
   "shared/ui/dialog.tsx",
   "shared/ui/dropdown-menu.tsx",
-  "shared/ui/popover.tsx",
-  "shared/ui/select.tsx",
   "shared/ui/sheet.tsx",
   "shared/ui/toast.tsx",
   "shared/ui/toggle-group.tsx",
-  "shared/ui/tooltip.tsx",
 ]);
 
 const sourceFilesIn = (directory: string): string[] =>

--- a/apps/web/src/shared/ui/popover.stories.tsx
+++ b/apps/web/src/shared/ui/popover.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 
 import { Button } from "./button.js";
-import { Popover, PopoverContent, PopoverTrigger } from "./popover.js";
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "./popover.js";
 
 const meta = {
   title: "Shared/UI/Popover",
@@ -14,12 +20,18 @@ type Story = StoryObj<typeof meta>;
 export const FilterPicker: Story = {
   render: () => (
     <Popover>
-      <PopoverTrigger asChild>
-        <Button variant="outline">Filter options</Button>
+      <PopoverTrigger render={<Button variant="outline" />}>
+        Filter options
       </PopoverTrigger>
-      <PopoverContent aria-label="Saved filter options" className="w-64">
+      <PopoverContent
+        align="start"
+        aria-label="Saved filter options"
+        className="w-64"
+      >
         <div className="grid gap-2">
-          <p className="text-sm font-medium text-popover-foreground">Saved filters</p>
+          <p className="text-sm font-medium text-popover-foreground">
+            Saved filters
+          </p>
           <ul className="space-y-1 text-sm text-muted-foreground">
             <li>Updated recently</li>
             <li>Owned by reviewer</li>
@@ -37,8 +49,8 @@ export const FilterPicker: Story = {
 export const OpenByDefault: Story = {
   render: () => (
     <Popover defaultOpen>
-      <PopoverTrigger asChild>
-        <Button variant="outline">Help</Button>
+      <PopoverTrigger render={<Button variant="outline" />}>
+        Help
       </PopoverTrigger>
       <PopoverContent aria-label="Help details" className="w-64">
         <div className="grid gap-2 text-sm">
@@ -51,4 +63,38 @@ export const OpenByDefault: Story = {
       </PopoverContent>
     </Popover>
   ),
+};
+
+export const ControlledModal: Story = {
+  render: function ControlledModalPopover() {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <div className="flex items-center gap-3">
+        <Popover modal open={open} onOpenChange={setOpen}>
+          <PopoverTrigger render={<Button variant="outline" />}>
+            Controlled popover
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            aria-label="Controlled popover details"
+            className="w-64"
+            side="right"
+            sideOffset={8}
+          >
+            <p className="text-sm text-muted-foreground">
+              This state exercises controlled open callbacks, modal focus,
+              custom positioning, and the close part.
+            </p>
+            <PopoverClose render={<Button size="sm" variant="outline" />}>
+              Close
+            </PopoverClose>
+          </PopoverContent>
+        </Popover>
+        <span className="text-sm text-muted-foreground">
+          {open ? "Open" : "Closed"}
+        </span>
+      </div>
+    );
+  },
 };

--- a/apps/web/src/shared/ui/popover.test.tsx
+++ b/apps/web/src/shared/ui/popover.test.tsx
@@ -1,0 +1,697 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { Button } from "./button.js";
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from "./popover.js";
+
+describe("Popover", () => {
+  it("keeps positioning props on the Base UI positioner and supports a custom anchor", async () => {
+    const getAnchorRect = () =>
+      ({
+        bottom: 70,
+        height: 20,
+        left: 100,
+        right: 140,
+        top: 50,
+        width: 40,
+        x: 100,
+        y: 50,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    const { container } = render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open details</PopoverTrigger>
+        <PopoverAnchor asChild>
+          <span
+            ref={(element) => {
+              if (element) element.getBoundingClientRect = getAnchorRect;
+            }}
+            data-testid="custom-anchor"
+          >
+            Custom anchor
+          </span>
+        </PopoverAnchor>
+        <PopoverContent
+          align="start"
+          alignOffset={8}
+          aria-label="Positioned details"
+          avoidCollisions={false}
+          className="custom-popover"
+          data-testid="positioned-content"
+          side="bottom"
+          sideOffset={12}
+        >
+          Positioned content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    const content = await screen.findByRole("dialog", {
+      name: "Positioned details",
+    });
+    const positioner = content.parentElement;
+    const anchor = screen.getByTestId("custom-anchor");
+
+    expect(anchor).toHaveAttribute("data-slot", "popover-anchor");
+    expect(anchor.parentElement).toBe(container);
+    expect(content).toHaveAttribute("data-testid", "positioned-content");
+    expect(content).toHaveClass(
+      "z-50",
+      "w-72",
+      "rounded-lg",
+      "border",
+      "border-border",
+      "bg-popover",
+      "p-4",
+      "text-popover-foreground",
+      "shadow-[var(--shadow-panel)]",
+      "outline-none",
+      "custom-popover",
+    );
+    expect(positioner).toHaveClass("isolate", "z-50", "outline-none");
+    expect(positioner).toHaveAttribute("data-side", "bottom");
+    expect(positioner).toHaveAttribute("data-align", "start");
+    expect(positioner).toHaveStyle({
+      position: "fixed",
+      transform: "translate(108px, 82px)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("keeps Radix's viewport collision boundary inside a clipping portal container", async () => {
+    const documentElement = document.documentElement;
+    const originalClientWidth = Object.getOwnPropertyDescriptor(
+      documentElement,
+      "clientWidth",
+    );
+    const originalClientHeight = Object.getOwnPropertyDescriptor(
+      documentElement,
+      "clientHeight",
+    );
+    const originalDocumentRect = documentElement.getBoundingClientRect;
+    const portalContainer = document.createElement("div");
+    const rect = (x: number, y: number, width: number, height: number) =>
+      ({
+        bottom: y + height,
+        height,
+        left: x,
+        right: x + width,
+        top: y,
+        width,
+        x,
+        y,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    Object.defineProperty(documentElement, "clientWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(documentElement, "clientHeight", {
+      configurable: true,
+      value: 768,
+    });
+    documentElement.getBoundingClientRect = () => rect(0, 0, 1024, 768);
+    portalContainer.style.height = "40px";
+    portalContainer.style.overflow = "hidden";
+    portalContainer.style.transform = "translateZ(0)";
+    portalContainer.style.width = "40px";
+    Object.defineProperty(portalContainer, "clientWidth", {
+      configurable: true,
+      value: 40,
+    });
+    Object.defineProperty(portalContainer, "clientHeight", {
+      configurable: true,
+      value: 40,
+    });
+    portalContainer.getBoundingClientRect = () => rect(0, 0, 40, 40);
+    document.body.append(portalContainer);
+
+    const renderWithBoundary = (collisionBoundary?: "clipping-ancestors") =>
+      render(
+        <Popover defaultOpen>
+          <PopoverTrigger>Open boundary details</PopoverTrigger>
+          <PopoverAnchor asChild>
+            <span
+              ref={(element) => {
+                if (element) {
+                  element.getBoundingClientRect = () => rect(400, 200, 40, 20);
+                }
+              }}
+            >
+              Boundary anchor
+            </span>
+          </PopoverAnchor>
+          <PopoverContent
+            aria-label="Boundary details"
+            collisionBoundary={collisionBoundary}
+            container={portalContainer}
+          >
+            Boundary content
+          </PopoverContent>
+        </Popover>,
+      );
+
+    try {
+      const defaultRender = renderWithBoundary();
+      const defaultPositioner = (
+        await screen.findByRole("dialog", { name: "Boundary details" })
+      ).parentElement;
+      await waitFor(() =>
+        expect(
+          defaultPositioner?.style.getPropertyValue("--available-width"),
+        ).not.toBe(""),
+      );
+      const defaultAvailableWidth = Number.parseFloat(
+        defaultPositioner?.style.getPropertyValue("--available-width") ?? "",
+      );
+      defaultRender.unmount();
+
+      const clippedRender = renderWithBoundary("clipping-ancestors");
+      const clippedPositioner = (
+        await screen.findByRole("dialog", { name: "Boundary details" })
+      ).parentElement;
+      await waitFor(() =>
+        expect(
+          clippedPositioner?.style.getPropertyValue("--available-width"),
+        ).not.toBe(""),
+      );
+      const clippedAvailableWidth = Number.parseFloat(
+        clippedPositioner?.style.getPropertyValue("--available-width") ?? "",
+      );
+
+      expect(defaultAvailableWidth).toBeGreaterThan(clippedAvailableWidth);
+      expect(defaultAvailableWidth).toBeGreaterThan(40);
+      clippedRender.unmount();
+    } finally {
+      portalContainer.remove();
+      documentElement.getBoundingClientRect = originalDocumentRect;
+      if (originalClientWidth) {
+        Object.defineProperty(
+          documentElement,
+          "clientWidth",
+          originalClientWidth,
+        );
+      } else {
+        delete (documentElement as { clientWidth?: number }).clientWidth;
+      }
+      if (originalClientHeight) {
+        Object.defineProperty(
+          documentElement,
+          "clientHeight",
+          originalClientHeight,
+        );
+      } else {
+        delete (documentElement as { clientHeight?: number }).clientHeight;
+      }
+    }
+  });
+
+  it("preserves asChild composition, open callbacks, focus, and close behavior", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <Button variant="outline">Edit filter</Button>
+        </PopoverTrigger>
+        <PopoverContent aria-label="Edit filter details">
+          <label htmlFor="filter-name">Filter name</label>
+          <input id="filter-name" />
+          <PopoverClose asChild>
+            <Button size="sm">Done</Button>
+          </PopoverClose>
+        </PopoverContent>
+      </Popover>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Edit filter" });
+    expect(trigger).toHaveAttribute("data-slot", "popover-trigger");
+
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Edit filter details" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByLabelText("Filter name")).toHaveFocus(),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ reason: "trigger-press" }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Edit filter details" }),
+      ).toBeNull(),
+    );
+    expect(trigger).toHaveFocus();
+    expect(onOpenChange).toHaveBeenLastCalledWith(
+      false,
+      expect.objectContaining({ reason: "close-press" }),
+    );
+  });
+
+  it("maps prevented Radix escape dismissal onto Base UI cancellation", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover defaultOpen onOpenChange={onOpenChange}>
+        <PopoverTrigger>Open protected details</PopoverTrigger>
+        <PopoverContent
+          aria-label="Protected details"
+          onEscapeKeyDown={onEscapeKeyDown}
+        >
+          <button type="button">Focusable content</button>
+        </PopoverContent>
+      </Popover>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Protected details" }),
+    ).toBeInTheDocument();
+    screen.getByRole("button", { name: "Focusable content" }).focus();
+
+    await user.keyboard("{Escape}");
+
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Protected details" }),
+    ).toBeInTheDocument();
+  });
+
+  it("maps prevented focus-out dismissal onto Base UI cancellation", async () => {
+    const user = userEvent.setup();
+    const onFocusOutside = vi.fn(
+      (event: CustomEvent<{ originalEvent: FocusEvent }>) => {
+        event.preventDefault();
+      },
+    );
+    const onInteractOutside = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside target</button>
+        <Popover defaultOpen onOpenChange={onOpenChange}>
+          <PopoverTrigger>Open focus-protected details</PopoverTrigger>
+          <PopoverContent
+            aria-label="Focus-protected details"
+            onFocusOutside={onFocusOutside}
+            onInteractOutside={onInteractOutside}
+          >
+            <button type="button">Inside target</button>
+          </PopoverContent>
+        </Popover>
+      </>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Focus-protected details" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Inside target" }),
+      ).toHaveFocus(),
+    );
+    await user.tab();
+
+    await waitFor(() => expect(onFocusOutside).toHaveBeenCalledTimes(1));
+    expect(onFocusOutside.mock.calls[0]?.[0]).toMatchObject({
+      type: "dismissableLayer.focusOutside",
+    });
+    expect(
+      onFocusOutside.mock.calls[0]?.[0].detail.originalEvent,
+    ).toBeInstanceOf(FocusEvent);
+    expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Focus-protected details" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not relabel Base UI's intentional mouse click as pointerDownOutside", async () => {
+    const sequence: string[] = [];
+    const onPointerDownOutside = vi.fn();
+    const onInteractOutside = vi.fn((event: CustomEvent) => {
+      sequence.push("interact-outside");
+      event.preventDefault();
+    });
+    const onOpenChange = vi.fn();
+
+    render(
+      <>
+        <button type="button">Mouse outside target</button>
+        <Popover defaultOpen onOpenChange={onOpenChange}>
+          <PopoverTrigger>Open mouse-protected details</PopoverTrigger>
+          <PopoverContent
+            aria-label="Mouse-protected details"
+            onInteractOutside={onInteractOutside}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            Mouse-protected content
+          </PopoverContent>
+        </Popover>
+      </>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Mouse-protected details" }),
+    ).toBeInTheDocument();
+    const outsideTarget = screen.getByRole("button", {
+      name: "Mouse outside target",
+    });
+    outsideTarget.addEventListener(
+      "pointerdown",
+      () => sequence.push("native-pointerdown"),
+      { once: true },
+    );
+    outsideTarget.addEventListener(
+      "click",
+      () => sequence.push("native-click"),
+      { once: true },
+    );
+
+    fireEvent.pointerDown(outsideTarget, { pointerType: "mouse" });
+
+    expect(sequence).toEqual(["native-pointerdown"]);
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    expect(onInteractOutside).not.toHaveBeenCalled();
+
+    fireEvent.click(outsideTarget);
+
+    expect(sequence).toEqual([
+      "native-pointerdown",
+      "native-click",
+      "interact-outside",
+    ]);
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    expect(onInteractOutside.mock.calls[0]?.[0]).toMatchObject({
+      cancelable: true,
+      type: "popover.outsidePress",
+    });
+    expect(onInteractOutside.mock.calls[0]?.[0].detail.originalEvent).toEqual(
+      expect.objectContaining({ type: "click" }),
+    );
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Mouse-protected details" }),
+    ).toBeInTheDocument();
+  });
+
+  it("reports focus-out before the final click for a real focusable outside interaction", async () => {
+    const user = userEvent.setup();
+    const sequence: string[] = [];
+    const onPointerDownOutside = vi.fn();
+    const onFocusOutside = vi.fn(
+      (event: CustomEvent<{ originalEvent: FocusEvent }>) => {
+        sequence.push(`focus-out:${event.detail.originalEvent.type}`);
+      },
+    );
+    const onInteractOutside = vi.fn(
+      (event: CustomEvent<{ originalEvent: Event }>) => {
+        sequence.push(
+          `interact:${event.type}:${event.detail.originalEvent.type}`,
+        );
+      },
+    );
+    const onOpenChange = vi.fn(
+      (open: boolean, eventDetails: { event: Event; reason: string }) => {
+        sequence.push(
+          `open:${String(open)}:${eventDetails.reason}:${eventDetails.event.type}`,
+        );
+      },
+    );
+
+    render(
+      <>
+        <button type="button">Focusable outside target</button>
+        <Popover defaultOpen onOpenChange={onOpenChange}>
+          <PopoverTrigger>Open focus-order details</PopoverTrigger>
+          <PopoverContent
+            aria-label="Focus-order details"
+            onFocusOutside={onFocusOutside}
+            onInteractOutside={onInteractOutside}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            <button type="button">Inside focus-order target</button>
+          </PopoverContent>
+        </Popover>
+      </>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Focus-order details" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Inside focus-order target" }),
+      ).toHaveFocus(),
+    );
+    const outsideTarget = screen.getByRole("button", {
+      name: "Focusable outside target",
+    });
+    outsideTarget.addEventListener(
+      "pointerdown",
+      () => sequence.push("native-pointerdown"),
+      { once: true },
+    );
+    outsideTarget.addEventListener(
+      "click",
+      () => sequence.push("native-click"),
+      { once: true },
+    );
+
+    await user.click(outsideTarget);
+
+    expect(sequence).toEqual([
+      "native-pointerdown",
+      "focus-out:focusout",
+      "interact:dismissableLayer.focusOutside:focusout",
+      "open:false:focus-out:focusout",
+      "native-click",
+      "interact:popover.outsidePress:click",
+      "open:false:outside-press:click",
+    ]);
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    expect(onFocusOutside).toHaveBeenCalledTimes(1);
+    expect(onInteractOutside).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+    expect(
+      screen.queryByRole("dialog", { name: "Focus-order details" }),
+    ).toBeNull();
+  });
+
+  it("cancels both focus-out and final-click phases through onInteractOutside", async () => {
+    const user = userEvent.setup();
+    const sequence: string[] = [];
+    const onPointerDownOutside = vi.fn();
+    const onInteractOutside = vi.fn(
+      (event: CustomEvent<{ originalEvent: Event }>) => {
+        sequence.push(
+          `interact:${event.type}:${event.detail.originalEvent.type}`,
+        );
+        event.preventDefault();
+      },
+    );
+    const onOpenChange = vi.fn();
+
+    render(
+      <>
+        <button type="button">Cancelable outside target</button>
+        <Popover defaultOpen onOpenChange={onOpenChange}>
+          <PopoverTrigger>Open cancel-order details</PopoverTrigger>
+          <PopoverContent
+            aria-label="Cancel-order details"
+            onInteractOutside={onInteractOutside}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            <button type="button">Inside cancel-order target</button>
+          </PopoverContent>
+        </Popover>
+      </>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Cancel-order details" }),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Inside cancel-order target" }),
+      ).toHaveFocus(),
+    );
+    const outsideTarget = screen.getByRole("button", {
+      name: "Cancelable outside target",
+    });
+    outsideTarget.addEventListener(
+      "pointerdown",
+      () => sequence.push("native-pointerdown"),
+      { once: true },
+    );
+    outsideTarget.addEventListener(
+      "click",
+      () => sequence.push("native-click"),
+      { once: true },
+    );
+
+    await user.click(outsideTarget);
+
+    expect(sequence).toEqual([
+      "native-pointerdown",
+      "interact:dismissableLayer.focusOutside:focusout",
+      "native-click",
+      "interact:popover.outsidePress:click",
+    ]);
+    expect(onPointerDownOutside).not.toHaveBeenCalled();
+    expect(onInteractOutside).toHaveBeenCalledTimes(2);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Cancel-order details" }),
+    ).toBeInTheDocument();
+  });
+
+  it("retains Radix-shaped pointerDownOutside for an actual Base UI pointerdown", async () => {
+    const sequence: string[] = [];
+    const onPointerDownOutside = vi.fn(
+      (event: CustomEvent<{ originalEvent: PointerEvent }>) => {
+        sequence.push("pointer-down-outside");
+        event.preventDefault();
+      },
+    );
+    const onInteractOutside = vi.fn(() => {
+      sequence.push("interact-outside");
+    });
+    const onOpenChange = vi.fn();
+
+    render(
+      <>
+        <button data-testid="pointer-outside-target" type="button">
+          Pointer outside target
+        </button>
+        <Popover defaultOpen modal="trap-focus" onOpenChange={onOpenChange}>
+          <PopoverTrigger>Open pointer-protected details</PopoverTrigger>
+          <PopoverContent
+            aria-label="Pointer-protected details"
+            onInteractOutside={onInteractOutside}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            Pointer-protected content
+          </PopoverContent>
+        </Popover>
+      </>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Pointer-protected details",
+      }),
+    ).toBeInTheDocument();
+    const outsideTarget = screen.getByTestId("pointer-outside-target");
+    outsideTarget.addEventListener(
+      "pointerdown",
+      () => sequence.push("native-pointerdown"),
+      { once: true },
+    );
+
+    fireEvent.pointerDown(outsideTarget, { pointerType: "mouse" });
+
+    expect(sequence).toEqual([
+      "native-pointerdown",
+      "pointer-down-outside",
+      "interact-outside",
+    ]);
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    const pointerOutsideEvent = onPointerDownOutside.mock.calls[0]![0];
+    expect(pointerOutsideEvent).toMatchObject({
+      cancelable: true,
+      type: "dismissableLayer.pointerDownOutside",
+    });
+    expect(pointerOutsideEvent.detail.originalEvent).toEqual(
+      expect.objectContaining({ type: "pointerdown" }),
+    );
+    expect(onInteractOutside).toHaveBeenCalledWith(pointerOutsideEvent);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", {
+        name: "Pointer-protected details",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("preserves prevented open autofocus and forced mounting", async () => {
+    const onOpenAutoFocus = vi.fn((event: Event) => {
+      event.preventDefault();
+    });
+    const { unmount } = render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Open focus details</PopoverTrigger>
+        <PopoverContent
+          aria-label="Focus details"
+          onOpenAutoFocus={onOpenAutoFocus}
+        >
+          <input aria-label="Autofocus candidate" />
+        </PopoverContent>
+      </Popover>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Focus details" }),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(onOpenAutoFocus).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText("Autofocus candidate")).not.toHaveFocus();
+
+    unmount();
+    render(
+      <Popover>
+        <PopoverTrigger>Closed trigger</PopoverTrigger>
+        <PopoverContent
+          forceMount
+          aria-label="Forced details"
+          data-testid="forced-content"
+        >
+          Forced content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    const forcedContent = screen.getByTestId("forced-content");
+    expect(forcedContent).toBeInTheDocument();
+    expect(forcedContent).toHaveAttribute("data-closed");
+  });
+
+  it("adds an accessible escape control when modal focus trapping is requested", async () => {
+    render(
+      <Popover defaultOpen modal>
+        <PopoverTrigger>Open modal details</PopoverTrigger>
+        <PopoverContent aria-label="Modal details">
+          Modal content
+        </PopoverContent>
+      </Popover>,
+    );
+
+    expect(
+      await screen.findByRole("dialog", { name: "Modal details" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close popover" })).toHaveClass(
+      "sr-only",
+    );
+  });
+});

--- a/apps/web/src/shared/ui/popover.tsx
+++ b/apps/web/src/shared/ui/popover.tsx
@@ -1,27 +1,495 @@
-import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+"use client";
+
+import { mergeProps } from "@base-ui/react/merge-props";
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import { useRender } from "@base-ui/react/use-render";
+import {
+  Children,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
-export const Popover = PopoverPrimitive.Root;
-export const PopoverTrigger = PopoverPrimitive.Trigger;
-export const PopoverAnchor = PopoverPrimitive.Anchor;
+type PopoverDismissEventHandler<TEvent extends Event = Event> = (
+  event: TEvent,
+) => void;
 
-export const PopoverContent = forwardRef<
-  ComponentRef<typeof PopoverPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-panel)] outline-none",
-        className,
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+type PopoverFocusOutsideEvent = CustomEvent<{
+  originalEvent: FocusEvent;
+}>;
+type PopoverPointerDownOutsideEvent = CustomEvent<{
+  originalEvent: PointerEvent;
+}>;
+type PopoverPressOutsideEvent = CustomEvent<{
+  originalEvent: MouseEvent | PointerEvent | TouchEvent;
+}>;
+type PopoverInteractOutsideEvent =
+  | PopoverFocusOutsideEvent
+  | PopoverPointerDownOutsideEvent
+  | PopoverPressOutsideEvent;
+
+interface PopoverDismissHandlers {
+  onEscapeKeyDown?: PopoverDismissEventHandler<KeyboardEvent> | undefined;
+  onFocusOutside?:
+    | PopoverDismissEventHandler<PopoverFocusOutsideEvent>
+    | undefined;
+  onInteractOutside?:
+    | PopoverDismissEventHandler<PopoverInteractOutsideEvent>
+    | undefined;
+  onPointerDownOutside?:
+    | PopoverDismissEventHandler<PopoverPointerDownOutsideEvent>
+    | undefined;
+}
+
+interface PopoverCompatibilityContextValue {
+  anchor: Element | null;
+  dismissHandlersRef: RefObject<PopoverDismissHandlers | null>;
+  modal: PopoverPrimitive.Root.Props["modal"];
+  setAnchor: (anchor: Element | null) => void;
+}
+
+const PopoverCompatibilityContext = createContext<
+  PopoverCompatibilityContextValue | undefined
+>(undefined);
+
+const noCollisionAvoidance = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;
+
+const radixCollisionAvoidance = {
+  fallbackAxisSide: "none",
+} as const;
+
+const radixCollisionBoundary: Element[] = [];
+
+function dispatchCompatibilityOutsideEvent<TEvent extends Event>(
+  name: string,
+  originalEvent: TEvent,
+  handler:
+    | PopoverDismissEventHandler<
+        CustomEvent<{
+          originalEvent: TEvent;
+        }>
+      >
+    | undefined,
+  interactHandler:
+    | PopoverDismissEventHandler<
+        CustomEvent<{
+          originalEvent: TEvent;
+        }>
+      >
+    | undefined,
+) {
+  const event = new CustomEvent(name, {
+    bubbles: false,
+    cancelable: true,
+    detail: { originalEvent },
+  });
+  const invokeHandlers = () => {
+    handler?.(event);
+    interactHandler?.(event);
+  };
+  const target = originalEvent.target;
+
+  if (target) {
+    target.addEventListener(name, invokeHandlers, { once: true });
+    target.dispatchEvent(event);
+  } else {
+    invokeHandlers();
+  }
+
+  return event.defaultPrevented;
+}
+
+function isPointerDownEvent(event: Event): event is PointerEvent {
+  return event.type === "pointerdown";
+}
+
+function preventDismissWhenHandled(
+  eventDetails: PopoverPrimitive.Root.ChangeEventDetails,
+  handlers: PopoverDismissHandlers | null,
+) {
+  if (!handlers) return false;
+
+  const { event, reason } = eventDetails;
+  let prevented = false;
+
+  if (reason === "escape-key") {
+    handlers.onEscapeKeyDown?.(event as KeyboardEvent);
+  } else if (reason === "outside-press") {
+    if (isPointerDownEvent(event)) {
+      prevented = dispatchCompatibilityOutsideEvent(
+        "dismissableLayer.pointerDownOutside",
+        event,
+        handlers.onPointerDownOutside,
+        handlers.onInteractOutside,
+      );
+    } else {
+      prevented = dispatchCompatibilityOutsideEvent(
+        "popover.outsidePress",
+        event as MouseEvent | PointerEvent | TouchEvent,
+        undefined,
+        handlers.onInteractOutside,
+      );
+    }
+  } else if (reason === "focus-out") {
+    prevented = dispatchCompatibilityOutsideEvent(
+      "dismissableLayer.focusOutside",
+      event as FocusEvent,
+      handlers.onFocusOutside,
+      handlers.onInteractOutside,
+    );
+  }
+
+  if (!prevented && !event.defaultPrevented) return false;
+
+  eventDetails.cancel();
+  return true;
+}
+
+function Popover({
+  modal = false,
+  onOpenChange,
+  ...props
+}: PopoverPrimitive.Root.Props) {
+  const [anchor, setAnchor] = useState<Element | null>(null);
+  const dismissHandlersRef = useRef<PopoverDismissHandlers | null>(null);
+
+  const handleOpenChange = useCallback<
+    NonNullable<PopoverPrimitive.Root.Props["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        preventDismissWhenHandled(eventDetails, dismissHandlersRef.current)
+      ) {
+        return;
+      }
+
+      onOpenChange?.(open, eventDetails);
+    },
+    [onOpenChange],
+  );
+
+  const compatibilityContext = useMemo<PopoverCompatibilityContextValue>(
+    () => ({ anchor, dismissHandlersRef, modal, setAnchor }),
+    [anchor, modal],
+  );
+
+  return (
+    <PopoverCompatibilityContext.Provider value={compatibilityContext}>
+      <PopoverPrimitive.Root
+        {...props}
+        modal={modal}
+        onOpenChange={handleOpenChange}
+      />
+    </PopoverCompatibilityContext.Provider>
+  );
+}
+
+export interface PopoverTriggerProps extends Omit<
+  PopoverPrimitive.Trigger.Props,
+  "render"
+> {
+  asChild?: boolean;
+  render?: PopoverPrimitive.Trigger.Props["render"];
+}
+
+const PopoverTrigger = forwardRef<HTMLButtonElement, PopoverTriggerProps>(
+  ({ asChild = false, children, render, ...props }, ref) => {
+    const child = asChild
+      ? (Children.only(children) as ReactElement)
+      : undefined;
+
+    return (
+      <PopoverPrimitive.Trigger
+        {...props}
+        ref={ref}
+        render={child ?? render}
+        data-slot="popover-trigger"
+      >
+        {child ? undefined : children}
+      </PopoverPrimitive.Trigger>
+    );
+  },
+);
+PopoverTrigger.displayName = "PopoverTrigger";
+
+export interface PopoverAnchorProps extends Omit<
+  useRender.ComponentProps<"div">,
+  "ref"
+> {
+  asChild?: boolean;
+}
+
+const PopoverAnchor = forwardRef<HTMLElement, PopoverAnchorProps>(
+  ({ asChild = false, children, render, ...props }, ref) => {
+    const compatibilityContext = useContext(PopoverCompatibilityContext);
+    const setAnchor = compatibilityContext?.setAnchor;
+    const child = asChild
+      ? (Children.only(children) as ReactElement)
+      : undefined;
+    const anchorChildren = child
+      ? (child.props as { children?: ReactNode }).children
+      : children;
+    const setAnchorRef = useCallback(
+      (element: HTMLElement | null) => {
+        setAnchor?.(element);
+      },
+      [setAnchor],
+    );
+
+    return useRender<{}, HTMLElement>({
+      defaultTagName: "div",
+      ref: [ref, setAnchorRef],
+      render: child ?? render,
+      props: mergeProps(props, {
+        "data-slot": "popover-anchor",
+        children: anchorChildren,
+      } as ComponentProps<"div">),
+    });
+  },
+);
+PopoverAnchor.displayName = "PopoverAnchor";
+
+type PopoverPositioningProps = Pick<
+  PopoverPrimitive.Positioner.Props,
+  | "align"
+  | "alignOffset"
+  | "anchor"
+  | "arrowPadding"
+  | "collisionAvoidance"
+  | "collisionBoundary"
+  | "collisionPadding"
+  | "disableAnchorTracking"
+  | "positionMethod"
+  | "side"
+  | "sideOffset"
+>;
+
+export type PopoverContentProps = Omit<PopoverPrimitive.Popup.Props, "render"> &
+  PopoverPositioningProps & {
+    asChild?: boolean;
+    avoidCollisions?: boolean;
+    container?: PopoverPrimitive.Portal.Props["container"];
+    forceMount?: boolean;
+    hideWhenDetached?: boolean;
+    keepMounted?: boolean;
+    onCloseAutoFocus?: PopoverDismissEventHandler;
+    onEscapeKeyDown?: PopoverDismissEventHandler<KeyboardEvent>;
+    onFocusOutside?: PopoverDismissEventHandler<PopoverFocusOutsideEvent>;
+    onInteractOutside?: PopoverDismissEventHandler<PopoverInteractOutsideEvent>;
+    onOpenAutoFocus?: PopoverDismissEventHandler;
+    onPointerDownOutside?: PopoverDismissEventHandler<PopoverPointerDownOutsideEvent>;
+    render?: PopoverPrimitive.Popup.Props["render"];
+    sticky?: boolean | "always" | "partial";
+  };
+
+const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
+  (
+    {
+      align = "center",
+      alignOffset = 0,
+      anchor,
+      arrowPadding = 0,
+      asChild = false,
+      avoidCollisions = true,
+      children,
+      className,
+      collisionAvoidance,
+      collisionBoundary = radixCollisionBoundary,
+      collisionPadding = 0,
+      container,
+      disableAnchorTracking,
+      finalFocus,
+      forceMount = false,
+      hideWhenDetached = false,
+      initialFocus,
+      keepMounted,
+      onCloseAutoFocus,
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onOpenAutoFocus,
+      onPointerDownOutside,
+      positionMethod = "fixed",
+      render,
+      side = "bottom",
+      sideOffset = 4,
+      sticky = "partial",
+      ...props
+    },
+    ref,
+  ) => {
+    const compatibilityContext = useContext(PopoverCompatibilityContext);
+    const dismissHandlers = useMemo<PopoverDismissHandlers>(
+      () => ({
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      }),
+      [
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      ],
+    );
+    const handleInitialFocus = useCallback(() => {
+      const event = new Event("openAutoFocus", { cancelable: true });
+      onOpenAutoFocus?.(event);
+      return event.defaultPrevented ? false : true;
+    }, [onOpenAutoFocus]);
+    const handleFinalFocus = useCallback(() => {
+      const event = new Event("closeAutoFocus", { cancelable: true });
+      onCloseAutoFocus?.(event);
+      return event.defaultPrevented ? false : true;
+    }, [onCloseAutoFocus]);
+
+    useEffect(() => {
+      const dismissHandlersRef = compatibilityContext?.dismissHandlersRef;
+      if (!dismissHandlersRef) return undefined;
+
+      dismissHandlersRef.current = dismissHandlers;
+
+      return () => {
+        if (dismissHandlersRef.current === dismissHandlers) {
+          dismissHandlersRef.current = null;
+        }
+      };
+    }, [compatibilityContext?.dismissHandlersRef, dismissHandlers]);
+
+    const child = asChild
+      ? (Children.only(children) as ReactElement)
+      : undefined;
+    const popupChildren = child
+      ? (child.props as { children?: ReactNode }).children
+      : children;
+    const resolvedAnchor =
+      anchor !== undefined ? anchor : compatibilityContext?.anchor;
+    const resolvedCollisionAvoidance =
+      collisionAvoidance ??
+      (avoidCollisions ? radixCollisionAvoidance : noCollisionAvoidance);
+    const resolvedSticky =
+      sticky === "always" ? true : sticky === "partial" ? false : sticky;
+
+    return (
+      <PopoverPrimitive.Portal
+        container={container}
+        keepMounted={keepMounted ?? forceMount}
+      >
+        <PopoverPrimitive.Positioner
+          align={align}
+          alignOffset={alignOffset}
+          anchor={resolvedAnchor}
+          arrowPadding={arrowPadding}
+          className={cn(
+            "isolate z-50 outline-none",
+            hideWhenDetached && "data-[anchor-hidden]:invisible",
+          )}
+          collisionAvoidance={resolvedCollisionAvoidance}
+          collisionBoundary={collisionBoundary}
+          collisionPadding={collisionPadding}
+          disableAnchorTracking={disableAnchorTracking}
+          positionMethod={positionMethod}
+          side={side}
+          sideOffset={sideOffset}
+          sticky={resolvedSticky}
+        >
+          <PopoverPrimitive.Popup
+            {...props}
+            ref={ref}
+            render={child ?? render}
+            data-slot="popover-content"
+            initialFocus={
+              initialFocus ?? (onOpenAutoFocus ? handleInitialFocus : undefined)
+            }
+            finalFocus={
+              finalFocus ?? (onCloseAutoFocus ? handleFinalFocus : undefined)
+            }
+            className={cn(
+              "z-50 w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-panel)] outline-none",
+              className,
+            )}
+          >
+            {popupChildren}
+            {compatibilityContext?.modal ? (
+              <PopoverPrimitive.Close
+                aria-label="Close popover"
+                className="sr-only"
+              >
+                Close popover
+              </PopoverPrimitive.Close>
+            ) : null}
+          </PopoverPrimitive.Popup>
+        </PopoverPrimitive.Positioner>
+      </PopoverPrimitive.Portal>
+    );
+  },
+);
+PopoverContent.displayName = "PopoverContent";
+
+const PopoverArrow = forwardRef<HTMLDivElement, PopoverPrimitive.Arrow.Props>(
+  ({ ...props }, ref) => (
+    <PopoverPrimitive.Arrow data-slot="popover-arrow" ref={ref} {...props} />
+  ),
+);
+PopoverArrow.displayName = "PopoverArrow";
+
+export interface PopoverCloseProps extends Omit<
+  PopoverPrimitive.Close.Props,
+  "render"
+> {
+  asChild?: boolean;
+  render?: PopoverPrimitive.Close.Props["render"];
+}
+
+const PopoverClose = forwardRef<HTMLButtonElement, PopoverCloseProps>(
+  ({ asChild = false, children, render, ...props }, ref) => {
+    const child = asChild
+      ? (Children.only(children) as ReactElement)
+      : undefined;
+
+    return (
+      <PopoverPrimitive.Close
+        {...props}
+        ref={ref}
+        render={child ?? render}
+        data-slot="popover-close"
+      >
+        {child ? undefined : children}
+      </PopoverPrimitive.Close>
+    );
+  },
+);
+PopoverClose.displayName = "PopoverClose";
+
+const PopoverPortal = PopoverPrimitive.Portal;
+const PopoverPositioner = PopoverPrimitive.Positioner;
+const PopoverPopup = PopoverPrimitive.Popup;
+
+export {
+  Popover,
+  PopoverAnchor,
+  PopoverArrow,
+  PopoverClose,
+  PopoverContent,
+  PopoverPortal,
+  PopoverPositioner,
+  PopoverPopup,
+  PopoverTrigger,
+};

--- a/apps/web/src/shared/ui/select.stories.tsx
+++ b/apps/web/src/shared/ui/select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
 
 import {
   Select,
@@ -17,6 +18,26 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
+
+function ControlledDensitySelect() {
+  const [value, setValue] = useState("compact");
+
+  return (
+    <Select value={value} onValueChange={setValue}>
+      <SelectTrigger aria-label="Controlled view density" className="w-56">
+        <SelectValue placeholder="Pick a view" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>View density</SelectLabel>
+          <SelectItem value="compact">Compact</SelectItem>
+          <SelectItem value="regular">Regular</SelectItem>
+          <SelectItem value="comfortable">Comfortable</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}
 
 export const Value: Story = {
   render: () => (
@@ -41,7 +62,7 @@ export const Value: Story = {
 
 export const OpenByDefault: Story = {
   parameters: {
-    a11y: { element: '[role="listbox"][data-state="open"]' },
+    a11y: { element: "[data-base-ui-portal]" },
   },
   render: () => (
     <Select defaultOpen defaultValue="regular">
@@ -63,6 +84,26 @@ export const OpenByDefault: Story = {
   ),
 };
 
+export const Placeholder: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger aria-label="Unselected view density" className="w-56">
+        <SelectValue placeholder="Pick a view" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="compact">Compact</SelectItem>
+          <SelectItem value="regular">Regular</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => <ControlledDensitySelect />,
+};
+
 export const Disabled: Story = {
   render: () => (
     <Select disabled defaultValue="regular">
@@ -70,8 +111,96 @@ export const Disabled: Story = {
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="regular">Regular</SelectItem>
+        <SelectGroup>
+          <SelectItem value="regular">Regular</SelectItem>
+        </SelectGroup>
       </SelectContent>
     </Select>
   ),
+};
+
+export const RightToLeft: Story = {
+  render: () => (
+    <Select dir="rtl" defaultValue="regular">
+      <SelectTrigger aria-label="Right-to-left view density" className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectItem value="compact">Compact</SelectItem>
+          <SelectItem value="regular">Regular</SelectItem>
+          <SelectItem value="comfortable">Comfortable</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const LongScrollableList: Story = {
+  render: () => (
+    <Select defaultOpen defaultValue="option-1">
+      <SelectTrigger aria-label="Long option list" className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent className="max-h-48">
+        <SelectGroup>
+          <SelectLabel>Long option list</SelectLabel>
+          {Array.from({ length: 30 }, (_, index) => (
+            <SelectItem key={index} value={`option-${index + 1}`}>
+              Option {index + 1}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+};
+
+export const MigrationContract: Story = {
+  tags: ["select-contract"],
+  render: () => (
+    <Select defaultOpen defaultValue="licensed_api">
+      <SelectTrigger aria-label="Access basis" className="w-56">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent data-testid="select-contract-popup">
+        <SelectGroup>
+          <SelectLabel>Access basis options</SelectLabel>
+          <SelectItem value="public_markdown">Public markdown</SelectItem>
+          <SelectItem value="licensed_api">Licensed API</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  ),
+  play: async ({ canvasElement }) => {
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+
+    const trigger = canvasElement.querySelector<HTMLElement>(
+      '[role="combobox"][aria-label="Access basis"]',
+    );
+    const popup = document.querySelector<HTMLElement>(
+      '[data-testid="select-contract-popup"]',
+    );
+    const listbox = popup?.querySelector<HTMLElement>('[role="listbox"]');
+    const group = popup?.querySelector<HTMLElement>('[role="group"]');
+
+    if (!trigger || !popup || !listbox || !group) {
+      throw new Error("Missing Base UI Select contract parts.");
+    }
+    if (!trigger.textContent?.includes("Licensed API")) {
+      throw new Error(
+        `Expected the formatted label in the trigger, received ${trigger.textContent ?? "no text"}.`,
+      );
+    }
+    if (popup.dataset.alignTrigger !== "false") {
+      throw new Error("Expected Radix popper compatibility positioning.");
+    }
+    if (!group.getAttribute("aria-labelledby")) {
+      throw new Error(
+        "Expected SelectGroup to be associated with SelectLabel.",
+      );
+    }
+  },
 };

--- a/apps/web/src/shared/ui/select.test.tsx
+++ b/apps/web/src/shared/ui/select.test.tsx
@@ -1,0 +1,199 @@
+import { axe } from "jest-axe";
+import { useDirection } from "@base-ui/react/direction-provider";
+import { render, screen } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "./select.js";
+
+function DirectionProbe() {
+  return <output data-testid="direction-probe">{useDirection()}</output>;
+}
+
+function DensitySelect({
+  defaultOpen,
+  defaultValue,
+  dir,
+  disabled,
+  onValueChange,
+  value,
+}: {
+  defaultOpen?: boolean;
+  defaultValue?: string;
+  dir?: "ltr" | "rtl";
+  disabled?: boolean;
+  onValueChange?: (value: string) => void;
+  value?: string;
+}) {
+  return (
+    <Select
+      defaultOpen={defaultOpen}
+      defaultValue={defaultValue}
+      dir={dir}
+      disabled={disabled}
+      onValueChange={onValueChange}
+      value={value}
+    >
+      <SelectTrigger aria-label="View density">
+        <SelectValue placeholder="Pick a view" />
+      </SelectTrigger>
+      <SelectContent data-testid="density-popup">
+        <SelectGroup>
+          <SelectLabel>View density options</SelectLabel>
+          <SelectItem value="compact">Compact</SelectItem>
+          <SelectItem value="regular">Regular</SelectItem>
+          <SelectItem value="comfortable">Comfortable</SelectItem>
+          <SelectItem disabled value="locked">
+            Locked option
+          </SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}
+
+describe("<Select>", () => {
+  it("infers item labels so formatted text survives in the trigger", () => {
+    render(<DensitySelect defaultValue="comfortable" />);
+
+    const trigger = screen.getByRole("combobox", { name: "View density" });
+    expect(trigger).toHaveTextContent("Comfortable");
+    expect(trigger).not.toHaveTextContent("comfortable");
+  });
+
+  it("changes an uncontrolled string value and preserves the callback shape", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <DensitySelect defaultValue="compact" onValueChange={onValueChange} />,
+    );
+
+    const trigger = screen.getByRole("combobox", { name: "View density" });
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: "Regular" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("regular");
+    expect(onValueChange.mock.calls[0]).toHaveLength(1);
+    expect(trigger).toHaveTextContent("Regular");
+  });
+
+  it("reports a controlled change without replacing the supplied value", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { rerender } = render(
+      <DensitySelect value="compact" onValueChange={onValueChange} />,
+    );
+    const trigger = screen.getByRole("combobox", { name: "View density" });
+
+    await user.click(trigger);
+    await user.click(await screen.findByRole("option", { name: "Regular" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("regular");
+    expect(trigger).toHaveTextContent("Compact");
+
+    rerender(<DensitySelect value="regular" onValueChange={onValueChange} />);
+    expect(trigger).toHaveTextContent("Regular");
+  });
+
+  it("preserves placeholder, disabled option, and disabled root states", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<DensitySelect defaultOpen />);
+    const trigger = screen.getByRole("combobox", { name: "View density" });
+    expect(trigger).toHaveTextContent("Pick a view");
+
+    expect(
+      screen.getByRole("option", { name: "Locked option" }),
+    ).toHaveAttribute("aria-disabled", "true");
+    await user.keyboard("{Escape}");
+
+    rerender(<DensitySelect key="disabled" defaultValue="regular" disabled />);
+    const disabledTrigger = screen.getByRole("combobox", {
+      name: "View density",
+    });
+    expect(disabledTrigger).toBeDisabled();
+    expect(disabledTrigger).toHaveAttribute("data-disabled");
+    expect(disabledTrigger).toHaveTextContent("Regular");
+  });
+
+  it("maps group labels and Radix popper positioning to Base UI parts", () => {
+    render(
+      <Select defaultOpen defaultValue="compact">
+        <SelectTrigger aria-label="Positioned density">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent
+          align="end"
+          position="popper"
+          side="top"
+          sideOffset={8}
+          data-testid="select-popup"
+        >
+          <SelectGroup>
+            <SelectLabel>Density choices</SelectLabel>
+            <SelectItem value="compact">Compact</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+
+    const popup = screen.getByTestId("select-popup");
+    expect(popup).toHaveAttribute("data-align-trigger", "false");
+    expect(popup).toHaveAttribute("data-align", "end");
+    expect(popup.parentElement).toHaveStyle({ position: "fixed" });
+    expect(
+      screen.getByRole("group", { name: "Density choices" }),
+    ).toBeInTheDocument();
+  });
+
+  it("provides the supplied direction and forwards logical positioning", () => {
+    render(
+      <Select dir="rtl" defaultOpen defaultValue="regular">
+        <DirectionProbe />
+        <SelectTrigger aria-label="Right-to-left density">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent
+          avoidCollisions={false}
+          position="popper"
+          side="inline-start"
+          data-testid="rtl-popup"
+        >
+          <SelectGroup>
+            <SelectItem value="regular">Regular</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(screen.getByTestId("direction-probe")).toHaveTextContent("rtl");
+    expect(screen.getByTestId("rtl-popup")).toHaveAttribute(
+      "data-side",
+      "inline-start",
+    );
+  });
+
+  it("has no critical or serious axe violations while open", async () => {
+    const view = render(<DensitySelect defaultOpen defaultValue="regular" />);
+
+    const popup = await screen.findByTestId("density-popup");
+    const listbox = await screen.findByRole("listbox");
+    const portal = view.baseElement.querySelector("[data-base-ui-portal]");
+    expect(portal).toContainElement(popup);
+    expect(popup).toContainElement(listbox);
+
+    const results = await axe(view.baseElement);
+    expect(
+      results.violations.filter(
+        ({ impact }) => impact === "critical" || impact === "serious",
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -1,20 +1,120 @@
-import * as SelectPrimitive from "@radix-ui/react-select";
+import { DirectionProvider } from "@base-ui/react/direction-provider";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
 import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 import {
+  Children,
   forwardRef,
-  type ComponentPropsWithoutRef,
+  isValidElement,
   type ComponentRef,
+  type ReactNode,
+  useRef,
 } from "react";
 
 import { cn } from "../lib/cn.js";
 
-export const Select = SelectPrimitive.Root;
+type BaseSelectRootProps = SelectPrimitive.Root.Props<string, false>;
+
+export interface SelectProps extends Omit<
+  BaseSelectRootProps,
+  "children" | "defaultValue" | "items" | "onValueChange" | "value"
+> {
+  children?: ReactNode;
+  defaultValue?: string | undefined;
+  dir?: "ltr" | "rtl" | undefined;
+  items?: BaseSelectRootProps["items"];
+  onValueChange?: ((value: string) => void) | undefined;
+  value?: string | undefined;
+}
+
+type SelectItemDefinition = {
+  label: ReactNode;
+  value: string;
+};
+
+function collectItemDefinitions(children: ReactNode): SelectItemDefinition[] {
+  const items: SelectItemDefinition[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement<{ children?: ReactNode; value?: unknown }>(child)) {
+      return;
+    }
+
+    if (child.type === SelectItem && typeof child.props.value === "string") {
+      items.push({ label: child.props.children, value: child.props.value });
+      return;
+    }
+
+    items.push(...collectItemDefinitions(child.props.children));
+  });
+
+  return items;
+}
+
+function itemDefinitionsMatch(
+  current: SelectItemDefinition[],
+  next: SelectItemDefinition[],
+): boolean {
+  return (
+    current.length === next.length &&
+    current.every(
+      (item, index) =>
+        item.value === next[index]?.value && item.label === next[index]?.label,
+    )
+  );
+}
+
+export function Select({
+  children,
+  defaultValue,
+  dir,
+  items,
+  onValueChange,
+  value,
+  ...props
+}: SelectProps) {
+  const nextInferredItems = collectItemDefinitions(children);
+  const inferredItemsRef = useRef(nextInferredItems);
+  if (!itemDefinitionsMatch(inferredItemsRef.current, nextInferredItems)) {
+    inferredItemsRef.current = nextInferredItems;
+  }
+  const resolvedItems =
+    items ??
+    (inferredItemsRef.current.length === 0
+      ? undefined
+      : inferredItemsRef.current);
+  const root = (
+    <SelectPrimitive.Root<string>
+      defaultValue={defaultValue}
+      items={resolvedItems}
+      onValueChange={
+        onValueChange === undefined
+          ? undefined
+          : (nextValue) => {
+              if (nextValue !== null) {
+                onValueChange(nextValue);
+              }
+            }
+      }
+      value={value}
+      {...props}
+    >
+      {children}
+    </SelectPrimitive.Root>
+  );
+
+  return dir === undefined ? (
+    root
+  ) : (
+    <DirectionProvider direction={dir}>{root}</DirectionProvider>
+  );
+}
+
 export const SelectGroup = SelectPrimitive.Group;
 export const SelectValue = SelectPrimitive.Value;
 
 export const SelectTrigger = forwardRef<
   ComponentRef<typeof SelectPrimitive.Trigger>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+  SelectPrimitive.Trigger.Props
 >(({ className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
@@ -25,111 +125,214 @@ export const SelectTrigger = forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
-      <IconChevronDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
+    <SelectPrimitive.Icon
+      render={<IconChevronDown className="size-4 opacity-50" />}
+    />
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 export const SelectScrollUpButton = forwardRef<
-  ComponentRef<typeof SelectPrimitive.ScrollUpButton>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+  ComponentRef<typeof SelectPrimitive.ScrollUpArrow>,
+  SelectPrimitive.ScrollUpArrow.Props
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
+  <SelectPrimitive.ScrollUpArrow
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "top-0 flex w-full cursor-default items-center justify-center py-1",
+      className,
+    )}
     {...props}
   >
-    <IconChevronUp className="h-4 w-4" />
-  </SelectPrimitive.ScrollUpButton>
+    <IconChevronUp className="size-4" />
+  </SelectPrimitive.ScrollUpArrow>
 ));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpArrow.displayName;
 
 export const SelectScrollDownButton = forwardRef<
-  ComponentRef<typeof SelectPrimitive.ScrollDownButton>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+  ComponentRef<typeof SelectPrimitive.ScrollDownArrow>,
+  SelectPrimitive.ScrollDownArrow.Props
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
+  <SelectPrimitive.ScrollDownArrow
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn(
+      "bottom-0 flex w-full cursor-default items-center justify-center py-1",
+      className,
+    )}
     {...props}
   >
-    <IconChevronDown className="h-4 w-4" />
-  </SelectPrimitive.ScrollDownButton>
+    <IconChevronDown className="size-4" />
+  </SelectPrimitive.ScrollDownArrow>
 ));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownArrow.displayName;
+
+type SelectPositionerProps = Pick<
+  SelectPrimitive.Positioner.Props,
+  | "align"
+  | "alignItemWithTrigger"
+  | "alignOffset"
+  | "anchor"
+  | "arrowPadding"
+  | "collisionAvoidance"
+  | "collisionBoundary"
+  | "collisionPadding"
+  | "disableAnchorTracking"
+  | "positionMethod"
+  | "side"
+  | "sideOffset"
+>;
+
+export interface SelectContentProps
+  extends SelectPrimitive.Popup.Props, SelectPositionerProps {
+  avoidCollisions?: boolean | undefined;
+  hideWhenDetached?: boolean | undefined;
+  position?: "item-aligned" | "popper" | undefined;
+  sticky?: boolean | "always" | "partial" | undefined;
+}
+
+const viewportCollisionBoundary: Element[] = [];
+const disabledCollisionAvoidance: NonNullable<
+  SelectPrimitive.Positioner.Props["collisionAvoidance"]
+> = { align: "none", fallbackAxisSide: "none", side: "none" };
 
 export const SelectContent = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
-      ref={ref}
-      className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[var(--shadow-panel)]",
-        position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-        className,
-      )}
-      position={position}
-      {...props}
-    >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
-        className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
-        )}
-      >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+  ComponentRef<typeof SelectPrimitive.Popup>,
+  SelectContentProps
+>(
+  (
+    {
+      align = "start",
+      alignItemWithTrigger,
+      alignOffset = 0,
+      anchor,
+      arrowPadding = 0,
+      avoidCollisions = true,
+      children,
+      className,
+      collisionAvoidance,
+      collisionBoundary = viewportCollisionBoundary,
+      collisionPadding = 10,
+      disableAnchorTracking,
+      hideWhenDetached = false,
+      position = "popper",
+      positionMethod = "fixed",
+      side = "bottom",
+      sideOffset = 0,
+      sticky = "partial",
+      ...props
+    },
+    ref,
+  ) => {
+    const alignsSelectedItem =
+      alignItemWithTrigger ?? position === "item-aligned";
+    const resolvedCollisionAvoidance =
+      avoidCollisions || collisionAvoidance !== undefined
+        ? collisionAvoidance
+        : disabledCollisionAvoidance;
+
+    return (
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Positioner
+          align={align}
+          alignItemWithTrigger={alignsSelectedItem}
+          alignOffset={alignOffset}
+          anchor={anchor}
+          arrowPadding={arrowPadding}
+          collisionAvoidance={resolvedCollisionAvoidance}
+          collisionBoundary={collisionBoundary}
+          collisionPadding={collisionPadding}
+          disableAnchorTracking={disableAnchorTracking}
+          positionMethod={positionMethod}
+          side={side}
+          sideOffset={sideOffset}
+          sticky={sticky === true || sticky === "always"}
+          className={cn(hideWhenDetached && "data-anchor-hidden:invisible")}
+        >
+          <SelectPrimitive.Popup
+            ref={ref}
+            data-align-trigger={alignsSelectedItem}
+            className={cn(
+              "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[var(--shadow-panel)]",
+              !alignsSelectedItem &&
+                "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+              className,
+            )}
+            {...props}
+          >
+            <SelectScrollUpButton />
+            <SelectPrimitive.List
+              className={cn(
+                "p-1",
+                !alignsSelectedItem &&
+                  "h-[var(--anchor-height)] w-full min-w-[var(--anchor-width)]",
+              )}
+            >
+              {children}
+            </SelectPrimitive.List>
+            <SelectScrollDownButton />
+          </SelectPrimitive.Popup>
+        </SelectPrimitive.Positioner>
+      </SelectPrimitive.Portal>
+    );
+  },
+);
+SelectContent.displayName = SelectPrimitive.Popup.displayName;
 
 export const SelectLabel = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Label>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+  ComponentRef<typeof SelectPrimitive.GroupLabel>,
+  SelectPrimitive.GroupLabel.Props
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
+  <SelectPrimitive.GroupLabel
     ref={ref}
     className={cn("px-2 py-1.5 text-sm font-semibold", className)}
     {...props}
   />
 ));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
+SelectLabel.displayName = SelectPrimitive.GroupLabel.displayName;
+
+export interface SelectItemProps extends Omit<
+  SelectPrimitive.Item.Props,
+  "label" | "value"
+> {
+  label?: string | undefined;
+  textValue?: string | undefined;
+  value: string;
+}
 
 export const SelectItem = forwardRef<
   ComponentRef<typeof SelectPrimitive.Item>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
+  SelectItemProps
+>(({ className, children, label, textValue, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
+    label={label ?? textValue}
     {...props}
   >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <IconCheck className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <SelectPrimitive.ItemIndicator
+      render={
+        <span className="absolute right-2 flex size-3.5 items-center justify-center" />
+      }
+    >
+      <IconCheck className="size-4" />
+    </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 export const SelectSeparator = forwardRef<
   ComponentRef<typeof SelectPrimitive.Separator>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+  SelectPrimitive.Separator.Props
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
 ));
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;

--- a/apps/web/src/shared/ui/tooltip.stories.tsx
+++ b/apps/web/src/shared/ui/tooltip.stories.tsx
@@ -17,8 +17,8 @@ type Story = StoryObj<typeof meta>;
 export const Hint: Story = {
   render: () => (
     <Tooltip delayDuration={0}>
-      <TooltipTrigger asChild>
-        <Button variant="outline">Show hint</Button>
+      <TooltipTrigger render={<Button variant="outline" />}>
+        Show hint
       </TooltipTrigger>
       <TooltipContent>Explains the current synthetic action.</TooltipContent>
     </Tooltip>
@@ -28,8 +28,8 @@ export const Hint: Story = {
 export const OpenByDefault: Story = {
   render: () => (
     <Tooltip defaultOpen>
-      <TooltipTrigger asChild>
-        <Button variant="outline">Open tooltip</Button>
+      <TooltipTrigger render={<Button variant="outline" />}>
+        Open tooltip
       </TooltipTrigger>
       <TooltipContent>Open by default for surface-token review.</TooltipContent>
     </Tooltip>
@@ -39,14 +39,32 @@ export const OpenByDefault: Story = {
 export const DisabledControl: Story = {
   render: () => (
     <Tooltip defaultOpen>
-      <TooltipTrigger asChild>
-        <span>
-          <Button disabled variant="outline">
-            Disabled action
-          </Button>
-        </span>
+      <TooltipTrigger render={<span />}>
+        <Button disabled variant="outline">
+          Disabled action
+        </Button>
       </TooltipTrigger>
-      <TooltipContent>Disabled controls can still provide context.</TooltipContent>
+      <TooltipContent>
+        Disabled controls can still provide context.
+      </TooltipContent>
+    </Tooltip>
+  ),
+};
+
+export const Positioned: Story = {
+  render: () => (
+    <Tooltip defaultOpen>
+      <TooltipTrigger render={<Button variant="outline" />}>
+        Positioned tooltip
+      </TooltipTrigger>
+      <TooltipContent
+        align="start"
+        alignOffset={8}
+        side="bottom"
+        sideOffset={12}
+      >
+        Position and offsets are forwarded to Base UI.
+      </TooltipContent>
     </Tooltip>
   ),
 };

--- a/apps/web/src/shared/ui/tooltip.test.tsx
+++ b/apps/web/src/shared/ui/tooltip.test.tsx
@@ -1,0 +1,323 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const { capturedPositionerProps } = vi.hoisted(() => ({
+  capturedPositionerProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@base-ui/react/tooltip", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@base-ui/react/tooltip")>();
+  const React = await import("react");
+  const CapturingPositioner = React.forwardRef<
+    HTMLDivElement,
+    ComponentProps<typeof original.Tooltip.Positioner>
+  >((props, ref) => {
+    capturedPositionerProps.push(props as Record<string, unknown>);
+    return React.createElement(original.Tooltip.Positioner, { ...props, ref });
+  });
+
+  return {
+    ...original,
+    Tooltip: { ...original.Tooltip, Positioner: CapturingPositioner },
+  };
+});
+
+import { Button } from "./button.js";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip.js";
+
+function TestTooltip({
+  defaultOpen = false,
+  delayDuration,
+}: {
+  defaultOpen?: boolean;
+  delayDuration?: number;
+}) {
+  return (
+    <Tooltip
+      defaultOpen={defaultOpen}
+      {...(delayDuration === undefined ? {} : { delayDuration })}
+    >
+      <TooltipTrigger render={<Button variant="outline" />}>
+        Show details
+      </TooltipTrigger>
+      <TooltipContent data-testid="content">Helpful details</TooltipContent>
+    </Tooltip>
+  );
+}
+
+describe("Tooltip", () => {
+  it("preserves Radix collision defaults across Positioner renders", async () => {
+    capturedPositionerProps.length = 0;
+    const { rerender } = render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Collision trigger</TooltipTrigger>
+          <TooltipContent>Collision content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Collision content",
+    );
+    const firstPositionerProps = capturedPositionerProps.at(-1);
+    const collisionBoundary = firstPositionerProps?.collisionBoundary;
+    expect(firstPositionerProps?.collisionAvoidance).toEqual({
+      fallbackAxisSide: "none",
+    });
+    expect(collisionBoundary).toEqual([]);
+
+    rerender(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger>Collision trigger</TooltipTrigger>
+          <TooltipContent>Updated collision content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Updated collision content",
+    );
+    expect(capturedPositionerProps.at(-1)?.collisionBoundary).toBe(
+      collisionBoundary,
+    );
+  });
+
+  it("renders the preserved popup styling in a positioned Base UI portal", async () => {
+    const { container } = render(
+      <TooltipProvider>
+        <Tooltip defaultOpen>
+          <TooltipTrigger
+            aria-describedby="persistent-help"
+            render={<Button variant="outline" />}
+          >
+            Positioned trigger
+          </TooltipTrigger>
+          <span id="persistent-help">Persistent help</span>
+          <TooltipContent
+            align="start"
+            alignOffset={8}
+            avoidCollisions={false}
+            className="custom-tooltip"
+            data-testid="positioned-content"
+            id="positioned-tooltip"
+            side="bottom"
+            sideOffset={12}
+          >
+            Positioned content
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    const content = await screen.findByRole("tooltip");
+    const positioner = content.parentElement;
+    const trigger = screen.getByRole("button", { name: "Positioned trigger" });
+
+    expect(content).toHaveAttribute("data-testid", "positioned-content");
+    expect(content).toHaveClass(
+      "z-50",
+      "overflow-hidden",
+      "rounded-md",
+      "border",
+      "border-border",
+      "bg-popover",
+      "px-3",
+      "py-1.5",
+      "text-xs",
+      "text-popover-foreground",
+      "shadow-md",
+      "custom-tooltip",
+    );
+    expect(positioner).toHaveClass("isolate", "z-50");
+    expect(positioner).toHaveStyle({ position: "fixed" });
+    expect(positioner).toHaveAttribute("data-side", "bottom");
+    expect(positioner).toHaveAttribute("data-align", "start");
+    expect(positioner).toHaveStyle({ transform: "translate(8px, 12px)" });
+    expect(content).toHaveAttribute("id", "positioned-tooltip");
+    expect(trigger).toHaveAttribute(
+      "aria-describedby",
+      "persistent-help positioned-tooltip",
+    );
+    expect(container).not.toContainElement(content);
+  });
+
+  it("opens on hover with the Radix-compatible root delay and closes on Escape", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <TooltipProvider>
+        <Tooltip delayDuration={0} onOpenChange={onOpenChange}>
+          <TooltipTrigger render={<Button variant="outline" />}>
+            Hover trigger
+          </TooltipTrigger>
+          <TooltipContent>Hover content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hover trigger" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Hover content",
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ reason: "trigger-hover" }),
+    );
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("tooltip")).toBeNull());
+    expect(
+      screen.getByRole("button", { name: "Hover trigger" }),
+    ).not.toHaveAttribute("aria-describedby");
+    expect(onOpenChange).toHaveBeenLastCalledWith(
+      false,
+      expect.objectContaining({ reason: "escape-key" }),
+    );
+  });
+
+  it("opens immediately on keyboard focus and composes the existing Button", async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider>
+        <TestTooltip />
+      </TooltipProvider>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "Show details" })).toHaveFocus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Helpful details",
+    );
+  });
+
+  it("does not expose an ARIA description when a consumer cancels opening", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <TooltipProvider>
+        <Tooltip
+          onOpenChange={(nextOpen, eventDetails) => {
+            onOpenChange(nextOpen, eventDetails);
+            if (nextOpen) eventDetails.cancel();
+          }}
+        >
+          <TooltipTrigger>Canceled trigger</TooltipTrigger>
+          <TooltipContent>Canceled content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    await user.tab();
+
+    const trigger = screen.getByRole("button", { name: "Canceled trigger" });
+    expect(trigger).toHaveFocus();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ reason: "trigger-focus" }),
+    );
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute("aria-describedby");
+  });
+
+  it("keeps the popup and ARIA description when a consumer cancels closing", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <TooltipProvider>
+        <Tooltip
+          defaultOpen
+          onOpenChange={(nextOpen, eventDetails) => {
+            onOpenChange(nextOpen, eventDetails);
+            if (!nextOpen) eventDetails.cancel();
+          }}
+        >
+          <TooltipTrigger>Canceled close trigger</TooltipTrigger>
+          <TooltipContent id="canceled-close-tooltip">
+            Canceled close content
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    const tooltip = await screen.findByRole("tooltip");
+    const trigger = screen.getByRole("button", {
+      name: "Canceled close trigger",
+    });
+    expect(trigger).toHaveAttribute(
+      "aria-describedby",
+      "canceled-close-tooltip",
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(
+      false,
+      expect.objectContaining({ reason: "escape-key" }),
+    );
+    expect(screen.getByRole("tooltip")).toBe(tooltip);
+    expect(trigger).toHaveAttribute(
+      "aria-describedby",
+      "canceled-close-tooltip",
+    );
+  });
+
+  it("maps the Radix-compatible provider delay to Base UI hover timing", async () => {
+    const user = userEvent.setup();
+    render(
+      <TooltipProvider delayDuration={0}>
+        <Tooltip>
+          <TooltipTrigger>Provider delay trigger</TooltipTrigger>
+          <TooltipContent>Provider delay content</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    await user.hover(
+      screen.getByRole("button", { name: "Provider delay trigger" }),
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Provider delay content",
+    );
+  });
+
+  it("maps provider hoverability and forced mounting compatibility props", async () => {
+    const { rerender } = render(
+      <TooltipProvider disableHoverableContent>
+        <TestTooltip defaultOpen />
+      </TooltipProvider>,
+    );
+
+    const openContent = await screen.findByTestId("content");
+    expect(openContent.parentElement).toHaveStyle({ pointerEvents: "none" });
+
+    rerender(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>Closed trigger</TooltipTrigger>
+          <TooltipContent forceMount data-testid="forced-content">
+            Forced content
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+
+    const forcedContent = screen.getByTestId("forced-content");
+    expect(forcedContent).toBeInTheDocument();
+    expect(forcedContent.parentElement).toHaveAttribute("hidden");
+  });
+});

--- a/apps/web/src/shared/ui/tooltip.tsx
+++ b/apps/web/src/shared/ui/tooltip.tsx
@@ -1,24 +1,287 @@
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { forwardRef, type ComponentPropsWithoutRef, type ComponentRef } from "react";
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ComponentRef,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 
 import { cn } from "../lib/cn.js";
 
-export const TooltipProvider = TooltipPrimitive.Provider;
-export const Tooltip = TooltipPrimitive.Root;
-export const TooltipTrigger = TooltipPrimitive.Trigger;
+const radixDefaultOpenDelay = 700;
+const radixDefaultSkipDelay = 300;
+
+interface TooltipProviderCompatibilityValue {
+  readonly delay: number;
+  readonly disableHoverableContent: boolean;
+}
+
+const TooltipProviderCompatibilityContext =
+  createContext<TooltipProviderCompatibilityValue>({
+    delay: radixDefaultOpenDelay,
+    disableHoverableContent: false,
+  });
+
+interface TooltipRootCompatibilityValue {
+  readonly contentId: string;
+  readonly delay: number;
+  readonly generatedContentId: string;
+  readonly open: boolean;
+  readonly setContentId: Dispatch<SetStateAction<string>>;
+}
+
+const TooltipRootCompatibilityContext =
+  createContext<TooltipRootCompatibilityValue>({
+    contentId: "",
+    delay: radixDefaultOpenDelay,
+    generatedContentId: "",
+    open: false,
+    setContentId: () => undefined,
+  });
+
+export interface TooltipProviderProps extends TooltipPrimitive.Provider.Props {
+  /** @deprecated Use `delay` instead. */
+  delayDuration?: number;
+  /** @deprecated Use `timeout` instead. */
+  skipDelayDuration?: number;
+  /** @deprecated Set `disableHoverablePopup` on each Tooltip instead. */
+  disableHoverableContent?: boolean;
+}
+
+export function TooltipProvider({
+  children,
+  delay,
+  delayDuration,
+  timeout,
+  skipDelayDuration,
+  disableHoverableContent = false,
+  ...props
+}: TooltipProviderProps) {
+  const effectiveDelay = delay ?? delayDuration ?? radixDefaultOpenDelay;
+  const effectiveTimeout =
+    timeout ?? skipDelayDuration ?? radixDefaultSkipDelay;
+  const compatibilityValue = useMemo(
+    () => ({ delay: effectiveDelay, disableHoverableContent }),
+    [disableHoverableContent, effectiveDelay],
+  );
+
+  return (
+    <TooltipProviderCompatibilityContext.Provider value={compatibilityValue}>
+      <TooltipPrimitive.Provider
+        delay={effectiveDelay}
+        timeout={effectiveTimeout}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Provider>
+    </TooltipProviderCompatibilityContext.Provider>
+  );
+}
+
+export interface TooltipProps<Payload = unknown> extends TooltipPrimitive.Root
+  .Props<Payload> {
+  /** @deprecated Set `delay` on TooltipTrigger instead. */
+  delayDuration?: number;
+  /** @deprecated Use `disableHoverablePopup` instead. */
+  disableHoverableContent?: boolean;
+}
+
+export function Tooltip<Payload = unknown>({
+  children,
+  defaultOpen = false,
+  delayDuration,
+  disabled = false,
+  disableHoverableContent,
+  disableHoverablePopup,
+  onOpenChange,
+  open,
+  ...props
+}: TooltipProps<Payload>) {
+  const provider = useContext(TooltipProviderCompatibilityContext);
+  const generatedContentId = useId();
+  const [contentId, setContentId] = useState(generatedContentId);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const effectiveDelay = delayDuration ?? provider.delay;
+  const effectiveDisableHoverablePopup =
+    disableHoverablePopup ??
+    disableHoverableContent ??
+    provider.disableHoverableContent;
+  const effectiveOpen = !disabled && (open ?? uncontrolledOpen);
+  const compatibilityValue = useMemo(
+    () => ({
+      contentId,
+      delay: effectiveDelay,
+      generatedContentId,
+      open: effectiveOpen,
+      setContentId,
+    }),
+    [contentId, effectiveDelay, effectiveOpen, generatedContentId],
+  );
+
+  return (
+    <TooltipRootCompatibilityContext.Provider value={compatibilityValue}>
+      <TooltipPrimitive.Root
+        defaultOpen={defaultOpen}
+        disabled={disabled}
+        disableHoverablePopup={effectiveDisableHoverablePopup}
+        onOpenChange={(nextOpen, eventDetails) => {
+          onOpenChange?.(nextOpen, eventDetails);
+          if (open === undefined && !eventDetails.isCanceled) {
+            setUncontrolledOpen(nextOpen);
+          }
+        }}
+        open={open}
+        {...props}
+      >
+        {children}
+      </TooltipPrimitive.Root>
+    </TooltipRootCompatibilityContext.Provider>
+  );
+}
+
+export const TooltipTrigger = forwardRef<
+  HTMLButtonElement,
+  TooltipPrimitive.Trigger.Props
+>(({ delay, ...props }, ref) => {
+  const root = useContext(TooltipRootCompatibilityContext);
+  const ariaDescribedBy = [
+    props["aria-describedby"],
+    root.open ? root.contentId : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <TooltipPrimitive.Trigger
+      {...props}
+      aria-describedby={ariaDescribedBy || undefined}
+      delay={delay ?? root.delay}
+      ref={ref}
+    />
+  );
+});
+TooltipTrigger.displayName = "TooltipTrigger";
+
+type TooltipPositionerProps = Pick<
+  TooltipPrimitive.Positioner.Props,
+  | "align"
+  | "alignOffset"
+  | "anchor"
+  | "arrowPadding"
+  | "collisionAvoidance"
+  | "collisionBoundary"
+  | "collisionPadding"
+  | "disableAnchorTracking"
+  | "positionMethod"
+  | "side"
+  | "sideOffset"
+>;
+
+export interface TooltipContentProps
+  extends
+    Omit<TooltipPrimitive.Popup.Props, "className">,
+    TooltipPositionerProps {
+  className?: string;
+  /** @deprecated Base UI uses `collisionAvoidance`. */
+  avoidCollisions?: boolean;
+  /** Keeps the Base UI Portal mounted while the tooltip is closed. */
+  forceMount?: boolean;
+  /** Hides the Positioner when Base UI reports that its anchor is hidden. */
+  hideWhenDetached?: boolean;
+}
+
+const radixCollisionAvoidance = {
+  fallbackAxisSide: "none",
+} as const;
+
+const noCollisionAvoidance = {
+  side: "none",
+  align: "none",
+  fallbackAxisSide: "none",
+} as const;
+
+const radixCollisionBoundary: Element[] = [];
 
 export const TooltipContent = forwardRef<
-  ComponentRef<typeof TooltipPrimitive.Content>,
-  ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md",
+  ComponentRef<typeof TooltipPrimitive.Popup>,
+  TooltipContentProps
+>(
+  (
+    {
+      align = "center",
+      alignOffset = 0,
+      anchor,
+      arrowPadding = 0,
+      avoidCollisions = true,
       className,
-    )}
-    {...props}
-  />
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+      collisionAvoidance,
+      collisionBoundary = radixCollisionBoundary,
+      collisionPadding = 0,
+      disableAnchorTracking,
+      forceMount,
+      hideWhenDetached = false,
+      id,
+      positionMethod = "fixed",
+      role = "tooltip",
+      side = "top",
+      sideOffset = 4,
+      ...props
+    },
+    ref,
+  ) => {
+    const root = useContext(TooltipRootCompatibilityContext);
+    const effectiveId = id ?? root.generatedContentId;
+
+    useLayoutEffect(() => {
+      root.setContentId(effectiveId);
+      return () => {
+        root.setContentId((currentId) =>
+          currentId === effectiveId ? root.generatedContentId : currentId,
+        );
+      };
+    }, [effectiveId, root.generatedContentId, root.setContentId]);
+
+    return (
+      <TooltipPrimitive.Portal keepMounted={forceMount}>
+        <TooltipPrimitive.Positioner
+          align={align}
+          alignOffset={alignOffset}
+          anchor={anchor}
+          arrowPadding={arrowPadding}
+          className={cn(
+            "isolate z-50",
+            hideWhenDetached && "data-[anchor-hidden]:invisible",
+          )}
+          collisionAvoidance={
+            collisionAvoidance ??
+            (avoidCollisions ? radixCollisionAvoidance : noCollisionAvoidance)
+          }
+          collisionBoundary={collisionBoundary}
+          collisionPadding={collisionPadding}
+          disableAnchorTracking={disableAnchorTracking}
+          positionMethod={positionMethod}
+          side={side}
+          sideOffset={sideOffset}
+        >
+          <TooltipPrimitive.Popup
+            ref={ref}
+            className={cn(
+              "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md",
+              className,
+            )}
+            id={effectiveId}
+            role={role}
+            {...props}
+          />
+        </TooltipPrimitive.Positioner>
+      </TooltipPrimitive.Portal>
+    );
+  },
+);
+TooltipContent.displayName = "TooltipContent";


### PR DESCRIPTION
## What changed

- migrate shared Tooltip, Popover, and Select wrappers from Radix to Base UI 1.6
- preserve existing visual classes and consumer APIs through focused compatibility adapters for delays, positioning, cancellation, portals, formatted labels, controlled state, RTL, and disabled states
- keep compensation-source labels human-readable while persisting canonical source-policy values
- add focused component, accessibility, Storybook, and real-consumer regressions
- remove these three wrappers from the temporary direct-Radix boundary

## Why

This is the next compatibility-first migration slice. It keeps primitive replacement separate from the later visual redesign while shrinking direct Radix ownership from eight wrappers to five.

## Validation

- focused overlay suite: 5 files, 36 tests passed
- full web suite: 279 files, 1,541 tests passed
- corepack pnpm web:check
- corepack pnpm web:build
- git diff --check
- review gate: PASS with 0 Blocker and 0 High findings

## Known compatibility differences

- Base Popover cannot expose the initiating pointerdown through its public Root callback on the default nonmodal outside-click path, so the adapter emits truthful cancellable outside events instead of falsely casting click events to PointerEvent
- focusable outside clicks may produce focus-out and click close phases; this is documented and has no repository consumer
- focus-out compatibility event targets differ from Radix; cancellation remains covered

## Documentation

Public documentation is intentionally deferred to the final PR in this migration and redesign stack. Focused migration reports under .migration record the compatibility decisions in this slice.