### PR TITLE
fix(release): advance pinned installer metadata

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -3,9 +3,11 @@
 set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
+# BEGIN JOBCTRL RELEASE PINS
 INSTALLER_URL=""
 INSTALLER_SHA256=""
 INSTALLER_VERSION=""
+# END JOBCTRL RELEASE PINS
 
 usage() {
   cat <<'EOF'

--- a/scripts/distribution-homebrew.render.bundle.mjs
+++ b/scripts/distribution-homebrew.render.bundle.mjs
@@ -13276,13 +13276,55 @@ function createReleaseChannelPointer({ descriptorRaw, signatureRaw, descriptorUr
     signature: { url: signatureUrl, sha256: sha256Bytes(Buffer.from(signatureRaw, "utf8")) }
   });
 }
+var INSTALL_SCRIPT_PIN_HEADER_START = "# BEGIN JOBCTRL RELEASE PINS";
+var INSTALL_SCRIPT_PIN_HEADER_END = "# END JOBCTRL RELEASE PINS";
+function installScriptPinHeader(templateRaw) {
+  const markers = /* @__PURE__ */ new Map([
+    [INSTALL_SCRIPT_PIN_HEADER_START, []],
+    [INSTALL_SCRIPT_PIN_HEADER_END, []]
+  ]);
+  let offset = 0;
+  for (const line of templateRaw.split("\n")) {
+    markers.get(line)?.push(offset);
+    offset += line.length + 1;
+  }
+  const [markerStart] = markers.get(INSTALL_SCRIPT_PIN_HEADER_START);
+  const [headerEnd] = markers.get(INSTALL_SCRIPT_PIN_HEADER_END);
+  invariant4(markers.get(INSTALL_SCRIPT_PIN_HEADER_START).length === 1, "install script template must contain exactly one release-pin header start marker");
+  invariant4(markers.get(INSTALL_SCRIPT_PIN_HEADER_END).length === 1, "install script template must contain exactly one release-pin header end marker");
+  invariant4(markerStart < headerEnd, "install script template release-pin header markers are out of order");
+  const headerStart = markerStart + INSTALL_SCRIPT_PIN_HEADER_START.length + 1;
+  return { header: templateRaw.slice(headerStart, headerEnd), headerStart, headerEnd };
+}
+function replaceInstallScriptPin(header, key, value) {
+  const lines = header.split("\n");
+  const assignmentPattern = new RegExp(`^[\\t ]*(?:(?:export|readonly|declare|typeset|local)[\\t ]+)?${key}=`);
+  const assignmentIndexes = lines.reduce((indexes, line, index) => {
+    if (assignmentPattern.test(line)) indexes.push(index);
+    return indexes;
+  }, []);
+  invariant4(assignmentIndexes.length === 1, `published install script must contain exactly one ${key} assignment`);
+  const assignmentIndex = assignmentIndexes[0];
+  invariant4(
+    new RegExp(`^${key}="[^"\\r\\n]*"$`).test(lines[assignmentIndex]),
+    `published install script has a malformed ${key} assignment`
+  );
+  lines[assignmentIndex] = `${key}="${value}"`;
+  return lines.join("\n");
+}
 function renderPinnedInstallScript({ templateRaw, installerUrl, installerSha256, installerVersion }) {
   invariant4(typeof templateRaw === "string" && templateRaw.startsWith("#!/usr/bin/env bash\n"), "install script template is invalid");
   invariant4(typeof installerUrl === "string" && installerUrl.startsWith("https://"), "published installer URL must use HTTPS");
   invariant4(SHA256_PATTERN3.test(installerSha256), "published installer SHA-256 is invalid");
   invariant4(VERSION_PATTERN2.test(installerVersion), "published installer version is invalid");
-  const rendered = templateRaw.replace(/^INSTALLER_URL=""$/m, `INSTALLER_URL="${installerUrl}"`).replace(/^INSTALLER_SHA256=""$/m, `INSTALLER_SHA256="${installerSha256}"`).replace(/^INSTALLER_VERSION=""$/m, `INSTALLER_VERSION="${installerVersion}"`);
-  invariant4(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(rendered), "published install script has an unresolved release pin");
+  const pinHeader = installScriptPinHeader(templateRaw);
+  const renderedHeader = [
+    ["INSTALLER_URL", installerUrl],
+    ["INSTALLER_SHA256", installerSha256],
+    ["INSTALLER_VERSION", installerVersion]
+  ].reduce((header, [key, value]) => replaceInstallScriptPin(header, key, value), pinHeader.header);
+  invariant4(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(renderedHeader), "published install script has an unresolved release pin");
+  const rendered = `${templateRaw.slice(0, pinHeader.headerStart)}${renderedHeader}${templateRaw.slice(pinHeader.headerEnd)}`;
   invariant4(rendered.includes("no signed native installer is published yet; P6 release signing is still blocked"), "published install script lost its fail-closed fallback");
   return rendered;
 }

--- a/scripts/distribution-homebrew.render.bundle.mjs.sha256
+++ b/scripts/distribution-homebrew.render.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-afd02946182e8254dc8f0b006deb4ec3e6e48c01e6cb97c248921712b8b79898  distribution-homebrew.render.bundle.mjs
+717f33a0df6c953649ec68a991b46ace72804025cf63f02ede81bdf3220167f2  distribution-homebrew.render.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.finalizer.bundle.mjs
+++ b/scripts/distribution-release.finalizer.bundle.mjs
@@ -13251,13 +13251,55 @@ function createReleaseChannelPointer({ descriptorRaw, signatureRaw, descriptorUr
     signature: { url: signatureUrl, sha256: sha256Bytes(Buffer.from(signatureRaw, "utf8")) }
   });
 }
+var INSTALL_SCRIPT_PIN_HEADER_START = "# BEGIN JOBCTRL RELEASE PINS";
+var INSTALL_SCRIPT_PIN_HEADER_END = "# END JOBCTRL RELEASE PINS";
+function installScriptPinHeader(templateRaw) {
+  const markers = /* @__PURE__ */ new Map([
+    [INSTALL_SCRIPT_PIN_HEADER_START, []],
+    [INSTALL_SCRIPT_PIN_HEADER_END, []]
+  ]);
+  let offset = 0;
+  for (const line of templateRaw.split("\n")) {
+    markers.get(line)?.push(offset);
+    offset += line.length + 1;
+  }
+  const [markerStart] = markers.get(INSTALL_SCRIPT_PIN_HEADER_START);
+  const [headerEnd] = markers.get(INSTALL_SCRIPT_PIN_HEADER_END);
+  invariant4(markers.get(INSTALL_SCRIPT_PIN_HEADER_START).length === 1, "install script template must contain exactly one release-pin header start marker");
+  invariant4(markers.get(INSTALL_SCRIPT_PIN_HEADER_END).length === 1, "install script template must contain exactly one release-pin header end marker");
+  invariant4(markerStart < headerEnd, "install script template release-pin header markers are out of order");
+  const headerStart = markerStart + INSTALL_SCRIPT_PIN_HEADER_START.length + 1;
+  return { header: templateRaw.slice(headerStart, headerEnd), headerStart, headerEnd };
+}
+function replaceInstallScriptPin(header, key, value) {
+  const lines = header.split("\n");
+  const assignmentPattern = new RegExp(`^[\\t ]*(?:(?:export|readonly|declare|typeset|local)[\\t ]+)?${key}=`);
+  const assignmentIndexes = lines.reduce((indexes, line, index) => {
+    if (assignmentPattern.test(line)) indexes.push(index);
+    return indexes;
+  }, []);
+  invariant4(assignmentIndexes.length === 1, `published install script must contain exactly one ${key} assignment`);
+  const assignmentIndex = assignmentIndexes[0];
+  invariant4(
+    new RegExp(`^${key}="[^"\\r\\n]*"$`).test(lines[assignmentIndex]),
+    `published install script has a malformed ${key} assignment`
+  );
+  lines[assignmentIndex] = `${key}="${value}"`;
+  return lines.join("\n");
+}
 function renderPinnedInstallScript({ templateRaw, installerUrl, installerSha256, installerVersion }) {
   invariant4(typeof templateRaw === "string" && templateRaw.startsWith("#!/usr/bin/env bash\n"), "install script template is invalid");
   invariant4(typeof installerUrl === "string" && installerUrl.startsWith("https://"), "published installer URL must use HTTPS");
   invariant4(SHA256_PATTERN3.test(installerSha256), "published installer SHA-256 is invalid");
   invariant4(VERSION_PATTERN2.test(installerVersion), "published installer version is invalid");
-  const rendered = templateRaw.replace(/^INSTALLER_URL=""$/m, `INSTALLER_URL="${installerUrl}"`).replace(/^INSTALLER_SHA256=""$/m, `INSTALLER_SHA256="${installerSha256}"`).replace(/^INSTALLER_VERSION=""$/m, `INSTALLER_VERSION="${installerVersion}"`);
-  invariant4(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(rendered), "published install script has an unresolved release pin");
+  const pinHeader = installScriptPinHeader(templateRaw);
+  const renderedHeader = [
+    ["INSTALLER_URL", installerUrl],
+    ["INSTALLER_SHA256", installerSha256],
+    ["INSTALLER_VERSION", installerVersion]
+  ].reduce((header, [key, value]) => replaceInstallScriptPin(header, key, value), pinHeader.header);
+  invariant4(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(renderedHeader), "published install script has an unresolved release pin");
+  const rendered = `${templateRaw.slice(0, pinHeader.headerStart)}${renderedHeader}${templateRaw.slice(pinHeader.headerEnd)}`;
   invariant4(rendered.includes("no signed native installer is published yet; P6 release signing is still blocked"), "published install script lost its fail-closed fallback");
   return rendered;
 }

--- a/scripts/distribution-release.finalizer.bundle.mjs.sha256
+++ b/scripts/distribution-release.finalizer.bundle.mjs.sha256
@@ -1,2 +1,2 @@
-14dde3f31391cd0af74b7cafca798762737ff316255f5a33a7d8a012cbfa32cf  distribution-release.finalizer.bundle.mjs
+17abb43a0a42f92e12a08de956dc379ffc205f9ccff70cfaac7c6808a0403dc7  distribution-release.finalizer.bundle.mjs
 9fccd02acf8b52c9a28b4e1956f791f8ec126230e2c336f534191f1bcb646ebd  distribution-release-authority-bundles.NOTICE.txt

--- a/scripts/distribution-release.mjs
+++ b/scripts/distribution-release.mjs
@@ -933,16 +933,58 @@ export function createReleaseChannelPointer({ descriptorRaw, signatureRaw, descr
   });
 }
 
+const INSTALL_SCRIPT_PIN_HEADER_START = "# BEGIN JOBCTRL RELEASE PINS";
+const INSTALL_SCRIPT_PIN_HEADER_END = "# END JOBCTRL RELEASE PINS";
+
+function installScriptPinHeader(templateRaw) {
+  const markers = new Map([
+    [INSTALL_SCRIPT_PIN_HEADER_START, []],
+    [INSTALL_SCRIPT_PIN_HEADER_END, []],
+  ]);
+  let offset = 0;
+  for (const line of templateRaw.split("\n")) {
+    markers.get(line)?.push(offset);
+    offset += line.length + 1;
+  }
+  const [markerStart] = markers.get(INSTALL_SCRIPT_PIN_HEADER_START);
+  const [headerEnd] = markers.get(INSTALL_SCRIPT_PIN_HEADER_END);
+  invariant(markers.get(INSTALL_SCRIPT_PIN_HEADER_START).length === 1, "install script template must contain exactly one release-pin header start marker");
+  invariant(markers.get(INSTALL_SCRIPT_PIN_HEADER_END).length === 1, "install script template must contain exactly one release-pin header end marker");
+  invariant(markerStart < headerEnd, "install script template release-pin header markers are out of order");
+  const headerStart = markerStart + INSTALL_SCRIPT_PIN_HEADER_START.length + 1;
+  return { header: templateRaw.slice(headerStart, headerEnd), headerStart, headerEnd };
+}
+
+function replaceInstallScriptPin(header, key, value) {
+  const lines = header.split("\n");
+  const assignmentPattern = new RegExp(`^[\\t ]*(?:(?:export|readonly|declare|typeset|local)[\\t ]+)?${key}=`);
+  const assignmentIndexes = lines.reduce((indexes, line, index) => {
+    if (assignmentPattern.test(line)) indexes.push(index);
+    return indexes;
+  }, []);
+  invariant(assignmentIndexes.length === 1, `published install script must contain exactly one ${key} assignment`);
+  const assignmentIndex = assignmentIndexes[0];
+  invariant(
+    new RegExp(`^${key}="[^"\\r\\n]*"$`).test(lines[assignmentIndex]),
+    `published install script has a malformed ${key} assignment`,
+  );
+  lines[assignmentIndex] = `${key}="${value}"`;
+  return lines.join("\n");
+}
+
 export function renderPinnedInstallScript({ templateRaw, installerUrl, installerSha256, installerVersion }) {
   invariant(typeof templateRaw === "string" && templateRaw.startsWith("#!/usr/bin/env bash\n"), "install script template is invalid");
   invariant(typeof installerUrl === "string" && installerUrl.startsWith("https://"), "published installer URL must use HTTPS");
   invariant(SHA256_PATTERN.test(installerSha256), "published installer SHA-256 is invalid");
   invariant(VERSION_PATTERN.test(installerVersion), "published installer version is invalid");
-  const rendered = templateRaw
-    .replace(/^INSTALLER_URL=""$/m, `INSTALLER_URL="${installerUrl}"`)
-    .replace(/^INSTALLER_SHA256=""$/m, `INSTALLER_SHA256="${installerSha256}"`)
-    .replace(/^INSTALLER_VERSION=""$/m, `INSTALLER_VERSION="${installerVersion}"`);
-  invariant(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(rendered), "published install script has an unresolved release pin");
+  const pinHeader = installScriptPinHeader(templateRaw);
+  const renderedHeader = [
+    ["INSTALLER_URL", installerUrl],
+    ["INSTALLER_SHA256", installerSha256],
+    ["INSTALLER_VERSION", installerVersion],
+  ].reduce((header, [key, value]) => replaceInstallScriptPin(header, key, value), pinHeader.header);
+  invariant(!/^INSTALLER_(?:URL|SHA256|VERSION)=""$/m.test(renderedHeader), "published install script has an unresolved release pin");
+  const rendered = `${templateRaw.slice(0, pinHeader.headerStart)}${renderedHeader}${templateRaw.slice(pinHeader.headerEnd)}`;
   invariant(rendered.includes("no signed native installer is published yet; P6 release signing is still blocked"), "published install script lost its fail-closed fallback");
   return rendered;
 }

--- a/scripts/distribution-release.test.mjs
+++ b/scripts/distribution-release.test.mjs
@@ -550,7 +550,7 @@ test("published paths, installer pins, and smoke contract use canonical HTTPS as
   assert.equal(urls.descriptorUrl, "https://releases.jobctrl.dev/v1/stable/darwin-arm64.json");
   assert.equal(urls.immutableDescriptorUrl, "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000042/release-descriptor.json");
   const rendered = renderPinnedInstallScript({
-    templateRaw: '#!/usr/bin/env bash\nINSTALLER_URL=""\nINSTALLER_SHA256=""\nINSTALLER_VERSION=""\n# no signed native installer is published yet; P6 release signing is still blocked\n',
+    templateRaw: '#!/usr/bin/env bash\n# BEGIN JOBCTRL RELEASE PINS\nINSTALLER_URL=""\nINSTALLER_SHA256=""\nINSTALLER_VERSION=""\n# END JOBCTRL RELEASE PINS\n# no signed native installer is published yet; P6 release signing is still blocked\n',
     installerUrl: urls.installerUrl,
     installerSha256: "a".repeat(64),
     installerVersion: "2.0.0",
@@ -560,6 +560,80 @@ test("published paths, installer pins, and smoke contract use canonical HTTPS as
   assert.deepEqual(plan.map((step) => step.args[0]), ["--fail", "--fail", "--source", "start", "status", "version", "stop", "status"]);
   assert.ok(plan[2].args.includes("--release-url"));
   assert.ok(!plan[2].args.includes("--descriptor-url"));
+});
+
+test("install-script rendering advances the actual bounded pin header without changing fixture assignments", async () => {
+  const [template, publicInstall] = await Promise.all([
+    readFile(path.join(process.cwd(), "scripts", "get"), "utf8"),
+    readFile(path.join(process.cwd(), "docs", "public", "install.sh"), "utf8"),
+  ]);
+  assert.equal(publicInstall, template, "the public installer must match the canonical template");
+  const fixtureBranch = 'if [[ -n "$FIXTURE_CONTRACT" ]]; then';
+  const fixtureBody = template.slice(template.indexOf(fixtureBranch));
+  assert.ok(fixtureBody.startsWith(fixtureBranch));
+  const first = renderPinnedInstallScript({
+    templateRaw: template,
+    installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000042/jobctrl-installer",
+    installerSha256: "a".repeat(64),
+    installerVersion: "2.0.0",
+  });
+  const rerendered = renderPinnedInstallScript({
+    templateRaw: first,
+    installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+    installerSha256: "b".repeat(64),
+    installerVersion: "2.0.1",
+  });
+  assert.match(rerendered, /INSTALLER_URL="https:\/\/releases\.jobctrl\.dev\/v1\/artifacts\/stable-build-0000043\/jobctrl-installer"/);
+  assert.match(rerendered, /INSTALLER_SHA256="b{64}"/);
+  assert.match(rerendered, /INSTALLER_VERSION="2\.0\.1"/);
+  assert.doesNotMatch(rerendered, /stable-build-0000042|a{64}|INSTALLER_VERSION="2\.0\.0"/);
+  assert.equal(rerendered.slice(rerendered.indexOf(fixtureBranch)), fixtureBody, "fixture assignments must remain byte-for-byte unchanged");
+
+  assert.throws(
+    () => renderPinnedInstallScript({
+      templateRaw: template.replace('INSTALLER_URL=""', "INSTALLER_URL=https://releases.jobctrl.dev/jobctrl-installer"),
+      installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+      installerSha256: "b".repeat(64),
+      installerVersion: "2.0.1",
+    }),
+    /malformed INSTALLER_URL assignment/,
+  );
+  assert.throws(
+    () => renderPinnedInstallScript({
+      templateRaw: template.replace('INSTALLER_VERSION=""', 'INSTALLER_VERSION="2.0.0"\nexport INSTALLER_VERSION="2.0.1"'),
+      installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+      installerSha256: "b".repeat(64),
+      installerVersion: "2.0.1",
+    }),
+    /exactly one INSTALLER_VERSION assignment/,
+  );
+  assert.throws(
+    () => renderPinnedInstallScript({
+      templateRaw: template.replace('# BEGIN JOBCTRL RELEASE PINS', '# BEGIN JOBCTRL RELEASE PINS\n# BEGIN JOBCTRL RELEASE PINS'),
+      installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+      installerSha256: "b".repeat(64),
+      installerVersion: "2.0.1",
+    }),
+    /exactly one release-pin header start marker/,
+  );
+  assert.throws(
+    () => renderPinnedInstallScript({
+      templateRaw: template.replace('# END JOBCTRL RELEASE PINS', '# END JOBCTRL RELEASE PINS\n# END JOBCTRL RELEASE PINS'),
+      installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+      installerSha256: "b".repeat(64),
+      installerVersion: "2.0.1",
+    }),
+    /exactly one release-pin header end marker/,
+  );
+  assert.throws(
+    () => renderPinnedInstallScript({
+      templateRaw: template.replace('Usage: scripts/get', '# END JOBCTRL RELEASE PINS\nUsage: scripts/get'),
+      installerUrl: "https://releases.jobctrl.dev/v1/artifacts/stable-build-0000043/jobctrl-installer",
+      installerSha256: "b".repeat(64),
+      installerVersion: "2.0.1",
+    }),
+    /exactly one release-pin header end marker/,
+  );
 });
 
 test("channel pointers atomically bind one immutable descriptor/signature pair", () => {

--- a/scripts/get
+++ b/scripts/get
@@ -3,9 +3,11 @@
 set -euo pipefail
 
 # P6 renders these from the signed publication. Empty pins fail closed.
+# BEGIN JOBCTRL RELEASE PINS
 INSTALLER_URL=""
 INSTALLER_SHA256=""
 INSTALLER_VERSION=""
+# END JOBCTRL RELEASE PINS
 
 usage() {
   cat <<'EOF'


### PR DESCRIPTION
## What changed

- bound release URL, checksum, and version pins inside an explicit installer header
- advance all three pins when rendering later releases, even when the source is already pinned
- reject missing, duplicate, reversed, malformed, or heredoc-spoofed markers and assignments
- preserve local fixture assignments byte-for-byte
- regenerate both sealed release-authority bundles and their checksums

## Why

The prior renderer only replaced empty assignments. After the first public installer cutover, a later release could silently retain the previous release URL, checksum, and version. The renderer also needed an unambiguous boundary because the installer contains separate fixture-mode assignments.

## Validation

- actual `scripts/get` first render and v2.0.1 rerender advance URL/SHA/version
- fixture body remains byte-identical; rendered shell passes `bash -n`
- 84 focused release, Homebrew, manifest, build, and installer tests passed
- both authority bundles reproduce and all checksums pass
- installer asset parity passed
- strict release privacy scan passed
- docs build and runtime checks passed
- independent reviewer: PASS (0 findings)
- independent Tier 3 QA: PASS (0 findings)
- `git diff --check`
