### PR TITLE
fix(docs): add launch metadata

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -3,6 +3,8 @@ import { defineConfig, type DefaultTheme } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
 const REPO_URL = "https://github.com/ebarti/JobCtrl";
+const DOCS_SITE_URL = "https://jobctrl.dev";
+const SOCIAL_IMAGE_URL = `${DOCS_SITE_URL}/assets/brand/lockup-primary.png`;
 
 // Docs that stay in the repository but are not published on the site.
 // docs/README.md is the repo-facing documentation map (GitHub renders it when
@@ -31,6 +33,14 @@ function routeForRewrittenPage(docPath: string): string | null {
   if (!rewritten) return null;
   // With cleanUrls: `index.md` -> `/`, `developer/index.md` -> `/developer/`.
   return "/" + rewritten.replace(/index\.md$/, "").replace(/\.md$/, "");
+}
+
+function canonicalUrlForPage(docPath: string): string {
+  const rewrittenPath = PAGE_REWRITES[docPath] ?? docPath;
+  const route = rewrittenPath
+    .replace(/(?:^|\/)index\.md$/, "/")
+    .replace(/\.md$/, "");
+  return new URL(route.startsWith("/") ? route : `/${route}`, DOCS_SITE_URL).toString();
 }
 
 // One guide, one navigation tree. The first two groups answer the questions a
@@ -235,9 +245,23 @@ export default withMermaid(
       ["link", { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
       ["link", { rel: "apple-touch-icon", sizes: "180x180", href: "/apple-touch-icon.png" }],
       ["link", { rel: "icon", type: "image/png", sizes: "512x512", href: "/assets/brand/app-icon.png" }],
-      ["meta", { property: "og:image", content: "https://jobctrl.dev/assets/brand/lockup-primary.png" }],
       ["meta", { name: "theme-color", content: "#6d28d9" }],
     ],
+    transformHead: ({ pageData, title, description }) => {
+      const canonicalUrl = canonicalUrlForPage(pageData.relativePath);
+      return [
+        ["link", { rel: "canonical", href: canonicalUrl }],
+        ["meta", { property: "og:type", content: "website" }],
+        ["meta", { property: "og:url", content: canonicalUrl }],
+        ["meta", { property: "og:title", content: title }],
+        ["meta", { property: "og:description", content: description }],
+        ["meta", { property: "og:image", content: SOCIAL_IMAGE_URL }],
+        ["meta", { name: "twitter:card", content: "summary_large_image" }],
+        ["meta", { name: "twitter:title", content: title }],
+        ["meta", { name: "twitter:description", content: description }],
+        ["meta", { name: "twitter:image", content: SOCIAL_IMAGE_URL }],
+      ];
+    },
     srcExclude: [
       "plans/**",
       "incidents/**",

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ features:
     linkText: Understand the audit trail
   - icon: ✅
     title: Supervised Apply
-    details: Rehearse with dry runs, approve every live submission explicitly, a browser-level guard blocks dry-run submits, and no application is ever submitted twice.
+    details: Rehearse with dry runs, require explicit approval for live submissions by default, a browser-level guard blocks dry-run submits, and no application is ever submitted twice.
     link: /user/apply
     linkText: Understand apply controls
   - icon: 🔒

--- a/scripts/check-docs-site-runtime.mjs
+++ b/scripts/check-docs-site-runtime.mjs
@@ -31,6 +31,7 @@ const { chromium } = require("@playwright/test");
 const PAGES = [
   { path: "/", visualSelector: null, images: false },
   { path: "/architecture/", visualSelector: ".system-topology", images: false },
+  { path: "/developer/", visualSelector: null, images: false },
   {
     path: "/architecture/scoring",
     visualSelector: ".mermaid svg",
@@ -91,6 +92,14 @@ const PAGES = [
   },
   { path: "/comparison", visualSelector: null, images: true },
 ];
+
+const SOCIAL_METADATA_ROUTES = new Set([
+  "/",
+  "/architecture/",
+  "/developer/",
+  "/user/apply",
+]);
+const SOCIAL_IMAGE_URL = "https://jobctrl.dev/assets/brand/lockup-primary.png";
 
 const LIFECYCLE_EXPLANATION_CONTRACTS = [
   {
@@ -317,6 +326,50 @@ async function productTourGeometry(page) {
   });
 }
 
+async function assertSocialMetadata(page, route) {
+  const metadata = await page.evaluate(() => {
+    const values = (selector, attribute = "content") =>
+      Array.from(document.head.querySelectorAll(selector)).map((element) =>
+        element.getAttribute(attribute),
+      );
+    return {
+      title: document.title,
+      description: values('meta[name="description"]')[0],
+      canonical: values('link[rel="canonical"]', "href"),
+      ogType: values('meta[property="og:type"]'),
+      ogUrl: values('meta[property="og:url"]'),
+      ogTitle: values('meta[property="og:title"]'),
+      ogDescription: values('meta[property="og:description"]'),
+      ogImage: values('meta[property="og:image"]'),
+      twitterCard: values('meta[name="twitter:card"]'),
+      twitterTitle: values('meta[name="twitter:title"]'),
+      twitterDescription: values('meta[name="twitter:description"]'),
+      twitterImage: values('meta[name="twitter:image"]'),
+    };
+  });
+  const expectedCanonical = `https://jobctrl.dev${route}`;
+  const expected = {
+    canonical: [expectedCanonical],
+    ogType: ["website"],
+    ogUrl: [expectedCanonical],
+    ogTitle: [metadata.title],
+    ogDescription: [metadata.description],
+    ogImage: [SOCIAL_IMAGE_URL],
+    twitterCard: ["summary_large_image"],
+    twitterTitle: [metadata.title],
+    twitterDescription: [metadata.description],
+    twitterImage: [SOCIAL_IMAGE_URL],
+  };
+  const mismatches = Object.entries(expected)
+    .filter(([key, values]) => JSON.stringify(metadata[key]) !== JSON.stringify(values))
+    .map(([key]) => key);
+  if (!metadata.title || !metadata.description || mismatches.length > 0) {
+    fail(`${route}: canonical or social metadata is missing, duplicated, or conflicting (${mismatches.join(", ")})`);
+  } else {
+    console.log(`ok    ${route} canonical and social metadata`);
+  }
+}
+
 const port = await freePort();
 const preview = spawn(
   "corepack",
@@ -371,6 +424,10 @@ try {
     await page.goto(`http://127.0.0.1:${port}${spec.path}`, {
       waitUntil: "networkidle",
     });
+
+    if (SOCIAL_METADATA_ROUTES.has(spec.path)) {
+      await assertSocialMetadata(page, spec.path);
+    }
 
     if (spec.visualSelector) {
       const visual = page.locator(spec.visualSelector).first();

--- a/scripts/docs-launch-copy.test.mjs
+++ b/scripts/docs-launch-copy.test.mjs
@@ -74,6 +74,15 @@ test("comparison omits the annotated recommendation and methodology sections", a
   assert.match(comparison, /^## Appendix: evidence-backed capability matrix$/m);
 });
 
+test("homepage describes live submission approval as the default", async () => {
+  const homepage = await read("docs/index.md");
+
+  assert.match(homepage, /require explicit approval for live submissions by default/i);
+  assert.match(homepage, /browser-level guard blocks dry-run submits/i);
+  assert.match(homepage, /no application is ever submitted twice/i);
+  assert.doesNotMatch(homepage, /approve every live submission explicitly/i);
+});
+
 test("launch provider guidance requires one of Codex, Claude, or Google", async () => {
   const readme = await read("README.md");
   const gettingStarted = await read("docs/user/getting-started.md");


### PR DESCRIPTION
## What changed

- add route-specific canonical URLs and complete Open Graph/Twitter metadata to the public docs site
- describe live-submission approval accurately as the default behavior
- regression-test metadata across root, nested index, rewritten index, and leaf routes

## Why

The launch site exposed an image tag but omitted canonical, title, description, and Twitter metadata. The homepage also overstated approval as an unconditional rule even though it is a configurable default.

## Validation

- `node --test scripts/docs-launch-copy.test.mjs` (6 passed)
- `corepack pnpm docs:build` (passed; 8,238 emitted references resolved)
- `corepack pnpm docs:check:runtime` (passed for `/`, `/architecture/`, `/developer/`, and `/user/apply` metadata)
- `git diff --check`
- independent review: PASS (0 Blocker, 0 High, 0 Medium, 0 Low)
