### PR TITLE
feat(web): redesign the product interface with Rhea

### DIFF
--- a/apps/web/components.json
+++ b/apps/web/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "base-luma",
+  "style": "base-rhea",
   "rsc": false,
   "tsx": true,
   "tailwind": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
+    "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/jetbrains-mono": "5.2.8",
-    "@fontsource-variable/plus-jakarta-sans": "5.2.8",
     "@jobctrl/api-client": "workspace:*",
     "@jobctrl/contracts": "workspace:*",
     "@jobctrl/domain-types": "workspace:*",

--- a/apps/web/src/contexts/discovery/components/DiscoveryAutomationSettingsPanel.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryAutomationSettingsPanel.tsx
@@ -30,7 +30,7 @@ export function DiscoveryAutomationSettingsPanel() {
 
   return (
     <section className="card full discovery-automation-settings">
-      <CardHeader title="Automation settings" meta="SQLite · scoring and apply" />
+      <CardHeader title="Automation settings" meta="supervision, scoring, and apply" />
       {settingsQuery.error ? <div className="banner inline">{settingsQuery.error.message}</div> : null}
       {settingsQuery.data ? (
         <DiscoveryAutomationSettingsForm initial={settingsQuery.data} />

--- a/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.tsx
@@ -59,7 +59,7 @@ export function DiscoveryRuntimeSettingsPanel() {
 
   return (
     <section className="card full discovery-runtime-settings">
-      <CardHeader title="Runtime settings" meta="discovery config" />
+      <CardHeader title="Runtime settings" meta="sources, timing, and filtering" />
       {settingsQuery.error ? <div className="banner inline">{settingsQuery.error.message}</div> : null}
       {settingsQuery.data ? (
         <DiscoveryRuntimeSettingsForm initial={settingsQuery.data} />

--- a/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
@@ -83,7 +83,9 @@ describe("<ProfileEditor>", () => {
     expect(
       await screen.findByRole("heading", { name: "Configuration & templates" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Application configurations" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 3, name: "Application configuration" }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Location filter")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Target search" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Revision policy" })).toBeInTheDocument();

--- a/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeImportWizard.tsx
@@ -1,40 +1,108 @@
 import { Link, Outlet, useRouterState } from "@tanstack/react-router";
 
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import { buttonVariants } from "../../../shared/ui/button.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../../shared/ui/card.js";
+import { PageHead } from "../../../shared/ui/page-head.js";
 
 const STEPS: ReadonlyArray<{
   readonly key: string;
   readonly label: string;
+  readonly description: string;
   readonly to: "/profile/import/upload" | "/profile/import/preview" | "/profile/import/confirm";
 }> = [
-  { key: "upload", label: "1 · Upload PDF", to: "/profile/import/upload" },
-  { key: "preview", label: "2 · Preview options", to: "/profile/import/preview" },
-  { key: "confirm", label: "3 · Confirm import", to: "/profile/import/confirm" },
+  {
+    key: "upload",
+    label: "Upload PDF",
+    description: "Choose the source resume",
+    to: "/profile/import/upload",
+  },
+  {
+    key: "preview",
+    label: "Preview options",
+    description: "Review the PDF and scope",
+    to: "/profile/import/preview",
+  },
+  {
+    key: "confirm",
+    label: "Confirm import",
+    description: "Apply the selected data",
+    to: "/profile/import/confirm",
+  },
 ];
 
 export function ResumeImportWizard() {
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const activeStepIndex = Math.max(
+    0,
+    STEPS.findIndex((step) => step.to === pathname),
+  );
+
   return (
-    <section className="card full">
-      <CardHeader title="Resume import" meta="three-step wizard" />
-      <nav className="wizard-steps" aria-label="Wizard steps">
-        {STEPS.map((step) => {
-          const active = pathname === step.to;
-          return (
-            <Link
-              key={step.key}
-              to={step.to}
-              className={`tab ${active ? "on" : ""}`}
-              aria-current={active ? "step" : undefined}
-            >
-              {step.label}
-            </Link>
-          );
-        })}
-      </nav>
-      <div className="wizard-body">
-        <Outlet />
-      </div>
-    </section>
+    <div className="resume-import-page">
+      <PageHead
+        eyebrow="Setup"
+        title="Import resume"
+        subtitle="Bring an existing resume into your canonical profile without losing control over which data is imported."
+        actions={
+          <Link className={buttonVariants({ variant: "outline", size: "sm" })} to="/profile">
+            Back to profile
+          </Link>
+        }
+      />
+
+      <Card
+        className="resume-import-wizard"
+        role="region"
+        aria-labelledby="resume-import-wizard-title"
+      >
+        <CardHeader className="resume-import-wizard__header">
+          <div>
+            <CardTitle id="resume-import-wizard-title" role="heading" aria-level={2}>
+              Resume import
+            </CardTitle>
+            <CardDescription>
+              Upload, inspect, and confirm one PDF in three clear steps.
+            </CardDescription>
+          </div>
+          <span className="resume-import-wizard__progress" aria-live="polite">
+            Step {activeStepIndex + 1} of {STEPS.length}
+          </span>
+        </CardHeader>
+
+        <nav className="resume-import-steps" aria-label="Resume import steps">
+          {STEPS.map((step, index) => {
+            const active = pathname === step.to;
+            return (
+              <Link
+                key={step.key}
+                to={step.to}
+                className="resume-import-step-link"
+                aria-current={active ? "step" : undefined}
+                data-active={active || undefined}
+                data-complete={index < activeStepIndex || undefined}
+              >
+                <span className="resume-import-step-link__number" aria-hidden="true">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="resume-import-step-link__copy">
+                  <strong>{step.label}</strong>
+                  <small>{step.description}</small>
+                </span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        <CardContent className="resume-import-wizard__content">
+          <Outlet />
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
+++ b/apps/web/src/contexts/profile/components/ResumeTemplatePanel.tsx
@@ -171,7 +171,7 @@ export function ResumeTemplatePanel({ profileHtmlPreviewUrl }: ResumeTemplatePan
   };
 
   return (
-    <section className="form-section resume-template-panel" aria-label="Resume templates">
+    <section className="form-section resume-template-panel resume-template-workspace" aria-label="Resume templates">
       <h3>Resume templates</h3>
       <div className="resume-template-shell">
         <div className="resume-template-controls">

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -162,7 +162,10 @@ describe("<StructuredProfileEditor>", () => {
     render(<StatefulEditor mode="preferences" />);
 
     expect(screen.queryByLabelText("AI may reframe experience titles")).not.toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Change experience titles" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Change experience titles" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
   it("labels keyword density as advisory emphasis and edits revision gates", () => {
@@ -209,10 +212,11 @@ describe("<StructuredProfileEditor>", () => {
     render(<StatefulEditor mode="preferences" />);
 
     expect(screen.queryByLabelText("Bullet style")).not.toBeInTheDocument();
-    expect(screen.getByRole("group", { name: "Bullet standards" })).toBeInTheDocument();
-    expect(screen.getByRole("checkbox", { name: "Impact" })).toBeChecked();
-    expect(screen.getByRole("checkbox", { name: "Technical depth" })).toBeChecked();
-    expect(screen.getByRole("checkbox", { name: "Leadership" })).toBeChecked();
+    const bulletStandards = screen.getByRole("group", { name: "Bullet standards" });
+    expect(within(bulletStandards).getByRole("link", { name: "Guide" })).toBeInTheDocument();
+    expect(within(bulletStandards).getByRole("checkbox", { name: "Impact" })).toBeChecked();
+    expect(within(bulletStandards).getByRole("checkbox", { name: "Technical depth" })).toBeChecked();
+    expect(within(bulletStandards).getByRole("checkbox", { name: "Leadership" })).toBeChecked();
   });
 
   it("preserves extracted achievement evidence without exposing it as profile input", () => {

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1,5 +1,15 @@
-import { useEffect, useRef, type ReactNode } from "react";
-import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { IconChevronDown, IconExternalLink, IconPlus, IconTrash } from "@tabler/icons-react";
+
+import { Checkbox } from "../../../shared/ui/checkbox.js";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../../shared/ui/select.js";
 
 import {
   GoogleAddressSearchField,
@@ -136,6 +146,39 @@ export interface StructuredProfileEditorProps {
   styleText: string;
   onProfileTextChange: (value: string) => void;
   onStyleTextChange: (value: string) => void;
+}
+
+function ConfigurationSection({
+  children,
+  defaultOpen,
+  description,
+  title,
+}: {
+  readonly children: ReactNode;
+  readonly defaultOpen?: boolean;
+  readonly description: string;
+  readonly title: string;
+}) {
+  const [open, setOpen] = useState(defaultOpen ?? false);
+
+  return (
+    <details
+      className="form-section configuration-section"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary>
+        <span className="configuration-section__title-group">
+          <span aria-level={3} className="configuration-section__title" role="heading">
+            {title}
+          </span>
+          <span className="configuration-section__description">{description}</span>
+        </span>
+        <IconChevronDown aria-hidden="true" className="configuration-section__indicator" size={16} />
+      </summary>
+      <div className="configuration-section__body">{children}</div>
+    </details>
+  );
 }
 
 export function StructuredProfileEditor({
@@ -522,30 +565,33 @@ export function StructuredProfileEditor({
   ) => (
     <label className="field">
       <span>{label}</span>
-      <select
-        aria-label={label}
-        value={textAt(profile, path)}
-        onChange={(event) => updateProfilePath(path, event.target.value)}
-      >
-        {options.map((option) => {
-          const value = Array.isArray(option) ? option[0] : option;
-          const text = Array.isArray(option) ? option[1] : option;
-          return (
-            <option key={value} value={value}>
-              {text}
-            </option>
-          );
-        })}
-      </select>
+      <Select value={textAt(profile, path)} onValueChange={(value) => updateProfilePath(path, value)}>
+        <SelectTrigger aria-label={label} className="configuration-select-trigger">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {options.map((option) => {
+              const value = Array.isArray(option) ? option[0] : option;
+              const text = Array.isArray(option) ? option[1] : option;
+              return (
+                <SelectItem key={value} value={value}>
+                  {text}
+                </SelectItem>
+              );
+            })}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </label>
   );
 
   const inventedAdjacentExperienceField = () => (
     <label className="field check">
-      <input
-        type="checkbox"
+      <Checkbox
+        aria-label="Enable profile enhancement"
         checked={allowsInventedAdjacentExperience()}
-        onChange={(event) => setInventedAdjacentExperienceAllowed(event.target.checked)}
+        onCheckedChange={setInventedAdjacentExperienceAllowed}
       />
       <span>Enable profile enhancement</span>
     </label>
@@ -553,10 +599,10 @@ export function StructuredProfileEditor({
 
   const checkboxField = (path: string, label: string) => (
     <label className="field check">
-      <input
-        type="checkbox"
+      <Checkbox
+        aria-label={label}
         checked={Boolean(getPathValue(profile, path))}
-        onChange={(event) => updateProfilePath(path, event.target.checked)}
+        onCheckedChange={(checked) => updateProfilePath(path, checked)}
       />
       <span>{label}</span>
     </label>
@@ -615,7 +661,7 @@ export function StructuredProfileEditor({
 
   const disabledCheckboxField = (label: string) => (
     <label className="field check disabled">
-      <input type="checkbox" checked={false} disabled />
+      <Checkbox aria-label={label} checked={false} disabled />
       <span>{label}</span>
     </label>
   );
@@ -900,15 +946,33 @@ export function StructuredProfileEditor({
 
   const bulletStandardsField = () => (
     <fieldset className="field wide checkbox-group-field bullet-standards-group">
-      <legend>Bullet standards</legend>
+      <legend>
+        <span>Bullet standards</span>
+        <a
+          className="configuration-help-link"
+          href="https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Guide
+          <IconExternalLink aria-hidden="true" size={12} />
+        </a>
+      </legend>
       <div className="checkbox-options">
         {BULLET_STANDARD_OPTIONS.map(([value, label]) => (
-          <label className="choice target-choice" key={value}>
-            <input type="checkbox" checked readOnly value={value} />
+          <label className="choice target-choice required-choice" key={value}>
+            <Checkbox
+              aria-label={`${label}, required`}
+              checked
+              disabled
+              name="bullet-standard"
+              value={value}
+            />
             <span>{label}</span>
           </label>
         ))}
       </div>
+      <small>Required evidence-quality standards; these cannot be disabled.</small>
     </fieldset>
   );
 
@@ -1031,17 +1095,20 @@ export function StructuredProfileEditor({
   const styleSelect = (path: string, label: string, options: Array<[string, string]>) => (
     <label className="field">
       <span>{label}</span>
-      <select
-        aria-label={label}
-        value={textAt(style, path)}
-        onChange={(event) => updateStylePath(path, event.target.value)}
-      >
-        {options.map(([value, text]) => (
-          <option key={value} value={value}>
-            {text}
-          </option>
-        ))}
-      </select>
+      <Select value={textAt(style, path)} onValueChange={(value) => updateStylePath(path, value)}>
+        <SelectTrigger aria-label={label} className="configuration-select-trigger">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {options.map(([value, text]) => (
+              <SelectItem key={value} value={value}>
+                {text}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
     </label>
   );
 
@@ -1391,8 +1458,11 @@ export function StructuredProfileEditor({
         targetSearchSection()
       ) : (
         <>
-          <section className="form-section">
-            <h3>Application configurations</h3>
+          <ConfigurationSection
+            defaultOpen
+            description="Availability, work authorization, and compensation defaults."
+            title="Application configuration"
+          >
             <div className="field-grid">
               {applicationConfigurationFields}
               {selectField("work_authorization.legally_authorized_to_work", "Legally authorized to work", [
@@ -1425,10 +1495,13 @@ export function StructuredProfileEditor({
               })}
               {textField("compensation.currency_conversion_note", "Currency note")}
             </div>
-          </section>
+          </ConfigurationSection>
 
-          <section className="form-section">
-            <h3>Tailoring controls</h3>
+          <ConfigurationSection
+            defaultOpen
+            description="Evidence-safe writing rules and generation thresholds."
+            title="Tailoring controls"
+          >
             <div className="tailoring-controls-grid">
               {adjacentExperienceClaimsGroup()}
               {generationPermissionsGroup()}
@@ -1436,10 +1509,12 @@ export function StructuredProfileEditor({
               {revisionPolicyGroup()}
               {additionalGuidanceGroup()}
             </div>
-          </section>
+          </ConfigurationSection>
 
-          <section className="form-section">
-            <h3>Resume style</h3>
+          <ConfigurationSection
+            description="Defaults for generated resumes outside the template workspace."
+            title="Resume style"
+          >
             <div className="field-grid">
               {styleSelect("document_font_size", "Text size", [
                 ["10pt", "Small"],
@@ -1478,7 +1553,7 @@ export function StructuredProfileEditor({
               {styleNumber("page_scale", "Page scale", 0.7, 1, 0.01)}
               {styleNumber("hints_column_width_cm", "Date column width (cm)", 1.5, 5, 0.1)}
             </div>
-          </section>
+          </ConfigurationSection>
         </>
       )}
     </div>

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { IconChevronDown, IconExternalLink, IconPlus, IconTrash } from "@tabler/icons-react";
 
 import { Checkbox } from "../../../shared/ui/checkbox.js";
@@ -191,6 +191,7 @@ export function StructuredProfileEditor({
 }: StructuredProfileEditorProps) {
   const profile = parseJsonRecord(profileText);
   const style = parseJsonRecord(styleText);
+  const bulletStandardsLabelId = useId();
   const focusTargetsRef = useRef(new Map<string, HTMLInputElement | HTMLSelectElement>());
   const pendingFocusKeyRef = useRef<string | null>(null);
 
@@ -589,7 +590,6 @@ export function StructuredProfileEditor({
   const inventedAdjacentExperienceField = () => (
     <label className="field check">
       <Checkbox
-        aria-label="Enable profile enhancement"
         checked={allowsInventedAdjacentExperience()}
         onCheckedChange={setInventedAdjacentExperienceAllowed}
       />
@@ -600,7 +600,6 @@ export function StructuredProfileEditor({
   const checkboxField = (path: string, label: string) => (
     <label className="field check">
       <Checkbox
-        aria-label={label}
         checked={Boolean(getPathValue(profile, path))}
         onCheckedChange={(checked) => updateProfilePath(path, checked)}
       />
@@ -661,7 +660,7 @@ export function StructuredProfileEditor({
 
   const disabledCheckboxField = (label: string) => (
     <label className="field check disabled">
-      <Checkbox aria-label={label} checked={false} disabled />
+      <Checkbox checked={false} disabled />
       <span>{label}</span>
     </label>
   );
@@ -945,9 +944,12 @@ export function StructuredProfileEditor({
   };
 
   const bulletStandardsField = () => (
-    <fieldset className="field wide checkbox-group-field bullet-standards-group">
+    <fieldset
+      aria-labelledby={bulletStandardsLabelId}
+      className="field wide checkbox-group-field bullet-standards-group"
+    >
       <legend>
-        <span>Bullet standards</span>
+        <span id={bulletStandardsLabelId}>Bullet standards</span>
         <a
           className="configuration-help-link"
           href="https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring"
@@ -962,7 +964,6 @@ export function StructuredProfileEditor({
         {BULLET_STANDARD_OPTIONS.map(([value, label]) => (
           <label className="choice target-choice required-choice" key={value}>
             <Checkbox
-              aria-label={`${label}, required`}
               checked
               disabled
               name="bullet-standard"

--- a/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
@@ -8,7 +8,7 @@ export function TargetSearchSettingsPanel() {
 
   return (
     <section className="card full target-search-settings">
-      <CardHeader title="Discovery settings" meta="target search" />
+      <CardHeader title="Target search" meta="roles, locations, and work models" />
       {profileQuery.error ? <div className="banner inline">{profileQuery.error.message}</div> : null}
       {profileQuery.data ? (
         <ProfileForm initial={profileQuery.data} section="target-search" />

--- a/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
@@ -1,8 +1,10 @@
 import { ProfileImportRequestSchema, type ProfileImportRequest } from "@jobctrl/contracts";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconCheck, IconFileTypePdf, IconMinus } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
+import { Button, buttonVariants } from "../../../shared/ui/button.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useImportResumeMutation } from "../hooks/useImportResumeMutation.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
@@ -46,11 +48,14 @@ export function ImportConfirmForm() {
 
   if (!filename || !pdfBase64) {
     return (
-      <div className="wizard-step">
+      <div className="wizard-step resume-import-step resume-import-empty-step">
         <Empty title="No upload found. Start at step 1." />
-        <div className="form-actions">
-          <Link className="tab" to="/profile/import/upload">
-            back to upload
+        <div className="form-actions resume-import-actions">
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            to="/profile/import/upload"
+          >
+            Back to upload
           </Link>
         </div>
       </div>
@@ -60,42 +65,112 @@ export function ImportConfirmForm() {
   const errorMessage = importResume.error?.message ?? "";
   const summary =
     importProfile && importStyle
-      ? "profile + style"
+      ? "Profile and style"
       : importProfile
-        ? "profile only"
+        ? "Profile only"
         : importStyle
-          ? "style only"
-          : "no fields";
+          ? "Style only"
+          : "No sections selected";
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-step--confirm"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-      {statusMessage ? <div className="status-line">{statusMessage}</div> : null}
-      <p>
-        Importing <b>{filename}</b> with {summary}.
-      </p>
+      <header className="resume-import-step__header">
+        <span className="resume-import-step__eyebrow">Confirm import</span>
+        <h2>Review the final import</h2>
+        <p>Check the source and selected scope once more before applying the import.</p>
+      </header>
+
+      {errorMessage ? (
+        <div className="banner inline resume-import-alert" role="alert">
+          {errorMessage}
+        </div>
+      ) : null}
+      {statusMessage ? (
+        <div className="status-line resume-import-status" role="status">
+          {statusMessage}
+        </div>
+      ) : null}
+
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
+          return message ? (
+            <div className="banner inline resume-import-alert" role="alert">
+              {message}
+            </div>
+          ) : null;
+        }}
+      </form.Subscribe>
+
+      <dl className="resume-import-confirmation-summary">
+        <div>
+          <dt>Source PDF</dt>
+          <dd>
+            <IconFileTypePdf size={20} stroke={1.65} aria-hidden="true" />
+            <span>{filename}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>Import scope</dt>
+          <dd>{summary}</dd>
+        </div>
+      </dl>
+
+      <div
+        className="resume-import-scope-review"
+        role="group"
+        aria-label="Selected import sections"
+      >
+        <div data-selected={importProfile || undefined}>
+          {importProfile ? (
+            <IconCheck size={18} stroke={2} aria-hidden="true" />
+          ) : (
+            <IconMinus size={18} stroke={2} aria-hidden="true" />
+          )}
+          <span>
+            <strong>Profile data</strong>
+            <small>{importProfile ? "Included in this import" : "Not selected"}</small>
+          </span>
+        </div>
+        <div data-selected={importStyle || undefined}>
+          {importStyle ? (
+            <IconCheck size={18} stroke={2} aria-hidden="true" />
+          ) : (
+            <IconMinus size={18} stroke={2} aria-hidden="true" />
+          )}
+          <span>
+            <strong>Style data</strong>
+            <small>{importStyle ? "Included in this import" : "Not selected"}</small>
+          </span>
+        </div>
+      </div>
+
       <form.Subscribe
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions">
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              to="/profile/import/preview"
+            >
+              Back
+            </Link>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting}
             >
-              {isSubmitting ? "importing..." : "confirm import"}
-            </button>
-            <Link className="tab" to="/profile/import/preview">
-              back
-            </Link>
+              {isSubmitting ? "Importing…" : "Confirm import"}
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-preview-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-preview-form.tsx
@@ -1,8 +1,20 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconFileTypePdf } from "@tabler/icons-react";
 import { z } from "zod";
 
+import { Button, buttonVariants } from "../../../shared/ui/button.js";
+import { Checkbox } from "../../../shared/ui/checkbox.js";
 import { Empty } from "../../../shared/ui/empty.js";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "../../../shared/ui/field.js";
+import { PdfPreviewViewer } from "../../../shared/ui/PdfPreviewViewer.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
 
 interface PreviewFormValues {
@@ -22,6 +34,7 @@ const PreviewValidator = z
 export function ImportPreviewForm() {
   const navigate = useNavigate();
   const filename = useProfileImportStore((state) => state.filename);
+  const pdfBase64 = useProfileImportStore((state) => state.pdfBase64);
   const importProfile = useProfileImportStore((state) => state.importProfile);
   const importStyle = useProfileImportStore((state) => state.importStyle);
   const setOptions = useProfileImportStore((state) => state.setOptions);
@@ -46,13 +59,16 @@ export function ImportPreviewForm() {
     },
   });
 
-  if (!filename) {
+  if (!filename || !pdfBase64) {
     return (
-      <div className="wizard-step">
+      <div className="wizard-step resume-import-step resume-import-empty-step">
         <Empty title="Pick a PDF on the previous step before continuing." />
-        <div className="form-actions">
-          <Link className="tab" to="/profile/import/upload">
-            back to upload
+        <div className="form-actions resume-import-actions">
+          <Link
+            className={buttonVariants({ variant: "outline" })}
+            to="/profile/import/upload"
+          >
+            Back to upload
           </Link>
         </div>
       </div>
@@ -61,59 +77,123 @@ export function ImportPreviewForm() {
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-step--preview"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      <p className="status-line">
-        Selected: <b>{filename}</b>
-      </p>
-      <div className="import-options">
-        <form.Field name="importProfile">
-          {(field) => (
-            <label>
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.checked)}
-              />
-              profile data
-            </label>
-          )}
-        </form.Field>
-        <form.Field name="importStyle">
-          {(field) => (
-            <label>
-              <input
-                type="checkbox"
-                checked={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.target.checked)}
-              />
-              style data
-            </label>
-          )}
-        </form.Field>
+      <header className="resume-import-step__header">
+        <span className="resume-import-step__eyebrow">Preview options</span>
+        <h2>Review the PDF and choose the import scope</h2>
+        <p>The original document stays visible while you decide which sections to bring across.</p>
+      </header>
+
+      <div className="resume-import-selected-file">
+        <IconFileTypePdf size={22} stroke={1.65} aria-hidden="true" />
+        <span>
+          <small>Selected PDF</small>
+          <strong>{filename}</strong>
+        </span>
       </div>
+
+      <FieldSet className="resume-import-option-set">
+        <FieldLegend>What should be imported?</FieldLegend>
+        <FieldDescription>
+          Select at least one section. You can edit the resulting profile after import.
+        </FieldDescription>
+        <div className="import-options resume-import-options">
+          <form.Field name="importProfile">
+            {(field) => (
+              <Field orientation="horizontal" className="resume-import-option">
+                <Checkbox
+                  id="resume-import-profile-data"
+                  checked={field.state.value}
+                  onBlur={field.handleBlur}
+                  onCheckedChange={(checked) => field.handleChange(checked)}
+                />
+                <FieldContent>
+                  <FieldLabel htmlFor="resume-import-profile-data">Profile data</FieldLabel>
+                  <FieldDescription>
+                    Canonical profile fields parsed from the source resume.
+                  </FieldDescription>
+                </FieldContent>
+              </Field>
+            )}
+          </form.Field>
+          <form.Field name="importStyle">
+            {(field) => (
+              <Field orientation="horizontal" className="resume-import-option">
+                <Checkbox
+                  id="resume-import-style-data"
+                  checked={field.state.value}
+                  onBlur={field.handleBlur}
+                  onCheckedChange={(checked) => field.handleChange(checked)}
+                />
+                <FieldContent>
+                  <FieldLabel htmlFor="resume-import-style-data">Style data</FieldLabel>
+                  <FieldDescription>
+                    Resume rendering style parsed from the source document.
+                  </FieldDescription>
+                </FieldContent>
+              </Field>
+            )}
+          </form.Field>
+        </div>
+      </FieldSet>
+
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
+          return message ? (
+            <div className="banner inline resume-import-alert" role="alert">
+              {message}
+            </div>
+          ) : null;
+        }}
+      </form.Subscribe>
+
+      <section className="resume-import-document-preview" aria-labelledby="resume-import-preview-title">
+        <header>
+          <div>
+            <h3 id="resume-import-preview-title">Original PDF</h3>
+            <p>Inspect every page before continuing.</p>
+          </div>
+          <span>{filename}</span>
+        </header>
+        <div className="resume-import-document-preview__viewer">
+          <PdfPreviewViewer
+            url={`data:application/pdf;base64,${pdfBase64}`}
+            cacheKey={filename}
+            title="Uploaded resume"
+            loadingTitle="Preparing resume preview"
+            loadingMessage="Rendering the selected PDF."
+            pageAltPrefix="Uploaded resume"
+            openLabel="Open original PDF"
+          />
+        </div>
+      </section>
+
       <form.Subscribe
         selector={(state) => ({ canSubmit: state.canSubmit, isSubmitting: state.isSubmitting })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions">
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              to="/profile/import/upload"
+            >
+              Back
+            </Link>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting}
             >
-              next
-            </button>
-            <Link className="tab" to="/profile/import/upload">
-              back
-            </Link>
+              Continue to confirmation
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-upload-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-upload-form.tsx
@@ -1,9 +1,11 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useForm } from "@tanstack/react-form";
+import { IconFileTypePdf } from "@tabler/icons-react";
 import { useState } from "react";
 import { z } from "zod";
 
 import { fileToBase64 } from "../../../shared/lib/file.js";
+import { Button, buttonVariants } from "../../../shared/ui/button.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
 
 interface UploadFormValues {
@@ -63,21 +65,55 @@ export function ImportUploadForm() {
 
   return (
     <form
-      className="wizard-step"
+      className="wizard-step resume-import-step resume-import-step--upload"
       onSubmit={(event) => {
         event.preventDefault();
         event.stopPropagation();
         void form.handleSubmit();
       }}
     >
-      {readError ? <div className="banner inline">{readError}</div> : null}
+      <header className="resume-import-step__header">
+        <span className="resume-import-step__eyebrow">Upload PDF</span>
+        <h2>Choose your source resume</h2>
+        <p>Select the PDF you want to inspect before deciding which information to import.</p>
+      </header>
+
+      {readError ? (
+        <div className="banner inline resume-import-alert" role="alert">
+          {readError}
+        </div>
+      ) : null}
+
+      <form.Subscribe selector={(state) => state.errors}>
+        {(errors) => {
+          const message = errors
+            .flat()
+            .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
+          return message ? (
+            <div className="banner inline resume-import-alert" role="alert">
+              {message}
+            </div>
+          ) : null;
+        }}
+      </form.Subscribe>
+
       <form.Field name="filename">
         {(field) => (
-          <label className="import-target">
-            <span className="import-icon">PDF</span>
-            <span>
-              <b>Resume PDF</b>
-              <small>{field.state.value || "No file selected"}</small>
+          <label
+            className="import-target resume-import-target"
+            data-ready={Boolean(field.state.value) || undefined}
+            aria-busy={reading}
+          >
+            <span className="resume-import-target__icon" aria-hidden="true">
+              <IconFileTypePdf size={30} stroke={1.65} />
+            </span>
+            <span className="resume-import-target__copy">
+              <b>{field.state.value ? "PDF selected" : "Choose a resume PDF"}</b>
+              <small aria-live="polite">
+                {reading
+                  ? "Reading the selected file…"
+                  : field.state.value || "PDF files only"}
+              </small>
             </span>
             <input
               aria-label="Resume PDF"
@@ -85,10 +121,17 @@ export function ImportUploadForm() {
               accept="application/pdf"
               onChange={(event) => void handleFile(event.target.files?.[0] ?? null)}
             />
-            <em>{reading ? "reading..." : "choose file"}</em>
+            <span className="resume-import-target__action" aria-hidden="true">
+              {reading ? "Reading…" : field.state.value ? "Choose another" : "Choose PDF"}
+            </span>
           </label>
         )}
       </form.Field>
+
+      <p className="resume-import-step__hint">
+        The selected file is not imported until you review the options and confirm the final step.
+      </p>
+
       <form.Subscribe
         selector={(state) => ({
           canSubmit: state.canSubmit,
@@ -96,17 +139,19 @@ export function ImportUploadForm() {
         })}
       >
         {({ canSubmit, isSubmitting }) => (
-          <div className="form-actions">
-            <button
+          <div className="form-actions resume-import-actions">
+            <Link
+              className={buttonVariants({ variant: "outline" })}
+              to="/profile"
+            >
+              Cancel
+            </Link>
+            <Button
               type="submit"
-              className="tab on"
               disabled={!canSubmit || isSubmitting || reading}
             >
-              next
-            </button>
-            <Link className="tab" to="/profile">
-              cancel
-            </Link>
+              Continue to options
+            </Button>
           </div>
         )}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -20,7 +20,7 @@ describe("<ProfileForm>", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Personal information" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Application configurations" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Application configuration" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Target role")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "preferences" })).not.toBeInTheDocument();
   });
@@ -101,7 +101,9 @@ describe("<ProfileForm>", () => {
       />,
     );
 
-    expect(await screen.findByRole("heading", { name: "Application configurations" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 3, name: "Application configuration" }),
+    ).toBeInTheDocument();
     expect(screen.queryByLabelText("Location filter")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Tailoring controls" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Target search" })).not.toBeInTheDocument();
@@ -142,7 +144,7 @@ describe("<ProfileForm>", () => {
     expect(screen.getByRole("group", { name: "Target work model 1" })).toBeInTheDocument();
     expect(screen.getByLabelText("Remote")).toBeInTheDocument();
     expect(screen.getByLabelText("Hybrid")).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Application configurations" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Application configuration" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/demo/guide/DemoGuide.tsx
+++ b/apps/web/src/demo/guide/DemoGuide.tsx
@@ -121,7 +121,7 @@ export function DemoGuide() {
 
   return (
     <aside
-      className="fixed bottom-4 right-4 z-40 grid w-[min(22rem,calc(100vw-2rem))] gap-3 rounded-xl border border-border bg-card p-4 text-card-foreground shadow-[var(--shadow-panel)] motion-reduce:transition-none"
+      className="demo-guide-panel fixed bottom-4 right-4 z-40 grid w-[min(22rem,calc(100vw-2rem))] gap-3 rounded-xl border border-border bg-card p-4 text-card-foreground shadow-[var(--shadow-panel)] motion-reduce:transition-none"
       aria-labelledby="demo-guide-title"
     >
       <div className="flex items-start justify-between gap-3">

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -21,6 +21,18 @@ import { ThemeProvider } from "./shared/providers/ThemeProvider.js";
 import { ToasterProvider } from "./shared/providers/ToasterProvider.js";
 import { TooltipProvider } from "./shared/ui/tooltip.js";
 import "./styles/globals.css";
+import "./styles/redesign-common.css";
+import "./styles/redesign-overlays.css";
+import "./styles/redesign-shell.css";
+import "./styles/redesign-data.css";
+import "./styles/redesign-analytics.css";
+import "./styles/redesign-dashboard.css";
+import "./styles/redesign-detail-surfaces.css";
+import "./styles/redesign-job-detail.css";
+import "./styles/redesign-configuration.css";
+import "./styles/redesign-apply-review.css";
+import "./styles/redesign-profile-import.css";
+import "./styles/redesign-route-gaps.css";
 
 const queryClient = createQueryClient();
 const root = createRoot(document.getElementById("root")!);

--- a/apps/web/src/shared/layout/SideRail.tsx
+++ b/apps/web/src/shared/layout/SideRail.tsx
@@ -100,7 +100,12 @@ export function RailNav({ className, onNavigate }: RailNavProps) {
   return (
     <nav className={cn("side-rail__nav", className)} aria-label="Main navigation">
       {NAV_GROUPS.map((group) => (
-        <div key={group.label} className="side-rail__group">
+        <div
+          key={group.label}
+          className="side-rail__group"
+          role="group"
+          aria-label={group.label}
+        >
           <span className="side-rail__group-label">{group.label}</span>
           {group.items.map(({ label, to, icon: NavIcon }) => (
             <Link

--- a/apps/web/src/shared/layout/ThemeToggle.tsx
+++ b/apps/web/src/shared/layout/ThemeToggle.tsx
@@ -8,12 +8,12 @@ export function ThemeToggle() {
   return (
     <button
       type="button"
-      className="tab"
+      className="tab topbar__theme-toggle"
       aria-label={`Switch to ${next} theme`}
       onClick={() => setTheme(next)}
     >
       {theme === "dark" ? <IconSun aria-hidden="true" size={14} /> : <IconMoon aria-hidden="true" size={14} />}
-      <span>theme</span>
+      <span aria-hidden="true">{theme}</span>
     </button>
   );
 }

--- a/apps/web/src/shared/layout/Topbar.tsx
+++ b/apps/web/src/shared/layout/Topbar.tsx
@@ -1,4 +1,4 @@
-import { IconMenu2 } from "@tabler/icons-react";
+import { IconMenu2, IconSearch } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useState } from "react";
 
@@ -36,30 +36,40 @@ export function Topbar() {
           <LegalNotice className="legal-notice legal-notice--sheet" />
         </SheetContent>
       </Sheet>
-      <input
-        aria-label="Global search"
-        className="global-search"
-        placeholder="Filter jobs, errors, companies..."
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && query.trim()) {
-            void navigate({ to: "/jobs", search: { q: query.trim(), page: 1 } });
-          }
-        }}
-      />
-      <select
-        aria-label="Row density"
-        className="select"
-        value={density}
-        onChange={(event) => setDensity(event.target.value as Density)}
-      >
-        {DENSITY_OPTIONS.map((option) => (
-          <option key={option} value={option}>
-            {option}
-          </option>
-        ))}
-      </select>
+      <div className="topbar__search">
+        <IconSearch
+          className="topbar__search-icon"
+          size={16}
+          stroke={1.8}
+          aria-hidden="true"
+        />
+        <input
+          aria-label="Global search"
+          className="global-search"
+          placeholder="Filter jobs, errors, companies..."
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && query.trim()) {
+              void navigate({ to: "/jobs", search: { q: query.trim(), page: 1 } });
+            }
+          }}
+        />
+      </div>
+      <div className="topbar__density">
+        <select
+          aria-label="Row density"
+          className="select"
+          value={density}
+          onChange={(event) => setDensity(event.target.value as Density)}
+        >
+          {DENSITY_OPTIONS.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </div>
       <ThemeToggle />
       <ConnectionStatusPill />
       <LegalNotice className="legal-notice legal-notice--topbar" />

--- a/apps/web/src/shared/ui/badge.tsx
+++ b/apps/web/src/shared/ui/badge.tsx
@@ -4,15 +4,15 @@ import type { HTMLAttributes, JSX } from "react";
 import { cn } from "../lib/cn.js";
 
 const badgeVariants = cva(
-  "inline-flex min-h-[22px] items-center rounded-full border px-2.5 text-[11px] font-[850] leading-none tracking-[0.01em] transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex min-h-5 items-center rounded-md border px-1.5 text-[10px] font-medium leading-none tracking-[0.01em] transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-1",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-accent text-accent-foreground",
+        default: "border-border bg-secondary text-secondary-foreground",
         secondary: "border-transparent bg-muted text-muted-foreground",
         destructive:
-          "border-transparent bg-[color-mix(in_oklab,var(--destructive)_14%,var(--card))] text-destructive",
-        outline: "border-border text-muted-foreground",
+          "border-[color-mix(in_oklab,var(--destructive)_26%,var(--border))] bg-[color-mix(in_oklab,var(--destructive)_10%,var(--card))] text-destructive",
+        outline: "border-border bg-transparent text-muted-foreground",
       },
     },
     defaultVariants: {

--- a/apps/web/src/shared/ui/button.tsx
+++ b/apps/web/src/shared/ui/button.tsx
@@ -5,26 +5,26 @@ import { forwardRef } from "react";
 import { cn } from "../lib/cn.js";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-[12px] font-[800] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent text-[13px] font-medium transition-[color,background-color,border-color,box-shadow,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-[0_10px_20px_color-mix(in_oklab,var(--primary)_22%,transparent)] hover:bg-primary/90",
-        destructive: "bg-destructive text-white hover:bg-destructive/90",
+          "bg-primary text-primary-foreground shadow-[0_1px_2px_rgb(0_0_0_/_0.14)] hover:bg-primary/90 active:translate-y-px",
+        destructive: "bg-destructive text-white hover:bg-destructive/90 active:translate-y-px",
         outline:
-          "border border-border bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+          "border-border bg-card text-foreground hover:bg-muted",
         secondary:
-          "border border-[color-mix(in_oklab,var(--primary)_40%,var(--border))] bg-card text-primary hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-accent",
         ghost:
-          "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+          "text-muted-foreground hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-lg px-3 text-xs",
-        lg: "h-10 rounded-lg px-6",
-        icon: "h-9 w-9",
+        default: "h-9 px-3.5",
+        sm: "h-8 px-3 text-[12px]",
+        lg: "h-10 px-4",
+        icon: "size-9",
       },
     },
     defaultVariants: {

--- a/apps/web/src/shared/ui/card-header.tsx
+++ b/apps/web/src/shared/ui/card-header.tsx
@@ -7,9 +7,13 @@ export interface CardHeaderProps {
 
 export function CardHeader({ title, meta }: CardHeaderProps) {
   return (
-    <header className="card-hd">
-      <h2>{title}</h2>
-      {meta ? <span className="meta">{meta}</span> : null}
+    <header className="card-hd" data-slot="legacy-card-header">
+      <h2 data-slot="legacy-card-title">{title}</h2>
+      {meta ? (
+        <span className="meta" data-slot="legacy-card-meta">
+          {meta}
+        </span>
+      ) : null}
     </header>
   );
 }

--- a/apps/web/src/shared/ui/card.tsx
+++ b/apps/web/src/shared/ui/card.tsx
@@ -3,7 +3,7 @@ import { forwardRef, type HTMLAttributes } from "react";
 import { cn } from "../lib/cn.js";
 
 export const cardClassName =
-  "rounded-lg border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]";
+  "rounded-xl border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]";
 
 export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
@@ -14,7 +14,7 @@ Card.displayName = "Card";
 
 export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+    <div ref={ref} className={cn("flex flex-col gap-1.5 p-5", className)} {...props} />
   ),
 );
 CardHeader.displayName = "CardHeader";
@@ -23,7 +23,7 @@ export const CardTitle = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElemen
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn("text-base font-semibold leading-tight tracking-[-0.02em]", className)}
       {...props}
     />
   ),
@@ -32,21 +32,21 @@ CardTitle.displayName = "CardTitle";
 
 export const CardDescription = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <div ref={ref} className={cn("text-[13px] leading-5 text-muted-foreground", className)} {...props} />
   ),
 );
 CardDescription.displayName = "CardDescription";
 
 export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
   ),
 );
 CardContent.displayName = "CardContent";
 
 export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+    <div ref={ref} className={cn("flex items-center p-5 pt-0", className)} {...props} />
   ),
 );
 CardFooter.displayName = "CardFooter";

--- a/apps/web/src/shared/ui/checkbox.tsx
+++ b/apps/web/src/shared/ui/checkbox.tsx
@@ -15,7 +15,7 @@ export const Checkbox = forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-input shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:bg-primary data-checked:text-primary-foreground",
+      "peer inline-flex size-4 shrink-0 items-center justify-center rounded-[3px] border border-input bg-card shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground",
       className,
     )}
     {...props}
@@ -23,7 +23,7 @@ export const Checkbox = forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn("flex items-center justify-center text-current")}
     >
-      <IconCheck className="h-4 w-4" />
+      <IconCheck className="size-3" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ));

--- a/apps/web/src/shared/ui/command.tsx
+++ b/apps/web/src/shared/ui/command.tsx
@@ -70,8 +70,9 @@ export const Command = forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive
     ref={ref}
+    data-slot="command"
     className={cn(
-      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      "flex h-full w-full flex-col overflow-hidden rounded-[10px] bg-popover text-popover-foreground",
       className,
     )}
     {...props}
@@ -86,7 +87,7 @@ export function CommandDialog({ children, ...props }: CommandDialogProps) {
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
         <DialogTitle className="sr-only">Command palette</DialogTitle>
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input]]:h-11 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2">
           {children}
         </Command>
       </DialogContent>
@@ -99,12 +100,21 @@ export const CommandInput = forwardRef<
   ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => {
   return (
-    <div className="flex items-center border-b border-input bg-background px-3" cmdk-input-wrapper="">
-      <IconSearch className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <div
+      data-slot="command-input-wrapper"
+      className="flex items-center border-b border-border bg-popover px-3"
+      cmdk-input-wrapper=""
+    >
+      <IconSearch
+        aria-hidden
+        className="mr-2 shrink-0 text-muted-foreground"
+        size={16}
+      />
       <CommandPrimitive.Input
         ref={ref}
+        data-slot="command-input"
         className={cn(
-          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full bg-transparent py-2 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}
@@ -133,6 +143,7 @@ export const CommandList = forwardRef<
         listRef.current = node;
         assignForwardedRef(ref, node);
       }}
+      data-slot="command-list"
       className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
       {...props}
     />
@@ -143,8 +154,13 @@ CommandList.displayName = CommandPrimitive.List.displayName;
 export const CommandEmpty = forwardRef<
   ComponentRef<typeof CommandPrimitive.Empty>,
   ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    data-slot="command-empty"
+    className={cn("py-8 text-center text-[13px] text-muted-foreground", className)}
+    {...props}
+  />
 ));
 CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
 
@@ -154,8 +170,9 @@ export const CommandGroup = forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Group
     ref={ref}
+    data-slot="command-group"
     className={cn(
-      "overflow-hidden p-1 text-popover-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      "overflow-hidden p-1.5 text-popover-foreground [&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[11px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.08em] [&_[cmdk-group-heading]]:text-muted-foreground",
       className,
     )}
     {...props}
@@ -167,7 +184,12 @@ export const CommandSeparator = forwardRef<
   ComponentRef<typeof CommandPrimitive.Separator>,
   ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <CommandPrimitive.Separator ref={ref} className={cn("-mx-1 h-px bg-border", className)} {...props} />
+  <CommandPrimitive.Separator
+    ref={ref}
+    data-slot="command-separator"
+    className={cn("mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
 ));
 CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
 
@@ -177,8 +199,9 @@ export const CommandItem = forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Item
     ref={ref}
+    data-slot="command-item"
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      "relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] outline-none aria-selected:bg-muted aria-selected:text-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:shrink-0",
       className,
     )}
     {...props}
@@ -188,7 +211,11 @@ CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 export function CommandShortcut({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
   return (
-    <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />
+    <span
+      data-slot="command-shortcut"
+      className={cn("ml-auto text-[11px] tracking-wider text-muted-foreground", className)}
+      {...props}
+    />
   );
 }
 CommandShortcut.displayName = "CommandShortcut";

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -78,7 +78,7 @@ export function DataTable<TData>({
 
   return (
     <>
-      <div className="table" role="table">
+      <div className="table data-table-surface" role="table">
         <div role="rowgroup">
           <div className={headerClassName} role="row">
             {table.getFlatHeaders().map((header) => {

--- a/apps/web/src/shared/ui/detail-drawer-backdrop.tsx
+++ b/apps/web/src/shared/ui/detail-drawer-backdrop.tsx
@@ -16,7 +16,11 @@ export function DetailDrawerBackdrop({
   };
 
   return (
-    <div className="drawer-backdrop" onClick={handleClick}>
+    <div
+      className="drawer-backdrop"
+      data-slot="detail-drawer-backdrop"
+      onClick={handleClick}
+    >
       {children}
     </div>
   );

--- a/apps/web/src/shared/ui/dialog.tsx
+++ b/apps/web/src/shared/ui/dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 
 import { cn } from "../lib/cn.js";
+import { Button } from "./button.js";
 
 export interface DialogProps
   extends Omit<DialogPrimitive.Root.Props, "children"> {
@@ -17,7 +18,11 @@ export interface DialogProps
 }
 
 export function Dialog({ children, ...props }: DialogProps) {
-  return <DialogPrimitive.Root {...props}>{children}</DialogPrimitive.Root>;
+  return (
+    <DialogPrimitive.Root data-slot="dialog" {...props}>
+      {children}
+    </DialogPrimitive.Root>
+  );
 }
 Dialog.displayName = "Dialog";
 
@@ -38,6 +43,7 @@ export const DialogTrigger = forwardRef<HTMLButtonElement, DialogTriggerProps>(
 
     return (
       <DialogPrimitive.Trigger
+        data-slot="dialog-trigger"
         {...props}
         ref={ref}
         render={child ?? render}
@@ -63,6 +69,7 @@ export const DialogPortal = forwardRef<
   DialogPortalProps
 >(({ forceMount, keepMounted, ...props }, ref) => (
   <DialogPrimitive.Portal
+    data-slot="dialog-portal"
     {...props}
     keepMounted={keepMounted ?? forceMount}
     ref={ref}
@@ -86,7 +93,12 @@ export const DialogClose = forwardRef<HTMLButtonElement, DialogCloseProps>(
       : undefined;
 
     return (
-      <DialogPrimitive.Close {...props} ref={ref} render={child ?? render}>
+      <DialogPrimitive.Close
+        data-slot="dialog-close"
+        {...props}
+        ref={ref}
+        render={child ?? render}
+      >
         {child ? undefined : children}
       </DialogPrimitive.Close>
     );
@@ -100,8 +112,9 @@ export const DialogOverlay = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Backdrop
     ref={ref}
+    data-slot="dialog-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/35 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0",
+      "fixed inset-0 z-50 bg-black/30 duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0",
       className,
     )}
     {...props}
@@ -122,15 +135,25 @@ export const DialogContent = forwardRef<
     <DialogOverlay />
     <DialogPrimitive.Popup
       ref={ref}
+      data-slot="dialog-content"
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-popover p-6 text-popover-foreground shadow-lg duration-200 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 sm:rounded-lg",
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-5 rounded-[10px] border border-border bg-popover p-5 text-sm text-popover-foreground shadow-xl outline-none duration-150 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 sm:max-w-lg",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-        <IconX className="h-4 w-4" />
+      <DialogPrimitive.Close
+        data-slot="dialog-close"
+        render={
+          <Button
+            className="absolute right-3 top-3 size-8 bg-muted/60 text-muted-foreground shadow-none"
+            size="icon"
+            variant="ghost"
+          />
+        }
+      >
+        <IconX aria-hidden size={16} />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Popup>
@@ -144,8 +167,9 @@ export function DialogHeader({
 }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-slot="dialog-header"
       className={cn(
-        "flex flex-col space-y-1.5 text-center sm:text-left",
+        "flex flex-col gap-1.5 pr-8 text-left",
         className,
       )}
       {...props}
@@ -160,8 +184,9 @@ export function DialogFooter({
 }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-slot="dialog-footer"
       className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -176,8 +201,9 @@ export const DialogTitle = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
+    data-slot="dialog-title"
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "font-heading text-base font-medium leading-none tracking-[-0.02em]",
       className,
     )}
     {...props}
@@ -191,7 +217,11 @@ export const DialogDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    data-slot="dialog-description"
+    className={cn(
+      "text-[13px] leading-5 text-muted-foreground *:[a]:underline *:[a]:underline-offset-4 *:[a]:hover:text-foreground",
+      className,
+    )}
     {...props}
   />
 ));

--- a/apps/web/src/shared/ui/drawer.tsx
+++ b/apps/web/src/shared/ui/drawer.tsx
@@ -25,7 +25,15 @@ export const DrawerOverlay = forwardRef<
   ComponentRef<typeof DrawerPrimitive.Overlay>,
   ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Overlay ref={ref} className={cn("fixed inset-0 z-50 bg-black/35", className)} {...props} />
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    data-slot="drawer-overlay"
+    className={cn(
+      "fixed inset-0 z-50 bg-black/30 supports-backdrop-filter:backdrop-blur-[2px]",
+      className,
+    )}
+    {...props}
+  />
 ));
 DrawerOverlay.displayName = "DrawerOverlay";
 
@@ -37,13 +45,18 @@ export const DrawerContent = forwardRef<
     <DrawerOverlay />
     <DrawerPrimitive.Content
       ref={ref}
+      data-slot="drawer-content"
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-popover text-popover-foreground",
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-popover text-sm text-popover-foreground shadow-xl",
         className,
       )}
       {...props}
     >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      <div
+        aria-hidden
+        data-slot="drawer-handle"
+        className="mx-auto mt-3 h-1 w-9 rounded-full bg-muted-foreground/35"
+      />
       {children}
     </DrawerPrimitive.Content>
   </DrawerPortal>
@@ -53,7 +66,8 @@ DrawerContent.displayName = "DrawerContent";
 export function DrawerHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+      data-slot="drawer-header"
+      className={cn("grid gap-1.5 p-5 text-center sm:text-left", className)}
       {...props}
     />
   );
@@ -61,7 +75,13 @@ export function DrawerHeader({ className, ...props }: HTMLAttributes<HTMLDivElem
 DrawerHeader.displayName = "DrawerHeader";
 
 export function DrawerFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("mt-auto flex flex-col gap-2 p-4", className)} {...props} />;
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-5", className)}
+      {...props}
+    />
+  );
 }
 DrawerFooter.displayName = "DrawerFooter";
 
@@ -69,7 +89,15 @@ export const DrawerTitle = forwardRef<
   ComponentRef<typeof DrawerPrimitive.Title>,
   ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Title ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+  <DrawerPrimitive.Title
+    ref={ref}
+    data-slot="drawer-title"
+    className={cn(
+      "font-heading text-base font-medium leading-none tracking-[-0.02em]",
+      className,
+    )}
+    {...props}
+  />
 ));
 DrawerTitle.displayName = "DrawerTitle";
 
@@ -77,6 +105,11 @@ export const DrawerDescription = forwardRef<
   ComponentRef<typeof DrawerPrimitive.Description>,
   ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Description ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <DrawerPrimitive.Description
+    ref={ref}
+    data-slot="drawer-description"
+    className={cn("text-[13px] leading-5 text-muted-foreground", className)}
+    {...props}
+  />
 ));
 DrawerDescription.displayName = "DrawerDescription";

--- a/apps/web/src/shared/ui/dropdown-menu.tsx
+++ b/apps/web/src/shared/ui/dropdown-menu.tsx
@@ -32,13 +32,25 @@ export function DropdownMenu({
 export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
   MenuPrimitive.Trigger.Props
->((props, ref) => <MenuPrimitive.Trigger ref={ref} {...props} />);
+>((props, ref) => (
+  <MenuPrimitive.Trigger
+    data-slot="dropdown-menu-trigger"
+    ref={ref}
+    {...props}
+  />
+));
 DropdownMenuTrigger.displayName = "DropdownMenuTrigger";
 
 export const DropdownMenuGroup = forwardRef<
   ComponentRef<typeof MenuPrimitive.Group>,
   MenuPrimitive.Group.Props
->((props, ref) => <MenuPrimitive.Group ref={ref} {...props} />);
+>((props, ref) => (
+  <MenuPrimitive.Group
+    data-slot="dropdown-menu-group"
+    ref={ref}
+    {...props}
+  />
+));
 DropdownMenuGroup.displayName = "DropdownMenuGroup";
 
 export interface DropdownMenuPortalProps
@@ -79,15 +91,16 @@ export const DropdownMenuSubTrigger = forwardRef<
 >(({ className, inset, children, ...props }, ref) => (
   <MenuPrimitive.SubmenuTrigger
     ref={ref}
+    data-slot="dropdown-menu-sub-trigger"
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-popup-open:bg-accent data-popup-open:text-accent-foreground",
+      "flex min-h-8 cursor-default select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] outline-none transition-colors focus:bg-muted focus:text-foreground data-popup-open:bg-muted data-popup-open:text-foreground",
       inset && "pl-8",
       className,
     )}
     {...props}
   >
     {children}
-    <IconChevronRight aria-hidden className="ml-auto size-4" />
+    <IconChevronRight aria-hidden className="ml-auto" size={16} />
   </MenuPrimitive.SubmenuTrigger>
 ));
 DropdownMenuSubTrigger.displayName = "DropdownMenuSubTrigger";
@@ -179,7 +192,7 @@ export const DropdownMenuContent = forwardRef<
             ref={ref}
             data-slot="dropdown-menu-content"
             className={cn(
-              "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-panel)] outline-none",
+              "z-50 min-w-40 origin-(--transform-origin) overflow-hidden rounded-[10px] border border-border bg-popover p-1.5 text-popover-foreground shadow-xl outline-none duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
               className,
             )}
             {...props}
@@ -215,7 +228,7 @@ export const DropdownMenuSubContent = forwardRef<
       side={side}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-[var(--shadow-panel)]",
+        "z-50 min-w-40 overflow-hidden rounded-[10px] border border-border bg-popover p-1.5 text-popover-foreground shadow-xl",
         className,
       )}
       data-slot="dropdown-menu-sub-content"
@@ -231,8 +244,9 @@ export const DropdownMenuItem = forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <MenuPrimitive.Item
     ref={ref}
+    data-slot="dropdown-menu-item"
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] outline-none transition-colors focus:bg-muted focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:shrink-0",
       inset && "pl-8",
       className,
     )}
@@ -247,15 +261,16 @@ export const DropdownMenuCheckboxItem = forwardRef<
 >(({ className, children, ...props }, ref) => (
   <MenuPrimitive.CheckboxItem
     ref={ref}
+    data-slot="dropdown-menu-checkbox-item"
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex min-h-8 cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2.5 text-[13px] outline-none transition-colors focus:bg-muted focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}
   >
     <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <MenuPrimitive.CheckboxItemIndicator>
-        <IconCheck aria-hidden className="size-4" />
+      <MenuPrimitive.CheckboxItemIndicator data-slot="dropdown-menu-item-indicator">
+        <IconCheck aria-hidden size={16} />
       </MenuPrimitive.CheckboxItemIndicator>
     </span>
     {children}
@@ -269,15 +284,16 @@ export const DropdownMenuRadioItem = forwardRef<
 >(({ className, children, ...props }, ref) => (
   <MenuPrimitive.RadioItem
     ref={ref}
+    data-slot="dropdown-menu-radio-item"
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex min-h-8 cursor-default select-none items-center rounded-md py-1.5 pl-8 pr-2.5 text-[13px] outline-none transition-colors focus:bg-muted focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     {...props}
   >
     <span className="absolute left-2 flex size-3.5 items-center justify-center">
-      <MenuPrimitive.RadioItemIndicator>
-        <IconCircle aria-hidden className="size-2 fill-current" />
+      <MenuPrimitive.RadioItemIndicator data-slot="dropdown-menu-item-indicator">
+        <IconCircle aria-hidden className="fill-current" size={8} />
       </MenuPrimitive.RadioItemIndicator>
     </span>
     {children}
@@ -291,8 +307,9 @@ export const DropdownMenuLabel = forwardRef<
 >(({ className, inset, ...props }, ref) => (
   <MenuPrimitive.GroupLabel
     ref={ref}
+    data-slot="dropdown-menu-label"
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
+      "px-2.5 py-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground",
       inset && "pl-8",
       className,
     )}
@@ -307,7 +324,8 @@ export const DropdownMenuSeparator = forwardRef<
 >(({ className, ...props }, ref) => (
   <MenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    data-slot="dropdown-menu-separator"
+    className={cn("-mx-1.5 my-1.5 h-px bg-border", className)}
     {...props}
   />
 ));
@@ -319,8 +337,9 @@ export function DropdownMenuShortcut({
 }: HTMLAttributes<HTMLSpanElement>) {
   return (
     <span
+      data-slot="dropdown-menu-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-[11px] tracking-wider text-muted-foreground",
         className,
       )}
       {...props}

--- a/apps/web/src/shared/ui/empty.tsx
+++ b/apps/web/src/shared/ui/empty.tsx
@@ -3,5 +3,9 @@ export interface EmptyProps {
 }
 
 export function Empty({ title }: EmptyProps) {
-  return <div className="empty">{title}</div>;
+  return (
+    <div className="empty" data-slot="empty">
+      <span data-slot="empty-title">{title}</span>
+    </div>
+  );
 }

--- a/apps/web/src/shared/ui/field.tsx
+++ b/apps/web/src/shared/ui/field.tsx
@@ -13,7 +13,7 @@ function FieldSet({
     <fieldset
       data-slot="field-set"
       className={cn(
-        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        "flex flex-col gap-5 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
         className,
       )}
       {...props}
@@ -33,7 +33,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        "mb-3 font-medium data-[variant=label]:text-[12px] data-[variant=legend]:text-sm",
         className,
       )}
       {...props}
@@ -49,7 +49,7 @@ function FieldGroup({
     <div
       data-slot="field-group"
       className={cn(
-        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
         className,
       )}
       {...props}
@@ -58,7 +58,7 @@ function FieldGroup({
 }
 
 const fieldVariants = cva(
-  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  "group/field flex w-full gap-2.5 data-[invalid=true]:text-destructive",
   {
     variants: {
       orientation: {
@@ -115,7 +115,7 @@ function FieldLabel({
     <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:bg-input/30 has-[>[data-slot=field]]:rounded-2xl has-[>[data-slot=field]]:border *:data-[slot=field]:p-4",
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:bg-muted has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-3",
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className,
       )}
@@ -132,7 +132,7 @@ function FieldTitle({
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        "flex w-fit items-center gap-2 text-[12px] font-medium group-data-[disabled=true]/field:opacity-50",
         className,
       )}
       {...props}
@@ -148,7 +148,7 @@ function FieldDescription({
     <p
       data-slot="field-description"
       className={cn(
-        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "text-left text-[12px] leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
         "last:mt-0 nth-last-2:-mt-1",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
@@ -228,7 +228,7 @@ function FieldError({
     <div
       role="alert"
       data-slot="field-error"
-      className={cn("text-sm font-normal text-destructive", className)}
+      className={cn("text-[12px] font-normal text-destructive", className)}
       {...props}
     >
       {content}

--- a/apps/web/src/shared/ui/filterable-data-grid.tsx
+++ b/apps/web/src/shared/ui/filterable-data-grid.tsx
@@ -875,7 +875,7 @@ export function FilterableDataGrid<TData>({
 
   return (
     <div
-      className="filterable-data-grid"
+      className="filterable-data-grid data-surface"
       data-density={density ?? undefined}
     >
       <div className="data-grid-toolbar">

--- a/apps/web/src/shared/ui/input.tsx
+++ b/apps/web/src/shared/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     <input
       type={type}
       className={cn(
-        "flex h-[38px] w-full rounded-md border border-input bg-card px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-input bg-card px-3 py-1 text-[13px] shadow-none transition-[color,background-color,border-color,box-shadow] file:border-0 file:bg-transparent file:text-[13px] file:font-medium placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/label.tsx
+++ b/apps/web/src/shared/ui/label.tsx
@@ -8,7 +8,7 @@ import {
 import { cn } from "../lib/cn.js";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "text-[12px] font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 export const Label = forwardRef<

--- a/apps/web/src/shared/ui/page-head.tsx
+++ b/apps/web/src/shared/ui/page-head.tsx
@@ -18,13 +18,25 @@ export function PageHead({
   className,
 }: PageHeadProps): JSX.Element {
   return (
-    <div className={cn("page-head", className)}>
-      <div className="page-head-text">
-        {eyebrow ? <span className="eyebrow">{eyebrow}</span> : null}
-        <h1>{title}</h1>
-        {subtitle ? <p className="page-head-subtitle">{subtitle}</p> : null}
+    <div className={cn("page-head", className)} data-slot="page-head">
+      <div className="page-head-text" data-slot="page-head-text">
+        {eyebrow ? (
+          <span className="eyebrow" data-slot="page-head-eyebrow">
+            {eyebrow}
+          </span>
+        ) : null}
+        <h1 data-slot="page-head-title">{title}</h1>
+        {subtitle ? (
+          <p className="page-head-subtitle" data-slot="page-head-subtitle">
+            {subtitle}
+          </p>
+        ) : null}
       </div>
-      {actions ? <div className="page-head-actions">{actions}</div> : null}
+      {actions ? (
+        <div className="page-head-actions" data-slot="page-head-actions">
+          {actions}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/shared/ui/popover.tsx
+++ b/apps/web/src/shared/ui/popover.tsx
@@ -422,7 +422,7 @@ const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
               finalFocus ?? (onCloseAutoFocus ? handleFinalFocus : undefined)
             }
             className={cn(
-              "z-50 w-72 rounded-lg border border-border bg-popover p-4 text-popover-foreground shadow-[var(--shadow-panel)] outline-none",
+              "z-50 w-72 origin-(--transform-origin) rounded-[10px] border border-border bg-popover p-4 text-sm text-popover-foreground shadow-xl outline-none duration-150 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
               className,
             )}
           >

--- a/apps/web/src/shared/ui/saved-table-views-control.tsx
+++ b/apps/web/src/shared/ui/saved-table-views-control.tsx
@@ -254,7 +254,7 @@ export function SavedTableViewsControl({
   };
 
   return (
-    <div className="saved-table-views-control">
+    <div className="saved-table-views-control data-table-views">
       <label className="saved-table-views-select">
         <span>View</span>
         <select

--- a/apps/web/src/shared/ui/section.tsx
+++ b/apps/web/src/shared/ui/section.tsx
@@ -7,8 +7,8 @@ export interface SectionProps {
 
 export function Section({ title, children }: SectionProps) {
   return (
-    <section className="section">
-      <h3>{title}</h3>
+    <section className="section" data-slot="section">
+      <h3 data-slot="section-title">{title}</h3>
       {children}
     </section>
   );

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -119,7 +119,7 @@ export const SelectTrigger = forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-[38px] w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-card px-3 text-left text-[13px] shadow-none transition-[color,background-color,border-color,box-shadow] placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
@@ -253,7 +253,7 @@ export const SelectContent = forwardRef<
             ref={ref}
             data-align-trigger={alignsSelectedItem}
             className={cn(
-              "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[var(--shadow-panel)]",
+              "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-[0_8px_20px_rgb(0_0_0_/_0.1)]",
               !alignsSelectedItem &&
                 "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
               className,
@@ -285,7 +285,7 @@ export const SelectLabel = forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.GroupLabel
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    className={cn("px-2 py-1.5 text-[11px] font-semibold tracking-[0.02em] text-muted-foreground", className)}
     {...props}
   />
 ));
@@ -307,7 +307,7 @@ export const SelectItem = forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-[13px] outline-none focus:bg-muted focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className,
     )}
     label={label ?? textValue}

--- a/apps/web/src/shared/ui/sheet.tsx
+++ b/apps/web/src/shared/ui/sheet.tsx
@@ -11,13 +11,18 @@ import {
 } from "react";
 
 import { cn } from "../lib/cn.js";
+import { Button } from "./button.js";
 
 export interface SheetProps extends Omit<DialogPrimitive.Root.Props, "children"> {
   children?: ReactNode;
 }
 
 export function Sheet({ children, ...props }: SheetProps) {
-  return <DialogPrimitive.Root {...props}>{children}</DialogPrimitive.Root>;
+  return (
+    <DialogPrimitive.Root data-slot="sheet" {...props}>
+      {children}
+    </DialogPrimitive.Root>
+  );
 }
 Sheet.displayName = "Sheet";
 
@@ -38,6 +43,7 @@ export const SheetTrigger = forwardRef<HTMLButtonElement, SheetTriggerProps>(
 
     return (
       <DialogPrimitive.Trigger
+        data-slot="sheet-trigger"
         {...props}
         ref={ref}
         render={child ?? render}
@@ -65,7 +71,12 @@ export const SheetClose = forwardRef<HTMLButtonElement, SheetCloseProps>(
       : undefined;
 
     return (
-      <DialogPrimitive.Close {...props} ref={ref} render={child ?? render}>
+      <DialogPrimitive.Close
+        data-slot="sheet-close"
+        {...props}
+        ref={ref}
+        render={child ?? render}
+      >
         {child ? undefined : children}
       </DialogPrimitive.Close>
     );
@@ -87,6 +98,7 @@ export const SheetPortal = forwardRef<
   SheetPortalProps
 >(({ forceMount, keepMounted, ...props }, ref) => (
   <DialogPrimitive.Portal
+    data-slot="sheet-portal"
     {...props}
     keepMounted={keepMounted ?? forceMount}
     ref={ref}
@@ -99,8 +111,9 @@ export const SheetOverlay = forwardRef<
   DialogPrimitive.Backdrop.Props
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Backdrop
+    data-slot="sheet-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/35 transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0",
+      "fixed inset-0 z-50 bg-black/30 transition-opacity duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-starting-style:opacity-0 data-ending-style:opacity-0",
       className,
     )}
     {...props}
@@ -110,7 +123,7 @@ export const SheetOverlay = forwardRef<
 SheetOverlay.displayName = "SheetOverlay";
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-popover p-6 text-popover-foreground shadow-lg transition ease-in-out data-open:duration-500 data-closed:duration-300",
+  "fixed z-50 flex flex-col gap-5 bg-popover p-6 text-sm text-popover-foreground shadow-xl transition ease-in-out data-open:duration-200 data-closed:duration-150",
   {
     variants: {
       side: {
@@ -143,13 +156,23 @@ export const SheetContent = forwardRef<
     <SheetOverlay />
     <DialogPrimitive.Popup
       ref={ref}
+      data-slot="sheet-content"
       data-side={side}
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
-        <IconX className="h-4 w-4" />
+      <DialogPrimitive.Close
+        data-slot="sheet-close"
+        render={
+          <Button
+            className="absolute right-3 top-3 size-8 bg-muted/60 text-muted-foreground shadow-none"
+            size="icon"
+            variant="ghost"
+          />
+        }
+      >
+        <IconX aria-hidden size={16} />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Popup>
@@ -163,8 +186,9 @@ export function SheetHeader({
 }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-slot="sheet-header"
       className={cn(
-        "flex flex-col space-y-2 text-center sm:text-left",
+        "flex flex-col gap-1.5 pr-8 text-left",
         className,
       )}
       {...props}
@@ -179,8 +203,9 @@ export function SheetFooter({
 }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
+      data-slot="sheet-footer"
       className={cn(
-        "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+        "mt-auto flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -195,7 +220,11 @@ export const SheetTitle = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    data-slot="sheet-title"
+    className={cn(
+      "font-heading text-base font-medium leading-none tracking-[-0.02em] text-foreground",
+      className,
+    )}
     {...props}
   />
 ));
@@ -207,7 +236,8 @@ export const SheetDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    data-slot="sheet-description"
+    className={cn("text-[13px] leading-5 text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/apps/web/src/shared/ui/skeleton.tsx
+++ b/apps/web/src/shared/ui/skeleton.tsx
@@ -3,5 +3,5 @@ import type { HTMLAttributes, JSX } from "react";
 import { cn } from "../lib/cn.js";
 
 export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>): JSX.Element {
-  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />;
+  return <div className={cn("animate-pulse rounded-sm bg-muted", className)} {...props} />;
 }

--- a/apps/web/src/shared/ui/switch.tsx
+++ b/apps/web/src/shared/ui/switch.tsx
@@ -13,7 +13,7 @@ export const Switch = forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitive.Root
     className={cn(
-      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:bg-primary data-unchecked:bg-muted",
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-input bg-muted p-0.5 transition-[background-color,border-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 data-disabled:cursor-not-allowed data-disabled:opacity-50 data-checked:border-primary data-checked:bg-primary",
       className,
     )}
     {...props}
@@ -21,7 +21,7 @@ export const Switch = forwardRef<
   >
     <SwitchPrimitive.Thumb
       className={cn(
-        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0",
+        "pointer-events-none block size-4 rounded-full bg-card shadow-[0_1px_2px_rgb(0_0_0_/_0.16)] transition-transform data-checked:translate-x-4 data-unchecked:translate-x-0",
       )}
     />
   </SwitchPrimitive.Root>

--- a/apps/web/src/shared/ui/table-pager.tsx
+++ b/apps/web/src/shared/ui/table-pager.tsx
@@ -23,7 +23,7 @@ export function TablePager({
 }: TablePagerProps): JSX.Element {
   const pages = Math.max(totalPages, 1);
   return (
-    <div className="pager">
+    <div className="pager data-table-pager">
       <button
         className="tab"
         type="button"

--- a/apps/web/src/shared/ui/table.tsx
+++ b/apps/web/src/shared/ui/table.tsx
@@ -9,8 +9,12 @@ import { cn } from "../lib/cn.js";
 
 export const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
-    <div className="relative w-full overflow-auto">
-      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    <div className="data-table-scroll relative w-full overflow-auto">
+      <table
+        ref={ref}
+        className={cn("data-table w-full caption-bottom text-sm", className)}
+        {...props}
+      />
     </div>
   ),
 );

--- a/apps/web/src/shared/ui/tabs.tsx
+++ b/apps/web/src/shared/ui/tabs.tsx
@@ -95,7 +95,7 @@ export const TabsList = forwardRef<
       activateOnFocus={activateOnFocus ?? activationMode === "automatic"}
       loopFocus={loopFocus ?? loop}
       className={cn(
-        "inline-flex h-9 items-center justify-center rounded-full border border-border bg-muted p-[3px] text-muted-foreground",
+        "inline-flex h-9 items-center justify-start gap-1 border-b border-border bg-transparent p-0 text-muted-foreground",
         className,
       )}
       {...props}
@@ -118,7 +118,7 @@ export const TabsTrigger = forwardRef<
   <TabsPrimitive.Tab
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-3.5 py-1 text-[11px] font-[850] tracking-[0.01em] transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:bg-card data-active:text-primary data-active:shadow-[var(--shadow-panel)]",
+      "inline-flex h-9 items-center justify-center whitespace-nowrap border-b-2 border-transparent px-3 text-[12px] font-medium transition-[color,border-color] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-active:border-foreground data-active:text-foreground",
       className,
     )}
     {...props}

--- a/apps/web/src/shared/ui/textarea.tsx
+++ b/apps/web/src/shared/ui/textarea.tsx
@@ -8,7 +8,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-card px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex min-h-20 w-full rounded-md border border-input bg-card px-3 py-2 text-[13px] shadow-none transition-[color,background-color,border-color,box-shadow] placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       ref={ref}

--- a/apps/web/src/shared/ui/title-stack.tsx
+++ b/apps/web/src/shared/ui/title-stack.tsx
@@ -7,9 +7,11 @@ export interface TitleStackProps {
 
 export function TitleStack({ primary, secondary }: TitleStackProps): JSX.Element {
   return (
-    <span className="title-stack">
-      <b>{primary}</b>
-      {secondary ? <span>{secondary}</span> : null}
+    <span className="title-stack" data-slot="title-stack">
+      <b data-slot="title-stack-primary">{primary}</b>
+      {secondary ? (
+        <span data-slot="title-stack-secondary">{secondary}</span>
+      ) : null}
     </span>
   );
 }

--- a/apps/web/src/shared/ui/toast.tsx
+++ b/apps/web/src/shared/ui/toast.tsx
@@ -54,6 +54,7 @@ export const ToastViewport = forwardRef<
   return (
     <ToastPrimitive.Viewport
       ref={ref}
+      data-slot="toast-viewport"
       {...(resolvedLabel === undefined ? {} : { "aria-label": resolvedLabel })}
       className={cn(
         "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
@@ -66,13 +67,13 @@ export const ToastViewport = forwardRef<
 ToastViewport.displayName = ToastPrimitive.Viewport.displayName;
 
 const toastVariants = cva(
-  "group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-lg border p-4 pr-6 shadow-lg transition-all",
+  "group pointer-events-auto relative flex w-full items-center justify-between gap-3 overflow-hidden rounded-[10px] border p-4 pr-10 shadow-xl transition-all",
   {
     variants: {
       variant: {
         default: "border-border bg-popover text-popover-foreground",
         destructive:
-          "destructive group border-destructive bg-destructive text-white",
+          "destructive border-destructive/35 border-l-[3px] border-l-destructive bg-popover text-popover-foreground",
       },
     },
     defaultVariants: {
@@ -90,6 +91,7 @@ export const Toast = forwardRef<
 >(({ className, swipeDirection = "right", variant, ...props }, ref) => (
   <ToastPrimitive.Root
     ref={ref}
+    data-slot="toast"
     className={cn(toastVariants({ variant }), className)}
     swipeDirection={swipeDirection}
     {...props}
@@ -103,7 +105,8 @@ export const ToastContent = forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitive.Content
     ref={ref}
-    className={cn("flex w-full items-center justify-between gap-2", className)}
+    data-slot="toast-content"
+    className={cn("flex w-full items-start justify-between gap-3", className)}
     {...props}
   />
 ));
@@ -119,9 +122,10 @@ export const ToastAction = forwardRef<
 >(({ altText, "aria-label": ariaLabel, className, ...props }, ref) => (
   <ToastPrimitive.Action
     ref={ref}
+    data-slot="toast-action"
     aria-label={ariaLabel ?? altText}
     className={cn(
-      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-border bg-transparent px-3 text-[12px] font-medium transition-colors hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
       className,
     )}
     {...props}
@@ -135,15 +139,16 @@ export const ToastClose = forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitive.Close
     ref={ref}
+    data-slot="toast-close"
     aria-label="Close"
     className={cn(
-      "absolute right-1 top-1 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring group-hover:opacity-100",
+      "absolute right-2 top-2 rounded-md p-1 text-muted-foreground opacity-60 transition-[background-color,color,opacity] hover:bg-muted hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring group-hover:opacity-100",
       className,
     )}
     toast-close=""
     {...props}
   >
-    <IconX className="size-4" />
+    <IconX aria-hidden size={16} />
   </ToastPrimitive.Close>
 ));
 ToastClose.displayName = ToastPrimitive.Close.displayName;
@@ -154,7 +159,8 @@ export const ToastTitle = forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitive.Title
     ref={ref}
-    className={cn("text-sm font-semibold", className)}
+    data-slot="toast-title"
+    className={cn("text-[13px] font-semibold leading-5", className)}
     {...props}
   />
 ));
@@ -166,7 +172,8 @@ export const ToastDescription = forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitive.Description
     ref={ref}
-    className={cn("text-sm opacity-90", className)}
+    data-slot="toast-description"
+    className={cn("text-[12px] leading-5 text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/apps/web/src/shared/ui/toaster.tsx
+++ b/apps/web/src/shared/ui/toaster.tsx
@@ -73,7 +73,10 @@ export function ToastList() {
       data-toast-id={toast.id}
     >
       <ToastContent>
-        <div className="grid gap-1">
+        <div
+          className="flex min-w-0 flex-1 flex-col gap-0.5"
+          data-slot="toast-copy"
+        >
           <ToastTitle />
           <ToastDescription />
         </div>

--- a/apps/web/src/shared/ui/toggle-group.tsx
+++ b/apps/web/src/shared/ui/toggle-group.tsx
@@ -183,7 +183,7 @@ const ToggleGroup = React.forwardRef<HTMLDivElement, ToggleGroupProps>(
         onValueChange={handleValueChange}
         style={{ "--gap": spacing, ...style } as React.CSSProperties}
         className={cn(
-          "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-3xl data-vertical:flex-col data-vertical:items-stretch",
+          "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] data-[spacing=0]:data-[variant=outline]:rounded-md data-vertical:flex-col data-vertical:items-stretch",
           className,
         )}
         {...rootProps}
@@ -236,7 +236,7 @@ const ToggleGroupItem = React.forwardRef<
       data-variant={context.variant || variant}
       value={value}
       className={cn(
-        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-3xl group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-3xl group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-3xl group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-3xl data-pressed:bg-muted group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-3 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-2.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-2.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-md group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-md group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-md group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-md data-pressed:bg-secondary group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
         toggleVariants({
           size: context.size || size,
           variant: context.variant || variant,

--- a/apps/web/src/shared/ui/toggle.tsx
+++ b/apps/web/src/shared/ui/toggle.tsx
@@ -7,17 +7,17 @@ import * as React from "react";
 import { cn } from "../lib/cn.js";
 
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-3xl text-sm font-medium whitespace-nowrap transition-colors outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/30 data-disabled:pointer-events-none data-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-pressed:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-[13px] font-medium whitespace-nowrap transition-[color,background-color,border-color,box-shadow] outline-none hover:bg-muted hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 data-disabled:pointer-events-none data-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-pressed:bg-secondary dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        outline: "border border-input bg-transparent hover:bg-muted",
+        outline: "border border-input bg-card hover:bg-muted",
       },
       size: {
         default:
           "h-9 min-w-9 px-3 has-data-[icon=inline-end]:pr-2.5 has-data-[icon=inline-start]:pl-2.5",
-        sm: "h-8 min-w-8 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-8 min-w-8 px-2.5 text-[12px] has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         lg: "h-10 min-w-10 px-4 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3",
       },
     },

--- a/apps/web/src/shared/ui/tooltip.tsx
+++ b/apps/web/src/shared/ui/tooltip.tsx
@@ -271,8 +271,9 @@ export const TooltipContent = forwardRef<
         >
           <TooltipPrimitive.Popup
             ref={ref}
+            data-slot="tooltip-content"
             className={cn(
-              "z-50 overflow-hidden rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md",
+              "z-50 max-w-xs origin-(--transform-origin) overflow-hidden rounded-md bg-foreground px-2.5 py-1.5 text-xs leading-4 text-background shadow-lg outline-none duration-100 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
               className,
             )}
             id={effectiveId}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
-@import "@fontsource-variable/plus-jakarta-sans";
+@import "@fontsource-variable/geist";
 @import "@fontsource-variable/jetbrains-mono";
 @import "./tokens.css";
 
@@ -21,7 +21,7 @@
     background: var(--background);
     color: var(--foreground);
     font-family: var(--font-sans);
-    font-size: 13px;
+    font-size: 14px;
   }
 
   h1,
@@ -31,8 +31,8 @@
   h5,
   h6 {
     font-family: var(--font-heading);
-    font-weight: 700;
-    letter-spacing: -0.03em;
+    font-weight: 650;
+    letter-spacing: -0.025em;
   }
 
   button,
@@ -8059,13 +8059,13 @@ input[type="radio"] {
   --color-status-info: var(--status-info);
   --color-status-info-foreground: var(--status-info-foreground);
   --color-status-info-muted: var(--status-info-muted);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);

--- a/apps/web/src/styles/redesign-analytics.css
+++ b/apps/web/src/styles/redesign-analytics.css
@@ -1,0 +1,371 @@
+/* Outcome analytics is a single decision workspace: one quiet control row,
+ * one legible summary strip, and the table as the primary subject. */
+
+.analytics-view {
+  container-type: inline-size;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.analytics-view > .banner.inline {
+  margin: 14px 18px 0;
+}
+
+.analytics-controls {
+  display: flex;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 24px;
+  min-width: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 18px;
+}
+
+.analytics-controls-copy {
+  display: grid;
+  align-content: center;
+  flex: 0 0 auto;
+  gap: 2px;
+  min-width: 116px;
+  padding-block: 13px;
+}
+
+.analytics-controls-copy > span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.analytics-controls-copy > strong {
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.analytics-view .analytics-toolbar {
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  gap: 18px;
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
+}
+
+.analytics-view .analytics-toolbar .segmented {
+  position: relative;
+  align-self: stretch;
+  min-height: 48px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 520;
+  letter-spacing: 0;
+}
+
+.analytics-view .analytics-toolbar .segmented::after {
+  position: absolute;
+  inset-inline: 0;
+  inset-block-end: -1px;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.analytics-view .analytics-toolbar .segmented:hover,
+.analytics-view .analytics-toolbar .segmented:focus-visible {
+  border-color: transparent;
+  background: transparent;
+  color: var(--foreground);
+}
+
+.analytics-view .analytics-toolbar .segmented:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 3px;
+}
+
+.analytics-view .analytics-toolbar .segmented.active {
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  font-weight: 650;
+}
+
+.analytics-view .analytics-toolbar .segmented.active::after {
+  background: var(--foreground);
+}
+
+.analytics-summary-strip {
+  display: grid;
+  grid-template-columns:
+    repeat(4, minmax(92px, 0.72fr))
+    repeat(2, minmax(152px, 1.3fr));
+  gap: 0;
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.analytics-summary-strip > .analytics-summary-metric {
+  display: grid;
+  align-content: start;
+  gap: 7px;
+  min-width: 0;
+  border-right: 1px solid var(--border);
+  padding: 19px 18px 21px;
+}
+
+.analytics-summary-strip > .analytics-summary-metric:last-child {
+  border-right: 0;
+}
+
+.analytics-summary-metric dt,
+.analytics-summary-metric dd {
+  margin: 0;
+}
+
+.analytics-summary-metric dt {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.075em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.analytics-summary-metric dd {
+  color: var(--foreground);
+  font-size: clamp(24px, 2vw, 30px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.analytics-summary-metric-secondary dd {
+  font-size: clamp(20px, 1.7vw, 25px);
+}
+
+.analytics-caption {
+  display: grid;
+  grid-template-columns: 17px minmax(0, 1fr);
+  align-items: start;
+  gap: 9px;
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+  padding: 12px 18px 13px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.analytics-caption > svg {
+  margin-top: 1px;
+  color: var(--muted-foreground);
+}
+
+.analytics-caption > p {
+  max-width: 112ch;
+  margin: 0;
+}
+
+.analytics-breakdown-region {
+  min-width: 0;
+}
+
+.analytics-breakdown-region .filterable-data-grid {
+  border-top: 0;
+}
+
+.analytics-breakdown-region .data-grid-toolbar {
+  min-height: 52px;
+  padding: 11px 18px;
+}
+
+.analytics-breakdown-region .data-grid-view-title {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.analytics-breakdown-region .filterable-data-grid-scroll {
+  border-bottom: 0;
+}
+
+.analytics-data-grid-table {
+  min-width: 1080px;
+  table-layout: fixed;
+}
+
+.analytics-data-grid-table .analytics-group-column {
+  width: 22%;
+  white-space: normal;
+}
+
+.analytics-data-grid-table .analytics-applied-column {
+  width: 8%;
+  font-variant-numeric: tabular-nums;
+}
+
+.analytics-data-grid-table .analytics-rate-column {
+  width: 17.5%;
+  white-space: normal;
+}
+
+.analytics-group-cell {
+  gap: 5px;
+}
+
+.analytics-group-cell > b {
+  font-size: 13px;
+  font-weight: 630;
+  letter-spacing: -0.01em;
+}
+
+.analytics-group-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+}
+
+.analytics-data-grid-table .analytics-group-meta .tag {
+  color: var(--muted-foreground);
+}
+
+.analytics-data-grid-table .analytics-rate {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  white-space: normal;
+}
+
+.analytics-data-grid-table .analytics-rate b {
+  color: var(--foreground);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 630;
+  line-height: 1.35;
+}
+
+.analytics-data-grid-table .analytics-rate > span {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.analytics-data-grid-table .analytics-row-small .analytics-rate.suppressed b {
+  color: var(--muted-foreground);
+  font-weight: 520;
+}
+
+.analytics-breakdown-empty {
+  padding: 52px 18px;
+}
+
+@media (max-width: 1100px) {
+  .analytics-controls {
+    gap: 18px;
+  }
+
+  .analytics-view .analytics-toolbar {
+    gap: 13px;
+  }
+
+  .analytics-summary-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric:nth-child(3n) {
+    border-right: 0;
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric:nth-last-child(-n + 3) {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 720px) {
+  .analytics-controls {
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+  }
+
+  .analytics-controls-copy {
+    min-width: 96px;
+    padding-block: 0;
+  }
+
+  .analytics-view .analytics-toolbar {
+    width: auto;
+  }
+
+  .analytics-view .analytics-toolbar .segmented {
+    display: none;
+  }
+
+  .analytics-view .analytics-select-label {
+    display: grid;
+    width: min(100%, 240px);
+    max-width: none;
+    gap: 4px;
+  }
+
+  .analytics-view .analytics-select-label > span {
+    display: none;
+  }
+
+  .analytics-view .analytics-select-label .select {
+    width: 100%;
+  }
+
+  .analytics-summary-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric,
+  .analytics-summary-strip > .analytics-summary-metric:nth-child(3n) {
+    border-right: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    padding: 16px 14px 18px;
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .analytics-summary-strip > .analytics-summary-metric:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+
+  .analytics-caption {
+    padding-inline: 14px;
+  }
+
+  .analytics-breakdown-region .data-grid-toolbar {
+    padding-inline: 14px;
+  }
+}
+
+@media (max-width: 460px) {
+  .analytics-controls-copy {
+    display: none;
+  }
+
+  .analytics-view .analytics-toolbar,
+  .analytics-view .analytics-select-label {
+    width: 100%;
+  }
+}

--- a/apps/web/src/styles/redesign-apply-review.css
+++ b/apps/web/src/styles/redesign-apply-review.css
@@ -1,0 +1,831 @@
+/* Application review is an editorial workspace, not a collection of status
+ * cards. The shell deliberately uses two quiet rails: a compact decision queue
+ * and a wide review canvas where the real resume editor remains the focal point. */
+
+.apply-review-layout {
+  gap: 24px;
+}
+
+.apply-review-layout .page-head {
+  margin-bottom: 0;
+}
+
+.apply-review-surface {
+  min-width: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--card);
+}
+
+.apply-review-shell {
+  grid-template-columns: minmax(236px, 278px) minmax(0, 1fr);
+  min-height: min(78dvh, 920px);
+}
+
+.apply-review-queue {
+  border-right-color: var(--border);
+  background: color-mix(in oklch, var(--muted) 58%, var(--card));
+}
+
+.apply-review-queue-head {
+  gap: 3px;
+  padding: 17px 18px 15px;
+  background: transparent;
+}
+
+.apply-review-queue-head > span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.apply-review-queue-head > b {
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.apply-review-queue-list {
+  gap: 0;
+  max-height: min(72dvh, 860px);
+  padding: 5px 10px 12px;
+}
+
+.apply-review-queue-item {
+  gap: 5px;
+  border: 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 78%, transparent);
+  border-radius: 0;
+  background: transparent;
+  padding: 12px 8px 13px;
+  transition: background-color 140ms ease, box-shadow 140ms ease;
+}
+
+.apply-review-queue-item:hover,
+.apply-review-queue-item.selected {
+  border-color: color-mix(in oklch, var(--border) 78%, transparent);
+  background: color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.apply-review-queue-item.selected {
+  box-shadow: inset 2px 0 0 var(--foreground);
+}
+
+.apply-review-queue-title {
+  align-items: baseline;
+  gap: 9px;
+}
+
+.apply-review-queue-fit {
+  min-width: 1rem;
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 760;
+  line-height: 1;
+}
+
+.apply-review-queue-fit[data-score-tone="positive"],
+.apply-review-selected-score[data-score-tone="positive"] {
+  color: var(--success);
+}
+
+.apply-review-queue-fit[data-score-tone="neutral"],
+.apply-review-selected-score[data-score-tone="neutral"] {
+  color: var(--warning);
+}
+
+.apply-review-queue-fit[data-score-tone="negative"],
+.apply-review-selected-score[data-score-tone="negative"] {
+  color: var(--destructive);
+}
+
+.apply-review-queue-item .meta {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.apply-review-queue-item > .tag,
+.apply-review-inline-state,
+.apply-review-audit-summary .tag,
+.apply-review-audit-revision .tag,
+.apply-review-audit-shipped-fit .tag,
+.apply-review-audit-tags .tag,
+.apply-review-requirement-fit-grid .tag,
+.apply-review-evidence-list .tag,
+.apply-review-selected-facts .compensation-strip .tag,
+.apply-review-selected-facts .resume-template-job-select .tag {
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 610;
+  line-height: 1.45;
+}
+
+.apply-review-queue-item > .tag::before,
+.apply-review-inline-state::before {
+  width: 5px;
+  height: 5px;
+  flex: none;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+  opacity: 0.75;
+}
+
+.apply-review-queue-item > .tag.ok,
+.apply-review-inline-state.ok,
+.apply-review-audit-summary .tag.ok,
+.apply-review-audit-revision .tag.ok,
+.apply-review-audit-shipped-fit .tag.ok,
+.apply-review-requirement-fit-grid .tag.ok {
+  color: var(--success);
+}
+
+.apply-review-queue-item > .tag.warn,
+.apply-review-inline-state.warn,
+.apply-review-audit-summary .tag.warn,
+.apply-review-audit-revision .tag.warn,
+.apply-review-audit-shipped-fit .tag.warn,
+.apply-review-requirement-fit-grid .tag.warn {
+  color: var(--warning);
+}
+
+.apply-review-queue-item > .tag.info,
+.apply-review-inline-state.info,
+.apply-review-audit-summary .tag.info,
+.apply-review-audit-revision .tag.info,
+.apply-review-audit-shipped-fit .tag.info,
+.apply-review-requirement-fit-grid .tag.info {
+  color: var(--status-info);
+}
+
+.apply-review-selected {
+  display: grid;
+  min-width: 0;
+}
+
+.apply-review-selected-head {
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 33rem);
+  gap: 22px;
+  padding: 21px 28px 18px;
+  background: var(--card);
+}
+
+.apply-review-selected-context {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px 24px;
+  align-items: start;
+}
+
+.apply-review-selected-identity {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+
+.apply-review-selected-label {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.apply-review-selected-identity h2 {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-size: clamp(20px, 1.65vw, 26px);
+  font-weight: 670;
+  letter-spacing: -0.045em;
+  line-height: 1.1;
+}
+
+.apply-review-selected-identity p {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.apply-review-selected-summary {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px 12px;
+  min-width: 0;
+  padding-top: 3px;
+}
+
+.apply-review-selected-score {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  color: var(--muted-foreground);
+}
+
+.apply-review-selected-score b {
+  font-size: 24px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  letter-spacing: -0.06em;
+  line-height: 1;
+}
+
+.apply-review-selected-score > span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.apply-review-selected-facts {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(0, 1fr) minmax(210px, 0.7fr);
+  gap: 14px 24px;
+  padding-top: 13px;
+  border-top: 1px solid var(--border);
+}
+
+.apply-review-selected-facts .compensation-strip {
+  align-self: center;
+  gap: 5px 9px;
+}
+
+.apply-review-selected-facts .compensation-strip-label,
+.apply-review-selected-facts .field > span {
+  font-size: 10px;
+  font-weight: 660;
+  letter-spacing: 0.07em;
+}
+
+.apply-review-selected-facts .resume-template-job-select {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 5px;
+}
+
+.apply-review-selected-facts .resume-template-job-select-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.apply-review-selected-facts .resume-template-job-select select {
+  width: 100%;
+  max-width: none;
+}
+
+.apply-review-audit-facts {
+  grid-column: 1 / -1;
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid color-mix(in oklch, var(--border) 82%, transparent);
+}
+
+.apply-review-audit-facts > div {
+  grid-template-columns: minmax(100px, 0.18fr) minmax(0, 1fr);
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 82%, transparent);
+}
+
+.apply-review-audit-facts > div:last-child {
+  border-bottom: 0;
+}
+
+.apply-review-audit-facts dt {
+  font-size: 10px;
+  font-weight: 670;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.apply-review-audit-facts dd {
+  gap: 4px 12px;
+}
+
+.apply-review-audit-facts .tag {
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.apply-review-audit-facts .tag.warn {
+  color: var(--warning);
+}
+
+.apply-review-selected-actions {
+  align-content: start;
+  justify-self: stretch;
+  justify-content: flex-end;
+  gap: 9px;
+}
+
+.apply-review-selected-actions > .tab,
+.apply-review-selected-actions .apply-review-actions > .tab {
+  min-height: 34px;
+  border-radius: calc(var(--radius) * 0.75);
+}
+
+.apply-review-selected-actions > .tab {
+  border-color: var(--border);
+  background: var(--card);
+}
+
+.apply-review-selected-actions .apply-review-actions {
+  gap: 7px;
+}
+
+.apply-review-selected-actions .apply-review-approval-binding,
+.apply-review-selected-actions .apply-review-approval-block {
+  padding-top: 5px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.apply-review-selected-actions .apply-review-approval-block {
+  color: var(--warning);
+}
+
+.apply-review-workspace {
+  grid-template-columns: minmax(310px, 0.34fr) minmax(520px, 0.66fr);
+  gap: 0;
+  padding: 0;
+  background: var(--card);
+}
+
+.apply-review-pane {
+  min-height: min(62dvh, 820px);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.apply-review-evidence-pane {
+  border-right: 1px solid var(--border);
+}
+
+.apply-review-pane > header {
+  gap: 3px;
+  padding: 16px 20px 14px;
+  background: color-mix(in oklch, var(--muted) 36%, var(--card));
+}
+
+.apply-review-materials-pane > header {
+  padding-inline: 26px;
+  background: var(--card);
+}
+
+.apply-review-pane > header .eyebrow {
+  font-size: 10px;
+}
+
+.apply-review-pane > header h2 {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.apply-review-pane-scroll {
+  gap: 0;
+  padding: 18px 20px 24px;
+}
+
+.apply-review-materials-scroll {
+  padding: 18px 26px 28px;
+}
+
+.apply-review-preview-block {
+  gap: 10px;
+  padding-bottom: 20px;
+}
+
+.apply-review-preview-block + .apply-review-preview-block {
+  padding-top: 20px;
+}
+
+.apply-review-preview-block h3,
+.artifact-comparison-head h3 {
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.apply-review-document {
+  max-height: min(44dvh, 600px);
+  border: 0;
+  border-left: 2px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 2px 0 2px 13px;
+  color: var(--foreground);
+  line-height: 1.62;
+}
+
+.apply-review-materials-pane .apply-review-resume-review {
+  margin-top: -1px;
+}
+
+.apply-review-html-line-review {
+  border: 1px solid var(--border);
+  background: color-mix(in oklch, var(--muted) 24%, var(--card));
+  padding: 0;
+}
+
+.apply-review-html-line-review .resume-plate-editor {
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.apply-review-html-line-review .resume-plate-toolbar {
+  border-bottom-color: var(--border);
+  background: var(--card);
+  padding: 10px 12px;
+}
+
+.apply-review-html-line-review .resume-plate-scroll {
+  min-height: min(68dvh, 780px);
+  background: color-mix(in oklch, var(--muted) 48%, var(--card));
+  padding: clamp(14px, 2vw, 28px);
+}
+
+.apply-review-html-line-review .resume-plate-page {
+  box-shadow: 0 12px 26px color-mix(in oklch, var(--foreground) 9%, transparent);
+}
+
+.apply-review-artifact-risk {
+  gap: 10px;
+  padding: 0 0 18px;
+}
+
+.apply-review-artifact-risk .artifact-risk-summary {
+  gap: 7px 14px;
+}
+
+.apply-review-artifact-risk .artifact-risk-metrics {
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.apply-review-artifact-risk .artifact-risk-metrics > div {
+  flex: 1 1 130px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 9px 11px;
+}
+
+.apply-review-artifact-risk .artifact-risk-metrics > div:last-child {
+  border-right: 0;
+}
+
+.apply-review-artifact-risk .artifact-risk-findings {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.apply-review-artifact-risk .artifact-risk-finding {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+}
+
+.apply-review-artifact-risk .artifact-risk-finding summary {
+  padding: 9px 0;
+}
+
+.artifact-comparison {
+  gap: 14px;
+}
+
+.artifact-comparison-head,
+.artifact-comparison-delta-head,
+.artifact-comparison-side-head {
+  gap: 6px 12px;
+}
+
+.artifact-comparison-sides {
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.artifact-comparison-side,
+.artifact-comparison-delta {
+  gap: 9px;
+  border: 0;
+  border-radius: 0;
+  padding: 13px 0;
+}
+
+.artifact-comparison-side + .artifact-comparison-side {
+  border-left: 1px solid var(--border);
+  padding-left: 16px;
+}
+
+.artifact-comparison-side:first-child {
+  padding-right: 16px;
+}
+
+.artifact-comparison-delta {
+  border-bottom: 1px solid var(--border);
+}
+
+.artifact-comparison-tag-group > span {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+}
+
+.artifact-comparison-tag-group .tag {
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.apply-review-requirement-led-audit {
+  gap: 13px;
+}
+
+.apply-review-audit-section {
+  gap: 7px;
+}
+
+.apply-review-audit-section h4 {
+  font-size: 10px;
+  font-weight: 670;
+  letter-spacing: 0.07em;
+}
+
+.apply-review-audit-list {
+  gap: 10px;
+  padding-left: 16px;
+}
+
+.apply-review-audit-tags {
+  grid-template-columns: minmax(84px, 0.24fr) minmax(0, 1fr);
+  gap: 8px;
+}
+
+.apply-review-audit-tags > span:first-child {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.apply-review-ideal-profile section {
+  border-left-width: 1px;
+  padding-left: 12px;
+}
+
+.apply-review-ideal-requirements {
+  gap: 0;
+  padding-left: 18px;
+}
+
+.apply-review-ideal-requirements li {
+  padding: 11px 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 80%, transparent);
+}
+
+.apply-review-ideal-requirements li:last-child {
+  border-bottom: 0;
+}
+
+.apply-review-ideal-requirement-head {
+  gap: 6px 12px;
+}
+
+.apply-review-requirement-fit-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 9px;
+}
+
+.apply-review-requirement-fit-grid > div {
+  gap: 2px;
+}
+
+.apply-review-requirement-fit-grid > div > span {
+  font-size: 10px;
+}
+
+.apply-review-score-evidence {
+  gap: 12px;
+}
+
+.apply-review-score-evidence .score-dimensions {
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.apply-review-score-evidence .score-dimension {
+  padding: 9px 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 75%, transparent);
+}
+
+.apply-review-score-evidence .score-dimension:last-child {
+  border-bottom: 0;
+}
+
+.apply-review-evidence-list {
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.apply-review-evidence-list > div {
+  grid-template-columns: minmax(108px, 0.4fr) minmax(0, 1fr);
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.apply-review-evidence-list dt {
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.apply-review-preview-block .preformatted {
+  border-left: 2px solid var(--border);
+  background: transparent;
+}
+
+.apply-review-preview-block .apply-review-facts {
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.apply-review-preview-block .apply-review-facts > div {
+  padding: 8px 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 80%, transparent);
+}
+
+.apply-review-preview-block .apply-review-facts > div:last-child {
+  border-bottom: 0;
+}
+
+@media (max-width: 1320px) {
+  .apply-review-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apply-review-evidence-pane {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .apply-review-selected-head {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apply-review-selected-actions {
+    justify-content: flex-start;
+  }
+
+  .apply-review-selected-actions .apply-review-actions,
+  .apply-review-selected-actions .apply-review-approval-binding {
+    justify-content: flex-start;
+    text-align: left;
+  }
+}
+
+@media (max-width: 1080px) {
+  .apply-review-shell,
+  .apply-review-workspace {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apply-review-queue {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .apply-review-queue-list {
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(230px, 0.82fr);
+    grid-template-columns: none;
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-height: none;
+  }
+
+  .apply-review-queue-item {
+    min-height: 88px;
+    border-bottom: 0;
+    border-right: 1px solid color-mix(in oklch, var(--border) 78%, transparent);
+  }
+
+  .apply-review-evidence-pane {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .apply-review-pane {
+    min-height: auto;
+  }
+
+  .apply-review-pane-scroll {
+    overflow: visible;
+  }
+}
+
+@media (max-width: 720px) {
+  .apply-review-surface {
+    margin-inline: -16px;
+  }
+
+  .apply-review-selected-head,
+  .apply-review-materials-scroll {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .apply-review-selected-context,
+  .apply-review-selected-facts {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .apply-review-selected-summary {
+    justify-content: flex-start;
+  }
+
+  .apply-review-audit-facts > div,
+  .apply-review-requirement-fit-grid,
+  .apply-review-evidence-list > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 4px;
+  }
+
+  .apply-review-pane > header,
+  .apply-review-pane-scroll {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+
+  .apply-review-html-line-review .resume-plate-scroll {
+    min-height: 520px;
+    padding: 10px;
+  }
+
+  .artifact-comparison-sides {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .artifact-comparison-side + .artifact-comparison-side {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+    padding-top: 13px;
+    padding-left: 0;
+  }
+
+  .artifact-comparison-side:first-child {
+    padding-right: 0;
+  }
+
+  .apply-review-artifact-risk .artifact-risk-metrics > div {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .apply-review-artifact-risk .artifact-risk-metrics > div:last-child {
+    border-bottom: 0;
+  }
+}

--- a/apps/web/src/styles/redesign-common.css
+++ b/apps/web/src/styles/redesign-common.css
@@ -1,0 +1,211 @@
+/* Shared visual language for legacy page composers while they move onto the
+ * Base UI/shadcn primitive layer. Keep this file semantic: page-specific
+ * layouts live in their own redesign stylesheets. */
+
+.main {
+  padding: clamp(24px, 3vw, 40px) clamp(20px, 3.5vw, 48px) 88px;
+}
+
+.page-head {
+  align-items: flex-start;
+  margin-bottom: 28px;
+}
+
+.page-head-text {
+  gap: 7px;
+}
+
+.eyebrow {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+}
+
+.page-head h1 {
+  font-size: clamp(28px, 2.4vw, 36px);
+  font-weight: 680;
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+}
+
+.page-head-subtitle {
+  max-width: 76ch;
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.page-head-actions {
+  gap: 10px;
+}
+
+.card {
+  border-color: color-mix(in oklch, var(--border) 88%, var(--foreground));
+  border-radius: calc(var(--radius) * 1.25);
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--foreground) 5%, transparent),
+    0 8px 24px color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+
+.card-hd {
+  align-items: flex-start;
+  min-height: 0;
+  padding: 19px 20px 15px;
+  background: transparent;
+}
+
+.card-hd h2 {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+.toolbar {
+  gap: 10px;
+  padding: 12px 20px;
+  background: color-mix(in oklch, var(--muted) 45%, var(--card));
+}
+
+.tab {
+  min-height: 36px;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius) * 0.8);
+  padding: 7px 12px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease;
+}
+
+.tab:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.tab.on {
+  border-color: var(--foreground);
+  background: var(--foreground);
+  box-shadow: none;
+  color: var(--background);
+}
+
+.tab.on:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--foreground) 86%, var(--background));
+  background: color-mix(in oklch, var(--foreground) 86%, var(--background));
+  color: var(--background);
+}
+
+.tab:disabled {
+  opacity: 0.4;
+}
+
+.icon-button {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted-foreground);
+  box-shadow: none;
+}
+
+.icon-button:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.select,
+select,
+input,
+textarea {
+  min-height: 38px;
+  border-color: var(--input);
+  border-radius: calc(var(--radius) * 0.8);
+  background: var(--card);
+  padding: 8px 11px;
+  box-shadow: 0 1px 1px color-mix(in oklch, var(--foreground) 3%, transparent);
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease;
+}
+
+select:hover:not(:disabled),
+input:hover:not(:disabled),
+textarea:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--foreground) 28%, var(--border));
+}
+
+select:focus-visible,
+input:focus-visible,
+textarea:focus-visible {
+  border-color: var(--foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--foreground) 10%, transparent);
+  outline: none;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  width: 16px;
+  min-height: 16px;
+  height: 16px;
+  padding: 0;
+  accent-color: var(--foreground);
+  box-shadow: none;
+}
+
+.field {
+  gap: 7px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.field-hint,
+.field .meta {
+  color: var(--muted-foreground);
+  font-weight: 400;
+  line-height: 1.45;
+}
+
+.settings-tabs {
+  gap: 2px;
+  padding: 3px;
+  border-radius: calc(var(--radius) * 0.9);
+  background: var(--muted);
+}
+
+.settings-tabs .tab {
+  min-height: 32px;
+  border-radius: calc(var(--radius) * 0.65);
+  padding-inline: 14px;
+}
+
+.settings-tabs .tab.on {
+  border-color: var(--border);
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+.section {
+  border-color: var(--border);
+  border-radius: calc(var(--radius) * 1.1);
+  box-shadow: none;
+}
+
+.section h3 {
+  letter-spacing: -0.015em;
+}
+
+@media (max-width: 720px) {
+  .main {
+    padding: 20px 16px 72px;
+  }
+
+  .page-head {
+    margin-bottom: 22px;
+  }
+}

--- a/apps/web/src/styles/redesign-configuration.css
+++ b/apps/web/src/styles/redesign-configuration.css
@@ -1,0 +1,890 @@
+/*
+ * Configuration and discovery use an editorial workspace treatment: a small
+ * number of meaningful surfaces, open section bands, and dense but breathable
+ * forms. This intentionally overrides the older nested-card presentation.
+ */
+
+.profile-layout,
+.config-layout,
+.discovery-workspace {
+  --configuration-surface: var(--card);
+  --configuration-subtle: color-mix(in oklch, var(--muted) 62%, var(--card));
+  --configuration-rule: color-mix(in oklch, var(--border) 88%, var(--foreground));
+}
+
+/* Profile and preferences -------------------------------------------------- */
+
+.profile-layout > .card,
+.profile-layout-single > .card {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.profile-layout > .card > .card-hd {
+  min-height: 0;
+  padding: 0 0 16px;
+  border: 0;
+  background: transparent;
+}
+
+.profile-layout > .card > .card-hd h2 {
+  font-size: 17px;
+  font-weight: 670;
+  letter-spacing: -0.03em;
+}
+
+.profile-layout .profile-evidence-toolbar {
+  margin-bottom: 16px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.profile-layout .editor-bulk-actions {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  border: 1px solid var(--configuration-rule);
+  border-radius: 8px;
+  background: var(--configuration-surface);
+}
+
+.profile-layout .profile-sections {
+  gap: 0;
+  padding: 0;
+}
+
+.profile-layout .profile-sections > .form-section {
+  overflow: visible;
+  border: 0;
+  border-top: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+}
+
+/* Personal information is the one clear profile-subject card. */
+.profile-layout .profile-sections > .form-section:first-child {
+  margin-bottom: 16px;
+  border: 1px solid var(--configuration-rule);
+  border-radius: 8px;
+  background: var(--configuration-surface);
+}
+
+.profile-layout .profile-sections > .form-section > h3 {
+  padding: 17px 20px 13px;
+  border-bottom: 1px solid var(--configuration-rule);
+  background: transparent;
+  color: var(--foreground);
+  font-size: 15px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+}
+
+.profile-layout .profile-sections > .form-section:not(:first-child) > h3 {
+  padding: 18px 0 10px;
+  border: 0;
+}
+
+.profile-layout .profile-sections > .form-section .field-grid,
+.profile-layout .profile-sections > .form-section .target-preferences-grid {
+  padding: 16px 20px 20px;
+}
+
+.profile-layout .profile-sections > .form-section:not(:first-child) > .field-grid,
+.profile-layout .profile-sections > .form-section:not(:first-child) > .target-preferences-grid {
+  padding-inline: 0;
+}
+
+.profile-layout .repeat-list {
+  gap: 0;
+  padding: 0 0 18px;
+}
+
+.profile-layout .repeat-card {
+  gap: 14px;
+  border: 0;
+  border-top: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+  padding: 16px 0;
+}
+
+.profile-layout .repeat-list > .tab {
+  align-self: flex-start;
+  margin-top: 4px;
+}
+
+.profile-layout .repeat-card .field-grid {
+  padding: 0;
+}
+
+.profile-layout .bullet-row,
+.profile-layout .skill-row,
+.profile-layout .achievement-evidence-card {
+  border-color: var(--configuration-rule);
+  border-radius: 6px;
+  background: var(--configuration-surface);
+  box-shadow: none;
+}
+
+.profile-layout .target-work-model-option,
+.profile-layout .date-range-present,
+.profile-layout .month-selector {
+  border-color: transparent;
+  border-radius: 4px;
+  background: var(--configuration-subtle);
+}
+
+.profile-layout .target-work-model-option:has(input:checked),
+.profile-layout .date-range-present:has(input:checked) {
+  background: color-mix(in oklch, var(--foreground) 9%, var(--card));
+  color: var(--foreground);
+}
+
+/* Preferences are disclosure bands rather than a stack of decorative cards. */
+.profile-layout-single .configuration-section {
+  overflow: hidden;
+  border: 0;
+  border-top: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+}
+
+.profile-layout-single .configuration-section:last-of-type {
+  border-bottom: 1px solid var(--configuration-rule);
+}
+
+.configuration-section > summary {
+  display: flex;
+  min-height: 70px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  cursor: pointer;
+  list-style: none;
+  padding: 16px 0;
+}
+
+.configuration-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+.configuration-section > summary::marker {
+  content: "";
+}
+
+.configuration-section__title-group {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.configuration-section__title {
+  color: var(--foreground);
+  font-size: 15px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+}
+
+.configuration-section__description {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.configuration-section__indicator {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+  transition: transform 150ms ease, color 150ms ease;
+}
+
+.configuration-section[open] > summary .configuration-section__indicator {
+  color: var(--foreground);
+  transform: rotate(180deg);
+}
+
+.configuration-section > summary:hover .configuration-section__title,
+.configuration-section > summary:focus-visible .configuration-section__title {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--foreground) 28%, transparent);
+  text-underline-offset: 4px;
+}
+
+.configuration-section__body {
+  padding: 0 0 20px;
+}
+
+.configuration-section .field-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 15px 18px;
+  padding: 0;
+}
+
+.configuration-section .field-grid.one {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.configuration-section .tailoring-controls-grid {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 0 22px;
+  padding: 0;
+}
+
+.configuration-section .tailoring-control-group {
+  min-width: 0;
+  align-self: stretch;
+  border: 0;
+  border-top: 1px solid var(--configuration-rule);
+  margin: 0;
+  padding: 16px 0 18px;
+}
+
+.configuration-section .tailoring-control-group:nth-child(1) {
+  grid-column: span 4;
+}
+
+.configuration-section .tailoring-control-group:nth-child(2) {
+  grid-column: span 8;
+}
+
+.configuration-section .tailoring-control-group:nth-child(3),
+.configuration-section .tailoring-control-group:nth-child(4) {
+  grid-column: span 6;
+}
+
+.configuration-section .tailoring-controls-grid > .field-grid {
+  grid-column: 1 / -1;
+  border-top: 1px solid var(--configuration-rule);
+  padding-top: 16px;
+}
+
+.configuration-section .tailoring-control-group legend,
+.configuration-section .bullet-standards-group legend {
+  margin-bottom: 10px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.configuration-section .bullet-standards-group legend {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.configuration-help-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 560;
+  text-decoration: none;
+}
+
+.configuration-help-link:hover,
+.configuration-help-link:focus-visible {
+  color: var(--foreground);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.configuration-section .tailoring-control-group .field-grid {
+  gap: 12px 14px;
+  padding: 0;
+}
+
+.configuration-section .tailoring-control-group .bullet-standards-group {
+  margin-top: 2px;
+}
+
+.configuration-section .checkbox-options {
+  gap: 8px 14px;
+}
+
+.configuration-section .checkbox-options.vertical {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px 16px;
+}
+
+.configuration-section .choice,
+.profile-layout .choice,
+.discovery-workspace .choice {
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.configuration-section .target-choice,
+.profile-layout .target-choice,
+.discovery-workspace .target-choice {
+  min-height: 24px;
+}
+
+.configuration-section .field.check,
+.configuration-section .target-choice.required-choice {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+}
+
+.configuration-section .field.check > button,
+.configuration-section .target-choice.required-choice > button {
+  margin-top: 1px;
+}
+
+.configuration-section .required-choice > [data-disabled] {
+  opacity: 1;
+}
+
+.configuration-section .bullet-standards-group > small {
+  display: block;
+  margin-top: 8px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 430;
+  line-height: 1.4;
+}
+
+.configuration-select-trigger {
+  min-height: 40px;
+  border-color: var(--input);
+  border-radius: 6px;
+  background: var(--configuration-surface);
+  box-shadow: none;
+}
+
+/* The template editor is a full-width tool, not a small preview card. */
+.profile-layout-single .resume-template-workspace {
+  overflow: hidden;
+  margin: 24px 0 0;
+  border: 1px solid var(--configuration-rule);
+  border-radius: 8px;
+  background: var(--configuration-surface);
+}
+
+.profile-layout-single .resume-template-workspace > h3 {
+  padding: 17px 20px 13px;
+  border-bottom: 1px solid var(--configuration-rule);
+  background: transparent;
+  color: var(--foreground);
+  font-size: 15px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+}
+
+.resume-template-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  padding: 16px;
+}
+
+.resume-template-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 12px 16px;
+}
+
+.resume-template-controls .field-grid {
+  grid-column: 1 / -1;
+  grid-template-columns: repeat(auto-fit, minmax(138px, 1fr));
+  gap: 10px 12px;
+  padding: 0;
+}
+
+.resume-template-controls .field {
+  gap: 5px;
+}
+
+.resume-template-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid var(--configuration-rule);
+  padding-top: 12px;
+}
+
+.resume-template-preview {
+  min-width: 0;
+  border-top: 1px solid var(--configuration-rule);
+  padding-top: 16px;
+}
+
+.resume-template-plate-editor {
+  height: min(80dvh, 980px);
+  min-height: 620px;
+  border: 1px solid var(--configuration-rule);
+  border-radius: 7px;
+}
+
+.resume-template-plate-editor .resume-plate-scroll {
+  padding: clamp(14px, 2vw, 26px);
+}
+
+/* Settings navigation and provider screens -------------------------------- */
+
+.config-layout {
+  gap: 24px;
+}
+
+.config-layout .settings-tabs {
+  width: 100%;
+  align-self: stretch;
+  gap: 0;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+}
+
+.config-layout .settings-tabs .tab {
+  min-height: 38px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 9px 13px 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  box-shadow: none;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.config-layout .settings-tabs .tab:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.config-layout .settings-tabs .tab.on {
+  border-color: var(--foreground);
+  background: transparent;
+  color: var(--foreground);
+  box-shadow: none;
+}
+
+.config-layout > .card {
+  overflow: hidden;
+  border-color: var(--configuration-rule);
+  border-radius: 8px;
+  background: var(--configuration-surface);
+  box-shadow: none;
+}
+
+.config-layout > .card > .card-hd {
+  padding: 17px 20px 13px;
+  background: transparent;
+}
+
+.config-layout .provider-card-list {
+  gap: 0;
+  padding: 0;
+}
+
+.config-layout .provider-card {
+  border: 0;
+  border-top: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+  padding: 18px 20px;
+}
+
+.config-layout .provider-card-header {
+  gap: 24px;
+}
+
+.config-layout .provider-card .tag,
+.profile-layout .tag {
+  border-radius: 4px;
+  box-shadow: none;
+}
+
+.config-layout .model-selection-list {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.config-layout .model-selection-list .provider-card {
+  border-top: 0;
+  border-left: 1px solid var(--configuration-rule);
+}
+
+.config-layout .model-selection-list .provider-card:first-child {
+  border-left: 0;
+}
+
+.config-layout .model-selection-intro {
+  border-color: var(--configuration-rule);
+  background: var(--configuration-subtle);
+  padding: 14px 20px;
+}
+
+.config-layout .provider-choice,
+.config-layout .codex-auth-options section,
+.config-layout .provider-cloud-guidance,
+.config-layout .provider-legacy-warning {
+  border-color: var(--configuration-rule);
+  border-radius: 6px;
+  background: var(--configuration-subtle);
+}
+
+.config-layout .provider-choice:has(input:checked) {
+  border-color: var(--foreground);
+  background: var(--configuration-surface);
+  box-shadow: inset 2px 0 0 var(--foreground);
+}
+
+/* Discovery ---------------------------------------------------------------- */
+
+.discovery-workspace {
+  gap: 22px;
+}
+
+.discovery-workspace > .card {
+  overflow: hidden;
+  margin: 0;
+  border-color: var(--configuration-rule);
+  border-radius: 8px;
+  background: var(--configuration-surface);
+  box-shadow: none;
+}
+
+.discovery-workspace > .card > .card-hd {
+  min-height: 0;
+  padding: 17px 20px 13px;
+  background: transparent;
+}
+
+.discovery-workspace > .card > .card-hd h2 {
+  font-size: 15px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+}
+
+.discovery-workspace .config-form,
+.discovery-workspace .target-preferences-grid {
+  gap: 16px 20px;
+  padding: 16px 20px 20px;
+}
+
+.discovery-workspace .discovery-runtime-settings .config-form {
+  padding: 0;
+}
+
+.discovery-workspace .discovery-runtime-settings .field-grid {
+  gap: 16px 20px;
+  padding: 16px 20px 20px;
+}
+
+.discovery-workspace .editor-bulk-actions,
+.discovery-workspace .form-actions {
+  padding: 12px 20px 18px;
+}
+
+.discovery-workspace .discovery-automation-settings-form {
+  grid-template-columns: minmax(0, 0.75fr) minmax(0, 1.25fr);
+  align-items: start;
+}
+
+.discovery-workspace .discovery-automation-settings-form > .field,
+.discovery-workspace .discovery-automation-settings-form > .field-hint,
+.discovery-workspace .discovery-automation-settings-form > .status-line,
+.discovery-workspace .discovery-automation-settings-form > .form-actions {
+  grid-column: auto;
+}
+
+.discovery-workspace .discovery-automation-settings-form > .form-actions {
+  align-self: end;
+  justify-self: start;
+  padding: 0;
+}
+
+.discovery-workspace .discovery-tabs {
+  padding: 0 20px 20px;
+  background: transparent;
+}
+
+.discovery-workspace .discovery-tab-list {
+  width: 100%;
+  margin: 0 0 16px;
+  border-bottom: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.discovery-workspace .discovery-tab-list [role="tab"] {
+  min-height: 38px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.discovery-workspace .discovery-tab-list [role="tab"][data-active] {
+  border-color: var(--foreground);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.discovery-workspace .discovery-tab-panel {
+  margin: 0;
+}
+
+.discovery-workspace .discovery-tab-panel .discovery-control-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.discovery-workspace .discovery-panel-head {
+  min-height: 46px;
+  padding: 10px 0;
+}
+
+.discovery-workspace .discovery-panel-head h3 {
+  font-size: 14px;
+  letter-spacing: -0.015em;
+}
+
+.discovery-workspace .discovery-source-summary {
+  gap: 0;
+  border-color: var(--configuration-rule);
+  padding: 0;
+}
+
+.discovery-workspace .discovery-source-summary span {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  border: 0;
+  border-left: 1px solid var(--configuration-rule);
+  border-radius: 0;
+  background: transparent;
+  padding: 11px 12px;
+}
+
+.discovery-workspace .discovery-source-summary span:first-child {
+  border-left: 0;
+}
+
+.discovery-workspace .discovery-source-summary strong {
+  font-size: 18px;
+  letter-spacing: -0.035em;
+}
+
+.discovery-workspace .source-upsert-form {
+  grid-template-columns: minmax(150px, 0.6fr) minmax(180px, 0.8fr) minmax(132px, 0.45fr) minmax(260px, 1.2fr) auto;
+  align-items: end;
+  gap: 10px;
+  border-color: var(--configuration-rule);
+  padding: 14px 0 0;
+}
+
+.discovery-workspace .source-upsert-form .wide,
+.discovery-workspace .source-upsert-form button {
+  grid-column: auto;
+}
+
+.discovery-workspace .discovery-review-row,
+.discovery-workspace .discovery-preview-row {
+  gap: 12px;
+  padding: 12px 0;
+}
+
+.discovery-workspace .discovery-review-row:first-child,
+.discovery-workspace .discovery-preview-row:first-child {
+  border-top: 1px solid var(--configuration-rule);
+}
+
+.discovery-workspace .source-politeness-badge,
+.discovery-workspace .source-table-tone {
+  border-radius: 3px;
+}
+
+/* Shared controls on these dense form surfaces. */
+.profile-layout .field,
+.config-layout .field,
+.discovery-workspace .field {
+  gap: 6px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.profile-layout .field > span:first-child,
+.config-layout .field > span:first-child,
+.discovery-workspace .field > span:first-child,
+.profile-layout .field > label,
+.config-layout .field > label,
+.discovery-workspace .field > label {
+  color: var(--muted-foreground);
+}
+
+.profile-layout input:not([type="checkbox"]):not([type="radio"]),
+.profile-layout select,
+.profile-layout textarea,
+.config-layout input:not([type="checkbox"]):not([type="radio"]),
+.config-layout select,
+.config-layout textarea,
+.discovery-workspace input:not([type="checkbox"]):not([type="radio"]),
+.discovery-workspace select,
+.discovery-workspace textarea {
+  min-height: 40px;
+  border-color: var(--input);
+  border-radius: 6px;
+  background: var(--configuration-surface);
+  box-shadow: none;
+}
+
+.profile-layout select,
+.config-layout select,
+.discovery-workspace select {
+  padding-right: 30px;
+}
+
+.profile-layout textarea,
+.config-layout textarea,
+.discovery-workspace textarea {
+  min-height: 96px;
+  line-height: 1.5;
+}
+
+.profile-layout input[type="checkbox"],
+.profile-layout input[type="radio"],
+.config-layout input[type="checkbox"],
+.config-layout input[type="radio"],
+.discovery-workspace input[type="checkbox"],
+.discovery-workspace input[type="radio"] {
+  accent-color: var(--foreground);
+}
+
+@media (max-width: 1080px) {
+  .configuration-section .tailoring-control-group:nth-child(1),
+  .configuration-section .tailoring-control-group:nth-child(2),
+  .configuration-section .tailoring-control-group:nth-child(3),
+  .configuration-section .tailoring-control-group:nth-child(4) {
+    grid-column: span 6;
+  }
+
+  .discovery-workspace .source-upsert-form {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .discovery-workspace .source-upsert-form .wide,
+  .discovery-workspace .source-upsert-form button {
+    grid-column: 1 / -1;
+  }
+
+  .config-layout .model-selection-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .config-layout .model-selection-list .provider-card {
+    border-top: 1px solid var(--configuration-rule);
+    border-left: 0;
+  }
+
+  .config-layout .model-selection-list .provider-card:first-child {
+    border-top: 0;
+  }
+}
+
+@media (max-width: 760px) {
+  .profile-layout .profile-sections > .form-section .field-grid,
+  .profile-layout .profile-sections > .form-section .target-preferences-grid,
+  .configuration-section .field-grid,
+  .discovery-workspace .config-form,
+  .discovery-workspace .target-preferences-grid,
+  .discovery-workspace .discovery-runtime-settings .field-grid,
+  .discovery-workspace .discovery-automation-settings-form {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .configuration-section .tailoring-controls-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .configuration-section .tailoring-control-group:nth-child(n) {
+    grid-column: auto;
+  }
+
+  .configuration-section .checkbox-options.vertical {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .configuration-section > summary {
+    min-height: 0;
+    padding-block: 14px;
+  }
+
+  .resume-template-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .resume-template-actions {
+    justify-content: flex-start;
+  }
+
+  .resume-template-plate-editor {
+    min-height: 480px;
+  }
+
+  .config-layout .settings-tabs {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  .config-layout .settings-tabs .tab {
+    flex: 0 0 auto;
+  }
+
+  .discovery-workspace > .card > .card-hd,
+  .discovery-workspace .config-form,
+  .discovery-workspace .target-preferences-grid,
+  .discovery-workspace .discovery-runtime-settings .field-grid {
+    padding-inline: 14px;
+  }
+
+  .discovery-workspace .discovery-tabs {
+    padding-inline: 14px;
+  }
+
+  .discovery-workspace .discovery-tab-list {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+  }
+
+  .discovery-workspace .discovery-tab-list [role="tab"] {
+    flex: 0 0 auto;
+  }
+
+  .discovery-workspace .discovery-source-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .discovery-workspace .discovery-source-summary span:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .discovery-workspace .discovery-source-summary span:nth-child(n + 3) {
+    border-top: 1px solid var(--configuration-rule);
+  }
+
+  .discovery-workspace .discovery-review-row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .discovery-workspace .discovery-review-row .row-actions {
+    grid-column: 2;
+  }
+}

--- a/apps/web/src/styles/redesign-dashboard.css
+++ b/apps/web/src/styles/redesign-dashboard.css
@@ -1,0 +1,311 @@
+.dashboard-view {
+  display: grid;
+  align-content: start;
+}
+
+.dashboard-view .kpis {
+  grid-template-columns: repeat(6, minmax(124px, 1fr));
+  gap: 0;
+  overflow: hidden;
+  margin-bottom: 20px;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.15);
+  background: var(--card);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+
+.dashboard-view .kpis > * {
+  min-height: 118px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.dashboard-view .kpis > *:last-child {
+  border-right: 0;
+}
+
+.dashboard-view .kpis [data-slot="stat-label"] {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.dashboard-view .kpis [data-slot="stat-value"] {
+  margin-top: auto;
+  font-size: clamp(30px, 2.8vw, 42px);
+  font-weight: 650;
+  letter-spacing: -0.055em;
+}
+
+.dashboard-stack {
+  gap: 20px;
+}
+
+.dashboard-ops {
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.15);
+  background: var(--card);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.dashboard-ops > :nth-child(1) {
+  grid-column: span 6;
+}
+
+.dashboard-ops > :nth-child(2),
+.dashboard-ops > :nth-child(3) {
+  grid-column: span 3;
+}
+
+.dashboard-ops > .card {
+  min-height: 100%;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.dashboard-ops > .card:last-child {
+  border-right: 0;
+}
+
+.dashboard-tail {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) * 1.15);
+  background: var(--card);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.dashboard-tail > .card {
+  min-height: 100%;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.dashboard-tail > .card:nth-child(2n) {
+  border-right: 0;
+}
+
+.dashboard-tail > .card:last-child {
+  border-right: 0;
+  border-bottom: 0;
+}
+
+.dashboard-view .card {
+  align-self: start;
+}
+
+.dashboard-view .funnel {
+  gap: 0;
+  padding: 4px 20px 14px;
+}
+
+.dashboard-view .funnel-row {
+  grid-template-columns: minmax(116px, max-content) minmax(160px, 1fr);
+  gap: 8px 18px;
+  min-height: 64px;
+  border-radius: 0;
+  padding: 12px 2px;
+  border-bottom: 1px solid var(--border);
+}
+
+.dashboard-view .funnel-row:last-child {
+  border-bottom: 0;
+}
+
+.dashboard-view .funnel-row:hover {
+  background: transparent;
+}
+
+.dashboard-view .funnel-row:hover .funnel-stage {
+  color: var(--muted-foreground);
+}
+
+.dashboard-view .funnel-stage {
+  font-size: 13px;
+  font-weight: 620;
+  transition: color 140ms ease;
+}
+
+.dashboard-view .funnel-num {
+  display: inline-block;
+  width: 24px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+
+.dashboard-view .bar {
+  height: 7px;
+  border: 0;
+  border-radius: 999px;
+}
+
+.dashboard-view .bar > span:first-child {
+  border-radius: 999px 0 0 999px;
+}
+
+.dashboard-view .bar > span:last-child {
+  border-radius: 0 999px 999px 0;
+}
+
+.dashboard-view .conversion-body {
+  gap: 22px;
+  padding: 18px 20px 22px;
+}
+
+.dashboard-view .conversion-stage {
+  grid-template-columns: 86px minmax(80px, 1fr) 104px;
+}
+
+.dashboard-view .conversion-breakdowns {
+  gap: 20px 28px;
+  padding-top: 4px;
+}
+
+.dashboard-view .conversion-row {
+  padding-block: 10px;
+}
+
+.dashboard-view .conversion-breakdown-title {
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 620;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.dashboard-view .digest-row {
+  grid-template-columns: minmax(0, 1fr) auto 16px;
+  gap: 12px;
+  padding: 12px 18px;
+}
+
+.dashboard-view .digest-row:hover,
+.dashboard-view .clickable-row:hover {
+  background: color-mix(in oklch, var(--muted) 74%, var(--card));
+}
+
+.dashboard-view .digest-value {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.dashboard-view .digest-actions {
+  padding: 14px 18px;
+}
+
+.dashboard-view .mini-row {
+  min-height: 54px;
+  gap: 12px;
+  padding: 10px 18px;
+}
+
+.dashboard-view .title-stack {
+  gap: 3px;
+}
+
+.dashboard-view .title-stack b {
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.dashboard-view .title-stack span {
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.dashboard-view .work-status-stat {
+  border: 0;
+  border-radius: 5px;
+  background: color-mix(in oklch, var(--muted) 66%, var(--card));
+  box-shadow: none;
+}
+
+.dashboard-view .work-status-stat [data-slot="stat-value"] {
+  font-weight: 650;
+}
+
+@media (max-width: 1500px) {
+  .dashboard-view .kpis {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .dashboard-ops > :nth-child(1) {
+    grid-column: span 12;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dashboard-ops > :nth-child(2),
+  .dashboard-ops > :nth-child(3) {
+    grid-column: span 6;
+  }
+
+  .dashboard-ops > :nth-child(2) {
+    border-right: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 980px) {
+  .dashboard-tail {
+    grid-template-columns: 1fr;
+  }
+
+  .dashboard-tail > .card,
+  .dashboard-tail > .card:nth-child(2n) {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dashboard-tail > .card:last-child {
+    border-bottom: 0;
+  }
+}
+
+@media (max-width: 760px) {
+  .dashboard-view .kpis {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-view .kpis > * {
+    min-height: 112px;
+    border-right: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dashboard-view .kpis > *:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .dashboard-view .kpis > *:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+
+  .dashboard-ops > :nth-child(2),
+  .dashboard-ops > :nth-child(3) {
+    grid-column: span 12;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .dashboard-ops > :nth-child(3) {
+    border-bottom: 0;
+  }
+
+  .dashboard-view .funnel-row,
+  .dashboard-view .conversion-stage {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/styles/redesign-data.css
+++ b/apps/web/src/styles/redesign-data.css
@@ -1,0 +1,537 @@
+/*
+ * Data-intensive screens use a quieter treatment than the rest of the app:
+ * the table is the object, while toolbars and controls stay deliberately
+ * recessive. This keeps the large operational surfaces readable without
+ * turning each row, state, or action into another rounded card.
+ */
+
+.data-surface,
+.data-table-surface,
+.data-table-scroll {
+  min-width: 0;
+}
+
+.data-list-card {
+  overflow: hidden;
+  border-radius: calc(var(--radius) * 1.05);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.data-list-card > .toolbar,
+.data-list-card > .filter-bar {
+  background: transparent;
+}
+
+.data-surface {
+  border-top: 1px solid var(--border);
+  background: transparent;
+}
+
+.data-grid-toolbar {
+  min-height: 48px;
+  gap: 16px;
+  padding: 9px 16px;
+  background: transparent;
+}
+
+.data-grid-view-title {
+  gap: 9px;
+  font-size: 13px;
+  font-weight: 620;
+  letter-spacing: -0.01em;
+}
+
+.data-grid-view-title > svg {
+  color: var(--muted-foreground);
+}
+
+.data-grid-view-title .meta {
+  padding-left: 9px;
+  border-left: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 450;
+}
+
+.data-grid-tools {
+  gap: 5px;
+}
+
+.data-grid-filter-chips {
+  gap: 0;
+  padding: 0 16px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.data-grid-filter-chips button {
+  gap: 5px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 2px 10px;
+  color: var(--foreground);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.data-grid-filter-chips button:first-child {
+  padding-left: 0;
+}
+
+.data-grid-filter-chips button:last-child {
+  border-right: 0;
+}
+
+.data-grid-filter-chips button:hover {
+  background: transparent;
+  color: var(--primary);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.filterable-data-grid-scroll {
+  border-bottom: 1px solid var(--border);
+}
+
+.filterable-data-grid-table {
+  font-size: 12px;
+}
+
+.filterable-data-grid-table th,
+.filterable-data-grid-table td {
+  border-color: color-mix(in oklch, var(--border) 82%, transparent);
+  padding: 10px 12px;
+}
+
+.filterable-data-grid[data-density="compact"] .filterable-data-grid-table th,
+.filterable-data-grid[data-density="compact"] .filterable-data-grid-table td {
+  padding-top: 7px;
+  padding-bottom: 7px;
+}
+
+.filterable-data-grid[data-density="comfy"] .filterable-data-grid-table th,
+.filterable-data-grid[data-density="comfy"] .filterable-data-grid-table td {
+  padding-top: 14px;
+  padding-bottom: 14px;
+}
+
+.filterable-data-grid-table thead th {
+  background: color-mix(in oklch, var(--muted) 42%, var(--card));
+  color: color-mix(in oklch, var(--muted-foreground) 88%, var(--foreground));
+  font-size: 10px;
+  font-weight: 720;
+  letter-spacing: 0.07em;
+}
+
+.filterable-data-grid-table tbody th {
+  font-weight: 590;
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-activatable:hover {
+  background: color-mix(in oklch, var(--foreground) 3%, var(--card));
+}
+
+.filterable-data-grid-table tbody tr[aria-selected="true"] {
+  background: color-mix(in oklch, var(--foreground) 5%, var(--card));
+  box-shadow: inset 2px 0 0 var(--foreground);
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-success,
+.filterable-data-grid-table tbody tr.data-grid-row-tone-warning,
+.filterable-data-grid-table tbody tr.data-grid-row-tone-danger,
+.filterable-data-grid-table tbody tr.data-grid-row-tone-info {
+  box-shadow: inset 2px 0 0 var(--border);
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-success {
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--success) 58%, var(--border));
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-warning {
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--warning) 62%, var(--border));
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-danger {
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--destructive) 62%, var(--border));
+}
+
+.filterable-data-grid-table tbody tr.data-grid-row-tone-info {
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--status-info) 58%, var(--border));
+}
+
+.filterable-data-grid-table .data-grid-cell-tone-success,
+.filterable-data-grid-table .data-grid-cell-tone-warning,
+.filterable-data-grid-table .data-grid-cell-tone-danger,
+.filterable-data-grid-table .data-grid-cell-tone-info {
+  background: transparent;
+}
+
+.filterable-data-grid-table tbody tr.data-grid-group-row th {
+  background: color-mix(in oklch, var(--muted) 54%, var(--card));
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.data-grid-sort-button {
+  gap: 8px;
+}
+
+.data-grid-sort-button:hover {
+  color: var(--foreground);
+}
+
+.data-grid-sort-button svg,
+.data-grid-sort-button > span:last-child {
+  color: var(--muted-foreground);
+}
+
+.data-grid-column-resizer::after {
+  top: 9px;
+  bottom: 9px;
+  background: color-mix(in oklch, var(--border) 76%, transparent);
+}
+
+.data-grid-column-filter-button {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+}
+
+.data-grid-column-filter-button:hover,
+.data-grid-column-filter-button:focus-visible,
+.data-grid-column-filter-button.active {
+  border-color: transparent;
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.data-grid-column-filter-button.active {
+  color: var(--primary);
+}
+
+.data-grid-row-activation-button,
+.table-row-activation-button {
+  min-width: 0;
+  min-height: 0;
+  margin-left: 7px;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.data-grid-row-activation-button:hover,
+.table-row-activation-button:hover {
+  border: 0;
+  background: transparent;
+  color: var(--foreground);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Scores retain their useful colour signal without becoming colored tiles. */
+.jobs-data-grid-table .fit {
+  width: auto;
+  height: auto;
+  min-width: 1.5rem;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--muted-foreground);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 760;
+}
+
+.jobs-data-grid-table .fit[data-score-tone="positive"] {
+  color: var(--success);
+}
+
+.jobs-data-grid-table .fit[data-score-tone="negative"] {
+  color: var(--destructive);
+}
+
+.jobs-data-grid-table .fit[data-score-tone="neutral"] {
+  color: var(--warning);
+}
+
+.jobs-data-grid-table .fit[data-score-tone="unknown"] {
+  color: var(--muted-foreground);
+}
+
+.filterable-data-grid-table .tag,
+.filterable-data-grid-table .stage-pill,
+.filterable-data-grid-table .job-compensation-confidence {
+  min-height: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  font-size: 11px;
+  font-weight: 630;
+  letter-spacing: 0;
+}
+
+.filterable-data-grid-table .tag::before,
+.filterable-data-grid-table .stage-pill::before,
+.filterable-data-grid-table .job-compensation-confidence::before {
+  width: 5px;
+  height: 5px;
+  flex: none;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+  opacity: 0.72;
+}
+
+.filterable-data-grid-table .tag.muted,
+.filterable-data-grid-table .stage-pill.neutral,
+.filterable-data-grid-table .job-compensation-confidence-none {
+  box-shadow: none;
+  background: transparent;
+}
+
+.filterable-data-grid-table .job-compensation-confidence-high {
+  color: var(--success);
+}
+
+.filterable-data-grid-table .job-compensation-confidence-medium {
+  color: var(--warning);
+}
+
+.filterable-data-grid-table .job-compensation-confidence-low {
+  color: var(--destructive);
+}
+
+.data-table-pager {
+  min-height: 52px;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px;
+  background: transparent;
+}
+
+.data-table-pager .tab {
+  min-height: 30px;
+  border-color: transparent;
+  border-radius: 4px;
+  padding: 5px 9px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.data-table-pager .tab:hover:not(:disabled) {
+  border-color: transparent;
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.data-table-pager .meta {
+  padding-inline: 5px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.data-table-pager select {
+  min-height: 30px;
+  border-radius: 4px;
+  padding: 4px 25px 4px 8px;
+  font-size: 11px;
+}
+
+.data-table-views {
+  gap: 2px;
+}
+
+.data-table-views button,
+.data-table-views .saved-table-views-select select {
+  min-width: 30px;
+  min-height: 30px;
+  border-color: transparent;
+  border-radius: 4px;
+  background: transparent;
+  box-shadow: none;
+}
+
+.data-table-views button:hover:not(:disabled),
+.data-table-views .saved-table-views-select select:hover:not(:disabled) {
+  border-color: transparent;
+  background: var(--muted);
+}
+
+.data-table-views .saved-table-views-select {
+  gap: 5px;
+}
+
+.data-table-views .saved-table-views-select span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.data-table-views .saved-table-views-select select {
+  max-width: 158px;
+  padding: 4px 27px 4px 8px;
+  font-size: 11px;
+}
+
+.data-grid-column-filter-dialog .data-grid-filter-condition {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 4px 0;
+}
+
+.data-grid-filter-operator {
+  border-radius: 4px;
+}
+
+.data-grid-filter-operator button.active {
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.data-grid-value-list {
+  border-radius: 4px;
+}
+
+.data-grid-value-option {
+  border-radius: 3px;
+}
+
+.saved-table-density {
+  border-radius: 4px;
+}
+
+.saved-table-rule-list div,
+.saved-table-column-row {
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.data-table-scroll .data-table {
+  border-collapse: collapse;
+}
+
+.data-table-scroll .data-table thead tr {
+  background: color-mix(in oklch, var(--muted) 42%, var(--card));
+}
+
+.data-table-scroll .data-table th {
+  height: 38px;
+  padding-inline: 12px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 720;
+  letter-spacing: 0.07em;
+}
+
+.data-table-scroll .data-table td {
+  padding: 10px 12px;
+  border-color: color-mix(in oklch, var(--border) 82%, transparent);
+}
+
+.data-table-scroll .data-table tr:hover {
+  background: color-mix(in oklch, var(--foreground) 3%, var(--card));
+}
+
+.data-table-surface .table-head {
+  min-height: 38px;
+  background: color-mix(in oklch, var(--muted) 42%, var(--card));
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 720;
+  letter-spacing: 0.07em;
+}
+
+.data-table-surface .table-row-activatable:hover {
+  background: color-mix(in oklch, var(--foreground) 3%, var(--card));
+}
+
+.analytics-view .analytics-toolbar {
+  gap: 3px;
+  padding: 10px 16px;
+  background: transparent;
+}
+
+.analytics-view .segmented {
+  min-height: 28px;
+  border-color: transparent;
+  border-radius: 4px;
+  padding-inline: 9px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.analytics-view .segmented:hover,
+.analytics-view .segmented:focus-visible {
+  border-color: transparent;
+  background: var(--muted);
+}
+
+.analytics-view .segmented.active {
+  background: var(--foreground);
+  color: var(--background);
+  font-weight: 650;
+}
+
+.analytics-summary-strip {
+  grid-template-columns: repeat(auto-fit, minmax(144px, 1fr));
+}
+
+.analytics-summary-strip > div {
+  gap: 5px;
+  padding: 15px 16px 17px;
+}
+
+.analytics-summary-strip span {
+  font-weight: 650;
+}
+
+.analytics-summary-strip b {
+  font-size: 24px;
+  font-weight: 720;
+}
+
+.analytics-caption {
+  background: transparent;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .data-grid-toolbar {
+    gap: 8px;
+    padding-inline: 12px;
+  }
+
+  .data-grid-view-title .meta {
+    display: none;
+  }
+
+  .data-grid-filter-chips {
+    padding-inline: 12px;
+  }
+
+  .data-table-pager {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-inline: 12px;
+  }
+}

--- a/apps/web/src/styles/redesign-detail-surfaces.css
+++ b/apps/web/src/styles/redesign-detail-surfaces.css
@@ -1,0 +1,631 @@
+/* Secondary workspaces follow the same Rhea-inspired hierarchy as the main
+ * screens: one clear surface, calm dividers, and dense evidence rows. */
+
+.drawer-backdrop {
+  top: var(--topbar-height);
+  left: 232px;
+  align-items: stretch;
+  justify-content: center;
+  padding: 24px 36px 48px;
+  background: var(--background);
+  backdrop-filter: none;
+}
+
+.detail-drawer:not(.job-detail-drawer) {
+  position: relative;
+  width: min(920px, 100%);
+  max-height: calc(100dvh - var(--topbar-height) - 48px);
+  margin-left: auto;
+  margin-right: auto;
+  border: 1px solid color-mix(in oklch, var(--border) 82%, var(--foreground));
+  border-radius: calc(var(--radius) * 1.45);
+  background: var(--card);
+  box-shadow: 0 24px 70px color-mix(in oklch, var(--foreground) 22%, transparent);
+  scrollbar-gutter: stable;
+}
+
+.detail-drawer.artifact-detail-drawer {
+  width: min(1320px, 100%);
+}
+
+.drawer-close {
+  z-index: 4;
+  display: inline-flex;
+  width: 34px;
+  height: 34px;
+  align-items: center;
+  justify-content: center;
+  margin: 14px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: color-mix(in oklch, var(--card) 92%, transparent);
+  color: var(--muted-foreground);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 7%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.drawer-close:hover {
+  border-color: color-mix(in oklch, var(--foreground) 24%, var(--border));
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.detail-drawer:not(.job-detail-drawer) .drawer-head {
+  gap: 14px;
+  align-items: flex-start;
+  padding: 26px 64px 22px 28px;
+  background: var(--card);
+}
+
+.detail-drawer:not(.job-detail-drawer) .drawer-head > span:first-child {
+  padding-top: 2px;
+}
+
+.detail-drawer:not(.job-detail-drawer) .drawer-head small {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.detail-drawer:not(.job-detail-drawer) .drawer-head h2 {
+  margin: 2px 0 0;
+  font-size: clamp(20px, 2vw, 27px);
+  font-weight: 680;
+  letter-spacing: -0.035em;
+  line-height: 1.12;
+}
+
+.detail-drawer:not(.job-detail-drawer) .drawer-head p {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.detail-drawer:not(.job-detail-drawer) > .section,
+.contact-detail-drawer > .section,
+.contact-detail-drawer > .outreach-thread-panel {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  padding: 24px 28px;
+}
+
+.detail-drawer:not(.job-detail-drawer) > .section:last-child,
+.contact-detail-drawer > .outreach-thread-panel:last-child {
+  border-bottom: 0;
+}
+
+.detail-drawer:not(.job-detail-drawer) .section > h3,
+.detail-drawer:not(.job-detail-drawer) .outreach-thread-head h3 {
+  margin-bottom: 14px;
+  font-size: 13px;
+  font-weight: 680;
+  letter-spacing: -0.015em;
+}
+
+.detail-drawer:not(.job-detail-drawer) .detail-list {
+  gap: 0;
+  margin-bottom: 18px;
+  border-top: 1px solid var(--border);
+}
+
+.detail-drawer:not(.job-detail-drawer) .detail-list > div {
+  grid-template-columns: minmax(112px, 0.35fr) minmax(0, 1fr);
+  gap: 20px;
+  padding: 10px 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 76%, transparent);
+}
+
+.detail-drawer:not(.job-detail-drawer) .detail-list dt {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.detail-drawer:not(.job-detail-drawer) .detail-list dd {
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.detail-drawer:not(.job-detail-drawer) .timeline {
+  position: relative;
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.detail-drawer:not(.job-detail-drawer) .timeline::before {
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  left: 3px;
+  width: 1px;
+  background: var(--border);
+  content: "";
+}
+
+.detail-drawer:not(.job-detail-drawer) .timeline > li {
+  position: relative;
+  display: grid;
+  gap: 3px;
+  padding: 9px 0 9px 20px;
+}
+
+.detail-drawer:not(.job-detail-drawer) .timeline > li::before {
+  position: absolute;
+  top: 14px;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  border: 2px solid var(--card);
+  border-radius: 50%;
+  background: var(--muted-foreground);
+  box-shadow: 0 0 0 1px var(--border);
+  content: "";
+}
+
+.detail-drawer:not(.job-detail-drawer) .timeline p {
+  margin: 3px 0 0;
+  color: var(--muted-foreground);
+  line-height: 1.5;
+}
+
+/* Artifact details use one settings rail and one dominant preview surface. */
+.artifact-detail-layout {
+  grid-template-columns: minmax(330px, 380px) minmax(540px, 1fr);
+  min-height: calc(100dvh - 126px);
+}
+
+.artifact-detail-sidebar {
+  background: color-mix(in oklch, var(--muted) 30%, var(--card));
+}
+
+.artifact-detail-sidebar > .section,
+.artifact-detail-sidebar > .tailoring-explanation-section {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  padding: 22px 24px;
+  background: transparent;
+}
+
+.artifact-detail-sidebar > .section:last-child {
+  border-bottom: 0;
+}
+
+.artifact-detail-sidebar .tab + .tab {
+  margin-left: 6px;
+}
+
+.artifact-preview-panel {
+  display: grid;
+  min-height: 760px;
+  background: oklch(0.18 0 0);
+}
+
+.artifact-preview-panel .pdf-preview-viewer {
+  min-height: 100%;
+  border: 0;
+  border-radius: 0;
+}
+
+.artifact-preview-panel .pdf-preview-toolbar {
+  min-height: 48px;
+  padding: 9px 14px;
+  border-bottom-color: oklch(1 0 0 / 12%);
+  background: oklch(0.205 0 0);
+}
+
+.artifact-preview-panel .pdf-preview-pages {
+  padding: 28px;
+}
+
+.artifact-comparison,
+.artifact-comparison-body,
+.artifact-comparison-side,
+.artifact-comparison-delta {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.artifact-comparison-head,
+.artifact-comparison-side-head,
+.artifact-comparison-delta-head {
+  padding-right: 0;
+  padding-left: 0;
+  background: transparent;
+}
+
+.artifact-comparison-sides,
+.artifact-comparison-delta-grid {
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.artifact-comparison-side,
+.artifact-comparison-delta-grid > div {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.artifact-comparison-side + .artifact-comparison-side,
+.artifact-comparison-delta-grid > div:nth-child(even) {
+  padding-left: 12px;
+  border-left: 1px solid var(--border);
+}
+
+.artifact-comparison-tag-group .tag,
+.artifact-detail-sidebar .tag {
+  border: 0;
+  border-radius: 3px;
+}
+
+/* Contact details are a single thread, not a stack of cards. */
+.contact-detail-actions {
+  display: flex;
+  gap: 8px;
+  padding: 14px 28px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--muted) 34%, var(--card));
+}
+
+.contact-detail-drawer .contact-provenance-list,
+.contact-detail-drawer .outreach-draft-history-list,
+.contact-detail-drawer .outreach-send-log-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--border);
+  list-style: none;
+}
+
+.contact-detail-drawer .contact-provenance-item,
+.contact-detail-drawer .outreach-draft-history-item,
+.contact-detail-drawer .outreach-send-log-item {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 12px 0;
+  box-shadow: none;
+}
+
+.contact-detail-drawer .outreach-approved-draft,
+.contact-detail-drawer .outreach-candidate-draft,
+.contact-detail-drawer .outreach-send-log,
+.contact-detail-drawer .outreach-follow-up,
+.contact-detail-drawer .draft-gate-results,
+.contact-detail-drawer .draft-gate-block {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.contact-detail-drawer .outreach-approved-draft,
+.contact-detail-drawer .outreach-candidate-draft,
+.contact-detail-drawer .outreach-send-log,
+.contact-detail-drawer .outreach-follow-up {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.contact-detail-drawer .outreach-draft-body {
+  margin: 10px 0;
+  padding: 16px;
+  border-left: 2px solid var(--foreground);
+  border-radius: 0;
+  background: color-mix(in oklch, var(--muted) 46%, var(--card));
+  color: var(--foreground);
+  line-height: 1.65;
+}
+
+.contact-detail-drawer .outreach-draft-actions,
+.contact-detail-drawer .outreach-send-log-actions,
+.contact-detail-drawer .form-actions {
+  gap: 7px;
+}
+
+/* The evidence map is a three-pane research workspace; rows carry selection
+ * state so evidence, gaps, and provenance do not become card mosaics. */
+.evidence-map-view {
+  overflow: hidden;
+  border-radius: calc(var(--radius) * 1.15);
+}
+
+.evidence-map-view > .toolbar {
+  min-height: 64px;
+  padding: 12px 18px;
+  background: var(--card);
+}
+
+.evidence-map-toolbar label {
+  gap: 6px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+.evidence-map-shell {
+  grid-template-columns:
+    minmax(250px, 0.72fr)
+    minmax(410px, 1.18fr)
+    minmax(280px, 0.82fr);
+  min-height: 660px;
+  border-top: 1px solid var(--border);
+}
+
+.evidence-entry-list,
+.evidence-detail,
+.evidence-side-panel {
+  padding: 0;
+}
+
+.evidence-entry-list {
+  background: color-mix(in oklch, var(--muted) 28%, var(--card));
+}
+
+.evidence-entry-list > ul,
+.evidence-gap-list,
+.evidence-story-list {
+  gap: 0;
+}
+
+.evidence-entry-link {
+  align-items: flex-start;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 13px 15px;
+}
+
+.evidence-entry-link:hover {
+  background: color-mix(in oklch, var(--muted) 72%, var(--card));
+}
+
+.evidence-entry-link.selected {
+  background: var(--card);
+  box-shadow: inset 3px 0 0 var(--foreground);
+}
+
+.evidence-entry-link strong {
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.evidence-entry-link .muted {
+  font-size: 10px;
+}
+
+.evidence-entry-meta {
+  justify-content: flex-end;
+}
+
+.evidence-entry-meta .tag,
+.evidence-tags .tag,
+.evidence-chip-list .tag {
+  border: 0;
+  border-radius: 3px;
+  padding: 2px 5px;
+  font-size: 9px;
+}
+
+.evidence-detail {
+  gap: 0;
+}
+
+.evidence-detail > header {
+  gap: 8px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.evidence-detail > section,
+.evidence-detail-group,
+.evidence-story {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--border);
+}
+
+.evidence-detail > section:last-child {
+  border-bottom: 0;
+}
+
+.evidence-detail h2 {
+  font-size: 22px;
+  font-weight: 680;
+  letter-spacing: -0.03em;
+}
+
+.evidence-detail h3,
+.evidence-side-panel h2 {
+  font-size: 12px;
+  font-weight: 680;
+}
+
+.evidence-story dl > div {
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 14px;
+  padding: 8px 0;
+}
+
+.evidence-usage-list {
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.evidence-usage-link {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 10px 0;
+  font-size: 11px;
+}
+
+.evidence-usage-link:hover {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.evidence-side-panel {
+  align-content: start;
+  gap: 0;
+  background: color-mix(in oklch, var(--muted) 28%, var(--card));
+}
+
+.evidence-side-panel > h2 {
+  margin: 0;
+  padding: 18px 16px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted-foreground);
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.evidence-gap-list > li,
+.evidence-story-list > li {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 13px 16px;
+}
+
+.evidence-gap-list > li:hover,
+.evidence-story-list > li:hover {
+  background: color-mix(in oklch, var(--muted) 60%, var(--card));
+}
+
+.evidence-gap-list .tag {
+  width: fit-content;
+  border: 0;
+  border-radius: 3px;
+}
+
+/* Run timeline route uses the same dense event grammar as run drawers. */
+.apply-run-timeline {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 32px;
+}
+
+.apply-run-timeline-list {
+  position: relative;
+  gap: 0;
+}
+
+.apply-run-timeline-list::before {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 4px;
+  width: 1px;
+  background: var(--border);
+  content: "";
+}
+
+.apply-run-timeline-event {
+  grid-template-columns: 10px minmax(0, 1fr);
+  gap: 14px;
+  padding: 11px 0;
+}
+
+.apply-run-timeline-marker {
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  border: 2px solid var(--background);
+  box-shadow: 0 0 0 1px currentColor;
+}
+
+.apply-run-timeline-body {
+  gap: 5px;
+}
+
+.apply-run-timeline-head strong {
+  font-size: 12px;
+  font-weight: 650;
+}
+
+@media (max-width: 980px) {
+  .artifact-detail-layout,
+  .evidence-map-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .artifact-detail-sidebar,
+  .evidence-entry-list,
+  .evidence-detail {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .artifact-preview-panel {
+    min-height: 660px;
+  }
+
+  .evidence-map-shell {
+    min-height: 0;
+  }
+}
+
+@media (max-width: 1180px) and (min-width: 821px) {
+  .drawer-backdrop {
+    left: 68px;
+    padding: 20px 24px 40px;
+  }
+
+  .detail-drawer:not(.job-detail-drawer) {
+    max-height: calc(100dvh - var(--topbar-height) - 40px);
+  }
+}
+
+@media (max-width: 820px) {
+  .drawer-backdrop {
+    inset: 0;
+    padding: 0;
+  }
+
+  .detail-drawer:not(.job-detail-drawer),
+  .detail-drawer.artifact-detail-drawer {
+    width: 100dvw;
+    max-height: 100dvh;
+    border-width: 0;
+    border-radius: 0;
+  }
+}
+
+@media (max-width: 620px) {
+  .detail-drawer:not(.job-detail-drawer) .drawer-head,
+  .detail-drawer:not(.job-detail-drawer) > .section,
+  .contact-detail-drawer > .section,
+  .contact-detail-drawer > .outreach-thread-panel,
+  .contact-detail-actions {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .detail-drawer:not(.job-detail-drawer) .detail-list > div,
+  .evidence-story dl > div {
+    grid-template-columns: 1fr;
+    gap: 3px;
+  }
+
+  .artifact-preview-panel .pdf-preview-pages {
+    padding: 14px;
+  }
+
+  .apply-run-timeline {
+    padding: 22px 16px;
+  }
+}

--- a/apps/web/src/styles/redesign-job-detail.css
+++ b/apps/web/src/styles/redesign-job-detail.css
@@ -1,0 +1,877 @@
+/*
+ * Job detail is an editorial workspace, not a dashboard of independent
+ * status cards. It uses a single reading column, a narrow operational rail,
+ * and dividers to keep the dense audit record legible.
+ */
+
+.job-detail-drawer {
+  width: min(1440px, 100%);
+  block-size: calc(100dvh - var(--topbar-height) - 48px);
+  margin: 0 auto;
+  border-radius: 10px;
+  background: var(--card);
+  box-shadow: 0 24px 72px color-mix(in srgb, #000 22%, transparent);
+}
+
+.job-detail-drawer .drawer-close {
+  z-index: 2;
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  margin: 14px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  color: var(--muted-foreground);
+}
+
+.job-detail-drawer .drawer-close:hover,
+.job-detail-drawer .drawer-close:focus-visible {
+  border-color: var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.job-detail-drawer .drawer-head {
+  display: grid;
+  grid-template-columns: 60px minmax(0, 1fr);
+  gap: 18px;
+  padding: 30px 72px 24px 34px;
+  border-bottom: 1px solid var(--border);
+}
+
+.job-overview-score {
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  padding-top: 3px;
+}
+
+.job-overview-score-label,
+.job-overview-provenance,
+.job-overview-readiness-label,
+.job-detail-section-heading > span,
+.job-audit-triage-kicker,
+.job-audit-metrics dt,
+.job-audit-tag-group > span,
+.job-audit-fact-list dt,
+.job-detail-sidebar .section > h3,
+.compensation-detail-grid dt,
+.compensation-panel .eyebrow {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.075em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.job-detail-drawer .drawer-head .fit {
+  display: block;
+  width: auto;
+  height: auto;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  font-size: 34px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 690;
+  letter-spacing: -0.075em;
+  line-height: 0.95;
+}
+
+.job-detail-drawer .drawer-head .fit[data-score-tone="positive"] {
+  color: var(--success);
+}
+
+.job-detail-drawer .drawer-head .fit[data-score-tone="negative"] {
+  color: var(--destructive);
+}
+
+.job-detail-drawer .drawer-head .fit[data-score-tone="neutral"],
+.job-detail-drawer .drawer-head .fit[data-score-tone="unknown"] {
+  color: var(--muted-foreground);
+}
+
+.job-overview-copy {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.job-overview-provenance {
+  overflow-wrap: anywhere;
+}
+
+.job-detail-drawer .drawer-head h2 {
+  margin: 0;
+  color: var(--foreground);
+  font-family: var(--jh-font-heading);
+  font-size: clamp(24px, 2.1vw, 34px);
+  font-weight: 670;
+  letter-spacing: -0.055em;
+  line-height: 1.04;
+}
+
+.job-overview-location {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.job-overview-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 18px;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.job-detail-drawer .external-link {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 610;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+}
+
+.job-detail-drawer .external-link:hover {
+  text-decoration-color: currentColor;
+}
+
+.job-detail-drawer .job-overview-readiness {
+  gap: 7px;
+  margin: 0;
+}
+
+.job-detail-drawer .job-detail-top-actions {
+  gap: 12px 20px;
+  padding: 14px 34px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in oklch, var(--muted) 36%, var(--card));
+}
+
+.job-detail-drawer .job-detail-top-actions .action-panel {
+  flex: 1 1 620px;
+  gap: 5px;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.job-detail-drawer .job-detail-top-actions > .tab,
+.job-detail-drawer .action-panel .tab {
+  min-height: 30px;
+  border-radius: 5px;
+  padding: 6px 9px;
+  font-size: 11px;
+}
+
+.job-detail-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.33fr);
+  min-width: 0;
+  align-items: start;
+  border-top: 0;
+}
+
+.job-detail-primary,
+.job-detail-sidebar,
+.job-detail-follow-up {
+  min-width: 0;
+}
+
+.job-detail-sidebar {
+  position: sticky;
+  top: 0;
+  max-height: calc(100dvh - 176px);
+  overflow: auto;
+  border-left: 1px solid var(--border);
+  scrollbar-gutter: stable;
+}
+
+.job-detail-drawer .section {
+  padding: 24px 34px;
+  border-bottom: 1px solid var(--border);
+}
+
+.job-detail-drawer .section h3 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.018em;
+}
+
+.job-detail-sidebar .section {
+  padding: 21px 22px;
+}
+
+.job-detail-sidebar .section > h3 {
+  margin-bottom: 14px;
+}
+
+.job-detail-section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.job-detail-description .description-text {
+  max-width: 82ch;
+  gap: 14px;
+  color: color-mix(in oklch, var(--foreground) 88%, var(--muted-foreground));
+  font-size: 14px;
+  line-height: 1.63;
+}
+
+.job-detail-description .description-text h4 {
+  margin-top: 6px;
+  color: var(--foreground);
+  font-size: 14px;
+}
+
+.job-detail-description .description-text li {
+  margin-block: 4px;
+}
+
+.job-audit-triage {
+  background: color-mix(in oklch, var(--muted) 28%, var(--card));
+}
+
+.job-audit-triage-grid,
+.job-audit-triage-column {
+  gap: 16px;
+}
+
+.job-audit-triage-heading {
+  display: grid;
+  gap: 5px;
+}
+
+.job-audit-triage-heading h3 {
+  font-size: 17px !important;
+}
+
+.job-detail-drawer .job-audit-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.job-detail-drawer .job-audit-metrics > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 12px 14px 12px 0;
+  border-right: 1px solid var(--border);
+}
+
+.job-detail-drawer .job-audit-metrics > div:not(:first-child) {
+  padding-left: 14px;
+}
+
+.job-detail-drawer .job-audit-metrics > div:nth-child(3n) {
+  border-right: 0;
+}
+
+.job-detail-drawer .job-audit-metrics dd {
+  min-width: 0;
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 640;
+  overflow-wrap: anywhere;
+}
+
+.job-audit-rationale {
+  max-width: 88ch;
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.job-detail-drawer .job-audit-tag-group {
+  gap: 8px;
+  padding-top: 2px;
+}
+
+.job-detail-drawer .job-audit-tag-group > div,
+.job-detail-drawer .job-audit-fact-list dd {
+  gap: 6px 14px;
+}
+
+.job-detail-drawer .job-audit-tag-group .tag,
+.job-detail-drawer .job-audit-fact-list .tag,
+.job-detail-drawer .job-overview-readiness .tag,
+.job-detail-drawer .job-detail-sidebar .tag,
+.job-detail-drawer .compensation-audit-section .tag,
+.job-detail-drawer .job-detail-role-analysis .tag,
+.job-detail-drawer .interview-prep-panel .tag,
+.job-detail-drawer .job-detail-follow-up .tag,
+.job-detail-drawer .stage-pill {
+  display: inline-flex;
+  min-height: 0;
+  gap: 5px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  padding: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 590;
+  letter-spacing: 0;
+  line-height: 1.35;
+  text-transform: none;
+}
+
+.job-detail-drawer .tag::before,
+.job-detail-drawer .stage-pill::before {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  align-self: center;
+  border-radius: 999px;
+  background: currentColor;
+  content: "";
+}
+
+.job-detail-drawer .tag.ok,
+.job-detail-drawer .stage-pill.succeeded {
+  color: var(--success);
+}
+
+.job-detail-drawer .tag.warn,
+.job-detail-drawer .stage-pill.failed,
+.job-detail-drawer .stage-pill.exhausted,
+.job-detail-drawer .stage-pill.blocked {
+  color: var(--warning);
+}
+
+.job-detail-drawer .tag.danger {
+  color: var(--destructive);
+}
+
+.job-detail-drawer .tag.info,
+.job-detail-drawer .stage-pill.running,
+.job-detail-drawer .stage-pill.queued {
+  color: var(--status-info);
+}
+
+.job-detail-drawer .score-policy-row {
+  gap: 10px;
+  border-top: 1px solid var(--border);
+  padding: 13px 0 0;
+}
+
+.job-detail-drawer .job-audit-score-correction {
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.job-detail-drawer .score-correction {
+  display: grid;
+  grid-template-columns: 104px minmax(190px, 1fr) 34px;
+  gap: 8px 10px;
+  align-items: end;
+}
+
+.job-detail-drawer .score-correction label {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.job-detail-drawer .score-correction label > span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 620;
+}
+
+.job-detail-drawer .score-correction input {
+  min-width: 0;
+  height: 34px;
+  border-radius: 5px;
+  background: var(--card);
+  font-size: 12px;
+}
+
+.job-detail-drawer .score-correction button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid var(--foreground);
+  border-radius: 5px;
+  background: var(--foreground);
+  color: var(--background);
+}
+
+.job-detail-drawer .score-correction button:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--foreground) 88%, var(--background));
+}
+
+.job-detail-drawer .score-correction small {
+  grid-column: 1 / -1;
+  font-size: 11px;
+}
+
+.job-detail-drawer .job-audit-concerns {
+  gap: 10px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.job-detail-drawer .job-audit-fact-list > div {
+  grid-template-columns: 112px minmax(0, 1fr);
+  gap: 10px;
+  padding-block: 7px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border) 75%, transparent);
+}
+
+.job-detail-drawer .job-audit-fact-list > div:last-child {
+  border-bottom: 0;
+}
+
+.job-detail-drawer .compensation-audit-section {
+  gap: 16px;
+}
+
+.job-detail-drawer .compensation-audit-heading {
+  gap: 12px 18px;
+}
+
+.job-detail-drawer .compensation-refresh-control {
+  gap: 7px;
+}
+
+.job-detail-drawer .compensation-refresh-path {
+  min-width: min(248px, 100%);
+}
+
+.job-detail-drawer .compensation-strip {
+  gap: 8px 16px;
+  padding: 11px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+
+.job-detail-drawer .compensation-strip-label {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.job-detail-drawer .compensation-panels {
+  gap: 0;
+}
+
+.job-detail-drawer .compensation-panel {
+  gap: 13px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.job-detail-drawer .compensation-panel + .compensation-panel {
+  margin-left: 28px;
+  border-left: 1px solid var(--border);
+  padding-left: 28px;
+}
+
+.job-detail-drawer .compensation-panel header {
+  display: grid;
+  gap: 4px;
+  align-items: start;
+}
+
+.job-detail-drawer .compensation-panel header b {
+  color: var(--foreground);
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.job-detail-drawer .compensation-detail-grid {
+  gap: 9px 16px;
+}
+
+.job-detail-drawer .compensation-detail-grid > div {
+  gap: 4px;
+}
+
+.job-detail-drawer .compensation-detail-grid dd {
+  font-size: 12px;
+}
+
+.job-detail-drawer .compensation-evidence-row {
+  border: 0;
+  border-left: 2px solid var(--border);
+  border-radius: 0;
+  padding: 3px 0 3px 12px;
+}
+
+.job-detail-drawer .compensation-evidence-rows > summary b,
+.job-detail-drawer .compensation-warning-list code {
+  border-radius: 3px;
+}
+
+.job-detail-drawer .requirement-fit-missing {
+  margin: 0;
+  border-right: 0;
+  border-left: 3px solid var(--warning);
+  background: color-mix(in oklch, var(--warning) 7%, var(--card));
+}
+
+.job-detail-drawer .job-detail-role-analysis .employer-analysis {
+  gap: 12px;
+}
+
+.job-detail-drawer .job-detail-role-analysis .employer-analysis-requirement,
+.job-detail-drawer .job-detail-role-analysis .employer-analysis-keyword,
+.job-detail-drawer .job-detail-role-analysis .employer-analysis-sub {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0 0 14px;
+}
+
+.job-detail-drawer .job-detail-role-analysis .employer-analysis-match-side {
+  border-left: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 0 0 0 14px;
+}
+
+.job-detail-drawer .interview-prep-item {
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  padding: 0 0 14px;
+}
+
+.job-detail-drawer .timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.job-detail-drawer .timeline-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 12px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  padding: 11px 0;
+}
+
+.job-detail-drawer .timeline-row-head {
+  gap: 7px;
+}
+
+.job-detail-drawer .timeline-row > .tag {
+  justify-self: end;
+}
+
+.job-detail-drawer .timeline-diagnostics {
+  grid-column: 1 / -1;
+  gap: 5px;
+  border-left: 1px solid var(--border);
+  padding-left: 11px;
+}
+
+.job-detail-drawer .timeline-action {
+  grid-column: 1 / -1;
+  width: fit-content;
+  min-height: 29px;
+}
+
+.job-detail-drawer .section .mini-row {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 10px;
+  min-height: 0;
+  padding: 10px 0;
+}
+
+.job-detail-drawer .section .mini-row > .tag,
+.job-detail-drawer .section .mini-row > span:not(.tag) {
+  grid-row: 1;
+}
+
+.job-detail-drawer .section .mini-row > .tag {
+  grid-column: 2;
+  justify-self: end;
+}
+
+.job-detail-drawer .section .mini-row > span:not(.tag) {
+  grid-column: 1;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 610;
+}
+
+.job-detail-drawer .section .mini-row > code {
+  grid-column: 1;
+  grid-row: 2;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.job-detail-drawer .section .mini-row > button,
+.job-detail-drawer .section .mini-row > a {
+  grid-column: 2;
+  grid-row: 2;
+  justify-self: end;
+}
+
+.job-detail-drawer .job-audit-disclosure > summary {
+  justify-content: space-between;
+}
+
+.job-detail-drawer .job-audit-summary-title {
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.job-detail-drawer .job-audit-timeline {
+  gap: 0;
+  border-top: 1px solid var(--border);
+}
+
+.job-detail-drawer .job-audit-entry {
+  gap: 10px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.job-detail-drawer .job-audit-entry:last-child {
+  border-bottom: 0;
+}
+
+.job-detail-drawer .job-audit-marker {
+  width: 6px;
+  height: 6px;
+  margin-top: 7px;
+}
+
+.job-detail-drawer .job-audit-head {
+  gap: 4px 9px;
+}
+
+.job-detail-drawer .job-audit-head .tag {
+  color: var(--muted-foreground);
+}
+
+.job-detail-drawer .job-audit-head strong {
+  font-size: 12px;
+  font-weight: 630;
+}
+
+.job-detail-drawer .job-audit-description,
+.job-detail-drawer .job-audit-head time,
+.job-detail-drawer .job-audit-actor {
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.job-detail-drawer .job-audit-details div {
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 9px;
+}
+
+.job-detail-follow-up {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-top: 1px solid var(--border);
+}
+
+.job-detail-follow-up > .section {
+  min-height: 100%;
+  border-right: 1px solid var(--border);
+  border-bottom: 0;
+}
+
+.job-detail-follow-up > .section:last-child {
+  border-right: 0;
+}
+
+.job-detail-drawer .apply-history,
+.job-detail-drawer .outcome-timeline {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  margin: 0;
+}
+
+.job-detail-drawer .apply-history-row,
+.job-detail-drawer .outcome-timeline .timeline-row {
+  border-radius: 0;
+  background: transparent;
+}
+
+@media (max-width: 1040px) {
+  .job-detail-drawer {
+    width: 100%;
+    block-size: calc(100dvh - var(--topbar-height) - 32px);
+    margin: 0;
+  }
+
+  .job-detail-drawer .drawer-head {
+    padding-right: 60px;
+  }
+
+  .job-detail-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .job-detail-sidebar {
+    position: static;
+    max-height: none;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+  }
+
+  .job-detail-follow-up {
+    grid-template-columns: 1fr;
+  }
+
+  .job-detail-follow-up > .section {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 820px) {
+  .drawer-backdrop:has(.job-detail-drawer) {
+    inset: 0;
+    padding: 0;
+  }
+
+  .job-detail-drawer {
+    width: 100dvw;
+    block-size: 100dvh;
+    margin: 0;
+    border: 0;
+    border-radius: 0;
+  }
+
+  .job-detail-drawer .drawer-head {
+    grid-template-columns: 45px minmax(0, 1fr);
+    gap: 12px;
+    padding: 24px 48px 20px 20px;
+  }
+
+  .job-detail-drawer .drawer-close {
+    margin: 10px;
+  }
+
+  .job-detail-drawer .drawer-head .fit {
+    font-size: 27px;
+  }
+
+  .job-detail-drawer .drawer-head h2 {
+    font-size: 24px;
+  }
+
+  .job-detail-drawer .job-detail-top-actions,
+  .job-detail-drawer .section {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .job-detail-drawer .job-audit-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .job-detail-drawer .job-audit-metrics > div:nth-child(3n) {
+    border-right: 1px solid var(--border);
+  }
+
+  .job-detail-drawer .job-audit-metrics > div:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .job-detail-drawer .job-audit-metrics > div:nth-child(n + 3) {
+    border-top: 1px solid var(--border);
+  }
+
+  .job-detail-drawer .score-correction {
+    grid-template-columns: 84px minmax(0, 1fr) 34px;
+  }
+
+  .job-detail-drawer .compensation-panels {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .job-detail-drawer .compensation-panel + .compensation-panel {
+    margin-left: 0;
+    border-top: 1px solid var(--border);
+    border-left: 0;
+    padding-top: 18px;
+    padding-left: 0;
+  }
+
+  .job-detail-drawer .job-audit-fact-list > div {
+    grid-template-columns: 1fr;
+    gap: 5px;
+  }
+
+  .job-detail-drawer .job-detail-role-analysis .employer-analysis-requirement {
+    grid-template-columns: 1fr;
+  }
+
+  .job-detail-drawer .job-detail-role-analysis .employer-analysis-match-side {
+    border-top: 1px solid var(--border);
+    border-left: 0;
+    padding: 12px 0 0;
+  }
+}
+
+@media (max-width: 460px) {
+  .job-detail-drawer .job-audit-metrics,
+  .job-detail-drawer .score-correction {
+    grid-template-columns: 1fr;
+  }
+
+  .job-detail-drawer .job-audit-metrics > div,
+  .job-detail-drawer .job-audit-metrics > div:not(:first-child) {
+    border-right: 0;
+    border-top: 1px solid var(--border);
+    padding: 10px 0;
+  }
+
+  .job-detail-drawer .job-audit-metrics > div:first-child {
+    border-top: 0;
+  }
+
+  .job-detail-drawer .score-correction button {
+    width: 100%;
+  }
+}

--- a/apps/web/src/styles/redesign-overlays.css
+++ b/apps/web/src/styles/redesign-overlays.css
@@ -1,0 +1,97 @@
+/* Shared overlays and feedback use one restrained neutral surface language.
+ * Page-specific drawer geometry remains in the owning redesign stylesheets. */
+
+.empty {
+  display: flex;
+  min-height: 96px;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.empty > [data-slot="empty-title"] {
+  max-width: 54ch;
+}
+
+.banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  border: 1px solid color-mix(in oklch, var(--destructive) 28%, var(--border));
+  border-left: 3px solid var(--destructive);
+  border-radius: 8px;
+  background: var(--card);
+  padding: 11px 13px;
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.banner.inline {
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.banner[role="status"],
+.banner.credential-store-notice--guidance {
+  border-color: color-mix(in oklch, var(--status-info) 26%, var(--border));
+  border-left-color: var(--status-info);
+}
+
+.banner.credential-store-notice--failure,
+.banner[role="alert"] {
+  border-left-color: var(--destructive);
+}
+
+[data-slot="dialog-content"],
+[data-slot="sheet-content"],
+[data-slot="drawer-content"],
+[data-slot="popover-content"],
+[data-slot="dropdown-menu-content"],
+[data-slot="dropdown-menu-sub-content"],
+[data-slot="toast"] {
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--foreground) 7%, transparent),
+    0 18px 44px color-mix(in oklch, var(--foreground) 12%, transparent);
+}
+
+[data-slot="dialog-content"]:focus-visible,
+[data-slot="sheet-content"]:focus-visible,
+[data-slot="drawer-content"]:focus-visible,
+[data-slot="popover-content"]:focus-visible,
+[data-slot="dropdown-menu-content"]:focus-visible,
+[data-slot="dropdown-menu-sub-content"]:focus-visible {
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  [data-slot="dialog-content"] {
+    max-height: calc(100dvh - 32px);
+    overflow-y: auto;
+  }
+
+  [data-slot="toast-viewport"] {
+    padding: 12px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="dialog-overlay"],
+  [data-slot="dialog-content"],
+  [data-slot="sheet-overlay"],
+  [data-slot="sheet-content"],
+  [data-slot="popover-content"],
+  [data-slot="dropdown-menu-content"],
+  [data-slot="dropdown-menu-sub-content"],
+  [data-slot="tooltip-content"],
+  [data-slot="toast"] {
+    animation-duration: 1ms !important;
+    transition-duration: 1ms !important;
+  }
+}

--- a/apps/web/src/styles/redesign-profile-import.css
+++ b/apps/web/src/styles/redesign-profile-import.css
@@ -1,0 +1,706 @@
+/*
+ * Resume import is one focused, three-step subject. The layout uses a single
+ * Rhea-style surface with flat progress bands and dividers instead of nested
+ * decorative cards.
+ */
+
+.resume-import-page {
+  --resume-import-rule: color-mix(in oklch, var(--border) 88%, var(--foreground));
+  --resume-import-subtle: color-mix(in oklch, var(--muted) 58%, var(--card));
+  width: min(100%, 1240px);
+  margin-inline: auto;
+}
+
+.resume-import-wizard {
+  overflow: hidden;
+  border-color: var(--resume-import-rule);
+  border-radius: calc(var(--radius) * 1.25);
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--foreground) 5%, transparent),
+    0 18px 48px color-mix(in oklch, var(--foreground) 4%, transparent);
+}
+
+.resume-import-wizard__header {
+  display: flex;
+  min-height: 86px;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 28px;
+  border-bottom: 1px solid var(--resume-import-rule);
+  padding: 22px 26px 20px;
+}
+
+.resume-import-wizard__header > div:first-child {
+  display: grid;
+  gap: 5px;
+}
+
+.resume-import-wizard__header [data-slot="card-title"],
+.resume-import-wizard__header [role="heading"] {
+  color: var(--foreground);
+  font-size: 17px;
+  font-weight: 670;
+  letter-spacing: -0.03em;
+}
+
+.resume-import-wizard__progress {
+  flex: 0 0 auto;
+  padding-top: 2px;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 550;
+  letter-spacing: 0.02em;
+}
+
+.resume-import-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-bottom: 1px solid var(--resume-import-rule);
+  background: color-mix(in oklch, var(--muted) 34%, var(--card));
+}
+
+.resume-import-step-link {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  min-height: 76px;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  border-right: 1px solid var(--resume-import-rule);
+  padding: 14px 20px;
+  color: var(--muted-foreground);
+  text-decoration: none;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.resume-import-step-link:last-child {
+  border-right: 0;
+}
+
+.resume-import-step-link::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 2px;
+  background: transparent;
+  content: "";
+}
+
+.resume-import-step-link:hover,
+.resume-import-step-link:focus-visible {
+  background: var(--resume-import-subtle);
+  color: var(--foreground);
+}
+
+.resume-import-step-link:focus-visible {
+  z-index: 1;
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+.resume-import-step-link[data-active] {
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.resume-import-step-link[data-active]::after {
+  background: var(--foreground);
+}
+
+.resume-import-step-link[data-complete] {
+  color: var(--foreground);
+}
+
+.resume-import-step-link__number {
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.resume-import-step-link__copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.resume-import-step-link__copy strong {
+  overflow: hidden;
+  color: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-step-link__copy small {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-wizard__content {
+  padding: 0;
+}
+
+.resume-import-step {
+  display: grid;
+  gap: 22px;
+  padding: 30px 32px 32px;
+}
+
+.resume-import-step__header {
+  display: grid;
+  max-width: 76ch;
+  gap: 6px;
+}
+
+.resume-import-step__eyebrow {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.085em;
+  text-transform: uppercase;
+}
+
+.resume-import-step__header h2 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: clamp(21px, 2vw, 26px);
+  font-weight: 680;
+  letter-spacing: -0.04em;
+  line-height: 1.12;
+}
+
+.resume-import-step__header p,
+.resume-import-document-preview header p,
+.resume-import-step__hint {
+  margin: 0;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.resume-import-alert {
+  border: 1px solid color-mix(in oklch, var(--destructive) 34%, var(--border));
+  border-radius: calc(var(--radius) * 0.75);
+  background: color-mix(in oklch, var(--destructive) 6%, var(--card));
+  padding: 11px 13px;
+  color: var(--destructive);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: left;
+}
+
+.resume-import-target {
+  display: grid;
+  min-height: 154px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  border: 1px dashed color-mix(in oklch, var(--foreground) 28%, var(--border));
+  border-radius: calc(var(--radius) * 0.9);
+  background: color-mix(in oklch, var(--muted) 44%, var(--card));
+  padding: 24px;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    box-shadow 140ms ease;
+}
+
+.resume-import-target:hover {
+  border-color: color-mix(in oklch, var(--foreground) 52%, var(--border));
+  background: color-mix(in oklch, var(--muted) 68%, var(--card));
+}
+
+.resume-import-target:has(input:focus-visible) {
+  border-color: var(--foreground);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--foreground) 9%, transparent);
+}
+
+.resume-import-target[data-ready] {
+  border-style: solid;
+}
+
+.resume-import-target .resume-import-target__icon {
+  display: inline-flex;
+  width: 48px;
+  height: 58px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--resume-import-rule);
+  border-radius: calc(var(--radius) * 0.65);
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+
+.resume-import-target .resume-import-target__copy {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.resume-import-target__copy b {
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.resume-import-target__copy small {
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-size: 12px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-target input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.resume-import-target .resume-import-target__action {
+  display: block;
+  border-left: 1px solid var(--resume-import-rule);
+  padding: 6px 0 6px 18px;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 620;
+  white-space: nowrap;
+}
+
+.resume-import-step__hint {
+  margin-top: -10px;
+}
+
+.resume-import-actions {
+  display: flex;
+  grid-column: auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 9px;
+  border-top: 1px solid var(--resume-import-rule);
+  padding-top: 20px;
+}
+
+.resume-import-selected-file {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 11px;
+  border-block: 1px solid var(--resume-import-rule);
+  padding: 11px 2px;
+}
+
+.resume-import-selected-file > svg {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
+.resume-import-selected-file > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.resume-import-selected-file small {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.resume-import-selected-file strong {
+  overflow: hidden;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-option-set {
+  gap: 5px;
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.resume-import-option-set [data-slot="field-legend"] {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 660;
+  letter-spacing: -0.02em;
+}
+
+.resume-import-option-set > [data-slot="field-description"] {
+  margin: 0 0 8px;
+}
+
+.resume-import-option-set .resume-import-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  border: 0;
+  border-block: 1px solid var(--resume-import-rule);
+  border-radius: 0;
+  padding: 0;
+}
+
+.resume-import-option {
+  min-width: 0;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 16px 18px 17px 2px;
+}
+
+.resume-import-option + .resume-import-option {
+  border-left: 1px solid var(--resume-import-rule);
+  padding-left: 18px;
+}
+
+.resume-import-option [role="checkbox"] {
+  margin-top: 2px;
+}
+
+.resume-import-option [data-slot="field-label"] {
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.resume-import-option [data-slot="field-description"] {
+  max-width: 52ch;
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.resume-import-document-preview {
+  display: grid;
+  gap: 12px;
+  border-top: 1px solid var(--resume-import-rule);
+  padding-top: 22px;
+}
+
+.resume-import-document-preview > header {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.resume-import-document-preview > header > div {
+  display: grid;
+  gap: 3px;
+}
+
+.resume-import-document-preview h3 {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 14px;
+  font-weight: 660;
+  letter-spacing: -0.02em;
+}
+
+.resume-import-document-preview > header > span {
+  max-width: min(46ch, 50%);
+  overflow: hidden;
+  color: var(--muted-foreground);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-document-preview__viewer {
+  height: clamp(560px, 68vh, 820px);
+  overflow: hidden;
+  border: 1px solid var(--resume-import-rule);
+  border-radius: calc(var(--radius) * 0.85);
+  background: var(--muted);
+}
+
+.resume-import-document-preview .pdf-preview-viewer {
+  background: color-mix(in oklch, var(--muted) 82%, var(--card));
+}
+
+.resume-import-document-preview .pdf-preview-toolbar {
+  min-height: 46px;
+  background: var(--foreground);
+  color: var(--background);
+  font-size: 11px;
+}
+
+.resume-import-document-preview .pdf-preview-toolbar .toolbar-status {
+  color: color-mix(in oklch, var(--background) 72%, var(--foreground));
+}
+
+.resume-import-document-preview .pdf-preview-toolbar a {
+  color: var(--background);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in oklch, var(--background) 36%, transparent);
+  text-underline-offset: 3px;
+}
+
+.resume-import-document-preview .pdf-preview-pages {
+  padding: 24px;
+}
+
+.resume-import-document-preview .pdf-preview-page {
+  width: min(100%, 860px);
+}
+
+.resume-import-status {
+  border: 1px solid var(--resume-import-rule);
+  border-radius: calc(var(--radius) * 0.7);
+  padding: 10px 12px;
+  background: var(--resume-import-subtle);
+  color: var(--foreground);
+  font-size: 12px;
+}
+
+.resume-import-confirmation-summary {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  border-block: 1px solid var(--resume-import-rule);
+}
+
+.resume-import-confirmation-summary > div {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.28fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 22px;
+  padding: 14px 2px;
+}
+
+.resume-import-confirmation-summary > div + div {
+  border-top: 1px solid color-mix(in oklch, var(--border) 78%, transparent);
+}
+
+.resume-import-confirmation-summary dt {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 570;
+}
+
+.resume-import-confirmation-summary dd {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 620;
+}
+
+.resume-import-confirmation-summary dd span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resume-import-scope-review {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--resume-import-rule);
+}
+
+.resume-import-scope-review > div {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 15px 18px 16px 2px;
+  color: var(--muted-foreground);
+}
+
+.resume-import-scope-review > div + div {
+  border-left: 1px solid var(--resume-import-rule);
+  padding-left: 18px;
+}
+
+.resume-import-scope-review > div[data-selected] {
+  color: var(--foreground);
+}
+
+.resume-import-scope-review svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.resume-import-scope-review span {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.resume-import-scope-review strong {
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.resume-import-scope-review small {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.resume-import-empty-step {
+  justify-items: center;
+  padding-block: 54px;
+  text-align: center;
+}
+
+.resume-import-empty-step .empty {
+  padding: 0;
+}
+
+.resume-import-empty-step .resume-import-actions {
+  width: 100%;
+  justify-content: center;
+}
+
+@media (max-width: 820px) {
+  .resume-import-step-link {
+    min-height: 66px;
+    gap: 8px;
+    padding: 12px 14px;
+  }
+
+  .resume-import-step-link__copy small {
+    display: none;
+  }
+
+  .resume-import-step {
+    padding: 26px 24px 28px;
+  }
+
+  .resume-import-option-set .resume-import-options,
+  .resume-import-scope-review {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .resume-import-option + .resume-import-option,
+  .resume-import-scope-review > div + div {
+    border-top: 1px solid var(--resume-import-rule);
+    border-left: 0;
+    padding-left: 2px;
+  }
+}
+
+@media (max-width: 620px) {
+  .resume-import-wizard__header {
+    min-height: 0;
+    flex-direction: column;
+    gap: 10px;
+    padding: 18px 18px 16px;
+  }
+
+  .resume-import-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .resume-import-step-link {
+    min-height: 52px;
+    border-right: 0;
+    border-bottom: 1px solid var(--resume-import-rule);
+    padding: 10px 18px;
+  }
+
+  .resume-import-step-link:last-child {
+    border-bottom: 0;
+  }
+
+  .resume-import-step-link::after {
+    top: 0;
+    right: auto;
+    bottom: 0;
+    width: 2px;
+    height: auto;
+  }
+
+  .resume-import-step {
+    gap: 19px;
+    padding: 22px 18px 24px;
+  }
+
+  .resume-import-target {
+    min-height: 0;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 14px;
+    padding: 18px;
+  }
+
+  .resume-import-target .resume-import-target__action {
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--resume-import-rule);
+    border-left: 0;
+    padding: 12px 0 0;
+  }
+
+  .resume-import-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .resume-import-actions > * {
+    width: 100%;
+  }
+
+  .resume-import-document-preview > header {
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .resume-import-document-preview > header > span {
+    max-width: 100%;
+  }
+
+  .resume-import-document-preview__viewer {
+    height: 520px;
+  }
+
+  .resume-import-document-preview .pdf-preview-toolbar {
+    flex-wrap: wrap;
+  }
+
+  .resume-import-document-preview .pdf-preview-toolbar a {
+    margin-left: 0;
+  }
+
+  .resume-import-document-preview .pdf-preview-pages {
+    padding: 14px;
+  }
+
+  .resume-import-confirmation-summary > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 5px;
+  }
+}

--- a/apps/web/src/styles/redesign-route-gaps.css
+++ b/apps/web/src/styles/redesign-route-gaps.css
@@ -1,0 +1,160 @@
+/* Route-adjacent production surfaces that render outside the application shell.
+ * Keep them aligned with the neutral Rhea system instead of their older,
+ * promotional rounded-card treatment. */
+
+.demo-consent-shell {
+  min-height: 100dvh;
+  padding: clamp(20px, 5vw, 56px);
+  background: var(--background);
+  color: var(--foreground);
+}
+
+.demo-consent-card {
+  width: min(100%, 620px);
+  padding: clamp(24px, 4vw, 40px);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--foreground) 6%, transparent),
+    0 18px 50px color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+.demo-consent-mark {
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
+  background: var(--foreground);
+  color: var(--card);
+  font-size: 13px;
+  font-weight: 760;
+  letter-spacing: -0.04em;
+}
+
+.demo-consent-kicker {
+  margin: 24px 0 8px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+}
+
+.demo-consent-card h1 {
+  max-width: 16ch;
+  font-size: clamp(30px, 5vw, 42px);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 1.04;
+}
+
+.demo-consent-card p {
+  color: var(--muted-foreground);
+  line-height: 1.58;
+}
+
+.demo-consent-requirement {
+  margin-top: 22px;
+  color: var(--foreground) !important;
+  font-size: 14px;
+  font-weight: 620;
+}
+
+.demo-consent-return-note,
+.demo-consent-error {
+  margin-top: 16px;
+  padding: 10px 0 10px 13px;
+  border-radius: 0;
+  background: transparent;
+  font-size: 12px;
+}
+
+.demo-consent-return-note {
+  border-left: 2px solid var(--status-info);
+}
+
+.demo-consent-error {
+  border: 0;
+  border-left: 2px solid var(--destructive);
+  color: var(--destructive);
+}
+
+.demo-consent-links a {
+  color: var(--foreground);
+  font-weight: 620;
+  text-decoration-color: color-mix(in oklch, var(--foreground) 35%, transparent);
+  text-underline-offset: 3px;
+}
+
+.demo-consent-links a:hover,
+.demo-consent-links a:focus-visible {
+  text-decoration-color: var(--foreground);
+}
+
+.demo-consent-actions {
+  gap: 8px;
+  margin-top: 24px;
+}
+
+.demo-consent-actions button {
+  min-height: 40px;
+  padding: 9px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 650;
+  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.demo-consent-actions button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.demo-consent-accept {
+  border-color: var(--foreground);
+  background: var(--foreground);
+  color: var(--card);
+}
+
+.demo-consent-accept:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--foreground) 88%, var(--card));
+}
+
+.demo-consent-decline {
+  border-color: var(--border);
+  background: var(--card);
+  color: var(--foreground);
+}
+
+.demo-consent-decline:hover:not(:disabled) {
+  background: var(--muted);
+}
+
+.demo-guide-panel {
+  border-radius: 10px;
+  box-shadow:
+    0 1px 2px color-mix(in oklch, var(--foreground) 8%, transparent),
+    0 16px 40px color-mix(in oklch, var(--foreground) 11%, transparent);
+}
+
+.demo-guide-panel nav button {
+  border-radius: 6px;
+}
+
+@media (max-width: 520px) {
+  .demo-consent-shell {
+    place-items: stretch;
+    padding: 0;
+  }
+
+  .demo-consent-card {
+    min-height: 100dvh;
+    border: 0;
+    border-radius: 0;
+    padding: 28px 20px;
+    box-shadow: none;
+  }
+
+  .demo-consent-card h1 {
+    font-size: 32px;
+  }
+}

--- a/apps/web/src/styles/redesign-shell.css
+++ b/apps/web/src/styles/redesign-shell.css
@@ -1,0 +1,400 @@
+/*
+ * Rhea shell: a restrained, tool-like frame that keeps navigation and status
+ * visible without turning either into a stack of decorative cards. This file
+ * is intentionally imported after globals.css by the redesign entrypoint.
+ */
+
+.app-shell {
+  grid-template-columns: 232px minmax(0, 1fr);
+  min-height: 100dvh;
+  background: var(--background);
+}
+
+.main-shell {
+  background: var(--background);
+}
+
+.demo-workspace-notice,
+.demo-receipt-history {
+  margin: 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.demo-workspace-notice {
+  position: static;
+  gap: 4px 12px;
+  padding: 8px 28px;
+  background: color-mix(in oklch, var(--warning) 7%, var(--background));
+  font-size: 11px;
+}
+
+.demo-workspace-notice strong {
+  color: var(--foreground);
+}
+
+.demo-receipt-history {
+  padding: 8px 28px;
+  background: var(--card);
+  font-size: 11px;
+}
+
+.side-rail {
+  gap: 0;
+  padding: 18px 12px 16px;
+  background: var(--card);
+  border-right-color: var(--border);
+  backdrop-filter: none;
+}
+
+.side-rail__brand {
+  min-height: 40px;
+  margin: 0 0 20px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  color: var(--foreground);
+}
+
+.side-rail__brand:hover {
+  background: var(--muted);
+}
+
+.brand-lockup {
+  gap: 8px;
+}
+
+.brand-mark-svg {
+  width: 26px;
+  height: 26px;
+}
+
+.side-rail__wordmark {
+  font-size: 16px;
+  font-weight: 760;
+  letter-spacing: -0.045em;
+}
+
+.side-rail__nav {
+  gap: 0;
+  margin-top: 0;
+}
+
+.side-rail__group {
+  gap: 1px;
+}
+
+.side-rail__group + .side-rail__group {
+  margin-top: 18px;
+}
+
+.side-rail__group-label {
+  padding: 0 9px 5px;
+  color: var(--muted-foreground);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.085em;
+}
+
+.side-rail__link {
+  gap: 9px;
+  min-height: 34px;
+  padding: 7px 9px;
+  border-radius: 6px;
+  color: color-mix(in oklch, var(--foreground) 72%, var(--muted-foreground));
+  font-size: 12px;
+  font-weight: 560;
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+.side-rail__link:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.side-rail__link.on {
+  background: var(--foreground);
+  color: var(--card);
+  font-weight: 650;
+}
+
+.side-rail__link.on::before {
+  display: none;
+}
+
+.side-rail__icon {
+  width: 16px;
+  height: 16px;
+}
+
+.side-rail__footer {
+  gap: 7px;
+  margin-top: 12px;
+  padding: 12px 8px 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  font-size: 10px;
+}
+
+.side-rail__status-dot {
+  width: 7px;
+  height: 7px;
+  box-shadow: none;
+}
+
+.legal-notice {
+  gap: 1px;
+  font-size: 9px;
+  line-height: 1.45;
+}
+
+.legal-notice--rail {
+  padding: 12px 8px 0;
+}
+
+.side-rail__tagline {
+  font-size: 11px;
+}
+
+.topbar {
+  gap: 10px 16px;
+  min-height: 56px;
+  padding: 0 28px;
+  background: var(--background);
+  border-bottom-color: var(--border);
+  backdrop-filter: none;
+}
+
+.topbar__search {
+  display: flex;
+  flex: 1 1 300px;
+  align-items: center;
+  min-width: 220px;
+  max-width: 500px;
+  min-height: 34px;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted-foreground);
+  transition: border-color 120ms ease, color 120ms ease;
+}
+
+.topbar__search:focus-within {
+  border-bottom-color: var(--foreground);
+  color: var(--foreground);
+}
+
+.topbar__search-icon {
+  flex: 0 0 auto;
+}
+
+.global-search {
+  min-width: 0;
+  max-width: none;
+  min-height: 34px;
+  padding: 0 0 0 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-size: 12px;
+  outline: 0;
+}
+
+.global-search:focus-visible {
+  border-color: transparent;
+  outline: 0;
+}
+
+.global-search::placeholder {
+  color: var(--muted-foreground);
+  opacity: 0.82;
+}
+
+.topbar__density {
+  flex: 0 0 auto;
+}
+
+.topbar__density .select {
+  min-width: 100px;
+  min-height: 32px;
+  padding: 5px 28px 5px 9px;
+  border-color: var(--border);
+  border-radius: 5px;
+  background: var(--card);
+  font-size: 11px;
+  font-weight: 550;
+  text-transform: capitalize;
+}
+
+.topbar__theme-toggle {
+  min-height: 32px;
+  padding: 5px 0;
+  border-radius: 0;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 550;
+  text-transform: lowercase;
+}
+
+.topbar__theme-toggle:hover,
+.topbar__theme-toggle:focus-visible {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.connection-pill-group {
+  gap: 11px;
+  margin-left: auto;
+}
+
+.connection-pill,
+.connection-spend {
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.015em;
+}
+
+.connection-pill {
+  gap: 5px;
+  text-transform: lowercase;
+}
+
+.connection-pill::before {
+  width: 6px;
+  height: 6px;
+}
+
+.connection-pill[data-status="open"] {
+  color: var(--success);
+}
+
+.connection-spend[data-status="over_budget"],
+.connection-pill[data-status="closed"],
+.connection-pill[data-status="lost"] {
+  color: var(--destructive);
+}
+
+.connection-banner {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 40;
+  flex: 0 1 420px;
+  padding: 9px 12px;
+  border-radius: 6px;
+  background: var(--card);
+  box-shadow: 0 12px 24px color-mix(in oklch, var(--foreground) 8%, transparent);
+  font-size: 11px;
+}
+
+.connection-pill-group:has(.connection-banner) {
+  flex: 0 0 auto;
+}
+
+.main {
+  padding: 32px 36px 80px;
+}
+
+.sheet-nav {
+  gap: 0;
+  margin-top: 14px;
+}
+
+.sheet-nav .side-rail__group + .side-rail__group {
+  margin-top: 18px;
+}
+
+.sheet-nav .side-rail__link {
+  padding: 7px 9px;
+}
+
+@media (max-width: 1180px) {
+  .app-shell {
+    grid-template-columns: 68px minmax(0, 1fr);
+  }
+
+  .side-rail {
+    padding: 18px 10px 14px;
+  }
+
+  .side-rail__brand {
+    margin-bottom: 18px;
+    padding: 4px;
+  }
+
+  .side-rail__link {
+    padding: 7px;
+  }
+
+  .side-rail__footer {
+    padding: 0;
+    border-top: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .topbar {
+    gap: 8px 12px;
+    min-height: 58px;
+    padding: 10px 16px;
+  }
+
+  .topbar .topbar__hamburger {
+    min-height: 32px;
+    padding: 5px;
+    border-radius: 5px;
+  }
+
+  .topbar__search {
+    flex-basis: 220px;
+    order: 1;
+  }
+
+  .topbar__density {
+    order: 2;
+  }
+
+  .topbar__theme-toggle {
+    order: 3;
+  }
+
+  .connection-pill-group {
+    order: 4;
+  }
+
+  .main {
+    padding: 24px 16px 56px;
+  }
+
+  .demo-workspace-notice,
+  .demo-receipt-history {
+    padding-right: 16px;
+    padding-left: 16px;
+  }
+}
+
+@media (max-width: 560px) {
+  .topbar__search {
+    order: 5;
+    flex-basis: 100%;
+    max-width: none;
+  }
+
+  .connection-spend {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .side-rail__link,
+  .topbar__search {
+    transition: none;
+  }
+}

--- a/apps/web/src/styles/token-contract.test.ts
+++ b/apps/web/src/styles/token-contract.test.ts
@@ -122,10 +122,10 @@ describe("shadcn token contract", () => {
       expect(matches.length, `expected light and dark definitions for token ${token}`).toBeGreaterThanOrEqual(2);
     }
 
-    expect(tokensCss, "expected the mock-up 8px radius token").toContain("--radius: 0.5rem;");
-    expect(tokensCss, "expected light violet primary value").toContain("--primary: oklch(0.541 0.281 293.009);");
-    expect(tokensCss, "expected dark violet primary value").toContain("--primary: oklch(0.702 0.183 293.541);");
-    expect(tokensCss, "expected violet-ramp chart token").toContain("--chart-1: oklch(0.541 0.281 293.009);");
+    expect(tokensCss, "expected the Rhea radius token").toContain("--radius: 0.625rem;");
+    expect(tokensCss, "expected light near-black primary value").toContain("--primary: oklch(0.145 0 0);");
+    expect(tokensCss, "expected dark near-white primary value").toContain("--primary: oklch(0.985 0 0);");
+    expect(tokensCss, "expected neutral chart ramp anchor").toContain("--chart-1: oklch(0.24 0 0);");
   });
 
   it("maps tokens through Tailwind CSS-first theme variables", () => {
@@ -176,7 +176,7 @@ describe("shadcn token contract", () => {
   });
 
   it("keeps shadcn preset config and packages wired", () => {
-    expect(componentsJson.style, "expected luma/radix shadcn style").toBe("radix-luma");
+    expect(componentsJson.style, "expected Rhea/Base shadcn style").toBe("base-rhea");
     expect(componentsJson.tailwind.config, "expected CSS-first shadcn Tailwind config").toBe("");
     expect(componentsJson.tailwind.css, "expected shadcn to use the global CSS entrypoint").toBe(
       "src/styles/globals.css",
@@ -190,9 +190,9 @@ describe("shadcn token contract", () => {
     expect(packageJson.dependencies.shadcn, "expected shadcn dependency").toBe("4.11.0");
     expect(packageJson.dependencies["tw-animate-css"], "expected Tailwind v4 animation dependency").toBe("1.4.0");
     expect(
-      packageJson.dependencies["@fontsource-variable/plus-jakarta-sans"],
-      "expected Plus Jakarta Sans font dependency",
-    ).toBe("5.2.8");
+      packageJson.dependencies["@fontsource-variable/geist"],
+      "expected Geist font dependency",
+    ).toBe("^5.2.9");
     expect(
       packageJson.dependencies["@fontsource-variable/jetbrains-mono"],
       "expected JetBrains Mono font dependency",

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -1,40 +1,40 @@
 :root {
   color-scheme: light;
-  --radius: 0.5rem;
+  --radius: 0.625rem;
 
-  --background: oklch(0.967 0.003 264.542);
+  --background: oklch(0.972 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.541 0.281 293.009);
-  --primary-foreground: oklch(0.985 0.006 293);
-  --secondary: oklch(0.967 0.001 286.375);
-  --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.535 0 0);
-  --accent: oklch(0.943 0.029 294.588);
-  --accent-foreground: oklch(0.541 0.281 293.009);
+  --primary: oklch(0.145 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.94 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.948 0 0);
+  --muted-foreground: oklch(0.49 0 0);
+  --accent: oklch(0.93 0 0);
+  --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.928 0.006 264.531);
-  --input: oklch(0.928 0.006 264.531);
-  --ring: oklch(0.541 0.281 293.009 / 0.36);
+  --border: oklch(0.89 0 0);
+  --input: oklch(0.82 0 0);
+  --ring: oklch(0.32 0 0 / 0.34);
 
-  --chart-1: oklch(0.541 0.281 293.009);
-  --chart-2: oklch(0.606 0.25 292.717);
-  --chart-3: oklch(0.702 0.183 293.541);
-  --chart-4: oklch(0.811 0.111 293.571);
-  --chart-5: oklch(0.894 0.057 293.283);
+  --chart-1: oklch(0.24 0 0);
+  --chart-2: oklch(0.38 0 0);
+  --chart-3: oklch(0.52 0 0);
+  --chart-4: oklch(0.66 0 0);
+  --chart-5: oklch(0.78 0 0);
 
-  --sidebar: oklch(1 0 0 / 0.84);
+  --sidebar: oklch(0.99 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.541 0.281 293.009);
-  --sidebar-primary-foreground: oklch(0.985 0.006 293);
-  --sidebar-accent: oklch(0.943 0.029 294.588);
-  --sidebar-accent-foreground: oklch(0.541 0.281 293.009);
-  --sidebar-border: oklch(0.928 0.006 264.531);
-  --sidebar-ring: oklch(0.541 0.281 293.009 / 0.36);
+  --sidebar-primary: oklch(0.145 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.94 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.89 0 0);
+  --sidebar-ring: oklch(0.32 0 0 / 0.34);
 
   --success: oklch(0.54 0.13 145);
   --success-foreground: oklch(0.985 0 0);
@@ -42,20 +42,20 @@
   --warning: oklch(0.72 0.15 72);
   --warning-foreground: oklch(0.145 0 0);
   --warning-muted: color-mix(in oklch, var(--warning) 16%, var(--card));
-  --status-info: oklch(0.56 0.11 242);
+  --status-info: oklch(0.56 0.12 242);
   --status-info-foreground: oklch(0.985 0 0);
   --status-info-muted: color-mix(in oklch, var(--status-info) 14%, var(--card));
 
-  --shadow-panel: 0 12px 34px rgb(31 41 55 / 0.08);
+  --shadow-panel: 0 1px 2px rgb(0 0 0 / 0.05);
   --rail-width: 236px;
   --rail-width-collapsed: 72px;
   --topbar-height: 60px;
 
   --jh-font-sans:
-    "Plus Jakarta Sans Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Geist Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
   --jh-font-heading:
-    "Plus Jakarta Sans Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    "Geist Variable", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
   --jh-font-mono:
     "JetBrains Mono Variable", "SFMono-Regular", ui-monospace, Menlo, Consolas, monospace;
 }
@@ -65,37 +65,37 @@
 
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
+  --card: oklch(0.185 0 0);
   --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
+  --popover: oklch(0.185 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.702 0.183 293.541);
-  --primary-foreground: oklch(0.21 0.03 293.5);
-  --secondary: oklch(0.274 0.006 286.033);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.145 0 0);
+  --secondary: oklch(0.27 0 0);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.269 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.32 0.075 293.5);
-  --accent-foreground: oklch(0.87 0.08 293.5);
+  --accent: oklch(0.29 0 0);
+  --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.702 0.183 293.541 / 0.4);
+  --input: oklch(1 0 0 / 18%);
+  --ring: oklch(0.85 0 0 / 0.42);
 
-  --chart-1: oklch(0.702 0.183 293.541);
-  --chart-2: oklch(0.606 0.25 292.717);
-  --chart-3: oklch(0.541 0.281 293.009);
-  --chart-4: oklch(0.811 0.111 293.571);
-  --chart-5: oklch(0.894 0.057 293.283);
+  --chart-1: oklch(0.9 0 0);
+  --chart-2: oklch(0.76 0 0);
+  --chart-3: oklch(0.62 0 0);
+  --chart-4: oklch(0.48 0 0);
+  --chart-5: oklch(0.34 0 0);
 
-  --sidebar: oklch(0.205 0 0 / 0.86);
+  --sidebar: oklch(0.17 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.702 0.183 293.541);
-  --sidebar-primary-foreground: oklch(0.21 0.03 293.5);
-  --sidebar-accent: oklch(0.32 0.075 293.5);
-  --sidebar-accent-foreground: oklch(0.87 0.08 293.5);
+  --sidebar-primary: oklch(0.985 0 0);
+  --sidebar-primary-foreground: oklch(0.145 0 0);
+  --sidebar-accent: oklch(0.29 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.702 0.183 293.541 / 0.4);
+  --sidebar-ring: oklch(0.85 0 0 / 0.42);
 
   --success: oklch(0.66 0.14 145);
   --success-foreground: oklch(0.145 0 0);
@@ -107,7 +107,7 @@
   --status-info-foreground: oklch(0.145 0 0);
   --status-info-muted: color-mix(in oklch, var(--status-info) 18%, var(--card));
 
-  --shadow-panel: 0 12px 34px rgb(0 0 0 / 0.45);
+  --shadow-panel: 0 1px 2px rgb(0 0 0 / 0.28);
 }
 
 :where(.app-shell) {

--- a/apps/web/src/views/analytics/AnalyticsView.tsx
+++ b/apps/web/src/views/analytics/AnalyticsView.tsx
@@ -49,6 +49,8 @@ export function AnalyticsView() {
   const analytics = analyticsQuery.data ?? null;
   const message = analyticsQuery.error instanceof Error ? analyticsQuery.error.message : null;
   const applied = analytics?.totals.applied ?? 0;
+  const activeDimensionLabel =
+    DIMENSION_OPTIONS.find((option) => option.value === dimension)?.label ?? "Dimension";
 
   const setDimension = (next: AnalyticsDimension) => {
     void navigate({ search: (prev: AnalyticsSearch) => ({ ...prev, dimension: next }) });
@@ -61,58 +63,64 @@ export function AnalyticsView() {
         title="Outcome analytics"
         subtitle={analytics ? `${applied} applied` : "loading"}
       />
-      <section className="card full analytics-view">
+      <section className="card full analytics-view data-list-card" aria-label="Outcome analytics workspace">
         {message ? <div className="banner inline">{message}</div> : null}
-        <div className="analytics-toolbar" role="group" aria-label="Outcome analytics dimension">
-          {DIMENSION_OPTIONS.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              className={option.value === dimension ? "segmented active" : "segmented"}
-              aria-pressed={option.value === dimension}
-              onClick={() => setDimension(option.value)}
-            >
-              {option.label}
-            </button>
-          ))}
-          <label className="analytics-select-label">
-            <span>Dimension</span>
-            <select
-              className="select"
-              value={dimension}
-              onChange={(event) => {
-                const next = event.target.value;
-                if (isAnalyticsDimension(next)) setDimension(next);
-              }}
-            >
-              {DIMENSION_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </label>
+        <div className="analytics-controls">
+          <div className="analytics-controls-copy">
+            <span>Breakdown</span>
+            <strong>{activeDimensionLabel}</strong>
+          </div>
+          <div className="analytics-toolbar" role="group" aria-label="Outcome analytics dimension">
+            {DIMENSION_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={option.value === dimension ? "segmented active" : "segmented"}
+                aria-pressed={option.value === dimension}
+                onClick={() => setDimension(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+            <label className="analytics-select-label">
+              <span>Dimension</span>
+              <select
+                className="select"
+                value={dimension}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  if (isAnalyticsDimension(next)) setDimension(next);
+                }}
+              >
+                {DIMENSION_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
-        <div className="analytics-summary-strip">
-          <div>
-            <span>Applied</span>
-            <b>{analytics?.totals.applied ?? "-"}</b>
+        <dl className="analytics-summary-strip" aria-label="Outcome summary">
+          <div className="analytics-summary-metric analytics-summary-metric-primary">
+            <dt>Applied</dt>
+            <dd>{analytics?.totals.applied ?? "-"}</dd>
           </div>
-          <div>
-            <span>Replies</span>
-            <b>{analytics?.totals.reply ?? "-"}</b>
+          <div className="analytics-summary-metric analytics-summary-metric-primary">
+            <dt>Replies</dt>
+            <dd>{analytics?.totals.reply ?? "-"}</dd>
           </div>
-          <div>
-            <span>Interviews</span>
-            <b>{analytics?.totals.interview ?? "-"}</b>
+          <div className="analytics-summary-metric analytics-summary-metric-primary">
+            <dt>Interviews</dt>
+            <dd>{analytics?.totals.interview ?? "-"}</dd>
           </div>
-          <div>
-            <span>Offers</span>
-            <b>{analytics?.totals.offer ?? "-"}</b>
+          <div className="analytics-summary-metric analytics-summary-metric-primary">
+            <dt>Offers</dt>
+            <dd>{analytics?.totals.offer ?? "-"}</dd>
           </div>
-          <div>
-            <span>Median response</span>
-            <b>
+          <div className="analytics-summary-metric analytics-summary-metric-secondary">
+            <dt>Median response</dt>
+            <dd>
               {analytics
                 ? formatDuration(
                     analytics.timeToResponse.medianMinutes,
@@ -120,11 +128,11 @@ export function AnalyticsView() {
                     analytics.minSample,
                   )
                 : "-"}
-            </b>
+            </dd>
           </div>
-          <div>
-            <span>Suggestions accepted</span>
-            <b>
+          <div className="analytics-summary-metric analytics-summary-metric-secondary">
+            <dt>Suggestions accepted</dt>
+            <dd>
               {analytics
                 ? formatAcceptance(
                     analytics.suggestionAccuracy.acceptanceRate,
@@ -132,9 +140,9 @@ export function AnalyticsView() {
                     analytics.minSample,
                   )
                 : "-"}
-            </b>
+            </dd>
           </div>
-        </div>
+        </dl>
         <SmallSampleNotice {...(analytics ? { minSample: analytics.minSample } : {})} />
         <DimensionBreakdownPanel
           analytics={analytics}

--- a/apps/web/src/views/analytics/DimensionBreakdownPanel.tsx
+++ b/apps/web/src/views/analytics/DimensionBreakdownPanel.tsx
@@ -85,8 +85,16 @@ export function DimensionBreakdownPanel({
 }: DimensionBreakdownPanelProps) {
   const rows = analytics ? outcomeRows(analytics, dimension) : [];
   return rows.length || loading ? (
-    <OutcomeRateTable rows={rows} loading={loading} />
+    <div className="analytics-breakdown-region">
+      <OutcomeRateTable
+        rows={rows}
+        loading={loading}
+        title={`Outcomes by ${DIMENSION_LABELS[dimension].toLowerCase()}`}
+      />
+    </div>
   ) : (
-    <Empty title={`No ${DIMENSION_LABELS[dimension].toLowerCase()} outcome rows yet.`} />
+    <div className="analytics-breakdown-empty">
+      <Empty title={`No ${DIMENSION_LABELS[dimension].toLowerCase()} outcome rows yet.`} />
+    </div>
   );
 }

--- a/apps/web/src/views/analytics/OutcomeRateTable.tsx
+++ b/apps/web/src/views/analytics/OutcomeRateTable.tsx
@@ -59,13 +59,15 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
     getSortValue: (row) => row.label,
     getFilterValue: (row) => row.label,
     render: (row) => (
-      <span className="title-stack">
+      <span className="title-stack analytics-group-cell">
         <b>{row.label}</b>
-        <span>
+        <span className="analytics-group-meta">
           <span className={`tag ${row.badgeTone}`}>{row.dimension}</span> {countLabel(row)}
         </span>
       </span>
     ),
+    className: "analytics-group-column",
+    headerClassName: "analytics-group-column",
   },
   {
     id: "applied",
@@ -73,6 +75,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
     sortable: true,
     getSortValue: (row) => row.applied,
     render: (row) => <span className="mono">{row.applied}</span>,
+    className: "analytics-applied-column",
+    headerClassName: "analytics-applied-column",
   },
   {
     id: "reply",
@@ -85,6 +89,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
         <span>{row.reply} replies</span>
       </span>
     ),
+    className: "analytics-rate-column",
+    headerClassName: "analytics-rate-column",
   },
   {
     id: "interview",
@@ -97,6 +103,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
         <span>{row.interview} interviews</span>
       </span>
     ),
+    className: "analytics-rate-column",
+    headerClassName: "analytics-rate-column",
   },
   {
     id: "offer",
@@ -109,6 +117,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
         <span>{row.offer} offers</span>
       </span>
     ),
+    className: "analytics-rate-column",
+    headerClassName: "analytics-rate-column",
   },
   {
     id: "rejection",
@@ -121,6 +131,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
         <span>{row.rejection} rejections</span>
       </span>
     ),
+    className: "analytics-rate-column",
+    headerClassName: "analytics-rate-column",
   },
 ];
 
@@ -166,14 +178,19 @@ function sortRows(rows: readonly OutcomeRateRow[], sort: DataGridSortState): Out
 export interface OutcomeRateTableProps {
   readonly rows: readonly OutcomeRateRow[];
   readonly loading: boolean;
+  readonly title?: string;
 }
 
-export function OutcomeRateTable({ rows, loading }: OutcomeRateTableProps) {
+export function OutcomeRateTable({
+  rows,
+  loading,
+  title = "Outcome analytics table",
+}: OutcomeRateTableProps) {
   const [sort, setSort] = useState<DataGridSortState>({ columnId: "applied", direction: "desc" });
   const sortedRows = useMemo(() => sortRows(rows, sort), [rows, sort]);
   return (
     <FilterableDataGrid<OutcomeRateRow>
-      title="Outcome analytics table"
+      title={title}
       data={sortedRows}
       columns={outcomeRateColumns}
       getRowId={(row) => row.id}

--- a/apps/web/src/views/analytics/SmallSampleNotice.tsx
+++ b/apps/web/src/views/analytics/SmallSampleNotice.tsx
@@ -1,3 +1,5 @@
+import { IconInfoCircle } from "@tabler/icons-react";
+
 export interface SmallSampleNoticeProps {
   minSample?: number;
 }
@@ -8,10 +10,13 @@ export function SmallSampleNotice({ minSample }: SmallSampleNoticeProps) {
       ? "A rate appears once a group reaches the minimum sample count"
       : `A rate appears once a group has at least ${minSample} applications`;
   return (
-    <p className="analytics-caption">
-      Descriptive associations from your own recorded outcomes — not causal claims. Recorded outcomes from
-      canonical rows only. {sampleText}; smaller groups show counts only. Analytics never
-      enter scoring, ranking, or apply eligibility.
-    </p>
+    <aside className="analytics-caption" aria-label="Analytics interpretation note">
+      <IconInfoCircle size={15} aria-hidden="true" />
+      <p>
+        Descriptive associations from your own recorded outcomes — not causal claims. Recorded outcomes from
+        canonical rows only. {sampleText}; smaller groups show counts only. Analytics never
+        enter scoring, ranking, or apply eligibility.
+      </p>
+    </aside>
   );
 }

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -41,6 +41,7 @@ import { MarkdownDocument } from "../../shared/ui/MarkdownDocument.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 import type { PdfAuditLineSelection, PdfAuditLineTarget } from "../../shared/ui/PdfPreviewViewer.js";
 import { JobDetailDrawer } from "../jobs/JobDetailDrawer.js";
+import "../../styles/redesign-apply-review.css";
 
 type MaterialStatus = {
   readonly kind: ApplyReviewQueueItem["applyAudit"]["state"];
@@ -76,6 +77,13 @@ function auditTone(state: ApplyReviewQueueItem["applyAudit"]["state"]): Material
   if (state === "ready") return "ok";
   if (state === "preparing") return "info";
   return "warn";
+}
+
+function fitTone(score: number | null): "positive" | "neutral" | "negative" | "unknown" {
+  if (score === null || !Number.isFinite(score)) return "unknown";
+  if (score >= 7) return "positive";
+  if (score >= 5) return "neutral";
+  return "negative";
 }
 
 function selectedItem(
@@ -419,7 +427,7 @@ function ApplyReviewQueue({
   return (
     <aside className="apply-review-queue" aria-label="Application review queue">
       <div className="apply-review-queue-head">
-        <span className="eyebrow">Queue</span>
+        <span>Review queue</span>
         <b>{items.length} human decision{items.length === 1 ? "" : "s"}</b>
       </div>
       <div className="apply-review-queue-list">
@@ -434,7 +442,17 @@ function ApplyReviewQueue({
               onClick={() => onSelect(item.jobKey)}
             >
               <span className="apply-review-queue-title">
-                <span className="tag ok">{item.fitScore ?? "-"}</span>
+                <span
+                  className="apply-review-queue-fit"
+                  data-score-tone={fitTone(item.fitScore)}
+                  aria-label={
+                    item.fitScore === null
+                      ? "Fit score not recorded"
+                      : `Fit score ${item.fitScore} out of 10`
+                  }
+                >
+                  {item.fitScore ?? "–"}
+                </span>
                 <b>{item.title}</b>
               </span>
               <span className="meta">
@@ -1101,6 +1119,7 @@ function ResumeReviewSurface({
 function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
   const reviewState = reviewStateLabel(item);
   const activeRun = activeApplyRun(item);
+  const status = materialStatus(item);
   const resumeAuditArtifactId = item.materialsPreview.resumeTextArtifactId ?? item.materialsPreview.resumePdfArtifactId;
   const templatesQuery = useResumeTemplatesQuery();
   const setJobTemplate = useSetJobResumeTemplateMutation();
@@ -1185,20 +1204,38 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
           className="apply-review-selected-context"
           aria-label={`Review controls and material facts for ${item.title}`}
         >
-          {reviewState ? <span className="tag muted">Current decision: {reviewState}.</span> : null}
-          <CompensationSummaryStrip
-            summary={item.compensationSummary}
-            label="Compensation"
-          />
-          <ApplyAuditFacts item={item} />
-          <JobResumeTemplateSelect
-            current={item.materialsPreview.resumeTemplate}
-            disabled={templatesQuery.isLoading || setJobTemplate.isPending || ensureCurrentMaterials.isPending}
-            onTemplateChange={handleTemplateChange}
-            refreshing={setJobTemplate.isPending || ensureCurrentMaterials.isPending}
-            templates={templatesQuery.data?.templates ?? []}
-          />
-          {templateMutationError ? <span className="tag warn">{templateMutationError}</span> : null}
+          <div className="apply-review-selected-identity">
+            <span className="apply-review-selected-label">Decision workspace</span>
+            <h2>{item.title}</h2>
+            <p>{item.company} · discovered via {item.source}</p>
+          </div>
+          <div className="apply-review-selected-summary" aria-label="Selected job status">
+            <span className="apply-review-selected-score" data-score-tone={fitTone(item.fitScore)}>
+              <b>{item.fitScore ?? "–"}</b>
+              <span>fit</span>
+            </span>
+            <span className={`apply-review-inline-state ${status.tone}`}>
+              {status.label}
+            </span>
+            {reviewState ? <span className="apply-review-inline-state muted">{reviewState}</span> : null}
+          </div>
+          <div className="apply-review-selected-facts">
+            <CompensationSummaryStrip
+              summary={item.compensationSummary}
+              label="Compensation"
+            />
+            <JobResumeTemplateSelect
+              current={item.materialsPreview.resumeTemplate}
+              disabled={templatesQuery.isLoading || setJobTemplate.isPending || ensureCurrentMaterials.isPending}
+              onTemplateChange={handleTemplateChange}
+              refreshing={setJobTemplate.isPending || ensureCurrentMaterials.isPending}
+              templates={templatesQuery.data?.templates ?? []}
+            />
+            <ApplyAuditFacts item={item} />
+            {templateMutationError ? (
+              <span className="apply-review-inline-state warn">{templateMutationError}</span>
+            ) : null}
+          </div>
         </div>
         <div className="apply-review-selected-actions">
           <button
@@ -1237,7 +1274,7 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
       ) : null}
 
       <section className="apply-review-workspace" aria-label={`Review evidence for ${item.title}`}>
-        <article className="apply-review-pane">
+        <article className="apply-review-pane apply-review-evidence-pane">
           <header>
             <span className="eyebrow">Job Position</span>
             <h2>Requirements and original post</h2>
@@ -1260,15 +1297,21 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
                 <Empty title="No captured job post text." />
               )}
             </section>
+            <RequirementLedAuditPanel audit={item.materialsPreview.requirementLedAudit} />
           </div>
         </article>
 
-        <article className="apply-review-pane">
+        <article className="apply-review-pane apply-review-materials-pane">
           <header>
             <span className="eyebrow">Application Materials</span>
             <h2>Tailored resume and cover</h2>
           </header>
           <div className="apply-review-pane-scroll apply-review-materials-scroll">
+            <ResumeReviewSurface
+              item={item}
+              onComparisonTargetChange={handleComparisonTargetChange}
+              onDraftGateChange={handleDraftGateChange}
+            />
             {resumeAuditArtifactId ? <ArtifactGroundingRiskPanel artifactId={resumeAuditArtifactId} /> : null}
             <ArtifactComparison
               emptyRightMessage="Render a saved draft to compare it with the accepted artifact."
@@ -1277,12 +1320,6 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
               rightArtifactId={comparisonDraft?.artifactId ?? null}
               rightLabel="Rendered draft"
               rightRiskLabels={comparisonDraft?.riskLabels ?? []}
-            />
-            <RequirementLedAuditPanel audit={item.materialsPreview.requirementLedAudit} />
-            <ResumeReviewSurface
-              item={item}
-              onComparisonTargetChange={handleComparisonTargetChange}
-              onDraftGateChange={handleDraftGateChange}
             />
             <EmailApplicationPreview item={item} />
             <TextPreview
@@ -1344,7 +1381,7 @@ export function ApplyReviewView({
         title="Application review"
         subtitle={`${readyCount} ready · ${preparingCount} preparing · ${repairCount} need repair`}
       />
-      <section className="card full">
+      <section className="apply-review-surface">
         {queueError ? <div className="banner inline">{queueError}</div> : null}
         {queue.isFetching && !queue.data ? <Empty title="Loading review queue." /> : null}
         {queue.data && selected ? (

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -1,4 +1,5 @@
 import type { ArtifactSummary } from "@jobctrl/contracts";
+import { IconX } from "@tabler/icons-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -114,7 +115,7 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
           type="button"
           onClick={close}
         >
-          x
+          <IconX aria-hidden="true" size={18} stroke={1.8} />
         </button>
         {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
         {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}

--- a/apps/web/src/views/artifacts/ArtifactsView.tsx
+++ b/apps/web/src/views/artifacts/ArtifactsView.tsx
@@ -72,7 +72,7 @@ export function ArtifactsView() {
         title="Artifacts"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-list-card">
         {message ? <div className="banner inline">{message}</div> : null}
         <ArtifactFilterBar search={search} />
         <ArtifactsTable

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -37,8 +37,12 @@ export function DashboardView() {
     (suggestion) => suggestion.status === "pending",
   );
   return (
-    <>
-      <PageHead eyebrow="Overview" title="Dashboard" />
+    <div className="dashboard-view">
+      <PageHead
+        eyebrow="Overview"
+        title="Dashboard"
+        subtitle="Pipeline health, outcomes, active work, and the decisions that need attention."
+      />
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
       {message ? <div className="banner">{message}</div> : null}
       {outcomesError ? <div className="banner">{outcomesError}</div> : null}
@@ -74,6 +78,6 @@ export function DashboardView() {
       ) : (
         <Empty title={isLoading ? "Loading dashboard." : "No dashboard data."} />
       )}
-    </>
+    </div>
   );
 }

--- a/apps/web/src/views/dashboard/WorkStatusCard.tsx
+++ b/apps/web/src/views/dashboard/WorkStatusCard.tsx
@@ -25,11 +25,13 @@ export function WorkStatusCard({ summary }: { summary: DashboardSummary }) {
       />
       <div className="grid grid-cols-2 gap-3 p-4">
         <StatCard
+          className="work-status-stat"
           label="Active work"
           value={work.active}
           delta="queued or moving"
         />
         <StatCard
+          className="work-status-stat"
           label="Stuck work"
           value={work.stuck}
           valueTone={work.stuck ? "down" : undefined}

--- a/apps/web/src/views/debug/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.tsx
@@ -1,3 +1,4 @@
+import { IconX } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
@@ -36,7 +37,7 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
           type="button"
           onClick={close}
         >
-          x
+          <IconX aria-hidden="true" size={18} stroke={1.8} />
         </button>
         {!activity ? (
           <Empty title={`Activity event ${eventId} is no longer in the recent list.`} />

--- a/apps/web/src/views/debug/DebugView.tsx
+++ b/apps/web/src/views/debug/DebugView.tsx
@@ -69,7 +69,7 @@ export function DebugView() {
         title="Debug"
         subtitle={data ? `${data.pagination.total} activity events` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-list-card">
         {message ? <div className="banner inline">{message}</div> : null}
         <DebugFilterBar search={search} onChange={setSearch} />
         <DebugActivityTable

--- a/apps/web/src/views/discovery/DiscoveryView.test.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.test.tsx
@@ -9,8 +9,12 @@ describe("DiscoveryView", () => {
   it("renders discovery controls as tabs with a source registry table", async () => {
     renderWithProviders(<DiscoveryView />);
 
-    expect(await screen.findByRole("heading", { name: "Discovery settings" })).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Target search" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Target search" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 3, name: "Target search" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Target tracks" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Management" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Director of Engineering" })).toBeInTheDocument();

--- a/apps/web/src/views/discovery/DiscoveryView.tsx
+++ b/apps/web/src/views/discovery/DiscoveryView.tsx
@@ -8,7 +8,7 @@ export function DiscoveryView() {
   return (
     <>
       <PageHead eyebrow="Pipeline" title="Discovery" />
-      <div className="discovery-view-stack">
+      <div className="discovery-view-stack discovery-workspace">
         <TargetSearchSettingsPanel />
         <DiscoveryAutomationSettingsPanel />
         <DiscoveryRuntimeSettingsPanel />

--- a/apps/web/src/views/jobs/JobAuditTriage.tsx
+++ b/apps/web/src/views/jobs/JobAuditTriage.tsx
@@ -20,8 +20,11 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
     <section className="section job-audit-triage" aria-label="Job audit triage">
       <div className="job-audit-triage-grid">
         <div className="job-audit-triage-column">
-          <div className="job-audit-triage-kicker">Ranking</div>
-          <div className="job-audit-metrics" aria-label="Ranking summary">
+          <header className="job-audit-triage-heading">
+            <span className="job-audit-triage-kicker">Assessment</span>
+            <h3>Fit & evidence</h3>
+          </header>
+          <dl className="job-audit-metrics" aria-label="Ranking summary">
             <Metric label="Fit score" value={`${job.fitScore ?? "-"}/10`} />
             <Metric label="Band" value={score?.fitBand ?? "not recorded"} />
             <Metric label="Confidence" value={score?.confidence ?? "not recorded"} />
@@ -32,11 +35,11 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
                 <Metric label="Must-haves" value={percent(requirementFitReport.summary.mustHaveCoverage)} />
               </>
             ) : null}
-          </div>
+          </dl>
           {reasoning ? (
-            <p>{reasoning}</p>
+            <p className="job-audit-rationale">{reasoning}</p>
           ) : (
-            <p className="muted">No score rationale was stored for this job.</p>
+            <p className="job-audit-rationale muted">No score rationale was stored for this job.</p>
           )}
           {requirementFitReport ? (
             <RequirementFitGroups report={requirementFitReport} />
@@ -61,7 +64,10 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
               />
             </div>
           ) : null}
-          <ScoreCorrectionControl jobId={job.jobKey} currentScore={job.fitScore} />
+          <div className="job-audit-score-correction">
+            <span className="job-audit-triage-kicker">Score correction</span>
+            <ScoreCorrectionControl jobId={job.jobKey} currentScore={job.fitScore} />
+          </div>
           {factGroups.length ? (
             <div className="job-audit-concerns">
               <div className="job-audit-triage-kicker">Apply concerns</div>
@@ -96,8 +102,8 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
 function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div>
-      <span>{label}</span>
-      <b>{value}</b>
+      <dt>{label}</dt>
+      <dd>{value}</dd>
     </div>
   );
 }

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -1,5 +1,6 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
 import type { JobAuditEntry, StageSummary } from "@jobctrl/contracts";
+import { IconX } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
 import { ApplyHistory } from "../../contexts/apply/components/ApplyHistory.js";
@@ -106,7 +107,7 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
           type="button"
           onClick={onClose}
         >
-          x
+          <IconX aria-hidden="true" size={18} stroke={1.8} />
         </button>
         {errorMessage ? <Empty title={errorMessage} /> : null}
         {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
@@ -140,61 +141,71 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                   Evidence map
                 </Link>
               </div>
-              <JobAuditTriage detail={detail} />
-              <CompensationAuditSection
-                jobId={detail.job.jobKey}
-                summary={detail.job.compensationSummary}
-                audit={detail.compensationAudit}
-                fallbackSalary={detail.job.salary}
-              />
-              <section className="section job-detail-description">
-                <h3>Description</h3>
-                <JobDescription text={detail.job.descriptionPreview} />
-              </section>
-              <div className="job-detail-drawer-main">
-                <Section title="Preparation diagnostics">
-                  <StageTimeline
+              <div className="job-detail-workspace job-detail-drawer-main">
+                <main className="job-detail-primary">
+                  <JobAuditTriage detail={detail} />
+                  <section className="section job-detail-description">
+                    <div className="job-detail-section-heading">
+                      <h3>Description</h3>
+                      <span>Original posting text</span>
+                    </div>
+                    <JobDescription text={detail.job.descriptionPreview} />
+                  </section>
+                  <CompensationAuditSection
                     jobId={detail.job.jobKey}
-                    stages={preparationStages(detail.stages)}
+                    summary={detail.job.compensationSummary}
+                    audit={detail.compensationAudit}
+                    fallbackSalary={detail.job.salary}
                   />
-                </Section>
-                <Section title="Active artifacts">
-                  {detail.artifacts.length ? (
-                    detail.artifacts.map((artifact) => (
-                      <div className="mini-row" key={artifact.artifactId}>
-                        <ArtifactStatusBadge status={artifact.status} />
-                        <span>{artifact.type}</span>
-                        <code>{artifact.localPath}</code>
-                        <OpenArtifactButton
-                          artifactId={artifact.artifactId}
-                          disabled={artifact.status === "missing"}
+                  {detail.employerAnalysis && !detail.requirementFitReport ? (
+                    <RequirementFitMissingCallout jobId={detail.job.jobKey} />
+                  ) : null}
+                  <EmployerAnalysisPanel
+                    analysis={detail.employerAnalysis}
+                    className="section job-detail-role-analysis"
+                    requirementFitReport={detail.requirementFitReport}
+                  />
+                  <InterviewPrepPanel
+                    jobId={detail.job.jobKey}
+                    prep={detail.interviewPrep}
+                    reflectionContent={
+                      detail.interviewPrep ? (
+                        <InterviewReflectionPanel
+                          jobId={detail.job.jobKey}
+                          prepGeneration={detail.interviewPrep.generation}
                         />
-                      </div>
-                    ))
-                  ) : (
-                    <Empty title="No active apply-ready artifacts." />
-                  )}
-                </Section>
-                {detail.employerAnalysis && !detail.requirementFitReport ? (
-                  <RequirementFitMissingCallout jobId={detail.job.jobKey} />
-                ) : null}
-                <EmployerAnalysisPanel
-                  analysis={detail.employerAnalysis}
-                  className="section job-detail-role-analysis"
-                  requirementFitReport={detail.requirementFitReport}
-                />
-                <InterviewPrepPanel
-                  jobId={detail.job.jobKey}
-                  prep={detail.interviewPrep}
-                  reflectionContent={
-                    detail.interviewPrep ? (
-                      <InterviewReflectionPanel
-                        jobId={detail.job.jobKey}
-                        prepGeneration={detail.interviewPrep.generation}
-                      />
-                    ) : null
-                  }
-                />
+                      ) : null
+                    }
+                  />
+                </main>
+                <aside className="job-detail-sidebar" aria-label="Job preparation and audit">
+                  <Section title="Preparation diagnostics">
+                    <StageTimeline
+                      jobId={detail.job.jobKey}
+                      stages={preparationStages(detail.stages)}
+                    />
+                  </Section>
+                  <Section title="Active artifacts">
+                    {detail.artifacts.length ? (
+                      detail.artifacts.map((artifact) => (
+                        <div className="mini-row" key={artifact.artifactId}>
+                          <ArtifactStatusBadge status={artifact.status} />
+                          <span>{artifact.type}</span>
+                          <code>{artifact.localPath}</code>
+                          <OpenArtifactButton
+                            artifactId={artifact.artifactId}
+                            disabled={artifact.status === "missing"}
+                          />
+                        </div>
+                      ))
+                    ) : (
+                      <Empty title="No active apply-ready artifacts." />
+                    )}
+                  </Section>
+                  <JobAuditHistorySection entries={detail.auditHistory} />
+                </aside>
+              </div>
+              <div className="job-detail-follow-up">
                 <Section title="Apply history">
                   <ApplyHistory jobId={detail.job.jobKey} />
                 </Section>
@@ -205,7 +216,6 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
                   jobId={detail.job.jobKey}
                   {...(detail.job.company ? { employer: detail.job.company } : {})}
                 />
-                <JobAuditHistorySection entries={detail.auditHistory} />
               </div>
             </div>
           </>

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -14,28 +14,33 @@ function auditTone(state: JobDetail["applyAudit"]["state"]): "ok" | "info" | "wa
 export function JobOverview({ detail }: JobOverviewProps) {
   const { applyAudit, job } = detail;
   return (
-    <div className="drawer-head">
-      <ScoreBadge score={job.fitScore} />
-      <span>
-        <small>
+    <header className="drawer-head job-overview">
+      <div className="job-overview-score" aria-label={`Fit score ${job.fitScore ?? "not scored"}`}>
+        <span className="job-overview-score-label">Fit</span>
+        <ScoreBadge score={job.fitScore} />
+      </div>
+      <div className="job-overview-copy">
+        <small className="job-overview-provenance">
           {job.company}
           {job.postingSource ? ` · posting: ${job.postingSource}` : ""}
           {job.discoverySource ? ` · discovered via: ${job.discoverySource}` : ""}
         </small>
         <h2>{job.title}</h2>
-        <p>
+        <p className="job-overview-location">
           {job.location || "-"} · {job.salary || "-"}
         </p>
-        <a className="external-link" href={job.url} rel="noreferrer" target="_blank">
-          open original posting
-        </a>
-        <div className="job-overview-readiness" aria-label="Apply readiness">
-          <span className="job-overview-readiness-label">Apply readiness</span>
-          <span className={`tag ${auditTone(applyAudit.state)}`} title={applyAudit.summary}>
-            {applyAudit.label}
-          </span>
+        <div className="job-overview-meta-row">
+          <a className="external-link" href={job.url} rel="noreferrer" target="_blank">
+            open original posting
+          </a>
+          <div className="job-overview-readiness" aria-label="Apply readiness">
+            <span className="job-overview-readiness-label">Apply readiness</span>
+            <span className={`tag ${auditTone(applyAudit.state)}`} title={applyAudit.summary}>
+              {applyAudit.label}
+            </span>
+          </div>
         </div>
-      </span>
-    </div>
+      </div>
+    </header>
   );
 }

--- a/apps/web/src/views/jobs/JobsView.tsx
+++ b/apps/web/src/views/jobs/JobsView.tsx
@@ -672,7 +672,7 @@ export function JobsView() {
         title="Jobs"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-list-card">
         {message ? <div className="banner inline">{message}</div> : null}
         <JobBulkActions
           search={search}

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
@@ -1,4 +1,5 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
+import { IconX } from "@tabler/icons-react";
 
 import { ContactDeleteButton } from "../../contexts/outreach/components/ContactDeleteButton.js";
 import { ContactEditButton } from "../../contexts/outreach/components/ContactEditButton.js";
@@ -45,7 +46,7 @@ export function OutreachDetailDrawer({ contactId, onClose }: OutreachDetailDrawe
           type="button"
           onClick={onClose}
         >
-          x
+          <IconX aria-hidden="true" size={18} stroke={1.8} />
         </button>
         {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
         {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}

--- a/apps/web/src/views/outreach/OutreachView.tsx
+++ b/apps/web/src/views/outreach/OutreachView.tsx
@@ -43,7 +43,7 @@ export function OutreachView() {
         actions={<DueFollowUpsBadge />}
       />
       <DueFollowUpsPanel />
-      <section className="card full">
+      <section className="card full data-list-card">
         {message ? <div className="banner inline">{message}</div> : null}
         <div className="toolbar">
           <label className="field compact">

--- a/apps/web/src/views/runs/RunsView.tsx
+++ b/apps/web/src/views/runs/RunsView.tsx
@@ -76,7 +76,7 @@ export function RunsView() {
         title="Workflow runs"
         subtitle={data ? `${data.pagination.total} total` : "loading"}
       />
-      <section className="card full">
+      <section className="card full data-list-card">
         {message ? <div className="banner inline">{message}</div> : null}
         <RunsFilterBar
           status={search.status}

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -1,3 +1,4 @@
+import { IconX } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
@@ -44,7 +45,7 @@ export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
           type="button"
           onClick={close}
         >
-          x
+          <IconX aria-hidden="true" size={18} stroke={1.8} />
         </button>
         {message ? <Empty title={message} /> : null}
         {!message && isLoading ? <Empty title="Loading workflow run." /> : null}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,10 +144,10 @@ importers:
       '@base-ui/react':
         specifier: ^1.6.0
         version: 1.6.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@fontsource-variable/geist':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@fontsource-variable/jetbrains-mono':
-        specifier: 5.2.8
-        version: 5.2.8
-      '@fontsource-variable/plus-jakarta-sans':
         specifier: 5.2.8
         version: 5.2.8
       '@jobctrl/api-client':
@@ -1092,11 +1092,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@fontsource-variable/geist@5.2.9':
+    resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
+
   '@fontsource-variable/jetbrains-mono@5.2.8':
     resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
-
-  '@fontsource-variable/plus-jakarta-sans@5.2.8':
-    resolution: {integrity: sha512-iQecBizIdZxezODNHzOn4SvvRMrZL/S8k4MEXGDynCmUrImVW0VmX+tIAMqnADwH4haXlHSXqMgU6+kcfBQJdw==}
 
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
@@ -7536,9 +7536,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource-variable/jetbrains-mono@5.2.8': {}
+  '@fontsource-variable/geist@5.2.9': {}
 
-  '@fontsource-variable/plus-jakarta-sans@5.2.8': {}
+  '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@hapi/address@5.1.1':
     dependencies:


### PR DESCRIPTION
## Summary

- establishes the neutral Rhea-inspired JobCtrl interface system with Geist typography, restrained radii, semantic text and rule-based status treatments
- redesigns the shell, shared primitives, overlays, dashboard, data tables, analytics, job detail, Apply Review, configuration, resume import, and routed detail workspaces
- preserves existing controls, states, audit evidence, actions, and product data while replacing the previous card-heavy and pill-heavy presentation
- uses the real resume and PDF preview components on material and import surfaces

## Why

The previous implementation mixed inconsistent component treatments, excessive rounded status containers, nested cards, cramped controls, and large unused areas. This stack layer applies one coherent visual language after the Base UI migration and before the pipeline operations work from #439 is adapted.

## Stack

- Base: #457
- Design plan: #440
- Next: adapted pipeline operations visibility from #439
- Final stack tip: canonical docs and cumulative product QA

## Validation

No build, typecheck, browser pass, or QA was run in this intermediate PR. This stack is not released between phases; validation is intentionally deferred until the pipeline implementation and canonical documentation are complete, as agreed for the cumulative final branch.