### PR TITLE
fix(distribution): update Python development baseline

### DIFF
--- a/packaging/distribution/source-baseline.json
+++ b/packaging/distribution/source-baseline.json
@@ -8,7 +8,7 @@
     "pnpmPackageRecords": 1447,
     "pythonCoreRuntimeDirect": 18,
     "pythonProviderRuntimeDirect": 4,
-    "pythonDevelopmentDirect": 6,
+    "pythonDevelopmentDirect": 8,
     "uvPackageRecords": 102
   },
   "referenceFootprint": {


### PR DESCRIPTION
## Summary

- align the source dependency baseline with the current eight Python development dependencies
- retain the existing uv lock record count and observational footprint data

## Validation

- `corepack pnpm distribution:measure`
- `corepack pnpm distribution:audit`
- `node scripts/distribution-manifest.test.mjs`
- `git diff --check`