### PR TITLE
feat(pipeline): add operations workspace

### DIFF
--- a/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.test.ts
+++ b/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.test.ts
@@ -1,0 +1,63 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { LOCAL_TENANT } from "@jobctrl/domain-types";
+import { waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { pipelineKeys } from "../../pipeline/queryKeys.js";
+import { renderHookWithProviders } from "../../../test/render.js";
+import { buildTestPorts } from "../../../test/testPorts.js";
+import { usePipelineOperationsQuery } from "./usePipelineOperationsQuery.js";
+
+const snapshot: PipelineOperationsSnapshot = {
+  generatedAt: "2026-07-14T10:00:00.000Z",
+  etaEstimatorVersion: "pipeline-eta-v1",
+  freshness: { status: "fresh", asOf: "2026-07-14T10:00:00.000Z", staleAfterSeconds: 45 },
+  execution: null,
+  capacity: {
+    status: "unavailable",
+    asOf: "2026-07-14T10:00:00.000Z",
+    staleAfterSeconds: 45,
+    taskQueue: null,
+    reason: "Worker runtime telemetry is unavailable.",
+    approximateTaskQueue: {
+      status: "unavailable",
+      observedAt: "2026-07-14T10:00:00.000Z",
+      reasonCode: "telemetry_unavailable",
+    },
+  },
+  sourceFamilies: null,
+  reconciliation: null,
+  stages: [],
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: "2026-07-14T10:00:00.000Z" },
+};
+
+describe("usePipelineOperationsQuery", () => {
+  it("reads the pipeline operations snapshot through the operations port", async () => {
+    const pipelineOperations = vi.fn(async () => snapshot);
+    const { result, queryClient } = renderHookWithProviders(() => usePipelineOperationsQuery(), {
+      ports: buildTestPorts({ api: { pipelineOperations } }),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(pipelineOperations).toHaveBeenCalledOnce();
+    expect(result.current.data).toEqual(snapshot);
+    expect(queryClient.getQueryData(pipelineKeys.operations(LOCAL_TENANT))).toEqual(snapshot);
+  });
+
+  it("surfaces pipeline operations read errors", async () => {
+    const pipelineOperations = vi.fn(async () => {
+      throw new Error("operations unavailable");
+    });
+    const { result } = renderHookWithProviders(() => usePipelineOperationsQuery(), {
+      ports: buildTestPorts({ api: { pipelineOperations } }),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe("operations unavailable");
+  });
+});

--- a/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.ts
+++ b/apps/web/src/contexts/operations/hooks/usePipelineOperationsQuery.ts
@@ -1,0 +1,28 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { useTenantId } from "../../../shared/providers/TenantProvider.js";
+import { usePorts } from "../../../shared/providers/PortsProvider.js";
+import { pipelineKeys } from "../../pipeline/queryKeys.js";
+
+const ACTIVE_POLL_INTERVAL_MS = 15_000;
+const IDLE_POLL_INTERVAL_MS = 60_000;
+const PIPELINE_OPERATIONS_STALE_TIME_MS = 10_000;
+
+function isActiveExecution(snapshot: PipelineOperationsSnapshot | undefined): boolean {
+  const phase = snapshot?.execution?.phase;
+  return phase === "discovering" || phase === "draining";
+}
+
+export function usePipelineOperationsQuery(): UseQueryResult<PipelineOperationsSnapshot> {
+  const tenantId = useTenantId();
+  const { api } = usePorts();
+  return useQuery({
+    queryKey: pipelineKeys.operations(tenantId),
+    queryFn: () => api.pipelineOperations(),
+    staleTime: PIPELINE_OPERATIONS_STALE_TIME_MS,
+    refetchInterval: (query) =>
+      isActiveExecution(query.state.data) ? ACTIVE_POLL_INTERVAL_MS : IDLE_POLL_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+  });
+}

--- a/apps/web/src/contexts/operations/index.ts
+++ b/apps/web/src/contexts/operations/index.ts
@@ -129,6 +129,7 @@ export {
 export { useJobApplicationOutcomesQuery } from "./hooks/useJobApplicationOutcomesQuery.js";
 export { useJobDetailQuery } from "./hooks/useJobDetailQuery.js";
 export { useJobsListQuery } from "./hooks/useJobsListQuery.js";
+export { usePipelineOperationsQuery } from "./hooks/usePipelineOperationsQuery.js";
 export { useWorkflowRunsListQuery } from "./hooks/useWorkflowRunsListQuery.js";
 
 export { EventStreamProvider, useEventStreamStatus } from "./providers/EventStreamProvider.js";

--- a/apps/web/src/contexts/operations/invalidation-router.test.ts
+++ b/apps/web/src/contexts/operations/invalidation-router.test.ts
@@ -15,6 +15,7 @@ import { jobsKeys } from "./jobsKeys.js";
 import { outcomesKeys } from "./outcomesKeys.js";
 import { workflowRunsKeys } from "./workflowRunsKeys.js";
 import { discoveryKeys } from "../discovery/queryKeys.js";
+import { pipelineKeys } from "../pipeline/queryKeys.js";
 import { profileKeys } from "../profile/queryKeys.js";
 import { outreachKeys } from "../outreach/queryKeys.js";
 
@@ -272,38 +273,46 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemStarted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     artifactsKeys.lists(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PreparationWorkItemFailed: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepQueued: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepStarted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepCompleted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   PipelineStepFailed: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ApplyRunStarted: [
     applyRunsKeys.lists(LOCAL_TENANT),
@@ -372,27 +381,36 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageCompleted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageFailed: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageExhausted: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
-  StageReset: [jobsKeys.lists(LOCAL_TENANT), jobsKeys.detail(LOCAL_TENANT, JOB_ID)],
+  StageReset: [
+    jobsKeys.lists(LOCAL_TENANT),
+    jobsKeys.detail(LOCAL_TENANT, JOB_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
+  ],
   StageBlocked: [
     jobsKeys.lists(LOCAL_TENANT),
     jobsKeys.detail(LOCAL_TENANT, JOB_ID),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageSkipped: [
     jobsKeys.lists(LOCAL_TENANT),
@@ -400,6 +418,7 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
     digestKeys.all(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   StageCanceled: [
     jobsKeys.lists(LOCAL_TENANT),
@@ -407,34 +426,41 @@ const expectedInvalidations: Record<DomainEventUnion["eventType"], ExpectedKeys>
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
     digestKeys.all(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ProfileUpdated: [profileKeys.profile(LOCAL_TENANT)],
   ProfileImported: [profileKeys.profile(LOCAL_TENANT)],
   WorkflowStarted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCompleted: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowFailed: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowCanceled: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
     applyReviewKeys.queue(LOCAL_TENANT),
     dashboardKeys.summary(LOCAL_TENANT),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowTimedOut: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   WorkflowTerminated: [
     workflowRunsKeys.lists(LOCAL_TENANT),
     workflowRunsKeys.detail(LOCAL_TENANT, WORKFLOW_ID),
+    pipelineKeys.operations(LOCAL_TENANT),
   ],
   ContactCreated: [outreachKeys.contactLists(LOCAL_TENANT)],
   ContactUpdated: [

--- a/apps/web/src/contexts/pipeline/components/PipelineActiveWork.tsx
+++ b/apps/web/src/contexts/pipeline/components/PipelineActiveWork.tsx
@@ -1,0 +1,108 @@
+import type { PipelineActiveItem, PipelineOperationsSnapshot } from "@jobctrl/contracts";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../shared/ui/card.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import {
+  FactGrid,
+  InlineDisclosure,
+  StatusText,
+  safeOperationalIdentifier,
+  sentenceCase,
+} from "./pipelineOperationsDisplay.js";
+
+function itemTitle(item: PipelineActiveItem): string {
+  switch (item.kind) {
+    case "resolved_job":
+      return item.title ?? item.company ?? safeOperationalIdentifier(item.jobKey);
+    case "source_family":
+      return item.sourceFamily;
+    case "orchestration":
+      return item.operation;
+    case "unresolved_runtime_activity":
+      return safeOperationalIdentifier(item.opaqueId);
+  }
+}
+
+function ActiveItemDetails({ item }: { readonly item: PipelineActiveItem }) {
+  return (
+    <li className="pipeline-active-item">
+      <div className="pipeline-active-item__heading">
+        <div>
+          <h3>{itemTitle(item)}</h3>
+          <span>{item.activityType}</span>
+        </div>
+        <StatusText status="in_progress">Attempt {item.attempt}</StatusText>
+      </div>
+      <FactGrid
+        label={`${itemTitle(item)} active-work diagnostics`}
+        facts={[
+          { label: "Kind", value: sentenceCase(item.kind) },
+          { label: "Activity", value: item.activityType },
+          { label: "Workflow", value: item.workflowId ?? "Not reported" },
+          { label: "Execution", value: item.executionId ?? "Not reported" },
+          { label: "Attempt", value: item.attempt },
+          { label: "Started", value: formatDateTime(item.startedAt) },
+          ...(item.kind === "resolved_job"
+            ? [
+                { label: "Job key", value: safeOperationalIdentifier(item.jobKey) },
+                { label: "Title", value: item.title ?? "Not reported" },
+                { label: "Company", value: item.company ?? "Not reported" },
+                { label: "Stage", value: item.stage },
+              ]
+            : []),
+          ...(item.kind === "source_family" ? [{ label: "Source family", value: item.sourceFamily }] : []),
+          ...(item.kind === "orchestration" ? [{ label: "Operation", value: item.operation }] : []),
+          ...(item.kind === "unresolved_runtime_activity"
+            ? [{ label: "Opaque id", value: safeOperationalIdentifier(item.opaqueId) }]
+            : []),
+        ]}
+      />
+    </li>
+  );
+}
+
+export function PipelineActiveWork({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const inventoryLabel = snapshot.activeItemsTotal === null ? "Unknown total" : `${snapshot.activeItemsTotal} total`;
+
+  return (
+    <Card className="pipeline-card pipeline-active-work">
+      <CardHeader className="pipeline-card__header">
+        <CardTitle><h2>Active work</h2></CardTitle>
+        <CardDescription>Current runtime inventory, including unresolved activities that still consume capacity.</CardDescription>
+      </CardHeader>
+      <CardContent className="pipeline-card__content">
+        <div className="pipeline-active-work__summary">
+          <StatusText status={snapshot.activeItems.length > 0 ? "in_progress" : "completed"}>{inventoryLabel}</StatusText>
+          <span>
+            {snapshot.activeItemsTruncated === null
+              ? "Truncation unknown"
+              : snapshot.activeItemsTruncated
+                ? "Inventory truncated"
+                : "Complete inventory"}
+          </span>
+        </div>
+        <InlineDisclosure label="Active work details" defaultOpen={snapshot.activeItems.length > 0}>
+          <div className="pipeline-detail-stack">
+            <FactGrid
+              label="Active-work inventory"
+              facts={[
+                { label: "Inventory total", value: snapshot.activeItemsTotal ?? "Unknown" },
+                { label: "Inventory truncated", value: snapshot.activeItemsTruncated === null ? "Unknown" : snapshot.activeItemsTruncated ? "Yes" : "No" },
+              ]}
+            />
+            {snapshot.activeItems.length > 0 ? (
+              <ol className="pipeline-active-items">
+                {snapshot.activeItems.map((item, index) => (
+                  <ActiveItemDetails item={item} key={`${item.kind}-${item.activityType}-${item.startedAt}-${index}`} />
+                ))}
+              </ol>
+            ) : (
+              <Empty title="No active work is visible in the current runtime inventory." />
+            )}
+          </div>
+        </InlineDisclosure>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/PipelineCapacityCard.tsx
+++ b/apps/web/src/contexts/pipeline/components/PipelineCapacityCard.tsx
@@ -1,0 +1,66 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../shared/ui/card.js";
+import { Progress, ProgressLabel, ProgressValue } from "../../../shared/ui/progress.js";
+import {
+  CapacityDetails,
+  FactGrid,
+  InlineDisclosure,
+  StatusText,
+  formatSeconds,
+  sentenceCase,
+} from "./pipelineOperationsDisplay.js";
+
+export function PipelineCapacityCard({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const capacity = snapshot.capacity;
+  const queue = capacity.approximateTaskQueue;
+  const saturation = capacity.status === "available" && capacity.slotSaturation !== null
+    ? Math.round(capacity.slotSaturation * 100)
+    : null;
+
+  return (
+    <Card className="pipeline-card pipeline-capacity-card">
+      <CardHeader className="pipeline-card__header">
+        <CardTitle><h2>Worker capacity</h2></CardTitle>
+        <CardDescription>Shared Temporal activity slots and approximate queue pressure.</CardDescription>
+      </CardHeader>
+      <CardContent className="pipeline-card__content">
+        <StatusText status={capacity.status} />
+        {capacity.status === "available" ? (
+          <>
+            <FactGrid
+              label="Worker capacity summary"
+              facts={[
+                { label: "Active slots", value: `${capacity.activeSlots}/${capacity.configuredSlots}` },
+                { label: "Available slots", value: capacity.availableSlots },
+                { label: "Workers", value: capacity.freshWorkerCount },
+                { label: "Task queue", value: capacity.taskQueue ?? "Not reported" },
+                { label: "Internal concurrency", value: capacity.kind === "shared_activity_pool_with_internal_parallelism" ? capacity.internalParallelism : "Not reported" },
+              ]}
+            />
+            {saturation !== null ? (
+              <Progress value={saturation}>
+                <ProgressLabel>Slot saturation</ProgressLabel>
+                <ProgressValue>{saturation}%</ProgressValue>
+              </Progress>
+            ) : null}
+          </>
+        ) : (
+          <p className="pipeline-muted-copy">{capacity.reason}</p>
+        )}
+        <div className="pipeline-queue-subject">
+          <span>Queue observation</span>
+          <strong>{sentenceCase(queue.status)}</strong>
+          {queue.status === "available" ? (
+            <small>
+              {queue.activity.approximateBacklogCount} activity tasks · {formatSeconds(queue.activity.approximateBacklogAgeSeconds)} oldest
+            </small>
+          ) : null}
+        </div>
+        <InlineDisclosure label="Capacity and queue diagnostics">
+          <CapacityDetails capacity={capacity} />
+        </InlineDisclosure>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/PipelineOperationsSummary.tsx
+++ b/apps/web/src/contexts/pipeline/components/PipelineOperationsSummary.tsx
@@ -1,0 +1,98 @@
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../../shared/ui/card.js";
+import { Separator } from "../../../shared/ui/separator.js";
+import {
+  CohortDetails,
+  EtaDetails,
+  FactGrid,
+  FreshnessDetails,
+  InlineDisclosure,
+  StatusText,
+  etaLabel,
+  sentenceCase,
+} from "./pipelineOperationsDisplay.js";
+
+export function PipelineOperationsSummary({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const execution = snapshot.execution;
+  const phase = execution?.phase ?? "idle";
+  const sourceProgress = snapshot.sourceFamilies
+    ? `${snapshot.sourceFamilies.counts.succeeded}/${snapshot.sourceFamilies.planned}`
+    : "Not available";
+
+  return (
+    <Card className="pipeline-card pipeline-operations-summary">
+      <CardHeader className="pipeline-card__header">
+        <CardTitle><h2>Pipeline operations</h2></CardTitle>
+        <CardDescription>Execution scope, backlog, and the latest completion estimate.</CardDescription>
+      </CardHeader>
+      <CardContent className="pipeline-card__content">
+        <output className="pipeline-phase-message" aria-live="polite" aria-atomic="true">
+          <span>Phase</span>
+          <StatusText status={phase}>{sentenceCase(phase)}</StatusText>
+        </output>
+        <dl className="pipeline-summary-strip" aria-label="Pipeline operations summary">
+          <div>
+            <dt>Current cohort</dt>
+            <dd>{execution ? `${execution.currentExecution.remaining} remaining` : "No selected execution"}</dd>
+          </div>
+          <div>
+            <dt>Execution sweep</dt>
+            <dd>{execution ? `${execution.sweptExistingBacklog.remaining} remaining` : "Not available"}</dd>
+          </div>
+          <div>
+            <dt>Source families</dt>
+            <dd>{sourceProgress}</dd>
+          </div>
+          <div>
+            <dt>Overall ETA</dt>
+            <dd>{etaLabel(snapshot.overallEta)}</dd>
+          </div>
+          <div>
+            <dt>Snapshot</dt>
+            <dd><time dateTime={snapshot.generatedAt}>{formatDateTime(snapshot.generatedAt)}</time></dd>
+          </div>
+          <div>
+            <dt>Read model</dt>
+            <dd><StatusText status={snapshot.freshness.status} /></dd>
+          </div>
+        </dl>
+        <Separator />
+        <InlineDisclosure label="Execution diagnostics">
+          <div className="pipeline-detail-stack">
+            <FactGrid
+              label="Execution identity"
+              facts={[
+                { label: "Workflow id", value: execution?.discoverWorkflowId ?? "Not available" },
+                { label: "Temporal run id", value: execution?.discoverRunId ?? "Not available" },
+                { label: "Selected as", value: execution ? sentenceCase(execution.selectedAs) : "No execution selected" },
+                { label: "Workflow status", value: execution ? sentenceCase(execution.workflowStatus) : "Not available" },
+                { label: "Phase", value: execution ? sentenceCase(execution.phase) : "Idle" },
+                { label: "Membership closed", value: execution ? (execution.membershipClosed ? "Yes" : "No") : "Not available" },
+                { label: "Started", value: execution ? formatDateTime(execution.startedAt) : "Not available" },
+                { label: "Finished", value: execution ? formatDateTime(execution.finishedAt) : "Not available" },
+                { label: "Error code", value: execution?.errorCode ?? "None" },
+                { label: "ETA estimator", value: snapshot.etaEstimatorVersion },
+              ]}
+            />
+            {execution ? (
+              <>
+                <CohortDetails cohort={execution.currentExecution} label="Current execution cohort" />
+                <CohortDetails cohort={execution.sweptExistingBacklog} label="Execution sweep cohort" />
+              </>
+            ) : null}
+            <EtaDetails eta={snapshot.overallEta} label="Overall ETA diagnostics" />
+            <FreshnessDetails freshness={snapshot.freshness} />
+          </div>
+        </InlineDisclosure>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/PipelineOperationsWorkspace.tsx
+++ b/apps/web/src/contexts/pipeline/components/PipelineOperationsWorkspace.tsx
@@ -1,0 +1,47 @@
+import { usePipelineOperationsQuery } from "../../operations/hooks/usePipelineOperationsQuery.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../shared/ui/card.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { PipelineActiveWork } from "./PipelineActiveWork.js";
+import { PipelineCapacityCard } from "./PipelineCapacityCard.js";
+import { PipelineOperationsSummary } from "./PipelineOperationsSummary.js";
+import { PipelineStageTable } from "./PipelineStageTable.js";
+import { SourceCrawlProgress } from "./SourceCrawlProgress.js";
+import { StageTriggerPanel } from "./StageTriggerPanel.js";
+
+export function PipelineOperationsWorkspace() {
+  const operations = usePipelineOperationsQuery();
+  const message = operations.error instanceof Error ? operations.error.message : null;
+
+  return (
+    <div className="pipeline-workspace" aria-label="Pipeline operations workspace">
+      {message ? (
+        <Card className="pipeline-card pipeline-notice-card">
+          <CardHeader className="pipeline-card__header">
+            <CardTitle><h2>Pipeline operations unavailable</h2></CardTitle>
+            <CardDescription>{message}</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : null}
+      {operations.data ? (
+        <>
+          <PipelineOperationsSummary snapshot={operations.data} />
+          <SourceCrawlProgress snapshot={operations.data} />
+          <PipelineCapacityCard snapshot={operations.data} />
+          <PipelineStageTable snapshot={operations.data} />
+          <PipelineActiveWork snapshot={operations.data} />
+        </>
+      ) : (
+        <Card className="pipeline-card pipeline-loading-card">
+          <CardHeader className="pipeline-card__header">
+            <CardTitle><h2>Operations snapshot</h2></CardTitle>
+            <CardDescription>Execution, capacity, and backlog facts appear when the read model is available.</CardDescription>
+          </CardHeader>
+          <CardContent className="pipeline-card__content">
+            <Empty title={operations.isLoading ? "Loading pipeline operations." : "No pipeline operations snapshot is available."} />
+          </CardContent>
+        </Card>
+      )}
+      <StageTriggerPanel />
+    </div>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/PipelineStageTable.tsx
+++ b/apps/web/src/contexts/pipeline/components/PipelineStageTable.tsx
@@ -1,0 +1,126 @@
+import type { PipelineOperationalStage, PipelineOperationsSnapshot } from "@jobctrl/contracts";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../shared/ui/card.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../../../shared/ui/table.js";
+import {
+  CapacityDetails,
+  CountDetails,
+  CountSummary,
+  EtaDetails,
+  FactGrid,
+  InlineDisclosure,
+  StatusText,
+  etaLabel,
+  sentenceCase,
+} from "./pipelineOperationsDisplay.js";
+
+function scopeLabel(scope: PipelineOperationalStage["scope"]): string {
+  switch (scope) {
+    case "current_execution":
+      return "Current execution";
+    case "execution_sweep":
+      return "Execution sweep";
+    case "global_outside_execution":
+      return "Global backlog";
+  }
+}
+
+function StageRow({ stage }: { readonly stage: PipelineOperationalStage }) {
+  return (
+    <TableRow>
+      <TableCell className="pipeline-stage-name">
+        <strong>{stage.label}</strong>
+        <code>{stage.stage}</code>
+      </TableCell>
+      <TableCell>
+        <StatusText status={stage.scope === "current_execution" ? "in_progress" : "pending"}>
+          {scopeLabel(stage.scope)}
+        </StatusText>
+      </TableCell>
+      <TableCell>
+        <CountSummary counts={stage.currentExecution} />
+        <InlineDisclosure label="All outcomes">
+          <CountDetails counts={stage.currentExecution} label={`${stage.label} current-execution outcomes`} />
+        </InlineDisclosure>
+      </TableCell>
+      <TableCell>
+        {stage.existingBacklog.kind === "domain_jobs" ? (
+          <>
+            <CountSummary counts={stage.existingBacklog.counts} />
+            <InlineDisclosure label="All backlog">
+              <div className="pipeline-detail-stack">
+                <FactGrid facts={[{ label: "Kind", value: "Domain jobs" }]} />
+                <CountDetails counts={stage.existingBacklog.counts} label={`${stage.label} existing backlog`} />
+              </div>
+            </InlineDisclosure>
+          </>
+        ) : (
+          <FactGrid
+            facts={[
+              { label: "Kind", value: "Not separate" },
+              { label: "Reason", value: stage.existingBacklog.reason },
+            ]}
+          />
+        )}
+      </TableCell>
+      <TableCell className="pipeline-stage-runtime">
+        <strong>{stage.capacity.status === "available" ? `${stage.capacity.activeSlots}/${stage.capacity.configuredSlots} active` : sentenceCase(stage.capacity.status)}</strong>
+        <span>{etaLabel(stage.eta)}</span>
+        <InlineDisclosure label="Runtime diagnostics">
+          <div className="pipeline-detail-stack">
+            <CapacityDetails capacity={stage.capacity} label={`${stage.label} capacity diagnostics`} />
+            <EtaDetails eta={stage.eta} label={`${stage.label} ETA diagnostics`} />
+          </div>
+        </InlineDisclosure>
+      </TableCell>
+      <TableCell className="pipeline-stage-observed">
+        <time dateTime={stage.asOf}>{formatDateTime(stage.asOf)}</time>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+export function PipelineStageTable({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  return (
+    <Card className="pipeline-card pipeline-stage-table-card">
+      <CardHeader className="pipeline-card__header">
+        <CardTitle><h2>Operational stage ledger</h2></CardTitle>
+        <CardDescription>Current execution and sweep work stay separate from the backlog outside this run.</CardDescription>
+      </CardHeader>
+      <CardContent className="pipeline-card__content">
+        {snapshot.stages.length > 0 ? (
+          <Table>
+            <TableCaption>Stage state, existing backlog, worker capacity, ETA, and observation time.</TableCaption>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Stage</TableHead>
+                <TableHead>Scope</TableHead>
+                <TableHead>Current execution</TableHead>
+                <TableHead>Existing backlog</TableHead>
+                <TableHead>Capacity / ETA</TableHead>
+                <TableHead>Observed</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {snapshot.stages.map((stage, index) => (
+                <StageRow key={`${stage.scope}-${stage.stage}-${index}`} stage={stage} />
+              ))}
+            </TableBody>
+          </Table>
+        ) : (
+          <Empty title="No operational stage rows are available." />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/SourceCrawlProgress.tsx
+++ b/apps/web/src/contexts/pipeline/components/SourceCrawlProgress.tsx
@@ -1,0 +1,100 @@
+import type { PipelineOperationsSnapshot, PipelineStageCounts } from "@jobctrl/contracts";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../../shared/ui/card.js";
+import { Empty } from "../../../shared/ui/empty.js";
+import { Progress, ProgressLabel, ProgressValue } from "../../../shared/ui/progress.js";
+import { Separator } from "../../../shared/ui/separator.js";
+import {
+  CountDetails,
+  CountSummary,
+  EtaDetails,
+  InlineDisclosure,
+  StatusText,
+} from "./pipelineOperationsDisplay.js";
+
+function completedCount(counts: PipelineStageCounts): number {
+  return counts.succeeded
+    + counts.skipped
+    + counts.blocked
+    + counts.failed
+    + counts.exhausted
+    + counts.canceled
+    + counts.needsVerification;
+}
+
+export function SourceCrawlProgress({ snapshot }: { readonly snapshot: PipelineOperationsSnapshot }) {
+  const sources = snapshot.sourceFamilies;
+  const reconciliation = snapshot.reconciliation;
+  const completion = sources && sources.planned > 0
+    ? Math.min(100, Math.round((completedCount(sources.counts) / sources.planned) * 100))
+    : 0;
+
+  return (
+    <Card className="pipeline-card pipeline-source-progress">
+      <CardHeader className="pipeline-card__header">
+        <CardTitle><h2>Source crawl progress</h2></CardTitle>
+        <CardDescription>
+          Parallel source work and enrichment site batches inside a running activity. Temporal worker capacity is shown below.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="pipeline-card__content">
+        {sources ? (
+          <>
+            <div className="pipeline-source-progress__heading">
+              <StatusText status={sources.counts.processing > 0 ? "processing" : completion === 100 ? "completed" : "pending"}>
+                {sources.counts.succeeded}/{sources.planned} succeeded
+              </StatusText>
+              <time dateTime={sources.asOf}>{formatDateTime(sources.asOf)}</time>
+            </div>
+            <Progress value={completion}>
+              <ProgressLabel>Source-family plan</ProgressLabel>
+              <ProgressValue>{completion}% terminal</ProgressValue>
+            </Progress>
+            <CountSummary counts={sources.counts} />
+            <InlineDisclosure label="Source-family diagnostics">
+              <div className="pipeline-detail-stack">
+                <CountDetails counts={sources.counts} label="Source-family outcomes" />
+                <EtaDetails eta={sources.eta} label="Source-family ETA diagnostics" />
+              </div>
+            </InlineDisclosure>
+          </>
+        ) : (
+          <Empty title="No source-family plan is available for the selected execution." />
+        )}
+        <Separator />
+        <div className="pipeline-reconciliation">
+          <div className="pipeline-section-heading">
+            <div>
+              <h3>Reconciliation</h3>
+              <p>Two post-source steps remain separate from source-family progress.</p>
+            </div>
+            {reconciliation ? <time dateTime={reconciliation.asOf}>{formatDateTime(reconciliation.asOf)}</time> : null}
+          </div>
+          {reconciliation ? (
+            <>
+              <div className="pipeline-reconciliation__rows">
+                <div>
+                  <strong>Enrichment pass</strong>
+                  <CountSummary counts={reconciliation.enrichment} />
+                </div>
+                <div>
+                  <strong>Preparation fanout</strong>
+                  <CountSummary counts={reconciliation.preparationFanout} />
+                </div>
+              </div>
+              <InlineDisclosure label="Reconciliation diagnostics">
+                <div className="pipeline-detail-stack">
+                  <CountDetails counts={reconciliation.enrichment} label="Enrichment pass outcomes" />
+                  <CountDetails counts={reconciliation.preparationFanout} label="Preparation fanout outcomes" />
+                </div>
+              </InlineDisclosure>
+            </>
+          ) : (
+            <Empty title="No reconciliation projection is available for the selected execution." />
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -110,7 +110,7 @@ describe("StageTriggerPanel", () => {
     const user = userEvent.setup();
     renderWithProviders(<StageTriggerPanel />);
 
-    expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
     expect(screen.getByLabelText("Limit")).toBeInTheDocument();
     expect(screen.getByLabelText("Dry run")).toBeInTheDocument();
     expect(screen.queryByLabelText("Minimum score")).not.toBeInTheDocument();
@@ -124,7 +124,7 @@ describe("StageTriggerPanel", () => {
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     expect(screen.getByLabelText("Limit")).toBeInTheDocument();
-    expect(screen.getByLabelText("Workers")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
     expect(screen.getByLabelText("Minimum score")).toBeInTheDocument();
     expect(screen.getByLabelText("Apply model")).toBeInTheDocument();
     expect(screen.getByLabelText("Apply model")).toHaveRole("combobox");
@@ -336,8 +336,8 @@ describe("StageTriggerPanel", () => {
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     await user.clear(screen.getByLabelText("Limit"));
     await user.type(screen.getByLabelText("Limit"), "12");
-    await user.clear(screen.getByLabelText("Workers"));
-    await user.type(screen.getByLabelText("Workers"), "3");
+    await user.clear(screen.getByLabelText("Internal concurrency"));
+    await user.type(screen.getByLabelText("Internal concurrency"), "3");
     await user.clear(screen.getByLabelText("Minimum score"));
     await user.type(screen.getByLabelText("Minimum score"), "8");
     await user.click(screen.getByLabelText("Headless browser"));
@@ -687,8 +687,8 @@ describe("StageTriggerPanel", () => {
     const { unmount } = renderWithProviders(<StageTriggerPanel />);
 
     expect(screen.getByRole("tab", { name: "Discover" })).toHaveAttribute("aria-selected", "true");
-    await user.clear(screen.getByLabelText("Workers"));
-    await user.type(screen.getByLabelText("Workers"), "5");
+    await user.clear(screen.getByLabelText("Internal concurrency"));
+    await user.type(screen.getByLabelText("Internal concurrency"), "5");
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     await user.clear(screen.getByLabelText("Limit"));
@@ -696,14 +696,14 @@ describe("StageTriggerPanel", () => {
     await user.click(screen.getByLabelText("Headless browser"));
 
     await user.click(screen.getByRole("tab", { name: "Discover" }));
-    expect(screen.getByLabelText("Workers")).toHaveValue(5);
+    expect(screen.getByLabelText("Internal concurrency")).toHaveValue(5);
     expect(screen.queryByLabelText("Re-tailor")).not.toBeInTheDocument();
 
     unmount();
     renderWithProviders(<StageTriggerPanel />);
 
     expect(screen.getByRole("tab", { name: "Discover" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByLabelText("Workers")).toHaveValue(5);
+    expect(screen.getByLabelText("Internal concurrency")).toHaveValue(5);
 
     await user.click(screen.getByRole("tab", { name: "Apply" }));
     expect(screen.getByLabelText("Limit")).toHaveValue(13);

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -13,7 +13,13 @@ import { IconPlayerPlay } from "@tabler/icons-react";
 import { type FormEvent, type ReactNode, useState } from "react";
 
 import { Button } from "../../../shared/ui/button.js";
-import { CardHeader } from "../../../shared/ui/card-header.js";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../../../shared/ui/card.js";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../shared/ui/tabs.js";
 import { useDashboardSummaryQuery } from "../../operations/hooks/useDashboardSummaryQuery.js";
 import { useSourceRegistryQuery } from "../../operations/hooks/useDiscoveryProductControlsQuery.js";
@@ -487,7 +493,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
         ) : null}
         {controls.workers ? (
           <label className="field">
-            <span>Workers</span>
+            <span>Internal concurrency</span>
             <input
               min={1}
               max={16}
@@ -644,7 +650,7 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
 
       <div className="stage-trigger-actions">
         <Button disabled={runStages.isPending || workerUnhealthy} type="submit">
-          <IconPlayerPlay aria-hidden="true" size={16} />
+          <IconPlayerPlay aria-hidden="true" data-icon="inline-start" />
           {workerUnhealthy
             ? health.isPending
               ? "Checking worker"
@@ -700,31 +706,36 @@ export function StageTriggerPanel({ stagePanels = {} }: StageTriggerPanelProps =
 
   return (
     <>
-      <section className="card full stage-trigger-panel">
-        <CardHeader title="Pipeline actions" meta={headerMeta} />
-        <Tabs
-          className="stage-trigger-tabs"
-          value={activeStage}
-          onValueChange={(value) => {
-            if (USER_FACING_PIPELINE_STAGE_SET.has(value as PipelineRunStage)) {
-              setActiveStage(value as PipelineRunStage);
-            }
-          }}
-        >
-          <TabsList aria-label="Pipeline stages" className="stage-trigger-tab-list">
+      <Card className="pipeline-card stage-trigger-panel">
+        <CardHeader className="pipeline-card__header">
+          <CardTitle><h2>Pipeline actions</h2></CardTitle>
+          <CardDescription>{headerMeta}</CardDescription>
+        </CardHeader>
+        <CardContent className="pipeline-card__content">
+          <Tabs
+            className="stage-trigger-tabs"
+            value={activeStage}
+            onValueChange={(value) => {
+              if (USER_FACING_PIPELINE_STAGE_SET.has(value as PipelineRunStage)) {
+                setActiveStage(value as PipelineRunStage);
+              }
+            }}
+          >
+            <TabsList aria-label="Pipeline stages" className="stage-trigger-tab-list">
+              {USER_FACING_PIPELINE_STAGES.map((stage) => (
+                <TabsTrigger key={stage} value={stage}>
+                  {labelForStage(stage)}
+                </TabsTrigger>
+              ))}
+            </TabsList>
             {USER_FACING_PIPELINE_STAGES.map((stage) => (
-              <TabsTrigger key={stage} value={stage}>
-                {labelForStage(stage)}
-              </TabsTrigger>
+              <TabsContent key={stage} forceMount value={stage} className="stage-trigger-tab-panel">
+                {stage === activeStage ? stageForm : null}
+              </TabsContent>
             ))}
-          </TabsList>
-          {USER_FACING_PIPELINE_STAGES.map((stage) => (
-            <TabsContent key={stage} forceMount value={stage} className="stage-trigger-tab-panel">
-              {stage === activeStage ? stageForm : null}
-            </TabsContent>
-          ))}
-        </Tabs>
-      </section>
+          </Tabs>
+        </CardContent>
+      </Card>
       {activeStagePanel}
     </>
   );

--- a/apps/web/src/contexts/pipeline/components/pipelineOperationsDisplay.tsx
+++ b/apps/web/src/contexts/pipeline/components/pipelineOperationsDisplay.tsx
@@ -1,0 +1,269 @@
+import type {
+  PipelineApproximateTaskQueue,
+  PipelineCapacity,
+  PipelineEta,
+  PipelineExecutionCohortSummary,
+  PipelineOperationsFreshness,
+  PipelineStageCounts,
+  PipelineTaskQueueStats,
+} from "@jobctrl/contracts";
+import { IconChevronDown } from "@tabler/icons-react";
+import type { ReactNode } from "react";
+
+import { formatDateTime } from "../../../shared/lib/formatters.js";
+import { Badge } from "../../../shared/ui/badge.js";
+import { Button } from "../../../shared/ui/button.js";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../../shared/ui/collapsible.js";
+import { StatusDot } from "../../../shared/ui/status-dot.js";
+import type { StatusDotState } from "../../../shared/ui/status-tokens.js";
+
+export const COUNT_FIELDS = [
+  ["eligible", "Eligible"],
+  ["waiting", "Waiting"],
+  ["processing", "Processing"],
+  ["succeeded", "Succeeded"],
+  ["skipped", "Skipped"],
+  ["blocked", "Blocked"],
+  ["failed", "Failed"],
+  ["exhausted", "Exhausted"],
+  ["canceled", "Canceled"],
+  ["needsVerification", "Needs verification"],
+  ["stale", "Stale"],
+  ["unknown", "Unknown"],
+] as const;
+
+export const COHORT_FIELDS = [
+  ["members", "Members"],
+  ["planned", "Planned"],
+  ["notEligible", "Not eligible"],
+  ["pending", "Pending plan"],
+  ["failedPlan", "Failed plan"],
+  ["terminal", "Terminal"],
+  ["remaining", "Remaining"],
+] as const;
+
+export function sentenceCase(value: string): string {
+  return value.replaceAll("_", " ").replace(/^./, (character) => character.toUpperCase());
+}
+
+export function safeOperationalIdentifier(value: string): string {
+  return /(?:https?:\/\/|www\.)/i.test(value) ? "Sensitive identifier withheld" : value;
+}
+
+export function formatSeconds(value: number): string {
+  if (value < 60) return `${Math.round(value)} sec`;
+  if (value < 3_600) return `${Math.round(value / 60)} min`;
+  return `${(value / 3_600).toFixed(value < 36_000 ? 1 : 0)} hr`;
+}
+
+export function etaLabel(eta: PipelineEta): string {
+  switch (eta.status) {
+    case "available":
+      return `${formatSeconds(eta.lowSeconds)}–${formatSeconds(eta.highSeconds)}`;
+    case "calibrating":
+      return `Calibrating · ${eta.completedSamples}/${eta.minimumSamples}`;
+    case "paused":
+      return `Paused · ${sentenceCase(eta.reason)}`;
+    case "stale":
+      return `Stale · ${sentenceCase(eta.reason)}`;
+    case "unavailable":
+      return eta.reason === "no_work" ? "No work remaining" : `Unavailable · ${sentenceCase(eta.reason)}`;
+  }
+}
+
+export function statusDotState(status: string): StatusDotState {
+  if (["completed", "succeeded", "fresh", "available"].includes(status)) return "succeeded";
+  if (["failed", "unavailable"].includes(status)) return "failed";
+  if (["completed_with_issues", "blocked", "paused", "unsupported"].includes(status)) return "blocked";
+  if (["discovering", "draining", "processing", "in_progress"].includes(status)) return "running";
+  if (["stale", "calibrating"].includes(status)) return "stale";
+  if (status === "canceled") return "canceled";
+  return "pending";
+}
+
+export function StatusText({ status, children }: { readonly status: string; readonly children?: ReactNode }) {
+  return (
+    <Badge className="pipeline-status" variant="outline">
+      <StatusDot state={statusDotState(status)} />
+      <span>{children ?? sentenceCase(status)}</span>
+    </Badge>
+  );
+}
+
+interface Fact {
+  readonly label: string;
+  readonly value: ReactNode;
+}
+
+export function FactGrid({ facts, label }: { readonly facts: readonly Fact[]; readonly label?: string }) {
+  return (
+    <dl className="pipeline-facts" aria-label={label}>
+      {facts.map((fact) => (
+        <div key={fact.label}>
+          <dt>{fact.label}</dt>
+          <dd>{fact.value ?? "-"}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function InlineDisclosure({
+  label,
+  children,
+  defaultOpen = false,
+}: {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly defaultOpen?: boolean;
+}) {
+  return (
+    <Collapsible className="pipeline-disclosure" defaultOpen={defaultOpen}>
+      <CollapsibleTrigger
+        render={<Button className="pipeline-disclosure__trigger" size="sm" type="button" variant="ghost" />}
+      >
+        <IconChevronDown aria-hidden="true" data-icon="inline-start" />
+        {label}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="pipeline-disclosure__content">
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export function CountDetails({ counts, label }: { readonly counts: PipelineStageCounts; readonly label: string }) {
+  return (
+    <FactGrid
+      label={label}
+      facts={COUNT_FIELDS.map(([field, fieldLabel]) => ({ label: fieldLabel, value: counts[field] }))}
+    />
+  );
+}
+
+export function CountSummary({ counts }: { readonly counts: PipelineStageCounts }) {
+  const active = counts.waiting + counts.processing;
+  const issues = counts.blocked + counts.failed + counts.exhausted + counts.needsVerification + counts.stale + counts.unknown;
+  return (
+    <span className="pipeline-count-summary">
+      <span><b>{active}</b> active</span>
+      <span><b>{counts.succeeded}</b> done</span>
+      {issues > 0 ? <span><b>{issues}</b> attention</span> : null}
+    </span>
+  );
+}
+
+export function CohortDetails({ cohort, label }: { readonly cohort: PipelineExecutionCohortSummary; readonly label: string }) {
+  return (
+    <FactGrid
+      label={label}
+      facts={COHORT_FIELDS.map(([field, fieldLabel]) => ({ label: fieldLabel, value: cohort[field] }))}
+    />
+  );
+}
+
+export function EtaDetails({ eta, label }: { readonly eta: PipelineEta; readonly label: string }) {
+  const facts: Fact[] = [
+    { label: "Status", value: sentenceCase(eta.status) },
+    ...(eta.status === "available"
+      ? [
+          { label: "Low", value: formatSeconds(eta.lowSeconds) },
+          { label: "High", value: formatSeconds(eta.highSeconds) },
+          { label: "Confidence", value: sentenceCase(eta.confidence) },
+          { label: "Basis", value: sentenceCase(eta.basis) },
+          { label: "Samples", value: eta.sampleSize },
+          { label: "Caveat", value: eta.caveat ?? "None" },
+        ]
+      : []),
+    ...(eta.status === "calibrating"
+      ? [
+          { label: "Completed samples", value: eta.completedSamples },
+          { label: "Minimum samples", value: eta.minimumSamples },
+          { label: "Reason", value: sentenceCase(eta.reason) },
+        ]
+      : []),
+    ...(eta.status === "paused" || eta.status === "stale" || eta.status === "unavailable"
+      ? [{ label: "Reason", value: sentenceCase(eta.reason) }]
+      : []),
+    { label: "As of", value: formatDateTime(eta.asOf) },
+  ];
+  return <FactGrid facts={facts} label={label} />;
+}
+
+function queueStats(prefix: string, stats: PipelineTaskQueueStats): Fact[] {
+  return [
+    { label: `${prefix} pollers`, value: stats.pollerCount },
+    { label: `${prefix} backlog`, value: stats.approximateBacklogCount },
+    { label: `${prefix} backlog age`, value: formatSeconds(stats.approximateBacklogAgeSeconds) },
+    { label: `${prefix} add rate`, value: `${stats.tasksAddRate}/sec` },
+    { label: `${prefix} dispatch rate`, value: `${stats.tasksDispatchRate}/sec` },
+  ];
+}
+
+export function TaskQueueDetails({ queue, label = "Task queue diagnostics" }: {
+  readonly queue: PipelineApproximateTaskQueue;
+  readonly label?: string;
+}) {
+  const facts: Fact[] = [
+    { label: "Observation", value: sentenceCase(queue.status) },
+    { label: "Observed", value: formatDateTime(queue.observedAt) },
+    ...(queue.status === "available" ? [...queueStats("Workflow", queue.workflow), ...queueStats("Activity", queue.activity)] : []),
+    ...(queue.status === "stale" ? [{ label: "Last known status", value: sentenceCase(queue.lastKnownStatus) }] : []),
+    ...(queue.status === "unsupported" || queue.status === "unavailable"
+      ? [{ label: "Reason code", value: queue.reasonCode }]
+      : []),
+  ];
+  return <FactGrid facts={facts} label={label} />;
+}
+
+export function CapacityDetails({ capacity, label = "Capacity diagnostics" }: {
+  readonly capacity: PipelineCapacity;
+  readonly label?: string;
+}) {
+  const facts: Fact[] = [
+    { label: "Status", value: sentenceCase(capacity.status) },
+    { label: "Observed", value: formatDateTime(capacity.asOf) },
+    { label: "Stale after", value: `${capacity.staleAfterSeconds} sec` },
+    { label: "Task queue", value: capacity.taskQueue ?? "Not reported" },
+    ...(capacity.status === "available"
+      ? [
+          { label: "Pool", value: sentenceCase(capacity.kind) },
+          { label: "Fresh workers", value: capacity.freshWorkerCount },
+          { label: "Stale workers", value: capacity.staleWorkerCount },
+          { label: "Invalid workers", value: capacity.invalidWorkerCount },
+          { label: "Configured slots", value: capacity.configuredSlots },
+          { label: "Active slots", value: capacity.activeSlots },
+          { label: "Available slots", value: capacity.availableSlots },
+          { label: "Executor threads", value: capacity.executorThreads },
+          { label: "Slot saturation", value: capacity.slotSaturation === null ? "Not available" : `${Math.round(capacity.slotSaturation * 100)}%` },
+          ...(capacity.kind === "shared_activity_pool_with_internal_parallelism"
+            ? [{ label: "Internal concurrency", value: capacity.internalParallelism }]
+            : []),
+        ]
+      : [{ label: "Reason", value: capacity.reason }]),
+  ];
+  return (
+    <div className="pipeline-detail-stack">
+      <FactGrid facts={facts} label={label} />
+      <TaskQueueDetails queue={capacity.approximateTaskQueue} />
+    </div>
+  );
+}
+
+export function FreshnessDetails({ freshness }: { readonly freshness: PipelineOperationsFreshness }) {
+  return (
+    <FactGrid
+      label="Read-model freshness"
+      facts={[
+        { label: "Read-model status", value: sentenceCase(freshness.status) },
+        { label: "As of", value: formatDateTime(freshness.asOf) },
+        { label: "Stale after", value: `${freshness.staleAfterSeconds} sec` },
+        ...(freshness.status === "fresh" ? [] : [{ label: "Freshness reason", value: freshness.reason }]),
+      ]}
+    />
+  );
+}

--- a/apps/web/src/contexts/pipeline/handlers.ts
+++ b/apps/web/src/contexts/pipeline/handlers.ts
@@ -15,6 +15,7 @@ import type {
   PipelineStepFailed,
   PipelineStepQueued,
   PipelineStepStarted,
+  TenantId,
   WorkflowStarted,
   WorkflowCompleted,
   WorkflowFailed,
@@ -30,11 +31,16 @@ import { digestKeys } from "../operations/digestKeys.js";
 import { invalidate, type InvalidationItem } from "../operations/invalidation-router.js";
 import { jobsKeys } from "../operations/jobsKeys.js";
 import { workflowRunsKeys } from "../operations/workflowRunsKeys.js";
+import { pipelineKeys } from "./queryKeys.js";
+
+const pipelineOperationsInvalidation = (tenantId: TenantId): InvalidationItem =>
+  invalidate(pipelineKeys.operations(tenantId));
 
 export const stageStartedHandler = (event: StageStarted): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageCompletedHandler = (
@@ -43,12 +49,14 @@ export const stageCompletedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageFailedHandler = (event: StageFailed): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageExhaustedHandler = (
@@ -57,17 +65,20 @@ export const stageExhaustedHandler = (
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageResetHandler = (event: StageReset): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageBlockedHandler = (event: StageBlocked): readonly InvalidationItem[] => [
   invalidate(jobsKeys.lists(event.tenantId)),
   invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageSkippedHandler = (event: StageSkipped): readonly InvalidationItem[] => [
@@ -76,6 +87,7 @@ export const stageSkippedHandler = (event: StageSkipped): readonly InvalidationI
   invalidate(applyReviewKeys.queue(event.tenantId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(digestKeys.all(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const stageCanceledHandler = (
@@ -86,6 +98,7 @@ export const stageCanceledHandler = (
   invalidate(applyReviewKeys.queue(event.tenantId)),
   invalidate(dashboardKeys.summary(event.tenantId)),
   invalidate(digestKeys.all(event.tenantId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 type PreparationWorkItemEvent =
@@ -100,6 +113,7 @@ const preparationWorkItemHandler = (
   const invalidations = [
     invalidate(jobsKeys.lists(event.tenantId)),
     invalidate(jobsKeys.detail(event.tenantId, event.payload.jobId)),
+    pipelineOperationsInvalidation(event.tenantId),
   ];
   if (
     event.eventType === "PreparationWorkItemCompleted" &&
@@ -122,9 +136,7 @@ type PipelineStepLifecycleEvent =
   | PipelineStepCompleted
   | PipelineStepFailed;
 
-// The dedicated pipeline-operations query lands later. Until then, refresh the
-// narrowest existing execution-scoped read model that can expose lifecycle
-// diagnostics. The global activity list invalidation is appended by dispatch.
+// The global activity-list invalidation is appended by dispatch.
 const pipelineStepLifecycleHandler = (
   event: PipelineStepLifecycleEvent,
 ): readonly InvalidationItem[] => [
@@ -132,6 +144,7 @@ const pipelineStepLifecycleHandler = (
   invalidate(
     workflowRunsKeys.detail(event.tenantId, event.payload.execution.workflowId),
   ),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const pipelineStepQueuedHandler = pipelineStepLifecycleHandler;
@@ -157,6 +170,7 @@ const workflowLifecycleHandler = (
 ): readonly InvalidationItem[] => [
   invalidate(workflowRunsKeys.lists(event.tenantId)),
   invalidate(workflowRunsKeys.detail(event.tenantId, event.payload.workflowId)),
+  pipelineOperationsInvalidation(event.tenantId),
 ];
 
 export const workflowStartedHandler = workflowLifecycleHandler;

--- a/apps/web/src/contexts/pipeline/queryKeys.ts
+++ b/apps/web/src/contexts/pipeline/queryKeys.ts
@@ -2,4 +2,5 @@ import type { TenantId } from "@jobctrl/domain-types";
 
 export const pipelineKeys = {
   all: (tenantId: TenantId) => ["tenant", tenantId, "pipeline"] as const,
+  operations: (tenantId: TenantId) => [...pipelineKeys.all(tenantId), "operations"] as const,
 };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -32,6 +32,7 @@ import "./styles/redesign-job-detail.css";
 import "./styles/redesign-configuration.css";
 import "./styles/redesign-apply-review.css";
 import "./styles/redesign-profile-import.css";
+import "./styles/redesign-pipelines.css";
 import "./styles/redesign-route-gaps.css";
 
 const queryClient = createQueryClient();

--- a/apps/web/src/shared/ui/collapsible.tsx
+++ b/apps/web/src/shared/ui/collapsible.tsx
@@ -1,0 +1,19 @@
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/apps/web/src/shared/ui/progress.tsx
+++ b/apps/web/src/shared/ui/progress.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { Progress as ProgressPrimitive } from "@base-ui/react/progress"
+
+import { cn } from "@/shared/lib/cn"
+
+function Progress({
+  className,
+  children,
+  value,
+  ...props
+}: ProgressPrimitive.Root.Props) {
+  return (
+    <ProgressPrimitive.Root
+      value={value}
+      data-slot="progress"
+      className={cn("flex flex-wrap gap-3", className)}
+      {...props}
+    >
+      {children}
+      <ProgressTrack>
+        <ProgressIndicator />
+      </ProgressTrack>
+    </ProgressPrimitive.Root>
+  )
+}
+
+function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
+  return (
+    <ProgressPrimitive.Track
+      className={cn(
+        "relative flex h-2 w-full items-center overflow-x-hidden rounded-2xl bg-muted",
+        className
+      )}
+      data-slot="progress-track"
+      {...props}
+    />
+  )
+}
+
+function ProgressIndicator({
+  className,
+  ...props
+}: ProgressPrimitive.Indicator.Props) {
+  return (
+    <ProgressPrimitive.Indicator
+      data-slot="progress-indicator"
+      className={cn("h-full bg-primary transition-all", className)}
+      {...props}
+    />
+  )
+}
+
+function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props) {
+  return (
+    <ProgressPrimitive.Label
+      className={cn("text-sm font-medium", className)}
+      data-slot="progress-label"
+      {...props}
+    />
+  )
+}
+
+function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props) {
+  return (
+    <ProgressPrimitive.Value
+      className={cn(
+        "ml-auto text-sm text-muted-foreground tabular-nums",
+        className
+      )}
+      data-slot="progress-value"
+      {...props}
+    />
+  )
+}
+
+export {
+  Progress,
+  ProgressTrack,
+  ProgressIndicator,
+  ProgressLabel,
+  ProgressValue,
+}

--- a/apps/web/src/styles/redesign-pipelines.css
+++ b/apps/web/src/styles/redesign-pipelines.css
@@ -1,0 +1,447 @@
+.pipelines-view {
+  display: grid;
+  align-content: start;
+}
+
+.pipeline-workspace {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.pipeline-card {
+  align-self: start;
+}
+
+.pipeline-card h2,
+.pipeline-card h3,
+.pipeline-card p {
+  margin: 0;
+}
+
+.pipeline-card h2 {
+  font: inherit;
+}
+
+.pipeline-card__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pipeline-operations-summary,
+.pipeline-stage-table-card,
+.pipeline-active-work,
+.pipeline-loading-card,
+.pipeline-notice-card,
+.stage-trigger-panel {
+  grid-column: 1 / -1;
+}
+
+.pipeline-source-progress {
+  grid-column: span 8;
+}
+
+.pipeline-capacity-card {
+  grid-column: span 4;
+}
+
+.pipeline-phase-message,
+.pipeline-source-progress__heading,
+.pipeline-section-heading,
+.pipeline-active-work__summary,
+.pipeline-active-item__heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pipeline-phase-message > span:first-child,
+.pipeline-summary-strip dt,
+.pipeline-facts dt,
+.pipeline-queue-subject > span,
+.pipeline-active-item__heading > div > span {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.pipeline-status {
+  min-height: 0;
+  gap: 6px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--foreground);
+  font-size: 11px;
+  font-weight: 620;
+}
+
+.pipeline-status .status-dot {
+  width: 7px;
+  height: 7px;
+  border-width: 2px;
+  background: transparent;
+}
+
+.pipeline-summary-strip {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  margin: 0;
+  border-block: 1px solid var(--border);
+}
+
+.pipeline-summary-strip > div {
+  min-width: 0;
+  padding: 15px 16px;
+  border-right: 1px solid var(--border);
+}
+
+.pipeline-summary-strip > div:first-child {
+  padding-left: 0;
+}
+
+.pipeline-summary-strip > div:last-child {
+  border-right: 0;
+  padding-right: 0;
+}
+
+.pipeline-summary-strip dd,
+.pipeline-facts dd {
+  min-width: 0;
+  margin: 5px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 590;
+  line-height: 1.4;
+}
+
+.pipeline-facts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--border);
+}
+
+.pipeline-facts > div {
+  min-width: 0;
+  padding: 11px 12px 11px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.pipeline-detail-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pipeline-disclosure {
+  min-width: 0;
+}
+
+.pipeline-disclosure__trigger {
+  justify-content: flex-start;
+  padding-inline: 0;
+}
+
+.pipeline-disclosure__trigger svg {
+  transition: transform 140ms ease;
+}
+
+.pipeline-disclosure[data-open] .pipeline-disclosure__trigger svg {
+  transform: rotate(180deg);
+}
+
+.pipeline-disclosure__content {
+  padding-top: 10px;
+}
+
+.pipeline-count-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px 12px;
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.pipeline-count-summary b {
+  color: var(--foreground);
+  font-variant-numeric: tabular-nums;
+}
+
+.pipeline-source-progress__heading time,
+.pipeline-section-heading time,
+.pipeline-stage-observed,
+.pipeline-muted-copy,
+.pipeline-section-heading p,
+.pipeline-active-work__summary > span,
+.pipeline-queue-subject small {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.pipeline-source-progress [data-slot="progress"],
+.pipeline-capacity-card [data-slot="progress"] {
+  gap: 6px;
+}
+
+.pipeline-reconciliation,
+.pipeline-active-items {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pipeline-section-heading {
+  align-items: flex-start;
+}
+
+.pipeline-section-heading h3,
+.pipeline-active-item__heading h3 {
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.pipeline-reconciliation__rows {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-block: 1px solid var(--border);
+}
+
+.pipeline-reconciliation__rows > div {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 13px 16px 13px 0;
+  border-right: 1px solid var(--border);
+}
+
+.pipeline-reconciliation__rows > div:last-child {
+  border-right: 0;
+  padding-left: 16px;
+}
+
+.pipeline-queue-subject {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 12px;
+  padding-block: 12px;
+  border-block: 1px solid var(--border);
+}
+
+.pipeline-queue-subject small {
+  grid-column: 1 / -1;
+}
+
+.pipeline-stage-table-card .pipeline-card__content {
+  padding-inline: 0;
+}
+
+.pipeline-stage-table-card .pipeline-card__header {
+  padding-inline: 20px;
+}
+
+.pipeline-stage-table-card .data-table-scroll {
+  border-block: 1px solid var(--border);
+}
+
+.pipeline-stage-table-card table {
+  min-width: 1120px;
+}
+
+.pipeline-stage-table-card th:first-child,
+.pipeline-stage-table-card td:first-child {
+  padding-left: 20px;
+}
+
+.pipeline-stage-table-card th:last-child,
+.pipeline-stage-table-card td:last-child {
+  padding-right: 20px;
+}
+
+.pipeline-stage-table-card td {
+  vertical-align: top;
+  padding-block: 12px;
+}
+
+.pipeline-stage-name,
+.pipeline-stage-runtime {
+  min-width: 150px;
+}
+
+.pipeline-stage-name strong,
+.pipeline-stage-name code,
+.pipeline-stage-runtime > strong,
+.pipeline-stage-runtime > span {
+  display: block;
+}
+
+.pipeline-stage-name code,
+.pipeline-stage-runtime > span {
+  margin-top: 4px;
+  color: var(--muted-foreground);
+  font-size: 10px;
+}
+
+.pipeline-stage-table-card .pipeline-disclosure__trigger {
+  height: 26px;
+  margin-top: 4px;
+  font-size: 10px;
+}
+
+.pipeline-stage-table-card .pipeline-facts {
+  grid-template-columns: repeat(2, minmax(112px, 1fr));
+  min-width: 260px;
+}
+
+.pipeline-stage-observed {
+  width: 150px;
+  white-space: nowrap;
+}
+
+.pipeline-active-work__summary {
+  justify-content: flex-start;
+}
+
+.pipeline-active-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.pipeline-active-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-block: 2px;
+}
+
+.pipeline-active-item + .pipeline-active-item {
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.pipeline-active-item__heading > div {
+  min-width: 0;
+}
+
+.stage-trigger-panel {
+  margin: 0;
+}
+
+.stage-trigger-panel .pipeline-card__content {
+  gap: 0;
+}
+
+.stage-trigger-panel .stage-trigger-tabs {
+  background: transparent;
+  padding: 0;
+}
+
+.stage-trigger-panel .stage-trigger-tab-panel .stage-trigger-form {
+  padding: 16px 0 0;
+}
+
+.stage-trigger-panel .stage-trigger-grid {
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
+}
+
+@media (max-width: 1180px) {
+  .pipeline-source-progress,
+  .pipeline-capacity-card {
+    grid-column: 1 / -1;
+  }
+
+  .pipeline-summary-strip {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .pipeline-summary-strip > div:nth-child(3) {
+    border-right: 0;
+  }
+
+  .pipeline-summary-strip > div:nth-child(4) {
+    padding-left: 0;
+  }
+
+  .stage-trigger-panel .stage-trigger-grid {
+    grid-template-columns: repeat(3, minmax(120px, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .pipeline-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+
+  .pipeline-card,
+  .pipeline-source-progress,
+  .pipeline-capacity-card {
+    grid-column: 1;
+  }
+
+  .pipeline-summary-strip,
+  .pipeline-facts,
+  .pipeline-reconciliation__rows,
+  .stage-trigger-panel .stage-trigger-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .pipeline-summary-strip > div,
+  .pipeline-summary-strip > div:first-child,
+  .pipeline-summary-strip > div:last-child {
+    padding-inline: 10px;
+    border-right: 1px solid var(--border);
+  }
+
+  .pipeline-summary-strip > div:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .pipeline-summary-strip > div:nth-child(2n + 1) {
+    padding-left: 0;
+  }
+
+  .pipeline-reconciliation__rows > div,
+  .pipeline-reconciliation__rows > div:last-child {
+    padding-inline: 0;
+    border-right: 0;
+  }
+
+  .pipeline-reconciliation__rows > div + div {
+    border-top: 1px solid var(--border);
+  }
+
+  .pipeline-phase-message,
+  .pipeline-source-progress__heading,
+  .pipeline-section-heading,
+  .pipeline-active-item__heading {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 520px) {
+  .pipeline-summary-strip,
+  .pipeline-facts,
+  .pipeline-reconciliation__rows,
+  .stage-trigger-panel .stage-trigger-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .pipeline-summary-strip > div,
+  .pipeline-summary-strip > div:first-child,
+  .pipeline-summary-strip > div:last-child,
+  .pipeline-summary-strip > div:nth-child(2n) {
+    padding-inline: 0;
+    border-right: 0;
+  }
+}

--- a/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
+++ b/apps/web/src/views/pipelines/PipelinesView.fixtures.ts
@@ -1,0 +1,430 @@
+import type {
+  PipelineCapacity,
+  PipelineEta,
+  PipelineOperationalStage,
+  PipelineOperationsSnapshot,
+  PipelineStageCounts,
+} from "@jobctrl/contracts";
+
+const AS_OF = "2026-07-14T12:00:00.000Z";
+
+function counts(overrides: Partial<PipelineStageCounts> = {}): PipelineStageCounts {
+  return {
+    eligible: 0,
+    waiting: 0,
+    processing: 0,
+    succeeded: 0,
+    skipped: 0,
+    blocked: 0,
+    failed: 0,
+    exhausted: 0,
+    canceled: 0,
+    needsVerification: 0,
+    stale: 0,
+    unknown: 0,
+    ...overrides,
+  };
+}
+
+const etaAvailable: PipelineEta = {
+  status: "available",
+  lowSeconds: 480,
+  highSeconds: 720,
+  confidence: "medium",
+  basis: "stage_throughput",
+  sampleSize: 14,
+  asOf: AS_OF,
+  caveat: "Estimate excludes unrelated backlog outside this discovery run.",
+};
+
+const etaCalibrating: PipelineEta = {
+  status: "calibrating",
+  completedSamples: 2,
+  minimumSamples: 8,
+  asOf: AS_OF,
+  reason: "insufficient_samples",
+};
+
+const etaUnavailable: PipelineEta = {
+  status: "unavailable",
+  reason: "telemetry_stale",
+  asOf: AS_OF,
+};
+
+const availableCapacity: PipelineCapacity = {
+  status: "available",
+  kind: "shared_activity_pool_with_internal_parallelism",
+  asOf: AS_OF,
+  staleAfterSeconds: 45,
+  taskQueue: "jobctrl-default",
+  freshWorkerCount: 1,
+  staleWorkerCount: 0,
+  invalidWorkerCount: 0,
+  configuredSlots: 4,
+  activeSlots: 2,
+  availableSlots: 2,
+  executorThreads: 6,
+  internalParallelism: 2,
+  slotSaturation: 0.5,
+  approximateTaskQueue: {
+    status: "available",
+    observedAt: AS_OF,
+    workflow: {
+      pollerCount: 1,
+      approximateBacklogCount: 0,
+      approximateBacklogAgeSeconds: 0,
+      tasksAddRate: 0.1,
+      tasksDispatchRate: 0.1,
+    },
+    activity: {
+      pollerCount: 1,
+      approximateBacklogCount: 2,
+      approximateBacklogAgeSeconds: 18,
+      tasksAddRate: 0.4,
+      tasksDispatchRate: 0.5,
+    },
+  },
+};
+
+function stage(
+  stageName: string,
+  label: string,
+  scope: PipelineOperationalStage["scope"],
+  currentExecution: PipelineStageCounts,
+  eta: PipelineEta = etaAvailable,
+  existingBacklog: PipelineOperationalStage["existingBacklog"] = {
+    kind: "domain_jobs",
+    counts: counts(),
+  },
+): PipelineOperationalStage {
+  return {
+    stage: stageName,
+    label,
+    scope,
+    currentExecution,
+    existingBacklog,
+    capacity: availableCapacity,
+    eta,
+    asOf: AS_OF,
+  };
+}
+
+const discoveringStages: PipelineOperationalStage[] = [
+  stage("source_planning", "Plan sources", "current_execution", counts({ eligible: 1, succeeded: 1 })),
+  stage("source_family", "Crawl sources", "current_execution", counts({ eligible: 3, processing: 2, succeeded: 1 })),
+  stage("reconciliation", "Reconciliation", "current_execution", counts({ eligible: 2, waiting: 2 })),
+  stage("enrich", "Enrich", "execution_sweep", counts({ eligible: 9, waiting: 5, processing: 2, succeeded: 2 })),
+  stage("score", "Score", "execution_sweep", counts({ eligible: 7, waiting: 4, processing: 1, succeeded: 2 })),
+  stage("tailor", "Tailor", "execution_sweep", counts({ eligible: 4, waiting: 4 })),
+  stage(
+    "score",
+    "Score",
+    "global_outside_execution",
+    counts(),
+    etaUnavailable,
+    { kind: "domain_jobs", counts: counts({ eligible: 11, waiting: 8, failed: 1, stale: 2 }) },
+  ),
+  stage(
+    "tailor",
+    "Tailor",
+    "global_outside_execution",
+    counts(),
+    etaUnavailable,
+    { kind: "domain_jobs", counts: counts({ eligible: 6, waiting: 5, needsVerification: 1 }) },
+  ),
+];
+
+function snapshot(overrides: Partial<PipelineOperationsSnapshot> = {}): PipelineOperationsSnapshot {
+  return {
+    generatedAt: AS_OF,
+    etaEstimatorVersion: "pipeline-eta-v1",
+    freshness: { status: "fresh", asOf: AS_OF, staleAfterSeconds: 45 },
+    execution: {
+      discoverWorkflowId: "discover-local",
+      discoverRunId: "run-discover-20260714",
+      selectedAs: "active_or_draining",
+      workflowStatus: "in_progress",
+      phase: "discovering",
+      membershipClosed: false,
+      startedAt: "2026-07-14T11:48:00.000Z",
+      finishedAt: null,
+      errorCode: null,
+      currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 6, failedPlan: 0, terminal: 3, remaining: 6 },
+      sweptExistingBacklog: { members: 11, planned: 11, notEligible: 0, pending: 8, failedPlan: 0, terminal: 3, remaining: 8 },
+    },
+    capacity: availableCapacity,
+    sourceFamilies: {
+      planned: 3,
+      counts: counts({ eligible: 3, processing: 2, succeeded: 1 }),
+      eta: etaAvailable,
+      asOf: AS_OF,
+    },
+    reconciliation: {
+      enrichment: counts({ eligible: 1, waiting: 1 }),
+      preparationFanout: counts({ eligible: 1, waiting: 1 }),
+      asOf: AS_OF,
+    },
+    stages: discoveringStages,
+    activeItems: [
+      {
+        kind: "source_family",
+        activityType: "discovery_source_family",
+        workflowId: "discover-local",
+        executionId: "run-discover-20260714",
+        attempt: 1,
+        startedAt: "2026-07-14T11:50:00.000Z",
+        sourceFamily: "JobSpy / LinkedIn",
+      },
+      {
+        kind: "source_family",
+        activityType: "discovery_source_family",
+        workflowId: "discover-local",
+        executionId: "run-discover-20260714",
+        attempt: 1,
+        startedAt: "2026-07-14T11:51:00.000Z",
+        sourceFamily: "Workday careers",
+      },
+    ],
+    activeItemsTotal: 2,
+    activeItemsTruncated: false,
+    overallEta: etaAvailable,
+    ...overrides,
+  };
+}
+
+export const pipelinesDiscoveringSnapshot = snapshot();
+
+export const pipelinesDrainingSnapshot = snapshot({
+  execution: {
+    ...pipelinesDiscoveringSnapshot.execution!,
+    phase: "draining",
+    membershipClosed: true,
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 3, failedPlan: 0, terminal: 6, remaining: 3 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, processing: 1 }),
+    asOf: AS_OF,
+  },
+  activeItems: [
+    {
+      kind: "orchestration",
+      activityType: "discovery_preparation_fanout",
+      workflowId: "discover-local",
+      executionId: "run-discover-20260714",
+      attempt: 1,
+      startedAt: "2026-07-14T11:58:00.000Z",
+      operation: "Starting preparation workflows",
+    },
+  ],
+  activeItemsTotal: 1,
+  overallEta: {
+    status: "available",
+    lowSeconds: 120,
+    highSeconds: 180,
+    confidence: "high",
+    basis: "cohort_throughput",
+    sampleSize: 18,
+    asOf: AS_OF,
+    caveat: null,
+  },
+});
+
+export const pipelinesCompletedSnapshot = snapshot({
+  execution: {
+    ...pipelinesDiscoveringSnapshot.execution!,
+    selectedAs: "latest_terminal",
+    workflowStatus: "succeeded",
+    phase: "completed",
+    membershipClosed: true,
+    finishedAt: "2026-07-14T12:04:00.000Z",
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 0, failedPlan: 0, terminal: 9, remaining: 0 },
+    sweptExistingBacklog: { members: 11, planned: 11, notEligible: 0, pending: 0, failedPlan: 0, terminal: 11, remaining: 0 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, succeeded: 1 }),
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({
+    ...entry,
+    currentExecution: counts({ eligible: entry.currentExecution.eligible, succeeded: entry.currentExecution.eligible }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+  })),
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+});
+
+export const pipelinesCompletedWithIssuesSnapshot = snapshot({
+  freshness: {
+    status: "stale",
+    asOf: "2026-07-14T11:45:00.000Z",
+    staleAfterSeconds: 45,
+    reason: "Worker telemetry is older than the configured freshness threshold.",
+  },
+  execution: {
+    ...pipelinesCompletedSnapshot.execution!,
+    phase: "completed_with_issues",
+    errorCode: "source_retry_exhausted",
+    currentExecution: { members: 9, planned: 9, notEligible: 0, pending: 0, failedPlan: 0, terminal: 9, remaining: 0 },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 2, exhausted: 1 }),
+    eta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, blocked: 1 }),
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({
+    ...entry,
+    eta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+  })),
+  activeItems: [],
+  activeItemsTotal: null,
+  activeItemsTruncated: null,
+  overallEta: { status: "stale", reason: "telemetry_stale", asOf: AS_OF },
+});
+
+export const pipelinesCalibratingSnapshot = snapshot({
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, processing: 1, succeeded: 2 }),
+    eta: etaCalibrating,
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, eta: etaCalibrating })),
+  overallEta: etaCalibrating,
+});
+
+export const pipelinesUnavailableTelemetrySnapshot = snapshot({
+  freshness: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+  },
+  capacity: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    taskQueue: "jobctrl-default",
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+    approximateTaskQueue: { status: "unavailable", observedAt: AS_OF, reasonCode: "runtime_telemetry_missing" },
+  },
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, processing: 1, succeeded: 2 }),
+    eta: etaUnavailable,
+    asOf: AS_OF,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, capacity: {
+    status: "unavailable",
+    asOf: AS_OF,
+    staleAfterSeconds: 45,
+    taskQueue: "jobctrl-default",
+    reason: "No worker runtime telemetry has been recorded for this task queue.",
+    approximateTaskQueue: { status: "unavailable", observedAt: AS_OF, reasonCode: "runtime_telemetry_missing" },
+  }, eta: etaUnavailable })),
+  activeItems: [],
+  activeItemsTotal: null,
+  activeItemsTruncated: null,
+  overallEta: etaUnavailable,
+});
+
+export const pipelinesMultiWorkerCapacitySnapshot = snapshot({
+  capacity: {
+    ...availableCapacity,
+    freshWorkerCount: 3,
+    configuredSlots: 12,
+    activeSlots: 9,
+    availableSlots: 3,
+    executorThreads: 18,
+    internalParallelism: 3,
+    slotSaturation: 0.75,
+  },
+  stages: discoveringStages.map((entry) => ({ ...entry, capacity: {
+    ...availableCapacity,
+    freshWorkerCount: 3,
+    configuredSlots: 12,
+    activeSlots: 9,
+    availableSlots: 3,
+    executorThreads: 18,
+    internalParallelism: 3,
+    slotSaturation: 0.75,
+  } })),
+  activeItems: [
+    ...pipelinesDiscoveringSnapshot.activeItems,
+    {
+      kind: "resolved_job",
+      activityType: "score_job",
+      workflowId: "prepare-job-8",
+      executionId: "run-prepare-job-8",
+      attempt: 2,
+      startedAt: "2026-07-14T11:56:00.000Z",
+      jobKey: "job-8",
+      title: "Staff Platform Engineer",
+      company: "Northstar",
+      stage: "score",
+    },
+    {
+      kind: "unresolved_runtime_activity",
+      activityType: "workflow_activity",
+      workflowId: "discover-local",
+      executionId: "run-discover-20260714",
+      attempt: 3,
+      startedAt: "2026-07-14T11:57:00.000Z",
+      opaqueId: "activity-opaque-17",
+    },
+  ],
+  activeItemsTotal: 9,
+  activeItemsTruncated: true,
+});
+
+/**
+ * Guards the original topology: three source-family activities are not the
+ * two one-off reconciliation activities. The view must never total them as
+ * five source families or describe the reconciliation pair as a sixth source.
+ */
+export const pipelinesThreeSourceSixStepSnapshot = snapshot({
+  sourceFamilies: {
+    planned: 3,
+    counts: counts({ eligible: 3, succeeded: 3 }),
+    eta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+    asOf: AS_OF,
+  },
+  reconciliation: {
+    enrichment: counts({ eligible: 1, succeeded: 1 }),
+    preparationFanout: counts({ eligible: 1, succeeded: 1 }),
+    asOf: AS_OF,
+  },
+  stages: [
+    stage("source_planning", "Plan sources", "current_execution", counts({ eligible: 1, succeeded: 1 })),
+    stage("source_family", "Crawl sources", "current_execution", counts({ eligible: 3, succeeded: 3 })),
+    stage("reconciliation", "Reconciliation", "current_execution", counts({ eligible: 2, succeeded: 2 })),
+    stage("enrich", "Enrich", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+    stage("score", "Score", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+    stage("tailor", "Tailor", "execution_sweep", counts({ eligible: 1, succeeded: 1 })),
+  ],
+  activeItems: [],
+  activeItemsTotal: 0,
+  activeItemsTruncated: false,
+  overallEta: { status: "unavailable", reason: "no_work", asOf: AS_OF },
+});

--- a/apps/web/src/views/pipelines/PipelinesView.stories.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.stories.tsx
@@ -1,5 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
 
+import {
+  pipelinesCalibratingSnapshot,
+  pipelinesCompletedSnapshot,
+  pipelinesCompletedWithIssuesSnapshot,
+  pipelinesDiscoveringSnapshot,
+  pipelinesDrainingSnapshot,
+  pipelinesMultiWorkerCapacitySnapshot,
+  pipelinesThreeSourceSixStepSnapshot,
+  pipelinesUnavailableTelemetrySnapshot,
+} from "./PipelinesView.fixtures.js";
 import { PipelinesView } from "./PipelinesView.js";
 
 const meta = {
@@ -14,4 +25,67 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+function operationsSnapshot(snapshot: typeof pipelinesDiscoveringSnapshot) {
+  return http.get("*/v1/pipeline/operations", () => HttpResponse.json(snapshot));
+}
+
+export const Discovering: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesDiscoveringSnapshot)] },
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("*/v1/pipeline/operations", async () => {
+          await new Promise((resolve) => setTimeout(resolve, 60_000));
+          return HttpResponse.json(pipelinesDiscoveringSnapshot);
+        }),
+      ],
+    },
+  },
+};
+
+export const Draining: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesDrainingSnapshot)] },
+  },
+};
+
+export const Completed: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCompletedSnapshot)] },
+  },
+};
+
+export const CompletedWithIssuesAndStaleTelemetry: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCompletedWithIssuesSnapshot)] },
+  },
+};
+
+export const CalibratingEta: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesCalibratingSnapshot)] },
+  },
+};
+
+export const UnavailableTelemetryAndEta: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesUnavailableTelemetrySnapshot)] },
+  },
+};
+
+export const MultiWorkerCapacity: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesMultiWorkerCapacitySnapshot)] },
+  },
+};
+
+export const ThreeSourceSixStepRegression: Story = {
+  parameters: {
+    msw: { handlers: [operationsSnapshot(pipelinesThreeSourceSixStepSnapshot)] },
+  },
+};

--- a/apps/web/src/views/pipelines/PipelinesView.test.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.test.tsx
@@ -1,9 +1,29 @@
-import { screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import type { PipelineOperationsSnapshot } from "@jobctrl/contracts";
+import { screen, within } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useStageTriggerStore } from "../../contexts/pipeline/stores/stage-trigger-store.js";
 import { renderWithProviders } from "../../test/render.js";
+import { buildTestPorts } from "../../test/testPorts.js";
+import {
+  pipelinesCalibratingSnapshot,
+  pipelinesDiscoveringSnapshot,
+  pipelinesMultiWorkerCapacitySnapshot,
+  pipelinesThreeSourceSixStepSnapshot,
+  pipelinesUnavailableTelemetrySnapshot,
+} from "./PipelinesView.fixtures.js";
 import { PipelinesView } from "./PipelinesView.js";
+
+async function renderPipelineOperations(snapshot: PipelineOperationsSnapshot) {
+  const pipelineOperations = vi.fn(async () => snapshot);
+  const view = renderWithProviders(<PipelinesView />, {
+    ports: buildTestPorts({ api: { pipelineOperations } }),
+  });
+
+  await screen.findByRole("heading", { name: "Operational stage ledger" });
+  return { ...view, pipelineOperations };
+}
 
 describe("PipelinesView", () => {
   beforeEach(() => {
@@ -11,23 +31,118 @@ describe("PipelinesView", () => {
     useStageTriggerStore.getState().reset();
   });
 
-  it("hosts the pipeline action controls", async () => {
-    renderWithProviders(<PipelinesView />);
+  it("keeps the original action controls aligned with the live operations workspace", async () => {
+    const user = userEvent.setup();
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
 
-    expect(
-      screen.getByRole("heading", { name: "Pipeline actions" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Pipeline actions" })).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Run Discover" })).toBeEnabled();
+    expect(screen.getByLabelText("Limit")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
+    expect(screen.getByLabelText("Source")).toBeInTheDocument();
+    expect(screen.getByLabelText("Dry run")).toBeChecked();
+
+    await user.click(screen.getByRole("tab", { name: "Apply" }));
+
+    expect(screen.getByLabelText("Minimum score")).toBeInTheDocument();
+    expect(screen.getByLabelText("Internal concurrency")).toBeInTheDocument();
+    expect(screen.getByLabelText("Apply model")).toBeInTheDocument();
+    expect(screen.getByLabelText("Headless browser")).toBeInTheDocument();
+    expect(screen.getByLabelText("Continuous")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Source")).not.toBeInTheDocument();
   });
 
-  it("does not show secondary discovery navigation inside pipeline actions", () => {
-    renderWithProviders(<PipelinesView />);
+  it("distinguishes current execution, sweep, and global backlog in one dense stage table", async () => {
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
 
-    expect(
-      screen.queryByRole("heading", { name: "Discovery" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Open Discovery" }),
-    ).not.toBeInTheDocument();
+    const table = screen.getByRole("table", { name: /stage state, existing backlog/i });
+    expect(within(table).getAllByText("Current execution").length).toBeGreaterThan(0);
+    expect(within(table).getAllByText("Execution sweep").length).toBeGreaterThan(0);
+    expect(within(table).getAllByText("Global backlog").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("table")).toHaveLength(1);
+  });
+
+  it("keeps the three source families separate from the two reconciliation steps", async () => {
+    await renderPipelineOperations(pipelinesThreeSourceSixStepSnapshot);
+
+    const sourceCard = screen.getByRole("heading", { name: "Source crawl progress" }).closest(".pipeline-card");
+    if (!sourceCard) throw new Error("Expected source crawl progress card.");
+
+    expect(sourceCard).toHaveTextContent("3/3 succeeded");
+    expect(sourceCard).toHaveTextContent("Reconciliation");
+    expect(sourceCard).toHaveTextContent("Enrichment pass");
+    expect(sourceCard).toHaveTextContent("Preparation fanout");
+  });
+
+  it("announces only the stable phase message and keeps calibration inspectable", async () => {
+    const { container } = await renderPipelineOperations(pipelinesCalibratingSnapshot);
+
+    const liveMessage = container.querySelector(".pipeline-phase-message");
+    if (!liveMessage) throw new Error("Expected the compact phase message.");
+
+    expect(liveMessage).toHaveAttribute("aria-live", "polite");
+    expect(container.querySelectorAll("[aria-live]")).toHaveLength(1);
+    expect(liveMessage).toHaveTextContent("Discovering");
+    expect(liveMessage).not.toHaveTextContent("Calibrating");
+    expect(screen.getAllByText(/Calibrating · 2\/8/).length).toBeGreaterThan(0);
+  });
+
+  it("labels unavailable telemetry without inventing an ETA", async () => {
+    await renderPipelineOperations(pipelinesUnavailableTelemetrySnapshot);
+
+    const capacity = screen.getByRole("heading", { name: "Worker capacity" }).closest(".pipeline-card");
+    if (!capacity) throw new Error("Expected worker capacity card.");
+
+    expect(capacity).toHaveTextContent("Unavailable");
+    expect(capacity).toHaveTextContent("No worker runtime telemetry");
+    expect(screen.queryByText(/estimate:.*min/i)).not.toBeInTheDocument();
+  });
+
+  it("reports active inventory truth and multi-worker internal concurrency", async () => {
+    await renderPipelineOperations(pipelinesMultiWorkerCapacitySnapshot);
+
+    const activeWork = screen.getByRole("heading", { name: "Active work" }).closest(".pipeline-card");
+    const capacity = screen.getByRole("heading", { name: "Worker capacity" }).closest(".pipeline-card");
+    if (!activeWork || !capacity) throw new Error("Expected active-work and capacity cards.");
+
+    expect(activeWork).toHaveTextContent("9 total");
+    expect(activeWork).toHaveTextContent("Inventory truncated");
+    expect(within(activeWork).getByText("Staff Platform Engineer")).toBeInTheDocument();
+    expect(within(activeWork).getAllByText("activity-opaque-17").length).toBeGreaterThan(0);
+    expect(capacity).toHaveTextContent("Internal concurrency");
+    expect(capacity).toHaveTextContent("3");
+  });
+
+  it("withholds URL-shaped job keys from the operations inspector", async () => {
+    const sensitiveJobKey = "https://jobs.example.test/private/123";
+    await renderPipelineOperations({
+      ...pipelinesDiscoveringSnapshot,
+      activeItems: [
+        {
+          kind: "resolved_job",
+          activityType: "score_job",
+          workflowId: "prep-opaque",
+          executionId: "run-opaque",
+          attempt: 1,
+          startedAt: "2026-07-14T11:59:00.000Z",
+          jobKey: sensitiveJobKey,
+          title: "Private role",
+          company: "Private employer",
+          stage: "score",
+        },
+      ],
+      activeItemsTotal: 1,
+      activeItemsTruncated: false,
+    });
+
+    expect(screen.queryByText(sensitiveJobKey)).not.toBeInTheDocument();
+    expect(screen.getAllByText("Sensitive identifier withheld").length).toBeGreaterThan(0);
+  });
+
+  it("does not show secondary discovery navigation inside pipeline actions", async () => {
+    await renderPipelineOperations(pipelinesDiscoveringSnapshot);
+
+    expect(screen.queryByRole("heading", { name: "Discovery" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Open Discovery" })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/views/pipelines/PipelinesView.tsx
+++ b/apps/web/src/views/pipelines/PipelinesView.tsx
@@ -1,11 +1,15 @@
-import { StageTriggerPanel } from "../../contexts/pipeline/components/StageTriggerPanel.js";
+import { PipelineOperationsWorkspace } from "../../contexts/pipeline/components/PipelineOperationsWorkspace.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 
 export function PipelinesView() {
   return (
-    <>
-      <PageHead eyebrow="Pipeline" title="Pipelines" />
-      <StageTriggerPanel />
-    </>
+    <div className="pipelines-view">
+      <PageHead
+        eyebrow="Pipeline"
+        title="Pipelines"
+        subtitle="Follow the current discovery execution, the backlog around it, and the capacity doing the work."
+      />
+      <PipelineOperationsWorkspace />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- add the pipeline operations query hook and event-driven cache invalidation
- rebuild Pipelines as a Rhea operations workspace with execution, source, capacity, stage, and active-work surfaces
- preserve the complete operations snapshot behind compact scan paths and Base UI disclosures
- retain all existing pipeline launch controls with clearer internal-concurrency labeling
- add scenario fixtures, stories, and focused regression coverage

## Why

The P2 read model exposes execution-scoped progress, outside backlog, capacity, queue pressure, ETA, and active runtime inventory. This layer turns those facts into a dense operational workspace without reintroducing the legacy route-workspace primitives or decorative card nesting.

## Validation

Not run in this phase. The approved unreleased stack defers cumulative frontend QA, typecheck, build, and browser verification until the final documentation layer.