### PR TITLE
feat(discovery): persist resumable search units

### DIFF
--- a/apps/api/src/db.ts
+++ b/apps/api/src/db.ts
@@ -9,7 +9,7 @@ export type SqliteValue = string | number | bigint | null;
 // writer that stamps ``PRAGMA user_version``; the API only reads it to fail
 // closed on a database written by a newer build. Bump both constants together
 // whenever the schema shape changes.
-export const SUPPORTED_SCHEMA_VERSION = 3;
+export const SUPPORTED_SCHEMA_VERSION = 4;
 
 export class IncompatibleSchemaVersionError extends Error {
   constructor(current: number) {

--- a/docs/plans/2026-07-17-resumable-jobstreaming-discovery-plan.md
+++ b/docs/plans/2026-07-17-resumable-jobstreaming-discovery-plan.md
@@ -24,6 +24,11 @@ typed provider failures, and explicit acknowledgement mechanics.
 
 ## Delivery stack
 
+- **Phase 1:** published as PR #468; focused verification and independent
+  review passed.
+- **Phase 2:** this stacked change.
+- **Phase 3:** pending on Phase 2.
+
 ### Phase 1 — provider boundary
 
 - Replace `python-jobspy` with the pinned JobStreaming 0.0.2 release.

--- a/workers/automation/src/jobctrl/database.py
+++ b/workers/automation/src/jobctrl/database.py
@@ -28,7 +28,7 @@ from jobctrl.config import DB_PATH, DEFAULTS, migrate_legacy_job_tables
 # the ninth-context canonical tables (``ensure_contact_tables``).
 # v3 (Discovery execution lineage): immutable Temporal execution/job membership
 # and the idempotently filled preparation work plan used by Operations.
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 
 class IncompatibleSchemaVersionError(RuntimeError):
@@ -287,6 +287,7 @@ def init_db(db_path: Path | str | None = None) -> sqlite3.Connection:
     ensure_operational_metric_tables(conn)
     ensure_source_observation_tables(conn)
     ensure_discovery_execution_tables(conn)
+    ensure_discovery_search_unit_tables(conn)
     ensure_discovery_control_tables(conn)
     ensure_discovery_settings_tables(conn)
     ensure_contact_tables(conn)
@@ -893,6 +894,7 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
             payload_json        TEXT,
             entity_kind         TEXT,
             entity_ref          TEXT,
+            idempotency_key     TEXT,
             FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
         )
     """)
@@ -904,6 +906,15 @@ def ensure_state_tables(conn: sqlite3.Connection | None = None) -> list[str]:
         conn.execute("ALTER TABLE job_events ADD COLUMN entity_kind TEXT")
     if "entity_ref" not in event_cols:
         conn.execute("ALTER TABLE job_events ADD COLUMN entity_ref TEXT")
+    if "idempotency_key" not in event_cols:
+        conn.execute("ALTER TABLE job_events ADD COLUMN idempotency_key TEXT")
+    conn.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_job_events_idempotency_key
+        ON job_events(idempotency_key)
+        WHERE idempotency_key IS NOT NULL
+        """
+    )
     conn.execute("""
         CREATE TABLE IF NOT EXISTS job_artifacts (
             artifact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -3077,6 +3088,100 @@ def ensure_discovery_execution_tables(conn: sqlite3.Connection | None = None) ->
     )
     conn.commit()
     return ["discovery_execution_jobs"]
+
+
+def ensure_discovery_search_unit_tables(
+    conn: sqlite3.Connection | None = None,
+) -> list[str]:
+    """Create caller-owned JobStreaming plans, checkpoints, and receipts.
+
+    A unit belongs to one exact Temporal Discover workflow/run. ``lease_epoch``
+    is the fencing token: reclaiming an unfinished unit increments it, so an
+    older activity attempt can no longer advance the checkpoint or accept a
+    result. Provider checkpoint JSON remains opaque at this layer.
+    """
+
+    if conn is None:
+        conn = get_connection()
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS discovery_search_units (
+            tenant_id              TEXT NOT NULL,
+            discover_workflow_id   TEXT NOT NULL,
+            discover_run_id        TEXT NOT NULL,
+            unit_id                TEXT NOT NULL,
+            ordinal                INTEGER NOT NULL CHECK (ordinal >= 0),
+            request_json           TEXT NOT NULL,
+            request_fingerprint    TEXT NOT NULL,
+            state                  TEXT NOT NULL DEFAULT 'pending'
+                CHECK (state IN ('pending', 'running', 'completed', 'skipped', 'failed', 'canceled')),
+            lease_owner            TEXT,
+            lease_attempt          INTEGER NOT NULL DEFAULT 0 CHECK (lease_attempt >= 0),
+            lease_epoch            INTEGER NOT NULL DEFAULT 0 CHECK (lease_epoch >= 0),
+            recovery_count         INTEGER NOT NULL DEFAULT 0 CHECK (recovery_count >= 0),
+            checkpoint_json        TEXT,
+            checkpoint_revision    INTEGER CHECK (checkpoint_revision >= 0),
+            last_error_code        TEXT,
+            last_error_type        TEXT,
+            last_error_retryable   INTEGER,
+            reset_checkpoint       INTEGER NOT NULL DEFAULT 0 CHECK (reset_checkpoint IN (0, 1)),
+            created_at             TEXT NOT NULL,
+            updated_at             TEXT NOT NULL,
+            completed_at           TEXT,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ),
+            UNIQUE (
+                tenant_id, discover_workflow_id, discover_run_id, ordinal
+            ),
+            CHECK (
+                (checkpoint_json IS NULL AND checkpoint_revision IS NULL)
+                OR (checkpoint_json IS NOT NULL AND checkpoint_revision IS NOT NULL)
+            )
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_search_units_state
+        ON discovery_search_units(
+            tenant_id, discover_workflow_id, discover_run_id, state, ordinal
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS discovery_search_unit_jobs (
+            tenant_id              TEXT NOT NULL,
+            discover_workflow_id   TEXT NOT NULL,
+            discover_run_id        TEXT NOT NULL,
+            unit_id                TEXT NOT NULL,
+            job_url                TEXT NOT NULL,
+            was_new                INTEGER NOT NULL CHECK (was_new IN (0, 1)),
+            accepted_at            TEXT NOT NULL,
+            PRIMARY KEY (
+                tenant_id, discover_workflow_id, discover_run_id, unit_id, job_url
+            ),
+            FOREIGN KEY (
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) REFERENCES discovery_search_units(
+                tenant_id, discover_workflow_id, discover_run_id, unit_id
+            ) ON DELETE CASCADE,
+            FOREIGN KEY (job_url) REFERENCES jobs(url) ON DELETE CASCADE
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_discovery_search_unit_jobs_execution
+        ON discovery_search_unit_jobs(
+            tenant_id, discover_workflow_id, discover_run_id, was_new
+        )
+        """
+    )
+    conn.commit()
+    return ["discovery_search_units", "discovery_search_unit_jobs"]
 
 
 def _backfill_one_observation_row(

--- a/workers/automation/src/jobctrl/discovery/jobspy.py
+++ b/workers/automation/src/jobctrl/discovery/jobspy.py
@@ -19,6 +19,7 @@ from jobctrl import config
 from jobctrl.database import get_connection, init_db, resurface_deleted_job
 from jobctrl.domain.discovery import JobMetadata, PostingUrl, SearchStrategy, Source
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import DiscoverySearchUnitLease
 from jobctrl.domain.discovery.identity import JobSourceObservation, normalize_observed_url
 from jobctrl.domain.discovery.source_registry import BROAD_BOARD_LEAD_POLICY
 from jobctrl.domain.ports.discovery import ScrapedJobPosting
@@ -86,9 +87,7 @@ def _scrape_with_retry(kwargs: dict, max_retries: int = 2, backoff: float = 5.0)
             scrape_legacy_options,
         )
     except ImportError as exc:
-        raise ImportError(
-            "jobstreaming 0.0.2 is not installed. Run the JobCtrl setup again."
-        ) from exc
+        raise ImportError("jobstreaming 0.0.2 is not installed. Run the JobCtrl setup again.") from exc
     return scrape_legacy_options(
         kwargs,
         max_retries=max_retries,
@@ -146,6 +145,7 @@ def store_jobspy_results(
     run_id: str = "jobspy",
     search_cfg: dict | None = None,
     discovery_execution: DiscoveryExecutionRef | None = None,
+    search_unit_lease: DiscoverySearchUnitLease | None = None,
 ) -> tuple[int, int]:
     """Store JobSpy DataFrame results into the DB. Returns (new, existing)."""
     now = datetime.now(timezone.utc).isoformat()
@@ -156,13 +156,19 @@ def store_jobspy_results(
     repository = SqliteJobRepository(
         conn,
         discovery_execution=discovery_execution,
-        source_family="jobspy" if discovery_execution is not None else None,
+        source_family=("jobspy" if discovery_execution is not None or search_unit_lease is not None else None),
+        search_unit_lease=search_unit_lease,
     )
-    use_case = DiscoverJobsUseCase(
-        repository=repository,
-        publisher=DurableJobEventPublisher(conn, stage="discover"),
-        acceptance_policy=acceptance_policy,
-    )
+    write_fence: Callable[[], None] | None = None
+    if search_unit_lease is not None:
+        from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+            SqliteDiscoverySearchUnitRepository,
+        )
+
+        search_units = SqliteDiscoverySearchUnitRepository(conn)
+
+        def write_fence() -> None:
+            search_units.fence_write(search_unit_lease)
 
     for _, row in df.iterrows():
         if limit > 0 and new >= limit:
@@ -212,6 +218,12 @@ def store_jobspy_results(
         # posting for future direct discovery.
         apply_url = _nullable_str(row.get("job_url_direct"))
         source_id = _jobspy_source_id(site_label)
+        provider_event_key = _nullable_str(row.get("jobstreaming_job_key")) or _jobspy_source_native_id(row, url)
+        consumption_prefix = _jobstreaming_consumption_prefix(
+            search_unit_lease,
+            source_id=source_id,
+            provider_event_key=provider_event_key,
+        )
         posting = _jobspy_posting_from_row(
             url=url,
             source_id=source_id,
@@ -240,6 +252,7 @@ def store_jobspy_results(
                 duplicate_url=url,
                 source=source_id,
                 observed_at=now,
+                write_fence=write_fence,
             )
             _record_jobspy_source_observation(
                 conn,
@@ -249,6 +262,12 @@ def store_jobspy_results(
                 run_id=run_id,
                 observed_at=now,
                 discovery_execution=discovery_execution,
+                search_unit_lease=search_unit_lease,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "JobSourceObserved",
+                ),
             )
             _learn_posting_source(
                 conn,
@@ -256,6 +275,11 @@ def store_jobspy_results(
                 posting_url=apply_url,
                 discovered_via_source_id=source_id,
                 observed_at=now,
+                write_fence=write_fence,
+                event_idempotency_prefix=_consumption_event_key(
+                    consumption_prefix,
+                    "learned-source",
+                ),
             )
             _refresh_existing_jobspy_job(
                 conn,
@@ -271,8 +295,23 @@ def store_jobspy_results(
                 application_url=apply_url,
                 detail_scraped_at=detail_scraped_at,
                 updated_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "JobMetadataUpdated",
+                ),
             )
-            _upsert_posted_compensation_fact(conn, job_url=duplicate_url, parsed_at=now)
+            _upsert_posted_compensation_fact(
+                conn,
+                job_url=duplicate_url,
+                parsed_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "CompensationFactsUpdated",
+                ),
+            )
+            _apply_write_fence(write_fence)
             resurface_deleted_job(conn, duplicate_url, resurfaced_at=now)
             existing += 1
             continue
@@ -285,6 +324,7 @@ def store_jobspy_results(
                 duplicate_url=url,
                 source=source_id,
                 observed_at=now,
+                write_fence=write_fence,
             )
             _record_jobspy_source_observation(
                 conn,
@@ -294,6 +334,12 @@ def store_jobspy_results(
                 run_id=run_id,
                 observed_at=now,
                 discovery_execution=discovery_execution,
+                search_unit_lease=search_unit_lease,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "JobSourceObserved",
+                ),
             )
             _learn_posting_source(
                 conn,
@@ -301,6 +347,11 @@ def store_jobspy_results(
                 posting_url=apply_url,
                 discovered_via_source_id=source_id,
                 observed_at=now,
+                write_fence=write_fence,
+                event_idempotency_prefix=_consumption_event_key(
+                    consumption_prefix,
+                    "learned-source",
+                ),
             )
             _refresh_existing_jobspy_job(
                 conn,
@@ -316,12 +367,42 @@ def store_jobspy_results(
                 application_url=apply_url,
                 detail_scraped_at=detail_scraped_at,
                 updated_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "JobMetadataUpdated",
+                ),
             )
-            _upsert_posted_compensation_fact(conn, job_url=stored_duplicate_url, parsed_at=now)
+            _upsert_posted_compensation_fact(
+                conn,
+                job_url=stored_duplicate_url,
+                parsed_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "CompensationFactsUpdated",
+                ),
+            )
+            _apply_write_fence(write_fence)
             resurface_deleted_job(conn, stored_duplicate_url, resurfaced_at=now)
             existing += 1
             continue
 
+        use_case = DiscoverJobsUseCase(
+            repository=repository,
+            publisher=DurableJobEventPublisher(
+                conn,
+                stage="discover",
+                write_fence=write_fence,
+                idempotency_prefix=_consumption_event_key(
+                    consumption_prefix,
+                    "ingest",
+                ),
+            ),
+            acceptance_policy=acceptance_policy,
+            observation_id_factory=((lambda: f"obs:{consumption_prefix}") if consumption_prefix is not None else None),
+            republish_canonical_identity=consumption_prefix is not None,
+        )
         summary = use_case.execute(
             tenant_id=LOCAL_TENANT,
             postings=(posting,),
@@ -342,18 +423,38 @@ def store_jobspy_results(
                 application_url=apply_url,
                 detail_scraped_at=detail_scraped_at,
                 updated_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "JobMetadataUpdated",
+                ),
             )
-            _upsert_posted_compensation_fact(conn, job_url=url, parsed_at=now)
+            _upsert_posted_compensation_fact(
+                conn,
+                job_url=url,
+                parsed_at=now,
+                write_fence=write_fence,
+                idempotency_key=_consumption_event_key(
+                    consumption_prefix,
+                    "CompensationFactsUpdated",
+                ),
+            )
             _learn_posting_source(
                 conn,
                 job_url=url,
                 posting_url=apply_url,
                 discovered_via_source_id=source_id,
                 observed_at=now,
+                write_fence=write_fence,
+                event_idempotency_prefix=_consumption_event_key(
+                    consumption_prefix,
+                    "learned-source",
+                ),
             )
         if summary.new_jobs > 0:
             new += 1
         elif summary.observed > 0 or summary.duplicates_linked > 0:
+            _apply_write_fence(write_fence)
             resurface_deleted_job(conn, url, resurfaced_at=now)
             existing += 1
 
@@ -385,17 +486,32 @@ def _jobspy_posting_from_row(
         source_id=source_id,
         source_native_id=source_native_id,
         canonical_url=url,
-        )
+    )
 
 
-def _upsert_posted_compensation_fact(conn: sqlite3.Connection, *, job_url: str, parsed_at: str) -> None:
+def _upsert_posted_compensation_fact(
+    conn: sqlite3.Connection,
+    *,
+    job_url: str,
+    parsed_at: str,
+    write_fence: Callable[[], None] | None = None,
+    idempotency_key: str | None = None,
+) -> None:
     from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
 
+    repository = SqlitePostedCompensationRepository(conn)
+    _apply_write_fence(write_fence)
     row = conn.execute("SELECT salary FROM jobs WHERE url = ?", (job_url,)).fetchone()
     if row is None:
         return
     salary = row["salary"] if isinstance(row, sqlite3.Row) else row[0]
-    SqlitePostedCompensationRepository(conn).parse_and_save_job_salary(job_url, salary, parsed_at=parsed_at)
+    repository.parse_and_save_job_salary(
+        job_url,
+        salary,
+        parsed_at=parsed_at,
+        event_idempotency_key=idempotency_key,
+        event_write_fence=write_fence,
+    )
 
 
 def _jobspy_source_native_id(row, url: str) -> str:
@@ -448,7 +564,10 @@ def _refresh_existing_jobspy_job(
     application_url: str | None,
     detail_scraped_at: str | None,
     updated_at: str,
+    write_fence: Callable[[], None] | None = None,
+    idempotency_key: str | None = None,
 ) -> None:
+    _apply_write_fence(write_fence)
     cursor = conn.execute(
         """
         UPDATE jobs SET
@@ -497,6 +616,7 @@ def _refresh_existing_jobspy_job(
                 "source": site,
             },
             occurred_at=updated_at,
+            idempotency_key=idempotency_key,
         )
 
 
@@ -507,6 +627,38 @@ def _nullable_str(value: object) -> str | None:
     if not text or text.casefold() in {"nan", "none", "nat", "<na>"}:
         return None
     return text
+
+
+def _apply_write_fence(write_fence: Callable[[], None] | None) -> None:
+    if write_fence is not None:
+        write_fence()
+
+
+def _jobstreaming_consumption_prefix(
+    lease: DiscoverySearchUnitLease | None,
+    *,
+    source_id: str,
+    provider_event_key: str,
+) -> str | None:
+    """Build a replay-stable key without exposing provider or query payloads."""
+
+    if lease is None:
+        return None
+    material = "\x1f".join(
+        (
+            lease.execution.tenant_id,
+            lease.execution.workflow_id,
+            lease.execution.temporal_run_id,
+            lease.unit_id,
+            source_id,
+            provider_event_key,
+        )
+    )
+    return "jobstreaming:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _consumption_event_key(prefix: str | None, event_type: str) -> str | None:
+    return f"{prefix}:{event_type}" if prefix is not None else None
 
 
 def _jobspy_source_id(source_label: str) -> str:
@@ -523,16 +675,18 @@ def _record_jobspy_source_observation(
     run_id: str,
     observed_at: str,
     discovery_execution: DiscoveryExecutionRef | None = None,
+    search_unit_lease: DiscoverySearchUnitLease | None = None,
+    write_fence: Callable[[], None] | None = None,
+    idempotency_key: str | None = None,
 ) -> None:
     normalized = normalize_observed_url(observed_url)
     source_native_id = normalized or observed_url
-    observation_id = "jobspy:" + hashlib.sha256(
-        f"{source_id}:{source_native_id}".encode("utf-8")
-    ).hexdigest()[:24]
+    observation_id = "jobspy:" + hashlib.sha256(f"{source_id}:{source_native_id}".encode("utf-8")).hexdigest()[:24]
     SqliteJobRepository(
         conn,
         discovery_execution=discovery_execution,
-        source_family="jobspy" if discovery_execution is not None else None,
+        source_family=("jobspy" if discovery_execution is not None or search_unit_lease is not None else None),
+        search_unit_lease=search_unit_lease,
     ).attach_source_observation(
         LOCAL_TENANT,
         JobId(job_url),
@@ -547,6 +701,7 @@ def _record_jobspy_source_observation(
     )
     from jobctrl.state import record_job_event
 
+    _apply_write_fence(write_fence)
     record_job_event(
         conn,
         job_url,
@@ -571,6 +726,7 @@ def _record_jobspy_source_observation(
             "observedAt": observed_at,
         },
         occurred_at=observed_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -581,6 +737,8 @@ def _learn_posting_source(
     posting_url: str | None,
     discovered_via_source_id: str,
     observed_at: str,
+    write_fence: Callable[[], None] | None = None,
+    event_idempotency_prefix: str | None = None,
 ) -> None:
     if not posting_url:
         return
@@ -594,6 +752,8 @@ def _learn_posting_source(
         posting_url=posting_url,
         discovered_via_source_id=discovered_via_source_id,
         observed_at=observed_at,
+        write_fence=write_fence,
+        event_idempotency_prefix=event_idempotency_prefix,
     )
 
 
@@ -690,16 +850,19 @@ def _find_content_duplicate_survivor(
         stored_employer = stored_company if stored_company else existing["site"]
         if not is_genuine_employer_identity(stored_employer):
             continue
-        if content_match_basis(
-            incoming_key=incoming_key,
-            incoming_description=description,
-            candidate_title=existing["title"],
-            candidate_employer=stored_employer,
-            candidate_descriptions=(
-                existing["listing_description"],
-                existing["enriched_description"],
-            ),
-        ) is not None:
+        if (
+            content_match_basis(
+                incoming_key=incoming_key,
+                incoming_description=description,
+                candidate_title=existing["title"],
+                candidate_employer=stored_employer,
+                candidate_descriptions=(
+                    existing["listing_description"],
+                    existing["enriched_description"],
+                ),
+            )
+            is not None
+        ):
             return str(existing["url"])
     return None
 
@@ -725,6 +888,7 @@ def _record_content_duplicate_link(
     duplicate_url: str,
     source: str,
     observed_at: str,
+    write_fence: Callable[[], None] | None = None,
 ) -> None:
     link_key = job_content_fingerprint(
         title=surviving_url,
@@ -733,6 +897,7 @@ def _record_content_duplicate_link(
     )
     if link_key is None:
         return
+    _apply_write_fence(write_fence)
     duplicate_link_id = "content:" + link_key[:32]
     normalized_url = normalize_observed_url(duplicate_url)
     conn.execute(
@@ -841,9 +1006,7 @@ def _run_one_search(
         if "linkedin" in other_sites:
             kwargs["linkedin_fetch_description"] = True
         try:
-            df, failures = _jobstreaming_frame_and_failures(
-                _scrape_with_retry(kwargs, max_retries=max_retries)
-            )
+            df, failures = _jobstreaming_frame_and_failures(_scrape_with_retry(kwargs, max_retries=max_retries))
             provider_errors += failures
             all_dfs.append(df)
         except ImportError:
@@ -868,9 +1031,7 @@ def _run_one_search(
         if proxy_config:
             gd_kwargs["proxies"] = [proxy_config.jobspy]
         try:
-            gd_df, failures = _jobstreaming_frame_and_failures(
-                _scrape_with_retry(gd_kwargs, max_retries=max_retries)
-            )
+            gd_df, failures = _jobstreaming_frame_and_failures(_scrape_with_retry(gd_kwargs, max_retries=max_retries))
             provider_errors += failures
             all_dfs.append(gd_df)
         except ImportError:
@@ -1038,9 +1199,7 @@ def search_jobs(
             min_interval_seconds=BROAD_BOARD_LEAD_POLICY.min_request_interval_seconds,
             max_concurrency=BROAD_BOARD_LEAD_POLICY.max_concurrent_requests_per_host,
         ):
-            df, provider_errors = _jobstreaming_frame_and_failures(
-                _scrape_with_retry(kwargs)
-            )
+            df, provider_errors = _jobstreaming_frame_and_failures(_scrape_with_retry(kwargs))
     except Exception as e:
         log.error("JobSpy search failed: %s", e)
         return {"error": str(e), "total": 0, "new": 0, "existing": 0, "errors": 1}
@@ -1194,9 +1353,7 @@ def _full_crawl(
             # outcome is durable even though we break out before the crawl's
             # normal end-of-run persistence.
             politeness_conn.commit()
-            log.warning(
-                "JobSpy per-run search-invocation budget exhausted after %d searches", completed
-            )
+            log.warning("JobSpy per-run search-invocation budget exhausted after %d searches", completed)
             break
         emit_progress(s, "JobSpy search started")
         with limiter.slot(

--- a/workers/automation/src/jobctrl/domain/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/domain/discovery/__init__.py
@@ -32,6 +32,14 @@ from jobctrl.domain.discovery.value_objects import (
     SearchStrategy,
     Source,
 )
+from jobctrl.domain.discovery.search_units import (
+    DISCOVERY_SEARCH_UNIT_STATES,
+    DiscoverySearchSpec,
+    DiscoverySearchUnit,
+    DiscoverySearchUnitLease,
+    DiscoverySearchUnitState,
+    search_unit_id,
+)
 from jobctrl.domain.discovery.source_registry import (
     BROAD_BOARD_LEAD_POLICY,
     SMART_EXTRACT_EXPERIMENTAL_POLICY,
@@ -82,6 +90,12 @@ __all__ = [
     "DiscoveryExecutionRef",
     "DiscoveryExecutionWorkPlanState",
     "DiscoveryPreparationStep",
+    "DISCOVERY_SEARCH_UNIT_STATES",
+    "DiscoverySearchSpec",
+    "DiscoverySearchUnit",
+    "DiscoverySearchUnitLease",
+    "DiscoverySearchUnitState",
+    "search_unit_id",
     "Employer",
     "JobMetadata",
     "PostingUrl",

--- a/workers/automation/src/jobctrl/domain/discovery/search_units.py
+++ b/workers/automation/src/jobctrl/domain/discovery/search_units.py
@@ -1,0 +1,201 @@
+"""Caller-owned discovery search units and fencing value objects."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+
+
+DiscoverySearchUnitState = Literal[
+    "pending",
+    "running",
+    "completed",
+    "skipped",
+    "failed",
+    "canceled",
+]
+
+DISCOVERY_SEARCH_UNIT_STATES: tuple[DiscoverySearchUnitState, ...] = (
+    "pending",
+    "running",
+    "completed",
+    "skipped",
+    "failed",
+    "canceled",
+)
+
+_SAFE_BOARD = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_SAFE_UNIT_ID = re.compile(r"^search-[0-9]{4}-[a-f0-9]{16}$")
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverySearchSpec:
+    """Immutable JobCtrl plan for one provider stream.
+
+    ``provider_location`` is what JobStreaming receives. ``target_location``
+    remains the user's original search location and owns post-fetch filtering;
+    they differ for Glassdoor's simplified location syntax.
+    """
+
+    query: str
+    provider_location: str
+    target_location: str
+    sites: tuple[str, ...]
+    results_per_site: int
+    hours_old: int | None
+    remote_only: bool
+    country_indeed: str
+    linkedin_fetch_description: bool = False
+    match_mode: str = "strict"
+    target_track: str = ""
+    seniority_floor: str = ""
+    accept_locations: tuple[str, ...] = ()
+    reject_locations: tuple[str, ...] = ()
+    local_accept_locations: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("query", self.query),
+            ("provider_location", self.provider_location),
+            ("target_location", self.target_location),
+            ("country_indeed", self.country_indeed),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field_name} must be a non-empty string")
+        if not self.sites:
+            raise ValueError("sites must contain at least one board")
+        if len(set(self.sites)) != len(self.sites):
+            raise ValueError("sites must be unique")
+        invalid_sites = [site for site in self.sites if not _SAFE_BOARD.fullmatch(site)]
+        if invalid_sites:
+            raise ValueError(f"invalid board name: {invalid_sites[0]}")
+        if self.results_per_site < 1:
+            raise ValueError("results_per_site must be positive")
+        if self.hours_old is not None and self.hours_old < 1:
+            raise ValueError("hours_old must be positive when supplied")
+        if self.match_mode not in {"strict", "recall"}:
+            raise ValueError("match_mode must be strict or recall")
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return the canonical JSON-compatible plan payload."""
+
+        return {
+            "schema_version": 1,
+            "query": self.query,
+            "provider_location": self.provider_location,
+            "target_location": self.target_location,
+            "sites": list(self.sites),
+            "results_per_site": self.results_per_site,
+            "hours_old": self.hours_old,
+            "remote_only": self.remote_only,
+            "country_indeed": self.country_indeed,
+            "linkedin_fetch_description": self.linkedin_fetch_description,
+            "match_mode": self.match_mode,
+            "target_track": self.target_track,
+            "seniority_floor": self.seniority_floor,
+            "accept_locations": list(self.accept_locations),
+            "reject_locations": list(self.reject_locations),
+            "local_accept_locations": list(self.local_accept_locations),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_payload(), sort_keys=True, separators=(",", ":"))
+
+    def fingerprint(self) -> str:
+        return hashlib.sha256(self.to_json().encode("utf-8")).hexdigest()
+
+    @classmethod
+    def from_json(cls, payload: str) -> DiscoverySearchSpec:
+        decoded = json.loads(payload)
+        if not isinstance(decoded, dict) or decoded.get("schema_version") != 1:
+            raise ValueError("unsupported discovery search spec schema")
+        return cls(
+            query=str(decoded.get("query") or ""),
+            provider_location=str(decoded.get("provider_location") or ""),
+            target_location=str(decoded.get("target_location") or ""),
+            sites=tuple(str(site) for site in decoded.get("sites") or ()),
+            results_per_site=int(decoded.get("results_per_site") or 0),
+            hours_old=(int(decoded["hours_old"]) if decoded.get("hours_old") is not None else None),
+            remote_only=bool(decoded.get("remote_only", False)),
+            country_indeed=str(decoded.get("country_indeed") or ""),
+            linkedin_fetch_description=bool(decoded.get("linkedin_fetch_description", False)),
+            match_mode=str(decoded.get("match_mode") or "strict"),
+            target_track=str(decoded.get("target_track") or ""),
+            seniority_floor=str(decoded.get("seniority_floor") or ""),
+            accept_locations=tuple(str(value) for value in decoded.get("accept_locations") or ()),
+            reject_locations=tuple(str(value) for value in decoded.get("reject_locations") or ()),
+            local_accept_locations=tuple(str(value) for value in decoded.get("local_accept_locations") or ()),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverySearchUnit:
+    execution: DiscoveryExecutionRef
+    unit_id: str
+    ordinal: int
+    spec: DiscoverySearchSpec
+    request_fingerprint: str
+    state: DiscoverySearchUnitState
+    lease_owner: str | None
+    lease_attempt: int
+    lease_epoch: int
+    recovery_count: int
+    checkpoint_revision: int | None
+    accepted_jobs: int
+    new_jobs: int
+    last_error_code: str | None
+    last_error_type: str | None
+    last_error_retryable: bool | None
+    reset_checkpoint: bool
+    created_at: str
+    updated_at: str
+    completed_at: str | None
+
+    @property
+    def existing_jobs(self) -> int:
+        return self.accepted_jobs - self.new_jobs
+
+    @property
+    def recovered(self) -> bool:
+        return self.recovery_count > 0
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverySearchUnitLease:
+    execution: DiscoveryExecutionRef
+    unit_id: str
+    owner_token: str
+    attempt: int
+    epoch: int
+
+    def __post_init__(self) -> None:
+        validate_unit_id(self.unit_id)
+        if not self.owner_token.strip():
+            raise ValueError("owner_token must be non-empty")
+        if self.attempt < 1:
+            raise ValueError("attempt must be positive")
+        if self.epoch < 1:
+            raise ValueError("epoch must be positive")
+
+
+def search_unit_id(ordinal: int, spec: DiscoverySearchSpec) -> str:
+    if ordinal < 0 or ordinal > 9999:
+        raise ValueError("ordinal must be between 0 and 9999")
+    return f"search-{ordinal:04d}-{spec.fingerprint()[:16]}"
+
+
+def validate_unit_id(value: str) -> str:
+    if not _SAFE_UNIT_ID.fullmatch(value):
+        raise ValueError("invalid discovery search unit id")
+    return value
+
+
+def validate_search_unit_state(value: str) -> DiscoverySearchUnitState:
+    if value not in DISCOVERY_SEARCH_UNIT_STATES:
+        raise ValueError(f"unknown discovery search unit state: {value}")
+    return value  # type: ignore[return-value]

--- a/workers/automation/src/jobctrl/domain/discovery/use_cases.py
+++ b/workers/automation/src/jobctrl/domain/discovery/use_cases.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Iterable, Literal, Protocol
+from typing import Callable, Iterable, Literal, Protocol
 
 from jobctrl.domain.discovery.aggregate import Job
 from jobctrl.domain.discovery.identity import (
@@ -233,6 +233,8 @@ class DiscoverJobsUseCase:
         acceptance_policy: PostingAcceptancePolicy | None = None,
         run_id_factory: object | None = None,
         clock: object | None = None,
+        observation_id_factory: Callable[[], str] | None = None,
+        republish_canonical_identity: bool = False,
     ) -> None:
         self._repository = repository
         self._publisher = publisher
@@ -240,6 +242,8 @@ class DiscoverJobsUseCase:
         self._acceptance_policy = acceptance_policy or accept_all_postings
         self._run_id_factory = run_id_factory or (lambda: f"run:{uuid.uuid4().hex}")
         self._clock = clock or (lambda: datetime.now(timezone.utc).isoformat())
+        self._observation_id_factory = observation_id_factory or (lambda: f"obs:{uuid.uuid4().hex}")
+        self._republish_canonical_identity = republish_canonical_identity
 
     def execute(
         self,
@@ -307,7 +311,9 @@ class DiscoverJobsUseCase:
             pass  # span carries the identity decision metadata
 
         observed_at = self._clock()
-        observation_id = f"obs:{uuid.uuid4().hex}"
+        observation_id = str(self._observation_id_factory()).strip()
+        if not observation_id:
+            raise ValueError("observation_id_factory returned an empty identifier")
 
         if owner_id is None:
             acceptance = self._acceptance_policy(posting)
@@ -493,6 +499,29 @@ class DiscoverJobsUseCase:
         ):
             existing = self._repository.load(tenant_id, owner_id)
             if existing is not None:
+                if self._republish_canonical_identity:
+                    stored_identity = self._repository.load_canonical_identity(
+                        tenant_id,
+                        owner_id,
+                    )
+                    if stored_identity is None:
+                        self._repository.set_canonical_identity(
+                            tenant_id,
+                            owner_id,
+                            identity,
+                        )
+                    self._publisher.publish(
+                        create_canonical_job_identity_resolved(
+                            tenant_id,
+                            CanonicalJobIdentityResolvedPayload(
+                                job_id=str(owner_id),
+                                canonical_url=identity.canonical_url,
+                                ats_kind=identity.ats_kind.value,
+                                source_native_id=identity.source_native_id,
+                                confidence=identity.confidence,
+                            ),
+                        )
+                    )
                 if not acceptance.accepted:
                     reason = _policy_rejection_reason(acceptance)
                     if not existing.is_deleted:
@@ -575,7 +604,13 @@ class DiscoverJobsUseCase:
 
         duplicate_link_id: str | None = None
         if is_distinct_url:
-            duplicate_link_id = f"dup:{uuid.uuid4().hex}"
+            duplicate_link_id = (
+                "dup:"
+                + uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"{tenant_id}:{owner_id}:{observation_id}",
+                ).hex
+            )
             if content_match is not None:
                 if content_match.basis == "fingerprint":
                     link_reason = "content_fingerprint_match"
@@ -584,9 +619,7 @@ class DiscoverJobsUseCase:
                     link_reason = "content_shingle_match"
                     link_confidence = CONTENT_SHINGLE_MATCH_CONFIDENCE
             else:
-                link_reason = (
-                    "canonical_url_match" if identity.canonical_url else "source_native_id_match"
-                )
+                link_reason = "canonical_url_match" if identity.canonical_url else "source_native_id_match"
                 link_confidence = identity.confidence
             link = DuplicateJobLink(
                 duplicate_link_id=duplicate_link_id,

--- a/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/compensation/sqlite_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
-from typing import Any
+from typing import Any, Callable
 
 from jobctrl.database import ensure_posted_compensation_tables
 from jobctrl.domain.compensation import PostedCompensationFact, parse_posted_compensation
@@ -35,7 +35,13 @@ class SqlitePostedCompensationRepository:
         self._conn = conn
         ensure_posted_compensation_tables(conn)
 
-    def save_fact(self, fact: PostedCompensationFact) -> None:
+    def save_fact(
+        self,
+        fact: PostedCompensationFact,
+        *,
+        event_idempotency_key: str | None = None,
+        event_write_fence: Callable[[], None] | None = None,
+    ) -> None:
         self._conn.execute(
             """
             INSERT INTO job_posted_compensation_facts (
@@ -87,7 +93,12 @@ class SqlitePostedCompensationRepository:
             ),
         )
         self._conn.commit()
-        self._record_updated_event(fact)
+        if event_write_fence is not None:
+            event_write_fence()
+        self._record_updated_event(
+            fact,
+            idempotency_key=event_idempotency_key,
+        )
 
     def get_fact(self, tenant_id: str, job_url: str) -> PostedCompensationFact | None:
         row = self._conn.execute(
@@ -112,6 +123,8 @@ class SqlitePostedCompensationRepository:
         tenant_id: str = "local",
         source_field: str = "jobs.salary",
         parsed_at: str | None = None,
+        event_idempotency_key: str | None = None,
+        event_write_fence: Callable[[], None] | None = None,
     ) -> PostedCompensationFact:
         fact = parse_posted_compensation(
             salary,
@@ -120,13 +133,15 @@ class SqlitePostedCompensationRepository:
             source_field=source_field,
             parsed_at=parsed_at,
         )
-        self.save_fact(fact)
+        self.save_fact(
+            fact,
+            event_idempotency_key=event_idempotency_key,
+            event_write_fence=event_write_fence,
+        )
         return fact
 
     def backfill_from_legacy_jobs(self, *, tenant_id: str = "local", parsed_at: str | None = None) -> int:
-        rows = self._conn.execute(
-            "SELECT url, salary, full_description, description FROM jobs ORDER BY url"
-        ).fetchall()
+        rows = self._conn.execute("SELECT url, salary, full_description, description FROM jobs ORDER BY url").fetchall()
         for row in rows:
             source_text, source_field = posted_compensation_source_from_job(row)
             self.parse_and_save_job_salary(
@@ -139,7 +154,12 @@ class SqlitePostedCompensationRepository:
         self._conn.commit()
         return len(rows)
 
-    def _record_updated_event(self, fact: PostedCompensationFact) -> None:
+    def _record_updated_event(
+        self,
+        fact: PostedCompensationFact,
+        *,
+        idempotency_key: str | None = None,
+    ) -> None:
         try:
             from jobctrl.state import record_job_event
 
@@ -159,6 +179,7 @@ class SqlitePostedCompensationRepository:
                     "marketEstimateState": None,
                     "updatedAt": fact.parsed_at,
                 },
+                idempotency_key=idempotency_key,
             )
             self._conn.commit()
         except sqlite3.OperationalError:

--- a/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/__init__.py
@@ -30,6 +30,12 @@ from jobctrl.infrastructure.discovery.sqlite_execution_repository import (
 from jobctrl.infrastructure.discovery.sqlite_run_repository import (
     SqliteDiscoveryRunRepository,
 )
+from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+    DiscoverySearchPlanConflict,
+    SqliteDiscoverySearchUnitCheckpointStore,
+    SqliteDiscoverySearchUnitRepository,
+    StaleDiscoverySearchUnitLease,
+)
 from jobctrl.infrastructure.discovery.production_wiring import (
     DiscoveryAcceptanceReport,
     ManualCaptureImport,
@@ -54,9 +60,13 @@ __all__ = [
     "SourceControlSeedSummary",
     "SqliteDiscoveryRunRepository",
     "SqliteDiscoveryExecutionRepository",
+    "SqliteDiscoverySearchUnitCheckpointStore",
+    "SqliteDiscoverySearchUnitRepository",
     "SqliteJobRepository",
+    "StaleDiscoverySearchUnitLease",
     "WorkdayBoardAdapter",
     "WorkdayEmployer",
+    "DiscoverySearchPlanConflict",
     "build_discovery_acceptance_report",
     "enqueue_manual_action_for_sources",
     "import_manual_capture_item",

--- a/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/production_wiring.py
@@ -14,7 +14,7 @@ import json
 import re
 import sqlite3
 import threading
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Iterable
@@ -190,11 +190,22 @@ _WORKDAY_HOST_ALIAS_SOURCE_RE = re.compile(r"^workday:(?P<employer>.+)-wd\d+-myw
 class DurableJobEventPublisher:
     """Persist domain events to ``job_events`` while still fanning out locally."""
 
-    def __init__(self, conn: sqlite3.Connection, *, stage: str) -> None:
+    def __init__(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        stage: str,
+        write_fence: Callable[[], None] | None = None,
+        idempotency_prefix: str | None = None,
+    ) -> None:
         self._conn = conn
         self._stage = stage
+        self._write_fence = write_fence
+        self._idempotency_prefix = idempotency_prefix
 
     def publish(self, event: DomainEvent) -> None:
+        if self._write_fence is not None:
+            self._write_fence()
         payload = {"tenantId": str(event.tenant_id), **event.payload}
         job_url = _event_job_url(event)
         record_job_event(
@@ -205,6 +216,9 @@ class DurableJobEventPublisher:
             message=event.event_type,
             payload=payload,
             occurred_at=event.occurred_at,
+            idempotency_key=(
+                f"{self._idempotency_prefix}:{event.event_type}" if self._idempotency_prefix is not None else None
+            ),
         )
         self._conn.commit()
 
@@ -322,6 +336,8 @@ def learn_posting_source_from_url(
     posting_url: str | None,
     discovered_via_source_id: str,
     observed_at: str,
+    write_fence: Callable[[], None] | None = None,
+    event_idempotency_prefix: str | None = None,
 ) -> LearnedPostingSource:
     """Learn a durable owner source from a broad-board posting URL.
 
@@ -341,6 +357,7 @@ def learn_posting_source_from_url(
         )
 
     ensure_worker_discovery_tables(conn)
+    _apply_optional_write_fence(write_fence)
     detected = _detect_ats_kind(candidate_url)
     if detected is None:
         candidate = _source_location_candidate(
@@ -358,7 +375,14 @@ def learn_posting_source_from_url(
             },
         )
         if _locator_candidate_is_new(conn, candidate):
-            _record_locator_event(conn, candidate)
+            _record_locator_event(
+                conn,
+                candidate,
+                idempotency_key=_event_idempotency_key(
+                    event_idempotency_prefix,
+                    "SourceLocationCandidateDiscovered",
+                ),
+            )
         _upsert_locator_candidate(conn, candidate)
         _enqueue_manual_action_from_candidate(conn, candidate)
         conn.commit()
@@ -375,16 +399,23 @@ def learn_posting_source_from_url(
         source_native_id=_source_native_id_from_url(candidate_url),
         confidence=0.82,
     )
-    SqliteJobRepository(conn).set_canonical_identity(
+    identity_repository = SqliteJobRepository(conn)
+    _apply_optional_write_fence(write_fence)
+    identity_repository.set_canonical_identity(
         LOCAL_TENANT,
         JobId(job_url),
         identity,
     )
+    _apply_optional_write_fence(write_fence)
     _record_canonical_identity_resolved_event(
         conn,
         job_url=job_url,
         identity=identity,
         occurred_at=observed_at,
+        idempotency_key=_event_idempotency_key(
+            event_idempotency_prefix,
+            "CanonicalJobIdentityResolved",
+        ),
     )
 
     if detected is AtsKind.WORKDAY:
@@ -405,7 +436,14 @@ def learn_posting_source_from_url(
             },
         )
         if _locator_candidate_is_new(conn, candidate):
-            _record_locator_event(conn, candidate)
+            _record_locator_event(
+                conn,
+                candidate,
+                idempotency_key=_event_idempotency_key(
+                    event_idempotency_prefix,
+                    "SourceLocationCandidateDiscovered",
+                ),
+            )
         _upsert_locator_candidate(conn, candidate)
         _enqueue_manual_action_from_candidate(conn, candidate)
         conn.commit()
@@ -431,7 +469,12 @@ def learn_posting_source_from_url(
         },
     )
     source_id = _source_id_from_locator_candidate(conn, candidate)
-    _promote_locator_candidate(conn, candidate)
+    _apply_optional_write_fence(write_fence)
+    _promote_locator_candidate(
+        conn,
+        candidate,
+        event_idempotency_prefix=event_idempotency_prefix,
+    )
     conn.commit()
     return LearnedPostingSource(
         source_id=source_id,
@@ -685,10 +728,7 @@ def _promote_ats_source_description_to_enrichment(
             job_url,
             "enrich",
             "StageCompleted",
-            message=(
-                "ATS source description promoted to enrichment: "
-                f"{len(description)} description chars"
-            ),
+            message=(f"ATS source description promoted to enrichment: {len(description)} description chars"),
             payload={
                 "source_id": posting.source_id,
                 "source_native_id": identity.source_native_id,
@@ -810,9 +850,7 @@ def _query_specs_by_family(search_cfg: Mapping[str, Any]) -> dict[str, tuple[dic
     query_specs_by_family = {
         "ats_api": tuple(_ats_query_specs(search_cfg)),
         "jobspy": tuple(query_specs_for_source(search_cfg.get("queries", []), "jobspy")),
-        "smartextract": tuple(
-            query_specs_for_source(search_cfg.get("queries", []), "smartextract")
-        ),
+        "smartextract": tuple(query_specs_for_source(search_cfg.get("queries", []), "smartextract")),
         "workday": tuple(
             query_specs_for_source(
                 search_cfg.get("queries", []),
@@ -822,9 +860,7 @@ def _query_specs_by_family(search_cfg: Mapping[str, Any]) -> dict[str, tuple[dic
         ),
     }
     if not query_specs_by_family["workday"]:
-        query_specs_by_family["workday"] = tuple(
-            query_specs_for_source(search_cfg.get("queries", []), "workday")
-        )
+        query_specs_by_family["workday"] = tuple(query_specs_for_source(search_cfg.get("queries", []), "workday"))
     return query_specs_by_family
 
 
@@ -875,9 +911,7 @@ def retire_invalid_canonical_ats_jobs(
 
 
 def _source_family(*, source_id: str, strategy: str, ats_kind: str) -> str | None:
-    if ats_kind in {"greenhouse", "lever", "ashby"} or source_id.startswith(
-        ("greenhouse:", "lever:", "ashby:")
-    ):
+    if ats_kind in {"greenhouse", "lever", "ashby"} or source_id.startswith(("greenhouse:", "lever:", "ashby:")):
         return "ats_api"
     if ats_kind == "workday" or source_id.startswith("workday:") or strategy == "workday_api":
         return "workday"
@@ -926,9 +960,7 @@ def _source_rejection_reasons(
 ) -> list[str]:
     reasons: list[str] = []
     effective_accept_locs = accept_locs or [location for location in locations if location]
-    location_evidence = " ".join(
-        str(part).strip() for part in (location, title) if str(part or "").strip()
-    )
+    location_evidence = " ".join(str(part).strip() for part in (location, title) if str(part or "").strip())
     if not _usable_description_text(description):
         reasons.append("missing_description")
     if query_specs and not title_matches_any_query(title, query_specs):
@@ -1339,6 +1371,8 @@ def _upsert_locator_candidate(
 def _promote_locator_candidate(
     conn: sqlite3.Connection,
     candidate: SourceLocationCandidate,
+    *,
+    event_idempotency_prefix: str | None = None,
 ) -> bool:
     source_id = _source_id_from_locator_candidate(conn, candidate)
     now = utc_now()
@@ -1379,6 +1413,10 @@ def _promote_locator_candidate(
             policy_id=policy_id,
             state="active",
             occurred_at=now,
+            idempotency_key=_event_idempotency_key(
+                event_idempotency_prefix,
+                "SourceRegistryEntryCreated",
+            ),
         )
         changed = True
     else:
@@ -1403,6 +1441,10 @@ def _promote_locator_candidate(
                 source_id=source_id,
                 changed_fields=tuple(changed_fields),
                 occurred_at=now,
+                idempotency_key=_event_idempotency_key(
+                    event_idempotency_prefix,
+                    "SourceRegistryEntryUpdated",
+                ),
             )
         changed = bool(changed_fields)
     had_pending_candidate = not _locator_candidate_is_new(conn, candidate)
@@ -1413,6 +1455,10 @@ def _promote_locator_candidate(
             candidate_id=candidate.candidate_id,
             source_id=source_id,
             occurred_at=now,
+            idempotency_key=_event_idempotency_key(
+                event_idempotency_prefix,
+                "SourceLocationCandidatePromoted",
+            ),
         )
     return changed or had_pending_candidate
 
@@ -1445,6 +1491,8 @@ def _delete_locator_candidate(conn: sqlite3.Connection, candidate_id: str) -> No
 def _record_locator_event(
     conn: sqlite3.Connection,
     candidate: SourceLocationCandidate,
+    *,
+    idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
@@ -1467,6 +1515,7 @@ def _record_locator_event(
             "discoveredAt": candidate.discovered_at,
         },
         occurred_at=candidate.discovered_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -1476,6 +1525,7 @@ def _record_locator_promoted_event(
     candidate_id: str,
     source_id: str,
     occurred_at: str,
+    idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
@@ -1493,6 +1543,7 @@ def _record_locator_promoted_event(
             "promotedAt": occurred_at,
         },
         occurred_at=occurred_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -1504,6 +1555,7 @@ def _record_source_registry_created_event(
     policy_id: str,
     state: str,
     occurred_at: str,
+    idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
@@ -1523,6 +1575,7 @@ def _record_source_registry_created_event(
             "createdAt": occurred_at,
         },
         occurred_at=occurred_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -1532,6 +1585,7 @@ def _record_source_registry_updated_event(
     source_id: str,
     changed_fields: tuple[str, ...],
     occurred_at: str,
+    idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
@@ -1549,6 +1603,7 @@ def _record_source_registry_updated_event(
             "updatedAt": occurred_at,
         },
         occurred_at=occurred_at,
+        idempotency_key=idempotency_key,
     )
 
 
@@ -1558,6 +1613,7 @@ def _record_canonical_identity_resolved_event(
     job_url: str,
     identity: CanonicalJobIdentity,
     occurred_at: str,
+    idempotency_key: str | None = None,
 ) -> None:
     record_job_event(
         conn,
@@ -1578,7 +1634,17 @@ def _record_canonical_identity_resolved_event(
             "confidence": identity.confidence,
         },
         occurred_at=occurred_at,
+        idempotency_key=idempotency_key,
     )
+
+
+def _apply_optional_write_fence(write_fence: Callable[[], None] | None) -> None:
+    if write_fence is not None:
+        write_fence()
+
+
+def _event_idempotency_key(prefix: str | None, event_type: str) -> str | None:
+    return f"{prefix}:{event_type}" if prefix is not None else None
 
 
 def _enqueue_manual_action_from_candidate(
@@ -1822,13 +1888,17 @@ def _adapter_for_source(
     location_accept, location_reject = configured_location_filters(search_cfg)
     if ats_kind not in (AtsKind.GREENHOUSE, AtsKind.LEVER, AtsKind.ASHBY):
         return None
-    fetcher = http if http is not None else _gateway_ats_fetcher(
-        source,
-        source_id=source_id,
-        ats_kind=ats_kind,
-        gateway=gateway,
-        conn=conn,
-        run_id=run_id,
+    fetcher = (
+        http
+        if http is not None
+        else _gateway_ats_fetcher(
+            source,
+            source_id=source_id,
+            ats_kind=ats_kind,
+            gateway=gateway,
+            conn=conn,
+            run_id=run_id,
+        )
     )
     common = dict(
         source_id=source_id,

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_repository.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from jobctrl.domain.discovery.aggregate import Job
 from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import DiscoverySearchUnitLease
 from jobctrl.domain.discovery.identity import (
     AtsKind,
     CanonicalJobIdentity,
@@ -93,10 +94,17 @@ class SqliteJobRepository:
         *,
         discovery_execution: DiscoveryExecutionRef | None = None,
         source_family: str | None = None,
+        search_unit_lease: DiscoverySearchUnitLease | None = None,
     ) -> None:
+        if search_unit_lease is not None:
+            if discovery_execution is None:
+                discovery_execution = search_unit_lease.execution
+            elif discovery_execution != search_unit_lease.execution:
+                raise ValueError("search-unit lease does not match discovery execution")
         self._conn = conn
         self._discovery_execution = discovery_execution
         self._source_family = source_family.strip() if source_family else None
+        self._search_unit_lease = search_unit_lease
         if discovery_execution is not None and self._source_family is None:
             raise ValueError("source_family is required with discovery_execution")
         self._ensure_deleted_jobs_table()
@@ -110,6 +118,14 @@ class SqliteJobRepository:
             self._execution_repository = SqliteDiscoveryExecutionRepository(conn)
         else:
             self._execution_repository = None
+        if search_unit_lease is not None:
+            from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+                SqliteDiscoverySearchUnitRepository,
+            )
+
+            self._search_unit_repository = SqliteDiscoverySearchUnitRepository(conn)
+        else:
+            self._search_unit_repository = None
 
     # ------------------------------------------------------------------
     # Schema bootstrapping
@@ -248,6 +264,12 @@ class SqliteJobRepository:
     # Write
     # ------------------------------------------------------------------
 
+    def _fence_search_unit_write(self) -> None:
+        if self._search_unit_repository is None:
+            return
+        assert self._search_unit_lease is not None
+        self._search_unit_repository.fence_write(self._search_unit_lease)
+
     def save(self, job: Job) -> None:
         """Insert / upsert a Job into the wide ``jobs`` table.
 
@@ -264,6 +286,8 @@ class SqliteJobRepository:
             "SELECT url, discovered_at FROM jobs WHERE url = ?",
             (job.posting_url.value,),
         ).fetchone()
+        was_new = existing is None
+        self._fence_search_unit_write()
 
         if existing is not None:
             existing_url = existing["url"] if isinstance(existing, sqlite3.Row) else existing[0]
@@ -273,11 +297,7 @@ class SqliteJobRepository:
                     owner=JobId(str(existing_url)),
                     attempted=job.job_id,
                 )
-            existing_discovered_at = (
-                existing["discovered_at"]
-                if isinstance(existing, sqlite3.Row)
-                else existing[1]
-            )
+            existing_discovered_at = existing["discovered_at"] if isinstance(existing, sqlite3.Row) else existing[1]
             preserved_discovered_at = existing_discovered_at or job.discovered_at
             self._conn.execute(
                 """
@@ -325,6 +345,14 @@ class SqliteJobRepository:
                 ),
             )
         self._sync_tombstone(job)
+        if self._search_unit_repository is not None:
+            assert self._search_unit_lease is not None
+            self._search_unit_repository.record_accepted_job(
+                self._search_unit_lease,
+                job.posting_url.value,
+                was_new=was_new,
+                accepted_at=job.discovered_at,
+            )
         self._conn.commit()
 
     def soft_delete(
@@ -338,6 +366,7 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        self._fence_search_unit_write()
         deleted = existing.soft_delete(reason=reason, deleted_at=deleted_at)
         self._conn.execute(
             """
@@ -363,6 +392,7 @@ class SqliteJobRepository:
         existing = self.load(tenant_id, job_id)
         if existing is None:
             return None
+        self._fence_search_unit_write()
         restored = existing.restore()
         restore_timestamp = _restore_timestamp(restored_at, deleted_at=existing.deleted_at)
         # Mirror the API's restore semantics — set restored_at rather
@@ -448,9 +478,7 @@ class SqliteJobRepository:
                     (str(tenant_id), normalized),
                 ).fetchone()
                 if row is not None:
-                    job_url = (
-                        row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
-                    )
+                    job_url = row["job_url"] if isinstance(row, sqlite3.Row) else row[0]
                     if job_url:
                         return JobId(str(job_url))
 
@@ -499,9 +527,7 @@ class SqliteJobRepository:
         )
         if incoming_key is None:
             return None
-        self._conn.create_function(
-            "jh_normalize_identity", 1, normalize_identity_text, deterministic=True
-        )
+        self._conn.create_function("jh_normalize_identity", 1, normalize_identity_text, deterministic=True)
         rows = self._conn.execute(
             """
             SELECT j.url, j.title, j.company, j.site,
@@ -554,6 +580,7 @@ class SqliteJobRepository:
         also collapses cosmetic URL variants.
         """
 
+        self._fence_search_unit_write()
         normalized = normalize_observed_url(observation.observed_url)
         updated = self._conn.execute(
             """
@@ -624,10 +651,19 @@ class SqliteJobRepository:
                     observation.observed_at,
                 ),
             )
+        if self._search_unit_repository is not None:
+            assert self._search_unit_lease is not None
+            self._search_unit_repository.record_accepted_job(
+                self._search_unit_lease,
+                str(job_id),
+                was_new=False,
+                accepted_at=observation.observed_at,
+            )
         if self._execution_repository is not None:
             assert self._discovery_execution is not None
             if str(tenant_id) != self._discovery_execution.tenant_id:
                 raise ValueError("source observation tenant does not match discovery execution")
+            self._fence_search_unit_write()
             # The Temporal execution ref is the authority. ``observation.run_id``
             # is retained only as first-observation source metadata and may be
             # updated independently in ``job_source_observations`` on retries.
@@ -649,6 +685,7 @@ class SqliteJobRepository:
     ) -> None:
         """Persist (or replace) the canonical identity decision for a Job."""
 
+        self._fence_search_unit_write()
         self._conn.execute(
             """
             INSERT INTO job_canonical_identities (
@@ -681,6 +718,7 @@ class SqliteJobRepository:
     ) -> None:
         """Persist a confirmed duplicate-link audit record."""
 
+        self._fence_search_unit_write()
         self._conn.execute(
             """
             INSERT INTO job_duplicate_links (
@@ -726,6 +764,7 @@ class SqliteJobRepository:
         mint a fresh event row (audit noise).
         """
 
+        self._fence_search_unit_write()
         before = self._conn.total_changes
         self._conn.execute(
             """

--- a/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
+++ b/workers/automation/src/jobctrl/infrastructure/discovery/sqlite_search_unit_repository.py
@@ -1,0 +1,688 @@
+"""SQLite search-unit planning, fencing, checkpoints, and acceptance receipts."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from datetime import datetime, timezone
+from typing import Iterable
+
+from jobstreaming import (
+    CheckpointConflictError,
+    CheckpointError,
+    CheckpointStore,
+    SearchCheckpoint,
+)
+
+from jobctrl.database import ensure_discovery_search_unit_tables
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import (
+    DiscoverySearchSpec,
+    DiscoverySearchUnit,
+    DiscoverySearchUnitLease,
+    search_unit_id,
+    validate_search_unit_state,
+    validate_unit_id,
+)
+
+
+_SAFE_ERROR_IDENTIFIER = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+
+_SELECT_UNIT = """
+    SELECT u.tenant_id, u.discover_workflow_id, u.discover_run_id,
+           u.unit_id, u.ordinal, u.request_json, u.request_fingerprint,
+           u.state, u.lease_owner, u.lease_attempt, u.lease_epoch, u.recovery_count,
+           u.checkpoint_revision, u.last_error_code, u.last_error_type,
+           u.last_error_retryable, u.reset_checkpoint,
+           u.created_at, u.updated_at, u.completed_at,
+           COUNT(j.job_url) AS accepted_jobs,
+           COALESCE(SUM(j.was_new), 0) AS new_jobs
+      FROM discovery_search_units u
+      LEFT JOIN discovery_search_unit_jobs j
+        ON j.tenant_id = u.tenant_id
+       AND j.discover_workflow_id = u.discover_workflow_id
+       AND j.discover_run_id = u.discover_run_id
+       AND j.unit_id = u.unit_id
+"""
+
+_GROUP_UNIT = """
+    GROUP BY u.tenant_id, u.discover_workflow_id, u.discover_run_id,
+             u.unit_id, u.ordinal, u.request_json, u.request_fingerprint,
+             u.state, u.lease_owner, u.lease_attempt, u.lease_epoch, u.recovery_count,
+             u.checkpoint_revision, u.last_error_code, u.last_error_type,
+             u.last_error_retryable, u.reset_checkpoint,
+             u.created_at, u.updated_at, u.completed_at
+"""
+
+
+class DiscoverySearchPlanConflict(ValueError):
+    """Raised when a retry tries to rewrite an immutable execution plan."""
+
+
+class StaleDiscoverySearchUnitLease(CheckpointConflictError):
+    """Raised after a newer activity attempt fences an older unit owner."""
+
+
+class SqliteDiscoverySearchUnitRepository:
+    """Caller-owned durable state for JobStreaming consumption."""
+
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        ensure_discovery_search_unit_tables(conn)
+
+    def plan_units(
+        self,
+        execution: DiscoveryExecutionRef,
+        specs: Iterable[DiscoverySearchSpec],
+        *,
+        created_at: str | None = None,
+    ) -> list[DiscoverySearchUnit]:
+        """Create an immutable ordered plan, or validate its exact replay."""
+
+        planned_at = created_at or _utc_now()
+        desired = [
+            (search_unit_id(ordinal, spec), ordinal, spec, spec.to_json(), spec.fingerprint())
+            for ordinal, spec in enumerate(specs)
+        ]
+        with self._conn:
+            for unit_id, ordinal, _spec, request_json, fingerprint in desired:
+                self._conn.execute(
+                    """
+                    INSERT INTO discovery_search_units (
+                        tenant_id, discover_workflow_id, discover_run_id,
+                        unit_id, ordinal, request_json, request_fingerprint,
+                        state, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (
+                        execution.tenant_id,
+                        execution.workflow_id,
+                        execution.temporal_run_id,
+                        unit_id,
+                        ordinal,
+                        request_json,
+                        fingerprint,
+                        planned_at,
+                        planned_at,
+                    ),
+                )
+
+            rows = self._list_rows(execution)
+            actual = [(str(row[3]), int(row[4]), str(row[5]), str(row[6])) for row in rows]
+            expected = [
+                (unit_id, ordinal, request_json, fingerprint)
+                for unit_id, ordinal, _spec, request_json, fingerprint in desired
+            ]
+            if actual != expected:
+                raise DiscoverySearchPlanConflict("discovery search plan differs from the persisted execution plan")
+        return [self._row_to_unit(row) for row in rows]
+
+    def list_units(self, execution: DiscoveryExecutionRef) -> list[DiscoverySearchUnit]:
+        return [self._row_to_unit(row) for row in self._list_rows(execution)]
+
+    def get_unit(
+        self,
+        execution: DiscoveryExecutionRef,
+        unit_id: str,
+    ) -> DiscoverySearchUnit | None:
+        validate_unit_id(unit_id)
+        row = self._conn.execute(
+            f"""
+            {_SELECT_UNIT}
+             WHERE u.tenant_id = ?
+               AND u.discover_workflow_id = ?
+               AND u.discover_run_id = ?
+               AND u.unit_id = ?
+            {_GROUP_UNIT}
+            """,
+            (*_execution_params(execution), unit_id),
+        ).fetchone()
+        return self._row_to_unit(row) if row is not None else None
+
+    def claim_next(
+        self,
+        execution: DiscoveryExecutionRef,
+        owner_token: str,
+        attempt: int,
+        *,
+        claimed_at: str | None = None,
+    ) -> DiscoverySearchUnitLease | None:
+        """Claim the first unfinished unit and fence any prior activity owner."""
+
+        owner = _required_owner(owner_token)
+        if attempt < 1:
+            raise ValueError("attempt must be positive")
+        now = claimed_at or _utc_now()
+        while True:
+            watermark = self._conn.execute(
+                """
+                SELECT lease_attempt, lease_owner
+                  FROM discovery_search_units
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND lease_attempt > 0
+                 ORDER BY lease_attempt DESC, lease_epoch DESC
+                 LIMIT 1
+                """,
+                _execution_params(execution),
+            ).fetchone()
+            if watermark is not None:
+                watermark_attempt = int(watermark[0])
+                watermark_owner = str(watermark[1])
+                if attempt < watermark_attempt or (attempt == watermark_attempt and owner != watermark_owner):
+                    raise StaleDiscoverySearchUnitLease(
+                        f"activity attempt {attempt} cannot claim discovery work after attempt {watermark_attempt}"
+                    )
+            row = self._conn.execute(
+                """
+                SELECT unit_id, state, lease_owner, lease_attempt, lease_epoch
+                  FROM discovery_search_units
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND state IN ('pending', 'running')
+                 ORDER BY ordinal
+                 LIMIT 1
+                """,
+                _execution_params(execution),
+            ).fetchone()
+            if row is None:
+                return None
+            unit_id = str(row[0])
+            state = str(row[1])
+            current_owner = str(row[2]) if row[2] is not None else None
+            current_attempt = int(row[3])
+            current_epoch = int(row[4])
+            if state == "running" and current_owner == owner and current_attempt == attempt:
+                return DiscoverySearchUnitLease(
+                    execution=execution,
+                    unit_id=unit_id,
+                    owner_token=owner,
+                    attempt=attempt,
+                    epoch=current_epoch,
+                )
+            if state == "running" and attempt <= current_attempt:
+                raise StaleDiscoverySearchUnitLease(
+                    f"activity attempt {attempt} cannot reclaim search unit {unit_id} from attempt {current_attempt}"
+                )
+
+            next_epoch = current_epoch + 1
+            with self._conn:
+                updated = self._conn.execute(
+                    """
+                    UPDATE discovery_search_units
+                       SET state = 'running',
+                           lease_owner = ?,
+                           lease_attempt = ?,
+                           lease_epoch = ?,
+                           recovery_count = recovery_count + CASE
+                               WHEN state = 'running' THEN 1 ELSE 0 END,
+                           updated_at = ?,
+                           completed_at = NULL
+                     WHERE tenant_id = ?
+                       AND discover_workflow_id = ?
+                       AND discover_run_id = ?
+                       AND unit_id = ?
+                       AND state IN ('pending', 'running')
+                       AND lease_epoch = ?
+                       AND (state = 'pending' OR lease_attempt < ?)
+                       AND NOT EXISTS (
+                           SELECT 1
+                             FROM discovery_search_units newer
+                            WHERE newer.tenant_id = discovery_search_units.tenant_id
+                              AND newer.discover_workflow_id = discovery_search_units.discover_workflow_id
+                              AND newer.discover_run_id = discovery_search_units.discover_run_id
+                              AND (
+                                  newer.lease_attempt > ?
+                                  OR (
+                                      newer.lease_attempt = ?
+                                      AND newer.lease_attempt > 0
+                                      AND newer.lease_owner <> ?
+                                  )
+                              )
+                       )
+                    """,
+                    (
+                        owner,
+                        attempt,
+                        next_epoch,
+                        now,
+                        *_execution_params(execution),
+                        unit_id,
+                        current_epoch,
+                        attempt,
+                        attempt,
+                        attempt,
+                        owner,
+                    ),
+                )
+            if updated.rowcount == 1:
+                return DiscoverySearchUnitLease(
+                    execution=execution,
+                    unit_id=unit_id,
+                    owner_token=owner,
+                    attempt=attempt,
+                    epoch=next_epoch,
+                )
+
+    def fence_write(self, lease: DiscoverySearchUnitLease) -> None:
+        """Acquire SQLite's writer ordering and reject a superseded owner."""
+
+        updated = self._conn.execute(
+            """
+            UPDATE discovery_search_units
+               SET lease_epoch = lease_epoch
+             WHERE tenant_id = ?
+               AND discover_workflow_id = ?
+               AND discover_run_id = ?
+               AND unit_id = ?
+               AND state = 'running'
+               AND lease_owner = ?
+               AND lease_epoch = ?
+            """,
+            (
+                *_execution_params(lease.execution),
+                lease.unit_id,
+                lease.owner_token,
+                lease.epoch,
+            ),
+        )
+        if updated.rowcount != 1:
+            # A stale owner must not leave an implicit SQLite transaction open,
+            # and any writes it staged before the fence are invalid together.
+            self._conn.rollback()
+            raise StaleDiscoverySearchUnitLease(f"search unit {lease.unit_id} is owned by a newer activity attempt")
+
+    def checkpoint_store(
+        self,
+        lease: DiscoverySearchUnitLease,
+    ) -> SqliteDiscoverySearchUnitCheckpointStore:
+        return SqliteDiscoverySearchUnitCheckpointStore(self, lease)
+
+    def load_checkpoint(self, lease: DiscoverySearchUnitLease) -> SearchCheckpoint | None:
+        row = self._lease_row(lease, "checkpoint_json")
+        if row[0] is None:
+            return None
+        try:
+            return SearchCheckpoint.model_validate_json(str(row[0]))
+        except Exception as exc:
+            raise CheckpointError(f"unable to read checkpoint for search unit {lease.unit_id}") from exc
+
+    def save_checkpoint(
+        self,
+        lease: DiscoverySearchUnitLease,
+        checkpoint: SearchCheckpoint,
+        *,
+        saved_at: str | None = None,
+    ) -> None:
+        """Compare-and-swap one provider checkpoint revision under the lease."""
+
+        expected_revision = checkpoint.revision - 1 if checkpoint.revision > 0 else None
+        with self._conn:
+            updated = self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET checkpoint_json = ?,
+                       checkpoint_revision = ?,
+                       updated_at = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND unit_id = ?
+                   AND state = 'running'
+                   AND lease_owner = ?
+                   AND lease_epoch = ?
+                   AND (
+                       (? IS NULL AND checkpoint_revision IS NULL)
+                       OR checkpoint_revision = ?
+                   )
+                """,
+                (
+                    checkpoint.model_dump_json(),
+                    checkpoint.revision,
+                    saved_at or _utc_now(),
+                    *_execution_params(lease.execution),
+                    lease.unit_id,
+                    lease.owner_token,
+                    lease.epoch,
+                    expected_revision,
+                    expected_revision,
+                ),
+            )
+        if updated.rowcount != 1:
+            raise CheckpointConflictError(f"stale lease or checkpoint revision for search unit {lease.unit_id}")
+
+    def clear_checkpoint(
+        self,
+        lease: DiscoverySearchUnitLease,
+        *,
+        cleared_at: str | None = None,
+    ) -> None:
+        with self._conn:
+            self.fence_write(lease)
+            self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET checkpoint_json = NULL,
+                       checkpoint_revision = NULL,
+                       reset_checkpoint = 0,
+                       updated_at = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND unit_id = ?
+                """,
+                (
+                    cleared_at or _utc_now(),
+                    *_execution_params(lease.execution),
+                    lease.unit_id,
+                ),
+            )
+
+    def reset_checkpoint_if_requested(
+        self,
+        lease: DiscoverySearchUnitLease,
+    ) -> bool:
+        """Apply a durable provider reset request before opening the next stream."""
+
+        row = self._lease_row(lease, "reset_checkpoint")
+        if not bool(row[0]):
+            return False
+        self.clear_checkpoint(lease)
+        return True
+
+    def record_accepted_job(
+        self,
+        lease: DiscoverySearchUnitLease,
+        job_url: str,
+        *,
+        was_new: bool,
+        accepted_at: str | None = None,
+    ) -> None:
+        """Record an idempotent accepted-job receipt under the current fence."""
+
+        normalized_url = job_url.strip()
+        if not normalized_url:
+            raise ValueError("job_url must be non-empty")
+        with self._conn:
+            self.fence_write(lease)
+            self._conn.execute(
+                """
+                INSERT INTO discovery_search_unit_jobs (
+                    tenant_id, discover_workflow_id, discover_run_id,
+                    unit_id, job_url, was_new, accepted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT (
+                    tenant_id, discover_workflow_id, discover_run_id,
+                    unit_id, job_url
+                ) DO UPDATE SET
+                    was_new = MAX(discovery_search_unit_jobs.was_new, excluded.was_new)
+                """,
+                (
+                    *_execution_params(lease.execution),
+                    lease.unit_id,
+                    normalized_url,
+                    int(was_new),
+                    accepted_at or _utc_now(),
+                ),
+            )
+
+    def record_failure(
+        self,
+        lease: DiscoverySearchUnitLease,
+        *,
+        error_code: str,
+        error_type: str,
+        retryable: bool,
+        reset_checkpoint: bool,
+        failed_at: str | None = None,
+    ) -> None:
+        """Persist a bounded failure; retryable failures remain reclaimable.
+
+        A requested cursor reset is durable intent, not an immediate deletion.
+        The caller must acknowledge the provider error against the current
+        revision first. The next fenced attempt applies the reset with
+        :meth:`reset_checkpoint_if_requested` before it opens a stream.
+        """
+
+        code = _safe_error_identifier(error_code, "error_code")
+        kind = _safe_error_identifier(error_type, "error_type")
+        terminal_state = "running" if retryable else "failed"
+        now = failed_at or _utc_now()
+        with self._conn:
+            self.fence_write(lease)
+            self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET state = ?,
+                       last_error_code = ?,
+                       last_error_type = ?,
+                       last_error_retryable = ?,
+                       reset_checkpoint = ?,
+                       updated_at = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND unit_id = ?
+                """,
+                (
+                    terminal_state,
+                    code,
+                    kind,
+                    int(retryable),
+                    int(reset_checkpoint),
+                    now,
+                    *_execution_params(lease.execution),
+                    lease.unit_id,
+                ),
+            )
+
+    def mark_completed(
+        self,
+        lease: DiscoverySearchUnitLease,
+        *,
+        completed_at: str | None = None,
+    ) -> None:
+        now = completed_at or _utc_now()
+        with self._conn:
+            self.fence_write(lease)
+            self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET state = 'completed',
+                       updated_at = ?,
+                       completed_at = ?,
+                       last_error_retryable = NULL,
+                       reset_checkpoint = 0
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND unit_id = ?
+                """,
+                (now, now, *_execution_params(lease.execution), lease.unit_id),
+            )
+
+    def mark_canceled(
+        self,
+        lease: DiscoverySearchUnitLease,
+        *,
+        canceled_at: str | None = None,
+    ) -> None:
+        now = canceled_at or _utc_now()
+        with self._conn:
+            self.fence_write(lease)
+            self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET state = 'canceled',
+                       updated_at = ?,
+                       completed_at = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND unit_id = ?
+                """,
+                (now, now, *_execution_params(lease.execution), lease.unit_id),
+            )
+
+    def mark_pending_skipped(
+        self,
+        execution: DiscoveryExecutionRef,
+        *,
+        skipped_at: str | None = None,
+    ) -> int:
+        """Close unclaimed units after the caller's durable result limit is met."""
+
+        now = skipped_at or _utc_now()
+        with self._conn:
+            updated = self._conn.execute(
+                """
+                UPDATE discovery_search_units
+                   SET state = 'skipped',
+                       updated_at = ?,
+                       completed_at = ?
+                 WHERE tenant_id = ?
+                   AND discover_workflow_id = ?
+                   AND discover_run_id = ?
+                   AND state = 'pending'
+                """,
+                (now, now, *_execution_params(execution)),
+            )
+        return updated.rowcount
+
+    def execution_counts(self, execution: DiscoveryExecutionRef) -> dict[str, int]:
+        row = self._conn.execute(
+            """
+            SELECT COUNT(*) AS accepted_jobs,
+                   COALESCE(SUM(was_new), 0) AS new_jobs
+              FROM discovery_search_unit_jobs
+             WHERE tenant_id = ?
+               AND discover_workflow_id = ?
+               AND discover_run_id = ?
+            """,
+            _execution_params(execution),
+        ).fetchone()
+        accepted = int(row[0] or 0)
+        new_jobs = int(row[1] or 0)
+        return {
+            "accepted": accepted,
+            "new": new_jobs,
+            "existing": accepted - new_jobs,
+        }
+
+    def _lease_row(self, lease: DiscoverySearchUnitLease, columns: str) -> sqlite3.Row:
+        row = self._conn.execute(
+            f"""
+            SELECT {columns}
+              FROM discovery_search_units
+             WHERE tenant_id = ?
+               AND discover_workflow_id = ?
+               AND discover_run_id = ?
+               AND unit_id = ?
+               AND state = 'running'
+               AND lease_owner = ?
+               AND lease_epoch = ?
+            """,
+            (
+                *_execution_params(lease.execution),
+                lease.unit_id,
+                lease.owner_token,
+                lease.epoch,
+            ),
+        ).fetchone()
+        if row is None:
+            raise StaleDiscoverySearchUnitLease(f"search unit {lease.unit_id} is owned by a newer activity attempt")
+        return row
+
+    def _list_rows(self, execution: DiscoveryExecutionRef) -> list[sqlite3.Row]:
+        return self._conn.execute(
+            f"""
+            {_SELECT_UNIT}
+             WHERE u.tenant_id = ?
+               AND u.discover_workflow_id = ?
+               AND u.discover_run_id = ?
+            {_GROUP_UNIT}
+             ORDER BY u.ordinal
+            """,
+            _execution_params(execution),
+        ).fetchall()
+
+    @staticmethod
+    def _row_to_unit(row: sqlite3.Row | tuple[object, ...]) -> DiscoverySearchUnit:
+        spec = DiscoverySearchSpec.from_json(str(row[5]))
+        fingerprint = str(row[6])
+        if spec.fingerprint() != fingerprint:
+            raise DiscoverySearchPlanConflict("persisted search request fingerprint is invalid")
+        return DiscoverySearchUnit(
+            execution=DiscoveryExecutionRef(
+                tenant_id=str(row[0]),
+                workflow_id=str(row[1]),
+                temporal_run_id=str(row[2]),
+            ),
+            unit_id=validate_unit_id(str(row[3])),
+            ordinal=int(row[4]),
+            spec=spec,
+            request_fingerprint=fingerprint,
+            state=validate_search_unit_state(str(row[7])),
+            lease_owner=str(row[8]) if row[8] is not None else None,
+            lease_attempt=int(row[9]),
+            lease_epoch=int(row[10]),
+            recovery_count=int(row[11]),
+            checkpoint_revision=int(row[12]) if row[12] is not None else None,
+            last_error_code=str(row[13]) if row[13] is not None else None,
+            last_error_type=str(row[14]) if row[14] is not None else None,
+            last_error_retryable=(bool(row[15]) if row[15] is not None else None),
+            reset_checkpoint=bool(row[16]),
+            created_at=str(row[17]),
+            updated_at=str(row[18]),
+            completed_at=str(row[19]) if row[19] is not None else None,
+            accepted_jobs=int(row[20]),
+            new_jobs=int(row[21]),
+        )
+
+
+class SqliteDiscoverySearchUnitCheckpointStore(CheckpointStore):
+    """JobStreaming checkpoint store bound to one fenced unit lease."""
+
+    def __init__(
+        self,
+        repository: SqliteDiscoverySearchUnitRepository,
+        lease: DiscoverySearchUnitLease,
+    ) -> None:
+        self._repository = repository
+        self._lease = lease
+
+    def load(self) -> SearchCheckpoint | None:
+        return self._repository.load_checkpoint(self._lease)
+
+    def save(self, checkpoint: SearchCheckpoint) -> None:
+        self._repository.save_checkpoint(self._lease, checkpoint)
+
+    def clear(self) -> None:
+        self._repository.clear_checkpoint(self._lease)
+
+
+def _execution_params(execution: DiscoveryExecutionRef) -> tuple[str, str, str]:
+    return execution.tenant_id, execution.workflow_id, execution.temporal_run_id
+
+
+def _required_owner(owner_token: str) -> str:
+    owner = owner_token.strip()
+    if not owner:
+        raise ValueError("owner_token must be non-empty")
+    if len(owner) > 256:
+        raise ValueError("owner_token must be at most 256 characters")
+    return owner
+
+
+def _safe_error_identifier(value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if not _SAFE_ERROR_IDENTIFIER.fullmatch(normalized):
+        raise ValueError(f"{field_name} must be a bounded safe identifier")
+    return normalized
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/workers/automation/src/jobctrl/state.py
+++ b/workers/automation/src/jobctrl/state.py
@@ -664,6 +664,7 @@ def record_job_event(
     publisher: EventPublisher | None = None,
     entity_kind: str | None = None,
     entity_ref: str | None = None,
+    idempotency_key: str | None = None,
 ) -> None:
     """Append a durable per-job event and publish through the in-process bus.
 
@@ -693,12 +694,13 @@ def record_job_event(
     accidentally (round-1 review L3).
     """
     ts = occurred_at or utc_now()
-    conn.execute(
+    cursor = conn.execute(
         """
         INSERT INTO job_events (
             job_url, stage, event_type, level, message, occurred_at, payload_json,
-            entity_kind, entity_ref
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            entity_kind, entity_ref, idempotency_key
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT DO NOTHING
         """,
         (
             job_url,
@@ -710,8 +712,11 @@ def record_job_event(
             _json_dumps(payload),
             entity_kind,
             entity_ref,
+            idempotency_key,
         ),
     )
+    if cursor.rowcount == 0:
+        return
     if publisher is None:
         # Default to the process-wide ``InProcessEventBus`` so the
         # projection builder's wildcard subscriber refreshes after every

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from jobstreaming import CheckpointConflictError, SearchCheckpoint, build_search_request
+
+from jobctrl.database import close_connection, init_db
+from jobctrl.domain.discovery import (
+    AtsKind,
+    CanonicalJobIdentity,
+    Employer,
+    Job,
+    JobMetadata,
+    PostingUrl,
+    SearchStrategy,
+    Source,
+)
+from jobctrl.domain.discovery.execution import DiscoveryExecutionRef
+from jobctrl.domain.discovery.search_units import DiscoverySearchSpec
+from jobctrl.domain.identifiers import JobId
+from jobctrl.domain.tenant import LOCAL_TENANT
+from jobctrl.discovery.jobspy import store_jobspy_results
+from jobctrl.infrastructure.compensation import SqlitePostedCompensationRepository
+from jobctrl.infrastructure.discovery.sqlite_repository import SqliteJobRepository
+from jobctrl.infrastructure.discovery.sqlite_search_unit_repository import (
+    DiscoverySearchPlanConflict,
+    SqliteDiscoverySearchUnitRepository,
+    StaleDiscoverySearchUnitLease,
+)
+
+
+def _execution() -> DiscoveryExecutionRef:
+    return DiscoveryExecutionRef(
+        tenant_id="local",
+        workflow_id="discover-local",
+        temporal_run_id="temporal-run-1",
+    )
+
+
+def _spec(*, query: str = "Director of Engineering") -> DiscoverySearchSpec:
+    return DiscoverySearchSpec(
+        query=query,
+        provider_location="Barcelona, Spain",
+        target_location="Barcelona, Spain",
+        sites=("indeed", "linkedin"),
+        results_per_site=25,
+        hours_old=72,
+        remote_only=True,
+        country_indeed="spain",
+        linkedin_fetch_description=True,
+        match_mode="recall",
+        target_track="engineering_leadership",
+        seniority_floor="director",
+        accept_locations=("Barcelona, Spain", "Europe"),
+        reject_locations=("United States",),
+        local_accept_locations=("Barcelona, Spain",),
+    )
+
+
+@pytest.fixture
+def search_db(tmp_path: Path):
+    db_path = tmp_path / "jobctrl.db"
+    conn = init_db(db_path)
+    try:
+        yield conn
+    finally:
+        close_connection(db_path)
+
+
+def test_search_spec_round_trips_with_stable_fingerprint() -> None:
+    spec = _spec()
+
+    restored = DiscoverySearchSpec.from_json(spec.to_json())
+
+    assert restored == spec
+    assert restored.fingerprint() == spec.fingerprint()
+    assert "proxy" not in restored.to_payload()
+
+
+def test_execution_plan_is_idempotent_but_cannot_be_rewritten(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    specs = [_spec(), _spec(query="VP Engineering")]
+
+    first = repository.plan_units(execution, specs, created_at="2026-07-17T10:00:00+00:00")
+    replay = repository.plan_units(execution, specs, created_at="2026-07-17T11:00:00+00:00")
+
+    assert [unit.unit_id for unit in first] == [unit.unit_id for unit in replay]
+    assert [unit.ordinal for unit in replay] == [0, 1]
+    assert all(unit.state == "pending" for unit in replay)
+    assert all(unit.created_at == "2026-07-17T10:00:00+00:00" for unit in replay)
+
+    with pytest.raises(DiscoverySearchPlanConflict):
+        repository.plan_units(execution, [_spec(query="Changed after retry")])
+
+    assert [unit.spec for unit in repository.list_units(execution)] == specs
+
+
+def test_checkpoint_save_is_compare_and_swap_and_reclaim_fences_old_owner(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(execution, [_spec()])
+    first_lease = repository.claim_next(execution, "activity-attempt-1", 1)
+    assert first_lease is not None
+    first_store = repository.checkpoint_store(first_lease)
+    competing_store = repository.checkpoint_store(first_lease)
+    request = build_search_request(
+        site_name=["indeed", "linkedin"],
+        search_term="Director of Engineering",
+        location="Barcelona, Spain",
+        results_wanted=25,
+        country_indeed="spain",
+    )
+    initial = SearchCheckpoint.for_request(request)
+
+    first_store.save(initial)
+    loaded_once = first_store.load()
+    loaded_twice = competing_store.load()
+    assert loaded_once is not None and loaded_twice is not None
+    first_store.save(loaded_once.model_copy(update={"revision": 1}))
+    with pytest.raises(CheckpointConflictError):
+        competing_store.save(loaded_twice.model_copy(update={"revision": 1}))
+
+    second_lease = repository.claim_next(execution, "activity-attempt-2", 2)
+    assert second_lease is not None
+    assert second_lease.epoch == first_lease.epoch + 1
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        first_store.load()
+
+    resumed = repository.checkpoint_store(second_lease).load()
+    assert resumed is not None
+    assert resumed.revision == 1
+    unit = repository.get_unit(execution, second_lease.unit_id)
+    assert unit is not None
+    assert unit.recovery_count == 1
+    assert unit.recovered is True
+    assert unit.lease_attempt == 2
+
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        repository.claim_next(execution, "activity-attempt-1-late", 1)
+    current = repository.get_unit(execution, second_lease.unit_id)
+    assert current is not None
+    assert current.lease_owner == "activity-attempt-2"
+    assert current.lease_attempt == 2
+    assert current.lease_epoch == second_lease.epoch
+
+
+def test_retryable_failure_defers_cursor_reset_until_reclaimed(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(execution, [_spec()])
+    lease = repository.claim_next(execution, "attempt-1", 1)
+    assert lease is not None
+    checkpoint = SearchCheckpoint.for_request(
+        build_search_request(
+            site_name="indeed",
+            search_term="Director of Engineering",
+            location="Barcelona, Spain",
+        )
+    )
+    repository.checkpoint_store(lease).save(checkpoint)
+
+    repository.record_failure(
+        lease,
+        error_code="cursor_expired",
+        error_type="CursorExpiredError",
+        retryable=True,
+        reset_checkpoint=True,
+        failed_at="2026-07-17T10:05:00+00:00",
+    )
+
+    failed = repository.get_unit(execution, lease.unit_id)
+    assert failed is not None
+    assert failed.state == "running"
+    assert failed.checkpoint_revision == 0
+    assert failed.last_error_code == "cursor_expired"
+    assert failed.last_error_retryable is True
+    assert failed.reset_checkpoint is True
+
+    # JobStreaming acknowledges the persisted ErrorEvent against the current
+    # revision before the next activity attempt applies the requested reset.
+    repository.checkpoint_store(lease).save(checkpoint.model_copy(update={"revision": 1}))
+    acknowledged = repository.get_unit(execution, lease.unit_id)
+    assert acknowledged is not None
+    assert acknowledged.checkpoint_revision == 1
+    assert acknowledged.reset_checkpoint is True
+
+    retry = repository.claim_next(execution, "attempt-2", 2)
+    assert retry is not None
+    assert retry.epoch == 2
+    assert repository.reset_checkpoint_if_requested(retry) is True
+    assert repository.checkpoint_store(retry).load() is None
+    reset = repository.get_unit(execution, retry.unit_id)
+    assert reset is not None
+    assert reset.reset_checkpoint is False
+    assert repository.reset_checkpoint_if_requested(retry) is False
+
+
+def test_execution_attempt_watermark_fences_old_owner_from_pending_unit(
+    search_db,
+) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(
+        execution,
+        [_spec(), _spec(query="VP Engineering"), _spec(query="CTO")],
+    )
+    first = repository.claim_next(execution, "attempt-1", 1)
+    assert first is not None
+    repository.mark_completed(first)
+    second = repository.claim_next(execution, "attempt-2", 2)
+    assert second is not None
+    repository.mark_completed(second)
+
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        repository.claim_next(execution, "attempt-1-late", 1)
+
+    third = repository.claim_next(execution, "attempt-2", 2)
+    assert third is not None
+    assert third.attempt == 2
+    assert [unit.state for unit in repository.list_units(execution)] == [
+        "completed",
+        "completed",
+        "running",
+    ]
+
+
+def test_terminal_failure_and_cancel_are_not_reclaimed(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(execution, [_spec(), _spec(query="VP Engineering")])
+    failed_lease = repository.claim_next(execution, "attempt-1", 1)
+    assert failed_lease is not None
+    repository.record_failure(
+        failed_lease,
+        error_code="invalid_request",
+        error_type="InvalidRequestError",
+        retryable=False,
+        reset_checkpoint=False,
+    )
+    canceled_lease = repository.claim_next(execution, "attempt-1", 1)
+    assert canceled_lease is not None
+    repository.mark_canceled(canceled_lease)
+
+    assert repository.claim_next(execution, "attempt-2", 2) is None
+    assert [unit.state for unit in repository.list_units(execution)] == [
+        "failed",
+        "canceled",
+    ]
+
+
+def test_result_limit_marks_only_unclaimed_units_skipped(search_db) -> None:
+    repository = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    repository.plan_units(
+        execution,
+        [_spec(), _spec(query="VP Engineering"), _spec(query="CTO")],
+    )
+    active_lease = repository.claim_next(execution, "attempt-1", 1)
+    assert active_lease is not None
+
+    skipped = repository.mark_pending_skipped(
+        execution,
+        skipped_at="2026-07-17T10:05:00+00:00",
+    )
+
+    assert skipped == 2
+    assert [unit.state for unit in repository.list_units(execution)] == [
+        "running",
+        "skipped",
+        "skipped",
+    ]
+    assert repository.claim_next(execution, "attempt-2", 2) is not None
+
+
+def test_job_write_and_new_receipt_share_the_fenced_repository_path(search_db) -> None:
+    search_units = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    search_units.plan_units(execution, [_spec()])
+    first_lease = search_units.claim_next(execution, "attempt-1", 1)
+    assert first_lease is not None
+    jobs = SqliteJobRepository(
+        search_db,
+        discovery_execution=execution,
+        source_family="jobspy",
+        search_unit_lease=first_lease,
+    )
+    discovered_at = "2026-07-17T10:00:00+00:00"
+    job = Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId("https://example.test/jobs/1"),
+        posting_url=PostingUrl(value="https://example.test/jobs/1"),
+        source=Source(board="indeed"),
+        employer=Employer.unknown(),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(
+            title="Director of Engineering",
+            description="Lead the engineering organization.",
+            location="Barcelona, Spain",
+        ),
+        discovered_at=discovered_at,
+    )
+
+    jobs.save(job)
+    jobs.save(job)
+
+    unit = search_units.get_unit(execution, first_lease.unit_id)
+    assert unit is not None
+    assert unit.accepted_jobs == 1
+    assert unit.new_jobs == 1
+    assert unit.existing_jobs == 0
+    assert search_units.execution_counts(execution) == {
+        "accepted": 1,
+        "new": 1,
+        "existing": 0,
+    }
+
+    second_lease = search_units.claim_next(execution, "attempt-2", 2)
+    assert second_lease is not None
+    stale_jobs = SqliteJobRepository(
+        search_db,
+        discovery_execution=execution,
+        source_family="jobspy",
+        search_unit_lease=first_lease,
+    )
+    stale_job = Job.discover(
+        tenant_id=LOCAL_TENANT,
+        job_id=JobId("https://example.test/jobs/stale"),
+        posting_url=PostingUrl(value="https://example.test/jobs/stale"),
+        source=Source(board="indeed"),
+        employer=Employer.unknown(),
+        search_strategy=SearchStrategy.JOBSPY,
+        metadata=JobMetadata(
+            title="Stale attempt",
+            description="This write must be fenced.",
+            location="Remote",
+        ),
+        discovered_at=discovered_at,
+    )
+
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        stale_jobs.save(stale_job)
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        stale_jobs.set_canonical_identity(
+            LOCAL_TENANT,
+            job.job_id,
+            CanonicalJobIdentity(
+                canonical_url=job.posting_url.value,
+                ats_kind=AtsKind.OTHER,
+                source_native_id="stale-native-id",
+                confidence=1.0,
+            ),
+        )
+    assert (
+        search_db.execute("SELECT 1 FROM jobs WHERE url = ?", ("https://example.test/jobs/stale",)).fetchone() is None
+    )
+
+
+def test_jobspy_storage_records_new_receipt_once_across_replay(search_db) -> None:
+    search_units = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    search_units.plan_units(execution, [_spec()])
+    lease = search_units.claim_next(execution, "attempt-1", 1)
+    assert lease is not None
+    frame = pd.DataFrame(
+        [
+            {
+                "id": "indeed-1",
+                "job_url": "https://example.test/jobs/jobstreaming-1",
+                "job_url_direct": "https://boards.greenhouse.io/example/jobs/12345",
+                "title": "Director of Engineering",
+                "company": "Example",
+                "description": "Lead engineering, platform, security, and delivery. " * 8,
+                "location": "Barcelona, Spain",
+                "site": "indeed",
+                "is_remote": True,
+            }
+        ]
+    )
+    search_cfg = {
+        "queries": [{"query": "Director of Engineering"}],
+        "locations": [{"location": "Barcelona, Spain", "remote": True}],
+        "location_accept": ["Barcelona, Spain", "Spain", "Europe"],
+        "location": {
+            "accept_patterns": ["Barcelona, Spain", "Spain", "Europe"],
+            "reject_patterns": [],
+        },
+    }
+
+    first = store_jobspy_results(
+        search_db,
+        frame,
+        "Director of Engineering",
+        run_id="discovery:jobspy:first",
+        search_cfg=search_cfg,
+        discovery_execution=execution,
+        search_unit_lease=lease,
+    )
+    first_events = {
+        str(row[0]): int(row[1])
+        for row in search_db.execute(
+            """
+            SELECT event_type, COUNT(*)
+              FROM job_events
+             WHERE job_url = ?
+             GROUP BY event_type
+            """,
+            ("https://example.test/jobs/jobstreaming-1",),
+        ).fetchall()
+    }
+    replay = store_jobspy_results(
+        search_db,
+        frame,
+        "Director of Engineering",
+        run_id="discovery:jobspy:retry",
+        search_cfg=search_cfg,
+        discovery_execution=execution,
+        search_unit_lease=lease,
+    )
+
+    assert first == (1, 0)
+    assert replay == (0, 1)
+    replay_events = {
+        str(row[0]): int(row[1])
+        for row in search_db.execute(
+            """
+            SELECT event_type, COUNT(*)
+              FROM job_events
+             WHERE job_url = ?
+             GROUP BY event_type
+            """,
+            ("https://example.test/jobs/jobstreaming-1",),
+        ).fetchall()
+    }
+    assert replay_events == first_events
+    assert first_events["JobMetadataUpdated"] == 1
+    assert search_db.execute(
+        """
+        SELECT COUNT(*)
+          FROM job_events
+         WHERE job_url = ?
+           AND idempotency_key LIKE 'jobstreaming:%'
+        """,
+        ("https://example.test/jobs/jobstreaming-1",),
+    ).fetchone()[0] == sum(first_events.values())
+    assert search_units.execution_counts(execution) == {
+        "accepted": 1,
+        "new": 1,
+        "existing": 0,
+    }
+
+
+def test_mid_event_supersession_is_fenced_and_retry_repairs_audit_rows(
+    search_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    search_units = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    search_units.plan_units(execution, [_spec()])
+    first_lease = search_units.claim_next(execution, "attempt-1", 1)
+    assert first_lease is not None
+    frame = pd.DataFrame(
+        [
+            {
+                "id": "indeed-mid-event",
+                "job_url": "https://example.test/jobs/mid-event",
+                "title": "Director of Engineering",
+                "company": "Example",
+                "description": "Lead engineering, platform, security, and delivery. " * 8,
+                "location": "Barcelona, Spain",
+                "site": "indeed",
+                "is_remote": True,
+            }
+        ]
+    )
+    search_cfg = {
+        "queries": [{"query": "Director of Engineering"}],
+        "locations": [{"location": "Barcelona, Spain", "remote": True}],
+        "location_accept": ["Barcelona, Spain", "Spain", "Europe"],
+        "location": {
+            "accept_patterns": ["Barcelona, Spain", "Spain", "Europe"],
+            "reject_patterns": [],
+        },
+    }
+    original_set_identity = SqliteJobRepository.set_canonical_identity
+    reclaimed: list = []
+
+    def reclaim_before_identity(self, tenant_id, job_id, identity):
+        if not reclaimed:
+            next_lease = search_units.claim_next(execution, "attempt-2", 2)
+            assert next_lease is not None
+            reclaimed.append(next_lease)
+        return original_set_identity(self, tenant_id, job_id, identity)
+
+    monkeypatch.setattr(
+        SqliteJobRepository,
+        "set_canonical_identity",
+        reclaim_before_identity,
+    )
+
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        store_jobspy_results(
+            search_db,
+            frame,
+            "Director of Engineering",
+            run_id="discovery:jobspy:interrupted",
+            search_cfg=search_cfg,
+            discovery_execution=execution,
+            search_unit_lease=first_lease,
+        )
+
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM jobs WHERE url = ?",
+            ("https://example.test/jobs/mid-event",),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
+            ("https://example.test/jobs/mid-event",),
+        ).fetchone()[0]
+        == 0
+    )
+    assert reclaimed
+
+    resumed = store_jobspy_results(
+        search_db,
+        frame,
+        "Director of Engineering",
+        run_id="discovery:jobspy:resumed",
+        search_cfg=search_cfg,
+        discovery_execution=execution,
+        search_unit_lease=reclaimed[0],
+    )
+
+    assert resumed == (0, 1)
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_canonical_identities WHERE job_url = ?",
+            ("https://example.test/jobs/mid-event",),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_source_observations WHERE job_url = ?",
+            ("https://example.test/jobs/mid-event",),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
+            ("https://example.test/jobs/mid-event",),
+        ).fetchone()[0]
+        == 4
+    )
+    assert search_units.execution_counts(execution) == {
+        "accepted": 1,
+        "new": 1,
+        "existing": 0,
+    }
+
+
+def test_compensation_event_rechecks_fence_after_fact_commit(search_db) -> None:
+    job_url = "https://example.test/jobs/compensation-fence"
+    search_db.execute(
+        """
+        INSERT INTO jobs (url, title, salary, description, location, site, strategy)
+        VALUES (?, 'Director of Engineering', 'EUR 150000/year',
+                'Lead engineering.', 'Barcelona, Spain', 'indeed', 'jobspy')
+        """,
+        (job_url,),
+    )
+    search_db.commit()
+    search_units = SqliteDiscoverySearchUnitRepository(search_db)
+    execution = _execution()
+    search_units.plan_units(execution, [_spec()])
+    first_lease = search_units.claim_next(execution, "attempt-1", 1)
+    assert first_lease is not None
+    compensation = SqlitePostedCompensationRepository(search_db)
+    reclaimed: list = []
+
+    def supersede_before_event() -> None:
+        next_lease = search_units.claim_next(execution, "attempt-2", 2)
+        assert next_lease is not None
+        reclaimed.append(next_lease)
+        search_units.fence_write(first_lease)
+
+    with pytest.raises(StaleDiscoverySearchUnitLease):
+        compensation.parse_and_save_job_salary(
+            job_url,
+            "EUR 150000/year",
+            parsed_at="2026-07-17T10:00:00+00:00",
+            event_idempotency_key="jobstreaming:test:CompensationFactsUpdated",
+            event_write_fence=supersede_before_event,
+        )
+
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_posted_compensation_facts WHERE job_url = ?",
+            (job_url,),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
+            (job_url,),
+        ).fetchone()[0]
+        == 0
+    )
+    assert reclaimed
+
+    compensation.parse_and_save_job_salary(
+        job_url,
+        "EUR 150000/year",
+        parsed_at="2026-07-17T10:01:00+00:00",
+        event_idempotency_key="jobstreaming:test:CompensationFactsUpdated",
+        event_write_fence=lambda: search_units.fence_write(reclaimed[0]),
+    )
+    assert (
+        search_db.execute(
+            "SELECT COUNT(*) FROM job_events WHERE job_url = ?",
+            (job_url,),
+        ).fetchone()[0]
+        == 1
+    )


### PR DESCRIPTION
## Summary

Phase 2 of the three-PR resumable JobStreaming discovery stack, based on #468 (which is based on #467).

- persist immutable query/location/board search units under the exact Discover workflow and Temporal run
- store opaque JobStreaming checkpoints with revision compare-and-swap
- fence stale activity attempts with an execution-wide Temporal-attempt high-water mark and per-unit lease epoch
- persist replay-safe accepted-job receipts and durable run-wide new/existing counts
- defer cursor resets until a provider error has been acknowledged, then apply the reset on the next fenced attempt
- make accepted-result side effects fence-aware and give their durable events stable consumption keys so replay cannot inflate audit history
- represent limit-closed work explicitly as skipped instead of leaving ambiguous pending rows
- keep the TypeScript API schema-version guard aligned with the Python worker's v4 durability schema

## Why

A retried broad-board activity currently starts its family crawl over with only in-memory progress. This layer establishes the caller-owned correctness boundary needed for a killed activity to resume safely in Phase 3: immutable work, monotonic ownership, durable consumption state, and idempotent replay.

## Validation

- `ruff check` on every touched Python surface
- 179 focused discovery, persistence, compensation, state, and migration tests passed
- regressions cover execution-wide stale-attempt fencing, checkpoint CAS, error-ack/reset ordering, mid-event supersession, the compensation commit window, replay event cardinality, cancellation, terminal failure, and durable limit counts
- API typecheck and 10 schema-version guard tests passed after aligning the v4 guard
- `git diff --check`
- independent review: `Gate: PASS; Blocker=0 High=0 Medium=0 Low=0`

Canonical user and architecture documentation remains intentionally deferred to the final PR because these phases form one unreleased stack.