### PR TITLE
fix(ci): install Python Playwright Chromium

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm --filter @jobctrl/web exec playwright install --with-deps chromium
 
+      - name: Install Python Playwright Chromium
+        run: uv --project workers/automation run playwright install chromium
+
       - name: Test web e2e
         run: pnpm --filter @jobctrl/web e2e
 

--- a/apps/api/test/typescript-ci-workflow-contract.test.ts
+++ b/apps/api/test/typescript-ci-workflow-contract.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const workflowPath = new URL("../../../.github/workflows/typescript.yml", import.meta.url);
+
+describe("TypeScript CI browser provisioning contract", () => {
+  it("installs the Python Playwright Chromium revision before browser E2E", () => {
+    const workflow = readFileSync(workflowPath, "utf8");
+    const nodeChromiumInstall =
+      "pnpm --filter @jobctrl/web exec playwright install --with-deps chromium";
+    const pythonChromiumInstall = "uv --project workers/automation run playwright install chromium";
+    const e2eCommand = "pnpm --filter @jobctrl/web e2e";
+
+    expect(workflow).toContain("- name: Install Python Playwright Chromium");
+    expect(workflow).toContain(pythonChromiumInstall);
+    expect(workflow.indexOf(nodeChromiumInstall)).toBeGreaterThanOrEqual(0);
+    expect(workflow.indexOf(pythonChromiumInstall)).toBeGreaterThan(
+      workflow.indexOf(nodeChromiumInstall),
+    );
+    expect(workflow.indexOf(e2eCommand)).toBeGreaterThan(workflow.indexOf(pythonChromiumInstall));
+  });
+});

--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+import {
+  loadE2eDbPath,
+  refreshE2eWorkerHeartbeat,
+} from "../fixtures/e2e-state.js";
 
 const TARGET = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 const PRIOR = "https://alternate.example.test/gitlab/qa-platform-director";
@@ -205,6 +208,10 @@ test("repeat application block and reasoned override reach only the simulated su
       ),
     ).toBeVisible();
 
+    // The accepted live-submit path enforces the real worker-readiness gate.
+    // Renew this test-owned fixture because the serial E2E suite can outlive
+    // the seeded heartbeat's freshness window before reaching this request.
+    refreshE2eWorkerHeartbeat();
     const acceptedBySimulation = await request.post(
       `/v1/jobs/${encodeURIComponent(TARGET)}/actions/apply`,
       { data: { dryRun: false }, headers: trustedMutationHeaders },

--- a/docs/architecture/frontend/testing.md
+++ b/docs/architecture/frontend/testing.md
@@ -194,16 +194,21 @@ runs, in order:
    compile-time guards (`Record<DomainEventType, InvalidationHandler>`
    exhaustiveness, etc.) fire here — this is the CI-enforced parity guard.
 2. `pnpm --filter @jobctrl/api test` (the API Vitest suite; API only).
-3. `pnpm --filter @jobctrl/web build` (Vite production build).
-4. `pnpm --filter @jobctrl/web storybook:build` (static Storybook build).
-5. `pnpm --filter @jobctrl/web storybook:test` (Storybook test runner —
-   play functions + `@storybook/addon-a11y` axe checks — after installing
-   Playwright Chromium).
+3. `pnpm --filter @jobctrl/web test` (web unit and integration coverage).
+4. `pnpm --filter @jobctrl/web test-d` (web type assertions).
+5. `pnpm --filter @jobctrl/web build` (Vite production build).
+6. `pnpm --filter @jobctrl/web storybook:build` (static Storybook build).
+7. Install Chromium for both the Node Playwright E2E runner and the locked
+   Python Playwright runtime used by API-backed preview routes.
+8. `pnpm --filter @jobctrl/web e2e` (browser coverage against the local API
+   and web servers).
+9. `pnpm --filter @jobctrl/web storybook:test` (Storybook test runner —
+   play functions + `@storybook/addon-a11y` axe checks).
 
 Not yet gated in CI (run locally / pre-merge; tracked in `docs/backlog.md`):
 the web Vitest unit + integration suite — including the event-handler and
-stage-state parity tests (§10.2) — ESLint, and the Playwright e2e suite
-(§10.4). Chromatic / Loki visual regression is named-not-built (§10.5). The
+stage-state parity tests (§10.2) — and ESLint. Chromatic / Loki visual
+regression is named-not-built (§10.5). The
 frontend's parity tests are the analogue of the backend's
 `scripts/check-domain-type-parity.py`; today their CI-enforced half is the
 `pnpm -r check` typecheck, with the runtime backstop running locally.


### PR DESCRIPTION
## Summary

- provision the locked Python Playwright Chromium revision before web E2E
- add a workflow contract test for browser-install ordering
- refresh the repeat-application E2E fixture immediately before the real worker-readiness-gated submit path
- align the frontend CI architecture reference with the actual workflow

## Why

Hosted run `29852756005` confirmed two independent E2E setup defects:

1. API-backed profile preview invokes the source Python runtime. The TypeScript workflow installed only the Node Playwright browser revision, so a clean runner could not launch Python’s renderer.
2. The serial repeat-application spec could reach its accepted simulated submit after the seeded worker heartbeat aged past the real readiness window.

## Validation

- hosted run `29852756005`: profile and preferences E2E failures are resolved after browser provisioning; the remaining repeat-heartbeat failure is addressed here
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/typescript.yml")'`
- direct Node assertion of the workflow contract-test ordering
- offline Python Playwright Chromium launch using the cached Python browser revision
- `git diff --check`

The focused Vitest command and targeted E2E specs could not run locally because the isolated worktree had no Node dependencies and registry DNS was unavailable. The next TypeScript CI run is the authoritative verification.