### PR TITLE
fix(demo): disclose public data controller

### DIFF
--- a/apps/web/src/demo/consent/DemoConsentGate.test.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.test.tsx
@@ -24,6 +24,19 @@ describe("DemoConsentGate", () => {
     const user = userEvent.setup();
 
     expect(screen.getByText(/demo can only be used after accepting first-party analytics cookies/i)).toBeVisible();
+    expect(screen.getByText(/data controller: eloi barti, acting as an individual/i)).toBeVisible();
+    expect(screen.getByRole("link", { name: "me@eloibarti.com" })).toHaveAttribute(
+      "href",
+      "mailto:me@eloibarti.com",
+    );
+    expect(screen.getByRole("link", { name: "demo data notice" })).toHaveAttribute(
+      "href",
+      "https://jobctrl.dev/user/data-and-safety#public-demo",
+    );
+    expect(screen.getByRole("link", { name: "security boundary" })).toHaveAttribute(
+      "href",
+      "https://jobctrl.dev/user/security#public-demo-boundary",
+    );
     const acceptButton = screen.getByRole("button", { name: "Accept cookies and enter demo" });
     expect(acceptButton).toHaveAttribute("data-slot", "button");
     await user.click(acceptButton);

--- a/apps/web/src/demo/consent/DemoConsentGate.tsx
+++ b/apps/web/src/demo/consent/DemoConsentGate.tsx
@@ -64,6 +64,10 @@ export function DemoConsentGate({
           experience. The demo uses synthetic jobs and stays in this browser; do not enter
           personal data, credentials, or secrets.
         </p>
+        <p>
+          Data controller: Eloi Barti, acting as an individual. Privacy questions: {" "}
+          <a href="mailto:me@eloibarti.com">me@eloibarti.com</a>.
+        </p>
         {initialChoice === "denied" ? (
           <p className="demo-consent-return-note">
             You previously declined. Accept now to enter, or decline again to return to

--- a/docs/user/data-and-safety.md
+++ b/docs/user/data-and-safety.md
@@ -41,6 +41,9 @@ returns to `https://jobctrl.dev`; opening the demo again shows the choice again.
 The demo does not initialize its browser-local workspace until the consent
 service confirms acceptance.
 
+The data controller for the public demo is Eloi Barti, acting as an individual.
+For privacy questions, contact [me@eloibarti.com](mailto:me@eloibarti.com).
+
 After acceptance, Cloudflare sets a versioned consent cookie plus random
 HttpOnly visitor and session identifiers. The persistent cookies expire within
 six months, the session cookie at the end of the browser session, and raw demo

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -37,6 +37,15 @@ boundary.
 | Bundled runtime | Payload path confinement, isolated Python startup, manifest verification, and hash-locked provider packs with activation-time revalidation. |
 | Privacy and release | Metadata-only telemetry, synthetic-demo isolation, private local file modes for sensitive control files, and release scanning for secrets and private artifacts. |
 
+## Public Demo Boundary
+
+The hosted public demo uses synthetic data in a browser-local workspace. Its
+shortcuts and actions are simulations: they do not contact employers, send
+messages, or make external changes.
+
+For the demo's first-party cookie consent, retention, data-controller identity,
+and privacy contact, read the canonical [Public Demo data notice](data-and-safety.md#public-demo).
+
 ## What Leaves Your Machine
 
 | Outbound call | When | What can be sent |

--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -342,6 +342,40 @@ PUBLIC_COPYRIGHT_SNIPPETS = (
     f"Copyright (C) 2026 {PUBLIC_COPYRIGHT_HOLDER}",
     f"Copyright © 2026 {PUBLIC_COPYRIGHT_HOLDER}",
 )
+PUBLIC_DEMO_CONTROLLER_NAME = "El" + "oi Barti"
+PUBLIC_DEMO_CONTROLLER_EMAIL = "me@" + "el" + "oi" + "barti" + ".com"
+PUBLIC_DEMO_CONTROLLER_SOURCE_SNIPPETS = {
+    Path("apps/web/src/demo/consent/DemoConsentGate.tsx"): (
+        f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+        f'<a href="mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+    ),
+    Path("apps/web/src/demo/consent/DemoConsentGate.test.tsx"): (
+        f"screen.getByText(/data controller: {PUBLIC_DEMO_CONTROLLER_NAME.lower()}, acting as an individual/i)",
+        f'name: "{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
+        f'"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
+    ),
+    Path("docs/user/data-and-safety.md"): (
+        f"The data controller for the public demo is {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual.\n"
+        f"For privacy questions, contact [{PUBLIC_DEMO_CONTROLLER_EMAIL}](mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}).",
+    ),
+    Path("docs/.vitepress/dist/user/data-and-safety.html"): (
+        f"The data controller for the public demo is {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual.",
+        f'href="mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+    ),
+}
+PUBLIC_DEMO_CONTROLLER_BUILD_ASSET_PREFIXES = (
+    Path("dist/web/assets"),
+    Path("dist/web-storybook/assets"),
+    Path("apps/web/dist/assets"),
+)
+PUBLIC_DEMO_CONTROLLER_BUILD_SNIPPETS = (
+    f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+    f'href:"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}",children:"{PUBLIC_DEMO_CONTROLLER_EMAIL}"',
+)
+PUBLIC_DEMO_CONTROLLER_BUILD_SOURCE_MAP_SNIPPETS = (
+    f"Data controller: {PUBLIC_DEMO_CONTROLLER_NAME}, acting as an individual. Privacy questions:",
+    f'href=\\"mailto:{PUBLIC_DEMO_CONTROLLER_EMAIL}\\">{PUBLIC_DEMO_CONTROLLER_EMAIL}</a>',
+)
 
 
 def candidate_files(root: Path = ROOT) -> list[Path]:
@@ -576,14 +610,42 @@ def scan_text(
 ) -> list[str]:
     """Scan text content for forbidden strings and non-empty secret assignments."""
     findings = []
+    redacted_text = _redact_public_demo_controller_disclosure(text, rel)
     for needle in needles:
-        scan_target = _redact_public_attribution(text, rel, needle)
+        scan_target = _redact_public_attribution(redacted_text, rel, needle)
         if _contains_needle(scan_target, needle):
             findings.append(f"{label}: contains {needle.reason}")
 
     if _is_secret_assignment_file(rel):
         findings.extend(scan_secret_assignments(label, text))
     return findings
+
+
+def _redact_public_demo_controller_disclosure(text: str, rel: Path) -> str:
+    """Exclude the approved controller disclosure only at its public release surfaces."""
+    snippets = PUBLIC_DEMO_CONTROLLER_SOURCE_SNIPPETS.get(rel)
+    if snippets is None and _is_public_demo_controller_build_asset(rel):
+        snippets = (
+            PUBLIC_DEMO_CONTROLLER_BUILD_SOURCE_MAP_SNIPPETS
+            if rel.suffix.lower() == ".map"
+            else PUBLIC_DEMO_CONTROLLER_BUILD_SNIPPETS
+        )
+    if snippets is None:
+        return text
+
+    redacted = text
+    for snippet in snippets:
+        redacted = redacted.replace(snippet, "<public demo controller disclosure>")
+    return redacted
+
+
+def _is_public_demo_controller_build_asset(rel: Path) -> bool:
+    if rel.is_absolute() or ".." in rel.parts:
+        return False
+    return rel.suffix.lower() in {*MINIFIED_BUILD_SUFFIXES, ".map"} and any(
+        rel.is_relative_to(prefix)
+        for prefix in PUBLIC_DEMO_CONTROLLER_BUILD_ASSET_PREFIXES
+    )
 
 
 def _redact_public_attribution(text: str, rel: Path, needle: ForbiddenNeedle) -> str:

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -46,6 +46,108 @@ def test_public_copyright_attribution_does_not_disable_private_name_detection() 
     ) == ["README.md: contains private first name"]
 
 
+def test_public_demo_controller_disclosure_is_limited_to_exact_public_surfaces() -> None:
+    controller = "El" + "oi Barti"
+    email = "me@" + "el" + "oi" + "barti" + ".com"
+    source_disclosure = (
+        f"Data controller: {controller}, acting as an individual. Privacy questions:\n"
+        f'<a href="mailto:{email}">{email}</a>'
+    )
+    docs_disclosure = (
+        f"The data controller for the public demo is {controller}, acting as an individual.\n"
+        f"For privacy questions, contact [{email}](mailto:{email})."
+    )
+    test_disclosure = (
+        f"screen.getByText(/data controller: {controller.lower()}, acting as an individual/i)\n"
+        f'screen.getByRole("link", {{ name: "{email}" }})).toHaveAttribute(\n'
+        f'  "href",\n  "mailto:{email}",\n)'
+    )
+    emitted_demo_disclosure = (
+        f'Data controller: {controller}, acting as an individual. Privacy questions: "," '
+        f'I.jsx("a",{{href:"mailto:{email}",children:"{email}"}})'
+    )
+
+    assert release_check.scan_text(
+        "apps/web/src/demo/consent/DemoConsentGate.tsx",
+        source_disclosure,
+        Path("apps/web/src/demo/consent/DemoConsentGate.tsx"),
+    ) == []
+    assert release_check.scan_text(
+        "docs/user/data-and-safety.md",
+        docs_disclosure,
+        Path("docs/user/data-and-safety.md"),
+    ) == []
+    assert release_check.scan_text(
+        "apps/web/src/demo/consent/DemoConsentGate.test.tsx",
+        test_disclosure,
+        Path("apps/web/src/demo/consent/DemoConsentGate.test.tsx"),
+    ) == []
+    assert release_check.scan_text(
+        "dist/web/assets/demo.js",
+        emitted_demo_disclosure,
+        Path("dist/web/assets/demo.js"),
+    ) == []
+    assert release_check.scan_text(
+        "dist/web/assets/demo.js.map",
+        source_disclosure.replace('"', '\\"'),
+        Path("dist/web/assets/demo.js.map"),
+    ) == []
+    assert release_check.scan_text(
+        "docs/.vitepress/dist/user/data-and-safety.html",
+        (
+            f"The data controller for the public demo is {controller}, acting as an individual.\n"
+            f'<a href="mailto:{email}">{email}</a>'
+        ),
+        Path("docs/.vitepress/dist/user/data-and-safety.html"),
+    ) == []
+
+    expected = {
+        "contains private username/domain",
+        "contains private first name",
+        "contains private personal domain",
+    }
+    for label, rel in (
+        ("docs/unrelated.md", Path("docs/unrelated.md")),
+        ("dist/web/assets/unrelated.js", Path("dist/web/assets/unrelated.js")),
+        ("dist/web/assets/unrelated.js.map", Path("dist/web/assets/unrelated.js.map")),
+    ):
+        findings = release_check.scan_text(label, f"{controller} {email}", rel)
+        assert {finding.split(": ", 1)[1] for finding in findings} == expected
+
+
+def test_public_demo_controller_build_assets_reject_archive_path_traversal(tmp_path: Path) -> None:
+    controller = "El" + "oi Barti"
+    email = "me@" + "el" + "oi" + "barti" + ".com"
+    payload = (
+        f'Data controller: {controller}, acting as an individual. Privacy questions: "," '
+        f'I.jsx("a",{{href:"mailto:{email}",children:"{email}"}})'
+    ).encode()
+    member = "dist/web/assets/../../private.js"
+    zip_path = tmp_path / "dist/controller.zip"
+    zip_path.parent.mkdir(parents=True)
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr(member, payload)
+
+    tar_path = tmp_path / "dist/controller.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as archive:
+        info = tarfile.TarInfo(member)
+        info.size = len(payload)
+        archive.addfile(info, io.BytesIO(payload))
+
+    assert not release_check._is_public_demo_controller_build_asset(Path(member))
+    assert not release_check._is_public_demo_controller_build_asset(
+        Path("/dist/web/assets/demo.js")
+    )
+    for archive_path, findings in (
+        (zip_path, release_check.scan_zip_archive(tmp_path, zip_path)),
+        (tar_path, release_check.scan_tar_archive(tmp_path, tar_path)),
+    ):
+        assert (
+            f"{archive_path.relative_to(tmp_path)}!{member}: contains private username/domain"
+            in findings
+        )
+
+
 def test_public_demo_fixture_allowlist_is_exact_and_keeps_the_pdf_ban() -> None:
     allowed = Path("apps/web/public/demo/profile-resume.pdf")
 


### PR DESCRIPTION
## What changed

- identify the public demo data controller and privacy contact before consent
- add the same disclosure to the canonical public-demo data and security documentation
- narrowly permit the exact approved disclosure on named release surfaces while preserving privacy findings everywhere else
- reject traversal-shaped and absolute generated-archive paths before any release-scanner exception applies

## Why

The consent screen linked to privacy documentation but did not identify who controls the public demo data or how to contact them. Adding that disclosure also required a narrowly scoped update to the release privacy scanner so approved public legal text is not mistaken for leaked local identity data.

## Validation

- release-check regression suite: 44 passed
- strict release privacy scan: passed
- consent behavior/accessibility tests: 4 passed
- web typecheck: passed
- demo production build: passed
- docs build: passed
- five demo consent browser scenarios: passed
- desktop/mobile disclosure and consent product-path smoke: passed with no overflow or console errors
- independent reviewer: PASS (0 findings)
- independent QA: PASS (0 findings)
- `git diff --check`
