### PR TITLE
feat(pipeline): expose operations snapshot

### DIFF
--- a/apps/api/src/pipeline-eta.ts
+++ b/apps/api/src/pipeline-eta.ts
@@ -1,0 +1,403 @@
+/**
+ * Pure, explainable ETA estimation for the pipeline operations read model.
+ *
+ * This module deliberately receives already bounded projection/telemetry facts;
+ * it neither opens a database nor reaches Temporal.  Keeping evidence selection
+ * here makes the estimator's source and fallback rules testable in isolation.
+ */
+
+export const PIPELINE_ETA_ESTIMATOR_VERSION = "pipeline-eta-v1" as const;
+export const PIPELINE_ETA_MINIMUM_SAMPLES = 5;
+export const PIPELINE_ETA_MAX_SAMPLES = 50;
+export const PIPELINE_ETA_SAMPLE_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
+
+export type PipelineEtaEvidenceSource =
+  | "job_stage_state"
+  | "pipeline_step_projection"
+  | "operational_attempt_metric";
+
+/** A terminal duration candidate supplied by the operations read model. */
+export interface PipelineEtaDurationSample {
+  readonly source: PipelineEtaEvidenceSource;
+  readonly succeeded: boolean;
+  readonly durationMs: number | null;
+  readonly completedAt: string;
+}
+
+/**
+ * A unit of current-cohort service demand.  `primaryEvidence` ensures canonical
+ * stage rows and orchestration-step projections stay separate; operational
+ * metrics are considered only when the primary source has no usable evidence.
+ */
+export interface PipelineEtaStageInput {
+  readonly stage: string;
+  readonly remainingCurrentStage: number;
+  readonly primaryEvidence: Exclude<PipelineEtaEvidenceSource, "operational_attempt_metric">;
+  readonly samples: readonly PipelineEtaDurationSample[];
+}
+
+/** The remaining required stage sequence for one current-cohort job. */
+export interface PipelineEtaRemainingPath {
+  readonly stageIds: readonly string[];
+}
+
+/** Bounded external work that competes for the same shared activity slots. */
+export interface PipelineEtaBoundedContention {
+  readonly kind: "bounded";
+  readonly existingBacklog: readonly PipelineEtaStageDemand[];
+  readonly retries: readonly PipelineEtaStageDemand[];
+  /** Approximate infrastructure queue work was observed, even if its count is zero. */
+  readonly queuePresent: boolean;
+}
+
+export interface PipelineEtaStageDemand {
+  readonly stage: string;
+  readonly count: number;
+}
+
+/** A missing, truncated, or unresolved queue-ahead observation cannot be bounded safely. */
+export interface PipelineEtaUnboundedContention {
+  readonly kind: "unknown" | "truncated" | "unresolved";
+}
+
+export type PipelineEtaContention = PipelineEtaBoundedContention | PipelineEtaUnboundedContention;
+
+/** All data needed to estimate one current execution without database access. */
+export interface PipelineEtaEstimatorInput {
+  readonly asOf: string;
+  readonly scope: "known" | "unknown";
+  /** True until terminal reconciliation has closed the execution's job membership. */
+  readonly membershipOpen: boolean;
+  readonly telemetryFresh: boolean;
+  readonly workerAvailable: boolean;
+  readonly budgetAvailable: boolean;
+  readonly blocked: boolean;
+  readonly dispatchObserved: boolean;
+  readonly configuredSlots: number | null;
+  readonly stages: readonly PipelineEtaStageInput[];
+  readonly remainingPaths: readonly PipelineEtaRemainingPath[];
+  readonly contention: PipelineEtaContention;
+}
+
+/** Structural counterpart of the shared `PipelineEta` API union. */
+export type PipelineEtaEstimate =
+  | {
+      readonly status: "available";
+      readonly lowSeconds: number;
+      readonly highSeconds: number;
+      readonly confidence: "low" | "medium" | "high";
+      readonly basis: "source_rate" | "stage_throughput" | "cohort_throughput";
+      readonly sampleSize: number;
+      readonly asOf: string;
+      readonly caveat: string | null;
+    }
+  | {
+      readonly status: "calibrating";
+      readonly reason: "insufficient_samples" | "membership_open";
+      readonly completedSamples: number;
+      readonly minimumSamples: number;
+      readonly asOf: string;
+    }
+  | {
+      readonly status: "paused";
+      readonly reason: "worker_unavailable" | "budget_exceeded" | "blocked" | "no_dispatch";
+      readonly asOf: string;
+    }
+  | {
+      readonly status: "stale";
+      readonly reason: "telemetry_stale" | "observation_stale" | "unknown_scope";
+      readonly asOf: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly reason: "no_work" | "telemetry_stale" | "unsupported" | "unknown_scope" | "contention_unbounded";
+      readonly asOf: string;
+    };
+
+type StageEstimate = {
+  readonly stage: string;
+  readonly sampleSize: number;
+  readonly p50Ms: number | null;
+  readonly p90Ms: number | null;
+};
+
+/**
+ * Selects a percentile with the nearest-rank method. Invalid/empty input has no
+ * percentile rather than a fabricated zero.
+ */
+export function nearestRankPercentile(values: readonly number[], percentile: number): number | null {
+  if (!Number.isFinite(percentile) || percentile <= 0 || percentile > 100) return null;
+  const sorted = values.filter(isPositiveFinite).sort((left, right) => left - right);
+  if (sorted.length === 0) return null;
+  return sorted[Math.ceil((percentile / 100) * sorted.length) - 1] ?? null;
+}
+
+/**
+ * Round a non-zero ETA range outward. Below one hour the display unit is one
+ * minute; one hour and above it is five minutes. Equal bounds retain one unit
+ * of uncertainty rather than becoming a misleading exact estimate.
+ */
+export function roundEtaRangeSeconds(
+  lowSeconds: number,
+  highSeconds: number,
+): { lowSeconds: number; highSeconds: number } | null {
+  if (!Number.isFinite(lowSeconds) || !Number.isFinite(highSeconds) || lowSeconds < 0 || highSeconds < lowSeconds) {
+    return null;
+  }
+
+  const lowIncrement = etaRoundingIncrement(lowSeconds);
+  const highIncrement = etaRoundingIncrement(highSeconds);
+  const low = Math.floor(lowSeconds / lowIncrement) * lowIncrement;
+  let high = Math.ceil(highSeconds / highIncrement) * highIncrement;
+
+  if (highSeconds > 0 && high <= low) {
+    high = low + etaRoundingIncrement(low);
+  }
+
+  return { lowSeconds: low, highSeconds: high };
+}
+
+/**
+ * Computes an honest range or an explicit non-estimate. Gate ordering is
+ * intentional: a more fundamental unknown wins over downstream calculations.
+ */
+export function estimatePipelineEta(input: PipelineEtaEstimatorInput): PipelineEtaEstimate {
+  const activeStages = input.stages.filter((stage) => normalizedCount(stage.remainingCurrentStage) > 0);
+
+  // Scope/no-work must win even when the last telemetry sample is stale.
+  if (input.scope === "unknown") return unavailable(input.asOf, "unknown_scope");
+  if (activeStages.length === 0) return unavailable(input.asOf, "no_work");
+  if (!input.telemetryFresh) return stale(input.asOf, "telemetry_stale");
+
+  // A pause is more useful than a numeric range when the current cohort cannot progress.
+  if (!input.workerAvailable) return paused(input.asOf, "worker_unavailable");
+  if (!input.budgetAvailable) return paused(input.asOf, "budget_exceeded");
+  if (input.blocked) return paused(input.asOf, "blocked");
+  if (!input.dispatchObserved) return paused(input.asOf, "no_dispatch");
+
+  if (input.contention.kind !== "bounded") return unavailable(input.asOf, "contention_unbounded");
+
+  const stageEstimates = input.stages.map((stage) => estimateStage(stage, input.asOf));
+  const estimatesByStage = new Map(stageEstimates.map((estimate) => [estimate.stage, estimate]));
+  const paths = normalizedPaths(input.remainingPaths, activeStages);
+  const pathStageIds = new Set(paths.flatMap((path) => path.stageIds));
+  const relevantStageIds = new Set([...activeStages.map((stage) => stage.stage), ...pathStageIds]);
+  const relevantEstimates = [...relevantStageIds].map((stage) => estimatesByStage.get(stage));
+
+  if (relevantEstimates.some((estimate) => estimate === undefined)) {
+    return unavailable(input.asOf, "unknown_scope");
+  }
+
+  const completeEstimates = relevantEstimates.filter((estimate): estimate is StageEstimate => estimate !== undefined);
+  const completedSamples = Math.min(...completeEstimates.map((estimate) => estimate.sampleSize));
+
+  // Membership remains provisional even with sufficient service-time evidence.
+  if (input.membershipOpen) {
+    return calibrating(input.asOf, "membership_open", completedSamples);
+  }
+
+  if (
+    completeEstimates.some(
+      (estimate) => estimate.sampleSize < PIPELINE_ETA_MINIMUM_SAMPLES || estimate.p50Ms === null || estimate.p90Ms === null,
+    )
+  ) {
+    return calibrating(input.asOf, "insufficient_samples", completedSamples);
+  }
+
+  const configuredSlots = normalizedCount(input.configuredSlots ?? 0);
+  if (configuredSlots === 0) return unavailable(input.asOf, "unsupported");
+
+  const externalDemand = boundedExternalDemand(input.contention, estimatesByStage);
+  if (externalDemand === null) return unavailable(input.asOf, "contention_unbounded");
+
+  const currentDemand = activeStages.reduce(
+    (total, stage) => {
+      const estimate = estimatesByStage.get(stage.stage);
+      return total + normalizedCount(stage.remainingCurrentStage) * (estimate?.p50Ms ?? 0);
+    },
+    0,
+  );
+  const currentDemandP90 = activeStages.reduce(
+    (total, stage) => {
+      const estimate = estimatesByStage.get(stage.stage);
+      return total + normalizedCount(stage.remainingCurrentStage) * (estimate?.p90Ms ?? 0);
+    },
+    0,
+  );
+  const longestPathP50 = longestPathDemand(paths, estimatesByStage, "p50Ms");
+  const longestPathP90 = longestPathDemand(paths, estimatesByStage, "p90Ms");
+
+  if (longestPathP50 === null || longestPathP90 === null) return unavailable(input.asOf, "unknown_scope");
+
+  const rawLowSeconds = Math.max(currentDemand / configuredSlots, longestPathP50) / 1_000;
+  const rawHighSeconds = Math.max(
+    (currentDemandP90 + externalDemand) / configuredSlots,
+    longestPathP90,
+    rawLowSeconds * 1_000,
+  ) / 1_000;
+  const rounded = roundEtaRangeSeconds(rawLowSeconds, rawHighSeconds);
+  if (!rounded || rounded.highSeconds === 0) return unavailable(input.asOf, "unsupported");
+
+  return {
+    status: "available",
+    ...rounded,
+    confidence: confidenceFor(completeEstimates, input.contention),
+    basis: "stage_throughput",
+    sampleSize: completeEstimates.reduce((total, estimate) => total + estimate.sampleSize, 0),
+    asOf: input.asOf,
+    caveat: externalContentionCaveat(input.contention),
+  };
+}
+
+function estimateStage(stage: PipelineEtaStageInput, asOf: string): StageEstimate {
+  const samples = selectedSamples(stage, asOf);
+  return {
+    stage: stage.stage,
+    sampleSize: samples.length,
+    p50Ms: nearestRankPercentile(samples, 50),
+    p90Ms: nearestRankPercentile(samples, 90),
+  };
+}
+
+function selectedSamples(stage: PipelineEtaStageInput, asOf: string): number[] {
+  const cutoff = Date.parse(asOf) - PIPELINE_ETA_SAMPLE_WINDOW_MS;
+  const asOfMs = Date.parse(asOf);
+  if (!Number.isFinite(cutoff) || !Number.isFinite(asOfMs)) return [];
+
+  const usable = stage.samples.filter((sample) => {
+    const completedAt = Date.parse(sample.completedAt);
+    return (
+      sample.succeeded &&
+      isPositiveFinite(sample.durationMs) &&
+      Number.isFinite(completedAt) &&
+      completedAt >= cutoff &&
+      completedAt <= asOfMs
+    );
+  });
+  const primary = newestDurations(usable.filter((sample) => sample.source === stage.primaryEvidence));
+
+  // Metrics remain a true fallback. They never inflate or blend canonical evidence.
+  return primary.length > 0
+    ? primary
+    : newestDurations(usable.filter((sample) => sample.source === "operational_attempt_metric"));
+}
+
+function newestDurations(samples: readonly PipelineEtaDurationSample[]): number[] {
+  return [...samples]
+    .sort((left, right) => Date.parse(right.completedAt) - Date.parse(left.completedAt))
+    .slice(0, PIPELINE_ETA_MAX_SAMPLES)
+    .map((sample) => sample.durationMs)
+    .filter((durationMs): durationMs is number => isPositiveFinite(durationMs));
+}
+
+function normalizedPaths(
+  paths: readonly PipelineEtaRemainingPath[],
+  activeStages: readonly PipelineEtaStageInput[],
+): readonly PipelineEtaRemainingPath[] {
+  const validPaths = paths.filter((path) => path.stageIds.length > 0);
+  return validPaths.length > 0 ? validPaths : activeStages.map((stage) => ({ stageIds: [stage.stage] }));
+}
+
+function boundedExternalDemand(
+  contention: PipelineEtaBoundedContention,
+  estimatesByStage: ReadonlyMap<string, StageEstimate>,
+): number | null {
+  let demand = 0;
+  for (const work of [...contention.existingBacklog, ...contention.retries]) {
+    const count = normalizedCount(work.count);
+    if (count === 0) continue;
+    const stage = estimatesByStage.get(work.stage);
+    if (!stage || stage.p90Ms === null) return null;
+    demand += count * stage.p90Ms;
+  }
+  return demand;
+}
+
+function longestPathDemand(
+  paths: readonly PipelineEtaRemainingPath[],
+  estimatesByStage: ReadonlyMap<string, StageEstimate>,
+  percentile: "p50Ms" | "p90Ms",
+): number | null {
+  let longest = 0;
+  for (const path of paths) {
+    let demand = 0;
+    for (const stageId of path.stageIds) {
+      const stage = estimatesByStage.get(stageId);
+      const duration = stage?.[percentile];
+      if (duration === null || duration === undefined) return null;
+      demand += duration;
+    }
+    longest = Math.max(longest, demand);
+  }
+  return longest;
+}
+
+function confidenceFor(
+  estimates: readonly StageEstimate[],
+  contention: PipelineEtaBoundedContention,
+): "low" | "medium" | "high" {
+  const minimumStageSamples = Math.min(...estimates.map((estimate) => estimate.sampleSize));
+  const hasExternalContention =
+    contention.queuePresent ||
+    contention.existingBacklog.some((work) => normalizedCount(work.count) > 0) ||
+    contention.retries.some((work) => normalizedCount(work.count) > 0);
+
+  if (minimumStageSamples >= 20 && !hasExternalContention) return "high";
+  if (minimumStageSamples >= 10) return "medium";
+  return "low";
+}
+
+function externalContentionCaveat(contention: PipelineEtaBoundedContention): string | null {
+  return contention.queuePresent ||
+    contention.existingBacklog.some((work) => normalizedCount(work.count) > 0) ||
+    contention.retries.some((work) => normalizedCount(work.count) > 0)
+    ? "Includes bounded external backlog, retry, or queue contention."
+    : null;
+}
+
+function etaRoundingIncrement(seconds: number): number {
+  return seconds >= 60 * 60 ? 5 * 60 : 60;
+}
+
+function normalizedCount(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function isPositiveFinite(value: number | null): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function unavailable(
+  asOf: string,
+  reason: Extract<PipelineEtaEstimate, { status: "unavailable" }> ["reason"],
+): Extract<PipelineEtaEstimate, { status: "unavailable" }> {
+  return { status: "unavailable", reason, asOf };
+}
+
+function stale(
+  asOf: string,
+  reason: Extract<PipelineEtaEstimate, { status: "stale" }> ["reason"],
+): Extract<PipelineEtaEstimate, { status: "stale" }> {
+  return { status: "stale", reason, asOf };
+}
+
+function paused(
+  asOf: string,
+  reason: Extract<PipelineEtaEstimate, { status: "paused" }> ["reason"],
+): Extract<PipelineEtaEstimate, { status: "paused" }> {
+  return { status: "paused", reason, asOf };
+}
+
+function calibrating(
+  asOf: string,
+  reason: Extract<PipelineEtaEstimate, { status: "calibrating" }> ["reason"],
+  completedSamples: number,
+): Extract<PipelineEtaEstimate, { status: "calibrating" }> {
+  return {
+    status: "calibrating",
+    reason,
+    completedSamples: Math.max(0, completedSamples),
+    minimumSamples: PIPELINE_ETA_MINIMUM_SAMPLES,
+    asOf,
+  };
+}

--- a/apps/api/src/pipeline-operations.ts
+++ b/apps/api/src/pipeline-operations.ts
@@ -1,0 +1,1921 @@
+import { createHash } from "node:crypto";
+
+import type {
+  DiscoveryExecutionSummary,
+  PipelineActiveItem,
+  PipelineCapacity,
+  PipelineEta,
+  PipelineExecutionCohortSummary,
+  PipelineOperationsFreshness,
+  PipelineOperationsSnapshot,
+  PipelineOperationalStage,
+  PipelineStageCounts,
+} from "./contracts.js";
+import { allRows, tableExists, type SqliteDatabase, type SqliteValue } from "./db.js";
+import {
+  estimatePipelineEta,
+  type PipelineEtaEstimatorInput,
+  type PipelineEtaStageInput,
+} from "./pipeline-eta.js";
+import { refreshProjections } from "./projections.js";
+import { readWorkerRuntimeTelemetry, type WorkerRuntimeTelemetrySnapshot } from "./worker-runtime-telemetry.js";
+import { readLlmSpendHealth } from "./worker-health.js";
+
+const DEFAULT_TENANT = "local";
+const ETA_SAMPLE_LIMIT = 50;
+const ETA_SAMPLE_WINDOW_MS = 14 * 24 * 60 * 60 * 1_000;
+
+const JOB_STAGES = ["enrich", "score", "tailor", "cover"] as const;
+const STEP_STAGES = ["source_planning", "source_family", "reconciliation", "pdf_render"] as const;
+const OPERATIONAL_STAGES = [...STEP_STAGES, ...JOB_STAGES] as const;
+
+const STAGE_LABELS: Record<(typeof OPERATIONAL_STAGES)[number], string> = {
+  source_planning: "Plan sources",
+  source_family: "Crawl sources",
+  reconciliation: "Reconciliation",
+  pdf_render: "Render PDF",
+  enrich: "Enrich",
+  score: "Score",
+  tailor: "Tailor",
+  cover: "Cover letter",
+};
+
+const RUNTIME_ACTIVITY_STAGE: Record<string, string> = {
+  discovery_enrichment: "enrich",
+  score: "score",
+  score_job: "score",
+  tailor: "tailor",
+  tailor_job: "tailor",
+  cover: "cover",
+  cover_letter: "cover",
+  render_pdf: "pdf_render",
+  plan_discovery_sources: "source_planning",
+  discovery_source_family: "source_family",
+  discovery_preparation_fanout: "reconciliation",
+};
+
+const STEP_ACTIVITY_TYPES: Record<string, string> = {
+  source_planning: "plan_discovery_sources",
+  source_family: "discovery_source_family",
+  enrichment_pass: "discovery_enrichment",
+  preparation_fanout: "discovery_preparation_fanout",
+  existing_backlog_sweep: "discovery_preparation_fanout",
+  pdf_render: "render_pdf",
+};
+
+interface WorkflowRow extends Record<string, unknown> {
+  workflow_id: string;
+  temporal_run_id: string | null;
+  workflow_type: string;
+  status: string;
+  input_summary_json: string | null;
+  error_code: string | null;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+interface MembershipRow extends Record<string, unknown> {
+  job_url: string;
+  cohort_kind: "observed_this_run" | "existing_backlog";
+  preparation_workflow_id: string | null;
+  work_plan_state: "pending" | "planned" | "not_eligible" | "failed";
+  required_steps_json: string | null;
+}
+
+interface StageStateRow extends Record<string, unknown> {
+  job_url: string;
+  stage: string;
+  state: string | null;
+  duration_ms: number | null;
+  finished_at: string | null;
+  retryable: number | null;
+}
+
+interface PipelineStepRow extends Record<string, unknown> {
+  step_kind: string;
+  item_key: string;
+  state: string;
+  attempt: number;
+  retryable: number;
+  duration_ms: number | null;
+  finished_at: string | null;
+  started_at: string | null;
+  detail_count: number | null;
+}
+
+interface JobDisplayRow extends Record<string, unknown> {
+  url: string;
+  title: string | null;
+  company: string | null;
+}
+
+interface MetricRow extends Record<string, unknown> {
+  stage: string;
+  outcome: string;
+  duration_ms: number | null;
+  occurred_at: string;
+}
+
+interface SelectedExecution {
+  row: WorkflowRow;
+  phase: DiscoveryExecutionSummary["phase"];
+  membershipClosed: boolean;
+  current: Cohort;
+  sweep: Cohort;
+  steps: PipelineStepRow[];
+  selectedAs: DiscoveryExecutionSummary["selectedAs"];
+}
+
+interface Cohort {
+  members: MembershipRow[];
+  stageStates: Map<string, Map<string, StageStateRow>>;
+  preparationWorkflowStatuses: Map<string, string>;
+  preparationWorkflowRunIds: Map<string, string>;
+  summary: PipelineExecutionCohortSummary;
+}
+
+interface PipelineOperationsOptions {
+  dbPath: string;
+  configPath: string;
+  now?: Date;
+  tenantId?: string;
+}
+
+interface EtaSample {
+  source: "job_stage_state" | "pipeline_step_projection" | "operational_attempt_metric";
+  succeeded: boolean;
+  durationMs: number | null;
+  completedAt: string;
+}
+
+interface GlobalRetryability {
+  hasUnboundedRetryableDemand: boolean;
+}
+
+/**
+ * Build the current (not historical) Discover operations view.  The execution
+ * identity is always the persisted workflow-id/run-id pair; a workflow id by
+ * itself is intentionally never selected because Temporal workflow ids repeat.
+ */
+export function buildPipelineOperationsSnapshot(
+  db: SqliteDatabase,
+  options: PipelineOperationsOptions,
+): PipelineOperationsSnapshot {
+  const now = options.now ?? new Date();
+  const generatedAt = now.toISOString();
+  const tenantId = options.tenantId ?? DEFAULT_TENANT;
+  refreshProjections(db, tenantId);
+  const telemetry = readWorkerRuntimeTelemetry(options.dbPath, { now });
+  const budgetAvailable = readLlmSpendHealth(options.dbPath, options.configPath, now).status !== "over_budget";
+  const capacity = buildCapacity(telemetry, selectedInternalParallelism(db, tenantId));
+  const freshness = buildFreshness(telemetry);
+  const executions = loadExecutions(db, tenantId);
+  const selected = selectExecution(db, tenantId, executions);
+
+  if (!selected) {
+    const overallEta = estimatePipelineEta({
+      asOf: generatedAt,
+      scope: "unknown",
+      membershipOpen: false,
+      telemetryFresh: telemetry.status === "available",
+      workerAvailable: telemetry.status === "available" && telemetry.configuredSlots > 0,
+      budgetAvailable,
+      blocked: false,
+      dispatchObserved: dispatchObserved(telemetry),
+      configuredSlots: telemetry.status === "available" ? telemetry.configuredSlots : null,
+      stages: [],
+      remainingPaths: [],
+      contention: { kind: "unknown" },
+    }) as PipelineEta;
+    return {
+      generatedAt,
+      etaEstimatorVersion: "pipeline-eta-v1",
+      freshness,
+      execution: null,
+      capacity,
+      sourceFamilies: null,
+      reconciliation: null,
+      stages: buildGlobalStages(db, tenantId, capacity, generatedAt, telemetry, budgetAvailable, now),
+      activeItems: [],
+      activeItemsTotal: null,
+      activeItemsTruncated: null,
+      overallEta,
+    };
+  }
+
+  const selectedCapacity = buildCapacity(telemetry, internalParallelism(selected.row));
+  const currentCounts = stageCountsForCohort(selected.current, selected.steps);
+  const sweepCounts = stageCountsForCohort(selected.sweep, selected.steps);
+  const globalCounts = globalStageCounts(db, tenantId, selected);
+  const globalRetryability = loadGlobalRetryability(db, tenantId, selected);
+  const sourceFamilies = sourceFamilyProgress(
+    db,
+    tenantId,
+    selected,
+    sweepCounts,
+    globalCounts,
+    globalRetryability,
+    generatedAt,
+    telemetry,
+    budgetAvailable,
+    now,
+  );
+  const reconciliation = reconciliationProgress(selected);
+  const active = buildActiveItems(db, selected, telemetry);
+  const etaInput = buildEtaInput(
+    db,
+    tenantId,
+    selected,
+    currentCounts,
+    sweepCounts,
+    globalCounts,
+    globalRetryability,
+    telemetry,
+    budgetAvailable,
+    generatedAt,
+    now,
+  );
+  const overallEta = estimatePipelineEta(etaInput) as PipelineEta;
+  const stages = buildStages({
+    db,
+    tenantId,
+    selected,
+    capacity: selectedCapacity,
+    currentCounts,
+    sweepCounts,
+    globalCounts,
+    globalRetryability,
+    telemetry,
+    budgetAvailable,
+    generatedAt,
+    now,
+  });
+
+  return {
+    generatedAt,
+    etaEstimatorVersion: "pipeline-eta-v1",
+    freshness,
+    execution: executionSummary(selected),
+    capacity: selectedCapacity,
+    sourceFamilies,
+    reconciliation,
+    stages,
+    activeItems: active.items,
+    activeItemsTotal: active.total,
+    activeItemsTruncated: active.truncated,
+    overallEta,
+  };
+}
+
+function loadExecutions(db: SqliteDatabase, tenantId: string): WorkflowRow[] {
+  if (!tableExists(db, "workflow_run_projections")) return [];
+  return allRows<WorkflowRow>(
+    db,
+    `SELECT workflow_id, temporal_run_id, workflow_type, status, input_summary_json,
+            error_code, started_at, finished_at
+       FROM workflow_run_projections
+      WHERE tenant_id = ?
+        AND workflow_type = 'DiscoverWorkflow'
+        AND temporal_run_id IS NOT NULL
+        AND trim(temporal_run_id) <> ''
+      ORDER BY COALESCE(started_at, finished_at) DESC, workflow_id DESC`,
+    [tenantId],
+  );
+}
+
+function selectExecution(
+  db: SqliteDatabase,
+  tenantId: string,
+  rows: WorkflowRow[],
+): SelectedExecution | null {
+  const candidates = rows
+    .map((row) => materializeExecution(db, tenantId, row))
+    .filter((candidate): candidate is Omit<SelectedExecution, "selectedAs"> => candidate !== null);
+  const active = candidates.find(
+    (candidate) => candidate.phase === "discovering" || candidate.phase === "draining",
+  );
+  if (active) return { ...active, selectedAs: "active_or_draining" };
+  const terminal = candidates[0];
+  return terminal ? { ...terminal, selectedAs: "latest_terminal" } : null;
+}
+
+function materializeExecution(
+  db: SqliteDatabase,
+  tenantId: string,
+  row: WorkflowRow,
+): Omit<SelectedExecution, "selectedAs"> | null {
+  const runId = nullableText(row.temporal_run_id);
+  if (!runId) return null;
+  const memberships = loadMemberships(db, tenantId, row.workflow_id, runId);
+  const stageStates = loadStageStates(db, memberships.map((membership) => membership.job_url));
+  const preparationWorkflows = loadPreparationWorkflows(db, tenantId, memberships);
+  const steps = loadPipelineSteps(db, tenantId, row.workflow_id, runId);
+  const current = cohort(
+    memberships.filter((membership) => membership.cohort_kind === "observed_this_run"),
+    stageStates,
+    steps,
+    preparationWorkflows.statuses,
+    preparationWorkflows.runIds,
+  );
+  const sweep = cohort(
+    memberships.filter((membership) => membership.cohort_kind === "existing_backlog"),
+    stageStates,
+    steps,
+    preparationWorkflows.statuses,
+    preparationWorkflows.runIds,
+  );
+  const membershipClosed = hasTerminalFanout(steps, isTerminalWorkflowStatus(row.status));
+  const phase = phaseFor(row.status, current, sweep, steps, membershipClosed);
+  return { row, phase, membershipClosed, current, sweep, steps };
+}
+
+function loadMemberships(
+  db: SqliteDatabase,
+  tenantId: string,
+  workflowId: string,
+  runId: string,
+): MembershipRow[] {
+  if (!tableExists(db, "discovery_execution_jobs")) return [];
+  return allRows<MembershipRow>(
+    db,
+    `SELECT job_url, cohort_kind, preparation_workflow_id, work_plan_state, required_steps_json
+       FROM discovery_execution_jobs
+      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?`,
+    [tenantId, workflowId, runId],
+  );
+}
+
+function loadStageStates(db: SqliteDatabase, jobUrls: string[]): Map<string, Map<string, StageStateRow>> {
+  const grouped = new Map<string, Map<string, StageStateRow>>();
+  if (jobUrls.length === 0 || !tableExists(db, "job_stage_states")) return grouped;
+  for (const group of chunks(jobUrls, 500)) {
+    const placeholders = group.map(() => "?").join(", ");
+    const rows = allRows<StageStateRow>(
+      db,
+      `SELECT job_url, stage, state, duration_ms, finished_at, retryable
+         FROM job_stage_states
+        WHERE job_url IN (${placeholders})`,
+      group,
+    );
+    for (const row of rows) {
+      const stages = grouped.get(row.job_url) ?? new Map<string, StageStateRow>();
+      stages.set(row.stage, row);
+      grouped.set(row.job_url, stages);
+    }
+  }
+  return grouped;
+}
+
+function loadPreparationWorkflows(
+  db: SqliteDatabase,
+  tenantId: string,
+  memberships: MembershipRow[],
+): { statuses: Map<string, string>; runIds: Map<string, string> } {
+  const statuses = new Map<string, string>();
+  const runIds = new Map<string, string>();
+  if (!tableExists(db, "workflow_run_projections")) return { statuses, runIds };
+  const workflowIds = [...new Set(
+    memberships
+      .map((member) => nullableText(member.preparation_workflow_id))
+      .filter((workflowId): workflowId is string => workflowId !== null),
+  )];
+  for (const group of chunks(workflowIds, 500)) {
+    const rows = allRows<{ workflow_id: string; status: string; temporal_run_id: string | null }>(
+      db,
+      `SELECT workflow_id, status, temporal_run_id
+         FROM workflow_run_projections
+        WHERE tenant_id = ? AND workflow_id IN (${group.map(() => "?").join(", ")})`,
+      [tenantId, ...group],
+    );
+    for (const row of rows) {
+      statuses.set(row.workflow_id, row.status);
+      const runId = nullableText(row.temporal_run_id);
+      if (runId) runIds.set(row.workflow_id, runId);
+    }
+  }
+  return { statuses, runIds };
+}
+
+function loadPipelineSteps(
+  db: SqliteDatabase,
+  tenantId: string,
+  workflowId: string,
+  runId: string,
+): PipelineStepRow[] {
+  if (!tableExists(db, "pipeline_step_projections")) return [];
+  return allRows<PipelineStepRow>(
+    db,
+    `SELECT step_kind, item_key, state, attempt, retryable, duration_ms, finished_at,
+            started_at, detail_count
+       FROM pipeline_step_projections
+      WHERE tenant_id = ? AND discover_workflow_id = ? AND discover_run_id = ?`,
+    [tenantId, workflowId, runId],
+  );
+}
+
+function cohort(
+  members: MembershipRow[],
+  stageStates: Map<string, Map<string, StageStateRow>>,
+  steps: PipelineStepRow[] = [],
+  preparationWorkflowStatuses = new Map<string, string>(),
+  preparationWorkflowRunIds = new Map<string, string>(),
+): Cohort {
+  return {
+    members,
+    stageStates,
+    preparationWorkflowStatuses,
+    preparationWorkflowRunIds,
+    summary: cohortSummary(members, stageStates, steps, preparationWorkflowStatuses),
+  };
+}
+
+function cohortSummary(
+  members: MembershipRow[],
+  stageStates: Map<string, Map<string, StageStateRow>>,
+  steps: PipelineStepRow[],
+  preparationWorkflowStatuses: Map<string, string>,
+): PipelineExecutionCohortSummary {
+  let planned = 0;
+  let notEligible = 0;
+  let pending = 0;
+  let failedPlan = 0;
+  let terminal = 0;
+  let remaining = 0;
+  for (const member of members) {
+    if (member.work_plan_state === "planned") {
+      planned += 1;
+      if (plannedMemberResolved(member, stageStates.get(member.job_url), steps, preparationWorkflowStatuses)) terminal += 1;
+      else remaining += 1;
+      continue;
+    }
+    if (member.work_plan_state === "not_eligible") {
+      notEligible += 1;
+      terminal += 1;
+    } else if (member.work_plan_state === "failed") {
+      failedPlan += 1;
+      terminal += 1;
+    } else {
+      pending += 1;
+      remaining += 1;
+    }
+  }
+  return { members: members.length, planned, notEligible, pending, failedPlan, terminal, remaining };
+}
+
+function plannedMemberResolved(
+  member: MembershipRow,
+  states: Map<string, StageStateRow> | undefined,
+  pipelineSteps: PipelineStepRow[],
+  preparationWorkflowStatuses: Map<string, string>,
+): boolean {
+  const required = requiredSteps(member);
+  if (required.length === 0) return false;
+  return required.every((stage) => {
+    const terminalOwner = memberPreparationWorkflowFailed(member, preparationWorkflowStatuses);
+    if (stage === "pdf") return isTerminalStepState(pdfStepForMember(member, pipelineSteps), terminalOwner);
+    return isTerminalStageState(states?.get(stage), terminalOwner);
+  });
+}
+
+function hasTerminalFanout(steps: PipelineStepRow[], discoverWorkflowTerminal: boolean): boolean {
+  return steps.some(
+    (step) =>
+      step.step_kind === "preparation_fanout" &&
+      step.item_key === "terminal" &&
+      isTerminalStepState(step, discoverWorkflowTerminal),
+  );
+}
+
+function hasTerminalFanoutIssue(steps: PipelineStepRow[], discoverWorkflowTerminal: boolean): boolean {
+  return steps.some(
+    (step) =>
+      step.step_kind === "preparation_fanout" &&
+      step.item_key === "terminal" &&
+      isTerminalStepFailure(step, discoverWorkflowTerminal),
+  );
+}
+
+function phaseFor(
+  status: string,
+  current: Cohort,
+  sweep: Cohort,
+  steps: PipelineStepRow[],
+  membershipClosed: boolean,
+): DiscoveryExecutionSummary["phase"] {
+  if (status === "in_progress" || status === "starting") return "discovering";
+  if (status === "canceled") return "canceled";
+  if (status === "failed" || status === "timed_out" || status === "terminated") return "failed";
+  if (status === "succeeded" || status === "dry_run_complete") {
+    if (hasPlannedMismatch(current) || hasPlannedMismatch(sweep)) return "completed_with_issues";
+    if (hasUnresolvedPlannedMember(current, steps) || hasUnresolvedPlannedMember(sweep, steps)) {
+      return "draining";
+    }
+    if (
+      !membershipClosed ||
+      current.summary.failedPlan > 0 ||
+      current.summary.pending > 0 ||
+      sweep.summary.failedPlan > 0 ||
+      sweep.summary.pending > 0 ||
+      hasTerminalFanoutIssue(steps, isTerminalWorkflowStatus(status)) ||
+      hasTerminalIssue(current, steps) ||
+      hasTerminalIssue(sweep, steps)
+    ) {
+      return "completed_with_issues";
+    }
+    return "completed";
+  }
+  return "discovering";
+}
+
+function hasPlannedMismatch(cohortValue: Cohort): boolean {
+  return cohortValue.members.some(
+    (member) => member.work_plan_state === "planned" && requiredSteps(member).length === 0,
+  );
+}
+
+function hasUnresolvedPlannedMember(cohortValue: Cohort, steps: PipelineStepRow[]): boolean {
+  return cohortValue.members.some(
+    (member) =>
+      member.work_plan_state === "planned" &&
+      !plannedMemberResolved(
+        member,
+        cohortValue.stageStates.get(member.job_url),
+        steps,
+        cohortValue.preparationWorkflowStatuses,
+      ),
+  );
+}
+
+function hasTerminalIssue(cohortValue: Cohort, steps: PipelineStepRow[]): boolean {
+  return cohortValue.members.some((member) => {
+    if (member.work_plan_state !== "planned") return member.work_plan_state === "failed";
+    const states = cohortValue.stageStates.get(member.job_url);
+    return requiredSteps(member).some((stage) => {
+      const terminalOwner = memberPreparationWorkflowFailed(member, cohortValue.preparationWorkflowStatuses);
+      if (stage === "pdf") return isTerminalStepFailure(pdfStepForMember(member, steps), terminalOwner);
+      const state = states?.get(stage);
+      return state !== undefined && !isSuccessfulStageState(state) && !isRetryableStageFailure(state, terminalOwner);
+    });
+  });
+}
+
+function executionSummary(selected: SelectedExecution): DiscoveryExecutionSummary {
+  const runId = nullableText(selected.row.temporal_run_id);
+  if (!runId) {
+    throw new Error("Selected discovery execution must have a persisted Temporal run id");
+  }
+  return {
+    discoverWorkflowId: selected.row.workflow_id,
+    discoverRunId: runId,
+    selectedAs: selected.selectedAs,
+    workflowStatus: workflowStatus(selected.row.status),
+    phase: selected.phase,
+    membershipClosed: selected.membershipClosed,
+    startedAt: nullableText(selected.row.started_at),
+    finishedAt: nullableText(selected.row.finished_at),
+    errorCode: safeCode(selected.row.error_code),
+    currentExecution: selected.current.summary,
+    sweptExistingBacklog: selected.sweep.summary,
+  };
+}
+
+function workflowStatus(value: string): DiscoveryExecutionSummary["workflowStatus"] {
+  if (["in_progress", "succeeded", "failed", "canceled", "timed_out", "terminated"].includes(value)) {
+    return value as DiscoveryExecutionSummary["workflowStatus"];
+  }
+  return "in_progress";
+}
+
+function buildFreshness(telemetry: WorkerRuntimeTelemetrySnapshot): PipelineOperationsFreshness {
+  if (telemetry.status === "available") {
+    if (telemetry.taskQueueObservation.status === "unsupported") {
+      return {
+        status: "unsupported",
+        asOf: telemetry.asOf,
+        staleAfterSeconds: telemetry.staleAfterSeconds,
+        reason: telemetry.taskQueueObservation.reasonCode,
+      };
+    }
+    return { status: "fresh", asOf: telemetry.asOf, staleAfterSeconds: telemetry.staleAfterSeconds };
+  }
+  if (telemetry.status === "stale") {
+    return {
+      status: "stale",
+      asOf: telemetry.asOf,
+      staleAfterSeconds: telemetry.staleAfterSeconds,
+      reason: telemetry.reason,
+    };
+  }
+  return {
+    status: "unavailable",
+    asOf: telemetry.asOf,
+    staleAfterSeconds: telemetry.staleAfterSeconds,
+    reason: telemetry.reason,
+  };
+}
+
+function buildCapacity(
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  internalParallelism: number | null,
+): PipelineCapacity {
+  if (telemetry.status !== "available") {
+    return {
+      status: telemetry.status,
+      asOf: telemetry.asOf,
+      staleAfterSeconds: telemetry.staleAfterSeconds,
+      taskQueue: telemetry.taskQueue,
+      reason: telemetry.reason,
+      approximateTaskQueue: telemetry.taskQueueObservation,
+    };
+  }
+  const common = {
+    status: "available" as const,
+    asOf: telemetry.asOf,
+    staleAfterSeconds: telemetry.staleAfterSeconds,
+    taskQueue: telemetry.taskQueue,
+    freshWorkerCount: telemetry.freshWorkerCount,
+    staleWorkerCount: telemetry.staleWorkerCount,
+    invalidWorkerCount: telemetry.invalidWorkerCount,
+    configuredSlots: telemetry.configuredSlots,
+    activeSlots: telemetry.activeSlots,
+    availableSlots: telemetry.availableSlots,
+    executorThreads: telemetry.executorThreads,
+    slotSaturation: telemetry.slotSaturation,
+    approximateTaskQueue: telemetry.taskQueueObservation,
+  };
+  return internalParallelism === null
+    ? { ...common, kind: "shared_activity_pool" }
+    : { ...common, kind: "shared_activity_pool_with_internal_parallelism", internalParallelism };
+}
+
+function selectedInternalParallelism(db: SqliteDatabase, tenantId: string): number | null {
+  const row = loadExecutions(db, tenantId)[0];
+  return row ? internalParallelism(row) : null;
+}
+
+function internalParallelism(row: WorkflowRow): number | null {
+  const parsed = parseRecord(row.input_summary_json);
+  const workers = parsed?.workers;
+  return typeof workers === "number" && Number.isSafeInteger(workers) && workers > 0 ? workers : null;
+}
+
+function stageCountsForCohort(
+  cohortValue: Cohort,
+  steps: PipelineStepRow[],
+): Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts> {
+  const counts = new Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>();
+  counts.set("source_planning", projectionCounts(steps.filter((step) => step.step_kind === "source_planning")));
+  counts.set("source_family", sourceFamilyCounts(steps));
+  counts.set("reconciliation", reconciliationCounts(steps));
+  counts.set("pdf_render", pdfCounts(cohortValue, steps));
+  for (const stage of JOB_STAGES) {
+    counts.set(stage, jobStageCounts(cohortValue, stage));
+  }
+  return counts;
+}
+
+function sourceFamilyCounts(steps: PipelineStepRow[]): PipelineStageCounts {
+  const families = steps.filter((step) => step.step_kind === "source_family");
+  const planned = maxDetailCount(steps.filter((step) => step.step_kind === "source_planning"));
+  return projectionCounts(families, planned);
+}
+
+function reconciliationCounts(steps: PipelineStepRow[]): PipelineStageCounts {
+  const components = reconciliationComponents(steps);
+  return addCounts(components.enrichment_pass, components.preparation_fanout);
+}
+
+function reconciliationComponents(steps: PipelineStepRow[]): {
+  enrichment_pass: PipelineStageCounts;
+  preparation_fanout: PipelineStageCounts;
+} {
+  return {
+    enrichment_pass: projectionCounts(steps.filter((step) => step.step_kind === "enrichment_pass")),
+    preparation_fanout: projectionCounts(steps.filter((step) => step.step_kind === "preparation_fanout")),
+  };
+}
+
+function addCounts(left: PipelineStageCounts, right: PipelineStageCounts): PipelineStageCounts {
+  return {
+    eligible: left.eligible + right.eligible,
+    waiting: left.waiting + right.waiting,
+    processing: left.processing + right.processing,
+    succeeded: left.succeeded + right.succeeded,
+    skipped: left.skipped + right.skipped,
+    blocked: left.blocked + right.blocked,
+    failed: left.failed + right.failed,
+    exhausted: left.exhausted + right.exhausted,
+    canceled: left.canceled + right.canceled,
+    needsVerification: left.needsVerification + right.needsVerification,
+    stale: left.stale + right.stale,
+    unknown: left.unknown + right.unknown,
+  };
+}
+
+function pdfCounts(cohortValue: Cohort, steps: PipelineStepRow[]): PipelineStageCounts {
+  const counts = emptyCounts();
+  for (const member of cohortValue.members) {
+    if (member.work_plan_state !== "planned" || !requiredSteps(member).includes("pdf")) continue;
+    counts.eligible += 1;
+    const step = pdfStepForMember(member, steps);
+    if (step) addPipelineStepState(counts, step.state);
+    else counts.unknown += 1;
+  }
+  return counts;
+}
+
+function projectionCounts(rows: PipelineStepRow[], expectedEligible?: number | null): PipelineStageCounts {
+  const counts = emptyCounts();
+  const expected = expectedEligible ?? rows.length;
+  counts.eligible = Math.max(expected, rows.length);
+  for (const row of rows) {
+    addPipelineStepState(counts, row.state);
+  }
+  const known = outcomeSum(counts);
+  if (known < counts.eligible) counts.unknown += counts.eligible - known;
+  return counts;
+}
+
+function addPipelineStepState(counts: PipelineStageCounts, state: string): void {
+  if (state === "queued") counts.waiting += 1;
+  else if (state === "running") counts.processing += 1;
+  else if (state === "succeeded") counts.succeeded += 1;
+  else if (state === "failed") counts.failed += 1;
+  else counts.unknown += 1;
+}
+
+function pdfStepForMember(member: MembershipRow, steps: PipelineStepRow[]): PipelineStepRow | undefined {
+  const workflowId = nullableText(member.preparation_workflow_id);
+  if (!workflowId || !workflowId.startsWith("prep-")) return undefined;
+  const idempotencyKey = workflowId.slice("prep-".length);
+  if (!idempotencyKey) return undefined;
+  const itemKey = `pdf:${createHash("sha256").update(idempotencyKey).digest("hex")}`;
+  return steps.find((step) => step.step_kind === "pdf_render" && step.item_key === itemKey);
+}
+
+function isTerminalStepState(step: PipelineStepRow | undefined, terminalOwnerFailed = false): boolean {
+  return step?.state === "succeeded" || isTerminalStepFailure(step, terminalOwnerFailed);
+}
+
+function isTerminalStepFailure(step: PipelineStepRow | undefined, terminalOwnerFailed = false): boolean {
+  return step?.state === "failed" && (Number(step.retryable) !== 1 || terminalOwnerFailed);
+}
+
+function jobStageCounts(cohortValue: Cohort, stage: (typeof JOB_STAGES)[number]): PipelineStageCounts {
+  const counts = emptyCounts();
+  for (const member of cohortValue.members) {
+    const eligible =
+      stage === "enrich"
+        ? member.work_plan_state !== "not_eligible"
+        : member.work_plan_state === "planned" && requiredSteps(member).includes(stage);
+    if (!eligible) continue;
+    counts.eligible += 1;
+    addStageState(counts, cohortValue.stageStates.get(member.job_url)?.get(stage)?.state ?? null);
+  }
+  return counts;
+}
+
+function addStageState(counts: PipelineStageCounts, state: string | null): void {
+  switch (state) {
+    case "pending":
+    case "queued":
+      counts.waiting += 1;
+      break;
+    case "running":
+      counts.processing += 1;
+      break;
+    case "succeeded":
+      counts.succeeded += 1;
+      break;
+    case "skipped":
+      counts.skipped += 1;
+      break;
+    case "blocked":
+      counts.blocked += 1;
+      break;
+    case "failed":
+      counts.failed += 1;
+      break;
+    case "exhausted":
+      counts.exhausted += 1;
+      break;
+    case "canceled":
+      counts.canceled += 1;
+      break;
+    case "needs_verification":
+      counts.needsVerification += 1;
+      break;
+    case "stale":
+      counts.stale += 1;
+      break;
+    default:
+      counts.unknown += 1;
+  }
+}
+
+function globalStageCounts(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+): Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts> {
+  const counts = new Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>();
+  for (const stage of OPERATIONAL_STAGES) counts.set(stage, emptyCounts());
+  if (!tableExists(db, "job_stage_states")) return counts;
+  const excluded = selected.current.members.concat(selected.sweep.members).map((member) => member.job_url);
+  const where = ["jss.stage IN ('enrich', 'score', 'tailor', 'cover')"];
+  const params: SqliteValue[] = [];
+  if (excluded.length > 0) {
+    where.push(`jss.job_url NOT IN (${excluded.map(() => "?").join(", ")})`);
+    params.push(...excluded);
+  }
+  const rows = allRows<StageStateRow>(
+    db,
+    `SELECT jss.job_url, jss.stage, jss.state, jss.duration_ms, jss.finished_at
+       FROM job_stage_states jss
+      WHERE ${where.join(" AND ")}`,
+    params,
+  );
+  for (const row of rows) {
+    const target = counts.get(row.stage as (typeof OPERATIONAL_STAGES)[number]);
+    if (!target) continue;
+    target.eligible += 1;
+    addStageState(target, row.state);
+  }
+  return counts;
+}
+
+function loadGlobalRetryability(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+): GlobalRetryability {
+  if (!tableExists(db, "job_stage_states")) return { hasUnboundedRetryableDemand: false };
+  const excluded = selected.current.members.concat(selected.sweep.members).map((member) => member.job_url);
+  const where = ["stage IN ('enrich', 'score', 'tailor', 'cover')", "state = 'failed'", "retryable = 1"];
+  const params: SqliteValue[] = [];
+  if (excluded.length > 0) {
+    where.push(`job_url NOT IN (${excluded.map(() => "?").join(", ")})`);
+    params.push(...excluded);
+  }
+  const rows = allRows<{ job_url: string }>(
+    db,
+    `SELECT job_url FROM job_stage_states WHERE ${where.join(" AND ")}`,
+    params,
+  );
+  if (rows.length === 0) return { hasUnboundedRetryableDemand: false };
+
+  const owners = loadUniqueGlobalPreparationOwners(
+    db,
+    tenantId,
+    [...new Set(rows.map((row) => row.job_url))],
+  );
+  const statuses = loadPreparationWorkflowStatusById(
+    db,
+    tenantId,
+    [...new Set([...owners.values()].filter((workflowId): workflowId is string => workflowId !== null))],
+  );
+  for (const row of rows) {
+    const workflowId = owners.get(row.job_url);
+    // A global stage row has no workflow/run identity. Even a unique workflow
+    // id cannot safely bind it to a nonterminal folded projection, so only a
+    // proven failed terminal owner can remove its retryable queue-ahead risk.
+    if (!workflowId || !isFailedTerminalWorkflowStatus(statuses.get(workflowId))) {
+      return { hasUnboundedRetryableDemand: true };
+    }
+  }
+  return { hasUnboundedRetryableDemand: false };
+}
+
+function loadUniqueGlobalPreparationOwners(
+  db: SqliteDatabase,
+  tenantId: string,
+  jobUrls: string[],
+): Map<string, string | null> {
+  const owners = new Map<string, string | null>(jobUrls.map((jobUrl) => [jobUrl, null] as const));
+  if (jobUrls.length === 0 || !tableExists(db, "discovery_execution_jobs")) return owners;
+  const candidates = new Map(jobUrls.map((jobUrl) => [jobUrl, new Set<string>()] as const));
+  const ambiguous = new Set<string>();
+  for (const group of chunks(jobUrls, 500)) {
+    const rows = allRows<{ job_url: string; preparation_workflow_id: string | null }>(
+      db,
+      `SELECT job_url, preparation_workflow_id
+         FROM discovery_execution_jobs
+        WHERE tenant_id = ? AND job_url IN (${group.map(() => "?").join(", ")})`,
+      [tenantId, ...group],
+    );
+    for (const row of rows) {
+      const workflowId = nullableText(row.preparation_workflow_id);
+      if (!workflowId) {
+        ambiguous.add(row.job_url);
+        continue;
+      }
+      candidates.get(row.job_url)?.add(workflowId);
+    }
+  }
+  for (const jobUrl of jobUrls) {
+    const workflowIds = candidates.get(jobUrl);
+    if (!ambiguous.has(jobUrl) && workflowIds?.size === 1) {
+      owners.set(jobUrl, [...workflowIds][0]);
+    }
+  }
+  return owners;
+}
+
+function loadPreparationWorkflowStatusById(
+  db: SqliteDatabase,
+  tenantId: string,
+  workflowIds: string[],
+): Map<string, string> {
+  const statuses = new Map<string, string>();
+  if (workflowIds.length === 0 || !tableExists(db, "workflow_run_projections")) return statuses;
+  for (const group of chunks(workflowIds, 500)) {
+    const rows = allRows<{ workflow_id: string; status: string }>(
+      db,
+      `SELECT workflow_id, status
+         FROM workflow_run_projections
+        WHERE tenant_id = ?
+          AND workflow_type = 'JobPreparationWorkflow'
+          AND workflow_id IN (${group.map(() => "?").join(", ")})`,
+      [tenantId, ...group],
+    );
+    for (const row of rows) statuses.set(row.workflow_id, row.status);
+  }
+  return statuses;
+}
+
+function buildStages(input: {
+  db: SqliteDatabase;
+  tenantId: string;
+  selected: SelectedExecution;
+  capacity: PipelineCapacity;
+  currentCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>;
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>;
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>;
+  globalRetryability: GlobalRetryability;
+  telemetry: WorkerRuntimeTelemetrySnapshot;
+  budgetAvailable: boolean;
+  generatedAt: string;
+  now: Date;
+}): PipelineOperationalStage[] {
+  const result: PipelineOperationalStage[] = [];
+  for (const stage of OPERATIONAL_STAGES) {
+    const current = input.currentCounts.get(stage) ?? emptyCounts();
+    const sweep = input.sweepCounts.get(stage) ?? emptyCounts();
+    const global = input.globalCounts.get(stage) ?? emptyCounts();
+    const stageEta = estimateForStage(
+      input.db,
+      input.tenantId,
+      stage,
+      current,
+      input.selected,
+      input.telemetry,
+      input.budgetAvailable,
+      input.generatedAt,
+      input.now,
+      retryableRemainingForStage(input.selected, input.selected.current, stage, true),
+      true,
+      currentStageContention(
+        input.selected,
+        stage,
+        input.sweepCounts,
+        input.globalCounts,
+        input.globalRetryability,
+        input.telemetry,
+      ),
+    );
+    result.push({
+      stage,
+      label: STAGE_LABELS[stage],
+      scope: "current_execution",
+      currentExecution: current,
+      existingBacklog: { kind: "not_separate", reason: "current_execution_scope" },
+      capacity: input.capacity,
+      eta: stageEta,
+      asOf: input.generatedAt,
+    });
+    result.push({
+      stage,
+      label: STAGE_LABELS[stage],
+      scope: "execution_sweep",
+      currentExecution: emptyCounts(),
+      existingBacklog: isJobStage(stage) || stage === "pdf_render"
+        ? { kind: "domain_jobs", counts: sweep }
+        : { kind: "not_separate", reason: "no_separate_sweep_queue" },
+      capacity: input.capacity,
+      eta: estimatePipelineEta({
+        ...stageEtaInput(
+          input.db,
+          input.tenantId,
+          stage,
+          sweep,
+          input.selected,
+          input.telemetry,
+          input.budgetAvailable,
+          input.generatedAt,
+          input.now,
+          retryableRemainingForStage(input.selected, input.selected.sweep, stage, false),
+          false,
+        ),
+        membershipOpen: false,
+      }) as PipelineEta,
+      asOf: input.generatedAt,
+    });
+    result.push({
+      stage,
+      label: STAGE_LABELS[stage],
+      scope: "global_outside_execution",
+      currentExecution: emptyCounts(),
+      existingBacklog: isJobStage(stage)
+        ? { kind: "domain_jobs", counts: global }
+        : { kind: "not_separate", reason: "no_global_domain_queue" },
+      capacity: input.capacity,
+      eta: estimatePipelineEta({
+        ...stageEtaInput(
+          input.db,
+          input.tenantId,
+          stage,
+          global,
+          input.selected,
+          input.telemetry,
+          input.budgetAvailable,
+          input.generatedAt,
+          input.now,
+          0,
+          false,
+        ),
+        membershipOpen: false,
+      }) as PipelineEta,
+      asOf: input.generatedAt,
+    });
+  }
+  return result;
+}
+
+function buildGlobalStages(
+  db: SqliteDatabase,
+  tenantId: string,
+  capacity: PipelineCapacity,
+  generatedAt: string,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  now: Date,
+): PipelineOperationalStage[] {
+  const noSelection: SelectedExecution = {
+    row: {
+      workflow_id: "none",
+      temporal_run_id: "none",
+      workflow_type: "DiscoverWorkflow",
+      status: "succeeded",
+      input_summary_json: null,
+      error_code: null,
+      started_at: null,
+      finished_at: null,
+    },
+    phase: "completed",
+    membershipClosed: true,
+    current: cohort([], new Map()),
+    sweep: cohort([], new Map()),
+    steps: [],
+    selectedAs: "latest_terminal",
+  };
+  const global = globalStageCounts(db, tenantId, noSelection);
+  return OPERATIONAL_STAGES.map((stage) => {
+    const counts = global.get(stage) ?? emptyCounts();
+    return {
+      stage,
+      label: STAGE_LABELS[stage],
+      scope: "global_outside_execution",
+      currentExecution: emptyCounts(),
+      existingBacklog: isJobStage(stage)
+        ? { kind: "domain_jobs" as const, counts }
+        : { kind: "not_separate" as const, reason: "no_global_domain_queue" },
+      capacity,
+      eta: estimatePipelineEta(
+        stageEtaInput(db, tenantId, stage, counts, noSelection, telemetry, budgetAvailable, generatedAt, now, 0, false),
+      ) as PipelineEta,
+      asOf: generatedAt,
+    };
+  });
+}
+
+function sourceFamilyProgress(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalRetryability: GlobalRetryability,
+  generatedAt: string,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  now: Date,
+): PipelineOperationsSnapshot["sourceFamilies"] {
+  const sourceRows = selected.steps.filter((step) => step.step_kind === "source_family");
+  const sourcePlanRows = selected.steps.filter((step) => step.step_kind === "source_planning");
+  if (sourceRows.length === 0 && sourcePlanRows.length === 0) return null;
+  const planned = Math.max(maxDetailCount(sourcePlanRows) ?? 0, sourceRows.length);
+  const counts = projectionCounts(sourceRows, planned);
+  return {
+    planned,
+    counts,
+    eta: estimatePipelineEta({
+      ...basicEtaInput(selected, telemetry, budgetAvailable, generatedAt),
+      scope: "known",
+      membershipOpen: false,
+      stages: [
+        {
+          stage: "source_family",
+          remainingCurrentStage: etaRemainingCount(
+            counts,
+            retryablePipelineSteps(sourceRows, isTerminalWorkflowStatus(selected.row.status)),
+          ),
+          primaryEvidence: "pipeline_step_projection",
+          samples: pipelineStepHistorySamples(db, tenantId, "source_family", now),
+        },
+      ],
+      remainingPaths: [],
+      contention: sourceContention(selected, sweepCounts, globalCounts, globalRetryability, telemetry),
+    }) as PipelineEta,
+    asOf: generatedAt,
+  };
+}
+
+function reconciliationProgress(
+  selected: SelectedExecution,
+): PipelineOperationsSnapshot["reconciliation"] {
+  const components = reconciliationComponents(selected.steps);
+  const enrichment = components.enrichment_pass;
+  const preparationFanout = components.preparation_fanout;
+  if (enrichment.eligible === 0 && preparationFanout.eligible === 0) return null;
+  return {
+    enrichment,
+    preparationFanout,
+    asOf: latestStepObservation(
+      selected.steps.filter(
+        (step) => step.step_kind === "enrichment_pass" || step.step_kind === "preparation_fanout",
+      ),
+    ),
+  };
+}
+
+function buildActiveItems(
+  db: SqliteDatabase,
+  selected: SelectedExecution,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+): { items: PipelineActiveItem[]; total: number | null; truncated: boolean | null } {
+  if (telemetry.status !== "available") return { items: [], total: null, truncated: null };
+  const byWorkflow = new Map(
+    selected.current.members
+      .concat(selected.sweep.members)
+      .filter((member): member is MembershipRow & { preparation_workflow_id: string } =>
+        nullableText(member.preparation_workflow_id) !== null,
+      )
+      .map((member) => [member.preparation_workflow_id, member]),
+  );
+  const display = loadJobDisplays(
+    db,
+    [...byWorkflow.values()].map((member) => member.job_url),
+  );
+  const runtimeItems: PipelineActiveItem[] = telemetry.activeDetails.map((detail) => {
+    const member = detail.workflowRef ? byWorkflow.get(detail.workflowRef) : undefined;
+    const stage = RUNTIME_ACTIVITY_STAGE[detail.activityType];
+    if (member && stage && isJobStage(stage)) {
+      const job = display.get(member.job_url);
+      return {
+        kind: "resolved_job" as const,
+        activityType: detail.activityType,
+        workflowId: detail.workflowRef,
+        executionId: detail.executionRef,
+        attempt: detail.attempt,
+        startedAt: detail.startedAt,
+        // The runtime operational ref, not the DB job URL, is the safe display key.
+        jobKey: detail.operationalRef.opaqueId,
+        title: job?.title ?? null,
+        company: job?.company ?? null,
+        stage,
+      };
+    }
+    return {
+      kind: "unresolved_runtime_activity" as const,
+      activityType: detail.activityType,
+      workflowId: detail.workflowRef,
+      executionId: detail.executionRef,
+      attempt: detail.attempt,
+      startedAt: detail.startedAt,
+      opaqueId: detail.operationalRef.opaqueId,
+    };
+  });
+  const consumedRuntimeItemIndexes = new Set<number>();
+  const projectionItems: PipelineActiveItem[] = [];
+  for (const step of selected.steps
+    .filter((step) => step.state === "running")
+    .sort((left, right) => Date.parse(left.started_at ?? "") - Date.parse(right.started_at ?? ""))) {
+    const activityType = STEP_ACTIVITY_TYPES[step.step_kind] ?? step.step_kind;
+    const pdfMember =
+      step.step_kind === "pdf_render"
+        ? selected.current.members
+            .concat(selected.sweep.members)
+            .find((member) => pdfStepForMember(member, [step]) !== undefined)
+        : undefined;
+    const runtimeIndex = runtimeItems.findIndex(
+      (item, index) =>
+        !consumedRuntimeItemIndexes.has(index) &&
+        isExactRuntimeProjectionMatch(item, activityType, selected, step.step_kind === "pdf_render", pdfMember),
+    );
+    // Fresh runtime telemetry is the active-work authority. Projection rows
+    // only enrich a runtime item whose safe workflow identity proves the pair.
+    if (runtimeIndex < 0) continue;
+    consumedRuntimeItemIndexes.add(runtimeIndex);
+    const runtimeItem = runtimeItems[runtimeIndex];
+    const base = {
+      activityType,
+      workflowId: runtimeItem.workflowId,
+      executionId: runtimeItem.executionId,
+      attempt: Math.max(1, Math.floor(nonnegative(step.attempt) ?? 1)),
+      startedAt: step.started_at ?? latestStepObservation([step]),
+    };
+    if (pdfMember) {
+      const job = display.get(pdfMember.job_url);
+      projectionItems.push({
+        ...base,
+        kind: "resolved_job",
+        jobKey: step.item_key,
+        title: job?.title ?? null,
+        company: job?.company ?? null,
+        stage: "pdf_render",
+      });
+    } else if (step.step_kind === "source_family") {
+      projectionItems.push({ ...base, kind: "source_family", sourceFamily: safeItemKey(step.item_key) });
+    } else {
+      projectionItems.push({ ...base, kind: "orchestration", operation: step.step_kind });
+    }
+  }
+  const all = runtimeItems
+    .filter((_item, index) => !consumedRuntimeItemIndexes.has(index))
+    .concat(projectionItems)
+    .sort((left, right) => Date.parse(left.startedAt) - Date.parse(right.startedAt));
+  const items = all.slice(0, 20);
+  return {
+    items,
+    total: telemetry.activeDetailsTotal,
+    truncated:
+      telemetry.activeDetailsTruncated ||
+      telemetry.activeSlots > telemetry.activeDetailsTotal ||
+      all.length > items.length,
+  };
+}
+
+function isExactRuntimeProjectionMatch(
+  item: PipelineActiveItem,
+  activityType: string,
+  selected: SelectedExecution,
+  isPdfRender: boolean,
+  pdfMember: MembershipRow | undefined,
+): boolean {
+  if (item.activityType !== activityType) return false;
+  if (isPdfRender) {
+    const workflowId = pdfMember ? nullableText(pdfMember.preparation_workflow_id) : null;
+    // The latest persisted preparation projection is the only canonical
+    // workflow-id/run-id identity available for a render activity. A workflow
+    // id can repeat across Temporal runs, so do not hydrate it without a run.
+    const runId = workflowId ? preparationWorkflowRunId(selected, workflowId) : undefined;
+    return workflowId !== null && runId !== undefined && item.workflowId === workflowId && item.executionId === runId;
+  }
+  return item.workflowId === selected.row.workflow_id && item.executionId === selected.row.temporal_run_id;
+}
+
+function preparationWorkflowRunId(selected: SelectedExecution, workflowId: string): string | undefined {
+  return selected.current.preparationWorkflowRunIds.get(workflowId) ??
+    selected.sweep.preparationWorkflowRunIds.get(workflowId);
+}
+
+function loadJobDisplays(db: SqliteDatabase, jobUrls: string[]): Map<string, JobDisplayRow> {
+  const result = new Map<string, JobDisplayRow>();
+  if (jobUrls.length === 0 || !hasColumns(db, "jobs", ["url", "title", "company"])) return result;
+  for (const group of chunks(jobUrls, 500)) {
+    const rows = allRows<JobDisplayRow>(
+      db,
+      `SELECT url, title, company FROM jobs WHERE url IN (${group.map(() => "?").join(", ")})`,
+      group,
+    );
+    for (const row of rows) result.set(row.url, row);
+  }
+  return result;
+}
+
+function buildEtaInput(
+  db: SqliteDatabase,
+  tenantId: string,
+  selected: SelectedExecution,
+  currentCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalRetryability: GlobalRetryability,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  generatedAt: string,
+  now: Date,
+): PipelineEtaEstimatorInput {
+  const stages: PipelineEtaStageInput[] = OPERATIONAL_STAGES.filter((stage) => stage !== "reconciliation").map((stage) => ({
+      stage,
+      remainingCurrentStage: etaRemainingCount(
+        currentCounts.get(stage) ?? emptyCounts(),
+        retryableRemainingForStage(selected, selected.current, stage, true),
+      ),
+      primaryEvidence: usesStepProjection(stage)
+        ? ("pipeline_step_projection" as const)
+        : ("job_stage_state" as const),
+      samples: evidenceSamples(db, tenantId, stage, now),
+    }));
+  const reconciliation = reconciliationComponents(selected.steps);
+  stages.push(
+    ...(["enrichment_pass", "preparation_fanout"] as const).map((stage) => ({
+      stage,
+      remainingCurrentStage: etaRemainingCount(
+        reconciliation[stage],
+        retryablePipelineSteps(
+          selected.steps.filter((step) => step.step_kind === stage),
+          isTerminalWorkflowStatus(selected.row.status),
+        ),
+      ),
+      primaryEvidence: "pipeline_step_projection" as const,
+      samples: pipelineStepHistorySamples(db, tenantId, stage, now),
+    })),
+  );
+  return {
+    ...basicEtaInput(selected, telemetry, budgetAvailable, generatedAt),
+    scope: "known" as const,
+    membershipOpen: !selected.membershipClosed,
+    blocked: stages.some((stage) => (currentCounts.get(stage.stage as (typeof OPERATIONAL_STAGES)[number])?.blocked ?? 0) > 0),
+    stages,
+    remainingPaths: remainingPaths(selected.current, selected.steps),
+    contention: contention(selected, sweepCounts, globalCounts, globalRetryability, telemetry),
+  };
+}
+
+function stageEtaInput(
+  db: SqliteDatabase,
+  tenantId: string,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+  counts: PipelineStageCounts,
+  selected: SelectedExecution,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  generatedAt: string,
+  now: Date,
+  retryableRemaining = 0,
+  includeExecutionSteps = true,
+  contentionInput: PipelineEtaEstimatorInput["contention"] = sharedRuntimeContention(telemetry),
+): PipelineEtaEstimatorInput {
+  const stages =
+    stage === "reconciliation" && includeExecutionSteps
+      ? (["enrichment_pass", "preparation_fanout"] as const).map((stepKind) => ({
+          stage: stepKind,
+          remainingCurrentStage: etaRemainingCount(
+            reconciliationComponents(selected.steps)[stepKind],
+            retryablePipelineSteps(
+              selected.steps.filter((step) => step.step_kind === stepKind),
+              isTerminalWorkflowStatus(selected.row.status),
+            ),
+          ),
+          primaryEvidence: "pipeline_step_projection" as const,
+          samples: pipelineStepHistorySamples(db, tenantId, stepKind, now),
+        }))
+      : [
+          {
+            stage,
+            remainingCurrentStage: etaRemainingCount(counts, retryableRemaining),
+            primaryEvidence: usesStepProjection(stage)
+              ? ("pipeline_step_projection" as const)
+              : ("job_stage_state" as const),
+            samples: evidenceSamples(db, tenantId, stage, now),
+          },
+        ];
+  return {
+    ...basicEtaInput(selected, telemetry, budgetAvailable, generatedAt),
+    scope: "known" as const,
+    membershipOpen: false,
+    blocked: counts.blocked > 0,
+    stages,
+    remainingPaths: [],
+    contention: contentionInput,
+  };
+}
+
+function basicEtaInput(
+  selected: SelectedExecution,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  generatedAt: string,
+) {
+  return {
+    asOf: generatedAt,
+    scope: "known" as const,
+    membershipOpen: !selected.membershipClosed,
+    telemetryFresh: telemetry.status === "available",
+    workerAvailable: telemetry.status === "available" && telemetry.configuredSlots > 0,
+    budgetAvailable,
+    blocked: false,
+    dispatchObserved: dispatchObserved(telemetry),
+    configuredSlots: telemetry.status === "available" ? telemetry.configuredSlots : null,
+    stages: [],
+    remainingPaths: [],
+    contention: sharedRuntimeContention(telemetry),
+  };
+}
+
+function estimateForStage(
+  db: SqliteDatabase,
+  tenantId: string,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+  counts: PipelineStageCounts,
+  selected: SelectedExecution,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+  budgetAvailable: boolean,
+  generatedAt: string,
+  now: Date,
+  retryableRemaining = 0,
+  includeExecutionSteps = true,
+  contentionInput: PipelineEtaEstimatorInput["contention"] = sharedRuntimeContention(telemetry),
+): PipelineEta {
+  return estimatePipelineEta(
+    stageEtaInput(
+      db,
+      tenantId,
+      stage,
+      counts,
+      selected,
+      telemetry,
+      budgetAvailable,
+      generatedAt,
+      now,
+      retryableRemaining,
+      includeExecutionSteps,
+      contentionInput,
+    ),
+  ) as PipelineEta;
+}
+
+function evidenceSamples(
+  db: SqliteDatabase,
+  tenantId: string,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+  now: Date,
+): EtaSample[] {
+  const primary = usesStepProjection(stage)
+    ? pipelineStepHistorySamples(db, tenantId, stepKindForStage(stage), now)
+    : jobStageSamples(db, stage, now);
+  // The estimator itself only reads metrics when the owning primary source is empty.
+  return primary.length > 0 ? primary : attemptMetricSamples(db, tenantId, stage, now);
+}
+
+function jobStageSamples(db: SqliteDatabase, stage: string, now: Date): EtaSample[] {
+  if (!tableExists(db, "job_stage_states")) return [];
+  const rows = allRows<StageStateRow>(
+    db,
+    `SELECT job_url, stage, state, duration_ms, finished_at
+       FROM job_stage_states
+      WHERE stage = ? AND state = 'succeeded' AND duration_ms > 0 AND finished_at IS NOT NULL
+      ORDER BY finished_at DESC
+      LIMIT ?`,
+    [stage, ETA_SAMPLE_LIMIT],
+  );
+  return rows
+    .filter((row) => withinEtaWindow(row.finished_at, now))
+    .map((row) => ({
+      source: "job_stage_state" as const,
+      succeeded: true,
+      durationMs: nonnegative(row.duration_ms),
+      completedAt: row.finished_at!,
+    }));
+}
+
+function pipelineStepSamples(steps: PipelineStepRow[], stepKind: string, now: Date): EtaSample[] {
+  return steps
+    .filter(
+      (step) =>
+        step.step_kind === stepKind &&
+        step.state === "succeeded" &&
+        nonnegative(step.duration_ms) !== null &&
+        nonnegative(step.duration_ms)! > 0 &&
+        withinEtaWindow(step.finished_at, now),
+    )
+    .sort((left, right) => Date.parse(right.finished_at ?? "") - Date.parse(left.finished_at ?? ""))
+    .slice(0, ETA_SAMPLE_LIMIT)
+    .map((step) => ({
+      source: "pipeline_step_projection" as const,
+      succeeded: true,
+      durationMs: nonnegative(step.duration_ms),
+      completedAt: step.finished_at!,
+    }));
+}
+
+function pipelineStepHistorySamples(
+  db: SqliteDatabase,
+  tenantId: string,
+  stepKind: string,
+  now: Date,
+): EtaSample[] {
+  if (!tableExists(db, "pipeline_step_projections")) return [];
+  const rows = allRows<PipelineStepRow>(
+    db,
+    `SELECT step_kind, item_key, state, attempt, retryable, duration_ms, finished_at,
+            started_at, detail_count
+       FROM pipeline_step_projections
+      WHERE tenant_id = ? AND step_kind = ? AND state = 'succeeded'
+        AND duration_ms > 0 AND finished_at IS NOT NULL
+      ORDER BY finished_at DESC
+      LIMIT ?`,
+    [tenantId, stepKind, ETA_SAMPLE_LIMIT],
+  );
+  return pipelineStepSamples(rows, stepKind, now);
+}
+
+function attemptMetricSamples(db: SqliteDatabase, tenantId: string, stage: string, now: Date): EtaSample[] {
+  if (!tableExists(db, "operational_attempt_metrics")) return [];
+  const rows = allRows<MetricRow>(
+    db,
+    `SELECT stage, outcome, duration_ms, occurred_at
+       FROM operational_attempt_metrics
+      WHERE tenant_id = ? AND stage = ? AND duration_ms > 0
+        AND outcome IN ('succeeded', 'success')
+      ORDER BY occurred_at DESC
+      LIMIT ?`,
+    [tenantId, stageForMetric(stage), ETA_SAMPLE_LIMIT],
+  );
+  return rows
+    .filter((row) => withinEtaWindow(row.occurred_at, now))
+    .map((row) => ({
+      source: "operational_attempt_metric" as const,
+      succeeded: true,
+      durationMs: nonnegative(row.duration_ms),
+      completedAt: row.occurred_at,
+    }));
+}
+
+function remainingPaths(
+  cohortValue: Cohort,
+  pipelineSteps: PipelineStepRow[],
+): Array<{ stageIds: string[] }> {
+  return cohortValue.members.flatMap((member) => {
+    if (member.work_plan_state !== "planned") return [];
+    const states = cohortValue.stageStates.get(member.job_url);
+    const stageIds = requiredSteps(member).filter((stage) => {
+      const terminalOwner = memberPreparationWorkflowFailed(member, cohortValue.preparationWorkflowStatuses);
+      if (stage === "pdf") return !isTerminalStepState(pdfStepForMember(member, pipelineSteps), terminalOwner);
+      return !isTerminalStageState(states?.get(stage), terminalOwner);
+    });
+    return stageIds.length > 0 ? [{ stageIds: stageIds.map((stage) => (stage === "pdf" ? "pdf_render" : stage)) }] : [];
+  });
+}
+
+function contention(
+  selected: SelectedExecution,
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalRetryability: GlobalRetryability,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+) {
+  if (telemetry.status !== "available" || hasUnboundedQueueContention(telemetry)) {
+    return { kind: "unknown" as const };
+  }
+  if (telemetry.activeDetailsTruncated || telemetry.activeSlots > telemetry.activeDetailsTotal) {
+    return { kind: "truncated" as const };
+  }
+  if (globalRetryability.hasUnboundedRetryableDemand) return { kind: "unknown" as const };
+  const existingBacklog = [...JOB_STAGES, "pdf_render" as const].map((stage) => ({
+    stage,
+    count:
+      remainingCount(sweepCounts.get(stage) ?? emptyCounts()) +
+      remainingCount(globalCounts.get(stage) ?? emptyCounts()),
+  })).filter((entry) => entry.count > 0);
+  // Global stage-count projections do not retain retryability. Do not inflate
+  // queue-ahead demand with terminal failures; sweep membership is exact.
+  const retries = [...JOB_STAGES, "pdf_render" as const].map((stage) => ({
+    stage,
+    count: retryableRemainingForStage(selected, selected.sweep, stage, false),
+  })).filter((entry) => entry.count > 0);
+  return { kind: "bounded" as const, existingBacklog, retries, queuePresent: queuePresent(telemetry) };
+}
+
+function sharedRuntimeContention(telemetry: WorkerRuntimeTelemetrySnapshot) {
+  if (telemetry.status !== "available" || hasUnboundedQueueContention(telemetry)) {
+    return { kind: "unknown" as const };
+  }
+  if (telemetry.activeDetailsTruncated || telemetry.activeSlots > telemetry.activeDetailsTotal) {
+    return { kind: "truncated" as const };
+  }
+  return { kind: "bounded" as const, existingBacklog: [], retries: [], queuePresent: false };
+}
+
+function currentStageContention(
+  selected: SelectedExecution,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalRetryability: GlobalRetryability,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+): PipelineEtaEstimatorInput["contention"] {
+  if (!isJobStage(stage) && stage !== "pdf_render") {
+    return sourceContention(selected, sweepCounts, globalCounts, globalRetryability, telemetry);
+  }
+  const runtime = sharedRuntimeContention(telemetry);
+  if (runtime.kind !== "bounded") return runtime;
+  if (globalRetryability.hasUnboundedRetryableDemand) return { kind: "unknown" };
+  const sweep = sweepCounts.get(stage) ?? emptyCounts();
+  const global = globalCounts.get(stage) ?? emptyCounts();
+  const heterogeneousDemand = [...JOB_STAGES, "pdf_render" as const].some((otherStage) => {
+    if (otherStage === stage) return false;
+    return remainingCount(sweepCounts.get(otherStage) ?? emptyCounts()) > 0 ||
+      remainingCount(globalCounts.get(otherStage) ?? emptyCounts()) > 0 ||
+      retryableRemainingForStage(selected, selected.sweep, otherStage, false) > 0;
+  });
+  // The ETA sample only prices this stage. Competing work from another stage
+  // shares its slots but has no interchangeable duration evidence, so it
+  // cannot be safely bounded as a same-stage queue-ahead count.
+  if (heterogeneousDemand) return { kind: "unknown" };
+  const externalCount = remainingCount(sweep) + remainingCount(global);
+  const retryCount = retryableRemainingForStage(selected, selected.sweep, stage, false);
+  return {
+    kind: "bounded",
+    existingBacklog: externalCount > 0 ? [{ stage, count: externalCount }] : [],
+    retries: retryCount > 0 ? [{ stage, count: retryCount }] : [],
+    queuePresent: false,
+  };
+}
+
+function sourceContention(
+  selected: SelectedExecution,
+  sweepCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalCounts: Map<(typeof OPERATIONAL_STAGES)[number], PipelineStageCounts>,
+  globalRetryability: GlobalRetryability,
+  telemetry: WorkerRuntimeTelemetrySnapshot,
+) {
+  const runtime = sharedRuntimeContention(telemetry);
+  if (runtime.kind !== "bounded") return runtime;
+  if (globalRetryability.hasUnboundedRetryableDemand) return { kind: "unknown" as const };
+  const competingDomainWork = [...JOB_STAGES, "pdf_render" as const].some(
+    (stage) =>
+      remainingCount(sweepCounts.get(stage) ?? emptyCounts()) > 0 ||
+      remainingCount(globalCounts.get(stage) ?? emptyCounts()) > 0 ||
+      retryableRemainingForStage(selected, selected.sweep, stage, false) > 0,
+  );
+  // Source-family duration evidence cannot price heterogeneous preparation
+  // work in the same activity pool, so keep that ETA unavailable rather than
+  // pretending the shared slots are reserved for source work.
+  return competingDomainWork ? { kind: "unknown" as const } : runtime;
+}
+
+function etaRemainingCount(counts: PipelineStageCounts, retryableFailures: number): number {
+  return remainingCount(counts) + retryableFailures;
+}
+
+function retryableRemainingForStage(
+  selected: SelectedExecution,
+  cohortValue: Cohort,
+  stage: (typeof OPERATIONAL_STAGES)[number],
+  includeExecutionSteps: boolean,
+): number {
+  if (isJobStage(stage)) {
+    return cohortValue.members.filter(
+      (member) =>
+        (stage === "enrich"
+          ? member.work_plan_state !== "not_eligible"
+          : member.work_plan_state === "planned" && requiredSteps(member).includes(stage)) &&
+        retryableStageFailureForMember(cohortValue, member, stage),
+    ).length;
+  }
+  if (stage === "pdf_render") {
+    return cohortValue.members.filter(
+      (member) =>
+        member.work_plan_state === "planned" &&
+        requiredSteps(member).includes("pdf") &&
+        isRetryableStepFailure(
+          pdfStepForMember(member, selected.steps),
+          memberPreparationWorkflowFailed(member, cohortValue.preparationWorkflowStatuses),
+        ),
+    ).length;
+  }
+  if (!includeExecutionSteps) return 0;
+  if (stage === "reconciliation") {
+    return retryablePipelineSteps(
+      selected.steps.filter(
+        (step) => step.step_kind === "enrichment_pass" || step.step_kind === "preparation_fanout",
+      ),
+      isTerminalWorkflowStatus(selected.row.status),
+    );
+  }
+  return retryablePipelineSteps(
+    selected.steps.filter((step) => step.step_kind === stage),
+    isTerminalWorkflowStatus(selected.row.status),
+  );
+}
+
+function retryablePipelineSteps(steps: PipelineStepRow[], terminalOwnerTerminal = false): number {
+  return steps.filter((step) => isRetryableStepFailure(step, terminalOwnerTerminal)).length;
+}
+
+function retryableStageFailureForMember(
+  cohortValue: Cohort,
+  member: MembershipRow,
+  stage: (typeof JOB_STAGES)[number],
+): boolean {
+  const state = cohortValue.stageStates.get(member.job_url)?.get(stage);
+  return state !== undefined && isRetryableStageFailure(
+    state,
+    memberPreparationWorkflowFailed(member, cohortValue.preparationWorkflowStatuses),
+  );
+}
+
+function isRetryableStepFailure(step: PipelineStepRow | undefined, terminalOwnerTerminal = false): boolean {
+  return step?.state === "failed" && Number(step.retryable) === 1 && !terminalOwnerTerminal;
+}
+
+function memberPreparationWorkflowFailed(
+  member: MembershipRow,
+  preparationWorkflowStatuses: Map<string, string>,
+): boolean {
+  const workflowId = nullableText(member.preparation_workflow_id);
+  return workflowId !== null && isFailedTerminalWorkflowStatus(preparationWorkflowStatuses.get(workflowId));
+}
+
+function isFailedTerminalWorkflowStatus(status: string | undefined): boolean {
+  return status === "failed" || status === "canceled" || status === "timed_out" || status === "terminated";
+}
+
+function isTerminalWorkflowStatus(status: string | undefined): boolean {
+  return isFailedTerminalWorkflowStatus(status) || status === "succeeded" || status === "dry_run_complete";
+}
+
+function isJobStage(stage: string): stage is (typeof JOB_STAGES)[number] {
+  return (JOB_STAGES as readonly string[]).includes(stage);
+}
+
+function usesStepProjection(stage: string): boolean {
+  return !isJobStage(stage);
+}
+
+function stepKindForStage(stage: string): string {
+  return stage;
+}
+
+function stageForMetric(stage: string): string {
+  return stage === "pdf_render" ? "pdf" : stage === "source_family" ? "discover" : stage;
+}
+
+function dispatchObserved(telemetry: WorkerRuntimeTelemetrySnapshot): boolean {
+  return (
+    (telemetry.status === "available" && telemetry.activeSlots > 0) ||
+    (telemetry.taskQueueObservation.status === "available" && telemetry.taskQueueObservation.activity.tasksDispatchRate > 0)
+  );
+}
+
+function queuePresent(telemetry: WorkerRuntimeTelemetrySnapshot): boolean {
+  return telemetry.taskQueueObservation.status === "available" && telemetry.taskQueueObservation.activity.approximateBacklogCount > 0;
+}
+
+function hasUnboundedQueueContention(telemetry: WorkerRuntimeTelemetrySnapshot): boolean {
+  const observation = telemetry.taskQueueObservation;
+  if (observation.status !== "available") return true;
+  return (
+    observation.workflow.approximateBacklogCount > 0 ||
+    observation.activity.approximateBacklogCount > 0
+  );
+}
+
+function requiredSteps(member: MembershipRow): Array<"score" | "tailor" | "cover" | "pdf"> {
+  const parsed = parseJson(member.required_steps_json);
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(
+    (value): value is "score" | "tailor" | "cover" | "pdf" =>
+      value === "score" || value === "tailor" || value === "cover" || value === "pdf",
+  );
+}
+
+function emptyCounts(): PipelineStageCounts {
+  return {
+    eligible: 0,
+    waiting: 0,
+    processing: 0,
+    succeeded: 0,
+    skipped: 0,
+    blocked: 0,
+    failed: 0,
+    exhausted: 0,
+    canceled: 0,
+    needsVerification: 0,
+    stale: 0,
+    unknown: 0,
+  };
+}
+
+function outcomeSum(counts: PipelineStageCounts): number {
+  return (
+    counts.waiting +
+    counts.processing +
+    counts.succeeded +
+    counts.skipped +
+    counts.blocked +
+    counts.failed +
+    counts.exhausted +
+    counts.canceled +
+    counts.needsVerification +
+    counts.stale +
+    counts.unknown
+  );
+}
+
+function remainingCount(counts: PipelineStageCounts): number {
+  return counts.waiting + counts.processing + counts.blocked + counts.needsVerification + counts.stale + counts.unknown;
+}
+
+function isTerminalStageState(state: StageStateRow | undefined, terminalOwnerFailed = false): boolean {
+  if (!state) return false;
+  return (
+    ["succeeded", "skipped", "exhausted", "canceled"].includes(state.state ?? "") ||
+    isTerminalStageFailure(state, terminalOwnerFailed)
+  );
+}
+
+function isSuccessfulStageState(state: StageStateRow): boolean {
+  return state.state === "succeeded" || state.state === "skipped";
+}
+
+function isRetryableStageFailure(state: StageStateRow, terminalOwnerFailed = false): boolean {
+  return state.state === "failed" && Number(state.retryable) === 1 && !terminalOwnerFailed;
+}
+
+function isTerminalStageFailure(state: StageStateRow, terminalOwnerFailed = false): boolean {
+  return state.state === "failed" && (Number(state.retryable) !== 1 || terminalOwnerFailed);
+}
+
+function maxDetailCount(rows: PipelineStepRow[]): number | null {
+  const values = rows
+    .map((row) => nonnegative(row.detail_count))
+    .filter((value): value is number => value !== null);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+function latestStepObservation(steps: PipelineStepRow[]): string {
+  const timestamps = steps
+    .flatMap((step) => [step.finished_at, step.started_at])
+    .filter((value): value is string => nullableText(value) !== null)
+    .sort((left, right) => Date.parse(right) - Date.parse(left));
+  return timestamps[0] ?? new Date(0).toISOString();
+}
+
+function withinEtaWindow(timestamp: string | null, now: Date): boolean {
+  if (!timestamp) return false;
+  const parsed = Date.parse(timestamp);
+  return !Number.isNaN(parsed) && parsed <= now.getTime() && parsed >= now.getTime() - ETA_SAMPLE_WINDOW_MS;
+}
+
+function nonnegative(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function nullableText(value: unknown): string | null {
+  return typeof value === "string" && value.trim() !== "" ? value : null;
+}
+
+function safeCode(value: unknown): string | null {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9_.:-]{0,79}$/.test(value) ? value : null;
+}
+
+function safeItemKey(value: string): string {
+  return /^[a-z0-9][a-z0-9_.:-]{0,159}$/.test(value) ? value : "unknown_source_family";
+}
+
+function parseJson(raw: string | null): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function parseRecord(raw: string | null): Record<string, unknown> | null {
+  const parsed = parseJson(raw);
+  return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : null;
+}
+
+function hasColumns(db: SqliteDatabase, tableName: string, columns: string[]): boolean {
+  if (!tableExists(db, tableName)) return false;
+  const present = new Set(
+    db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all().map((row) => String((row as { name: unknown }).name)),
+  );
+  return columns.every((column) => present.has(column));
+}
+
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replaceAll('"', '""')}"`;
+}
+
+function chunks<T>(items: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) result.push(items.slice(index, index + size));
+  return result;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -230,6 +230,7 @@ import {
   getWorkflowRunDetail,
   readSettingsConfig,
 } from "./read-model.js";
+import { buildPipelineOperationsSnapshot } from "./pipeline-operations.js";
 import { refreshProjections } from "./projections.js";
 import { createResumeHtmlPdfRenderer, type ResumeHtmlPdfRenderer } from "./resume-pdf-render.js";
 import {
@@ -533,6 +534,15 @@ export function buildApp(options: BuildAppOptions): FastifyInstance {
 
   app.get("/v1/dashboard/summary", async (_request, reply) =>
     withDb(reply, options.dbPath, (db) => buildDashboardSummary(db)),
+  );
+
+  app.get("/v1/pipeline/operations", async (_request, reply) =>
+    withDb(reply, options.dbPath, (db) =>
+      buildPipelineOperationsSnapshot(db, {
+        dbPath: options.dbPath,
+        configPath: options.configPath,
+      }),
+    ),
   );
 
   app.get("/v1/analytics/outcomes", async (_request, reply) =>

--- a/apps/api/test/pipeline-eta.test.ts
+++ b/apps/api/test/pipeline-eta.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PIPELINE_ETA_MAX_SAMPLES,
+  PIPELINE_ETA_MINIMUM_SAMPLES,
+  estimatePipelineEta,
+  nearestRankPercentile,
+  roundEtaRangeSeconds,
+  type PipelineEtaDurationSample,
+  type PipelineEtaEstimatorInput,
+  type PipelineEtaStageInput,
+} from "../src/pipeline-eta.js";
+
+const AS_OF = "2026-07-14T12:00:00.000Z";
+
+function sample(
+  durationMs: number,
+  options: Partial<PipelineEtaDurationSample> = {},
+): PipelineEtaDurationSample {
+  return {
+    source: "job_stage_state",
+    succeeded: true,
+    durationMs,
+    completedAt: "2026-07-14T11:59:00.000Z",
+    ...options,
+  };
+}
+
+function stage(
+  options: Partial<PipelineEtaStageInput> = {},
+): PipelineEtaStageInput {
+  return {
+    stage: "score",
+    remainingCurrentStage: 1,
+    primaryEvidence: "job_stage_state",
+    samples: Array.from({ length: PIPELINE_ETA_MINIMUM_SAMPLES }, () => sample(600_000)),
+    ...options,
+  };
+}
+
+function input(overrides: Partial<PipelineEtaEstimatorInput> = {}): PipelineEtaEstimatorInput {
+  const stages = overrides.stages ?? [stage()];
+  return {
+    asOf: AS_OF,
+    scope: "known",
+    membershipOpen: false,
+    telemetryFresh: true,
+    workerAvailable: true,
+    budgetAvailable: true,
+    blocked: false,
+    dispatchObserved: true,
+    configuredSlots: 1,
+    stages,
+    remainingPaths: [{ stageIds: ["score"] }],
+    contention: { kind: "bounded", existingBacklog: [], retries: [], queuePresent: false },
+    ...overrides,
+  };
+}
+
+describe("estimatePipelineEta", () => {
+  it("applies gate order before attempting any calculation", () => {
+    expect(
+      estimatePipelineEta(
+        input({
+          scope: "unknown",
+          stages: [stage({ remainingCurrentStage: 0 })],
+          telemetryFresh: false,
+          workerAvailable: false,
+        }),
+      ),
+    ).toMatchObject({ status: "unavailable", reason: "unknown_scope" });
+
+    expect(
+      estimatePipelineEta(input({ stages: [stage({ remainingCurrentStage: 0 })], telemetryFresh: false })),
+    ).toMatchObject({ status: "unavailable", reason: "no_work" });
+
+    expect(
+      estimatePipelineEta(input({ telemetryFresh: false, workerAvailable: false })),
+    ).toMatchObject({ status: "stale", reason: "telemetry_stale" });
+
+    expect(
+      estimatePipelineEta(
+        input({
+          workerAvailable: false,
+          budgetAvailable: false,
+          blocked: true,
+          dispatchObserved: false,
+          contention: { kind: "unresolved" },
+        }),
+      ),
+    ).toMatchObject({ status: "paused", reason: "worker_unavailable" });
+  });
+
+  it("keeps the overall ETA calibrating while terminal fanout membership is open", () => {
+    expect(estimatePipelineEta(input({ membershipOpen: true }))).toMatchObject({
+      status: "calibrating",
+      reason: "membership_open",
+      completedSamples: PIPELINE_ETA_MINIMUM_SAMPLES,
+    });
+
+    expect(estimatePipelineEta(input({ membershipOpen: false }))).toMatchObject({ status: "available" });
+  });
+
+  it("returns no_work instead of a zero-duration range", () => {
+    expect(
+      estimatePipelineEta(input({ stages: [stage({ remainingCurrentStage: 0 })] })),
+    ).toEqual({ status: "unavailable", reason: "no_work", asOf: AS_OF });
+  });
+
+  it("returns stale telemetry before evaluating worker or sample state", () => {
+    expect(
+      estimatePipelineEta(input({ telemetryFresh: false, stages: [stage({ samples: [] })] })),
+    ).toEqual({ status: "stale", reason: "telemetry_stale", asOf: AS_OF });
+  });
+
+  it.each([
+    ["workerAvailable", false, "worker_unavailable"],
+    ["budgetAvailable", false, "budget_exceeded"],
+    ["blocked", true, "blocked"],
+    ["dispatchObserved", false, "no_dispatch"],
+  ] as const)("pauses for %s", (key, value, reason) => {
+    const overrides = { [key]: value } as Partial<PipelineEtaEstimatorInput>;
+    expect(estimatePipelineEta(input(overrides))).toEqual({ status: "paused", reason, asOf: AS_OF });
+  });
+
+  it.each(["unknown", "truncated", "unresolved"] as const)(
+    "does not invent a range for %s external contention",
+    (kind) => {
+      expect(estimatePipelineEta(input({ contention: { kind } }))).toEqual({
+        status: "unavailable",
+        reason: "contention_unbounded",
+        asOf: AS_OF,
+      });
+    },
+  );
+
+  it("calibrates on the minimum primary evidence without unioning metric fallback", () => {
+    const primary = Array.from({ length: 4 }, () => sample(600_000));
+    const metrics = Array.from({ length: 12 }, () =>
+      sample(60_000, { source: "operational_attempt_metric" }),
+    );
+    expect(estimatePipelineEta(input({ stages: [stage({ samples: [...primary, ...metrics] })] }))).toMatchObject({
+      status: "calibrating",
+      reason: "insufficient_samples",
+      completedSamples: 4,
+      minimumSamples: 5,
+    });
+  });
+
+  it("uses operational metrics only when primary stage evidence is absent", () => {
+    const metrics = Array.from({ length: PIPELINE_ETA_MINIMUM_SAMPLES }, () =>
+      sample(600_000, { source: "operational_attempt_metric" }),
+    );
+    expect(estimatePipelineEta(input({ stages: [stage({ samples: metrics })] }))).toMatchObject({
+      status: "available",
+      sampleSize: PIPELINE_ETA_MINIMUM_SAMPLES,
+    });
+  });
+
+  it.each(["source_family", "preparation_fanout", "pdf_render"])(
+    "uses pipeline step projections as primary evidence for %s steps",
+    (stepName) => {
+      const projections = Array.from({ length: 4 }, () =>
+        sample(600_000, { source: "pipeline_step_projection" }),
+      );
+      const metrics = Array.from({ length: 12 }, () =>
+        sample(60_000, { source: "operational_attempt_metric" }),
+      );
+      expect(
+        estimatePipelineEta(
+          input({
+            stages: [
+              stage({
+                stage: stepName,
+                primaryEvidence: "pipeline_step_projection",
+                samples: [...projections, ...metrics],
+              }),
+            ],
+            remainingPaths: [{ stageIds: [stepName] }],
+          }),
+        ),
+      ).toMatchObject({ status: "calibrating", completedSamples: 4 });
+    },
+  );
+
+  it("uses nearest-rank percentiles and only the newest fifty valid samples in the fourteen-day window", () => {
+    expect(nearestRankPercentile([100, 200, 300, 400, 500], 50)).toBe(300);
+    expect(nearestRankPercentile([100, 200, 300, 400, 500], 90)).toBe(500);
+
+    const newest = Array.from({ length: PIPELINE_ETA_MAX_SAMPLES }, (_, index) =>
+      sample(600_000, {
+        completedAt: `2026-07-14T11:${String(index % 60).padStart(2, "0")}:00.000Z`,
+      }),
+    );
+    const olderButInWindow = Array.from({ length: 10 }, () =>
+      sample(9_999_000, { completedAt: "2026-07-13T00:00:00.000Z" }),
+    );
+    const expired = sample(9_999_000, { completedAt: "2026-06-29T11:59:00.000Z" });
+    const result = estimatePipelineEta(
+      input({ stages: [stage({ samples: [...newest, ...olderButInWindow, expired] })] }),
+    );
+    expect(result).toMatchObject({
+      status: "available",
+      sampleSize: PIPELINE_ETA_MAX_SAMPLES,
+      lowSeconds: 600,
+      highSeconds: 660,
+    });
+  });
+
+  it("rounds ranges outward and retains one displayed increment for an otherwise exact result", () => {
+    expect(roundEtaRangeSeconds(61, 119)).toEqual({ lowSeconds: 60, highSeconds: 120 });
+    expect(roundEtaRangeSeconds(60, 60)).toEqual({ lowSeconds: 60, highSeconds: 120 });
+    expect(roundEtaRangeSeconds(3_601, 3_601)).toEqual({ lowSeconds: 3_600, highSeconds: 3_900 });
+  });
+
+  it("uses the shared-pool lower bound as well as the longest remaining path", () => {
+    const result = estimatePipelineEta(
+      input({
+        configuredSlots: 4,
+        stages: [stage({ remainingCurrentStage: 8 })],
+      }),
+    );
+    expect(result).toMatchObject({ status: "available", lowSeconds: 1_200 });
+  });
+
+  it("adds bounded existing-backlog and retry demand before applying the pool bound to the high range", () => {
+    const result = estimatePipelineEta(
+      input({
+        configuredSlots: 4,
+        stages: [stage({ remainingCurrentStage: 4 })],
+        contention: {
+          kind: "bounded",
+          existingBacklog: [{ stage: "score", count: 1 }],
+          retries: [{ stage: "score", count: 2 }],
+          queuePresent: false,
+        },
+      }),
+    );
+    expect(result).toMatchObject({
+      status: "available",
+      lowSeconds: 600,
+      highSeconds: 1_080,
+      caveat: expect.any(String),
+    });
+  });
+
+  it("sets confidence from per-stage sample support and bounded contention", () => {
+    const highSamples = Array.from({ length: 20 }, () => sample(600_000));
+    const mediumSamples = Array.from({ length: 10 }, () => sample(600_000));
+    const lowSamples = Array.from({ length: 5 }, () => sample(600_000));
+
+    expect(estimatePipelineEta(input({ stages: [stage({ samples: highSamples })] }))).toMatchObject({
+      status: "available",
+      confidence: "high",
+    });
+    expect(
+      estimatePipelineEta(
+        input({
+          stages: [stage({ samples: mediumSamples })],
+          contention: { kind: "bounded", existingBacklog: [], retries: [], queuePresent: true },
+        }),
+      ),
+    ).toMatchObject({ status: "available", confidence: "medium" });
+    expect(estimatePipelineEta(input({ stages: [stage({ samples: lowSamples })] }))).toMatchObject({
+      status: "available",
+      confidence: "low",
+    });
+  });
+});

--- a/apps/api/test/pipeline-operations.test.ts
+++ b/apps/api/test/pipeline-operations.test.ts
@@ -1,0 +1,973 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import Database from "better-sqlite3";
+import { PipelineOperationsSnapshotSchema } from "@jobctrl/contracts";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildPipelineOperationsSnapshot } from "../src/pipeline-operations.js";
+import { ensureProjectionTables } from "../src/projections.js";
+
+const NOW = new Date("2026-07-14T12:00:00.000Z");
+const DISCOVER_WORKFLOW_ID = "discover-local";
+const DISCOVER_RUN_ID = "00000000-0000-4000-8000-000000000000";
+const PREPARATION_RUN_ID = "00000000-0000-4000-8000-000000000010";
+const fixtures: Fixture[] = [];
+
+interface Fixture {
+  directory: string;
+  dbPath: string;
+  configPath: string;
+  db: Database.Database;
+}
+
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    fixture.db.close();
+    fs.rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+describe("pipeline operations read model", () => {
+  it.each([
+    ["in_progress", "discovering", false, "pending"],
+    ["canceled", "canceled", false, "pending"],
+    ["failed", "failed", false, "pending"],
+    ["succeeded", "draining", true, "pending"],
+    ["succeeded", "completed", true, "succeeded"],
+    ["succeeded", "completed_with_issues", true, "failed"],
+  ] as const)("selects the %s execution phase", (status, phase, terminalFanout, scoreState) => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status });
+    insertMember(fixture, { key: "phase", requiredSteps: ["score"] });
+    insertStageState(fixture, "phase", "score", scoreState);
+    if (terminalFanout) insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+
+    expect(snapshot(fixture).execution).toMatchObject({ phase, membershipClosed: terminalFanout });
+  });
+
+  it("does not terminalize retryable fanout, stage, or PDF failures", () => {
+    const terminalFanout = createFixture();
+    insertExecution(terminalFanout, { status: "succeeded" });
+    insertMember(terminalFanout, { key: "fanout-retry", requiredSteps: ["score"] });
+    insertStageState(terminalFanout, "fanout-retry", "score", "succeeded");
+    insertStep(terminalFanout, {
+      stepKind: "preparation_fanout",
+      itemKey: "terminal",
+      state: "failed",
+      retryable: 1,
+    });
+    const terminalFanoutResult = snapshot(terminalFanout);
+    expect(terminalFanoutResult.execution).toMatchObject({
+      membershipClosed: true,
+      phase: "completed_with_issues",
+    });
+
+    const retryingFanout = createFixture();
+    insertExecution(retryingFanout, { status: "in_progress" });
+    insertMember(retryingFanout, { key: "fanout-backoff", requiredSteps: ["score"] });
+    insertStageState(retryingFanout, "fanout-backoff", "score", "succeeded");
+    insertStep(retryingFanout, {
+      stepKind: "preparation_fanout",
+      itemKey: "terminal",
+      state: "failed",
+      retryable: 1,
+    });
+    insertHeartbeat(retryingFanout, {
+      activeSlots: 1,
+      counts: { discovery_preparation_fanout: 1 },
+      details: [activityDetail("discovery_preparation_fanout", "op_000000000000000000000010", "discover-local")],
+    });
+    const fanoutResult = snapshot(retryingFanout);
+    expect(fanoutResult.execution).toMatchObject({
+      membershipClosed: false,
+      phase: "discovering",
+    });
+    expect(fanoutResult.overallEta).not.toMatchObject({ status: "unavailable", reason: "no_work" });
+
+    const retryableStage = createFixture();
+    insertExecution(retryableStage, { status: "succeeded" });
+    insertMember(retryableStage, { key: "stage-retry", requiredSteps: ["score"] });
+    insertStageState(retryableStage, "stage-retry", "score", "failed", null, null, 1);
+    insertStep(retryableStage, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    insertHeartbeat(retryableStage, {
+      activeSlots: 1,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000011", unmatchedWorkflowRef("retry-stage"))],
+    });
+    const stageResult = snapshot(retryableStage);
+    expect(stageResult.execution).toMatchObject({ phase: "draining" });
+    expect(stageResult.overallEta).not.toMatchObject({ status: "unavailable", reason: "no_work" });
+
+    const retryableSource = createFixture();
+    insertExecution(retryableSource, { status: "in_progress" });
+    insertStep(retryableSource, {
+      stepKind: "source_planning",
+      itemKey: "retry-plan",
+      state: "failed",
+      retryable: 1,
+    });
+    insertHeartbeat(retryableSource, {
+      activeSlots: 1,
+      counts: { plan_discovery_sources: 1 },
+      details: [activityDetail("plan_discovery_sources", "op_000000000000000000000013", "discover-local")],
+    });
+    expect(stage(snapshot(retryableSource), "source_planning", "current_execution").eta)
+      .not.toMatchObject({ status: "unavailable", reason: "no_work" });
+
+    const retryablePdf = createFixture();
+    const current = insertMember(retryablePdf, { key: "pdf-current-retry", requiredSteps: ["pdf"] });
+    const sweep = insertMember(retryablePdf, {
+      key: "pdf-sweep-retry",
+      cohort: "existing_backlog",
+      requiredSteps: ["pdf"],
+    });
+    insertExecution(retryablePdf, { status: "succeeded" });
+    insertStep(retryablePdf, {
+      stepKind: "pdf_render",
+      itemKey: pdfItemKey(current.preparationWorkflowId),
+      state: "failed",
+      retryable: 1,
+    });
+    insertStep(retryablePdf, {
+      stepKind: "pdf_render",
+      itemKey: pdfItemKey(sweep.preparationWorkflowId),
+      state: "failed",
+      retryable: 1,
+    });
+    insertStep(retryablePdf, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    insertHeartbeat(retryablePdf, {
+      activeSlots: 1,
+      counts: { render_pdf: 1 },
+      details: [activityDetail("render_pdf", "op_000000000000000000000012", current.preparationWorkflowId)],
+    });
+
+    const result = snapshot(retryablePdf);
+    expect(result.execution).toMatchObject({ phase: "draining" });
+    expect(result.overallEta).not.toMatchObject({ status: "unavailable", reason: "no_work" });
+    expect(stage(result, "pdf_render", "current_execution").currentExecution).toMatchObject({ failed: 1 });
+    expect(stage(result, "pdf_render", "execution_sweep").existingBacklog).toMatchObject({
+      kind: "domain_jobs",
+      counts: { failed: 1 },
+    });
+
+    const exhausted = createFixture();
+    const exhaustedMember = insertMember(exhausted, { key: "exhausted-stage", requiredSteps: ["score"] });
+    insertExecution(exhausted, { status: "succeeded" });
+    insertStageState(exhausted, "exhausted-stage", "score", "failed", null, null, 1);
+    insertWorkflowProjection(exhausted, exhaustedMember.preparationWorkflowId, "failed");
+    insertStep(exhausted, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    expect(snapshot(exhausted).execution).toMatchObject({
+      phase: "completed_with_issues",
+      currentExecution: { terminal: 1, remaining: 0 },
+    });
+
+    const exhaustedPdf = createFixture();
+    const exhaustedPdfMember = insertMember(exhaustedPdf, { key: "exhausted-pdf", requiredSteps: ["pdf"] });
+    insertExecution(exhaustedPdf, { status: "succeeded" });
+    insertStep(exhaustedPdf, {
+      stepKind: "pdf_render",
+      itemKey: pdfItemKey(exhaustedPdfMember.preparationWorkflowId),
+      state: "failed",
+      retryable: 1,
+    });
+    insertWorkflowProjection(exhaustedPdf, exhaustedPdfMember.preparationWorkflowId, "timed_out");
+    insertStep(exhaustedPdf, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    expect(snapshot(exhaustedPdf).execution).toMatchObject({
+      phase: "completed_with_issues",
+      currentExecution: { terminal: 1, remaining: 0 },
+    });
+  });
+
+  it("keeps promoted members current and swept members separate while excluding both from global backlog", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "promoted", cohort: "observed_this_run", requiredSteps: ["score"] });
+    insertMember(fixture, { key: "swept", cohort: "existing_backlog", requiredSteps: ["score"] });
+    insertMember(fixture, {
+      key: "outside",
+      cohort: "observed_this_run",
+      requiredSteps: [],
+      workflowId: "other",
+      runId: "other-run",
+    });
+    insertStageState(fixture, "promoted", "score", "succeeded");
+    insertStageState(fixture, "swept", "score", "pending");
+    insertStageState(fixture, "outside", "score", "succeeded");
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+
+    const result = snapshot(fixture);
+    expect(result.execution).toMatchObject({
+      phase: "draining",
+      currentExecution: { members: 1, planned: 1, terminal: 1, remaining: 0 },
+      sweptExistingBacklog: { members: 1, planned: 1, terminal: 0, remaining: 1 },
+    });
+    expect(stage(result, "score", "current_execution").currentExecution).toMatchObject({ eligible: 1, succeeded: 1 });
+    expect(stage(result, "score", "execution_sweep").existingBacklog).toMatchObject({
+      kind: "domain_jobs",
+      counts: { eligible: 1, waiting: 1 },
+    });
+    expect(stage(result, "score", "global_outside_execution").existingBacklog).toMatchObject({
+      kind: "domain_jobs",
+      counts: { eligible: 1, succeeded: 1, waiting: 0 },
+    });
+  });
+
+  it("selects the latest persisted terminal execution when no run is active or draining", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { workflowId: "discover-old", runId: "run-old", status: "succeeded" });
+    insertExecution(fixture, { workflowId: "discover-z-latest", runId: "run-latest", status: "canceled" });
+
+    expect(snapshot(fixture).execution).toMatchObject({
+      discoverWorkflowId: "discover-z-latest",
+      discoverRunId: "run-latest",
+      selectedAs: "latest_terminal",
+      phase: "canceled",
+    });
+  });
+
+  it("reports source-family 4/4 independently from reconciliation fanout", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "plan", state: "succeeded", detailCount: 4 });
+    for (let index = 1; index <= 4; index += 1) {
+      insertStep(fixture, { stepKind: "source_family", itemKey: `source-${index}`, state: "succeeded" });
+    }
+    insertStep(fixture, { stepKind: "enrichment_pass", itemKey: "current", state: "queued" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "current", state: "queued" });
+
+    const result = snapshot(fixture);
+    expect(result.sourceFamilies).toMatchObject({
+      planned: 4,
+      counts: { eligible: 4, succeeded: 4 },
+    });
+    expect(result.reconciliation).toMatchObject({
+      enrichment: { eligible: 1, waiting: 1 },
+      preparationFanout: { eligible: 1, waiting: 1 },
+    });
+    expect(stage(result, "source_family", "current_execution").currentExecution).toMatchObject({
+      eligible: 4,
+      succeeded: 4,
+    });
+  });
+
+  it("uses every bucket exactly once for the current execution stage scope", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    const states = [
+      "pending",
+      "running",
+      "succeeded",
+      "skipped",
+      "blocked",
+      "failed",
+      "exhausted",
+      "canceled",
+      "needs_verification",
+      "stale",
+      null,
+    ];
+    for (const [index, state] of states.entries()) {
+      const key = `bucket-${index}`;
+      insertMember(fixture, { key, requiredSteps: ["score"] });
+      if (state !== null) insertStageState(fixture, key, "score", state);
+    }
+
+    const counts = stage(snapshot(fixture), "score", "current_execution").currentExecution;
+    expect(counts).toMatchObject({
+      eligible: 11,
+      waiting: 1,
+      processing: 1,
+      succeeded: 1,
+      skipped: 1,
+      blocked: 1,
+      failed: 1,
+      exhausted: 1,
+      canceled: 1,
+      needsVerification: 1,
+      stale: 1,
+      unknown: 1,
+    });
+    expect(Object.entries(counts)
+      .filter(([name]) => name !== "eligible")
+      .reduce((total, [, value]) => total + value, 0)).toBe(counts.eligible);
+  });
+
+  it("uses exact PDF joins, merges safe runtime activity inventory, and omits private input data", () => {
+    const fixture = createFixture();
+    const current = insertMember(fixture, { key: "pdf-current", requiredSteps: ["pdf"] });
+    const sweep = insertMember(fixture, { key: "pdf-sweep", cohort: "existing_backlog", requiredSteps: ["pdf"] });
+    insertExecution(fixture, {
+      status: "succeeded",
+      inputSummary: { secret: "do-not-expose", resumeUrl: "https://private.invalid/resume" },
+    });
+    insertStep(fixture, { stepKind: "pdf_render", itemKey: pdfItemKey(current.preparationWorkflowId), state: "succeeded" });
+    insertStep(fixture, { stepKind: "pdf_render", itemKey: pdfItemKey(sweep.preparationWorkflowId), state: "running" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "source-alpha", state: "running" });
+    insertWorkflowProjection(fixture, sweep.preparationWorkflowId, "in_progress", PREPARATION_RUN_ID);
+    insertHeartbeat(fixture, {
+      activeSlots: 3,
+      counts: { render_pdf: 1, discovery_source_family: 1, score_job: 1 },
+      details: [
+        activityDetail("render_pdf", "op_000000000000000000000001", sweep.preparationWorkflowId, PREPARATION_RUN_ID),
+        activityDetail("discovery_source_family", "op_000000000000000000000004", "discover-local"),
+        activityDetail("score_job", "op_000000000000000000000002", unmatchedWorkflowRef("pdf-score")),
+      ],
+    });
+
+    const result = snapshot(fixture);
+    expect(result.execution).toMatchObject({ phase: "draining" });
+    expect(stage(result, "pdf_render", "current_execution").currentExecution).toMatchObject({
+      eligible: 1,
+      succeeded: 1,
+    });
+    expect(stage(result, "pdf_render", "execution_sweep").existingBacklog).toMatchObject({
+      kind: "domain_jobs",
+      counts: { eligible: 1, processing: 1 },
+    });
+    expect(result.capacity).toMatchObject({ status: "available", configuredSlots: 4, activeSlots: 3 });
+    expect(result.activeItems).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: "resolved_job",
+        activityType: "render_pdf",
+        stage: "pdf_render",
+        workflowId: sweep.preparationWorkflowId,
+        executionId: PREPARATION_RUN_ID,
+      }),
+      expect.objectContaining({ kind: "source_family", sourceFamily: "source-alpha" }),
+      expect.objectContaining({ kind: "unresolved_runtime_activity", activityType: "score_job" }),
+    ]));
+    expect(result.activeItemsTotal).toBe(3);
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("do-not-expose");
+    expect(serialized).not.toContain("https://private.invalid");
+  });
+
+  it("keeps inventory null when telemetry is unavailable and prefers primary ETA evidence over metrics", () => {
+    const unavailable = createFixture();
+    insertExecution(unavailable, { status: "in_progress" });
+    expect(snapshot(unavailable)).toMatchObject({ activeItems: [], activeItemsTotal: null, activeItemsTruncated: null });
+
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "eta-current", requiredSteps: ["score"] });
+    insertStageState(fixture, "eta-current", "score", "pending");
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000003", unmatchedWorkflowRef("eta"))],
+    });
+    for (let index = 0; index < 5; index += 1) {
+      const key = `eta-history-${index}`;
+      insertStageState(fixture, key, "score", "succeeded", 60_000, new Date(NOW.getTime() - index * 60_000).toISOString());
+    }
+    fixture.db.prepare(
+      `INSERT INTO operational_attempt_metrics (
+         tenant_id, occurred_at, stage, attempt_kind, outcome, duration_ms
+       ) VALUES ('local', ?, 'score', 'worker', 'succeeded', 7200000)`,
+    ).run(NOW.toISOString());
+
+    const eta = snapshot(fixture).overallEta;
+    expect(eta).toMatchObject({ status: "available", basis: "stage_throughput" });
+    if (eta.status === "available") expect(eta.highSeconds).toBeLessThan(1_000);
+  });
+
+  it("keeps pooled capacity visible but refuses an ETA when multi-worker slots cannot be fully inventoried", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "unexplained", requiredSteps: ["score"] });
+    insertStageState(fixture, "unexplained", "score", "pending");
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "unexplained-plan", state: "succeeded", detailCount: 1 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "unexplained-source", state: "running" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    for (let index = 0; index < 5; index += 1) {
+      insertStageState(
+        fixture,
+        `unexplained-history-${index}`,
+        "score",
+        "succeeded",
+        60_000,
+        new Date(NOW.getTime() - index * 60_000).toISOString(),
+      );
+    }
+    insertHeartbeat(fixture, {
+      workerId: "worker-a",
+      activeSlots: 1,
+      counts: { discovery_source_family: 1 },
+      details: [activityDetail("discovery_source_family", "op_000000000000000000000005", DISCOVER_WORKFLOW_ID)],
+    });
+    insertHeartbeat(fixture, {
+      workerId: "worker-b",
+      activeSlots: 2,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000006", unmatchedWorkflowRef("worker-b"))],
+    });
+
+    const result = snapshot(fixture);
+    expect(result.capacity).toMatchObject({
+      status: "available",
+      configuredSlots: 8,
+      activeSlots: 3,
+      availableSlots: 5,
+    });
+    expect(result.activeItemsTruncated).toBe(true);
+    expect(result.overallEta).toMatchObject({ status: "unavailable", reason: "contention_unbounded" });
+    expect(result.sourceFamilies?.eta).toMatchObject({ status: "unavailable", reason: "contention_unbounded" });
+    expect(stage(result, "source_family", "current_execution").eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+
+  it("does not promote a running projection into fresh zero-active runtime inventory", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "stale-projection", state: "running" });
+    insertHeartbeat(fixture, { activeSlots: 0, counts: {}, details: [] });
+
+    const result = snapshot(fixture);
+    expect(result.freshness).toMatchObject({ status: "fresh" });
+    expect(result.sourceFamilies).toMatchObject({ counts: { eligible: 1, processing: 1 } });
+    expect(result.activeItems).toEqual([]);
+    expect(result.activeItemsTotal).toBe(0);
+    expect(result.activeItemsTruncated).toBe(false);
+  });
+
+  it("does not enrich an unrelated runtime activity that shares a projection activity type", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "collision-source", state: "running" });
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { discovery_source_family: 1 },
+      details: [
+        activityDetail(
+          "discovery_source_family",
+          "op_000000000000000000000014",
+          "discover-local",
+          "00000000-0000-4000-8000-000000000099",
+        ),
+      ],
+    });
+
+    const result = snapshot(fixture);
+    expect(result.activeItems).toEqual([
+      expect.objectContaining({ kind: "unresolved_runtime_activity", activityType: "discovery_source_family" }),
+    ]);
+    expect(result.activeItems).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "source_family" }),
+    ]));
+  });
+
+  it("does not hydrate a PDF runtime activity from a different Temporal run", () => {
+    const fixture = createFixture();
+    const member = insertMember(fixture, { key: "pdf-run-collision", requiredSteps: ["pdf"] });
+    insertExecution(fixture, { status: "succeeded" });
+    insertStep(fixture, { stepKind: "pdf_render", itemKey: pdfItemKey(member.preparationWorkflowId), state: "running" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    insertWorkflowProjection(fixture, member.preparationWorkflowId, "in_progress", PREPARATION_RUN_ID);
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { render_pdf: 1 },
+      details: [
+        activityDetail(
+          "render_pdf",
+          "op_000000000000000000000016",
+          member.preparationWorkflowId,
+          "00000000-0000-4000-8000-000000000099",
+        ),
+      ],
+    });
+
+    const result = snapshot(fixture);
+    expect(result.activeItems).toEqual([
+      expect.objectContaining({ kind: "unresolved_runtime_activity", activityType: "render_pdf" }),
+    ]);
+    expect(result.activeItems).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "resolved_job", stage: "pdf_render" }),
+    ]));
+  });
+
+  it("includes same-pool sweep retries and global demand in the current stage ETA only", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "eta-current-scope", requiredSteps: ["score"] });
+    insertMember(fixture, { key: "eta-sweep-scope", cohort: "existing_backlog", requiredSteps: ["score"] });
+    insertStageState(fixture, "eta-current-scope", "score", "pending");
+    insertStageState(fixture, "eta-sweep-scope", "score", "failed", null, null, 1);
+    insertStageState(fixture, "eta-global-scope", "score", "pending");
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    for (let index = 0; index < 5; index += 1) {
+      insertStageState(
+        fixture,
+        `eta-same-pool-history-${index}`,
+        "score",
+        "succeeded",
+        60_000,
+        new Date(NOW.getTime() - index * 60_000).toISOString(),
+      );
+    }
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000017", unmatchedWorkflowRef("same-pool"))],
+    });
+
+    const result = snapshot(fixture);
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({
+      status: "available",
+      caveat: "Includes bounded external backlog, retry, or queue contention.",
+    });
+    expect(stage(result, "score", "execution_sweep").eta).toMatchObject({
+      status: "available",
+      caveat: null,
+    });
+  });
+
+  it("does not price source or a current stage as isolated from a retryable sweep stage", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "cross-stage-current", requiredSteps: ["score"] });
+    insertMember(fixture, { key: "cross-stage-sweep", cohort: "existing_backlog", requiredSteps: ["tailor"] });
+    insertStageState(fixture, "cross-stage-current", "score", "pending");
+    insertStageState(fixture, "cross-stage-sweep", "tailor", "failed", null, null, 1);
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "cross-stage-plan", state: "succeeded", detailCount: 1 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "cross-stage-source", state: "running" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    for (let index = 0; index < 5; index += 1) {
+      insertStageState(
+        fixture,
+        `cross-stage-history-${index}`,
+        "score",
+        "succeeded",
+        60_000,
+        new Date(NOW.getTime() - index * 60_000).toISOString(),
+      );
+    }
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000018", unmatchedWorkflowRef("cross-stage"))],
+    });
+
+    const result = snapshot(fixture);
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+    expect(result.sourceFamilies?.eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+
+  it.each([
+    ["with a unique nonterminal preparation owner", true],
+    ["without a resolvable preparation owner", false],
+  ] as const)("treats global retryable demand %s as unbounded overall and current contention", (_name, hasOwner) => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "global-retry-current", requiredSteps: ["score"] });
+    insertStageState(fixture, "global-retry-current", "score", "pending");
+    const globalKey = hasOwner ? "global-retry-owned" : "global-retry-unowned";
+    if (hasOwner) {
+      const owner = insertMember(fixture, {
+        key: globalKey,
+        requiredSteps: ["tailor"],
+        workflowId: "other-discovery",
+        runId: "other-run",
+      });
+      insertWorkflowProjection(fixture, owner.preparationWorkflowId, "in_progress", PREPARATION_RUN_ID);
+    }
+    insertStageState(fixture, globalKey, "tailor", "failed", null, null, 1);
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "global-retry-plan", state: "succeeded", detailCount: 1 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "global-retry-source", state: "running" });
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    for (let index = 0; index < 5; index += 1) {
+      insertStageState(
+        fixture,
+        `global-retry-history-${index}`,
+        "score",
+        "succeeded",
+        60_000,
+        new Date(NOW.getTime() - index * 60_000).toISOString(),
+      );
+    }
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { discovery_source_family: 1 },
+      details: [activityDetail("discovery_source_family", "op_000000000000000000000019", DISCOVER_WORKFLOW_ID)],
+    });
+
+    const result = snapshot(fixture);
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+    expect(result.sourceFamilies?.eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+    expect(result.overallEta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+
+  it("accepts a global retryable failure owned by a terminal JobPreparationWorkflow", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "succeeded" });
+    insertMember(fixture, { key: "global-terminal-current", requiredSteps: ["score"] });
+    insertStageState(fixture, "global-terminal-current", "score", "pending");
+    const owner = insertMember(fixture, {
+      key: "global-terminal-owner",
+      requiredSteps: ["tailor"],
+      workflowId: "other-discovery-terminal",
+      runId: "other-run-terminal",
+    });
+    insertStageState(fixture, "global-terminal-owner", "tailor", "failed", null, null, 1);
+    insertWorkflowProjection(fixture, owner.preparationWorkflowId, "failed", PREPARATION_RUN_ID);
+    insertStep(fixture, { stepKind: "preparation_fanout", itemKey: "terminal", state: "succeeded" });
+    for (let index = 0; index < 5; index += 1) {
+      insertStageState(
+        fixture,
+        `global-terminal-history-${index}`,
+        "score",
+        "succeeded",
+        60_000,
+        new Date(NOW.getTime() - index * 60_000).toISOString(),
+      );
+    }
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { score_job: 1 },
+      details: [activityDetail("score_job", "op_000000000000000000000020", unmatchedWorkflowRef("global-terminal"))],
+    });
+
+    const result = snapshot(fixture);
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({ status: "available" });
+    expect(result.overallEta).not.toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+
+  it("does not price source work as isolated when global preparation work shares the activity pool", () => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "global-plan", state: "succeeded", detailCount: 1 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "global-source", state: "running" });
+    insertStageState(fixture, "global-outside", "score", "pending");
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { discovery_source_family: 1 },
+      details: [activityDetail("discovery_source_family", "op_000000000000000000000015", DISCOVER_WORKFLOW_ID)],
+    });
+
+    expect(snapshot(fixture).sourceFamilies?.eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+
+  it.each([
+    ["unsupported queue observation", {
+      status: "unsupported",
+      observedAt: NOW.toISOString(),
+      reasonCode: "describe_task_queue_stats_unsupported",
+    }],
+    ["unavailable queue observation", {
+      status: "unavailable",
+      observedAt: NOW.toISOString(),
+      reasonCode: "not_sampled",
+    }],
+    ["stale queue observation", availableObservation({ observedAt: "2026-07-14T11:58:00.000Z" })],
+    ["workflow queue backlog", availableObservation({ workflowBacklog: 1 })],
+    ["activity queue backlog", availableObservation({ activityBacklog: 1 })],
+  ] as const)("treats %s as unbounded contention for overall, source, and stage ETAs", (_name, queueObservation) => {
+    const fixture = createFixture();
+    insertExecution(fixture, { status: "in_progress" });
+    insertMember(fixture, { key: "queue-score", requiredSteps: ["score"] });
+    insertStageState(fixture, "queue-score", "score", "pending");
+    insertStep(fixture, { stepKind: "source_planning", itemKey: "queue-plan", state: "succeeded", detailCount: 1 });
+    insertStep(fixture, { stepKind: "source_family", itemKey: "queue-source", state: "running" });
+    insertHeartbeat(fixture, {
+      activeSlots: 1,
+      counts: { discovery_source_family: 1 },
+      details: [activityDetail("discovery_source_family", "op_000000000000000000000007", "discover-local")],
+      queueObservation,
+    });
+
+    const result = snapshot(fixture);
+    expect(result.overallEta).toMatchObject({ status: "unavailable", reason: "contention_unbounded" });
+    expect(result.sourceFamilies?.eta).toMatchObject({ status: "unavailable", reason: "contention_unbounded" });
+    expect(stage(result, "score", "current_execution").eta).toMatchObject({
+      status: "unavailable",
+      reason: "contention_unbounded",
+    });
+  });
+});
+
+function createFixture(): Fixture {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "jobctrl-pipeline-operations-"));
+  const dbPath = path.join(directory, "jobctrl.db");
+  const configPath = path.join(directory, "config.json");
+  fs.writeFileSync(configPath, JSON.stringify({ daily_budget_usd: 25 }));
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE job_stage_states (
+      job_url TEXT NOT NULL,
+      stage TEXT NOT NULL,
+      state TEXT,
+      attempt_count INTEGER,
+      max_attempts INTEGER,
+      started_at TEXT,
+      updated_at TEXT,
+      finished_at TEXT,
+      duration_ms INTEGER,
+      error_code TEXT,
+      error_message TEXT,
+      retryable INTEGER,
+      blocked_by_json TEXT,
+      next_action TEXT
+    );
+    CREATE TABLE discovery_execution_jobs (
+      tenant_id TEXT NOT NULL,
+      discover_workflow_id TEXT NOT NULL,
+      discover_run_id TEXT NOT NULL,
+      job_url TEXT NOT NULL,
+      cohort_kind TEXT NOT NULL,
+      preparation_workflow_id TEXT,
+      work_plan_state TEXT NOT NULL,
+      required_steps_json TEXT
+    );
+    CREATE TABLE worker_runtime_heartbeats (
+      worker_id TEXT PRIMARY KEY,
+      component TEXT NOT NULL,
+      pid INTEGER NOT NULL,
+      hostname TEXT NOT NULL,
+      app_dir TEXT NOT NULL,
+      db_path TEXT NOT NULL,
+      task_queue TEXT NOT NULL,
+      started_at TEXT NOT NULL,
+      last_seen_at TEXT NOT NULL,
+      max_concurrent_activities INTEGER,
+      activity_executor_max_workers INTEGER,
+      active_activity_count INTEGER NOT NULL DEFAULT 0,
+      active_activity_counts_json TEXT NOT NULL DEFAULT '{}',
+      active_activity_details_json TEXT NOT NULL DEFAULT '[]',
+      active_activity_details_total INTEGER NOT NULL DEFAULT 0,
+      active_activity_details_truncated INTEGER NOT NULL DEFAULT 0,
+      activity_duration_summary_json TEXT NOT NULL DEFAULT '{}',
+      task_queue_observation_json TEXT,
+      heartbeat_schema_version INTEGER NOT NULL DEFAULT 2
+    );
+  `);
+  ensureProjectionTables(db);
+  const fixture = { directory, dbPath, configPath, db };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+function snapshot(fixture: Fixture) {
+  return PipelineOperationsSnapshotSchema.parse(buildPipelineOperationsSnapshot(fixture.db, {
+    dbPath: fixture.dbPath,
+    configPath: fixture.configPath,
+    now: NOW,
+  }));
+}
+
+function insertExecution(
+  fixture: Fixture,
+  input: { status: string; workflowId?: string; runId?: string; inputSummary?: Record<string, unknown> },
+): void {
+  fixture.db.prepare(
+    `INSERT OR REPLACE INTO workflow_run_projections (
+       workflow_id, tenant_id, workflow_type, status, input_summary_json, temporal_run_id, started_at, finished_at
+     ) VALUES (?, 'local', 'DiscoverWorkflow', ?, ?, ?, ?, ?)`,
+  ).run(
+    input.workflowId ?? DISCOVER_WORKFLOW_ID,
+    input.status,
+    JSON.stringify(input.inputSummary ?? { workers: 2 }),
+    input.runId ?? DISCOVER_RUN_ID,
+    "2026-07-14T11:00:00.000Z",
+    input.status === "in_progress" ? null : "2026-07-14T11:30:00.000Z",
+  );
+}
+
+function insertWorkflowProjection(
+  fixture: Fixture,
+  workflowId: string,
+  status: string,
+  runId: string | null = null,
+): void {
+  fixture.db.prepare(
+    `INSERT OR REPLACE INTO workflow_run_projections (
+       workflow_id, tenant_id, workflow_type, status, input_summary_json, temporal_run_id, started_at, finished_at
+     ) VALUES (?, 'local', 'JobPreparationWorkflow', ?, '{}', ?, ?, ?)`,
+  ).run(workflowId, status, runId, "2026-07-14T11:00:00.000Z", "2026-07-14T11:30:00.000Z");
+}
+
+function insertMember(
+  fixture: Fixture,
+  input: {
+    key: string;
+    cohort?: "observed_this_run" | "existing_backlog";
+    requiredSteps: string[];
+    workflowId?: string;
+    runId?: string;
+  },
+): { preparationWorkflowId: string } {
+  const preparationWorkflowId = `prep-preparation:${createHash("sha256").update(input.key).digest("hex")}`;
+  fixture.db.prepare(
+    `INSERT INTO discovery_execution_jobs (
+       tenant_id, discover_workflow_id, discover_run_id, job_url, cohort_kind,
+       preparation_workflow_id, work_plan_state, required_steps_json
+     ) VALUES ('local', ?, ?, ?, ?, ?, 'planned', ?)`,
+  ).run(
+    input.workflowId ?? DISCOVER_WORKFLOW_ID,
+    input.runId ?? DISCOVER_RUN_ID,
+    `https://private.invalid/${input.key}`,
+    input.cohort ?? "observed_this_run",
+    preparationWorkflowId,
+    JSON.stringify(input.requiredSteps),
+  );
+  return { preparationWorkflowId };
+}
+
+function insertStageState(
+  fixture: Fixture,
+  key: string,
+  stage: string,
+  state: string,
+  durationMs: number | null = null,
+  finishedAt: string | null = null,
+  retryable = 0,
+): void {
+  fixture.db.prepare(
+    `INSERT INTO job_stage_states (
+       job_url, stage, state, attempt_count, max_attempts, updated_at, finished_at, duration_ms, retryable
+     ) VALUES (?, ?, ?, 1, 3, ?, ?, ?, ?)`,
+  ).run(`https://private.invalid/${key}`, stage, state, NOW.toISOString(), finishedAt, durationMs, retryable);
+}
+
+function insertStep(
+  fixture: Fixture,
+  input: { stepKind: string; itemKey: string; state: string; detailCount?: number | null; retryable?: number },
+): void {
+  fixture.db.prepare(
+    `INSERT INTO pipeline_step_projections (
+       tenant_id, discover_workflow_id, discover_run_id, step_kind, item_key, state, attempt,
+       queued_at, started_at, finished_at, duration_ms, retryable, detail_count, last_event_id, last_updated_at
+     ) VALUES ('local', ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 0, ?)`,
+  ).run(
+    DISCOVER_WORKFLOW_ID,
+    DISCOVER_RUN_ID,
+    input.stepKind,
+    input.itemKey,
+    input.state,
+    "2026-07-14T11:00:00.000Z",
+    input.state === "running" ? "2026-07-14T11:05:00.000Z" : null,
+    input.state === "succeeded" || input.state === "failed" ? "2026-07-14T11:30:00.000Z" : null,
+    input.state === "succeeded" ? 60_000 : null,
+    input.retryable ?? 0,
+    input.detailCount ?? null,
+    NOW.toISOString(),
+  );
+}
+
+function insertHeartbeat(
+  fixture: Fixture,
+  input: {
+    workerId?: string;
+    activeSlots: number;
+    counts: Record<string, number>;
+    details: Record<string, unknown>[];
+    queueObservation?: unknown;
+  },
+): void {
+  fixture.db.prepare(
+    `INSERT INTO worker_runtime_heartbeats (
+       worker_id, component, pid, hostname, app_dir, db_path, task_queue, started_at, last_seen_at,
+       max_concurrent_activities, activity_executor_max_workers, active_activity_count,
+       active_activity_counts_json, active_activity_details_json, active_activity_details_total,
+       active_activity_details_truncated, activity_duration_summary_json, task_queue_observation_json,
+       heartbeat_schema_version
+     ) VALUES (?, 'temporal-worker', 1, 'localhost', ?, ?, 'jobctrl-default', ?, ?, 4, 6, ?, ?, ?, ?, 0, '{}', ?, 2)`,
+  ).run(
+    input.workerId ?? "worker",
+    fixture.directory,
+    fixture.dbPath,
+    NOW.toISOString(),
+    NOW.toISOString(),
+    input.activeSlots,
+    JSON.stringify(input.counts),
+    JSON.stringify(input.details),
+    Object.values(input.counts).reduce((total, count) => total + count, 0),
+    JSON.stringify(input.queueObservation ?? availableObservation()),
+  );
+}
+
+function activityDetail(
+  activityType: string,
+  opaqueId: string,
+  workflowRef: string,
+  executionRef = DISCOVER_RUN_ID,
+): Record<string, unknown> {
+  const kinds: Record<string, string> = {
+    render_pdf: "job-pdf-render",
+    score_job: "job-scoring",
+    discovery_source_family: "discovery-source-family",
+    discovery_preparation_fanout: "discovery-preparation-fanout",
+    plan_discovery_sources: "discovery-plan",
+  };
+  return {
+    activityType,
+    operationalRef: { kind: kinds[activityType], opaqueId },
+    workflowRef,
+    executionRef,
+    attempt: 1,
+    startedAt: "2026-07-14T11:05:00.000Z",
+  };
+}
+
+function availableObservation(options: { observedAt?: string; workflowBacklog?: number; activityBacklog?: number } = {}): Record<string, unknown> {
+  const stats = {
+    pollerCount: 1,
+    approximateBacklogCount: options.activityBacklog ?? 0,
+    approximateBacklogAgeSeconds: 0,
+    tasksAddRate: 1,
+    tasksDispatchRate: 1,
+  };
+  return {
+    status: "available",
+    observedAt: options.observedAt ?? NOW.toISOString(),
+    workflow: { ...stats, approximateBacklogCount: options.workflowBacklog ?? 0 },
+    activity: stats,
+  };
+}
+
+function pdfItemKey(preparationWorkflowId: string): string {
+  return `pdf:${createHash("sha256").update(preparationWorkflowId.slice("prep-".length)).digest("hex")}`;
+}
+
+function unmatchedWorkflowRef(key: string): string {
+  return `prep-preparation:${createHash("sha256").update(`unmatched:${key}`).digest("hex")}`;
+}
+
+function stage(
+  result: ReturnType<typeof snapshot>,
+  name: string,
+  scope: "current_execution" | "execution_sweep" | "global_outside_execution",
+) {
+  const entry = result.stages.find((candidate) => candidate.stage === name && candidate.scope === scope);
+  if (!entry) throw new Error(`Missing ${name}/${scope} stage`);
+  return entry;
+}

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -7,6 +7,7 @@ import { createJobCtrlApiClient } from "@jobctrl/api-client";
 import {
   CREDENTIAL_VALUE_MAX_LENGTH,
   CredentialKeys,
+  PipelineOperationsSnapshotSchema,
   ProviderConfigurationKeys,
   SecretCredentialKeys,
   type ActionCommandPayload,
@@ -1309,6 +1310,18 @@ describe("local TypeScript API", () => {
     });
 
     await app.close();
+  });
+
+  it("serves the typed pipeline operations snapshot from the existing SQLite schema", async () => {
+    const app = buildApp(options);
+    try {
+      const response = await app.inject({ method: "GET", url: "/v1/pipeline/operations" });
+
+      expect(response.statusCode, response.body).toBe(200);
+      expect(PipelineOperationsSnapshotSchema.safeParse(response.json()).success).toBe(true);
+    } finally {
+      await app.close();
+    }
   });
 
   it("classifies current running work as active or stuck from canonical stage timestamps", async () => {

--- a/apps/web/src/demo/DemoApiClientAdapter.test.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.test.ts
@@ -109,6 +109,7 @@ async function replaceJobs(
 const READ_CASES = [
   ["health", (api: ApiClientPort) => api.health()],
   ["dashboardSummary", (api: ApiClientPort) => api.dashboardSummary()],
+  ["pipelineOperations", (api: ApiClientPort) => api.pipelineOperations()],
   ["outcomeAnalytics", (api: ApiClientPort) => api.outcomeAnalytics()],
   ["digest", (api: ApiClientPort) => api.digest()],
   ["activity", (api: ApiClientPort) => api.activity()],

--- a/apps/web/src/demo/DemoApiClientAdapter.ts
+++ b/apps/web/src/demo/DemoApiClientAdapter.ts
@@ -131,6 +131,8 @@ export class DemoApiClientAdapter implements ApiClientPort {
     return this.read((model) => model.dashboard.summary);
   }
 
+  pipelineOperations = this.unsupported("pipelineOperations");
+
   outcomeAnalytics() {
     return this.read((model) => model.analytics.summary);
   }

--- a/apps/web/src/demo/capabilities.ts
+++ b/apps/web/src/demo/capabilities.ts
@@ -12,6 +12,7 @@ const unavailable = (reason: string) => ({ class: "unavailable", reason }) as co
 export const DEMO_CAPABILITY_MANIFEST = {
   health: local("Shows synthetic browser-local service health."),
   dashboardSummary: local("Reads the synthetic dashboard projection."),
+  pipelineOperations: unavailable("Pipeline operations telemetry is unavailable in the public demo."),
   outcomeAnalytics: local("Reads synthetic conversion analytics."),
   digest: local("Reads the synthetic daily digest."),
   acknowledgeDigest: local("Acknowledges a digest only in browser-local state."),

--- a/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
+++ b/apps/web/src/shared/adapters/local/FetchApiClientAdapter.ts
@@ -24,6 +24,9 @@ export class FetchApiClientAdapter implements ApiClientPort {
   dashboardSummary() {
     return this.client.dashboardSummary();
   }
+  pipelineOperations() {
+    return this.client.pipelineOperations();
+  }
   outcomeAnalytics() {
     return this.client.outcomeAnalytics();
   }

--- a/apps/web/src/shared/ports/ApiClientPort.ts
+++ b/apps/web/src/shared/ports/ApiClientPort.ts
@@ -92,6 +92,7 @@ import type {
   OutcomeSuggestionDecisionResponse,
   OutcomeAnalyticsSummary,
   PaginatedResponse,
+  PipelineOperationsSnapshot,
   ProfileConfigResponse,
   ProfileImportRequest,
   ProfileImportResponse,
@@ -187,6 +188,7 @@ export interface ApiHealthResponse {
 export interface ApiClientPort {
   health(): Promise<ApiHealthResponse>;
   dashboardSummary(): Promise<DashboardSummary>;
+  pipelineOperations(): Promise<PipelineOperationsSnapshot>;
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary>;
   digest(): Promise<DailyDigest>;
   acknowledgeDigest(body?: DigestAcknowledgeRequest): Promise<DigestAcknowledgeResponse>;

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -95,6 +95,7 @@ import type {
   OutcomeSuggestionDecisionResponse,
   OutcomeAnalyticsSummary,
   PaginatedResponse,
+  PipelineOperationsSnapshot,
   PostedCompensationFactResponse,
   ProfileConfigResponse,
   ProfileImportRequest,
@@ -220,6 +221,10 @@ export class JobCtrlApiClient {
 
   dashboardSummary(): Promise<DashboardSummary> {
     return this.get("/v1/dashboard/summary");
+  }
+
+  pipelineOperations(): Promise<PipelineOperationsSnapshot> {
+    return this.get("/v1/pipeline/operations");
   }
 
   outcomeAnalytics(): Promise<OutcomeAnalyticsSummary> {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -2671,6 +2671,365 @@ export interface PipelineProgressSummary {
   updatedAt: string | null;
 }
 
+// ---------------------------------------------------------------------------
+// Pipeline operations read model
+//
+// This is deliberately separate from PipelineProgressSummary. The legacy
+// progress payload describes a stage's current progress line; this snapshot
+// describes an execution-scoped operational view, including the capacity and
+// external backlog that make an overall completion percentage misleading.
+// ---------------------------------------------------------------------------
+
+export const PIPELINE_OPERATIONS_PHASES = [
+  "discovering",
+  "draining",
+  "completed",
+  "completed_with_issues",
+  "failed",
+  "canceled",
+] as const;
+export const PipelineOperationsPhaseSchema = z.enum(PIPELINE_OPERATIONS_PHASES);
+export type PipelineOperationsPhase = z.infer<typeof PipelineOperationsPhaseSchema>;
+
+export const PIPELINE_OPERATIONS_STAGE_SCOPES = [
+  "current_execution",
+  "execution_sweep",
+  "global_outside_execution",
+] as const;
+export const PipelineOperationalStageScopeSchema = z.enum(PIPELINE_OPERATIONS_STAGE_SCOPES);
+export type PipelineOperationalStageScope = z.infer<typeof PipelineOperationalStageScopeSchema>;
+
+export const PipelineStageCountsSchema = z
+  .object({
+    /** The number of items the owning source has determined are in scope. */
+    eligible: z.number().int().nonnegative(),
+    waiting: z.number().int().nonnegative(),
+    processing: z.number().int().nonnegative(),
+    succeeded: z.number().int().nonnegative(),
+    skipped: z.number().int().nonnegative(),
+    blocked: z.number().int().nonnegative(),
+    failed: z.number().int().nonnegative(),
+    exhausted: z.number().int().nonnegative(),
+    canceled: z.number().int().nonnegative(),
+    needsVerification: z.number().int().nonnegative(),
+    stale: z.number().int().nonnegative(),
+    unknown: z.number().int().nonnegative(),
+  })
+  .strict();
+export type PipelineStageCounts = z.infer<typeof PipelineStageCountsSchema>;
+
+export const PipelineOperationsFreshnessSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("fresh"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("stale"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+      reason: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unsupported"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+      reason: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+      reason: z.string().min(1),
+    })
+    .strict(),
+]);
+export type PipelineOperationsFreshness = z.infer<typeof PipelineOperationsFreshnessSchema>;
+
+export const PipelineTaskQueueStatsSchema = z
+  .object({
+    pollerCount: z.number().int().nonnegative(),
+    approximateBacklogCount: z.number().int().nonnegative(),
+    approximateBacklogAgeSeconds: z.number().nonnegative(),
+    tasksAddRate: z.number().nonnegative(),
+    tasksDispatchRate: z.number().nonnegative(),
+  })
+  .strict();
+export type PipelineTaskQueueStats = z.infer<typeof PipelineTaskQueueStatsSchema>;
+
+export const PipelineApproximateTaskQueueSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("available"),
+      observedAt: z.string(),
+      workflow: PipelineTaskQueueStatsSchema,
+      activity: PipelineTaskQueueStatsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("stale"),
+      observedAt: z.string(),
+      lastKnownStatus: z.enum(["available", "unsupported", "unavailable"]),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unsupported"),
+      observedAt: z.string(),
+      reasonCode: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      observedAt: z.string(),
+      reasonCode: z.string().min(1),
+    })
+    .strict(),
+]);
+export type PipelineApproximateTaskQueue = z.infer<typeof PipelineApproximateTaskQueueSchema>;
+
+const PipelineAvailableCapacityBaseSchema = z.object({
+  status: z.literal("available"),
+  asOf: z.string(),
+  staleAfterSeconds: z.number().int().positive(),
+  taskQueue: z.string().nullable(),
+  freshWorkerCount: z.number().int().nonnegative(),
+  staleWorkerCount: z.number().int().nonnegative(),
+  invalidWorkerCount: z.number().int().nonnegative(),
+  configuredSlots: z.number().int().nonnegative(),
+  activeSlots: z.number().int().nonnegative(),
+  availableSlots: z.number().int().nonnegative(),
+  executorThreads: z.number().int().nonnegative(),
+  slotSaturation: z.number().min(0).max(1).nullable(),
+  approximateTaskQueue: PipelineApproximateTaskQueueSchema,
+});
+
+const PipelineAvailableCapacitySchema = z.discriminatedUnion("kind", [
+  PipelineAvailableCapacityBaseSchema.extend({
+    kind: z.literal("shared_activity_pool"),
+  }).strict(),
+  PipelineAvailableCapacityBaseSchema.extend({
+    kind: z.literal("shared_activity_pool_with_internal_parallelism"),
+    internalParallelism: z.number().int().positive(),
+  }).strict(),
+]);
+
+export const PipelineCapacitySchema = z.union([
+  PipelineAvailableCapacitySchema,
+  z
+    .object({
+      status: z.literal("stale"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+      taskQueue: z.string().nullable(),
+      reason: z.string().min(1),
+      approximateTaskQueue: PipelineApproximateTaskQueueSchema,
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      asOf: z.string(),
+      staleAfterSeconds: z.number().int().positive(),
+      taskQueue: z.string().nullable(),
+      reason: z.string().min(1),
+      approximateTaskQueue: PipelineApproximateTaskQueueSchema,
+    })
+    .strict(),
+]);
+export type PipelineCapacity = z.infer<typeof PipelineCapacitySchema>;
+
+export const PipelineEtaSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("available"),
+      lowSeconds: z.number().nonnegative(),
+      highSeconds: z.number().nonnegative(),
+      confidence: z.enum(["low", "medium", "high"]),
+      basis: z.enum(["source_rate", "stage_throughput", "cohort_throughput"]),
+      sampleSize: z.number().int().nonnegative(),
+      asOf: z.string(),
+      caveat: z.string().nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("calibrating"),
+      completedSamples: z.number().int().nonnegative(),
+      minimumSamples: z.number().int().positive(),
+      asOf: z.string(),
+      reason: z.enum(["insufficient_samples", "membership_open"]),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("paused"),
+      reason: z.enum(["worker_unavailable", "budget_exceeded", "blocked", "no_dispatch"]),
+      asOf: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("stale"),
+      reason: z.enum(["telemetry_stale", "observation_stale", "unknown_scope"]),
+      asOf: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal("unavailable"),
+      reason: z.enum([
+        "no_work",
+        "telemetry_stale",
+        "unsupported",
+        "unknown_scope",
+        "contention_unbounded",
+      ]),
+      asOf: z.string(),
+    })
+    .strict(),
+]);
+export type PipelineEta = z.infer<typeof PipelineEtaSchema>;
+
+export const PipelineExecutionCohortSummarySchema = z
+  .object({
+    members: z.number().int().nonnegative(),
+    planned: z.number().int().nonnegative(),
+    notEligible: z.number().int().nonnegative(),
+    pending: z.number().int().nonnegative(),
+    failedPlan: z.number().int().nonnegative(),
+    terminal: z.number().int().nonnegative(),
+    remaining: z.number().int().nonnegative(),
+  })
+  .strict();
+export type PipelineExecutionCohortSummary = z.infer<typeof PipelineExecutionCohortSummarySchema>;
+
+export const DiscoveryExecutionSummarySchema = z
+  .object({
+    discoverWorkflowId: z.string().min(1),
+    discoverRunId: z.string().min(1),
+    selectedAs: z.enum(["active_or_draining", "latest_terminal"]),
+    workflowStatus: z.enum(WORKFLOW_RUN_STATUSES),
+    phase: PipelineOperationsPhaseSchema,
+    membershipClosed: z.boolean(),
+    startedAt: z.string().nullable(),
+    finishedAt: z.string().nullable(),
+    errorCode: z.string().nullable(),
+    currentExecution: PipelineExecutionCohortSummarySchema,
+    sweptExistingBacklog: PipelineExecutionCohortSummarySchema,
+  })
+  .strict();
+export type DiscoveryExecutionSummary = z.infer<typeof DiscoveryExecutionSummarySchema>;
+
+export const PipelineStageBacklogSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("domain_jobs"),
+      counts: PipelineStageCountsSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("not_separate"),
+      reason: z.string().min(1),
+    })
+    .strict(),
+]);
+export type PipelineStageBacklog = z.infer<typeof PipelineStageBacklogSchema>;
+
+export const PipelineOperationalStageSchema = z
+  .object({
+    stage: z.string().min(1),
+    label: z.string().min(1),
+    scope: PipelineOperationalStageScopeSchema,
+    currentExecution: PipelineStageCountsSchema,
+    existingBacklog: PipelineStageBacklogSchema,
+    capacity: PipelineCapacitySchema,
+    eta: PipelineEtaSchema,
+    asOf: z.string(),
+  })
+  .strict();
+export type PipelineOperationalStage = z.infer<typeof PipelineOperationalStageSchema>;
+
+export const SourceFamilyProgressSchema = z
+  .object({
+    planned: z.number().int().nonnegative(),
+    counts: PipelineStageCountsSchema,
+    eta: PipelineEtaSchema,
+    asOf: z.string(),
+  })
+  .strict();
+export type SourceFamilyProgress = z.infer<typeof SourceFamilyProgressSchema>;
+
+export const DiscoveryReconciliationProgressSchema = z
+  .object({
+    enrichment: PipelineStageCountsSchema,
+    preparationFanout: PipelineStageCountsSchema,
+    asOf: z.string(),
+  })
+  .strict();
+export type DiscoveryReconciliationProgress = z.infer<typeof DiscoveryReconciliationProgressSchema>;
+
+const PipelineActiveItemBaseSchema = z.object({
+  activityType: z.string().min(1),
+  workflowId: z.string().nullable(),
+  executionId: z.string().nullable(),
+  attempt: z.number().int().positive(),
+  startedAt: z.string(),
+});
+
+export const PipelineActiveItemSchema = z.discriminatedUnion("kind", [
+  PipelineActiveItemBaseSchema.extend({
+    kind: z.literal("resolved_job"),
+    jobKey: z.string().min(1),
+    title: z.string().nullable(),
+    company: z.string().nullable(),
+    stage: z.string().min(1),
+  }).strict(),
+  PipelineActiveItemBaseSchema.extend({
+    kind: z.literal("source_family"),
+    sourceFamily: z.string().min(1),
+  }).strict(),
+  PipelineActiveItemBaseSchema.extend({
+    kind: z.literal("orchestration"),
+    operation: z.string().min(1),
+  }).strict(),
+  PipelineActiveItemBaseSchema.extend({
+    kind: z.literal("unresolved_runtime_activity"),
+    opaqueId: z.string().min(1),
+  }).strict(),
+]);
+export type PipelineActiveItem = z.infer<typeof PipelineActiveItemSchema>;
+
+export const PipelineOperationsSnapshotSchema = z
+  .object({
+    generatedAt: z.string(),
+    etaEstimatorVersion: z.literal("pipeline-eta-v1"),
+    freshness: PipelineOperationsFreshnessSchema,
+    execution: DiscoveryExecutionSummarySchema.nullable(),
+    capacity: PipelineCapacitySchema,
+    sourceFamilies: SourceFamilyProgressSchema.nullable(),
+    reconciliation: DiscoveryReconciliationProgressSchema.nullable(),
+    stages: z.array(PipelineOperationalStageSchema),
+    activeItems: z.array(PipelineActiveItemSchema).max(20),
+    /** Null when worker runtime inventory cannot make an exact statement. */
+    activeItemsTotal: z.number().int().nonnegative().nullable(),
+    /** Null when the inventory itself is unavailable or stale. */
+    activeItemsTruncated: z.boolean().nullable(),
+    overallEta: PipelineEtaSchema,
+  })
+  .strict();
+export type PipelineOperationsSnapshot = z.infer<typeof PipelineOperationsSnapshotSchema>;
+
 export interface ApplyRunTimelineEventSummary {
   at: string | null;
   type: string;


### PR DESCRIPTION
## Summary

- add pipeline operations and ETA read-model aggregation
- expose the operations snapshot through API, contract, and client surfaces
- carry focused API coverage for the new read-model behavior

## Why

This gives later operations UI phases a stable view of stage backlog, capacity, throughput, and estimated completion without coupling the frontend to raw runtime telemetry.

## Stack

This PR is stacked on #460 and targets `feat/pipeline-runtime-observability-rhea`.

## Validation

Validation is intentionally deferred to the final cumulative stack under the approved stacked-delivery plan. No tests, builds, typechecks, or QA were run for this intermediate phase.