### PR TITLE
fix(release): isolate QA artifacts from archive scans

### DIFF
--- a/scripts/release_check.py
+++ b/scripts/release_check.py
@@ -120,6 +120,10 @@ ARCHIVE_DIRS = (
     Path("dist"),
     Path("workers/automation/dist"),
 )
+NON_RELEASE_QA_OUTPUT_DIRS = (
+    Path("dist/playwright-report"),
+    Path("dist/web-storybook"),
+)
 
 FORBIDDEN_PATH_NAMES = {
     ".env",
@@ -580,6 +584,8 @@ def scan_demo_build_outputs(
     """Scan ignored web-build outputs, source maps, and copied demo fixture bytes."""
     findings: list[str] = []
     for build_dir in DEMO_BUILD_DIRS:
+        if build_dir in NON_RELEASE_QA_OUTPUT_DIRS:
+            continue
         path = root / build_dir
         if not path.exists():
             continue
@@ -1656,15 +1662,42 @@ def scan_dist_archives(
         if not dist_path.exists():
             continue
         for archive in sorted(candidate for candidate in dist_path.rglob("*") if candidate.is_file()):
+            if _is_non_release_qa_output(root, archive):
+                continue
             if archive.suffix in {".whl", ".zip"}:
-                findings.extend(scan_zip_archive(root, archive, needles=needles))
+                archive_findings = scan_zip_archive(root, archive, needles=needles)
             elif archive.name.endswith(".tar.gz"):
-                findings.extend(scan_tar_archive(root, archive, needles=needles))
+                archive_findings = scan_tar_archive(root, archive, needles=needles)
+            else:
+                archive_findings = []
+            findings.extend(archive_findings)
             if expected_version is not None and (archive.suffix == ".whl" or archive.name.endswith(".tar.gz")):
-                findings.extend(
-                    _distribution_version_findings(root, archive, expected_version)
-                )
+                if not _has_unreadable_archive_finding(root, archive, archive_findings):
+                    findings.extend(
+                        _distribution_version_findings(root, archive, expected_version)
+                    )
     return findings
+
+
+def _is_non_release_qa_output(root: Path, path: Path) -> bool:
+    """Return whether a file belongs to an ignored non-release QA output tree."""
+    relative = path.relative_to(root)
+    return any(
+        relative.parts[: len(output_dir.parts)] == output_dir.parts
+        for output_dir in NON_RELEASE_QA_OUTPUT_DIRS
+    )
+
+
+def _unreadable_archive_finding(path: Path, root: Path, archive_type: str) -> str:
+    return f"{path.relative_to(root)}: unreadable {archive_type} archive"
+
+
+def _has_unreadable_archive_finding(
+    root: Path,
+    path: Path,
+    findings: Iterable[str],
+) -> bool:
+    return any(finding.startswith(f"{path.relative_to(root)}: unreadable ") for finding in findings)
 
 
 def _distribution_version_findings(
@@ -1674,20 +1707,24 @@ def _distribution_version_findings(
 ) -> list[str]:
     """Verify built wheel/sdist metadata matches the source project version."""
     metadata: list[tuple[str, str]] = []
-    if archive.suffix == ".whl":
-        with zipfile.ZipFile(archive) as bundle:
-            for name in bundle.namelist():
-                if name.endswith(".dist-info/METADATA"):
-                    metadata.append((name, bundle.read(name).decode("utf-8")))
-    elif archive.name.endswith(".tar.gz"):
-        with tarfile.open(archive) as bundle:
-            for info in bundle.getmembers():
-                if info.isfile() and info.name.endswith("/PKG-INFO"):
-                    extracted = bundle.extractfile(info)
-                    if extracted is not None:
-                        metadata.append((info.name, extracted.read().decode("utf-8")))
-    else:
-        return []
+    try:
+        if archive.suffix == ".whl":
+            with zipfile.ZipFile(archive) as bundle:
+                for name in bundle.namelist():
+                    if name.endswith(".dist-info/METADATA"):
+                        metadata.append((name, bundle.read(name).decode("utf-8")))
+        elif archive.name.endswith(".tar.gz"):
+            with tarfile.open(archive) as bundle:
+                for info in bundle.getmembers():
+                    if info.isfile() and info.name.endswith("/PKG-INFO"):
+                        extracted = bundle.extractfile(info)
+                        if extracted is not None:
+                            metadata.append((info.name, extracted.read().decode("utf-8")))
+        else:
+            return []
+    except (OSError, RuntimeError, UnicodeDecodeError, tarfile.TarError, zipfile.BadZipFile):
+        archive_type = "ZIP" if archive.suffix == ".whl" else "tar"
+        return [_unreadable_archive_finding(archive, root, archive_type)]
 
     label = archive.relative_to(root)
     if len(metadata) != 1:
@@ -1714,14 +1751,17 @@ def scan_zip_archive(
 ) -> list[str]:
     """Scan a wheel archive."""
     findings: list[str] = []
-    with zipfile.ZipFile(path) as archive:
-        for info in archive.infolist():
-            member = Path(info.filename)
-            label = f"{path.relative_to(root)}!{info.filename}"
-            name_findings = scan_name(label, member, needles=needles)
-            findings.extend(name_findings)
-            if not name_findings:
-                findings.extend(scan_file_contents(label, member, archive.read(info), needles=needles))
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                member = Path(info.filename)
+                label = f"{path.relative_to(root)}!{info.filename}"
+                name_findings = scan_name(label, member, needles=needles)
+                findings.extend(name_findings)
+                if not name_findings:
+                    findings.extend(scan_file_contents(label, member, archive.read(info), needles=needles))
+    except (OSError, RuntimeError, zipfile.BadZipFile):
+        findings.append(_unreadable_archive_finding(path, root, "ZIP"))
     return findings
 
 
@@ -1733,19 +1773,22 @@ def scan_tar_archive(
 ) -> list[str]:
     """Scan an sdist archive."""
     findings: list[str] = []
-    with tarfile.open(path) as archive:
-        for info in archive.getmembers():
-            if not info.isfile():
-                continue
-            member = Path(info.name)
-            label = f"{path.relative_to(root)}!{info.name}"
-            name_findings = scan_name(label, member, needles=needles)
-            findings.extend(name_findings)
-            if name_findings:
-                continue
-            extracted = archive.extractfile(info)
-            if extracted is not None:
-                findings.extend(scan_file_contents(label, member, extracted.read(), needles=needles))
+    try:
+        with tarfile.open(path) as archive:
+            for info in archive.getmembers():
+                if not info.isfile():
+                    continue
+                member = Path(info.name)
+                label = f"{path.relative_to(root)}!{info.name}"
+                name_findings = scan_name(label, member, needles=needles)
+                findings.extend(name_findings)
+                if name_findings:
+                    continue
+                extracted = archive.extractfile(info)
+                if extracted is not None:
+                    findings.extend(scan_file_contents(label, member, extracted.read(), needles=needles))
+    except (OSError, tarfile.TarError):
+        findings.append(_unreadable_archive_finding(path, root, "tar"))
     return findings
 
 

--- a/workers/automation/tests/test_release_check.py
+++ b/workers/automation/tests/test_release_check.py
@@ -213,6 +213,71 @@ def test_demo_build_source_maps_and_archives_scan_fixture_bytes(tmp_path: Path) 
     assert "dist/web/demo-build.zip!demo/profile-resume.pdf: demo PDF fixture does not match its pinned content digest" in archive_findings
 
 
+def test_release_scanner_ignores_non_release_qa_output_archives(tmp_path: Path) -> None:
+    trace = tmp_path / "dist/playwright-report/failure/trace.zip"
+    storybook_archive = tmp_path / "dist/web-storybook/assets/report.zip"
+    for archive in (trace, storybook_archive):
+        archive.parent.mkdir(parents=True, exist_ok=True)
+        archive.write_bytes(b"not a ZIP archive")
+
+    assert release_check.scan_dist_archives(tmp_path) == []
+    _write(tmp_path / "dist/web-storybook/assets/app.js", "SyntheticSecret")
+    assert release_check.scan_demo_build_outputs(
+        tmp_path,
+        needles=(release_check.ForbiddenNeedle("SyntheticSecret", "synthetic identity"),),
+    ) == []
+
+
+def test_release_scanner_rejects_corrupt_distribution_archives(tmp_path: Path) -> None:
+    _write_version_surfaces(tmp_path, "2.0.0")
+    archive = tmp_path / "dist/jobctrl-2.0.0-darwin-arm64.zip"
+    wheel = tmp_path / "workers/automation/dist/jobctrl-2.0.0-py3-none-any.whl"
+    archive.parent.mkdir(parents=True)
+    wheel.parent.mkdir(parents=True)
+    archive.write_bytes(b"not a ZIP archive")
+    wheel.write_bytes(b"not a ZIP archive")
+
+    assert release_check.scan_dist_archives(tmp_path) == [
+        "dist/jobctrl-2.0.0-darwin-arm64.zip: unreadable ZIP archive",
+        "workers/automation/dist/jobctrl-2.0.0-py3-none-any.whl: unreadable ZIP archive",
+    ]
+
+
+def test_release_scanner_keeps_stale_distribution_wheels_in_scope(tmp_path: Path) -> None:
+    _write_version_surfaces(tmp_path, "2.0.0")
+    wheel = tmp_path / "workers/automation/dist/jobctrl-0.3.0-py3-none-any.whl"
+    wheel.parent.mkdir(parents=True)
+    with zipfile.ZipFile(wheel, "w") as bundle:
+        bundle.writestr(
+            "jobctrl-0.3.0.dist-info/METADATA",
+            "Name: jobctrl\nVersion: 0.3.0\n",
+        )
+
+    assert release_check.scan_dist_archives(tmp_path) == [
+        "workers/automation/dist/jobctrl-0.3.0-py3-none-any.whl!"
+        "jobctrl-0.3.0.dist-info/METADATA: distribution version '0.3.0' does not match "
+        "workers/automation/pyproject.toml '2.0.0'"
+    ]
+
+
+def test_release_scanner_rejects_invalid_utf8_distribution_metadata(tmp_path: Path) -> None:
+    _write_version_surfaces(tmp_path, "2.0.0")
+    wheel = tmp_path / "workers/automation/dist/jobctrl-2.0.0-py3-none-any.whl"
+    sdist = tmp_path / "workers/automation/dist/jobctrl-2.0.0.tar.gz"
+    wheel.parent.mkdir(parents=True)
+    with zipfile.ZipFile(wheel, "w") as bundle:
+        bundle.writestr("jobctrl-2.0.0.dist-info/METADATA", b"\xff")
+    with tarfile.open(sdist, "w:gz") as bundle:
+        info = tarfile.TarInfo("jobctrl-2.0.0/PKG-INFO")
+        info.size = 1
+        bundle.addfile(info, io.BytesIO(b"\xff"))
+
+    assert release_check.scan_dist_archives(tmp_path) == [
+        "workers/automation/dist/jobctrl-2.0.0-py3-none-any.whl: unreadable ZIP archive",
+        "workers/automation/dist/jobctrl-2.0.0.tar.gz: unreadable tar archive",
+    ]
+
+
 def test_source_tree_keeps_scanning_all_utf8_code_while_build_maps_are_scanned_explicitly(
     tmp_path: Path,
 ) -> None:
@@ -1102,6 +1167,20 @@ def test_cli_exit_code_is_nonzero_on_synthetic_violation(
     )
 
     assert release_check.main(()) == 1
+
+
+def test_cli_strict_scan_ignores_corrupt_playwright_report_archives(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    trace = tmp_path / "dist/playwright-report/failure/trace.zip"
+    trace.parent.mkdir(parents=True)
+    trace.write_bytes(b"not a ZIP archive")
+    _track_all(tmp_path)
+
+    monkeypatch.setattr(release_check, "ROOT", tmp_path)
+
+    assert release_check.main(("--strict-prompt",)) == 0
 
 
 def _write_version_surfaces(root: Path, version: str) -> None:


### PR DESCRIPTION
## What changed

- exclude only Playwright reports and Storybook builds from release-archive scanning because they are QA outputs, not shipped artifacts
- convert corrupt ZIP, wheel, tar, and invalid UTF-8 distribution metadata into blocking findings instead of uncaught exceptions
- preserve scanning for near-miss paths, real distribution roots, stale package versions, traversal-like archive members, and controller-disclosure boundaries

## Why

Running the release privacy gate after browser or Storybook QA made it order-dependent: corrupt Playwright traces could crash the scanner, and generated Storybook bundles produced irrelevant private-data matches. Actual release archives must still be scanned and fail closed.

## Validation

- release-check regression suite: 49 passed
- strict release privacy scan: passed
- Ruff on changed Python files: passed
- adversarial QA covered corrupt ZIP/wheel/tar, invalid UTF-8 metadata, stale versions, traversal-like members, symlinks, and similarly named non-excluded roots
- independent reviewer: PASS (0 findings)
- independent QA: PASS (0 findings)
- `git diff --check`
