### PR TITLE
fix(installer): support GNU stat mode lookup

### DIFF
--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -72,6 +72,18 @@ login_profile() {
     *) /usr/bin/printf '%s' "$HOME/.zprofile" ;;
   esac
 }
+profile_mode() {
+  local profile="$1" mode
+  if mode="$(/usr/bin/stat -f '%Lp' "$profile" 2>/dev/null)"; then
+    :
+  elif mode="$(/usr/bin/stat -c '%a' "$profile" 2>/dev/null)"; then
+    :
+  else
+    return 1
+  fi
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  /usr/bin/printf '%s' "$mode"
+}
 append_managed_path() {
   local bin_dir="$1" profile mode temporary line
   profile="$(login_profile)"
@@ -81,7 +93,7 @@ append_managed_path() {
   if [[ -e "$profile" && ! -f "$profile" ]]; then fail "login profile is not a regular file: $profile"; fi
   if [[ -f "$profile" ]] && /usr/bin/grep -Fqx "$line" "$profile"; then return; fi
   if [[ -f "$profile" ]]; then
-    mode="$(/usr/bin/stat -f '%Lp' "$profile")"
+    mode="$(profile_mode "$profile")" || fail "could not read login profile mode"
     temporary="$(/usr/bin/mktemp "${profile}.jobctrl.XXXXXX")"
     /bin/cat "$profile" > "$temporary" || { /bin/rm -f "$temporary"; fail "could not read login profile $profile"; }
     /usr/bin/printf '\n%s\n' "$line" >> "$temporary" || { /bin/rm -f "$temporary"; fail "could not update login profile $profile"; }

--- a/scripts/get
+++ b/scripts/get
@@ -72,6 +72,18 @@ login_profile() {
     *) /usr/bin/printf '%s' "$HOME/.zprofile" ;;
   esac
 }
+profile_mode() {
+  local profile="$1" mode
+  if mode="$(/usr/bin/stat -f '%Lp' "$profile" 2>/dev/null)"; then
+    :
+  elif mode="$(/usr/bin/stat -c '%a' "$profile" 2>/dev/null)"; then
+    :
+  else
+    return 1
+  fi
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  /usr/bin/printf '%s' "$mode"
+}
 append_managed_path() {
   local bin_dir="$1" profile mode temporary line
   profile="$(login_profile)"
@@ -81,7 +93,7 @@ append_managed_path() {
   if [[ -e "$profile" && ! -f "$profile" ]]; then fail "login profile is not a regular file: $profile"; fi
   if [[ -f "$profile" ]] && /usr/bin/grep -Fqx "$line" "$profile"; then return; fi
   if [[ -f "$profile" ]]; then
-    mode="$(/usr/bin/stat -f '%Lp' "$profile")"
+    mode="$(profile_mode "$profile")" || fail "could not read login profile mode"
     temporary="$(/usr/bin/mktemp "${profile}.jobctrl.XXXXXX")"
     /bin/cat "$profile" > "$temporary" || { /bin/rm -f "$temporary"; fail "could not read login profile $profile"; }
     /usr/bin/printf '\n%s\n' "$line" >> "$temporary" || { /bin/rm -f "$temporary"; fail "could not update login profile $profile"; }

--- a/scripts/get.test.mjs
+++ b/scripts/get.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { chmodSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, readlinkSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
@@ -13,7 +13,8 @@ const SYSTEM_BASH = "/bin/bash";
 
 function makeTmp() { return mkdtempSync(path.join(os.tmpdir(), "jobctrl-get-test-")); }
 function sha256(value) { return createHash("sha256").update(value).digest("hex"); }
-function run(args, env) { return spawnSync(SYSTEM_BASH, [GET, ...args], { encoding: "utf8", env: { ...process.env, ...env } }); }
+function run(args, env, installer = GET) { return spawnSync(SYSTEM_BASH, [installer, ...args], { encoding: "utf8", env: { ...process.env, ...env } }); }
+const GNU_STAT = process.platform === "linux" ? "/usr/bin/stat" : ["/opt/homebrew/bin/gstat", "/usr/local/bin/gstat"].find(existsSync);
 
 function fixture(root, { validDigest = true } = {}) {
   const bin = path.join(root, "bin");
@@ -121,6 +122,20 @@ test("get appends one managed line while preserving a regular login profile's co
     const contents = readFileSync(profile, "utf8");
     assert.match(contents, /^export EXISTING=1$/m);
     assert.equal((contents.match(/JobCtrl managed path/g) ?? []).length, 1);
+    assert.equal(statSync(profile).mode & 0o777, 0o640);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test("get preserves a profile's mode through the GNU stat fallback", { skip: GNU_STAT === undefined }, () => {
+  const root = makeTmp(); try {
+    const value = fixture(root);
+    const profile = path.join(root, ".zprofile");
+    const gnuGet = path.join(root, "get-with-gnu-stat");
+    writeFileSync(gnuGet, readFileSync(GET, "utf8").replaceAll("/usr/bin/stat", GNU_STAT));
+    writeFileSync(profile, "export EXISTING=1\n");
+    chmodSync(profile, 0o640);
+    const result = run(["--local-fixture-contract", value.contract], value.env, gnuGet);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
     assert.equal(statSync(profile).mode & 0o777, 0o640);
   } finally { rmSync(root, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Summary
- preserve login-profile modes with BSD `stat -f` on macOS and GNU `stat -c` on Linux CI
- validate the resulting octal mode before the existing atomic profile replacement
- keep the hosted installer byte-identical and cover the GNU fallback

## Validation
- `node scripts/get.test.mjs`
- `node scripts/check-install-asset.mjs`
- `corepack pnpm distribution:audit`
- `python3 scripts/release_check.py --strict-prompt`
- `git diff --check`

## Independent gates
- focused QA: PASS
- code review: PASS

`corepack pnpm scripts:test` exercises the installer tests successfully; its two remaining screenshot-workspace failures are unchanged and outside this installer patch.