### PR TITLE
feat(web): align redesign with shadcn Rhea components

### DIFF
--- a/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
+++ b/apps/web/src/contexts/profile/components/ProfileEditor.test.tsx
@@ -83,7 +83,7 @@ describe("<ProfileEditor>", () => {
     expect(
       await screen.findByRole("heading", { name: "Configuration & templates" }),
     ).toBeInTheDocument();
-    expect(await screen.findByRole("heading", { name: "Application configurations" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Application configuration" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Location filter")).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Target search" })).not.toBeInTheDocument();
     expect(screen.getByRole("group", { name: "Revision policy" })).toBeInTheDocument();

--- a/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
+++ b/apps/web/src/contexts/profile/components/StructuredProfileEditor.tsx
@@ -1,7 +1,32 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  Fragment,
+  useEffect,
+  useRef,
+  useState,
+  type InputHTMLAttributes,
+  type ReactNode,
+  type TextareaHTMLAttributes,
+} from "react";
 import { IconChevronDown, IconExternalLink, IconPlus, IconTrash } from "@tabler/icons-react";
 
+import { Alert, AlertDescription } from "../../../shared/ui/alert.js";
 import { Checkbox } from "../../../shared/ui/checkbox.js";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../../shared/ui/collapsible.js";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+} from "../../../shared/ui/field.js";
+import { Input } from "../../../shared/ui/input.js";
 import {
   Select,
   SelectContent,
@@ -10,6 +35,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../../shared/ui/select.js";
+import { Separator } from "../../../shared/ui/separator.js";
+import { Textarea } from "../../../shared/ui/textarea.js";
 
 import {
   GoogleAddressSearchField,
@@ -139,6 +166,23 @@ const ROLE_AREA_PLACEHOLDER = "Engineering, security, platform";
 const TARGET_LOCATION_LABEL = "Locations and work models";
 const GOOGLE_MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY ?? "";
 
+type StructuredInputAttributes = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  "onChange" | "type" | "value"
+> & {
+  valueKind?: "text";
+};
+
+type StructuredTextareaAttributes = Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "onChange" | "placeholder" | "value"
+>;
+
+function editorControlId(scope: "profile" | "style", path: string, suffix = "") {
+  const normalizedPath = path.replace(/[^a-z0-9]+/gi, "-").replace(/^-|-$/g, "");
+  return `structured-${scope}-${normalizedPath}${suffix ? `-${suffix}` : ""}`;
+}
+
 export interface StructuredProfileEditorProps {
   applicationConfigurationFields?: ReactNode;
   mode?: "profile" | "preferences" | "target-search";
@@ -162,12 +206,12 @@ function ConfigurationSection({
   const [open, setOpen] = useState(defaultOpen ?? false);
 
   return (
-    <details
+    <Collapsible
       className="form-section configuration-section"
       open={open}
-      onToggle={(event) => setOpen(event.currentTarget.open)}
+      onOpenChange={setOpen}
     >
-      <summary>
+      <CollapsibleTrigger className="configuration-section__trigger">
         <span className="configuration-section__title-group">
           <span aria-level={3} className="configuration-section__title" role="heading">
             {title}
@@ -175,9 +219,11 @@ function ConfigurationSection({
           <span className="configuration-section__description">{description}</span>
         </span>
         <IconChevronDown aria-hidden="true" className="configuration-section__indicator" size={16} />
-      </summary>
-      <div className="configuration-section__body">{children}</div>
-    </details>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="configuration-section__body" keepMounted>
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -224,9 +270,11 @@ export function StructuredProfileEditor({
 
   if (!profile || !style) {
     return (
-      <div className="banner inline">
-        The structured editor needs valid profile data. Reload the profile after fixing the saved data.
-      </div>
+      <Alert className="banner inline">
+        <AlertDescription>
+          The structured editor needs valid profile data. Reload the profile after fixing the saved data.
+        </AlertDescription>
+      </Alert>
     );
   }
 
@@ -387,15 +435,17 @@ export function StructuredProfileEditor({
   const textField = (
     path: string,
     label: string,
-    type = "text",
-    attrs: Record<string, unknown> = {},
+    type: InputHTMLAttributes<HTMLInputElement>["type"] = "text",
+    attrs: StructuredInputAttributes = {},
   ) => {
     const { valueKind, ...inputAttrs } = attrs;
+    const id = inputAttrs.id ?? editorControlId("profile", path);
     return (
-      <label className="field">
-        <span>{label}</span>
-        <input
+      <Field className="field">
+        <FieldLabel htmlFor={id}>{label}</FieldLabel>
+        <Input
           {...inputAttrs}
+          id={id}
           type={type}
           value={textAt(profile, path)}
           onChange={(event) =>
@@ -407,7 +457,7 @@ export function StructuredProfileEditor({
             )
           }
         />
-      </label>
+      </Field>
     );
   };
 
@@ -434,7 +484,7 @@ export function StructuredProfileEditor({
 
   const constrainedNumberOrEmpty = (
     value: string,
-    attrs: Record<string, unknown>,
+    attrs: Pick<InputHTMLAttributes<HTMLInputElement>, "max" | "min">,
     keepText = false,
   ) => {
     const parsed = numberOrEmpty(value);
@@ -457,45 +507,73 @@ export function StructuredProfileEditor({
     value: ProfileMonthValue,
     onChange: (value: ProfileMonthValue) => void,
     disabled = false,
-  ) => (
-    <div className="month-selector">
-      <span>{label}</span>
+  ) => {
+    const emptyMonthValue = "__empty-month__";
+    const emptyYearValue = "__empty-year__";
+    const monthItems = [
+      { label: "Month", value: emptyMonthValue },
+      ...PROFILE_MONTHS.map((month) => ({ label: month.label, value: month.value })),
+    ];
+    const yearItems = [
+      { label: "Year", value: emptyYearValue },
+      ...years.map((year) => ({ label: year, value: year })),
+    ];
+    return (
+    <FieldSet className="month-selector">
+      <FieldLegend variant="label">{label}</FieldLegend>
       <div className="month-selector-controls">
-        <select
-          aria-label={`${label} month`}
+        <Select
           disabled={disabled}
-          value={value.month}
-          onChange={(event) => onChange({ ...value, month: event.target.value })}
+          items={monthItems}
+          value={value.month || emptyMonthValue}
+          onValueChange={(month) =>
+            onChange({ ...value, month: month === emptyMonthValue ? "" : month })
+          }
         >
-          <option value="">Month</option>
-          {PROFILE_MONTHS.map((month) => (
-            <option key={month.value} value={month.value}>
-              {month.label}
-            </option>
-          ))}
-        </select>
-        <select
-          aria-label={`${label} year`}
+          <SelectTrigger aria-label={`${label} month`} className="configuration-select-trigger">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {monthItems.map((month) => (
+                <SelectItem key={month.value} value={month.value}>
+                  {month.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+        <Select
           disabled={disabled}
-          value={value.year}
-          onChange={(event) => onChange({ ...value, year: event.target.value })}
+          items={yearItems}
+          value={value.year || emptyYearValue}
+          onValueChange={(year) =>
+            onChange({ ...value, year: year === emptyYearValue ? "" : year })
+          }
         >
-          <option value="">Year</option>
-          {years.map((year) => (
-            <option key={year} value={year}>
-              {year}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger aria-label={`${label} year`} className="configuration-select-trigger">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {yearItems.map((year) => (
+                <SelectItem key={year.value} value={year.value}>
+                  {year.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
       </div>
-    </div>
-  );
+    </FieldSet>
+    );
+  };
 
   const monthField = (path: string, label: string) => {
     const value = parseProfileMonth(textAt(profile, path));
     return (
-      <div className="field month-field">
-        <span>{label}</span>
+      <Field className="field month-field">
+        <FieldTitle>{label}</FieldTitle>
         <div className="month-field-body">
           {monthSelector(label, value, (next) => updateProfilePath(path, formatProfileMonth(next)))}
           <button
@@ -507,7 +585,7 @@ export function StructuredProfileEditor({
             clear
           </button>
         </div>
-      </div>
+      </Field>
     );
   };
 
@@ -517,27 +595,28 @@ export function StructuredProfileEditor({
     const updateDateRange = (next: Partial<typeof value>) => {
       updateProfilePath(path, formatProfileDateRange({ ...value, ...next }));
     };
+    const presentId = editorControlId("profile", path, "present");
     return (
-      <div className="field date-range-field wide">
-        <span>{label}</span>
+      <Field className="field date-range-field wide" data-invalid={hasError || undefined}>
+        <FieldTitle>{label}</FieldTitle>
         <div className={`date-range-body${hasError ? " invalid" : ""}`}>
           {monthSelector("Start", value.start, (start) => updateDateRange({ start }))}
           {value.present
             ? null
             : monthSelector("End", value.end, (end) => updateDateRange({ end, present: false }))}
-          <label className="choice date-range-present">
-            <input
-              type="checkbox"
+          <Field className="choice date-range-present" orientation="horizontal">
+            <Checkbox
+              id={presentId}
               checked={value.present}
-              onChange={(event) =>
+              onCheckedChange={(checked) =>
                 updateDateRange({
-                  end: event.target.checked ? emptyProfileMonth() : value.end,
-                  present: event.target.checked,
+                  end: checked ? emptyProfileMonth() : value.end,
+                  present: checked,
                 })
               }
             />
-            <span>Present</span>
-          </label>
+            <FieldLabel htmlFor={presentId}>Present</FieldLabel>
+          </Field>
           <button
             className="tab"
             type="button"
@@ -553,8 +632,8 @@ export function StructuredProfileEditor({
             clear
           </button>
         </div>
-        {hasError ? <span className="field-error">End date must be after start date.</span> : null}
-      </div>
+        {hasError ? <FieldError>End date must be after start date.</FieldError> : null}
+      </Field>
     );
   };
 
@@ -562,51 +641,64 @@ export function StructuredProfileEditor({
     path: string,
     label: string,
     options: Array<[string, string]> | string[],
-  ) => (
-    <label className="field">
-      <span>{label}</span>
-      <Select value={textAt(profile, path)} onValueChange={(value) => updateProfilePath(path, value)}>
-        <SelectTrigger aria-label={label} className="configuration-select-trigger">
+  ) => {
+    const id = editorControlId("profile", path);
+    const items = options.map((option) => ({
+      label: Array.isArray(option) ? option[1] : option,
+      value: Array.isArray(option) ? option[0] : option,
+    }));
+    return (
+    <Field className="field">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Select
+        items={items}
+        value={textAt(profile, path)}
+        onValueChange={(value) => updateProfilePath(path, value)}
+      >
+        <SelectTrigger id={id} aria-label={label} className="configuration-select-trigger">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            {options.map((option) => {
-              const value = Array.isArray(option) ? option[0] : option;
-              const text = Array.isArray(option) ? option[1] : option;
-              return (
-                <SelectItem key={value} value={value}>
-                  {text}
+            {items.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
                 </SelectItem>
-              );
-            })}
+              ))}
           </SelectGroup>
         </SelectContent>
       </Select>
-    </label>
-  );
+    </Field>
+    );
+  };
 
-  const inventedAdjacentExperienceField = () => (
-    <label className="field check">
+  const inventedAdjacentExperienceField = () => {
+    const id = editorControlId("profile", ALLOW_ADJACENT_ACHIEVEMENT_DRAFTS_PATH);
+    return (
+    <Field className="field check" orientation="horizontal">
       <Checkbox
-        aria-label="Enable profile enhancement"
+        id={id}
         checked={allowsInventedAdjacentExperience()}
         onCheckedChange={setInventedAdjacentExperienceAllowed}
       />
-      <span>Enable profile enhancement</span>
-    </label>
-  );
+      <FieldLabel htmlFor={id}>Enable profile enhancement</FieldLabel>
+    </Field>
+    );
+  };
 
-  const checkboxField = (path: string, label: string) => (
-    <label className="field check">
+  const checkboxField = (path: string, label: string) => {
+    const id = editorControlId("profile", path);
+    return (
+    <Field className="field check" orientation="horizontal">
       <Checkbox
-        aria-label={label}
+        id={id}
         checked={Boolean(getPathValue(profile, path))}
         onCheckedChange={(checked) => updateProfilePath(path, checked)}
       />
-      <span>{label}</span>
-    </label>
-  );
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+    </Field>
+    );
+  };
 
   const numberField = (
     path: string,
@@ -615,10 +707,12 @@ export function StructuredProfileEditor({
   ) => {
     const value = getPathValue(profile, path);
     const displayedValue = value === undefined || value === null || value === "" ? attrs.defaultValue : value;
+    const id = editorControlId("profile", path);
     return (
-      <label className="field">
-        <span>{label}</span>
-        <input
+      <Field className="field">
+        <FieldLabel htmlFor={id}>{label}</FieldLabel>
+        <Input
+          id={id}
           type="number"
           min={attrs.min}
           max={attrs.max}
@@ -629,7 +723,7 @@ export function StructuredProfileEditor({
             updateProfilePath(path, typeof parsed === "number" ? Math.round(parsed) : parsed);
           }}
         />
-      </label>
+      </Field>
     );
   };
 
@@ -641,10 +735,12 @@ export function StructuredProfileEditor({
     const rawValue = getPathValue(profile, path);
     const ratioValue = rawValue === undefined || rawValue === null || rawValue === "" ? attrs.defaultValue : Number(rawValue);
     const percentValue = Number.isFinite(ratioValue) ? Math.round(ratioValue * 100) : Math.round(attrs.defaultValue * 100);
+    const id = editorControlId("profile", path);
     return (
-      <label className="field">
-        <span>{label}</span>
-        <input
+      <Field className="field">
+        <FieldLabel htmlFor={id}>{label}</FieldLabel>
+        <Input
+          id={id}
           type="number"
           min={attrs.min}
           max={attrs.max}
@@ -655,43 +751,54 @@ export function StructuredProfileEditor({
             updateProfilePath(path, typeof parsed === "number" ? Math.round(parsed) / 100 : parsed);
           }}
         />
-      </label>
+      </Field>
     );
   };
 
-  const disabledCheckboxField = (label: string) => (
-    <label className="field check disabled">
-      <Checkbox aria-label={label} checked={false} disabled />
-      <span>{label}</span>
-    </label>
-  );
+  const disabledCheckboxField = (label: string) => {
+    const id = editorControlId("profile", label, "disabled");
+    return (
+    <Field className="field check disabled" data-disabled orientation="horizontal">
+      <Checkbox id={id} checked={false} disabled />
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+    </Field>
+    );
+  };
 
   const textareaField = (
     path: string,
     label: string,
     placeholder = "",
-    attrs: Record<string, unknown> = {},
-  ) => (
-    <label className="field wide">
-      <span>{label}</span>
-      <textarea
+    attrs: StructuredTextareaAttributes = {},
+  ) => {
+    const id = attrs.id ?? editorControlId("profile", path);
+    return (
+    <Field className="field wide">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Textarea
         {...attrs}
+        id={id}
         placeholder={placeholder}
         value={textAt(profile, path)}
         onChange={(event) => updateProfilePath(path, event.target.value)}
       />
-    </label>
-  );
+    </Field>
+    );
+  };
 
-  const listField = (path: string, label: string) => (
-    <label className="field wide">
-      <span>{label}</span>
-      <textarea
+  const listField = (path: string, label: string) => {
+    const id = editorControlId("profile", path);
+    return (
+    <Field className="field wide">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Textarea
+        id={id}
         value={textArrayAt(profile, path).join("\n")}
         onChange={(event) => updateProfilePath(path, lines(event.target.value))}
       />
-    </label>
-  );
+    </Field>
+    );
+  };
 
   const delimitedListField = (
     path: string,
@@ -717,12 +824,12 @@ export function StructuredProfileEditor({
       updateValues([...values, ""]);
     };
     return (
-      <div className="field wide inline-list-field">
-        <span>{label}</span>
+      <Field className="field wide inline-list-field">
+        <FieldTitle>{label}</FieldTitle>
         <div className={`inline-list${options.compact ? " compact" : ""}`}>
           {values.map((value, index) => (
             <div className="inline-list-row" key={`${path}-${index}`}>
-              <input
+              <Input
                 aria-label={`${label} ${index + 1}`}
                 placeholder={options.placeholder}
                 ref={registerFocusTarget(focusKey(index))}
@@ -756,7 +863,7 @@ export function StructuredProfileEditor({
             {addLabel}
           </button>
         </div>
-      </div>
+      </Field>
     );
   };
 
@@ -790,29 +897,49 @@ export function StructuredProfileEditor({
     };
 
     return (
-      <fieldset className="field wide checkbox-group-field">
-        <legend>{label}</legend>
-        <div className="checkbox-group-list">
-          {groups.map((group) => (
-            <div
-              className={`checkbox-option-group${group.label ? "" : " ungrouped"}`}
-              key={`${path}-${group.label || "ungrouped"}`}
-            >
-              {group.label ? <span className="checkbox-group-label">{group.label}</span> : null}
-              <div className="checkbox-options">
+      <FieldSet className="field wide checkbox-group-field">
+        <FieldLegend>{label}</FieldLegend>
+        <FieldGroup className="checkbox-group-list">
+          {groups.map((group) => {
+            const optionFields = (
+              <FieldGroup className="checkbox-options">
                 {group.options.map((option) => (
-                  <label className="choice target-choice" key={`${path}-${option.value}`}>
-                    <input
-                      type="checkbox"
+                  <Field
+                    className="choice target-choice"
+                    key={`${path}-${option.value}`}
+                    orientation="horizontal"
+                  >
+                    <Checkbox
+                      id={editorControlId("profile", path, option.value)}
                       checked={selected.has(option.value)}
-                      onChange={(event) => updateSelection(option.value, event.target.checked)}
+                      onCheckedChange={(checked) => updateSelection(option.value, checked)}
                     />
-                    <span>{option.label}</span>
-                  </label>
+                    <FieldLabel htmlFor={editorControlId("profile", path, option.value)}>
+                      {option.label}
+                    </FieldLabel>
+                  </Field>
                 ))}
-              </div>
-            </div>
-          ))}
+              </FieldGroup>
+            );
+            return group.label ? (
+              <FieldSet
+                className="checkbox-option-group"
+                key={`${path}-${group.label}`}
+              >
+                <FieldLegend className="checkbox-group-label" variant="label">
+                  {group.label}
+                </FieldLegend>
+                {optionFields}
+              </FieldSet>
+            ) : (
+              <FieldGroup
+                className="checkbox-option-group ungrouped"
+                key={`${path}-ungrouped`}
+              >
+                {optionFields}
+              </FieldGroup>
+            );
+          })}
           {customValues.length > 0 ? (
             <div className="unsupported-target-values">
               <span>Unsupported saved values</span>
@@ -831,8 +958,8 @@ export function StructuredProfileEditor({
               </div>
             </div>
           ) : null}
-        </div>
-      </fieldset>
+        </FieldGroup>
+      </FieldSet>
     );
   };
 
@@ -881,12 +1008,12 @@ export function StructuredProfileEditor({
     };
 
     return (
-      <div className="field wide target-location-model-field">
-        <span>{TARGET_LOCATION_LABEL}</span>
+      <Field className="field wide target-location-model-field">
+        <FieldTitle>{TARGET_LOCATION_LABEL}</FieldTitle>
         <div className="target-location-model-list">
           {rows.map((row, index) => (
             <div className="target-location-model-row" key={`${locationPath}-${index}`}>
-              <input
+              <Input
                 aria-label={`Target location ${index + 1}`}
                 ref={registerFocusTarget(locationFocusKey(index))}
                 value={row.location}
@@ -904,22 +1031,28 @@ export function StructuredProfileEditor({
                   insertRowAfter(index, { location: event.currentTarget.value });
                 }}
               />
-              <fieldset className="target-work-model-group" aria-label={`Target work model ${index + 1}`}>
-                {workModelOptions.map((value) => {
-                  const checkboxId = `target-work-model-${index}-${value.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
-                  return (
-                    <label className="target-work-model-option" key={value} htmlFor={checkboxId}>
-                      <input
-                        id={checkboxId}
-                        type="checkbox"
-                        checked={commaListAt(row.workModel).includes(value)}
-                        onChange={(event) => toggleWorkModel(index, value, event.target.checked)}
-                      />
-                      <span>{value}</span>
-                    </label>
-                  );
-                })}
-              </fieldset>
+              <FieldSet className="target-work-model-group">
+                <FieldLegend className="sr-only">Target work model {index + 1}</FieldLegend>
+                <FieldGroup className="target-work-model-options">
+                  {workModelOptions.map((value) => {
+                    const checkboxId = `target-work-model-${index}-${value.toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+                    return (
+                      <Field
+                        className="target-work-model-option"
+                        key={value}
+                        orientation="horizontal"
+                      >
+                        <Checkbox
+                          id={checkboxId}
+                          checked={commaListAt(row.workModel).includes(value)}
+                          onCheckedChange={(checked) => toggleWorkModel(index, value, checked)}
+                        />
+                        <FieldLabel htmlFor={checkboxId}>{value}</FieldLabel>
+                      </Field>
+                    );
+                  })}
+                </FieldGroup>
+              </FieldSet>
               <button
                 className="icon-button"
                 type="button"
@@ -940,55 +1073,60 @@ export function StructuredProfileEditor({
             add location
           </button>
         </div>
-      </div>
+      </Field>
     );
   };
 
   const bulletStandardsField = () => (
-    <fieldset className="field wide checkbox-group-field bullet-standards-group">
-      <legend>
-        <span>Bullet standards</span>
-        <a
-          className="configuration-help-link"
-          href="https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Guide
-          <IconExternalLink aria-hidden="true" size={12} />
-        </a>
-      </legend>
-      <div className="checkbox-options">
+    <FieldSet className="field wide checkbox-group-field bullet-standards-group">
+      <FieldLegend>Bullet standards</FieldLegend>
+      <a
+        className="configuration-help-link"
+        href="https://jobctrl.dev/architecture/tailoring#inputs-to-tailoring"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Guide
+        <IconExternalLink aria-hidden="true" size={12} />
+      </a>
+      <FieldGroup className="checkbox-options">
         {BULLET_STANDARD_OPTIONS.map(([value, label]) => (
-          <label className="choice target-choice required-choice" key={value}>
+          <Field
+            className="choice target-choice required-choice"
+            data-disabled
+            key={value}
+            orientation="horizontal"
+          >
             <Checkbox
-              aria-label={`${label}, required`}
+              id={editorControlId("profile", "bullet-standard", value)}
               checked
               disabled
               name="bullet-standard"
               value={value}
             />
-            <span>{label}</span>
-          </label>
+            <FieldLabel htmlFor={editorControlId("profile", "bullet-standard", value)}>
+              {label}
+            </FieldLabel>
+          </Field>
         ))}
-      </div>
-      <small>Required evidence-quality standards; these cannot be disabled.</small>
-    </fieldset>
+      </FieldGroup>
+      <FieldDescription>Required evidence-quality standards; these cannot be disabled.</FieldDescription>
+    </FieldSet>
   );
 
   const adjacentExperienceClaimsGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Adjacent experience claims</legend>
-      <div className="field-grid one">
+    <FieldSet className="field wide checkbox-group-field tailoring-control-group">
+      <FieldLegend>Adjacent experience claims</FieldLegend>
+      <FieldGroup className="field-grid one">
         {inventedAdjacentExperienceField()}
-      </div>
-    </fieldset>
+      </FieldGroup>
+    </FieldSet>
   );
 
   const generationPermissionsGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Generation permissions</legend>
-      <div className="checkbox-options vertical">
+    <FieldSet className="field wide checkbox-group-field tailoring-control-group">
+      <FieldLegend>Generation permissions</FieldLegend>
+      <FieldGroup className="checkbox-options vertical">
         {checkboxField(
           "resume.tailoring_rules.tailoring_policy.allow_summary_rewrite",
           "Rewrite executive summary",
@@ -1002,14 +1140,14 @@ export function StructuredProfileEditor({
           "Select and order existing skills",
         )}
         {disabledCheckboxField("Change experience titles")}
-      </div>
-    </fieldset>
+      </FieldGroup>
+    </FieldSet>
   );
 
   const writingStyleGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group">
-      <legend>Writing style</legend>
-      <div className="field-grid">
+    <FieldSet className="field wide checkbox-group-field tailoring-control-group">
+      <FieldLegend>Writing style</FieldLegend>
+      <FieldGroup className="field-grid">
         {selectField("resume.tailoring_rules.writing_style.tone", "Writing tone", [
           ["direct", "Direct"],
           ["executive", "Executive"],
@@ -1028,14 +1166,14 @@ export function StructuredProfileEditor({
           "Avoid first-person language",
         )}
         {bulletStandardsField()}
-      </div>
-    </fieldset>
+      </FieldGroup>
+    </FieldSet>
   );
 
   const revisionPolicyGroup = () => (
-    <fieldset className="field wide checkbox-group-field tailoring-control-group revision-policy-group">
-      <legend>Revision policy</legend>
-      <div className="field-grid">
+    <FieldSet className="field wide checkbox-group-field tailoring-control-group revision-policy-group">
+      <FieldLegend>Revision policy</FieldLegend>
+      <FieldGroup className="field-grid">
         {numberField("resume.tailoring_rules.revision_gates.min_fit_score", "Minimum fit score", {
           min: 1,
           max: 10,
@@ -1054,25 +1192,25 @@ export function StructuredProfileEditor({
           step: 1,
           defaultValue: 1,
         })}
-      </div>
-    </fieldset>
+      </FieldGroup>
+    </FieldSet>
   );
 
   const additionalGuidanceGroup = () => (
-    <div className="field-grid one">
+    <FieldGroup className="field-grid one">
       {textareaField(
         "resume.tailoring_rules.custom_tailoring_prompt",
         "Additional guidance",
         "Writing and positioning guidance; evidence rules still apply.",
         { maxLength: 1200 },
       )}
-    </div>
+    </FieldGroup>
   );
 
   const targetSearchSection = () => (
     <section className="form-section">
       <h3>Target search</h3>
-      <div className="target-preferences-grid">
+      <FieldGroup className="target-preferences-grid">
         {targetSearchCheckboxGroup("experience.target_track", "Target tracks", TARGET_TRACK_GROUPS)}
         {targetSearchCheckboxGroup(
           "experience.target_seniority_floor",
@@ -1088,34 +1226,45 @@ export function StructuredProfileEditor({
         })}
         {delimitedListField("experience.target_role", "Target roles", "add role", { compact: true })}
         {targetLocationWorkModelField()}
-      </div>
+      </FieldGroup>
     </section>
   );
 
-  const styleSelect = (path: string, label: string, options: Array<[string, string]>) => (
-    <label className="field">
-      <span>{label}</span>
-      <Select value={textAt(style, path)} onValueChange={(value) => updateStylePath(path, value)}>
-        <SelectTrigger aria-label={label} className="configuration-select-trigger">
+  const styleSelect = (path: string, label: string, options: Array<[string, string]>) => {
+    const id = editorControlId("style", path);
+    const items = options.map(([value, text]) => ({ label: text, value }));
+    return (
+    <Field className="field">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Select
+        items={items}
+        value={textAt(style, path)}
+        onValueChange={(value) => updateStylePath(path, value)}
+      >
+        <SelectTrigger id={id} aria-label={label} className="configuration-select-trigger">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            {options.map(([value, text]) => (
-              <SelectItem key={value} value={value}>
-                {text}
+            {items.map((item) => (
+              <SelectItem key={item.value} value={item.value}>
+                {item.label}
               </SelectItem>
             ))}
           </SelectGroup>
         </SelectContent>
       </Select>
-    </label>
-  );
+    </Field>
+    );
+  };
 
-  const styleNumber = (path: string, label: string, min: number, max: number, step: number) => (
-    <label className="field">
-      <span>{label}</span>
-      <input
+  const styleNumber = (path: string, label: string, min: number, max: number, step: number) => {
+    const id = editorControlId("style", path);
+    return (
+    <Field className="field">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <Input
+        id={id}
         type="number"
         min={min}
         max={max}
@@ -1123,8 +1272,9 @@ export function StructuredProfileEditor({
         value={textAt(style, path)}
         onChange={(event) => updateStylePath(path, numberOrEmpty(event.target.value))}
       />
-    </label>
-  );
+    </Field>
+    );
+  };
 
   const experienceEntries = recordArrayAt(profile, "resume.experience_entries");
   const educationEntries = recordArrayAt(profile, "resume.education_entries");
@@ -1146,7 +1296,7 @@ export function StructuredProfileEditor({
         <>
           <section className="form-section">
             <h3>Personal information</h3>
-            <div className="field-grid">
+            <FieldGroup className="field-grid">
               {textField("personal.full_name", "Full name", "text", { required: true })}
               {textField("personal.preferred_name", "Preferred name")}
               {textField("personal.email", "Email", "email", { required: true })}
@@ -1164,12 +1314,12 @@ export function StructuredProfileEditor({
               {textField("personal.github_url", "GitHub URL", "url")}
               {textField("personal.portfolio_url", "Portfolio URL", "url")}
               {textField("personal.website_url", "Website URL", "url")}
-            </div>
+            </FieldGroup>
           </section>
 
           <section className="form-section">
             <h3>Resume baseline</h3>
-            <div className="field-grid">
+            <FieldGroup className="field-grid">
               {textField("experience.years_of_experience_total", "Total years of experience", "number", {
                 min: 0,
                 step: 1,
@@ -1184,274 +1334,323 @@ export function StructuredProfileEditor({
                 "number",
                 { min: 1, max: 99, step: 1 },
               )}
-            </div>
-            <div className="field-grid one">
+            </FieldGroup>
+            <FieldGroup className="field-grid one">
               {textareaField("resume.executive_profile.baseline_text", "Executive profile baseline")}
               {listField("resume_constraints.real_metrics", "Verified resume metrics")}
-            </div>
+            </FieldGroup>
           </section>
 
           <section className="form-section">
-        <h3>Experience entries</h3>
-        <div className="repeat-list">
-          {experienceEntries.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
-            const requiredBullets = new Set(
-              asTextArray(
-                recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
-              ),
-            );
-            return (
-              <div className="repeat-card" key={`${entryId || "experience"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["title"]) || `Experience ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredExperienceIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_experience_entry_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.experience_entries", index)}
-                    >
-                      remove experience
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {dateRangeField(`resume.experience_entries.${index}.date_range`, "Date range")}
-                  {textField(`resume.experience_entries.${index}.title`, "Title")}
-                  {textField(`resume.experience_entries.${index}.company`, "Company")}
-                  {textField(`resume.experience_entries.${index}.location`, "Location")}
-                </div>
-                <div className="bullet-list">
-                  {bullets.map((bullet, bulletIndex) => (
-                    <div className="bullet-row" key={`${entryId}-${bulletIndex}`}>
-                      <div className="bullet-row-top">
-                        <span className="bullet-label">Bullet {bulletIndex + 1}</span>
-                        <label className="choice bullet-choice">
-                          <input
-                            type="checkbox"
-                            checked={requiredBullets.has(bullet)}
-                            disabled={!entryId || !bullet}
-                            onChange={(event) =>
-                              setRequiredBullet(entryId, bullet, event.target.checked)
+            <h3>Experience entries</h3>
+            <FieldGroup className="repeat-list">
+              {experienceEntries.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                const bullets = editableTextArrayAt(profile, `resume.experience_entries.${index}.bullets`);
+                const requiredBullets = new Set(
+                  asTextArray(
+                    recordAt(profile, "resume.tailoring_rules.required_bullets_by_experience_id")[entryId],
+                  ),
+                );
+                const requiredEntryId = editorControlId("profile", `experience-${index}`, "required");
+                return (
+                  <Fragment key={`${entryId || "experience"}-${index}`}>
+                    {index > 0 ? <Separator className="repeat-section-separator" /> : null}
+                    <FieldSet className="repeat-section">
+                      <FieldLegend>
+                        {textFrom(entry["title"]) || `Experience ${index + 1}`}
+                      </FieldLegend>
+                      <div className="repeat-controls">
+                        <Field
+                          className="choice"
+                          data-disabled={!entryId || undefined}
+                          orientation="horizontal"
+                        >
+                          <Checkbox
+                            id={requiredEntryId}
+                            checked={requiredExperienceIds.has(entryId)}
+                            disabled={!entryId}
+                            onCheckedChange={(checked) =>
+                              setRequiredId(
+                                "resume.tailoring_rules.required_experience_entry_ids",
+                                entryId,
+                                checked,
+                              )
                             }
                           />
-                          <span>Required</span>
-                        </label>
+                          <FieldLabel htmlFor={requiredEntryId}>must appear in final resume</FieldLabel>
+                        </Field>
+                        <button
+                          className="tab"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.experience_entries", index)}
+                        >
+                          remove experience
+                        </button>
                       </div>
-                      <textarea
-                        aria-label={`Bullet ${bulletIndex + 1}`}
-                        value={bullet}
-                        onChange={(event) =>
-                          updateProfilePath(
-                            `resume.experience_entries.${index}.bullets.${bulletIndex}`,
-                            event.target.value,
-                          )
-                        }
-                      />
-                      <button
-                        className="icon-button"
-                        type="button"
-                        aria-label={`Remove bullet ${bulletIndex + 1}`}
-                        title="Remove bullet"
-                        onClick={() => removeBullet(index, bulletIndex)}
-                      >
-                        <IconTrash size={14} aria-hidden="true" />
-                      </button>
-                    </div>
-                  ))}
-                  <button className="tab add-bullet" type="button" onClick={() => addBullet(index)}>
-                    <IconPlus size={14} aria-hidden="true" />
-                    add bullet
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.experience_entries")}
-          >
-            add experience
-          </button>
-        </div>
+                      <FieldGroup className="field-grid">
+                        {dateRangeField(`resume.experience_entries.${index}.date_range`, "Date range")}
+                        {textField(`resume.experience_entries.${index}.title`, "Title")}
+                        {textField(`resume.experience_entries.${index}.company`, "Company")}
+                        {textField(`resume.experience_entries.${index}.location`, "Location")}
+                      </FieldGroup>
+                      <Separator />
+                      <FieldGroup className="bullet-list">
+                        {bullets.map((bullet, bulletIndex) => {
+                          const requiredBulletId = editorControlId(
+                            "profile",
+                            `experience-${index}-bullet-${bulletIndex}`,
+                            "required",
+                          );
+                          return (
+                            <Field className="bullet-row" key={`${entryId}-${bulletIndex}`}>
+                              <div className="bullet-row-top">
+                                <FieldTitle className="bullet-label">Bullet {bulletIndex + 1}</FieldTitle>
+                                <Field
+                                  className="choice bullet-choice"
+                                  data-disabled={!entryId || !bullet || undefined}
+                                  orientation="horizontal"
+                                >
+                                  <Checkbox
+                                    id={requiredBulletId}
+                                    checked={requiredBullets.has(bullet)}
+                                    disabled={!entryId || !bullet}
+                                    onCheckedChange={(checked) =>
+                                      setRequiredBullet(entryId, bullet, checked)
+                                    }
+                                  />
+                                  <FieldLabel htmlFor={requiredBulletId}>Required</FieldLabel>
+                                </Field>
+                              </div>
+                              <Textarea
+                                aria-label={`Bullet ${bulletIndex + 1}`}
+                                value={bullet}
+                                onChange={(event) =>
+                                  updateProfilePath(
+                                    `resume.experience_entries.${index}.bullets.${bulletIndex}`,
+                                    event.target.value,
+                                  )
+                                }
+                              />
+                              <button
+                                className="icon-button"
+                                type="button"
+                                aria-label={`Remove bullet ${bulletIndex + 1}`}
+                                title="Remove bullet"
+                                onClick={() => removeBullet(index, bulletIndex)}
+                              >
+                                <IconTrash size={14} aria-hidden="true" />
+                              </button>
+                            </Field>
+                          );
+                        })}
+                        <button className="tab add-bullet" type="button" onClick={() => addBullet(index)}>
+                          <IconPlus size={14} aria-hidden="true" />
+                          add bullet
+                        </button>
+                      </FieldGroup>
+                    </FieldSet>
+                  </Fragment>
+                );
+              })}
+              <button
+                className="tab"
+                type="button"
+                onClick={() => addRepeatItem("resume.experience_entries")}
+              >
+                add experience
+              </button>
+            </FieldGroup>
           </section>
 
           <section className="form-section">
-        <h3>Education</h3>
-        <div className="repeat-list">
-          {educationEntries.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            return (
-              <div className="repeat-card" key={`${entryId || "education"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["degree"]) || `Education ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredEducationIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_education_entry_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.education_entries", index)}
-                    >
-                      remove education
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {monthField(`resume.education_entries.${index}.date`, "Completion month")}
-                  {textField(`resume.education_entries.${index}.degree`, "Degree")}
-                  {textField(`resume.education_entries.${index}.institution`, "Institution")}
-                  {textField(`resume.education_entries.${index}.location`, "Location")}
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.education_entries")}
-          >
-            add education
-          </button>
-        </div>
+            <h3>Education</h3>
+            <FieldGroup className="repeat-list">
+              {educationEntries.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                const requiredEntryId = editorControlId("profile", `education-${index}`, "required");
+                return (
+                  <Fragment key={`${entryId || "education"}-${index}`}>
+                    {index > 0 ? <Separator className="repeat-section-separator" /> : null}
+                    <FieldSet className="repeat-section">
+                      <FieldLegend>
+                        {textFrom(entry["degree"]) || `Education ${index + 1}`}
+                      </FieldLegend>
+                      <div className="repeat-controls">
+                        <Field
+                          className="choice"
+                          data-disabled={!entryId || undefined}
+                          orientation="horizontal"
+                        >
+                          <Checkbox
+                            id={requiredEntryId}
+                            checked={requiredEducationIds.has(entryId)}
+                            disabled={!entryId}
+                            onCheckedChange={(checked) =>
+                              setRequiredId(
+                                "resume.tailoring_rules.required_education_entry_ids",
+                                entryId,
+                                checked,
+                              )
+                            }
+                          />
+                          <FieldLabel htmlFor={requiredEntryId}>must appear in final resume</FieldLabel>
+                        </Field>
+                        <button
+                          className="tab"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.education_entries", index)}
+                        >
+                          remove education
+                        </button>
+                      </div>
+                      <FieldGroup className="field-grid">
+                        {monthField(`resume.education_entries.${index}.date`, "Completion month")}
+                        {textField(`resume.education_entries.${index}.degree`, "Degree")}
+                        {textField(`resume.education_entries.${index}.institution`, "Institution")}
+                        {textField(`resume.education_entries.${index}.location`, "Location")}
+                      </FieldGroup>
+                    </FieldSet>
+                  </Fragment>
+                );
+              })}
+              <button
+                className="tab"
+                type="button"
+                onClick={() => addRepeatItem("resume.education_entries")}
+              >
+                add education
+              </button>
+            </FieldGroup>
           </section>
 
           <section className="form-section">
-        <h3>Skill categories</h3>
-        <div className="repeat-list">
-          {skillCategories.map((entry, index) => {
-            const entryId = textFrom(entry["id"]);
-            const skills = editableTextArrayAt(profile, `resume.skill_categories.${index}.items`);
-            const requiredSkills = new Set(
-              asTextArray(
-                recordAt(profile, "resume.tailoring_rules.required_skills_by_category_id")[entryId],
-              ),
-            );
-            return (
-              <div className="repeat-card" key={`${entryId || "skills"}-${index}`}>
-                <div className="repeat-hd">
-                  <b>{textFrom(entry["label"]) || `Skill category ${index + 1}`}</b>
-                  <div className="repeat-controls">
-                    <label className="choice">
-                      <input
-                        type="checkbox"
-                        checked={requiredSkillIds.has(entryId)}
-                        disabled={!entryId}
-                        onChange={(event) =>
-                          setRequiredId(
-                            "resume.tailoring_rules.required_skill_category_ids",
-                            entryId,
-                            event.target.checked,
-                          )
-                        }
-                      />
-                      <span>must appear in final resume</span>
-                    </label>
-                    <button
-                      className="tab"
-                      type="button"
-                      onClick={() => removeRepeatItem("resume.skill_categories", index)}
-                    >
-                      remove skill category
-                    </button>
-                  </div>
-                </div>
-                <div className="field-grid">
-                  {textField(`resume.skill_categories.${index}.label`, "Label")}
-                </div>
-                <div className="skill-list">
-                  {skills.map((skill, skillIndex) => (
-                    <div className="skill-row" key={`${entryId}-${skillIndex}`}>
-                      <label className="skill-input field">
-                        <span>Skill {skillIndex + 1}</span>
-                        <input
-                          value={skill}
-                          onChange={(event) =>
-                            updateProfilePath(
-                              `resume.skill_categories.${index}.items.${skillIndex}`,
-                              event.target.value,
-                            )
-                          }
-                        />
-                      </label>
-                      <label className="choice skill-choice">
-                        <input
-                          type="checkbox"
-                          checked={requiredSkills.has(skill)}
-                          disabled={!entryId || !skill}
-                          onChange={(event) =>
-                            setRequiredSkill(entryId, skill, event.target.checked)
-                          }
-                        />
-                        <span>Required</span>
-                      </label>
-                      <button
-                        className="icon-button"
-                        type="button"
-                        aria-label={`Remove skill ${skillIndex + 1}`}
-                        title="Remove skill"
-                        onClick={() => removeSkill(index, skillIndex)}
-                      >
-                        <IconTrash size={14} aria-hidden="true" />
-                      </button>
-                    </div>
-                  ))}
-                  <button className="tab add-bullet" type="button" onClick={() => addSkill(index)}>
-                    <IconPlus size={14} aria-hidden="true" />
-                    add skill
-                  </button>
-                </div>
-              </div>
-            );
-          })}
-          <button
-            className="tab"
-            type="button"
-            onClick={() => addRepeatItem("resume.skill_categories")}
-          >
-            add skill category
-          </button>
-        </div>
+            <h3>Skill categories</h3>
+            <FieldGroup className="repeat-list">
+              {skillCategories.map((entry, index) => {
+                const entryId = textFrom(entry["id"]);
+                const skills = editableTextArrayAt(profile, `resume.skill_categories.${index}.items`);
+                const requiredSkills = new Set(
+                  asTextArray(
+                    recordAt(profile, "resume.tailoring_rules.required_skills_by_category_id")[entryId],
+                  ),
+                );
+                const requiredEntryId = editorControlId("profile", `skills-${index}`, "required");
+                return (
+                  <Fragment key={`${entryId || "skills"}-${index}`}>
+                    {index > 0 ? <Separator className="repeat-section-separator" /> : null}
+                    <FieldSet className="repeat-section">
+                      <FieldLegend>
+                        {textFrom(entry["label"]) || `Skill category ${index + 1}`}
+                      </FieldLegend>
+                      <div className="repeat-controls">
+                        <Field
+                          className="choice"
+                          data-disabled={!entryId || undefined}
+                          orientation="horizontal"
+                        >
+                          <Checkbox
+                            id={requiredEntryId}
+                            checked={requiredSkillIds.has(entryId)}
+                            disabled={!entryId}
+                            onCheckedChange={(checked) =>
+                              setRequiredId(
+                                "resume.tailoring_rules.required_skill_category_ids",
+                                entryId,
+                                checked,
+                              )
+                            }
+                          />
+                          <FieldLabel htmlFor={requiredEntryId}>must appear in final resume</FieldLabel>
+                        </Field>
+                        <button
+                          className="tab"
+                          type="button"
+                          onClick={() => removeRepeatItem("resume.skill_categories", index)}
+                        >
+                          remove skill category
+                        </button>
+                      </div>
+                      <FieldGroup className="field-grid">
+                        {textField(`resume.skill_categories.${index}.label`, "Label")}
+                      </FieldGroup>
+                      <Separator />
+                      <FieldGroup className="skill-list">
+                        {skills.map((skill, skillIndex) => {
+                          const skillId = editorControlId(
+                            "profile",
+                            `skill-category-${index}-skill-${skillIndex}`,
+                          );
+                          const requiredSkillId = `${skillId}-required`;
+                          return (
+                            <Field className="skill-row" key={`${entryId}-${skillIndex}`}>
+                              <Field className="skill-input field">
+                                <FieldLabel htmlFor={skillId}>Skill {skillIndex + 1}</FieldLabel>
+                                <Input
+                                  id={skillId}
+                                  value={skill}
+                                  onChange={(event) =>
+                                    updateProfilePath(
+                                      `resume.skill_categories.${index}.items.${skillIndex}`,
+                                      event.target.value,
+                                    )
+                                  }
+                                />
+                              </Field>
+                              <Field
+                                className="choice skill-choice"
+                                data-disabled={!entryId || !skill || undefined}
+                                orientation="horizontal"
+                              >
+                                <Checkbox
+                                  id={requiredSkillId}
+                                  checked={requiredSkills.has(skill)}
+                                  disabled={!entryId || !skill}
+                                  onCheckedChange={(checked) =>
+                                    setRequiredSkill(entryId, skill, checked)
+                                  }
+                                />
+                                <FieldLabel htmlFor={requiredSkillId}>Required</FieldLabel>
+                              </Field>
+                              <button
+                                className="icon-button"
+                                type="button"
+                                aria-label={`Remove skill ${skillIndex + 1}`}
+                                title="Remove skill"
+                                onClick={() => removeSkill(index, skillIndex)}
+                              >
+                                <IconTrash size={14} aria-hidden="true" />
+                              </button>
+                            </Field>
+                          );
+                        })}
+                        <button className="tab add-bullet" type="button" onClick={() => addSkill(index)}>
+                          <IconPlus size={14} aria-hidden="true" />
+                          add skill
+                        </button>
+                      </FieldGroup>
+                    </FieldSet>
+                  </Fragment>
+                );
+              })}
+              <button
+                className="tab"
+                type="button"
+                onClick={() => addRepeatItem("resume.skill_categories")}
+              >
+                add skill category
+              </button>
+            </FieldGroup>
           </section>
 
           <section className="form-section">
-        <h3>Voluntary EEO</h3>
-        <div className="field-grid">
-          {textField("eeo_voluntary.gender", "Gender")}
-          {textField("eeo_voluntary.race_ethnicity", "Race / ethnicity")}
-          {textField("eeo_voluntary.veteran_status", "Veteran status")}
-          {textField("eeo_voluntary.disability_status", "Disability status")}
-        </div>
+            <h3>Voluntary EEO</h3>
+            <FieldGroup className="field-grid">
+              {textField("eeo_voluntary.gender", "Gender")}
+              {textField("eeo_voluntary.race_ethnicity", "Race / ethnicity")}
+              {textField("eeo_voluntary.veteran_status", "Veteran status")}
+              {textField("eeo_voluntary.disability_status", "Disability status")}
+            </FieldGroup>
           </section>
         </>
       ) : mode === "target-search" ? (
@@ -1463,7 +1662,7 @@ export function StructuredProfileEditor({
             description="Availability, work authorization, and compensation defaults."
             title="Application configuration"
           >
-            <div className="field-grid">
+            <FieldGroup className="field-grid">
               {applicationConfigurationFields}
               {selectField("work_authorization.legally_authorized_to_work", "Legally authorized to work", [
                 "Yes",
@@ -1494,7 +1693,7 @@ export function StructuredProfileEditor({
                 valueKind: "text",
               })}
               {textField("compensation.currency_conversion_note", "Currency note")}
-            </div>
+            </FieldGroup>
           </ConfigurationSection>
 
           <ConfigurationSection
@@ -1502,20 +1701,20 @@ export function StructuredProfileEditor({
             description="Evidence-safe writing rules and generation thresholds."
             title="Tailoring controls"
           >
-            <div className="tailoring-controls-grid">
+            <FieldGroup className="tailoring-controls-grid">
               {adjacentExperienceClaimsGroup()}
               {generationPermissionsGroup()}
               {writingStyleGroup()}
               {revisionPolicyGroup()}
               {additionalGuidanceGroup()}
-            </div>
+            </FieldGroup>
           </ConfigurationSection>
 
           <ConfigurationSection
             description="Defaults for generated resumes outside the template workspace."
             title="Resume style"
           >
-            <div className="field-grid">
+            <FieldGroup className="field-grid">
               {styleSelect("document_font_size", "Text size", [
                 ["10pt", "Small"],
                 ["11pt", "Regular"],
@@ -1552,7 +1751,7 @@ export function StructuredProfileEditor({
               ])}
               {styleNumber("page_scale", "Page scale", 0.7, 1, 0.01)}
               {styleNumber("hints_column_width_cm", "Date column width (cm)", 1.5, 5, 0.1)}
-            </div>
+            </FieldGroup>
           </ConfigurationSection>
         </>
       )}

--- a/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
+++ b/apps/web/src/contexts/profile/components/TargetSearchSettingsPanel.tsx
@@ -8,7 +8,7 @@ export function TargetSearchSettingsPanel() {
 
   return (
     <section className="card full target-search-settings">
-      <CardHeader title="Target search" meta="roles, locations, and work models" />
+      <CardHeader title="Discovery settings" meta="roles, locations, and work models" />
       {profileQuery.error ? <div className="banner inline">{profileQuery.error.message}</div> : null}
       {profileQuery.data ? (
         <ProfileForm initial={profileQuery.data} section="target-search" />

--- a/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-confirm-form.tsx
@@ -4,6 +4,7 @@ import { useForm } from "@tanstack/react-form";
 import { IconCheck, IconFileTypePdf, IconMinus } from "@tabler/icons-react";
 import { useEffect, useState } from "react";
 
+import { Alert, AlertDescription } from "../../../shared/ui/alert.js";
 import { Button, buttonVariants } from "../../../shared/ui/button.js";
 import { Empty } from "../../../shared/ui/empty.js";
 import { useImportResumeMutation } from "../hooks/useImportResumeMutation.js";
@@ -88,14 +89,14 @@ export function ImportConfirmForm() {
       </header>
 
       {errorMessage ? (
-        <div className="banner inline resume-import-alert" role="alert">
-          {errorMessage}
-        </div>
+        <Alert className="resume-import-alert" variant="destructive">
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
       ) : null}
       {statusMessage ? (
-        <div className="status-line resume-import-status" role="status">
-          {statusMessage}
-        </div>
+        <Alert className="resume-import-status" role="status">
+          <AlertDescription>{statusMessage}</AlertDescription>
+        </Alert>
       ) : null}
 
       <form.Subscribe selector={(state) => state.errors}>
@@ -104,9 +105,9 @@ export function ImportConfirmForm() {
             .flat()
             .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
           return message ? (
-            <div className="banner inline resume-import-alert" role="alert">
-              {message}
-            </div>
+            <Alert className="resume-import-alert" variant="destructive">
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
           ) : null;
         }}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-preview-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-preview-form.tsx
@@ -3,6 +3,7 @@ import { useForm } from "@tanstack/react-form";
 import { IconFileTypePdf } from "@tabler/icons-react";
 import { z } from "zod";
 
+import { Alert, AlertDescription } from "../../../shared/ui/alert.js";
 import { Button, buttonVariants } from "../../../shared/ui/button.js";
 import { Checkbox } from "../../../shared/ui/checkbox.js";
 import { Empty } from "../../../shared/ui/empty.js";
@@ -10,6 +11,7 @@ import {
   Field,
   FieldContent,
   FieldDescription,
+  FieldGroup,
   FieldLabel,
   FieldLegend,
   FieldSet,
@@ -103,7 +105,7 @@ export function ImportPreviewForm() {
         <FieldDescription>
           Select at least one section. You can edit the resulting profile after import.
         </FieldDescription>
-        <div className="import-options resume-import-options">
+        <FieldGroup className="import-options resume-import-options">
           <form.Field name="importProfile">
             {(field) => (
               <Field orientation="horizontal" className="resume-import-option">
@@ -140,7 +142,7 @@ export function ImportPreviewForm() {
               </Field>
             )}
           </form.Field>
-        </div>
+        </FieldGroup>
       </FieldSet>
 
       <form.Subscribe selector={(state) => state.errors}>
@@ -149,9 +151,9 @@ export function ImportPreviewForm() {
             .flat()
             .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
           return message ? (
-            <div className="banner inline resume-import-alert" role="alert">
-              {message}
-            </div>
+            <Alert className="resume-import-alert" variant="destructive">
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
           ) : null;
         }}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/import-upload-form.tsx
+++ b/apps/web/src/contexts/profile/forms/import-upload-form.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { z } from "zod";
 
 import { fileToBase64 } from "../../../shared/lib/file.js";
+import { Alert, AlertDescription } from "../../../shared/ui/alert.js";
 import { Button, buttonVariants } from "../../../shared/ui/button.js";
 import { useProfileImportStore } from "../stores/profile-import-store.js";
 
@@ -79,9 +80,9 @@ export function ImportUploadForm() {
       </header>
 
       {readError ? (
-        <div className="banner inline resume-import-alert" role="alert">
-          {readError}
-        </div>
+        <Alert className="resume-import-alert" variant="destructive">
+          <AlertDescription>{readError}</AlertDescription>
+        </Alert>
       ) : null}
 
       <form.Subscribe selector={(state) => state.errors}>
@@ -90,9 +91,9 @@ export function ImportUploadForm() {
             .flat()
             .find((entry): entry is string => typeof entry === "string" && entry.length > 0);
           return message ? (
-            <div className="banner inline resume-import-alert" role="alert">
-              {message}
-            </div>
+            <Alert className="resume-import-alert" variant="destructive">
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
           ) : null;
         }}
       </form.Subscribe>

--- a/apps/web/src/contexts/profile/forms/profile-form.test.tsx
+++ b/apps/web/src/contexts/profile/forms/profile-form.test.tsx
@@ -20,7 +20,7 @@ describe("<ProfileForm>", () => {
     });
 
     expect(await screen.findByRole("heading", { name: "Personal information" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Application configurations" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Application configuration" })).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Target role")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "preferences" })).not.toBeInTheDocument();
   });
@@ -101,7 +101,7 @@ describe("<ProfileForm>", () => {
       />,
     );
 
-    expect(await screen.findByRole("heading", { name: "Application configurations" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Application configuration" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Location filter")).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Tailoring controls" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Target search" })).not.toBeInTheDocument();
@@ -142,7 +142,7 @@ describe("<ProfileForm>", () => {
     expect(screen.getByRole("group", { name: "Target work model 1" })).toBeInTheDocument();
     expect(screen.getByLabelText("Remote")).toBeInTheDocument();
     expect(screen.getByLabelText("Hybrid")).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Application configurations" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Application configuration" })).not.toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Personal information" })).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx
+++ b/apps/web/src/contexts/scoring/components/CompensationSourcePolicyPanel.tsx
@@ -198,6 +198,13 @@ function CompensationSourceControls({
   const prerequisitesMet =
     control.accessMode !== null &&
     (!control.europeCoverageRequired || control.europeCoverageConfirmed);
+  const accessModeItems = [
+    { label: "Not configured", value: NOT_CONFIGURED },
+    ...control.allowedAccessModes.map((mode) => ({
+      label: formatLabel(mode),
+      value: mode,
+    })),
+  ];
 
   const update = (
     patch: Partial<
@@ -247,16 +254,18 @@ function CompensationSourceControls({
             {source.displayName} access mode
           </FieldLabel>
           <Select
+            items={accessModeItems}
             disabled={busy}
             value={control.accessMode ?? NOT_CONFIGURED}
-            onValueChange={(value) =>
+            onValueChange={(value) => {
+              if (value === null) return;
               update({
                 accessMode:
                   value === NOT_CONFIGURED
                     ? null
                     : (value as UserCompensationSourceControl["accessMode"]),
-              })
-            }
+              });
+            }}
           >
             <SelectTrigger
               id={accessModeId}
@@ -264,17 +273,17 @@ function CompensationSourceControls({
             >
               <SelectValue placeholder="Choose access basis" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent alignItemWithTrigger={false}>
               <SelectGroup>
-                <SelectItem
-                  disabled={control.enabled}
-                  value={NOT_CONFIGURED}
-                >
-                  Not configured
-                </SelectItem>
-                {control.allowedAccessModes.map((mode) => (
-                  <SelectItem key={mode} value={mode}>
-                    {formatLabel(mode)}
+                {accessModeItems.map((item) => (
+                  <SelectItem
+                    key={item.value}
+                    disabled={
+                      item.value === NOT_CONFIGURED && control.enabled
+                    }
+                    value={item.value}
+                  >
+                    {item.label}
                   </SelectItem>
                 ))}
               </SelectGroup>

--- a/apps/web/src/shared/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/layout/Topbar.test.tsx
@@ -70,16 +70,25 @@ describe("<Topbar>", () => {
   it("renders the search, density control, and no inline navigation rail", async () => {
     renderTopbar();
 
-    expect(await screen.findByRole("textbox", { name: "Global search" })).toBeInTheDocument();
-    expect(screen.queryByRole("navigation", { name: "Main navigation" })).not.toBeInTheDocument();
-
-    const density = screen.getByRole("combobox", { name: "Row density" });
-    expect(density).toHaveDisplayValue("regular");
-    expect(screen.getByRole("option", { name: "compact" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "regular" })).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "comfy" })).toBeInTheDocument();
     expect(
-      screen.getByText("Copyright © 2026 Eloi Barti", { selector: ".legal-notice--topbar span" }),
+      await screen.findByRole("textbox", { name: "Global search" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("navigation", { name: "Main navigation" }),
+    ).not.toBeInTheDocument();
+
+    const density = screen.getByRole("group", { name: "Row density" });
+    expect(density).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "regular" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "compact" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "comfy" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Copyright © 2026 Eloi Barti", {
+        selector: ".legal-notice--topbar span",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -87,29 +96,44 @@ describe("<Topbar>", () => {
     const user = userEvent.setup();
     renderTopbar();
 
-    await user.click(await screen.findByRole("button", { name: "Open navigation" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Open navigation" }),
+    );
 
-    const nav = await screen.findByRole("navigation", { name: "Main navigation" });
-    for (const label of ["Dashboard", "Apply review", "Jobs", "Contacts", "Settings"]) {
+    const nav = await screen.findByRole("navigation", {
+      name: "Main navigation",
+    });
+    for (const label of [
+      "Dashboard",
+      "Apply review",
+      "Jobs",
+      "Contacts",
+      "Settings",
+    ]) {
       expect(screen.getByRole("link", { name: label })).toBeInTheDocument();
     }
     const dialog = screen.getByRole("dialog");
-    expect(within(dialog).getByText("Copyright © 2026 Eloi Barti")).toBeInTheDocument();
-    expect(within(dialog).getByRole("link", { name: "AGPL-3.0-only" })).toHaveAttribute(
+    expect(
+      within(dialog).getByText("Copyright © 2026 Eloi Barti"),
+    ).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("link", { name: "AGPL-3.0-only" }),
+    ).toHaveAttribute(
       "href",
       "https://github.com/ebarti/JobCtrl/blob/main/LICENSE",
     );
-    expect(within(dialog).getByRole("link", { name: "Source code" })).toHaveAttribute(
-      "href",
-      "https://github.com/ebarti/JobCtrl",
-    );
+    expect(
+      within(dialog).getByRole("link", { name: "Source code" }),
+    ).toHaveAttribute("href", "https://github.com/ebarti/JobCtrl");
     expect(nav).toBeInTheDocument();
   });
 
   it("keeps global search Enter navigation scoped to non-empty trimmed queries", async () => {
     const user = userEvent.setup();
     const { router } = renderTopbar();
-    const search = await screen.findByRole("textbox", { name: "Global search" });
+    const search = await screen.findByRole("textbox", {
+      name: "Global search",
+    });
 
     await user.type(search, "   {Enter}");
     expect(router.state.location.pathname).toBe("/dashboard");
@@ -127,12 +151,10 @@ describe("<Topbar>", () => {
   it("updates the persisted density store from the row density control", async () => {
     const user = userEvent.setup();
     renderTopbar();
-    const density = await screen.findByRole("combobox", { name: "Row density" });
-
-    await user.selectOptions(density, "compact");
+    await user.click(screen.getByRole("button", { name: "compact" }));
     expect(useUiPreferencesStore.getState().density).toBe("compact");
 
-    await user.selectOptions(density, "comfy");
+    await user.click(screen.getByRole("button", { name: "comfy" }));
     expect(useUiPreferencesStore.getState().density).toBe("comfy");
   });
 });

--- a/apps/web/src/shared/layout/Topbar.tsx
+++ b/apps/web/src/shared/layout/Topbar.tsx
@@ -4,7 +4,20 @@ import { useState } from "react";
 
 import { useDensity } from "../hooks/useDensity.js";
 import type { Density } from "../stores/ui-preferences.js";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "../ui/sheet.js";
+import { Button } from "../ui/button.js";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "../ui/input-group.js";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "../ui/sheet.js";
+import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group.js";
 import { BrandMark } from "./BrandMark.js";
 import { ConnectionStatusPill } from "./ConnectionStatusPill.js";
 import { LegalNotice } from "./LegalNotice.js";
@@ -21,10 +34,17 @@ export function Topbar() {
   return (
     <header className="topbar">
       <Sheet open={navOpen} onOpenChange={setNavOpen}>
-        <SheetTrigger asChild>
-          <button type="button" className="tab topbar__hamburger" aria-label="Open navigation">
-            <IconMenu2 aria-hidden="true" size={18} />
-          </button>
+        <SheetTrigger
+          render={
+            <Button
+              aria-label="Open navigation"
+              className="topbar__hamburger"
+              size="icon"
+              variant="ghost"
+            />
+          }
+        >
+          <IconMenu2 aria-hidden="true" />
         </SheetTrigger>
         <SheetContent side="left" aria-describedby={undefined}>
           <SheetHeader>
@@ -36,14 +56,11 @@ export function Topbar() {
           <LegalNotice className="legal-notice legal-notice--sheet" />
         </SheetContent>
       </Sheet>
-      <div className="topbar__search">
-        <IconSearch
-          className="topbar__search-icon"
-          size={16}
-          stroke={1.8}
-          aria-hidden="true"
-        />
-        <input
+      <InputGroup className="topbar__search">
+        <InputGroupAddon>
+          <IconSearch className="topbar__search-icon" aria-hidden="true" />
+        </InputGroupAddon>
+        <InputGroupInput
           aria-label="Global search"
           className="global-search"
           placeholder="Filter jobs, errors, companies..."
@@ -51,25 +68,32 @@ export function Topbar() {
           onChange={(event) => setQuery(event.target.value)}
           onKeyDown={(event) => {
             if (event.key === "Enter" && query.trim()) {
-              void navigate({ to: "/jobs", search: { q: query.trim(), page: 1 } });
+              void navigate({
+                to: "/jobs",
+                search: { q: query.trim(), page: 1 },
+              });
             }
           }}
         />
-      </div>
-      <div className="topbar__density">
-        <select
-          aria-label="Row density"
-          className="select"
-          value={density}
-          onChange={(event) => setDensity(event.target.value as Density)}
-        >
-          {DENSITY_OPTIONS.map((option) => (
-            <option key={option} value={option}>
-              {option}
-            </option>
-          ))}
-        </select>
-      </div>
+      </InputGroup>
+      <ToggleGroup
+        aria-label="Row density"
+        className="topbar__density"
+        size="sm"
+        spacing={0}
+        type="single"
+        value={density}
+        variant="outline"
+        onValueChange={(value) => {
+          if (value) setDensity(value as Density);
+        }}
+      >
+        {DENSITY_OPTIONS.map((option) => (
+          <ToggleGroupItem key={option} value={option}>
+            {option}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
       <ThemeToggle />
       <ConnectionStatusPill />
       <LegalNotice className="legal-notice legal-notice--topbar" />

--- a/apps/web/src/shared/ui/alert.tsx
+++ b/apps/web/src/shared/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/shared/lib/cn";
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-2xl border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2.5 right-3", className)}
+      {...props}
+    />
+  );
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction };

--- a/apps/web/src/shared/ui/card-header.tsx
+++ b/apps/web/src/shared/ui/card-header.tsx
@@ -1,19 +1,31 @@
 import type { ReactNode } from "react";
 
+import {
+  CardAction,
+  CardHeader as CardHeaderPrimitive,
+  CardTitle,
+} from "./card.js";
+
 export interface CardHeaderProps {
   title: string;
   meta?: ReactNode;
 }
 
+/**
+ * Compatibility adapter for legacy `.card` sections. New card surfaces should
+ * compose the primitives from `card.tsx` directly.
+ */
 export function CardHeader({ title, meta }: CardHeaderProps) {
   return (
-    <header className="card-hd" data-slot="legacy-card-header">
-      <h2 data-slot="legacy-card-title">{title}</h2>
+    <CardHeaderPrimitive className="card-hd">
+      <CardTitle>
+        <h2>{title}</h2>
+      </CardTitle>
       {meta ? (
-        <span className="meta" data-slot="legacy-card-meta">
-          {meta}
-        </span>
+        <CardAction>
+          <span className="meta">{meta}</span>
+        </CardAction>
       ) : null}
-    </header>
+    </CardHeaderPrimitive>
   );
 }

--- a/apps/web/src/shared/ui/card.tsx
+++ b/apps/web/src/shared/ui/card.tsx
@@ -1,52 +1,110 @@
-import { forwardRef, type HTMLAttributes } from "react";
+import * as React from "react";
 
 import { cn } from "../lib/cn.js";
 
 export const cardClassName =
-  "rounded-xl border border-border bg-card text-card-foreground shadow-[var(--shadow-panel)]";
+  "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-[min(var(--radius-4xl),24px)] bg-card py-(--card-spacing) text-sm text-card-foreground shadow-sm ring-1 ring-foreground/5 [--card-spacing:--spacing(5)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-[min(var(--radius-4xl),24px)] *:[img:last-child]:rounded-b-[min(var(--radius-4xl),24px)]";
 
-export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn(cardClassName, className)} {...props} />
-  ),
-);
-Card.displayName = "Card";
+export interface CardProps extends React.ComponentProps<"div"> {
+  size?: "default" | "sm";
+}
 
-export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex flex-col gap-1.5 p-5", className)} {...props} />
-  ),
-);
-CardHeader.displayName = "CardHeader";
-
-export const CardTitle = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, size = "default", ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("text-base font-semibold leading-tight tracking-[-0.02em]", className)}
+      data-slot="card"
+      data-size={size}
+      className={cn(cardClassName, className)}
       {...props}
     />
   ),
 );
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-header"
+    className={cn(
+      "group/card-header @container/card-header grid auto-rows-min items-start gap-1.5 rounded-t-[min(var(--radius-4xl),24px)] px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+      className,
+    )}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-title"
+    className={cn("font-heading text-base font-medium", className)}
+    {...props}
+  />
+));
 CardTitle.displayName = "CardTitle";
 
-export const CardDescription = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("text-[13px] leading-5 text-muted-foreground", className)} {...props} />
-  ),
-);
+export const CardDescription = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-description"
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
 CardDescription.displayName = "CardDescription";
 
-export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
-  ),
-);
+export const CardAction = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-action"
+    className={cn(
+      "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+      className,
+    )}
+    {...props}
+  />
+));
+CardAction.displayName = "CardAction";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-content"
+    className={cn("px-(--card-spacing)", className)}
+    {...props}
+  />
+));
 CardContent.displayName = "CardContent";
 
-export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("flex items-center p-5 pt-0", className)} {...props} />
-  ),
-);
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div">
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-slot="card-footer"
+    className={cn(
+      "flex items-center rounded-b-[min(var(--radius-4xl),24px)] px-(--card-spacing) [.border-t]:pt-(--card-spacing)",
+      className,
+    )}
+    {...props}
+  />
+));
 CardFooter.displayName = "CardFooter";

--- a/apps/web/src/shared/ui/detail-drawer-backdrop.tsx
+++ b/apps/web/src/shared/ui/detail-drawer-backdrop.tsx
@@ -1,27 +1,47 @@
-import type { MouseEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 
-export interface DetailDrawerBackdropProps {
+import { cn } from "../lib/cn.js";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "./sheet.js";
+
+export interface DetailDrawerProps {
   children: ReactNode;
+  className?: string;
+  description: string;
   onDismiss: () => void;
+  title: string;
 }
 
-export function DetailDrawerBackdrop({
+export function DetailDrawer({
   children,
+  className,
+  description,
   onDismiss,
-}: DetailDrawerBackdropProps) {
-  const handleClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      onDismiss();
-    }
-  };
-
+  title,
+}: DetailDrawerProps) {
   return (
-    <div
-      className="drawer-backdrop"
-      data-slot="detail-drawer-backdrop"
-      onClick={handleClick}
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open) onDismiss();
+      }}
     >
-      {children}
-    </div>
+      <SheetContent
+        className={cn("drawer detail-drawer", className)}
+        data-slot="detail-drawer"
+        side="right"
+      >
+        <SheetHeader className="sr-only">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+        {children}
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/apps/web/src/shared/ui/dialog.tsx
+++ b/apps/web/src/shared/ui/dialog.tsx
@@ -114,7 +114,7 @@ export const DialogOverlay = forwardRef<
     ref={ref}
     data-slot="dialog-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/30 duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0",
+      "fixed inset-0 isolate bg-foreground/20 duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0",
       className,
     )}
     {...props}
@@ -137,7 +137,7 @@ export const DialogContent = forwardRef<
       ref={ref}
       data-slot="dialog-content"
       className={cn(
-        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-5 rounded-[10px] border border-border bg-popover p-5 text-sm text-popover-foreground shadow-xl outline-none duration-150 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 sm:max-w-lg",
+        "fixed left-1/2 top-1/2 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-5 rounded-[10px] border border-border bg-popover p-5 text-sm text-popover-foreground shadow-xl outline-none duration-150 data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 sm:max-w-lg",
         className,
       )}
       {...props}
@@ -147,13 +147,13 @@ export const DialogContent = forwardRef<
         data-slot="dialog-close"
         render={
           <Button
-            className="absolute right-3 top-3 size-8 bg-muted/60 text-muted-foreground shadow-none"
+            className="absolute right-3 top-3"
             size="icon"
             variant="ghost"
           />
         }
       >
-        <IconX aria-hidden size={16} />
+        <IconX aria-hidden />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Popup>

--- a/apps/web/src/shared/ui/drawer.tsx
+++ b/apps/web/src/shared/ui/drawer.tsx
@@ -29,7 +29,7 @@ export const DrawerOverlay = forwardRef<
     ref={ref}
     data-slot="drawer-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/30 supports-backdrop-filter:backdrop-blur-[2px]",
+      "fixed inset-0 isolate bg-foreground/20 supports-backdrop-filter:backdrop-blur-[2px]",
       className,
     )}
     {...props}
@@ -47,7 +47,7 @@ export const DrawerContent = forwardRef<
       ref={ref}
       data-slot="drawer-content"
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-popover text-sm text-popover-foreground shadow-xl",
+        "fixed inset-x-0 bottom-0 mt-24 flex h-auto flex-col rounded-t-[10px] border border-border bg-popover text-sm text-popover-foreground shadow-xl",
         className,
       )}
       {...props}

--- a/apps/web/src/shared/ui/input-group.tsx
+++ b/apps/web/src/shared/ui/input-group.tsx
@@ -1,0 +1,155 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/shared/lib/cn";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import { Textarea } from "@/shared/ui/textarea";
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-2xl border border-transparent bg-input/50 transition-[color,box-shadow] duration-200 outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/30 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 **:data-[slot=kbd]:rounded-2xl **:data-[slot=kbd]:bg-muted-foreground/10 **:data-[slot=kbd]:px-1.5 [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  },
+);
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 rounded-2xl text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-xl px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs": "size-6 rounded-xl p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  },
+);
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset";
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+};

--- a/apps/web/src/shared/ui/select.stories.tsx
+++ b/apps/web/src/shared/ui/select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DirectionProvider } from "@base-ui/react/direction-provider";
 import { useState } from "react";
 
 import {
@@ -19,11 +20,35 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const densityItems = [
+  { label: "Compact", value: "compact" },
+  { label: "Regular", value: "regular" },
+  { label: "Comfortable", value: "comfortable" },
+  { label: "Locked option", value: "locked" },
+];
+const selectableDensityItems = densityItems.slice(0, 3);
+const placeholderDensityItems = densityItems.slice(0, 2);
+const regularDensityItems = [densityItems[1]!];
+const longListItems = Array.from({ length: 30 }, (_, index) => ({
+  label: `Option ${index + 1}`,
+  value: `option-${index + 1}`,
+}));
+const accessBasisItems = [
+  { label: "Public markdown", value: "public_markdown" },
+  { label: "Licensed API", value: "licensed_api" },
+];
+
 function ControlledDensitySelect() {
   const [value, setValue] = useState("compact");
 
   return (
-    <Select value={value} onValueChange={setValue}>
+    <Select
+      items={selectableDensityItems}
+      value={value}
+      onValueChange={(nextValue) => {
+        if (nextValue !== null) setValue(nextValue);
+      }}
+    >
       <SelectTrigger aria-label="Controlled view density" className="w-56">
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
@@ -41,7 +66,7 @@ function ControlledDensitySelect() {
 
 export const Value: Story = {
   render: () => (
-    <Select defaultValue="compact">
+    <Select items={densityItems} defaultValue="compact">
       <SelectTrigger aria-label="View density" className="w-56">
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
@@ -65,7 +90,7 @@ export const OpenByDefault: Story = {
     a11y: { element: "[data-base-ui-portal]" },
   },
   render: () => (
-    <Select defaultOpen defaultValue="regular">
+    <Select items={densityItems} defaultOpen defaultValue="regular">
       <SelectTrigger aria-label="View density" className="w-56">
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
@@ -86,7 +111,7 @@ export const OpenByDefault: Story = {
 
 export const Placeholder: Story = {
   render: () => (
-    <Select>
+    <Select items={placeholderDensityItems}>
       <SelectTrigger aria-label="Unselected view density" className="w-56">
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
@@ -106,7 +131,7 @@ export const Controlled: Story = {
 
 export const Disabled: Story = {
   render: () => (
-    <Select disabled defaultValue="regular">
+    <Select items={regularDensityItems} disabled defaultValue="regular">
       <SelectTrigger aria-label="View density" className="w-56">
         <SelectValue placeholder="Pick a view" />
       </SelectTrigger>
@@ -121,33 +146,35 @@ export const Disabled: Story = {
 
 export const RightToLeft: Story = {
   render: () => (
-    <Select dir="rtl" defaultValue="regular">
-      <SelectTrigger aria-label="Right-to-left view density" className="w-56">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectGroup>
-          <SelectItem value="compact">Compact</SelectItem>
-          <SelectItem value="regular">Regular</SelectItem>
-          <SelectItem value="comfortable">Comfortable</SelectItem>
-        </SelectGroup>
-      </SelectContent>
-    </Select>
+    <DirectionProvider direction="rtl">
+      <Select items={selectableDensityItems} defaultValue="regular">
+        <SelectTrigger aria-label="Right-to-left view density" className="w-56">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value="compact">Compact</SelectItem>
+            <SelectItem value="regular">Regular</SelectItem>
+            <SelectItem value="comfortable">Comfortable</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </DirectionProvider>
   ),
 };
 
 export const LongScrollableList: Story = {
   render: () => (
-    <Select defaultOpen defaultValue="option-1">
+    <Select items={longListItems} defaultOpen defaultValue="option-1">
       <SelectTrigger aria-label="Long option list" className="w-56">
         <SelectValue />
       </SelectTrigger>
       <SelectContent className="max-h-48">
         <SelectGroup>
           <SelectLabel>Long option list</SelectLabel>
-          {Array.from({ length: 30 }, (_, index) => (
-            <SelectItem key={index} value={`option-${index + 1}`}>
-              Option {index + 1}
+          {longListItems.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              {item.label}
             </SelectItem>
           ))}
         </SelectGroup>
@@ -156,14 +183,17 @@ export const LongScrollableList: Story = {
   ),
 };
 
-export const MigrationContract: Story = {
+export const BaseContract: Story = {
   tags: ["select-contract"],
   render: () => (
-    <Select defaultOpen defaultValue="licensed_api">
+    <Select items={accessBasisItems} defaultOpen defaultValue="licensed_api">
       <SelectTrigger aria-label="Access basis" className="w-56">
         <SelectValue />
       </SelectTrigger>
-      <SelectContent data-testid="select-contract-popup">
+      <SelectContent
+        alignItemWithTrigger={false}
+        data-testid="select-contract-popup"
+      >
         <SelectGroup>
           <SelectLabel>Access basis options</SelectLabel>
           <SelectItem value="public_markdown">Public markdown</SelectItem>
@@ -195,7 +225,7 @@ export const MigrationContract: Story = {
       );
     }
     if (popup.dataset.alignTrigger !== "false") {
-      throw new Error("Expected Radix popper compatibility positioning.");
+      throw new Error("Expected trigger-edge popup positioning.");
     }
     if (!group.getAttribute("aria-labelledby")) {
       throw new Error(

--- a/apps/web/src/shared/ui/select.test.tsx
+++ b/apps/web/src/shared/ui/select.test.tsx
@@ -1,5 +1,8 @@
 import { axe } from "jest-axe";
-import { useDirection } from "@base-ui/react/direction-provider";
+import {
+  DirectionProvider,
+  useDirection,
+} from "@base-ui/react/direction-provider";
 import { render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -18,28 +21,39 @@ function DirectionProbe() {
   return <output data-testid="direction-probe">{useDirection()}</output>;
 }
 
+const densityItems = [
+  { label: "Compact", value: "compact" },
+  { label: "Regular", value: "regular" },
+  { label: "Comfortable", value: "comfortable" },
+  { label: "Locked option", value: "locked" },
+];
+
 function DensitySelect({
   defaultOpen,
   defaultValue,
-  dir,
   disabled,
   onValueChange,
   value,
 }: {
   defaultOpen?: boolean;
   defaultValue?: string;
-  dir?: "ltr" | "rtl";
   disabled?: boolean;
   onValueChange?: (value: string) => void;
   value?: string;
 }) {
   return (
     <Select
+      items={densityItems}
       defaultOpen={defaultOpen}
       defaultValue={defaultValue}
-      dir={dir}
       disabled={disabled}
-      onValueChange={onValueChange}
+      onValueChange={
+        onValueChange === undefined
+          ? undefined
+          : (nextValue) => {
+              if (nextValue !== null) onValueChange(nextValue);
+            }
+      }
       value={value}
     >
       <SelectTrigger aria-label="View density">
@@ -61,7 +75,7 @@ function DensitySelect({
 }
 
 describe("<Select>", () => {
-  it("infers item labels so formatted text survives in the trigger", () => {
+  it("uses explicit item labels so formatted text survives in the trigger", () => {
     render(<DensitySelect defaultValue="comfortable" />);
 
     const trigger = screen.getByRole("combobox", { name: "View density" });
@@ -123,15 +137,19 @@ describe("<Select>", () => {
     expect(disabledTrigger).toHaveTextContent("Regular");
   });
 
-  it("maps group labels and Radix popper positioning to Base UI parts", () => {
+  it("maps group labels and trigger-edge positioning to Base UI parts", () => {
     render(
-      <Select defaultOpen defaultValue="compact">
+      <Select
+        items={[{ label: "Compact", value: "compact" }]}
+        defaultOpen
+        defaultValue="compact"
+      >
         <SelectTrigger aria-label="Positioned density">
           <SelectValue />
         </SelectTrigger>
         <SelectContent
           align="end"
-          position="popper"
+          alignItemWithTrigger={false}
           side="top"
           sideOffset={8}
           data-testid="select-popup"
@@ -155,22 +173,27 @@ describe("<Select>", () => {
 
   it("provides the supplied direction and forwards logical positioning", () => {
     render(
-      <Select dir="rtl" defaultOpen defaultValue="regular">
-        <DirectionProbe />
-        <SelectTrigger aria-label="Right-to-left density">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent
-          avoidCollisions={false}
-          position="popper"
-          side="inline-start"
-          data-testid="rtl-popup"
+      <DirectionProvider direction="rtl">
+        <Select
+          items={[{ label: "Regular", value: "regular" }]}
+          defaultOpen
+          defaultValue="regular"
         >
-          <SelectGroup>
-            <SelectItem value="regular">Regular</SelectItem>
-          </SelectGroup>
-        </SelectContent>
-      </Select>,
+          <DirectionProbe />
+          <SelectTrigger aria-label="Right-to-left density">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent
+            alignItemWithTrigger={false}
+            side="inline-start"
+            data-testid="rtl-popup"
+          >
+            <SelectGroup>
+              <SelectItem value="regular">Regular</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </DirectionProvider>,
     );
 
     expect(screen.getByTestId("direction-probe")).toHaveTextContent("rtl");

--- a/apps/web/src/shared/ui/select.tsx
+++ b/apps/web/src/shared/ui/select.tsx
@@ -1,338 +1,211 @@
-import { DirectionProvider } from "@base-ui/react/direction-provider";
 import { Select as SelectPrimitive } from "@base-ui/react/select";
-import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react";
 import {
-  Children,
-  forwardRef,
-  isValidElement,
-  type ComponentRef,
-  type ReactNode,
-  useRef,
-} from "react";
+  IconCheck,
+  IconChevronDown,
+  IconChevronUp,
+  IconSelector,
+} from "@tabler/icons-react";
+import * as React from "react";
 
 import { cn } from "../lib/cn.js";
 
-type BaseSelectRootProps = SelectPrimitive.Root.Props<string, false>;
+const Select = SelectPrimitive.Root;
 
-export interface SelectProps extends Omit<
-  BaseSelectRootProps,
-  "children" | "defaultValue" | "items" | "onValueChange" | "value"
-> {
-  children?: ReactNode;
-  defaultValue?: string | undefined;
-  dir?: "ltr" | "rtl" | undefined;
-  items?: BaseSelectRootProps["items"];
-  onValueChange?: ((value: string) => void) | undefined;
-  value?: string | undefined;
-}
-
-type SelectItemDefinition = {
-  label: ReactNode;
-  value: string;
-};
-
-function collectItemDefinitions(children: ReactNode): SelectItemDefinition[] {
-  const items: SelectItemDefinition[] = [];
-
-  Children.forEach(children, (child) => {
-    if (!isValidElement<{ children?: ReactNode; value?: unknown }>(child)) {
-      return;
-    }
-
-    if (child.type === SelectItem && typeof child.props.value === "string") {
-      items.push({ label: child.props.children, value: child.props.value });
-      return;
-    }
-
-    items.push(...collectItemDefinitions(child.props.children));
-  });
-
-  return items;
-}
-
-function itemDefinitionsMatch(
-  current: SelectItemDefinition[],
-  next: SelectItemDefinition[],
-): boolean {
+function SelectGroup({
+  className,
+  ...props
+}: SelectPrimitive.Group.Props) {
   return (
-    current.length === next.length &&
-    current.every(
-      (item, index) =>
-        item.value === next[index]?.value && item.label === next[index]?.label,
-    )
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1.5 p-1", className)}
+      {...props}
+    />
   );
 }
 
-export function Select({
-  children,
-  defaultValue,
-  dir,
-  items,
-  onValueChange,
-  value,
+function SelectValue({
+  className,
   ...props
-}: SelectProps) {
-  const nextInferredItems = collectItemDefinitions(children);
-  const inferredItemsRef = useRef(nextInferredItems);
-  if (!itemDefinitionsMatch(inferredItemsRef.current, nextInferredItems)) {
-    inferredItemsRef.current = nextInferredItems;
-  }
-  const resolvedItems =
-    items ??
-    (inferredItemsRef.current.length === 0
-      ? undefined
-      : inferredItemsRef.current);
-  const root = (
-    <SelectPrimitive.Root<string>
-      defaultValue={defaultValue}
-      items={resolvedItems}
-      onValueChange={
-        onValueChange === undefined
-          ? undefined
-          : (nextValue) => {
-              if (nextValue !== null) {
-                onValueChange(nextValue);
-              }
-            }
-      }
-      value={value}
+}: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-2xl border border-transparent bg-input/50 px-3 py-2 text-sm whitespace-nowrap transition-[color,box-shadow] duration-200 outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
       {...props}
     >
       {children}
-    </SelectPrimitive.Root>
-  );
-
-  return dir === undefined ? (
-    root
-  ) : (
-    <DirectionProvider direction={dir}>{root}</DirectionProvider>
+      <SelectPrimitive.Icon
+        render={
+          <IconSelector className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
   );
 }
 
-export const SelectGroup = SelectPrimitive.Group;
-export const SelectValue = SelectPrimitive.Value;
-
-export const SelectTrigger = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Trigger>,
-  SelectPrimitive.Trigger.Props
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-card px-3 text-left text-[13px] shadow-none transition-[color,background-color,border-color,box-shadow] placeholder:text-muted-foreground focus-visible:border-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon
-      render={<IconChevronDown className="size-4 opacity-50" />}
-    />
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
-
-export const SelectScrollUpButton = forwardRef<
-  ComponentRef<typeof SelectPrimitive.ScrollUpArrow>,
-  SelectPrimitive.ScrollUpArrow.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpArrow
-    ref={ref}
-    className={cn(
-      "top-0 flex w-full cursor-default items-center justify-center py-1",
-      className,
-    )}
-    {...props}
-  >
-    <IconChevronUp className="size-4" />
-  </SelectPrimitive.ScrollUpArrow>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpArrow.displayName;
-
-export const SelectScrollDownButton = forwardRef<
-  ComponentRef<typeof SelectPrimitive.ScrollDownArrow>,
-  SelectPrimitive.ScrollDownArrow.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownArrow
-    ref={ref}
-    className={cn(
-      "bottom-0 flex w-full cursor-default items-center justify-center py-1",
-      className,
-    )}
-    {...props}
-  >
-    <IconChevronDown className="size-4" />
-  </SelectPrimitive.ScrollDownArrow>
-));
-SelectScrollDownButton.displayName =
-  SelectPrimitive.ScrollDownArrow.displayName;
-
-type SelectPositionerProps = Pick<
-  SelectPrimitive.Positioner.Props,
-  | "align"
-  | "alignItemWithTrigger"
-  | "alignOffset"
-  | "anchor"
-  | "arrowPadding"
-  | "collisionAvoidance"
-  | "collisionBoundary"
-  | "collisionPadding"
-  | "disableAnchorTracking"
-  | "positionMethod"
-  | "side"
-  | "sideOffset"
->;
-
-export interface SelectContentProps
-  extends SelectPrimitive.Popup.Props, SelectPositionerProps {
-  avoidCollisions?: boolean | undefined;
-  hideWhenDetached?: boolean | undefined;
-  position?: "item-aligned" | "popper" | undefined;
-  sticky?: boolean | "always" | "partial" | undefined;
-}
-
-const viewportCollisionBoundary: Element[] = [];
-const disabledCollisionAvoidance: NonNullable<
-  SelectPrimitive.Positioner.Props["collisionAvoidance"]
-> = { align: "none", fallbackAxisSide: "none", side: "none" };
-
-export const SelectContent = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Popup>,
-  SelectContentProps
->(
-  (
-    {
-      align = "start",
-      alignItemWithTrigger,
-      alignOffset = 0,
-      anchor,
-      arrowPadding = 0,
-      avoidCollisions = true,
-      children,
-      className,
-      collisionAvoidance,
-      collisionBoundary = viewportCollisionBoundary,
-      collisionPadding = 10,
-      disableAnchorTracking,
-      hideWhenDetached = false,
-      position = "popper",
-      positionMethod = "fixed",
-      side = "bottom",
-      sideOffset = 0,
-      sticky = "partial",
-      ...props
-    },
-    ref,
-  ) => {
-    const alignsSelectedItem =
-      alignItemWithTrigger ?? position === "item-aligned";
-    const resolvedCollisionAvoidance =
-      avoidCollisions || collisionAvoidance !== undefined
-        ? collisionAvoidance
-        : disabledCollisionAvoidance;
-
-    return (
-      <SelectPrimitive.Portal>
-        <SelectPrimitive.Positioner
-          align={align}
-          alignItemWithTrigger={alignsSelectedItem}
-          alignOffset={alignOffset}
-          anchor={anchor}
-          arrowPadding={arrowPadding}
-          collisionAvoidance={resolvedCollisionAvoidance}
-          collisionBoundary={collisionBoundary}
-          collisionPadding={collisionPadding}
-          disableAnchorTracking={disableAnchorTracking}
-          positionMethod={positionMethod}
-          side={side}
-          sideOffset={sideOffset}
-          sticky={sticky === true || sticky === "always"}
-          className={cn(hideWhenDetached && "data-anchor-hidden:invisible")}
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn(
+            "isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl text-popover-foreground shadow-lg ring-1 ring-foreground/5 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:ring-foreground/10 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 animate-none! relative bg-popover/70 before:pointer-events-none before:absolute before:inset-0 before:-z-1 before:rounded-[inherit] before:backdrop-blur-2xl before:backdrop-saturate-150 **:data-[slot$=-item]:focus:bg-foreground/10 **:data-[slot$=-item]:data-highlighted:bg-foreground/10 **:data-[slot$=-separator]:bg-foreground/5 **:data-[slot$=-trigger]:focus:bg-foreground/10 **:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! **:data-[variant=destructive]:focus:bg-foreground/10! **:data-[variant=destructive]:text-accent-foreground! **:data-[variant=destructive]:**:text-accent-foreground!",
+            className,
+          )}
+          {...props}
         >
-          <SelectPrimitive.Popup
-            ref={ref}
-            data-align-trigger={alignsSelectedItem}
-            className={cn(
-              "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-[0_8px_20px_rgb(0_0_0_/_0.1)]",
-              !alignsSelectedItem &&
-                "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-              className,
-            )}
-            {...props}
-          >
-            <SelectScrollUpButton />
-            <SelectPrimitive.List
-              className={cn(
-                "p-1",
-                !alignsSelectedItem &&
-                  "h-[var(--anchor-height)] w-full min-w-[var(--anchor-width)]",
-              )}
-            >
-              {children}
-            </SelectPrimitive.List>
-            <SelectScrollDownButton />
-          </SelectPrimitive.Popup>
-        </SelectPrimitive.Positioner>
-      </SelectPrimitive.Portal>
-    );
-  },
-);
-SelectContent.displayName = SelectPrimitive.Popup.displayName;
-
-export const SelectLabel = forwardRef<
-  ComponentRef<typeof SelectPrimitive.GroupLabel>,
-  SelectPrimitive.GroupLabel.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.GroupLabel
-    ref={ref}
-    className={cn("px-2 py-1.5 text-[11px] font-semibold tracking-[0.02em] text-muted-foreground", className)}
-    {...props}
-  />
-));
-SelectLabel.displayName = SelectPrimitive.GroupLabel.displayName;
-
-export interface SelectItemProps extends Omit<
-  SelectPrimitive.Item.Props,
-  "label" | "value"
-> {
-  label?: string | undefined;
-  textValue?: string | undefined;
-  value: string;
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  );
 }
 
-export const SelectItem = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Item>,
-  SelectItemProps
->(({ className, children, label, textValue, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-[13px] outline-none focus:bg-muted focus:text-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
-      className,
-    )}
-    label={label ?? textValue}
-    {...props}
-  >
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-    <SelectPrimitive.ItemIndicator
-      render={
-        <span className="absolute right-2 flex size-3.5 items-center justify-center" />
-      }
-    >
-      <IconCheck className="size-4" />
-    </SelectPrimitive.ItemIndicator>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-2 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
 
-export const SelectSeparator = forwardRef<
-  ComponentRef<typeof SelectPrimitive.Separator>,
-  SelectPrimitive.Separator.Props
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex min-h-7 w-full cursor-default items-center gap-2 rounded-xl py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <IconCheck className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <IconChevronUp />
+    </SelectPrimitive.ScrollUpArrow>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <IconChevronDown />
+    </SelectPrimitive.ScrollDownArrow>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/apps/web/src/shared/ui/sheet.tsx
+++ b/apps/web/src/shared/ui/sheet.tsx
@@ -113,7 +113,7 @@ export const SheetOverlay = forwardRef<
   <DialogPrimitive.Backdrop
     data-slot="sheet-overlay"
     className={cn(
-      "fixed inset-0 z-50 bg-black/30 transition-opacity duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-starting-style:opacity-0 data-ending-style:opacity-0",
+      "fixed inset-0 isolate bg-foreground/20 transition-opacity duration-150 supports-backdrop-filter:backdrop-blur-[2px] data-starting-style:opacity-0 data-ending-style:opacity-0",
       className,
     )}
     {...props}
@@ -123,7 +123,7 @@ export const SheetOverlay = forwardRef<
 SheetOverlay.displayName = "SheetOverlay";
 
 const sheetVariants = cva(
-  "fixed z-50 flex flex-col gap-5 bg-popover p-6 text-sm text-popover-foreground shadow-xl transition ease-in-out data-open:duration-200 data-closed:duration-150",
+  "fixed flex flex-col gap-5 bg-popover p-6 text-sm text-popover-foreground shadow-xl transition ease-in-out data-open:duration-200 data-closed:duration-150",
   {
     variants: {
       side: {
@@ -166,13 +166,13 @@ export const SheetContent = forwardRef<
         data-slot="sheet-close"
         render={
           <Button
-            className="absolute right-3 top-3 size-8 bg-muted/60 text-muted-foreground shadow-none"
+            className="absolute right-3 top-3"
             size="icon"
             variant="ghost"
           />
         }
       >
-        <IconX aria-hidden size={16} />
+        <IconX aria-hidden />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Popup>

--- a/apps/web/src/shared/ui/status-badge.tsx
+++ b/apps/web/src/shared/ui/status-badge.tsx
@@ -1,0 +1,45 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { JSX } from "react";
+
+import { cn } from "../lib/cn.js";
+import { Badge, type BadgeProps } from "./badge.js";
+import type { StatusTagTone } from "./status-tokens.js";
+
+const statusBadgeVariants = cva(
+  "min-h-0 gap-1.5 rounded-none border-0 bg-transparent p-0 text-[11px] font-semibold leading-5 shadow-none before:size-1.5 before:shrink-0 before:rounded-full before:bg-current before:content-['']",
+  {
+    variants: {
+      tone: {
+        danger: "text-destructive",
+        info: "text-status-info",
+        muted: "text-muted-foreground",
+        ok: "text-success",
+        warn: "text-warning",
+      } satisfies Record<StatusTagTone, string>,
+    },
+    defaultVariants: {
+      tone: "muted",
+    },
+  },
+);
+
+export interface StatusBadgeProps
+  extends Omit<BadgeProps, "variant">,
+    VariantProps<typeof statusBadgeVariants> {}
+
+/**
+ * Restrained domain-state label. The dot and text carry tone without turning
+ * operational state into a filled pill or competing with primary actions.
+ */
+export function StatusBadge({ className, tone, ...props }: StatusBadgeProps): JSX.Element {
+  return (
+    <Badge
+      data-slot="status-badge"
+      variant="outline"
+      className={cn(statusBadgeVariants({ tone }), className)}
+      {...props}
+    />
+  );
+}
+
+export { statusBadgeVariants };

--- a/apps/web/src/styles/redesign-analytics.css
+++ b/apps/web/src/styles/redesign-analytics.css
@@ -3,11 +3,16 @@
 
 .analytics-view {
   container-type: inline-size;
+  gap: 0;
   overflow: hidden;
-  background: var(--card);
+  padding-block: 0;
 }
 
-.analytics-view > .banner.inline {
+.analytics-content {
+  padding: 0;
+}
+
+.analytics-error {
   margin: 14px 18px 0;
 }
 
@@ -30,6 +35,10 @@
   padding-block: 13px;
 }
 
+.analytics-controls-copy strong {
+  display: block;
+}
+
 .analytics-controls-copy > span {
   color: var(--muted-foreground);
   font-size: 10px;
@@ -46,6 +55,8 @@
 }
 
 .analytics-view .analytics-toolbar {
+  display: flex;
+  align-items: stretch;
   justify-content: flex-end;
   flex: 1 1 auto;
   gap: 18px;
@@ -55,10 +66,16 @@
   background: transparent;
 }
 
-.analytics-view .analytics-toolbar .segmented {
+.analytics-dimension-toggle {
+  align-self: stretch;
+  gap: 18px;
+}
+
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"] {
   position: relative;
   align-self: stretch;
   min-height: 48px;
+  min-width: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -69,7 +86,7 @@
   letter-spacing: 0;
 }
 
-.analytics-view .analytics-toolbar .segmented::after {
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"]::after {
   position: absolute;
   inset-inline: 0;
   inset-block-end: -1px;
@@ -78,27 +95,31 @@
   content: "";
 }
 
-.analytics-view .analytics-toolbar .segmented:hover,
-.analytics-view .analytics-toolbar .segmented:focus-visible {
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"]:hover,
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"]:focus-visible {
   border-color: transparent;
   background: transparent;
   color: var(--foreground);
 }
 
-.analytics-view .analytics-toolbar .segmented:focus-visible {
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"]:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 3px;
 }
 
-.analytics-view .analytics-toolbar .segmented.active {
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"][data-state="on"] {
   border: 0;
   background: transparent;
   color: var(--foreground);
   font-weight: 650;
 }
 
-.analytics-view .analytics-toolbar .segmented.active::after {
+.analytics-view .analytics-dimension-toggle [data-slot="toggle-group-item"][data-state="on"]::after {
   background: var(--foreground);
+}
+
+.analytics-dimension-select {
+  display: none;
 }
 
 .analytics-summary-strip {
@@ -152,27 +173,23 @@
 }
 
 .analytics-caption {
-  display: grid;
-  grid-template-columns: 17px minmax(0, 1fr);
-  align-items: start;
-  gap: 9px;
   margin: 0;
+  border: 0;
   border-bottom: 1px solid var(--border);
+  border-radius: 0;
   background: transparent;
   padding: 12px 18px 13px;
-  color: var(--muted-foreground);
+}
+
+.analytics-caption [data-slot="alert-title"] {
+  color: var(--foreground);
+  font-size: 11px;
+}
+
+.analytics-caption [data-slot="alert-description"] {
+  max-width: 112ch;
   font-size: 11px;
   line-height: 1.5;
-}
-
-.analytics-caption > svg {
-  margin-top: 1px;
-  color: var(--muted-foreground);
-}
-
-.analytics-caption > p {
-  max-width: 112ch;
-  margin: 0;
 }
 
 .analytics-breakdown-region {
@@ -234,10 +251,6 @@
   gap: 6px;
   color: var(--muted-foreground);
   font-size: 11px;
-}
-
-.analytics-data-grid-table .analytics-group-meta .tag {
-  color: var(--muted-foreground);
 }
 
 .analytics-data-grid-table .analytics-rate {
@@ -312,23 +325,14 @@
     width: auto;
   }
 
-  .analytics-view .analytics-toolbar .segmented {
+  .analytics-view .analytics-dimension-toggle {
     display: none;
   }
 
-  .analytics-view .analytics-select-label {
-    display: grid;
+  .analytics-dimension-select {
+    display: flex;
     width: min(100%, 240px);
     max-width: none;
-    gap: 4px;
-  }
-
-  .analytics-view .analytics-select-label > span {
-    display: none;
-  }
-
-  .analytics-view .analytics-select-label .select {
-    width: 100%;
   }
 
   .analytics-summary-strip {

--- a/apps/web/src/styles/redesign-apply-review.css
+++ b/apps/web/src/styles/redesign-apply-review.css
@@ -109,14 +109,6 @@
   white-space: nowrap;
 }
 
-.apply-review-queue-item > .tag,
-.apply-review-inline-state,
-.apply-review-audit-summary .tag,
-.apply-review-audit-revision .tag,
-.apply-review-audit-shipped-fit .tag,
-.apply-review-audit-tags .tag,
-.apply-review-requirement-fit-grid .tag,
-.apply-review-evidence-list .tag,
 .apply-review-selected-facts .compensation-strip .tag,
 .apply-review-selected-facts .resume-template-job-select .tag {
   min-height: 0;
@@ -131,42 +123,16 @@
   line-height: 1.45;
 }
 
-.apply-review-queue-item > .tag::before,
-.apply-review-inline-state::before {
-  width: 5px;
-  height: 5px;
-  flex: none;
-  border-radius: 50%;
-  background: currentColor;
-  content: "";
-  opacity: 0.75;
+.apply-review-queue-item > [data-slot="status-badge"] {
+  justify-self: start;
 }
 
-.apply-review-queue-item > .tag.ok,
-.apply-review-inline-state.ok,
-.apply-review-audit-summary .tag.ok,
-.apply-review-audit-revision .tag.ok,
-.apply-review-audit-shipped-fit .tag.ok,
-.apply-review-requirement-fit-grid .tag.ok {
-  color: var(--success);
+.apply-review-queue-alert {
+  margin: 14px;
 }
 
-.apply-review-queue-item > .tag.warn,
-.apply-review-inline-state.warn,
-.apply-review-audit-summary .tag.warn,
-.apply-review-audit-revision .tag.warn,
-.apply-review-audit-shipped-fit .tag.warn,
-.apply-review-requirement-fit-grid .tag.warn {
-  color: var(--warning);
-}
-
-.apply-review-queue-item > .tag.info,
-.apply-review-inline-state.info,
-.apply-review-audit-summary .tag.info,
-.apply-review-audit-revision .tag.info,
-.apply-review-audit-shipped-fit .tag.info,
-.apply-review-requirement-fit-grid .tag.info {
-  color: var(--status-info);
+.apply-review-inline-alert {
+  grid-column: 1 / -1;
 }
 
 .apply-review-selected {
@@ -628,6 +594,19 @@
 
 .apply-review-ideal-requirement-head {
   gap: 6px 12px;
+}
+
+.apply-review-requirement-meta,
+.apply-review-evidence-token {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  font-weight: 560;
+  line-height: 1.45;
+}
+
+.apply-review-ideal-requirement-head .apply-review-requirement-meta + .apply-review-requirement-meta,
+.apply-review-evidence-token + .apply-review-evidence-token {
+  margin-left: 10px;
 }
 
 .apply-review-requirement-fit-grid {

--- a/apps/web/src/styles/redesign-configuration.css
+++ b/apps/web/src/styles/redesign-configuration.css
@@ -101,13 +101,42 @@
   padding: 0 0 18px;
 }
 
-.profile-layout .repeat-card {
-  gap: 14px;
+.profile-layout .repeat-section {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px 20px;
   border: 0;
-  border-top: 1px solid var(--configuration-rule);
   border-radius: 0;
   background: transparent;
+  margin: 0;
   padding: 16px 0;
+}
+
+.profile-layout .repeat-section > [data-slot="field-legend"] {
+  grid-column: 1;
+  margin: 0;
+  align-self: center;
+  color: var(--foreground);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.profile-layout .repeat-section > .repeat-controls {
+  grid-column: 2;
+  grid-row: 1;
+  justify-content: flex-end;
+}
+
+.profile-layout .repeat-section > .field-grid,
+.profile-layout .repeat-section > .bullet-list,
+.profile-layout .repeat-section > .skill-list,
+.profile-layout .repeat-section > [data-slot="separator"] {
+  grid-column: 1 / -1;
+}
+
+.profile-layout .repeat-section-separator {
+  background: var(--configuration-rule);
 }
 
 .profile-layout .repeat-list > .tab {
@@ -115,12 +144,20 @@
   margin-top: 4px;
 }
 
-.profile-layout .repeat-card .field-grid {
+.profile-layout .repeat-section .field-grid {
   padding: 0;
 }
 
 .profile-layout .bullet-row,
-.profile-layout .skill-row,
+.profile-layout .skill-row {
+  border: 0;
+  border-bottom: 1px solid color-mix(in oklch, var(--configuration-rule) 72%, transparent);
+  border-radius: 0;
+  background: transparent;
+  padding: 11px 0;
+  box-shadow: none;
+}
+
 .profile-layout .achievement-evidence-card {
   border-color: var(--configuration-rule);
   border-radius: 6px;
@@ -136,8 +173,8 @@
   background: var(--configuration-subtle);
 }
 
-.profile-layout .target-work-model-option:has(input:checked),
-.profile-layout .date-range-present:has(input:checked) {
+.profile-layout .target-work-model-option:has([data-checked]),
+.profile-layout .date-range-present:has([data-checked]) {
   background: color-mix(in oklch, var(--foreground) 9%, var(--card));
   color: var(--foreground);
 }
@@ -155,23 +192,20 @@
   border-bottom: 1px solid var(--configuration-rule);
 }
 
-.configuration-section > summary {
+.configuration-section > .configuration-section__trigger {
   display: flex;
+  width: 100%;
   min-height: 70px;
   align-items: center;
   justify-content: space-between;
   gap: 18px;
+  border: 0;
+  background: transparent;
+  color: inherit;
   cursor: pointer;
-  list-style: none;
+  font: inherit;
   padding: 16px 0;
-}
-
-.configuration-section > summary::-webkit-details-marker {
-  display: none;
-}
-
-.configuration-section > summary::marker {
-  content: "";
+  text-align: left;
 }
 
 .configuration-section__title-group {
@@ -199,13 +233,13 @@
   transition: transform 150ms ease, color 150ms ease;
 }
 
-.configuration-section[open] > summary .configuration-section__indicator {
+.configuration-section > .configuration-section__trigger[data-panel-open] .configuration-section__indicator {
   color: var(--foreground);
   transform: rotate(180deg);
 }
 
-.configuration-section > summary:hover .configuration-section__title,
-.configuration-section > summary:focus-visible .configuration-section__title {
+.configuration-section > .configuration-section__trigger:hover .configuration-section__title,
+.configuration-section > .configuration-section__trigger:focus-visible .configuration-section__title {
   text-decoration: underline;
   text-decoration-color: color-mix(in oklch, var(--foreground) 28%, transparent);
   text-underline-offset: 4px;
@@ -268,11 +302,7 @@
 }
 
 .configuration-section .bullet-standards-group legend {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  padding-right: 48px;
 }
 
 .configuration-help-link {
@@ -298,10 +328,20 @@
 }
 
 .configuration-section .tailoring-control-group .bullet-standards-group {
+  position: relative;
   margin-top: 2px;
 }
 
-.configuration-section .checkbox-options {
+.configuration-section .bullet-standards-group > .configuration-help-link {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.configuration-section .checkbox-options,
+.profile-layout .checkbox-options,
+.discovery-workspace .checkbox-options {
+  flex-direction: row;
   gap: 8px 14px;
 }
 
@@ -341,13 +381,35 @@
   opacity: 1;
 }
 
-.configuration-section .bullet-standards-group > small {
+.configuration-section .bullet-standards-group > [data-slot="field-description"] {
   display: block;
   margin-top: 8px;
   color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 430;
   line-height: 1.4;
+}
+
+.profile-layout .target-work-model-options,
+.discovery-workspace .target-work-model-options {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.profile-layout .month-selector > [data-slot="field-legend"] {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.profile-layout .month-selector-controls > button:first-of-type {
+  flex: 0 0 92px;
+}
+
+.profile-layout .month-selector-controls > button:last-of-type {
+  flex: 1 1 96px;
 }
 
 .configuration-select-trigger {
@@ -724,6 +786,9 @@
 .profile-layout .field > span:first-child,
 .config-layout .field > span:first-child,
 .discovery-workspace .field > span:first-child,
+.profile-layout .field > [data-slot="field-label"],
+.config-layout .field > [data-slot="field-label"],
+.discovery-workspace .field > [data-slot="field-label"],
 .profile-layout .field > label,
 .config-layout .field > label,
 .discovery-workspace .field > label {
@@ -800,6 +865,16 @@
 }
 
 @media (max-width: 760px) {
+  .profile-layout .repeat-section {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .profile-layout .repeat-section > .repeat-controls {
+    grid-column: 1;
+    grid-row: auto;
+    justify-content: flex-start;
+  }
+
   .profile-layout .profile-sections > .form-section .field-grid,
   .profile-layout .profile-sections > .form-section .target-preferences-grid,
   .configuration-section .field-grid,
@@ -822,7 +897,7 @@
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .configuration-section > summary {
+  .configuration-section > .configuration-section__trigger {
     min-height: 0;
     padding-block: 14px;
   }

--- a/apps/web/src/styles/redesign-dashboard.css
+++ b/apps/web/src/styles/redesign-dashboard.css
@@ -43,6 +43,15 @@
   gap: 20px;
 }
 
+.dashboard-error-alert {
+  margin-bottom: 20px;
+}
+
+.dashboard-view .dashboard-inline-alert {
+  width: auto;
+  margin: 12px 18px;
+}
+
 .dashboard-ops {
   grid-template-columns: repeat(12, minmax(0, 1fr));
   gap: 0;
@@ -226,15 +235,66 @@
   line-height: 1.35;
 }
 
-.dashboard-view .work-status-stat {
-  border: 0;
-  border-radius: 5px;
-  background: color-mix(in oklch, var(--muted) 66%, var(--card));
-  box-shadow: none;
+.dashboard-view .work-status-card {
+  gap: 0;
+  padding-block: 0;
 }
 
-.dashboard-view .work-status-stat [data-slot="stat-value"] {
-  font-weight: 650;
+.dashboard-view .work-status-content {
+  padding: 0;
+}
+
+.dashboard-view .work-status-metrics {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 1px minmax(0, 1fr);
+  gap: 0;
+  margin: 0;
+  padding: 18px 20px;
+}
+
+.dashboard-view .work-status-metric {
+  display: grid;
+  align-content: start;
+  gap: 5px;
+  min-width: 0;
+  padding-inline: 0 20px;
+}
+
+.dashboard-view .work-status-metric:last-child {
+  padding-inline: 20px 0;
+}
+
+.dashboard-view .work-status-metric dt {
+  color: var(--muted-foreground);
+  font-size: 10px;
+  font-weight: 680;
+  letter-spacing: 0.075em;
+  text-transform: uppercase;
+}
+
+.dashboard-view .work-status-metric dd {
+  margin: 0;
+  color: var(--foreground);
+  font-size: 28px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 680;
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.dashboard-view .work-status-metric[data-attention="true"] dd {
+  color: var(--destructive);
+}
+
+.dashboard-view .work-status-metric > span {
+  color: var(--muted-foreground);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.dashboard-view .work-status-metric-separator {
+  align-self: stretch;
+  height: auto;
 }
 
 @media (max-width: 1500px) {
@@ -307,5 +367,20 @@
   .dashboard-view .funnel-row,
   .dashboard-view .conversion-stage {
     grid-template-columns: 1fr;
+  }
+
+  .dashboard-view .work-status-metrics {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .dashboard-view .work-status-metric,
+  .dashboard-view .work-status-metric:last-child {
+    padding: 0;
+  }
+
+  .dashboard-view .work-status-metric-separator {
+    width: 100%;
+    height: 1px;
   }
 }

--- a/apps/web/src/styles/redesign-detail-surfaces.css
+++ b/apps/web/src/styles/redesign-detail-surfaces.css
@@ -1,53 +1,37 @@
 /* Secondary workspaces follow the same Rhea-inspired hierarchy as the main
  * screens: one clear surface, calm dividers, and dense evidence rows. */
 
-.drawer-backdrop {
+[data-slot="sheet-overlay"]:has(+ [data-slot="detail-drawer"]) {
   top: var(--topbar-height);
   left: 232px;
-  align-items: stretch;
-  justify-content: center;
-  padding: 24px 36px 48px;
-  background: var(--background);
-  backdrop-filter: none;
 }
 
-.detail-drawer:not(.job-detail-drawer) {
-  position: relative;
-  width: min(920px, 100%);
-  max-height: calc(100dvh - var(--topbar-height) - 48px);
-  margin-left: auto;
+[data-slot="detail-drawer"] {
+  top: calc(var(--topbar-height) + 24px);
+  right: 36px;
+  bottom: 48px;
+  left: calc(232px + 36px);
+  height: auto;
+  max-width: none;
   margin-right: auto;
-  border: 1px solid color-mix(in oklch, var(--border) 82%, var(--foreground));
-  border-radius: calc(var(--radius) * 1.45);
-  background: var(--card);
-  box-shadow: 0 24px 70px color-mix(in oklch, var(--foreground) 22%, transparent);
+  margin-left: auto;
+  gap: 0;
+  overflow: auto;
+  padding: 0;
   scrollbar-gutter: stable;
 }
 
+.detail-drawer:not(.job-detail-drawer) {
+  width: min(920px, calc(100dvw - 304px));
+  border: 1px solid color-mix(in oklch, var(--border) 82%, var(--foreground));
+  border-radius: calc(var(--radius) * 1.45);
+  background: var(--card);
+  box-shadow: 0 24px 70px
+    color-mix(in oklch, var(--foreground) 22%, transparent);
+}
+
 .detail-drawer.artifact-detail-drawer {
-  width: min(1320px, 100%);
-}
-
-.drawer-close {
-  z-index: 4;
-  display: inline-flex;
-  width: 34px;
-  height: 34px;
-  align-items: center;
-  justify-content: center;
-  margin: 14px;
-  border: 1px solid var(--border);
-  border-radius: 50%;
-  background: color-mix(in oklch, var(--card) 92%, transparent);
-  color: var(--muted-foreground);
-  box-shadow: 0 1px 2px color-mix(in oklch, var(--foreground) 7%, transparent);
-  backdrop-filter: blur(8px);
-}
-
-.drawer-close:hover {
-  border-color: color-mix(in oklch, var(--foreground) 24%, var(--border));
-  background: var(--muted);
-  color: var(--foreground);
+  width: min(1320px, calc(100dvw - 304px));
 }
 
 .detail-drawer:not(.job-detail-drawer) .drawer-head {
@@ -580,26 +564,40 @@
 }
 
 @media (max-width: 1180px) and (min-width: 821px) {
-  .drawer-backdrop {
+  [data-slot="sheet-overlay"]:has(+ [data-slot="detail-drawer"]) {
     left: 68px;
-    padding: 20px 24px 40px;
+  }
+
+  [data-slot="detail-drawer"] {
+    top: calc(var(--topbar-height) + 20px);
+    right: 24px;
+    bottom: 40px;
+    left: calc(68px + 24px);
   }
 
   .detail-drawer:not(.job-detail-drawer) {
-    max-height: calc(100dvh - var(--topbar-height) - 40px);
+    width: min(920px, calc(100dvw - 116px));
+  }
+
+  .detail-drawer.artifact-detail-drawer {
+    width: min(1320px, calc(100dvw - 116px));
   }
 }
 
 @media (max-width: 820px) {
-  .drawer-backdrop {
+  [data-slot="sheet-overlay"]:has(+ [data-slot="detail-drawer"]) {
     inset: 0;
-    padding: 0;
+  }
+
+  [data-slot="detail-drawer"] {
+    inset: 0;
+    height: 100dvh;
+    margin: 0;
   }
 
   .detail-drawer:not(.job-detail-drawer),
   .detail-drawer.artifact-detail-drawer {
     width: 100dvw;
-    max-height: 100dvh;
     border-width: 0;
     border-radius: 0;
   }

--- a/apps/web/src/styles/redesign-job-detail.css
+++ b/apps/web/src/styles/redesign-job-detail.css
@@ -5,32 +5,11 @@
  */
 
 .job-detail-drawer {
-  width: min(1440px, 100%);
-  block-size: calc(100dvh - var(--topbar-height) - 48px);
+  width: min(1440px, calc(100dvw - 304px));
   margin: 0 auto;
   border-radius: 10px;
   background: var(--card);
   box-shadow: 0 24px 72px color-mix(in srgb, #000 22%, transparent);
-}
-
-.job-detail-drawer .drawer-close {
-  z-index: 2;
-  display: inline-flex;
-  width: 32px;
-  height: 32px;
-  align-items: center;
-  justify-content: center;
-  margin: 14px;
-  border: 1px solid transparent;
-  border-radius: 5px;
-  color: var(--muted-foreground);
-}
-
-.job-detail-drawer .drawer-close:hover,
-.job-detail-drawer .drawer-close:focus-visible {
-  border-color: var(--border);
-  background: var(--muted);
-  color: var(--foreground);
 }
 
 .job-detail-drawer .drawer-head {
@@ -136,7 +115,11 @@
   font-size: 12px;
   font-weight: 610;
   text-decoration: underline;
-  text-decoration-color: color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  text-decoration-color: color-mix(
+    in oklch,
+    var(--muted-foreground) 55%,
+    transparent
+  );
   text-decoration-thickness: 1px;
   text-underline-offset: 4px;
 }
@@ -735,13 +718,14 @@
   background: transparent;
 }
 
-@media (max-width: 1040px) {
+@media (max-width: 1180px) and (min-width: 821px) {
   .job-detail-drawer {
-    width: 100%;
-    block-size: calc(100dvh - var(--topbar-height) - 32px);
+    width: calc(100dvw - 116px);
     margin: 0;
   }
+}
 
+@media (max-width: 1040px) {
   .job-detail-drawer .drawer-head {
     padding-right: 60px;
   }
@@ -768,11 +752,6 @@
 }
 
 @media (max-width: 820px) {
-  .drawer-backdrop:has(.job-detail-drawer) {
-    inset: 0;
-    padding: 0;
-  }
-
   .job-detail-drawer {
     width: 100dvw;
     block-size: 100dvh;
@@ -785,10 +764,6 @@
     grid-template-columns: 45px minmax(0, 1fr);
     gap: 12px;
     padding: 24px 48px 20px 20px;
-  }
-
-  .job-detail-drawer .drawer-close {
-    margin: 10px;
   }
 
   .job-detail-drawer .drawer-head .fit {

--- a/apps/web/src/styles/redesign-profile-import.css
+++ b/apps/web/src/styles/redesign-profile-import.css
@@ -193,14 +193,13 @@
 }
 
 .resume-import-alert {
-  border: 1px solid color-mix(in oklch, var(--destructive) 34%, var(--border));
   border-radius: calc(var(--radius) * 0.75);
-  background: color-mix(in oklch, var(--destructive) 6%, var(--card));
   padding: 11px 13px;
-  color: var(--destructive);
+}
+
+.resume-import-alert [data-slot="alert-description"] {
   font-size: 12px;
   line-height: 1.45;
-  text-align: left;
 }
 
 .resume-import-target {
@@ -482,6 +481,10 @@
   background: var(--resume-import-subtle);
   color: var(--foreground);
   font-size: 12px;
+}
+
+.resume-import-status [data-slot="alert-description"] {
+  color: inherit;
 }
 
 .resume-import-confirmation-summary {

--- a/apps/web/src/styles/redesign-shell.css
+++ b/apps/web/src/styles/redesign-shell.css
@@ -215,18 +215,6 @@
   flex: 0 0 auto;
 }
 
-.topbar__density .select {
-  min-width: 100px;
-  min-height: 32px;
-  padding: 5px 28px 5px 9px;
-  border-color: var(--border);
-  border-radius: 5px;
-  background: var(--card);
-  font-size: 11px;
-  font-weight: 550;
-  text-transform: capitalize;
-}
-
 .topbar__theme-toggle {
   min-height: 32px;
   padding: 5px 0;

--- a/apps/web/src/views/analytics/AnalyticsView.tsx
+++ b/apps/web/src/views/analytics/AnalyticsView.tsx
@@ -6,7 +6,24 @@ import {
   type AnalyticsDimension,
   type AnalyticsSearch,
 } from "../../routes/-analytics.search.js";
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../../shared/ui/card.js";
 import { PageHead } from "../../shared/ui/page-head.js";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../../shared/ui/select.js";
+import { ToggleGroup, ToggleGroupItem } from "../../shared/ui/toggle-group.js";
 import { DimensionBreakdownPanel } from "./DimensionBreakdownPanel.js";
 import { SmallSampleNotice } from "./SmallSampleNotice.js";
 
@@ -63,93 +80,111 @@ export function AnalyticsView() {
         title="Outcome analytics"
         subtitle={analytics ? `${applied} applied` : "loading"}
       />
-      <section className="card full analytics-view data-list-card" aria-label="Outcome analytics workspace">
-        {message ? <div className="banner inline">{message}</div> : null}
-        <div className="analytics-controls">
-          <div className="analytics-controls-copy">
+      <Card className="analytics-view data-list-card" aria-label="Outcome analytics workspace">
+        <CardHeader className="analytics-controls">
+          <CardTitle className="analytics-controls-copy">
             <span>Breakdown</span>
             <strong>{activeDimensionLabel}</strong>
-          </div>
-          <div className="analytics-toolbar" role="group" aria-label="Outcome analytics dimension">
-            {DIMENSION_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className={option.value === dimension ? "segmented active" : "segmented"}
-                aria-pressed={option.value === dimension}
-                onClick={() => setDimension(option.value)}
-              >
-                {option.label}
-              </button>
-            ))}
-            <label className="analytics-select-label">
-              <span>Dimension</span>
-              <select
-                className="select"
-                value={dimension}
-                onChange={(event) => {
-                  const next = event.target.value;
-                  if (isAnalyticsDimension(next)) setDimension(next);
-                }}
-              >
-                {DIMENSION_OPTIONS.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          </div>
-        </div>
-        <dl className="analytics-summary-strip" aria-label="Outcome summary">
-          <div className="analytics-summary-metric analytics-summary-metric-primary">
-            <dt>Applied</dt>
-            <dd>{analytics?.totals.applied ?? "-"}</dd>
-          </div>
-          <div className="analytics-summary-metric analytics-summary-metric-primary">
-            <dt>Replies</dt>
-            <dd>{analytics?.totals.reply ?? "-"}</dd>
-          </div>
-          <div className="analytics-summary-metric analytics-summary-metric-primary">
-            <dt>Interviews</dt>
-            <dd>{analytics?.totals.interview ?? "-"}</dd>
-          </div>
-          <div className="analytics-summary-metric analytics-summary-metric-primary">
-            <dt>Offers</dt>
-            <dd>{analytics?.totals.offer ?? "-"}</dd>
-          </div>
-          <div className="analytics-summary-metric analytics-summary-metric-secondary">
-            <dt>Median response</dt>
-            <dd>
-              {analytics
-                ? formatDuration(
-                    analytics.timeToResponse.medianMinutes,
-                    analytics.timeToResponse.n,
-                    analytics.minSample,
-                  )
-                : "-"}
-            </dd>
-          </div>
-          <div className="analytics-summary-metric analytics-summary-metric-secondary">
-            <dt>Suggestions accepted</dt>
-            <dd>
-              {analytics
-                ? formatAcceptance(
-                    analytics.suggestionAccuracy.acceptanceRate,
-                    analytics.suggestionAccuracy.n,
-                    analytics.minSample,
-                  )
-                : "-"}
-            </dd>
-          </div>
-        </dl>
-        <SmallSampleNotice {...(analytics ? { minSample: analytics.minSample } : {})} />
-        <DimensionBreakdownPanel
-          analytics={analytics}
-          dimension={dimension}
-          loading={analyticsQuery.isFetching}
-        />
-      </section>
+          </CardTitle>
+          <CardAction className="analytics-toolbar">
+            <ToggleGroup
+              className="analytics-dimension-toggle"
+              type="single"
+              value={dimension}
+              aria-label="Outcome analytics dimension"
+              onValueChange={(next) => {
+                if (isAnalyticsDimension(next)) setDimension(next);
+              }}
+            >
+              {DIMENSION_OPTIONS.map((option) => (
+                <ToggleGroupItem
+                  key={option.value}
+                  value={option.value}
+                  aria-label={`Break down outcomes by ${option.label.toLowerCase()}`}
+                >
+                  {option.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            <Select
+              items={[...DIMENSION_OPTIONS]}
+              value={dimension}
+              onValueChange={(next) => {
+                if (isAnalyticsDimension(next)) setDimension(next);
+              }}
+            >
+              <SelectTrigger className="analytics-dimension-select" aria-label="Outcome analytics dimension">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent alignItemWithTrigger={false} side="bottom">
+                <SelectGroup>
+                  {DIMENSION_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </CardAction>
+        </CardHeader>
+        <CardContent className="analytics-content">
+          {message ? (
+            <Alert variant="destructive" className="analytics-error">
+              <AlertTitle>Outcome analytics could not be loaded</AlertTitle>
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          ) : null}
+          <dl className="analytics-summary-strip" aria-label="Outcome summary">
+            <div className="analytics-summary-metric analytics-summary-metric-primary">
+              <dt>Applied</dt>
+              <dd>{analytics?.totals.applied ?? "-"}</dd>
+            </div>
+            <div className="analytics-summary-metric analytics-summary-metric-primary">
+              <dt>Replies</dt>
+              <dd>{analytics?.totals.reply ?? "-"}</dd>
+            </div>
+            <div className="analytics-summary-metric analytics-summary-metric-primary">
+              <dt>Interviews</dt>
+              <dd>{analytics?.totals.interview ?? "-"}</dd>
+            </div>
+            <div className="analytics-summary-metric analytics-summary-metric-primary">
+              <dt>Offers</dt>
+              <dd>{analytics?.totals.offer ?? "-"}</dd>
+            </div>
+            <div className="analytics-summary-metric analytics-summary-metric-secondary">
+              <dt>Median response</dt>
+              <dd>
+                {analytics
+                  ? formatDuration(
+                      analytics.timeToResponse.medianMinutes,
+                      analytics.timeToResponse.n,
+                      analytics.minSample,
+                    )
+                  : "-"}
+              </dd>
+            </div>
+            <div className="analytics-summary-metric analytics-summary-metric-secondary">
+              <dt>Suggestions accepted</dt>
+              <dd>
+                {analytics
+                  ? formatAcceptance(
+                      analytics.suggestionAccuracy.acceptanceRate,
+                      analytics.suggestionAccuracy.n,
+                      analytics.minSample,
+                    )
+                  : "-"}
+              </dd>
+            </div>
+          </dl>
+          <SmallSampleNotice {...(analytics ? { minSample: analytics.minSample } : {})} />
+          <DimensionBreakdownPanel
+            analytics={analytics}
+            dimension={dimension}
+            loading={analyticsQuery.isFetching}
+          />
+        </CardContent>
+      </Card>
     </>
   );
 }

--- a/apps/web/src/views/analytics/OutcomeRateTable.tsx
+++ b/apps/web/src/views/analytics/OutcomeRateTable.tsx
@@ -5,12 +5,14 @@ import {
   FilterableDataGrid,
   type DataGridSortState,
 } from "../../shared/ui/filterable-data-grid.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
+import type { StatusTagTone } from "../../shared/ui/status-tokens.js";
 
 export interface OutcomeRateRow {
   readonly id: string;
   readonly dimension: string;
   readonly label: string;
-  readonly badgeTone: "info" | "muted" | "ok" | "warn";
+  readonly badgeTone: StatusTagTone;
   readonly applied: number;
   readonly reply: number;
   readonly interview: number;
@@ -62,7 +64,8 @@ const outcomeRateColumns: Array<DataGridColumn<OutcomeRateRow>> = [
       <span className="title-stack analytics-group-cell">
         <b>{row.label}</b>
         <span className="analytics-group-meta">
-          <span className={`tag ${row.badgeTone}`}>{row.dimension}</span> {countLabel(row)}
+          <StatusBadge tone={row.badgeTone}>{row.dimension}</StatusBadge>
+          <span>{countLabel(row)}</span>
         </span>
       </span>
     ),

--- a/apps/web/src/views/analytics/SmallSampleNotice.tsx
+++ b/apps/web/src/views/analytics/SmallSampleNotice.tsx
@@ -1,5 +1,7 @@
 import { IconInfoCircle } from "@tabler/icons-react";
 
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
+
 export interface SmallSampleNoticeProps {
   minSample?: number;
 }
@@ -10,13 +12,14 @@ export function SmallSampleNotice({ minSample }: SmallSampleNoticeProps) {
       ? "A rate appears once a group reaches the minimum sample count"
       : `A rate appears once a group has at least ${minSample} applications`;
   return (
-    <aside className="analytics-caption" aria-label="Analytics interpretation note">
-      <IconInfoCircle size={15} aria-hidden="true" />
-      <p>
+    <Alert className="analytics-caption" aria-label="Analytics interpretation note">
+      <IconInfoCircle aria-hidden="true" />
+      <AlertTitle>How to read these outcomes</AlertTitle>
+      <AlertDescription>
         Descriptive associations from your own recorded outcomes — not causal claims. Recorded outcomes from
         canonical rows only. {sampleText}; smaller groups show counts only. Analytics never
         enter scoring, ranking, or apply eligibility.
-      </p>
-    </aside>
+      </AlertDescription>
+    </Alert>
   );
 }

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -36,10 +36,12 @@ import { useResumeReviewDraftQuery } from "../../contexts/operations/hooks/useRe
 import { useResumeTemplatesQuery } from "../../contexts/profile/hooks/useResumeTemplatesQuery.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { MarkdownDocument } from "../../shared/ui/MarkdownDocument.js";
 import { PageHead } from "../../shared/ui/page-head.js";
 import type { PdfAuditLineSelection, PdfAuditLineTarget } from "../../shared/ui/PdfPreviewViewer.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 import { JobDetailDrawer } from "../jobs/JobDetailDrawer.js";
 import "../../styles/redesign-apply-review.css";
 
@@ -391,9 +393,9 @@ function ApplyAuditFacts({ item }: { readonly item: ApplyReviewQueueItem }) {
           <dt>{group.label}</dt>
           <dd>
             {group.facts.map((fact) => (
-              <span className={`tag ${factTone(fact)}`} key={`${group.label}:${fact.code}:${fact.detail ?? ""}`}>
+              <StatusBadge tone={factTone(fact)} key={`${group.label}:${fact.code}:${fact.detail ?? ""}`}>
                 {fact.detail ? `${fact.label}: ${fact.detail}` : fact.label}
-              </span>
+              </StatusBadge>
             ))}
           </dd>
         </div>
@@ -458,7 +460,7 @@ function ApplyReviewQueue({
               <span className="meta">
                 {item.company} · {item.source}
               </span>
-              <span className={`tag ${status.tone}`}>{status.label}</span>
+              <StatusBadge tone={status.tone}>{status.label}</StatusBadge>
             </button>
           );
         })}
@@ -501,10 +503,10 @@ function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) 
                       <div className="apply-review-ideal-requirement-head">
                         <b>{requirement.text}</b>
                         <span>
-                          {tier ? <span className="tag muted">{tier}</span> : null}
+                          {tier ? <span className="apply-review-requirement-meta">{tier}</span> : null}
                           {weight ? (
                             <span
-                              className="tag muted"
+                              className="apply-review-requirement-meta"
                               title="Relative priority from job-post analysis, not a match score"
                             >
                               {weight}
@@ -518,25 +520,25 @@ function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) 
                       >
                         <div>
                           <span>Candidate fit</span>
-                          <b className={`tag ${fit.tone}`} title={fit.title}>
+                          <StatusBadge tone={fit.tone} title={fit.title}>
                             {fit.label}
-                          </b>
+                          </StatusBadge>
                         </div>
                         <div>
                           <span>Tailoring action</span>
-                          <b className={`tag ${tailoring.tone}`} title={tailoring.title}>
+                          <StatusBadge tone={tailoring.tone} title={tailoring.title}>
                             {tailoring.label}
-                          </b>
+                          </StatusBadge>
                         </div>
                         <div>
                           <span>Resume coverage</span>
-                          <b className={`tag ${coverage.tone}`} title={coverage.title}>
+                          <StatusBadge tone={coverage.tone} title={coverage.title}>
                             {coverage.label}
-                          </b>
+                          </StatusBadge>
                           {requirement.coverage.state === "covered" ? (
-                            <b className="tag muted">
+                            <StatusBadge tone="muted">
                               {formatBulletCount(requirement.coverage.bulletCount)}
-                            </b>
+                            </StatusBadge>
                           ) : null}
                         </div>
                       </div>
@@ -595,7 +597,7 @@ function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) 
                 <dt>{group.label}</dt>
                 <dd>
                   {group.values.map((value) => (
-                    <span className="tag muted" key={value}>
+                    <span className="apply-review-evidence-token" key={value}>
                       {value}
                     </span>
                   ))}
@@ -607,7 +609,7 @@ function RequirementEvidence({ item }: { readonly item: ApplyReviewQueueItem }) 
               <dd>
                 {item.position.missing.length ? (
                   item.position.missing.map((value) => (
-                    <span className="tag muted" key={value}>
+                    <span className="apply-review-evidence-token" key={value}>
                       {value}
                     </span>
                   ))
@@ -686,8 +688,8 @@ function RequirementLedAuditPanel({
     >
       <h3>Requirement-led tailoring audit</h3>
       <div className="apply-review-audit-summary" aria-label="Requirement-led audit summary">
-        <span className={`tag ${audit.uncoveredRequirements.length ? "warn" : "ok"}`}>{coveredLabel}</span>
-        {audit.reviewBlockers.length ? <span className="tag warn">{reviewBlockerLabel}</span> : null}
+        <StatusBadge tone={audit.uncoveredRequirements.length ? "warn" : "ok"}>{coveredLabel}</StatusBadge>
+        {audit.reviewBlockers.length ? <StatusBadge tone="warn">{reviewBlockerLabel}</StatusBadge> : null}
       </div>
       <BulletOverflowAudit overflows={audit.bulletLimitOverflows} />
       <RevisionAudit
@@ -718,9 +720,9 @@ function AuditTagGroup({
       <span>{label}</span>
       <span>
         {values.map((value) => (
-          <span className={`tag ${tone}`} key={`${label}:${value}`}>
+          <StatusBadge tone={tone} key={`${label}:${value}`}>
             {formatValue(value)}
-          </span>
+          </StatusBadge>
         ))}
       </span>
     </div>
@@ -785,21 +787,21 @@ function RevisionAudit({
       {shippedFit ? (
         <div className="apply-review-audit-shipped-fit" aria-label="Shipped grounded fit">
           {shippedFit.mustHaveCoverage !== null ? (
-            <span className="tag muted">
+            <StatusBadge tone="muted">
               Must-have coverage: {Math.round(shippedFit.mustHaveCoverage * 100)}%
-            </span>
+            </StatusBadge>
           ) : null}
-          <span className={`tag ${shippedFit.coverageBasis === "grounded_shipped_text_v1" ? "ok" : "warn"}`}>
+          <StatusBadge tone={shippedFit.coverageBasis === "grounded_shipped_text_v1" ? "ok" : "warn"}>
             {shippedFit.coverageBasis === "grounded_shipped_text_v1"
               ? "grounded (shipped text)"
               : "judge-claimed (legacy)"}
-          </span>
+          </StatusBadge>
           {shippedFit.score !== null ? (
-            <span className="tag muted">Shipped fit: {formatScoreValue(shippedFit.score)}/10</span>
+            <StatusBadge tone="muted">Shipped fit: {formatScoreValue(shippedFit.score)}/10</StatusBadge>
           ) : null}
-          <span className={`tag ${shippedFit.passed ? "ok" : "warn"}`}>
+          <StatusBadge tone={shippedFit.passed ? "ok" : "warn"}>
             {shippedFit.passed ? "meets revision gate" : "below revision gate"}
-          </span>
+          </StatusBadge>
           <AuditTagGroup
             label={shippedFitFindingsLabel(shippedFit)}
             values={shippedFit.warnings}
@@ -810,22 +812,22 @@ function RevisionAudit({
       ) : null}
       {revision ? (
         <div className="apply-review-audit-revision">
-          <span className={`tag ${revision.thresholdFailed || revision.reviewBlocked ? "warn" : "ok"}`}>
+          <StatusBadge tone={revision.thresholdFailed || revision.reviewBlocked ? "warn" : "ok"}>
             Fit gate: {formatScoreValue(revision.score)}/10
-          </span>
-          <span className={`tag ${revision.coverageBasis === "grounded_shipped_text_v1" ? "ok" : "warn"}`}>
+          </StatusBadge>
+          <StatusBadge tone={revision.coverageBasis === "grounded_shipped_text_v1" ? "ok" : "warn"}>
             {revision.coverageBasis === "grounded_shipped_text_v1" ? "grounded" : "judge-claimed (legacy)"}
-          </span>
+          </StatusBadge>
           {revision.mustHaveCoverage !== null ? (
-            <span className="tag muted">
+            <StatusBadge tone="muted">
               {shippedFit ? "Gate-recorded coverage" : "Must-have coverage"}:{" "}
               {Math.round(revision.mustHaveCoverage * 100)}%
-            </span>
+            </StatusBadge>
           ) : null}
           {revision.revisionsUsed !== null && revision.maxRevisionAttempts !== null ? (
-            <span className="tag muted">
+            <StatusBadge tone="muted">
               Revisions used: {revision.revisionsUsed} of {revision.maxRevisionAttempts}
-            </span>
+            </StatusBadge>
           ) : null}
           {revision.reason ? <p className="meta">{formatAuditMessage(revision.reason)}</p> : null}
           <AuditTagGroup label="Prioritized fixes" values={revision.prioritizedFixes} tone="muted" />
@@ -1214,10 +1216,8 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
               <b>{item.fitScore ?? "–"}</b>
               <span>fit</span>
             </span>
-            <span className={`apply-review-inline-state ${status.tone}`}>
-              {status.label}
-            </span>
-            {reviewState ? <span className="apply-review-inline-state muted">{reviewState}</span> : null}
+            <StatusBadge tone={status.tone}>{status.label}</StatusBadge>
+            {reviewState ? <StatusBadge tone="muted">{reviewState}</StatusBadge> : null}
           </div>
           <div className="apply-review-selected-facts">
             <CompensationSummaryStrip
@@ -1233,7 +1233,10 @@ function SelectedReview({ item }: { readonly item: ApplyReviewQueueItem }) {
             />
             <ApplyAuditFacts item={item} />
             {templateMutationError ? (
-              <span className="apply-review-inline-state warn">{templateMutationError}</span>
+              <Alert variant="destructive" className="apply-review-inline-alert">
+                <AlertTitle>Resume template could not be updated</AlertTitle>
+                <AlertDescription>{templateMutationError}</AlertDescription>
+              </Alert>
             ) : null}
           </div>
         </div>
@@ -1382,7 +1385,12 @@ export function ApplyReviewView({
         subtitle={`${readyCount} ready · ${preparingCount} preparing · ${repairCount} need repair`}
       />
       <section className="apply-review-surface">
-        {queueError ? <div className="banner inline">{queueError}</div> : null}
+        {queueError ? (
+          <Alert variant="destructive" className="apply-review-queue-alert">
+            <AlertTitle>Application review queue could not be loaded</AlertTitle>
+            <AlertDescription>{queueError}</AlertDescription>
+          </Alert>
+        ) : null}
         {queue.isFetching && !queue.data ? <Empty title="Loading review queue." /> : null}
         {queue.data && selected ? (
           <div className="apply-review-shell">

--- a/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
+++ b/apps/web/src/views/artifacts/ArtifactDetailPanel.tsx
@@ -1,5 +1,4 @@
 import type { ArtifactSummary } from "@jobctrl/contracts";
-import { IconX } from "@tabler/icons-react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -11,10 +10,9 @@ import { artifactStatusTone } from "../../contexts/materials/lib/artifact-status
 import { useArtifactDetailQuery } from "../../contexts/operations/hooks/useArtifactDetailQuery.js";
 import { useArtifactsListQuery } from "../../contexts/operations/hooks/useArtifactsListQuery.js";
 import type { ArtifactsListInput } from "../../contexts/operations/types.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { usePorts } from "../../shared/providers/PortsProvider.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { DetailDrawer } from "../../shared/ui/detail-drawer-backdrop.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { PdfPreviewViewer } from "../../shared/ui/PdfPreviewViewer.js";
 import { Section } from "../../shared/ui/section.js";
@@ -24,10 +22,16 @@ export interface ArtifactDetailPanelProps {
 }
 
 function isPreviewablePdfArtifact(type: string, localPath: string): boolean {
-  return type.toLowerCase().endsWith("_pdf") || localPath.toLowerCase().endsWith(".pdf");
+  return (
+    type.toLowerCase().endsWith("_pdf") ||
+    localPath.toLowerCase().endsWith(".pdf")
+  );
 }
 
-function artifactPreviewCacheKey(createdAt: string | null, sizeBytes: number | null): string {
+function artifactPreviewCacheKey(
+  createdAt: string | null,
+  sizeBytes: number | null,
+): string {
   return `${createdAt ?? "unknown"}:${sizeBytes ?? "unknown"}`;
 }
 
@@ -35,7 +39,9 @@ function isSuppressed(status: string): boolean {
   return status.toLowerCase() === "suppressed";
 }
 
-function artifactComparisonListInput(type: string | null | undefined): ArtifactsListInput {
+function artifactComparisonListInput(
+  type: string | null | undefined,
+): ArtifactsListInput {
   const input: ArtifactsListInput = {
     pageSize: 200,
     sort: "created_at",
@@ -61,7 +67,9 @@ function comparableArtifacts(
 }
 
 function artifactOptionLabel(artifact: ArtifactSummary): string {
-  const template = artifact.resumeTemplate?.effective.templateName ?? artifact.resumeTemplate?.effective.templateId;
+  const template =
+    artifact.resumeTemplate?.effective.templateName ??
+    artifact.resumeTemplate?.effective.templateId;
   const created = formatDateTime(artifact.createdAt);
   return [artifact.status, template, created].filter(Boolean).join(" / ");
 }
@@ -74,16 +82,21 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   const close = useCallback(() => {
     void navigate({ to: "/artifacts", search });
   }, [navigate, search]);
-  useEscapeKey(true, close);
 
-  const { data: detail, error: queryError } = useArtifactDetailQuery(artifactId);
+  const { data: detail, error: queryError } =
+    useArtifactDetailQuery(artifactId);
   const comparisonListInput = useMemo(
     () => artifactComparisonListInput(detail?.artifact.type),
     [detail?.artifact.type],
   );
-  const comparisonList = useArtifactsListQuery(comparisonListInput, { enabled: Boolean(detail) });
+  const comparisonList = useArtifactsListQuery(comparisonListInput, {
+    enabled: Boolean(detail),
+  });
   const comparisonCandidates = useMemo(
-    () => (detail ? comparableArtifacts(detail.artifact, comparisonList.data?.items ?? []) : []),
+    () =>
+      detail
+        ? comparableArtifacts(detail.artifact, comparisonList.data?.items ?? [])
+        : [],
     [comparisonList.data?.items, detail],
   );
   const [comparisonArtifactId, setComparisonArtifactId] = useState<string>("");
@@ -91,166 +104,183 @@ export function ArtifactDetailPanel({ artifactId }: ArtifactDetailPanelProps) {
   const errorMessage =
     queryError instanceof Error
       ? queryError.message
-      : openArtifact.error?.message ?? "";
+      : (openArtifact.error?.message ?? "");
 
   useEffect(() => {
     setComparisonArtifactId((current) =>
       comparisonCandidates.some((candidate) => candidate.artifactId === current)
         ? current
-        : comparisonCandidates[0]?.artifactId ?? "",
+        : (comparisonCandidates[0]?.artifactId ?? ""),
     );
   }, [artifactId, comparisonCandidates]);
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer artifact-detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Artifact details"
-      >
-        <button
-          aria-label="Close artifact details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          <IconX aria-hidden="true" size={18} stroke={1.8} />
-        </button>
-        {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
-        {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
-        {detail ? (
-          <>
-            <div className="drawer-head">
-              <span>
-                <span
-                  className={`tag ${artifactStatusTone(detail.artifact.status)}`}
-                  title={artifactStatusDescription(detail.artifact.status)}
+    <DetailDrawer
+      className="artifact-detail-drawer"
+      description="Inspect the selected artifact, its audit details, comparison, and preview."
+      onDismiss={close}
+      title="Artifact details"
+    >
+      {errorMessage && !detail ? <Empty title={errorMessage} /> : null}
+      {!detail && !errorMessage ? <Empty title="Loading artifact." /> : null}
+      {detail ? (
+        <>
+          <div className="drawer-head">
+            <span>
+              <span
+                className={`tag ${artifactStatusTone(detail.artifact.status)}`}
+                title={artifactStatusDescription(detail.artifact.status)}
+              >
+                {detail.artifact.status}
+              </span>
+            </span>
+            <span>
+              <small>{detail.artifact.company}</small>
+              <h2>{detail.artifact.title || detail.artifact.type}</h2>
+              <p>
+                {detail.artifact.type} · created{" "}
+                {formatDateTime(detail.artifact.createdAt)}
+              </p>
+            </span>
+          </div>
+          <div className="artifact-detail-layout">
+            <div className="artifact-detail-sidebar">
+              <Section title="Artifact details">
+                {isSuppressed(detail.artifact.status) ? (
+                  <div className="banner inline">
+                    This artifact is historical audit material and is not active
+                    apply-ready material.
+                  </div>
+                ) : null}
+                <dl className="detail-list">
+                  <div>
+                    <dt>Status</dt>
+                    <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
+                  </div>
+                  <div>
+                    <dt>Artifact id</dt>
+                    <dd className="mono">{detail.artifact.artifactId}</dd>
+                  </div>
+                  <div>
+                    <dt>Job</dt>
+                    <dd>{detail.artifact.jobKey || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Local path</dt>
+                    <dd className="mono">{detail.artifact.localPath || "-"}</dd>
+                  </div>
+                  <div>
+                    <dt>Size</dt>
+                    <dd>{detail.artifact.size}</dd>
+                  </div>
+                </dl>
+                <button
+                  className="tab on"
+                  type="button"
+                  disabled={
+                    openArtifact.isPending ||
+                    detail.artifact.status === "missing"
+                  }
+                  onClick={() =>
+                    openArtifact.mutate({
+                      artifactId: detail.artifact.artifactId,
+                    })
+                  }
                 >
-                  {detail.artifact.status}
-                </span>
-              </span>
-              <span>
-                <small>{detail.artifact.company}</small>
-                <h2>{detail.artifact.title || detail.artifact.type}</h2>
-                <p>
-                  {detail.artifact.type} · created {formatDateTime(detail.artifact.createdAt)}
-                </p>
-              </span>
+                  {openArtifact.isPending
+                    ? "opening"
+                    : isDemo
+                      ? "preview in browser"
+                      : "open"}
+                </button>
+                <button
+                  className="tab"
+                  type="button"
+                  disabled={!detail.artifact.jobKey}
+                  onClick={() =>
+                    void navigate({
+                      to: "/jobs/$jobId",
+                      params: { jobId: detail.artifact.jobKey },
+                    })
+                  }
+                >
+                  open related job
+                </button>
+              </Section>
+              <TailoringExplanationSection
+                explanation={detail.tailoringExplanation}
+              />
+              <Section title="Artifact comparison">
+                {comparisonList.isFetching && !comparisonList.data ? (
+                  <p className="meta">Loading comparable artifacts.</p>
+                ) : null}
+                {comparisonCandidates.length ? (
+                  <>
+                    <label className="field compact artifact-comparison-picker">
+                      <span>Compare with</span>
+                      <select
+                        value={comparisonArtifactId}
+                        onChange={(event) =>
+                          setComparisonArtifactId(event.currentTarget.value)
+                        }
+                      >
+                        {comparisonCandidates.map((candidate) => (
+                          <option
+                            key={candidate.artifactId}
+                            value={candidate.artifactId}
+                          >
+                            {artifactOptionLabel(candidate)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                    <ArtifactComparison
+                      leftArtifactId={detail.artifact.artifactId}
+                      leftLabel="Selected"
+                      rightArtifactId={comparisonArtifactId || null}
+                      rightLabel="Comparison"
+                      showTitle={false}
+                    />
+                  </>
+                ) : (
+                  <Empty title="No other artifact for this job and type was found in the current artifact list." />
+                )}
+              </Section>
             </div>
-            <div className="artifact-detail-layout">
-              <div className="artifact-detail-sidebar">
-                <Section title="Artifact details">
-                  {isSuppressed(detail.artifact.status) ? (
-                    <div className="banner inline">
-                      This artifact is historical audit material and is not active apply-ready material.
-                    </div>
-                  ) : null}
-                  <dl className="detail-list">
-                    <div>
-                      <dt>Status</dt>
-                      <dd>{artifactStatusDescription(detail.artifact.status)}</dd>
-                    </div>
-                    <div>
-                      <dt>Artifact id</dt>
-                      <dd className="mono">{detail.artifact.artifactId}</dd>
-                    </div>
-                    <div>
-                      <dt>Job</dt>
-                      <dd>{detail.artifact.jobKey || "-"}</dd>
-                    </div>
-                    <div>
-                      <dt>Local path</dt>
-                      <dd className="mono">{detail.artifact.localPath || "-"}</dd>
-                    </div>
-                    <div>
-                      <dt>Size</dt>
-                      <dd>{detail.artifact.size}</dd>
-                    </div>
-                  </dl>
-                  <button
-                    className="tab on"
-                    type="button"
-                    disabled={openArtifact.isPending || detail.artifact.status === "missing"}
-                    onClick={() => openArtifact.mutate({ artifactId: detail.artifact.artifactId })}
-                  >
-                    {openArtifact.isPending
-                      ? "opening"
-                      : isDemo
-                        ? "preview in browser"
-                        : "open"}
-                  </button>
-                  <button
-                    className="tab"
-                    type="button"
-                    disabled={!detail.artifact.jobKey}
-                    onClick={() =>
-                      void navigate({
-                        to: "/jobs/$jobId",
-                        params: { jobId: detail.artifact.jobKey },
-                      })
-                    }
-                  >
-                    open related job
-                  </button>
-                </Section>
-                <TailoringExplanationSection explanation={detail.tailoringExplanation} />
-                <Section title="Artifact comparison">
-                  {comparisonList.isFetching && !comparisonList.data ? (
-                    <p className="meta">Loading comparable artifacts.</p>
-                  ) : null}
-                  {comparisonCandidates.length ? (
-                    <>
-                      <label className="field compact artifact-comparison-picker">
-                        <span>Compare with</span>
-                        <select
-                          value={comparisonArtifactId}
-                          onChange={(event) => setComparisonArtifactId(event.currentTarget.value)}
-                        >
-                          {comparisonCandidates.map((candidate) => (
-                            <option key={candidate.artifactId} value={candidate.artifactId}>
-                              {artifactOptionLabel(candidate)}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
-                      <ArtifactComparison
-                        leftArtifactId={detail.artifact.artifactId}
-                        leftLabel="Selected"
-                        rightArtifactId={comparisonArtifactId || null}
-                        rightLabel="Comparison"
-                        showTitle={false}
-                      />
-                    </>
-                  ) : (
-                    <Empty title="No other artifact for this job and type was found in the current artifact list." />
+            {isPreviewablePdfArtifact(
+              detail.artifact.type,
+              detail.artifact.localPath,
+            ) ? (
+              <section
+                className="artifact-preview-panel"
+                aria-label="Artifact PDF preview"
+              >
+                <PdfPreviewViewer
+                  cacheKey={artifactPreviewCacheKey(
+                    detail.artifact.createdAt,
+                    detail.artifact.sizeBytes,
                   )}
-                </Section>
-              </div>
-              {isPreviewablePdfArtifact(detail.artifact.type, detail.artifact.localPath) ? (
-                <section className="artifact-preview-panel" aria-label="Artifact PDF preview">
-                  <PdfPreviewViewer
-                    cacheKey={artifactPreviewCacheKey(
+                  loadingMessage="The artifact PDF is loading into the in-app preview."
+                  loadingTitle="Rendering artifact PDF."
+                  openLabel="open PDF"
+                  pageAltPrefix={detail.artifact.title || detail.artifact.type}
+                  title="Artifact preview"
+                  url={api.artifactPreviewPdfUrl(
+                    detail.artifact.artifactId,
+                    artifactPreviewCacheKey(
                       detail.artifact.createdAt,
                       detail.artifact.sizeBytes,
-                    )}
-                    loadingMessage="The artifact PDF is loading into the in-app preview."
-                    loadingTitle="Rendering artifact PDF."
-                    openLabel="open PDF"
-                    pageAltPrefix={detail.artifact.title || detail.artifact.type}
-                    title="Artifact preview"
-                    url={api.artifactPreviewPdfUrl(
-                      detail.artifact.artifactId,
-                      artifactPreviewCacheKey(detail.artifact.createdAt, detail.artifact.sizeBytes),
-                    )}
-                  />
-                </section>
-              ) : null}
-            </div>
-            {errorMessage ? <div className="banner inline">{errorMessage}</div> : null}
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+                    ),
+                  )}
+                />
+              </section>
+            ) : null}
+          </div>
+          {errorMessage ? (
+            <div className="banner inline">{errorMessage}</div>
+          ) : null}
+        </>
+      ) : null}
+    </DetailDrawer>
   );
 }

--- a/apps/web/src/views/dashboard/ActiveRunsCard.tsx
+++ b/apps/web/src/views/dashboard/ActiveRunsCard.tsx
@@ -1,12 +1,36 @@
 import { useNavigate } from "@tanstack/react-router";
 
-import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
 import type { WorkflowRunSummary } from "../../contexts/operations/types.js";
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
+import type { StatusTagTone } from "../../shared/ui/status-tokens.js";
 
 const ACTIVE_RUN_LIMIT = 8;
+
+const ACTIVE_RUN_TONE = {
+  canceled: "muted",
+  captcha: "warn",
+  dry_run_complete: "muted",
+  expired: "danger",
+  failed: "danger",
+  in_progress: "info",
+  login_issue: "warn",
+  manual: "warn",
+  starting: "info",
+  succeeded: "ok",
+  terminated: "danger",
+  timed_out: "danger",
+} satisfies Record<WorkflowRunSummary["status"], StatusTagTone>;
+
+function activeRunStatusLabel(status: WorkflowRunSummary["status"]): string {
+  if (status === "dry_run_complete") {
+    return "dry-run complete";
+  }
+  return status.replaceAll("_", " ");
+}
 
 export interface ActiveRunsCardProps {
   runs: readonly WorkflowRunSummary[];
@@ -20,7 +44,12 @@ export function ActiveRunsCard({ runs, loading, error }: ActiveRunsCardProps) {
   return (
     <section className="card">
       <CardHeader title="Active runs" meta={`${visibleRuns.length} shown`} />
-      {error ? <div className="banner inline">{error}</div> : null}
+      {error ? (
+        <Alert variant="destructive" className="dashboard-inline-alert">
+          <AlertTitle>Active runs unavailable</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
       <div className="rows">
         {visibleRuns.length ? (
           visibleRuns.map((run) => (
@@ -35,7 +64,9 @@ export function ActiveRunsCard({ runs, loading, error }: ActiveRunsCardProps) {
                 })
               }
             >
-              <RunStatusBadge status={run.status} />
+              <StatusBadge tone={ACTIVE_RUN_TONE[run.status]}>
+                {activeRunStatusLabel(run.status)}
+              </StatusBadge>
               <span className="title-stack">
                 <b>{run.title || run.workflowType || "Workflow"}</b>
                 <span>{run.company || run.workflowType || run.workflowId}</span>

--- a/apps/web/src/views/dashboard/ApplyRunsCard.tsx
+++ b/apps/web/src/views/dashboard/ApplyRunsCard.tsx
@@ -4,6 +4,7 @@ import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 import { StatusDot } from "../../shared/ui/status-dot.js";
 import { applyRunDotState } from "./apply-run-dot-state.js";
 
@@ -34,7 +35,7 @@ export function ApplyRunsCard({ summary }: ApplyRunsCardProps) {
                   {run.company} · {formatDateTime(run.startedAt)}
                 </span>
               </span>
-              {run.dryRun ? <span className="tag info">dry-run</span> : null}
+              {run.dryRun ? <StatusBadge tone="info">dry-run</StatusBadge> : null}
             </button>
           ))
         ) : (

--- a/apps/web/src/views/dashboard/DashboardView.tsx
+++ b/apps/web/src/views/dashboard/DashboardView.tsx
@@ -2,6 +2,7 @@ import { OutcomeSuggestionsPanel } from "../../contexts/apply/components/Applica
 import { useApplicationOutcomesQuery } from "../../contexts/operations/hooks/useApplicationOutcomesQuery.js";
 import { useDashboardSummaryQuery } from "../../contexts/operations/hooks/useDashboardSummaryQuery.js";
 import { useWorkflowRunsListQuery } from "../../contexts/operations/hooks/useWorkflowRunsListQuery.js";
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { PageHead } from "../../shared/ui/page-head.js";
@@ -44,8 +45,18 @@ export function DashboardView() {
         subtitle="Pipeline health, outcomes, active work, and the decisions that need attention."
       />
       {summary ? <KpiGrid summary={summary} /> : <KpiSkeleton />}
-      {message ? <div className="banner">{message}</div> : null}
-      {outcomesError ? <div className="banner">{outcomesError}</div> : null}
+      {message ? (
+        <Alert variant="destructive" className="dashboard-error-alert">
+          <AlertTitle>Dashboard unavailable</AlertTitle>
+          <AlertDescription>{message}</AlertDescription>
+        </Alert>
+      ) : null}
+      {outcomesError ? (
+        <Alert variant="destructive" className="dashboard-error-alert">
+          <AlertTitle>Outcome suggestions unavailable</AlertTitle>
+          <AlertDescription>{outcomesError}</AlertDescription>
+        </Alert>
+      ) : null}
       {summary ? (
         <div className="dashboard-stack">
           <div className="dashboard-ops">

--- a/apps/web/src/views/dashboard/DigestPanel.tsx
+++ b/apps/web/src/views/dashboard/DigestPanel.tsx
@@ -6,6 +6,7 @@ import {
   type DailyDigest,
 } from "../../contexts/operations/index.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
+import { Alert, AlertDescription, AlertTitle } from "../../shared/ui/alert.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 
@@ -122,8 +123,18 @@ export function DigestPanel() {
   return (
     <section className="card digest-panel">
       <CardHeader title="Daily digest" meta={meta} />
-      {digest.error instanceof Error ? <div className="banner inline">{digest.error.message}</div> : null}
-      {acknowledgeError ? <div className="banner inline">{acknowledgeError}</div> : null}
+      {digest.error instanceof Error ? (
+        <Alert variant="destructive" className="dashboard-inline-alert">
+          <AlertTitle>Daily digest unavailable</AlertTitle>
+          <AlertDescription>{digest.error.message}</AlertDescription>
+        </Alert>
+      ) : null}
+      {acknowledgeError ? (
+        <Alert variant="destructive" className="dashboard-inline-alert">
+          <AlertTitle>Could not mark the digest reviewed</AlertTitle>
+          <AlertDescription>{acknowledgeError}</AlertDescription>
+        </Alert>
+      ) : null}
       {data ? (
         <>
           <div className="digest-list">

--- a/apps/web/src/views/dashboard/Funnel.tsx
+++ b/apps/web/src/views/dashboard/Funnel.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import type { DashboardSummary, Stage } from "../../contexts/operations/types.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { SegmentBar } from "../../shared/ui/segment-bar.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 import { kpiSearchFor } from "./KpiGrid.js";
 
 export interface FunnelProps {
@@ -113,8 +114,12 @@ export function Funnel({ summary }: FunnelProps) {
               ]}
             />
             <span className="legend">
-              {stage.failed ? <span className="danger">{stage.failed} failed</span> : null}
-              {stage.blocked ? <span className="warn">{stage.blocked} blocked</span> : null}
+              {stage.failed ? (
+                <StatusBadge tone="danger">{stage.failed} failed</StatusBadge>
+              ) : null}
+              {stage.blocked ? (
+                <StatusBadge tone="warn">{stage.blocked} blocked</StatusBadge>
+              ) : null}
               {stage.running ? <span>{stage.running} running</span> : null}
               <span>{stage.pending} pending</span>
               {stage.diagnostic ? <span>{stage.diagnostic}</span> : null}

--- a/apps/web/src/views/dashboard/RecentActivityCard.tsx
+++ b/apps/web/src/views/dashboard/RecentActivityCard.tsx
@@ -4,12 +4,14 @@ import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
+import type { StatusTagTone } from "../../shared/ui/status-tokens.js";
 
 const RECENT_ACTIVITY_LIMIT = 8;
 
 type Activity = DashboardSummary["activity"][number];
 
-function activityTone(activity: Activity): string {
+function activityTone(activity: Activity): StatusTagTone {
   const level = activity.level.trim().toLowerCase();
   if (level === "error") return "danger";
   if (level === "warn" || level === "warning") return "warn";
@@ -46,9 +48,7 @@ export function RecentActivityCard({ summary }: { summary: DashboardSummary }) {
                 })
               }
             >
-              <span className={`tag ${activityTone(entry)}`}>
-                {entry.level}
-              </span>
+              <StatusBadge tone={activityTone(entry)}>{entry.level}</StatusBadge>
               <span className="title-stack">
                 <b>{entry.message}</b>
                 <span>

--- a/apps/web/src/views/dashboard/SourceHealthCard.tsx
+++ b/apps/web/src/views/dashboard/SourceHealthCard.tsx
@@ -2,6 +2,7 @@ import { SourcePolitenessBadges } from "../../contexts/discovery/components/Sour
 import type { DashboardSummary } from "../../contexts/operations/types.js";
 import { CardHeader } from "../../shared/ui/card-header.js";
 import { Empty } from "../../shared/ui/empty.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 import { StatusDot } from "../../shared/ui/status-dot.js";
 import type { StatusDotState } from "../../shared/ui/status-tokens.js";
 
@@ -48,7 +49,7 @@ export function SourceHealthCard({ summary }: SourceHealthCardProps) {
                 />
               </span>
               {source.consecutiveFailures ? (
-                <span className="tag danger">{source.consecutiveFailures} fails</span>
+                <StatusBadge tone="danger">{source.consecutiveFailures} fails</StatusBadge>
               ) : null}
             </div>
           ))

--- a/apps/web/src/views/dashboard/WorkStatusCard.tsx
+++ b/apps/web/src/views/dashboard/WorkStatusCard.tsx
@@ -1,10 +1,17 @@
 import { useNavigate } from "@tanstack/react-router";
 
 import type { DashboardSummary } from "../../contexts/operations/types.js";
-import { CardHeader } from "../../shared/ui/card-header.js";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "../../shared/ui/card.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { RelativeTime } from "../../shared/ui/relative-time.js";
-import { StatCard } from "../../shared/ui/stat-card.js";
+import { Separator } from "../../shared/ui/separator.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 import { kpiSearchFor } from "./KpiGrid.js";
 
 function formatThreshold(seconds: number): string {
@@ -18,62 +25,69 @@ export function WorkStatusCard({ summary }: { summary: DashboardSummary }) {
   const navigate = useNavigate();
   const { work } = summary;
   return (
-    <section className="card">
-      <CardHeader
-        title="Work status"
-        meta={`${work.active} active · ${work.stuck} stuck`}
-      />
-      <div className="grid grid-cols-2 gap-3 p-4">
-        <StatCard
-          className="work-status-stat"
-          label="Active work"
-          value={work.active}
-          delta="queued or moving"
-        />
-        <StatCard
-          className="work-status-stat"
-          label="Stuck work"
-          value={work.stuck}
-          valueTone={work.stuck ? "down" : undefined}
-          delta={
-            work.stuck
-              ? `worker unavailable · stale over ${formatThreshold(work.stuckAfterSeconds)}`
-              : `no stuck work over ${formatThreshold(work.stuckAfterSeconds)}`
-          }
-        />
-      </div>
-      <div className="rows">
-        {work.stuckItems.length ? (
-          work.stuckItems.map((item) => (
-            <button
-              key={`${item.jobKey}:${item.stage}`}
-              type="button"
-              className="mini-row clickable-row"
-              onClick={() =>
-                void navigate({
-                  to: "/jobs/$jobId",
-                  params: { jobId: item.jobKey },
-                  search: kpiSearchFor("all"),
-                })
-              }
-            >
-              <span className="tag danger">stuck</span>
-              <span className="title-stack">
-                <b>{item.title}</b>
-                <span>
-                  {item.company} · {item.stage}
+    <Card className="card work-status-card">
+      <CardHeader className="card-hd">
+        <CardTitle>
+          <h2>Work status</h2>
+        </CardTitle>
+        <CardAction>
+          <span className="meta">
+            {work.active} active · {work.stuck} stuck
+          </span>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="work-status-content">
+        <dl className="work-status-metrics" aria-label="Work status summary">
+          <div className="work-status-metric">
+            <dt>Active work</dt>
+            <dd>{work.active}</dd>
+            <span>queued or moving</span>
+          </div>
+          <Separator orientation="vertical" className="work-status-metric-separator" />
+          <div className="work-status-metric" data-attention={work.stuck ? "true" : "false"}>
+            <dt>Stuck work</dt>
+            <dd>{work.stuck}</dd>
+            <span>
+              {work.stuck
+                ? `worker unavailable · stale over ${formatThreshold(work.stuckAfterSeconds)}`
+                : `no stuck work over ${formatThreshold(work.stuckAfterSeconds)}`}
+            </span>
+          </div>
+        </dl>
+        <Separator />
+        <div className="rows">
+          {work.stuckItems.length ? (
+            work.stuckItems.map((item) => (
+              <button
+                key={`${item.jobKey}:${item.stage}`}
+                type="button"
+                className="mini-row clickable-row"
+                onClick={() =>
+                  void navigate({
+                    to: "/jobs/$jobId",
+                    params: { jobId: item.jobKey },
+                    search: kpiSearchFor("all"),
+                  })
+                }
+              >
+                <StatusBadge tone="danger">stuck</StatusBadge>
+                <span className="title-stack">
+                  <b>{item.title}</b>
+                  <span>
+                    {item.company} · {item.stage}
+                  </span>
                 </span>
-              </span>
-              <RelativeTime
-                value={item.updatedAt}
-                fallback="timestamp missing"
-              />
-            </button>
-          ))
-        ) : (
-          <Empty title="No stuck work." />
-        )}
-      </div>
-    </section>
+                <RelativeTime
+                  value={item.updatedAt}
+                  fallback="timestamp missing"
+                />
+              </button>
+            ))
+          ) : (
+            <Empty title="No stuck work." />
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/web/src/views/debug/ActivityDetailDrawer.tsx
+++ b/apps/web/src/views/debug/ActivityDetailDrawer.tsx
@@ -1,11 +1,9 @@
-import { IconX } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { useActivityEventQuery } from "../../contexts/operations/hooks/useActivityEventQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { DetailDrawer } from "../../shared/ui/detail-drawer-backdrop.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 import { activityLevelTone } from "./activity-tone.js";
@@ -19,67 +17,57 @@ export function ActivityDetailDrawer({ eventId }: ActivityDetailDrawerProps) {
   const close = useCallback(() => {
     void navigate({ to: "/debug" });
   }, [navigate]);
-  useEscapeKey(true, close);
 
   const { data: activity } = useActivityEventQuery(eventId);
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Activity details"
-      >
-        <button
-          aria-label="Close activity details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          <IconX aria-hidden="true" size={18} stroke={1.8} />
-        </button>
-        {!activity ? (
-          <Empty title={`Activity event ${eventId} is no longer in the recent list.`} />
-        ) : (
-          <>
-            <div className="drawer-head">
-              <span className={`tag ${activityLevelTone(activity.level)}`}>
-                {activity.level}
-              </span>
-              <span>
-                <small>{activity.stage}</small>
-                <h2>{activity.message}</h2>
-                <p>{formatDateTime(activity.at)}</p>
-              </span>
-            </div>
-            <Section title="Event details">
-              <dl className="detail-list">
-                <div>
-                  <dt>Event id</dt>
-                  <dd className="mono">{activity.eventId}</dd>
-                </div>
-                <div>
-                  <dt>Stage</dt>
-                  <dd>{activity.stage}</dd>
-                </div>
-                <div>
-                  <dt>Level</dt>
-                  <dd>{activity.level}</dd>
-                </div>
-                <div>
-                  <dt>Timestamp</dt>
-                  <dd>{formatDateTime(activity.at)}</dd>
-                </div>
-                <div>
-                  <dt>Message</dt>
-                  <dd>{activity.message}</dd>
-                </div>
-              </dl>
-            </Section>
-          </>
-        )}
-      </div>
-    </DetailDrawerBackdrop>
+    <DetailDrawer
+      description="Inspect the selected activity event and its lifecycle metadata."
+      onDismiss={close}
+      title="Activity details"
+    >
+      {!activity ? (
+        <Empty
+          title={`Activity event ${eventId} is no longer in the recent list.`}
+        />
+      ) : (
+        <>
+          <div className="drawer-head">
+            <span className={`tag ${activityLevelTone(activity.level)}`}>
+              {activity.level}
+            </span>
+            <span>
+              <small>{activity.stage}</small>
+              <h2>{activity.message}</h2>
+              <p>{formatDateTime(activity.at)}</p>
+            </span>
+          </div>
+          <Section title="Event details">
+            <dl className="detail-list">
+              <div>
+                <dt>Event id</dt>
+                <dd className="mono">{activity.eventId}</dd>
+              </div>
+              <div>
+                <dt>Stage</dt>
+                <dd>{activity.stage}</dd>
+              </div>
+              <div>
+                <dt>Level</dt>
+                <dd>{activity.level}</dd>
+              </div>
+              <div>
+                <dt>Timestamp</dt>
+                <dd>{formatDateTime(activity.at)}</dd>
+              </div>
+              <div>
+                <dt>Message</dt>
+                <dd>{activity.message}</dd>
+              </div>
+            </dl>
+          </Section>
+        </>
+      )}
+    </DetailDrawer>
   );
 }

--- a/apps/web/src/views/jobs/JobAuditTriage.tsx
+++ b/apps/web/src/views/jobs/JobAuditTriage.tsx
@@ -4,6 +4,7 @@ import type { JobDetail } from "../../contexts/operations/types.js";
 import { ResetStaleScoresButton } from "../../contexts/scoring/components/ResetStaleScoresButton.js";
 import { ScoreCorrectionControl } from "../../contexts/scoring/components/ScoreCorrectionControl.js";
 import { ScoreStalenessBadge } from "../../contexts/scoring/components/ScoreStalenessBadge.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 
 export interface JobAuditTriageProps {
   detail: JobDetail;
@@ -77,12 +78,12 @@ export function JobAuditTriage({ detail }: JobAuditTriageProps) {
                     <dt>{group.label}</dt>
                     <dd>
                       {group.facts.map((fact) => (
-                        <span
-                          className={`tag ${factTone(fact)}`}
+                        <StatusBadge
+                          tone={factTone(fact)}
                           key={`${group.label}:${fact.code}:${fact.detail ?? ""}`}
                         >
                           {fact.detail ? `${fact.label}: ${fact.detail}` : fact.label}
-                        </span>
+                        </StatusBadge>
                       ))}
                     </dd>
                   </div>
@@ -161,9 +162,9 @@ function TagGroup({
       <span>{label}</span>
       <div>
         {values.map((value) => (
-          <span className={`tag ${tone}`} key={value}>
+          <StatusBadge tone={tone} key={value}>
             {value}
-          </span>
+          </StatusBadge>
         ))}
       </div>
     </div>

--- a/apps/web/src/views/jobs/JobDetailDrawer.tsx
+++ b/apps/web/src/views/jobs/JobDetailDrawer.tsx
@@ -1,6 +1,5 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
 import type { JobAuditEntry, StageSummary } from "@jobctrl/contracts";
-import { IconX } from "@tabler/icons-react";
 import { Link } from "@tanstack/react-router";
 
 import { ApplyHistory } from "../../contexts/apply/components/ApplyHistory.js";
@@ -20,8 +19,7 @@ import { useJobDetailQuery } from "../../contexts/operations/hooks/useJobDetailQ
 import { JobActions } from "../../contexts/pipeline/components/JobActions.js";
 import { StageTimeline } from "../../contexts/pipeline/components/StageTimeline.js";
 import { RescoreJobButton } from "../../contexts/scoring/components/RescoreCurrentPolicyButton.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { DetailDrawer } from "../../shared/ui/detail-drawer-backdrop.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 import { JobAuditTriage } from "./JobAuditTriage.js";
@@ -72,23 +70,28 @@ function JobAuditHistorySection({
 
 function RequirementFitMissingCallout({ jobId }: { readonly jobId: string }) {
   return (
-    <section className="section requirement-fit-missing" aria-label="Requirement fit not assessed">
+    <section
+      className="section requirement-fit-missing"
+      aria-label="Requirement fit not assessed"
+    >
       <div>
         <h3>Requirement fit not assessed</h3>
         <p className="muted">
-          This job has employer requirements, but the stored score predates requirement-level fit.
-          Re-score it to produce candidate fit, score impact, and tailoring actions for each
-          requirement.
+          This job has employer requirements, but the stored score predates
+          requirement-level fit. Re-score it to produce candidate fit, score
+          impact, and tailoring actions for each requirement.
         </p>
       </div>
-      <RescoreJobButton className="tab on" jobId={jobId} label="re-score requirement fit" />
+      <RescoreJobButton
+        className="tab on"
+        jobId={jobId}
+        label="re-score requirement fit"
+      />
     </section>
   );
 }
 
 export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
-  useEscapeKey(true, onClose);
-
   const { data: detail, error: detailError } = useJobDetailQuery(jobId);
   const discoverySettingsQuery = useDiscoverySettingsQuery();
   const applyApprovalRequired =
@@ -99,128 +102,128 @@ export function JobDetailDrawer({ jobId, onClose }: JobDetailDrawerProps) {
   );
 
   return (
-    <DetailDrawerBackdrop onDismiss={onClose}>
-      <div className="drawer job-detail-drawer" role="dialog" aria-modal="true" aria-label="Job details">
-        <button
-          aria-label="Close job details"
-          className="drawer-close"
-          type="button"
-          onClick={onClose}
-        >
-          <IconX aria-hidden="true" size={18} stroke={1.8} />
-        </button>
-        {errorMessage ? <Empty title={errorMessage} /> : null}
-        {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
-        {detail ? (
-          <>
-            <JobOverview detail={detail} />
-            <div className="job-detail-drawer-content">
-              <div className="job-detail-top-actions">
-                <JobActions
-                  jobId={detail.job.jobKey}
-                  currentStage={detail.job.currentSubstage}
-                  canRetryStage={canRetryStage(currentSubstage)}
-                  canRunCurrentStage={canRunCurrentStage(currentSubstage)}
-                  canRetailor={detail.artifacts.length > 0}
-                  applyApprovalRequired={applyApprovalRequired}
-                />
-                <Link
-                  aria-label={`Open Apply Review for ${detail.job.title}`}
-                  className="tab"
-                  search={{ jobKey: detail.job.jobKey }}
-                  to="/apply-review"
-                >
-                  Open Apply Review
-                </Link>
-                <Link
-                  aria-label={`Open evidence map for ${detail.job.title}`}
-                  className="tab"
-                  search={{ q: "", entry: "", job: detail.job.jobKey }}
-                  to="/evidence-map"
-                >
-                  Evidence map
-                </Link>
-              </div>
-              <div className="job-detail-workspace job-detail-drawer-main">
-                <main className="job-detail-primary">
-                  <JobAuditTriage detail={detail} />
-                  <section className="section job-detail-description">
-                    <div className="job-detail-section-heading">
-                      <h3>Description</h3>
-                      <span>Original posting text</span>
-                    </div>
-                    <JobDescription text={detail.job.descriptionPreview} />
-                  </section>
-                  <CompensationAuditSection
-                    jobId={detail.job.jobKey}
-                    summary={detail.job.compensationSummary}
-                    audit={detail.compensationAudit}
-                    fallbackSalary={detail.job.salary}
-                  />
-                  {detail.employerAnalysis && !detail.requirementFitReport ? (
-                    <RequirementFitMissingCallout jobId={detail.job.jobKey} />
-                  ) : null}
-                  <EmployerAnalysisPanel
-                    analysis={detail.employerAnalysis}
-                    className="section job-detail-role-analysis"
-                    requirementFitReport={detail.requirementFitReport}
-                  />
-                  <InterviewPrepPanel
-                    jobId={detail.job.jobKey}
-                    prep={detail.interviewPrep}
-                    reflectionContent={
-                      detail.interviewPrep ? (
-                        <InterviewReflectionPanel
-                          jobId={detail.job.jobKey}
-                          prepGeneration={detail.interviewPrep.generation}
-                        />
-                      ) : null
-                    }
-                  />
-                </main>
-                <aside className="job-detail-sidebar" aria-label="Job preparation and audit">
-                  <Section title="Preparation diagnostics">
-                    <StageTimeline
-                      jobId={detail.job.jobKey}
-                      stages={preparationStages(detail.stages)}
-                    />
-                  </Section>
-                  <Section title="Active artifacts">
-                    {detail.artifacts.length ? (
-                      detail.artifacts.map((artifact) => (
-                        <div className="mini-row" key={artifact.artifactId}>
-                          <ArtifactStatusBadge status={artifact.status} />
-                          <span>{artifact.type}</span>
-                          <code>{artifact.localPath}</code>
-                          <OpenArtifactButton
-                            artifactId={artifact.artifactId}
-                            disabled={artifact.status === "missing"}
-                          />
-                        </div>
-                      ))
-                    ) : (
-                      <Empty title="No active apply-ready artifacts." />
-                    )}
-                  </Section>
-                  <JobAuditHistorySection entries={detail.auditHistory} />
-                </aside>
-              </div>
-              <div className="job-detail-follow-up">
-                <Section title="Apply history">
-                  <ApplyHistory jobId={detail.job.jobKey} />
-                </Section>
-                <Section title="Application outcomes">
-                  <JobOutcomePanel jobId={detail.job.jobKey} />
-                </Section>
-                <JobContactsPanel
-                  jobId={detail.job.jobKey}
-                  {...(detail.job.company ? { employer: detail.job.company } : {})}
-                />
-              </div>
+    <DetailDrawer
+      className="job-detail-drawer"
+      description="Review the selected job, its evidence, preparation state, materials, and outcomes."
+      onDismiss={onClose}
+      title="Job details"
+    >
+      {errorMessage ? <Empty title={errorMessage} /> : null}
+      {!detail && !errorMessage ? <Empty title="Loading job." /> : null}
+      {detail ? (
+        <>
+          <JobOverview detail={detail} />
+          <div className="job-detail-drawer-content">
+            <div className="job-detail-top-actions">
+              <JobActions
+                jobId={detail.job.jobKey}
+                currentStage={detail.job.currentSubstage}
+                canRetryStage={canRetryStage(currentSubstage)}
+                canRunCurrentStage={canRunCurrentStage(currentSubstage)}
+                canRetailor={detail.artifacts.length > 0}
+                applyApprovalRequired={applyApprovalRequired}
+              />
+              <Link
+                aria-label={`Open Apply Review for ${detail.job.title}`}
+                className="tab"
+                search={{ jobKey: detail.job.jobKey }}
+                to="/apply-review"
+              >
+                Open Apply Review
+              </Link>
+              <Link
+                aria-label={`Open evidence map for ${detail.job.title}`}
+                className="tab"
+                search={{ q: "", entry: "", job: detail.job.jobKey }}
+                to="/evidence-map"
+              >
+                Evidence map
+              </Link>
             </div>
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+            <div className="job-detail-workspace job-detail-drawer-main">
+              <main className="job-detail-primary">
+                <JobAuditTriage detail={detail} />
+                <section className="section job-detail-description">
+                  <div className="job-detail-section-heading">
+                    <h3>Description</h3>
+                    <span>Original posting text</span>
+                  </div>
+                  <JobDescription text={detail.job.descriptionPreview} />
+                </section>
+                <CompensationAuditSection
+                  jobId={detail.job.jobKey}
+                  summary={detail.job.compensationSummary}
+                  audit={detail.compensationAudit}
+                  fallbackSalary={detail.job.salary}
+                />
+                {detail.employerAnalysis && !detail.requirementFitReport ? (
+                  <RequirementFitMissingCallout jobId={detail.job.jobKey} />
+                ) : null}
+                <EmployerAnalysisPanel
+                  analysis={detail.employerAnalysis}
+                  className="section job-detail-role-analysis"
+                  requirementFitReport={detail.requirementFitReport}
+                />
+                <InterviewPrepPanel
+                  jobId={detail.job.jobKey}
+                  prep={detail.interviewPrep}
+                  reflectionContent={
+                    detail.interviewPrep ? (
+                      <InterviewReflectionPanel
+                        jobId={detail.job.jobKey}
+                        prepGeneration={detail.interviewPrep.generation}
+                      />
+                    ) : null
+                  }
+                />
+              </main>
+              <aside
+                className="job-detail-sidebar"
+                aria-label="Job preparation and audit"
+              >
+                <Section title="Preparation diagnostics">
+                  <StageTimeline
+                    jobId={detail.job.jobKey}
+                    stages={preparationStages(detail.stages)}
+                  />
+                </Section>
+                <Section title="Active artifacts">
+                  {detail.artifacts.length ? (
+                    detail.artifacts.map((artifact) => (
+                      <div className="mini-row" key={artifact.artifactId}>
+                        <ArtifactStatusBadge status={artifact.status} />
+                        <span>{artifact.type}</span>
+                        <code>{artifact.localPath}</code>
+                        <OpenArtifactButton
+                          artifactId={artifact.artifactId}
+                          disabled={artifact.status === "missing"}
+                        />
+                      </div>
+                    ))
+                  ) : (
+                    <Empty title="No active apply-ready artifacts." />
+                  )}
+                </Section>
+                <JobAuditHistorySection entries={detail.auditHistory} />
+              </aside>
+            </div>
+            <div className="job-detail-follow-up">
+              <Section title="Apply history">
+                <ApplyHistory jobId={detail.job.jobKey} />
+              </Section>
+              <Section title="Application outcomes">
+                <JobOutcomePanel jobId={detail.job.jobKey} />
+              </Section>
+              <JobContactsPanel
+                jobId={detail.job.jobKey}
+                {...(detail.job.company
+                  ? { employer: detail.job.company }
+                  : {})}
+              />
+            </div>
+          </div>
+        </>
+      ) : null}
+    </DetailDrawer>
   );
 }

--- a/apps/web/src/views/jobs/JobOverview.tsx
+++ b/apps/web/src/views/jobs/JobOverview.tsx
@@ -1,5 +1,6 @@
 import type { JobDetail } from "../../contexts/operations/types.js";
 import { ScoreBadge } from "../../contexts/scoring/components/ScoreBadge.js";
+import { StatusBadge } from "../../shared/ui/status-badge.js";
 
 export interface JobOverviewProps {
   detail: JobDetail;
@@ -35,9 +36,9 @@ export function JobOverview({ detail }: JobOverviewProps) {
           </a>
           <div className="job-overview-readiness" aria-label="Apply readiness">
             <span className="job-overview-readiness-label">Apply readiness</span>
-            <span className={`tag ${auditTone(applyAudit.state)}`} title={applyAudit.summary}>
+            <StatusBadge tone={auditTone(applyAudit.state)} title={applyAudit.summary}>
               {applyAudit.label}
-            </span>
+            </StatusBadge>
           </div>
         </div>
       </div>

--- a/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
+++ b/apps/web/src/views/outreach/OutreachDetailDrawer.tsx
@@ -1,5 +1,4 @@
 import { JobCtrlApiError } from "@jobctrl/api-client";
-import { IconX } from "@tabler/icons-react";
 
 import { ContactDeleteButton } from "../../contexts/outreach/components/ContactDeleteButton.js";
 import { ContactEditButton } from "../../contexts/outreach/components/ContactEditButton.js";
@@ -7,9 +6,8 @@ import { ContactProvenanceList } from "../../contexts/outreach/components/Contac
 import { ContactRoleBadge } from "../../contexts/outreach/components/ContactRoleBadge.js";
 import { OutreachThreadPanel } from "../../contexts/outreach/components/OutreachThreadPanel.js";
 import { useContactDetailQuery } from "../../contexts/outreach/hooks/useContactDetailQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { DetailDrawer } from "../../shared/ui/detail-drawer-backdrop.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 
@@ -25,61 +23,54 @@ function detailErrorTitle(error: unknown): string {
   return error instanceof Error ? error.message : "";
 }
 
-export function OutreachDetailDrawer({ contactId, onClose }: OutreachDetailDrawerProps) {
-  useEscapeKey(true, onClose);
-
+export function OutreachDetailDrawer({
+  contactId,
+  onClose,
+}: OutreachDetailDrawerProps) {
   const { data, error } = useContactDetailQuery(contactId);
   const errorMessage = detailErrorTitle(error);
   const contact = data?.contact;
 
   return (
-    <DetailDrawerBackdrop onDismiss={onClose}>
-      <div
-        className="drawer detail-drawer contact-detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Contact details"
-      >
-        <button
-          aria-label="Close contact details"
-          className="drawer-close"
-          type="button"
-          onClick={onClose}
-        >
-          <IconX aria-hidden="true" size={18} stroke={1.8} />
-        </button>
-        {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
-        {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}
-        {contact ? (
-          <>
-            <div className="drawer-head">
-              <span>
-                <ContactRoleBadge role={contact.role} />
-              </span>
-              <span>
-                <small>{contact.employer ?? "No employer"}</small>
-                <h2>{contact.displayName}</h2>
-                <p>
-                  {contact.jobId ? `Linked job ${contact.jobId}` : "Not linked to a job"} · updated{" "}
-                  {formatDateTime(contact.updatedAt)}
-                </p>
-              </span>
-            </div>
-            <div className="contact-detail-actions">
-              <ContactEditButton contact={contact} />
-              <ContactDeleteButton
-                contactId={contact.contactId}
-                displayName={contact.displayName}
-                onDeleted={onClose}
-              />
-            </div>
-            <Section title="Facts and provenance">
-              <ContactProvenanceList attributes={contact.attributes} />
-            </Section>
-            <OutreachThreadPanel contactId={contact.contactId} />
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+    <DetailDrawer
+      className="contact-detail-drawer"
+      description="Review the selected contact's facts, provenance, and outreach history."
+      onDismiss={onClose}
+      title="Contact details"
+    >
+      {errorMessage && !contact ? <Empty title={errorMessage} /> : null}
+      {!contact && !errorMessage ? <Empty title="Loading contact." /> : null}
+      {contact ? (
+        <>
+          <div className="drawer-head">
+            <span>
+              <ContactRoleBadge role={contact.role} />
+            </span>
+            <span>
+              <small>{contact.employer ?? "No employer"}</small>
+              <h2>{contact.displayName}</h2>
+              <p>
+                {contact.jobId
+                  ? `Linked job ${contact.jobId}`
+                  : "Not linked to a job"}{" "}
+                · updated {formatDateTime(contact.updatedAt)}
+              </p>
+            </span>
+          </div>
+          <div className="contact-detail-actions">
+            <ContactEditButton contact={contact} />
+            <ContactDeleteButton
+              contactId={contact.contactId}
+              displayName={contact.displayName}
+              onDeleted={onClose}
+            />
+          </div>
+          <Section title="Facts and provenance">
+            <ContactProvenanceList attributes={contact.attributes} />
+          </Section>
+          <OutreachThreadPanel contactId={contact.contactId} />
+        </>
+      ) : null}
+    </DetailDrawer>
   );
 }

--- a/apps/web/src/views/runs/WorkflowRunDrawer.tsx
+++ b/apps/web/src/views/runs/WorkflowRunDrawer.tsx
@@ -1,12 +1,10 @@
-import { IconX } from "@tabler/icons-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { RunStatusBadge } from "../../contexts/apply/components/RunStatusBadge.js";
 import { useWorkflowRunDetailQuery } from "../../contexts/operations/hooks/useWorkflowRunDetailQuery.js";
-import { useEscapeKey } from "../../shared/hooks/useEscapeKey.js";
 import { formatDateTime } from "../../shared/lib/formatters.js";
-import { DetailDrawerBackdrop } from "../../shared/ui/detail-drawer-backdrop.js";
+import { DetailDrawer } from "../../shared/ui/detail-drawer-backdrop.js";
 import { Empty } from "../../shared/ui/empty.js";
 import { Section } from "../../shared/ui/section.js";
 
@@ -25,120 +23,111 @@ export function WorkflowRunDrawer({ runId }: WorkflowRunDrawerProps) {
   const close = useCallback(() => {
     void navigate({ to: "/runs" });
   }, [navigate]);
-  useEscapeKey(true, close);
 
   const { data: run, isLoading, error } = useWorkflowRunDetailQuery(runId);
   const message = error instanceof Error ? error.message : null;
   const notFound = !isLoading && !message && !run;
 
   return (
-    <DetailDrawerBackdrop onDismiss={close}>
-      <div
-        className="drawer detail-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Workflow run details"
-      >
-        <button
-          aria-label="Close workflow run details"
-          className="drawer-close"
-          type="button"
-          onClick={close}
-        >
-          <IconX aria-hidden="true" size={18} stroke={1.8} />
-        </button>
-        {message ? <Empty title={message} /> : null}
-        {!message && isLoading ? <Empty title="Loading workflow run." /> : null}
-        {notFound ? <Empty title="Workflow run not found." /> : null}
-        {run ? (
-          <>
-            <div className="drawer-head">
-              <RunStatusBadge status={run.status} />
-              <span>
-                <small>{run.workflowType || "workflow"}</small>
-                <h2>{run.title || run.workflowType || "Workflow run"}</h2>
-                <p>
-                  {run.status}
-                  {run.dryRun ? " · dry-run" : ""}
-                </p>
-              </span>
-            </div>
-            <Section title="Run details">
+    <DetailDrawer
+      description="Inspect the selected workflow run, failure details, and lifecycle timeline."
+      onDismiss={close}
+      title="Workflow run details"
+    >
+      {message ? <Empty title={message} /> : null}
+      {!message && isLoading ? <Empty title="Loading workflow run." /> : null}
+      {notFound ? <Empty title="Workflow run not found." /> : null}
+      {run ? (
+        <>
+          <div className="drawer-head">
+            <RunStatusBadge status={run.status} />
+            <span>
+              <small>{run.workflowType || "workflow"}</small>
+              <h2>{run.title || run.workflowType || "Workflow run"}</h2>
+              <p>
+                {run.status}
+                {run.dryRun ? " · dry-run" : ""}
+              </p>
+            </span>
+          </div>
+          <Section title="Run details">
+            <dl className="detail-list">
+              <div>
+                <dt>Workflow id</dt>
+                <dd className="mono">{run.workflowId}</dd>
+              </div>
+              <div>
+                <dt>Type</dt>
+                <dd>{run.workflowType || "-"}</dd>
+              </div>
+              <div>
+                <dt>Status</dt>
+                <dd>{run.status}</dd>
+              </div>
+              {run.jobKey ? (
+                <div>
+                  <dt>Job</dt>
+                  <dd>{run.title || run.jobKey}</dd>
+                </div>
+              ) : null}
+              <div>
+                <dt>Started</dt>
+                <dd>{formatDateTime(run.startedAt)}</dd>
+              </div>
+              <div>
+                <dt>Finished</dt>
+                <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : "-"}</dd>
+              </div>
+              {run.temporalRunId ? (
+                <div>
+                  <dt>Temporal run id</dt>
+                  <dd className="mono">{run.temporalRunId}</dd>
+                </div>
+              ) : null}
+            </dl>
+          </Section>
+          {run.errorMessage || run.errorCode ? (
+            <Section title="Failure">
               <dl className="detail-list">
-                <div>
-                  <dt>Workflow id</dt>
-                  <dd className="mono">{run.workflowId}</dd>
-                </div>
-                <div>
-                  <dt>Type</dt>
-                  <dd>{run.workflowType || "-"}</dd>
-                </div>
-                <div>
-                  <dt>Status</dt>
-                  <dd>{run.status}</dd>
-                </div>
-                {run.jobKey ? (
+                {run.errorCode ? (
                   <div>
-                    <dt>Job</dt>
-                    <dd>{run.title || run.jobKey}</dd>
+                    <dt>Error code</dt>
+                    <dd className="mono">{run.errorCode}</dd>
+                  </div>
+                ) : null}
+                {run.errorMessage ? (
+                  <div>
+                    <dt>Message</dt>
+                    <dd>{run.errorMessage}</dd>
                   </div>
                 ) : null}
                 <div>
-                  <dt>Started</dt>
-                  <dd>{formatDateTime(run.startedAt)}</dd>
+                  <dt>Retryable</dt>
+                  <dd>{run.retryable ? "yes" : "no"}</dd>
                 </div>
-                <div>
-                  <dt>Finished</dt>
-                  <dd>{run.finishedAt ? formatDateTime(run.finishedAt) : "-"}</dd>
-                </div>
-                {run.temporalRunId ? (
-                  <div>
-                    <dt>Temporal run id</dt>
-                    <dd className="mono">{run.temporalRunId}</dd>
-                  </div>
-                ) : null}
               </dl>
             </Section>
-            {run.errorMessage || run.errorCode ? (
-              <Section title="Failure">
-                <dl className="detail-list">
-                  {run.errorCode ? (
-                    <div>
-                      <dt>Error code</dt>
-                      <dd className="mono">{run.errorCode}</dd>
-                    </div>
-                  ) : null}
-                  {run.errorMessage ? (
-                    <div>
-                      <dt>Message</dt>
-                      <dd>{run.errorMessage}</dd>
-                    </div>
-                  ) : null}
-                  <div>
-                    <dt>Retryable</dt>
-                    <dd>{run.retryable ? "yes" : "no"}</dd>
-                  </div>
-                </dl>
-              </Section>
-            ) : null}
-            <Section title="Timeline">
-              {run.events.length === 0 ? (
-                <Empty title="No lifecycle events recorded yet." />
-              ) : (
-                <ol className="timeline">
-                  {run.events.map((event, index) => (
-                    <li key={`${event.eventType}-${index}`}>
-                      <span className="mono">{event.eventType}</span>
-                      <span className="muted"> {formatDateTime(event.occurredAt)}</span>
-                      {event.message ? <p>{event.message}</p> : null}
-                    </li>
-                  ))}
-                </ol>
-              )}
-            </Section>
-          </>
-        ) : null}
-      </div>
-    </DetailDrawerBackdrop>
+          ) : null}
+          <Section title="Timeline">
+            {run.events.length === 0 ? (
+              <Empty title="No lifecycle events recorded yet." />
+            ) : (
+              <ol className="timeline">
+                {run.events.map((event, index) => (
+                  <li key={`${event.eventType}-${index}`}>
+                    <span className="mono">{event.eventType}</span>
+                    <span className="muted">
+                      {" "}
+                      {formatDateTime(event.occurredAt)}
+                    </span>
+                    {event.message ? <p>{event.message}</p> : null}
+                  </li>
+                ))}
+              </ol>
+            )}
+          </Section>
+        </>
+      ) : null}
+    </DetailDrawer>
   );
 }


### PR DESCRIPTION
## Summary

- aligns the redesign with the installed shadcn Base UI Rhea primitives instead of retaining hand-built compatibility markup
- updates Card, Dialog, Sheet, Drawer, Alert, InputGroup, Select, Field, ToggleGroup, status, and route-workspace composition
- migrates profile forms, resume import, analytics, Apply Review, dashboard, job status, and routed detail drawers while preserving all existing fields, controls, audit facts, states, and actions
- replaces colored rounded status blobs with restrained shared dot-and-text status treatment and flattens nested card layouts
- preserves the selected neutral Rhea theme, Geist typography, and Tabler icons

## Stack

- Base: #462
- Earlier redesign: #458
- Pipeline operations: #459–#462
- Next: canonical documentation, then cumulative QA

## Validation

Focused checks for the High review fixes on #458 and #459 passed before those fixes were propagated through the stack. No build, broad test suite, browser pass, or cumulative QA was run for this cohesion layer; those remain intentionally deferred until canonical documentation is complete at the final stack tip.