### PR TITLE
fix(demo): wait for production domain readiness

### DIFF
--- a/.github/workflows/demo-site.yml
+++ b/.github/workflows/demo-site.yml
@@ -8,6 +8,7 @@ on:
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "scripts/demo-*.mjs"
       - ".github/workflows/demo-site.yml"
   push:
     branches: ["main"]
@@ -17,6 +18,7 @@ on:
       - "packages/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "scripts/demo-*.mjs"
       - ".github/workflows/demo-site.yml"
   workflow_dispatch:
 

--- a/scripts/demo-deployment.test.mjs
+++ b/scripts/demo-deployment.test.mjs
@@ -53,6 +53,7 @@ test("deployment workflow pins Wrangler, gates production, and deploys in safe o
   const edgePackage = await parse("apps/demo-edge/package.json");
   assert.equal(edgePackage.devDependencies.wrangler, "4.107.0");
   assert.match(workflow, /wrangler@4\.107\.0 pages deploy/);
+  assert.match(workflow, /- "scripts\/demo-\*\.mjs"/);
   const setupNode = "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0";
   assert.equal(workflow.split(setupNode).length - 1, 3);
   assert.equal((workflow.match(/node-version: 22\.21\.1/g) ?? []).length, 3);

--- a/scripts/demo-smoke.mjs
+++ b/scripts/demo-smoke.mjs
@@ -3,6 +3,8 @@ import { randomBytes } from "node:crypto";
 import { pathToFileURL } from "node:url";
 
 const CLOUDFLARE_INJECTION_MARKER = /challenge-platform|beacon\.min\.js|\/cdn-cgi\/rum/i;
+const DEMO_SHELL_READY_ATTEMPTS = 31;
+const DEMO_SHELL_READY_DELAY_MS = 3_000;
 const SYNTHETIC_HTML_ASSETS = [
   "/demo/application-preview.html",
   "/demo/profile-resume.html",
@@ -25,20 +27,51 @@ export async function assertSyntheticHtmlAssetsAreClean(request) {
   }
 }
 
+export async function waitForDemoShell(
+  fetchShell,
+  {
+    attempts = DEMO_SHELL_READY_ATTEMPTS,
+    delayMs = DEMO_SHELL_READY_DELAY_MS,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    log = console.warn,
+  } = {},
+) {
+  let lastStatus = "unknown";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const response = await fetchShell();
+    if (response.ok) {
+      return response;
+    }
+
+    lastStatus = response.status;
+    await response.body?.cancel?.();
+    if (attempt < attempts) {
+      log(`Demo shell is not ready (attempt ${attempt}/${attempts}): / returned ${lastStatus}`);
+      await sleep(delayMs);
+    }
+  }
+
+  assert.fail(`demo shell was not ready after ${attempts} attempts: / returned ${lastStatus}`);
+}
+
 async function runDemoSmoke() {
   const baseUrl = new URL(process.env.DEMO_BASE_URL ?? process.argv[2] ?? "");
   assert.equal(baseUrl.protocol, "https:", "DEMO_BASE_URL must use HTTPS");
 
-  const request = async (path, init) => {
-    const response = await fetch(new URL(path, baseUrl), {
+  const fetchPath = (path, init) =>
+    fetch(new URL(path, baseUrl), {
       redirect: "manual",
       ...init,
     });
+
+  const request = async (path, init) => {
+    const response = await fetchPath(path, init);
     assert.ok(response.ok, `${path} returned ${response.status}`);
     return response;
   };
 
-  const shell = await request("/");
+  const shell = await waitForDemoShell(() => fetchPath("/"));
   const shellHtml = await shell.text();
   assert.match(shellHtml, /<div id="root"><\/div>/);
   assertNoCloudflareInjection("/", shellHtml);

--- a/scripts/demo-smoke.test.mjs
+++ b/scripts/demo-smoke.test.mjs
@@ -1,7 +1,53 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { assertNoCloudflareInjection, assertSyntheticHtmlAssetsAreClean } from "./demo-smoke.mjs";
+import {
+  assertNoCloudflareInjection,
+  assertSyntheticHtmlAssetsAreClean,
+  waitForDemoShell,
+} from "./demo-smoke.mjs";
+
+test("demo smoke waits for the production custom domain to become ready", async () => {
+  const statuses = [403, 403, 200];
+  const delays = [];
+
+  const response = await waitForDemoShell(
+    async () => {
+      const status = statuses.shift();
+      return { ok: status >= 200 && status < 300, status };
+    },
+    {
+      attempts: 3,
+      delayMs: 25,
+      sleep: async (delayMs) => delays.push(delayMs),
+      log: () => {},
+    },
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(delays, [25, 25]);
+});
+
+test("demo smoke still fails after the bounded readiness window", async () => {
+  let requests = 0;
+
+  await assert.rejects(
+    waitForDemoShell(
+      async () => {
+        requests += 1;
+        return { ok: false, status: 403 };
+      },
+      {
+        attempts: 3,
+        delayMs: 0,
+        sleep: async () => {},
+        log: () => {},
+      },
+    ),
+    /demo shell was not ready after 3 attempts: \/ returned 403/,
+  );
+  assert.equal(requests, 3);
+});
 
 test("demo smoke rejects known Cloudflare HTML injection markers", () => {
   for (const marker of ["challenge-platform", "https://static.cloudflareinsights.com/beacon.min.js", "/cdn-cgi/rum"]) {


### PR DESCRIPTION
## What changed

- wait up to 90 seconds for the production custom-domain shell after a Pages deployment
- retain strict one-shot validation for deep links, synthetic assets, consent behavior, security headers, and Cloudflare injection markers
- add regression coverage for transient 403 recovery and persistent 403 failure

## Why

Demo Site run 29856245521 completed D1 migration, both Worker deployments, route publication, and Pages deployment, then requested the custom domain less than one second later. That first request returned 403, while the same root subsequently returned 200 consistently. The smoke harness treated publication convergence as a product failure.

## Validation

- `node --test scripts/demo-smoke.test.mjs scripts/demo-deployment.test.mjs`
- relevant script suite: 119 passed
- `DEMO_BASE_URL=https://demo.jobctrl.dev node scripts/demo-smoke.mjs`
- `git diff --check`