### PR TITLE
fix(security): scope Codex sandbox to its binary

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -43,6 +43,32 @@ jobs:
       - name: Release scan
         run: python scripts/release_check.py
 
+      - name: Validate Python workflow contract
+        run: node scripts/check-python-workflow-contract.mjs
+
+      - name: Enable Linux user namespaces for Bubblewrap
+        if: ${{ runner.os == 'Linux' && runner.environment == 'github-hosted' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Bubblewrap needs unprivileged user namespaces on GitHub-hosted Linux
+          # runners. This step runs in each Python matrix lane before the
+          # sandboxed Codex SDK regression test.
+          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [ -n "$current_userns" ] && [ "$current_userns" != "1" ]; then
+            echo "Enabling kernel.unprivileged_userns_clone for Bubblewrap."
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi
+
+          # Ubuntu 24.04+ can additionally block unprivileged user namespaces
+          # via AppArmor, which prevents Bubblewrap from configuring loopback.
+          current_apparmor="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+          if [ -n "$current_apparmor" ] && [ "$current_apparmor" != "0" ]; then
+            echo "Disabling kernel.apparmor_restrict_unprivileged_userns for Bubblewrap."
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+
       - name: Test
         run: pytest workers/automation/tests -v
 

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -64,8 +64,10 @@ of a regular Codex CLI `auth.json`; the explicit Codex provider verify action
 uses the same copy-once behavior before checking the isolated login. Existing
 JobCtrl-owned auth is not overwritten, and the normal Codex home is unchanged.
 The auth file stays outside `codex_home/workspace/`; the permissions profile
-denies root reads and grants prompt-driven reads only to that workspace subtree
-plus minimal provider runtime paths.
+denies root reads and grants prompt-driven reads only to that workspace subtree,
+minimal runtime paths, and the one canonical Codex executable required to start
+the app server. It never grants the executable's parent directory, its
+site-packages tree, or sibling files.
 Structured Claude analysis/voice calls expose no built-in tools.
 Codex analysis disables its shell, denies approvals, and gives any command
 child an empty inherited environment, so provider API keys authenticate the SDK

--- a/docs/user/security.md
+++ b/docs/user/security.md
@@ -266,7 +266,7 @@ or verify that login.
 | Secret | Boundary |
 | --- | --- |
 | Provider/runtime keys | Shell, plaintext `~/.jobctrl/.env`, or the guided macOS Keychain boundary; never SQLite. |
-| Codex login | Stable `$JOBCTRL_DIR/codex_home/auth.json`, separate from SQLite and the normal Codex home. Valid normal CLI auth may be reused once only when this file is absent; existing isolated auth is never overwritten, and prompt-driven reads are limited to `codex_home/workspace/`. |
+| Codex login | Stable `$JOBCTRL_DIR/codex_home/auth.json`, separate from SQLite and the normal Codex home. Valid normal CLI auth may be reused once only when this file is absent; existing isolated auth is never overwritten. Prompt-driven reads are limited to `codex_home/workspace/` plus the exact canonical Codex executable required to start the app server—not its package directory or sibling files. |
 | Claude/Google web entries | Keychain for API keys plus cloud activation flags/non-secret identifiers; AWS, Google, and Azure credential files remain in their vendor stores. Status only is returned. |
 | CAPTCHA key | `CAPSOLVER_API_KEY` saved from Settings to Keychain on macOS, or supplied by the environment elsewhere; read by the owned local solver, not the model. |
 | Job-site passwords | Optional local profile value typed through a focused-field credential tool, never returned to the model. |

--- a/scripts/check-python-workflow-contract.mjs
+++ b/scripts/check-python-workflow-contract.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workflow = await readFile(new URL("../.github/workflows/python.yml", import.meta.url), "utf8");
+const setupStep = `      - name: Enable Linux user namespaces for Bubblewrap
+        if: \${{ runner.os == 'Linux' && runner.environment == 'github-hosted' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+`;
+const usernsGuard = `          current_userns="$(sysctl -n kernel.unprivileged_userns_clone 2>/dev/null || true)"
+          if [ -n "$current_userns" ] && [ "$current_userns" != "1" ]; then
+            echo "Enabling kernel.unprivileged_userns_clone for Bubblewrap."
+            sudo sysctl -w kernel.unprivileged_userns_clone=1
+          fi`;
+const apparmorGuard = `          current_apparmor="$(sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+          if [ -n "$current_apparmor" ] && [ "$current_apparmor" != "0" ]; then
+            echo "Disabling kernel.apparmor_restrict_unprivileged_userns for Bubblewrap."
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi`;
+
+assert.ok(workflow.includes(setupStep), "Python CI must scope Bubblewrap sysctl setup to hosted Linux.");
+assert.ok(workflow.includes(usernsGuard), "Python CI must guard and enable unprivileged user namespaces.");
+assert.ok(workflow.includes(apparmorGuard), "Python CI must guard and disable Ubuntu AppArmor userns restriction.");
+
+const setupIndex = workflow.indexOf(setupStep);
+const testIndex = workflow.indexOf("      - name: Test\n");
+assert.ok(setupIndex >= 0 && setupIndex < testIndex, "Bubblewrap setup must precede the Python test step.");

--- a/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
+++ b/workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py
@@ -24,6 +24,7 @@ No timeout (D-19): ``thread.run`` is awaited to completion; effort is pinned to
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -60,12 +61,7 @@ _CODEX_SCOPE = "jobctrl.analysis.codex"
 # public Python wrapper, while the pinned app-server runtime supports
 # default_permissions profiles.
 _CODEX_PERMISSION_PROFILE = "jobctrl-analysis-readonly"
-_CODEX_PERMISSION_PROFILE_OVERRIDE = (
-    f"permissions.{_CODEX_PERMISSION_PROFILE}="
-    '{filesystem={":root"="deny",":minimal"="read",":workspace_roots"={"."="read"}},'
-    "network={enabled=false}}"
-)
-_CODEX_CONFIG_OVERRIDES = (
+_CODEX_STATIC_CONFIG_OVERRIDES = (
     "features.plugins=false",
     "features.apps=false",
     # Employer analysis is a pure structured-generation call. Do not expose a
@@ -76,7 +72,6 @@ _CODEX_CONFIG_OVERRIDES = (
     "allow_login_shell=false",
     'shell_environment_policy={inherit="none"}',
     f'default_permissions="{_CODEX_PERMISSION_PROFILE}"',
-    _CODEX_PERMISSION_PROFILE_OVERRIDE,
 )
 _CODEX_WORKSPACE_DIRNAME = "workspace"
 _CODEX_PROCESS_HOME_DIRNAME = "home"
@@ -131,6 +126,62 @@ def _isolated_codex_env(codex_home: Path, process_home: Path) -> dict[str, str]:
     return env
 
 
+def _canonical_codex_binary() -> Path:
+    """Resolve one executable file trusted by the selected Codex runtime.
+
+    ``resolve_codex_binary`` owns provider-pack verification in bundled mode and
+    the explicit source-install override policy. The sandbox must receive its
+    exact canonical executable path, rather than a directory that could expose
+    sibling package files or be retargeted through a symlink.
+    """
+
+    configured = Path(resolve_codex_binary())
+    try:
+        binary = configured.resolve(strict=True)
+    except (OSError, RuntimeError) as exc:
+        raise RuntimeError(f"Codex binary could not be canonicalized: {configured}") from exc
+    if not binary.is_file():
+        raise RuntimeError(f"Codex binary is not a regular file: {binary}")
+    if not os.access(binary, os.X_OK):
+        raise RuntimeError(f"Codex binary is not executable: {binary}")
+    return binary
+
+
+def _codex_permission_profile_override(codex_binary: Path) -> str:
+    """Grant the sandbox read access to only the canonical Codex executable.
+
+    The value is a TOML command-line override. JSON string encoding is valid for
+    TOML basic strings and prevents a quote or backslash in an operator-provided
+    source-install path from changing the surrounding permissions structure.
+    """
+
+    quoted_binary = json.dumps(str(codex_binary))
+    return (
+        f"permissions.{_CODEX_PERMISSION_PROFILE}="
+        '{filesystem={":root"="deny",":minimal"="read",":workspace_roots"={"."="read"},'
+        f"{quoted_binary}=\"read\"}},"
+        "network={enabled=false}}"
+    )
+
+
+def _codex_config_overrides(codex_binary: Path) -> tuple[str, ...]:
+    """Build the immutable Codex configuration for one canonical executable."""
+
+    return (*_CODEX_STATIC_CONFIG_OVERRIDES, _codex_permission_profile_override(codex_binary))
+
+
+def _codex_config_kwargs(dirs: _CodexHomeDirs) -> dict[str, Any]:
+    """Build one SDK configuration bound to the exact sandbox-permitted binary."""
+
+    codex_binary = _canonical_codex_binary()
+    return {
+        "cwd": str(dirs.workdir),
+        "env": _isolated_codex_env(dirs.codex_home, dirs.process_home),
+        "config_overrides": _codex_config_overrides(codex_binary),
+        "codex_bin": str(codex_binary),
+    }
+
+
 def _load_async_codex_factory() -> AsyncCodexFactory:
     """Build an ``AsyncCodex`` CM with a locked-down command permissions profile.
 
@@ -146,16 +197,7 @@ def _load_async_codex_factory() -> AsyncCodexFactory:
 
     def _make() -> Any:
         dirs = _prepare_isolated_codex_home()
-        config_kwargs: dict[str, Any] = {
-            "cwd": str(dirs.workdir),
-            "env": _isolated_codex_env(dirs.codex_home, dirs.process_home),
-            "config_overrides": _CODEX_CONFIG_OVERRIDES,
-        }
-        # Prefer the SDK-pinned bundled runtime. A system ``codex`` on PATH may
-        # speak a different app-server protocol; JOBCTRL_CODEX_BIN is the
-        # explicit escape hatch for setup-managed platform fallbacks.
-        config_kwargs["codex_bin"] = str(resolve_codex_binary())
-        return AsyncCodex(config=CodexConfig(**config_kwargs))
+        return AsyncCodex(config=CodexConfig(**_codex_config_kwargs(dirs)))
 
     return _make
 
@@ -178,14 +220,7 @@ def _load_catalog_async_codex_factory() -> AsyncCodexFactory:
 
     def _make() -> Any:
         dirs = _prepare_isolated_codex_home(ensure_auth=False)
-        return AsyncCodex(
-            config=CodexConfig(
-                cwd=str(dirs.workdir),
-                env=_isolated_codex_env(dirs.codex_home, dirs.process_home),
-                config_overrides=_CODEX_CONFIG_OVERRIDES,
-                codex_bin=str(resolve_codex_binary()),
-            )
-        )
+        return AsyncCodex(config=CodexConfig(**_codex_config_kwargs(dirs)))
 
     return _make
 

--- a/workers/automation/tests/test_codex_home_isolation.py
+++ b/workers/automation/tests/test_codex_home_isolation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import stat
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -42,9 +43,27 @@ def _assert_private_mode(path: Path, expected: int) -> None:
         assert _mode(path) == expected
 
 
+def _write_executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o700)
+    return path
+
+
+def _profile_filesystem_permissions(overrides: tuple[str, ...]) -> dict[str, object]:
+    profile_override = next(
+        value
+        for value in overrides
+        if value.startswith(f"permissions.{adapter._CODEX_PERMISSION_PROFILE}=")
+    )
+    parsed = tomllib.loads(profile_override)
+    return parsed["permissions"][adapter._CODEX_PERMISSION_PROFILE]["filesystem"]
+
+
 def test_config_overrides_select_workspace_only_permission_profile() -> None:
     profile = adapter._CODEX_PERMISSION_PROFILE
-    overrides = adapter._CODEX_CONFIG_OVERRIDES
+    binary = Path("/trusted/codex-bin")
+    overrides = adapter._codex_config_overrides(binary)
 
     assert "features.plugins=false" in overrides
     assert "features.apps=false" in overrides
@@ -53,11 +72,54 @@ def test_config_overrides_select_workspace_only_permission_profile() -> None:
     assert 'shell_environment_policy={inherit="none"}' in overrides
     assert f'default_permissions="{profile}"' in overrides
 
-    profile_override = next(value for value in overrides if value.startswith(f"permissions.{profile}="))
-    assert '":root"="deny"' in profile_override
-    assert '":minimal"="read"' in profile_override
-    assert '":workspace_roots"={"."="read"}' in profile_override
-    assert "network={enabled=false}" in profile_override
+    filesystem = _profile_filesystem_permissions(overrides)
+    assert filesystem[":root"] == "deny"
+    assert filesystem[":minimal"] == "read"
+    assert filesystem[":workspace_roots"] == {".": "read"}
+    assert filesystem[str(binary)] == "read"
+    assert "network={enabled=false}" in overrides[-1]
+
+
+def test_canonical_codex_binary_resolves_symlink_and_rejects_sibling_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    if os.name == "nt":
+        pytest.skip("symlink path semantics are covered on supported Unix runtimes")
+    binary = _write_executable(tmp_path / 'provider-pack/site-packages/codex "binary"')
+    sibling = _write_executable(binary.with_name("sibling-canary"))
+    alias = tmp_path / "codex-alias"
+    alias.symlink_to(binary)
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: alias)
+
+    canonical = adapter._canonical_codex_binary()
+    filesystem = _profile_filesystem_permissions(adapter._codex_config_overrides(canonical))
+
+    assert canonical == binary.resolve()
+    assert filesystem == {
+        ":root": "deny",
+        ":minimal": "read",
+        ":workspace_roots": {".": "read"},
+        str(canonical): "read",
+    }
+    assert str(alias) not in filesystem
+    assert str(canonical.parent) not in filesystem
+    assert str(sibling) not in filesystem
+
+
+@pytest.mark.parametrize("binary_kind", ["missing", "directory", "not-executable"])
+def test_canonical_codex_binary_requires_one_existing_executable_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, binary_kind: str
+) -> None:
+    binary = tmp_path / "codex-bin"
+    if binary_kind == "directory":
+        binary.mkdir()
+    elif binary_kind == "not-executable":
+        binary.write_text("not executable", encoding="utf-8")
+        binary.chmod(0o600)
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: binary)
+
+    with pytest.raises(RuntimeError, match="Codex binary"):
+        adapter._canonical_codex_binary()
 
 
 def test_prepare_isolated_codex_home_copies_auth_outside_workspace(
@@ -160,7 +222,8 @@ def test_bundled_codex_factory_uses_persisted_credentials(
     auth.parent.mkdir(parents=True)
     auth.write_text('{"OPENAI_API_KEY":"sk-persisted"}', encoding="utf-8")
     monkeypatch.setattr(jobctrl.runtime, "activate_provider_pack", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: tmp_path / "codex-bin")
+    binary = _write_executable(tmp_path / "codex-bin")
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: binary)
 
     class FakeAsyncCodex:
         def __init__(self, *, config: Any) -> None:
@@ -170,12 +233,61 @@ def test_bundled_codex_factory_uses_persisted_credentials(
 
     codex = adapter._load_async_codex_factory()()
 
-    assert codex.config.config_overrides == adapter._CODEX_CONFIG_OVERRIDES
+    assert codex.config.codex_bin == str(binary.resolve())
+    assert codex.config.config_overrides == adapter._codex_config_overrides(binary.resolve())
     assert codex.config.env["OPENAI_API_KEY"] == ""
     assert all(
         codex.config.env[key] == ""
         for key in setup_probes.CODEX_NEUTRALIZED_AUTH_ENV
     )
+
+
+@pytest.mark.parametrize("factory_name", ["_load_async_codex_factory", "_load_catalog_async_codex_factory"])
+@pytest.mark.parametrize("runtime_mode", ["source", "bundled"])
+def test_codex_factories_grant_only_the_exact_canonical_binary_across_runtime_layouts(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    factory_name: str,
+    runtime_mode: str,
+) -> None:
+    import jobctrl.runtime
+    import openai_codex
+
+    app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
+    (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-source"}', encoding="utf-8")
+    binary = _write_executable(
+        tmp_path / runtime_mode / "site-packages/codex_cli_bin/bin/codex"
+    )
+    sibling = _write_executable(binary.with_name("provider-pack-canary"))
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: binary)
+    monkeypatch.setenv("JOBCTRL_RUNTIME_MODE", runtime_mode)
+    pack_calls: list[tuple[str, Path]] = []
+
+    if runtime_mode == "bundled":
+        auth = app_dir / "codex_home/auth.json"
+        auth.parent.mkdir(parents=True)
+        auth.write_text('{"OPENAI_API_KEY":"sk-bundled"}', encoding="utf-8")
+        monkeypatch.setattr(
+            jobctrl.runtime,
+            "activate_provider_pack",
+            lambda pack_id, *, app_dir: pack_calls.append((pack_id, app_dir)),
+        )
+
+    class FakeAsyncCodex:
+        def __init__(self, *, config: Any) -> None:
+            self.config = config
+
+    monkeypatch.setattr(openai_codex, "AsyncCodex", FakeAsyncCodex)
+
+    codex = getattr(adapter, factory_name)()()
+    canonical = binary.resolve()
+    filesystem = _profile_filesystem_permissions(codex.config.config_overrides)
+
+    assert codex.config.codex_bin == str(canonical)
+    assert filesystem[str(canonical)] == "read"
+    assert str(canonical.parent) not in filesystem
+    assert str(sibling) not in filesystem
+    assert pack_calls == ([('codex-provider-runtime', app_dir)] if runtime_mode == "bundled" else [])
 
 
 @pytest.mark.asyncio
@@ -184,7 +296,8 @@ async def test_live_factory_uses_jobctrl_codex_home_without_cleanup(
 ) -> None:
     app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
     (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-fake-factory"}')
-    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: tmp_path / "codex-bin")
+    binary = _write_executable(tmp_path / "codex-bin")
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: binary)
 
     class FakeAsyncCodex:
         instances: list["FakeAsyncCodex"] = []
@@ -201,7 +314,8 @@ async def test_live_factory_uses_jobctrl_codex_home_without_cleanup(
             assert Path(self.config.env["HOME"]) == codex_home / "home"
             assert (codex_home / "auth.json").is_file()
             assert not (Path(self.config.cwd) / "auth.json").exists()
-            assert self.config.config_overrides == adapter._CODEX_CONFIG_OVERRIDES
+            assert self.config.codex_bin == str(binary.resolve())
+            assert self.config.config_overrides == adapter._codex_config_overrides(binary.resolve())
             return self
 
         async def __aexit__(self, *exc: Any) -> None:
@@ -229,7 +343,8 @@ async def test_live_factory_uses_same_jobctrl_codex_home_when_contexts_overlap(
 ) -> None:
     app_dir, source_codex_home = _isolate_homes(monkeypatch, tmp_path)
     (source_codex_home / "auth.json").write_text('{"OPENAI_API_KEY":"sk-fake-concurrent"}')
-    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: tmp_path / "codex-bin")
+    binary = _write_executable(tmp_path / "codex-bin")
+    monkeypatch.setattr(adapter, "resolve_codex_binary", lambda: binary)
 
     class FakeAsyncCodex:
         instances: list["FakeAsyncCodex"] = []


### PR DESCRIPTION
## Summary

- configure Bubblewrap user namespaces only on GitHub-hosted Linux runners, following the guarded official action pattern
- canonicalize and validate the one trusted Codex executable, then grant the sandbox read access to that exact file only
- keep root denied, network disabled, and package directories, provider packs, parent directories, sibling files, credentials, and sandbox writes unavailable
- cover source and bundled runtime layouts, symlinks and quoted paths, invalid executables, auth isolation, and the CI workflow contract

## Validation

- `uv --project workers/automation run --extra dev pytest workers/automation/tests/test_codex_home_isolation.py -q` (17 passed)
- `uv --project workers/automation run ruff check workers/automation/src/jobctrl/infrastructure/analysis/codex_analysis_adapter.py workers/automation/tests/test_codex_home_isolation.py`
- `node scripts/check-python-workflow-contract.mjs`
- `git diff origin/main...HEAD --check`

Docs build was not run in this isolated worktree because its `node_modules` do not include VitePress. The PR is rebased onto current `main`, including #492 and #493.