### PR TITLE
fix(release): stabilize launch candidate

### DIFF
--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -280,11 +280,17 @@ export function repeatEvidenceFingerprint(
 }
 
 function jobIdentity(db: SqliteDatabase, jobKey: string): JobIdentityRow | null {
-  const companyExpression = columnExists(db, "jobs", "company")
-    ? "j.company"
-    : tableExists(db, "job_list_projections")
-      ? `(SELECT jlp.employer FROM job_list_projections jlp
-           WHERE jlp.tenant_id = ? AND jlp.job_id = j.url LIMIT 1)`
+  const hasCompanyColumn = columnExists(db, "jobs", "company");
+  const hasJobListProjections = tableExists(db, "job_list_projections");
+  const companyExpression = hasJobListProjections
+    ? `COALESCE(
+        ${hasCompanyColumn ? "NULLIF(j.company, '')" : "NULL"},
+        (SELECT jlp.employer FROM job_list_projections jlp
+         WHERE jlp.tenant_id = ? AND jlp.job_id = j.url LIMIT 1),
+        ''
+      )`
+    : hasCompanyColumn
+      ? "COALESCE(j.company, '')"
       : "''";
   const enrichmentExpression = tableExists(db, "job_enrichments")
     ? `(SELECT je.application_url
@@ -293,7 +299,7 @@ function jobIdentity(db: SqliteDatabase, jobKey: string): JobIdentityRow | null 
          ORDER BY je.updated_at DESC LIMIT 1),`
     : "";
   const params = [
-    ...(companyExpression.includes("jlp.tenant_id") ? [DEFAULT_TENANT] : []),
+    ...(hasJobListProjections ? [DEFAULT_TENANT] : []),
     ...(enrichmentExpression ? [DEFAULT_TENANT] : []),
     jobKey,
   ];

--- a/apps/api/src/repeat-application.ts
+++ b/apps/api/src/repeat-application.ts
@@ -670,7 +670,7 @@ function auditTrail(db: SqliteDatabase, targetJobKey: string): RepeatApplication
        LEFT JOIN application_repeat_overrides o
          ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
       WHERE a.tenant_id = ? AND a.target_job_key = ?
-      ORDER BY a.occurred_at DESC, a.audit_id DESC LIMIT 50`,
+      ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50`,
     [DEFAULT_TENANT, targetJobKey],
   ).map((row) => ({
     auditId: row.audit_id,

--- a/apps/api/test/qa-workflow.test.ts
+++ b/apps/api/test/qa-workflow.test.ts
@@ -267,7 +267,10 @@ describe("seeded local QA workflow", () => {
     });
 
     await app.close();
-  }, 10_000);
+  // This exercises four persisted configuration surfaces in one app instance.
+  // The focused path is fast, but parallel API-suite startup and SQLite work can
+  // exceed the default allowance without changing the behavior under test.
+  }, 30_000);
 });
 
 function createMemoryCredentialStore(): CredentialStore {

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -37,6 +37,11 @@ beforeEach(() => {
       application_url TEXT,
       updated_at TEXT NOT NULL
     );
+    CREATE TABLE job_list_projections (
+      tenant_id TEXT NOT NULL,
+      job_id TEXT NOT NULL,
+      employer TEXT NOT NULL
+    );
     CREATE TABLE job_events (
       event_id INTEGER PRIMARY KEY AUTOINCREMENT,
       job_url TEXT,
@@ -184,6 +189,26 @@ describe("repeat application evidence", () => {
     expect(normalizeRoleTitle("Sr. Backend Eng II (Remote)")).toBe(
       "senior backend engineer 2",
     );
+  });
+
+  it("preserves the projected employer in evidence when the writable job value is empty", () => {
+    insertJob(PRIOR, "Senior Backend Engineer", "");
+    insertJob(TARGET, "Backend Senior Eng", "");
+    db.prepare("UPDATE jobs SET company = NULL").run();
+    db.prepare(
+      `INSERT INTO job_list_projections (tenant_id, job_id, employer)
+       VALUES ('local', ?, 'Acme Inc'), ('local', ?, 'Acme Inc')`,
+    ).run(PRIOR, TARGET);
+    confirmPrior();
+
+    const assessment = evaluateRepeatApplication(db, TARGET);
+
+    expect(assessment.status).toBe("confirmation_required");
+    expect(assessment.matches[0]).toMatchObject({
+      relationship: "same_employer_equivalent_role",
+      priorApplication: { company: "Acme Inc" },
+    });
+    expect(assessment.matches[0]?.identityEvidence).toContain("employer:acme");
   });
 
   it.each([

--- a/apps/api/test/repeat-application.test.ts
+++ b/apps/api/test/repeat-application.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 
 import Database from "better-sqlite3";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   assertLiveApplicationMayDispatch,
@@ -90,7 +90,10 @@ beforeEach(() => {
   ensureRepeatApplicationTables(db);
 });
 
-afterEach(() => db.close());
+afterEach(() => {
+  vi.useRealTimers();
+  db.close();
+});
 
 function insertJob(url: string, title: string, company: string): void {
   db.prepare(
@@ -255,6 +258,8 @@ describe("repeat application evidence", () => {
   });
 
   it("records a reasoned override bound to the complete evidence and rejects stale evidence", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW));
     insertJob(PRIOR, "Senior Backend Engineer", "Acme Inc");
     insertJob(TARGET, "Senior Backend Engineer", "Acme Inc");
     confirmPrior();
@@ -280,7 +285,21 @@ describe("repeat application evidence", () => {
     expect(response.assessment.auditTrail.map((entry) => entry.action)).toContain(
       "override_recorded",
     );
-    expect(response.assessment.auditTrail[0]).toMatchObject({
+
+    // UUIDs do not encode insertion order.  Force the tied timestamps into
+    // the inverse lexical UUID order to reproduce the production race.
+    db.prepare(
+      "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'confirmation_required'",
+    ).run("ffffffff-ffff-ffff-ffff-ffffffffffff");
+    db.prepare(
+      "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'override_recorded'",
+    ).run("00000000-0000-0000-0000-000000000000");
+    const ordered = evaluateRepeatApplication(db, TARGET, {
+      recordAudit: false,
+      evaluatedAt: NOW,
+    });
+    expect(ordered.auditTrail[0]).toMatchObject({
+      action: "override_recorded",
       targetJobKey: TARGET,
       priorJobKey: PRIOR,
       evidence: [

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -907,19 +907,27 @@ scenarioTest("eventless discovery and settings writes resync across tabs and sur
   const second = await context.newPage();
 
   await Promise.all([page.goto("/discovery"), second.goto("/discovery")]);
-  await expect(page.getByLabel("Results per board")).toHaveValue("12");
-  await expect(second.getByLabel("Results per board")).toHaveValue("12");
-  await page.getByLabel("Results per board").fill("23");
+  const resultsPerBoard = page.getByRole("spinbutton", {
+    name: "Results per board",
+    exact: true,
+  });
+  const secondResultsPerBoard = second.getByRole("spinbutton", {
+    name: "Results per board",
+    exact: true,
+  });
+  await expect(resultsPerBoard).toHaveValue("12");
+  await expect(secondResultsPerBoard).toHaveValue("12");
+  await resultsPerBoard.fill("23");
   const discoveryForm = page.locator("form").filter({
-    has: page.getByLabel("Results per board"),
+    has: resultsPerBoard,
   });
   await discoveryForm
     .getByRole("button", { name: "Save changes", exact: true })
     .click();
   await expect(page.getByText("Runtime settings saved.")).toBeVisible();
-  await expect(second.getByLabel("Results per board")).toHaveValue("23");
+  await expect(secondResultsPerBoard).toHaveValue("23");
   await second.reload();
-  await expect(second.getByLabel("Results per board")).toHaveValue("23");
+  await expect(secondResultsPerBoard).toHaveValue("23");
 
   await Promise.all([page.goto("/settings"), second.goto("/settings")]);
   await expect(page.getByLabel("Concurrent applications")).toHaveValue("1");

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -128,6 +128,10 @@ function jobRow(page: Page, title: string): Locator {
   });
 }
 
+function visible(page: Page, locator: Locator): Locator {
+  return locator.and(page.locator(":visible"));
+}
+
 async function expectJobState(
   page: Page,
   title: string,
@@ -778,7 +782,7 @@ scenarioTest("every P2 product route and seeded deep link renders populated acro
       "article",
     ],
     ["/analytics", "Outcome analytics", "bundled-capture"],
-    ["/profile", "Profile", "Baseline resume editor"],
+    ["/profile", "Profile", "Personal information"],
     ["/settings", "Settings", "Config"],
     ["/settings/credentials", "Settings", "Codex"],
     ["/outreach", "Contacts", "Synthetic hiring partner"],
@@ -802,25 +806,29 @@ scenarioTest("every P2 product route and seeded deep link renders populated acro
   for (const [route, identity, populatedText, role = "heading"] of routes) {
     await page.goto(STATIC_HOST);
     await page.goto(route);
-    const identityLocator =
+    const identityLocator = visible(
+      page,
       role === "article"
-        ? page.getByRole("article", { name: identity })
-        : page.getByRole("heading", { name: identity }).first();
+        ? page.getByRole("article", { name: identity, exact: true })
+        : page.getByRole("heading", { name: identity, exact: true }),
+    );
+    const contentScope = role === "article" ? identityLocator : page.locator("main");
+    const populatedLocator = visible(
+      page,
+      contentScope.getByText(populatedText, { exact: false }),
+    );
+
+    await expect(identityLocator).toHaveCount(1);
     await expect(identityLocator).toBeVisible();
-    await expect(
-      page.getByText(populatedText, { exact: false }).first(),
-    ).toBeVisible();
+    await expect(populatedLocator).not.toHaveCount(0);
+    await expect(populatedLocator.first()).toBeVisible();
     expect(page.url()).toContain(route);
 
     await page.reload();
-    await expect(
-      role === "article"
-        ? page.getByRole("article", { name: identity })
-        : page.getByRole("heading", { name: identity }).first(),
-    ).toBeVisible();
-    await expect(
-      page.getByText(populatedText, { exact: false }).first(),
-    ).toBeVisible();
+    await expect(identityLocator).toHaveCount(1);
+    await expect(identityLocator).toBeVisible();
+    await expect(populatedLocator).not.toHaveCount(0);
+    await expect(populatedLocator.first()).toBeVisible();
   }
 
   expect(runtimeErrors).toEqual([]);
@@ -1007,9 +1015,18 @@ scenarioTest("score correction is browser-local, cross-tab visible, reload durab
   await expect(page.getByText("8/10", { exact: true })).toBeVisible();
   await expect(second.getByText("8/10", { exact: true })).toBeVisible();
 
-  await page.getByLabel("Correct score").fill("9");
-  await page.getByLabel("Reason").fill("Reviewed bundled synthetic evidence");
-  await page.getByRole("button", { name: "Save score correction" }).click();
+  const scoreEvidence = page.locator("details").filter({
+    has: page.locator("summary", { hasText: "Score evidence and controls" }),
+  });
+  const scoreEvidenceToggle = scoreEvidence.locator(":scope > summary");
+  await expect(scoreEvidenceToggle).toHaveText("Score evidence and controls");
+  await expect(scoreEvidence).not.toHaveAttribute("open", "");
+  await scoreEvidenceToggle.click();
+  await expect(scoreEvidence).toHaveAttribute("open", "");
+
+  await scoreEvidence.getByLabel("Correct score").fill("9");
+  await scoreEvidence.getByLabel("Reason").fill("Reviewed bundled synthetic evidence");
+  await scoreEvidence.getByRole("button", { name: "Save score correction" }).click();
   await expect(page.getByText("Scoring policy updated;", { exact: false })).toBeVisible();
   await expect(page.getByText("9/10", { exact: true })).toBeVisible();
   await expect(second.getByText("9/10", { exact: true })).toBeVisible();

--- a/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
+++ b/apps/web/e2e/demo-workspace-tests/demo-workspace.spec.ts
@@ -945,7 +945,7 @@ scenarioTest("eventless discovery and settings writes resync across tabs and sur
     has: page.getByLabel("Concurrent applications"),
   });
   await executionForm.getByRole("button", { name: "Save changes", exact: true }).click();
-  await expect(page.getByText("settings saved", { exact: true })).toBeVisible();
+  await expect(executionForm.getByRole("status")).toHaveText("Settings saved.");
   await expect(second.getByLabel("Concurrent applications")).toHaveValue("3");
   await second.reload();
   await expect(second.getByLabel("Concurrent applications")).toHaveValue("3");

--- a/apps/web/e2e/fixtures/e2e-state.ts
+++ b/apps/web/e2e/fixtures/e2e-state.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import Database from "better-sqlite3";
 
 interface E2eState {
   workspace?: { dbPath?: string };
@@ -25,4 +26,28 @@ export function loadE2eDbPath(): string {
     );
   }
   return state.workspace.dbPath;
+}
+
+/**
+ * The E2E seed intentionally models a worker-ready local runtime. Long,
+ * single-worker browser runs can outlive the worker-health freshness window,
+ * so a test that depends on that precondition must renew its fixture instead
+ * of inheriting elapsed suite time.
+ */
+export function refreshE2eWorkerHeartbeat(now = new Date()): void {
+  const db = new Database(loadE2eDbPath());
+  try {
+    const result = db
+      .prepare(
+        "UPDATE worker_runtime_heartbeats SET last_seen_at = ? WHERE component = 'temporal-worker'",
+      )
+      .run(now.toISOString());
+    if (result.changes === 0) {
+      throw new Error(
+        "E2E fixture did not contain a temporal-worker heartbeat to refresh.",
+      );
+    }
+  } finally {
+    db.close();
+  }
 }

--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -48,6 +48,9 @@ const DOCS_SERVICE_ENVIRONMENT =
           ? { PLAYWRIGHT_BROWSERS_PATH: E2E_PLAYWRIGHT_BROWSERS_PATH }
           : {}),
         TZ: "UTC",
+        // Profile screenshot capture uses the real profile-preview renderer.
+        // Its source runtime must not rewrite the committed Python lockfile.
+        UV_LOCKED: "1",
       }
     : {};
 

--- a/apps/web/e2e/tests/dashboard.spec.ts
+++ b/apps/web/e2e/tests/dashboard.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+import { refreshE2eWorkerHeartbeat } from "../fixtures/e2e-state.js";
+
 test("Dashboard renders KPIs, click 'Jobs' KPI navigates to /jobs and row count matches", async ({
   page,
 }) => {
@@ -63,6 +65,7 @@ test("Dashboard renders KPIs, click 'Jobs' KPI navigates to /jobs and row count 
 
 test("@mobile Dashboard keeps the operational overview in the first viewport", async ({ page }) => {
   await page.setViewportSize({ width: 320, height: 568 });
+  refreshE2eWorkerHeartbeat();
   await page.goto("/dashboard");
 
   await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();

--- a/apps/web/e2e/tests/interview-prep.spec.ts
+++ b/apps/web/e2e/tests/interview-prep.spec.ts
@@ -72,8 +72,8 @@ function seedAcceptedPrep(dbPath: string, occurredAt: string): void {
          control, grounding_audit_json, warnings_json, position
        ) VALUES (?, 1, 'prep-e2e-star', 'local', 'star_draft', 'Platform ownership story',
          'Use the platform ownership story to answer systems and team-enablement questions.',
-         '["ev_platform"]', '["r1"]', '["Owned the developer platform across product teams."]',
-         'grounded_prep', 'never_fabricate', '["ev_platform supports the STAR draft."]', '[]', 0)
+         '["ev-platform"]', '["r1"]', '["Owned the developer platform across product teams."]',
+         'grounded_prep', 'never_fabricate', '["ev-platform supports the STAR draft."]', '[]', 0)
        ON CONFLICT(job_url, generation, item_id) DO UPDATE SET
          title = excluded.title,
          generated_text = excluded.generated_text`,
@@ -112,11 +112,16 @@ test("Interview prep: explicit generation queues and accepted prep surfaces with
     .locator("table.jobs-data-grid-table tbody tr")
     .filter({ hasText: "Director of Platform Engineering" });
   await expect(row).toBeVisible({ timeout: 30_000 });
-  await row
-    .getByRole("button", { name: /^Open job Director of Platform Engineering/ })
-    .click();
+  // Desktop exposes the named row-activation control to keyboard users only.
+  // Pointer users activate the visible job title (and Playwright verifies it is
+  // not covered by persistent shell chrome).
+  const visibleTitle = row
+    .locator('[data-slot="title-stack-primary"]')
+    .filter({ hasText: /^Director of Platform Engineering$/ });
+  await expect(visibleTitle).toBeVisible();
+  await visibleTitle.click();
 
-  const drawer = page.getByRole("dialog", { name: "Job details" });
+  const drawer = page.getByRole("article", { name: "Job details" });
   await expect(drawer).toBeVisible({ timeout: 10_000 });
 
   const generateButton = drawer.getByRole("button", { name: /generate interview prep/i });
@@ -168,7 +173,10 @@ test("Interview prep: explicit generation queues and accepted prep surfaces with
   await expect(reflections.getByText(reflectionNote)).toBeVisible();
   await expect(reflections.getByText("prep generation 1")).toBeVisible();
 
-  await expect(drawer.getByRole("link", { name: "ev_platform" })).toBeVisible();
-  await drawer.getByRole("link", { name: "ev_platform" }).click();
-  await expect(page).toHaveURL(/\/evidence-map\?.*entry=ev_platform/);
+  const evidenceLink = drawer.getByRole("link", {
+    name: "Owned platform reliability improvements for incident response.",
+  });
+  await expect(evidenceLink).toHaveAttribute("href", /entry=ev-platform/);
+  await evidenceLink.click();
+  await expect(page).toHaveURL(/\/evidence-map\?.*entry=ev-platform/);
 });

--- a/apps/web/e2e/tests/mobile-shell-width.spec.ts
+++ b/apps/web/e2e/tests/mobile-shell-width.spec.ts
@@ -221,18 +221,25 @@ test("job detail keeps its title and actions readable at desktop and mobile widt
     { width: 1440, height: 900 },
     { width: 390, height: 844 },
   ]) {
+    const usesActionDisclosure = viewport.width <= 820;
     await page.setViewportSize(viewport);
     await page.goto(JOB_DETAIL_ROUTE);
 
     const workspace = page.getByRole("article", { name: "Job details" });
     const toolbar = workspace.getByRole("toolbar", { name: "Job actions" });
+    const commandTrigger = workspace.getByRole("button", {
+      name: "More job actions",
+    });
+    const workflowActions = workspace.locator(
+      "#job-detail-workflow-commands",
+    );
+    const preparationActions = toolbar.getByRole("group", {
+      name: "Preparation actions",
+    });
+    const applicationActions = toolbar.getByRole("group", {
+      name: "Application actions",
+    });
     await expect(workspace).toBeVisible({ timeout: 30_000 });
-    await expect(
-      workspace.getByRole("group", { name: "Preparation actions" }),
-    ).toBeVisible();
-    await expect(
-      workspace.getByRole("group", { name: "Application actions" }),
-    ).toBeVisible();
     await expect(
       toolbar.getByRole("link", { name: /apply review/i }),
     ).toHaveCount(0);
@@ -288,6 +295,22 @@ test("job detail keeps its title and actions readable at desktop and mobile widt
     expect(layout.pageScrollWidth).toBeLessThanOrEqual(
       layout.viewportWidth + 1,
     );
+
+    if (usesActionDisclosure) {
+      await expect(commandTrigger).toBeVisible();
+      await expect(commandTrigger).toHaveAttribute("aria-expanded", "false");
+      await expect(workflowActions).toBeHidden();
+      await commandTrigger.click();
+      await expect(commandTrigger).toHaveAttribute("aria-expanded", "true");
+    } else {
+      await expect(commandTrigger).toBeHidden();
+    }
+
+    await expect(preparationActions).toBeVisible();
+    await expect(
+      preparationActions.getByRole("button", { name: "Generate materials" }),
+    ).toBeVisible();
+    await expect(applicationActions).toBeVisible();
   }
 });
 

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -10,6 +10,41 @@ const TARGET = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 const PRIOR = "https://alternate.example.test/gitlab/qa-platform-director";
 const CANONICAL = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director-canonical";
 const CONFIRMED_AT = "2026-07-20T08:00:00.000Z";
+type DatabaseRow = Record<string, unknown>;
+type RepeatApplicationTable =
+  | "application_repeat_overrides"
+  | "application_repeat_override_consumptions"
+  | "application_repeat_audit";
+
+function repeatApplicationTablesExist(db: Database.Database): boolean {
+  return Boolean(
+    db
+      .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+      .get("application_repeat_overrides"),
+  );
+}
+
+function clearRepeatApplicationState(db: Database.Database): void {
+  db.prepare(
+    "DELETE FROM application_repeat_override_consumptions WHERE override_id IN (SELECT override_id FROM application_repeat_overrides WHERE target_job_key = ?)",
+  ).run(TARGET);
+  db.prepare("DELETE FROM application_repeat_audit WHERE target_job_key = ?").run(TARGET);
+  db.prepare("DELETE FROM application_repeat_overrides WHERE target_job_key = ?").run(TARGET);
+}
+
+function restoreRows(
+  db: Database.Database,
+  table: RepeatApplicationTable,
+  rows: readonly DatabaseRow[],
+): void {
+  for (const row of rows) {
+    const columns = Object.keys(row);
+    db.prepare(
+      `INSERT INTO ${table} (${columns.map((column) => `"${column}"`).join(", ")})
+       VALUES (${columns.map(() => "?").join(", ")})`,
+    ).run(...columns.map((column) => row[column]));
+  }
+}
 
 test("repeat application block and reasoned override reach only the simulated submit boundary", async ({
   page,
@@ -45,9 +80,36 @@ test("repeat application block and reasoned override reach only the simulated su
   const originalApplyStage = db
     .prepare("SELECT * FROM job_stage_states WHERE job_url = ? AND stage = 'apply'")
     .get(TARGET) as Record<string, unknown> | undefined;
+  const hasRepeatApplicationTables = repeatApplicationTablesExist(db);
+  const originalRepeatOverrides = hasRepeatApplicationTables
+    ? (db
+        .prepare(
+          "SELECT * FROM application_repeat_overrides WHERE tenant_id = 'local' AND target_job_key = ?",
+        )
+        .all(TARGET) as Array<Record<string, unknown>>)
+    : [];
+  const originalRepeatOverrideConsumptions = hasRepeatApplicationTables
+    ? (db
+        .prepare(
+          `SELECT c.*
+             FROM application_repeat_override_consumptions c
+             JOIN application_repeat_overrides o
+               ON o.tenant_id = c.tenant_id AND o.override_id = c.override_id
+            WHERE o.tenant_id = 'local' AND o.target_job_key = ?`,
+        )
+        .all(TARGET) as Array<Record<string, unknown>>)
+    : [];
+  const originalRepeatAudit = hasRepeatApplicationTables
+    ? (db
+        .prepare(
+          "SELECT * FROM application_repeat_audit WHERE tenant_id = 'local' AND target_job_key = ?",
+        )
+        .all(TARGET) as Array<Record<string, unknown>>)
+    : [];
   let originalTargetApplication: Record<string, unknown> | undefined;
 
   try {
+    if (hasRepeatApplicationTables) clearRepeatApplicationState(db);
     const target = db.prepare("SELECT * FROM jobs WHERE url = ?").get(TARGET) as Record<
       string,
       unknown
@@ -213,7 +275,7 @@ print(job["url"])
 
     const override = db
       .prepare(
-        `SELECT target_job_key, prior_job_key, reason, confirmed_by, confirmed_at
+        `SELECT override_id, target_job_key, prior_job_key, evidence_fingerprint, reason, confirmed_by, confirmed_at
            FROM application_repeat_overrides
           WHERE tenant_id = 'local' AND target_job_key = ?
           ORDER BY confirmed_at DESC LIMIT 1`,
@@ -225,15 +287,38 @@ print(job["url"])
       confirmed_by: "user",
     });
     expect(String(override.reason)).toContain("withdrawn before review");
-    expect(
-      db
-        .prepare(
-          `SELECT COUNT(*) AS count FROM application_repeat_audit
-            WHERE target_job_key = ?
-              AND action IN ('blocked', 'override_recorded', 'override_consumed')`,
-        )
-        .get(TARGET),
-    ).toMatchObject({ count: 3 });
+    const auditRows = db
+      .prepare(
+        `SELECT action, evidence_fingerprint, override_id
+           FROM application_repeat_audit
+          WHERE tenant_id = 'local'
+            AND target_job_key = ?
+            AND evidence_fingerprint = ?
+            AND action IN ('blocked', 'override_recorded', 'override_consumed')
+          ORDER BY CASE action
+            WHEN 'blocked' THEN 1
+            WHEN 'override_recorded' THEN 2
+            WHEN 'override_consumed' THEN 3
+          END`,
+      )
+      .all(TARGET, override.evidence_fingerprint) as Array<Record<string, unknown>>;
+    expect(auditRows).toEqual([
+      {
+        action: "blocked",
+        evidence_fingerprint: override.evidence_fingerprint,
+        override_id: null,
+      },
+      {
+        action: "override_recorded",
+        evidence_fingerprint: override.evidence_fingerprint,
+        override_id: override.override_id,
+      },
+      {
+        action: "override_consumed",
+        evidence_fingerprint: override.evidence_fingerprint,
+        override_id: override.override_id,
+      },
+    ]);
     expect(
       db
         .prepare(
@@ -241,12 +326,9 @@ print(job["url"])
              FROM application_repeat_override_consumptions c
              JOIN application_repeat_audit a
                ON a.override_id = c.override_id AND a.action = 'override_consumed'
-            WHERE c.override_id = (
-              SELECT override_id FROM application_repeat_overrides
-               WHERE target_job_key = ? ORDER BY confirmed_at DESC LIMIT 1
-            )`,
+            WHERE c.override_id = ?`,
         )
-        .get(TARGET),
+        .get(override.override_id),
     ).toMatchObject({
       run_id: "e2e-worker-repeat-claim",
       action: "override_consumed",
@@ -271,11 +353,16 @@ print(job["url"])
          VALUES (${columns.map(() => "?").join(", ")})`,
       ).run(...columns.map((column) => originalApplyStage[column]));
     }
-    db.prepare("DELETE FROM application_repeat_audit WHERE target_job_key = ?").run(TARGET);
-    db.prepare(
-      "DELETE FROM application_repeat_override_consumptions WHERE override_id IN (SELECT override_id FROM application_repeat_overrides WHERE target_job_key = ?)",
-    ).run(TARGET);
-    db.prepare("DELETE FROM application_repeat_overrides WHERE target_job_key = ?").run(TARGET);
+    if (repeatApplicationTablesExist(db)) {
+      clearRepeatApplicationState(db);
+      restoreRows(db, "application_repeat_overrides", originalRepeatOverrides);
+      restoreRows(
+        db,
+        "application_repeat_override_consumptions",
+        originalRepeatOverrideConsumptions,
+      );
+      restoreRows(db, "application_repeat_audit", originalRepeatAudit);
+    }
     db.prepare(
       "DELETE FROM job_canonical_identities WHERE tenant_id = 'local' AND job_url IN (?, ?)",
     ).run(TARGET, PRIOR);

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -45,6 +45,7 @@ test("repeat application block and reasoned override reach only the simulated su
   const originalApplyStage = db
     .prepare("SELECT * FROM job_stage_states WHERE job_url = ? AND stage = 'apply'")
     .get(TARGET) as Record<string, unknown> | undefined;
+  let originalTargetApplication: Record<string, unknown> | undefined;
 
   try {
     const target = db.prepare("SELECT * FROM jobs WHERE url = ?").get(TARGET) as Record<
@@ -52,6 +53,14 @@ test("repeat application block and reasoned override reach only the simulated su
       unknown
     >;
     if (!target) throw new Error("QA target job is missing");
+    originalTargetApplication = {
+      apply_status: target.apply_status,
+      applied_at: target.applied_at,
+    };
+    db.prepare("UPDATE jobs SET apply_status = 'applied', applied_at = ? WHERE url = ?").run(
+      CONFIRMED_AT,
+      TARGET,
+    );
     const prior: Record<string, unknown> = {
       ...target,
       url: PRIOR,
@@ -121,6 +130,7 @@ test("repeat application block and reasoned override reach only the simulated su
     await page.getByLabel("Reason for another live attempt").fill(
       "The prior application was withdrawn before review; this retry is intentional.",
     );
+    await page.getByRole("radio", { name: `Confirm prior application: ${PRIOR}` }).check();
     await page.getByRole("button", { name: "Confirm one live attempt" }).click();
     await expect(
       page.getByText("Repeat application confirmation recorded", { exact: true }),
@@ -284,6 +294,13 @@ print(job["url"])
       PRIOR,
     );
     db.prepare("DELETE FROM jobs WHERE url = ?").run(PRIOR);
+    if (originalTargetApplication) {
+      db.prepare("UPDATE jobs SET apply_status = ?, applied_at = ? WHERE url = ?").run(
+        originalTargetApplication.apply_status,
+        originalTargetApplication.applied_at,
+        TARGET,
+      );
+    }
     db.close();
   }
 });

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -98,7 +98,13 @@ test("repeat application block and reasoned override reach only the simulated su
     await expect(
       page.getByText("matching canonical ATS identity", { exact: true }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: "Inspect prior application" })).toBeVisible();
+    const priorApplicationLink = page.getByRole("link", {
+      name: `Inspect prior application: ${PRIOR}`,
+    });
+    await expect(priorApplicationLink).toHaveAttribute(
+      "href",
+      `/jobs/${encodeURIComponent(PRIOR)}`,
+    );
     await expect(page.getByRole("button", { name: /Authorize live submit/i })).toBeDisabled();
     const trustedMutationHeaders = {
       origin: new URL(page.url()).origin,

--- a/apps/web/e2e/tests/route-visual-qa.spec.ts
+++ b/apps/web/e2e/tests/route-visual-qa.spec.ts
@@ -1726,7 +1726,10 @@ test("density modes, focus rings, filters, forms, and destructive controls remai
   );
   await expectKeyboardFocusIndicator(
     page,
-    page.getByLabel("Results per board"),
+    page.getByRole("spinbutton", {
+      name: "Results per board",
+      exact: true,
+    }),
     "discovery results per board input",
   );
   await expect(page.getByRole("checkbox", { name: "LinkedIn" })).toBeVisible();

--- a/apps/web/e2e/tests/ui-remediation-accessibility.spec.ts
+++ b/apps/web/e2e/tests/ui-remediation-accessibility.spec.ts
@@ -92,7 +92,18 @@ test("forms expose labels, validation state, and an announced upload error", asy
   await expect(page.getByLabel("Minimum fit score")).toBeVisible({
     timeout: 30_000,
   });
-  await expect(page.getByLabel("Results per board")).toBeVisible();
+  await expect(
+    page.getByRole("spinbutton", {
+      name: "Results per board",
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: "Help for Results per board",
+      exact: true,
+    }),
+  ).toBeVisible();
   await expect(page.getByRole("checkbox", { name: "LinkedIn" })).toBeVisible();
 
   await page.goto("/settings");

--- a/apps/web/e2e/tests/ui-remediation-accessibility.spec.ts
+++ b/apps/web/e2e/tests/ui-remediation-accessibility.spec.ts
@@ -1,6 +1,8 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { getViolations, injectAxe } from "axe-playwright";
 
+import { sampleHealthResponse } from "../../src/test/fixtures/projections.js";
+
 const REPRESENTATIVE_ROUTES = [
   "/dashboard",
   "/jobs",
@@ -76,6 +78,28 @@ async function expectMinimumTarget(locator: Locator, label: string) {
   expect(box!.height, `${label} target height`).toBeGreaterThanOrEqual(24);
 }
 
+async function expectRejectedResumeUpload(page: Page) {
+  const resumeImport = page.getByRole("region", {
+    name: "Resume import",
+    exact: true,
+  });
+  const fileInput = resumeImport.getByLabel("Resume PDF");
+  const continueButton = resumeImport.getByRole("button", {
+    name: "Continue to options",
+  });
+  await expect(fileInput).toBeAttached({ timeout: 30_000 });
+  await expect(continueButton).toBeDisabled();
+  await fileInput.setInputFiles({
+    name: "resume.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("synthetic resume"),
+  });
+  await expect(resumeImport.getByRole("alert")).toContainText(
+    "Choose a PDF file.",
+  );
+  await expect(continueButton).toBeDisabled();
+}
+
 test("representative remediated routes have no critical or serious axe violations", async ({
   page,
 }) => {
@@ -112,20 +136,31 @@ test("forms expose labels, validation state, and an announced upload error", asy
   });
 
   await page.goto("/profile/import/upload");
-  const fileInput = page.getByLabel("Resume PDF");
-  const continueButton = page.getByRole("button", {
-    name: "Continue to options",
+  await expectRejectedResumeUpload(page);
+});
+
+test("resume upload error remains announced with a stale worker warning", async ({
+  page,
+}) => {
+  await page.route("**/v1/health", async (route) => {
+    await route.fulfill({
+      json: {
+        ...sampleHealthResponse,
+        worker: {
+          ...sampleHealthResponse.worker,
+          status: "stale",
+          message:
+            "JobCtrl automation worker heartbeat is stale; last seen at test time.",
+        },
+      },
+    });
   });
-  await expect(fileInput).toBeAttached({ timeout: 30_000 });
-  await expect(continueButton).toBeDisabled();
-  await fileInput.setInputFiles({
-    name: "resume.txt",
-    mimeType: "text/plain",
-    buffer: Buffer.from("synthetic resume"),
-  });
-  const alert = page.getByRole("alert");
-  await expect(alert).toContainText("Choose a PDF file.");
-  await expect(continueButton).toBeDisabled();
+
+  await page.goto("/profile/import/upload");
+  await expect(page.locator(".connection-banner")).toContainText(
+    "worker heartbeat is stale",
+  );
+  await expectRejectedResumeUpload(page);
 });
 
 test("200 percent text-scale approximation preserves representative task access", async ({

--- a/apps/web/e2e/tests/wizard.spec.ts
+++ b/apps/web/e2e/tests/wizard.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { refreshE2eWorkerHeartbeat } from "../fixtures/e2e-state.js";
+
 test("Resume import upload keeps continuation unavailable until a PDF is selected", async ({
   page,
 }) => {
@@ -42,6 +44,7 @@ test("Profile import keeps the upload task in the first mobile viewport @mobile"
   page,
 }) => {
   await page.setViewportSize({ width: 320, height: 568 });
+  refreshE2eWorkerHeartbeat();
   await page.goto("/profile/import/upload");
 
   const progress = page.getByRole("navigation", {

--- a/apps/web/e2e/tests/worker-heartbeat-fixture.spec.ts
+++ b/apps/web/e2e/tests/worker-heartbeat-fixture.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+import Database from "better-sqlite3";
+
+import {
+  loadE2eDbPath,
+  refreshE2eWorkerHeartbeat,
+} from "../fixtures/e2e-state.js";
+
+test("@mobile E2E worker fixture restores a healthy heartbeat", async ({
+  request,
+}) => {
+  const db = new Database(loadE2eDbPath());
+  try {
+    db.prepare("UPDATE worker_runtime_heartbeats SET last_seen_at = ?").run(
+      "2020-01-01T00:00:00.000Z",
+    );
+  } finally {
+    db.close();
+  }
+
+  refreshE2eWorkerHeartbeat();
+
+  const response = await request.get("/v1/health");
+  expect(response.ok()).toBe(true);
+  await expect(response.json()).resolves.toMatchObject({
+    worker: { status: "healthy" },
+  });
+});

--- a/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.test.tsx
+++ b/apps/web/src/contexts/discovery/components/DiscoveryRuntimeSettingsPanel.test.tsx
@@ -36,6 +36,9 @@ describe("<DiscoveryRuntimeSettingsPanel>", () => {
         screen.getByRole("button", { name: `Help for ${settingName}` }),
       ).toBeInTheDocument();
     }
+    expect(
+      screen.getByRole("spinbutton", { name: "Results per board" }),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Help for Schedule cron" }));
     const help = await screen.findByRole("dialog", { name: "Schedule cron help" });

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.test.tsx
@@ -82,6 +82,10 @@ describe("StageTriggerPanel", () => {
     expect(
       await screen.findByRole("button", { name: "Worker unavailable" }),
     ).toBeDisabled();
+    expect(screen.getByRole("alert")).toHaveAttribute(
+      "data-typography",
+      "body",
+    );
     expect(screen.getByRole("alert")).toHaveTextContent(
       "No JobCtrl automation worker heartbeat has been written to the API database.",
     );

--- a/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
+++ b/apps/web/src/contexts/pipeline/components/StageTriggerPanel.tsx
@@ -970,13 +970,22 @@ export function StageTriggerPanel({
           />
         ) : null}
         {!runAvailability.available ? (
-          <span className="status-line" id={unavailableReasonId} role="status">
+          <span
+            className="status-line"
+            data-typography="body"
+            id={unavailableReasonId}
+            role="status"
+          >
             Pipeline runs require the local app. <a href="/runs">Review bundled runs</a>
             {" or "}
             <a href={LOCAL_INSTALL_GUIDE_URL}>install JobCtrl</a>.
           </span>
         ) : workerUnhealthy ? (
-          <span className="status-line danger-action" role="alert">
+          <span
+            className="status-line danger-action"
+            data-typography="body"
+            role="alert"
+          >
             {workerHealthMessage}
           </span>
         ) : runStages.isPending ? (
@@ -986,7 +995,7 @@ export function StageTriggerPanel({
               progress={visibleStageProgress}
             />
           ) : (
-            <span className="status-line" role="status">
+            <span className="status-line" data-typography="body" role="status">
               {relevantPendingActivity
                 ? stageActivityStatusLine(statusStage, relevantPendingActivity)
                 : pendingStageStatusLine(statusStage)}
@@ -1004,12 +1013,17 @@ export function StageTriggerPanel({
                 ? "status-line danger-action"
                 : "status-line"
             }
+            data-typography="body"
             role="status"
           >
             {pipelineRunStatusLine(statusStage, runStages.data)}
           </span>
         ) : runStages.error ? (
-          <span className="status-line danger-action" role="status">
+          <span
+            className="status-line danger-action"
+            data-typography="body"
+            role="status"
+          >
             {pipelineRequestErrorLine(statusStage, runStages.error)}
           </span>
         ) : visibleStageActivity ? (
@@ -1019,6 +1033,7 @@ export function StageTriggerPanel({
                 ? "status-line danger-action"
                 : "status-line"
             }
+            data-typography="body"
             role="status"
           >
             {stageActivityStatusLine(statusStage, visibleStageActivity)}

--- a/apps/web/src/styles/redesign-apply-review.css
+++ b/apps/web/src/styles/redesign-apply-review.css
@@ -44,6 +44,24 @@
   gap: 8px;
 }
 
+.repeat-application-prior-options {
+  gap: 8px;
+}
+
+.repeat-application-prior {
+  min-width: 0;
+}
+
+.repeat-application-prior [data-slot="input"] {
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  flex: 0 0 auto;
+  margin-top: 1px;
+  padding: 0;
+  accent-color: var(--primary);
+}
+
 .repeat-application-confirmation-form > button {
   justify-self: start;
 }

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -874,7 +874,9 @@ describe("<ApplyReviewView>", () => {
 
     expect(await screen.findByText("Review prior application before live submit")).toBeInTheDocument();
     expect(screen.getByText("worker-confirmed submission", { exact: false })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Inspect prior application" })).toHaveAttribute(
+    expect(screen.getByRole("link", {
+      name: "Inspect prior application: https://example.com/jobs/prior-platform",
+    })).toHaveAttribute(
       "href",
       `/jobs/${encodeURIComponent("https://example.com/jobs/prior-platform")}`,
     );

--- a/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.test.tsx
@@ -831,6 +831,20 @@ describe("<ApplyReviewView>", () => {
           },
           identityEvidence: ["employer:globex", "role:principal platform engineer"],
         },
+        {
+          relationship: "same_employer_equivalent_role",
+          reason: "The employer identity matches exactly and the normalized role titles are materially equivalent.",
+          priorApplication: {
+            jobKey: "https://alternate.example.test/jobs/prior-platform",
+            title: "Principal Platform Engineer",
+            company: "Globex",
+            applicationUrl: "https://alternate.example.test/jobs/prior-platform/apply",
+            factKind: "application_submitted",
+            factId: "event:43",
+            confirmedAt: "2026-05-01T10:00:00Z",
+          },
+          identityEvidence: ["employer:globex", "role:principal platform engineer"],
+        },
       ],
       auditTrail: [
         {
@@ -873,7 +887,7 @@ describe("<ApplyReviewView>", () => {
     });
 
     expect(await screen.findByText("Review prior application before live submit")).toBeInTheDocument();
-    expect(screen.getByText("worker-confirmed submission", { exact: false })).toBeInTheDocument();
+    expect(screen.getAllByText("worker-confirmed submission", { exact: false })).toHaveLength(2);
     expect(screen.getByRole("link", {
       name: "Inspect prior application: https://example.com/jobs/prior-platform",
     })).toHaveAttribute(
@@ -887,11 +901,15 @@ describe("<ApplyReviewView>", () => {
       screen.getByLabelText("Reason for another live attempt"),
       "The first application was withdrawn before review.",
     );
+    expect(screen.getByRole("button", { name: "Confirm one live attempt" })).toBeDisabled();
+    await userEvent.click(screen.getByRole("radio", {
+      name: "Confirm prior application: https://alternate.example.test/jobs/prior-platform",
+    }));
     await userEvent.click(screen.getByRole("button", { name: "Confirm one live attempt" }));
     expect(screen.getByRole("button", { name: "Recording confirmation" })).toBeDisabled();
     expect(confirmRepeatApplication).toHaveBeenCalledWith(queue.items[0]!.jobKey, {
       evidenceFingerprint: fingerprint,
-      priorJobKey: "https://example.com/jobs/prior-platform",
+      priorJobKey: "https://alternate.example.test/jobs/prior-platform",
       reason: "The first application was withdrawn before review.",
       confirmedBy: "user",
     });

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -60,6 +60,13 @@ import {
   CollapsibleTrigger,
 } from "../../shared/ui/collapsible.js";
 import { Empty } from "../../shared/ui/empty.js";
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+} from "../../shared/ui/field.js";
 import { Input } from "../../shared/ui/input.js";
 import { MarkdownDocument } from "../../shared/ui/MarkdownDocument.js";
 import { PageHead } from "../../shared/ui/page-head.js";
@@ -1442,21 +1449,34 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
 
       {needsConfirmation && assessment.matches.length > 0 && assessment.evidenceFingerprint ? (
         <div className="repeat-application-confirmation-form">
-          <fieldset>
-            <legend>Select the prior application for this confirmation</legend>
-            {assessment.matches.map((match) => (
-              <label key={`${match.relationship}:${match.priorApplication.factId}`}>
-                <input
-                  type="radio"
-                  name={`repeat-application-prior-${encodeURIComponent(item.jobKey)}`}
-                  value={match.priorApplication.jobKey}
-                  checked={selectedPrior?.priorApplication.jobKey === match.priorApplication.jobKey}
-                  onChange={() => setSelectedPriorJobKey(match.priorApplication.jobKey)}
-                />
-                Confirm prior application: {match.priorApplication.jobKey}
-              </label>
-            ))}
-          </fieldset>
+          <FieldSet>
+            <FieldLegend>Select the prior application for this confirmation</FieldLegend>
+            <FieldGroup data-slot="radio-group" className="repeat-application-prior-options">
+              {assessment.matches.map((match) => {
+                const priorJobKey = match.priorApplication.jobKey;
+                const controlId = `repeat-application-prior-${encodeURIComponent(item.jobKey)}-${encodeURIComponent(priorJobKey)}`;
+                return (
+                  <Field
+                    className="repeat-application-prior"
+                    key={`${match.relationship}:${match.priorApplication.factId}`}
+                    orientation="horizontal"
+                  >
+                    <Input
+                      checked={selectedPrior?.priorApplication.jobKey === priorJobKey}
+                      id={controlId}
+                      name={`repeat-application-prior-${encodeURIComponent(item.jobKey)}`}
+                      onChange={() => setSelectedPriorJobKey(priorJobKey)}
+                      type="radio"
+                      value={priorJobKey}
+                    />
+                    <FieldLabel htmlFor={controlId}>
+                      Confirm prior application: {priorJobKey}
+                    </FieldLabel>
+                  </Field>
+                );
+              })}
+            </FieldGroup>
+          </FieldSet>
           <label htmlFor={`repeat-application-reason-${encodeURIComponent(item.jobKey)}`}>
             Reason for another live attempt
           </label>

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1403,7 +1403,10 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
               {formatDateTime(match.priorApplication.confirmedAt)}
             </p>
             <p className="meta">{match.reason}</p>
-            <a href={`/jobs/${encodeURIComponent(match.priorApplication.jobKey)}`}>
+            <a
+              href={`/jobs/${encodeURIComponent(match.priorApplication.jobKey)}`}
+              aria-label={`Inspect prior application: ${match.priorApplication.jobKey}`}
+            >
               Inspect prior application
             </a>
             <details>

--- a/apps/web/src/views/apply-review/ApplyReviewView.tsx
+++ b/apps/web/src/views/apply-review/ApplyReviewView.tsx
@@ -1355,13 +1355,17 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
   const assessment = item.repeatApplication;
   const mutation = useRepeatApplicationOverrideMutation();
   const [reason, setReason] = useState("");
+  const [selectedPriorJobKey, setSelectedPriorJobKey] = useState<string | null>(null);
   const needsConfirmation = ["blocked", "confirmation_required", "override_consumed"].includes(
     assessment.status,
   );
-  const primary = assessment.matches[0] ?? null;
+  const selectedPrior = assessment.matches.find(
+    (match) => match.priorApplication.jobKey === selectedPriorJobKey,
+  ) ?? (assessment.matches.length === 1 ? assessment.matches[0] ?? null : null);
 
   useEffect(() => {
     setReason("");
+    setSelectedPriorJobKey(null);
     mutation.reset();
   }, [item.jobKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -1436,8 +1440,23 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
         </details>
       ) : null}
 
-      {needsConfirmation && primary && assessment.evidenceFingerprint ? (
+      {needsConfirmation && assessment.matches.length > 0 && assessment.evidenceFingerprint ? (
         <div className="repeat-application-confirmation-form">
+          <fieldset>
+            <legend>Select the prior application for this confirmation</legend>
+            {assessment.matches.map((match) => (
+              <label key={`${match.relationship}:${match.priorApplication.factId}`}>
+                <input
+                  type="radio"
+                  name={`repeat-application-prior-${encodeURIComponent(item.jobKey)}`}
+                  value={match.priorApplication.jobKey}
+                  checked={selectedPrior?.priorApplication.jobKey === match.priorApplication.jobKey}
+                  onChange={() => setSelectedPriorJobKey(match.priorApplication.jobKey)}
+                />
+                Confirm prior application: {match.priorApplication.jobKey}
+              </label>
+            ))}
+          </fieldset>
           <label htmlFor={`repeat-application-reason-${encodeURIComponent(item.jobKey)}`}>
             Reason for another live attempt
           </label>
@@ -1451,21 +1470,24 @@ function RepeatApplicationGuardPanel({ item }: { readonly item: ApplyReviewQueue
           <Button
             type="button"
             variant="outline"
-            disabled={mutation.isPending || reason.trim().length < 10}
-            onClick={() => mutation.mutate({
-              jobId: item.jobKey,
-              body: {
-                evidenceFingerprint: assessment.evidenceFingerprint!,
-                priorJobKey: primary.priorApplication.jobKey,
-                reason: reason.trim(),
-                confirmedBy: "user",
-              },
-            })}
+            disabled={mutation.isPending || reason.trim().length < 10 || !selectedPrior}
+            onClick={() => {
+              if (!selectedPrior) return;
+              mutation.mutate({
+                jobId: item.jobKey,
+                body: {
+                  evidenceFingerprint: assessment.evidenceFingerprint!,
+                  priorJobKey: selectedPrior.priorApplication.jobKey,
+                  reason: reason.trim(),
+                  confirmedBy: "user",
+                },
+              });
+            }}
           >
             {mutation.isPending ? "Recording confirmation" : "Confirm one live attempt"}
           </Button>
           <p className="meta">
-            This confirmation is bound to this target, the prior application above, and the current evidence. It is consumed by one worker claim.
+            This confirmation is bound to this target, the selected prior application, and the current evidence. It is consumed by one worker claim.
           </p>
         </div>
       ) : null}

--- a/apps/web/test/playwright-config.test.ts
+++ b/apps/web/test/playwright-config.test.ts
@@ -74,6 +74,7 @@ describe("Playwright server isolation", () => {
       XDG_CACHE_HOME: path.join(serviceHome, ".cache"),
       PLAYWRIGHT_BROWSERS_PATH: "/tmp/jobctrl-playwright-browsers",
       TZ: "UTC",
+      UV_LOCKED: "1",
     });
     expect(config.webServer[1]?.env).toMatchObject({
       VITE_DEV_API_PROXY_TARGET: "http://127.0.0.1:18767",

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -612,6 +612,10 @@ resumes, databases, logs, Gmail tokens, or browser profiles; do not run apply
 automation, mailbox scans, real crawling, or real LLM calls for screenshots;
 keep output deterministic (fixed per-surface viewports, synthetic database,
 seeded pipeline operations and heartbeat, no external providers).
+The Profile preview renderer runs with the Python lock held; its fixed dependency
+cutoff is defined in `workers/automation/pyproject.toml`, not inherited from a
+caller-provided `UV_EXCLUDE_NEWER` value. A stale lock must fail rather than
+being rewritten by screenshot generation.
 
 ### Launch Demo Asset Inventory
 

--- a/scripts/docs-screenshot-environment.mjs
+++ b/scripts/docs-screenshot-environment.mjs
@@ -69,6 +69,10 @@ export function createDocsScreenshotEnvironment({
   return {
     ...environment,
     TZ: "UTC",
+    // The Profile capture exercises the real resume-preview renderer, which
+    // invokes `uv run`. Screenshot generation is an artifact-only workflow:
+    // it must fail on a stale lock rather than rewriting project dependencies.
+    UV_LOCKED: "1",
     JOBCTRL_DOCS_SCREENSHOTS: "1",
     JOBCTRL_E2E_APP_DIR: appDir,
     JOBCTRL_E2E_DB_PATH: path.join(appDir, "jobctrl.db"),

--- a/scripts/docs-screenshot-environment.test.mjs
+++ b/scripts/docs-screenshot-environment.test.mjs
@@ -15,6 +15,7 @@ test("documentation screenshot environment allows toolchain state but excludes h
       HOME: "/Users/example",
       PLAYWRIGHT_BROWSERS_PATH: "/Users/example/playwright",
       LANG: "en_US.UTF-8",
+      UV_EXCLUDE_NEWER: "8 days",
       OPENAI_API_KEY: "must-not-escape",
       GEMINI_API_KEY: "must-not-escape",
       GOOGLE_APPLICATION_CREDENTIALS: "/private/service-account.json",
@@ -45,6 +46,11 @@ test("documentation screenshot environment allows toolchain state but excludes h
   );
   assert.equal(environment.JOBCTRL_E2E_API_PORT, "18767");
   assert.equal(environment.JOBCTRL_E2E_WEB_PORT, "15174");
+  assert.equal(
+    "UV_EXCLUDE_NEWER" in environment,
+    false,
+    "the fixed cutoff belongs to workers/automation/pyproject.toml",
+  );
 
   for (const key of [
     "OPENAI_API_KEY",

--- a/scripts/docs-screenshot-environment.test.mjs
+++ b/scripts/docs-screenshot-environment.test.mjs
@@ -32,6 +32,11 @@ test("documentation screenshot environment allows toolchain state but excludes h
     "/Users/example/playwright",
   );
   assert.equal(environment.TZ, "UTC");
+  assert.equal(
+    environment.UV_LOCKED,
+    "1",
+    "profile preview rendering must not rewrite workers/automation/uv.lock",
+  );
   assert.equal(environment.JOBCTRL_DOCS_SCREENSHOTS, "1");
   assert.equal(environment.JOBCTRL_E2E_APP_DIR, appDir);
   assert.equal(

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -108,8 +108,11 @@ pythonVersion = "3.11"
 [tool.uv]
 default-groups = ["provider-runtime"]
 
-# The workspace dependency cutoff (UV_EXCLUDE_NEWER) intentionally freezes the
-# broad dependency graph. Provider runtimes and the audited JobStreaming
-# integration move independently, so admit only their reviewed releases
-# without moving the global cutoff for everything else.
+# The workspace dependency cutoff intentionally freezes the broad dependency
+# graph. Keep it as a fixed project value, rather than a caller-provided
+# relative `UV_EXCLUDE_NEWER` value, so locked source runtimes and release
+# workflows resolve against the same graph. Provider runtimes and the audited
+# JobStreaming integration move independently, so admit only their reviewed
+# releases without moving the global cutoff for everything else.
+exclude-newer = "2026-07-09T19:15:43.240437Z"
 exclude-newer-package = { "google-antigravity" = "2026-06-04T21:19:27Z", "claude-agent-sdk" = "2026-07-10T00:00:00Z", "jobstreaming" = "2026-07-18T00:00:00Z" }

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -297,9 +297,22 @@ def _normalize_tokens(value: str | None) -> list[str]:
 
 
 def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
-    row = conn.execute(
+    company_expression = "j.company"
+    company_params: tuple[str, ...] = ()
+    if _table_exists(conn, "job_list_projections"):
+        company_expression = """
+            COALESCE(
+              NULLIF(j.company, ''),
+              (SELECT jlp.employer
+                 FROM job_list_projections jlp
+                WHERE jlp.tenant_id = ? AND jlp.job_id = j.url
+                LIMIT 1)
+            )
         """
-        SELECT j.url, j.title, j.company,
+        company_params = (LOCAL_TENANT,)
+    row = conn.execute(
+        f"""
+        SELECT j.url, j.title, {company_expression} AS company,
                COALESCE(
                  (SELECT je.application_url
                     FROM job_enrichments je
@@ -308,10 +321,10 @@ def _job_identity(conn, job_key: str) -> dict[str, Any] | None:
                  j.application_url,
                  j.url
                ) AS application_url
-          FROM jobs j
+         FROM jobs j
          WHERE j.url = ?
         """,
-        (LOCAL_TENANT, job_key),
+        (*company_params, LOCAL_TENANT, job_key),
     ).fetchone()
     if row is None:
         return None

--- a/workers/automation/src/jobctrl/domain/apply/repeat_application.py
+++ b/workers/automation/src/jobctrl/domain/apply/repeat_application.py
@@ -600,7 +600,7 @@ def _audit_trail(conn, target_job_key: str) -> list[dict[str, Any]]:
           LEFT JOIN application_repeat_overrides o
             ON o.tenant_id = a.tenant_id AND o.override_id = a.override_id
          WHERE a.tenant_id = ? AND a.target_job_key = ?
-         ORDER BY a.occurred_at DESC, a.audit_id DESC LIMIT 50
+         ORDER BY a.occurred_at DESC, a.rowid DESC LIMIT 50
         """,
         (LOCAL_TENANT, target_job_key),
     ).fetchall()

--- a/workers/automation/tests/test_discovery_search_units.py
+++ b/workers/automation/tests/test_discovery_search_units.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from jobstreaming import CheckpointConflictError, SearchCheckpoint, build_search_request
 
-from jobctrl.database import close_connection, init_db
+from jobctrl.database import SCHEMA_VERSION, close_connection, init_db
 from jobctrl.domain.discovery import (
     AtsKind,
     CanonicalJobIdentity,
@@ -282,7 +282,10 @@ def test_v4_search_unit_tables_migrate_consumption_ordering(
                AND name = 'discovery_search_unit_filtered_events'
             """
         ).fetchone()[0] == 1
-        assert migrated.execute("PRAGMA user_version").fetchone()[0] == 5
+        # ``user_version`` guards the complete database shape, so reopening a
+        # v4 fixture must advance to the current schema rather than pinning
+        # this search-unit migration to its historical v5 release.
+        assert migrated.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
     finally:
         close_connection(db_path)
 

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -19,6 +19,7 @@ from jobctrl.apply.launcher import (
 )
 from jobctrl.database import SCHEMA_VERSION, close_connection, get_connection, init_db
 from jobctrl.domain.apply.repeat_application import (
+    consume_repeat_application_override,
     evaluate_repeat_application,
     repeat_evidence_fingerprint,
 )
@@ -248,6 +249,36 @@ def test_equivalent_role_requires_confirmation_but_distinct_and_similar_employer
     )
     conn.commit()
     assert evaluate_repeat_application(conn, TARGET)["status"] == "clear"
+
+
+def test_audit_trail_orders_equal_timestamps_by_sqlite_insertion_order(tmp_path: Path) -> None:
+    conn = _seed_equivalent_repeat(tmp_path / "jobs.db")
+    initial = evaluate_repeat_application(conn, TARGET, evaluated_at=NOW)
+    _insert_override(conn, initial)
+    ready = evaluate_repeat_application(conn, TARGET, record_audit=False, evaluated_at=NOW)
+    assert ready["status"] == "override_ready"
+    consume_repeat_application_override(
+        conn,
+        ready,
+        target_job_key=TARGET,
+        run_id="equal-timestamp-run",
+        consumed_at=NOW,
+    )
+
+    # UUIDs do not encode insertion order.  Force the tied timestamps into
+    # the inverse lexical UUID order to reproduce the production race.
+    conn.execute(
+        "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'confirmation_required'",
+        ("ffffffff-ffff-ffff-ffff-ffffffffffff",),
+    )
+    conn.execute(
+        "UPDATE application_repeat_audit SET audit_id = ? WHERE action = 'override_consumed'",
+        ("00000000-0000-0000-0000-000000000000",),
+    )
+    ordered = evaluate_repeat_application(conn, TARGET, record_audit=False, evaluated_at=NOW)
+
+    assert ordered["auditTrail"][0]["action"] == "override_consumed"
+    assert ordered["auditTrail"][0]["priorJobKey"] == PRIOR
 
 
 def test_unconfirmed_sources_do_not_establish_application_history(tmp_path: Path) -> None:

--- a/workers/automation/tests/test_repeat_application_prevention.py
+++ b/workers/automation/tests/test_repeat_application_prevention.py
@@ -208,6 +208,30 @@ def test_exact_canonical_and_accepted_duplicate_identities_block(tmp_path: Path)
     assert linked["matches"][0]["relationship"] == "accepted_duplicate"
 
 
+def test_projected_employer_preserves_repeat_evidence_when_job_company_is_missing(tmp_path: Path) -> None:
+    conn = init_db(tmp_path / "jobs.db")
+    _insert_job(conn, url=PRIOR, title="Senior Backend Engineer", company="")
+    _insert_job(conn, url=TARGET, title="Backend Senior Eng", company="", ready=True)
+    conn.execute("UPDATE jobs SET company = NULL")
+    conn.execute("DELETE FROM job_list_projections")
+    conn.executemany(
+        """
+        INSERT INTO job_list_projections (tenant_id, job_id, employer)
+        VALUES ('local', ?, 'Acme Inc')
+        """,
+        [(PRIOR,), (TARGET,)],
+    )
+    _confirm_application(conn)
+
+    assessment = evaluate_repeat_application(conn, TARGET)
+
+    assert assessment["status"] == "confirmation_required"
+    match = assessment["matches"][0]
+    assert match["relationship"] == "same_employer_equivalent_role"
+    assert match["priorApplication"]["company"] == "Acme Inc"
+    assert match["identityEvidence"][0] == "employer:acme"
+
+
 def test_equivalent_role_requires_confirmation_but_distinct_and_similar_employers_clear(
     tmp_path: Path,
 ) -> None:

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -15,7 +15,6 @@ resolution-markers = [
 
 [options]
 exclude-newer = "2026-07-09T19:15:43.240437Z"
-exclude-newer-span = "P8D"
 
 [options.exclude-newer-package]
 claude-agent-sdk = "2026-07-10T00:00:00Z"


### PR DESCRIPTION
## Summary

- bind repeat-application overrides to the explicitly selected prior application and keep TypeScript/Python evidence fingerprints aligned
- make repeat-audit chronology deterministic for equal timestamps while preserving the complete causal trail
- stabilize launch-critical web, mobile, accessibility, demo-workspace, and screenshot QA fixtures without weakening product assertions
- preserve pipeline status typography and pin the documentation screenshot runtime to the repository lock policy

## Validation

- Python: 2,574 passed
- API: 647 passed
- Web unit: 1,952 passed
- Web E2E: 80 passed, 2 opt-in capture lanes skipped by design
- Documentation screenshots: passed with all 32 image hashes and `uv.lock` unchanged
- Documentation build/runtime: 8,239 references resolved; runtime contract passed
- Demo edge: typecheck, 27 tests, worker dry-runs, generated types, and production demo build passed
- Release: strict scanner, focused scanner tests, aggregate type/lint/vet checks, and diff checks passed
- Independent reviewer and QA gates: PASS with zero findings

## Safety

The repeat-application path was exercised through the simulated submit boundary and one-time worker consumption. No live application was submitted.
