### PR TITLE
fix(release): align source dependency baseline

### DIFF
--- a/packaging/distribution/source-baseline.json
+++ b/packaging/distribution/source-baseline.json
@@ -9,7 +9,7 @@
     "pythonCoreRuntimeDirect": 18,
     "pythonProviderRuntimeDirect": 4,
     "pythonDevelopmentDirect": 6,
-    "uvPackageRecords": 103
+    "uvPackageRecords": 102
   },
   "referenceFootprint": {
     "status": "observational",


### PR DESCRIPTION
## Summary

- update the reproducible UV package-record count from 103 to 102
- restore the distribution contract after PR #468 intentionally replaced `python-jobspy` with `jobstreaming`
- unblock the Demo Site workflow's `scripts:test` gate once GitHub-hosted runners are available

## Root cause

PR #468 changed `workers/automation/uv.lock` from 103 to 102 package records, but `packaging/distribution/source-baseline.json` retained the previous derived count. Hosted workflows did not expose the mismatch because the private repository's Actions jobs are currently blocked before runner allocation by the account billing/spending state.

## Validation

- `node --test scripts/distribution-manifest.test.mjs` — 18/18 passed
- `corepack pnpm scripts:test` — 115/115 passed
- `corepack pnpm distribution:audit` — passed
- `corepack pnpm demo-edge:test` — 31/31 passed
- `corepack pnpm demo-edge:dry-run` — passed
- `corepack pnpm demo:build` — passed
- `corepack pnpm docs:build` — passed; 8,244 emitted references resolved
- `corepack pnpm docs:check:runtime` — passed
- clean exact-tree `python3 scripts/release_check.py --strict-prompt` — passed
- release-check self-test — 42/42 passed
- independent review — PASS, zero findings
- `git diff --check` — passed

## Deployment status

The production demo and docs remain on older Cloudflare deployments. Their post-merge workflows cannot start while GitHub Actions reports the account billing/spending-limit restriction. The repository publication checklist requires real hosted steps on the exact `main` SHA, so this change does not bypass that gate with a local production deployment.