### PR TITLE
fix(ci): install Python test dependencies

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e "workers/automation[dev]"
+        run: pip install -e "workers/automation[dev,providers]"
 
       - name: Install LaTeX
         env:

--- a/workers/automation/pyproject.toml
+++ b/workers/automation/pyproject.toml
@@ -47,7 +47,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["build>=1.2", "hatchling==1.29.0", "pytest>=7.0", "pytest-asyncio>=0.23", "pytest-randomly>=4.0", "ruff>=0.1"]
+dev = [
+    "build>=1.2",
+    "cryptography>=43.0",
+    "google-auth>=2.0",
+    "hatchling==1.29.0",
+    "pytest>=7.0",
+    "pytest-asyncio>=0.23",
+    "pytest-randomly>=4.0",
+    "ruff>=0.1",
+]
 providers = [
     "claude-agent-sdk==0.2.115",
     "openai-codex==0.1.0b3",

--- a/workers/automation/uv.lock
+++ b/workers/automation/uv.lock
@@ -612,6 +612,8 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "build" },
+    { name = "cryptography" },
+    { name = "google-auth" },
     { name = "hatchling" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -642,7 +644,9 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2" },
     { name = "claude-agent-sdk", marker = "extra == 'providers'", specifier = "==0.2.115" },
+    { name = "cryptography", marker = "extra == 'dev'", specifier = ">=43.0" },
     { name = "google-antigravity", marker = "extra == 'providers'", specifier = "==0.1.2" },
+    { name = "google-auth", marker = "extra == 'dev'", specifier = ">=2.0" },
     { name = "hatchling", marker = "extra == 'dev'", specifier = "==1.29.0" },
     { name = "httpx", specifier = ">=0.24" },
     { name = "jobstreaming", specifier = "==0.0.2" },


### PR DESCRIPTION
## Summary

- declare the cryptography and Google ADC libraries used directly by Python tests in the `dev` extra
- install the existing `providers` extra in Python CI, because the full suite exercises the optional provider adapters
- refresh the worker lock metadata without changing the repository dependency cutoff

## Why

Python CI previously installed only `workers/automation[dev]` on a clean runner. That excluded direct test imports and the intentionally optional Claude, Codex, and Antigravity SDKs. The project already defines the tested provider set as the `providers` extra, so CI now installs `workers/automation[dev,providers]` rather than duplicating provider dependencies into `dev`.

## Validation

- clean Python 3.12 `pip install -e 'workers/automation[dev,providers]'`
- provider SDK import check for Claude, Codex, and Antigravity
- provider-focused test selection: `128 passed`
- initial direct dependency selection: `46 passed`
- complete worker test collection: `2575 tests collected`
- locked dev-extra imports for `cryptography` and `google-auth`
- `uv lock --check`
- workflow YAML parse/assertion and `git diff --check`