### PR TITLE
fix(ci): isolate Claude CLI command tests

### DIFF
--- a/workers/automation/tests/test_claude_code_cli_adapter.py
+++ b/workers/automation/tests/test_claude_code_cli_adapter.py
@@ -25,11 +25,16 @@ from jobctrl.infrastructure.apply.claude_code_cli import (
 
 @pytest.fixture(autouse=True)
 def _isolate_apply_tests_from_host_keychain(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep Popen fakes from intercepting config's unrelated Keychain probe."""
+    """Keep command-construction fakes from reaching host runtime probes."""
 
     from jobctrl import config
 
     monkeypatch.setattr(config, "_KEYCHAIN_FALLBACK_DIAGNOSTICS", ())
+    monkeypatch.setattr(
+        claude_code_cli,
+        "resolve_claude_apply_binary",
+        lambda: "/bin/claude",
+    )
 
 
 class _FakeStdin:


### PR DESCRIPTION
## Summary
- isolate Claude CLI command-construction tests from host binary discovery
- keep the production resolver and SDK behavior unchanged

## Validation
- clean-PATH reproduction on Python 3.13: failing before the fixture change, passing after
- Python 3.11, 3.12, and 3.13: pytest -q --randomly-seed=117 workers/automation/tests/test_claude_code_cli_adapter.py (18 passed each)
- targeted Ruff and git diff --check