### PR TITLE
fix(ci): provision uv for launcher audit

### DIFF
--- a/.github/workflows/launcher.yml
+++ b/.github/workflows/launcher.yml
@@ -44,6 +44,11 @@ jobs:
           node-version: "22.21.1"
           cache: pnpm
 
+      - name: Set up pinned uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: 0.11.7
+
       - name: Install Node dependencies
         run: corepack pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- provision the repository-pinned `uv` action in Native Launcher CI
- ensure the distribution provider-lock audit can execute its required `uv export` step

## Root cause

The launcher workflow ran `distribution:audit`, whose provider-lock check invokes `uv`, but the macOS runner never installed `uv`.

## Validation

- `corepack pnpm distribution:audit`
- YAML parse and focused launcher workflow contract assertion
- `git diff --check`

`corepack pnpm scripts:test` remains blocked by two pre-existing screenshot-workspace tests on the current base; this PR does not touch that code or contract.