### PR TITLE
test(web): refresh repeat application heartbeat

### DIFF
--- a/apps/web/e2e/tests/repeat-application.spec.ts
+++ b/apps/web/e2e/tests/repeat-application.spec.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 import Database from "better-sqlite3";
 
-import { loadE2eDbPath } from "../fixtures/e2e-state.js";
+import {
+  loadE2eDbPath,
+  refreshE2eWorkerHeartbeat,
+} from "../fixtures/e2e-state.js";
 
 const TARGET = "https://boards.greenhouse.io/gitlab/jobs/qa-platform-director";
 const PRIOR = "https://alternate.example.test/gitlab/qa-platform-director";
@@ -205,6 +208,10 @@ test("repeat application block and reasoned override reach only the simulated su
       ),
     ).toBeVisible();
 
+    // The accepted live-submit path enforces the real worker-readiness gate.
+    // Renew this test-owned fixture because the serial E2E suite can outlive
+    // the seeded heartbeat's freshness window before reaching this request.
+    refreshE2eWorkerHeartbeat();
     const acceptedBySimulation = await request.post(
       `/v1/jobs/${encodeURIComponent(TARGET)}/actions/apply`,
       { data: { dryRun: false }, headers: trustedMutationHeaders },


### PR DESCRIPTION
## Summary
- refresh the test-owned worker heartbeat immediately before the post-confirmation simulated live-submit request
- retain the production worker-readiness gate and every repeat-application safety assertion

## Validation
- corepack pnpm web:check
- corepack pnpm --filter @jobctrl/web test-d
- focused Playwright: repeat-application and worker-heartbeat fixture specs (2 passed)
- git diff --check