### PR TITLE
fix(ci): run Demo Site workflow on Node 22

### DIFF
--- a/.github/workflows/demo-site.yml
+++ b/.github/workflows/demo-site.yml
@@ -40,9 +40,9 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20.19"
+          node-version: 22.21.1
           cache: pnpm
 
       - name: Install dependencies
@@ -81,9 +81,9 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20.19"
+          node-version: 22.21.1
 
       - name: Download demo artifact
         uses: actions/download-artifact@v4
@@ -116,9 +116,9 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "20.19"
+          node-version: 22.21.1
           cache: pnpm
 
       - name: Install dependencies

--- a/scripts/demo-deployment.test.mjs
+++ b/scripts/demo-deployment.test.mjs
@@ -53,6 +53,10 @@ test("deployment workflow pins Wrangler, gates production, and deploys in safe o
   const edgePackage = await parse("apps/demo-edge/package.json");
   assert.equal(edgePackage.devDependencies.wrangler, "4.107.0");
   assert.match(workflow, /wrangler@4\.107\.0 pages deploy/);
+  const setupNode = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0";
+  assert.equal(workflow.split(setupNode).length - 1, 3);
+  assert.equal((workflow.match(/node-version: 22\.21\.1/g) ?? []).length, 3);
+  assert.doesNotMatch(workflow, /node-version: "20\.19"/);
   assert.match(workflow, /vars\.DEMO_DEPLOY_ENABLED == 'true'/);
   assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
   assert.doesNotMatch(workflow, /pull_request_target/);


### PR DESCRIPTION
## Summary
- run every Demo Site job on the repository-pinned Node 22.21.1 runtime
- retain Wrangler 4.107.0 and its dry-run deployment verification
- lock the workflow contract so future changes cannot reintroduce Node 20

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/demo-site.yml")'`
- `node --test scripts/demo-deployment.test.mjs`
- `corepack pnpm demo-edge:check`
- `corepack pnpm demo-edge:test`
- `corepack pnpm demo-edge:dry-run`
- `git diff --check`

`corepack pnpm scripts:test` passed 119 tests; two existing screenshot-workspace containment tests remain environment-sensitive under the local Node 26 runtime and are outside this workflow-only change.